### PR TITLE
Use typecode_ndarray for ndarray subclasses

### DIFF
--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -419,7 +419,7 @@ int typecode(DispatcherObject *dispatcher, PyObject *val) {
         return typecode_arrayscalar(dispatcher, val);
     }
     /* Array handling */
-    else if (tyobj == &PyArray_Type) {
+    else if (PyType_IsSubtype(tyobj, &PyArray_Type)) {
         return typecode_ndarray(dispatcher, (PyArrayObject*)val);
     }
 


### PR DESCRIPTION
With example code:

```python
from numba import njit
import numpy as np

@njit
def numba_copy_x_to_y(x, y):
    for i in range(len(x)):
        y[i] = x[i]

dtype = np.dtype([('x', np.int32), ('y', np.float32)])

a = np.zeros(1000, dtype)
b = np.zeros(1000, dtype)
aa = np.recarray(1000, dtype)
bb = np.recarray(1000, dtype)

for i in range(1000):
    a[i] = (i, float(i))
    aa[i] = (i, float(i))
```

Before this patch:

```
In [2]: %timeit numba_copy_x_to_y(aa, bb)
10000 loops, best of 3: 96 µs per loop

In [3]: %timeit numba_copy_x_to_y(a, b)
100000 loops, best of 3: 4.65 µs per loop
```

After patch:

```
In [16]: %timeit numba_copy_x_to_y(aa, bb)
100000 loops, best of 3: 4.04 µs per loop

In [17]: %timeit numba_copy_x_to_y(a, b)
100000 loops, best of 3: 4.14 µs per loop
```

(Thanks to @pitrou and @seibert for spotting that recarray dispatch was taking the slow path).