### PR TITLE
Fix double incref in global lookup in object mode (potential memory leak...

### DIFF
--- a/numba/objmode.py
+++ b/numba/objmode.py
@@ -368,7 +368,6 @@ class PyLower(BaseLower):
                 self.pyapi.raise_missing_global_error(name)
                 self.return_exception_raised()
 
-        self.incref(retval)
         return retval
 
     # -------------------------------------------------------------------------
@@ -394,7 +393,8 @@ class PyLower(BaseLower):
         Args
         ----
         mod:
-            The __builtins__ dictionary or module
+            The __builtins__ dictionary or module, as looked up in
+            a module's globals.
         name: str
             The object to lookup
         """

--- a/numba/tests/test_func_lifetime.py
+++ b/numba/tests/test_func_lifetime.py
@@ -87,14 +87,11 @@ class TestFuncLifetime(TestCase):
         c_f = jit(**jitargs)(global_usecase2)
         self.assertPreciseEqual(c_f(), 6)
 
-        # XXX global_obj will survive, perhaps because of buggy code
-        # generation.
         refs = [weakref.ref(obj) for obj in (c_f, global_obj)]
         obj = c_f = global_obj = None
         gc.collect()
         self.assertEqual([wr() for wr in refs], [None] * len(refs))
 
-    @unittest.expectedFailure
     def test_global_obj_lifetime(self):
         self.check_global_obj_lifetime(forceobj=True)
 


### PR DESCRIPTION
...)
