### PR TITLE
Remove gpu_head and related code

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -9,7 +9,6 @@ import math
 import copy
 from ctypes import c_void_p
 import numpy as np
-from .ndarray import (ndarray_populate_head, ArrayHeaderManager)
 from . import driver as _driver
 from . import devices
 from numba import dummyarray, types, numpy_support
@@ -51,10 +50,10 @@ class DeviceNDArrayBase(object):
     """A on GPU NDArray representation
     """
     __cuda_memory__ = True
-    __cuda_ndarray__ = True # There must be a gpu_head and gpu_data attribute
+    __cuda_ndarray__ = True     # There must be gpu_data attribute
 
     def __init__(self, shape, strides, dtype, stream=0, writeback=None,
-                 gpu_head=None, gpu_data=None):
+                 gpu_data=None):
         """
         Args
         ----
@@ -69,8 +68,6 @@ class DeviceNDArrayBase(object):
             cuda stream.
         writeback
             Deprecated.
-        gpu_head
-            user provided device memory for the ndarray head structure
         gpu_data
             user provided device memory for the ndarray data buffer
         """
@@ -100,13 +97,6 @@ class DeviceNDArrayBase(object):
             gpu_data = None
             self.alloc_size = 0
 
-        self.gpu_mem = ArrayHeaderManager(devices.get_context())
-
-        if gpu_head is None:
-            gpu_head = ndarray_populate_head(self.gpu_mem, gpu_data,
-                                             self.shape, self.strides,
-                                             stream=stream)
-        self.gpu_head = gpu_head
         self.gpu_data = gpu_data
 
         self.__writeback = writeback    # should deprecate the use of this
@@ -119,12 +109,6 @@ class DeviceNDArrayBase(object):
         clone = copy.copy(self)
         clone.stream = stream
         return clone
-
-    def __del__(self):
-        try:
-            self.gpu_mem.free(self.gpu_head)
-        except:
-            pass
 
     def _default_stream(self, stream):
         return self.stream if not stream else stream
@@ -146,7 +130,6 @@ class DeviceNDArrayBase(object):
             return c_void_p(0)
         else:
             return self.gpu_data.device_ctypes_pointer
-
 
     def copy_to_device(self, ary, stream=0):
         """Copy `ary` to `self`.
@@ -232,7 +215,7 @@ class DeviceNDArrayBase(object):
     def as_cuda_arg(self):
         """Returns a device memory object that is used as the argument.
         """
-        return self.gpu_head
+        return self.gpu_data
 
 
 class DeviceNDArray(DeviceNDArrayBase):
@@ -272,7 +255,7 @@ class DeviceNDArray(DeviceNDArrayBase):
         if extents == [self._dummy.extent]:
             return cls(shape=newarr.shape, strides=newarr.strides,
                        dtype=self.dtype, gpu_data=self.gpu_data,
-                       gpu_head=self.gpu_head, stream=stream)
+                       stream=stream)
 
         else:
             raise NotImplementedError("operation requires copying")
@@ -316,26 +299,15 @@ class MappedNDArray(DeviceNDArrayBase, np.ndarray):
     """
 
     def device_setup(self, gpu_data, stream=0):
-        self.gpu_mem = ArrayHeaderManager(devices.get_context())
-        gpu_head = ndarray_populate_head(self.gpu_mem, gpu_data, self.shape,
-                                         self.strides, stream=stream)
         self.gpu_data = gpu_data
