### PR TITLE
Skip the overhead of negative index tests when using an unsigned index

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -77,7 +77,8 @@ def make_arrayiter_cls(iterator_type):
     """
 
     class ArrayIteratorStruct(cgutils.Structure):
-        _fields = [('index', types.CPointer(types.intp)),
+        # We use an unsigned index to avoid the cost of negative index tests.
+        _fields = [('index', types.CPointer(types.uintp)),
                    ('array', iterator_type.array_type)]
 
     return ArrayIteratorStruct
@@ -99,9 +100,9 @@ def getiter_array(context, builder, sig, args):
     return iterobj._getvalue()
 
 
-def _getitem_array1d(context, builder, arrayty, array, idx):
+def _getitem_array1d(context, builder, arrayty, array, idx, wraparound):
     ptr = cgutils.get_item_pointer(builder, arrayty, array, [idx],
-                                   wraparound=True)
+                                   wraparound=wraparound)
     return context.unpack_value(builder, arrayty.dtype, ptr)
 
 @builtin
@@ -126,15 +127,16 @@ def iternext_array(context, builder, sig, args, result):
     result.set_valid(is_valid)
 
     with cgutils.ifthen(builder, is_valid):
-        value = _getitem_array1d(context, builder, arrayty, ary, index)
+        value = _getitem_array1d(context, builder, arrayty, ary, index,
+                                 wraparound=False)
         result.yield_(value)
         nindex = builder.add(index, context.get_constant(types.intp, 1))
         builder.store(nindex, iterobj.index)
 
 @builtin
-@implement('getitem', types.Kind(types.Array), types.intp)
+@implement('getitem', types.Kind(types.Array), types.Kind(types.Integer))
 def getitem_array1d_intp(context, builder, sig, args):
-    aryty, _ = sig.args
+    aryty, idxty = sig.args
     if aryty.ndim != 1:
         # TODO
         raise NotImplementedError("1D indexing into %dD array" % aryty.ndim)
@@ -143,7 +145,8 @@ def getitem_array1d_intp(context, builder, sig, args):
 
     arystty = make_array(aryty)
     ary = arystty(context, builder, ary)
-    return _getitem_array1d(context, builder, aryty, ary, idx)
+    return _getitem_array1d(context, builder, aryty, ary, idx,
+                            wraparound=idxty.signed)
 
 @builtin
 @implement('getitem', types.Kind(types.Array), types.slice3_type)
@@ -281,17 +284,17 @@ def getitem_array_tuple(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.Array), types.intp,
+@implement('setitem', types.Kind(types.Array), types.Kind(types.Integer),
            types.Any)
 def setitem_array1d(context, builder, sig, args):
-    aryty, _, valty = sig.args
+    aryty, idxty, valty = sig.args
     ary, idx, val = args
 
     arystty = make_array(aryty)
     ary = arystty(context, builder, ary)
 
     ptr = cgutils.get_item_pointer(builder, aryty, ary, [idx],
-                                   wraparound=True)
+                                   wraparound=idxty.signed)
 
     val = context.cast(builder, val, valty, aryty.dtype)
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -221,12 +221,12 @@ def getitem_array_unituple(context, builder, sig, args):
         return retary._getvalue()
     else:
         # Indexing
-        assert idxty.dtype == types.intp
+        assert isinstance(idxty.dtype, types.Integer)
         indices = cgutils.unpack_tuple(builder, idx, count=len(idxty))
         indices = [context.cast(builder, i, t, types.intp)
                    for t, i in zip(idxty, indices)]
         ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
-                                       wraparound=True)
+                                       wraparound=idxty.dtype.signed)
 
         return context.unpack_value(builder, aryty.dtype, ptr)
 
@@ -316,7 +316,7 @@ def setitem_array_unituple(context, builder, sig, args):
     indices = [context.cast(builder, i, t, types.intp)
                for t, i in zip(idxty, indices)]
     ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
-                                   wraparound=True)
+                                   wraparound=idxty.dtype.signed)
     context.pack_value(builder, aryty.dtype, val, ptr)
 
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -372,8 +372,8 @@ def normalize_index(index):
     # elif index == types.slice2_type:
     #     return types.slice2_type
 
-    else:
-        return types.intp
+    elif isinstance(index, types.Integer):
+        return types.intp if index.signed else types.uintp
 
 
 @builtin
@@ -415,7 +415,7 @@ class GetItemArray(AbstractTemplate):
                 res = ary.copy(ndim=ndim, layout='A')
             else:
                 res = ary.dtype
-        elif idx == types.intp:
+        elif isinstance(idx, types.Integer):
             if ary.ndim != 1:
                 return
             res = ary.dtype

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -354,7 +354,8 @@ class CmpOpIsNot(CmpOpIdentity):
 def normalize_index(index):
     if isinstance(index, types.UniTuple):
         if index.dtype in types.integer_domain:
-            return types.UniTuple(types.intp, len(index))
+            idxtype = types.intp if index.dtype.signed else types.uintp
+            return types.UniTuple(idxtype, len(index))
         elif index.dtype == types.slice3_type:
             return index
 


### PR DESCRIPTION
This improves performance when using indirect indexing, as reported in http://article.gmane.org/gmane.comp.python.numba.user/362
