### PR TITLE
Shorten names of records and structured arrays

### DIFF
--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -9,6 +9,7 @@ from numba import typing, types, cgutils
 from numba.utils import cached_property
 from numba.targets.base import BaseContext
 from numba.targets.callconv import MinimalCallConv
+from numba.lowering import transform_arg_name
 from .cudadrv import nvvm
 from . import codegen, nvvmutils
 
@@ -63,7 +64,7 @@ class CUDATargetContext(BaseContext):
             ch = m.group(0)
             return "_%X_" % ord(ch)
 
-        qualified = name + '.' + '.'.join(str(a) for a in argtypes)
+        qualified = name + '.' + '.'.join(transform_arg_name(a) for a in argtypes)
         mangled = VALID_CHARS.sub(repl, qualified)
         return mangled
 

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -23,8 +23,21 @@ class ForbiddenConstruct(LoweringError):
     pass
 
 
+def transform_arg_name(arg):
+    if isinstance(arg, types.Record):
+        return "Record_%s" % arg._code
+    elif (isinstance(arg, types.Array) and
+          isinstance(arg.dtype, types.Record)):
+        c = '' and arg.const or 'non'
+        return "array(Record_%s, %sd, %s, %sconst)" % \
+            (arg.dtype._code, arg.ndim, arg.layout, c)
+    else:
+        return str(arg)
+
+
 def default_mangler(name, argtypes):
-    codedargs = '.'.join(str(a).replace(' ', '_') for a in argtypes)
+    codedargs = '.'.join(transform_arg_name(a).replace(' ', '_')
+                             for a in argtypes)
     return '.'.join([name, codedargs])
 
 


### PR DESCRIPTION
Mangling the `str` of structured types can cause the names of
functions to become extremely long (long enough to crash NVVM with
a segfault).

This commit modifies the mangling to use the typecodes of
structured types rather than a full description of all their
fields.

The test attempts to ensure correctness by checking that no field
names form part of the transformed name, and that the transformed
name is not excessively long for any other reason.