### PR TITLE
Silence CUDA tests

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -74,7 +74,6 @@ class TestCudaDriver(unittest.TestCase):
 
     def test_cuda_driver_basic(self):
         module = self.context.create_module_ptx(self.ptx)
-        print(module.info_log)
         function = module.get_function('_Z10helloworldPi')
 
         array = (c_int * 100)()
@@ -94,7 +93,6 @@ class TestCudaDriver(unittest.TestCase):
 
     def test_cuda_driver_stream(self):
         module = self.context.create_module_ptx(self.ptx)
-        print(module.info_log)
         function = module.get_function('_Z10helloworldPi')
 
         array = (c_int * 100)()

--- a/numba/cuda/tests/cudadrv/test_detect.py
+++ b/numba/cuda/tests/cudadrv/test_detect.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import, print_function
 from numba import cuda
 from numba.cuda.testing import unittest
-
+from numba.tests.support import captured_stdout
 
 class TestCudaDetect(unittest.TestCase):
     def test_cuda_detect(self):
         # exercise the code path
-        cuda.detect()
+        with captured_stdout() as out:
+            cuda.detect()
+        output = out.getvalue()
+        self.assertIn('Found', output)
+        self.assertIn('CUDA devices', output)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba/cuda/tests/cudadrv/test_events.py
@@ -16,7 +16,8 @@ class TestCudaEvent(unittest.TestCase):
         evtend.record()
         evtend.wait()
         evtend.synchronize()
-        print(evtstart.elapsed_time(evtend))
+        # Exercise the code path
+        evtstart.elapsed_time(evtend)
 
     def test_event_elapsed_stream(self):
         N = 32
@@ -30,7 +31,8 @@ class TestCudaEvent(unittest.TestCase):
         evtend.record(stream=stream)
         evtend.wait(stream=stream)
         evtend.synchronize()
-        print(evtstart.elapsed_time(evtend))
+        # Exercise the code path
+        evtstart.elapsed_time(evtend)
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -22,8 +22,7 @@ class TestLinker(unittest.TestCase):
         bar = cuda.declare_device('bar', 'int32(int32)')
 
         link = os.path.join(os.path.dirname(__file__), 'data', 'jitlink.ptx')
-        print('link to:', link)
-        
+
         @cuda.jit('void(int32[:], int32[:])', link=[link])
         def foo(x, y):
             i = cuda.grid(1)

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -14,7 +14,6 @@ is64bit = sizeof(c_size_t) == sizeof(c_uint64)
 class TestNvvmDriver(unittest.TestCase):
     def get_ptx(self):
         nvvm = NVVM()
-        print(nvvm.get_version())
 
         if is64bit:
             return gpu64
@@ -27,15 +26,12 @@ class TestNvvmDriver(unittest.TestCase):
 
         cu.add_module(nvvmir.encode('utf8'))
         ptx = cu.compile().decode('utf8')
-        print(ptx)
         self.assertTrue('simple' in ptx)
         self.assertTrue('ave' in ptx)
-        print(cu.log)
 
     def test_nvvm_compile_simple(self):
         nvvmir = self.get_ptx()
         ptx = llvm_to_ptx(nvvmir).decode('utf8')
-        print(ptx)
         self.assertTrue('simple' in ptx)
         self.assertTrue('ave' in ptx)
 
@@ -45,12 +41,10 @@ class TestNvvmDriver(unittest.TestCase):
         kernel = m.add_function(fty, name='mycudakernel')
         bldr = Builder.new(kernel.append_basic_block('entry'))
         bldr.ret_void()
-        print(m)
         set_cuda_kernel(kernel)
 
         fix_data_layout(m)
         ptx = llvm_to_ptx(str(m)).decode('utf8')
-        print(ptx)
         self.assertTrue('mycudakernel' in ptx)
         if is64bit:
             self.assertTrue('.address_size 64' in ptx)
@@ -62,7 +56,6 @@ class TestNvvmDriver(unittest.TestCase):
         compute_xx = 'compute_{0}{1}'.format(*arch)
         ptx = llvm_to_ptx(nvvmir, arch=compute_xx, ftz=1, prec_sqrt=0,
                           prec_div=0).decode('utf8')
-        print(ptx)
         self.assertIn(".target sm_{0}{1}".format(*arch), ptx)
         self.assertIn('simple', ptx)
         self.assertIn('ave', ptx)

--- a/numba/cuda/tests/cudadrv/test_pinned.py
+++ b/numba/cuda/tests/cudadrv/test_pinned.py
@@ -35,14 +35,12 @@ class TestPinned(CUDATestCase):
         with cuda.pinned(A):
             for i in range(REPEAT):
                 total += self._template('pinned', A)
-        print('pinned', total / REPEAT)
 
     def test_unpinned(self):
         A = np.arange(2*1024*1024) # 16 MB
         total = 0
         for i in range(REPEAT):
             total += self._template('unpinned', A)
-        print('unpinned', total / REPEAT)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -16,13 +16,10 @@ class TestResetDevice(CUDATestCase):
         def newthread(exception_queue):
             try:
                 devices = range(driver.get_device_count())
-                print('Devices', devices)
                 for _ in range(2):
                     for d in devices:
                         cuda.select_device(d)
-                        print('Selected device', d)
                         cuda.close()
-                        print('Closed device', d)
             except Exception as e:
                 exception_queue.put(e)
 

--- a/numba/cuda/tests/cudapy/test_autojit.py
+++ b/numba/cuda/tests/cudapy/test_autojit.py
@@ -16,7 +16,6 @@ class TestCudaAutoJit(unittest.TestCase):
         what(np.empty(1), np.empty(1, dtype=np.int32), 21)
         what(np.empty(1), 1.0, 21)
 
