### PR TITLE
[WIP] Stack array allocation

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -432,6 +432,30 @@ class Intrinsic(object):
     def __str__(self):
         return self.name
 
+class StackArray(object):
+    """
+    Represents stack array allocation
+    """
+
+    def __init__(self, type, shape, dtype):
+        self.type = type
+        self.shape = shape
+        self.dtype = dtype
+        self.name = 'stackarray'
+
+    @property
+    def args(self):
+        return (self.shape, self.dtype)
+
+    @property
+    def kws(self):
+        return ()
+
+    def __repr__(self):
+        return 'StackArray(%s, %s, %s)' % (self.type, self.self.shape, self.dtype)
+
+    def __str__(self):
+        return 'stack allocate %s of %s' % (self.shape, self.dtype)
 
 class Scope(object):
     """

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -443,7 +443,10 @@ class Lower(BaseLower):
                                                   signature.args)]
 
             if isinstance(expr.func, ir.StackArray):
-                res = self.context.create_stack_array(self.builder, expr.func)
+                res = self.context.create_stack_array(self.builder,
+                                                      expr.func.type,
+                                                      expr.func.dtype,
+                                                      expr.func.shape)
             elif isinstance(fnty, types.Method):
                 # Method of objects are handled differently
                 fnobj = self.loadvar(expr.func.name)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -432,6 +432,8 @@ class Lower(BaseLower):
             if isinstance(expr.func, ir.Intrinsic):
                 fnty = expr.func.name
                 castvals = expr.func.args
+            elif isinstance(expr.func, ir.StackArray):
+                pass
             else:
                 assert not expr.kws, expr.kws
                 fnty = self.typeof(expr.func.name)
@@ -440,7 +442,9 @@ class Lower(BaseLower):
                             for av, at, ft in zip(argvals, argtyps,
                                                   signature.args)]
 
-            if isinstance(fnty, types.Method):
+            if isinstance(expr.func, ir.StackArray):
+                res = self.context.create_stack_array(self.builder, expr.func)
+            elif isinstance(fnty, types.Method):
                 # Method of objects are handled differently
                 fnobj = self.loadvar(expr.func.name)
                 res = self.context.call_class_method(self.builder, fnobj,

--- a/numba/stack_array.py
+++ b/numba/stack_array.py
@@ -1,0 +1,19 @@
+from numba import ir, macro, types
+
+def new(shape, dtype):
+    from numba import typing
+    ndim = 1
+    if isinstance(shape, tuple):
+        ndim = len(shape)
+    elif not isinstance(shape, int):
+        raise TypeError("invalid type for shape; got {0}".format(type(shape)))
+    restype = types.Array(dtype, ndim, 'C')
+    if isinstance(shape, int):
+        sig = typing.signature(restype, types.intp, types.Any)
+    else:
+        sig = typing.signature(restype, types.UniTuple(types.intp, ndim),
+                               types.Any)
+    return ir.StackArray(sig, shape, dtype)
+
+new = macro.Macro('stack_array.new', new, callable=True,
+                  argnames=['shape', 'dtype'])

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -841,22 +841,22 @@ class BaseContext(object):
             return builder.or_(real_istrue, imag_istrue)
         raise NotImplementedError("is_true", val, typ)
 
-    def create_stack_array(self, builder, array):
+    def create_stack_array(self, builder, sig, dtype, shape):
         # TODO: Assuming integer shape here.
-        arystty = arrayobj.make_array(array.type.return_type)
+        arystty = arrayobj.make_array(sig.return_type)
         ary = arystty(self, builder)
 
-        nitems = self.get_constant(types.intp, array.shape)
+        nitems = self.get_constant(types.intp, shape)
         ary.nitems = nitems
 
-        itemsize = self.get_constant(types.intp, array.dtype.bitwidth/8)
+        itemsize = self.get_constant(types.intp, dtype.bitwidth/8)
         ary.itemsize = itemsize
 
-        ty = self.get_value_type(array.dtype)
+        ty = self.get_value_type(dtype)
         allocate_data = builder.alloca(ty, size=nitems)
         ary.data = allocate_data
 
-        shape = self.get_constant(types.intp, array.shape)
+        shape = self.get_constant(types.intp, shape)
         ary.shape = cgutils.pack_array(builder, [shape])
 
         strides = self.get_constant(types.intp, 1)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -841,6 +841,29 @@ class BaseContext(object):
             return builder.or_(real_istrue, imag_istrue)
         raise NotImplementedError("is_true", val, typ)
 
+    def create_stack_array(self, builder, array):
+        # TODO: Assuming integer shape here.
+        arystty = arrayobj.make_array(array.type.return_type)
+        ary = arystty(self, builder)
+
+        nitems = self.get_constant(types.intp, array.shape)
+        ary.nitems = nitems
+
+        itemsize = self.get_constant(types.intp, array.dtype.bitwidth/8)
+        ary.itemsize = itemsize
+
+        ty = self.get_value_type(array.dtype)
+        allocate_data = builder.alloca(ty, size=nitems)
+        ary.data = allocate_data
+
+        shape = self.get_constant(types.intp, array.shape)
+        ary.shape = cgutils.pack_array(builder, [shape])
+
+        strides = self.get_constant(types.intp, 1)
+        ary.strides = cgutils.pack_array(builder, [strides])
+
+        return ary._getvalue()
+
     def call_function(self, builder, callee, resty, argtys, args, env=None):
         """
         Call the Numba-compiled *callee*, using the same calling

