### PR TITLE
Keyword arguments in JIT function calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   # Install enum34 for Python < 3.4
   - if [ $PY_MAJOR_MINOR \< "3.4" ]; then conda install --yes enum34; fi
   # Install funcsigs for Python < 3.3
-  - if [ $PY_MAJOR_MINOR \< "3.3" ]; then conda install --yes funcsigs; fi
+  - if [ $PY_MAJOR_MINOR \< "3.3" ]; then conda install --yes -c numba funcsigs; fi
   # The next couple lines fix a crash with multiprocessing on Travis
   # and are not specific to using Miniconda
   - sudo rm -rf /dev/shm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - export PATH=$HOME/miniconda3/bin:$PATH
   - PY_MAJOR_MINOR=${TRAVIS_PYTHON_VERSION:0:3}
   # Setup environment
-  - conda create -n travisci --yes python=$PY_MAJOR_MINOR numpy cffi
+  - conda create -n travisci --yes python=$PY_MAJOR_MINOR numpy cffi pip
   - source activate travisci
   # Install llvmdev (separate channel, for now)
   - conda install --yes -c numba llvmdev
@@ -28,6 +28,8 @@ before_install:
   - if [ $PY_MAJOR_MINOR == "2.6" ]; then conda install --yes unittest2 argparse; fi
   # Install enum34 for Python < 3.4
   - if [ $PY_MAJOR_MINOR \< "3.4" ]; then conda install --yes enum34; fi
+  # Install funcsigs for Python < 3.3
+  - if [ $PY_MAJOR_MINOR \< "3.3" ]; then pip install funcsigs; fi
   # The next couple lines fix a crash with multiprocessing on Travis
   # and are not specific to using Miniconda
   - sudo rm -rf /dev/shm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - export PATH=$HOME/miniconda3/bin:$PATH
   - PY_MAJOR_MINOR=${TRAVIS_PYTHON_VERSION:0:3}
   # Setup environment
-  - conda create -n travisci --yes python=$PY_MAJOR_MINOR numpy cffi pip
+  - conda create -n travisci --yes python=$PY_MAJOR_MINOR numpy cffi
   - source activate travisci
   # Install llvmdev (separate channel, for now)
   - conda install --yes -c numba llvmdev
@@ -29,7 +29,7 @@ before_install:
   # Install enum34 for Python < 3.4
   - if [ $PY_MAJOR_MINOR \< "3.4" ]; then conda install --yes enum34; fi
   # Install funcsigs for Python < 3.3
-  - if [ $PY_MAJOR_MINOR \< "3.3" ]; then pip install funcsigs; fi
+  - if [ $PY_MAJOR_MINOR \< "3.3" ]; then conda install --yes funcsigs; fi
   # The next couple lines fix a crash with multiprocessing on Travis
   # and are not specific to using Miniconda
   - sudo rm -rf /dev/shm

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dependencies
   * llvmlite
   * numpy (version 1.6 or higher)
   * argparse (for pycc in python2.6)
+  * funcsigs (for Python 2)
 
 Installing
 =================

--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -96,6 +96,7 @@ PyObject* init_types(PyObject *self, PyObject *args)
 static void
 Dispatcher_dealloc(DispatcherObject *self)
 {
+    Py_DECREF(self->argnames);
     dispatcher_del(self->dispatcher);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
@@ -113,6 +114,7 @@ Dispatcher_init(DispatcherObject *self, PyObject *args, PyObject *kwds)
                           &tmaddrobj, &argct, &PyTuple_Type, &self->argnames)) {
         return -1;
     }
+    Py_INCREF(self->argnames);
     tmaddr = PyLong_AsVoidPtr(tmaddrobj);
     self->dispatcher = dispatcher_new(tmaddr, argct);
     self->can_compile = 1;

--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -1,4 +1,7 @@
+#define PY_SSIZE_T_CLEAN
+
 #include "_pymodule.h"
+
 #include <structmember.h>
 #include <string.h>
 #include <time.h>
@@ -15,6 +18,8 @@ typedef struct DispatcherObject{
     char can_compile;        /* Can auto compile */
     /* Borrowed references */
     PyObject *firstdef, *fallbackdef, *interpdef;
+    /* Tuple of argument names */
+    PyObject *argnames;
 } DispatcherObject;
 
 static int tc_int8;
@@ -103,7 +108,9 @@ Dispatcher_init(DispatcherObject *self, PyObject *args, PyObject *kwds)
     PyObject *tmaddrobj;
     void *tmaddr;
     int argct;
-    if (!PyArg_ParseTuple(args, "Oi", &tmaddrobj, &argct)) {
+
+    if (!PyArg_ParseTuple(args, "OiO!",
+                          &tmaddrobj, &argct, &PyTuple_Type, &self->argnames)) {
         return -1;
     }
     tmaddr = PyLong_AsVoidPtr(tmaddrobj);
@@ -484,8 +491,52 @@ compile_and_invoke(DispatcherObject *self, PyObject *args, PyObject *kws)
     return retval;
 }
 
