### PR TITLE
Expose __doc__ and __code__ from JIT'ed functions

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -18,6 +18,16 @@ class Overloaded(_dispatcher.Dispatcher):
     __numba__ = "py_func"
 
     def __init__(self, py_func, locals={}, targetoptions={}):
+        """
+        Parameters
+        ----------
+        py_func: function object to be compiled
+        locals: dict, optional
+            Mapping of local variable names to Numba types.  Used to override
+            the types deduced by the type inference engine.
+        targetoptions: dict, optional
+            Target-specific config options.
+        """
         self.tm = default_type_manager
 
         argspec = inspect.getargspec(py_func)
@@ -27,11 +37,12 @@ class Overloaded(_dispatcher.Dispatcher):
 
         self.py_func = py_func
         self.func_code = get_code_object(py_func)
+        self.__code__ = self.func_code  # python 3
         self.overloads = {}
 
         self.targetoptions = targetoptions
         self.locals = locals
-        self.doc = py_func.__doc__
+        self.__doc__ = py_func.__doc__
         self._compiling = False
 
         self.targetdescr.typing_context.insert_overloaded(self)

--- a/numba/tests/test_func_interface.py
+++ b/numba/tests/test_func_interface.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import numba.unittest_support as unittest
+from numba import jit
+import sys
+
+
+class TestFuncInterface(unittest.TestCase):
+    def test_jit_function_docstring(self):
+
+        def add(x, y):
+            '''Return sum of two numbers'''
+            return x + y
+
+        c_add = jit(add)
+        self.assertEqual(c_add.__doc__, 'Return sum of two numbers')
+
+    def test_jit_function_code_object(self):
+        def add(x, y):
+            return x + y
+
+        c_add = jit(add)
+        if sys.version_info[0] >= 3:
+            self.assertEqual(c_add.__code__, add.__code__)
+        else:
+            self.assertEqual(c_add.func_code, add.func_code)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Resolves #470 (although not the broader doctest issue, which is partially a Python problem)
