### PR TITLE
Data model refactor 2

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -52,6 +52,9 @@ _struct_proxy_cache = {}
 
 
 def create_struct_proxy(fe_type):
+    """
+    Returns a specialized StructProxy subclass for the given fe_type.
+    """
     res = _struct_proxy_cache.get(fe_type)
     if res is None:
         clsname = StructProxy.__name__ + '_' + str(fe_type)
@@ -63,6 +66,11 @@ def create_struct_proxy(fe_type):
 
 
 class StructProxy(object):
+    """
+    Creates a `Structure` like interface that is constructed with information
+    from DataModel instance.  FE type must have a data model that is a
+    subclass of StructModel.
+    """
     # The following class members must be overridden by subclass
     _fe_type = None
 

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -10,6 +10,7 @@ import re
 from llvmlite import ir
 from llvmlite.llvmpy.core import Constant, Type
 import llvmlite.llvmpy.core as lc
+from numba import datamodel
 
 from . import utils
 
@@ -130,7 +131,7 @@ class StructProxy(object):
         """
         Return the number of fields.
         """
-        return len(self._namemap)
+        return self._datamodel.field_count
 
     def _getpointer(self):
         """

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -377,6 +377,9 @@ class CUDAKernel(CUDAKernelBase):
             wb()
 
     def _prepare_args(self, ty, val, stream, retr, kernelargs):
+        """
+        Convert arguments to ctypes and append to kernelargs
+        """
         if isinstance(ty, types.Array):
             devary, conv = devicearray.auto_device(val, stream=stream)
             if conv:

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 import copy
-import ctypes
 
+from numba import ctypes_support as ctypes
 from numba.typing.templates import AbstractTemplate
 from numba import config, compiler, types
 from numba.typing.templates import ConcreteTemplate
@@ -11,7 +11,6 @@ from .cudadrv.devices import get_context
 from .cudadrv import nvvm, devicearray, driver
 from .errors import KernelRuntimeError
 from .api import get_current_device
-from numba.targets.arrayobj import make_array_ctype
 
 
 def compile_cuda(pyfunc, return_type, args, debug, inline):

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -77,7 +77,9 @@ class CUDATargetContext(BaseContext):
 
     def generate_kernel_wrapper(self, func, argtypes):
         module = func.module
-        argtys = [self.get_argument_type(ty) for ty in argtypes]
+
+        arginfo = self.get_arg_info(argtypes)
+        argtys = list(arginfo.argument_types)
         wrapfnty = Type.function(Type.void(), argtys)
         wrapper_module = self.create_module("cuda.kernel.wrapper")
         fnty = Type.function(Type.int(),
@@ -100,11 +102,7 @@ class CUDATargetContext(BaseContext):
             gv_tid.append(define_error_gv("__tid%s__" % i))
             gv_ctaid.append(define_error_gv("__ctaid%s__" % i))
 
-        callargs = []
-        for at, av in zip(argtypes, wrapfn.args):
-            av = self.get_argument_value(builder, at, av)
-            callargs.append(av)
-
+        callargs = arginfo.from_arguments(builder, wrapfn.args)
         status, _ = self.call_conv.call_function(
             builder, func, types.void, argtypes, callargs)
 

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -78,7 +78,7 @@ class CUDATargetContext(BaseContext):
     def generate_kernel_wrapper(self, func, argtypes):
         module = func.module
 
-        arginfo = self.get_arg_info(argtypes)
+        arginfo = self.get_arg_packer(argtypes)
         argtys = list(arginfo.argument_types)
         wrapfnty = Type.function(Type.void(), argtys)
         wrapper_module = self.create_module("cuda.kernel.wrapper")

--- a/numba/cuda/tests/cudapy/test_macro.py
+++ b/numba/cuda/tests/cudapy/test_macro.py
@@ -51,13 +51,16 @@ class TestMacro(unittest.TestCase):
     def getarg(self):
         return np.array(100, dtype=np.float32)
 
+    def getarg2(self):
+        return self.getarg().reshape(1,1)
+
     def test_global_constants(self):
         udt = cuda.jit((float32[:],))(udt_global_constants)
         udt(self.getarg())
 
     def test_global_build_tuple(self):
         udt = cuda.jit((float32[:, :],))(udt_global_build_tuple)
-        udt(self.getarg())
+        udt(self.getarg2())
 
     def test_global_build_list(self):
         with self.assertRaises(MacroError) as raises:
@@ -68,7 +71,7 @@ class TestMacro(unittest.TestCase):
 
     def test_global_constant_tuple(self):
         udt = cuda.jit((float32[:, :],))(udt_global_constant_tuple)
-        udt(self.getarg())
+        udt(self.getarg2())
 
     def test_invalid_1(self):
         with self.assertRaises(ValueError) as raises:

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,4 +1,4 @@
 from .manager import DataModelManager
-from .funcinfo import FunctionInfo
+from .arginfo import ArgInfo
 from .registry import register_default, defaultDataModelManager, register
 from .models import PrimitiveModel, CompositeModel, StructModel

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,4 +1,4 @@
 from .manager import DataModelManager
-from .arginfo import ArgInfo
-from .registry import register_default, defaultDataModelManager, register
+from .argpacker import ArgPacker
+from .registry import register_default, default_manager, register
 from .models import PrimitiveModel, CompositeModel, StructModel

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,0 +1,4 @@
+from .manager import DataModelManager
+from .funcinfo import FunctionInfo
+from .registry import register_default, defaultDataModelManager, register
+from .models import PrimitiveModel, CompositeModel, StructModel

--- a/numba/datamodel/arginfo.py
+++ b/numba/datamodel/arginfo.py
@@ -75,10 +75,15 @@ class ArgInfo(object):
 
     @property
     def argument_types(self):
+        """Return a list of LLVM types that are results of flattening
+        composite types.
+        """
         return tuple(self._be_args)
 
 
 def _unflatten(posmap, flatiter):
+    """Rebuild a nested tuple structure
+    """
     poss = deque(posmap)
     vals = deque(flatiter)
 

--- a/numba/datamodel/argpacker.py
+++ b/numba/datamodel/argpacker.py
@@ -3,11 +3,17 @@ from __future__ import print_function, absolute_import
 from collections import deque
 
 
-class ArgInfo(object):
+class ArgPacker(object):
     """
     Compute the position for each high-level typed argument.
     It flattens every composite argument into primitive types.
     It maintains a position map for unflattening the arguments.
+
+    Since struct (esp. nested struct) have specific ABI requirements (e.g.
+    alignemnt, pointer address-space, ...) in different architecture (e.g.
+    OpenCL, CUDA), flattening composite argument types simplifes the call
+    setup from the Python side.  Functions are receiving simple primitive
+    types and there are only a handful of these.
     """
     def __init__(self, dmm, fe_args):
         self._dmm = dmm

--- a/numba/datamodel/funcinfo.py
+++ b/numba/datamodel/funcinfo.py
@@ -1,0 +1,88 @@
+from __future__ import print_function, absolute_import
+
+from collections import deque
+
+
+class FunctionInfo(object):
+    def __init__(self, dmm, fe_ret, fe_args):
+        self._dmm = dmm
+        self._fe_ret = fe_ret
+        self._fe_args = fe_args
+        self._nargs = len(fe_args)
+        self._dm_ret = self._dmm.lookup(fe_ret)
+        self._dm_args = [self._dmm.lookup(ty) for ty in fe_args]
+        argtys = [bt.get_argument_type() for bt in self._dm_args]
+        if len(argtys):
+            self._be_args, self._posmap = zip(*_flatten(argtys))
+        else:
+            self._be_args = self._posmap = ()
+        self._be_ret = self._dm_ret.get_return_type()
+
+    def as_arguments(self, builder, values):
+        if len(values) != self._nargs:
+            raise TypeError("invalid number of args")
+
+        if not values:
+            return ()
+
+        args = [dm.as_argument(builder, val)
+                for dm, val in zip(self._dm_args, values)]
+
+        args, _ = zip(*_flatten(args))
+        return args
+
+    def from_arguments(self, builder, args):
+        if len(args) != len(self._posmap):
+            raise TypeError("invalid number of args")
+
+        if not args:
+            return ()
+
+        valtree = _unflatten(self._posmap, args)
+        values = [dm.from_argument(builder, val)
+                  for dm, val in zip(self._dm_args, valtree)]
+
+        return values
+
+    @property
+    def argument_types(self):
+        return tuple(self._be_args)
+
+    @property
+    def return_type(self):
+        return self._be_ret
+
+
+def _unflatten(posmap, flatiter):
+    poss = deque(posmap)
+    vals = deque(flatiter)
+
+    res = []
+    while poss:
+        assert len(poss) == len(vals)
+        cur = poss.popleft()
+        ptr = res
+        for loc in cur[:-1]:
+            if loc >= len(ptr):
+                ptr.append([])
+            ptr = ptr[loc]
+
+        assert len(ptr) == cur[-1]
+        ptr.append(vals.popleft())
+
+    return res
+
+
+def _flatten(iterable, indices=(0,)):
+    """
+    Flatten nested iterable of (tuple, list) with position information
+    """
+    for i in iterable:
+        if isinstance(i, (tuple, list)):
+            inner = indices + (0,)
+            for j, k in _flatten(i, indices=inner):
+                yield j, k
+        else:
+            yield i, indices
+        indices = indices[:-1] + (indices[-1] + 1,)
+

--- a/numba/datamodel/manager.py
+++ b/numba/datamodel/manager.py
@@ -1,0 +1,31 @@
+from __future__ import print_function, absolute_import
+
+from numba import types
+
+
+class DataModelManager(object):
+    """Manages mapping of FE types to their corresponding data model
+    """
+
+    def __init__(self):
+        # handler map
+        # key: numba.types.Type subclass
+        # value: function
+        self._handlers = {}
+
+    def register(self, fetypecls, handler):
+        """Register the datamodel factory corresponding to a frontend-type class
+        """
+        assert issubclass(fetypecls, types.Type)
+        self._handlers[fetypecls] = handler
+
+    def lookup(self, fetype):
+        """Returns the corresponding datamodel given the frontend-type instance
+        """
+        handler = self._handlers[type(fetype)]
+        return handler(self, fetype)
+
+    def __getitem__(self, fetype):
+        """Shorthand for lookup()
+        """
+        return self.lookup(fetype)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -374,7 +374,8 @@ class StructModel(CompositeModel):
         """
         if isinstance(pos, str):
             pos = self.get_field_position(pos)
-        return builder.extract_value(val, [pos])
+        return builder.extract_value(val, [pos],
+                                     name="extracted." + self._fields[pos])
 
     def set(self, builder, stval, val, pos):
         """Set a field at the given position or the fieldname
@@ -396,7 +397,8 @@ class StructModel(CompositeModel):
         """
         if isinstance(pos, str):
             pos = self.get_field_position(pos)
