### PR TITLE
Allow @jit with multiple signatures

### DIFF
--- a/docs/source/reference/compilation.rst
+++ b/docs/source/reference/compilation.rst
@@ -4,13 +4,14 @@ Compilation
 JIT functions
 -------------
 
-.. decorator:: numba.jit([signature], *, nopython=False, nogil=False, forceobj=False, locals={})
+.. decorator:: numba.jit(*signatures, nopython=False, nogil=False, forceobj=False, locals={})
 
    Compile the decorated function on-the-fly to produce efficient machine
    code.  All parameters all optional.
 
-   *signature* represents the expected :ref:`numba-types` of function arguments
-   and return value.  It can be given in several forms:
+   If present, the *signatures* represent the expected :ref:`numba-types`
+   of function arguments and return values.  Each signature can be
+   given in several forms:
 
    * A tuple of :ref:`numba-types` arguments (for example
      ``(numba.int32, numba.double)``) representing the types of the
@@ -28,21 +29,21 @@ JIT functions
 
    This decorator has several modes of operation:
 
-   * If *signature* is given, a single specialization is compiled
-     corresponding to this signature.  Calling the decorated function will
-     then try to convert the arguments to this signature, and raise a
-     :class:`TypeError` if converting fails.  If converting succeeds, the
-     compiled machine code is executed with the converted arguments and the
-     return value is converted back according to the signature.
+   * If one more *signature* is given, a specialization is compiled
+     for each signature.  Calling the decorated function will
+     then try to choose the best matching signature, and raise a
+     :class:`TypeError` if no appropriate conversion is available for the
+     funciton arguments.  If converting succeeds, the compiled machine code
+     is executed with the converted arguments and the return value is
+     converted back according to the signature.
 
-   * If *signature* is not given, the decorated function implements
-     multiple dispatch and lazy compilation.  Each call to the decorated
-     function will try to re-use an existing specialization if it exists
-     (for example, a call with two integer arguments may re-use a
-     specialization for argument types ``(numba.int64, numba.int64)``).
-     If no suitable specialization exists, a new specialization is compiled
-     on-the-fly, stored for later use, and executed with the converted
-     arguments.
+   * If no *signature* is given, the decorated function implements
+     lazy compilation.  Each call to the decorated function will try to
+     re-use an existing specialization if it exists (for example, a call
+     with two integer arguments may re-use a specialization for argument
+     types ``(numba.int64, numba.int64)``).  If no suitable specialization
+     exists, a new specialization is compiled on-the-fly, stored for later
+     use, and executed with the converted arguments.
 
    If true, *nopython* forces the function to be compiled in :term:`nopython
    mode`. If not possible, compilation will raise an error.

--- a/docs/source/reference/compilation.rst
+++ b/docs/source/reference/compilation.rst
@@ -4,14 +4,15 @@ Compilation
 JIT functions
 -------------
 
-.. decorator:: numba.jit(*signatures, nopython=False, nogil=False, forceobj=False, locals={})
+.. decorator:: numba.jit(signature=None, nopython=False, nogil=False, forceobj=False, locals={})
 
    Compile the decorated function on-the-fly to produce efficient machine
    code.  All parameters all optional.
 
-   If present, the *signatures* represent the expected :ref:`numba-types`
-   of function arguments and return values.  Each signature can be
-   given in several forms:
+   If present, the *signature* is either a single signature or a list of
+   signatures representing the expected :ref:`numba-types` of function
+   arguments and return values.  Each signature can be given in several
+   forms:
 
    * A tuple of :ref:`numba-types` arguments (for example
      ``(numba.int32, numba.double)``) representing the types of the
@@ -61,6 +62,11 @@ JIT functions
    of particular local variables, for example if you want to force the
    use of single precision floats at some point.  In general, we recommend
    you let Numba's compiler infer the types of local variables by itself.
+
+   Here is an example with two signatures::
+
+      @jit(["int32(int32)", "float32(float32)"], nopython=True)
+      def f(x): ...
 
    Not putting any parentheses after the decorator is equivalent to calling
    the decorator without any arguments, i.e.::

