### PR TITLE
Allow JIT to see variables from enclosing, non-global scopes

### DIFF
--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -108,6 +108,7 @@ def _make_bytecode_table():
                     ('LOAD_CONST', 2),
                     ('LOAD_FAST', 2),
                     ('LOAD_GLOBAL', 2),
+                    ('LOAD_DEREF', 2),
                     ('POP_BLOCK', 0),
                     ('POP_TOP', 0),
                     ('RAISE_VARARGS', 2),
@@ -241,10 +242,10 @@ class ByteCodeSupportError(Exception):
 
 class ByteCodeBase(object):
     __slots__ = 'func', 'func_name', 'argspec', 'filename', 'co_names', \
-                'co_varnames', 'co_consts', 'table', 'labels'
+                'co_varnames', 'co_consts', 'co_freevars', 'table', 'labels'
 
     def __init__(self, func, func_name, argspec, filename, co_names,
-                 co_varnames, co_consts, table, labels):
+                 co_varnames, co_consts, co_freevars, table, labels):
         self.func = func
         self.module = inspect.getmodule(func)
         self.func_name = func_name
@@ -253,6 +254,7 @@ class ByteCodeBase(object):
         self.co_names = co_names
         self.co_varnames = co_varnames
         self.co_consts = co_consts
+        self.co_freevars = co_freevars
         self.table = table
         self.labels = labels
         self.firstlineno = min(inst.lineno for inst in self.table.values())
@@ -288,8 +290,6 @@ class ByteCode(ByteCodeBase):
         if not code:
             raise ByteCodeSupportError("%s does not provide its bytecode" %
                                        func)
-        if code.co_freevars:
-            raise ByteCodeSupportError("does not support freevars")
         if code.co_cellvars:
             raise ByteCodeSupportError("does not support cellvars")
 
@@ -305,6 +305,7 @@ class ByteCode(ByteCodeBase):
                                        co_names=code.co_names,
                                        co_varnames=code.co_varnames,
                                        co_consts=code.co_consts,
+                                       co_freevars=code.co_freevars,
                                        table=table,
                                        labels=list(sorted(labels)))
 

--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -134,6 +134,11 @@ class DataFlowAnalysis(object):
         info.append(inst, res=res)
         info.push(res)
 
+    def op_LOAD_DEREF(self, info, inst):
+        res = info.make_temp()
+        info.append(inst, res=res)
+        info.push(res)
+
     def op_LOAD_ATTR(self, info, inst):
         item = info.pop()
         res = info.make_temp()

--- a/numba/looplifting.py
+++ b/numba/looplifting.py
@@ -72,6 +72,7 @@ def lift_loop(bytecode):
                              co_names=outernames,
                              co_varnames=bytecode.co_varnames,
                              co_consts=bytecode.co_consts,
+                             co_freevars=bytecode.co_freevars,
                              table=codetable,
                              labels=outerlabels & set(codetable.keys()))
     return outerbc, lbclist
@@ -171,6 +172,7 @@ def make_loop_bytecode(bytecode, loop, args):
                          co_names=bytecode.co_names,
                          co_varnames=bytecode.co_varnames,
                          co_consts=co_consts,
+                         co_freevars=bytecode.co_freevars,
                          table=codetable,
                          labels=bytecode.labels)
 

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+import numba.unittest_support as unittest
+from numba import jit
+
+
+class TestClosure(unittest.TestCase):
+    def test_jit_closure_variable(self):
+        Y = 10
+
+        def add_Y(x):
+            return x + Y
+
+        c_add_Y = jit('i4(i4)', nopython=True)(add_Y)
+        self.assertEquals(c_add_Y(1), 11)
+
+        # Like globals in Numba, the value of the closure is captured
+        # at time of JIT
+        Y = 12  # should not affect function
+        self.assertEquals(c_add_Y(1), 11)
+
+    def test_jit_multiple_closure_variables(self):
+        Y = 10
+        Z = 2
+
+        def add_Y_mult_Z(x):
+            return (x + Y) * Z
+
+        c_add_Y_mult_Z = jit('i4(i4)', nopython=True)(add_Y_mult_Z)
+        self.assertEquals(c_add_Y_mult_Z(1), 22)
+
+    def test_jit_inner_function(self):
+        @jit('i4(i4)', nopython=True)
+        def mult_10(a):
+            return a * 10
+
+        def do_math(x):
+            return mult_10(x + 4)
+
+        c_do_math = jit('i4(i4)', nopython=True)(do_math)
+
+        self.assertEquals(c_do_math(1), 50)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The ability to reference variables (and functions) from function closures is very handy, especially if you want to generate JIT functions composed with helper functions passed in by the user.  For example, this would now be possible:

``` python
import numpy as np
import numba


def make_jit_func(transform):
    c_transform = numba.jit('f8(f8)', nopython=True)(transform)

    def sum_with_transform(ary):
        s = 0.0
        for i in range(ary.shape[0]):
            s += c_transform(ary[i])
        return s

    return numba.jit('f8(f8[:])')(sum_with_transform)


def my_transform(x):
    return 1 + x ** 2
# Generate a custom JIT summation function with my transform embedded
sum_with_transform = make_jit_func(my_transform)

ary = np.arange(10, dtype=np.float64)

print(sum_with_transform(ary))
```

The semantics are the same as for globals: The value and type of the non-local variable are captured at the time of JIT compilation.
