### PR TITLE
[WIP] An attempt at JIT classes

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -667,3 +667,10 @@ def handle_numpy_flat_type(dmm, ty):
         return FlatIter(dmm, ty)
 
 
+@register_default(types.Structure)
+def handle_structure(dmm, ty):
+    return StructModel(dmm, ty, ty.members)
+
+@register_default(types.StructRef)
+def handle_structref(dmm, ty):
+    return dmm[types.CPointer(ty.base)]

--- a/numba/extensible.py
+++ b/numba/extensible.py
@@ -1,0 +1,119 @@
+from __future__ import absolute_import
+import types
+import ctypes
+import numba.types
+from numba.targets.registry import CPUTarget
+from numba import njit
+
+
+_field_setter_name = "field_setter{clsname}_{field}"
+_field_setter_template = """
+def field_setter{clsname}_{field}(base, value):
+    base.{field} = value
+"""
+
+
+def _build_field_setter(clsname, field):
+    src = _field_setter_template.format(clsname=clsname, field=field)
+    dct = {}
+    exec(src, dct)
+    fnobj = dct[_field_setter_name.format(clsname=clsname, field=field)]
+    return njit(fnobj)
+
+
+_field_getter_name = "field_getter{clsname}_{field}"
+_field_getter_template = """
+def field_getter{clsname}_{field}(base):
+    return base.{field}
+"""
+
+
+def _build_field_getter(clsname, field):
+    src = _field_getter_template.format(clsname=clsname, field=field)
+    dct = {}
+    exec(src, dct)
+    fnobj = dct[_field_getter_name.format(clsname=clsname, field=field)]
+    return njit(fnobj)
+
+
+class _FieldDescriptor(object):
+    __slots__ = ('_clsname', '_name', '_type', '_offset', '_setter', '_getter')
+
+    def __init__(self, clsname, name, nbtype, offset):
+        self._clsname = clsname
+        self._name = name
+        self._type = nbtype
+        self._offset = offset
+        self._setter = _build_field_setter(self._clsname, self._name)
+        self._getter = _build_field_getter(self._clsname, self._name)
+
+    def __get__(self, instance, owner):
+        return self._getter(instance)
+
+    def __set__(self, instance, value):
+        self._setter(instance, value)
+
+
+class _MethodDescriptor(object):
+    __slots__ = ('_name', '_function')
+
+    def __init__(self, name, function):
+        self._name = name
+        self._function = function
+
+    def __get__(self, instance, owner):
+        print(self, instance, owner)
+        raise NotImplementedError
+
+
+class _NativeData(object):
+    def __init__(self, clsname, descriptors):
+        fieldtypes = [(d._name, d._type) for d in descriptors]
+        self._type = numba.types.Structure(clsname, fieldtypes)
+        self._ref_type = numba.types.StructRef(self._type)
+        ctx = CPUTarget.target_context
+        llty = ctx.get_value_type(self._type)
+        sizeof = ctx.get_abi_sizeof(llty)
+        byteseq = (ctypes.c_byte * sizeof)()
+        self._data = byteseq
+        self._dataptr = ctypes.addressof(self._data)
+
+    @property
+    def data_pointer(self):
+        return self._dataptr
+
+    @property
+    def numba_type(self):
+        return self._ref_type
+
+
+class PlainOldData(type):
+    def __new__(cls, clsname, parents, dct):
+        # Discover all the methods.  They are still functions at this point.
+        methods = [(name, value) for name, value in dct.items()
+                   if isinstance(value, types.FunctionType)]
+
+        # Set __slots__ to empty to disable __dict__ and disallow adding
+        # fields dynamically
+        dct['__slots__'] = ('__numba__',)
+
+        # Insert descriptor for each field
+        descriptors = []
+        for offset, (name, typ) in enumerate(dct.pop('__fields__')):
+            desc = _FieldDescriptor(clsname, name, typ, offset)
+            dct[name] = desc
+            descriptors.append(desc)
+
+        # Insert descriptor for methods:
+        for name, func in methods:
+            dct[name] = _MethodDescriptor(name, func)
+
+        def ctor(self, **kwargs):
+            assert not kwargs, "args at ctor not implemented"
+            self.__numba__ = _NativeData(clsname, descriptors)
+
+        dct['__init__'] = ctor
+
+        return super(PlainOldData, cls).__new__(cls, clsname, parents, dct)
+
+