-        print(what.definitions)
         self.assertTrue(len(what.definitions) == 2)
 
 

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -114,14 +114,11 @@ class TestBlackScholes(unittest.TestCase):
         stream.synchronize()
 
         dt = (time1 - time0)
-        print("numbapro.cuda time: %f msec" % ((1000 * dt) / iterations))
 
         delta = np.abs(callResultNumpy - callResultNumbapro)
         L1norm = delta.sum() / np.abs(callResultNumpy).sum()
 
         max_abs_err = delta.max()
-        print('L1norm', L1norm)
-        print('Max absolute error', max_abs_err)
         self.assertTrue(L1norm < 1e-13)
         self.assertTrue(max_abs_err < 1e-13)
 

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -34,7 +34,6 @@ def cuconst3d(A):
 class TestCudaConstantMemory(unittest.TestCase):
     def test_const_array(self):
         jcuconst = cuda.jit('void(float64[:])')(cuconst)
-        print(jcuconst.ptx)
         self.assertTrue('.const' in jcuconst.ptx)
         A = numpy.empty_like(CONST1D)
         jcuconst[2, 5](A)
@@ -42,22 +41,16 @@ class TestCudaConstantMemory(unittest.TestCase):
 
     def test_const_array_2d(self):
         jcuconst2d = cuda.jit('void(int32[:,:])')(cuconst2d)
-        print(jcuconst2d.ptx)
         self.assertTrue('.const' in jcuconst2d.ptx)
         A = numpy.empty_like(CONST2D, order='C')
         jcuconst2d[(2,2), (5,5)](A)
-        print(CONST2D)
-        print(A)
         self.assertTrue(numpy.all(A == CONST2D))
 
     def test_const_array_3d(self):
         jcuconst3d = cuda.jit('void(complex64[:,:,:])')(cuconst3d)
-        print(jcuconst3d.ptx)
         self.assertTrue('.const' in jcuconst3d.ptx)
         A = numpy.empty_like(CONST3D, order='F')
         jcuconst3d[1, (5, 5, 5)](A)
-        print(CONST3D)
-        print(A)
         self.assertTrue(numpy.all(A == CONST3D))
 
 

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -79,8 +79,6 @@ class TestCudaLaplace(unittest.TestCase):
             A[j, 0] = 1.0
             Anew[j, 0] = 1.0
 
-        print("Jacobi relaxation Calculation: %d x %d mesh" % (n, m))
-
         timer = time.time()
         iter = 0
 
@@ -113,14 +111,9 @@ class TestCudaLaplace(unittest.TestCase):
             dA = dAnew
             dAnew = tmp
 
-            if iter % 100 == 0:
-                print("%5d, %0.6f (elapsed: %f s)" %
-                      (iter, error, time.time() - timer))
-
             iter += 1
 
         runtime = time.time() - timer
-        print(" total: %f s" % runtime)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -49,8 +49,6 @@ class TestCudaMatMul(unittest.TestCase):
         B = np.array(np.random.random((n, n)), dtype=np.float32)
         C = np.empty_like(A)
 
-        print("N = %d x %d" % (n, n))
-
         s = time()
         stream = cuda.stream()
         with stream.auto_synchronize():
@@ -71,10 +69,6 @@ class TestCudaMatMul(unittest.TestCase):
         Cans = Amat * Bmat
         e = time()
         tcpu = e - s
-
-        print('cpu:  %f' % tcpu)
-        print('cuda: %f' % tcuda)
-        print('cuda speedup: %.2fx' % (tcpu / tcuda))
 
         # Check result
         self.assertTrue(np.allclose(C, Cans))

--- a/numba/cuda/tests/cudapy/test_multigpu.py
+++ b/numba/cuda/tests/cudapy/test_multigpu.py
@@ -24,14 +24,10 @@ class TestMultiGPUContext(unittest.TestCase):
         with cuda.gpus[0]:
             copy_plus_1[1, N](A, B)
 
-        print(A, B)
         check(A, B)
 
         copy_plus_1[1, N](A, B)
-        print(A, B)
         check(A, B)
-
-        print(len(cuda.gpus))
 
         with cuda.gpus[0]:
             A0 = np.arange(N, dtype=np.float64)
@@ -42,9 +38,6 @@ class TestMultiGPUContext(unittest.TestCase):
                 A1 = np.arange(N, dtype=np.float64)
                 B1 = np.arange(N, dtype=np.float64)
                 copy_plus_1[1, N](A1, B1)
-
-        print(A0, A1)
-        print(B0, B1)
 
         check(A0, B0)
         check(A1, B1)

--- a/numba/cuda/tests/cudapy/test_py2_div_issue.py
+++ b/numba/cuda/tests/cudapy/test_py2_div_issue.py
@@ -25,15 +25,6 @@ class TestCudaPy2Div(unittest.TestCase):
         z = 1.0
         preCalc[1, 15](y, yA, yB, numDataPoints)
 
-        print('y')
-        print(y)
-
-        print('yA')
-        print(yA)
-
-        print('yB')
-        print(yB)
-
         self.assertTrue(np.all(y == yA))
         self.assertTrue(np.all(y == yB))
 


### PR DESCRIPTION
Issue reference: #696

I think the output from the CUDA tests falls into the categories of:

- Printing out information that might at one time have been used for debugging, but is just noise now.
- Printing out PTX dumps and the contents of large arrays - too cumbersome to be of use in debugging.
- Printing out timing results:
  - I thought about adding asserts to ensure that e.g. the time of a pinned transfer is less than an unpinned one, but suspect this would probably cause transient failures due to other normal operations going on a system.
  - Other cases print out timing information for the execution of kernels, but again the runtimes are very short so it seems to me that any timing information wouldn't necessarily be useful for benchmarking or comparison purposes.