### PR TITLE
Array ctypes data

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -773,15 +773,13 @@ class GeneratorModel(CompositeModel):
     def from_return(self, builder, value):
         return value
 
+
 @register_default(types.ArrayCTypes)
 class ArrayCTypesModel(StructModel):
     def __init__(self, dmm, fe_type):
-        ndim = fe_type.ndim
-        members = [('data', types.uintp),
-                   ]
+        # ndim = fe_type.ndim
+        members = [('data', types.uintp)]
         super(ArrayCTypesModel, self).__init__(dmm, fe_type, members)
-
-
 
 
 # =============================================================================

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -773,6 +773,16 @@ class GeneratorModel(CompositeModel):
     def from_return(self, builder, value):
         return value
 
+@register_default(types.ArrayCTypes)
+class ArrayCTypesModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        ndim = fe_type.ndim
+        members = [('data', types.uintp),
+                   ]
+        super(ArrayCTypesModel, self).__init__(dmm, fe_type, members)
+
+
+
 
 # =============================================================================
 

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -1021,6 +1021,11 @@ class PythonAPI(object):
         elif isinstance(typ, types.CharSeq):
             return self.from_native_charseq(val, typ)
 
+        elif typ == types.voidptr:
+            ll_intp = self.context.get_value_type(types.uintp)
+            addr = self.builder.ptrtoint(val, ll_intp)
+            return self.from_native_value(addr, types.uintp)
+
         raise NotImplementedError(typ)
 
     def to_native_int(self, obj, typ):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -789,6 +789,29 @@ def array_readonly(context, builder, typ, value):
 
 
 @builtin_attr
+@impl_attribute(types.Kind(types.Array), "ctypes",
+                types.Kind(types.ArrayCTypes))
+def array_ctypes(context, builder, typ, value):
+    arrayty = make_array(typ)
+    array = arrayty(context, builder, value)
+    # Cast void* data to uintp
+    addr = builder.ptrtoint(array.data, context.get_value_type(types.uintp))
+    # Create new ArrayCType structure
+    ctinfo_type = cgutils.create_struct_proxy(types.ArrayCTypes(typ))
+    ctinfo = ctinfo_type(context, builder)
+    ctinfo.data = addr
+    return ctinfo._getvalue()
+
+
+@builtin_attr
+@impl_attribute(types.Kind(types.ArrayCTypes), "data", types.uintp)
+def array_ctypes(context, builder, typ, value):
+    ctinfo_type = cgutils.create_struct_proxy(typ)
+    ctinfo = ctinfo_type(context, builder, value=value)
+    return ctinfo.data
+
+
+@builtin_attr
 @impl_attribute_generic(types.Kind(types.Array))
 def array_record_getattr(context, builder, typ, value, attr):
     arrayty = make_array(typ)
@@ -819,7 +842,6 @@ def array_record_getattr(context, builder, typ, value, attr):
                    itemsize=context.get_constant(types.intp, datasize),
                    parent=array.parent)
     return rary._getvalue()
-
 
 
 #-------------------------------------------------------------------------------

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -805,7 +805,7 @@ def array_ctypes(context, builder, typ, value):
 
 @builtin_attr
 @impl_attribute(types.Kind(types.ArrayCTypes), "data", types.uintp)
-def array_ctypes(context, builder, typ, value):
+def array_ctypes_data(context, builder, typ, value):
     ctinfo_type = cgutils.create_struct_proxy(typ)
     ctinfo = ctinfo_type(context, builder, value=value)
     return ctinfo.data

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -712,6 +712,9 @@ class BaseContext(object):
             assert toty.layout == 'A'
             return val
 
+        elif fromty in types.integer_domain and toty == types.voidptr:
+            return builder.inttoptr(val, self.get_value_type(toty))
+
         raise NotImplementedError("cast", val, fromty, toty)
 
     def make_optional(self, optionaltype):

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -52,6 +52,10 @@ def size_after_slicing_usecase(buf, i):
     return sliced.size
 
 
+def array_ctypes_data(arr):
+    return arr.ctypes.data
+
+
 class TestArrayAttr(unittest.TestCase):
     def setUp(self):
         self.a = np.arange(10).reshape(2, 5)
@@ -144,6 +148,14 @@ class TestSlicedArrayAttr(unittest.TestCase):
         arr = np.arange(2 * 5 * 3).reshape(2, 5, 3)
         for i in range(arr.shape[0]):
             self.assertEqual(pyfunc(arr, i), cfunc(arr, i))
