### PR TITLE
Fix NRT refct return leak.

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -187,6 +187,15 @@ class Lower(BaseLower):
             ty = self.typeof(inst.target.name)
             val = self.lower_assign(ty, inst)
             self.storevar(val, inst.target.name)
+            # TODO: emit incref/decref in the numba IR properly.
+            # Workaround due to lack of proper incref/decref info.
+            if self.context.enable_nrt:
+                if isinstance(inst.value, ir.Expr) and inst.value.op == 'call':
+                    callexpr = inst.value
+                    # NPM function returns new reference
+                    if isinstance(self.typeof(callexpr.func.name),
+                                  types.Dispatcher):
+                        self.decref(ty, val)
 
         elif isinstance(inst, ir.Branch):
             cond = self.loadvar(inst.cond.name)

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -401,6 +401,26 @@ class TestDynArray(unittest.TestCase):
         # getrefcount owns 1, got_y owns 1
         self.assertEqual(2, sys.getrefcount(got_y))
 
+    def test_issue_with_return_leak(self):
+        """
+        Dispatcher returns a new reference.
+        It need to workaround it for now.
+        """
+        @nrtjit
+        def inner(out):
+            return out
+
+        def pyfunc(x):
+            return inner(x)
+
+        cfunc = nrtjit(pyfunc)
+
+        arr = np.arange(10)
+        old_refct = sys.getrefcount(arr)
+
+        self.assertEqual(old_refct, sys.getrefcount(pyfunc(arr)))
+        self.assertEqual(old_refct, sys.getrefcount(cfunc(arr)))
+
 
 def benchmark_refct_speed():
     def pyfunc(x, y, t):


### PR DESCRIPTION
The problem is due to NPM function  ``types.Dispatcher`` is returning new reference but the rest of the compiler is relying on variable binding for knowing when to incref.

This is a workaround.  A better fix is to emit incref/decref properly.