### PR TITLE
Vectorization at call time

### DIFF
--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -26,6 +26,7 @@
 #if PY_MAJOR_VERSION >= 3
     #define PyString_AsString PyUnicode_AsUTF8
     #define PyString_Check PyUnicode_Check
+    #define PyString_FromFormat PyUnicode_FromFormat
     #define PyString_FromString PyUnicode_FromString
     #define PyString_InternFromString PyUnicode_InternFromString
     #define PyInt_Type PyLong_Type

--- a/numba/npyufunc/__init__.py
+++ b/numba/npyufunc/__init__.py
@@ -1,3 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import
 from .decorators import Vectorize, GUVectorize, vectorize, guvectorize
+from ._internal import PyUFunc_None, PyUFunc_Zero, PyUFunc_One
+from . import _internal
+if hasattr(_internal, 'PyUFunc_ReorderableNone'):
+    PyUFunc_ReorderableNone = _internal.PyUFunc_ReorderableNone
+del _internal

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -479,7 +479,7 @@ PyTypeObject PyDUFunc_Type = {
     PyObject_HEAD_INIT(NULL)
     0,                                          /* ob_size */
 #endif
-    "numba.DUFunc",                             /* tp_name*/
+    "numba._DUFunc",                            /* tp_name*/
     sizeof(PyDUFuncObject),                     /* tp_basicsize*/
     0,                                          /* tp_itemsize */
     /* methods */

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -449,6 +449,16 @@ dufunc__add_loop(PyDUFuncObject * self, PyObject * args)
 
     arg_types_arr = _build_arg_types_array(arg_types, (Py_ssize_t)ufunc->nargs);
     if (!arg_types_arr) goto _dufunc__add_loop_fail;
+
+    /* Check to see if any of the input types are user defined dtypes.
+       If they are, we should use PyUFunc_RegisterLoopForType() since
+       dispatch on a user defined dtype uses a Python dictionary
+       keyed by usertype (and not the functions array).
+
+       For more information, see how the usertype argument is used in
+       PyUFunc_RegisterLoopForType(), defined by Numpy at
+       .../numpy/core/src/umath/ufunc_object.c
+    */
     for (idx = 0; idx < ufunc->nargs; idx++) {
         if (arg_types_arr[idx] >= NPY_USERDEF) {
             usertype = arg_types_arr[idx];

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -4,6 +4,7 @@
  */
 
 #include "_internal.h"
+#include "Python.h"
 
 /* A small object that handles deallocation of some of a PyUFunc's fields */
 typedef struct {
@@ -104,8 +105,184 @@ PyTypeObject PyUFuncCleaner_Type = {
     0,                                          /* tp_version_tag */
 };
 
+/* ______________________________________________________________________
+ * DUFunc: A call-time (hence dynamic) specializable ufunc.
+ */
+
+typedef struct {
+    PyObject_HEAD
+    PyUFuncObject * ufunc;
+    PyObject * dispatcher;
+    PyObject * keepalive;
+} PyDUFuncObject;
+
+static void
+dufunc_dealloc(PyDUFuncObject *self)
+{
+    Py_XDECREF(self->ufunc);
+    Py_XDECREF(self->dispatcher);
+    Py_XDECREF(self->keepalive);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyObject *
+dufunc_repr(PyDUFuncObject *dufunc)
+{
+#if PY_MAJOR_VERSION >= 3
+    return PyUnicode_FromFormat("<numba.dufunc '%s'>", dufunc->ufunc->name);
+#else
+    return PyString_FromFormat("<numba.dufunc '%s'>", dufunc->ufunc->name);
+#endif
+}
+
+static PyObject *
+dufunc_call(PyDUFuncObject *self, PyObject *args, PyObject *kws)
+{
+    PyObject *result = (PyObject *)NULL;
+
+    result = PyUFunc_Type.tp_call((PyObject *)self->ufunc, args, kws);
+    if (result == NULL) {
+        /* TODO */
+    }
+    return result;
+}
+
+/* ____________________________________________________________
+ * Shims to expose ufunc methods.
+ */
+
+static struct _ufunc_dispatch {
+    PyCFunction ufunc_reduce;
+    PyCFunction ufunc_accumulate;
+    PyCFunction ufunc_reduceat;
+    PyCFunction ufunc_outer;
+    PyCFunction ufunc_at;
+} ufunc_dispatch = {NULL, NULL, NULL, NULL, NULL};
+
+static int
+init_ufunc_dispatch(void)
+{
+    int result = 0;
+    PyMethodDef * crnt = PyUFunc_Type.tp_methods;
+    const char * crnt_name = NULL;
+    for (; crnt->ml_name != NULL; crnt++) {
+        crnt_name = crnt->ml_name;
+        switch(crnt_name[0]) {
+        case 'a':
+            if (strncmp(crnt_name, "at", 3) == 0) {
+                ufunc_dispatch.ufunc_at = crnt->ml_meth;
+            } else if (strncmp(crnt_name, "accumulate", 11) == 0) {
+                ufunc_dispatch.ufunc_accumulate = crnt->ml_meth;
+            } else {
+                result = -1;
+            }
+            break;
+        case 'o':
+            if (strncmp(crnt_name, "outer", 6) == 0) {
+                ufunc_dispatch.ufunc_outer = crnt->ml_meth;
+            } else {
+                result = -1;
+            }
+            break;
+        case 'r':
+            if (strncmp(crnt_name, "reduce", 7) == 0) {
+                ufunc_dispatch.ufunc_reduce = crnt->ml_meth;
+            } else if (strncmp(crnt_name, "reduceat", 9) == 0) {
+                ufunc_dispatch.ufunc_reduceat = crnt->ml_meth;
+            } else {
+                result = -1;
+            }
+            break;
+        default:
+            result = -1; /* Unknown method */
+        }
+        if (result < 0) break;
+    }
+    if (result == 0) {
+        /* Sanity check. */
+        result = ((ufunc_dispatch.ufunc_reduce != NULL) &&
+                  (ufunc_dispatch.ufunc_accumulate != NULL) &&
+                  (ufunc_dispatch.ufunc_reduceat != NULL) &&
+                  (ufunc_dispatch.ufunc_outer != NULL) &&
+                  (ufunc_dispatch.ufunc_at != NULL));
+    }
+    return result;
+}
+
+PyTypeObject PyDUFunc_Type = {
+#if PY_MAJOR_VERSION >= 3
+    PyVarObject_HEAD_INIT(NULL, 0)
+#else
+    PyObject_HEAD_INIT(NULL)
+    0,                                          /* ob_size */
+#endif
+    "numba.DUFunc",                             /* tp_name*/
+    sizeof(PyDUFuncObject),                     /* tp_basicsize*/
+    0,                                          /* tp_itemsize */
+    /* methods */
+    (destructor) dufunc_dealloc,                /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+#if defined(NPY_PY3K)
+    0,                                          /* tp_reserved */
+#else
+    0,                                          /* tp_compare */
+#endif
+    (reprfunc) dufunc_repr,                     /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    (ternaryfunc) dufunc_call,                  /* tp_call */
+    (reprfunc) dufunc_repr,                     /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,                         /* tp_flags */
+    0,                                          /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    0,                                          /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    0,                                          /* tp_new */
+    0,                                          /* tp_free */
+    0,                                          /* tp_is_gc */
+    0,                                          /* tp_bases */
+    0,                                          /* tp_mro */
+    0,                                          /* tp_cache */
+    0,                                          /* tp_subclasses */
+    0,                                          /* tp_weaklist */
+    0,                                          /* tp_del */
+    0,                                          /* tp_version_tag */
+};
+
+static PyObject *
+dufunc_fromfunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
+{
+    PyDUFuncObject * dufunc = (PyDUFuncObject *)NULL;
+    return (PyObject *)dufunc;
+}
+
+/* ______________________________________________________________________
+ * Module initialization boilerplate follows.
+ */
+
 static PyMethodDef ext_methods[] = {
     {"fromfunc", (PyCFunction) ufunc_fromfunc, METH_VARARGS, NULL},
+    {"dufunc", (PyCFunction) dufunc_fromfunc, METH_VARARGS, NULL},
     { NULL }
 };
 
@@ -126,6 +303,15 @@ MOD_INIT(_internal)
             ext_methods)
 
     if (m == NULL)
+        return MOD_ERROR_VAL;
+
+    if (PyType_Ready(&PyUFuncCleaner_Type) < 0)
+        return MOD_ERROR_VAL;
+
+    PyDUFunc_Type.tp_new = PyType_GenericNew;
+    if (init_ufunc_dispatch() != 0)
+        return MOD_ERROR_VAL;
+    if (PyType_Ready(&PyDUFunc_Type) < 0)
         return MOD_ERROR_VAL;
 
     if (PyModule_AddIntMacro(m, PyUFunc_One)

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -131,11 +131,7 @@ dufunc_dealloc(PyDUFuncObject *self)
 static PyObject *
 dufunc_repr(PyDUFuncObject *dufunc)
 {
-#if PY_MAJOR_VERSION >= 3
-    return PyUnicode_FromFormat("<numba._DUFunc '%s'>", dufunc->ufunc->name);
-#else
     return PyString_FromFormat("<numba._DUFunc '%s'>", dufunc->ufunc->name);
-#endif
 }
 
 static PyObject *
@@ -225,20 +221,12 @@ dufunc_init(PyDUFuncObject *self, PyObject *args, PyObject *kws)
     /* Construct the UFunc. */
     tmp = PyObject_GetAttrString(py_func_obj, "__name__");
     if (tmp) {
-#if PY_MAJOR_VERSION >= 3
-        name = PyUnicode_AsUTF8(tmp);
-#else
         name = PyString_AsString(tmp);
-#endif
     }
     Py_XDECREF(tmp);
     tmp = PyObject_GetAttrString(py_func_obj, "__doc__");
     if (tmp && (tmp != Py_None)) {
-#if PY_MAJOR_VERSION >= 3
-        doc = PyUnicode_AsUTF8(tmp);
-#else
         doc = PyString_AsString(tmp);
-#endif
     }
     Py_XDECREF(tmp);
     tmp = NULL;
@@ -619,11 +607,7 @@ PyTypeObject PyDUFunc_Type = {
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
-    0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
+    0,                                          /* tp_compare/tp_reserved */
     (reprfunc) dufunc_repr,                     /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -196,7 +196,7 @@ dufunc_init(PyDUFuncObject *self, PyObject *args, PyObject *kws)
     int nin=-1, nout=1;
     char *name=NULL, *doc=NULL;
 
-    static char * kwlist[] = {"dispatcher", "identity", "keepalive", "nin",
+    static char * kwlist[] = {"dispatcher", "identity", "_keepalive", "nin",
                               "nout", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kws, "O|iO!nn", kwlist,
@@ -273,11 +273,11 @@ dufunc_init(PyDUFuncObject *self, PyObject *args, PyObject *kws)
 }
 
 static PyMemberDef dufunc_members[] = {
-    {"dispatcher", T_OBJECT_EX, offsetof(PyDUFuncObject, dispatcher), 0,
+    {"_dispatcher", T_OBJECT_EX, offsetof(PyDUFuncObject, dispatcher), 0,
          "Dispatcher object for the core Python function."},
     {"ufunc", T_OBJECT_EX, offsetof(PyDUFuncObject, ufunc), 0,
          "Numpy Ufunc for the dynamic ufunc."},
-    {"keepalive", T_OBJECT_EX, offsetof(PyDUFuncObject, keepalive), 0,
+    {"_keepalive", T_OBJECT_EX, offsetof(PyDUFuncObject, keepalive), 0,
          "List of objects to keep alive during life of dufunc."},
 };
 
@@ -580,7 +580,7 @@ dufunc_setfrozen(PyDUFuncObject * self, PyObject * value, void * closure)
 }
 
 static PyGetSetDef dufunc_getsets[] = {
-    {"frozen",
+    {"_frozen",
      (getter)dufunc_getfrozen, (setter)dufunc_setfrozen,
      "flag indicating call-time compilation has been disabled",
      NULL},

--- a/numba/npyufunc/_internal.c
+++ b/numba/npyufunc/_internal.c
@@ -156,7 +156,7 @@ dufunc_call(PyDUFuncObject *self, PyObject *args, PyObject *kws)
         /* Break back into Python when we fail at dispatch. */
         PyErr_Clear();
         PyObject *method = PyObject_GetAttrString(
-            (PyObject*)self, "_compile_at_args");
+            (PyObject*)self, "_compile_for_args");
 
         if (method) {
             result = PyObject_Call(method, args, kws);
@@ -408,11 +408,11 @@ dufunc_at(PyDUFuncObject * self, PyObject * args)
 }
 
 static PyObject *
-dufunc__compile_at_args(PyDUFuncObject * self, PyObject * args,
+dufunc__compile_for_args(PyDUFuncObject * self, PyObject * args,
                         PyObject * kws)
 {
     PyErr_SetString(PyExc_NotImplementedError,
-                    "Abstract method _DUFunc._compile_at_args() called!");
+                    "Abstract method _DUFunc._compile_for_args() called!");
     return NULL;
 }
 
@@ -550,10 +550,10 @@ static struct PyMethodDef dufunc_methods[] = {
     {"at",
         (PyCFunction)dufunc_at,
         METH_VARARGS, NULL},
-    {"_compile_at_args",
-        (PyCFunction)dufunc__compile_at_args,
+    {"_compile_for_args",
+        (PyCFunction)dufunc__compile_for_args,
         METH_VARARGS | METH_KEYWORDS,
-        "Abstract method: subclasses should overload _compile_at_args() to compile the ufunc at the given arguments' types."},
+        "Abstract method: subclasses should overload _compile_for_args() to compile the ufunc at the given arguments' types."},
     {"_add_loop",
         (PyCFunction)dufunc__add_loop,
         METH_VARARGS,

--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 import inspect
 
-from . import _internal
+from . import _internal, dufunc
 from .ufuncbuilder import UFuncBuilder, GUFuncBuilder
 
 from numba.targets.registry import TargetRegistry
@@ -93,15 +93,17 @@ def vectorize(ftylist_or_function=(), **kws):
         # Common user mistake
         ftylist = [ftylist_or_function]
     elif inspect.isfunction(ftylist_or_function):
-        return Vectorize(ftylist_or_function, **kws).build_ufunc()
+        return dufunc.DUFunc(ftylist_or_function, **kws)
     elif ftylist_or_function is not None:
         ftylist = ftylist_or_function
 
     def wrap(func):
-        vec = Vectorize(func, **kws)
-        for fty in ftylist:
-            vec.add(fty)
-        return vec.build_ufunc()
+        if len(ftylist) > 0:
+            vec = Vectorize(func, **kws)
+            for fty in ftylist:
+                vec.add(fty)
+            return vec.build_ufunc()
+        return dufunc.DUFunc(func, **kws)
 
     return wrap
 

--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -43,13 +43,16 @@ class GUVectorize(_BaseVectorize):
 def vectorize(ftylist_or_function=(), **kws):
     """vectorize(ftylist_or_function=(), target='cpu', identity=None, **kws)
 
-    A decorator to create numpy ufunc object from Numba compiled code.  When n
+    A decorator that creates a Numpy ufunc object using Numba compiled
+    code.  When no arguments or only keyword arguments are given,
+    vectorize will return a Numba dynamic ufunc (DUFunc) object, where
+    compilation/specialization may occur at call-time.
 
     Args
     -----
     ftylist_or_function: function or iterable
 
-        When the first argument is a function, signatures are delt
+        When the first argument is a function, signatures are dealt
         with at call-time.
 
         When the first argument is an iterable of type signatures,

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, print_function, division
 import numpy
 
-from .. import jit, typeof, numpy_support, utils
+from .. import jit, typeof, utils, types, numpy_support
 from . import _internal, ufuncbuilder
 
 class DUFunc(_internal._DUFunc):
     # NOTE: __base_kwargs must be kept in synch with the kwlist in
     # _internal.c:dufunc_init()
-    __base_kwargs = set(('identity', 'keepalive', 'nin', 'nout'))
+    __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
     def __init__(self, py_func, **kws):
         dispatcher = jit(target='npyufunc')(py_func)
@@ -23,26 +23,29 @@ class DUFunc(_internal._DUFunc):
         super(DUFunc, self).__init__(dispatcher, **kws)
 
     def _compile_for_args(self, *args, **kws):
+        nin = self.ufunc.nin
+        args_len = len(args)
+        assert (args_len == nin) or (args_len == nin + self.ufunc.nout)
         assert len(kws) == 0
         argtys = []
         # To avoid a mismatch in how Numba types values as opposed to
         # Numpy, we need to first check for scalars.  For example, on
         # 64-bit systems, numba.typeof(3) => int32, but
         # numpy.array(3).dtype => int64.
-        for arg in args[:self.ufunc.nin]:
+        for arg in args[:nin]:
             if numpy_support.is_arrayscalar(arg):
                 argtys.append(numpy_support.map_arrayscalar_type(arg))
             else:
                 argty = typeof(arg)
-                if hasattr(argty, 'dtype'):
+                if isinstance(argty, types.Array):
                     argty = argty.dtype
                 argtys.append(argty)
         element_wise_signature = tuple(argtys)
         cres, args, return_type = ufuncbuilder._compile_element_wise_function(
-            self.dispatcher, self.targetoptions, element_wise_signature)
+            self._dispatcher, self.targetoptions, element_wise_signature)
         sig = ufuncbuilder._finalize_ufunc_signature(cres, args, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_element_wise_ufunc_wrapper(
             cres, sig)
         self._add_loop(utils.longint(ptr), dtypenums)
-        self.keepalive.append((ptr, cres.library, env))
+        self._keepalive.append((ptr, cres.library, env))
         return

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, print_function, division
+import numpy
+
+from numba import jit, typeof, utils
+from . import _internal, ufuncbuilder
+
+class DUFunc(_internal._DUFunc):
+    def __init__(self, py_func, **kws):
+        dispatcher = jit(target='npyufunc')(py_func)
+        super(DUFunc, self).__init__(dispatcher, **kws)
+        # Clean up keyword arguments, and assume everything else are
+        # compiler target options.
+        kws.pop('identity', None)
+        kws.pop('nin', None)
+        kws.pop('nout', None)
+        self.targetoptions = kws
+
+    def _compile_and_invoke(self, *args, **kws):
+        assert len(kws) == 0
+        ewise_sig = tuple(typeof(arg).dtype for arg in args)
+        #import pdb; pdb.set_trace()
+        cres, args, return_type = ufuncbuilder._compile_ewise_function(
+            self.dispatcher, self.targetoptions, ewise_sig)
+        sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
+        dtypenums, ptr, env = ufuncbuilder._build_ewise_ufunc_wrapper(cres, sig)
+        self._add_loop(numpy.dtype(numpy.void).num, utils.longint(ptr),
+                       dtypenums)
+        return self.ufunc(*args, **kws)

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,33 +1,48 @@
 from __future__ import absolute_import, print_function, division
 import numpy
 
-from numba import jit, typeof, utils
-from .. import numpy_support
+from .. import jit, typeof, numpy_support
 from . import _internal, ufuncbuilder
 
 class DUFunc(_internal._DUFunc):
+    # NOTE: __base_kwargs must be kept in synch with the kwlist in
+    # _internal.c:dufunc_init()
+    __base_kwargs = set(('identity', 'keepalive', 'nin', 'nout'))
+
     def __init__(self, py_func, **kws):
         dispatcher = jit(target='npyufunc')(py_func)
+        self.targetoptions = {}
+        # Loop over a copy of the keys instead of the keys themselves,
+        # since we're changing the dictionary while looping.
+        kws_keys = tuple(kws.keys())
+        for key in kws_keys:
+            if key not in self.__base_kwargs:
+                self.targetoptions[key] = kws.pop(key)
+        kws['identity'] = ufuncbuilder._BaseUFuncBuilder.parse_identity(
+            kws.pop('identity', None))
         super(DUFunc, self).__init__(dispatcher, **kws)
-        # Clean up _DUFunc keyword arguments, and assume anything that
-        # remains is a compiler option.
-        kws.pop('identity', None)
-        kws.pop('nin', None)
-        kws.pop('nout', None)
-        self.targetoptions = kws
 
     def _compile_for_args(self, *args, **kws):
         assert len(kws) == 0
-        argtys = tuple(numpy_support.map_arrayscalar_type(arg)
-                       if numpy_support.is_arrayscalar(arg)
-                       else typeof(arg)
-                       for arg in args[:self.ufunc.nin])
-        if all(hasattr(argty, 'dtype') for argty in argtys):
-            argtys = tuple(argty.dtype for argty in argtys)
-        cres, args, return_type = ufuncbuilder._compile_ewise_function(
-            self.dispatcher, self.targetoptions, argtys)
+        argtys = []
+        # To avoid a mismatch in how Numba types values as opposed to
+        # Numpy, we need to first check for scalars.  For example, on
+        # 64-bit systems, numba.typeof(3) => int32, but
+        # numpy.array(3).dtype => int64.
+        for arg in args[:self.ufunc.nin]:
+            if numpy_support.is_arrayscalar(arg):
+                argtys.append(numpy_support.map_arrayscalar_type(arg))
+            else:
+                argty = typeof(arg)
+                if hasattr(argty, 'dtype'):
+                    argty = argty.dtype
+                argtys.append(argty)
+        element_wise_signature = tuple(argtys)
+        cres, args, return_type = ufuncbuilder._compile_element_wise_function(
+            self.dispatcher, self.targetoptions, element_wise_signature)
         sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
-        dtypenums, ptr, env = ufuncbuilder._build_ewise_ufunc_wrapper(cres, sig)
-        self._add_loop(utils.longint(ptr), dtypenums)
+        dtypenums, ptr, env = ufuncbuilder._build_element_wise_ufunc_wrapper(
+            cres, sig)
+        self._add_loop(ptr, dtypenums)
         self.keepalive.append((ptr, cres.library, env))
         return

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -21,7 +21,7 @@ class DUFunc(_internal._DUFunc):
         argtys = tuple(numpy_support.map_arrayscalar_type(arg)
                        if numpy_support.is_arrayscalar(arg)
                        else typeof(arg)
-                       for arg in args)
+                       for arg in args[:self.ufunc.nin])
         if all(hasattr(argty, 'dtype') for argty in argtys):
             argtys = tuple(argty.dtype for argty in argtys)
         cres, args, return_type = ufuncbuilder._compile_ewise_function(

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 import numpy
 
 from numba import jit, typeof, utils
+from .. import numpy_support
 from . import _internal, ufuncbuilder
 
 class DUFunc(_internal._DUFunc):
@@ -17,7 +18,10 @@ class DUFunc(_internal._DUFunc):
 
     def _compile_for_args(self, *args, **kws):
         assert len(kws) == 0
-        argtys = tuple(typeof(arg) for arg in args)
+        argtys = tuple(numpy_support.map_arrayscalar_type(arg)
+                       if numpy_support.is_arrayscalar(arg)
+                       else typeof(arg)
+                       for arg in args)
         if all(hasattr(argty, 'dtype') for argty in argtys):
             argtys = tuple(argty.dtype for argty in argtys)
         cres, args, return_type = ufuncbuilder._compile_ewise_function(

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -8,21 +8,20 @@ class DUFunc(_internal._DUFunc):
     def __init__(self, py_func, **kws):
         dispatcher = jit(target='npyufunc')(py_func)
         super(DUFunc, self).__init__(dispatcher, **kws)
-        # Clean up keyword arguments, and assume everything else are
-        # compiler target options.
+        # Clean up _DUFunc keyword arguments, and assume anything that
+        # remains is a compiler option.
         kws.pop('identity', None)
         kws.pop('nin', None)
         kws.pop('nout', None)
         self.targetoptions = kws
 
-    def _compile_and_invoke(self, *args, **kws):
+    def _compile_at_args(self, *args, **kws):
         assert len(kws) == 0
         ewise_sig = tuple(typeof(arg).dtype for arg in args)
-        #import pdb; pdb.set_trace()
         cres, args, return_type = ufuncbuilder._compile_ewise_function(
             self.dispatcher, self.targetoptions, ewise_sig)
         sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_ewise_ufunc_wrapper(cres, sig)
-        self._add_loop(numpy.dtype(numpy.void).num, utils.longint(ptr),
-                       dtypenums)
-        return self.ufunc(*args, **kws)
+        self._add_loop(utils.longint(ptr), dtypenums)
+        self.keepalive.append((ptr, cres.library, env))
+        return

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -17,9 +17,11 @@ class DUFunc(_internal._DUFunc):
 
     def _compile_for_args(self, *args, **kws):
         assert len(kws) == 0
-        ewise_sig = tuple(typeof(arg).dtype for arg in args)
+        argtys = tuple(typeof(arg) for arg in args)
+        if all(hasattr(argty, 'dtype') for argty in argtys):
+            argtys = tuple(argty.dtype for argty in argtys)
         cres, args, return_type = ufuncbuilder._compile_ewise_function(
-            self.dispatcher, self.targetoptions, ewise_sig)
+            self.dispatcher, self.targetoptions, argtys)
         sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_ewise_ufunc_wrapper(cres, sig)
         self._add_loop(utils.longint(ptr), dtypenums)

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -15,7 +15,7 @@ class DUFunc(_internal._DUFunc):
         kws.pop('nout', None)
         self.targetoptions = kws
 
-    def _compile_at_args(self, *args, **kws):
+    def _compile_for_args(self, *args, **kws):
         assert len(kws) == 0
         ewise_sig = tuple(typeof(arg).dtype for arg in args)
         cres, args, return_type = ufuncbuilder._compile_ewise_function(

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -40,7 +40,7 @@ class DUFunc(_internal._DUFunc):
         element_wise_signature = tuple(argtys)
         cres, args, return_type = ufuncbuilder._compile_element_wise_function(
             self.dispatcher, self.targetoptions, element_wise_signature)
-        sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
+        sig = ufuncbuilder._finalize_ufunc_signature(cres, args, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_element_wise_ufunc_wrapper(
             cres, sig)
         self._add_loop(utils.longint(ptr), dtypenums)

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, division
 import numpy
 
-from .. import jit, typeof, numpy_support
+from .. import jit, typeof, numpy_support, utils
 from . import _internal, ufuncbuilder
 
 class DUFunc(_internal._DUFunc):
@@ -43,6 +43,6 @@ class DUFunc(_internal._DUFunc):
         sig = ufuncbuilder._check_ufunc_signature(cres, args, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_element_wise_ufunc_wrapper(
             cres, sig)
-        self._add_loop(ptr, dtypenums)
+        self._add_loop(utils.longint(ptr), dtypenums)
         self.keepalive.append((ptr, cres.library, env))
         return

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -88,6 +88,17 @@ def _compile_ewise_function(nb_func, targetoptions, sig=None,
 
     return cres, args, return_type
 
+def _check_ufunc_signature(cres, args, return_type):
+    if return_type is None:
+        if cres.objectmode:
+            # Object mode is used and return type is not specified
+            raise TypeError("return type must be specified for object mode")
+        else:
+            return_type = cres.signature.return_type
+
+    assert return_type != types.pyobject
+    return return_type(*args)
+
 def _build_ewise_ufunc_wrapper(cres, signature):
     # Buider wrapper for ufunc entry point
     ctx = cres.target_context
@@ -155,15 +166,7 @@ class UFuncBuilder(_BaseUFuncBuilder):
         self._cres = {}
 
     def _finalize_signature(self, cres, args, return_type):
-        if return_type is None:
-            if cres.objectmode:
-                # Object mode is used and return type is not specified
-                raise TypeError("return type must be specified for object mode")
-            else:
-                return_type = cres.signature.return_type
-
-        assert return_type != types.pyobject
-        return return_type(*args)
+        return _check_ufunc_signature(cres, args, return_type)
 
     def build_ufunc(self):
         dtypelist = []

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -88,7 +88,7 @@ def _compile_element_wise_function(nb_func, targetoptions, sig=None,
 
     return cres, args, return_type
 
-def _check_ufunc_signature(cres, args, return_type):
+def _finalize_ufunc_signature(cres, args, return_type):
     '''Given a compilation result, argument types, and a return type,
     build a valid Numba signature after validating that it doesn't
     violate the constraints for the compilation mode.
@@ -173,10 +173,10 @@ class UFuncBuilder(_BaseUFuncBuilder):
         self._cres = {}
 
     def _finalize_signature(self, cres, args, return_type):
-        '''Slated for deprecation, use ufuncbuilder._check_ufunc_signature()
+        '''Slated for deprecation, use ufuncbuilder._finalize_ufunc_signature()
         instead.
         '''
-        return _check_ufunc_signature(cres, args, return_type)
+        return _finalize_ufunc_signature(cres, args, return_type)
 
     def build_ufunc(self):
         dtypelist = []

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import
 import warnings
+import inspect
 import numpy as np
 
 from numba.decorators import jit
@@ -133,6 +134,7 @@ class UFuncBuilder(_BaseUFuncBuilder):
 
         # Get signature in the order they are added
         keepalive = []
+        cres = None
         for sig in self._sigs:
             cres = self._cres[sig]
             dtypenums, ptr, env = self.build(cres, sig)
@@ -142,7 +144,11 @@ class UFuncBuilder(_BaseUFuncBuilder):
 
         datlist = [None] * len(ptrlist)
 
-        inct = len(cres.signature.args)
+        if cres is None:
+            argspec = inspect.getargspec(self.py_func)
+            inct = len(argspec.args)
+        else:
+            inct = len(cres.signature.args)
         outct = 1
 
         # Becareful that fromfunc does not provide full error checking yet.

--- a/numba/tests/test_dufunc.py
+++ b/numba/tests/test_dufunc.py
@@ -12,11 +12,11 @@ class TestDUFunc(unittest.TestCase):
 
     def test_frozen(self):
         duadd = dufunc.DUFunc(pyuadd, nopython=True)
-        self.assertFalse(duadd.frozen)
-        duadd.frozen = True
-        self.assertTrue(duadd.frozen)
+        self.assertFalse(duadd._frozen)
+        duadd._frozen = True
+        self.assertTrue(duadd._frozen)
         with self.assertRaises(ValueError):
-            duadd.frozen = False
+            duadd._frozen = False
         with self.assertRaises(TypeError):
             duadd(np.linspace(0,1,10), np.linspace(1,2,10))
 

--- a/numba/tests/test_dufunc.py
+++ b/numba/tests/test_dufunc.py
@@ -1,0 +1,28 @@
+from __future__ import print_function, absolute_import, division
+from numba import unittest_support as unittest
+
+import numpy as np
+
+from numba.npyufunc import dufunc
+
+def pyuadd(a0, a1):
+    return a0 + a1
+
+class TestDUFunc(unittest.TestCase):
+
+    def test_frozen(self):
+        duadd = dufunc.DUFunc(pyuadd, nopython=True)
+        self.assertFalse(duadd.frozen)
+        duadd.frozen = True
+        self.assertTrue(duadd.frozen)
+        with self.assertRaises(ValueError):
+            duadd.frozen = False
+        with self.assertRaises(TypeError):
+            duadd(np.linspace(0,1,10), np.linspace(1,2,10))
+
+    def test_scalar(self):
+        duadd = dufunc.DUFunc(pyuadd, nopython=True)
+        self.assertEqual(pyuadd(1,2), duadd(1,2))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -195,6 +195,12 @@ class TestVectorizeDecor(unittest.TestCase):
         with self.assertRaises(ValueError):
             vectorize([sig], identity=2)(add)
 
+    def test_vectorize_no_args(self):
+        a = numpy.linspace(0,1,10)
+        b = numpy.linspace(1,2,10)
+        ufunc = vectorize(add)
+        self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
+
     def test_guvectorize(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)")(guadd)

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -7,6 +7,7 @@ import numpy
 from numba import unittest_support as unittest
 from numba.npyufunc.ufuncbuilder import UFuncBuilder, GUFuncBuilder
 from numba import vectorize, guvectorize
+from numba.npyufunc import PyUFunc_One
 from . import support
 
 
@@ -210,7 +211,7 @@ class TestVectorizeDecor(unittest.TestCase):
     def test_vectorize_only_kws(self):
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)
-        ufunc = vectorize(identity=1)(mul)
+        ufunc = vectorize(identity=PyUFunc_One, nopython=True)(mul)
         self.assertTrue(numpy.all(ufunc(a,b) == (a * b)))
 
     def test_guvectorize(self):

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -200,14 +200,12 @@ class TestVectorizeDecor(unittest.TestCase):
         with self.assertRaises(ValueError):
             vectorize([sig], identity=2)(add)
 
-    @unittest.skipIf(__name__ != '__main__', "Work in progress.")
     def test_vectorize_no_args(self):
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)
         ufunc = vectorize(add)
         self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
 
-    @unittest.skipIf(__name__ != '__main__', "Work in progress.")
     def test_vectorize_only_kws(self):
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -201,14 +201,13 @@ class TestVectorizeDecor(unittest.TestCase):
             vectorize([sig], identity=2)(add)
 
     def test_vectorize_no_args(self):
-        print("test_vectorize_no_args")
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)
-        c = numpy.empty(10)
         ufunc = vectorize(add)
-        print(type(ufunc))
         self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
-        ufunc(a, b, c)
+        ufunc2 = vectorize(add)
+        c = numpy.empty(10)
+        ufunc2(a, b, c)
         self.assertTrue(numpy.all(c == (a + b)))
 
     def test_vectorize_only_kws(self):

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -17,6 +17,10 @@ def add(a, b):
 def equals(a, b):
     return a == b
 
+def mul(a, b):
+    """A multiplication"""
+    return a * b
+
 def guadd(a, b, c):
     """A generalized addition"""
     x, y = c.shape
@@ -200,6 +204,12 @@ class TestVectorizeDecor(unittest.TestCase):
         b = numpy.linspace(1,2,10)
         ufunc = vectorize(add)
         self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
+
+    def test_vectorize_only_kws(self):
+        a = numpy.linspace(0,1,10)
+        b = numpy.linspace(1,2,10)
+        ufunc = vectorize(identity=1)(mul)
+        self.assertTrue(numpy.all(ufunc(a,b) == (a * b)))
 
     def test_guvectorize(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -199,12 +199,14 @@ class TestVectorizeDecor(unittest.TestCase):
         with self.assertRaises(ValueError):
             vectorize([sig], identity=2)(add)
 
+    @unittest.skipIf(__name__ != '__main__', "Work in progress.")
     def test_vectorize_no_args(self):
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)
         ufunc = vectorize(add)
         self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
 
+    @unittest.skipIf(__name__ != '__main__', "Work in progress.")
     def test_vectorize_only_kws(self):
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -201,10 +201,15 @@ class TestVectorizeDecor(unittest.TestCase):
             vectorize([sig], identity=2)(add)
 
     def test_vectorize_no_args(self):
+        print("test_vectorize_no_args")
         a = numpy.linspace(0,1,10)
         b = numpy.linspace(1,2,10)
+        c = numpy.empty(10)
         ufunc = vectorize(add)
+        print(type(ufunc))
         self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
+        ufunc(a, b, c)
+        self.assertTrue(numpy.all(c == (a + b)))
 
     def test_vectorize_only_kws(self):
         a = numpy.linspace(0,1,10)


### PR DESCRIPTION
I've introduced a new extension type, _DUFunc which aggregates three things:

* A Numpy UFunc
* A dispatcher object used for compilation
* A keepalive list for holding onto important compilation results

At call time, _DUFunc calls into Numpy's call handler.  If it gets a TypeError, it assumes dispatch failed, compiles the wrapped function at the call argument types, dynamically registers the new loop, and calls Numpy's call handler once more.

I've modified the vectorize decorator to return one of these objects in the case where no signatures are given for the wrapped function.