### PR TITLE
Fix size property of shared arrays

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -404,5 +404,6 @@ def _make_array(context, builder, dataptr, dtype, shape, layout='C'):
 
     ary.shape = cgutils.pack_array(builder, kshape)
     ary.strides = cgutils.pack_array(builder, kstrides)
+    ary.nitems = reduce(builder.mul, kshape[1:], kshape[0])
 
     return ary._getvalue()

--- a/numba/cuda/tests/cudapy/test_sm.py
+++ b/numba/cuda/tests/cudapy/test_sm.py
@@ -2,6 +2,7 @@ from numba import cuda, int32
 
 from numba.cuda.testing import unittest
 
+import numpy as np
 
 class TestSharedMemoryIssue(unittest.TestCase):
     def test_issue_953_sm_linkage_conflict(self):
@@ -15,6 +16,25 @@ class TestSharedMemoryIssue(unittest.TestCase):
             inner()
 
         outer()
+
+    def _check_shared_array_size(self, shape, expected):
+        @cuda.jit
+        def s(a):
+            arr = cuda.shared.array(shape, dtype=int32)
+            a[0] = arr.size
+
+        result = np.zeros(1, dtype=np.int32)
+        s(result)
+        self.assertEqual(result[0], expected)
+
+    def test_issue_1051_shared_size_broken_1d(self):
+        self._check_shared_array_size(2, 2)
+
+    def test_issue_1051_shared_size_broken_2d(self):
+        self._check_shared_array_size((2, 3), 6)
+
+    def test_issue_1051_shared_size_broken_3d(self):
+        self._check_shared_array_size((2, 3, 4), 24)
 
 
 if __name__ == '__main__':

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -623,7 +623,7 @@ def array_itemsize(context, builder, typ, value):
 
 @builtin_attr
 @impl_attribute(types.Kind(types.MemoryView), "nbytes", types.intp)
-def array_size(context, builder, typ, value):
+def array_nbytes(context, builder, typ, value):
     """
     nbytes = size * itemsize
     """


### PR DESCRIPTION
Fixes Issue #1051

The size property of arrays returns `ary.nitems`, which was not set for shared arrays.

Also fix a duplicate method name in numba/targets/arrayobj.py