### PR TITLE
WIP: Data model refactor

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -149,7 +149,6 @@ class Structure(object):
 
     # XXX Should this warrant several separate constructors?
     def __init__(self, context, builder, value=None, ref=None, cast_ref=False):
-        # raise NotImplementedError
         self._type = context.get_struct_type(self)
         self._context = context
         self._builder = builder
@@ -216,17 +215,11 @@ class Structure(object):
         Store the LLVM *value* into the field at *index*.
         """
         ptr = self._get_ptr_by_index(index)
-        # value = self._context.get_value_as_data(self._builder,
-        #                                         self._typemap[index],
-        #                                         value)
         if ptr.type.pointee != value.type:
-            print(self._typemap[index])
-            print(value)
-            print(self._value)
-            raise AssertionError("Type mismatch: __setitem__(%d, ...) "
-                                 "expected %r but got %r"
-                                 % (
-            index, str(ptr.type.pointee), str(value.type)))
+            fmt = "Type mismatch: __setitem__(%d, ...) expected %r but got %r"
+            raise AssertionError(fmt % (index,
+                                        str(ptr.type.pointee),
+                                        str(value.type)))
         self._builder.store(value, ptr)
 
     def __len__(self):
@@ -253,7 +246,7 @@ class Structure(object):
         assert value.type == self._type, (value.type, self._type)
         self._builder.store(value, self._value)
 
-        # __iter__ is derived by Python from __len__ and __getitem__
+    # __iter__ is derived by Python from __len__ and __getitem__
 
 
 def get_function(builder):
@@ -699,25 +692,6 @@ def get_record_member(builder, record, offset, typ):
     pval = inbound_gep(builder, record, 0, offset)
     assert not is_pointer(pval.type.pointee)
     return builder.bitcast(pval, Type.pointer(typ))
-
-
-def get_record_data(builder, record):
-    raise NotImplementedError
-    # return record #return builder.extract_value(record, 0)
-
-
-def set_record_data(builder, record, buf):
-    raise NotImplementedError
-
-    casted = builder.bitcast(buf, record.type.pointee)
-    builder.store(casted, record)
-
-
-def init_record_by_ptr(builder, ltyp, ptr):
-    raise NotImplementedError
-    tmp = alloca_once(builder, ltyp)
-    set_record_data(builder, tmp, ptr)
-    return builder.load(tmp)
 
 
 def is_neg_int(builder, val):

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -585,28 +585,28 @@ def is_struct_ptr(ltyp):
 
 
 def get_record_member(builder, record, offset, typ):
-    pdata = get_record_data(builder, record)
-    pval = inbound_gep(builder, pdata, 0, offset)
+    pval = inbound_gep(builder, record, 0, offset)
     assert not is_pointer(pval.type.pointee)
     return builder.bitcast(pval, Type.pointer(typ))
 
 
 def get_record_data(builder, record):
-    return builder.extract_value(record, 0)
+    raise NotImplementedError
+    # return record #return builder.extract_value(record, 0)
 
 
 def set_record_data(builder, record, buf):
-    pdata = inbound_gep(builder, record, 0, 0)
-    assert pdata.type.pointee == buf.type
-    builder.store(buf, pdata)
+    raise NotImplementedError
+
+    casted = builder.bitcast(buf, record.type.pointee)
+    builder.store(casted, record)
 
 
 def init_record_by_ptr(builder, ltyp, ptr):
+    raise NotImplementedError
     tmp = alloca_once(builder, ltyp)
-    pdata = ltyp.elements[0]
-    buf = builder.bitcast(ptr, pdata)
-    set_record_data(builder, tmp, buf)
-    return tmp
+    set_record_data(builder, tmp, ptr)
+    return builder.load(tmp)
 
 
 def is_neg_int(builder, val):

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -75,9 +75,6 @@ class StructProxy(object):
             if value is not None:
                 self._builder.store(value, self._value)
 
-
-
-
     def _get_ptr_by_index(self, index):
         geped = self._builder.gep(self._value,
                                   [Constant.int(Type.int(), 0),
@@ -219,10 +216,13 @@ class Structure(object):
         Store the LLVM *value* into the field at *index*.
         """
         ptr = self._get_ptr_by_index(index)
-        value = self._context.get_value_as_data(self._builder,
-                                                self._typemap[index],
-                                                value)
+        # value = self._context.get_value_as_data(self._builder,
+        #                                         self._typemap[index],
+        #                                         value)
         if ptr.type.pointee != value.type:
+            print(self._typemap[index])
+            print(value)
+            print(self._value)
             raise AssertionError("Type mismatch: __setitem__(%d, ...) "
                                  "expected %r but got %r"
                                  % (

--- a/numba/datamodel.py
+++ b/numba/datamodel.py
@@ -139,6 +139,7 @@ def handle_boolean(dmm, ty):
 @register_default(types.NoneType)
 @register_default(types.Function)
 @register_default(types.Type)
+@register_default(types.Object)
 def handle_opaque(dmm, ty):
     return OpaqueModel(dmm, ty)
 

--- a/numba/datamodel.py
+++ b/numba/datamodel.py
@@ -205,6 +205,11 @@ def handle_numpy_flat_type(dmm, ty):
         return FlatIter(dmm, ty)
 
 
+@register_default(types.UniTupleIter)
+def handle_unitupleiter(dmm, ty):
+    return UniTupleIter(dmm, ty)
+
+
 # ============== Define Data Models ==============
 
 class DataModel(object):
@@ -516,7 +521,7 @@ class StructModel(DataModel):
                                                    self.get(builder, value, i)))
         return tuple(extracted)
 
-    def _reverse_as(self, methname, builder, value):
+    def _from(self, methname, builder, value):
         assert len(value) == len(self._models)
         struct = ir.Constant(self.get_value_type(), ir.Undefined)
 
@@ -536,13 +541,13 @@ class StructModel(DataModel):
     def from_data(self, builder, value):
         vals = [builder.extract_value(value, [i])
                 for i in range(len(self._members))]
-        return self._reverse_as("from_data", builder, vals)
+        return self._from("from_data", builder, vals)
 
     def as_argument(self, builder, value):
         return self._as("as_argument", builder, value)
 
     def from_argument(self, builder, value):
-        return self._reverse_as("from_argument", builder, value)
+        return self._from("from_argument", builder, value)
 
     def as_return(self, builder, value):
         elems = self._as("as_data", builder, value)
@@ -554,7 +559,7 @@ class StructModel(DataModel):
     def from_return(self, builder, value):
         vals = [builder.extract_value(value, [i])
                 for i in range(len(self._members))]
-        return self._reverse_as("from_data", builder, vals)
+        return self._from("from_data", builder, vals)
 
     def get(self, builder, val, pos):
         if isinstance(pos, str):
@@ -699,3 +704,10 @@ class FlatIter(StructModel):
                    ('exhausted', types.CPointer(types.boolean)),
         ]
         super(FlatIter, self).__init__(dmm, fe_type, members)
+
+
+class UniTupleIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('index', types.CPointer(types.intp)),
+                   ('tuple', fe_type.unituple,)]
+        super(UniTupleIter, self).__init__(dmm, fe_type, members)

--- a/numba/datamodel.py
+++ b/numba/datamodel.py
@@ -57,6 +57,10 @@ class FunctionInfo(object):
 
         return values
 
+    @property
+    def argument_types(self):
+        return tuple(self._be_args)
+
 
 def _unflatten(posmap, flatiter):
     if 0 == len(posmap):