-        return builder.insert_value(stval, val, [pos])
+        return builder.insert_value(stval, val, [pos],
+                                    name="inserted." + self._fields[pos])
 
     def get_field_position(self, field):
         return self._fields.index(field)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1,0 +1,557 @@
+from __future__ import print_function, absolute_import
+
+from llvmlite import ir
+from numba import types, numpy_support
+from .registry import register_default
+
+
+class DataModel(object):
+    def __init__(self, dmm, fe_type):
+        self._dmm = dmm
+        self._fe_type = fe_type
+
+    @property
+    def fe_type(self):
+        return self._fe_type
+
+    def get_value_type(self):
+        raise NotImplementedError
+
+    def get_data_type(self):
+        return self.get_value_type()
+
+    def get_argument_type(self):
+        return self.get_value_type()
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def as_data(self, builder, value):
+        return NotImplemented
+
+    def as_argument(self, builder, value):
+        return NotImplemented
+
+    def as_return(self, builder, value):
+        return NotImplemented
+
+    def from_data(self, builder, value):
+        return NotImplemented
+
+    def from_argument(self, builder, value):
+        return NotImplemented
+
+    def from_return(self, builder, value):
+        return NotImplemented
+
+    def load_from_data_pointer(self, builder, value):
+        return NotImplemented
+
+    def _compared_fields(self):
+        return (type(self), self._fe_type)
+
+    def __hash__(self):
+        return hash(tuple(self._compared_fields()))
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self._compared_fields() == other._compared_fields()
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+@register_default(types.Boolean)
+class BooleanModel(DataModel):
+    def get_value_type(self):
+        return ir.IntType(1)
+
+    def get_data_type(self):
+        return ir.IntType(8)
+
+    def get_return_type(self):
+        return self.get_data_type()
+
+    def get_argument_type(self):
+        return self.get_data_type()
+
+    def as_data(self, builder, value):
+        return builder.zext(value, self.get_data_type())
+
+    def as_argument(self, builder, value):
+        return self.as_data(builder, value)
+
+    def as_return(self, builder, value):
+        return self.as_data(builder, value)
+
+    def from_data(self, builder, value):
+        return builder.trunc(value, self.get_value_type())
+
+    def from_argument(self, builder, value):
+        return self.from_data(builder, value)
+
+    def from_return(self, builder, value):
+        return self.from_data(builder, value)
+
+
+class PrimitiveModel(DataModel):
+    """A primitive type can be represented natively in the target in all
+    usage contexts.
+    """
+
+    def __init__(self, dmm, fe_type, be_type):
+        super(PrimitiveModel, self).__init__(dmm, fe_type)
+        self.be_type = be_type
+
+    def get_value_type(self):
+        return self.be_type
+
+    def as_data(self, builder, value):
+        return value
+
+    def as_argument(self, builder, value):
+        return self.as_data(builder, value)
+
+    def as_return(self, builder, value):
+        return self.as_data(builder, value)
+
+    def from_data(self, builder, value):
+        return value
+
+    def from_argument(self, builder, value):
+        return self.from_data(builder, value)
+
+    def from_return(self, builder, value):
+        return self.from_data(builder, value)
+
+
+@register_default(types.Opaque)
+@register_default(types.NoneType)
+@register_default(types.Function)
+@register_default(types.Type)
+@register_default(types.Object)
+class OpaqueModel(PrimitiveModel):
+    """
+    Passed as opaque pointers
+    """
+
+    def __init__(self, dmm, fe_type):
+        be_type = ir.IntType(8).as_pointer()
+        super(OpaqueModel, self).__init__(dmm, fe_type, be_type)
+
+
+@register_default(types.Integer)
+class IntegerModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        be_type = ir.IntType(fe_type.bitwidth)
+        super(IntegerModel, self).__init__(dmm, fe_type, be_type)
+
+
+class FloatModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        super(FloatModel, self).__init__(dmm, fe_type, ir.FloatType())
+
+
+class DoubleModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        super(DoubleModel, self).__init__(dmm, fe_type, ir.DoubleType())
+
+
+@register_default(types.CPointer)
+class PointerModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        be_type = dmm.lookup(fe_type.dtype).get_data_type().as_pointer()
+        super(PointerModel, self).__init__(dmm, fe_type, be_type)
+
+
+@register_default(types.UniTuple)
+class UniTupleModel(DataModel):
+    def __init__(self, dmm, fe_type):
+        super(UniTupleModel, self).__init__(dmm, fe_type)
+        self._elem_model = dmm.lookup(fe_type.dtype)
+        self._count = len(fe_type)
+
+    def get_value_type(self):
+        elem_type = self._elem_model.get_value_type()
+        return ir.ArrayType(elem_type, self._count)
+
+    def get_data_type(self):
+        elem_type = self._elem_model.get_data_type()
+        return ir.ArrayType(elem_type, self._count)
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def get_argument_type(self):
+        return [self._elem_model.get_argument_type()] * self._count
+
+    def as_argument(self, builder, value):
+        out = []
+        for i in range(self._count):
+            out.append(builder.extract_value(value, [i]))
+        return out
+
+    def from_argument(self, builder, value):
+        out = ir.Constant(self.get_value_type(), ir.Undefined)
+        for i, v in enumerate(value):
+            out = builder.insert_value(out, v, [i])
+        return out
+
+    def as_data(self, builder, value):
+        out = ir.Constant(self.get_data_type(), ir.Undefined)
+        for i in range(self._count):
+            val = builder.extract_value(value, [i])
+            dval = self._elem_model.as_data(builder, val)
+            out = builder.insert_value(out, dval, [i])
+        return out
+
+    def from_data(self, builder, value):
+        out = ir.Constant(self.get_value_type(), ir.Undefined)
+        for i in range(self._count):
+            val = builder.extract_value(value, [i])
+            dval = self._elem_model.from_data(builder, val)
+            out = builder.insert_value(out, dval, [i])
+        return out
+
+    def as_return(self, builder, value):
+        return value
+
+    def from_return(self, builder, value):
+        return value
+
+
+class CompositeModel(DataModel):
+    """Any model that is composed of multiple other models should subclass from
+    this.
+    """
+    pass
+
+
+class StructModel(CompositeModel):
+    def __init__(self, dmm, fe_type, members):
+        super(StructModel, self).__init__(dmm, fe_type)
+        if members:
+            self._fields, self._members = zip(*members)
+        else:
+            self._fields = self._members = ()
+        self._models = tuple([self._dmm.lookup(t) for t in self._members])
+
+    def get_value_type(self):
+        elems = [t.get_value_type() for t in self._models]
+        return ir.LiteralStructType(elems)
+
+    def get_data_type(self):
+        elems = [t.get_data_type() for t in self._models]
+        return ir.LiteralStructType(elems)
+
+    def get_argument_type(self):
+        return tuple([t.get_argument_type() for t in self._models])
+
+    def get_return_type(self):
+        return self.get_data_type()
+
+    def _as(self, methname, builder, value):
+        extracted = []
+        for i, dm in enumerate(self._models):
+            extracted.append(getattr(dm, methname)(builder,
+                                                   self.get(builder, value, i)))
+        return tuple(extracted)
+
+    def _from(self, methname, builder, value):
+        struct = ir.Constant(self.get_value_type(), ir.Undefined)
+
+        for i, (dm, val) in enumerate(zip(self._models, value)):
+            v = getattr(dm, methname)(builder, val)
+            struct = self.set(builder, struct, v, i)
+
+        return struct
+
+    def as_data(self, builder, value):
+        elems = self._as("as_data", builder, value)
+        struct = ir.Constant(self.get_data_type(), ir.Undefined)
+        for i, el in enumerate(elems):
+            struct = builder.insert_value(struct, el, [i])
+        return struct
+
+    def from_data(self, builder, value):
+        vals = [builder.extract_value(value, [i])
+                for i in range(len(self._members))]
+        return self._from("from_data", builder, vals)
+
+    def as_argument(self, builder, value):
+        return self._as("as_argument", builder, value)
+
+    def from_argument(self, builder, value):
+        return self._from("from_argument", builder, value)
+
+    def as_return(self, builder, value):
+        elems = self._as("as_data", builder, value)
+        struct = ir.Constant(self.get_data_type(), ir.Undefined)
+        for i, el in enumerate(elems):
+            struct = builder.insert_value(struct, el, [i])
+        return struct
+
+    def from_return(self, builder, value):
+        vals = [builder.extract_value(value, [i])
+                for i in range(len(self._members))]
+        return self._from("from_data", builder, vals)
+
+    def get(self, builder, val, pos):
+        if isinstance(pos, str):
+            pos = self.get_field_position(pos)
+        return builder.extract_value(val, [pos])
+
+    def set(self, builder, stval, val, pos):
+        if isinstance(pos, str):
+            pos = self.get_field_position(pos)
+        return builder.insert_value(stval, val, [pos])
+
+    def get_field_position(self, field):
+        return self._fields.index(field)
+
+    def get_type(self, pos):
+        if isinstance(pos, str):
+            pos = self.get_field_position(pos)
+        return self._members[pos]
+
+
+@register_default(types.Complex)
+class ComplexModel(StructModel):
+    _element_type = NotImplemented
+
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('real', fe_type.underlying_float),
+            ('imag', fe_type.underlying_float),
+        ]
+        super(ComplexModel, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.Tuple)
+class TupleModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('f' + str(i), t) for i, t in enumerate(fe_type)]
+        super(TupleModel, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.Array)
+class ArrayModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        ndim = fe_type.ndim
+        members = [
+            ('parent', types.pyobject),
+            ('nitems', types.intp),
+            ('itemsize', types.intp),
+            ('data', types.CPointer(fe_type.dtype)),
+            ('shape', types.UniTuple(types.intp, ndim)),
+            ('strides', types.UniTuple(types.intp, ndim)),
+        ]
+        super(ArrayModel, self).__init__(dmm, fe_type, members)
+
+    def as_data(self, builder, value):
+        return NotImplemented
+
+    def from_data(self, builder, value):
+        return NotImplemented
+
+
+@register_default(types.Optional)
+class OptionalModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('data', fe_type.type),
+            ('valid', types.boolean),
+        ]
+        self._value_model = dmm.lookup(fe_type.type)
+        super(OptionalModel, self).__init__(dmm, fe_type, members)
+
+    def get_return_type(self):
+        return self._value_model.get_return_type()
+
+    def as_return(self, builder, value):
+        return NotImplemented
+
+    def from_return(self, builder, value):
+        return self._value_model.from_return(builder, value)
+
+
+@register_default(types.Record)
+class RecordModel(CompositeModel):
+    def __init__(self, dmm, fe_type):
+        super(RecordModel, self).__init__(dmm, fe_type)
+        self._models = [self._dmm.lookup(t) for _, t in fe_type.members]
+        self._be_type = ir.ArrayType(ir.IntType(8), fe_type.size)
+
+    def get_value_type(self):
+        """Passed around as reference to underlying data
+        """
+        return self._be_type.as_pointer()
+
+    def get_argument_type(self):
+        return self.get_value_type()
+
+    def get_return_type(self):
+        return self.get_value_type()
+
+    def get_data_type(self):
+        return self._be_type
+
+    def as_data(self, builder, value):
+        return builder.load(value)
+
+    def from_data(self, builder, value):
+        raise NotImplementedError("use load_from_data_pointer() instead")
+
+    def as_argument(self, builder, value):
+        return value
+
+    def from_argument(self, builder, value):
+        return value
+
+    def as_return(self, builder, value):
+        return value
+
+    def from_return(self, builder, value):
+        return value
+
+    def load_from_data_pointer(self, builder, ptr):
+        return builder.bitcast(ptr, self.get_value_type())
+
+
+@register_default(types.UnicodeCharSeq)
+class UnicodeCharSeq(DataModel):
+    def __init__(self, dmm, fe_type):
+        super(UnicodeCharSeq, self).__init__(dmm, fe_type)
+        charty = ir.IntType(numpy_support.sizeof_unicode_char * 8)
+        self._be_type = ir.ArrayType(charty, fe_type.count)
+
+    def get_value_type(self):
+        return self._be_type
+
+    def get_data_type(self):
+        return self._be_type
+
+
+@register_default(types.CharSeq)
+class CharSeq(DataModel):
+    def __init__(self, dmm, fe_type):
+        super(CharSeq, self).__init__(dmm, fe_type)
+        charty = ir.IntType(8)
+        self._be_type = ir.ArrayType(charty, fe_type.count)
+
+    def get_value_type(self):
+        return self._be_type
+
+    def get_data_type(self):
+        return self._be_type
+
+    def as_data(self, builder, value):
+        return value
+
+    def from_data(self, builder, value):
+        return value
+
+
+class CConitugousFlatIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        assert fe_type.array_type.layout == 'C'
+        array_type = fe_type.array_type
+        dtype = array_type.dtype
+        members = [('array', types.CPointer(array_type)),
+                   ('stride', types.intp),
+                   ('pointer', types.CPointer(types.CPointer(dtype))),
+                   ('index', types.CPointer(types.intp)),
+                   ('indices', types.CPointer(types.intp)),
+        ]
+        super(CConitugousFlatIter, self).__init__(dmm, fe_type, members)
+
+
+class FlatIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        array_type = fe_type.array_type
+        dtype = array_type.dtype
+        members = [('array', types.CPointer(array_type)),
+                   ('pointers', types.CPointer(types.CPointer(dtype))),
+                   ('indices', types.CPointer(types.intp)),
+                   ('exhausted', types.CPointer(types.boolean)),
+        ]
+        super(FlatIter, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.UniTupleIter)
+class UniTupleIter(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('index', types.CPointer(types.intp)),
+                   ('tuple', fe_type.unituple,)]
+        super(UniTupleIter, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.Slice3Type)
+class Slice3(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('start', types.intp),
+                   ('stop', types.intp),
+                   ('step', types.intp)]
+        super(Slice3, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.NPDatetime)
+@register_default(types.NPTimedelta)
+class NPDatetimeModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        be_type = ir.IntType(64)
+        super(NPDatetimeModel, self).__init__(dmm, fe_type, be_type)
+
+
+@register_default(types.ArrayIterator)
+class ArrayIterator(StructModel):
+    def __init__(self, dmm, fe_type):
+        # We use an unsigned index to avoid the cost of negative index tests.
+        members = [('index', types.CPointer(types.uintp)),
+                   ('array', fe_type.array_type)]
+        super(ArrayIterator, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.EnumerateType)
+class EnumerateType(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('count', types.CPointer(types.intp)),
+                   ('iter', fe_type.source_type)]
+
+        super(EnumerateType, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.RangeIteratorType)
+class RangeIteratorType(StructModel):
+    def __init__(self, dmm, fe_type):
+        int_type = fe_type.yield_type
+        members = [('iter', types.CPointer(int_type)),
+                   ('stop', int_type),
+                   ('step', int_type),
+                   ('count', types.CPointer(int_type))]
+        super(RangeIteratorType, self).__init__(dmm, fe_type, members)
+
+
+# =============================================================================
+
+
+@register_default(types.Float)
+def handle_floats(dmm, ty):
+    if ty == types.float32:
+        return FloatModel(dmm, ty)
+    elif ty == types.float64:
+        return DoubleModel(dmm, ty)
+    else:
+        raise NotImplementedError(ty)
+
+
+@register_default(types.NumpyFlatType)
+def handle_numpy_flat_type(dmm, ty):
+    if ty.array_type.layout == 'C':
+        return CConitugousFlatIter(dmm, ty)
+    else:
+        return FlatIter(dmm, ty)
+
+

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -312,6 +312,10 @@ class StructModel(CompositeModel):
     def get_field_position(self, field):
         return self._fields.index(field)
 
