### PR TITLE
Remove float indexing

### DIFF
--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -43,6 +43,11 @@ def bad_index(arr, arr2d):
     y = arr.y
     arr2d[x, y] = 1.0
 
+def bad_float_index(arr):
+    # 2D index required for this function because 1D index
+    # fails typing
+    return arr[1, 2.0]
+
 class TestArrayManipulation(TestCase):
 
     def test_reshape_array(self, flags=enable_pyobj_flags):
@@ -175,13 +180,20 @@ class TestArrayManipulation(TestCase):
 
     def test_bad_index_npm(self):
         with self.assertTypingError() as raises:
-            pyfunc = bad_index
             arraytype1 = from_dtype(np.dtype([('x', np.int32),
                                               ('y', np.int32)]))
             arraytype2 = types.Array(types.int32, 2, 'C')
             compile_isolated(bad_index, (arraytype1, arraytype2),
                              flags=no_pyobj_flags)
         self.assertIn('is unsupported for indexing', str(raises.exception))
+
+    def test_bad_float_index_npm(self):
+        with self.assertTypingError() as raises:
+            compile_isolated(bad_float_index,
+                             (types.Array(types.float64, 2, 'C'),))
+        self.assertIn('Type float', str(raises.exception))
+        self.assertIn('is unsupported for indexing', str(raises.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -533,9 +533,6 @@ class TestIndexing(TestCase):
         self.assertEqual(pyfunc(a, 9, 9), cfunc(a, 9, 9))
         self.assertEqual(pyfunc(a, -1, -1), cfunc(a, -1, -1))
 
-    def test_2d_float_indexing_npm(self):
-        self.test_2d_float_indexing(flags=Noflags)
-
     def test_ellipse(self, flags=enable_pyobj_flags):
         pyfunc = ellipse_usecase
         arraytype = types.Array(types.int32, 2, 'C')

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -361,9 +361,7 @@ def normalize_index(index):
 
     elif isinstance(index, types.Tuple):
         for ty in index:
-            if (ty not in types.integer_domain and
-                        ty not in types.real_domain and
-                        ty != types.slice3_type):
+            if (ty not in types.integer_domain and ty != types.slice3_type):
                 raise TypeError('Type %s of index %s is unsupported for indexing'
                                  % (ty, index))
         return index


### PR DESCRIPTION
Some discussion in #792 and #906.

- Removal of support for float indexing no nopython mode, and of the associated test.
- Addition of a test of the error message when a float index is used in a tuple in nopython mode
- Note that this error message is not produced when all indices are floats, because in that case the function just fails typing.