### PR TITLE
Distinguish between built-in and user-defined fns

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from collections import namedtuple, defaultdict
+from types import BuiltinFunctionType, MethodType
 import llvm.core as lc
 from llvm.core import Type, Constant
 import numpy
@@ -351,7 +352,10 @@ class BaseContext(object):
     def get_function(self, fn, sig):
         if isinstance(fn, types.Function):
             key = fn.template.key
-            overloads = self.defns[key]
+            if isinstance(key, MethodType):
+                overloads = self.defns[key.im_func]
+            else:
+                overloads = self.defns[key]
         elif isinstance(fn, types.Dispatcher):
             key = fn.overloaded.get_overload(sig.args)
             overloads = self.defns[key]


### PR DESCRIPTION
When implementing functions from a module (e.g. `math` or `string`), the `key` for the `FunctionTemplate` is specified as the function.  In the case of the `math` module, the functions are of type `types.BuiltinFunctionType` while in the case of the `string` module they are of type `types.MethodType`.  The way that `context.get_function(...)` handles these has to be different, or the implementation is not found.
