### PR TITLE
Fix #953

### DIFF
--- a/numba/cuda/tests/cudapy/test_sm.py
+++ b/numba/cuda/tests/cudapy/test_sm.py
@@ -1,0 +1,21 @@
+from numba import cuda, int32
+
+from numba.cuda.testing import unittest
+
+
+class TestSharedMemoryIssue(unittest.TestCase):
+    def test_issue_953_sm_linkage_conflict(self):
+        @cuda.jit(device=True)
+        def inner():
+            inner_arr = cuda.shared.array(1, dtype=int32)
+
+        @cuda.jit
+        def outer():
+            outer_arr = cuda.shared.array(1, dtype=int32)
+            inner()
+
+        outer()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
by generating unique shared memory symbol
(This is a workaround for a NVVM bug)