### PR TITLE
Add support for callback into object mode

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -429,8 +429,37 @@ class Lower(BaseLower):
         elif isinstance(fnty, types.ExternalFunctionPointer):
             # Handle a C function pointer
             pointer = self.loadvar(expr.func.name)
-            res = self.context.call_function_pointer(self.builder, pointer,
-                                                     argvals, fnty.cconv)
+            # If the external function pointer uses libpython
+            if fnty.requires_gil:
+                pyapi = self.context.get_python_api(self.builder)
+                # Acquire the GIL
+                gil_state = pyapi.gil_ensure()
+                # Make PyObjects
+                newargvals = []
+                pyvals = []
+                for exptyp, gottyp, aval in zip(fnty.sig.args, signature.args,
+                                                argvals):
+                    # Adjust argument values to pyobjects
+                    if exptyp == types.ffi_forced_object:
+                        obj = pyapi.from_native_value(aval, gottyp)
+                        newargvals.append(obj)
+                        pyvals.append(obj)
+                    else:
+                        newargvals.append(aval)
+
+                # Call external function
+                res = self.context.call_function_pointer(self.builder, pointer,
+                                                         newargvals, fnty.cconv)
+                # Release PyObjects
+                for obj in pyvals:
+                    pyapi.decref(obj)
+
+                # Release the GIL
+                pyapi.gil_release(gil_state)
+            # If the external function pointer does NOT use libpython
+            else:
+                res = self.context.call_function_pointer(self.builder, pointer,
+                                                         argvals, fnty.cconv)
 
         else:
             # Normal function resolution (for Numba-compiled functions)

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -27,6 +27,7 @@ CTYPES_MAP = {
     ctypes.c_double: types.float64,
 
     ctypes.c_void_p: types.voidptr,
+    ctypes.py_object: types.ffi_forced_object,
 }
 
 


### PR DESCRIPTION
by allowing callback to have pyobject arguments.

Use this gist for benchmark and sample usecase: https://gist.github.com/sklam/b7afa4c639fc03fb8e03