### PR TITLE
support keyword arguments for builtin function

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -186,10 +186,10 @@ class _OverloadedBase(_dispatcher.Dispatcher):
             print('=' * 80, file=file)
 
     def _explain_ambiguous(self, *args, **kws):
-        assert not kws, "kwargs not handled"
         args = tuple([self.typeof_pyval(a) for a in args])
         sigs = [cr.signature for cr in self._compileinfos.values()]
-        res = resolve_overload(self.typingctx, self.py_func, sigs, args, kws)
+        res = resolve_overload(self.typingctx, self.py_func, sigs, args, kws,
+                               keywords=self._pysig.parameters)
         print("res =", res)
 
     def _explain_matching_error(self, *args, **kws):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -388,10 +388,22 @@ class Lower(BaseLower):
             try:
                 pysig = fnty.pysig
             except AttributeError:
-                if expr.kws:
+                # If the call has keyword argument and the call type
+                # is not:
+                #    - a function type, and;
+                #    - with keyword defined.
+                if (expr.kws and
+                    not (isinstance(fnty, types.Function) and
+                         fnty.template.keywords)):
                     raise NotImplementedError("unsupported keyword arguments "
                                               "when calling %s" % (fnty,))
-                args = expr.args
+
+                # If it is a function type,
+                # bind the keywords to the positional arguments
+                if isinstance(fnty, types.Function):
+                    args = fnty.template.bind_for_call(expr.args, expr.kws)
+                else:
+                    args = expr.args
             else:
                 ba = pysig.bind(*expr.args, **dict(expr.kws))
                 for i, param in enumerate(pysig.parameters.values()):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -17,7 +17,7 @@ from numba import types, cgutils
 from numba.targets.imputils import (builtin, builtin_attr, implement,
                                     impl_attribute, impl_attribute_generic,
                                     iterator_impl, iternext_impl,
-                                    struct_factory)
+                                    struct_factory, implement_keywords)
 from .builtins import Slice
 
 
@@ -1249,10 +1249,12 @@ def iternext_numpy_ndindex(context, builder, sig, args, result):
 
 
 @builtin
-@implement(numpy.empty, types.Kind(types.Integer))
-@implement(numpy.empty, types.Kind(types.BaseTuple))
-@implement(numpy.empty, types.Kind(types.Integer), types.Kind(types.Function))
-@implement(numpy.empty, types.Kind(types.BaseTuple), types.Kind(types.Function))
+@implement_keywords(numpy.empty, ['shape'], types.Kind(types.Integer))
+@implement_keywords(numpy.empty, ['shape'], types.Kind(types.BaseTuple))
+@implement_keywords(numpy.empty, ['shape', 'dtype'],
+                    types.Kind(types.Integer), types.Kind(types.Function))
+@implement_keywords(numpy.empty, ['shape', 'dtype'],
+                    types.Kind(types.BaseTuple), types.Kind(types.Function))
 def numpy_empty_nd(context, builder, sig, args):
     arrshapetype = sig.args[0]
     arrshape = args[0]

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -9,13 +9,37 @@ import functools
 
 from .. import typing, cgutils, types
 
+
+def _getattr_or_default(obj, attr, default):
+    """
+    Set attributes to ``obj`` with the ``default`` if it does not exist.
+    Returns the existing attributes or the ``default``.
+    """
+    val = getattr(obj, attr, default)
+    setattr(obj, attr, val)
+    return val
+
+
 def implement(func, *argtys):
+    """
+    Define an implementation that use positional argument only
+    """
     def wrapper(impl):
-        try:
-            sigs = impl.function_signatures
-        except AttributeError:
-            sigs = impl.function_signatures = []
+        sigs = _getattr_or_default(impl, 'function_signatures', [])
         sigs.append((func, typing.signature(types.Any, *argtys)))
+        return impl
+
+    return wrapper
+
+
+def implement_keywords(func, parameters, *argtys):
+    """
+    Define an implementation and specify the required set of parameters.
+    """
+    def wrapper(impl):
+        sigs = _getattr_or_default(impl, 'function_signatures', [])
+        sigs.append((func, typing.signature(types.Any, *argtys,
+                                            keywords=parameters)))
         return impl
 
     return wrapper

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -334,24 +334,25 @@ class NdEmpty(AbstractKeywordTemplate):
             # ctor, we use numpy.dtype to force it into a dtype object.
             np_dtype = from_dtype(numpy.dtype(dtype.template.key))
 
-        return_type = None
         if isinstance(shape, types.Integer):
-            return_type = types.double[::1]
+            ndim = 1
+        elif isinstance(shape, types.BaseTuple):
+            ndim = len(shape)
+            if not all(isinstance(s, types.Integer) for s in shape):
+                # Not all element in shape are integer
+                return
+        else:
+            return
 
-        elif isinstance(shape, (types.Tuple, types.UniTuple)):
-            if all(isinstance(s, types.Integer) for s in shape):
-                return_type = types.Array(dtype=np_dtype,
-                                          ndim=len(shape),
-                                          layout='C')
+        return_type = types.Array(dtype=np_dtype, ndim=ndim, layout='C')
 