--- a/numba/datamodel.py
+++ b/numba/datamodel.py
@@ -1,0 +1,448 @@
+from __future__ import print_function, absolute_import
+
+import functools
+from collections import deque
+from llvmlite import ir
+from numba import types
+
+
+class DataModelManager(object):
+    """Manages mapping of FE types to their corresponding data model
+    """
+
+    def __init__(self):
+        # handler map
+        # key: numba.types.Type subclass
+        # value: function
+        self._handlers = {}
+
+    def register(self, fetypecls, handler):
+        assert issubclass(fetypecls, types.Type)
+        self._handlers[fetypecls] = handler
+
+    def lookup(self, fetype):
+        handler = self._handlers[type(fetype)]
+        return handler(self, fetype)
+
+
+class FunctionInfo(object):
+    def __init__(self, dmm, fe_ret, fe_args):
+        self._dmm = dmm
+        self._fe_ret = fe_ret
+        self._fe_args = fe_args
+        self._nargs = len(fe_args)
+        self._dm_ret = self._dmm.lookup(fe_ret)
+        self._dm_args = [self._dmm.lookup(ty) for ty in fe_args]
+        argtys = [bt.get_argument_type() for bt in self._dm_args]
+        self._be_args, self._posmap = zip(*_flatten(argtys))
+
+    def as_arguments(self, builder, values):
+        if len(values) != self._nargs:
+            raise TypeError("invalid number of args")
+
+        args = [dm.as_argument(builder, val)
+                for dm, val in zip(self._dm_args, values)]
+
+        args, _ = zip(*_flatten(args))
+        return args
+
+    def reverse_as_arguments(self, builder, args):
+        if len(args) != len(self._posmap):
+            raise TypeError("invalid number of args")
+
+        valtree = _unflatten(self._posmap, args)
+
+        values = [dm.reverse_as_argument(builder, val)
+                  for dm, val in zip(self._dm_args, valtree)]
+
+        return values
+
+
+def _unflatten(posmap, flatiter):
+    if 0 == len(posmap):
+        raise StopIteration
+
+    poss = deque(posmap)
+    vals = deque(flatiter)
+
+    assert len(vals) == len(poss)
+
+    depth = len(poss[0])
+    last = None
+    while poss:
+        cur = poss[0]
+        # Depth increased
+        if len(cur) > depth:
+            ret = tuple(_unflatten(poss, vals))
+            yield ret
+            # skip processed data in the recursive call
+            for _ in range(len(ret)):
+                vals.popleft()
+                poss.popleft()
+        # Depth decreased
+        elif len(cur) < depth:
+            raise StopIteration
+        # Depth unchanged but new sequence
+        elif last is not None and last[:-1] != cur[:-1]:
+            raise StopIteration
+        # Depth unchanged and continue sequence
+        else:
+            yield vals.popleft()
+            last = poss.popleft()
+
+
+def _flatten(iterable, indices=(0,)):
+    """
+    Flatten nested iterable of (tuple, list) with position information
+    """
+    for i in iterable:
+        if isinstance(i, (tuple, list)):
+            inner = indices + (0,)
+            for j, k in _flatten(i, indices=inner):
+                yield j, k
+        else:
+            yield i, indices
+        indices = indices[:-1] + (indices[-1] + 1,)
+
+
+def register(dmm, typecls):
+    def wraps(fn):
+        dmm.register(typecls, fn)
+        return fn
+
+    return wraps
+
+
+defaultDataModelManager = DataModelManager()
+
+register_default = functools.partial(register, defaultDataModelManager)
+
+
+@register_default(types.Integer)
+def handle_integers(dmm, ty):
+    return IntegerModel(dmm, ty)
+
+
+@register_default(types.Float)
+def handle_floats(dmm, ty):
+    if ty == types.float32:
+        return FloatModel(dmm)
+    elif ty == types.float64:
+        return DoubleModel(dmm)
+    else:
+        raise NotImplementedError(ty)
+
+
+@register_default(types.Complex)
+def handle_complex_numbers(dmm, ty):
+    if ty == types.complex64:
+        return ComplexModel(dmm)
+    elif ty == types.complex128:
+        return DoubleComplexModel(dmm)
+    else:
+        raise NotImplementedError(ty)
+
+
+@register_default(types.CPointer)
+def handle_pointer(dmm, ty):
+    return PointerModel(dmm, ty)
+
+
+@register_default(types.UniTuple)
+def handle_unituple(dmm, ty):
+    return UniTupleModel(dmm, ty)
+
+
+@register_default(types.Array)
+def handle_array(dmm, ty):
+    return ArrayModel(dmm, ty)
+
+
+# ============== Define Data Models ==============
+
+class DataModel(object):
+    def __init__(self, dmm):
+        self._dmm = dmm
+
+    def get_value_type(self):
+        raise NotImplementedError
+
+    def get_data_type(self):
+        return self.get_value_type()
+
+    def get_argument_type(self):
+        return self.get_value_type()
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def as_data(self, builder, value):
+        return NotImplemented
+
+    def as_argument(self, builder, value):
+        return NotImplemented
+
+    def as_return(self, builder, value):
+        return NotImplemented
+
+    def reverse_as_data(self, builder, value):
+        return NotImplemented
+
+    def reverse_as_argument(self, builder, value):
+        return NotImplemented
+
+    def reverse_as_return(self, builder, value):
+        return NotImplemented
+
+    def _compared_fields(self):
+        """
+        The default comparison uses the type(self).
+        So any instance of the same type is equal.
+        """
+        return (type(self),)
+
+    def __hash__(self):
+        return hash(tuple(self._compared_fields()))
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self._compared_fields() == other._compared_fields()
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    # ===== Helpers =====
+
+    def data_to_argument(self, builder, value):
+        return self.as_argument(builder, self.reverse_as_data(builder, value))
+
+    def argument_to_data(self, builder, value):
+        return self.as_data(builder, self.reverse_as_argument(builder, value))
+
+
+class PrimitiveModel(DataModel):
+    """A primitive type can be represented natively in the target in all
+    usage contexts.
+    """
+
+    def __init__(self, dmm, be_type):
+        super(PrimitiveModel, self).__init__(dmm)
+        self.be_type = be_type
+
+    def get_value_type(self):
+        return self.be_type
+
+    def as_data(self, builder, value):
+        return value
+
+    def as_argument(self, builder, value):
+        return self.as_data(builder, value)
+
+    def as_return(self, builder, value):
+        return self.as_data(builder, value)
+
+    def reverse_as_data(self, builder, value):
+        return value
+
+    def reverse_as_argument(self, builder, value):
+        return self.reverse_as_data(builder, value)
+
+    def reverse_as_return(self, builder, value):
+        return self.reverse_as_data(builder, value)
+
+    def _compared_fields(self):
+        return (self.be_type,)
+
+
+class IntegerModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        self.fe_type = fe_type
+        self.signed = fe_type.signed
+        be_type = ir.IntType(self.fe_type.bitwidth)
+        super(IntegerModel, self).__init__(dmm, be_type)
+
+    def _compared_fields(self):
+        return self.be_type, self.signed
+
+
+class FloatModel(PrimitiveModel):
+    def __init__(self, dmm):
+        super(FloatModel, self).__init__(dmm, ir.FloatType())
+
+
+class DoubleModel(PrimitiveModel):
+    def __init__(self, dmm):
+        super(DoubleModel, self).__init__(dmm, ir.DoubleType())
+
+
+class BaseComplexModel(DataModel):
+    _element_type = NotImplemented
+
+    def __init__(self, dmm):
+        super(BaseComplexModel, self).__init__(dmm)
+        self._element_model = self._dmm.lookup(self._element_type)
+
+    def get_value_type(self):
+        elem = self._element_model.get_data_type()
+        return ir.LiteralStructType([elem] * 2)
+
+    def get_argument_type(self):
+        elem = self._element_model.get_data_type()
+        return tuple([elem] * 2)
+
+    def as_argument(self, builder, value):
+        real = builder.extract_value(value, [0])
+        imag = builder.extract_value(value, [1])
+
+        real = self._element_model.data_to_argument(builder, real)
+        imag = self._element_model.data_to_argument(builder, imag)
+
+        return real, imag
+
+    def reverse_as_argument(self, builder, value):
+        real, imag = value
+        real = self._element_model.argument_to_data(builder, real)
+        imag = self._element_model.argument_to_data(builder, imag)
+        valty = self.get_value_type()
+        val = ir.Constant(valty, ir.Undefined)
+        val = builder.insert_value(val, real, [0])
+        val = builder.insert_value(val, imag, [1])
+        return val
+
+    def as_return(self, builder, value):
+        return value
+
+    def reverse_as_return(self, builder, value):
+        return value
+
+    def as_data(self, builder, value):
+        return value
+
+    def reverse_as_data(self, builder, value):
+        return value
+
+
+class ComplexModel(BaseComplexModel):
+    _element_type = types.float32
+
+
+class DoubleComplexModel(BaseComplexModel):
+    _element_type = types.float64
+
+
+class PointerModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        be_type = dmm.lookup(fe_type.dtype).get_data_type().as_pointer()
+        super(PointerModel, self).__init__(dmm, be_type)
+
+
+class UniTupleModel(DataModel):
+    def __init__(self, dmm, fe_type):
+        self._elem_model = dmm.lookup(fe_type.dtype)
+        self._count = len(fe_type)
+
+    def get_value_type(self):
+        elem_type = self._elem_model.get_value_type()
+        return ir.ArrayType(elem_type, self._count)
+
+    def get_data_type(self):
+        elem_type = self._elem_model.get_data_type()
+        return ir.ArrayType(elem_type, self._count)
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def get_argument_type(self):
+        return [self._elem_model.get_argument_type()] * self._count
+
+    def as_argument(self, builder, value):
+        out = []
+        for i in range(self._count):
+            out.append(builder.extract_value(value, [i]))
+        return out
+
+    def reverse_as_argument(self, builder, value):
+        out = ir.Constant(self.get_value_type(), ir.Undefined)
+        for i, v in enumerate(value):
+            out = builder.insert_value(out, v, [i])
+        return out
+
+    def as_data(self, builder, value):
+        out = ir.Constant(self.get_data_type(), ir.Undefined)
+        for i in range(self._count):
+            val = builder.extract_value(value, [i])
+            dval = self._elem_model.as_data(builder, val)
+            out = builder.insert_value(out, dval, [i])
+        return out
+
+    def reverse_as_data(self, builder, value):
+        out = ir.Constant(self.get_value_type(), ir.Undefined)
+        for i in range(self._count):
+            val = builder.extract_value(value, [i])
+            dval = self._elem_model.reverse_as_data(builder, val)
+            out = builder.insert_value(out, dval, [i])
+        return out
+
+    def as_return(self, builder, value):
+        return value
+
+    def reverse_as_return(self, builder, value):
+        return value
+
+
+class ArrayModel(DataModel):
+    def __init__(self, dmm, fe_type):
+        super(ArrayModel, self).__init__(dmm)
+        self.fe_type = fe_type
+        self._ndim = self.fe_type.ndim
+        self._dataptr_model = self._dmm.lookup(types.CPointer(fe_type.dtype))
+        self._shape_model = self._dmm.lookup(types.UniTuple(types.intp,
+                                                            self._ndim))
+        self._strides_model = self._shape_model
+
+    def get_value_type(self):
+        elems = [
+            self._dataptr_model.get_data_type(),
+            self._shape_model.get_data_type(),
+            self._strides_model.get_data_type(),
+        ]
+        return ir.LiteralStructType(elems)
+
+    def get_argument_type(self):
+        return (self._dataptr_model.get_argument_type(),
+                self._shape_model.get_argument_type(),
+                self._strides_model.get_argument_type(),)
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def as_argument(self, builder, value):
+        data = builder.extract_value(value, [0])
+        shapes = builder.extract_value(value, [1])
+        strides = builder.extract_value(value, [2])
+        data = self._dataptr_model.data_to_argument(builder, data)
+        shapes = self._shape_model.data_to_argument(builder, shapes)
+        strides = self._shape_model.data_to_argument(builder, strides)
+        return data, shapes, strides
+
+    def reverse_as_argument(self, builder, value):
+        data, shapes, strides = value
+
+        data = self._dataptr_model.argument_to_data(builder, data)
+        shapes = self._shape_model.argument_to_data(builder, shapes)
+        strides = self._shape_model.argument_to_data(builder, strides)
+
+        val = ir.Constant(self.get_value_type(), ir.Undefined)
+        val = builder.insert_value(val, data, [0])
+        val = builder.insert_value(val, shapes, [1])
+        val = builder.insert_value(val, strides, [2])
+        return val
+
+    def as_return(self, builder, value):
+        return value
+
+    def reverse_as_return(self, builder, value):
+        return value
+

