### PR TITLE
Fix #511: support uint64 integers in type inference (e.g. 2**64 - 1)

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -768,7 +768,7 @@ class PyLower(BaseLower):
             ret = self.pyapi.float_from_double(fval)
             self.check_error(ret)
             return ret
-        elif isinstance(const, int):
+        elif isinstance(const, utils.INT_TYPES):
             if utils.bit_length(const) >= 64:
                 raise ValueError("Integer is too big to be lowered")
             ival = self.context.get_constant(types.intp, const)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -388,6 +388,9 @@ class BaseContext(object):
         elif ty in types.signed_domain:
             return Constant.int_signextend(lty, val)
 
+        elif ty in types.unsigned_domain:
+            return Constant.int(lty, val)
+
         elif ty in types.real_domain:
             return Constant.real(lty, val)
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -10,11 +10,6 @@ from numba.typeinfer import TypingError
 import numba.unittest_support as unittest
 
 
-INT_TYPES = (int,)
-if utils.PYVERSION < (3, 0):
-    INT_TYPES += (long,)
-
-
 class TestCase(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -27,7 +22,7 @@ class TestCase(unittest.TestCase):
             (LoweringError, TypingError, TypeError, NotImplementedError)) as cm:
             yield cm
 
-    _exact_typesets = [(bool,), INT_TYPES, (str,), (utils.unicode),]
+    _exact_typesets = [(bool,), utils.INT_TYPES, (str,), (utils.unicode),]
     _approx_typesets = [(float,), (complex,)]
 
     def assertPreciseEqual(self, first, second, prec='exact', msg=None):

--- a/numba/tests/test_intwidth.py
+++ b/numba/tests/test_intwidth.py
@@ -1,0 +1,70 @@
+
+import math
+import sys
+import unittest
+
+from numba import jit, utils
+from .support import TestCase
+
+
+max_uint64 = 18446744073709551615
+
+def usecase_uint64_global():
+    return max_uint64
+
+def usecase_uint64_constant():
+    return 18446744073709551615
+
+def usecase_uint64_floor():
+    return math.floor(18446744073709551615)
+
+
+class IntWidthTest(TestCase):
+
+    def check_nullary_func(self, pyfunc, **kwargs):
+        cfunc = jit(**kwargs)(pyfunc)
+        self.assertPreciseEqual(cfunc(), pyfunc())
+
+    def test_global_uint64(self, nopython=False):
+        pyfunc = usecase_uint64_global
+        self.check_nullary_func(pyfunc, nopython=nopython)
+
+    def test_global_uint64_npm(self):
+        self.test_global_uint64(nopython=True)
+
+    def test_constant_uint64(self, nopython=False):
+        pyfunc = usecase_uint64_constant
+        self.check_nullary_func(pyfunc, nopython=nopython)
+
+    def test_constant_uint64_npm(self):
+        self.test_constant_uint64(nopython=True)
+
+    def test_constant_uint64_function_call(self, nopython=False):
+        pyfunc = usecase_uint64_floor
+        self.check_nullary_func(pyfunc, nopython=nopython)
+
+    def test_constant_uint64_function_call_npm(self):
+        self.test_constant_uint64_function_call(nopython=True)
+
+    def test_bit_length(self):
+        f = utils.bit_length
+        self.assertEqual(f(0x7f), 7)
+        self.assertEqual(f(-0x7f), 7)
+        self.assertEqual(f(0x80), 8)
+        self.assertEqual(f(-0x80), 8)
+        self.assertEqual(f(0xff), 8)
+        self.assertEqual(f(-0xff), 8)
+        self.assertEqual(f(0x100), 9)
+        self.assertEqual(f(-0x100), 9)
+        self.assertEqual(f(0x7fffffff), 31)
+        self.assertEqual(f(0x80000000), 32)
+        self.assertEqual(f(0xffffffff), 32)
+        self.assertEqual(f(0xffffffffffffffff), 64)
+        self.assertEqual(f(0x10000000000000000), 65)
+        if utils.PYVERSION < (3, 0):
+            self.assertEqual(f(long(0xffffffffffffffff)), 64)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -442,7 +442,7 @@ class TypeInferer(object):
     def typeof_const(self, inst, target, const):
         if const is True or const is False:
             self.typevars[target.name].lock(types.boolean)
-        elif isinstance(const, (int, float)):
+        elif isinstance(const, utils.INT_TYPES + (float,)):
             ty = self.context.get_number_type(const)
             self.typevars[target.name].lock(ty)
         elif const is None:
@@ -483,6 +483,7 @@ class TypeInferer(object):
             self.typevars[target.name].lock(gvty)
             self.assumed_immutables.add(inst)
 
+        # XXX this is all duplicated from/in typeof_const
         elif gvar.name in ('True', 'False'):
             assert gvar.value in (True, False)
             self.typevars[target.name].lock(types.boolean)
@@ -499,7 +500,7 @@ class TypeInferer(object):
             self.typevars[target.name].lock(types.UniTuple(gvty, 2))
             self.assumed_immutables.add(inst)
 
-        elif isinstance(gvar.value, (int, float)):
+        elif isinstance(gvar.value, utils.INT_TYPES + (float,)):
             gvty = self.context.get_number_type(gvar.value)
             self.typevars[target.name].lock(gvty)
             self.assumed_immutables.add(inst)

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -25,12 +25,14 @@ class BaseContext(object):
         pass
 
     def get_number_type(self, num):
-        if isinstance(num, int):
+        if isinstance(num, utils.INT_TYPES):
             nbits = utils.bit_length(num)
             if nbits < 32:
                 typ = types.int32
             elif nbits < 64:
                 typ = types.int64
+            elif nbits == 64 and num >= 0:
+                typ = types.uint64
             else:
                 raise ValueError("Int value is too large: %s" % num)
             return typ

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -7,6 +7,11 @@ import numpy
 from numba.config import PYVERSION
 
 
+INT_TYPES = (int,)
+if PYVERSION < (3, 0):
+    INT_TYPES += (long,)
+
+
 class ConfigOptions(object):
     OPTIONS = ()
 
@@ -109,7 +114,10 @@ def runonce(fn):
 
 
 def bit_length(intval):
-    assert isinstance(intval, int)
+    """
+    Return the number of bits necessary to represent integer `intval`.
+    """
+    assert isinstance(intval, INT_TYPES)
     return len(bin(abs(intval))) - 2
 
 


### PR DESCRIPTION
I don't know if this is extremely important.
