### PR TITLE
[WIP] Convert native integer values to smallest allowed Python integer object representation

### DIFF
--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -30,8 +30,11 @@ def fix_python_api():
                         _helperlib.get_release_record_buffer())
     le.dylib_add_symbol("NumbaRecreateRecord",
                         _helperlib.get_recreate_record())
+    le.dylib_add_symbol("NumbaPyIntOrPyLongFromLongLong",
+                        _helperlib.get_pyint_or_pylong_from_longlong())
+    le.dylib_add_symbol("NumbaPyIntOrPyLongFromUnsignedLongLong",
+                        _helperlib.get_pyint_or_pylong_from_ulonglong())
     le.dylib_add_symbol("PyExc_NameError", id(NameError))
-
 
 
 class PythonAPI(object):
@@ -162,13 +165,21 @@ class PythonAPI(object):
         return self.builder.call(fn, [numobj])
 
     def long_from_ulonglong(self, numobj):
+        '''Return LLVM call to convert native long long to PyLong object.
+
+        On Python 2, this will convert to PyInt if in the necessary range.
+        '''
         fnty = Type.function(self.pyobj, [self.ulonglong])
-        fn = self._get_function(fnty, name="PyLong_FromUnsignedLongLong")
+        fn = self._get_function(fnty, name="NumbaPyIntOrPyLongFromUnsignedLongLong")
         return self.builder.call(fn, [numobj])
 
     def long_from_longlong(self, numobj):
+        '''Return LLVM call to convert native unsigned long long to PyLong object.
+
+        On Python 2, this will convert to PyInt if in the necessary range.
+        '''
         fnty = Type.function(self.pyobj, [self.ulonglong])
-        fn = self._get_function(fnty, name="PyLong_FromLongLong")
+        fn = self._get_function(fnty, name="NumbaPyIntOrPyLongFromLongLong")
         return self.builder.call(fn, [numobj])
 
     def _get_number_operator(self, name):

--- a/numba/tests/test_python_int.py
+++ b/numba/tests/test_python_int.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+import numba.unittest_support as unittest
+from numba import jit
+
+
+class TestPythonInt(unittest.TestCase):
+    def test_int_return_type(self):
+        # Issue 474
+        def f():
+            return 5
+
+        c_f = jit()(f)
+        self.assertEqual(type(c_f()), type(f()))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When boxing a native long long or unsigned long long on Python 2, we should use the PyInt_\* functions when the value is in range. This PR solves issue #474.

However, it introduces two new helper functions to _helperlib.c, which causes pycc tests to fail with missing symbol issues.  We need to refactor the compilation in pycc to allow helper methods to be linked into the generated module.
