### PR TITLE
Fix CUDA tests

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -23,10 +23,10 @@ class CUDACodeLibrary(CodeLibrary):
             if '.' in gv.name:
                 gv.name = gv.name.replace('.', '_')
 
-    def _dump_assembly(self):
-        # Do nothing: we can only dump assembler code when it is later
+    def get_asm_str(self):
+        # Return nothing: we can only dump assembler code when it is later
         # generated (in numba.cuda.compiler).
-        pass
+        return None
 
 
 class JITCUDACodegen(BaseCPUCodegen):

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -168,7 +168,11 @@ class CodeLibrary(object):
             dump("OPTIMIZED DUMP %s" % self._name, self.get_llvm_str())
 
         if config.DUMP_ASSEMBLY:
-            dump("ASSEMBLY %s" % self._name, self.get_asm_str())
+            # CUDA backend cannot return assembly this early, so don't
+            # attempt to dump assembly if nothing is produced.
+            asm = self.get_asm_str()
+            if asm:
+                dump("ASSEMBLY %s" % self._name, self.get_asm_str())
 
     def get_function(self, name):
         return self._final_module.get_function(name)


### PR DESCRIPTION
- Update the CUDA backend to replace _dump_assembly() with
  get_asm_str()
- Prevent a header with no code being produced in the case where
  there is no returned assembly string, which is the case for the
  CUDA backend.