### PR TITLE
Document semantics of range on Python 2

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -126,7 +126,8 @@ The following built-in functions are supported:
 * :func:`min`: only the multiple-argument form
 * :func:`max`: only the multiple-argument form
 * :func:`print`: only numbers and strings; no ``file`` or ``sep`` argument
-* :class:`range`
+* :class:`range`: semantics are similar to those of Python 3 even in Python 2:
+  a range object is returned instead of an array of values.
 * :func:`round`
 * :func:`zip`
 


### PR DESCRIPTION
It does not appear to be documented that `range` does not return an array of values even on Python 2 - a note on this is added here.