### PR TITLE
Notify user about deprecated kwargs argtypes.

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -20,6 +20,14 @@ def autojit(*args, **kws):
     return jit(*args, **kws)
 
 
+class DeprecationError(Exception):
+    pass
+
+
+_msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
+                                 "Signatures should be passed as the first "
+                                 "positional argument.")
+
 def jit(signature_or_function=None, locals={}, target='cpu', **options):
     """
     This decorator is used to compile a Python function into native code.
@@ -111,9 +119,9 @@ def jit(signature_or_function=None, locals={}, target='cpu', **options):
 
     """
     if 'argtypes' in options:
-        raise DeprecationWarning("Deprecatd keyword argument `argtypes`. "
-                                 "Signatures should be passed as the first "
-                                 "positional argument.")
+        raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
+    if 'restype' in options:
+        raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
 
     # Handle signature
     if signature_or_function is None:

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -110,6 +110,10 @@ def jit(signature_or_function=None, locals={}, target='cpu', **options):
                 return x + y
 
     """
+    if 'argtypes' in options:
+        raise DeprecationWarning("Deprecatd keyword argument `argtypes`. "
+                                 "Signatures should be passed as the first "
+                                 "positional argument.")
 
     # Handle signature
     if signature_or_function is None:


### PR DESCRIPTION
Otherwise, it will be included into options and the error message is
hard to understand.
Very early numba/numbapro code may contain argtypes uses.