### PR TITLE
Fix Issue #868

### DIFF
--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -16,6 +16,8 @@ def foo():
 def bar(x):
     return x.a
 
+def issue_868(a):
+    return a.shape * 2
 
 class TestTypingError(unittest.TestCase):
     def test_unknown_function(self):
@@ -34,6 +36,18 @@ class TestTypingError(unittest.TestCase):
         else:
             self.fail("Should raise error")
 
+    def test_issue_868(self):
+        '''
+        Summary: multiplying a scalar by a non-scalar would cause a crash in
+        type inference because TimeDeltaMixOp always assumed at least one of
+        its operands was an NPTimeDelta in its generic() method.
+        '''
+        try:
+            compile_isolated(issue_868, (types.Array(types.int32, 1, 'C'),))
+        except TypingError as e:
+            self.assertTrue(e.msg.startswith('Undeclared'))
+        else:
+            self.fail('Should raise error')
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/typing/npdatetime.py
+++ b/numba/typing/npdatetime.py
@@ -76,6 +76,8 @@ class TimedeltaMixOp(AbstractTemplate):
             td, other = right, left
         elif isinstance(left, types.NPTimedelta):
             td, other = left, right
+        else:
+            return
         # Force integer types to convert to signed because it matches
         # timedelta64 semantics better.
         if other not in types.signed_domain and other not in types.real_domain:


### PR DESCRIPTION
Multiplying a scalar by a non-scalar would cause a crash in type
inference because TimeDeltaMixOp always assumed at least one of
its operands was an NPTimeDelta in its generic() method. If
neither operand is an NPTimeDelta, it now returns None so that
attempts to type the expression can proceed (and fail with a more
meaningful error message)
