### PR TITLE
Fix looplifting bug for loop that does not return #1106

### DIFF
--- a/numba/looplifting.py
+++ b/numba/looplifting.py
@@ -170,7 +170,7 @@ def insert_loop_call(bytecode, loop, args, outer, outerlabels, returns,
             insertpt = insertpt.next()
     else:
         # No return value
-        poptop = ByteCodeInst.get(outer[-1].next, "POP_TOP", None)
+        poptop = ByteCodeInst.get(insertpt, "POP_TOP", None)
         poptop.lineno = loop[0].lineno
         insert_instruction(outer, poptop)
         insertpt = insertpt.next()

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -313,6 +313,20 @@ class TestLoopLiftingInAction(TestCase):
                 y += x
         self.assertEqual(test.py_func(), test())
 
+    def test_stack_offset_error_when_has_no_return(self):
+        from numba import jit
+        import warnings
+
+        def pyfunc(a):
+            if a:
+                for i in range(10):
+                    pass
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            cfunc = jit(forceobj=True)(pyfunc)
+            self.assertEqual(pyfunc(True), cfunc(True))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The POP_TOP bytecode is incorrectly inserted into the end of the block instead of the "next" slot.