### PR TITLE
Add fix and tests for nested array attributes

### DIFF
--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import numba.unittest_support as unittest
 import numpy as np
 from numba.compiler import compile_isolated, Flags
+from numba.numpy_support import from_dtype
 from numba import types
 
 
@@ -25,48 +26,110 @@ def array_size(a):
     return a.size
 
 
+def nested_array_itemsize(a):
+    return a.f.itemsize
+
+
+def nested_array_shape(a):
+    return a.f.shape
+
+
+def nested_array_strides(a):
+    return a.f.strides
+
+
+def nested_array_ndim(a):
+    return a.f.ndim
+
+
+def nested_array_size(a):
+    return a.f.size
+
+
 class TestArrayAttr(unittest.TestCase):
+    def setUp(self):
+        self.a = np.arange(10).reshape(2, 5)
+
+    def get_cfunc(self, pyfunc, argspec):
+        # Need to keep a reference to the compile result for the
+        # wrapper function object to remain valid (!)
+        self.__cres = compile_isolated(pyfunc, argspec)
+        return self.__cres.entry_point
+
     def test_shape(self):
         pyfunc = array_shape
-        cres = compile_isolated(pyfunc, (types.int32[:,:], types.int32))
-        cfunc = cres.entry_point
+        cfunc = self.get_cfunc(pyfunc, (types.int32[:,:], types.int32))
 
-        a = np.arange(10).reshape(2, 5)
-        for i in range(a.ndim):
-            self.assertEqual(pyfunc(a, i), cfunc(a, i))
+        for i in range(self.a.ndim):
+            self.assertEqual(pyfunc(self.a, i), cfunc(self.a, i))
 
     def test_strides(self):
         pyfunc = array_strides
-        cres = compile_isolated(pyfunc, (types.int32[:,:], types.int32))
-        cfunc = cres.entry_point
+        cfunc = self.get_cfunc(pyfunc, (types.int32[:,:], types.int32))
 
-        a = np.arange(10).reshape(2, 5)
-        for i in range(a.ndim):
-            self.assertEqual(pyfunc(a, i), cfunc(a, i))
+        for i in range(self.a.ndim):
+            self.assertEqual(pyfunc(self.a, i), cfunc(self.a, i))
 
     def test_ndim(self):
         pyfunc = array_ndim
-        cres = compile_isolated(pyfunc, (types.int32[:,:],))
-        cfunc = cres.entry_point
+        cfunc = self.get_cfunc(pyfunc, (types.int32[:,:],))
 
-        a = np.arange(10).reshape(2, 5)
-        self.assertEqual(pyfunc(a), cfunc(a))
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
 
     def test_size(self):
         pyfunc = array_size
-        cres = compile_isolated(pyfunc, (types.int32[:,:],))
-        cfunc = cres.entry_point
+        cfunc = self.get_cfunc(pyfunc, (types.int32[:,:],))
 
-        a = np.arange(10).reshape(2, 5)
-        self.assertEqual(pyfunc(a), cfunc(a))
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
 
     def test_itemsize(self):
         pyfunc = array_itemsize
-        cres = compile_isolated(pyfunc, (types.int32[:,:],))
-        cfunc = cres.entry_point
+        cfunc = self.get_cfunc(pyfunc, (types.int32[:,:],))
 
-        a = np.arange(10).reshape(2, 5)
-        self.assertEqual(pyfunc(a), cfunc(a))
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+
+class TestNestedArrayAttr(unittest.TestCase):
+    def setUp(self):
+        dtype = np.dtype([('a', np.int32), ('f', np.int32, (2, 5))])
+        self.a = np.recarray(1, dtype)[0]
+        self.nbrecord = from_dtype(self.a.dtype)
+
+    def get_cfunc(self, pyfunc):
+        # Need to keep a reference to the compile result for the
+        # wrapper function object to remain valid (!)
+        self.__cres = compile_isolated(pyfunc, (self.nbrecord,))
+        return self.__cres.entry_point
+
+    def test_shape(self):
+        pyfunc = nested_array_shape
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+    def test_strides(self):
+        pyfunc = nested_array_strides
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+    def test_ndim(self):
+        pyfunc = nested_array_ndim
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+    def test_size(self):
+        pyfunc = nested_array_size
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+    def test_itemsize(self):
+        pyfunc = nested_array_itemsize
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
 
 
 if __name__ == '__main__':

--- a/numba/types.py
+++ b/numba/types.py
@@ -818,7 +818,7 @@ class NestedArray(Array):
         for i in reversed(self._shape):
              strides.append(stride)
              stride *= i
-        return tuple(strides)
+        return tuple(reversed(strides))
 
 
 class UniTuple(IterableType):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -469,9 +469,6 @@ class ArrayAttribute(AttributeTemplate):
     def resolve_ndim(self, ary):
         return types.intp
 
-    # def resolve_flatten(self, ary):
-    #     return types.Method(Array_flatten, ary)
-
     def resolve_size(self, ary):
         return types.intp
 
@@ -483,6 +480,11 @@ class ArrayAttribute(AttributeTemplate):
             if attr in ary.dtype.fields:
                 return types.Array(ary.dtype.typeof(attr), ndim=ary.ndim,
                                    layout='A')
+
+
+@builtin_attr
+class NestedArrayAttribute(ArrayAttribute):
+    key = types.NestedArray
 
 
 def generic_homog(self, args, kws):


### PR DESCRIPTION
Fixes #1028.

Using nested array attributes failed typing, and nested arrays
also had erroneously reversed strides. This commit fixes these
issues and adds tests for nested array attributes.