### PR TITLE
Allow returning function objects in object mode

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -295,32 +295,37 @@ def legalize_given_types(args, return_type):
 def legalize_return_type(return_type, interp, targetctx):
     """
     Only accept array return type iff it is passed into the function.
+    Reject function object return types if in nopython mode.
     """
     assert assume.return_argument_array_only
 
-    if not isinstance(return_type, types.Array):
-        return
+    if isinstance(return_type, types.Array):
+        # Walk IR to discover all return statements
+        retstmts = []
+        for bid, blk in interp.blocks.items():
+            for inst in blk.body:
+                if isinstance(inst, ir.Return):
+                    retstmts.append(inst)
 
-    # Walk IR to discover all return statements
-    retstmts = []
-    for bid, blk in interp.blocks.items():
-        for inst in blk.body:
-            if isinstance(inst, ir.Return):
-                retstmts.append(inst)
+        assert retstmts, "No return statemants?"
 
-    assert retstmts, "No return statemants?"
+        # FIXME: In the future, we can return an array that is either a dynamically
+        #        allocated array or an array that is passed as argument.  This
+        #        must be statically resolvable.
 
-    # FIXME: In the future, we can return an array that is either a dynamically
-    #        allocated array or an array that is passed as argument.  This
-    #        must be statically resolvable.
+        # The return value must be the first modification of the value.
+        arguments = frozenset("%s.1" % arg for arg in interp.argspec.args)
 
-    # The return value must be the first modification of the value.
-    arguments = frozenset("%s.1" % arg for arg in interp.argspec.args)
+        if isinstance(return_type, types.Array):
+            for ret in retstmts:
+                if ret.value.name not in arguments:
+                    raise TypeError("Only accept returning of array passed into the "
+                                    "function as argument")
 
-    for ret in retstmts:
-        if ret.value.name not in arguments:
-            raise TypeError("Only accept returning of array passed into the "
-                            "function as argument")
+    elif (isinstance(return_type, types.Function) or
+            (isinstance(return_type, types.Dummy) and
+             return_type.name == 'abs')):
+        raise TypeError("Can't return function object in nopython mode")
 
     # Legalized; tag return handling
     targetctx.metadata['return.array'] = 'arg'

--- a/numba/tests/test_return_values.py
+++ b/numba/tests/test_return_values.py
@@ -1,0 +1,80 @@
+"""
+Test return values
+"""
+
+from __future__ import print_function
+
+import numba.unittest_support as unittest
+from numba.compiler import compile_isolated, Flags
+from numba.utils import PYVERSION
+from numba import types
+from .support import TestCase
+from numba.typeinfer import TypingError
+import math
+
+
+enable_pyobj_flags = Flags()
+enable_pyobj_flags.set("enable_pyobject")
+no_pyobj_flags = Flags()
+
+
+def get_nopython_func():
+    return abs
+
+def get_pyobj_func():
+    return pow
+
+def get_module_func():
+    return math.floor
+
+
+class TestReturnValues(TestCase):
+
+    def test_nopython_func(self, flags=enable_pyobj_flags):
+        # Test returning func that is supported in nopython mode
+        pyfunc = get_nopython_func
+        cr = compile_isolated(pyfunc, (), flags=flags)
+        cfunc = cr.entry_point
+        if flags == enable_pyobj_flags:
+            result = cfunc()
+            self.assertEqual(result, abs)
+        else:
+            result = cfunc()
+
+    def test_nopython_func_npm(self):
+        with self.assertRaises(TypeError):
+            self.test_nopython_func(flags=no_pyobj_flags)
+
+    def test_pyobj_func(self, flags=enable_pyobj_flags):
+        # Test returning func that is only supported in object mode
+        pyfunc = get_pyobj_func
+        cr = compile_isolated(pyfunc, (), flags=flags)
+        cfunc = cr.entry_point
+        if flags == enable_pyobj_flags:
+            result = cfunc()
+            self.assertEqual(result, pow)
+        else:
+            result = cfunc()
+
+    def test_pyobj_func_npm(self):
+        with self.assertRaises(TypingError):
+            self.test_pyobj_func(flags=no_pyobj_flags)
+
+    def test_module_func(self, flags=enable_pyobj_flags):
+        # Test returning imported func that is only supported in object mode
+        pyfunc = get_module_func
+        cr = compile_isolated(pyfunc, (), flags=flags)
+        cfunc = cr.entry_point
+        if flags == enable_pyobj_flags:
+            result = cfunc()
+            self.assertEqual(result, math.floor)
+        else:
+            result = cfunc()
+
+    def test_module_func_npm(self):
+        with self.assertRaises(TypeError):
+            self.test_module_func(flags=no_pyobj_flags)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allow returning function objects in object mode. If function object is returned in nopython mode, an exception is thrown. Fixes regression in oldnumba/tests/builtins/test_builtin_abs.py
