### PR TITLE
README: add a link to numba mailinglist archives

### DIFF
--- a/README
+++ b/README
@@ -26,4 +26,6 @@ python setup.py install
 python setup.py install
 
 * Follow Numba
-Join numba@librelist.org
+Join the numba mailinglist by sending any email to the address
+numba@librelist.org (your email will get discarded and you will get
+subscribed). Archives are at http://librelist.com/browser/numba/


### PR DESCRIPTION
It took me a while to figure out how to subscribe and view archives of the numba mailinglist.

This PR should make it clear to first time users.
