### PR TITLE
cffi should support void *

### DIFF
--- a/numba/cffi_support.py
+++ b/numba/cffi_support.py
@@ -85,6 +85,7 @@ if ffi is not None:
         ffi.typeof('double') :              types.double,
         # ffi.typeof('long double') :         longdouble,
         ffi.typeof('char *') :              types.voidptr,
+        ffi.typeof('void *') :              types.voidptr,
         ffi.typeof('ssize_t') :             types.intp,
         ffi.typeof('size_t') :              types.uintp,
     }


### PR DESCRIPTION
For example, `memcmp`'s signature wants a `void*`
