### PR TITLE
Fix a crash due to invalid IR generation for STORE_MAP

### DIFF
--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -614,8 +614,9 @@ class Interpreter(object):
         self.store(expr, res)
 
     def op_STORE_MAP(self, inst, dct, key, value):
-        self.current_block.append(
-            ir.StoreMap(dct=dct, key=key, value=value, loc=self.loc))
+        stmt = ir.StoreMap(dct=self.get(dct), key=self.get(key),
+                           value=self.get(value), loc=self.loc)
+        self.current_block.append(stmt)
 
     def op_UNARY_NEGATIVE(self, inst, value, res):
         value = self.get(value)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -648,9 +648,9 @@ class PyLower(BaseLower):
             self.check_int_status(ok)
 
         elif isinstance(inst, ir.StoreMap):
-            dct = self.loadvar(inst.dct)
-            key = self.loadvar(inst.key)
-            value = self.loadvar(inst.value)
+            dct = self.loadvar(inst.dct.name)
+            key = self.loadvar(inst.key.name)
+            value = self.loadvar(inst.value.name)
             ok = self.pyapi.dict_setitem(dct, key, value)
             self.check_int_status(ok)
 

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -7,11 +7,19 @@ from .support import TestCase, force_pyobj_flags
 def build_map():
     return {0: 1, 2: 3}
 
+def build_map_from_local_vars():
+    # There used to be a crash due to wrong IR generation for STORE_MAP
+    x = TestCase
+    return {0: x, x: 1}
+
 
 class DictTestCase(TestCase):
 
     def test_build_map(self, flags=force_pyobj_flags):
         self.run_nullary_func(build_map, flags=flags)
+
+    def test_build_map_from_local_vars(self, flags=force_pyobj_flags):
+        self.run_nullary_func(build_map_from_local_vars, flags=flags)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(the variables weren't fetched through Interpreter.get() and therefore were suppressed by the unused temps removal phase)
