### PR TITLE
Fix numpy int constructors on 32-bit builds

### DIFF
--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -37,6 +37,10 @@ def caster(restype, constructor):
 for tp in types.number_domain:
     register(caster(tp, getattr(numpy, str(tp))))
 
+register(caster(types.intc, numpy.intc))
+register(caster(types.uintc, numpy.uintc))
+register(caster(types.intp, numpy.intp))
+register(caster(types.uintp, numpy.uintp))
 
 ########################################################################
 

--- a/numba/tests/serialize_usecases.py
+++ b/numba/tests/serialize_usecases.py
@@ -76,7 +76,7 @@ def _get_dyn_func(**jit_args):
         def dyn_func(x):
             res = 0
             for i in range(x):
-                res += i
+                res += x
             return res
         """
     ns = {}

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -84,11 +84,11 @@ class TestDispatcherPickling(TestCase):
 
     def test_call_dyn_func(self):
         # Check serializing a dynamically-created function
-        self.run_with_protocols(self.check_call, dyn_func, 6, (4,))
+        self.run_with_protocols(self.check_call, dyn_func, 36, (6,))
 
     def test_call_dyn_func_objmode(self):
         # Same with an object mode function
-        self.run_with_protocols(self.check_call, dyn_func_objmode, 6, (4,))
+        self.run_with_protocols(self.check_call, dyn_func_objmode, 36, (6,))
 
     def test_other_process(self):
         """

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -245,8 +245,15 @@ for func in ['argmin', 'argmax']:
 # Numpy scalar constructors
 
 # Register numpy.int8, etc. as convertors to the equivalent Numba types
-for nb_type in types.number_domain:
-    np_type = getattr(numpy, str(nb_type))
+np_types = set(getattr(numpy, str(nb_type)) for nb_type in types.number_domain)
+# Those may or may not be aliases (depending on the Numpy build / version)
+np_types.add(numpy.intc)
+np_types.add(numpy.intp)
+np_types.add(numpy.uintc)
+np_types.add(numpy.uintp)
+
+for np_type in np_types:
+    nb_type = getattr(types, np_type.__name__)
 
     class Caster(AbstractTemplate):
         key = np_type


### PR DESCRIPTION
Also, workaround #969.