### PR TITLE
channel-minor issue in fbcorr example

### DIFF
--- a/tests/test_fbcorr.py
+++ b/tests/test_fbcorr.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 # ______________________________________________________________________
-'''test_filter2d
+'''test_fbcorr
 
-Test the filter2d() example from the PyCon'12 slide deck.
+Test the fbcorr() example .... 
 '''
 # ______________________________________________________________________
 


### PR DESCRIPTION
I was having a look at the fbcorr example in  the examples directory, and I think there might be a little error in it.   Perhaps the output is formatted incorrectly in channel-minor format (e.g. with the "channel" dimension last)?  
In particular, the pure python function throws an IndexError exception when called on the input specified in the example, since presumably the 1st and 3rd axes have been incorrectly swapped (I think). 

One thing I noticed is that the numba-compiled function does not produce an error -- it should produces what I think is unexpected output.    

Sorry if this is off-base ... 
