### PR TITLE
Improve round() support

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -91,7 +91,7 @@ The following built-in functions are supported:
 * :func:`max`: only the multiple-argument form
 * :func:`print`: only numbers and strings; no ``file`` or ``sep`` argument
 * :class:`range`
-* :func:`round`: only the two-argument form
+* :func:`round`
 * :func:`zip`
 
 

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -286,26 +286,6 @@ Numba_create_np_timedelta(npy_int64 value, int unit_code)
 }
 
 static
-double Numba_round_even(double y) {
-    double z = round(y);
-    if (fabs(y-z) == 0.5) {
-        /* halfway between two integers; use round-half-even */
-        z = 2.0*round(y / 2.0);
-    }
-    return z;
-}
-
-static
-float Numba_roundf_even(float y) {
-    float z = roundf(y);
-    if (fabsf(y-z) == 0.5) {
-        /* halfway between two integers; use round-half-even */
-        z = 2.0 * roundf(y / 2.0);
-    }
-    return z;
-}
-
-static
 uint64_t Numba_fptoui(double x) {
     /* First cast to signed int of the full width to make sure sign extension
        happens (this can make a difference on some platforms...). */
@@ -380,8 +360,6 @@ build_c_helpers_dict(void)
     declmethod(extract_np_timedelta);
     declmethod(create_np_timedelta);
     declmethod(recreate_record);
-    declmethod(round_even);
-    declmethod(roundf_even);
     declmethod(fptoui);
     declmethod(fptouif);
     declmethod(gil_ensure);

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1275,11 +1275,12 @@ def round_impl_f32(context, builder, sig, args):
     module = cgutils.get_module(builder)
     fnty = Type.function(Type.float(), [Type.float()])
     if utils.IS_PY3:
-        fn = module.get_or_insert_function(fnty, name="numba.roundf")
+        fn = module.get_or_insert_function(fnty, name="llvm.rint.f32")
+        res = builder.call(fn, args)
+        return builder.fptosi(res, Type.int(32))
     else:
-        fn = module.get_or_insert_function(fnty, name="roundf")
-    assert fn.is_declaration
-    return builder.call(fn, args)
+        fn = module.get_or_insert_function(fnty, name="llvm.round.f32")
+        return builder.call(fn, args)
 
 
 @builtin
@@ -1288,11 +1289,12 @@ def round_impl_f64(context, builder, sig, args):
     module = cgutils.get_module(builder)
     fnty = Type.function(Type.double(), [Type.double()])
     if utils.IS_PY3:
-        fn = module.get_or_insert_function(fnty, name="numba.round")
+        fn = module.get_or_insert_function(fnty, name="llvm.rint.f64")
+        res = builder.call(fn, args)
+        return builder.fptosi(res, Type.int(64))
     else:
-        fn = module.get_or_insert_function(fnty, name="round")
-    assert fn.is_declaration
-    return builder.call(fn, args)
+        fn = module.get_or_insert_function(fnty, name="llvm.round.f64")
+        return builder.call(fn, args)
 
 #-------------------------------------------------------------------------------
 

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -65,10 +65,6 @@ class _ExternalMathFunctions(_Installer):
             _add_missing_symbol("__fixunsdfdi", c_helpers["fptoui"])
             _add_missing_symbol("__fixunssfdi", c_helpers["fptouif"])
 
-        # Necessary for Python3
-        ll.add_symbol("numba.round", c_helpers["round_even"])
-        ll.add_symbol("numba.roundf", c_helpers["roundf_even"])
-
         # List available C-math
         for fname in intrinsics.INTR_MATH:
             # Force binding from CPython's C runtime library.

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -661,6 +661,9 @@ class TestBuiltins(TestCase):
                     self.assertPreciseEqual(cfunc(-x, n), pyfunc(-x, n),
                                             prec=prec)
 
+    def test_round2_npm(self):
+        self.test_round2(flags=no_pyobj_flags)
+
     def test_sum(self, flags=enable_pyobj_flags):
         pyfunc = sum_usecase
 

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -122,6 +122,9 @@ def reduce_usecase(reduce_func, x):
 def round_usecase1(x):
     return round(x)
 
+def round_usecase2(x, n):
+    return round(x, n)
+
 def sum_usecase(x):
     return sum(x)
 
@@ -642,6 +645,21 @@ class TestBuiltins(TestCase):
 
     def test_round1_npm(self):
         self.test_round1(flags=no_pyobj_flags)
+
+    def test_round2(self, flags=enable_pyobj_flags):
+        pyfunc = round_usecase2
+
+        for tp in (types.float64, types.float32):
+            prec = 'single' if tp is types.float32 else 'exact'
+            cr = compile_isolated(pyfunc, (tp, types.int32), flags=flags)
+            cfunc = cr.entry_point
+            for x in [0.0, 0.1, 0.125, 0.25, 0.5, 0.75, 1.25,
+                      1.5, 1.75, 2.25, 2.5, 2.75, 12.5, 15.0, 22.5]:
+                for n in (-1, 0, 1, 2):
+                    self.assertPreciseEqual(cfunc(x, n), pyfunc(x, n),
+                                            prec=prec)
+                    self.assertPreciseEqual(cfunc(-x, n), pyfunc(-x, n),
+                                            prec=prec)
 
     def test_sum(self, flags=enable_pyobj_flags):
         pyfunc = sum_usecase

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -119,7 +119,7 @@ def ord_usecase(x):
 def reduce_usecase(reduce_func, x):
     return functools.reduce(reduce_func, x)
 
-def round_usecase(x):
+def round_usecase1(x):
     return round(x)
 
 def sum_usecase(x):
@@ -630,17 +630,18 @@ class TestBuiltins(TestCase):
         with self.assertTypingError():
             self.test_reduce(flags=no_pyobj_flags)
 
-    def test_round(self, flags=enable_pyobj_flags):
-        pyfunc = round_usecase
+    def test_round1(self, flags=enable_pyobj_flags):
+        pyfunc = round_usecase1
 
-        cr = compile_isolated(pyfunc, (types.float64,), flags=flags)
-        cfunc = cr.entry_point
-        for x in [-0.5, -0.1, 0.0, 0.1, 0.5, 1.5, 5.0]:
-            # XXX round() doesn't return the right type under Python 3
-            self.assertEqual(cfunc(x), pyfunc(x))
+        for tp in (types.float64, types.float32):
+            cr = compile_isolated(pyfunc, (tp,), flags=flags)
+            cfunc = cr.entry_point
+            for x in [-1.6, -1.5, -1.4, -0.5, -0.1, -0.0,
+                      0.0, 0.1, 0.5, 0.6, 1.4, 1.5, 5.0]:
+                self.assertPreciseEqual(cfunc(x), pyfunc(x))
 
-    def test_round_npm(self):
-        self.test_round(flags=no_pyobj_flags)
+    def test_round1_npm(self):
+        self.test_round1(flags=no_pyobj_flags)
 
     def test_sum(self, flags=enable_pyobj_flags):
         pyfunc = sum_usecase

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -720,10 +720,16 @@ class Min(AbstractTemplate):
 
 class Round(ConcreteTemplate):
     key = round
-    cases = [
-        signature(types.float32, types.float32),
-        signature(types.float64, types.float64),
-    ]
+    if PYVERSION < (3, 0):
+        cases = [
+            signature(types.float32, types.float32),
+            signature(types.float64, types.float64),
+        ]
+    else:
+        cases = [
+            signature(types.int32, types.float32),
+            signature(types.int64, types.float64),
+        ]
 
 
 builtin_global(max, types.Function(Max))

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -730,6 +730,10 @@ class Round(ConcreteTemplate):
             signature(types.int32, types.float32),
             signature(types.int64, types.float64),
         ]
+    cases += [
+        signature(types.float32, types.float32, types.int32),
+        signature(types.float64, types.float64, types.int32),
+    ]
 
 
 builtin_global(max, types.Function(Max))


### PR DESCRIPTION
- Fix one-argument round() return value on Python 3
- Support two-argument round()
- Use LLVM intrinsics for better performance
