### PR TITLE
Fix #1089: range(uint64) casted to range(int32)

### DIFF
--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -142,3 +142,5 @@ def make_range_impl(range_state_type, range_iter_type, int_type):
 
 make_range_impl(types.range_state32_type, types.range_iter32_type, types.int32)
 make_range_impl(types.range_state64_type, types.range_iter64_type, types.int64)
+make_range_impl(types.unsigned_range_state64_type, types.unsigned_range_iter64_type,
+                types.uint64)

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -15,7 +15,6 @@ def loop1(n):
 def loop2(a, b):
     s = 0
     for i in range(a, b):
-        print(i)
         s += i
     return s
 
@@ -30,6 +29,14 @@ def loop3(a, b, c):
 def range2_writeout(a, b, out):
     i = 0
     for j in range(a, b):
+        out[i] = j
+        i += 1
+    return i
+
+
+def range3_writeout(a, b, c, out):
+    i = 0
+    for j in range(a, b, c):
         out[i] = j
         i += 1
     return i
@@ -70,6 +77,18 @@ class TestRange(unittest.TestCase):
         expected = numpy.zeros(b - a, dtype=numpy.int64)
         got = numpy.zeros(b - a, dtype=numpy.int64)
         self.assertTrue(cfunc(a, b, got), pyfunc(a, b, expected))
+        numpy.testing.assert_equal(expected, got)
+
+    def test_range3_writeout_uint64(self):
+        pyfunc = range3_writeout
+        cres = compile_isolated(pyfunc, [types.uint64, types.uint64,
+                                         types.uint64, types.int64[:]])
+        cfunc = cres.entry_point
+        a, b = 2552764644, 2552764787
+        c = 1
+        expected = numpy.zeros(b - a, dtype=numpy.int64)
+        got = numpy.zeros(b - a, dtype=numpy.int64)
+        self.assertTrue(cfunc(a, b, c, got), pyfunc(a, b, c, expected))
         numpy.testing.assert_equal(expected, got)
 
 

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -26,6 +26,14 @@ def loop3(a, b, c):
     return s
 
 
+def range1_writeout(n, out):
+    i = 0
+    for j in range(n):
+        out[i] = j
+        i += 1
+    return i
+
+
 def range2_writeout(a, b, out):
     i = 0
     for j in range(a, b):
@@ -68,6 +76,16 @@ class TestRange(unittest.TestCase):
         for args in arglist:
             self.assertEqual(cfunc(*args), pyfunc(*args))
 
+    def test_range1_writeout_uint64(self):
+        pyfunc = range1_writeout
+        cres = compile_isolated(pyfunc, [types.uint64, types.int64[:]])
+        cfunc = cres.entry_point
+        n = 50
+        expected = numpy.zeros(n, dtype=numpy.int64)
+        got = numpy.zeros(n, dtype=numpy.int64)
+        self.assertTrue(cfunc(n, got), pyfunc(n, expected))
+        numpy.testing.assert_equal(expected, got)
+
     def test_range2_writeout_uint64(self):
         pyfunc = range2_writeout
         cres = compile_isolated(pyfunc, [types.uint64, types.uint64,
@@ -85,6 +103,45 @@ class TestRange(unittest.TestCase):
                                          types.uint64, types.int64[:]])
         cfunc = cres.entry_point
         a, b = 2552764644, 2552764787
+        c = 1
+        expected = numpy.zeros(b - a, dtype=numpy.int64)
+        got = numpy.zeros(b - a, dtype=numpy.int64)
+        self.assertTrue(cfunc(a, b, c, got), pyfunc(a, b, c, expected))
+        numpy.testing.assert_equal(expected, got)
+
+    def test_range1_writeout_uint32(self):
+        pyfunc = range1_writeout
+        cres = compile_isolated(pyfunc, [types.uint32, types.int64[:]])
+        cfunc = cres.entry_point
+        n = 50
+        expected = numpy.zeros(n, dtype=numpy.int64)
+        got = numpy.zeros(n, dtype=numpy.int64)
+        self.assertTrue(cfunc(n, got), pyfunc(n, expected))
+        numpy.testing.assert_equal(expected, got)
+
+    def test_range2_writeout_uint32(self):
+        pyfunc = range2_writeout
+        cres = compile_isolated(pyfunc, [types.uint32, types.uint32,
+                                         types.int64[:]])
+        cfunc = cres.entry_point
+        # Test with integer that used the MSB of uint32
+        a, b = 0xF0000001, 0xF0000010
+        self.assertEqual(a >> 31, 1)
+        self.assertEqual(b >> 31, 1)
+        expected = numpy.zeros(b - a, dtype=numpy.int64)
+        got = numpy.zeros(b - a, dtype=numpy.int64)
+        self.assertTrue(cfunc(a, b, got), pyfunc(a, b, expected))
+        numpy.testing.assert_equal(expected, got)
+
+    def test_range3_writeout_uint32(self):
+        pyfunc = range3_writeout
+        cres = compile_isolated(pyfunc, [types.uint32, types.uint32,
+                                         types.uint32, types.int64[:]])
+        cfunc = cres.entry_point
+        # Test with integer that used the MSB of uint32
+        a, b = 0xF0000001, 0xF0000010
+        self.assertEqual(a >> 31, 1)
+        self.assertEqual(b >> 31, 1)
         c = 1
         expected = numpy.zeros(b - a, dtype=numpy.int64)
         got = numpy.zeros(b - a, dtype=numpy.int64)

--- a/numba/types.py
+++ b/numba/types.py
@@ -1117,8 +1117,11 @@ sign_type = Phantom('sign')
 
 range_iter32_type = RangeIteratorType('range_iter32', int32)
 range_iter64_type = RangeIteratorType('range_iter64', int64)
+unsigned_range_iter64_type = RangeIteratorType('unsigned_range_iter64', uint64)
 range_state32_type = RangeType('range_state32', range_iter32_type)
 range_state64_type = RangeType('range_state64', range_iter64_type)
+unsigned_range_state64_type = RangeType('unsigned_range_state64',
+                                        unsigned_range_iter64_type)
 
 # slice2_type = Type('slice2_type')
 slice3_type = Slice3Type('slice3_type')

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -77,6 +77,10 @@ class Range(ConcreteTemplate):
         signature(types.range_state64_type, types.int64, types.int64),
         signature(types.range_state64_type, types.int64, types.int64,
                   types.int64),
+        signature(types.unsigned_range_state64_type, types.uint64),
+        signature(types.unsigned_range_state64_type, types.uint64, types.uint64),
+        signature(types.unsigned_range_state64_type, types.uint64, types.uint64,
+                  types.uint64),
     ]
 
 


### PR DESCRIPTION
The problem originated from `range()` not defined for unsigned integer.  This patch adds an `uint64` definition.  `uint32` would also use `uint64` definition to avoid overflow in 32-bit range.  `uint64` is still subject to overflow for large range.