### PR TITLE
naive tuple support and indexing arrays from arrays in nopython mode

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -280,6 +280,13 @@ def getitem_array_arraytuple(context, builder, sig, args):
 
     # WATCHOUT: if idx.shape[0] is smaller than ndim, this would
     # produce segfaults
+    lenidx = builder.extract_value(idx.shape, 0)
+
+    too_short = builder.icmp_unsigned("<", lenidx, Constant.int(Type.int(16), ndim))
+
+    with cgutils.if_unlikely(builder, too_short):
+        context.call_conv.return_user_exc(builder, IndexError, ("Dimension Mismatch",))
+
     # there doesn't seem to be a way to check this at compile time
     # and checking at runtime is likely not worth it.
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -449,6 +449,17 @@ def _implement_integer_operators():
 _implement_integer_operators()
 
 
+def tuple_new_impl(context, builder, sig, args):
+    """ build tuple from unituple, tuple or array """
+    # this simply does nothing but directly return the original object
+    # because tuples are already tuples, and arrays, we convert to
+    # an ArrayTuple type (used in getitem)
+    [val] = args
+    return val
+builtin(implement(types.tuple_type, types.Kind(types.UniTuple))(tuple_new_impl))
+builtin(implement(types.tuple_type, types.Kind(types.Tuple))(tuple_new_impl))
+builtin(implement(types.tuple_type, types.Kind(types.Array))(tuple_new_impl))
+
 def optional_is_none(context, builder, sig, args):
     """Check if an Optional value is invalid
     """

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -19,6 +19,9 @@ def tuple_second(tup):
     a, b = tup
     return b
 
+def tuple_tuple_usecase(a, b):
+    return tuple((a, b))
+
 
 class TestTupleReturn(TestCase):
 
@@ -58,6 +61,14 @@ class TestTupleReturn(TestCase):
             ra, rb = cres.entry_point(a, b)
             self.assertPreciseEqual((ra, rb), (a, b))
 
+    def test_tuple_tuple(self):
+        scalarty = types.float32
+        cres = compile_isolated(tuple_tuple_usecase, (scalarty, scalarty))
+        a = b = 1
+        ra, rb = cres.entry_point(a, b)
+        self.assertEqual(ra, a)
+        self.assertEqual(rb, b)
+        
 
 class TestTuplePassing(TestCase):
 

--- a/numba/types.py
+++ b/numba/types.py
@@ -656,7 +656,6 @@ class ArrayIterator(IteratorType):
             self.yield_type = array_type.copy(ndim=array_type.ndim - 1)
         super(ArrayIterator, self).__init__(name, param=True)
 
-
 class Buffer(IterableType):
     """
     Type class for objects providing the buffer protocol.
@@ -820,6 +819,17 @@ class NestedArray(Array):
              stride *= i
         return tuple(strides)
 
+class ArrayTuple(Array):
+    def __init__(self, array):
+        dtype = array.dtype
+        ndim = array.ndim
+        layout = array.layout
+        const = array.const
+        name = "arraytuple(%s, %sd, %s, %s)" % (dtype, ndim, layout,
+                                           {True: 'const',
+                                            False: 'nonconst'}[const])
+        super(ArrayTuple, self).__init__(dtype, ndim, layout, const)
+        self.name = name
 
 class UniTuple(IterableType):
 
@@ -1078,6 +1088,8 @@ neg_type = Phantom('neg')
 print_type = Phantom('print')
 print_item_type = Phantom('print-item')
 sign_type = Phantom('sign')
+exception_type = Phantom('exception')
+tuple_type = Phantom('tuple')
 
 range_iter32_type = RangeIteratorType('range_iter32', int32)
 range_iter64_type = RangeIteratorType('range_iter64', int64)


### PR DESCRIPTION
Issue #985 
The idea is to add a `tuple` builtin function, that accepts Array input
and returns TupleArray . `getitem` then handles indexing via a TupleArray  .

After this patch, the following code shall work.
```
import numba
import numpy

@numba.jit(nopython=True)
def tuplefromarray(a, b):
    return a[tuple(b)]

@numba.jit(nopython=True)
def tuplefromtuple(a, b):
    return tuple((1, 2, 3))

a = numpy.arange(100).reshape(-1, 2)
b = numpy.ones( 2, dtype='i4')
print tuplefromtuple(a, b)
print tuplefromarray(a, b)
```