+    @property
+    def field_count(self):
+        return len(self._fields)
+
     def get_type(self, pos):
         if isinstance(pos, str):
             pos = self.get_field_position(pos)
@@ -335,6 +339,14 @@ class TupleModel(StructModel):
     def __init__(self, dmm, fe_type):
         members = [('f' + str(i), t) for i, t in enumerate(fe_type)]
         super(TupleModel, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.Pair)
+class PairModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('first', fe_type.first_type),
+                   ('second', fe_type.second_type)]
+        super(PairModel, self).__init__(dmm, fe_type, members)
 
 
 @register_default(types.Array)
@@ -522,6 +534,14 @@ class EnumerateType(StructModel):
                    ('iter', fe_type.source_type)]
 
         super(EnumerateType, self).__init__(dmm, fe_type, members)
+
+
+@register_default(types.ZipType)
+class ZipType(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('iter%d' % i, source_type.iterator_type)
+                   for i, source_type in enumerate(fe_type.source_types)]
+        super(ZipType, self).__init__(dmm, fe_type, members)
 
 
 @register_default(types.RangeIteratorType)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -132,6 +132,7 @@ class PrimitiveModel(DataModel):
 @register_default(types.Function)
 @register_default(types.Type)
 @register_default(types.Object)
+@register_default(types.Module)
 class OpaqueModel(PrimitiveModel):
     """
     Passed as opaque pointers

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -567,7 +567,7 @@ class CharSeq(DataModel):
         return value
 
 
-class CContiugousFlatIter(StructModel):
+class CContiguousFlatIter(StructModel):
     def __init__(self, dmm, fe_type):
         assert fe_type.array_type.layout == 'C'
         array_type = fe_type.array_type
@@ -578,7 +578,7 @@ class CContiugousFlatIter(StructModel):
                    ('index', types.CPointer(types.intp)),
                    ('indices', types.CPointer(types.intp)),
         ]
-        super(CContiugousFlatIter, self).__init__(dmm, fe_type, members)
+        super(CContiguousFlatIter, self).__init__(dmm, fe_type, members)
 
 
 class FlatIter(StructModel):
@@ -661,7 +661,7 @@ class RangeIteratorType(StructModel):
 @register_default(types.NumpyFlatType)
 def handle_numpy_flat_type(dmm, ty):
     if ty.array_type.layout == 'C':
-        return CContiugousFlatIter(dmm, ty)
+        return CContiguousFlatIter(dmm, ty)
     else:
         return FlatIter(dmm, ty)
 

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -6,6 +6,28 @@ from .registry import register_default
 
 
 class DataModel(object):
+    """
+    DataModel describe how a FE type is represented in the LLVM IR at
+    different contexts.
+
+    Contexts are:
+
+    - value: representation inside function body.  Maybe stored in stack.
+    The representation here are flexible.
+
+    - data: representation used when storing into containers (e.g. arrays).
+
+    - argument: representation used for function argument.  All composite
+    types are unflattened into multiple primitive types.
+
+    - return: representation used for return argument.
+
+    Throughput the compiler pipeline, a LLVM value is usually passed around
+    in the "value" representation.  All "as_" prefix function converts from
+    "value" representation.  All "from_" prefix function converts to the
+    "value"  representation.
+
+    """
     def __init__(self, dmm, fe_type):
         self._dmm = dmm
         self._fe_type = fe_type
@@ -21,6 +43,8 @@ class DataModel(object):
         return self.get_value_type()
 
     def get_argument_type(self):
+        """Return a LLVM type or nested tuple of LLVM type
+        """
         return self.get_value_type()
 
     def get_return_type(self):
@@ -30,6 +54,10 @@ class DataModel(object):
         return NotImplemented
 
     def as_argument(self, builder, value):
+        """
+        Takes one LLVM value
+        Return a LLVM value or nested tuple of LLVM value
+        """
         return NotImplemented
 
     def as_return(self, builder, value):
@@ -39,12 +67,18 @@ class DataModel(object):
         return NotImplemented
 
     def from_argument(self, builder, value):
+        """
+        Takes a LLVM value or nested tuple of LLVM value
+        Returns one LLVM value
+        """
         return NotImplemented
 
     def from_return(self, builder, value):
         return NotImplemented
 
     def load_from_data_pointer(self, builder, value):
+        """Only the record model this for pass by reference semantic.
+        """
         return NotImplemented
 
     def _compared_fields(self):

--- a/numba/datamodel/registry.py
+++ b/numba/datamodel/registry.py
@@ -15,6 +15,6 @@ def register(dmm, typecls):
     return wraps
 
 
-defaultDataModelManager = DataModelManager()
+default_manager = DataModelManager()
 
-register_default = functools.partial(register, defaultDataModelManager)
+register_default = functools.partial(register, default_manager)

--- a/numba/datamodel/registry.py
+++ b/numba/datamodel/registry.py
@@ -1,0 +1,20 @@
+from __future__ import print_function, absolute_import
+
+import functools
+from .manager import DataModelManager
+
+
+def register(dmm, typecls):
+    """Used as decorator to simplify datamodel registration.
+    Returns the object being decorated so that chaining is possible.
+    """
+    def wraps(fn):
+        dmm.register(typecls, fn)
+        return fn
+
+    return wraps
+
+
+defaultDataModelManager = DataModelManager()
+
+register_default = functools.partial(register, defaultDataModelManager)

--- a/numba/datamodel/testing.py
+++ b/numba/datamodel/testing.py
@@ -15,7 +15,7 @@ class DataModelTester(unittest.TestCase):
 
     def setUp(self):
         self.module = ir.Module()
-        self.datamodel = datamodel.defaultDataModelManager[self.fe_type]
+        self.datamodel = datamodel.default_manager[self.fe_type]
 
     def test_as_arg(self):
         """

