### PR TITLE
Disable Python 2.7 builds on Travis because of https://github.com/Contin...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ language: python
 
 python:
   - "2.6"
-  - "2.7"
+  #- "2.7"
   - "3.3"
   - "3.4"
 
 branches:
   only:
     - master
-    - llvmlite2
 
 before_install:
   # Install Miniconda


### PR DESCRIPTION
2.7 builds on Travis are currently broken because of https://github.com/ContinuumIO/anaconda-issues/issues/229