--- a/numba/tests/test_stack_arrays.py
+++ b/numba/tests/test_stack_arrays.py
@@ -1,0 +1,51 @@
+from numba import unittest_support as unittest
+from numba import njit, stack_array, types
+import numpy as np
+
+@njit
+def declaration_only():
+    a = stack_array.new(3, types.float64)
+
+@njit
+def decl_setitem():
+    a = stack_array.new(3, types.float64)
+    a[0] = 10.0
+    a[1] = 20.0
+    a[2] = 30.0
+
+@njit
+def decl_setitem_getitem():
+    a = stack_array.new(3, types.float64)
+    a[0] = 10.0
+    a[1] = 20.0
+    a[2] = 30.0
+    s = 0
+    for i in range(3):
+        s += a[i]
+    return s
+
+class TestStackArrays(unittest.TestCase):
+    def test_declaration(self):
+        '''
+        Tests that no error is thrown in the generation of code for a stack
+        array declaration.
+        '''
+        declaration_only()
+
+    def test_setitem(self):
+        '''
+        Tests that no error is thrown in the generation of code for setting
+        items in a stack array.
+        '''
+        decl_setitem()
+
+    def test_getitem(self):
+        '''
+        Provides a test of the operation of stack array declaration as well as
+        setting and getting items.
+        '''
+        s = decl_setitem_getitem()
+        np.testing.assert_allclose(60.0, s)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -420,7 +420,7 @@ class TypeInferer(object):
         for call, args, kws in self.usercalls:
             args = tuple(typemap[a.name] for a in args)
 
-            if isinstance(call.func, ir.Intrinsic):
+            if isinstance(call.func, (ir.Intrinsic, ir.StackArray)):
                 signature = call.func.type
             else:
                 assert not kws
@@ -561,7 +561,7 @@ class TypeInferer(object):
 
     def typeof_expr(self, inst, target, expr):
         if expr.op == 'call':
-            if isinstance(expr.func, ir.Intrinsic):
+            if isinstance(expr.func, (ir.Intrinsic, ir.StackArray)):
                 restype = expr.func.type.return_type
                 self.typevars[target.name].add_types(restype)
                 self.usercalls.append((inst.value, expr.args, expr.kws))

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -11,7 +11,8 @@ from numba import types
 from numba.typeconv import rules
 from . import templates
 # Initialize declarations
-from . import builtins, cmathdecl, mathdecl, npdatetime, npydecl, operatordecl
+from . import (builtins, cmathdecl, mathdecl, npdatetime, npydecl, operatordecl,
+               specialdecl)
 from numba import numpy_support, utils
 from . import ctypes_utils, cffi_utils
 
@@ -410,6 +411,7 @@ class Context(BaseContext):
         self.install(mathdecl.registry)
         self.install(npydecl.registry)
         self.install(operatordecl.registry)
+        self.install(specialdecl.registry)
 
 
 def new_method(fn, sig):

--- a/numba/typing/specialdecl.py
+++ b/numba/typing/specialdecl.py
@@ -1,0 +1,17 @@
+from numba import stack_array, types
+from numba.typing.templates import (AttributeTemplate, MacroTemplate,
+                                    Registry)
+
+registry = Registry()
+register = registry.register
+register_attr = registry.register_attr
+
+class StackArray_new(MacroTemplate):
+    key = stack_array.new
+
+@register_attr
+class StackArrayModuleTemplate(AttributeTemplate):
+    key = types.Module(stack_array)
+
+    def resolve_new(self, mod):
+        return types.Macro(StackArray_new)


### PR DESCRIPTION
I'm opening this PR for feedback on the general design/idea of allowing local arrays to be created inside nopython functions, with a view to supporting it on CPU and GPU targets and for ufuncs and gufuncs as well. This PR is opened with the hope that I can get the design right and it be something that everyone is happy with before I go too far down thoroughly implementing and testing it.

This is the smallest example of an implementation, which has some limitations:

- it only works on the CPU,
- it only works for 1D arrays,
- it is not tested thoroughly - there are some unit tests demonstrating its use, but they are not thorough.

Local arrays are created using `numba.local_array.new(shape, dtype)` inside a jitted function. This is macro-expanded to an instance of an `AllocateArray` IR node, which is added in this PR as well. Typing of the `AllocateArray` IR node works in the same way as typing of an `Intrinsic` node. In lowering, an `ArrayTemplate` struct is created and populated with the relevant data, as well as a pointer to newly-allocated space for the array data. The array data space is allocated using an `alloca` instruction.

My thoughts about where to proceed next include creating more thorough tests for operations on local arrays, and expanding the lowering implementation to handle multidimensional arrays, after making revisions to the design/idea based on any feedback.

Any thoughts/feedback appreciated!