### PR TITLE
better calculation of architecture bits

### DIFF
--- a/numba/kerneltranslate.py
+++ b/numba/kerneltranslate.py
@@ -7,10 +7,7 @@ import llvm.core as lc
 import llvm.passes as lp
 import llvm.ee as le
 
-if sys.maxint > 2**33:
-    _plat_bits = 64
-else:
-    _plat_bits = 32
+from .llvm_types import _plat_bits
 
 
 _pyobject_head = [lc.Type.int(_plat_bits), lc.Type.pointer(lc.Type.int(32))]

--- a/numba/llvm_types.py
+++ b/numba/llvm_types.py
@@ -5,14 +5,12 @@ Utility module containing common (to Numba) LLVM types.
 # ______________________________________________________________________
 
 import sys
+import platform
 import llvm.core as lc
 
 # ______________________________________________________________________
 
-if sys.maxint > 2**33:
-    _plat_bits = 64
-else:
-    _plat_bits = 32
+_plat_bits = int(platform.architecture()[0][:2])
 
 _int1 = lc.Type.int(1)
 _int8 = lc.Type.int(8)


### PR DESCRIPTION
The problem with using sys.maxint is that the integer type does necessary have the same size as a pointers.  For example, when using MSVC on 64-bit Windows, sys.maxint will be 2^31-1.
