### PR TITLE
Alternative fix for #571

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -233,7 +233,8 @@ def legalize_return_type(return_type, interp, targetctx):
     arguments = frozenset("%s.1" % arg for arg in interp.argspec.args)
 
     for ret in retstmts:
-        if ret.value.name not in arguments:
+        pred = ret.value.predecessor
+        if not isinstance(pred, ir.Var) or pred.name not in arguments:
             raise TypeError("Only accept returning of array passed into the "
                             "function as argument")
 

--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -190,7 +190,9 @@ class DataFlowAnalysis(object):
 
     def op_LOAD_FAST(self, info, inst):
         name = self.bytecode.co_varnames[inst.arg]
-        info.push(name)
+        temp = info.make_temp(prefix=name)
+        info.push(temp)
+        info.append(inst, source=name, store=temp)
 
     def op_LOAD_CONST(self, info, inst):
         res = info.make_temp('const')
@@ -242,7 +244,8 @@ class DataFlowAnalysis(object):
         pair = info.make_temp()
         indval = info.make_temp()
         pred = info.make_temp()
-        info.append(inst, iterator=iterator, pair=pair, indval=indval, pred=pred)
+        info.append(inst, iterator=iterator, pair=pair, indval=indval,
+                    pred=pred)
         info.push(indval)
 
     def op_CALL_FUNCTION(self, info, inst):
@@ -553,7 +556,7 @@ class BlockInfo(object):
 
     def make_temp(self, prefix=''):
         self.tempct += 1
-        name = '$%s%d.%d' % (prefix, self.offset, self.tempct)
+        name = '$%s.%d.%d' % (prefix, self.offset, self.tempct)
         return name
 
     def push(self, val):

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -401,6 +401,10 @@ class Interpreter(object):
         value = self.get(value)
         self.store(value=value, name=dstname)
 
+    def op_LOAD_FAST(self, inst, source, store):
+        value = self.get(source)
+        self.store(value=value, name=store)
+
     def op_DUP_TOPX(self, inst, orig, duped):
         for src, dst in zip(orig, duped):
             self.store(value=self.get(src), name=dst)

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -277,6 +277,7 @@ class Assign(Stmt):
     def __init__(self, value, target, loc):
         self.value = value
         self.target = target
+        self.target.predecessor = value # set predecessor
         self.loc = loc
 
     def __str__(self):
@@ -312,12 +313,16 @@ class Var(object):
 
     - loc: Loc
         Definition location
+
+    - predecessor:
+        predecessor of the value
     """
 
     def __init__(self, scope, name, loc):
         self.scope = scope
         self.name = name
         self.loc = loc
+        self.predecessor = None
 
     def __repr__(self):
         return 'Var(%s, %s)' % (self.name, self.loc)


### PR DESCRIPTION
- Add temporaries to LOAD_FAST
- Add predecessor attribute to ir.Var to help detecting array return value
