### PR TITLE
Issue #695: Automatically export C helper functions

### DIFF
--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -372,7 +372,7 @@ def _prepare_call_to_object_mode(context, builder, func, signature, args,
                                     ll_intp_ptr, ll_voidptr,
                                     ll_int, ll_int])
 
-    fn_array_new = mod.get_or_insert_function(fnty, name="NumbaNDArrayNew")
+    fn_array_new = mod.get_or_insert_function(fnty, name="numba_ndarray_new")
 
     # Convert each llarray into pyobject
     error_pointer = cgutils.alloca_once(builder, Type.int(1), name='error')


### PR DESCRIPTION
The pythonapi.fix_python_api function exports C helper functions.
However, each export is done manually by adding a new call to
llvm.ee.dylib_add_symbol for the appropriate helper defined in
_helperlib.c_helpers.  This commit automates the process by just
exporting _every_ symbol defined in _helperlib.c_helpers.