+
+
+class TestArrayCTypes(unittest.TestCase):
+    def test_array_ctypes_data(self):
+        pyfunc = array_ctypes_data
+        cfunc = njit(pyfunc)
+        arr = np.arange(3)
+        self.assertEqual(pyfunc(arr), cfunc(arr))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -204,6 +204,24 @@ class TestCTypes(unittest.TestCase):
         for got in outputs:
             self.assertEqual(expected, got)
 
+    def test_passing_array_ctypes_data(self):
+
+        def take_array_ptr(ptr):
+            return ptr
+
+        c_take_array_ptr = CFUNCTYPE(c_void_p, c_void_p)(take_array_ptr)
+
+        def pyfunc(arr):
+            return c_take_array_ptr(arr.ctypes.data)
+
+        cfunc = jit(nopython=True, nogil=True)(pyfunc)
+
+        arr = numpy.arange(5)
+
+        expected = pyfunc(arr)
+        got = cfunc(arr)
+
+        self.assertEqual(expected, got)
 
 
 if __name__ == '__main__':

--- a/numba/typeconv/rules.py
+++ b/numba/typeconv/rules.py
@@ -43,6 +43,9 @@ def _init_casting_rules(tm):
 
     tcr.promote_unsafe(types.complex64, types.complex128)
 
+    # Allow integers to cast ot void*
+    tcr.unsafe_unsafe(types.uintp, types.voidptr)
+
     return tcr
 
 

--- a/numba/types.py
+++ b/numba/types.py
@@ -823,7 +823,12 @@ class Array(Buffer):
 
 
 class ArrayCTypes(Type):
+    """
+    This is the type for `numpy.ndarray.ctypes`.
+    """
     def __init__(self, arytype):
+        # This depends on the ndim for the shape and strides attributes,
+        # even though they are not implemented, yet.
         self.ndim = arytype.ndim
         name = "ArrayCType(ndim={0})".format(self.ndim)
         super(ArrayCTypes, self).__init__(name, param=True)

--- a/numba/types.py
+++ b/numba/types.py
@@ -822,6 +822,17 @@ class Array(Buffer):
         return self.dtype, self.ndim, self.layout, self.mutable
 
 
+class ArrayCTypes(Type):
+    def __init__(self, arytype):
+        self.ndim = arytype.ndim
+        name = "ArrayCType(ndim={0})".format(self.ndim)
+        super(ArrayCTypes, self).__init__(name, param=True)
+
+    @property
+    def key(self):
+        return (self.ndim)
+
+
 class NestedArray(Array):
     """
     A NestedArray is an array nested within a structured type (which are "void"

--- a/numba/types.py
+++ b/numba/types.py
@@ -835,7 +835,7 @@ class ArrayCTypes(Type):
 
     @property
     def key(self):
-        return (self.ndim)
+        return self.ndim
 
 
 class NestedArray(Array):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -515,11 +515,23 @@ class ArrayAttribute(AttributeTemplate):
     def resolve_flat(self, ary):
         return types.NumpyFlatType(ary)
 
+    def resolve_ctypes(self, ary):
+        return types.ArrayCTypes(ary)
+
     def generic_resolve(self, ary, attr):
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:
                 return types.Array(ary.dtype.typeof(attr), ndim=ary.ndim,
                                    layout='A')
+
+
+@builtin_attr
+class ArrayCTypesAttribute(AttributeTemplate):
+    key = types.ArrayCTypes
+
+    def resolve_data(self, ctinfo):
+        return types.uintp
+
 
 
 @builtin_attr

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -13,6 +13,8 @@ from . import templates
 
 CTYPES_MAP = {
     None: types.none,
+    ctypes.c_bool: types.boolean,
+    
     ctypes.c_int8:  types.int8,
     ctypes.c_int16: types.int16,
     ctypes.c_int32: types.int32,


### PR DESCRIPTION
As a follow up to the discussion in https://groups.google.com/a/continuum.io/forum/?utm_medium=email&utm_source=footer#!msg/numba-users/b9E-S_heC-U/9jcGwygmhs4J

We want to expose ``ndarray.ctypes.data`` for consumption by a ctypes/cffi foreign function.

Sample usecase: https://gist.github.com/sklam/806244ed2dd6b89a2ca9

Note: This does not implement the other attributes in `ndarray.ctypes` as they need introduce a entire set of types that would return as a ctypes object.  E.g. ``ndarray.ctypes.shape`` gives ``(c_long * ndim)``.