### PR TITLE
Add option to disable loop vectorization on 32bit win32 (workaround for #649)

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -4,6 +4,10 @@ import os
 import re
 import warnings
 
+IS_WIN32 = sys.platform.startswith('win32')
+MACHINE_BITS = tuple.__itemsize__ * 8
+IS_32BITS = MACHINE_BITS == 32
+
 
 def _readenv(name, ctor, default):
     try:
@@ -49,6 +53,11 @@ NUMBA_DUMP_FUNC_OPT = _readenv("NUMBA_DUMP_FUNC_OPT", int, DEBUG)
 # Force dump of Optimized LLVM IR
 DUMP_OPTIMIZED = _readenv("NUMBA_DUMP_OPTIMIZED", int, DEBUG)
 
+# Force disable loop vectorize
+# Loop vectorizer is disabled on 32-bit win32 due to a bug (#649)
+LOOP_VECTORIZE = _readenv("NUMBA_LOOP_VECTORIZE", int,
+                          not (IS_WIN32 and IS_32BITS))
+
 # Force dump of generated assembly
 DUMP_ASSEMBLY = _readenv("NUMBA_DUMP_ASSEMBLY", int, DEBUG)
 
@@ -73,5 +82,6 @@ def _force_cc(text):
                              "and minor are decimals")
         grp = m.groups()
         return int(grp[0]), int(grp[1])
+
 
 FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _force_cc, None)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -162,7 +162,7 @@ class CPUContext(BaseContext):
         if 0 < config.OPT <= 3:
             # This uses the same passes for clang -O3
             pms = lp.build_pass_managers(tm=self.tm, opt=config.OPT,
-                                         loop_vectorize=True,
+                                         loop_vectorize=config.LOOP_VECTORIZE,
                                          fpm=False)
             return pms.pm
         else:

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -13,14 +13,12 @@ except ImportError:
 
 import numpy
 
-from numba.config import PYVERSION
+from numba.config import PYVERSION, MACHINE_BITS
 
 
 INT_TYPES = (int,)
 if PYVERSION < (3, 0):
     INT_TYPES += (long,)
-
-MACHINE_BITS = tuple.__itemsize__ * 8
 
 
 class ConfigOptions(object):


### PR DESCRIPTION
- Add environment variable to turn loop vectorization on/off.
  - Off by default on 32-bit win32 
