### PR TITLE
Bugfix for make_array_ctype in cudadrv

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -8,6 +8,7 @@ from functools import reduce
 
 import llvm.core as lc
 
+import numba.ctypes_support as ctypes
 import numpy
 from llvm.core import Constant
 from numba import errcode
@@ -41,6 +42,31 @@ def make_array(array_type):
                    ]
 
     return ArrayTemplate
+
+def make_array_ctype(ndim):
+    """Create a ctypes representation of an array_type.
+
+    Parameters
+    -----------
+    ndim: int
+        number of dimensions of array
+
+    Returns
+    -----------
+        a ctypes array structure for an array with the given number of
+        dimensions
+    """
+    c_intp = ctypes.c_ssize_t
+
+    class c_array(ctypes.Structure):
+        _fields_ = [('parent', ctypes.c_void_p),
+                    ('nitems', c_intp),
+                    ('itemsize', c_intp),
+                    ('data', ctypes.c_void_p),
+                    ('shape', c_intp * ndim),
+                    ('strides', c_intp * ndim)]
+
+    return c_array
 
 
 @struct_factory(types.ArrayIterator)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -343,6 +343,13 @@ class CPUContext(BaseContext):
     def get_abi_sizeof(self, lty):
         return self.engine.target_data.abi_size(lty)
 
+    def calc_array_sizeof(self, ndim):
+        '''
+        Calculate the size of an array struct on the CPU target
+        '''
+        aryty = types.Array(types.int32, ndim, 'A')
+        return self.get_abi_sizeof(self.get_value_type(aryty))
+
     def optimize_function(self, func):
         """Run O1 function passes
         """

--- a/numba/tests/test_array_type.py
+++ b/numba/tests/test_array_type.py
@@ -1,0 +1,35 @@
+from __future__ import print_function, division, absolute_import
+import numba.ctypes_support as ctypes
+
+from numba import unittest_support as unittest
+from numba import types
+from numba.targets.arrayobj import make_array, make_array_ctype
+from numba.targets.registry import CPUTarget
+
+class TestArrayType(unittest.TestCase):
+    '''
+    Tests that the ArrayTemplate returned by make_array and the ctypes array
+    struct returned by make_array_ctype both have the same size.
+    '''
+
+    def _cpu_array_sizeof(self, ndim):
+        ctx = CPUTarget.target_context
+        return ctx.calc_array_sizeof(ndim)
+
+    def _test_array(self, ndim):
+        c_array = make_array_ctype(ndim)
+        self.assertEqual(ctypes.sizeof(c_array),
+                         self._cpu_array_sizeof(ndim))
+
+    def test_1d_array(self):
+        self._test_array(1)
+
+    def test_2d_array(self):
+        self._test_array(2)
+
+    def test_3d_array(self):
+        self._test_array(3)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
The structure of the array ctype created by make_array_ctype did
not match the structure of the array structure returned by
make_array - it was missing the nitems and itemsize fields. This
commit:
- Adds these fields into the struct created by make_array_type,
- moves make_array_ctype into numba.targets.arrayobj,
- moves logic from calc_array_sizeof into the CPU target,
- adds a unit test so that further issues of this kind can be
  caught. Moving the two functions above was necessary for this
  test to run on non-CUDA systems (and their new locations are
  arguably logical anyway).