--- a/numba/datamodel.py
+++ b/numba/datamodel.py
@@ -660,3 +660,29 @@ class UnicodeCharSeq(DataModel):
 
     def get_data_type(self):
         return self._be_type
+
+
+class CConitugousFlatIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        assert fe_type.array_type.layout == 'C'
+        array_type = fe_type.array_type
+        dtype = array_type.dtype
+        members = [('array', types.CPointer(array_type)),
+                   ('stride', types.intp),
+                   ('pointer', types.CPointer(types.CPointer(dtype))),
+                   ('index', types.CPointer(types.intp)),
+                   ('indices', types.CPointer(types.intp)),
+        ]
+        super(CConitugousFlatIter, self).__init__(dmm, fe_type, members)
+
+
+class FlatIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        array_type = fe_type.array_type
+        dtype = array_type.dtype
+        members = [('array', types.CPointer(array_type)),
+                   ('pointers', types.CPointer(types.CPointer(dtype))),
+                   ('indices', types.CPointer(types.intp)),
+                   ('exhausted', types.CPointer(types.boolean)),
+        ]
+        super(FlatIter, self).__init__(dmm, fe_type, members)

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,4 +1,4 @@
 from .manager import DataModelManager
 from .funcinfo import FunctionInfo
-from .registry import *
-from .models import *
+from .registry import register_default, defaultDataModelManager, register
+from .models import PrimitiveModel, CompositeModel, StructModel

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,0 +1,4 @@
+from .manager import DataModelManager
+from .funcinfo import FunctionInfo
+from .registry import *
+from .models import *

--- a/numba/datamodel/funcinfo.py
+++ b/numba/datamodel/funcinfo.py
@@ -1,0 +1,88 @@
+from __future__ import print_function, absolute_import
+
+from collections import deque
+
+
+class FunctionInfo(object):
+    def __init__(self, dmm, fe_ret, fe_args):
+        self._dmm = dmm
+        self._fe_ret = fe_ret
+        self._fe_args = fe_args
+        self._nargs = len(fe_args)
+        self._dm_ret = self._dmm.lookup(fe_ret)
+        self._dm_args = [self._dmm.lookup(ty) for ty in fe_args]
+        argtys = [bt.get_argument_type() for bt in self._dm_args]
+        if len(argtys):
+            self._be_args, self._posmap = zip(*_flatten(argtys))
+        else:
+            self._be_args = self._posmap = ()
+        self._be_ret = self._dm_ret.get_return_type()
+
+    def as_arguments(self, builder, values):
+        if len(values) != self._nargs:
+            raise TypeError("invalid number of args")
+
+        if not values:
+            return ()
+
+        args = [dm.as_argument(builder, val)
+                for dm, val in zip(self._dm_args, values)]
+
+        args, _ = zip(*_flatten(args))
+        return args
+
+    def from_arguments(self, builder, args):
+        if len(args) != len(self._posmap):
+            raise TypeError("invalid number of args")
+
+        if not args:
+            return ()
+
+        valtree = _unflatten(self._posmap, args)
+        values = [dm.from_argument(builder, val)
+                  for dm, val in zip(self._dm_args, valtree)]
+
+        return values
+
+    @property
+    def argument_types(self):
+        return tuple(self._be_args)
+
+    @property
+    def return_type(self):
+        return self._be_ret
+
+
+def _unflatten(posmap, flatiter):
+    poss = deque(posmap)
+    vals = deque(flatiter)
+
+    res = []
+    while poss:
+        assert len(poss) == len(vals)
+        cur = poss.popleft()
+        ptr = res
+        for loc in cur[:-1]:
+            if loc >= len(ptr):
+                ptr.append([])
+            ptr = ptr[loc]
+
+        assert len(ptr) == cur[-1]
+        ptr.append(vals.popleft())
+
+    return res
+
+
+def _flatten(iterable, indices=(0,)):
+    """
+    Flatten nested iterable of (tuple, list) with position information
+    """
+    for i in iterable:
+        if isinstance(i, (tuple, list)):
+            inner = indices + (0,)
+            for j, k in _flatten(i, indices=inner):
+                yield j, k
+        else:
+            yield i, indices
+        indices = indices[:-1] + (indices[-1] + 1,)
+

--- a/numba/datamodel/manager.py
+++ b/numba/datamodel/manager.py
@@ -1,0 +1,26 @@
+from __future__ import print_function, absolute_import
+
+from numba import types
+
+
+class DataModelManager(object):
+    """Manages mapping of FE types to their corresponding data model
+    """
+
+    def __init__(self):
+        # handler map
+        # key: numba.types.Type subclass
+        # value: function
+        self._handlers = {}
+
+    def register(self, fetypecls, handler):
+        assert issubclass(fetypecls, types.Type)
+        self._handlers[fetypecls] = handler
+
+    def lookup(self, fetype):
+        handler = self._handlers[type(fetype)]
+        return handler(self, fetype)
+
+    def __getitem__(self, fetype):
+        return self.lookup(fetype)
+

--- a/numba/datamodel/manager.py
+++ b/numba/datamodel/manager.py
@@ -14,13 +14,18 @@ class DataModelManager(object):
         self._handlers = {}
 
     def register(self, fetypecls, handler):
+        """Register the datamodel factory corresponding to a frontend-type class
+        """
         assert issubclass(fetypecls, types.Type)
         self._handlers[fetypecls] = handler
 
     def lookup(self, fetype):
+        """Returns the corresponding datamodel given the frontend-type instance
+        """
         handler = self._handlers[type(fetype)]
         return handler(self, fetype)
 
     def __getitem__(self, fetype):
+        """Shorthand for lookup()
+        """
         return self.lookup(fetype)
