### PR TITLE
Avoid creating new PyObject in each lowered functions

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -57,6 +57,14 @@ FunctionAttributes = namedtuple("FunctionAttributes",
 DEFAULT_FUNCTION_ATTRIBUTES = FunctionAttributes('<anonymous>', '<unknown>', 0)
 
 
+_LowerResult = namedtuple("_LowerResult", [
+    "fndesc",
+    "exception_map",
+    "cfunc",
+    "env",
+])
+
+
 def get_function_attributes(func):
     '''
     Extract the function attributes from a Python function or object with
@@ -430,21 +438,21 @@ class Pipeline(object):
         if self.library is None:
             codegen = self.targetctx.jit_codegen()
             self.library = codegen.create_library(self.bc.func_qualname)
-        fndesc, exception_map, func, env = lowerfn()
+        lowered = lowerfn()
         signature = typing.signature(self.return_type, *self.args)
         cr = compile_result(typing_context=self.typingctx,
                             target_context=self.targetctx,
-                            entry_point=func,
+                            entry_point=lowered.cfunc,
                             typing_error=self.status.fail_reason,
                             type_annotation=self.type_annotation,
                             library=self.library,
-                            exception_map=exception_map,
+                            exception_map=lowered.exception_map,
                             signature=signature,
                             objectmode=objectmode,
                             interpmode=False,
                             lifted=self.lifted,
-                            fndesc=fndesc,
-                            environment=env,)
+                            fndesc=lowered.fndesc,
+                            environment=lowered.env,)
         return cr
 
     def stage_objectmode_backend(self):
@@ -675,14 +683,14 @@ def native_lowering_stage(targetctx, library, interp, typemap, restype,
     del lower
 
     if flags.no_compile:
-        return fndesc, exception_map, None, None
+        return _LowerResult(fndesc, exception_map, cfunc=None, env=None)
     else:
         # Prepare for execution
         cfunc = targetctx.get_executable(library, fndesc, env)
         # Insert native function for use by other jitted-functions.
         # We also register its library to allow for inlining.
         targetctx.insert_user_function(cfunc, fndesc, [library])
-        return fndesc, exception_map, cfunc, None
+        return _LowerResult(fndesc, exception_map, cfunc=cfunc, env=None)
 
 
 def py_lowering_stage(targetctx, library, interp, flags):
@@ -696,11 +704,11 @@ def py_lowering_stage(targetctx, library, interp, flags):
     del lower
 
     if flags.no_compile:
-        return fndesc, exception_map, None, env
+        return _LowerResult(fndesc, exception_map, cfunc=None, env=env)
     else:
         # Prepare for execution
         cfunc = targetctx.get_executable(library, fndesc, env)
-        return fndesc, exception_map, cfunc, env
+        return _LowerResult(fndesc, exception_map, cfunc, env)
 
 
 def ir_optimize_for_py_stage(interp):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 import sys
 from types import ModuleType
 
-from llvmlite.llvmpy.core import Type, Builder, Module
-import llvmlite.llvmpy.core as lc
-import llvmlite.binding as ll
+from llvmlite.llvmpy.core import Type, Builder
+
 
 from numba import (_dynfunc, errcode, ir, types, cgutils, utils, config,
                    cffi_support, typing)

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -12,7 +12,7 @@ from . import _internal
 from .sigparse import parse_signature
 from .wrappers import build_ufunc_wrapper, build_gufunc_wrapper
 from numba.targets import registry
-from numba import _dynfunc
+
 
 import llvmlite.llvmpy.core as lc
 
@@ -165,8 +165,8 @@ class UFuncBuilder(_BaseUFuncBuilder):
         env = None
         if cres.objectmode:
             # Get env
-            moduledict = cres.fndesc.lookup_module().__dict__
-            env = _dynfunc.Environment(globals=moduledict)
+            env = cres.environment
+            assert env is not None
             ll_intp = cres.target_context.get_value_type(types.intp)
             ll_pyobj = cres.target_context.get_value_type(types.pyobject)
             envptr = lc.Constant.int(ll_intp, id(env)).inttoptr(ll_pyobj)
@@ -263,7 +263,8 @@ class GUFuncBuilder(_BaseUFuncBuilder):
         llvm_func = library.get_function(cres.fndesc.llvm_func_name)
         wrapper, env = build_gufunc_wrapper(library, ctx, llvm_func,
                                             signature, self.sin, self.sout,
-                                            fndesc=cres.fndesc)
+                                            fndesc=cres.fndesc,
+                                            env=cres.environment)
 
         ptr = library.get_pointer_to_function(wrapper.name)
 

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -6,7 +6,6 @@ import llvmlite.llvmpy.core as lc
 from llvmlite import binding as ll
 
 from numba import types, cgutils, config
-from numba import _dynfunc
 
 
 def _build_ufunc_loop_body(load, store, context, func, builder, arrays, out,
@@ -129,8 +128,6 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
     """
     Wrap the scalar function with a loop that iterates over the arguments
     """
-    module = func.module
-
     byte_t = Type.int(8)
     byte_ptr_t = Type.pointer(byte_t)
     byte_ptr_ptr_t = Type.pointer(byte_ptr_t)
@@ -285,7 +282,8 @@ class UArrayArg(object):
 
 
 class _GufuncWrapper(object):
-    def __init__(self, library, context, func, signature, sin, sout, fndesc):
+    def __init__(self, library, context, func, signature, sin, sout, fndesc,
+                 env):
         self.library = library
         self.context = context
         self.func = func
@@ -294,11 +292,9 @@ class _GufuncWrapper(object):
         self.sout = sout
         self.fndesc = fndesc
         self.is_objectmode = self.signature.return_type == types.pyobject
-        self.env = None
+        self.env = env
 
     def build(self):
-        module = self.func.module
-
         byte_t = Type.int(8)
         byte_ptr_t = Type.pointer(byte_t)
         byte_ptr_ptr_t = Type.pointer(byte_ptr_t)
@@ -409,10 +405,7 @@ class _GufuncObjectWrapper(_GufuncWrapper):
         return innercall, error
 
     def gen_prologue(self, builder):
-        # Create an environment object for the function
-        moduledict = self.fndesc.lookup_module().__dict__
-        self.env = _dynfunc.Environment(globals=moduledict)
-
+        #  Get an environment object for the function
         ll_intp = self.context.get_value_type(types.intp)
         ll_pyobj = self.context.get_value_type(types.pyobject)
         self.envptr = Constant.int(ll_intp, id(self.env)).inttoptr(ll_pyobj)
@@ -426,11 +419,13 @@ class _GufuncObjectWrapper(_GufuncWrapper):
         self.pyapi.gil_release(self.gil)
 
 
-def build_gufunc_wrapper(library, context, func, signature, sin, sout, fndesc):
+def build_gufunc_wrapper(library, context, func, signature, sin, sout, fndesc,
+                         env):
     wrapcls = (_GufuncObjectWrapper
                if signature.return_type == types.pyobject
                else _GufuncWrapper)
-    return wrapcls(library, context, func, signature, sin, sout, fndesc).build()
+    return wrapcls(library, context, func, signature, sin, sout, fndesc,
+                   env).build()
 
 
 def _prepare_call_to_object_mode(context, builder, func, signature, args,

--- a/numba/objmode.py
+++ b/numba/objmode.py
@@ -41,6 +41,9 @@ class PyLower(BaseLower):
         # Add error handling block
         self.ehblock = self.function.append_basic_block('error')
 
+        # Strings to be frozen into the Environment object
+        self._frozen_string = set()
+
     def pre_lower(self):
         # Store environment argument for later use
         self.envarg = self.context.get_env_argument(self.function)
@@ -56,6 +59,8 @@ class PyLower(BaseLower):
         with cgutils.goto_block(self.builder, self.ehblock):
             self.cleanup()
             self.context.return_exc(self.builder)
+
+        self._finalize_frozen_string()
 
     def init_argument(self, arg):
         self.incref(arg)
@@ -76,12 +81,15 @@ class PyLower(BaseLower):
         elif isinstance(inst, ir.SetAttr):
             target = self.loadvar(inst.target.name)
             value = self.loadvar(inst.value.name)
-            ok = self.pyapi.object_setattr_string(target, inst.attr, value)
+            ok = self.pyapi.object_setattr(target,
+                                           self._freeze_string(inst.attr),
+                                           value)
             self.check_int_status(ok)
 
         elif isinstance(inst, ir.DelAttr):
             target = self.loadvar(inst.target.name)
-            ok = self.pyapi.object_delattr_string(target, inst.attr)
+            ok = self.pyapi.object_delattr(target,
+                                           self._freeze_string(inst.attr))
             self.check_int_status(ok)
 
         elif isinstance(inst, ir.StoreMap):
@@ -195,7 +203,7 @@ class PyLower(BaseLower):
             return ret
         elif expr.op == 'getattr':
             obj = self.loadvar(expr.value.name)
-            res = self.pyapi.object_getattr_string(obj, expr.attr)
+            res = self.pyapi.object_getattr(obj, self._freeze_string(expr.attr))
             self.check_error(res)
             return res
         elif expr.op == 'build_tuple':
@@ -318,7 +326,7 @@ class PyLower(BaseLower):
             2b) is it a module (for __main__ module)
         """
         moddict = self.get_module_dict()
-        obj = self.pyapi.dict_getitem_string(moddict, name)
+        obj = self.pyapi.dict_getitem(moddict, self._freeze_string(name))
         self.incref(obj)  # obj is borrowed
 
         try:
@@ -334,7 +342,8 @@ class PyLower(BaseLower):
             bbelse = self.builder.basic_block
 
             with cgutils.ifthen(self.builder, obj_is_null):
-                mod = self.pyapi.dict_getitem_string(moddict, "__builtins__")
+                mod = self.pyapi.dict_getitem(moddict,
+                                          self._freeze_string("__builtins__"))
                 builtin = self.builtin_lookup(mod, name)
                 bbif = self.builder.basic_block
 
@@ -358,7 +367,8 @@ class PyLower(BaseLower):
     def get_builtin_obj(self, name):
         # XXX The builtins dict could be bound into the environment
         moddict = self.get_module_dict()
-        mod = self.pyapi.dict_getitem_string(moddict, "__builtins__")
+        mod = self.pyapi.dict_getitem(moddict,
+                                      self._freeze_string("__builtins__"))
         return self.builtin_lookup(mod, name)
 
     def get_env_const(self, index):
@@ -378,13 +388,13 @@ class PyLower(BaseLower):
         name: str
             The object to lookup
         """
-        fromdict = self.pyapi.dict_getitem_string(mod, name)
+        fromdict = self.pyapi.dict_getitem(mod, self._freeze_string(name))
         self.incref(fromdict)       # fromdict is borrowed
         bbifdict = self.builder.basic_block
 
         with cgutils.if_unlikely(self.builder, self.is_null(fromdict)):
             # This happen if we are using the __main__ module
-            frommod = self.pyapi.object_getattr_string(mod, name)
+            frommod = self.pyapi.object_getattr(mod, self._freeze_string(name))
 
             with cgutils.if_unlikely(self.builder, self.is_null(frommod)):
                 self.pyapi.raise_missing_global_error(name)
@@ -503,3 +513,17 @@ class PyLower(BaseLower):
                 pass
             else:
                 self.pyapi.decref(value)
+
+    def _freeze_string(self, string):
+        """Freeze a python string object into the code.
+        Insert a reference to the Environment object later.
+        """
+        self._frozen_string.add(string)
+        return self.context.get_constant(types.intp, id(string)).inttoptr(
+            self.pyapi.pyobj)
+
+    def _finalize_frozen_string(self):
+        """Insert all referenced string into the Environment object.
+        """
+        for fs in self._frozen_string:
+            self.env.consts.append(fs)

--- a/numba/objmode.py
+++ b/numba/objmode.py
@@ -42,7 +42,7 @@ class PyLower(BaseLower):
         self.ehblock = self.function.append_basic_block('error')
 
         # Strings to be frozen into the Environment object
-        self._frozen_string = set()
+        self._frozen_strings = set()
 
     def pre_lower(self):
         # Store environment argument for later use
@@ -518,12 +518,12 @@ class PyLower(BaseLower):
         """Freeze a python string object into the code.
         Insert a reference to the Environment object later.
         """
-        self._frozen_string.add(string)
+        self._frozen_strings.add(string)
         return self.context.get_constant(types.intp, id(string)).inttoptr(
             self.pyapi.pyobj)
 
     def _finalize_frozen_string(self):
         """Insert all referenced string into the Environment object.
         """
-        for fs in self._frozen_string:
+        for fs in self._frozen_strings:
             self.env.consts.append(fs)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -180,6 +180,13 @@ class PythonAPI(object):
         cstr = self.context.insert_const_string(self.module, name)
         return self.builder.call(fn, [dic, cstr])
 
+    def dict_getitem(self, dic, name):
+        """Returns a borrowed reference
+        """
+        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fn = self._get_function(fnty, name="PyDict_GetItem")
+        return self.builder.call(fn, [dic, name])
+
     def dict_new(self, presize=0):
         if presize == 0:
             fnty = Type.function(self.pyobj, ())
@@ -617,16 +624,31 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name="PyObject_GetAttrString")
         return self.builder.call(fn, [obj, cstr])
 
+    def object_getattr(self, obj, attr):
+        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fn = self._get_function(fnty, name="PyObject_GetAttr")
+        return self.builder.call(fn, [obj, attr])
+
     def object_setattr_string(self, obj, attr, val):
         cstr = self.context.insert_const_string(self.module, attr)
         fnty = Type.function(Type.int(), [self.pyobj, self.cstring, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_SetAttrString")
         return self.builder.call(fn, [obj, cstr, val])
 
+    def object_setattr(self, obj, attr, val):
+        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj, self.pyobj])
+        fn = self._get_function(fnty, name="PyObject_SetAttr")
+        return self.builder.call(fn, [obj, attr, val])
+
     def object_delattr_string(self, obj, attr):
         # PyObject_DelAttrString() is actually a C macro calling
         # PyObject_SetAttrString() with value == NULL.
         return self.object_setattr_string(obj, attr, self.get_null_object())
+
+    def object_delattr(self, obj, attr):
+        # PyObject_DelAttrString() is actually a C macro calling
+        # PyObject_SetAttrString() with value == NULL.
+        return self.object_setattr(obj, attr, self.get_null_object())
 
     def object_getitem(self, obj, key):
         fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -173,7 +173,9 @@ class PythonAPI(object):
     #
 
     def dict_getitem_string(self, dic, name):
-        """Returns a borrowed reference
+        """Lookup name inside dict
+
+        Returns a borrowed reference
         """
         fnty = Type.function(self.pyobj, [self.pyobj, self.cstring])
         fn = self._get_function(fnty, name="PyDict_GetItemString")
@@ -181,7 +183,9 @@ class PythonAPI(object):
         return self.builder.call(fn, [dic, cstr])
 
     def dict_getitem(self, dic, name):
-        """Returns a borrowed reference
+        """Lookup name inside dict
+
+        Returns a borrowed reference
         """
         fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyDict_GetItem")
@@ -646,8 +650,8 @@ class PythonAPI(object):
         return self.object_setattr_string(obj, attr, self.get_null_object())
 
     def object_delattr(self, obj, attr):
-        # PyObject_DelAttrString() is actually a C macro calling
-        # PyObject_SetAttrString() with value == NULL.
+        # PyObject_DelAttr() is actually a C macro calling
+        # PyObject_SetAttr() with value == NULL.
         return self.object_setattr(obj, attr, self.get_null_object())
 
     def object_getitem(self, obj, key):


### PR DESCRIPTION
* Keep reference to constant python objects in Environment;
* Avoid Py*_*String API

And, small refactor to numba.compiler.lowering* to return namedtuples for clarity.