### PR TITLE
Fix tests and `cuda.devicearray` for NumPy 1.7

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -179,8 +179,12 @@ class DeviceNDArrayBase(object):
             _driver.device_to_host(hostary, self, self.alloc_size, stream=stream)
 
         if ary is None:
-            hostary = np.ndarray(shape=self.shape, strides=self.strides,
-                                 dtype=self.dtype, buffer=hostary)
+            if self.size == 0:
+                hostary = np.ndarray(shape=self.shape, dtype=self.dtype,
+                                     buffer=hostary)
+            else:
+                hostary = np.ndarray(shape=self.shape, dtype=self.dtype,
+                                     strides=self.strides, buffer=hostary)
         return hostary
 
     def to_host(self, stream=0):

--- a/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba/cuda/tests/cudapy/test_debug.py
@@ -19,7 +19,7 @@ class TestDebugOutput(unittest.TestCase):
             cfunc = cuda.jit((float64[:], float64[:]))(simple_cuda)
             # Call compiled function (to ensure PTX is generated)
             # and sanity-check results.
-            A = np.linspace(0, 1, 10, dtype=np.float64)
+            A = np.linspace(0, 1, 10).astype(np.float64)
             B = np.zeros_like(A)
             cfunc[1, 10](A, B)
             self.assertTrue(np.allclose(A + 1.5, B))

--- a/numba/tests/test_buffer_protocol.py
+++ b/numba/tests/test_buffer_protocol.py
@@ -110,7 +110,7 @@ class TestBufferProtocol(TestCase):
             ('complex64', -8j, 12 + 5j),
             ('complex128', -8j, 12 + 5j),
             ]:
-            yield memoryview(np.linspace(start, stop, n, dtype=dtype))
+            yield memoryview(np.linspace(start, stop, n).astype(dtype))
         # Different layouts
         arr = np.arange(12).reshape((3, 4))
         assert arr.flags.c_contiguous and not arr.flags.f_contiguous


### PR DESCRIPTION
- NumPy 1.7 and below object to receiving a `strides` kwarg for zero-length arrays.
- `linspace` does not take a `dtype` argument on 1.7 and below.