-

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -62,14 +62,6 @@ class DataModel(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    # ===== Helpers =====
-
-    def data_to_argument(self, builder, value):
-        return self.as_argument(builder, self.from_data(builder, value))
-
-    def argument_to_data(self, builder, value):
-        return self.as_data(builder, self.from_argument(builder, value))
-
 
 @register_default(types.Boolean)
 class BooleanModel(DataModel):

--- a/numba/datamodel/registry.py
+++ b/numba/datamodel/registry.py
@@ -1,0 +1,17 @@
+from __future__ import print_function, absolute_import
+
+import functools
+from .manager import DataModelManager
+
+
+def register(dmm, typecls):
+    def wraps(fn):
+        dmm.register(typecls, fn)
+        return fn
+
+    return wraps
+
+
+defaultDataModelManager = DataModelManager()
+
+register_default = functools.partial(register, defaultDataModelManager)

--- a/numba/datamodel/registry.py
+++ b/numba/datamodel/registry.py
@@ -5,6 +5,9 @@ from .manager import DataModelManager
 
 
 def register(dmm, typecls):
+    """Used as decorator to simplify datamodel registration.
+    Returns the object being decorated so that chaining is possible.
+    """
     def wraps(fn):
         dmm.register(typecls, fn)
         return fn

--- a/numba/datamodel/testing.py
+++ b/numba/datamodel/testing.py
@@ -1,0 +1,148 @@
+from __future__ import print_function, absolute_import
+
+from llvmlite import ir
+from llvmlite import binding as ll
+
+from numba import datamodel
+from numba import unittest_support as unittest
+
+
+class DataModelTester(unittest.TestCase):
+    """
+    Test the implementation of a DataModel for a frontend type.
+    """
+    fe_type = NotImplemented
+
+    def setUp(self):
+        self.module = ir.Module()
+        self.datamodel = datamodel.defaultDataModelManager[self.fe_type]
+
+    def test_as_arg(self):
+        """
+        - Is as_arg() and from_arg() implemented?
+        - Are they the inverse of each other?
+        """
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_arg")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        args = self.datamodel.as_argument(builder, undef_value)
+        self.assertIsNot(args, NotImplemented, "as_argument returned "
+                                               "NotImplementedError")
+
+        if isinstance(args, (tuple, list)):
+            def recur_flatten_type(args):
+                for arg in args:
+                    if isinstance(arg, (tuple, list)):
+                        yield tuple(recur_flatten_type(arg))
+                    else:
+                        yield arg.type
+
+            def recur_tuplize(args):
+                for arg in args:
+                    if isinstance(arg, (tuple, list)):
+                        yield tuple(recur_tuplize(arg))
+                    else:
+                        yield arg
+
+            argtypes = tuple(recur_flatten_type(args))
+            exptypes = tuple(recur_tuplize(
+                self.datamodel.get_argument_type()))
+            self.assertEqual(exptypes, argtypes)
+        else:
+            self.assertEqual(args.type,
+                             self.datamodel.get_argument_type())
+
+        rev_value = self.datamodel.from_argument(builder, args)
+        self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+    def test_as_return(self):
+        """
+        - Is as_return() and from_return() implemented?
+        - Are they the inverse of each other?
+        """
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_return")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        ret = self.datamodel.as_return(builder, undef_value)
+        self.assertIsNot(ret, NotImplemented, "as_return returned "
+                                              "NotImplementedError")
+
+        self.assertEqual(ret.type, self.datamodel.get_return_type())
+
+        rev_value = self.datamodel.from_return(builder, ret)
+        self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+
+class SupportAsDataMixin(object):
+    """Test as_data() and from_data()
+    """
+
+    def test_as_data(self):
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_data")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        data = self.datamodel.as_data(builder, undef_value)
+        self.assertIsNot(data, NotImplemented,
+                         "as_data returned NotImplemented")
+
+        self.assertEqual(data.type, self.datamodel.get_data_type())
+
+        rev_value = self.datamodel.from_data(builder, data)
+        self.assertEqual(rev_value.type,
+                         self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+
+class NotSupportAsDataMixin(object):
+    """Ensure as_data() and from_data() returns NotImplemented
+    """
+
+    def test_as_data_not_supported(self):
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_data")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        data = self.datamodel.as_data(builder, undef_value)
+        self.assertIs(data, NotImplemented)
+        rev_data = self.datamodel.from_data(builder, undef_value)
+        self.assertIs(rev_data, NotImplemented)
+
+
+def test_factory(support_as_data=True):
+    """A helper for returning a unittest TestCase for testing
+    """
+    baseclses = ()
+    if support_as_data:
+        baseclses += (SupportAsDataMixin,)
+    else:
+        baseclses += (NotSupportAsDataMixin,)
+    baseclses += (DataModelTester,)
+    return baseclses

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -232,7 +232,7 @@ class BaseLower(object):
         rawfnargs = self.context.get_arguments(self.function)
         fi = self.context.get_function_info(self.fndesc.restype,
                                             self.fndesc.argtypes)
-        fnargs = fi.reverse_as_arguments(self.builder, rawfnargs)
+        fnargs = fi.from_arguments(self.builder, rawfnargs)
 
         for ak, av in zip(self.fndesc.args, fnargs):
             av = self.init_argument(av)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -6,6 +6,7 @@ from types import ModuleType
 
 from llvmlite.llvmpy.core import Type, Builder
 
+
 from numba import (_dynfunc, errcode, ir, types, cgutils, utils, config,
                    cffi_support, typing, six)
 
@@ -98,7 +99,7 @@ class FunctionDescriptor(object):
         modname = func.__module__
         doc = func.__doc__ or ''
         args = interp.argspec.args
-        kws = ()  # TODO
+        kws = ()        # TODO
 
         if modname is None:
             # For dynamically generated functions (e.g. compile()),
@@ -117,7 +118,7 @@ class FunctionDescriptor(object):
     def _from_python_function(cls, interp, typemap, restype, calltypes,
                               native, mangler=None, inline=False):
         (qualname, unique_name, modname, doc, args, kws,
-        ) = cls._get_function_info(interp)
+         )= cls._get_function_info(interp)
         self = cls(native, modname, qualname, unique_name, doc,
                    typemap, restype, calltypes,
                    args, kws, mangler=mangler, inline=inline)
@@ -160,23 +161,16 @@ class ExternalFunctionDescriptor(FunctionDescriptor):
     def __init__(self, name, restype, argtypes):
         args = ["arg%d" % i for i in range(len(argtypes))]
         super(ExternalFunctionDescriptor, self).__init__(native=True,
-                                                         modname=None,
-                                                         qualname=name,
-                                                         unique_name=name,
-                                                         doc='',
-                                                         typemap=None,
-                                                         restype=restype,
-                                                         calltypes=None,
-                                                         args=args, kws=None,
-                                                         mangler=lambda a, x: a,
-                                                         argtypes=argtypes)
+                modname=None, qualname=name, unique_name=name, doc='',
+                typemap=None, restype=restype, calltypes=None,
+                args=args, kws=None, mangler=lambda a, x: a,
+                argtypes=argtypes)
 
 
 class BaseLower(object):
     """
     Lower IR to LLVM
     """
-
     def __init__(self, context, library, fndesc, interp):
         self.context = context
         self.library = library
@@ -470,9 +464,8 @@ class Lower(BaseLower):
                     try:
                         pysig = fnty.pysig
                     except AttributeError:
-                        raise NotImplementedError(
-                            "unsupported keyword arguments "
-                            "when calling %s" % (fnty,))
+                        raise NotImplementedError("unsupported keyword arguments "
+                                                  "when calling %s" % (fnty,))
                     ba = pysig.bind(*expr.args, **dict(expr.kws))
                     assert not ba.kwargs
                     args = ba.args
@@ -504,10 +497,8 @@ class Lower(BaseLower):
                 fndesc = ExternalFunctionDescriptor(
                     fnty.symbol, fnty.restype, fnty.argtypes)
                 func = self.context.declare_external_function(
-                    cgutils.get_module(self.builder), fndesc)
-                res = self.context.call_external_function(self.builder, func,
-                                                          fndesc.argtypes,
-                                                          castvals)
+                        cgutils.get_module(self.builder), fndesc)
+                res = self.context.call_external_function(self.builder, func, fndesc.argtypes, castvals)
 
             else:
                 # Normal function resolution
@@ -672,7 +663,7 @@ class Lower(BaseLower):
         if name not in self.varmap:
             self.varmap[name] = self.alloca_lltype(name, value.type)
         ptr = self.getvar(name)
-        assert value.type == ptr.type.pointee, \
+        assert value.type == ptr.type.pointee,\
             "store %s to ptr of %s" % (value.type, ptr.type.pointee)
         self.builder.store(value, ptr)
 

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -150,8 +150,6 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
 
     loopcount = builder.load(arg_dims, name="loopcount")
 
-    actual_args = context.get_arguments(func)
-
     # Prepare inputs
     arrays = []
     for i, typ in enumerate(signature.args):
@@ -177,7 +175,7 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
         unit_strided = builder.and_(unit_strided, ary.is_unit_strided)
 
     if objmode:
-    # General loop
+        # General loop
         pyapi = context.get_python_api(builder)
         gil = pyapi.gil_ensure()
         with cgutils.for_range(builder, loopcount, intp=intp_t):

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -791,10 +791,11 @@ class PythonAPI(object):
                 self.builder.ret(ptr)
 
             ltyp = self.context.get_value_type(typ)
-            val = cgutils.init_record_by_ptr(self.builder, ltyp, ptr)
+            val = self.builder.bitcast(ptr, ltyp)
 
             def dtor():
                 self.release_record_buffer(buf_as_voidptr)
+
 
         else:
             val = self.to_native_value(obj, typ)
@@ -950,9 +951,8 @@ class PythonAPI(object):
         elif isinstance(typ, types.Record):
             # Note we will create a copy of the record
             # This is the only safe way.
-            pdata = cgutils.get_record_data(self.builder, val)
-            size = Constant.int(Type.int(), pdata.type.pointee.count)
-            ptr = self.builder.bitcast(pdata, Type.pointer(Type.int(8)))
+            size = Constant.int(Type.int(), val.type.pointee.count)
+            ptr = self.builder.bitcast(val, Type.pointer(Type.int(8)))
             # Note: this will only work for CPU mode
             #       The following requires access to python object
             dtype_addr = Constant.int(self.py_ssize_t, id(typ.dtype))

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -25,22 +25,8 @@ def make_array(array_type):
     Return the Structure representation of the given *array_type*
     (an instance of types.Array).
     """
-    # dtype = array_type.dtype
-    # nd = array_type.ndim
-    # This structure should be kept in sync with Numba_adapt_ndarray()
-    # in _helperlib.c.
-    # class ArrayTemplate(cgutils.Structure):
-    #     _fields = [('parent', types.pyobject),
-    #                ('nitems', types.intp),
-    #                ('itemsize', types.intp),
-    #                # These three fields comprise the unofficiel llarray ABI
-    #                # (used by the GPU backend)
-    #                ('data', types.CPointer(dtype)),
-    #                ('shape', types.UniTuple(types.intp, nd)),
-    #                ('strides', types.UniTuple(types.intp, nd)),
-    #                ]
-
     return cgutils.create_struct_proxy(array_type)
+
 
 def make_array_ctype(ndim):
     """Create a ctypes representation of an array_type.
@@ -75,13 +61,7 @@ def make_arrayiter_cls(iterator_type):
     instance of types.ArrayIteratorType).
     """
     return cgutils.create_struct_proxy(iterator_type)
-    #
-    # class ArrayIteratorStruct(cgutils.Structure):
-    #     # We use an unsigned index to avoid the cost of negative index tests.
-    #     _fields = [('index', types.CPointer(types.uintp)),
-    #                ('array', iterator_type.array_type)]
-    #
-    # return ArrayIteratorStruct
+
 
 @builtin
 @implement('getiter', types.Kind(types.Array))

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -25,23 +25,22 @@ def make_array(array_type):
     Return the Structure representation of the given *array_type*
     (an instance of types.Array).
     """
-    dtype = array_type.dtype
-    nd = array_type.ndim
-
+    # dtype = array_type.dtype
+    # nd = array_type.ndim
     # This structure should be kept in sync with Numba_adapt_ndarray()
     # in _helperlib.c.
