### PR TITLE
Use a __name__ guard in runtests.py, to avoid infinite spawning loop wit...h multiprocessing under Windows

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -5,5 +5,6 @@ import sys
 
 import numba.testing as testing
 
-result = testing.test()
-sys.exit(0 if result else 1)
+if __name__ == "__main__":
+    result = testing.test()
+    sys.exit(0 if result else 1)


### PR DESCRIPTION
(part of issue #723)
