### PR TITLE
Spelling, etc. in documentation.

### DIFF
--- a/docs/source/doc/interface_c.rst
+++ b/docs/source/doc/interface_c.rst
@@ -8,8 +8,9 @@ Interfacing with C
 Ctypes and CFFI
 ===============
 Numba supports jitting ctypes and CFFI function calls. Numba will automatically
-figure out the signatures of the functions and data. Below is a gibbs sampling
-code that accesses ctypes (or CFFI) functions defined in another module (
+figure out the signatures of the functions and data. Below is a Gibbs sampling
+implementation that accesses ctypes (or CFFI) functions defined in another
+module (
 ``rk_seed``,  ``rk_gamma`` and ``rk_normal``), and that passes in a pointer to a struct
 also allocated with ctypes (``state_p``)::
 
@@ -36,7 +37,7 @@ Writing Low-level Code
 ======================
 
 Numba allows users to deal with high-level as well as low-level C-like code.
-Users can access and define new or external stucts, deal with pointers, and
+Users can access and define new or external structs, deal with pointers, and
 call C functions natively.
 
 .. NOTE:: Type declarations are covered in in :ref:`types`.

--- a/docs/source/doc/ir.rst
+++ b/docs/source/doc/ir.rst
@@ -58,7 +58,7 @@ furthermore implement its own ``visit`` method, allowing for quick
 visitor dispatch (compile with Cython or pre-compile with Numba).
 
 We can generate automatic mapping code to map schema instances to
-opaguely typed LLVM IR automatically, which is the abstract syntax
+opaquely typed LLVM IR automatically, which is the abstract syntax
 generated post-order. E.g. ``a + b * c`` becomes::
 
     !0 = metadata !{ metadata !"operator", i8* "Mul" }

--- a/docs/source/doc/pycc.rst
+++ b/docs/source/doc/pycc.rst
@@ -22,7 +22,7 @@ different names. The code can be compiled as follows::
 Which will create a pure shared library for your platform which can be
 linked against any other program.  This is **not** a Python extension.
 You would have to use ctypes to load the code that is created.
-Multiple files may be given to compile them simulteneously into a
+Multiple files may be given to compile them simultaneously into a
 shared library. Options exist to compile to native object files
 instead of a shared library, to emit LLVM code or to generate a C
 header file with function prototypes. For more information on the


### PR DESCRIPTION
Misspellings, capitalize Gibbs, one case of more natural wording.