--- a/numba/extensible.py
+++ b/numba/extensible.py
@@ -5,6 +5,7 @@ import numba.types
 from functools import partial
 from numba.targets.registry import CPUTarget
 from numba import jit, njit
+from numba import utils
 
 
 
@@ -87,7 +88,7 @@ class _NativeData(object):
     def __init__(self, spec):
         self._spec = spec
         self._data = self._spec._ctype()
-        self._dataptr = ctypes.addressof(self._data)
+        self._dataptr = utils.longint(ctypes.addressof(self._data))
 
     @property
     def data_pointer(self):
@@ -98,7 +99,7 @@ class _NativeData(object):
         return self._spec._ref_type
 
 
-class PlainOldData(type):
+class PlainOldDataMeta(type):
     def __new__(cls, clsname, parents, dct):
         # Discover all the methods.  They are still functions at this point.
         methods = [(name, value) for name, value in dct.items()
@@ -128,6 +129,8 @@ class PlainOldData(type):
 
         dct['__init__'] = ctor
 
-        return super(PlainOldData, cls).__new__(cls, clsname, parents, dct)
+        return super(PlainOldDataMeta, cls).__new__(cls, clsname, parents, dct)
 
 
+# Make an inheritable class to hide the metaclass for (2+3) compatibility
+PlainOldData = utils.with_metaclass(PlainOldDataMeta)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -908,6 +908,16 @@ class PythonAPI(object):
             llty = self.context.get_value_type(typ)
             return self.builder.inttoptr(addr, llty)
 
+        elif isinstance(typ, types.Structure):
+            base = self.object_getattr_string(obj, '__numba__')
+            addrobj = self.object_getattr_string(base, 'data_pointer')
+            addr = self.long_as_ulonglong(addrobj)
+            self.decref(base)
+            self.decref(addrobj)
+            llty = self.context.get_value_type(types.CPointer(typ))
+            ptr = self.builder.inttoptr(addr, llty)
+            return self.builder.load(ptr)
+
         raise NotImplementedError(typ)
 
     def from_native_return(self, val, typ):

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -899,6 +899,15 @@ class PythonAPI(object):
         elif isinstance(typ, (types.Tuple, types.UniTuple)):
             return self.to_native_tuple(obj, typ)
 
+        elif isinstance(typ, types.StructRef):
+            base = self.object_getattr_string(obj, '__numba__')
+            addrobj = self.object_getattr_string(base, 'data_pointer')
+            addr = self.long_as_ulonglong(addrobj)
+            self.decref(base)
+            self.decref(addrobj)
+            llty = self.context.get_value_type(typ)
+            return self.builder.inttoptr(addr, llty)
+
         raise NotImplementedError(typ)
 
     def from_native_return(self, val, typ):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -432,7 +432,7 @@ class BaseContext(object):
 
             # TODO this is ugly
             if (isinstance(fn, types.BoundFunction) and
-                    isinstance(fn.this, types.Structure)):
+                    isinstance(fn.this, (types.StructRef, types.Structure))):
                 overloaded = fn.this.methodtable[fn.template.key]
                 key = overloaded.get_overload(sig)
                 overloads = self.defns[key]
@@ -491,6 +491,15 @@ class BaseContext(object):
             def imp(context, builder, typ, val):
                 wrappercls = cgutils.create_struct_proxy(typ.base)
                 wrapper = wrappercls(context, builder, ref=val)
