### PR TITLE
Add support for struct-type Global assign

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -267,15 +267,15 @@ class Lower(BaseLower):
             elif ty == types.boolean:
                 return self.context.get_constant(ty, value.value)
 
+            elif self.context.is_struct_type(ty):
+                return self.context.get_constant_struct(self.builder, ty,
+                                                        value.value)
+
             elif ty in types.number_domain:
                 return self.context.get_constant(ty, value.value)
 
             elif isinstance(ty, types.Array):
                 return self.context.make_constant_array(self.builder, ty,
-                                                        value.value)
-            
-            elif self.context.is_struct_type(ty):
-                return self.context.get_constant_struct(self.builder, ty,
                                                         value.value)
 
             elif isinstance(ty, types.UniTuple):


### PR DESCRIPTION
`True` and `False` literals are handled as `ir.Global` rather than `ir.Const`.  However, there is no way to override the behavior of the `Context` object in the case of a struct type.  This commit remedies that.
