### PR TITLE
Return array type and set dtype to numba type (fixes issue #245)

### DIFF
--- a/numba/type_inference/modules/numpymodule.py
+++ b/numba/type_inference/modules/numpymodule.py
@@ -185,7 +185,7 @@ def dot(typesystem, a, b, out):
 def array(object, dtype, order, subok):
     type = array_from_type(object)
     if type.is_array and dtype is not None:
-        type = type.add('dtype', dtype)
+        return type.add('dtype', get_dtype(dtype).dtype)
     elif dtype is not None:
         return dtype
     else:


### PR DESCRIPTION
This is a tentative fix for issue #245: "local numpy array constructed with np.array was not recognized as numpy array".
- Return type if dtype specified.
- Convert dtype to numba type using `get_dtype()`.

Note: I am not very fluent with the code-base, so there are likely other places where similar changes are required, but this seems to do the trick.