--- a/numba/datamodel/testing.py
+++ b/numba/datamodel/testing.py
@@ -136,13 +136,20 @@ class NotSupportAsDataMixin(object):
         self.assertIs(rev_data, NotImplemented)
 
 
+class DataModelTester_SupportAsDataMixin(DataModelTester,
+                                         SupportAsDataMixin):
+    pass
+
+
+class DataModelTester_NotSupportAsDataMixin(DataModelTester,
+                                            NotSupportAsDataMixin):
+    pass
+
+
 def test_factory(support_as_data=True):
     """A helper for returning a unittest TestCase for testing
     """
-    baseclses = ()
     if support_as_data:
-        baseclses += (SupportAsDataMixin,)
+        return DataModelTester_SupportAsDataMixin
     else:
-        baseclses += (NotSupportAsDataMixin,)
-    baseclses += (DataModelTester,)
-    return baseclses
+        return DataModelTester_NotSupportAsDataMixin

--- a/numba/datamodel/testing.py
+++ b/numba/datamodel/testing.py
@@ -33,21 +33,17 @@ class DataModelTester(unittest.TestCase):
                                                "NotImplementedError")
 
         if isinstance(args, (tuple, list)):
-            def recur_flatten_type(args):
+            def recur_tuplize(args, func=None):
                 for arg in args:
                     if isinstance(arg, (tuple, list)):
-                        yield tuple(recur_flatten_type(arg))
+                        yield tuple(recur_tuplize(arg, func=func))
                     else:
-                        yield arg.type
+                        if func is None:
+                            yield arg
+                        else:
+                            yield func(arg)
 
-            def recur_tuplize(args):
-                for arg in args:
-                    if isinstance(arg, (tuple, list)):
-                        yield tuple(recur_tuplize(arg))
-                    else:
-                        yield arg
-
-            argtypes = tuple(recur_flatten_type(args))
+            argtypes = tuple(recur_tuplize(args, func=lambda x: x.type))
             exptypes = tuple(recur_tuplize(
                 self.datamodel.get_argument_type()))
             self.assertEqual(exptypes, argtypes)