-static
-PyObject*
+static int
+find_named_args(DispatcherObject *self, PyObject **pargs, PyObject **pkws)
+{
+    PyObject *oldargs = *pargs, *newargs;
+    PyObject *kws = *pkws;
+    Py_ssize_t pos_args = PyTuple_GET_SIZE(oldargs);
+    Py_ssize_t named_args, total_args, i;
+
+    if (kws == NULL || (named_args = PyDict_Size(kws)) == 0) {
+        Py_INCREF(oldargs);
+        return 0;
+    }
+    total_args = pos_args + named_args;
+    if (total_args > PyTuple_GET_SIZE(self->argnames)) {
+        PyErr_Format(PyExc_TypeError,
+                     "too many arguments: expected %d, got %d",
+                     (int) PyTuple_GET_SIZE(self->argnames), (int) total_args);
+        return -1;
+    }
+    newargs = PyTuple_New(total_args);
+    if (!newargs)
+        return -1;
+    for (i = 0; i < pos_args; i++) {
+        PyObject *value = PyTuple_GET_ITEM(oldargs, i);
+        Py_INCREF(value);
+        PyTuple_SET_ITEM(newargs, i, value);
+    }
+    for (i = pos_args; i < total_args; i++) {
+        PyObject *name = PyTuple_GET_ITEM(self->argnames, i);
+        PyObject *value = PyDict_GetItem(kws, name);
+        if (value == NULL) {
+            PyErr_Format(PyExc_TypeError,
+                         "missing argument '%s'",
+                         PyString_AsString(name));
+            Py_DECREF(newargs);
+            return -1;
+        }
+        Py_INCREF(value);
+        PyTuple_SET_ITEM(newargs, i, value);
+    }
+    *pargs = newargs;
+    *pkws = NULL;
+    return 0;
+}
+
+static PyObject*
 Dispatcher_call(DispatcherObject *self, PyObject *args, PyObject *kws)
 {
     PyObject *tmptype, *retval = NULL;
@@ -496,11 +547,9 @@ Dispatcher_call(DispatcherObject *self, PyObject *args, PyObject *kws)
     int matches;
     PyObject *cfunc;
 
-    /* Shortcut for single definition */
-    /*if (!self->can_compile && 1 == dispatcher_count(self->dispatcher)){
-        fn = self->firstdef;
-        return fn(NULL, args, kws);
-    }*/
+    if (find_named_args(self, &args, &kws))
+        return NULL;
+    /* Now we own a reference to args */
 
     argct = PySequence_Fast_GET_SIZE(args);
 
@@ -512,7 +561,8 @@ Dispatcher_call(DispatcherObject *self, PyObject *args, PyObject *kws)
     for (i = 0; i < argct; ++i) {
         tmptype = PySequence_Fast_GET_ITEM(args, i);
         tys[i] = typecode(self, tmptype);
-        if (tys[i] == -1) goto CLEANUP;
+        if (tys[i] == -1)
+            goto CLEANUP;
     }
 
     /* We only allow unsafe conversions if compilation of new specializations
@@ -547,6 +597,7 @@ Dispatcher_call(DispatcherObject *self, PyObject *args, PyObject *kws)
 CLEANUP:
     if (tys != prealloc)
         free(tys);
+    Py_DECREF(args);
 
     return retval;
 }
@@ -554,8 +605,6 @@ CLEANUP:
 static PyMethodDef Dispatcher_methods[] = {
     { "_insert", (PyCFunction)Dispatcher_Insert, METH_VARARGS,
       "insert new definition"},
-//    { "_find", (PyCFunction)Dispatcher_Find, METH_VARARGS,
-//      "find matching definition and return a tuple of (argtypes, callable)"},
     { NULL },
 };
 

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+
 import contextlib
 import functools
 import inspect
@@ -35,9 +36,10 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         # but newer python uses a different name
         self.__code__ = self.func_code
 
-        argnames = self.__code__.co_varnames[:arg_count]
+        self._pysig = utils.pysignature(self.py_func)
+        _argnames = tuple(self._pysig.parameters)
         _dispatcher.Dispatcher.__init__(self, self.tm.get_pointer(),
-                                        arg_count, argnames)
+                                        arg_count, _argnames)
 
         self.doc = py_func.__doc__
         self._compile_lock = utils.NonReentrantLock()
@@ -105,8 +107,16 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         Get a typing.ConcreteTemplate for this dispatcher and the given *args*
         and *kws*.  This allows to resolve the return type.
         """
+        # Fold keyword arguments
         if kws:
-            raise TypeError("kwargs not supported")
+            ba = self._pysig.bind(*args, **kws)
+            if ba.kwargs:
+                # There's a remaining keyword argument, e.g. if omitting
+                # some argument with a default value before it.
+                raise NotImplementedError("unhandled keyword argument: %s"
+                                          % list(ba.kwargs))
+            args = ba.args
+            kws = {}
         # Ensure an overload is available, but avoid compiler re-entrance
         if self._can_compile and not self.is_compiling:
             self.compile(tuple(args))
@@ -118,7 +128,7 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         # so avoid keeping a reference to `cfunc`.
         call_template = typing.make_concrete_template(
             name, key=func_name, signatures=self.nopython_signatures)
-        return call_template
+        return call_template, args, kws
 
     def get_overload(self, sig):
         args, return_type = sigutils.normalize_signature(sig)

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -21,7 +21,6 @@ class _OverloadedBase(_dispatcher.Dispatcher):
 
     def __init__(self, arg_count, py_func):
         self.tm = default_type_manager
-        _dispatcher.Dispatcher.__init__(self, self.tm.get_pointer(), arg_count)
 
         # A mapping of signatures to entry points
         self.overloads = {}
@@ -35,6 +34,10 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         self.func_code = get_code_object(py_func)
         # but newer python uses a different name
         self.__code__ = self.func_code
+
+        argnames = self.__code__.co_varnames[:arg_count]
+        _dispatcher.Dispatcher.__init__(self, self.tm.get_pointer(),
+                                        arg_count, argnames)
 
         self.doc = py_func.__doc__
         self._compile_lock = utils.NonReentrantLock()

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -17,7 +17,12 @@ def add(x, y):
     return x + y
 
 
+def addsub(x, y, z):
+    return x - y + z
+
+
 class TestDispatcher(TestCase):
+
     def test_numba_interface(self):
         """
         Check that vectorize can accept a decorated object.
@@ -31,7 +36,6 @@ class TestDispatcher(TestCase):
 
         # Just make sure this doesn't crash
         foo()
-
 
     def test_inspect_types(self):
         @jit
@@ -103,6 +107,28 @@ class TestDispatcher(TestCase):
         for t in threads:
             t.join()
         self.assertFalse(errors)
+
+    def test_named_args(self):
+        """
+        Test passing named arguments to a dispatcher.
+        """
+        def check(*args, **kwargs):
+            result = f(*args, **kwargs)
+            self.assertEqual(result, addsub(*args, **kwargs))
+        f = jit(addsub)
+        check(3, z=10, y=4)
+        check(3, 4, 10)
+        check(x=3, y=4, z=10)
+        # All calls above fall under the same specialization
+        self.assertEqual(len(f.overloads), 1)
+        # Errors
+        with self.assertRaises(TypeError) as cm:
+            f(3, 4, y=6, z=7)
+        self.assertIn("too many arguments: expected 3, got 4",
+                      str(cm.exception))
+        with self.assertRaises(TypeError) as cm:
+            f(3, 4, y=6)
+        self.assertIn("missing argument 'z'", str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_nested_calls.py
+++ b/numba/tests/test_nested_calls.py
@@ -1,20 +1,28 @@
 """
 Test problems in nested calls.
 Usually due to invalid type conversion between function boundaries.
-
 """
+
 from __future__ import print_function, division, absolute_import
+
 from numba import njit
 from numba import unittest_support as unittest
 
 
-class TestNestedCall(unittest.TestCase):
-    def test_boolean_return(self):
+@njit
+def f(a, b, c):
+    return a + 2 * b - c
 
+def g(x, y, z):
+    return f(x, c=y, b=z)
+
+
+class TestNestedCall(unittest.TestCase):
+
+    def test_boolean_return(self):
         @njit
         def inner(x):
             return not x
-
 
         @njit
         def outer(x):
@@ -23,9 +31,16 @@ class TestNestedCall(unittest.TestCase):
             else:
                 return False
 
-
         self.assertFalse(outer(True))
         self.assertTrue(outer(False))
+
+    def test_named_args(self):
+        """
+        Test a nested function call with named (keyword) arguments.
+        """
+        cfunc = njit(g)
+        self.assertEqual(cfunc(1, 2, 3), g(1, 2, 3))
+        self.assertEqual(cfunc(1, y=2, z=3), g(1, 2, 3))
 
 
 if __name__ == '__main__':

--- a/numba/types.py
+++ b/numba/types.py
@@ -353,6 +353,13 @@ class Dispatcher(WeakType):
         """
         return self._get_object()
 
+    @property
+    def pysig(self):
+        """
+        A inspect.Signature object corresponding to this type.
+        """
+        return self.overloaded._pysig
+
 
 class FunctionPointer(Function):
     """

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -53,7 +53,7 @@ class BaseContext(object):
             return func.template(self).apply(args, kws)
 
         if isinstance(func, types.Dispatcher):
-            template = func.overloaded.get_call_template(args, kws)
+            template, args, kws = func.overloaded.get_call_template(args, kws)
             return template(self).apply(args, kws)
 
         defns = self.functions[func]

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -32,6 +32,15 @@ else:
     longint = long
     get_ident = thread.get_ident
 
+try:
+    from inspect import signature as pysignature
+except ImportError:
+    try:
+        from funcsigs import signature as pysignature
+    except ImportError:
+        raise ImportError("please install the 'funcsigs' package "
+                          "('pip install funcsigs')")
+
 
 _shutting_down = False
 


### PR DESCRIPTION
Fix #728: Add keyword argument support for Overloaded objects.
Fix #729: Support calling functions with keyword arguments inside a numba compiled function.
