### PR TITLE
Fix for #1059

### DIFF
--- a/numba/datamodel/manager.py
+++ b/numba/datamodel/manager.py
@@ -22,10 +22,7 @@ class DataModelManager(object):
     def lookup(self, fetype):
         """Returns the corresponding datamodel given the frontend-type instance
         """
-        try:
-            handler = self._handlers[type(fetype)]
-        except KeyError:
-            raise NotImplementedError
+        handler = self._handlers[type(fetype)]
         return handler(self, fetype)
 
     def __getitem__(self, fetype):

--- a/numba/datamodel/manager.py
+++ b/numba/datamodel/manager.py
@@ -22,7 +22,10 @@ class DataModelManager(object):
     def lookup(self, fetype):
         """Returns the corresponding datamodel given the frontend-type instance
         """
-        handler = self._handlers[type(fetype)]
+        try:
+            handler = self._handlers[type(fetype)]
+        except KeyError:
+            raise NotImplementedError
         return handler(self, fetype)
 
     def __getitem__(self, fetype):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -487,6 +487,7 @@ class BaseContext(object):
         if isinstance(typ, types.Module):
             # Implement getattr for module-level globals.
             # We are treating them as constants.
+            # XXX We shouldn't have to retype this
             attrty = self.typing_context.resolve_module_constants(typ, attr)
             if attrty is not None and not isinstance(attrty, (types.Dispatcher,
                                                               types.Function,

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -487,22 +487,18 @@ class BaseContext(object):
         if isinstance(typ, types.Module):
             # Implement getattr for module-level globals.
             # We are treating them as constants.
-            # XXX We shouldn't have to retype this
             attrty = self.typing_context.resolve_module_constants(typ, attr)
-            if attrty is not None:
-                try:
-                    pyval = getattr(typ.pymod, attr)
-                    llval = self.get_constant(attrty, pyval)
-                except NotImplementedError:
-                    # Module attribute is not a simple constant
-                    # (e.g. it's a function), it will be handled later on.
-                    pass
-                else:
-                    @impl_attribute(typ, attr, attrty)
-                    def imp(context, builder, typ, val):
-                        return llval
-                    return imp
-            # No implementation
+            if attrty is not None and not isinstance(attrty, (types.Dispatcher,
+                                                              types.Function,
+                                                              types.Module)):
+                pyval = getattr(typ.pymod, attr)
+                llval = self.get_constant(attrty, pyval)
+                @impl_attribute(typ, attr, attrty)
+                def imp(context, builder, typ, val):
+                    return llval
+                return imp
+            # No implementation required for functions/modules, which are
+            # dealt with later
             return None
 
         # Lookup specific attribute implementation for this type

--- a/numba/tests/test_globals.py
+++ b/numba/tests/test_globals.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from numba import jit
 from numba import unittest_support as unittest
-
+from numba.tests import usecases
 
 X = np.arange(10)
 
@@ -56,6 +56,11 @@ def global_two_rec_arrs(a, b, c, d):
         b[i] = rec_X[i].b
         c[i] = rec_Y[i].c
         d[i] = rec_Y[i].d
+
+
+@jit(nopython=True)
+def global_module_func(s, e):
+    return usecases.sum1dnopython(s, e)
 
 
 class TestGlobals(unittest.TestCase):
@@ -137,6 +142,10 @@ class TestGlobals(unittest.TestCase):
     def test_two_global_rec_arrs_npm(self):
         self.check_two_global_rec_arrs(nopython=True)
 
+    def test_global_module(self):
+        # (see github issue #1059)
+        res = global_module_func(0, 10)
+        np.testing.assert_equal(45, res)
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/usecases.py
+++ b/numba/tests/usecases.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-
+from numba import jit
 
 def sum1d(s, e):
     c = 0
@@ -8,6 +8,7 @@ def sum1d(s, e):
         c += i
     return c
 
+sum1dnopython = jit(nopython=True)(sum1d)
 
 def sum2d(s, e):
     c = 0


### PR DESCRIPTION
`numba.target.base.BaseContext.get_attribute()` catches a `NotImplementedError` for module constants that cannot be lowered with `get_constant`. This causes a failure to lower functions in other modules, because the data model manager now ends up being called and raising a `KeyError`.

This changes `get_attribute` so that it avoids attempting to lower functions and modules as constants in the hope of recovering from any errors that occur in doing so, and adds a test for using a function from another module.