### PR TITLE
Fix `ValueError: path is on drive X:, start on drive D:` on Windows

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -38,7 +38,7 @@ class Loc(object):
             return "%s (%s)" % (self.filename, self.line)
 
     def strformat(self):
-        relpath = os.path.relpath(self.filename)
+        relpath = os.path.abspath(self.filename)
         return 'File "%s", line %d' % (relpath, self.line)
 
 


### PR DESCRIPTION
Fixes test errors on Windows:

```
Python 2.7.6 (default, Nov 10 2013, 19:24:24) [MSC v.1500 64 bit (AMD64)]
numpy 1.8.0
numba 0.12.1
llvmmath 0.1.2
llvmpy 0.12.3
llvm 3.3

======================================================================
ERROR: test_mod_complex (numba.tests.test_operators.TestOperators)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\numba\tests\test_operators.py", line 712, in test_mod_complex
    cres = compile_isolated(pyfunc, (types.complex64, types.complex64))
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 58, in compile_isolated
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 91, in compile_extra
    return_type, flags, locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 116, in compile_bytecode
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 266, in type_inference_stage
    infer.propagate()
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 289, in propagate
    self.constrains.propagate(self.context, self.typevars)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 108, in propagate
    raise TypingError("Internal error:\n%s" % e, constrain.loc)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 37, in __init__
    super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
  File "X:\Python27-x64\lib\site-packages\numba\ir.py", line 41, in strformat
    relpath = os.path.relpath(self.filename)
  File "X:\Python27-x64\lib\ntpath.py", line 512, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive X:, start on drive D:

======================================================================
ERROR: test_mod_complex_npm (numba.tests.test_operators.TestOperators)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\numba\tests\test_operators.py", line 719, in test_mod_complex_npm
    self.test_mod_complex(flags=Noflags)
  File "X:\Python27-x64\lib\site-packages\numba\tests\test_operators.py", line 712, in test_mod_complex
    cres = compile_isolated(pyfunc, (types.complex64, types.complex64))
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 58, in compile_isolated
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 91, in compile_extra
    return_type, flags, locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 116, in compile_bytecode
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 266, in type_inference_stage
    infer.propagate()
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 289, in propagate
    self.constrains.propagate(self.context, self.typevars)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 108, in propagate
    raise TypingError("Internal error:\n%s" % e, constrain.loc)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 37, in __init__
    super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
  File "X:\Python27-x64\lib\site-packages\numba\ir.py", line 41, in strformat
    relpath = os.path.relpath(self.filename)
  File "X:\Python27-x64\lib\ntpath.py", line 512, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive X:, start on drive D:

======================================================================
ERROR: test_unknown_attrs (numba.tests.test_typingerror.TestTypingError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\numba\tests\test_typingerror.py", line 31, in test_unknown_attrs
    compile_isolated(bar, (types.int32,))
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 58, in compile_isolated
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 91, in compile_extra
    return_type, flags, locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 116, in compile_bytecode
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 266, in type_inference_stage
    infer.propagate()
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 289, in propagate
    self.constrains.propagate(self.context, self.typevars)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 108, in propagate
    raise TypingError("Internal error:\n%s" % e, constrain.loc)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 37, in __init__
    super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
  File "X:\Python27-x64\lib\site-packages\numba\ir.py", line 41, in strformat
    relpath = os.path.relpath(self.filename)
  File "X:\Python27-x64\lib\ntpath.py", line 512, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive X:, start on drive D:

======================================================================
ERROR: test_unknown_function (numba.tests.test_typingerror.TestTypingError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\numba\tests\test_typingerror.py", line 23, in test_unknown_function
    compile_isolated(foo, ())
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 58, in compile_isolated
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 91, in compile_extra
    return_type, flags, locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 116, in compile_bytecode
    locals)
  File "X:\Python27-x64\lib\site-packages\numba\compiler.py", line 265, in type_inference_stage
    infer.build_constrain()
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 276, in build_constrain
    self.constrain_statement(inst)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 368, in constrain_statement
    self.typeof_assign(inst)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 390, in typeof_assign
    self.typeof_global(inst, inst.target, value)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 470, in typeof_global
    loc=inst.loc)
  File "X:\Python27-x64\lib\site-packages\numba\typeinfer.py", line 37, in __init__
    super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
  File "X:\Python27-x64\lib\site-packages\numba\ir.py", line 41, in strformat
    relpath = os.path.relpath(self.filename)
  File "X:\Python27-x64\lib\ntpath.py", line 512, in relpath
    % (path_prefix, start_prefix))
ValueError: path is on drive X:, start on drive D:
```
