### PR TITLE
[WIP] Option to disable jit (#1084)

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -460,21 +460,31 @@ class Pipeline(object):
         if self.library is None:
             codegen = self.targetctx.jit_codegen()
             self.library = codegen.create_library(self.bc.func_qualname)
-        lowered = lowerfn()
+        if config.DISABLE_JIT:
+            entry_point = self.func
+            call_helper = None
+            fndesc = None
+            environment = None
+        else:
+            lowered = lowerfn()
+            entry_point = lowered.cfunc
+            call_helper = lowered.call_helper
+            fndesc = lowered.fndesc
+            environment = lowered.env
         signature = typing.signature(self.return_type, *self.args)
         cr = compile_result(typing_context=self.typingctx,
                             target_context=self.targetctx,
-                            entry_point=lowered.cfunc,
+                            entry_point=entry_point,
                             typing_error=self.status.fail_reason,
                             type_annotation=self.type_annotation,
                             library=self.library,
-                            call_helper=lowered.call_helper,
+                            call_helper=call_helper,
                             signature=signature,
                             objectmode=objectmode,
                             interpmode=False,
                             lifted=self.lifted,
-                            fndesc=lowered.fndesc,
-                            environment=lowered.env,)
+                            fndesc=fndesc,
+                            environment=environment,)
         return cr
 
     def stage_objectmode_backend(self):

--- a/numba/config.py
+++ b/numba/config.py
@@ -117,3 +117,6 @@ FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _force_cc, None)
 # Enable AVX on supported platforms where it won't degrade performance.
 ENABLE_AVX = _readenv("NUMBA_ENABLE_AVX", int,
                       _cpu_name not in ('corei7-avx', 'core-avx-i'))
+
+# Disable jit for debugging
+DISABLE_JIT = _readenv("NUMBA_DISABLE_JIT", int, 0)

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -3,7 +3,7 @@ Contains function decorators and target_registry
 """
 from __future__ import print_function, division, absolute_import
 import warnings
-from . import sigutils
+from . import config, sigutils
 from .targets import registry
 
 # -----------------------------------------------------------------------------
@@ -140,6 +140,8 @@ def jit(signature_or_function=None, locals={}, target='cpu', **options):
     else:
         # A function is passed
         pyfunc = signature_or_function
+        if config.DISABLE_JIT:
+            return pyfunc
         dispatcher = registry.target_registry[target]
         dispatcher = dispatcher(py_func=pyfunc, locals=locals,
                                 targetoptions=options)
@@ -150,6 +152,8 @@ def _jit(sigs, locals, target, targetoptions):
     dispatcher = registry.target_registry[target]
 
     def wrapper(func):
+        if config.DISABLE_JIT:
+            return func
         disp = dispatcher(py_func=func, locals=locals,
                           targetoptions=targetoptions)
         for sig in sigs:

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -125,6 +125,7 @@ class CodeLibrary(object):
         """
         self._raise_if_finalized()
         assert isinstance(ir_module, llvmir.Module)
+        assert not config.DISABLE_JIT, 'Compilation occurring with disabled JIT'
         ll_module = ll.parse_assembly(str(ir_module))
         ll_module.verify()
         self.add_llvm_module(ll_module)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 
 from numba import unittest_support as unittest
-from numba import typeof, types
+from numba import config, typeof, types
 from numba.compiler import compile_isolated
 from numba.numpy_support import as_dtype
 from .support import TestCase
@@ -460,7 +460,10 @@ class TestArrayMethods(TestCase):
         check_types(argtypes, argtypes, values)
 
         argtypes = (types.complex64, types.complex128)
-        check_types(argtypes, argtypes, values * (1 - 1j))
+        if not config.DISABLE_JIT:
+            # XXX: The pure Python version doesn't work correctly because of
+            # https://github.com/numpy/numpy/issues/5779
+            check_types(argtypes, argtypes, values * (1 - 1j))
 
     def test_round_array(self):
         self.check_round_array(np_round_array)

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -5,7 +5,7 @@ import sys
 
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
-from numba import jit, types
+from numba import config, jit, types
 
 
 is_windows = sys.platform.startswith('win32')
@@ -82,6 +82,7 @@ def use_func_pointer(fa, fb, x):
         return fb(x)
 
 
+@unittest.skipIf(config.DISABLE_JIT, 'Not testing ctypes with disabled jit')
 class TestCTypes(unittest.TestCase):
 
     def test_c_sin(self):

--- a/numba/tests/test_multi3.py
+++ b/numba/tests/test_multi3.py
@@ -1,10 +1,11 @@
 ﻿from __future__ import print_function, absolute_import, division
 
 
-from numba import njit
+from numba import config, njit
 from numba import unittest_support as unittest
 import random
 
+@unittest.skipIf(config.DISABLE_JIT, 'Test hangs with disabled jit')
 class TestMulti3(unittest.TestCase):
     """
     This test is only valid for x86-32.
@@ -25,6 +26,7 @@ class TestMulti3(unittest.TestCase):
             return res
 
         x_cases = [-1, 0, 1, 0xffffffff - 1, 0xffffffff, 0xffffffff + 1]
+
         for _ in range(500):
             x_cases.append(random.randint(0, 0xffffffff))
 


### PR DESCRIPTION
This is work-in-progress, but I'm opening the PR in order to solicit feedback about how to proceed. Currently:

- Setting `NUMBA_DISABLE_JIT=1` causes the JIT decorator and the compile functions to return the original Python function instead of a compiled one
- However, various tests fail with the disabled JIT. At the moment, there are 112 failures and 102 errors in the tests (2020 tests run in total).
- I started going through making changes to tests to get them to pass again, but there may well be a fair bit of work to get them all passing/skipping as appropriate.

I initially approached this hoping to get all tests to pass, in order to prove (to the extent possible with a unit test suite) that behaviour with JIT enabled is the same as with JIT disabled. However, I'm wondering if that's practical at the moment. I don't mind spending a bit of time working through the other tests, but are there other opinions on what would be better to do instead?

Additionally, I was planning that the same configuration option would be used to turn cudasim on and off when it is integrated into Numba, in order to be consistent between CPU and GPU targets.