--- a/numba/datamodel/testing.py
+++ b/numba/datamodel/testing.py
@@ -1,0 +1,148 @@
+from __future__ import print_function, absolute_import
+
+from llvmlite import ir
+from llvmlite import binding as ll
+
+from numba import datamodel
+from numba import unittest_support as unittest
+
+
+class DataModelTester(unittest.TestCase):
+    """
+    Test the implementation of a DataModel for a frontend type.
+    """
+    fe_type = NotImplemented
+
+    def setUp(self):
+        self.module = ir.Module()
+        self.datamodel = datamodel.defaultDataModelManager[self.fe_type]
+
+    def test_as_arg(self):
+        """
+        - Is as_arg() and from_arg() implemented?
+        - Are they the inverse of each other?
+        """
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_arg")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        args = self.datamodel.as_argument(builder, undef_value)
+        self.assertIsNot(args, NotImplemented, "as_argument returned "
+                                               "NotImplementedError")
+
+        if isinstance(args, (tuple, list)):
+            def recur_flatten_type(args):
+                for arg in args:
+                    if isinstance(arg, (tuple, list)):
+                        yield tuple(recur_flatten_type(arg))
+                    else:
+                        yield arg.type
+
+            def recur_tuplize(args):
+                for arg in args:
+                    if isinstance(arg, (tuple, list)):
+                        yield tuple(recur_tuplize(arg))
+                    else:
+                        yield arg
+
+            argtypes = tuple(recur_flatten_type(args))
+            exptypes = tuple(recur_tuplize(
+                self.datamodel.get_argument_type()))
+            self.assertEqual(exptypes, argtypes)
+        else:
+            self.assertEqual(args.type,
+                             self.datamodel.get_argument_type())
+
+        rev_value = self.datamodel.from_argument(builder, args)
+        self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+    def test_as_return(self):
+        """
+        - Is as_return() and from_return() implemented?
+        - Are they the inverse of each other?
+        """
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_return")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        ret = self.datamodel.as_return(builder, undef_value)
+        self.assertIsNot(ret, NotImplemented, "as_return returned "
+                                              "NotImplementedError")
+
+        self.assertEqual(ret.type, self.datamodel.get_return_type())
+
+        rev_value = self.datamodel.from_return(builder, ret)
+        self.assertEqual(rev_value.type, self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+
+class SupportAsDataMixin(object):
+    """Test as_data() and from_data()
+    """
+
+    def test_as_data(self):
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_data")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        data = self.datamodel.as_data(builder, undef_value)
+        self.assertIsNot(data, NotImplemented,
+                         "as_data returned NotImplemented")
+
+        self.assertEqual(data.type, self.datamodel.get_data_type())
+
+        rev_value = self.datamodel.from_data(builder, data)
+        self.assertEqual(rev_value.type,
+                         self.datamodel.get_value_type())
+
+        builder.ret_void()  # end function
+
+        # Ensure valid LLVM generation
+        materialized = ll.parse_assembly(str(self.module))
+        print(materialized)
+
+
+class NotSupportAsDataMixin(object):
+    """Ensure as_data() and from_data() returns NotImplemented
+    """
+
+    def test_as_data_not_supported(self):
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(self.module, fnty, name="test_as_data")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        undef_value = ir.Constant(self.datamodel.get_value_type(), None)
+        data = self.datamodel.as_data(builder, undef_value)
+        self.assertIs(data, NotImplemented)
+        rev_data = self.datamodel.from_data(builder, undef_value)
+        self.assertIs(rev_data, NotImplemented)
+
+
+def test_factory(support_as_data=True):
+    """A helper for returning a unittest TestCase for testing
+    """
+    baseclses = ()
+    if support_as_data:
+        baseclses += (SupportAsDataMixin,)
+    else:
+        baseclses += (NotSupportAsDataMixin,)
+    baseclses += (DataModelTester,)
+    return baseclses

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -222,7 +222,7 @@ class BaseLower(object):
     def lower(self):
         # Init argument variables
         rawfnargs = self.call_conv.get_arguments(self.function)
-        arginfo = self.context.get_arg_info(self.fndesc.argtypes)
+        arginfo = self.context.get_arg_packer(self.fndesc.argtypes)
         fnargs = arginfo.from_arguments(self.builder, rawfnargs)
         for ak, av in zip(self.fndesc.args, fnargs):
             av = self.init_argument(av)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -221,10 +221,10 @@ class BaseLower(object):
 
     def lower(self):
         # Init argument variables
-        fnargs = self.call_conv.get_arguments(self.function)
+        rawfnargs = self.call_conv.get_arguments(self.function)
+        arginfo = self.context.get_arg_info(self.fndesc.argtypes)
+        fnargs = arginfo.from_arguments(self.builder, rawfnargs)
         for ak, av in zip(self.fndesc.args, fnargs):
-            at = self.typeof(ak)
-            av = self.context.get_argument_value(self.builder, at, av)
             av = self.init_argument(av)
             self.storevar(av, ak)
 
@@ -536,16 +536,12 @@ class Lower(BaseLower):
         elif expr.op == 'pair_first':
             val = self.loadvar(expr.value.name)
             ty = self.typeof(expr.value.name)
-            item = self.context.pair_first(self.builder, val, ty)
-            return self.context.get_argument_value(self.builder,
-                                                   ty.first_type, item)
+            return self.context.pair_first(self.builder, val, ty)
 
         elif expr.op == 'pair_second':
             val = self.loadvar(expr.value.name)
             ty = self.typeof(expr.value.name)
-            item = self.context.pair_second(self.builder, val, ty)
-            return self.context.get_argument_value(self.builder,
-                                                   ty.second_type, item)
+            return self.context.pair_second(self.builder, val, ty)
 
         elif expr.op in ('getiter', 'iternext'):
             val = self.loadvar(expr.value.name)

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -19,13 +19,6 @@ def _build_ufunc_loop_body(load, store, context, func, builder, arrays, out,
 
     # Ignoring error status and store result
     # Store
-    if out.byref:
-        retval = builder.load(retval)
-
-    if not cgutils.is_struct(retval.type):
-        retval = context.get_value_as_argument(builder, signature.return_type,
-                                               retval)
-
     store(retval)
 
     # increment indices
@@ -50,9 +43,6 @@ def _build_ufunc_loop_body_objmode(load, store, context, func, builder,
 
     # Ignoring error status and store result
     # Store
-    if out.byref:
-        retval = builder.load(retval)
-
     store(retval)
 
     # increment indices
@@ -160,18 +150,14 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
 
     loopcount = builder.load(arg_dims, name="loopcount")
 
-    actual_args = context.call_conv.get_arguments(func)
-
     # Prepare inputs
     arrays = []
     for i, typ in enumerate(signature.args):
-        arrays.append(UArrayArg(context, builder, arg_args, arg_steps, i,
-                                context.get_argument_type(typ)))
+        arrays.append(UArrayArg(context, builder, arg_args, arg_steps, i, typ))
 
     # Prepare output
-    valty = context.get_data_type(signature.return_type)
-    out = UArrayArg(context, builder, arg_args, arg_steps, len(actual_args),
-                    valty)
+    out = UArrayArg(context, builder, arg_args, arg_steps, len(arrays),
+                    signature.return_type)
 
     # Setup indices
     offsets = []
@@ -189,7 +175,7 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
         unit_strided = builder.and_(unit_strided, ary.is_unit_strided)
 
     if objmode:
-    # General loop
+        # General loop
         pyapi = context.get_python_api(builder)
         gil = pyapi.gil_ensure()
         with cgutils.for_range(builder, loopcount, intp=intp_t):
@@ -235,50 +221,44 @@ def build_ufunc_wrapper(library, context, func, signature, objmode, env):
 
 
 class UArrayArg(object):
-    def __init__(self, context, builder, args, steps, i, argtype):
-        # Get data
-        p = builder.gep(args, [context.get_constant(types.intp, i)])
-        if cgutils.is_struct_ptr(argtype):
-            self.byref = True
-            self.data = builder.bitcast(builder.load(p), argtype)
-        else:
-            self.byref = False
-            self.data = builder.bitcast(builder.load(p), Type.pointer(argtype))
-            # Get step
-        p = builder.gep(steps, [context.get_constant(types.intp, i)])
-        abisize = context.get_constant(types.intp,
-                                       context.get_abi_sizeof(argtype))
-        self.step = builder.load(p)
-        self.is_unit_strided = builder.icmp(ICMP_EQ, abisize, self.step)
+    def __init__(self, context, builder, args, steps, i, fe_type):
+        self.context = context
+        self.builder = builder
+        self.fe_type = fe_type
+        offset = self.context.get_constant(types.intp, i)
+        offseted_args = self.builder.load(builder.gep(args, [offset]))
+        self.data_type = context.get_data_type(fe_type).as_pointer()
+        self.dataptr = self.builder.bitcast(offseted_args, self.data_type)
+        sizeof = self.context.get_abi_sizeof(self.data_type)
+        self.abisize = self.context.get_constant(types.intp, sizeof)
+        offseted_step = self.builder.gep(steps, [offset])
+        self.step = self.builder.load(offseted_step)
+        self.is_unit_strided = builder.icmp(ICMP_EQ, self.abisize, self.step)
         self.builder = builder
 
     def load(self, ind):
         offset = self.builder.mul(self.step, ind)
         return self.load_direct(offset)
 
-    def load_direct(self, offset):
-        ptr = cgutils.pointer_add(self.builder, self.data, offset)
-        if self.byref:
-            return ptr
-        else:
-            return self.builder.load(ptr)
+    def load_direct(self, byteoffset):
+        ptr = cgutils.pointer_add(self.builder, self.dataptr, byteoffset)
+        return self.context.unpack_value(self.builder, self.fe_type, ptr)
 
     def load_aligned(self, ind):
-        ptr = self.builder.gep(self.data, [ind])
-        return self.builder.load(ptr)
+        byteoffset = self.builder.mul(self.step, ind)
+        return self.load_direct(byteoffset)
 
     def store(self, value, ind):
         offset = self.builder.mul(self.step, ind)
         self.store_direct(value, offset)
 
-    def store_direct(self, value, offset):
-        ptr = cgutils.pointer_add(self.builder, self.data, offset)
-        assert ptr.type.pointee == value.type, (ptr.type, value.type)
-        self.builder.store(value, ptr)
+    def store_direct(self, value, byteoffset):
+        ptr = cgutils.pointer_add(self.builder, self.dataptr, byteoffset)
+        self.context.pack_value(self.builder, self.fe_type, value, ptr)
 
     def store_aligned(self, value, ind):
-        ptr = self.builder.gep(self.data, [ind])
-        self.builder.store(value, ptr)
+        ptr = self.builder.gep(self.dataptr, [ind])
+        self.context.pack_value(self.builder, self.fe_type, value, ptr)
 
 
 class _GufuncWrapper(object):
@@ -358,13 +338,10 @@ class _GufuncWrapper(object):
 
         # Loop
         with cgutils.for_range(builder, loopcount, intp=intp_t) as ind:
-            args = [a.array_value for a in arrays]
+            args = [a.get_array_at_offset(ind) for a in arrays]
             innercall, error = self.gen_loop_body(builder, func, args)
             # If error, escape
             cgutils.cbranch_or_continue(builder, error, bbreturn)
-
-            for a in arrays:
-                a.next(ind)
 
         builder.branch(bbreturn)
         builder.position_at_end(bbreturn)
@@ -468,7 +445,7 @@ def _prepare_call_to_object_mode(context, builder, func, signature, args,
         builder.store(Constant.null(ll_pyobj), ptr)   # initialize to NULL
 
         arycls = context.make_array(arrtype)
-        array = arycls(context, builder, ref=arr)
+        array = arycls(context, builder, value=arr)
 
         zero = Constant.int(ll_int, 0)
 
@@ -497,7 +474,7 @@ def _prepare_call_to_object_mode(context, builder, func, signature, args,
     object_sig = [types.pyobject] * len(ndarray_objects)
 
     status, retval = context.call_conv.call_function(
-        builder, func, ll_pyobj, object_sig,
+        builder, func, types.pyobject, object_sig,
         ndarray_objects, env=env)
     builder.store(status.is_error, error_pointer)
 
@@ -531,52 +508,57 @@ class GUArrayArg(object):
         self.syms = syms
         self.as_scalar = not syms
 
+        offset = context.get_constant(types.intp, i)
+
+        core_step_ptr = builder.gep(steps, [offset], name="core.step.ptr")
+        self.core_step = builder.load(core_step_ptr)
+
         if self.as_scalar:
             self.ndim = 1
         else:
             self.ndim = len(syms)
+            self.shape = []
+            self.strides = []
 
-        core_step_ptr = builder.gep(steps,
-                                    [context.get_constant(types.intp, i)],
-                                    name="core.step.ptr")
-
-        self.core_step = builder.load(core_step_ptr)
-        self.strides = []
-        for j in range(self.ndim):
-            step = builder.gep(steps, [context.get_constant(types.intp,
+            for j in range(self.ndim):
+                stepptr = builder.gep(steps,
+                                      [context.get_constant(types.intp,
                                                             step_offset + j)],
-                               name="step.ptr")
+                                      name="step.ptr")
 
-            self.strides.append(builder.load(step))
+                step = builder.load(stepptr)
+                self.strides.append(step)
 
-        self.shape = []
-        for s in syms:
-            self.shape.append(sym_dim[s])
+            for s in syms:
+                self.shape.append(sym_dim[s])
 
-        data = builder.load(builder.gep(args,
-                                        [context.get_constant(types.intp,
-                                                              i)],
-                                        name="data.ptr"),
+        data = builder.load(builder.gep(args, [offset], name="data.ptr"),
                             name="data")
 
         self.data = data
 
+    def get_array_at_offset(self, ind):
+        context = self.context
+        builder = self.builder
+
         arytyp = types.Array(dtype=self.dtype, ndim=self.ndim, layout="A")
         arycls = context.make_array(arytyp)
 
-        self.array = arycls(context, builder)
-        self.array.data = builder.bitcast(self.data, self.array.data.type)
+        array = arycls(context, builder)
+        offseted_data = cgutils.pointer_add(self.builder,
+                                            self.data,
+                                            self.builder.mul(self.core_step,
+                                                             ind))
+        array.data = builder.bitcast(offseted_data, array.data.type)
+
         if not self.as_scalar:
-            self.array.shape = cgutils.pack_array(builder, self.shape)
-            self.array.strides = cgutils.pack_array(builder, self.strides)
+            array.shape = cgutils.pack_array(builder, self.shape)
+            array.strides = cgutils.pack_array(builder, self.strides)
         else:
             one = context.get_constant(types.intp, 1)
             zero = context.get_constant(types.intp, 0)
-            self.array.shape = cgutils.pack_array(builder, [one])
-            self.array.strides = cgutils.pack_array(builder, [zero])
-        self.array_value = self.array._getpointer()
+            array.shape = cgutils.pack_array(builder, [one])
+            array.strides = cgutils.pack_array(builder, [zero])
 
-    def next(self, i):
-        self.array.data = cgutils.pointer_add(self.builder,
-                                              self.array.data, self.core_step)
+        return array._getvalue()
 

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -2,10 +2,8 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from llvmlite.llvmpy.core import (Type, Builder, LINKAGE_INTERNAL,
                                   ICMP_EQ, Constant)
-import llvmlite.llvmpy.core as lc
-from llvmlite import binding as ll
 
-from numba import types, cgutils, config
+from numba import types, cgutils
 
 
 def _build_ufunc_loop_body(load, store, context, func, builder, arrays, out,

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -798,7 +798,7 @@ class PythonAPI(object):
                 self.builder.ret(ptr)
 
             ltyp = self.context.get_value_type(typ)
-            val = cgutils.init_record_by_ptr(self.builder, ltyp, ptr)
+            val = self.builder.bitcast(ptr, ltyp)
 
             def dtor():
                 self.release_record_buffer(buf_as_voidptr)
@@ -883,18 +883,18 @@ class PythonAPI(object):
 
         elif isinstance(typ, types.Optional):
             isnone = self.builder.icmp(lc.ICMP_EQ, obj, self.borrow_none())
+            noneval = self.context.make_optional_none(self.builder, typ.type)
+            retptr = cgutils.alloca_once(self.builder, noneval.type)
             with cgutils.ifelse(self.builder, isnone) as (then, orelse):
                 with then:
-                    noneval = self.context.make_optional_none(self.builder, typ.type)
-                    ret = cgutils.alloca_once(self.builder, noneval.type)
-                    self.builder.store(noneval, ret)
+                    self.builder.store(noneval, retptr)
 
                 with orelse:
                     val = self.to_native_value(obj, typ.type)
                     just = self.context.make_optional_value(self.builder,
                                                             typ.type, val)
-                    self.builder.store(just, ret)
-            return ret
+                    self.builder.store(just, retptr)
+            return self.builder.load(retptr)
 
         elif isinstance(typ, (types.Tuple, types.UniTuple)):
             return self.to_native_tuple(obj, typ)
@@ -960,9 +960,8 @@ class PythonAPI(object):
         elif isinstance(typ, types.Record):
             # Note we will create a copy of the record
             # This is the only safe way.
-            pdata = cgutils.get_record_data(self.builder, val)
-            size = Constant.int(Type.int(), pdata.type.pointee.count)
-            ptr = self.builder.bitcast(pdata, Type.pointer(Type.int(8)))
+            size = Constant.int(Type.int(), val.type.pointee.count)
+            ptr = self.builder.bitcast(val, Type.pointer(Type.int(8)))
             # Note: this will only work for CPU mode
             #       The following requires access to python object
             dtype_addr = Constant.int(self.py_ssize_t, id(typ.dtype))

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -24,23 +24,8 @@ def make_array(array_type):
     Return the Structure representation of the given *array_type*
     (an instance of types.Array).
     """
-    dtype = array_type.dtype
-    nd = array_type.ndim
+    return cgutils.create_struct_proxy(array_type)
 
-    # This structure should be kept in sync with Numba_adapt_ndarray()
-    # in _helperlib.c.
-    class ArrayTemplate(cgutils.Structure):
-        _fields = [('parent', types.pyobject),
-                   ('nitems', types.intp),
-                   ('itemsize', types.intp),
-                   # These three fields comprise the unofficiel llarray ABI
-                   # (used by the GPU backend)
-                   ('data', types.CPointer(dtype)),
-                   ('shape', types.UniTuple(types.intp, nd)),
-                   ('strides', types.UniTuple(types.intp, nd)),
-                   ]
-
-    return ArrayTemplate
 
 def make_array_ctype(ndim):
     """Create a ctypes representation of an array_type.
@@ -74,13 +59,7 @@ def make_arrayiter_cls(iterator_type):
     Return the Structure representation of the given *iterator_type* (an
     instance of types.ArrayIteratorType).
     """
-
-    class ArrayIteratorStruct(cgutils.Structure):
-        # We use an unsigned index to avoid the cost of negative index tests.
-        _fields = [('index', types.CPointer(types.uintp)),
-                   ('array', iterator_type.array_type)]
-
-    return ArrayIteratorStruct
+    return cgutils.create_struct_proxy(iterator_type)
 
 @builtin
 @implement('getiter', types.Kind(types.Array))
@@ -438,7 +417,7 @@ def array_sum(context, builder, sig, args):
             c += v
         return c
 
-    return context.compile_internal(builder, array_sum_impl, sig, args, 
+    return context.compile_internal(builder, array_sum_impl, sig, args,
                                     locals=dict(c=sig.return_type))
 
 
@@ -526,7 +505,7 @@ def array_max(context, builder, sig, args):
         for v in arry.flat:
             max_value = v
             break
-        
+
         for v in arry.flat:
             if v > max_value:
                 max_value = v

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -157,7 +157,7 @@ class BaseContext(object):
 
         self.cached_internal_func = {}
 
-        self.data_model_manager = datamodel.defaultDataModelManager
+        self.data_model_manager = datamodel.default_manager
 
         # Initialize
         self.init()
@@ -168,8 +168,8 @@ class BaseContext(object):
         """
         pass
 
-    def get_arg_info(self, fe_args):
-        return datamodel.ArgInfo(self.data_model_manager, fe_args)
+    def get_arg_packer(self, fe_args):
+        return datamodel.ArgPacker(self.data_model_manager, fe_args)
 
     @property
     def target_data(self):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -17,6 +17,8 @@ from numba.targets.imputils import (user_function, python_attr_impl,
                                     builtin_registry, impl_attribute,
                                     struct_registry, type_registry)
 from . import arrayobj, builtins, iterators, rangeobj, optional
+from numba import datamodel
+
 try:
     from . import npdatetime
 except NotImplementedError:
@@ -155,6 +157,8 @@ class BaseContext(object):
 
         self.cached_internal_func = {}
 
+        self.data_model_manager = datamodel.defaultDataModelManager
+
         # Initialize
         self.init()
 
@@ -163,6 +167,9 @@ class BaseContext(object):
         For subclasses to add initializer
         """
         pass
+
+    def get_arg_info(self, fe_args):
+        return datamodel.ArgInfo(self.data_model_manager, fe_args)
 
     @property
     def target_data(self):
@@ -221,7 +228,7 @@ class BaseContext(object):
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
         fn = module.get_or_insert_function(fnty, name=fndesc.mangled_name)
         assert fn.is_declaration
-        self.call_conv.decorate_function(fn, fndesc.args)
+        self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes)
         if fndesc.inline:
             fn.attributes.add('alwaysinline')
         return fn
@@ -256,12 +263,10 @@ class BaseContext(object):
             return cgutils.global_constant(mod, name, val)
 
     def get_argument_type(self, ty):
-        if ty == types.boolean:
-            return self.get_data_type(ty)
-        elif self.is_struct_type(ty):
-            return Type.pointer(self.get_value_type(ty))
-        else:
-            return self.get_value_type(ty)
+        return self.data_model_manager[ty].get_argument_type()
+
+    def get_return_type(self, ty):
+        return self.data_model_manager[ty].get_return_type()
 
     def get_data_type(self, ty):
         """
@@ -278,109 +283,29 @@ class BaseContext(object):
         else:
             return fac(self, ty)
 
-        if (isinstance(ty, types.Dummy) or
-                isinstance(ty, types.Module) or
-                isinstance(ty, types.Function) or
-                isinstance(ty, types.Dispatcher) or
-                isinstance(ty, types.Object) or
-                isinstance(ty, types.Macro)):
-            return PYOBJECT
-
-        elif isinstance(ty, types.CPointer):
-            dty = self.get_data_type(ty.dtype)
-            return Type.pointer(dty)
-
-        elif isinstance(ty, types.Optional):
-            return self.get_struct_type(self.make_optional(ty))
-
-        elif isinstance(ty, types.Array):
-            return self.get_struct_type(self.make_array(ty))
-
-        elif isinstance(ty, types.UniTuple):
-            dty = self.get_value_type(ty.dtype)
-            return Type.array(dty, ty.count)
-
-        elif isinstance(ty, types.Tuple):
-            dtys = [self.get_value_type(t) for t in ty]
-            return Type.struct(dtys)
-
-        elif isinstance(ty, types.Record):
-            # Record are represented as byte array
-            return Type.struct([Type.array(Type.int(8), ty.size)])
-
-        elif isinstance(ty, types.UnicodeCharSeq):
-            charty = Type.int(numpy_support.sizeof_unicode_char * 8)
-            return Type.struct([Type.array(charty, ty.count)])
-
-        elif isinstance(ty, types.CharSeq):
-            charty = Type.int(8)
-            return Type.struct([Type.array(charty, ty.count)])
-
-        elif ty in STRUCT_TYPES:
-            return self.get_struct_type(STRUCT_TYPES[ty])
-
-        else:
-            try:
-                impl = struct_registry.match(ty)
-            except KeyError:
-                pass
-            else:
-                return self.get_struct_type(impl(ty))
-
-        if isinstance(ty, types.Pair):
-            pairty = self.make_pair(ty.first_type, ty.second_type)
-            return self.get_struct_type(pairty)
-
-        else:
-            return LTYPEMAP[ty]
+        return self.data_model_manager[ty].get_data_type()
 
     def get_value_type(self, ty):
-        if ty == types.boolean:
-            return Type.int(1)
-        dataty = self.get_data_type(ty)
-
-        if isinstance(ty, types.Record):
-            # Record data are passed by refrence
-            memory = dataty.elements[0]
-            return Type.struct([Type.pointer(memory)])
-
-        return dataty
+        return self.data_model_manager[ty].get_value_type()
 
     def pack_value(self, builder, ty, value, ptr):
         """Pack data for array storage
         """
-        if isinstance(ty, types.Record):
-            pdata = cgutils.get_record_data(builder, value)
-            databuf = builder.load(pdata)
-            casted = builder.bitcast(ptr, Type.pointer(databuf.type))
-            builder.store(databuf, casted)
-            return
-
-        if ty == types.boolean:
-            value = cgutils.as_bool_byte(builder, value)
-        assert value.type == ptr.type.pointee
-        builder.store(value, ptr)
+        dataval = self.data_model_manager[ty].as_data(builder, value)
+        builder.store(dataval, ptr)
 
     def unpack_value(self, builder, ty, ptr):
         """Unpack data from array storage
         """
-
-        if isinstance(ty, types.Record):
-            vt = self.get_value_type(ty)
-            tmp = cgutils.alloca_once(builder, vt)
-            dataptr = cgutils.inbound_gep(builder, ptr, 0, 0)
-            builder.store(dataptr, cgutils.inbound_gep(builder, tmp, 0, 0))
-            return builder.load(tmp)
-
-        assert cgutils.is_pointer(ptr.type)
-        value = builder.load(ptr)
-        if ty == types.boolean:
-            return builder.trunc(value, Type.int(1))
+        dm = self.data_model_manager[ty]
+        val = dm.load_from_data_pointer(builder, ptr)
+        if val is NotImplemented:
+            return dm.from_data(builder, builder.load(ptr))
         else:
-            return value
+            return val
 
     def is_struct_type(self, ty):
-        return cgutils.is_struct(self.get_data_type(ty))
+        return isinstance(self.data_model_manager[ty], datamodel.CompositeModel)
 
     def get_constant_generic(self, builder, ty, val):
         """
@@ -393,7 +318,6 @@ class BaseContext(object):
 
     def get_constant_struct(self, builder, ty, val):
         assert self.is_struct_type(ty)
-        module = cgutils.get_module(builder)
 
         if ty in types.complex_domain:
             if ty == types.complex64:
@@ -558,56 +482,24 @@ class BaseContext(object):
         """
         Argument representation to local value representation
         """
-        if ty == types.boolean:
-            return builder.trunc(val, self.get_value_type(ty))
-        elif cgutils.is_struct_ptr(val.type):
-            return builder.load(val)
-        return val
+        return self.data_model_manager[ty].from_argument(builder, val)
 
     def get_returned_value(self, builder, ty, val):
         """
         Return value representation to local value representation
         """
-        # Same as get_argument_value
-        return self.get_argument_value(builder, ty, val)
+        return self.data_model_manager[ty].from_return(builder, val)
 
     def get_return_value(self, builder, ty, val):
         """
         Local value representation to return type representation
         """
-        if ty is types.boolean:
-            r = self.call_conv.get_return_type(ty).pointee
-            return builder.zext(val, r)
-        else:
-            return val
-
-    def get_struct_member_value(self, builder, ty, val):
-        """
-        Local value representation to struct member representation
-        """
-        # Currently same as get_return_value.
-        # TODO: make a "TypeLayout" class that describe the layout at
-        #       different situations for a value of a type.
-        return self.get_return_value(builder, ty, val)
+        return self.data_model_manager[ty].as_return(builder, val)
 
     def get_value_as_argument(self, builder, ty, val):
         """Prepare local value representation as argument type representation
         """
-        argty = self.get_argument_type(ty)
-        if argty == val.type:
-            return val
-
-        elif self.is_struct_type(ty):
-            # Arguments are passed by pointer
-            assert argty.pointee == val.type
-            tmp = cgutils.alloca_once(builder, val.type)
-            builder.store(val, tmp)
-            return tmp
-
-        elif ty == types.boolean:
-            return builder.zext(val, argty)
-
-        raise NotImplementedError("value %s -> arg %s" % (val.type, argty))
+        return self.data_model_manager[ty].as_argument(builder, val)
 
     def pair_first(self, builder, val, ty):
         """
@@ -615,7 +507,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.get_argument_value(builder, ty.first_type, pair.first)
+        return pair.first
 
     def pair_second(self, builder, val, ty):
         """
@@ -623,7 +515,7 @@ class BaseContext(object):
         """
         paircls = self.make_pair(ty.first_type, ty.second_type)
         pair = paircls(self, builder, value=val)
-        return self.get_argument_value(builder, ty.second_type, pair.second)
+        return pair.second
 
     def cast(self, builder, val, fromty, toty):
         if fromty == toty or toty == types.Any or isinstance(toty, types.Kind):
@@ -873,7 +765,7 @@ class BaseContext(object):
         """
         Get the LLVM struct type for the given Structure class *struct*.
         """
-        fields = [self.get_struct_member_type(v) for _, v in struct._fields]
+        fields = [self.get_value_type(v) for _, v in struct._fields]
         return Type.struct(fields)
 
     def get_dummy_value(self):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -501,6 +501,12 @@ class BaseContext(object):
         """
         return self.data_model_manager[ty].as_argument(builder, val)
 
+    def get_value_as_data(self, builder, ty, val):
+        return self.data_model_manager[ty].as_data(builder, val)
+
+    def get_data_as_value(self, builder, ty, val):
+        return self.data_model_manager[ty].from_data(builder, val)
+
     def pair_first(self, builder, val, ty):
         """
         Extract the first element of a heterogenous pair.

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1111,11 +1111,7 @@ def slice0_none_none_impl(context, builder, sig, args):
 
 
 def make_pair(first_type, second_type):
-    class Pair(cgutils.Structure):
-        _fields = [('first', first_type),
-                   ('second', second_type)]
-
-    return Pair
+    return cgutils.create_struct_proxy(types.Pair(first_type, second_type))
 
 
 @struct_factory(types.UniTupleIter)
@@ -1124,13 +1120,7 @@ def make_unituple_iter(tupiter):
     Return the Structure representation of the given *tupiter* (an
     instance of types.UniTupleIter).
     """
-    unituple = tupiter.unituple
-
-    class UniTupleIter(cgutils.Structure):
-        _fields = [('index', types.CPointer(types.intp)),
-                   ('tuple', tupiter.unituple,)]
-
-    return UniTupleIter
+    return cgutils.create_struct_proxy(tupiter)
 
 
 @builtin

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -162,9 +162,8 @@ class MinimalCallConv(BaseCallConv):
         """
         Get the implemented Function type for *restype* and *argtypes*.
         """
-        raise NotImplementedError
-        fi = self.context.get_function_info(restype, argtypes)
-        argtypes = list(fi.argument_types)
+        arginfo = self.context.get_arg_info(argtypes)
+        argtypes = list(arginfo.argument_types)
         resptr = self.get_return_type(restype)
         fnty = ir.FunctionType(errcode_t, [resptr] + argtypes)
         return fnty
@@ -195,8 +194,9 @@ class MinimalCallConv(BaseCallConv):
         retvaltmp = cgutils.alloca_once(builder, retty)
         # initialize return value
         builder.store(cgutils.get_null_value(retty), retvaltmp)
-        args = [self.context.get_value_as_argument(builder, ty, arg)
-                for ty, arg in zip(argtys, args)]
+
+        arginfo = self.context.get_arg_info(argtys)
+        args = arginfo.as_arguments(builder, args)
         realargs = [retvaltmp] + list(args)
         code = builder.call(callee, realargs)
         status = self._get_return_status(builder, code)

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -83,14 +83,8 @@ class BaseCallConv(object):
         """
         Get the actual type of the return argument for Numba type *ty*.
         """
-        if isinstance(ty, types.Optional):
-            return self.get_return_type(ty.type)
-        elif self.context.is_struct_type(ty):
-            # Argument type is already a pointer
-            return self.context.get_argument_type(ty)
-        else:
-            argty = self.context.get_argument_type(ty)
-            return ir.PointerType(argty)
+        restype = self.context.data_model_manager[ty].get_return_type()
+        return restype.as_pointer()
 
     def init_call_helper(self, builder):
         """
@@ -168,17 +162,20 @@ class MinimalCallConv(BaseCallConv):
         """
         Get the implemented Function type for *restype* and *argtypes*.
         """
-        argtypes = [self.context.get_argument_type(aty) for aty in argtypes]
+        raise NotImplementedError
+        fi = self.context.get_function_info(restype, argtypes)
+        argtypes = list(fi.argument_types)
         resptr = self.get_return_type(restype)
         fnty = ir.FunctionType(errcode_t, [resptr] + argtypes)
         return fnty
 
-    def decorate_function(self, fn, args):
+    def decorate_function(self, fn, args, fe_argtypes):
         """
         Set names of function arguments.
         """
-        for ak, av in zip(args, self.get_arguments(fn)):
-            av.name = "arg.%s" % ak
+        arginfo = self.context.get_arg_info(fe_argtypes)
+        arginfo.assign_names(self.get_arguments(fn),
+                             ['arg.' + a for a in args])
         fn.args[0].name = ".ret"
         return fn
 
@@ -312,20 +309,22 @@ class CPUCallConv(BaseCallConv):
         """
         Get the implemented Function type for *restype* and *argtypes*.
         """
-        argtypes = [self.context.get_argument_type(aty)
-                    for aty in argtypes]
+
+        arginfo = self.context.get_arg_info(argtypes)
+        argtypes = list(arginfo.argument_types)
         resptr = self.get_return_type(restype)
         fnty = ir.FunctionType(errcode_t,
                                [resptr, ir.PointerType(excinfo_ptr_t), PYOBJECT]
                                + argtypes)
         return fnty
 
-    def decorate_function(self, fn, args):
+    def decorate_function(self, fn, args, fe_argtypes):
         """
         Set names of function arguments.
         """
-        for ak, av in zip(args, self.get_arguments(fn)):
-            av.name = "arg.%s" % ak
+        arginfo = self.context.get_arg_info(fe_argtypes)
+        arginfo.assign_names(self.get_arguments(fn),
+                             ['arg.' + a for a in args])
         self._get_return_argument(fn).name = "retptr"
         self._get_excinfo_argument(fn).name = "excinfo"
         self.get_env_argument(fn).name = "env"
@@ -365,8 +364,8 @@ class CPUCallConv(BaseCallConv):
         excinfoptr = cgutils.alloca_once(builder, ir.PointerType(excinfo_t),
                                          name="excinfo")
 
-        args = [self.context.get_value_as_argument(builder, ty, arg)
-                for ty, arg in zip(argtys, args)]
+        arginfo = self.context.get_arg_info(argtys)
+        args = list(arginfo.as_arguments(builder, args))
         realargs = [retvaltmp, excinfoptr, env] + args
         code = builder.call(callee, realargs)
         status = self._get_return_status(builder, code,

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -162,7 +162,7 @@ class MinimalCallConv(BaseCallConv):
         """
         Get the implemented Function type for *restype* and *argtypes*.
         """
-        arginfo = self.context.get_arg_info(argtypes)
+        arginfo = self.context.get_arg_packer(argtypes)
         argtypes = list(arginfo.argument_types)
         resptr = self.get_return_type(restype)
         fnty = ir.FunctionType(errcode_t, [resptr] + argtypes)
@@ -172,7 +172,7 @@ class MinimalCallConv(BaseCallConv):
         """
         Set names of function arguments.
         """
-        arginfo = self.context.get_arg_info(fe_argtypes)
+        arginfo = self.context.get_arg_packer(fe_argtypes)
         arginfo.assign_names(self.get_arguments(fn),
                              ['arg.' + a for a in args])
         fn.args[0].name = ".ret"
@@ -195,7 +195,7 @@ class MinimalCallConv(BaseCallConv):
         # initialize return value
         builder.store(cgutils.get_null_value(retty), retvaltmp)
 
-        arginfo = self.context.get_arg_info(argtys)
+        arginfo = self.context.get_arg_packer(argtys)
         args = arginfo.as_arguments(builder, args)
         realargs = [retvaltmp] + list(args)
         code = builder.call(callee, realargs)
@@ -310,7 +310,7 @@ class CPUCallConv(BaseCallConv):
         Get the implemented Function type for *restype* and *argtypes*.
         """
 
-        arginfo = self.context.get_arg_info(argtypes)
+        arginfo = self.context.get_arg_packer(argtypes)
         argtypes = list(arginfo.argument_types)
         resptr = self.get_return_type(restype)
         fnty = ir.FunctionType(errcode_t,
@@ -322,7 +322,7 @@ class CPUCallConv(BaseCallConv):
         """
         Set names of function arguments.
         """
-        arginfo = self.context.get_arg_info(fe_argtypes)
+        arginfo = self.context.get_arg_packer(fe_argtypes)
         arginfo.assign_names(self.get_arguments(fn),
                              ['arg.' + a for a in args])
         self._get_return_argument(fn).name = "retptr"
@@ -364,7 +364,7 @@ class CPUCallConv(BaseCallConv):
         excinfoptr = cgutils.alloca_once(builder, ir.PointerType(excinfo_t),
                                          name="excinfo")
 
-        arginfo = self.context.get_arg_info(argtys)
+        arginfo = self.context.get_arg_packer(argtys)
         args = list(arginfo.as_arguments(builder, args))
         realargs = [retvaltmp, excinfoptr, env] + args
         code = builder.call(callee, realargs)

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -24,12 +24,7 @@ def make_enumerate_cls(enum_type):
     Return the Structure representation of the given *enum_type* (an
     instance of types.EnumerateType).
     """
-
-    class Enumerate(cgutils.Structure):
-        _fields = [('count', types.CPointer(types.intp)),
-                   ('iter', enum_type.source_type)]
-
-    return Enumerate
+    return cgutils.create_struct_proxy(enum_type)
 
 
 @builtin
@@ -91,12 +86,7 @@ def make_zip_cls(zip_type):
     Return the Structure representation of the given *zip_type* (an
     instance of types.ZipType).
     """
-
-    class Zip(cgutils.Structure):
-        _fields = [('iter%d' % i, source_type.iterator_type)
-                   for i, source_type in enumerate(zip_type.source_types)]
-
-    return Zip
+    return cgutils.create_struct_proxy(zip_type)
 
 @builtin
 @implement(zip, types.VarArg(types.Any))

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -164,8 +164,7 @@ class _ArrayHelper(namedtuple('_ArrayHelper', ('context', 'builder', 'ary',
         ctx = self.context
         bld = self.builder
 
-        # maybe there should be a "get_memory_value" or "get_storage_value"
-        store_value = ctx.get_struct_member_value(bld, self.base_type, value)
+        store_value = ctx.get_value_as_data(bld, self.base_type, value)
         assert ctx.get_data_type(self.base_type) == store_value.type
 
         bld.store(store_value, self._load_effective_address(indices))

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -6,12 +6,7 @@ def make_optional(valtype):
     """
     Return the Structure representation of a optional value
     """
-
-    class OptionalStruct(cgutils.Structure):
-        _fields = [('data', valtype),
-                   ('valid', types.boolean)]
-
-    return OptionalStruct
+    return cgutils.create_struct_proxy(types.Optional(valtype))
 
 
 def always_return_true_impl(context, builder, sig, args):

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -45,12 +45,13 @@ for ty in types.real_domain:
 @register
 @implement(types.print_item_type, types.Kind(types.CharSeq))
 def print_charseq(context, builder, sig, args):
+    [tx] = sig.args
     [x] = args
     py = context.get_python_api(builder)
     xp = cgutils.alloca_once(builder, x.type)
     builder.store(x, xp)
     byteptr = builder.bitcast(xp, Type.pointer(Type.int(8)))
-    size = context.get_constant(types.intp, x.type.elements[0].count)
+    size = context.get_constant(types.intp, tx.count)
     cstr = py.bytes_from_string_and_size(byteptr, size)
     py.print_object(cstr)
     py.decref(cstr)

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -15,16 +15,7 @@ def make_range_iterator(typ):
     Return the Structure representation of the given *typ* (an
     instance of types.RangeIteratorType).
     """
-    int_type = typ.yield_type
-
-    class RangeIter(cgutils.Structure):
-
-        _fields = [('iter', types.CPointer(int_type)),
-                   ('stop', int_type),
-                   ('step', int_type),
-                   ('count', types.CPointer(int_type))]
-
-    return RangeIter
+    return cgutils.create_struct_proxy(typ)
 
 
 def make_range_impl(range_state_type, range_iter_type, int_type):

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -96,11 +96,10 @@ class Test0DArrayOfInt32(*test_factory(support_as_data=False)):
     fe_type = types.Array(types.int32, 0, 'C')
 
 
-class TestFunctionInfo(unittest.TestCase):
+class TestArgInfo(unittest.TestCase):
     def _test_as_arguments(self, fe_args):
         dmm = datamodel.defaultDataModelManager
-        fe_ret = types.int32
-        fi = datamodel.FunctionInfo(dmm, fe_ret, fe_args)
+        fi = datamodel.ArgInfo(dmm, fe_args)
 
         module = ir.Module()
         fnty = ir.FunctionType(ir.VoidType(), [])

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -98,8 +98,8 @@ class Test0DArrayOfInt32(test_factory(support_as_data=False)):
 
 class TestArgInfo(unittest.TestCase):
     def _test_as_arguments(self, fe_args):
-        dmm = datamodel.defaultDataModelManager
-        fi = datamodel.ArgInfo(dmm, fe_args)
+        dmm = datamodel.default_manager
+        fi = datamodel.ArgPacker(dmm, fe_args)
 
         module = ir.Module()
         fnty = ir.FunctionType(ir.VoidType(), [])

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -8,91 +8,91 @@ from numba import datamodel
 from numba.datamodel.testing import test_factory
 
 
-class TestBool(*test_factory()):
+class TestBool(test_factory()):
     fe_type = types.boolean
 
 
-class TestPyObject(*test_factory()):
+class TestPyObject(test_factory()):
     fe_type = types.pyobject
 
 
-class TestInt8(*test_factory()):
+class TestInt8(test_factory()):
     fe_type = types.int8
 
 
-class TestInt16(*test_factory()):
+class TestInt16(test_factory()):
     fe_type = types.int16
 
 
-class TestInt32(*test_factory()):
+class TestInt32(test_factory()):
     fe_type = types.int32
 
 
-class TestInt64(*test_factory()):
+class TestInt64(test_factory()):
     fe_type = types.int64
 
 
-class TestUInt8(*test_factory()):
+class TestUInt8(test_factory()):
     fe_type = types.uint8
 
 
-class TestUInt16(*test_factory()):
+class TestUInt16(test_factory()):
     fe_type = types.uint16
 
 
-class TestUInt32(*test_factory()):
+class TestUInt32(test_factory()):
     fe_type = types.uint32
 
 
-class TestUInt64(*test_factory()):
+class TestUInt64(test_factory()):
     fe_type = types.uint64
 
 
-class TestFloat(*test_factory()):
+class TestFloat(test_factory()):
     fe_type = types.float32
 
 
-class TestDouble(*test_factory()):
+class TestDouble(test_factory()):
     fe_type = types.float64
 
 
-class TestComplex(*test_factory()):
+class TestComplex(test_factory()):
     fe_type = types.complex64
 
 
-class TestDoubleComplex(*test_factory()):
+class TestDoubleComplex(test_factory()):
     fe_type = types.complex128
 
 
-class TestPointerOfInt32(*test_factory()):
+class TestPointerOfInt32(test_factory()):
     fe_type = types.CPointer(types.int32)
 
 
-class TestUniTupleOf2xInt32(*test_factory()):
+class TestUniTupleOf2xInt32(test_factory()):
     fe_type = types.UniTuple(types.int32, 2)
 
 
-class TestUniTupleEmpty(*test_factory()):
+class TestUniTupleEmpty(test_factory()):
     fe_type = types.UniTuple(types.int32, 0)
 
 
-class TestTupleInt32Float32(*test_factory()):
+class TestTupleInt32Float32(test_factory()):
     fe_type = types.Tuple([types.int32, types.float32])
 
 
-class TestTupleEmpty(*test_factory()):
+class TestTupleEmpty(test_factory()):
     fe_type = types.Tuple([])
 
 
-class Test1DArrayOfInt32(*test_factory(support_as_data=False)):
+class Test1DArrayOfInt32(test_factory(support_as_data=False)):
     fe_type = types.Array(types.int32, 1, 'C')
 
 
-class Test2DArrayOfComplex128(*test_factory(support_as_data=False)):
+class Test2DArrayOfComplex128(test_factory(support_as_data=False)):
     fe_type = types.Array(types.complex128, 2, 'C')
 
 
-class Test0DArrayOfInt32(*test_factory(support_as_data=False)):
+class Test0DArrayOfInt32(test_factory(support_as_data=False)):
     fe_type = types.Array(types.int32, 0, 'C')
 
 

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -1,0 +1,142 @@
+from __future__ import print_function, absolute_import
+
+from llvmlite import ir, binding as ll
+
+from numba import types
+from numba import unittest_support as unittest
+from numba import datamodel
+from numba.datamodel.testing import test_factory
+
+
+class TestBool(*test_factory()):
+    fe_type = types.boolean
+
+
+class TestPyObject(*test_factory()):
+    fe_type = types.pyobject
+
+
+class TestInt8(*test_factory()):
+    fe_type = types.int8
+
+
+class TestInt16(*test_factory()):
+    fe_type = types.int16
+
+
+class TestInt32(*test_factory()):
+    fe_type = types.int32
+
+
+class TestInt64(*test_factory()):
+    fe_type = types.int64
+
+
+class TestUInt8(*test_factory()):
+    fe_type = types.uint8
+
+
+class TestUInt16(*test_factory()):
+    fe_type = types.uint16
+
+
+class TestUInt32(*test_factory()):
+    fe_type = types.uint32
+
+
+class TestUInt64(*test_factory()):
+    fe_type = types.uint64
+
+
+class TestFloat(*test_factory()):
+    fe_type = types.float32
+
+
+class TestDouble(*test_factory()):
+    fe_type = types.float64
+
+
+class TestComplex(*test_factory()):
+    fe_type = types.complex64
+
+
+class TestDoubleComplex(*test_factory()):
+    fe_type = types.complex128
+
+
+class TestPointerOfInt32(*test_factory()):
+    fe_type = types.CPointer(types.int32)
+
+
+class TestUniTupleOf2xInt32(*test_factory()):
+    fe_type = types.UniTuple(types.int32, 2)
+
+
+class TestUniTupleEmpty(*test_factory()):
+    fe_type = types.UniTuple(types.int32, 0)
+
+
+class TestTupleInt32Float32(*test_factory()):
+    fe_type = types.Tuple([types.int32, types.float32])
+
+
+class TestTupleEmpty(*test_factory()):
+    fe_type = types.Tuple([])
+
+
+class Test1DArrayOfInt32(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.int32, 1, 'C')
+
+
+class Test2DArrayOfComplex128(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.complex128, 2, 'C')
+
+
+class Test0DArrayOfInt32(*test_factory(support_as_data=False)):
+    fe_type = types.Array(types.int32, 0, 'C')
+
+
+class TestFunctionInfo(unittest.TestCase):
+    def _test_as_arguments(self, fe_args):
+        dmm = datamodel.defaultDataModelManager
+        fe_ret = types.int32
+        fi = datamodel.FunctionInfo(dmm, fe_ret, fe_args)
+
+        module = ir.Module()
+        fnty = ir.FunctionType(ir.VoidType(), [])
+        function = ir.Function(module, fnty, name="test_arguments")
+        builder = ir.IRBuilder()
+        builder.position_at_end(function.append_basic_block())
+
+        args = [ir.Constant(dmm.lookup(t).get_value_type(), None)
+                for t in fe_args]
+
+        values = fi.as_arguments(builder, args)
+        asargs = fi.from_arguments(builder, values)
+
+        self.assertEqual(len(asargs), len(fe_args))
+        valtys = tuple([v.type for v in values])
+        self.assertEqual(valtys, fi.argument_types)
+
+        expect_types = [a.type for a in args]
+        got_types = [a.type for a in asargs]
+
+        self.assertEqual(expect_types, got_types)
+
+        builder.ret_void()
+
+        ll.parse_assembly(str(module))
+
+    def test_int32_array_complex(self):
+        fe_args = [types.int32,
+                   types.Array(types.int32, 1, 'C'),
+                   types.complex64]
+        self._test_as_arguments(fe_args)
+
+    def test_two_arrays(self):
+        fe_args = [types.Array(types.int32, 1, 'C')] * 2
+        self._test_as_arguments(fe_args)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -154,6 +154,10 @@ class OpaqueType(Type):
         super(OpaqueType, self).__init__(name)
 
 
+class Boolean(Type):
+    pass
+
+
 @utils.total_ordering
 class Integer(Type):
     def __init__(self, *args, **kws):
@@ -914,6 +918,10 @@ class ExceptionInstance(Phantom):
         return self.exc_class
 
 
+class Slice3Type(Type):
+    pass
+
+
 # Utils
 
 def is_int_tuple(x):
@@ -937,7 +945,7 @@ string = Dummy('str')
 # Can only pass it around
 voidptr = Opaque('void*')
 
-boolean = bool_ = Type('bool')
+boolean = bool_ = Boolean('bool')
 
 byte = uint8 = Integer('uint8')
 uint16 = Integer('uint16')
@@ -974,7 +982,7 @@ range_state32_type = RangeType('range_state32', range_iter32_type)
 range_state64_type = RangeType('range_state64', range_iter64_type)
 
 # slice2_type = Type('slice2_type')
-slice3_type = Type('slice3_type')
+slice3_type = Slice3Type('slice3_type')
 
 signed_domain = frozenset([int8, int16, int32, int64])
 unsigned_domain = frozenset([uint8, uint16, uint32, uint64])

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ packages = [
     "numba.npyufunc",
     "numba.pycc",
     "numba.servicelib",
+    "numba.datamodel",
     "numba.cuda",
     "numba.cuda.cudadrv",
     "numba.cuda.tests",


### PR DESCRIPTION
Supersede #980 

* Adds DataModel for describing from a FE type is represented in different use-contexts.
* Adds ArgInfo for controlling how a FE type is represented as function argument. 
    * Deals with the complicated logic of flattening composite types and unflattening them

Changes in behavior of generated code:

* All function arguments are now simple primitive types.  LLVM arrays and structures are unpacked.
* To the CUDA backend, this means we are never passing structs, which required a extra memory transfer to handle.

More improvements:
* CUDA ndarray gpu_head is now redundant (https://github.com/numba/numba/issues/1012)
