### PR TITLE
Fix segfault in _helperlib.c:Numba_recreate_record() caused by incorrect use of Py_DECREF

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -161,15 +161,15 @@ PyObject* Numba_recreate_record(void *pdata, int size, PyObject *dtype){
     record = PyObject_GetItem(aryobj, index);
 
 CLEANUP:
-    Py_DECREF(numpy);
-    Py_DECREF(numpy_array);
-    Py_DECREF(numpy_record);
-    Py_DECREF(aryobj);
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(dtypearg);
-    Py_DECREF(buffer);
-    Py_DECREF(index);
+    Py_XDECREF(numpy);
+    Py_XDECREF(numpy_array);
+    Py_XDECREF(numpy_record);
+    Py_XDECREF(aryobj);
+    Py_XDECREF(args);
+    Py_XDECREF(kwargs);
+    Py_XDECREF(dtypearg);
+    Py_XDECREF(buffer);
+    Py_XDECREF(index);
 
     return record;
 }


### PR DESCRIPTION
Numba_recreate_record() segfaults if the pdata argument does not support the buffer interface because the cleanup stage tries to decrement the reference counter on null pointers.  The Py_XDECREF macro checks for NULL and does nothing, otherwise it behaves like Py_DECREF.

There is still a failure of the unittest test_record_dtype.TestRecordDtype.test_record_return on Python 3.4, but with this patch, it will stop segfaulting the interpreter.
