### PR TITLE
Use CPU host name for code generation on the JIT codegen, and forcibly disable AVX.

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -102,7 +102,6 @@ def _force_cc(text):
 
 FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _force_cc, None)
 
-# X86 specific
-# Enable SSE, SSE2 on 32-bit x86 platforms.
-# Default ON
-X86_SSE = _readenv("NUMBA_X86_SSE", int, 1)
+# x86-64 specific
+# Enable AVX on supported platforms.
+ENABLE_AVX = _readenv("NUMBA_ENABLE_AVX", int, 0)

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -316,7 +316,8 @@ class JITCPUCodegen(BaseCPUCodegen):
         # There are various performance issues with AVX and LLVM 3.5
         # (list at http://llvm.org/bugs/buglist.cgi?quicksearch=avx).
         # For now we'd rather disable it, since it can pessimize the code.
-        features.append('-avx')
+        if not config.ENABLE_AVX:
+            features.append('-avx')
 
         # Set feature attributes
         options['features'] = ','.join(features)


### PR DESCRIPTION
I'm not sure this is a better idea than letting LLVM use the "default" CPU model (presumably some kind of generic machine model?), but intuitively it should be able to select specialized optimization rules.
