### PR TITLE
Silence NumbaWarnings in the test suite on Python 3.4

### DIFF
--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -34,6 +34,9 @@ class NumbaTestProgram(unittest.main):
 
     def __init__(self, *args, **kwargs):
         self.discovered_suite = kwargs.pop('suite', None)
+        # HACK to force unittest not to change warning display options
+        # (so that NumbaWarnings don't appear all over the place)
+        sys.warnoptions.append('')
         super(NumbaTestProgram, self).__init__(*args, **kwargs)
 
     def createTests(self):


### PR DESCRIPTION
unittest enables warnings by default under recent Python versions, unless the user requested special settings using `-W`.
