### PR TITLE
TypeSystem refactor

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -781,11 +781,13 @@ class BaseContext(object):
                 tup = builder.insert_value(tup, val, idx)
             return tup
 
-        elif (types.is_int_tuple(toty) and types.is_int_tuple(fromty) and
-                len(toty) == len(fromty)):
+        elif (isinstance(fromty, (types.UniTuple, types.Tuple)) and
+                  isinstance(toty, (types.UniTuple, types.Tuple)) and
+                      len(toty) == len(fromty)):
+
             olditems = cgutils.unpack_tuple(builder, val, len(fromty))
-            items = [self.cast(builder, i, t, toty.dtype)
-                     for i, t in zip(olditems, fromty.types)]
+            items = [self.cast(builder, i, f, t)
+                     for i, f, t in zip(olditems, fromty, toty)]
             tup = self.get_constant_undef(toty)
             for idx, val in enumerate(items):
                 tup = builder.insert_value(tup, val, idx)

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -183,5 +183,71 @@ class TestIssue(object):
         foo(np.int32(0), np.int32(0), np.int32(1), np.int32(1), g)
 
 
+class TestCoercion(unittest.TestCase):
+    """
+    Test coercion of binary operations.
+    """
+    references = {
+        ('uint8', 'uint8'): 'uint8',
+        ('int8', 'int8'): 'int8',
+        ('uint16', 'uint16'): 'uint16',
+        ('int16', 'int16'): 'int16',
+        ('uint32', 'uint32'): 'uint32',
+        ('int32', 'int32'): 'int32',
+        ('uint64', 'uint64'): 'uint64',
+        ('int64', 'int64'): 'int64',
+
+        ('int8', 'uint8'): 'int16',
+        ('int8', 'uint16'): 'int32',
+        ('int8', 'uint32'): 'int64',
+
+        ('uint8', 'int32'): 'int32',
+        ('uint8', 'uint64'): 'uint64',
+
+        ('int16', 'int8'): 'int16',
+        ('int16', 'uint8'): 'int16',
+        ('int16', 'uint16'): 'int32',
+        ('int16', 'uint32'): 'int64',
+        ('int16', 'int64'): 'int64',
+        ('int16', 'uint64'): 'float64',
+
+        ('uint16', 'uint8'): 'uint16',
+        ('uint16', 'uint32'): 'uint32',
+        ('uint16', 'int32'): 'int32',
+        ('uint16', 'uint64'): 'uint64',
+
+        ('int32', 'int8'): 'int32',
+        ('int32', 'int16'): 'int32',
+        ('int32', 'uint32'): 'int64',
+        ('int32', 'int64'): 'int64',
+
+        ('uint32', 'uint8'): 'uint32',
+        ('uint32', 'int64'): 'int64',
+        ('uint32', 'uint64'): 'uint64',
+
+        ('int64', 'int8'): 'int64',
+        ('int64', 'uint8'): 'int64',
+        ('int64', 'uint16'): 'int64',
+
+        ('uint64', 'int8'): 'float64',
+        ('uint64', 'int32'): 'float64',
+        ('uint64', 'int64'): 'float64',
+    }
+
+    def test_integer(self):
+        ctx = typing.Context()
+        for ut, st in itertools.product(types.integer_domain,
+                                        types.integer_domain):
+            unified = ctx.unify_types(ut, st)
+            self._check_unify(ut, st, unified)
+
+    def _check_unify(self, aty, bty, unified):
+        key = (str(aty), str(bty))
+        expect = self.references.get(key,
+                                     self.references.get(tuple(reversed(key))))
+        msg = "{0}, {1} -> {2} != {3}".format(aty, bty, unified, expect)
+        self.assertEqual(str(unified), expect, msg=msg)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Simplify unify_pairs() logic
* No more patching the method
* Extend it through:
    * casting relationship using `numba.typeconv.rules.default_casting_rules`
    * Type.coerce() when the logic can't be expressed with the above 