### PR TITLE
Add missing key property to NestedArray and test

### DIFF
--- a/numba/types.py
+++ b/numba/types.py
@@ -822,7 +822,7 @@ class NestedArray(Array):
 
     @property
     def key(self):
-         return self.dtype, self.shape
+        return self.dtype, self.shape
 
 class UniTuple(IterableType):
 

--- a/numba/types.py
+++ b/numba/types.py
@@ -820,6 +820,9 @@ class NestedArray(Array):
              stride *= i
         return tuple(reversed(strides))
 
+    @property
+    def key(self):
+         return self.dtype, self.shape
 
 class UniTuple(IterableType):
 


### PR DESCRIPTION
This fixes an issue where having two nested arrays in a structured type with the same dtype and number of dimensions but differing shape would result in incorrect code being generated for accessing one of them.