### PR TITLE
Add a "gridsize" CUDA function to compute blockDim*gridDim in kernels

### DIFF
--- a/docs/source/CUDAJit.rst
+++ b/docs/source/CUDAJit.rst
@@ -71,6 +71,18 @@ For a 2D grid::
     x, y = cuda.grid(2)
     array[x, y] = something(x, y)
 
+Similarly, the total size of the grid in each dimension is frequently used
+as the stride when looping in a kernel, so there is also a shorthand function
+for that calculation.
+
+For a 1D grid::
+
+    xstride = cuda.gridsize(1)  # = cuda.blockDim.x * cuda.gridDim.x
+
+For a 2D grid::
+
+    xstride, ystride = cuda.gridsize(2)  # = cuda.blockDim.x * cuda.gridDim.x, cuda.blockDim.y * cuda.gridDim.y
+
 Memory Transfer
 ---------------
 

--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 # Re export
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
-                    shared, local, const, grid, atomic)
+                    shared, local, const, grid, gridsize, atomic)
 from .cudadrv.error import CudaSupportError
 from . import initialize
 from numba import config

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -16,6 +16,10 @@ class Cuda_grid(MacroTemplate):
     key = cuda.grid
 
 
+class Cuda_gridsize(MacroTemplate):
+    key = cuda.gridsize
+
+
 class Cuda_threadIdx_x(MacroTemplate):
     key = cuda.threadIdx.x
 
@@ -191,6 +195,9 @@ class CudaModuleTemplate(AttributeTemplate):
     def resolve_grid(self, mod):
         return types.Macro(Cuda_grid)
 
+    def resolve_gridsize(self, mod):
+        return types.Macro(Cuda_gridsize)
+
     def resolve_threadIdx(self, mod):
         return types.Module(cuda.threadIdx)
 
@@ -223,6 +230,7 @@ intrinsic_global(cuda, types.Module(cuda))
 ## Forces the use of the cuda namespace by not recognizing individual the
 ## following as globals.
 # intrinsic_global(cuda.grid, types.Function(Cuda_grid))
+# intrinsic_global(cuda.gridsize, types.Function(Cuda_gridsize))
 # intrinsic_global(cuda.threadIdx, types.Module(cuda.threadIdx))
 # intrinsic_global(cuda.shared, types.Module(cuda.shared))
 # intrinsic_global(cuda.shared.array, types.Function(Cuda_shared_array))

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -72,6 +72,32 @@ def ptx_grid2d(context, builder, sig, args):
     return cgutils.pack_array(builder, [r1, r2])
 
 
+@register
+@implement('ptx.gridsize.1d', types.intp)
+def ptx_gridsize1d(context, builder, sig, args):
+    assert len(args) == 1
+    ntidx = call_sreg(builder, "ntid.x")
+    nctaidx = call_sreg(builder, "nctaid.x")
+
+    res = builder.mul(ntidx, nctaidx)
+    return res
+
+
+@register
+@implement('ptx.gridsize.2d', types.intp)
+def ptx_gridsize2d(context, builder, sig, args):
+    assert len(args) == 1
+    ntidx = call_sreg(builder, "ntid.x")
+    nctaidx = call_sreg(builder, "nctaid.x")
+
+    ntidy = call_sreg(builder, "ntid.y")
+    nctaidy = call_sreg(builder, "nctaid.y")
+
+    r1 = builder.mul(ntidx, nctaidx)
+    r2 = builder.mul(ntidy, nctaidy)
+    return cgutils.pack_array(builder, [r1, r2])
+
+
 # -----------------------------------------------------------------------------
 
 def ptx_sreg_template(sreg):

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -101,6 +101,36 @@ def grid_expand(ndim):
 grid = macro.Macro('ptx.grid', grid_expand, callable=True)
 
 #-------------------------------------------------------------------------------
+# Gridsize Macro
+
+def gridsize_expand(ndim):
+    """gridsize(ndim)
+
+    ndim: [int] 1 or 2
+
+        if ndim == 1:
+            return cuda.blockDim.x * cuda.gridDim.x
+        elif ndim == 2:
+            x = cuda.blockDim.x * cuda.gridDim.x
+            y = cuda.blockDim.y * cuda.gridDim.y
+            return x, y
+    """
+    if ndim == 1:
+        fname = "ptx.gridsize.1d"
+        restype = types.int32
+    elif ndim == 2:
+        fname = "ptx.gridsize.2d"
+        restype = types.UniTuple(types.int32, 2)
+    else:
+        raise ValueError('argument can only be 1 or 2')
+
+    return ir.Intrinsic(fname, typing.signature(restype, types.intp),
+                        args=[ndim])
+
+
+gridsize = macro.Macro('ptx.gridsize', gridsize_expand, callable=True)
+
+#-------------------------------------------------------------------------------
 # synthreads
 
 class syncthreads(Stub):


### PR DESCRIPTION
Similar to the `grid()` convenience function that computes `threadIdx + blockIdx * blockDim` (for 1D or 2D), this patch creates a `gridsize()` convenience function that computes `blockDim * gridDim`, also for 1D or 2D.  This supports a common kernel pattern which allows any grid configuration to loop over an arbitrary amount of input data:

```
def example_kernel(input, output):
    n = input.shape[0]
    offset = grid(1)
    stride = gridsize(1)
    for i in range(offset, n, stride):
        output[i] = do_something(input[i])
```
