### PR TITLE
Removing `goto_entry_block` check MASSIVELY improves performance

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -98,8 +98,7 @@ def goto_entry_block(builder):
 
 
 def alloca_once(builder, ty, name=''):
-    with goto_entry_block(builder):
-        return builder.alloca(ty, name=name)
+    return builder.alloca(ty, name=name)
 
 
 def terminate(builder, bbend):


### PR DESCRIPTION
In my profiling, a huge amount of time is spent inside `alloca_once`.  Every time that `bb.instructions` is invoked, it causes a loop over all instructions that is very costly.  (This is also probably responsible for the super-linear scaling I have observed.)  If I remove the context wrapper, the performance is MUCH faster.  Testing the compilation of one function, the `devel` branch takes 199 s, while this branch only takes 4.6 s.  When I run a function compiled with this branch, it appears to work fine.

Is this PR safe?  Nong gave me the impression that LLVM will take care of this issue, rather than manually putting the `alloca` in the entry block.  Or is this the kind of thing that the optimizer will take care of?

Here is the FlameGraph for the `devel` branch version.  It's almost entirely trapped inside `alloca_once`.

![profile big](https://cloud.githubusercontent.com/assets/118141/2869315/c83ecddc-d264-11e3-9a83-af36fb5de899.png)
