### PR TITLE
Type seeding now seeds return type first, to ensure proper locking order

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -260,13 +260,14 @@ def type_inference_stage(typingctx, interp, args, return_type, locals={}):
 
     infer = typeinfer.TypeInferer(typingctx, interp.blocks)
 
+    # Seed return type
+    # needs to be seeded before args, to ensure locking return type first
+    if return_type is not None:
+        infer.seed_return(return_type)
+    
     # Seed argument types
     for arg, ty in zip(interp.argspec.args, args):
         infer.seed_type(arg, ty)
-
-    # Seed return type
-    if return_type is not None:
-        infer.seed_return(return_type)
 
     # Seed local types
     for k, v in locals.items():


### PR DESCRIPTION
In a case where I would try to compile a function like

``` python
@udf(int32(FunctionContext, IntVal))
def fn(context, x):
    return x
```

The type for `x` would get locked as `IntVal` rather than `int32`.  Setting the return type first solves this problem.