--- a/docs/source/user/jit.rst
+++ b/docs/source/user/jit.rst
@@ -61,8 +61,8 @@ to use single-precision floats).
 
 If you omit the return type, e.g. by writing ``(int32, int32)`` instead of
 ``int32(int32, int32)``, Numba will try to infer it for you.  Function
-signatures can also be strings; see the :func:`numba.jit` documentation for
-more details.
+signatures can also be strings, and you can pass several of them as a list;
+see the :func:`numba.jit` documentation for more details.
 
 Of course, the compiled function gives the expected results::
 

--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -96,14 +96,13 @@ PyObject* init_types(PyObject *self, PyObject *args)
 static void
 Dispatcher_dealloc(DispatcherObject *self)
 {
-    Py_DECREF(self->argnames);
+    Py_XDECREF(self->argnames);
     dispatcher_del(self->dispatcher);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 
-static
-int
+static int
 Dispatcher_init(DispatcherObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *tmaddrobj;

--- a/numba/_dispatcherimpl.cpp
+++ b/numba/_dispatcherimpl.cpp
@@ -87,7 +87,7 @@ void*
 dispatcher_resolve(dispatcher_t *obj, int sig[], int *count, int allow_unsafe) {
     Dispatcher *disp = static_cast<Dispatcher*>(obj);
     Type *args = reinterpret_cast<Type*>(sig);
-    void *callable = disp->resolve(args, *count, (bool) allow_unsafe );
+    void *callable = disp->resolve(args, *count, (bool) allow_unsafe);
     return callable;
 }
 

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -20,7 +20,7 @@ def autojit(*args, **kws):
     return jit(*args, **kws)
 
 
-def jit(*signatures, locals={}, target='cpu', **targetoptions):
+def jit(*signatures, **options):
     """
     This decorator is used to compile a Python function into native code.
     
@@ -106,24 +106,26 @@ def jit(*signatures, locals={}, target='cpu', **targetoptions):
                 return x + y
 
     """
+    locals = options.pop('locals', {})
+    target = options.pop('target', 'cpu')
 
     # Handle signature
     if not signatures:
         # No signature, no function in args
         def configured_jit(func):
-            return jit(func, locals=locals, target=target, **targetoptions)
+            return jit(func, locals=locals, target=target, **options)
         return configured_jit
     elif len(signatures) == 1 and not sigutils.is_signature(signatures[0]):
         # A function is passed
         pyfunc = signatures[0]
         dispatcher = registry.target_registry[target]
         dispatcher = dispatcher(py_func=pyfunc, locals=locals,
-                                targetoptions=targetoptions)
+                                targetoptions=options)
         return dispatcher
     else:
         # Signatures are provided
         return _jit(signatures, locals=locals, target=target,
-                    targetoptions=targetoptions)
+                    targetoptions=options)
 
 
 def _jit(sigs, locals, target, targetoptions):

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -20,29 +20,18 @@ def autojit(*args, **kws):
     return jit(*args, **kws)
 
 
-def jit(signature_or_function=None, argtypes=None, restype=None, locals={},
-        target='cpu', **targetoptions):
-    """jit([signature_or_function, [locals={}, [target='cpu', [**targetoptions]]]])
-
-    This function is used to compile a Python function into native code. It is
-    designed to be used as a decorator for the function to be compiled,
-    but it can also be called as a regular function.
+def jit(*signatures, locals={}, target='cpu', **targetoptions):
+    """
+    This decorator is used to compile a Python function into native code.
     
     Args
     -----
-    signature_or_function: function or str
-        This argument takes either the function to be compiled, or the signature
-        of the function to be compiled. If this function is used as a decorator,
-        the function to be compiled is the decorated function. In that case,
-        this argument should only be used to optionally specify the function
-        signature. If this function is called like a regular function, and this
-        argument is used to specify the function signature, this function will
-        return another jit function object which can be called again with the
-        function to be compiled as this argument.
-
-    argtypes: deprecated
-
-    restype: deprecated
+    signatures:
+        The (optional) list of signatures to be compiled.  If not passed,
+        required signatures will be compiled when the decorated function is
+        called, depending on the argument values.
+        As a convenience, you can directly pass the function to be compiled
+        instead.
 
     locals: dict
         Mapping of local variable names to Numba types. Used to override the
