### PR TITLE
Fixes boolean return value in nested calls

### DIFF
--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -23,6 +23,10 @@ def _build_ufunc_loop_body(load, store, context, func, builder, arrays, out,
     if out.byref:
         retval = builder.load(retval)
 
+    if not cgutils.is_struct(retval.type):
+        retval = context.get_value_as_argument(builder, signature.return_type,
+                                               retval)
+
     store(retval)
 
     # increment indices

--- a/numba/tests/test_nested_calls.py
+++ b/numba/tests/test_nested_calls.py
@@ -1,0 +1,32 @@
+"""
+Test problems in nested calls.
+Usually due to invalid type conversion between function boundaries.
+
+"""
+from __future__ import print_function, division, absolute_import
+from numba import njit
+from numba import unittest_support as unittest
+
+
+class TestNestedCall(unittest.TestCase):
+    def test_boolean_return(self):
+
+        @njit
+        def inner(x):
+            return not x
+
+
+        @njit
+        def outer(x):
+            if inner(x):
+                return True
+            else:
+                return False
+
+
+        self.assertFalse(outer(True))
+        self.assertTrue(outer(False))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes a bug that returned boolean are not converted to the proper local value representation.

Additional note: 
I am trying to make a refactor to make all these type conversion/adaptation at function boundaries, array load/store, and special usage less ugly.