### PR TITLE
Register NumPy casters on CUDA target

### DIFF
--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from numba import types
+from numba.typing.npydecl import register_casters
 from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                     AbstractTemplate, MacroTemplate,
                                     signature, Registry)
@@ -11,6 +12,7 @@ intrinsic = registry.register
 intrinsic_attr = registry.register_attr
 intrinsic_global = registry.register_global
 
+register_casters(intrinsic_global)
 
 class Cuda_grid(MacroTemplate):
     key = cuda.grid

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -6,6 +6,7 @@ import llvmlite.llvmpy.core as lc
 import llvmlite.llvmpy.ee as le
 import llvmlite.binding as ll
 from numba.targets.imputils import implement, Registry
+from numba.targets.npyimpl import register_casters
 from numba import cgutils
 from numba import types
 from .cudadrv import nvvm
@@ -14,6 +15,7 @@ from . import nvvmutils, stubs
 registry = Registry()
 register = registry.register
 
+register_casters(register)
 
 @register
 @implement('ptx.grid.1d', types.intp)

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -1,0 +1,71 @@
+from numba import unittest_support as unittest
+import numpy as np
+from numba import cuda, types
+import struct
+
+
+def float_to_int(x):
+    return np.int32(x)
+
+
+def int_to_float(x):
+    return np.float64(x) / 2
+
+
+def float_to_unsigned(x):
+    return types.uint32(x)
+
+
+def float_to_complex(x):
+    return np.complex128(x)
+
+
+class TestCasting(unittest.TestCase):
+    def _create_wrapped(self, pyfunc, intype, outtype):
+        wrapped_func = cuda.jit(device=True)(pyfunc)
+
+        @cuda.jit
+        def cuda_wrapper_fn(arg, res):
+            res[0] = wrapped_func(arg[0])
+
+        def wrapper_fn(arg):
+            argarray = np.zeros(1, dtype=intype)
+            argarray[0] = arg
+            resarray = np.zeros(1, dtype=outtype)
+            cuda_wrapper_fn(argarray, resarray)
+            return resarray[0]
+
+        return wrapper_fn
+
+    def test_float_to_int(self):
+        pyfunc = float_to_int
+        cfunc = self._create_wrapped(pyfunc, np.float32, np.int32)
+
+        self.assertEqual(cfunc(12.3), pyfunc(12.3))
+        self.assertEqual(cfunc(12.3), int(12.3))
+
+    def test_int_to_float(self):
+        pyfunc = int_to_float
+        cfunc = self._create_wrapped(pyfunc, np.int64, np.float64)
+
+        self.assertEqual(cfunc(321), pyfunc(321))
+        self.assertEqual(cfunc(321), 321. / 2)
+
+    def test_float_to_unsigned(self):
+        pyfunc = float_to_unsigned
+        cfunc = self._create_wrapped(pyfunc, np.float32, np.uint32)
+
+        self.assertEqual(cfunc(3.21), pyfunc(3.21))
+        self.assertEqual(cfunc(3.21), struct.unpack('I', struct.pack('i',
+                                                                      3))[0])
+
+    def test_float_to_complex(self):
+        pyfunc = float_to_complex
+        cfunc = self._create_wrapped(pyfunc, np.float64, np.complex128)
+
+        self.assertEqual(cfunc(-3.21), pyfunc(-3.21))
+        self.assertEqual(cfunc(-3.21), -3.21 + 0j)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -43,6 +43,8 @@ class TestCasting(unittest.TestCase):
 
         self.assertEqual(cfunc(12.3), pyfunc(12.3))
         self.assertEqual(cfunc(12.3), int(12.3))
+        self.assertEqual(cfunc(-12.3), pyfunc(-12.3))
+        self.assertEqual(cfunc(-12.3), int(-12.3))
 
     def test_int_to_float(self):
         pyfunc = int_to_float

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -34,13 +34,16 @@ def caster(restype, constructor):
 
     return _cast
 
-for tp in types.number_domain:
-    register(caster(tp, getattr(numpy, str(tp))))
+def register_casters(register_function):
+    for tp in types.number_domain:
+        register_function(caster(tp, getattr(numpy, str(tp))))
 
-register(caster(types.intc, numpy.intc))
-register(caster(types.uintc, numpy.uintc))
-register(caster(types.intp, numpy.intp))
-register(caster(types.uintp, numpy.uintp))
+    register_function(caster(types.intc, numpy.intc))
+    register_function(caster(types.uintc, numpy.uintc))
+    register_function(caster(types.intp, numpy.intp))
+    register_function(caster(types.uintp, numpy.uintp))
+
+register_casters(register)
 
 ########################################################################
 

--- a/numba/tests/test_casting.py
+++ b/numba/tests/test_casting.py
@@ -46,9 +46,9 @@ class TestCasting(unittest.TestCase):
         cfunc = cr.entry_point
 
         self.assertEqual(cr.signature.return_type, types.uint32)
-        self.assertEqual(cfunc(-3.21), pyfunc(-3.21))
-        self.assertEqual(cfunc(-3.21), struct.unpack('I', struct.pack('i',
-                                                                      -3))[0])
+        self.assertEqual(cfunc(3.21), pyfunc(3.21))
+        self.assertEqual(cfunc(3.21), struct.unpack('I', struct.pack('i',
+                                                                      3))[0])
 
     def test_float_to_complex(self):
         pyfunc = float_to_complex

--- a/numba/tests/test_casting.py
+++ b/numba/tests/test_casting.py
@@ -30,6 +30,8 @@ class TestCasting(unittest.TestCase):
         self.assertEqual(cr.signature.return_type, types.int32)
         self.assertEqual(cfunc(12.3), pyfunc(12.3))
         self.assertEqual(cfunc(12.3), int(12.3))
+        self.assertEqual(cfunc(-12.3), pyfunc(-12.3))
+        self.assertEqual(cfunc(-12.3), int(-12.3))
 
     def test_int_to_float(self):
         pyfunc = int_to_float

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -252,21 +252,24 @@ np_types.add(numpy.intp)
 np_types.add(numpy.uintc)
 np_types.add(numpy.uintp)
 
-for np_type in np_types:
-    nb_type = getattr(types, np_type.__name__)
 
-    class Caster(AbstractTemplate):
-        key = np_type
-        restype = nb_type
+def register_casters(register_global):
+    for np_type in np_types:
+        nb_type = getattr(types, np_type.__name__)
 
-        def generic(self, args, kws):
-            assert not kws
-            [a] = args
-            if a in types.number_domain:
-                return signature(self.restype, a)
+        class Caster(AbstractTemplate):
+            key = np_type
+            restype = nb_type
 
-    builtin_global(np_type, types.Function(Caster))
+            def generic(self, args, kws):
+                assert not kws
+                [a] = args
+                if a in types.number_domain:
+                    return signature(self.restype, a)
 
+        register_global(np_type, types.Function(Caster))
+
+register_casters(builtin_global)
 
 # -----------------------------------------------------------------------------
 # Miscellaneous functions


### PR DESCRIPTION
The included test is based on the test_casting test for the CPU target.

The CPU target also relied on undefined behaviour (casting a negative float to an unsigned int) so it is modified to test casting a positive float to an unsigned int and positive and negative floats to a signed int.