@@ -78,22 +67,23 @@ def jit(signature_or_function=None, argtypes=None, restype=None, locals={},
 
     Returns
     --------
-
-    compiled function
+    A callable usable as a compiled function.  Actual compiling will be
+    done lazily if no explicit signatures are passed.
 
     Examples
     --------
     The function can be used in the following ways:
 
-    1) jit(signature, [target='cpu', [**targetoptions]]) -> jit(function)
+    1) jit(*signatures, target='cpu', **targetoptions) -> jit(function)
 
         Equivalent to:
 
             d = dispatcher(function, targetoptions)
-            d.compile(signature)
+            for signature in signatures:
+                d.compile(signature)
 
-        Create a dispatcher object for a python function and default
-        target-options.  Then, compile the funciton with the given signature.
+        Create a dispatcher object for a python function.  Then, compile
+        the function with the given signature(s).
 
         Example:
 
@@ -101,74 +91,49 @@ def jit(signature_or_function=None, argtypes=None, restype=None, locals={},
             def foo(x, y):
                 return x + y
 
-    2) jit(function) -> dispatcher
+    2) jit(function, target='cpu', **targetoptions) -> dispatcher
 
-        Same as old autojit.  Create a dispatcher function object that
-        specialize at call site.
+        Create a dispatcher function object that specializes at call site.
 
-        Example:
+        Examples:
 
             @jit
             def foo(x, y):
                 return x + y
 
-    3) jit([target='cpu', [**targetoptions]]) -> configured_jit(function)
-
-        Same as old autojit and 2).  But configure with target and default
-        target-options.
-
-
-        Example:
-
             @jit(target='cpu', nopython=True)