-        if return_type is not None:
-            args = [shape]
-            keywords = set(['shape'])
-            if dtype is not None:
-                args.append(dtype)
-                keywords.add('dtype')
+        args = [shape]
+        keywords = set(['shape'])
+        if dtype is not None:
+            args.append(dtype)
+            keywords.add('dtype')
 
-            return signature(return_type, *args, keywords=keywords)
+        return signature(return_type, *args, keywords=keywords)
 
 
 builtin_global(numpy.empty, types.Function(NdEmpty))

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -318,6 +318,7 @@ class NdIndex(AbstractTemplate):
 
 builtin_global(numpy.ndindex, types.Function(NdIndex))
 
+
 @builtin
 class NdEmpty(AbstractKeywordTemplate):
     key = numpy.empty
@@ -339,10 +340,9 @@ class NdEmpty(AbstractKeywordTemplate):
 
         elif isinstance(shape, (types.Tuple, types.UniTuple)):
             if all(isinstance(s, types.Integer) for s in shape):
-                aryty = types.Array(dtype=np_dtype,
-                                    ndim=len(shape),
-                                    layout='C')
-                return_type = signature(aryty, shape, dtype)
+                return_type = types.Array(dtype=np_dtype,
+                                          ndim=len(shape),
+                                          layout='C')
 
         if return_type is not None:
             args = [shape]

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -346,9 +346,12 @@ class NdEmpty(AbstractKeywordTemplate):
 
         if return_type is not None:
             args = [shape]
+            keywords = set(['shape'])
             if dtype is not None:
                 args.append(dtype)
-            return signature(return_type, *args)
+                keywords.add('dtype')
+
+            return signature(return_type, *args, keywords=keywords)
 
 
 builtin_global(numpy.empty, types.Function(NdEmpty))

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -57,6 +57,11 @@ def make_concrete_template(name, key, signatures):
 
 
 def signature(return_type, *args, **kws):
+    """
+    Create a signature object.
+    The only accept keyword argument is ``recvr`` for specifying the
+    receiving object for a method.
+    """
     recvr = kws.pop('recvr', None)
     assert not kws, "Extra keyword arguments: {0}".format(kws.keys())
     return Signature(return_type, args, recvr=recvr)
@@ -229,6 +234,8 @@ def resolve_ambiguous_resolution(context, cases, args):
 
 
 class FunctionTemplate(object):
+    keywords = None
+
     def __init__(self, context):
         self.context = context
 
@@ -264,6 +271,12 @@ class AbstractTemplate(FunctionTemplate):
         if sig:
             cases = [sig]
             return self._select(cases, args, kws)
+
+
+class AbstractKeywordTemplate(AbstractTemplate):
+    def generic(self, args, kws):
+        vals = _flatten_keywords(self.keywords, args, kws)
+        return self.generic_keywords(dict(zip(self.keywords, vals)))
 
 
 class ConcreteTemplate(FunctionTemplate):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -258,6 +258,10 @@ class FunctionTemplate(object):
 
     @classmethod
     def bind_for_call(cls, args, kwargs):
+        """
+        Flatten the keyword arguments into position arguments and skipping
+        any undefined values.
+        """
         return _flatten_keywords(cls.keywords, args, kwargs,
                                  compressed=True)
 

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -127,6 +127,17 @@ def _rate_arguments(context, actualargs, formalargs):
 def _flatten_keywords(keywords, args, kws, compressed=False):
     """
     Flatten keyword arguments according to the declared keywords spec.
+
+    Returns a sequence of positional arguments by appending key-values from
+    ``kws`` according to the spec in ``keywords`` into the end of ``args``
+    (Note that ``args`` parameter is not modified).
+
+    If ``compressed`` is True, the missing key-values in ``kws`` is skipped.
+    Otherwise, they are defaulted to None and the values in returned sequence
+    should corresponding to the names in ``keywords`` the following will work:
+
+        keys, values = zip(keywords, returned_value)
+
     """
     if keywords:
         # Check

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -244,6 +244,11 @@ class FunctionTemplate(object):
                                     keywords=self.keywords)
         return selected
 
+    @classmethod
+    def bind_for_call(cls, args, kwargs):
+        return _flatten_keywords(cls.keywords, args, kwargs,
+                                 compressed=True)
+
 
 class AbstractTemplate(FunctionTemplate):
     """

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -295,6 +295,15 @@ class AbstractTemplate(FunctionTemplate):
 
 
 class AbstractKeywordTemplate(AbstractTemplate):
+    """
+    Extend this class and implement generic_keywords() for handling
+    calls that have keyword arguments.
+
+    generic_keywords(kwargs) takes a dictionary where the keys are the argument
+    names and the values are the type of the argument.  If the argument
+    is not defined at the call site, the associated value in the dictionary
+    will be ``None``.
+    """
     def generic(self, args, kws):
         vals = _flatten_keywords(self.keywords, args, kws)
         return self.generic_keywords(dict(zip(self.keywords, vals)))


### PR DESCRIPTION
This is an attempt to fix https://github.com/numba/numba/issues/1113 for a general case so that all builtin function can be defined to have keyword arguments. 

This PR does not:
- implement **kwargs