### PR TITLE
[DOC] Fix an example with vectorize

### DIFF
--- a/docs/source/arrays.rst
+++ b/docs/source/arrays.rst
@@ -202,7 +202,7 @@ Building ufuncs using @vectorize
 An alternative syntax is available through the use of the `vectorize` decorator::
 
     from numba import float32, float64
-    from numba.vectorize import Vectorize, vectorize
+    from numba.vectorize import vectorize
     import math
 
     pi = math.pi


### PR DESCRIPTION
The explicit vectorize import should be stated in this example, as it is intended to be a complete example.
