### PR TITLE
Fix issue #1103

### DIFF
--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -363,9 +363,12 @@ int typecode_ndarray(DispatcherObject *dispatcher, PyArrayObject *ary) {
     int ndim = PyArray_NDIM(ary);
     int layout = 0;
 
-    if (PyArray_ISFARRAY(ary)) {
+    /* The order in which we check for the right contiguous-ness is important.
+       The order must match the order by numba.numpy_support.map_layout.
+    */
+    if (PyArray_ISCARRAY(ary)){
         layout = 1;
-    } else if (PyArray_ISCARRAY(ary)){
+    } else if (PyArray_ISFARRAY(ary)) {
         layout = 2;
     }
 


### PR DESCRIPTION
Issue #1103 is caused by a mismatch in checking array layout.  The dispatcher checks for F order first but the compiler checks for C order first.  This results in the compiler generating a C ordered implementation and the dispatcher insert into a F ordered slot.  This problem can be observed when using an array that is both C and F contiguous for a autojitted function

The fix is simply modify the dispatcher to check for C order first.