-    class ArrayTemplate(cgutils.Structure):
-        _fields = [('parent', types.pyobject),
-                   ('nitems', types.intp),
-                   ('itemsize', types.intp),
-                   # These three fields comprise the unofficiel llarray ABI
-                   # (used by the GPU backend)
-                   ('data', types.CPointer(dtype)),
-                   ('shape', types.UniTuple(types.intp, nd)),
-                   ('strides', types.UniTuple(types.intp, nd)),
-                   ]
+    # class ArrayTemplate(cgutils.Structure):
+    #     _fields = [('parent', types.pyobject),
+    #                ('nitems', types.intp),
+    #                ('itemsize', types.intp),
+    #                # These three fields comprise the unofficiel llarray ABI
+    #                # (used by the GPU backend)
+    #                ('data', types.CPointer(dtype)),
+    #                ('shape', types.UniTuple(types.intp, nd)),
+    #                ('strides', types.UniTuple(types.intp, nd)),
+    #                ]
 
-    return ArrayTemplate
+    return cgutils.create_struct_proxy(array_type)
 
 def make_array_ctype(ndim):
     """Create a ctypes representation of an array_type.
@@ -75,13 +74,14 @@ def make_arrayiter_cls(iterator_type):
     Return the Structure representation of the given *iterator_type* (an
     instance of types.ArrayIteratorType).
     """
-
-    class ArrayIteratorStruct(cgutils.Structure):
-        # We use an unsigned index to avoid the cost of negative index tests.
-        _fields = [('index', types.CPointer(types.uintp)),
-                   ('array', iterator_type.array_type)]
-
-    return ArrayIteratorStruct
+    return cgutils.create_struct_proxy(iterator_type)
+    #
+    # class ArrayIteratorStruct(cgutils.Structure):
+    #     # We use an unsigned index to avoid the cost of negative index tests.
+    #     _fields = [('index', types.CPointer(types.uintp)),
+    #                ('array', iterator_type.array_type)]
+    #
+    # return ArrayIteratorStruct
 
 @builtin
 @implement('getiter', types.Kind(types.Array))
@@ -438,7 +438,7 @@ def array_sum(context, builder, sig, args):
             c += v
         return c
 
