### PR TITLE
Fix multi3

### DIFF
--- a/buildscripts/condarecipe.local/bld.bat
+++ b/buildscripts/condarecipe.local/bld.bat
@@ -1,5 +1,3 @@
-xcopy %RECIPE_DIR%\..\.. src /s
-cd src
 %PYTHON% setup.py install
 if errorlevel 1 exit 1
 

--- a/buildscripts/condarecipe.local/build.sh
+++ b/buildscripts/condarecipe.local/build.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-cp -r $RECIPE_DIR/../.. src
-cd src
+
 $PYTHON setup.py install

--- a/buildscripts/condarecipe.local/mandel.py
+++ b/buildscripts/condarecipe.local/mandel.py
@@ -1,0 +1,43 @@
+from numba import autojit
+import numpy as np
+#from pylab import imshow, jet, show, ion
+
+@autojit
+def mandel(x, y, max_iters):
+    """
+    Given the real and imaginary parts of a complex number,
+    determine if it is a candidate for membership in the Mandelbrot
+    set given a fixed number of iterations.
+    """
+    i = 0
+    c = complex(x,y)
+    z = 0.0j
+    for i in range(max_iters):
+        z = z*z + c
+        if (z.real*z.real + z.imag*z.imag) >= 4:
+            return i
+
+    return 255
+
+@autojit
+def create_fractal(min_x, max_x, min_y, max_y, image, iters):
+    height = image.shape[0]
+    width = image.shape[1]
+
+    pixel_size_x = (max_x - min_x) / width
+    pixel_size_y = (max_y - min_y) / height
+    for x in range(width):
+        real = min_x + x * pixel_size_x
+        for y in range(height):
+            imag = min_y + y * pixel_size_y
+            color = mandel(real, imag, iters)
+            image[y, x] = color
+
+    return image
+
+image = np.zeros((500, 750), dtype=np.uint8)
+create_fractal(-2.0, 1.0, -1.0, 1.0, image, 20)
+#jet()
+#ion()
+#show()
+print("mandel OK")

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -1,27 +1,30 @@
 package:
    name: numba
-   version: 99.9.9
+   version: {{ environ.get('GIT_DESCRIBE_TAG','') }}
+
+source:
+   path: ../..
 
 build:
-  #entry_points:
-  #  - pycc = numba.pycc:main
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   build:
-    - numpy
-    #- chrpath         [linux]
     - python
-    #- llvmmath
+    - numpy
   run:
     - python
     - argparse        [py26]
     - numpy
-    - llvmpy
-    #- llvmmath
-
+    # On channel https://binstar.org/numba/
+    - llvmlite 0.4.0
+    - funcsigs       [py26 or py27]
 test:
   requires:
-    - unittest2       [py26]
+    - argparse       [py26]
+    - unittest2      [py26]
+    - cudatoolkit
+  files:
+    - mandel.py
   commands:
     - pycc -h
-    - numba -h

--- a/buildscripts/condarecipe.local/run_test.py
+++ b/buildscripts/condarecipe.local/run_test.py
@@ -1,9 +1,12 @@
-import os
-import numba.testing
-if int(os.environ.get("NUMBA_MULTITEST", 1)):
-    testfn = numba.testing.multitest
+import sys
+import numba
+
+if sys.platform.startswith('win32'):
+    sys.argv += ['-b']
 else:
