### PR TITLE
Fix regression caused by the NRT pull request

### DIFF
--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -10,7 +10,8 @@ class _ArgManager(object):
     """
     A utility class to handle argument unboxing and cleanup
     """
-    def __init__(self, builder, api, endblk, nargs):
+    def __init__(self, context, builder, api, endblk, nargs):
+        self.context = context
         self.builder = builder
         self.api = api
         self.arg_count = 0  # how many function arguments have been processed
@@ -37,6 +38,14 @@ class _ArgManager(object):
         cleanupblk = cgutils.append_basic_block(self.builder,
                                                 "arg%d.err" % self.arg_count)
         with cgutils.goto_block(self.builder, cleanupblk):
+            # NRT cleanup
+
+            if self.context.enable_nrt:
+                def nrt_cleanup():
+                    self.context.nrt_decref(self.builder, ty, native.value)
+                nrt_cleanup()
+                self.cleanups.append(nrt_cleanup)
+
             if native.cleanup is not None:
                 native.cleanup()
                 self.cleanups.append(native.cleanup)
@@ -122,7 +131,7 @@ class PyCallWrapper(object):
         with cgutils.goto_block(builder, endblk):
             builder.ret(api.get_null_object())
 
-        cleanup_manager = _ArgManager(builder, api, endblk, nargs)
+        cleanup_manager = _ArgManager(self.context, builder, api, endblk, nargs)
 
         innerargs = []
         for obj, ty in zip(objs, self.fndesc.argtypes):

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -148,7 +148,7 @@ class PyCallWrapper(object):
             with cgutils.ifthen(builder, status.is_none):
                 api.return_none()
 
-            retval = api.from_native_return(res, self.fndesc.restype)
+            retval = api.from_native_return(res, self._simplified_return_type())
             builder.ret(retval)
 
         with cgutils.ifthen(builder, builder.not_(status.is_python_exc)):
@@ -191,3 +191,18 @@ class PyCallWrapper(object):
         kwlist = Constant.array(stringtype, strings)
         kwlist = cgutils.global_constant(self.module, ".kwlist", kwlist)
         return Constant.bitcast(kwlist, Type.pointer(stringtype))
+
+    def _simplified_return_type(self):
+        """
+        The NPM callconv has already converted simplified optional types.
+        We can simply use the value type from it.
+        """
+        restype = self.fndesc.restype
+        # Optional type
+        if isinstance(restype, types.Optional):
+            return restype.type
+        else:
+            return restype
+
+
+

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -38,6 +38,7 @@ class Flags(utils.ConfigOptions):
 
 
 DEFAULT_FLAGS = Flags()
+DEFAULT_FLAGS.set('nrt')
 
 
 CR_FIELDS = ["typing_context",

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -191,6 +191,9 @@ class PrimitiveModel(DataModel):
 @register_default(types.ExceptionType)
 @register_default(types.Dummy)
 @register_default(types.ExceptionInstance)
+@register_default(types.BoundFunction)
+@register_default(types.NumpyNdEnumerateType)
+@register_default(types.NumpyNdIndexType)
 class OpaqueModel(PrimitiveModel):
     """
     Passed as opaque pointers

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -955,6 +955,9 @@ class PythonAPI(object):
         raise NotImplementedError("cannot convert %s to native value" % (typ,))
 
     def from_native_return(self, val, typ):
+        assert not isinstance(typ, types.Optional), "callconv should have " \
+                                                    "prevented the return of " \
+                                                    "optional value"
         out = self.from_native_value(val, typ)
         if self.context.enable_nrt:
             self.context.nrt_decref(self.builder, typ, val)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -1256,14 +1256,14 @@ class PythonAPI(object):
         fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
         return self.builder.call(fn, (ary, ptr))
 
-    def nrt_adapt_buffer_from_python(self, ary, ptr):
+    def nrt_adapt_buffer_from_python(self, buf, ptr):
         assert self.context.enable_nrt
         fnty = Type.function(Type.void(), [Type.pointer(self.py_buffer_t),
                                            self.voidptr])
         fn = self._get_function(fnty, name="NRT_adapt_buffer_from_python")
         fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
         fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
-        return self.builder.call(fn, (ary, ptr))
+        return self.builder.call(fn, (buf, ptr))
 
     def from_native_charseq(self, val, typ):
         builder = self.builder

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -914,8 +914,6 @@ class PythonAPI(object):
 
             def cleanup_array():
                 val = self.builder.load(val_on_stack)
-                if self.context.enable_nrt:
-                    self.context.nrt_decref(self.builder, typ, val)
 
             return NativeValue(val, is_error=failed,
                                cleanup=cleanup_array)

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -40,10 +40,10 @@ typedef struct MemSys MemSys;
 /* Memory System API */
 
 /* Initialize the memory system */
-void NRT_MemSys_init();
+void NRT_MemSys_init(void);
 
 /* Shutdown the memory system */
-void NRT_MemSys_shutdown();
+void NRT_MemSys_shutdown(void);
 
 /*
  * Internal API
@@ -57,7 +57,7 @@ void NRT_MemSys_insert_meminfo(MemInfo *newnode);
  * Internal API
  * Pop a MemInfo from the freelist.
  */
-MemInfo* NRT_MemSys_pop_meminfo();
+MemInfo* NRT_MemSys_pop_meminfo(void);
 
 /*
  * Register the atomic increment and decrement functions
@@ -74,17 +74,17 @@ void NRT_MemSys_set_atomic_cas(atomic_cas_func cas);
 /*
  * Register a non-atomic STUB for increment and decrement
  */
-void NRT_MemSys_set_atomic_inc_dec_stub();
+void NRT_MemSys_set_atomic_inc_dec_stub(void);
 
 /*
  * Register a non-atomic STUB for compare and swap
  */
-void NRT_MemSys_set_atomic_cas_stub();
+void NRT_MemSys_set_atomic_cas_stub(void);
 
 /*
  * Process all pending deferred dtors
  */
-void NRT_MemSys_process_defer_dtor();
+void NRT_MemSys_process_defer_dtor(void);
 
 /* Memory Info API */
 


### PR DESCRIPTION
Changes:
* add "nrt" flag to the DEFAULT_FLAGS so that it is tested in all compile_isolated() tests.

Fixes:
* [x] fix problem due to unregistered datamodel for some fe types #1118 
* [x] fix returning of optional type #1114
* [x] fix argument cleanup at callwrapper for NRT managed object
* [x] cleanup code to avoid GCC warning #1116 