+                return getattr(wrapper, attr)
+            return imp
+
+        if isinstance(typ, types.Structure):
+            elemty = typ.typeof(attr)
+            @impl_attribute(typ, attr, elemty)
+            def imp(context, builder, typ, val):
+                wrappercls = cgutils.create_struct_proxy(typ)
+                wrapper = wrappercls(context, builder, value=val)
                 return getattr(wrapper, attr)
             return imp
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -430,6 +430,13 @@ class BaseContext(object):
             else:
                 overloads = self.defns[key]
 
+            # TODO this is ugly
+            if (isinstance(fn, types.BoundFunction) and
+                    isinstance(fn.this, types.Structure)):
+                overloaded = fn.this.methodtable[fn.template.key]
+                key = overloaded.get_overload(sig)
+                overloads = self.defns[key]
+
         elif isinstance(fn, types.Dispatcher):
             key = fn.overloaded.get_overload(sig.args)
             overloads = self.defns[key]

--- a/numba/tests/test_extensible.py
+++ b/numba/tests/test_extensible.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, print_function
+from numba import unittest_support as unittest
+from numba import extensible
+from numba import int32, float64
+
+
+class TestPlainOldData(unittest.TestCase):
+    def test_simple_usecase_from_python(self):
+        class Pair(metaclass=extensible.PlainOldData):
+            __fields__ = [
+                ('first', int32),
+                ('second', float64),
+            ]
+
+            def add_both_by(self, val):
+                self.first += val
+                self.second += val
+
+        pair = Pair()
+
+        self.assertEqual(pair.first, 0)
+        self.assertEqual(pair.second, 0)
+
+        pair.first = 1
+        pair.second = 2.2
+
+        self.assertEqual(pair.first, 1)
+        self.assertAlmostEqual(pair.second, 2.2)
+
+        pair.add_both_by(123)
+
+        self.assertEqual(pair.first, 123 + 1)
+        self.assertAlmostEqual(pair.second, 123 + 2.2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_extensible.py
+++ b/numba/tests/test_extensible.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 from numba import unittest_support as unittest
 from numba import extensible
 from numba import int32, float64
+from numba import njit
 
 
 class TestPlainOldData(unittest.TestCase):
@@ -31,6 +32,35 @@ class TestPlainOldData(unittest.TestCase):
 
         self.assertEqual(pair.first, 123 + 1)
         self.assertAlmostEqual(pair.second, 123 + 2.2)
+
+    def test_usecase_in_njit(self):
+        class Pair(extensible.PlainOldData):
+            __fields__ = [
+                ('first', int32),
+                ('second', float64),
+            ]
+
+            def add_both_by(self, val):
+                self.first += val
+                self.second += val
+
+        pair = Pair()
+
+        @njit
+        def foo(pair):
+            a = pair.first + pair.second
+            pair.add_both_by(a)
+
+        pair.first = 1
+        pair.second = 2
+
+        self.assertEqual(pair.first, 1)
+        self.assertEqual(pair.second, 2)
+
+        foo(pair)
+
+        self.assertEqual(pair.first, 1 + 1 + 2)
+        self.assertEqual(pair.second, 2 + 1 + 2)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_extensible.py
+++ b/numba/tests/test_extensible.py
@@ -6,7 +6,7 @@ from numba import int32, float64
 
 class TestPlainOldData(unittest.TestCase):
     def test_simple_usecase_from_python(self):
-        class Pair(metaclass=extensible.PlainOldData):
+        class Pair(extensible.PlainOldData):
             __fields__ = [
                 ('first', int32),
                 ('second', float64),

--- a/numba/tests/test_extensible.py
+++ b/numba/tests/test_extensible.py
@@ -63,5 +63,40 @@ class TestPlainOldData(unittest.TestCase):
         self.assertEqual(pair.second, 2 + 1 + 2)
 
 
+class TestImmutablePOD(unittest.TestCase):
+    def test_simple_usecase_from_python(self):
+        class Pair(extensible.ImmutablePOD):
+            __fields__ = [
+                ('first', int32),
+                ('second', float64),
+            ]
+
+            def combine(self, val):
+                return self.first + self.second + val
+
+        pair = Pair(first=2, second=3)
+        self.assertEqual(pair.first, 2)
+        self.assertEqual(pair.second, 3)
+        self.assertEqual(pair.combine(123), 123 + 2 + 3)
+
+    def test_nopython_usecase(self):
+        class Pair(extensible.ImmutablePOD):
+            __fields__ = [
+                ('first', int32),
+                ('second', float64),
+            ]
+
+            def combine(self, val):
+                return self.first + self.second + val
+
+        pair = Pair(first=2, second=3)
+
+        @njit
+        def foo(pair):
+            return pair.combine(123)
+
+        self.assertEqual(foo(pair), 123 + 2 + 3)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -974,6 +974,37 @@ def is_int_tuple(x):
         return False
 
 
+class Structure(Type):
+    def __init__(self, name, members):
+        self.members = tuple((k, v) for k, v in members)
+        self.fields = dict(self.members)
+        super(Structure, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.members
+
+    def typeof(self, key):
+        return self.fields[key]
+
+
+class StructRef(Type):
+    def __init__(self, base_struct):
+        self._struct = base_struct
+        super(StructRef, self).__init__("Ref({0})".format(self._struct.name))
+
+    @property
+    def key(self):
+        return self._struct.key
+
+    def typeof(self, key):
+        return self._struct.typeof(key)
+
+    @property
+    def base(self):
+        return self._struct
+
+
 # Short names
 
 

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -195,8 +195,10 @@ class BaseContext(object):
             return types.Array(dtype, ary.ndim, layout)
 
         if hasattr(val, '__numba__'):
-            ty = val.__numba__.numba_type
-            return ty
+            attrnb = val.__numba__
+            if hasattr(attrnb, "numba_type"):
+                ty = val.__numba__.numba_type
+                return ty
 
         return
 

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -74,7 +74,7 @@ class BaseContext(object):
                 return res
 
     def resolve_getattr(self, value, attr):
-        if isinstance(value, types.Record):
+        if isinstance(value, (types.Record, types.Structure, types.StructRef)):
             ret = value.typeof(attr)
             assert ret
             return ret
@@ -102,7 +102,7 @@ class BaseContext(object):
         return self.resolve_function_type("setitem", args, kws)
 
     def resolve_setattr(self, target, attr, value):
-        if isinstance(target, types.Record):
+        if isinstance(target, (types.Record, types.Structure, types.StructRef)):
             expectedty = target.typeof(attr)
             if self.type_compatibility(value, expectedty) is not None:
                 return templates.signature(types.void, target, value)
@@ -193,6 +193,10 @@ class BaseContext(object):
             else:
                 layout = 'A'
             return types.Array(dtype, ary.ndim, layout)
+
+        if hasattr(val, '__numba__'):
+            ty = val.__numba__.numba_type
+            return ty
 
         return
 


### PR DESCRIPTION
This is an experiment/proof-of-concept.  This PR is created for open discussion.

## What I did

Added `PlainOldData` metaclass that transform a class definition so that:
* it uses a custom storage equivalent to a C structure
* all fields are stored in native (nopython) format
* all field setters/getters are @njit functions
* all methods are @jit functions


## Example
The following snippet works:

```python
class Pair(extensible.PlainOldData):
    __fields__ = [
        ('first', int32),
        ('second', float64),
    ]

    def add_both_by(self, val):
        self.first += val
        self.second += val

pair = Pair()
pair.first = 1     # calls a @njit function to set
pair.second = 2.2        # calls a @njit function to set
pair.add_both_by(123)        # calls a @jit function bound to pair
print(pair.first, pair.second) 
```
## Details

An instance of `PlainOldData` is typed by numba as `StructRef`, a reference to a structure.  It is passed-by-reference.

## Todos
- ~~fix for python2~~
- implement constructor (other than the default zero-filling one)
- ~~implement usage within nopython mode~~

