### PR TITLE
Fix #903: respect stdcall calling convention on ctypes functions (Windows)

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -471,7 +471,8 @@ class Lower(BaseLower):
                 # Handle function pointer
                 pointer = fnty.funcptr
                 res = self.context.call_function_pointer(self.builder, pointer,
-                                                         signature, castvals)
+                                                         signature, castvals,
+                                                         fnty.cconv)
 
             elif isinstance(fnty, cffi_support.ExternCFunction):
                 # XXX unused?

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -870,13 +870,13 @@ class BaseContext(object):
         status = Status(code=code, ok=ok, err=err, exc=exc, none=none)
         return status
 
-    def call_function_pointer(self, builder, funcptr, signature, args):
+    def call_function_pointer(self, builder, funcptr, signature, args, cconv=None):
         retty = self.get_value_type(signature.return_type)
         fnty = Type.function(retty, [a.type for a in args])
         fnptrty = Type.pointer(fnty)
         addr = self.get_constant(types.intp, funcptr)
         ptr = builder.inttoptr(addr, fnptrty)
-        return builder.call(ptr, args)
+        return builder.call(ptr, args, cconv=cconv)
 
     def call_class_method(self, builder, func, signature, args):
         api = self.get_python_api(builder)

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -1,59 +1,88 @@
 from __future__ import print_function, absolute_import, division
+
 from ctypes import *
 import sys
+
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types
 
+
 is_windows = sys.platform.startswith('win32')
 
-if not is_windows:
-    proc = CDLL(None)
+if is_windows:
+    libc = cdll.msvcrt
+else:
+    libc = CDLL(None)
 
-    c_sin = proc.sin
-    c_sin.argtypes = [c_double]
-    c_sin.restype = c_double
+# A typed libc function (cdecl under Windows)
+
+c_sin = libc.sin
+c_sin.argtypes = [c_double]
+c_sin.restype = c_double
+
+def use_c_sin(x):
+    return c_sin(x)
+
+# An untyped libc function
+
+c_untyped = libc.cos
+
+def use_c_untyped(x):
+    return c_untyped(x)
+
+# A libc function wrapped in a CFUNCTYPE
+
+ctype_wrapping = CFUNCTYPE(c_double, c_double)(use_c_sin)
+
+def use_ctype_wrapping(x):
+    return ctype_wrapping(x)
+
+# A Python API function
+
+savethread = pythonapi.PyEval_SaveThread
+savethread.argtypes = []
+savethread.restype = c_void_p
+
+restorethread = pythonapi.PyEval_RestoreThread
+restorethread.argtypes = [c_void_p]
+restorethread.restype = None
+
+if is_windows:
+    # A function with the stdcall calling convention
+    c_sleep = windll.kernel32.Sleep
+    c_sleep.argtypes = [c_uint]
+    c_sleep.restype = None
+
+    def use_c_sleep(x):
+        c_sleep(x)
 
 
-    def use_c_sin(x):
-        return c_sin(x)
+def use_c_pointer(x):
+    """
+    Running in Python will cause a segfault.
+    """
+    threadstate = savethread()
+    x += 1
+    restorethread(threadstate)
+    return x
 
 
-    ctype_wrapping = CFUNCTYPE(c_double, c_double)(use_c_sin)
-
-
-    def use_ctype_wrapping(x):
-        return ctype_wrapping(x)
-
-
-
-    savethread = pythonapi.PyEval_SaveThread
-    savethread.argtypes = []
-    savethread.restype = c_void_p
-
-    restorethread = pythonapi.PyEval_RestoreThread
-    restorethread.argtypes = [c_void_p]
-    restorethread.restype = None
-
-
-    def use_c_pointer(x):
-        """
-        Running in Python will cause a segfault.
-        """
-        threadstate = savethread()
-        x += 1
-        restorethread(threadstate)
-        return x
-
-
-@unittest.skipIf(is_windows, "Test not supported on windows")
 class TestCTypes(unittest.TestCase):
+
     def test_c_sin(self):
         pyfunc = use_c_sin
         cres = compile_isolated(pyfunc, [types.double])
         cfunc = cres.entry_point
         x = 3.14
         self.assertEqual(pyfunc(x), cfunc(x))
+
+    @unittest.skipUnless(is_windows, "Windows-specific test")
+    def test_stdcall(self):
+        # Just check that it doesn't crash
+        cres = compile_isolated(use_c_sleep, [types.uintc])
+        cfunc = cres.entry_point
+        cfunc(1)
 
     def test_ctype_wrapping(self):
         pyfunc = use_ctype_wrapping
@@ -69,6 +98,13 @@ class TestCTypes(unittest.TestCase):
         cfunc = cres.entry_point
         x = 123
         self.assertTrue(cfunc(x), x + 1)
+
+    def test_untyped_function(self):
+        with self.assertRaises(TypeError) as raises:
+            compile_isolated(use_c_untyped, [types.double])
+        self.assertIn("ctypes function 'cos' doesn't define its argument types",
+                      str(raises.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -355,8 +355,13 @@ class Dispatcher(WeakType):
 
 
 class FunctionPointer(Function):
-    def __init__(self, template, funcptr):
+    """
+    A pointer to a native function (e.g. exported via ctypes or cffi).
+    """
+
+    def __init__(self, template, funcptr, cconv=None):
         self.funcptr = funcptr
+        self.cconv = cconv
         super(FunctionPointer, self).__init__(template)
 
 

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -2,7 +2,10 @@
 This file fixes portability issues for ctypes
 """
 from __future__ import absolute_import
+
 import ctypes
+import sys
+
 from numba import types
 from . import templates
 
@@ -44,12 +47,22 @@ def is_ctypes_funcptr(obj):
 
 
 def make_function_type(cfnptr):
+    if cfnptr.argtypes is None:
+        raise TypeError("ctypes function %r doesn't define its argument types; "
+                        "consider setting the `argtypes` attribute"
+                        % (cfnptr.__name__,))
     cargs = [convert_ctypes(a)
              for a in cfnptr.argtypes]
     cret = convert_ctypes(cfnptr.restype)
+    if sys.platform == 'win32' and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL:
+        # 'stdcall' calling convention under Windows
+        cconv = 'x86_stdcallcc'
+    else:
+        # Default C calling convention
+        cconv = None
 
     cases = [templates.signature(cret, *cargs)]
     template = templates.make_concrete_template("CFuncPtr", cfnptr, cases)
 
     pointer = ctypes.cast(cfnptr, ctypes.c_void_p).value
-    return types.FunctionPointer(template, pointer)
+    return types.FunctionPointer(template, pointer, cconv=cconv)


### PR DESCRIPTION
Also fix an error to give a better message.
