### PR TITLE
Fix #902: support ndenumerate() in nopython mode.

### DIFF
--- a/numba/types.py
+++ b/numba/types.py
@@ -468,6 +468,22 @@ class NumpyFlatType(IteratorType):
         return self.array_type
 
 
+class NumpyNdEnumerateType(IteratorType):
+    """
+    Type class for `np.ndenumerate()` objects.
+    """
+
+    def __init__(self, arrty):
+        self.array_type = arrty
+        self.yield_type = Tuple((UniTuple(intp, arrty.ndim), arrty.dtype))
+        name = "ndenumerate({arrayty})".format(arrayty=arrty)
+        super(NumpyNdEnumerateType, self).__init__(name, param=True)
+
+    @property
+    def key(self):
+        return self.array_type
+
+
 class EnumerateType(IteratorType):
     """
     Type class for `enumerate` objects.

--- a/numba/types.py
+++ b/numba/types.py
@@ -475,6 +475,8 @@ class NumpyNdEnumerateType(IteratorType):
 
     def __init__(self, arrty):
         self.array_type = arrty
+        # XXX making this a uintp has the side effect of forcing some
+        # arithmetic operations to return a float result.
         self.yield_type = Tuple((UniTuple(intp, arrty.ndim), arrty.dtype))
         name = "ndenumerate({arrayty})".format(arrayty=arrty)
         super(NumpyNdEnumerateType, self).__init__(name, param=True)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -12,6 +12,7 @@ from ..numpy_support import (ufunc_find_matching_loop,
 from ..typeinfer import TypingError
 
 registry = Registry()
+builtin = registry.register
 builtin_global = registry.register_global
 builtin_attr = registry.register_attr
 
@@ -238,6 +239,24 @@ for func in ['mean', 'var', 'std']:
 
 for func in ['argmin', 'argmax']:
     _numpy_reduction(func, Numpy_index_reduction)
+
+
+# -----------------------------------------------------------------------------
+# Miscellaneous functions
+
+@builtin
+class NdEnumerate(AbstractTemplate):
+    key = numpy.ndenumerate
+
+    def generic(self, args, kws):
+        assert not kws
+        arr, = args
+
+        if isinstance(arr, types.Array):
+            enumerate_type = types.NumpyNdEnumerateType(arr)
+            return signature(enumerate_type, *args)
+
+builtin_global(numpy.ndenumerate, types.Function(NdEnumerate))
 
 
 builtin_global(numpy, types.Module(numpy))


### PR DESCRIPTION
Note this also makes the iteration logic slightly simpler in the general (non-contiguous) case. The previous implementation was a bit wonky. Now the incrementation is made post hoc, which clear things up a lot.