### PR TITLE
Fixed wrong project URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     name = "numba",
     author = "Continuum Analytics, Inc.",
     author_email = "numba-users@continuum.io",
-    url = "https://numba.github.com",
+    url = "http://numba.github.com",
     license = "BSD",
     classifiers = [
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
The URL had an https:// prefix and didn't work in this way.
The current URL, which has a http:// prefix, redirects to
http://numba.pydata.org/
