### PR TITLE
Do not run np.reciprocal for int16 due to inconsistent undefined numpy behavior

### DIFF
--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1256,6 +1256,9 @@ class TestLoopTypes(TestCase):
 
 
 class TestLoopTypesNoPython(TestLoopTypes):
+    ### NOTE: int16 is tested in a separate class due to issues with
+    ###       np.reciprocal.  Functions added to this test should also
+    ###       be added to TestLoopTypesInt16NoPython!
     _compile_flags = no_pyobj_flags
 
     _ufuncs = [np.add, np.subtract, np.multiply, np.divide, np.logaddexp,
@@ -1278,7 +1281,36 @@ class TestLoopTypesNoPython(TestLoopTypes):
 
     # supported types are integral (signed and unsigned) as well as float and double
     # support for complex64(F) and complex128(D) should be coming soon.
-    _supported_types = '?bBhHiIlLqQfd'
+    _supported_types = '?bBHiIlLqQfd'  ## NOTE: "h" has been pulled into another class!
+
+
+class TestLoopTypesInt16NoPython(TestLoopTypes):
+    ### NOTE: int16 is tested in a separate class due to issues with
+    ###       np.reciprocal.  Functions added to this test should also
+    ###       be added to TestLoopTypesNoPython!
+    _compile_flags = no_pyobj_flags
+
+    _ufuncs = [np.add, np.subtract, np.multiply, np.divide, np.logaddexp,
+               np.logaddexp2, np.true_divide, np.floor_divide, np.negative,
+               np.remainder, np.mod, np.power, np.abs, np.absolute,
+               np.sign, np.conj, np.exp, np.exp2, np.log, np.log2,
+               np.log10, np.expm1, np.log1p, np.sqrt, np.square,  ## np.reciprocal,
+               np.conjugate, np.sin, np.cos, np.tan, np.arcsin, np.arccos,
+               np.arctan, np.arctan2, np.sinh, np.cosh, np.tanh,
+               np.arcsinh, np.arccosh, np.arctanh, np.deg2rad, np.rad2deg,
+               np.degrees, np.radians,
+               np.floor, np.ceil, np.trunc,
+               np.greater, np.greater_equal, np.less, np.less_equal,
+               np.not_equal, np.equal, np.logical_and, np.logical_or,
+               np.logical_xor, np.logical_not, np.maximum, np.minimum,
+               np.fmax, np.fmin, np.isnan, np.bitwise_and, np.bitwise_or,
+               np.bitwise_xor, np.bitwise_not, np.invert, np.left_shift,
+               np.right_shift, np.isinf, np.isfinite, np.signbit, np.copysign,
+               np.nextafter, np.spacing, np.ldexp, np.fmod ]
+
+    # supported types are integral (signed and unsigned) as well as float and double
+    # support for complex64(F) and complex128(D) should be coming soon.
+    _supported_types = 'h'
 
 
 class TestLoopTypesComplexNoPython(TestLoopTypes):


### PR DESCRIPTION
Numpy returns different values when converting a NaN to an int16 on 32 and 64-bit platforms.  The numpy docs do not seem to take a clear position, so for now skip this testing of np.reciprocal on int16 until we can implement all the required special cases.  (Note that the Numpy docs say that the reciprocal function "is not designed to work with integers.")