-    testfn = numba.testing.test
-if not testfn():
-    raise RuntimeError("Test failed")
+    sys.argv += ['-m', '-b']
+
+if not numba.test():
+    print("Test failed")
+    sys.exit(1)
 print('numba.__version__: %s' % numba.__version__)

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -399,10 +399,12 @@ static
 i128 umul64(uint64_t a, uint64_t b) {
     /* Adapted from __mulddi in compiler-rt */
     i128 r;
+    uint64_t t;
     const int bits_in_dword_2 = 32;
     const uint64_t lower_mask = (uint64_t)~0 >> bits_in_dword_2;
+
     r.s.low = (a & lower_mask) * (b & lower_mask);
-    uint64_t t = r.s.low >> bits_in_dword_2;
+    t = r.s.low >> bits_in_dword_2;
     r.s.low &= lower_mask;
     t += (a >> bits_in_dword_2) * (b & lower_mask);
     r.s.low += (t & lower_mask) << bits_in_dword_2;

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -384,6 +384,54 @@ Numba_poisson_ptrs(rnd_state_t *state, double lam)
  * Other helpers.
  */
 
+/* provide 128-bit multiplilcation inplace for __multi3
+ * on 32-bit platform */
+
+typedef union i128 {
+    struct {
+        uint64_t low;
+        int64_t high;
+    } s;
+} i128;
+
+
+static
+i128 umul64(uint64_t a, uint64_t b) {
+    /* Adapted from __mulddi in compiler-rt */
+    i128 r;
+    const int bits_in_dword_2 = 32;
+    const uint64_t lower_mask = (uint64_t)~0 >> bits_in_dword_2;
+    r.s.low = (a & lower_mask) * (b & lower_mask);
+    uint64_t t = r.s.low >> bits_in_dword_2;
+    r.s.low &= lower_mask;
+    t += (a >> bits_in_dword_2) * (b & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_dword_2;
+    r.s.high = t >> bits_in_dword_2;
+    t = r.s.low >> bits_in_dword_2;
+    r.s.low &= lower_mask;
+    t += (b >> bits_in_dword_2) * (a & lower_mask);
+    r.s.low += (t & lower_mask) << bits_in_dword_2;
+    r.s.high += t >> bits_in_dword_2;
+    r.s.high += (a >> bits_in_dword_2) * (b >> bits_in_dword_2);
+    return r;
+}
+
+static
+i128 mul128(i128 a, i128 b) {
+    /* Adapted from __multi3 in compiler-rt */
+    i128 r = umul64(a.s.low, b.s.low);
+    r.s.high += a.s.high * b.s.low + a.s.low * b.s.high;
+    return r;
+}
+
+
+static
+i128
+Numba_multi3(i128 x, i128 y) {
+	return mul128(x, y);
+}
+
+
 /* provide 64-bit division function to 32-bit platforms */
 static
 int64_t Numba_sdiv(int64_t a, int64_t b) {
@@ -1375,7 +1423,7 @@ build_c_helpers_dict(void)
 #define declmethod(func) _declpointer(#func, &Numba_##func)
 
 #define declpointer(ptr) _declpointer(#ptr, &ptr)
-
+	declmethod(multi3);
     declmethod(sdiv);
     declmethod(srem);
     declmethod(udiv);

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -65,6 +65,9 @@ class _ExternalMathFunctions(_Installer):
             _add_missing_symbol("__fixunsdfdi", c_helpers["fptoui"])
             _add_missing_symbol("__fixunssfdi", c_helpers["fptouif"])
 
+        if is32bit:
+            _add_missing_symbol("__multi3", c_helpers["multi3"])
+
         # List available C-math
         for fname in intrinsics.INTR_MATH:
             # Force binding from CPython's C runtime library.

--- a/numba/tests/test_multi3.py
+++ b/numba/tests/test_multi3.py
@@ -1,0 +1,40 @@
+﻿from __future__ import print_function, absolute_import, division
+
+
+from numba import njit
+from numba import unittest_support as unittest
+import random
+
+class TestMulti3(unittest.TestCase):
+    """
+    This test is only valid for x86-32.
+
+    Test __multi3 implementation in _helperlib.c.
+    The symbol defines a i128 multiplication.
+    It is necessary for working around an issue in LLVM (see issue #969).
+    The symbol does not exist in 32-bit platform, and should not be used by
+    LLVM.  However, optimization passes will create i65 multiplication that
+    is then lowered to __multi3.
+    """
+    def test_multi3(self):
+        @njit
+        def func(x):
+            res = 0
+            for i in range(x):
+                res += i
+            return res
+
+        x_cases = [-1, 0, 1, 0xffffffff - 1, 0xffffffff, 0xffffffff + 1]
+        for _ in range(500):
+            x_cases.append(random.randint(0, 0xffffffff))
+
+        def expected(x):
+            if x <= 0: return 0
+            return (x * (x - 1)) // 2
+
+        for x in x_cases:
+            self.assertEqual(expected(x), func(x))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement ``__multi3`` symbol for 32-bit platform in order to workaround a LLVM problem.  See #969.