-            def foo(x, y):
+            def bar(x, y):
                 return x + y
 
     """
 
-    # Handle deprecated argtypes and restype keyword arguments
-    if argtypes is not None:
-
-        assert signature_or_function is None, "argtypes used but " \
-                                              "signature is provided"
-        warnings.warn("Keyword argument 'argtypes' is deprecated",
-                      DeprecationWarning)
-        if restype is None:
-            signature_or_function = tuple(argtypes)
-        else:
-            signature_or_function = restype(*argtypes)
-
     # Handle signature
-    if signature_or_function is None:
-        # Used as autojit
-        def configured_jit(arg):
-            return jit(arg, locals=locals, target=target, **targetoptions)
+    if not signatures:
+        # No signature, no function in args
+        def configured_jit(func):
+            return jit(func, locals=locals, target=target, **targetoptions)
         return configured_jit
-    elif sigutils.is_signature(signature_or_function):
-        # Function signature is provided
-        sig = signature_or_function
-        return _jit(sig, locals=locals, target=target,
-                    targetoptions=targetoptions)
-    else:
-        # No signature is provided
-        pyfunc = signature_or_function
+    elif len(signatures) == 1 and not sigutils.is_signature(signatures[0]):
+        # A function is passed
+        pyfunc = signatures[0]
         dispatcher = registry.target_registry[target]
         dispatcher = dispatcher(py_func=pyfunc, locals=locals,
                                 targetoptions=targetoptions)
-        # NOTE This affects import time for large function
-        # # Compile a pure object mode
-        # if target == 'cpu' and not targetoptions.get('nopython', False):
-        #     dispatcher.compile((), locals=locals, forceobj=True)
         return dispatcher
+    else:
+        # Signatures are provided
+        return _jit(signatures, locals=locals, target=target,
+                    targetoptions=targetoptions)
 
 
-def _jit(sig, locals, target, targetoptions):
+def _jit(sigs, locals, target, targetoptions):
     dispatcher = registry.target_registry[target]
 
     def wrapper(func):
-        disp = dispatcher(py_func=func,  locals=locals,
+        disp = dispatcher(py_func=func, locals=locals,
                           targetoptions=targetoptions)
-        disp.compile(sig)
+        for sig in sigs:
+            disp.compile(sig)
         disp.disable_compile()
         return disp
 

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -184,7 +184,8 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         assert not kws, "kwargs not handled"
         args = tuple([self.typeof_pyval(a) for a in args])
         sigs = [cr.signature for cr in self._compileinfos.values()]
-        resolve_overload(self.typingctx, self.py_func, sigs, args, kws)
+        res = resolve_overload(self.typingctx, self.py_func, sigs, args, kws)
+        print("res =", res)
 
     def __repr__(self):
         return "%s(%s)" % (type(self).__name__, self.py_func)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -134,6 +134,7 @@ class TestDispatcher(TestCase):
 
     def test_explicit_signatures(self):
         f = jit("(int64,int64)")(add)
+        # Approximate match (unsafe conversion)
         self.assertPreciseEqual(f(1.5, 2.5), 3)
         self.assertEqual(len(f.overloads), 1, f.overloads)
         f = jit("(int64,int64)", "(float64,float64)")(add)
@@ -147,6 +148,10 @@ class TestDispatcher(TestCase):
             f(1j, 1j)
         self.assertIn("No matching definition", str(cm.exception))
         self.assertEqual(len(f.overloads), 2, f.overloads)
+        # A more interesting one...
+        f = jit("(float32,float32)", "(float64,float64)")(add)
+        self.assertPreciseEqual(f(np.float32(1), np.float32(2**-25)), 1.0)
+        self.assertPreciseEqual(f(1, 2**-25), 1.0000000298023224)
 
     def test_signature_mismatch(self):
         tmpl = "Signature mismatch: %d argument types given, but function takes 2 arguments"

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -2,6 +2,8 @@ from __future__ import print_function, division, absolute_import
 
 import threading
 
+import numpy as np
+
 from numba import unittest_support as unittest
 from numba import utils, vectorize, jit
 from .support import TestCase
@@ -130,6 +132,22 @@ class TestDispatcher(TestCase):
             f(3, 4, y=6)
         self.assertIn("missing argument 'z'", str(cm.exception))
 
+    def test_explicit_signatures(self):
+        f = jit("(int64,int64)")(add)
+        self.assertPreciseEqual(f(1.5, 2.5), 3)
+        self.assertEqual(len(f.overloads), 1, f.overloads)
+        f = jit("(int64,int64)", "(float64,float64)")(add)
+        # Exact signature matches
+        self.assertPreciseEqual(f(1, 2), 3)
+        self.assertPreciseEqual(f(1.5, 2.5), 4.0)
+        # Approximate match (int32 -> float64 is a safe conversion)
+        self.assertPreciseEqual(f(np.int32(1), 2.5), 3.5)
+        # No conversion
+        with self.assertRaises(TypeError) as cm:
+            f(1j, 1j)
+        self.assertIn("No matching definition", str(cm.exception))
+        self.assertEqual(len(f.overloads), 2, f.overloads)
+
     def test_signature_mismatch(self):
         tmpl = "Signature mismatch: %d argument types given, but function takes 2 arguments"
         with self.assertRaises(TypeError) as cm:
@@ -224,6 +242,7 @@ class TestDispatcher(TestCase):
         for asm in asms.values():
             # Look for the function name
             self.assertTrue("foo" in asm)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -137,7 +137,7 @@ class TestDispatcher(TestCase):
         # Approximate match (unsafe conversion)
         self.assertPreciseEqual(f(1.5, 2.5), 3)
         self.assertEqual(len(f.overloads), 1, f.overloads)
-        f = jit("(int64,int64)", "(float64,float64)")(add)
+        f = jit(["(int64,int64)", "(float64,float64)"])(add)
         # Exact signature matches
         self.assertPreciseEqual(f(1, 2), 3)
         self.assertPreciseEqual(f(1.5, 2.5), 4.0)
@@ -149,7 +149,7 @@ class TestDispatcher(TestCase):
         self.assertIn("No matching definition", str(cm.exception))
         self.assertEqual(len(f.overloads), 2, f.overloads)
         # A more interesting one...
-        f = jit("(float32,float32)", "(float64,float64)")(add)
+        f = jit(["(float32,float32)", "(float64,float64)"])(add)
         self.assertPreciseEqual(f(np.float32(1), np.float32(2**-25)), 1.0)
         self.assertPreciseEqual(f(1, 2**-25), 1.0000000298023224)
 

--- a/numba/typeconv/typeconv.hpp
+++ b/numba/typeconv/typeconv.hpp
@@ -8,36 +8,36 @@ This object must be int sized
 */
 class Type{
 public:
-	Type();
-	Type(int id);
-	Type(const Type& other);
-	Type& operator = (const Type& other);
-	bool valid() const;
-	bool operator ==(const Type& other) const;
-	bool operator !=(const Type& other) const;
-	bool operator <(const Type& other) const;
+    Type();
+    Type(int id);
+    Type(const Type& other);
+    Type& operator = (const Type& other);
+    bool valid() const;
+    bool operator ==(const Type& other) const;
+    bool operator !=(const Type& other) const;
+    bool operator <(const Type& other) const;
 
-	int get() const;
+    int get() const;
 
 private:
     int id;
 };
 
 enum TypeCompatibleCode{
-	// No match
-	TCC_FALSE = 0,
-	// Exact match
-	TCC_EXACT,
-	// Subtype is UNUSED
-	TCC_SUBTYPE,
-	// Promotion with no precision loss
-	TCC_PROMOTE,
-	// Conversion with no precision loss
-	// e.g. int32 to double
+    // No match
+    TCC_FALSE = 0,
+    // Exact match
+    TCC_EXACT,
+    // Subtype is UNUSED
+    TCC_SUBTYPE,
+    // Promotion with no precision loss
+    TCC_PROMOTE,
+    // Conversion with no precision loss
+    // e.g. int32 to double
     TCC_CONVERT_SAFE,
-	// Conversion with precision loss
-	// e.g. int64 to double (53 bits precision)
-	TCC_CONVERT_UNSAFE,
+    // Conversion with precision loss
+    // e.g. int64 to double (53 bits precision)
+    TCC_CONVERT_UNSAFE,
 };
 
 typedef std::pair<Type, Type> TypePair;
@@ -62,9 +62,9 @@ private:
 };
 
 struct Rating{
-    unsigned short promote;
-    unsigned short safe_convert;
-    unsigned short unsafe_convert;
+    unsigned int promote;
+    unsigned int safe_convert;
+    unsigned int unsafe_convert;
 
     Rating();
     void bad();
@@ -76,30 +76,30 @@ struct Rating{
 
 class TypeManager{
 public:
-	bool canPromote(Type from, Type to) const;
-	bool canUnsafeConvert(Type from, Type to) const;
-	bool canSafeConvert(Type from, Type to) const;
+    bool canPromote(Type from, Type to) const;
+    bool canUnsafeConvert(Type from, Type to) const;
+    bool canSafeConvert(Type from, Type to) const;
 
-	void addPromotion(Type from, Type to);
-	void addUnsafeConversion(Type from, Type to);
-	void addSafeConversion(Type from, Type to);
-	void addCompatibility(Type from, Type to, TypeCompatibleCode by);
+    void addPromotion(Type from, Type to);
+    void addUnsafeConversion(Type from, Type to);
+    void addSafeConversion(Type from, Type to);
+    void addCompatibility(Type from, Type to, TypeCompatibleCode by);
 
-	TypeCompatibleCode isCompatible(Type from, Type to) const;
+    TypeCompatibleCode isCompatible(Type from, Type to) const;
 
-	/**
-	Output stored in selected.
-	Returns
-	    Number of matches
-	*/
-	int selectOverload(Type sig[], Type ovsigs[], int &selected, int sigsz,
-	                   int ovct, bool allow_unsafe) const;
+    /**
+    Output stored in selected.
+    Returns
+        Number of matches
+    */
+    int selectOverload(Type sig[], Type ovsigs[], int &selected, int sigsz,
+                       int ovct, bool allow_unsafe) const;
 
 private:
-	int _selectOverload(Type sig[], Type ovsigs[], int &selected, int sigsz,
-	                    int ovct, bool allow_unsafe, Rating ratings[]) const;
+    int _selectOverload(Type sig[], Type ovsigs[], int &selected, int sigsz,
+                        int ovct, bool allow_unsafe, Rating ratings[]) const;
 
-	TCCMap tccmap;
+    TCCMap tccmap;
 };
 
 


### PR DESCRIPTION
Also:
* the deprecated `argtypes` and `restype` to `@jit` are removed
* some cosmetic cleanup in C++ code