### PR TITLE
Copy all function attributes (__doc__, __code__, __name__, etc) from original to JIT function

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 import inspect
 import contextlib
 import numpy
-import sys
 import functools
 from numba.config import PYVERSION
 from numba import _dispatcher, compiler, utils
@@ -40,12 +39,10 @@ class Overloaded(_dispatcher.Dispatcher):
         self.py_func = py_func
         functools.update_wrapper(self, py_func)
 
-        # other parts of Numba assume the Python 2 name for code object
-        # so we assign it specifically
+        # other parts of Numba assume the old Python 2 name for code object
         self.func_code = get_code_object(py_func)
-        # but if we are in Python 3, there is a different name for the code object
-        if sys.version_info[0] >= 3:
-            self.__code__ = self.func_code
+        # but newer python uses a different name
+        self.__code__ = self.func_code
 
         self.overloads = {}
 

--- a/numba/tests/test_func_interface.py
+++ b/numba/tests/test_func_interface.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import numba.unittest_support as unittest
 from numba import jit
-import sys
 
 
 class TestFuncInterface(unittest.TestCase):
@@ -37,10 +36,8 @@ class TestFuncInterface(unittest.TestCase):
             return x + y
 
         c_add = jit(add)
-        if sys.version_info[0] >= 3:
-            self.assertEqual(c_add.__code__, add.__code__)
-        else:
-            self.assertEqual(c_add.func_code, add.func_code)
+        self.assertEqual(c_add.__code__, add.__code__)
+        self.assertEqual(c_add.func_code, add.__code__)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uses functools.update_wrapper for most things, but **code** is done by hand.  Resolves #470.
