### PR TITLE
Additional math functions

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -168,11 +168,13 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.fabs`
 * :func:`math.floor`
 * :func:`math.frexp`
+* :func:`math.gamma`
 * :func:`math.hypot`
 * :func:`math.isfinite`
 * :func:`math.isinf`
 * :func:`math.isnan`
 * :func:`math.ldexp`
+* :func:`math.lgamma`
 * :func:`math.log`
 * :func:`math.log10`
 * :func:`math.log1p`

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -165,10 +165,12 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.expm1`
 * :func:`math.fabs`
 * :func:`math.floor`
+* :func:`math.frexp`
 * :func:`math.hypot`
 * :func:`math.isfinite`
 * :func:`math.isinf`
 * :func:`math.isnan`
+* :func:`math.ldexp`
 * :func:`math.log`
 * :func:`math.log10`
 * :func:`math.log1p`

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -161,6 +161,8 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.cos`
 * :func:`math.cosh`
 * :func:`math.degrees`
+* :func:`math.erf`
+* :func:`math.erfc`
 * :func:`math.exp`
 * :func:`math.expm1`
 * :func:`math.fabs`

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -18,9 +18,6 @@
 #endif
 
 
-static const double sqrtpi = 1.772453850905516027298167483341145182798;
-
-
 /* provide 64-bit division function to 32-bit platforms */
 static
 int64_t Numba_sdiv(int64_t a, int64_t b) {
@@ -86,6 +83,332 @@ float Numba_ldexpf(float x, int exp)
 static
 void Numba_cpow(Py_complex *a, Py_complex *b, Py_complex *c) {
     *c = _Py_c_pow(*a, *b);
+}
+
+/* provide gamma() and lgamma(); code borrowed from CPython */
+
+/*
+   sin(pi*x), giving accurate results for all finite x (especially x
+   integral or close to an integer).  This is here for use in the
+   reflection formula for the gamma function.  It conforms to IEEE
+   754-2008 for finite arguments, but not for infinities or nans.
+*/
+
+static const double pi = 3.141592653589793238462643383279502884197;
+static const double sqrtpi = 1.772453850905516027298167483341145182798;
+static const double logpi = 1.144729885849400174143427351353058711647;
+
+static double
+sinpi(double x)
+{
+    double y, r;
+    int n;
+    /* this function should only ever be called for finite arguments */
+    assert(Py_IS_FINITE(x));
+    y = fmod(fabs(x), 2.0);
+    n = (int)round(2.0*y);
+    assert(0 <= n && n <= 4);
+    switch (n) {
+    case 0:
+        r = sin(pi*y);
+        break;
+    case 1:
+        r = cos(pi*(y-0.5));
+        break;
+    case 2:
+        /* N.B. -sin(pi*(y-1.0)) is *not* equivalent: it would give
+           -0.0 instead of 0.0 when y == 1.0. */
+        r = sin(pi*(1.0-y));
+        break;
+    case 3:
+        r = -cos(pi*(y-1.5));
+        break;
+    case 4:
+        r = sin(pi*(y-2.0));
+        break;
+    default:
+        assert(0);  /* should never get here */
+        r = -1.23e200; /* silence gcc warning */
+    }
+    return copysign(1.0, x)*r;
+}
+
+/* Implementation of the real gamma function.  In extensive but non-exhaustive
+   random tests, this function proved accurate to within <= 10 ulps across the
+   entire float domain.  Note that accuracy may depend on the quality of the
+   system math functions, the pow function in particular.  Special cases
+   follow C99 annex F.  The parameters and method are tailored to platforms
+   whose double format is the IEEE 754 binary64 format.
+
+   Method: for x > 0.0 we use the Lanczos approximation with parameters N=13
+   and g=6.024680040776729583740234375; these parameters are amongst those
+   used by the Boost library.  Following Boost (again), we re-express the
+   Lanczos sum as a rational function, and compute it that way.  The
+   coefficients below were computed independently using MPFR, and have been
+   double-checked against the coefficients in the Boost source code.
+
+   For x < 0.0 we use the reflection formula.
+
+   There's one minor tweak that deserves explanation: Lanczos' formula for
+   Gamma(x) involves computing pow(x+g-0.5, x-0.5) / exp(x+g-0.5).  For many x
+   values, x+g-0.5 can be represented exactly.  However, in cases where it
+   can't be represented exactly the small error in x+g-0.5 can be magnified
+   significantly by the pow and exp calls, especially for large x.  A cheap
+   correction is to multiply by (1 + e*g/(x+g-0.5)), where e is the error
+   involved in the computation of x+g-0.5 (that is, e = computed value of
+   x+g-0.5 - exact value of x+g-0.5).  Here's the proof:
+
+   Correction factor
+   -----------------
+   Write x+g-0.5 = y-e, where y is exactly representable as an IEEE 754
+   double, and e is tiny.  Then:
+
+     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) = pow(y-e, x-0.5)/exp(y-e)
+     = pow(y, x-0.5)/exp(y) * C,
+
+   where the correction_factor C is given by
+
+     C = pow(1-e/y, x-0.5) * exp(e)
+
+   Since e is tiny, pow(1-e/y, x-0.5) ~ 1-(x-0.5)*e/y, and exp(x) ~ 1+e, so:
+
+     C ~ (1-(x-0.5)*e/y) * (1+e) ~ 1 + e*(y-(x-0.5))/y
+
+   But y-(x-0.5) = g+e, and g+e ~ g.  So we get C ~ 1 + e*g/y, and
+
+     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) ~ pow(y, x-0.5)/exp(y) * (1 + e*g/y),
+
+   Note that for accuracy, when computing r*C it's better to do
+
+     r + e*g/y*r;
+
+   than
+
+     r * (1 + e*g/y);
+
+   since the addition in the latter throws away most of the bits of
+   information in e*g/y.
+*/
+
+#define LANCZOS_N 13
+static const double lanczos_g = 6.024680040776729583740234375;
+static const double lanczos_g_minus_half = 5.524680040776729583740234375;
+static const double lanczos_num_coeffs[LANCZOS_N] = {
+    23531376880.410759688572007674451636754734846804940,
+    42919803642.649098768957899047001988850926355848959,
+    35711959237.355668049440185451547166705960488635843,
+    17921034426.037209699919755754458931112671403265390,
+    6039542586.3520280050642916443072979210699388420708,
+    1439720407.3117216736632230727949123939715485786772,
+    248874557.86205415651146038641322942321632125127801,
+    31426415.585400194380614231628318205362874684987640,
+    2876370.6289353724412254090516208496135991145378768,
+    186056.26539522349504029498971604569928220784236328,
+    8071.6720023658162106380029022722506138218516325024,
+    210.82427775157934587250973392071336271166969580291,
+    2.5066282746310002701649081771338373386264310793408
+};
+
+/* denominator is x*(x+1)*...*(x+LANCZOS_N-2) */
+static const double lanczos_den_coeffs[LANCZOS_N] = {
+    0.0, 39916800.0, 120543840.0, 150917976.0, 105258076.0, 45995730.0,
+    13339535.0, 2637558.0, 357423.0, 32670.0, 1925.0, 66.0, 1.0};
+
+/* gamma values for small positive integers, 1 though NGAMMA_INTEGRAL */
+#define NGAMMA_INTEGRAL 23
+static const double gamma_integral[NGAMMA_INTEGRAL] = {
+    1.0, 1.0, 2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0, 362880.0,
+    3628800.0, 39916800.0, 479001600.0, 6227020800.0, 87178291200.0,
+    1307674368000.0, 20922789888000.0, 355687428096000.0,
+    6402373705728000.0, 121645100408832000.0, 2432902008176640000.0,
+    51090942171709440000.0, 1124000727777607680000.0,
+};
+
+/* Lanczos' sum L_g(x), for positive x */
+
+static double
+lanczos_sum(double x)
+{
+    double num = 0.0, den = 0.0;
+    int i;
+    assert(x > 0.0);
+    /* evaluate the rational function lanczos_sum(x).  For large
+       x, the obvious algorithm risks overflow, so we instead
+       rescale the denominator and numerator of the rational
+       function by x**(1-LANCZOS_N) and treat this as a
+       rational function in 1/x.  This also reduces the error for
+       larger x values.  The choice of cutoff point (5.0 below) is
+       somewhat arbitrary; in tests, smaller cutoff values than
+       this resulted in lower accuracy. */
+    if (x < 5.0) {
+        for (i = LANCZOS_N; --i >= 0; ) {
+            num = num * x + lanczos_num_coeffs[i];
+            den = den * x + lanczos_den_coeffs[i];
+        }
+    }
+    else {
+        for (i = 0; i < LANCZOS_N; i++) {
+            num = num / x + lanczos_num_coeffs[i];
+            den = den / x + lanczos_den_coeffs[i];
+        }
+    }
+    return num/den;
+}
+
+static double
+Numba_gamma(double x)
+{
+    double absx, r, y, z, sqrtpow;
+
+    /* special cases */
+    if (!Py_IS_FINITE(x)) {
+        if (Py_IS_NAN(x) || x > 0.0)
+            return x;  /* tgamma(nan) = nan, tgamma(inf) = inf */
+        else {
+            /*errno = EDOM;*/
+            return Py_NAN;  /* tgamma(-inf) = nan, invalid */
+        }
+    }
+    if (x == 0.0) {
+        /*errno = EDOM;*/
+        /* tgamma(+-0.0) = +-inf, divide-by-zero */
+        return copysign(Py_HUGE_VAL, x);
+    }
+
+    /* integer arguments */
+    if (x == floor(x)) {
+        if (x < 0.0) {
+            /*errno = EDOM;*/  /* tgamma(n) = nan, invalid for */
+            return Py_NAN; /* negative integers n */
+        }
+        if (x <= NGAMMA_INTEGRAL)
+            return gamma_integral[(int)x - 1];
+    }
+    absx = fabs(x);
+
+    /* tiny arguments:  tgamma(x) ~ 1/x for x near 0 */
+    if (absx < 1e-20) {
+        r = 1.0/x;
+        /*if (Py_IS_INFINITY(r))
+            errno = ERANGE;*/
+        return r;
+    }
+
+    /* large arguments: assuming IEEE 754 doubles, tgamma(x) overflows for
+       x > 200, and underflows to +-0.0 for x < -200, not a negative
+       integer. */
+    if (absx > 200.0) {
+        if (x < 0.0) {
+            return 0.0/sinpi(x);
+        }
+        else {
+            /*errno = ERANGE;*/
+            return Py_HUGE_VAL;
+        }
+    }
+
+    y = absx + lanczos_g_minus_half;
+    /* compute error in sum */
+    if (absx > lanczos_g_minus_half) {
+        /* note: the correction can be foiled by an optimizing
+           compiler that (incorrectly) thinks that an expression like
+           a + b - a - b can be optimized to 0.0.  This shouldn't
+           happen in a standards-conforming compiler. */
+        double q = y - absx;
+        z = q - lanczos_g_minus_half;
+    }
+    else {
+        double q = y - lanczos_g_minus_half;
+        z = q - absx;
+    }
+    z = z * lanczos_g / y;
+    if (x < 0.0) {
+        r = -pi / sinpi(absx) / absx * exp(y) / lanczos_sum(absx);
+        r -= z * r;
+        if (absx < 140.0) {
+            r /= pow(y, absx - 0.5);
+        }
+        else {
+            sqrtpow = pow(y, absx / 2.0 - 0.25);
+            r /= sqrtpow;
+            r /= sqrtpow;
+        }
+    }
+    else {
+        r = lanczos_sum(absx) / exp(y);
+        r += z * r;
+        if (absx < 140.0) {
+            r *= pow(y, absx - 0.5);
+        }
+        else {
+            sqrtpow = pow(y, absx / 2.0 - 0.25);
+            r *= sqrtpow;
+            r *= sqrtpow;
+        }
+    }
+    /*if (Py_IS_INFINITY(r))
+        errno = ERANGE;*/
+    return r;
+}
+
+static float
+Numba_gammaf(float x)
+{
+    return (float) Numba_gamma(x);
+}
+
+/*
+   lgamma:  natural log of the absolute value of the Gamma function.
+   For large arguments, Lanczos' formula works extremely well here.
+*/
+
+static double
+Numba_lgamma(double x)
+{
+    double r, absx;
+
+    /* special cases */
+    if (!Py_IS_FINITE(x)) {
+        if (Py_IS_NAN(x))
+            return x;  /* lgamma(nan) = nan */
+        else
+            return Py_HUGE_VAL; /* lgamma(+-inf) = +inf */
+    }
+
+    /* integer arguments */
+    if (x == floor(x) && x <= 2.0) {
+        if (x <= 0.0) {
+            /*errno = EDOM;*/  /* lgamma(n) = inf, divide-by-zero for */
+            return Py_HUGE_VAL; /* integers n <= 0 */
+        }
+        else {
+            return 0.0; /* lgamma(1) = lgamma(2) = 0.0 */
+        }
+    }
+
+    absx = fabs(x);
+    /* tiny arguments: lgamma(x) ~ -log(fabs(x)) for small x */
+    if (absx < 1e-20)
+        return -log(absx);
+
+    /* Lanczos' formula.  We could save a fraction of a ulp in accuracy by
+       having a second set of numerator coefficients for lanczos_sum that
+       absorbed the exp(-lanczos_g) term, and throwing out the lanczos_g
+       subtraction below; it's probably not worth it. */
+    r = log(lanczos_sum(absx)) - lanczos_g;
+    r += (absx - 0.5) * (log(absx + lanczos_g - 0.5) - 1);
+    if (x < 0.0)
+        /* Use reflection formula to get value for negative x. */
+        r = logpi - log(fabs(sinpi(absx))) - log(absx) - r;
+    /*if (Py_IS_INFINITY(r))
+        errno = ERANGE;*/
+    return r;
+}
+
+static float
+Numba_lgammaf(float x)
+{
+    return (float) Numba_lgamma(x);
 }
 
 /* provide erf() and erfc(); code borrowed from CPython */
@@ -580,6 +903,10 @@ build_c_helpers_dict(void)
     declmethod(erff);
     declmethod(erfc);
     declmethod(erfcf);
+    declmethod(gamma);
+    declmethod(gammaf);
+    declmethod(lgamma);
+    declmethod(lgammaf);
     declmethod(complex_adaptor);
     declmethod(extract_record_data);
     declmethod(release_record_buffer);

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -18,6 +18,9 @@
 #endif
 
 
+static const double sqrtpi = 1.772453850905516027298167483341145182798;
+
+
 /* provide 64-bit division function to 32-bit platforms */
 static
 int64_t Numba_sdiv(int64_t a, int64_t b) {
@@ -83,6 +86,166 @@ float Numba_ldexpf(float x, int exp)
 static
 void Numba_cpow(Py_complex *a, Py_complex *b, Py_complex *c) {
     *c = _Py_c_pow(*a, *b);
+}
+
+/* provide erf() and erfc(); code borrowed from CPython */
+
+/*
+   Implementations of the error function erf(x) and the complementary error
+   function erfc(x).
+
+   Method: following 'Numerical Recipes' by Flannery, Press et. al. (2nd ed.,
+   Cambridge University Press), we use a series approximation for erf for
+   small x, and a continued fraction approximation for erfc(x) for larger x;
+   combined with the relations erf(-x) = -erf(x) and erfc(x) = 1.0 - erf(x),
+   this gives us erf(x) and erfc(x) for all x.
+
+   The series expansion used is:
+
+      erf(x) = x*exp(-x*x)/sqrt(pi) * [
+                     2/1 + 4/3 x**2 + 8/15 x**4 + 16/105 x**6 + ...]
+
+   The coefficient of x**(2k-2) here is 4**k*factorial(k)/factorial(2*k).
+   This series converges well for smallish x, but slowly for larger x.
+
+   The continued fraction expansion used is:
+
+      erfc(x) = x*exp(-x*x)/sqrt(pi) * [1/(0.5 + x**2 -) 0.5/(2.5 + x**2 - )
+                              3.0/(4.5 + x**2 - ) 7.5/(6.5 + x**2 - ) ...]
+
+   after the first term, the general term has the form:
+
+      k*(k-0.5)/(2*k+0.5 + x**2 - ...).
+
+   This expansion converges fast for larger x, but convergence becomes
+   infinitely slow as x approaches 0.0.  The (somewhat naive) continued
+   fraction evaluation algorithm used below also risks overflow for large x;
+   but for large x, erfc(x) == 0.0 to within machine precision.  (For
+   example, erfc(30.0) is approximately 2.56e-393).
+
+   Parameters: use series expansion for abs(x) < ERF_SERIES_CUTOFF and
+   continued fraction expansion for ERF_SERIES_CUTOFF <= abs(x) <
+   ERFC_CONTFRAC_CUTOFF.  ERFC_SERIES_TERMS and ERFC_CONTFRAC_TERMS are the
+   numbers of terms to use for the relevant expansions.  */
+
+#define ERF_SERIES_CUTOFF 1.5
+#define ERF_SERIES_TERMS 25
+#define ERFC_CONTFRAC_CUTOFF 30.0
+#define ERFC_CONTFRAC_TERMS 50
+
+/*
+   Error function, via power series.
+
+   Given a finite float x, return an approximation to erf(x).
+   Converges reasonably fast for small x.
+*/
+
+static double
+m_erf_series(double x)
+{
+    double x2, acc, fk, result;
+    int i, saved_errno;
+
+    x2 = x * x;
+    acc = 0.0;
+    fk = (double)ERF_SERIES_TERMS + 0.5;
+    for (i = 0; i < ERF_SERIES_TERMS; i++) {
+        acc = 2.0 + x2 * acc / fk;
+        fk -= 1.0;
+    }
+    /* Make sure the exp call doesn't affect errno;
+       see m_erfc_contfrac for more. */
+    saved_errno = errno;
+    result = acc * x * exp(-x2) / sqrtpi;
+    errno = saved_errno;
+    return result;
+}
+
+/*
+   Complementary error function, via continued fraction expansion.
+
+   Given a positive float x, return an approximation to erfc(x).  Converges
+   reasonably fast for x large (say, x > 2.0), and should be safe from
+   overflow if x and nterms are not too large.  On an IEEE 754 machine, with x
+   <= 30.0, we're safe up to nterms = 100.  For x >= 30.0, erfc(x) is smaller
+   than the smallest representable nonzero float.  */
+
+static double
+m_erfc_contfrac(double x)
+{
+    double x2, a, da, p, p_last, q, q_last, b, result;
+    int i, saved_errno;
+
+    if (x >= ERFC_CONTFRAC_CUTOFF)
+        return 0.0;
+
+    x2 = x*x;
+    a = 0.0;
+    da = 0.5;
+    p = 1.0; p_last = 0.0;
+    q = da + x2; q_last = 1.0;
+    for (i = 0; i < ERFC_CONTFRAC_TERMS; i++) {
+        double temp;
+        a += da;
+        da += 2.0;
+        b = da + x2;
+        temp = p; p = b*p - a*p_last; p_last = temp;
+        temp = q; q = b*q - a*q_last; q_last = temp;
+    }
+    /* Issue #8986: On some platforms, exp sets errno on underflow to zero;
+       save the current errno value so that we can restore it later. */
+    saved_errno = errno;
+    result = p / q * x * exp(-x2) / sqrtpi;
+    errno = saved_errno;
+    return result;
+}
+
+/* Error function erf(x), for general x */
+
+static double
+Numba_erf(double x)
+{
+    double absx, cf;
+
+    if (Py_IS_NAN(x))
+        return x;
+    absx = fabs(x);
+    if (absx < ERF_SERIES_CUTOFF)
+        return m_erf_series(x);
+    else {
+        cf = m_erfc_contfrac(absx);
+        return x > 0.0 ? 1.0 - cf : cf - 1.0;
+    }
+}
+
+static float
+Numba_erff(float x)
+{
+    return (float) Numba_erf(x);
+}
+
+/* Complementary error function erfc(x), for general x. */
+
+static double
+Numba_erfc(double x)
+{
+    double absx, cf;
+
+    if (Py_IS_NAN(x))
+        return x;
+    absx = fabs(x);
+    if (absx < ERF_SERIES_CUTOFF)
+        return 1.0 - m_erf_series(x);
+    else {
+        cf = m_erfc_contfrac(absx);
+        return x > 0.0 ? cf : 2.0 - cf;
+    }
+}
+
+static float
+Numba_erfcf(float x)
+{
+    return (float) Numba_erfc(x);
 }
 
 
@@ -413,6 +576,10 @@ build_c_helpers_dict(void)
     declmethod(ldexp);
     declmethod(ldexpf);
     declmethod(cpow);
+    declmethod(erf);
+    declmethod(erff);
+    declmethod(erfc);
+    declmethod(erfcf);
     declmethod(complex_adaptor);
     declmethod(extract_record_data);
     declmethod(release_record_buffer);

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -40,6 +40,45 @@ uint64_t Numba_urem(uint64_t a, uint64_t b) {
     return a % b;
 }
 
+/* provide frexp and ldexp; these wrappers deal with special cases
+ * (zero, nan, infinity) directly, to sidestep platform differences.
+ */
+static
+double Numba_frexp(double x, int *exp)
+{
+    if (!Py_IS_FINITE(x) || !x)
+        *exp = 0;
+    else
+        x = frexp(x, exp);
+    return x;
+}
+
+static
+float Numba_frexpf(float x, int *exp)
+{
+    if (Py_IS_NAN(x) || Py_IS_INFINITY(x) || !x)
+        *exp = 0;
+    else
+        x = frexpf(x, exp);
+    return x;
+}
+
+static
+double Numba_ldexp(double x, int exp)
+{
+    if (Py_IS_FINITE(x) && x && exp)
+        x = ldexp(x, exp);
+    return x;
+}
+
+static
+float Numba_ldexpf(float x, int exp)
+{
+    if (Py_IS_FINITE(x) && x && exp)
+        x = ldexpf(x, exp);
+    return x;
+}
+
 /* provide complex power */
 static
 void Numba_cpow(Py_complex *a, Py_complex *b, Py_complex *c) {
@@ -369,6 +408,10 @@ build_c_helpers_dict(void)
     declmethod(srem);
     declmethod(udiv);
     declmethod(urem);
+    declmethod(frexp);
+    declmethod(frexpf);
+    declmethod(ldexp);
+    declmethod(ldexpf);
     declmethod(cpow);
     declmethod(complex_adaptor);
     declmethod(extract_record_data);

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -193,6 +193,8 @@ unary_math_intr(math.cos, lc.INTR_COS)
 unary_math_extern(math.log1p, "log1pf", "log1p")
 if utils.PYVERSION > (2, 6):
     unary_math_extern(math.expm1, "expm1f", "expm1")
+    unary_math_extern(math.erf, "numba_erff", "numba_erf")
+    unary_math_extern(math.erfc, "numba_erfcf", "numba_erfc")
 unary_math_extern(math.tan, "tanf", "tan")
 unary_math_extern(math.asin, "asinf", "asin")
 unary_math_extern(math.acos, "acosf", "acos")

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -195,6 +195,8 @@ if utils.PYVERSION > (2, 6):
     unary_math_extern(math.expm1, "expm1f", "expm1")
     unary_math_extern(math.erf, "numba_erff", "numba_erf")
     unary_math_extern(math.erfc, "numba_erfcf", "numba_erfc")
+    unary_math_extern(math.gamma, "numba_gammaf", "numba_gamma")
+    unary_math_extern(math.lgamma, "numba_lgammaf", "numba_lgamma")
 unary_math_extern(math.tan, "tanf", "tan")
 unary_math_extern(math.asin, "asinf", "asin")
 unary_math_extern(math.acos, "acosf", "acos")

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -523,30 +523,24 @@ class TestMathLib(TestCase):
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erf(self, flags=enable_pyobj_flags):
         pyfunc = erf
-        x_types = [types.int16, types.int32, types.int64,
-                   types.uint16, types.uint32, types.uint64,
-                   types.float32, types.float64]
-        x_values = [1, 1, 1, 1, 1, 1, 1., 1.]
+        x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
+        x_types = [types.float32, types.float64] * (len(x_values) // 2)
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erf_npm(self):
-        with self.assertTypingError():
-            self.test_erf(flags=no_pyobj_flags)
+        self.test_erf(flags=no_pyobj_flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erfc(self, flags=enable_pyobj_flags):
         pyfunc = erfc
-        x_types = [types.int16, types.int32, types.int64,
-                   types.uint16, types.uint32, types.uint64,
-                   types.float32, types.float64]
-        x_values = [1, 1, 1, 1, 1, 1, 1., 1.]
+        x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
+        x_types = [types.float32, types.float64] * (len(x_values) // 2)
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erfc_npm(self):
-        with self.assertTypingError():
-            self.test_erfc(flags=no_pyobj_flags)
+        self.test_erfc(flags=no_pyobj_flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_gamma(self, flags=enable_pyobj_flags):

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -159,6 +159,14 @@ def copysign(x, y):
     return math.copysign(x, y)
 
 
+def frexp(x):
+    return math.frexp(x)
+
+
+def ldexp(x, e):
+    return math.ldexp(x, e)
+
+
 class TestMathLib(TestCase):
 
     def setUp(self):
@@ -591,6 +599,31 @@ class TestMathLib(TestCase):
 
     def test_copysign_npm(self):
         self.test_copysign(flags=no_pyobj_flags)
+
+    def test_frexp(self, flags=enable_pyobj_flags):
+        pyfunc = frexp
+        x_types = [types.float32, types.float64]
+        x_values = [-2.5, -0.0, 0.0, 3.5,
+                    float('-inf'), float('inf'), float('nan')]
+        self.run_unary(pyfunc, x_types, x_values, flags, prec='exact')
+
+    def test_frexp_npm(self):
+        self.test_frexp(flags=no_pyobj_flags)
+
+    def test_ldexp(self, flags=enable_pyobj_flags):
+        pyfunc = ldexp
+        for fltty in (types.float32, types.float64):
+            cr = self.ccache.compile(pyfunc, (fltty, types.int32), flags=flags)
+            cfunc = cr.entry_point
+            for args in [(2.5, -2), (2.5, 1), (0.0, 0), (0.0, 1),
+                         (-0.0, 0), (-0.0, 1),
+                         (float('inf'), 0), (float('-inf'), 0),
+                         (float('nan'), 0)]:
+                msg = 'for input %r' % (args,)
+                self.assertPreciseEqual(cfunc(*args), pyfunc(*args))
+
+    def test_ldexp_npm(self):
+        self.test_ldexp(flags=no_pyobj_flags)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -545,30 +545,27 @@ class TestMathLib(TestCase):
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_gamma(self, flags=enable_pyobj_flags):
         pyfunc = gamma
-        x_types = [types.int16, types.int32, types.int64,
-                   types.uint16, types.uint32, types.uint64,
-                   types.float32, types.float64]
-        x_values = [1, 1, 1, 1, 1, 1, 1., 1.]
+        x_values = [1., -0.9, -0.5, 0.5]
+        x_types = [types.float32, types.float64] * (len(x_values) // 2)
+        self.run_unary(pyfunc, x_types, x_values, flags)
+        x_values = [-0.1, 0.1, 2.5, 10.1, 50., float('inf')]
+        x_types = [types.float64] * len(x_values)
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_gamma_npm(self):
-        with self.assertTypingError():
-            self.test_gamma(flags=no_pyobj_flags)
+        self.test_gamma(flags=no_pyobj_flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_lgamma(self, flags=enable_pyobj_flags):
         pyfunc = lgamma
-        x_types = [types.int16, types.int32, types.int64,
-                   types.uint16, types.uint32, types.uint64,
-                   types.float32, types.float64]
-        x_values = [1, 1, 1, 1, 1, 1, 1., 1.]
+        x_values = [1., -0.9, -0.1, 0.1, 200., 1e10, 1e30, float('inf')]
+        x_types = [types.float32, types.float64] * (len(x_values) // 2)
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_lgamma_npm(self):
-        with self.assertTypingError():
-            self.test_lgamma(flags=no_pyobj_flags)
+        self.test_lgamma(flags=no_pyobj_flags)
 
     def test_pow(self, flags=enable_pyobj_flags):
         pyfunc = pow

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -115,5 +115,19 @@ class Math_pow(ConcreteTemplate):
         signature(types.float64, types.float64, types.float64),
     ]
 
+@registry.resolves_global(math.frexp)
+class Math_frexp(ConcreteTemplate):
+    cases = [
+        signature(types.Tuple((types.float64, types.intc)), types.float64),
+        signature(types.Tuple((types.float32, types.intc)), types.float32),
+    ]
+
+@registry.resolves_global(math.ldexp)
+class Math_ldexp(ConcreteTemplate):
+    cases = [
+        signature(types.float64, types.float64, types.intc),
+        signature(types.float32, types.float32, types.intc),
+    ]
+
 
 builtin_global(math, types.Module(math))

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -27,6 +27,8 @@ builtin_global = registry.register_global
 @registry.resolves_global(math.atanh)
 @registry.resolves_global(math.degrees)
 @registry.resolves_global(math.radians)
+@registry.resolves_global(math.erf)
+@registry.resolves_global(math.erfc)
 class Math_unary(ConcreteTemplate):
     cases = [
         signature(types.float64, types.int64),

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -27,10 +27,6 @@ builtin_global = registry.register_global
 @registry.resolves_global(math.atanh)
 @registry.resolves_global(math.degrees)
 @registry.resolves_global(math.radians)
-@registry.resolves_global(math.erf)
-@registry.resolves_global(math.erfc)
-@registry.resolves_global(math.gamma)
-@registry.resolves_global(math.lgamma)
 class Math_unary(ConcreteTemplate):
     cases = [
         signature(types.float64, types.int64),
@@ -38,6 +34,11 @@ class Math_unary(ConcreteTemplate):
         signature(types.float32, types.float32),
         signature(types.float64, types.float64),
     ]
+
+if utils.PYVERSION > (2, 6):
+    for func in (math.erf, math.erfc, math.gamma, math.lgamma):
+        Math_unary = registry.resolves_global(func)(Math_unary)
+
 
 @registry.resolves_global(math.atan2)
 class Math_atan2(ConcreteTemplate):

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -29,6 +29,8 @@ builtin_global = registry.register_global
 @registry.resolves_global(math.radians)
 @registry.resolves_global(math.erf)
 @registry.resolves_global(math.erfc)
+@registry.resolves_global(math.gamma)
+@registry.resolves_global(math.lgamma)
 class Math_unary(ConcreteTemplate):
     cases = [
         signature(types.float64, types.int64),

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -140,7 +140,8 @@ class SortedSet(collections.Set):
 
 class UniqueDict(dict):
     def __setitem__(self, key, value):
-        assert key not in self
+        if key in self:
+            raise AssertionError("key already in dictionary: %r" % (key,))
         super(UniqueDict, self).__setitem__(key, value)
 
 


### PR DESCRIPTION
This PR adds math.ldexp() and math.frexp().
Other functions in Python 3 are still unsupported: gamma(), lgamma(), erf(), erfc(). Supporting them involves copying a bunch of C code (because of Windows).