### PR TITLE
Added `llvmpy` as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(name='numba',
         # "Programming Language :: Python :: 3.3",
         "Topic :: Utilities",
       ],
+      requires=["llvmpy"],
       package_data={
         "numba": ["*.c", "*.h", "*.cpp", "*.inc"],
         "numba.npyufunc": ["*.c", "*.h"],


### PR DESCRIPTION
Without it, numba cannot be imported.
