### PR TITLE
Allow passing of tuples as arguments

### DIFF
--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -1,15 +1,27 @@
 from __future__ import print_function, division, absolute_import
+
 import numpy
+
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types
+from .support import TestCase
 
 
 def tuple_return_usecase(a, b):
     return a, b
 
+def tuple_first(tup):
+    a, b = tup
+    return a
 
-class TestTupleReturn(unittest.TestCase):
+def tuple_second(tup):
+    a, b = tup
+    return b
+
+
+class TestTupleReturn(TestCase):
+
     def test_array_tuple(self):
         aryty = types.Array(types.float64, 1, 'C')
         cres = compile_isolated(tuple_return_usecase, (aryty, aryty))
@@ -36,20 +48,32 @@ class TestTupleReturn(unittest.TestCase):
         allvalues.append((1, 2))
 
         alltypes.append((types.float32, types.float64))
-        allvalues.append((.1, .2))
+        allvalues.append((1.125, .25))
 
         alltypes.append((types.int32, types.float64))
-        allvalues.append((1231, .2))
+        allvalues.append((1231, .5))
 
         for (ta, tb), (a, b) in zip(alltypes, allvalues):
             cres = compile_isolated(tuple_return_usecase, (ta, tb))
             ra, rb = cres.entry_point(a, b)
+            self.assertPreciseEqual((ra, rb), (a, b))
 
-            for got, expect in zip((ra, rb), (a, b)):
-                if isinstance(got, float):
-                    self.assertAlmostEqual(got, expect)
-                else:
-                    self.assertEqual(got, expect)
+
+class TestTuplePassing(TestCase):
+
+    def test_unituple(self):
+        tuple_type = types.UniTuple(types.int32, 2)
+        cr_first = compile_isolated(tuple_first, (tuple_type,))
+        cr_second = compile_isolated(tuple_second, (tuple_type,))
+        self.assertPreciseEqual(cr_first.entry_point((4, 5)), 4)
+        self.assertPreciseEqual(cr_second.entry_point((4, 5)), 5)
+
+    def test_hetero_tuple(self):
+        tuple_type = types.Tuple((types.int64, types.float32))
+        cr_first = compile_isolated(tuple_first, (tuple_type,))
+        cr_second = compile_isolated(tuple_second, (tuple_type,))
+        self.assertPreciseEqual(cr_first.entry_point((2**61, 1.5)), 2**61)
+        self.assertPreciseEqual(cr_second.entry_point((2**61, 1.5)), 1.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was probably just an oversight, since returning tuples was already supported.