### PR TITLE
Refactor and fixes multigpu support

### DIFF
--- a/numba/cuda/cudadrv/devices.py
+++ b/numba/cuda/cudadrv/devices.py
@@ -18,20 +18,22 @@ from .driver import driver
 
 
 class _DeviceList(object):
-    def __init__(self):
-        # The list of devices is lazily created to defer CUDA driver
-        # initialization
-        self.lst = None
-
-    def __getitem__(self, devnum):
-        if self.lst is None:
+    def __getattr__(self, attr):
+        # First time looking at "lst" attribute.
+        if attr == "lst":
             # Device list is not initialized.
             # Query all CUDA devices.
             numdev = driver.get_device_count()
             gpus = [_DeviceContextManager(driver.get_device(devid))
                     for devid in range(numdev)]
+            # Define "lst" to avoid re-initialization
             self.lst = gpus
+            return gpus
 
+        # Other attributes
+        return super(_DeviceList, self).__getattr__(attr)
+
+    def __getitem__(self, devnum):
         return self.lst[devnum]
 
     def __str__(self):

--- a/numba/cuda/cudadrv/devices.py
+++ b/numba/cuda/cudadrv/devices.py
@@ -47,9 +47,10 @@ class _DeviceList(object):
 
     @property
     def current(self):
-        """Returns the active device
+        """Returns the active device or None if there's no active device
         """
-        return self.lst[_runtime.current_context.device.id]
+        if _runtime.context_stack:
+            return self.lst[_runtime.current_context.device.id]
 
 
 class _DeviceContextManager(object):

--- a/numba/cuda/cudadrv/devices.py
+++ b/numba/cuda/cudadrv/devices.py
@@ -118,7 +118,7 @@ class _Runtime(object):
     def _create_context(self, gpu):
         """Create a new context for the given gpu
         """
-        # Use lock to prevent internal state mutation
+        # Use lock to prevent internal state corruption
         with self._lock:
             ctx = gpu.create_context()
             self._contexts[ctx.handle.value] = ctx
@@ -145,8 +145,8 @@ class _Runtime(object):
         return ctx
 
     def push_context(self, gpu):
-        """Push a context for the given GPU if it is not the current context
-        on the context stack.
+        """Push a context for the given GPU or create a new one if no context
+        exist for the given GPU.
         """
         # First context
         if not self._contexts:

--- a/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+from numba import cuda
+from numba.cuda.testing import unittest
+
+
+class TestContextStack(unittest.TestCase):
+    def setUp(self):
+        # Reset before testing
+        cuda.close()
+
+    def test_gpus_current(self):
+        self.assertIs(cuda.gpus.current, None)
+        with cuda.gpus[0]:
+            self.assertEqual(cuda.gpus.current.id, 0)
+
+    def test_gpus_len(self):
+        self.assertGreater(len(cuda.gpus), 0)
+
+    def test_gpus_iter(self):
+        gpulist = list(cuda.gpus)
+        self.assertGreater(len(gpulist), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -1,7 +1,8 @@
 from __future__ import print_function, absolute_import
 
 from ctypes import c_int, sizeof
-from numba.cuda.cudadrv.driver import driver, host_to_device, device_to_host
+from numba.cuda.cudadrv.driver import host_to_device, device_to_host
+from numba.cuda.cudadrv import devices
 from numba.cuda.testing import unittest
 
 ptx1 = '''
@@ -59,14 +60,17 @@ ptx2 = '''
 
 class TestCudaDriver(unittest.TestCase):
     def setUp(self):
-        self.assertTrue(driver.get_device_count())
-        device = driver.get_device()
+        self.assertTrue(len(devices.gpus) > 0)
+        self.context = devices.get_context()
+        device = self.context.device
         ccmajor, _ = device.compute_capability
         if ccmajor >= 2:
             self.ptx = ptx2
         else:
             self.ptx = ptx1
-        self.context = device.get_or_create_context()
+
+    def tearDown(self):
+        del self.context
 
     def test_cuda_driver_basic(self):
         module = self.context.create_module_ptx(self.ptx)

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -1,14 +1,16 @@
 import ctypes
 import numpy
-from numba.cuda.cudadrv import driver, drvapi
+from numba.cuda.cudadrv import driver, drvapi, devices
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.utils import IS_PY3
 
 
 class TestCudaMemory(CUDATestCase):
     def setUp(self):
-        self.device = driver.driver.get_device()
-        self.context = self.device.get_or_create_context()
+        self.context = devices.get_context()
+
+    def tearDown(self):
+        del self.context
 
     def _template(self, obj):
         self.assertTrue(driver.is_device_memory(obj))
@@ -39,8 +41,10 @@ class TestCudaMemory(CUDATestCase):
 
 class TestCudaMemoryFunctions(CUDATestCase):
     def setUp(self):
-        device = driver.driver.get_device()
-        self.context = device.get_or_create_context()
+        self.context = devices.get_context()
+
+    def tearDown(self):
+        del self.context
 
     def test_memcpy(self):
         hstary = numpy.arange(100, dtype=numpy.uint32)

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -4,25 +4,40 @@ from numba import cuda
 from numba.cuda.cudadrv.driver import driver
 from numba.cuda.testing import unittest, CUDATestCase
 
+try:
+    from Queue import Queue  # Python 2
+except:
+    from queue import Queue  # Python 3
+
 
 class TestResetDevice(CUDATestCase):
     def test_reset_device(self):
 
-        def newthread():
-            devices = range(driver.get_device_count())
-            print('Devices', devices)
-            for _ in range(2):
-                for d in devices:
-                    cuda.select_device(d)
-                    print('Selected device', d)
-                    cuda.close()
-                    print('Closed device', d)
+        def newthread(exception_queue):
+            try:
+                devices = range(driver.get_device_count())
+                print('Devices', devices)
+                for _ in range(2):
+                    for d in devices:
+                        cuda.select_device(d)
+                        print('Selected device', d)
+                        cuda.close()
+                        print('Closed device', d)
+            except Exception as e:
+                exception_queue.put(e)
 
         # Do test on a separate thread so that we don't affect
         # the current context in the main thread.
-        t = threading.Thread(target=newthread)
+
+        exception_queue = Queue()
+        t = threading.Thread(target=newthread, args=(exception_queue,))
         t.start()
         t.join()
+
+        exceptions = []
+        while not exception_queue.empty():
+            exceptions.append(exception_queue.get())
+        self.assertEqual(exceptions, [])
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudadrv/test_select_device.py
+++ b/numba/cuda/tests/cudadrv/test_select_device.py
@@ -34,11 +34,11 @@ class TestSelectDevice(CUDATestCase):
             t = threading.Thread(target=newthread, args=(exception_queue,))
             t.start()
             t.join()
-        
+
         exceptions = []
         while not exception_queue.empty():
             exceptions.append(exception_queue.get())
-        self.assertEquals(exceptions, [])
+        self.assertEqual(exceptions, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Refactor the multigpu and cuda context stack management (in numba.cuda.cudadrv.devices)
    * enforces **one context per device per process** rule as introduced in CUDA 4.0 Runtime API
    * all cuda users (including tests) must use this to create context
* Fixes context leaking problems on python2.7 and python3.3 
* Fixes exception leaking in threads (numba/cuda/tests/cudadrv/test_reset_device.py)
* All cuda tests must use the new cuda context management