### PR TITLE
Fix #732: cannot import numba in ipynb

### DIFF
--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -385,4 +385,9 @@ try:
 except ImportError:
     pass
 else:
-    faulthandler.enable()
+    try:
+        # May fail in IPython Notebook with UnsupportedOperation
+        faulthandler.enable()
+    except BaseException as e:
+        msg = "Failed to enable faulthandler due to:\n{err}"
+        warnings.warn(msg.format(err=e))


### PR DESCRIPTION
Fix #732
- Allow `faulthandler.enable()` to fail