-    return context.compile_internal(builder, array_sum_impl, sig, args, 
+    return context.compile_internal(builder, array_sum_impl, sig, args,
                                     locals=dict(c=sig.return_type))
 
 
@@ -526,7 +526,7 @@ def array_max(context, builder, sig, args):
         for v in arry.flat:
             max_value = v
             break
-        
+
         for v in arry.flat:
             if v > max_value:
                 max_value = v

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -574,12 +574,6 @@ class BaseContext(object):
         Argument representation to local value representation
         """
         return self.data_model_manager[ty].from_argument(builder, val)
-        raise NotImplementedError
-        if ty == types.boolean:
-            return builder.trunc(val, self.get_value_type(ty))
-        elif cgutils.is_struct_ptr(val.type):
-            return builder.load(val)
-        return val
 
     def get_returned_value(self, builder, ty, val):
         """
@@ -670,8 +664,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.data_model_manager[ty.first_type].from_data(builder,
-            pair.first)
+        return pair.first
 
     def pair_second(self, builder, val, ty):
         """
@@ -679,9 +672,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.data_model_manager[ty.second_type].from_data(builder,
-            pair.second)
-
+        return pair.second
 
     def cast(self, builder, val, fromty, toty):
         if fromty == toty or toty == types.Any or isinstance(toty, types.Kind):
@@ -947,7 +938,7 @@ class BaseContext(object):
         """
         Get the LLVM struct type for the given Structure class *struct*.
         """
-        fields = [self.get_struct_member_type(v) for _, v in struct._fields]
+        fields = [self.get_value_type(v) for _, v in struct._fields]
         return Type.struct(fields)
 
     def get_dummy_value(self):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -293,62 +293,6 @@ class BaseContext(object):
             return fac(self, ty)
 
         return self.data_model_manager[ty].get_data_type()
-        #
-        # if (isinstance(ty, types.Dummy) or
-        #         isinstance(ty, types.Module) or
-        #         isinstance(ty, types.Function) or
-        #         isinstance(ty, types.Dispatcher) or
-        #         isinstance(ty, types.Object) or
-        #         isinstance(ty, types.Macro)):
-        #     return PYOBJECT
-        #
-        # elif isinstance(ty, types.CPointer):
-        #     dty = self.get_data_type(ty.dtype)
-        #     return Type.pointer(dty)
-        #
-        # elif isinstance(ty, types.Optional):
-        #     return self.get_struct_type(self.make_optional(ty))
-        #
-        # elif isinstance(ty, types.Array):
-        #     return self.get_struct_type(self.make_array(ty))
-        #
-        # elif isinstance(ty, types.UniTuple):
-        #     dty = self.get_value_type(ty.dtype)
-        #     return Type.array(dty, ty.count)
-        #
-        # elif isinstance(ty, types.Tuple):
-        #     dtys = [self.get_value_type(t) for t in ty]
-        #     return Type.struct(dtys)
-        #
-        # elif isinstance(ty, types.Record):
-        #     # Record are represented as byte array
-        #     return Type.struct([Type.array(Type.int(8), ty.size)])
-        #
-        # elif isinstance(ty, types.UnicodeCharSeq):
-        #     charty = Type.int(numpy_support.sizeof_unicode_char * 8)
-        #     return Type.struct([Type.array(charty, ty.count)])
-        #
-        # elif isinstance(ty, types.CharSeq):
-        #     charty = Type.int(8)
-        #     return Type.struct([Type.array(charty, ty.count)])
-        #
-        # elif ty in STRUCT_TYPES:
-        #     return self.get_struct_type(STRUCT_TYPES[ty])
-        #
-        # else:
-        #     try:
-        #         impl = struct_registry.match(ty)
-        #     except KeyError:
-        #         pass
-        #     else:
-        #         return self.get_struct_type(impl(ty))
-        #
-        # if isinstance(ty, types.Pair):
-        #     pairty = self.make_pair(ty.first_type, ty.second_type)
-        #     return self.get_struct_type(pairty)
-        #
-        # else:
-        #     return LTYPEMAP[ty]
 
     def get_value_type(self, ty):
         return self.data_model_manager[ty].get_value_type()
@@ -358,19 +302,6 @@ class BaseContext(object):
         """
         dataval = self.data_model_manager[ty].as_data(builder, value)
         builder.store(dataval, ptr)
-        return
-        #
-        # if isinstance(ty, types.Record):
-        #     pdata = cgutils.get_record_data(builder, value)
-        #     databuf = builder.load(pdata)
-        #     casted = builder.bitcast(ptr, Type.pointer(databuf.type))
-        #     builder.store(databuf, casted)
-        #     return
-        #
-        # if ty == types.boolean:
-        #     value = cgutils.as_bool_byte(builder, value)
-        # assert value.type == ptr.type.pointee
-        # builder.store(value, ptr)
 
     def unpack_value(self, builder, ty, ptr):
         """Unpack data from array storage
@@ -381,20 +312,6 @@ class BaseContext(object):
             return dm.from_data(builder, builder.load(ptr))
         else:
             return val
-        #
-        # if isinstance(ty, types.Record):
-        #     vt = self.get_value_type(ty)
-        #     tmp = cgutils.alloca_once(builder, vt)
-        #     dataptr = cgutils.inbound_gep(builder, ptr, 0, 0)
-        #     builder.store(dataptr, cgutils.inbound_gep(builder, tmp, 0, 0))
-        #     return builder.load(tmp)
-        #
-        # assert cgutils.is_pointer(ptr.type)
-        # value = builder.load(ptr)
-        # if ty == types.boolean:
-        #     return builder.trunc(value, Type.int(1))
-        # else:
-        #     return value
 
     def is_struct_type(self, ty):
         return isinstance(self.data_model_manager[ty],
@@ -415,8 +332,6 @@ class BaseContext(object):
 
     def get_constant_struct(self, builder, ty, val):
         assert self.is_struct_type(ty)
-        module = cgutils.get_module(builder)
-
         if ty in types.complex_domain:
             if ty == types.complex64:
                 innertype = types.float32

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -378,7 +378,7 @@ class BaseContext(object):
         dm = self.data_model_manager[ty]
         val = dm.load_from_data_pointer(builder, ptr)
         if val is NotImplemented:
-            return dm.reverse_as_data(builder, builder.load(ptr))
+            return dm.from_data(builder, builder.load(ptr))
         else:
             return val
         #
@@ -573,6 +573,7 @@ class BaseContext(object):
         """
         Argument representation to local value representation
         """
+        return self.data_model_manager[ty].from_argument(builder, val)
         raise NotImplementedError
         if ty == types.boolean:
             return builder.trunc(val, self.get_value_type(ty))
@@ -585,7 +586,7 @@ class BaseContext(object):
         Return value representation to local value representation
         """
         # Same as get_argument_value
-        return self.data_model_manager[ty].reverse_as_return(builder, val)
+        return self.data_model_manager[ty].from_return(builder, val)
         # return self.get_argument_value(builder, ty, val)
 
     def get_return_value(self, builder, ty, val):
@@ -669,7 +670,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.data_model_manager[ty.first_type].reverse_as_data(builder,
+        return self.data_model_manager[ty.first_type].from_data(builder,
             pair.first)
 
     def pair_second(self, builder, val, ty):
@@ -678,7 +679,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.data_model_manager[ty.second_type].reverse_as_data(builder,
+        return self.data_model_manager[ty.second_type].from_data(builder,
             pair.second)
 
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -314,10 +314,7 @@ class BaseContext(object):
             return val
 
     def is_struct_type(self, ty):
-        return isinstance(self.data_model_manager[ty],
-                          (datamodel.StructModel,
-                           datamodel.RecordModel,
-                           datamodel.BaseComplexModel))
+        return isinstance(self.data_model_manager[ty], datamodel.CompositeModel)
 
     def get_constant_generic(self, builder, ty, val):
         """

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 
 import sys
 
+from llvmlite import ir as llir
 import llvmlite.llvmpy.core as lc
 import llvmlite.llvmpy.ee as le
 import llvmlite.binding as ll
@@ -9,7 +10,7 @@ import llvmlite.binding as ll
 from numba import _dynfunc, config
 from numba.callwrapper import PyCallWrapper
 from .base import BaseContext, PYOBJECT
-from numba import utils, cgutils, types
+from numba import utils, cgutils, types, datamodel
 from numba.targets import (
     codegen, externals, intrinsics, cmathimpl, mathimpl, npyimpl, operatorimpl, printimpl)
 from .options import TargetOptions
@@ -107,10 +108,10 @@ class CPUContext(BaseContext):
         Actual arguments starts at the 3rd argument position.
         Caller is responsible to allocate space for return value.
         """
-        argtypes = [self.get_argument_type(aty)
-                    for aty in argtypes]
-        resptr = self.get_return_type(restype)
-        fnty = lc.Type.function(lc.Type.int(), [resptr, PYOBJECT] + argtypes)
+        argtypes = [types.pyobject] + list(argtypes)
+        fi = self.get_function_info(restype, argtypes)
+        argtys = (fi.return_type.as_pointer(),) + fi.argument_types
+        fnty = llir.FunctionType(llir.IntType(32), argtys)
         return fnty
 
     def declare_function(self, module, fndesc):
@@ -154,8 +155,8 @@ class CPUContext(BaseContext):
         # initialize return value to zeros
         builder.store(lc.Constant.null(retty), retvaltmp)
 
-        args = [self.get_value_as_argument(builder, ty, arg)
-                for ty, arg in zip(argtys, args)]
+        fi = self.get_function_info(resty, argtys)
+        args = fi.as_arguments(builder, args)
         realargs = [retvaltmp, env] + list(args)
         code = builder.call(callee, realargs)
         status = self.get_return_status(builder, code)

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -25,11 +25,7 @@ def make_enumerate_cls(enum_type):
     instance of types.EnumerateType).
     """
 
-    class Enumerate(cgutils.Structure):
-        _fields = [('count', types.CPointer(types.intp)),
-                   ('iter', enum_type.source_type)]
-
-    return Enumerate
+    return cgutils.create_struct_proxy(enum_type)
 
 
 @builtin

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -158,14 +158,15 @@ class _ArrayHelper(namedtuple('_ArrayHelper', ('context', 'builder', 'ary',
                                          inds=indices)
 
     def load_data(self, indices):
-        return self.builder.load(self._load_effective_address(indices))
+        loaded = self.builder.load(self._load_effective_address(indices))
+        return self.context.get_data_as_value(self.builder, self.base_type,
+                                              loaded)
 
     def store_data(self, indices, value):
         ctx = self.context
         bld = self.builder
 
-        # maybe there should be a "get_memory_value" or "get_storage_value"
-        store_value = ctx.get_struct_member_value(bld, self.base_type, value)
+        store_value = ctx.get_value_as_data(bld, self.base_type, value)
         assert ctx.get_data_type(self.base_type) == store_value.type
 
         bld.store(store_value, self._load_effective_address(indices))

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -2,17 +2,6 @@ from __future__ import print_function, absolute_import, division
 from numba import types, cgutils
 
 
-def make_optional(valtype):
-    """
-    Return the Structure representation of a optional value
-    """
-
-    class OptionalStruct(cgutils.Structure):
-        _fields = [('data', valtype),
-                   ('valid', types.boolean)]
-
-    return OptionalStruct
-
 
 def always_return_true_impl(context, builder, sig, args):
     return cgutils.true_bit

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -1,6 +1,12 @@
 from __future__ import print_function, absolute_import, division
 from numba import types, cgutils
 
+def make_optional(valtype):
+    """
+    Return the Structure representation of a optional value
+    """
+    assert not isinstance(valtype, types.Optional)
+    return cgutils.create_struct_proxy(types.Optional(valtype))
 
 
 def always_return_true_impl(context, builder, sig, args):

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -45,12 +45,13 @@ for ty in types.real_domain:
 @register
 @implement(types.print_item_type, types.Kind(types.CharSeq))
 def print_charseq(context, builder, sig, args):
+    [tx] = sig.args
     [x] = args
     py = context.get_python_api(builder)
     xp = cgutils.alloca_once(builder, x.type)
     builder.store(x, xp)
     byteptr = builder.bitcast(xp, Type.pointer(Type.int(8)))
-    size = context.get_constant(types.intp, x.type.elements[0].count)
+    size = context.get_constant(types.intp, tx.count)
     cstr = py.bytes_from_string_and_size(byteptr, size)
     py.print_object(cstr)
     py.decref(cstr)

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -16,16 +16,8 @@ def make_range_iterator(typ):
     Return the Structure representation of the given *typ* (an
     instance of types.RangeIteratorType).
     """
-    int_type = typ.yield_type
+    return cgutils.create_struct_proxy(typ)
 
-    class RangeIter(cgutils.Structure):
-
-        _fields = [('iter', types.CPointer(int_type)),
-                   ('stop', int_type),
-                   ('step', int_type),
-                   ('count', types.CPointer(int_type))]
-
-    return RangeIter
 
 
 def make_range_impl(range_state_type, range_iter_type, int_type):

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -170,6 +170,8 @@ class TestFunctionInfo(unittest.TestCase):
         asargs = fi.reverse_as_arguments(builder, values)
 
         self.assertEqual(len(asargs), len(fe_args))
+        valtys = tuple([v.type for v in values])
+        self.assertEqual(valtys, fi.argument_types)
 
         expect_types = [a.type for a in args]
         got_types = [a.type for a in asargs]

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -5,158 +5,95 @@ from llvmlite import ir, binding as ll
 from numba import types
 from numba import unittest_support as unittest
 from numba import datamodel
+from numba.datamodel.testing import test_factory
 
 
-def test_factory(name, fetype, support_as_data=True):
-    dmm = datamodel.defaultDataModelManager
-
-    class DataModelTester(unittest.TestCase):
-        datamodel = NotImplemented
-
-        def setUp(self):
-            self.module = ir.Module()
-
-        def test_as_arg(self):
-            fnty = ir.FunctionType(ir.VoidType(), [])
-            function = ir.Function(self.module, fnty, name="test_as_arg")
-            builder = ir.IRBuilder()
-            builder.position_at_end(function.append_basic_block())
-
-            undef_value = ir.Constant(self.datamodel.get_value_type(), None)
-            args = self.datamodel.as_argument(builder, undef_value)
-            self.assertIsNot(args, NotImplemented, "as_argument returned "
-                                                   "NotImplementedError")
-
-            if isinstance(args, (tuple, list)):
-                def recur_flatten_type(args):
-                    for arg in args:
-                        if isinstance(arg, (tuple, list)):
-                            yield tuple(recur_flatten_type(arg))
-                        else:
-                            yield arg.type
-
-                def recur_tuplize(args):
-                    for arg in args:
-                        if isinstance(arg, (tuple, list)):
-                            yield tuple(recur_tuplize(arg))
-                        else:
-                            yield arg
-
-                argtypes = tuple(recur_flatten_type(args))
-                exptypes = tuple(recur_tuplize(
-                    self.datamodel.get_argument_type()))
-                self.assertEqual(exptypes, argtypes)
-            else:
-                self.assertEqual(args.type,
-                                 self.datamodel.get_argument_type())
-
-            rev_value = self.datamodel.from_argument(builder, args)
-            self.assertEqual(rev_value.type, self.datamodel.get_value_type())
-
-            builder.ret_void()  # end function
-
-            # Ensure valid LLVM generation
-            materialized = ll.parse_assembly(str(self.module))
-            print(materialized)
-
-        def test_as_return(self):
-            fnty = ir.FunctionType(ir.VoidType(), [])
-            function = ir.Function(self.module, fnty, name="test_as_return")
-            builder = ir.IRBuilder()
-            builder.position_at_end(function.append_basic_block())
-
-            undef_value = ir.Constant(self.datamodel.get_value_type(), None)
-            ret = self.datamodel.as_return(builder, undef_value)
-            self.assertIsNot(ret, NotImplemented, "as_return returned "
-                                                  "NotImplementedError")
-
-            self.assertEqual(ret.type, self.datamodel.get_return_type())
-
-            rev_value = self.datamodel.from_return(builder, ret)
-            self.assertEqual(rev_value.type, self.datamodel.get_value_type())
-
-            builder.ret_void()  # end function
-
-            # Ensure valid LLVM generation
-            materialized = ll.parse_assembly(str(self.module))
-            print(materialized)
-
-        if support_as_data:
-            def test_as_data(self):
-                fnty = ir.FunctionType(ir.VoidType(), [])
-                function = ir.Function(self.module, fnty, name="test_as_data")
-                builder = ir.IRBuilder()
-                builder.position_at_end(function.append_basic_block())
-
-                undef_value = ir.Constant(self.datamodel.get_value_type(), None)
-                data = self.datamodel.as_data(builder, undef_value)
-                self.assertIsNot(data, NotImplemented, "as_data returned "
-                                                       "NotImplementedError")
-
-                self.assertEqual(data.type, self.datamodel.get_data_type())
-
-                rev_value = self.datamodel.from_data(builder, data)
-                self.assertEqual(rev_value.type,
-                                 self.datamodel.get_value_type())
-
-                builder.ret_void()  # end function
-
-                # Ensure valid LLVM generation
-                materialized = ll.parse_assembly(str(self.module))
-                print(materialized)
-        else:
-            def test_as_data_not_supported(self):
-                fnty = ir.FunctionType(ir.VoidType(), [])
-                function = ir.Function(self.module, fnty, name="test_as_data")
-                builder = ir.IRBuilder()
-                builder.position_at_end(function.append_basic_block())
-
-                undef_value = ir.Constant(self.datamodel.get_value_type(), None)
-                data = self.datamodel.as_data(builder, undef_value)
-                self.assertIs(data, NotImplemented)
-                rev_data = self.datamodel.from_data(builder, undef_value)
-                self.assertIs(rev_data, NotImplemented)
-
-    model = dmm.lookup(fetype)
-    testcls = type(name, (DataModelTester,), {'datamodel': model})
-    glbls = globals()
-    assert name not in glbls
-    glbls[name] = testcls
+class TestBool(*test_factory()):
+    fe_type = types.boolean
 
 
+class TestPyObject(*test_factory()):
+    fe_type = types.pyobject
 
-test_factory("TestBool", types.boolean)
-test_factory("TestPyObject", types.pyobject)
+
+class TestInt8(*test_factory()):
+    fe_type = types.int8
 
 
-for bits in [8, 16, 32, 64]:
-    # signed
-    test_factory("TestInt{0}".format(bits),
-                 getattr(types, 'int{0}'.format(bits)))
-    # unsigned
-    test_factory("TestUInt{0}".format(bits),
-                 getattr(types, 'uint{0}'.format(bits)))
+class TestInt16(*test_factory()):
+    fe_type = types.int16
 
-test_factory("TestFloat", types.float32)
-test_factory("TestDouble", types.float64)
-test_factory("TestComplex", types.complex64)
-test_factory("TestDoubleComplex", types.complex128)
 
-test_factory("TestPointerOfInt32", types.CPointer(types.int32))
+class TestInt32(*test_factory()):
+    fe_type = types.int32
 
-test_factory("TestUniTupleOf2xInt32", types.UniTuple(types.int32, 2))
-test_factory("TestUniTupleEmpty", types.UniTuple(types.int32, 0))
-test_factory("TestTupleInt32Float32", types.Tuple([types.int32, types.float32]))
-test_factory("TestTupleEmpty", types.Tuple([]))
 
-test_factory("Test1DArrayOfInt32", types.Array(types.int32, 1, 'C'),
-             support_as_data=False)
+class TestInt64(*test_factory()):
+    fe_type = types.int64
 
-test_factory("Test2DArrayOfComplex128", types.Array(types.complex128, 2, 'C'),
-             support_as_data=False)
 
-test_factory("Test0DArrayOfInt32", types.Array(types.int32, 0, 'C'),
-             support_as_data=False)
+class TestUInt8(*test_factory()):
+    fe_type = types.uint8
+
+
+class TestUInt16(*test_factory()):
+    fe_type = types.uint16
+
+
+class TestUInt32(*test_factory()):
+    fe_type = types.uint32
+
+
+class TestUInt64(*test_factory()):
+    fe_type = types.uint64
+
+
+class TestFloat(*test_factory()):
+    fe_type = types.float32
+
+
+class TestDouble(*test_factory()):
+    fe_type = types.float64
+
+
+class TestComplex(*test_factory()):
+    fe_type = types.complex64
+
+
+class TestDoubleComplex(*test_factory()):
+    fe_type = types.complex128
+
+
+class TestPointerOfInt32(*test_factory()):
+    fe_type = types.CPointer(types.int32)
+
+
+class TestUniTupleOf2xInt32(*test_factory()):
+    fe_type = types.UniTuple(types.int32, 2)
+
+
+class TestUniTupleEmpty(*test_factory()):
+    fe_type = types.UniTuple(types.int32, 0)
+
+
+class TestTupleInt32Float32(*test_factory()):
+    fe_type = types.Tuple([types.int32, types.float32])
+
+
+class TestTupleEmpty(*test_factory()):
+    fe_type = types.Tuple([])
+
+
+class Test1DArrayOfInt32(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.int32, 1, 'C')
+
+
+class Test2DArrayOfComplex128(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.complex128, 2, 'C')
+
+
+class Test0DArrayOfInt32(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.int32, 0, 'C')
 
 
 class TestFunctionInfo(unittest.TestCase):

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -124,6 +124,11 @@ def test_factory(name, fetype, support_as_data=True):
     glbls[name] = testcls
 
 
+
+test_factory("TestBool", types.boolean)
+test_factory("TestPyObject", types.pyobject)
+
+
 for bits in [8, 16, 32, 64]:
     # signed
     test_factory("TestInt{0}".format(bits),
@@ -149,11 +154,8 @@ test_factory("Test2DArrayOfInt32", types.Array(types.complex128, 2, 'C'),
 
 
 class TestFunctionInfo(unittest.TestCase):
-    def test_as_arguments(self):
+    def _test_as_arguments(self, fe_args):
         dmm = datamodel.defaultDataModelManager
-        fe_args = [types.int32,
-                   types.Array(types.int32, 1, 'C'),
-                   types.complex64]
         fe_ret = types.int32
         fi = datamodel.FunctionInfo(dmm, fe_ret, fe_args)
 
@@ -181,6 +183,16 @@ class TestFunctionInfo(unittest.TestCase):
         builder.ret_void()
 
         ll.parse_assembly(str(module))
+
+    def test_int32_array_complex(self):
+        fe_args = [types.int32,
+                   types.Array(types.int32, 1, 'C'),
+                   types.complex64]
+        self._test_as_arguments(fe_args)
+
+    def test_two_arrays(self):
+        fe_args = [types.Array(types.int32, 1, 'C')] * 2
+        self._test_as_arguments(fe_args)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -1,0 +1,185 @@
+from __future__ import print_function, absolute_import
+
+from llvmlite import ir, binding as ll
+
+from numba import types
+from numba import unittest_support as unittest
+from numba import datamodel
+
+
+def test_factory(name, fetype, support_as_data=True):
+    dmm = datamodel.defaultDataModelManager
+
+    class DataModelTester(unittest.TestCase):
+        datamodel = NotImplemented
+
+        def setUp(self):
+            self.module = ir.Module()
+
+        def test_as_arg(self):
+            fnty = ir.FunctionType(ir.VoidType(), [])
+            function = ir.Function(self.module, fnty, name="test_as_arg")
+            builder = ir.IRBuilder()
+            builder.position_at_end(function.append_basic_block())
+
+            undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+            args = self.datamodel.as_argument(builder, undef_value)
+            self.assertIsNot(args, NotImplemented, "as_argument returned "
+                                                   "NotImplementedError")
+
+            if isinstance(args, (tuple, list)):
+                def recur_flatten_type(args):
+                    for arg in args:
+                        if isinstance(arg, (tuple, list)):
+                            yield tuple(recur_flatten_type(arg))
+                        else:
+                            yield arg.type
+
+                def recur_tuplize(args):
+                    for arg in args:
+                        if isinstance(arg, (tuple, list)):
+                            yield tuple(recur_tuplize(arg))
+                        else:
+                            yield arg
+
+                argtypes = tuple(recur_flatten_type(args))
+                exptypes = tuple(recur_tuplize(
+                    self.datamodel.get_argument_type()))
+                self.assertEqual(exptypes, argtypes)
+            else:
+                self.assertEqual(args.type,
+                                 self.datamodel.get_argument_type())
+
+            rev_value = self.datamodel.reverse_as_argument(builder, args)
+            self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+            builder.ret_void()  # end function
+
+            # Ensure valid LLVM generation
+            materialized = ll.parse_assembly(str(self.module))
+            print(materialized)
+
+        def test_as_return(self):
+            fnty = ir.FunctionType(ir.VoidType(), [])
+            function = ir.Function(self.module, fnty, name="test_as_return")
+            builder = ir.IRBuilder()
+            builder.position_at_end(function.append_basic_block())
+
+            undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+            ret = self.datamodel.as_return(builder, undef_value)
+            self.assertIsNot(ret, NotImplemented, "as_return returned "
+                                                  "NotImplementedError")
+
+            self.assertEqual(ret.type, self.datamodel.get_return_type())
+
+            rev_value = self.datamodel.reverse_as_return(builder, ret)
+            self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+            builder.ret_void()  # end function
+
+            # Ensure valid LLVM generation
+            materialized = ll.parse_assembly(str(self.module))
+            print(materialized)
+
+        if support_as_data:
+            def test_as_data(self):
+                fnty = ir.FunctionType(ir.VoidType(), [])
+                function = ir.Function(self.module, fnty, name="test_as_data")
+                builder = ir.IRBuilder()
+                builder.position_at_end(function.append_basic_block())
+
+                undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+                data = self.datamodel.as_data(builder, undef_value)
+                self.assertIsNot(data, NotImplemented, "as_data returned "
+                                                       "NotImplementedError")
+
+                self.assertEqual(data.type, self.datamodel.get_data_type())
+
+                rev_value = self.datamodel.reverse_as_data(builder, data)
+                self.assertEqual(rev_value.type,
+                                 self.datamodel.get_value_type())
+
+                builder.ret_void()  # end function
+
+                # Ensure valid LLVM generation
+                materialized = ll.parse_assembly(str(self.module))
+                print(materialized)
+        else:
+            def test_as_data_not_supported(self):
+                fnty = ir.FunctionType(ir.VoidType(), [])
+                function = ir.Function(self.module, fnty, name="test_as_data")
+                builder = ir.IRBuilder()
+                builder.position_at_end(function.append_basic_block())
+
+                undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+                data = self.datamodel.as_data(builder, undef_value)
+                self.assertIs(data, NotImplemented)
+                rev_data = self.datamodel.reverse_as_data(builder, undef_value)
+                self.assertIs(rev_data, NotImplemented)
+
+    model = dmm.lookup(fetype)
+    testcls = type(name, (DataModelTester,), {'datamodel': model})
+    glbls = globals()
+    assert name not in glbls
+    glbls[name] = testcls
+
+
+for bits in [8, 16, 32, 64]:
+    # signed
+    test_factory("TestInt{0}".format(bits),
+                 getattr(types, 'int{0}'.format(bits)))
+    # unsigned
+    test_factory("TestUInt{0}".format(bits),
+                 getattr(types, 'uint{0}'.format(bits)))
+
+test_factory("TestFloat", types.float32)
+test_factory("TestDouble", types.float64)
+test_factory("TestComplex", types.complex64)
+test_factory("TestDoubleComplex", types.complex128)
+
+test_factory("TestPointerOfInt32", types.CPointer(types.int32))
+
+test_factory("TestUniTupleOf2xInt32", types.UniTuple(types.int32, 2))
+
+test_factory("Test1DArrayOfInt32", types.Array(types.int32, 1, 'C'),
+             support_as_data=False)
+
+test_factory("Test2DArrayOfInt32", types.Array(types.complex128, 2, 'C'),
+             support_as_data=False)
+
+
+class TestFunctionInfo(unittest.TestCase):
+    def test_as_arguments(self):
+        dmm = datamodel.defaultDataModelManager
+        fe_args = [types.int32,
+                   types.Array(types.int32, 1, 'C'),
+                   types.complex64]
+        fe_ret = types.int32
+        fi = datamodel.FunctionInfo(dmm, fe_ret, fe_args)
+
+        module = ir.Module()
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(module, fnty, name="test_arguments")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        args = [ir.Constant(dmm.lookup(t).get_value_type(), None)
+                for t in fe_args]
+
+        values = fi.as_arguments(builder, args)
+        asargs = fi.reverse_as_arguments(builder, values)
+
+        self.assertEqual(len(asargs), len(fe_args))
+
+        expect_types = [a.type for a in args]
+        got_types = [a.type for a in asargs]
+
+        self.assertEqual(expect_types, got_types)
+
+        builder.ret_void()
+
+        ll.parse_assembly(str(module))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -145,6 +145,7 @@ test_factory("TestDoubleComplex", types.complex128)
 test_factory("TestPointerOfInt32", types.CPointer(types.int32))
 
 test_factory("TestUniTupleOf2xInt32", types.UniTuple(types.int32, 2))
+test_factory("TestTupleInt32Float32", types.Tuple([types.int32, types.float32]))
 
 test_factory("Test1DArrayOfInt32", types.Array(types.int32, 1, 'C'),
              support_as_data=False)

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -145,12 +145,17 @@ test_factory("TestDoubleComplex", types.complex128)
 test_factory("TestPointerOfInt32", types.CPointer(types.int32))
 
 test_factory("TestUniTupleOf2xInt32", types.UniTuple(types.int32, 2))
+test_factory("TestUniTupleEmpty", types.UniTuple(types.int32, 0))
 test_factory("TestTupleInt32Float32", types.Tuple([types.int32, types.float32]))
+test_factory("TestTupleEmpty", types.Tuple([]))
 
 test_factory("Test1DArrayOfInt32", types.Array(types.int32, 1, 'C'),
              support_as_data=False)
 
-test_factory("Test2DArrayOfInt32", types.Array(types.complex128, 2, 'C'),
+test_factory("Test2DArrayOfComplex128", types.Array(types.complex128, 2, 'C'),
+             support_as_data=False)
+
+test_factory("Test0DArrayOfInt32", types.Array(types.int32, 0, 'C'),
              support_as_data=False)
 
 

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -50,7 +50,7 @@ def test_factory(name, fetype, support_as_data=True):
                 self.assertEqual(args.type,
                                  self.datamodel.get_argument_type())
 
-            rev_value = self.datamodel.reverse_as_argument(builder, args)
+            rev_value = self.datamodel.from_argument(builder, args)
             self.assertEqual(rev_value.type, self.datamodel.get_value_type())
 
             builder.ret_void()  # end function
@@ -72,7 +72,7 @@ def test_factory(name, fetype, support_as_data=True):
 
             self.assertEqual(ret.type, self.datamodel.get_return_type())
 
-            rev_value = self.datamodel.reverse_as_return(builder, ret)
+            rev_value = self.datamodel.from_return(builder, ret)
             self.assertEqual(rev_value.type, self.datamodel.get_value_type())
 
             builder.ret_void()  # end function
@@ -95,7 +95,7 @@ def test_factory(name, fetype, support_as_data=True):
 
                 self.assertEqual(data.type, self.datamodel.get_data_type())
 
-                rev_value = self.datamodel.reverse_as_data(builder, data)
+                rev_value = self.datamodel.from_data(builder, data)
                 self.assertEqual(rev_value.type,
                                  self.datamodel.get_value_type())
 
@@ -114,7 +114,7 @@ def test_factory(name, fetype, support_as_data=True):
                 undef_value = ir.Constant(self.datamodel.get_value_type(), None)
                 data = self.datamodel.as_data(builder, undef_value)
                 self.assertIs(data, NotImplemented)
-                rev_data = self.datamodel.reverse_as_data(builder, undef_value)
+                rev_data = self.datamodel.from_data(builder, undef_value)
                 self.assertIs(rev_data, NotImplemented)
 
     model = dmm.lookup(fetype)
@@ -170,7 +170,7 @@ class TestFunctionInfo(unittest.TestCase):
                 for t in fe_args]
 
         values = fi.as_arguments(builder, args)
-        asargs = fi.reverse_as_arguments(builder, values)
+        asargs = fi.from_arguments(builder, values)
 
         self.assertEqual(len(asargs), len(fe_args))
         valtys = tuple([v.type for v in values])

--- a/numba/tests/test_guvectorize_scalar.py
+++ b/numba/tests/test_guvectorize_scalar.py
@@ -18,7 +18,7 @@ class TestGUVectorizeScalar(unittest.TestCase):
         a pointer to the output location.
         """
 
-        @guvectorize(['void(int32[:], int32[:])'], '(n)->()')
+        @guvectorize(['void(int32[:], int32[:])'], '(n)->()', nopython=True)
         def sum_row(inp, out):
             tmp = 0.
             for i in range(inp.shape[0]):
@@ -34,21 +34,22 @@ class TestGUVectorizeScalar(unittest.TestCase):
 
         # verify result
         for i in range(inp.shape[0]):
-            assert out[i] == inp[i].sum()
+            np.testing.assert_allclose(inp[i].sum(), out[i])
 
     def test_scalar_input(self):
 
-        @guvectorize(['int32[:], int32[:], int32[:]'], '(n),()->(n)')
+        @guvectorize(['int32[:], int32[:], int32[:]'], '(n),()->(n)', nopython=True)
         def foo(inp, n, out):
             for i in range(inp.shape[0]):
-                out[i] = inp[i] * n[()]
+                out[i] = inp[i] * n[0]
 
         inp = np.arange(3 * 10, dtype=np.int32).reshape(10, 3)
         # out = np.empty_like(inp)
         out = foo(inp, 2)
 
         # verify result
-        self.assertTrue(np.all(inp * 2 == out))
+        np.testing.assert_allclose(inp * 2, out)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -870,6 +870,10 @@ class NoneType(Opaque):
 
         return Optional(other)
 
+
+class Slice3Type(Type):
+    pass
+
 # Utils
 
 def is_int_tuple(x):
@@ -931,7 +935,7 @@ range_state32_type = RangeType('range_state32', range_iter32_type)
 range_state64_type = RangeType('range_state64', range_iter64_type)
 
 # slice2_type = Type('slice2_type')
-slice3_type = Type('slice3_type')
+slice3_type = Slice3Type('slice3_type')
 
 signed_domain = frozenset([int8, int16, int32, int64])
 unsigned_domain = frozenset([uint8, uint16, uint32, uint64])

--- a/numba/types.py
+++ b/numba/types.py
@@ -154,6 +154,9 @@ class OpaqueType(Type):
         super(OpaqueType, self).__init__(name)
 
 
+class Boolean(Type):
+    pass
+
 @utils.total_ordering
 class Integer(Type):
     def __init__(self, *args, **kws):
@@ -890,7 +893,7 @@ string = Opaque('str')
 # Can only pass it around
 voidptr = Opaque('void*')
 
-boolean = bool_ = Type('bool')
+boolean = bool_ = Boolean('bool')
 
 byte = uint8 = Integer('uint8')
 uint16 = Integer('uint16')


### PR DESCRIPTION
An attempt to remove ``numba.types.Type`` based specialization from the backend context classes.  A new concept, ``DataModel``, is introduced to providing mapping among different data representation.  It expects the local (e.g. in function body) representation as the default.  The local representation can be transformed to argument , return and data representation by using the `as_arg`, `as_return` and `as_data` methods, respectively.  Argument representation is used for passing into function as function argument and must conform to the target ABI.  Return representation is used for the return value which numba passes usually as the first function argument.  Data representation is used for storing into an array.  It is important more aggregate type to define how each element are stored for properly alignment of fields.

There is also a ``FunctionInfo`` class that implements unpacking and flattening of nested aggregate types for use as function argument.  So that a type of {int, {float, double}} is passed into the function as three arguments (int, float, double).

The goal:
- simplify the backend context;
- make adding new types easier.

BTW, is datamodel a good name?