### PR TITLE
Fix #1080 - unnecessary promotion of bool args

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -208,11 +208,6 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         This is called from numba._dispatcher as a fallback if the native code
         cannot decide the type.
         """
-        if isinstance(val, utils.INT_TYPES):
-            # Ensure no autoscaling of integer type, to match the
-            # typecode() function in _dispatcher.c.
-            return types.int64
-
         tp = self.typingctx.resolve_argument_type(val)
         if tp is None:
             tp = types.pyobject

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -170,7 +170,13 @@ def issue_797(x0, y0, x1, y1, grid):
             y0 += sy
 
 
-class TestIssue(object):
+def issue_1080(a, b):
+    if not a:
+        return True
+    return b
+
+
+class TestIssue(unittest.TestCase):
     def test_issue_797(self):
         """https://github.com/numba/numba/issues/797#issuecomment-58592401
 
@@ -179,6 +185,14 @@ class TestIssue(object):
         foo = jit(nopython=True)(issue_797)
         g = np.zeros(shape=(10, 10), dtype=np.int32)
         foo(np.int32(0), np.int32(0), np.int32(1), np.int32(1), g)
+
+    def test_issue_1080(self):
+        """https://github.com/numba/numba/issues/1080
+
+        Erroneous promotion of boolean args to int64
+        """
+        foo = jit(nopython=True)(issue_1080)
+        foo(True, False)
 
 
 class TestCoercion(unittest.TestCase):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -127,8 +127,8 @@ class BaseContext(object):
 
         Unknown types will be mapped to pyobject.
         """
-        if isinstance(val, utils.INT_TYPES):
-            # Force all integers to be 64-bit
+        # Force all integers (except bools) to be 64-bit
+        if isinstance(val, utils.INT_TYPES) and not isinstance(val, bool):
             return types.int64
 
         tp = self.resolve_data_type(val)


### PR DESCRIPTION
Also remove duplicate logic for ensuring int types are always 64-bit from `typeof_pyval` in the dispatcher.