### PR TITLE
Followup to round() improvements

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -477,29 +477,30 @@ class Lower(BaseLower):
                             for av, at, ft in zip(argvals, argtyps,
                                                   signature.args)]
 
-            if isinstance(fnty, types.Method):
+            if isinstance(fnty, types.ExternalFunction):
+                # Handle a named external function
+                fndesc = ExternalFunctionDescriptor(
+                    fnty.symbol, fnty.sig.return_type, fnty.sig.args)
+                func = self.context.declare_external_function(
+                        cgutils.get_module(self.builder), fndesc)
+                res = self.context.call_external_function(
+                    self.builder, func, fndesc.argtypes, castvals)
+
+            elif isinstance(fnty, types.Method):
                 # Method of objects are handled differently
                 fnobj = self.loadvar(expr.func.name)
                 res = self.context.call_class_method(self.builder, fnobj,
                                                      signature, castvals)
 
             elif isinstance(fnty, types.FunctionPointer):
-                # Handle function pointer
+                # Handle a C function pointer
                 pointer = fnty.funcptr
                 res = self.context.call_function_pointer(self.builder, pointer,
                                                          signature, castvals,
                                                          fnty.cconv)
 
-            elif isinstance(fnty, cffi_support.ExternCFunction):
-                # XXX unused?
-                fndesc = ExternalFunctionDescriptor(
-                    fnty.symbol, fnty.restype, fnty.argtypes)
-                func = self.context.declare_external_function(
-                        cgutils.get_module(self.builder), fndesc)
-                res = self.context.call_external_function(self.builder, func, fndesc.argtypes, castvals)
-
             else:
-                # Normal function resolution
+                # Normal function resolution (for Numba-compiled functions)
                 impl = self.context.get_function(fnty, signature)
                 if signature.recvr:
                     # The "self" object is passed as the function object

--- a/numba/types.py
+++ b/numba/types.py
@@ -323,9 +323,9 @@ class Macro(Type):
 class Function(Type):
     def __init__(self, template):
         self.template = template
-        cls = type(self)
+        name = "%s(%s)" % (self.__class__.__name__, template.key)
         # TODO template is mutable.  Should use different naming scheme
-        super(Function, self).__init__("%s(%s)" % (cls.__name__, template.key))
+        super(Function, self).__init__(name)
 
     @property
     def key(self):
@@ -393,6 +393,19 @@ class FunctionPointer(Function):
         self.funcptr = funcptr
         self.cconv = cconv
         super(FunctionPointer, self).__init__(template)
+
+
+class ExternalFunction(Function):
+    """
+    A named native function (resolvable by LLVM).
+    """
+
+    def __init__(self, symbol, sig):
+        from . import typing
+        self.symbol = symbol
+        self.sig = sig
+        template = typing.make_concrete_template(symbol, symbol, [sig])
+        super(ExternalFunction, self).__init__(template)
 
 
 class BoundFunction(Function):

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -61,20 +61,17 @@ def make_function_type(cffi_func):
     return result
 
 
-class ExternCFunction(types.Function):
+class ExternCFunction(types.ExternalFunction):
     # XXX unused?
 
     def __init__(self, symbol, cstring):
         """Parse C function declaration/signature"""
-        self.symbol = symbol
         parser = cffi.cparser.Parser()
         rft = parser.parse_type(cstring) # "RawFunctionType"
         self.restype = type_map[rft.result.build_backend_type(ffi, None)]
         self.argtypes = [type_map[arg.build_backend_type(ffi, None)] for arg in rft.args]
         signature = templates.signature(self.restype, *self.argtypes)
-        cases = [signature]
-        template = templates.make_concrete_template('ExternCFunction', self.symbol, cases)
-        super(ExternCFunction, self).__init__(template)
+        super(ExternCFunction, self).__init__(symbol, signature)
 
 
 if ffi is not None:

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -201,8 +201,7 @@ class BaseContext(object):
         elif cffi_utils.SUPPORTED and cffi_utils.is_cffi_func(val):
             return cffi_utils.make_function_type(val)
 
-        elif (cffi_utils.SUPPORTED and
-                  isinstance(val, cffi_utils.ExternCFunction)):
+        elif isinstance(val, types.ExternalFunction):
             return val
 
         elif type(val) is type and issubclass(val, BaseException):


### PR DESCRIPTION
Improve code generation under Python 3 (avoid a float -> int -> float roundtrip).