### PR TITLE
Allowing decorators (@autojit) to be bound as instance methods

### DIFF
--- a/numba/numbawrapper.pyx
+++ b/numba/numbawrapper.pyx
@@ -48,6 +48,33 @@ cdef class NumbaWrapper(object):
         self.func_doc = py_func.__doc__
         self.module = py_func.__module__
 
+
+    def __get__(self, obj, objtype):
+        """Allow NumbaWrapper to be bound and used for instance methods.
+        """
+        if obj is None:
+            return self
+        return _BoundNumbaWrapper(self, obj)
+
+
+cdef class _BoundNumbaWrapper(object):
+    cdef public object wrapper
+    cdef public object obj
+
+    def __init__(self, wrapper, obj):
+        self.wrapper = wrapper
+        self.obj = obj
+
+
+    def __repr__(self):
+        return "<_BoundNumbaWrapper (%s, %s)>" % (self.wrapper, self.obj)
+
+
+    def __call__(self, *args, **kwargs):
+        realArgs = ( self.obj, ) + args
+        return self.wrapper(*realArgs, **kwargs)
+
+
 #------------------------------------------------------------------------
 # Create Numba Functions (numbafunction.c)
 #------------------------------------------------------------------------


### PR DESCRIPTION
Without this pull, the following does not work:

```
class A(object):
    @autojit
    def a(self, c):
        return c
A().a()
```

It does not work because the NumbaWrapper is not a descriptor, and misses the binding cue.

Note that I did not add any tests, as I am having issues getting them to run; I would be happy to add some to this pull request with some help getting them to run:

(ipython)walt@mrrobot:~/pycon/ipython/numba$ ./runtests.py 
Traceback (most recent call last):
  File "./runtests.py", line 6, in <module>
    import numba
  File "/home/walt/pycon/ipython/numba/numba/**init**.py", line 15, in <module>
    from numba import utils, typesystem
  File "/home/walt/pycon/ipython/numba/numba/utils.py", line 11, in <module>
    from numba.typesystem.typemapper import NumbaTypeMapper
  File "/home/walt/pycon/ipython/numba/numba/typesystem/**init**.py", line 9, in <module>
    from .typemapper import *
  File "/home/walt/pycon/ipython/numba/numba/typesystem/typemapper.py", line 18, in <module>
    from numba import numbawrapper
ImportError: cannot import name numbawrapper
(ipython)walt@mrrobot:~/pycon/ipython/numba$ 
