### PR TITLE
Basic support for @jit decoration of methods

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -217,7 +217,10 @@ class Overloaded(_OverloadedBase):
 
     def __get__(self, obj, objtype=None):
         '''Allow a JIT function to be bound as a method to an object'''
-        return create_bound_method(self, obj)
+        if obj is None:  # Unbound method
+            return self
+        else:  # Bound method
+            return create_bound_method(self, obj)
 
     def compile(self, sig, locals={}, **targetoptions):
         with self._compile_lock():

--- a/numba/tests/test_jitmethod.py
+++ b/numba/tests/test_jitmethod.py
@@ -4,8 +4,7 @@ import numpy as np
 
 
 class TestJITMethod(unittest.TestCase):
-    def test_jit_method_with_loop_lift(self):
-
+    def test_bound_jit_method_with_loop_lift(self):
         class Something(object):
             def __init__(self, x0):
                 self.x0 = x0
@@ -25,10 +24,22 @@ class TestJITMethod(unittest.TestCase):
             np.array([15, 15, 15, 15, 15], dtype=np.float32))
 
         # Check that loop lifting in nopython mode was successful
-        [cres] = Something.method._compileinfos.values()
+        [cres] = something.method._compileinfos.values()
         jitloop = cres.lifted[0]
         [loopcres] = jitloop._compileinfos.values()
         self.assertTrue(loopcres.fndesc.native)
+
+    def test_unbound_jit_method(self):
+        class Something(object):
+            def __init__(self, x0):
+                self.x0 = x0
+
+            @jit
+            def method(self):
+                return self.x0
+
+        something = Something(3)
+        self.assertEquals(Something.method(something), 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This short patch allows @jit to decorate methods.  The presence of `self` in all method argument lists will force methods to compile in object mode, but it is still possible to benefit from loop lifting as long as the loop does not access `self` directly.

In the future, we can apply more object mode optimization tricks to make @jit methods more useful.
