### PR TITLE
Support arrays of scalars inside structured types

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -43,12 +43,13 @@ Numba supports the following Numpy scalar types:
 * **Complex numbers:** single-precision (2x32-bit) and double-precision (2x64-bit) complex numbers
 * **Datetimes and timestamps:** of any unit
 * **Character sequences** (but no operations are available on them)
-* **Structured scalars:** structured scalars made of any of the types above
+* **Structured scalars:** structured scalars made of any of the types above and arrays of the types above
 
 The following scalar types and features are not supported:
 
 * **Arbitrary Python objects**
 * **Half-precision and extended-precision** real and complex numbers
+* **Nested structured scalars** the fields of structured scalars may not contain other structured scalars
 
 The operations supported on scalar Numpy numbers are the same as on the
 equivalent built-in types such as ``int`` or ``float``.  You can use

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -79,7 +79,7 @@ class StructProxy(object):
         self._dmm = self._context.data_model_manager
         self._datamodel = self._dmm[self._fe_type]
         if not isinstance(self._datamodel, datamodel.StructModel):
-            raise TypeError("Not a structure model: {0}".format(self._dmodel))
+            raise TypeError("Not a structure model: {0}".format(self._datamodel))
         self._builder = builder
 
         self._be_type = self._datamodel.get_value_type()

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -450,6 +450,7 @@ class PairModel(StructModel):
 
 
 @register_default(types.Array)
+@register_default(types.NestedArray)
 class ArrayModel(StructModel):
     def __init__(self, dmm, fe_type):
         ndim = fe_type.ndim

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -90,6 +90,9 @@ def from_dtype(dtype):
                 return _from_str_dtype(dtype)
             if dtype.char in 'mM' and npdatetime.NPDATETIME_SUPPORTED:
                 return _from_datetime_dtype(dtype)
+            if dtype.char in 'V':
+                subtype = from_dtype(dtype.subdtype[0])
+                return types.VoidArray(subtype, dtype.shape)
             raise NotImplementedError(dtype)
     else:
         return from_struct_dtype(dtype)
@@ -293,7 +296,7 @@ else:
 
 def from_struct_dtype(dtype):
     if dtype.hasobject:
-        raise TypeError("Do not support object containing dtype")
+        raise TypeError("Do not support dtype containing object")
 
     fields = {}
     for name, (elemdtype, offset) in dtype.fields.items():

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -92,7 +92,7 @@ def from_dtype(dtype):
                 return _from_datetime_dtype(dtype)
             if dtype.char in 'V':
                 subtype = from_dtype(dtype.subdtype[0])
-                return types.VoidArray(subtype, dtype.shape)
+                return types.NestedArray(subtype, dtype.shape)
             raise NotImplementedError(dtype)
     else:
         return from_struct_dtype(dtype)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -446,24 +446,15 @@ class BaseContext(object):
                     ary = aryty(context, builder)
                     dtype = elemty.dtype
                     ary.nitems = context.get_constant(types.intp, elemty.nitems)
-                    assert dtype.bitwidth % 8 == 0, ("Dtype bitwidth must be"
-                                                     "a multiple of bytes")
-                    size = dtype.bitwidth//8
-                    ary.itemsize = context.get_constant(types.intp, size)
-                    dataty = self.get_data_type(dtype)
+                    ary.itemsize = context.get_constant(types.intp, elemty.size)
                     ary.data = cgutils.get_record_member(builder, val, offset,
-                                                         dataty)
+                                                         self.get_data_type(dtype))
                     ary.shape = cgutils.pack_array(builder,
                                                    [ self.get_constant(types.intp, s)
                                                      for s in elemty.shape ])
-                    stride = size
-                    strides = []
-                    for i in reversed(elemty.shape):
-                        strides.append(stride)
-                        stride *= i
                     ary.strides = cgutils.pack_array(builder,
                                                      [self.get_constant(types.intp, s)
-                                                     for s in strides ])
+                                                     for s in elemty.strides ])
                     return ary._getvalue()
             else:
                 @impl_attribute(typ, attr, elemty)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -437,7 +437,7 @@ class BaseContext(object):
             offset = typ.offset(attr)
             elemty = typ.typeof(attr)
 
-            if isinstance(elemty, types.Array):
+            if isinstance(elemty, types.NestedArray):
                 # Inside a structured type only the array data is stored, so we
                 # create an array structure to point to that data.
                 aryty = arrayobj.make_array(elemty)

--- a/numba/types.py
+++ b/numba/types.py
@@ -727,6 +727,8 @@ class NestedArray(Array):
     """
 
     def __init__(self, dtype, shape):
+        assert dtype.bitwidth % 8 == 0, \
+            "Dtype bitwidth must be a multiple of bytes"
         self._shape = shape
         name = "nestedarray(%s, %s)" % (dtype, shape)
         ndim = len(shape)
@@ -743,6 +745,19 @@ class NestedArray(Array):
         for s in self.shape:
             l = l * s
         return l
+
+    @property
+    def size(self):
+        return self.dtype.bitwidth // 8
+
+    @property
+    def strides(self):
+        stride = self.size
+        strides = []
+        for i in reversed(self._shape):
+             strides.append(stride)
+             stride *= i
+        return tuple(strides)
 
 class UniTuple(IterableType):
 

--- a/numba/types.py
+++ b/numba/types.py
@@ -719,21 +719,19 @@ class Array(IterableType):
         return self.layout in 'CF'
 
 
-class VoidArray(Array):
+class NestedArray(Array):
     """
-    A VoidArray is an array nested within a structured type (which are "void"
+    A NestedArray is an array nested within a structured type (which are "void"
     type in NumPy parlance). Unlike an Array, the shape, and not just the number
-    of dimenions is part of the type of a VoidArray.
+    of dimenions is part of the type of a NestedArray.
     """
 
-    def __init__(self, dtype, shape, const=False):
+    def __init__(self, dtype, shape):
         self._shape = shape
-        name = "voidarray(%s, %s, %s)" % (dtype, shape,
-                                          {True: 'const',
-                                           False: 'nonconst'}[const])
+        name = "nestedarray(%s, %s)" % (dtype, shape)
         ndim = len(shape)
-        super(VoidArray, self).__init__(dtype, ndim, 'C', const=const,
-                                        name=name)
+        super(NestedArray, self).__init__(dtype, ndim, 'C', const=False,
+                                          name=name)
 
     @property
     def shape(self):


### PR DESCRIPTION
This adds support for arrays of scalars inside structured types by represented these arrays as a `types.VoidArray`, which behaves similarly to a `types.Array`, but the shape rather than just the number of dimensions is part of the type.

Only the raw array data is stored in a structured type, so an array structure is created and populated with relevant information when an array inside a structured type is accessed.