-        self.gpu_head = gpu_head
-
-    def __del__(self):
-        try:
-            self.gpu_mem.free(self.gpu_head)
-        except:
-            pass
 
 
-def from_array_like(ary, stream=0, gpu_head=None, gpu_data=None):
+def from_array_like(ary, stream=0, gpu_data=None):
     "Create a DeviceNDArray object that is like ary."
     if ary.ndim == 0:
         ary = ary.reshape(1)
     return DeviceNDArray(ary.shape, ary.strides, ary.dtype,
-                         writeback=ary, stream=stream, gpu_head=gpu_head,
-                         gpu_data=gpu_data)
+                         writeback=ary, stream=stream, gpu_data=gpu_data)
 
 
 errmsg_contiguous_buffer = ("Array contains non-contiguous buffer and cannot "

--- a/numba/cuda/cudadrv/ndarray.py
+++ b/numba/cuda/cudadrv/ndarray.py
@@ -1,10 +1,5 @@
 from __future__ import print_function, absolute_import, division
-import numpy as np
-import numba.ctypes_support as ctypes
-import contextlib
-from collections import deque
 from . import devices, driver
-from numba.targets.arrayobj import make_array_ctype
 from numba.targets.registry import CPUTarget
 
 
@@ -15,108 +10,6 @@ def _calc_array_sizeof(ndim):
     return ctx.calc_array_sizeof(ndim)
 
 
-class ArrayHeaderManager(object):
-    """
-    Manages array header memory for reusing the allocation.
-
-    It allocates one big chunk of memory and partition it for fix sized array
-    header.  It currently stores up to 4D array header in 64-bit mode or 8D
-    array header in 32-bit mode.
-
-    This allows the small array header allocation to be reused to avoid
-    breaking asynchronous streams and avoid fragmentation of memory.
-
-    When run out of preallocated space, it automatically fallback to regular
-    allocation.
-    """
-    # The number of preallocated array head
-    maxsize = 2 ** 10
-
-    # Maximum size for each array head
-    #    = 4 (ndim) * 8 (sizeof intp) * 2 (shape strides) + 8 (ptr)
-    elemsize = _calc_array_sizeof(4)
-
-    # Number of page-locked staging area
-    num_stages = 5
-
-    def __new__(cls, context):
-        mm = context.extras.get(cls)
-        if mm is None:
-            mm = object.__new__(cls)
-            mm.init(context)
-            context.extras[cls] = mm
-        return mm
-
-    def init(self, context):
-        self.context = context
-        self.data = self.context.memalloc(self.elemsize * self.maxsize)
-        self.queue = deque()
-        for i in range(self.maxsize):
-            offset = i * self.elemsize
-            mem = self.data.view(offset, offset + self.elemsize)
-            self.queue.append(mem)
-        self.allocated = set()
-        # A staging buffer to temporary store data for copying
-        self.stages = [np.ndarray(shape=self.elemsize, dtype=np.byte,
-                                  order='C',
-                                  buffer=context.memhostalloc(self.elemsize))
-                       for _ in range(self.num_stages)]
-        self.events = [context.create_event(timing=False)
-                       for _ in range(self.num_stages)]
-
-        self.stage_queue = deque(zip(self.events, self.stages))
-
-    @contextlib.contextmanager
-    def get_stage(self, stream):
-        """Get a pagelocked staging area and record the event when we are done.
-        """
-        evt, stage = self.stage_queue.popleft()
-        if not evt.query():
-            evt.wait(stream=stream)
-        yield stage
-        evt.record(stream=stream)
-        self.stage_queue.append((evt, stage))
-
-    def allocate(self, nd):
-        arraytype = make_array_ctype(nd)
-        sizeof = ctypes.sizeof(arraytype)
-        # Oversized or insufficient space
-        if sizeof > self.elemsize or not self.queue:
-            return _allocate_head(nd)
-
-        mem = self.queue.popleft()
-        self.allocated.add(mem)
-        return mem
-
-    def free(self, mem):
-        if mem in self.allocated:
-            self.allocated.discard(mem)
-            self.queue.append(mem)
-
-    def write(self, data, to, stream=0):
-        if data.size > self.elemsize:
-            # Cannot use pinned staging memory
-            stage = data
-            driver.host_to_device(to, stage, data.size, stream=stream)
-        else:
-            # Can use pinned staging memory
-            with self.get_stage(stream=stream) as stage_area:
-                stage = stage_area[:data.size]
-                stage[:] = data
-                driver.host_to_device(to, stage, data.size, stream=stream)
-
-    def __repr__(self):
-        return "<cuda managed memory %s >" % (self.context.device,)
-
-
-def _allocate_head(nd):
-    """Allocate the metadata structure
-    """
-    arraytype = make_array_ctype(nd)
-    gpu_head = devices.get_context().memalloc(ctypes.sizeof(arraytype))
-    return gpu_head
-
-
 def ndarray_device_allocate_data(ary):
     """
     Allocate gpu data buffer
@@ -125,24 +18,3 @@ def ndarray_device_allocate_data(ary):
     # allocate
     gpu_data = devices.get_context().memalloc(datasize)
     return gpu_data
-
-
-def ndarray_populate_head(gpu_mem, gpu_data, shape, strides, stream=0):
-    """
-    Populate the array header
-    """
-    nd = len(shape)
-    assert nd > 0, "0 or negative dimension"
-
-    arraytype = make_array_ctype(nd)
-    struct = arraytype(parent=None,
-                       data=driver.device_pointer(gpu_data),
-                       shape=shape,
-                       strides=strides)
-
-    gpu_head = gpu_mem.allocate(nd)
-    databytes = np.ndarray(shape=ctypes.sizeof(struct), dtype=np.byte,
-                           buffer=struct)
-    gpu_mem.write(databytes, gpu_head, stream=stream)
-    driver.device_memory_depends(gpu_head, gpu_data)
-    return gpu_head


### PR DESCRIPTION
Implement #1012 base on #1010 
* Save a GPU memory allocation and transfer for the gpu_head
* Remove complicated logic for maintaining a pagelocked staging area for gpu_head memory