### PR TITLE
Correct document for `pycc`, issue #218

### DIFF
--- a/docs/source/pycc.rst
+++ b/docs/source/pycc.rst
@@ -11,7 +11,7 @@ library. Below is an example::
         return a * b
 
     export('mult f8(f8, f8)')(mult)
-    export(['multf f4(f4, f4)', 'multi i4(i4, i4)'])(mult)
+    exportmany(['multf f4(f4, f4)', 'multi i4(i4, i4)'])(mult)
     export('multc c16(c16, c16)')(mult)
 
 This defines a trivial function and exports four specializations under


### PR DESCRIPTION
For issue #218, document for `pycc`
- Remove unpaired parentheses.
- Use `exportmany` for multi function str
