### PR TITLE
CUDA Simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    - cd ~ ; python -m numba.testing -v -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -v -b -m
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Numba'
-copyright = u'2012-2014, Continuum Analytics'
+copyright = u'2012-2015, Continuum Analytics'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/cuda/device-management.rst
+++ b/docs/source/cuda/device-management.rst
@@ -54,3 +54,19 @@ Users can then create a new context with another device.
       This makes it not very useful to close and create new devices, though it
       is certainly useful for choosing which device to use when the machine
       has multiple GPUs.
+
+The Device List
+===============
+
+The Device List is a list of all the GPUs in the system, and can be indexed to
+obtain a context manager that ensures execution on the selected GPU.
+
+.. attribute:: numba.cuda.gpus
+.. attribute:: numba.cuda.cudadrv.devices.gpus
+
+:py:data:`.gpus` is an instance of the :class:`_DeviceList` class, from which
+the current GPU context can also be retrieved:
+
+.. autoclass:: numba.cuda.cudadrv.devices._DeviceList
+    :members: current
+

--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -11,3 +11,4 @@ Numba for CUDA GPUs
    intrinsics.rst
    device-management.rst
    examples.rst
+   simulator.rst

--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -13,82 +13,34 @@ the host when a kernel finishes. To avoid the unnecessary transfer for
 read-only arrays, you can use the following APIs to manually control the
 transfer:
 
-.. function:: numba.cuda.to_device(array, stream=0)
-
-   Copy the Numpy *array* to device memory.  A device array reference
-   is returned which can be passed as argument to a kernel expecting the
-   same kind of array.
-
-   If a CUDA *stream* is given, then the transfer will be made asynchronously
-   as part as the given stream.  Otherwise, the transfer is synchronous:
-   the function returns after the copy is finished.
-
-   The lifetime of the allocated device memory is managed by Numba.  Once
-   it isn't referred to anymore, it is automatically released.
+.. autofunction:: numba.cuda.device_array
+.. autofunction:: numba.cuda.device_array_like
+.. autofunction:: numba.cuda.to_device
 
 Device arrays
 -------------
 
 Device array references have the following methods.  These methods are to be
-called on the host, not on the device.
+called in host code, not within CUDA-jitted functions.
 
-.. method:: copy_to_host(array=None, stream=0)
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceNDArray
+    :members: copy_to_host, is_c_contiguous, is_f_contiguous, ravel, reshape
 
-   Copy back contents of the device array to Numpy *array* on the host.
-   If *array* is not given, a new array is allocated and returned.
+Pinned memory
+=============
 
-   If a CUDA *stream* is given, then the transfer will be made asynchronously
-   as part as the given stream.  Otherwise, the transfer is synchronous:
-   the function returns after the copy is finished.
-
-   Example::
-
-      import numpy as np
-      from numba import cuda
-
-      arr = np.arange(1000)
-      d_arr = cuda.to_device(arr)
-
-      my_kernel[100, 100](d_arr)
-
-      result_array = d_arr.copy_to_host()
-
-.. method:: is_c_contiguous()
-
-   Return whether the array is C-contiguous.
-
-.. method:: is_f_contiguous()
-
-   Return whether the array is Fortran-contiguous.
-
-.. method:: ravel(order='C')
-
-   Flatten the array without changing its contents, similarly to
-   :meth:`numpy.ndarray.ravel`.
-
-.. method:: reshape(*newshape, order='C')
-
-   Change the array's shape without changing its contents, similarly to
-   :meth:`numpy.ndarray.reshape`.  Example::
-
-      d_arr = d_arr.reshape(20, 50, order='F')
-
+.. autofunction:: numba.cuda.pinned
+.. autofunction:: numba.cuda.pinned_array
 
 Streams
 =======
 
-.. function:: numba.cuda.stream()
+.. autofunction:: numba.cuda.stream
 
-   Create and return a CUDA stream.  A CUDA stream acts as a command queue
-   for the device.
+CUDA streams have the following methods:
 
-   CUDA streams have the following method:
-
-   .. method:: synchronize()
-
-      Wait for all commands in this stream to execute.  This will commit
-      any pending memory transfers.
-
+.. autoclass:: numba.cuda.cudadrv.driver.Stream
+    :members: synchronize, auto_synchronize
 
 .. _cuda-shared-memory:
 

--- a/docs/source/cuda/simulator.rst
+++ b/docs/source/cuda/simulator.rst
@@ -1,0 +1,84 @@
+
+.. _simulator:
+
+=================================================
+Debugging CUDA Python with the the CUDA Simulator
+=================================================
+
+Numba includes a CUDA Simulator that implements most of the semantics in CUDA
+Python using the Python interpreter and some additional Python code. This can
+be used to debug CUDA Python code, either by adding print statements to your
+code, or by using the debugger to step through the execution of an individual
+thread.
+
+Execution of kernels is performed by the simulator one block at a time. One
+thread is spawned for each thread in the block, and scheduling of the execution
+of these threads is left up to the operating system.
+
+Using the simulator
+===================
+
+The simulator is enabled by setting the environment variable
+:envvar:`NUMBA_ENABLE_CUDASIM` to 1. CUDA Python code may then be executed as
+normal. The easiest way to use the debugger inside a kernel is to only stop a
+single thread, otherwise the interaction with the debugger is difficult to
+handle. For example, the kernel below will  stop in the thread ``<<<(3,0,0), (1,
+0, 0)>>>``::
+
+    @cuda.jit
+    def vec_add(A, B, out):
+        x = cuda.threadIdx.x
+        bx = cuda.blockIdx.x
+        bdx = cuda.blockDim.x
+        if x == 1 and bx == 3:
+            from pdb import set_trace; set_trace()
+        i = bx * bdx + x
+        out[i] = A[i] + B[i]
+
+when invoked with a one-dimensional grid and one-dimensional blocks.
+
+Supported features
+==================
+
+The simulator aims to provide as complete a simulation of execution on a real
+GPU as possible - in particular, the following are supported:
+
+* Atomic operations
+* Constant memory
+* Local memory
+* Shared memory: declarations of shared memory arrays must be on separate source
+  lines, since the simulator uses source line information to keep track of
+  allocations of shared memory across threads.
+* :func:`.syncthreads` is supported - however, in the case where divergent
+  threads enter different :func:`.syncthreads` calls, the launch will not fail,
+  but unexpected behaviour will occur. A future version of the simulator may
+  detect this condition.
+* The stream API is supported, but all operations occur sequentially and
+  synchronously, unlike on a real device. Synchronising on a stream is therefore
+  a no-op.
+* The event API is also supported, but provides no meaningful timing
+  information.
+* Data transfer to and from the GPU - in particular, creating array objects with
+  :func:`.device_array` and :func:`.device_array_like`. The APIs for pinned memory
+  :func:`.pinned` and :func:`.pinned_array` are also supported, but no pinning
+  takes place.
+* The driver API implementation of the list of GPU contexts (``cuda.gpus`` and
+  ``cuda.cudadrv.devices.gpus``) is supported, and reports a single GPU context.
+  This context can be closed and reset as the real one would.
+* The :func:`.detect` function is supported, and reports one device called
+  `SIMULATOR`.
+
+Some limitations of the simulator include:
+
+* It does not perform type checking/type inference. If any argument types to a
+  jitted function are incorrect, or if the specification of the type of any
+  local variables are incorrect, this will not be detected by the simulator.
+* Only one GPU is simulated.
+* Multithreaded accesses to a single GPU are not supported, and will result in
+  unexpected behaviour.
+* Most of the driver API is unimplemented.
+* It is not possible to link PTX code with CUDA Python functions.
+
+Obviously, the speed of the simulator is also much lower than that of a real
+device. It may be necessary to reduce the size of input data and the size of the
+CUDA grid in order to make debugging with the simulator tractable.

--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -225,3 +225,12 @@ Python implementation of these functions.
 
 Setting the :envvar:`NUMBA_DISABLE_JIT` environment variable presently has no
 effect in CUDA Python.
+
+Debugging CUDA Python code
+==========================
+
+CUDA Python code can be run in the Python interpreter using the CUDA Simulator,
+allowing it to be debugged with the Python debugger or with print statements. To
+enable the CUDA simulator, set the environment variable
+:envvar:`NUMBA_ENABLE_CUDASIM` to 1. For more information on the CUDA Simulator,
+see :ref:`the CUDA Simulator documentation <simulator>`.

--- a/numba/config.py
+++ b/numba/config.py
@@ -120,3 +120,6 @@ ENABLE_AVX = _readenv("NUMBA_ENABLE_AVX", int,
 
 # Disable jit for debugging
 DISABLE_JIT = _readenv("NUMBA_DISABLE_JIT", int, 0)
+
+# Enable CUDA simulator
+ENABLE_CUDASIM = _readenv("NUMBA_ENABLE_CUDASIM", int, 0)

--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -1,32 +1,13 @@
 from __future__ import print_function, absolute_import, division
 
-# Re export
-from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
-                    shared, local, const, grid, gridsize, atomic)
-from .cudadrv.error import CudaSupportError
-from . import initialize
-from .errors import KernelRuntimeError
+from numba import config
 
-from .decorators import jit, autojit, declare_device
-from .api import *
-from .api import _auto_device, _profiling, _profile_start, _profile_stop
-
-
-def is_available():
-    """Returns a boolean to indicate the availability of a CUDA GPU.
-
-    This will initialize the driver if it hasn't been initialized.
-    """
-    return driver.driver.is_available
-
-
-def cuda_error():
-    """Returns None or an exception if the CUDA driver fails to initialize.
-    """
-    return driver.driver.initialization_error
-
-
-initialize.initialize_all()
+if config.ENABLE_CUDASIM:
+    from .simulator_init import *
+else:
+    from .device_init import *
+    from .device_init import (_auto_device, _profiling, _profile_start,
+                              _profile_stop)
 
 
 def test():

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -63,7 +63,7 @@ def to_device(obj, stream=0, copy=True, to=None):
 def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
     """device_array(shape, dtype=np.float, strides=None, order='C', stream=0)
 
-    Allocate an empty device ndarray. Similar to numpy.empty()
+    Allocate an empty device ndarray. Similar to :meth:`numpy.empty`.
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)

--- a/numba/cuda/cudadrv/__init__.py
+++ b/numba/cuda/cudadrv/__init__.py
@@ -5,3 +5,5 @@
 - Device array implementation
 
 """
+from numba import config
+assert not config.ENABLE_CUDASIM, 'Cannot use real driver API with simulator'

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -887,10 +887,18 @@ class Stream(object):
         return "<CUDA stream %d on %s>" % (self.handle.value, self.context)
 
     def synchronize(self):
+        '''
+        Wait for all commands in this stream to execute. This will commit any
+        pending memory transfers.
+        '''
         driver.cuStreamSynchronize(self.handle)
 
     @contextlib.contextmanager
     def auto_synchronize(self):
+        '''
+        A context manager that waits for all commands in this stream to execute
+        and commits any pending memory transfers upon exiting the context.
+        '''
         yield self
         self.synchronize()
 

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -1,0 +1,28 @@
+from __future__ import print_function, absolute_import, division
+
+# Re export
+from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
+                    shared, local, const, grid, gridsize, atomic)
+from .cudadrv.error import CudaSupportError
+from . import initialize
+from .errors import KernelRuntimeError
+
+from .decorators import jit, autojit, declare_device
+from .api import *
+from .api import _auto_device, _profiling, _profile_start, _profile_stop
+
+
+def is_available():
+    """Returns a boolean to indicate the availability of a CUDA GPU.
+
+    This will initialize the driver if it hasn't been initialized.
+    """
+    return driver.driver.is_available
+
+
+def cuda_error():
+    """Returns None or an exception if the CUDA driver fails to initialize.
+    """
+    return driver.driver.initialization_error
+
+initialize.initialize_all()

--- a/numba/cuda/simulator/__init__.py
+++ b/numba/cuda/simulator/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from .api import *
+from .array import (devicearray, device_array, device_array_like, pinned,
+                    pinned_array, to_device)
+
+
+# Ensure that any user code attempting to import cudadrv etc. gets the
+# simulator's version and not the real version if the simulator is enabled.
+from numba import config
+if config.ENABLE_CUDASIM:
+    import sys
+    from . import cudadrv
+    sys.modules['numba.cuda.cudadrv'] = cudadrv
+    sys.modules['numba.cuda.cudadrv.devicearray'] = cudadrv.devicearray
+    sys.modules['numba.cuda.cudadrv.devices'] = cudadrv.devices
+    sys.modules['numba.cuda.cudadrv.driver'] = cudadrv.driver
+    sys.modules['numba.cuda.cudadrv.drvapi'] = cudadrv.drvapi
+    sys.modules['numba.cuda.cudadrv.nvvm'] = cudadrv.nvvm
+
+    from . import compiler
+    sys.modules['numba.cuda.compiler'] = compiler

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -1,0 +1,86 @@
+'''
+Contains CUDA API functions
+'''
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+from .cudadrv.devices import require_context, reset, gpus
+from .kernel import FakeCUDAKernel
+from numba.types import Prototype
+from numba.typing import Signature
+from warnings import warn
+
+
+def select_device(dev=0):
+    assert dev == 0, 'Only a single device supported by the simulator'
+
+
+class stream(object):
+    '''
+    The stream API is supported in the simulator - however, all execution
+    occurs synchronously, so synchronization requires no operation.
+    '''
+    @contextmanager
+    def auto_synchronize(self):
+        yield
+
+    def synchronize(self):
+        pass
+
+
+def close():
+    gpus.closed = True
+
+
+def declare_device(*args, **kwargs):
+    pass
+
+
+def detect():
+    print('Found 1 CUDA devices')
+    print('id %d    %20s %40s' % (0, 'SIMULATOR', '[SUPPORTED]'))
+    print('%40s: 5.2' % 'compute capability')
+
+
+def list_devices():
+    return gpus
+
+
+# Events
+
+class Event(object):
+    '''
+    The simulator supports the event API, but they do not record timing info,
+    and all simulation is synchronous. Execution time is not recorded.
+    '''
+    def record(self, stream=0):
+        pass
+
+    def wait(self, stream=0):
+        pass
+
+    def synchronize(self):
+        pass
+
+    def elapsed_time(self, event):
+        warn('Simulator timings are bogus')
+        return 0.0
+
+event = Event
+
+
+def jit(fn_or_sig=None, device=False, debug=False, argtypes=None, inline=False, restype=None,
+        fastmath=False, link=None):
+    if link is not None:
+        raise NotImplementedError('Cannot link PTX in the simulator')
+    # Check for first argument specifying types - in that case the
+    # decorator is not being passed a function
+    if fn_or_sig is None or isinstance(fn_or_sig, (str, tuple, Signature, Prototype)):
+        def jitwrapper(fn):
+            return FakeCUDAKernel(fn,
+                                  device=device,
+                                  fastmath=fastmath)
+        return jitwrapper
+    return FakeCUDAKernel(fn_or_sig, device=device)
+
+autojit = jit

--- a/numba/cuda/simulator/array.py
+++ b/numba/cuda/simulator/array.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 import numpy as np
 from warnings import warn
-from six import raise_from
+from numba.six import raise_from
 
 class FakeShape(tuple):
     '''

--- a/numba/cuda/simulator/array.py
+++ b/numba/cuda/simulator/array.py
@@ -1,0 +1,132 @@
+from contextlib import contextmanager
+import numpy as np
+from warnings import warn
+from six import raise_from
+
+class FakeShape(tuple):
+    '''
+    The FakeShape class is used to provide a shape which does not allow negative
+    indexing, similar to the shape in CUDA Python. (Numpy shape arrays allow
+    negative indexing)
+    '''
+    def __getitem__(self, k):
+        if k < 0:
+            raise IndexError('tuple index out of range')
+        return super(FakeShape, self).__getitem__(k)
+
+
+class FakeCUDAArray(object):
+    '''
+    Implements the interface of a DeviceArray/DeviceRecord, but mostly just
+    wraps a NumPy array.
+    '''
+
+    def __init__(self, ary):
+        self._ary = ary
+
+    def __getattr__(self, attrname):
+        try:
+            attr = getattr(self._ary, attrname)
+            return attr
+        except AttributeError:
+            raise_from(AttributeError("Wrapped array has no attribute '%s'"
+                                      % attrname), e)
+
+    def __getitem__(self, idx):
+        item = self._ary.__getitem__(idx)
+        if isinstance(item, np.ndarray):
+            return FakeCUDAArray(item)
+        return item
+
+    def __setitem__(self, idx, val):
+        return self._ary.__setitem__(idx, val)
+
+    def copy_to_host(self, ary=None, stream=0):
+        if ary is None:
+            ary = np.empty_like(self._ary)
+        np.copyto(ary, self._ary)
+        return ary
+
+    def copy_to_device(self, ary, stream=0):
+       '''
+       Copy from the provided array into this array.
+
+       This may be less forgiving than the CUDA Python implementation, which
+       will copy data up to the length of the smallest of the two arrays,
+       whereas this uses np.copyto, which expects the size of the arrays to be
+       equal.
+       '''
+       np.copyto(self._ary, ary)
+
+    def to_host(self):
+        warn('to_host() is deprecated and will be removed')
+
+    @property
+    def shape(self):
+        return FakeShape(self._ary.shape)
+
+    def ravel(self, *args, **kwargs):
+        return FakeCUDAArray(self._ary.ravel(*args, **kwargs))
+
+    def reshape(self, *args, **kwargs):
+        return FakeCUDAArray(self._ary.reshape(*args, **kwargs))
+
+    def is_c_contiguous(self):
+       return self._ary.flags.c_contiguous
+
+    def is_f_contiguous(self):
+       return self._ary.flags.f_contiguous
+
+    def __str__(self):
+        return str(self._ary)
+
+    def __repr__(self):
+        return repr(self._ary)
+
+    def __len__(self):
+        return len(self._ary)
+
+
+errmsg_contiguous_buffer = ("Array contains non-contiguous buffer and cannot "
+                            "be transferred as a single memory region. Please "
+                            "ensure contiguous buffer with numpy "
+                            ".ascontiguousarray()")
+
+
+def sentry_contiguous(ary):
+    if not ary.flags['C_CONTIGUOUS'] and not ary.flags['F_CONTIGUOUS']:
+        if ary.strides[0] == 0:
+            # Broadcasted, ensure inner contiguous
+            return sentry_contiguous(ary[0])
+        else:
+            raise ValueError(errmsg_contiguous_buffer)
+
+
+def to_device(ary, stream=0, copy=True, to=None):
+    sentry_contiguous(ary)
+    return FakeCUDAArray(ary)
+
+
+@contextmanager
+def pinned(arg):
+    yield
+
+
+def pinned_array(shape, dtype=np.float, strides=None, order='C'):
+    return np.ndarray(shape=shape, strides=strides, dtype=dtype, order=order)
+
+
+def device_array(*args, **kwargs):
+    return FakeCUDAArray(np.ndarray(*args, **kwargs))
+
+
+def device_array_like(ary, stream=0):
+    return FakeCUDAArray(np.empty_like(ary))
+
+
+# Fake devicearray.auto_device
+class devicearray(object):
+    @staticmethod
+    def auto_device(ary):
+        return to_device(ary)
+

--- a/numba/cuda/simulator/array.py
+++ b/numba/cuda/simulator/array.py
@@ -28,7 +28,7 @@ class FakeCUDAArray(object):
         try:
             attr = getattr(self._ary, attrname)
             return attr
-        except AttributeError:
+        except AttributeError as e:
             raise_from(AttributeError("Wrapped array has no attribute '%s'"
                                       % attrname), e)
 
@@ -48,15 +48,15 @@ class FakeCUDAArray(object):
         return ary
 
     def copy_to_device(self, ary, stream=0):
-       '''
-       Copy from the provided array into this array.
+        '''
+        Copy from the provided array into this array.
 
-       This may be less forgiving than the CUDA Python implementation, which
-       will copy data up to the length of the smallest of the two arrays,
-       whereas this uses np.copyto, which expects the size of the arrays to be
-       equal.
-       '''
-       np.copyto(self._ary, ary)
+        This may be less forgiving than the CUDA Python implementation, which
+        will copy data up to the length of the smallest of the two arrays,
+        whereas this uses np.copyto, which expects the size of the arrays to be
+        equal.
+        '''
+        np.copyto(self._ary, ary)
 
     def to_host(self):
         warn('to_host() is deprecated and will be removed')
@@ -72,10 +72,10 @@ class FakeCUDAArray(object):
         return FakeCUDAArray(self._ary.reshape(*args, **kwargs))
 
     def is_c_contiguous(self):
-       return self._ary.flags.c_contiguous
+        return self._ary.flags.c_contiguous
 
     def is_f_contiguous(self):
-       return self._ary.flags.f_contiguous
+        return self._ary.flags.f_contiguous
 
     def __str__(self):
         return str(self._ary)

--- a/numba/cuda/simulator/compiler.py
+++ b/numba/cuda/simulator/compiler.py
@@ -1,0 +1,6 @@
+'''
+The compiler is not implemented in the simulator. This module provides a stub
+to allow tests to import successfully.
+'''
+
+compile_kernel = None

--- a/numba/cuda/simulator/cudadrv/__init__.py
+++ b/numba/cuda/simulator/cudadrv/__init__.py
@@ -1,0 +1,1 @@
+from . import devicearray, devices, driver, drvapi, nvvm

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -1,0 +1,9 @@
+'''
+The Device Array API is not implemented in the simulator. This module provides
+stubs to allow tests to import correctly.
+'''
+
+DeviceRecord = None
+from_record_like = None
+auto_device = None
+

--- a/numba/cuda/simulator/cudadrv/devices.py
+++ b/numba/cuda/simulator/cudadrv/devices.py
@@ -1,0 +1,68 @@
+class FakeCUDAContext(object):
+    '''
+    This stub implements functionality only for simulating a single GPU
+    at the moment.
+    '''
+    def __init__(self, device):
+        self._device = device
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+       pass
+
+    def __str__(self):
+        return "<Managed Device {self.id}>".format(self=self)
+
+    @property
+    def id(self):
+        return self._device
+
+    @property
+    def compute_capability(self):
+        return (5, 2)
+
+
+class FakeDeviceList(object):
+    '''
+    This stub implements a device list containing a single GPU. It also
+    keeps track of the GPU status, i.e. whether the context is closed or not,
+    which may have been set by the user calling reset()
+    '''
+    def __init__(self):
+        self.lst = (FakeCUDAContext(0),)
+        self.closed = False
+
+    def __getitem__(self, devnum):
+        self.closed = False
+        return self.lst[devnum]
+
+    def __str__(self):
+        return ', '.join([str(d) for d in self.lst])
+
+    def __iter__(self):
+        return iter(self.lst)
+
+    def __len__(self):
+        return len(self.lst)
+
+    @property
+    def current(self):
+        if self.closed:
+            return None
+        return self.lst[0]
+
+
+gpus = FakeDeviceList()
+
+
+def reset():
+    gpus[0].closed = True
+
+
+def require_context(func):
+    '''
+    In the simulator, a context is always "available", so this is a no-op.
+    '''
+    return func

--- a/numba/cuda/simulator/cudadrv/driver.py
+++ b/numba/cuda/simulator/cudadrv/driver.py
@@ -1,0 +1,15 @@
+'''
+Most of the driver API is unsupported in the simulator, but some stubs are
+provided to allow tests to import correctly.
+'''
+
+host_to_device = None
+device_to_host = None
+
+class FakeDriver(object):
+    def get_device_count(self):
+        return 1
+
+driver = FakeDriver()
+
+Linker = None

--- a/numba/cuda/simulator/cudadrv/drvapi.py
+++ b/numba/cuda/simulator/cudadrv/drvapi.py
@@ -1,0 +1,4 @@
+'''
+drvapi is not implemented in the simulator, but this module exists to allow
+tests to import correctly.
+'''

--- a/numba/cuda/simulator/cudadrv/nvvm.py
+++ b/numba/cuda/simulator/cudadrv/nvvm.py
@@ -1,0 +1,21 @@
+'''
+NVVM is not supported in the simulator, but stubs are provided to allow tests
+to import correctly.
+'''
+
+class NvvmSupportError(ImportError):
+    pass
+
+class NVVM(object):
+    def __init__(self):
+        raise NvvmSupportError('NVVM not supported in the simulator')
+
+CompilationUnit = None
+llvm_to_ptx = None
+set_cuda_kernel = None
+fix_data_layout = None
+get_arch_option = None
+SUPPORTED_CC = None
+LibDevice = None
+NvvmError = None
+

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -1,0 +1,180 @@
+from __future__ import print_function
+from .array import to_device
+from .kernelapi import Dim3, FakeCUDAModule, swapped_cuda_module
+from six import reraise
+import numpy as np
+import sys
+import threading
+
+
+class FakeCUDAKernel(object):
+    '''
+    Wraps a @cuda.jit-ed function.
+    '''
+
+    def __init__(self, fn, device, fastmath=False):
+        self.fn = fn
+        self._device = device
+        self._fastmath = fastmath
+        # Initial configuration: 1 block, 1 thread, stream 0, no dynamic shared
+        # memory.
+        self[1, 1, 0, 0]
+
+    def __call__(self, *args):
+        if self._device:
+            return self.fn(*args)
+
+        fake_cuda_module = FakeCUDAModule(self.grid_dim, self.block_dim,
+                                          self.dynshared_size)
+        # fake_args substitutes all numpy arrays for FakeCUDAArrays
+        # because they implement some semantics differently
+        def fake_arg(arg):
+            if isinstance(arg, np.ndarray) and arg.ndim > 0:
+                return to_device(arg)
+            return arg
+        fake_args = [fake_arg(arg) for arg in args]
+
+        with swapped_cuda_module(self.fn, fake_cuda_module):
+            # Execute one block at a time
+            for grid_point in np.ndindex(*self.grid_dim):
+                bm = BlockManager(self.fn, self.grid_dim, self.block_dim)
+                bm.run(grid_point, *fake_args)
+
+    def __getitem__(self, configuration):
+        grid_dim = configuration[0]
+        block_dim = configuration[1]
+
+        if not isinstance(grid_dim, (tuple, list)):
+            grid_dim = [grid_dim]
+        else:
+            grid_dim = list(grid_dim)
+
+        if not isinstance(block_dim, (tuple, list)):
+            block_dim = [block_dim]
+        else:
+            block_dim = list(block_dim)
+
+        while len(grid_dim) < 3:
+            grid_dim.append(1)
+
+        while len(block_dim) < 3:
+            block_dim.append(1)
+
+        self.grid_dim = grid_dim
+        self.block_dim = block_dim
+
+        if len(configuration) == 4:
+            self.dynshared_size = configuration[3]
+
+        return self
+
+    def bind(self):
+        pass
+
+    @property
+    def ptx(self):
+        '''
+        Required in order to proceed through some tests, but serves no functional
+        purpose.
+        '''
+        res = '.const'
+        res += '\n.local'
+        if self._fastmath:
+            res += '\ndiv.full.ftz.f32'
+        return res
+
+
+# Thread emulation
+
+
+class BlockThread(threading.Thread):
+    '''
+    Manages the execution of a function for a single CUDA thread.
+    '''
+    def __init__(self, f, manager, blockIdx, threadIdx):
+        super(BlockThread, self).__init__(target=f)
+        self.syncthreads_event = threading.Event()
+        self.syncthreads_blocked = False
+        self._manager = manager
+        self.blockIdx = Dim3(*blockIdx)
+        self.threadIdx = Dim3(*threadIdx)
+        self.exception = None
+
+    def run(self):
+        try:
+            super(BlockThread, self).run()
+        except Exception as e:
+            tid = 'tid=%s' % list(self.threadIdx)
+            ctaid = 'ctaid=%s' % list(self.blockIdx)
+            if str(e) == '':
+                msg = '%s %s' % (tid, ctaid)
+            else:
+                msg = '%s %s: %s' % (tid, ctaid, e)
+            tb = sys.exc_info()[2]
+            self.exception = (type(e), type(e)(msg), tb)
+
+    def syncthreads(self):
+        self.syncthreads_blocked = True
+        self.syncthreads_event.wait()
+        self.syncthreads_event.clear()
+
+    def __str__(self):
+        return 'Thread <<<%s, %s>>>' % (self.blockIdx, self.threadIdx)
+
+
+class BlockManager(object):
+    '''
+    Manages the execution of a thread block.
+
+    When run() is called, all threads are started. Each thread executes until it
+    hits syncthreads(), at which point it sets its own syncthreads_blocked to
+    True so that the BlockManager knows it is blocked. It then waits on its
+    syncthreads_event.
+
+    The BlockManager polls threads to determine if they are blocked in
+    syncthreads(). If it finds a blocked thread, it adds it to the set of
+    blocked threads. When all threads are blocked, it unblocks all the threads.
+    The thread are unblocked by setting their syncthreads_blocked back to False
+    and setting their syncthreads_event.
+
+    The polling continues until no threads are alive, when execution is
+    complete.
+    '''
+    def __init__(self, f, grid_dim, block_dim):
+        self._grid_dim = grid_dim
+        self._block_dim = block_dim
+        self._f = f
+
+    def run(self, grid_point, *args):
+        # Create all threads
+        threads = set()
+        livethreads = set()
+        blockedthreads = set()
+        for block_point in np.ndindex(*self._block_dim):
+            def target():
+                self._f(*args)
+            t = BlockThread(target, self, grid_point, block_point)
+            t.start()
+            threads.add(t)
+            livethreads.add(t)
+
+        # Potential optimisations:
+        # 1. Continue the while loop immediately after finding a blocked thread
+        # 2. Don't poll already-blocked threads
+        while livethreads:
+            for t in livethreads:
+                if t.syncthreads_blocked:
+                    blockedthreads.add(t)
+                elif t.exception:
+                    reraise(*(t.exception))
+            if livethreads == blockedthreads:
+                for t in blockedthreads:
+                    t.syncthreads_blocked = False
+                    t.syncthreads_event.set()
+                blockedthreads = set()
+            livethreads = set([ t for t in livethreads if t.is_alive() ])
+        # Final check for exceptions in case any were set prior to thread
+        # finishing, before we could check it
+        for t in threads:
+            if t.exception:
+                reraise(*(t.exception))

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from .array import to_device
 from .kernelapi import Dim3, FakeCUDAModule, swapped_cuda_module
-from six import reraise
+from numba.six import reraise
 import numpy as np
 import sys
 import threading

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -35,7 +35,7 @@ class FakeCUDALocal(object):
     CUDA Local arrays
     '''
     def array(self, shape, dtype):
-        dtype = numpy_support.to_dtype(dtype)
+        dtype = numpy_support.as_dtype(dtype)
         return np.empty(shape, dtype)
 
 
@@ -71,14 +71,14 @@ class FakeCUDAShared(object):
         self._dynshared = np.zeros(dynshared_size, dtype=np.byte)
 
     def array(self, shape, dtype):
-        dtype = numpy_support.to_dtype(dtype)
+        dtype = numpy_support.as_dtype(dtype)
         # Dynamic shared memory is requested with size 0 - this all shares the
         # same underlying memory
         if shape == 0:
             # Count must be the maximum number of whole elements that fit in the
             # buffer (Numpy complains if the buffer is not a multiple of the
             # element size)
-            count = self._dynshared_size // dtype(0).itemsize
+            count = self._dynshared_size // dtype.itemsize
             return np.frombuffer(self._dynshared.data, dtype=dtype, count=count)
 
         # Otherwise, identify allocations by source file and line number

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -1,0 +1,198 @@
+'''
+Implements the cuda module as called from within an executing kernel
+(@cuda.jit-decorated function).
+'''
+
+import numpy as np
+import threading
+import traceback
+from contextlib import contextmanager
+from numba import types, numpy_support
+
+class Dim3(object):
+    '''
+    Used to implement thread/block indices/dimensions
+    '''
+    def __init__(self, x, y, z):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def __str__(self):
+        return '(%s, %s, %s)' % (self.x, self.y, self.z)
+
+    def __repr__(self):
+        return 'Dim3(%s, %s, %s)' % (self.x, self.y, self.z)
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+        yield self.z
+
+
+class FakeCUDALocal(object):
+    '''
+    CUDA Local arrays
+    '''
+    def array(self, shape, dtype):
+        dtype = numpy_support.to_dtype(dtype)
+        return np.empty(shape, dtype)
+
+
+class FakeCUDAConst(object):
+    '''
+    CUDA Const arrays
+    '''
+    def array_like(self, ary):
+        return ary
+
+
+class FakeCUDAShared(object):
+    '''
+    CUDA Shared arrays.
+
+    Limitations: assumes that only one call to cuda.shared.array is on a line,
+    and that that line is only executed once per thread. i.e.::
+
+        a = cuda.shared.array(...); b = cuda.shared.array(...)
+
+    will erroneously alias a and b, and::
+
+        for i in range(10):
+            sharedarrs[i] = cuda.shared.array(...)
+
+    will alias all arrays created at that point (though it is not certain that
+    this would be supported by Numba anyway).
+    '''
+
+    def __init__(self, dynshared_size):
+        self._allocations = {}
+        self._dynshared_size = dynshared_size
+        self._dynshared = np.zeros(dynshared_size, dtype=np.byte)
+
+    def array(self, shape, dtype):
+        dtype = numpy_support.to_dtype(dtype)
+        # Dynamic shared memory is requested with size 0 - this all shares the
+        # same underlying memory
+        if shape == 0:
+            # Count must be the maximum number of whole elements that fit in the
+            # buffer (Numpy complains if the buffer is not a multiple of the
+            # element size)
+            count = self._dynshared_size // dtype(0).itemsize
+            return np.frombuffer(self._dynshared.data, dtype=dtype, count=count)
+
+        # Otherwise, identify allocations by source file and line number
+        caller = traceback.extract_stack()[-2][0:2]
+        res = self._allocations.get(caller)
+        if res is None:
+            res = np.empty(shape, dtype)
+            self._allocations[caller] = res
+        return res
+
+addlock = threading.Lock()
+maxlock = threading.Lock()
+
+class FakeCUDAAtomic(object):
+    def add(self, array, index, val):
+        with addlock:
+            array[index] += val
+
+    def max(self, array, index, val):
+        with maxlock:
+            # CUDA Python's semantics for max differ from Numpy's Python's,
+            # so we have special handling here (CUDA Python treats NaN as
+            # missing data).
+            if np.isnan(array[index]):
+                array[index] = val
+            elif np.isnan(val):
+                return
+            array[index] = max(array[index], val)
+
+class FakeCUDAModule(object):
+    '''
+    An instance of this class will be injected into the __globals__ for an
+    executing function in order to implement calls to cuda.*. This will fail to
+    work correctly if the user code does::
+
+        from numba import cuda as something_else
+
+    In other words, the CUDA module must be called cuda.
+    '''
+
+    def __init__(self, grid_dim, block_dim, dynshared_size):
+        self.gridDim = Dim3(*grid_dim)
+        self.blockDim = Dim3(*block_dim)
+        self._local = FakeCUDALocal()
+        self._shared = FakeCUDAShared(dynshared_size)
+        self._const = FakeCUDAConst()
+        self._atomic = FakeCUDAAtomic()
+
+    @property
+    def local(self):
+        return self._local
+
+    @property
+    def shared(self):
+        return self._shared
+
+    @property
+    def const(self):
+        return self._const
+
+    @property
+    def atomic(self):
+        return self._atomic
+
+    @property
+    def threadIdx(self):
+        return threading.current_thread().threadIdx
+
+    @property
+    def blockIdx(self):
+        return threading.current_thread().blockIdx
+
+    def syncthreads(self):
+        threading.current_thread().syncthreads()
+
+    def grid(self, n):
+        bdim = self.blockDim
+        bid = self.blockIdx
+        tid = self.threadIdx
+        x = bid.x * bdim.x + tid.x
+        if n == 1:
+            return x
+        y = bid.y * bdim.y + tid.y
+        if n == 2:
+            return (x, y)
+        z = bid.z * bdim.z + tid.z
+        if n == 3:
+            return (x, y, z)
+
+        raise RuntimeError("Global ID has 1-3 dimensions. %d requested" % n)
+
+    def gridsize(self, n):
+        bdim = self.blockDim
+        gdim = self.gridDim
+        x = bdim.x * gdim.x
+        if n == 1:
+            return x
+        y = bdim.y * gdim.y
+        if n == 2:
+            return (x, y)
+        z = bdim.z * gdim.z
+        if n == 3:
+            return (x, y, z)
+
+        raise RuntimeError("Global grid has 1-3 dimensions. %d requested" % n)
+
+
+@contextmanager
+def swapped_cuda_module(fn, fake_cuda_module):
+    fn_globs = fn.__globals__
+    original_cuda, fn_globs['cuda'] = fn_globs['cuda'], fake_cuda_module
+    try:
+        yield
+    finally:
+        fn_globs['cuda'] = original_cuda
+
+

--- a/numba/cuda/simulator_init.py
+++ b/numba/cuda/simulator_init.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+from .simulator import *
+
+
+def is_available():
+    """Returns a boolean to indicate the availability of a CUDA GPU.
+    """
+    # Simulator is always available
+    return True
+
+
+def cuda_error():
+    """Returns None or an exception if the CUDA driver fails to initialize.
+    """
+    # Simulator never fails to initialize
+    return None
+
+
+

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, absolute_import, division
-from numba import unittest_support as unittest
+from numba import config, unittest_support as unittest
 
 
 class CUDATestCase(unittest.TestCase):
@@ -7,3 +7,7 @@ class CUDATestCase(unittest.TestCase):
         from numba.cuda.cudadrv.devices import reset
 
         reset()
+
+
+def skip_on_cudasim(reason):
+    return unittest.skipIf(config.ENABLE_CUDASIM, reason)

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -4,8 +4,10 @@ from numba.cuda.cudadrv.devicearray import (DeviceRecord, from_record_like,
                                             auto_device)
 from numba import cuda, numpy_support
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 import numpy as np
 
+@skip_on_cudasim('Device Record API unsupported in the simulator')
 class TestCudaDeviceRecord(unittest.TestCase):
     """
     Tests the DeviceRecord class with np.void host types.

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -4,6 +4,7 @@ from ctypes import c_int, sizeof
 from numba.cuda.cudadrv.driver import host_to_device, device_to_host
 from numba.cuda.cudadrv import devices
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 
 ptx1 = '''
     .version 1.4
@@ -58,6 +59,7 @@ ptx2 = '''
 '''
 
 
+@skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 class TestCudaDriver(unittest.TestCase):
     def setUp(self):
         self.assertTrue(len(devices.gpus) > 0)

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -3,8 +3,10 @@ import numpy
 from numba.cuda.cudadrv import driver, drvapi, devices
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.utils import IS_PY3
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('CUDA Memory API unsupported in the simulator')
 class TestCudaMemory(CUDATestCase):
     def setUp(self):
         self.context = devices.get_context()
@@ -39,6 +41,7 @@ class TestCudaMemory(CUDATestCase):
         self._template(devmem)
 
 
+@skip_on_cudasim('CUDA Memory API unsupported in the simulator')
 class TestCudaMemoryFunctions(CUDATestCase):
     def setUp(self):
         self.context = devices.get_context()
@@ -82,6 +85,7 @@ class TestCudaMemoryFunctions(CUDATestCase):
         self.assertTrue(numpy.all(hst == hst2))
 
 
+@skip_on_cudasim('CUDA Memory API unsupported in the simulator')
 class TestMVExtent(CUDATestCase):
     def test_c_contiguous_array(self):
         ary = numpy.arange(100)

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -2,8 +2,10 @@ import numpy as np
 from numba.cuda.cudadrv import devicearray
 from numba import cuda
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('Device Array API unsupported in the simulator')
 class TestCudaNDArray(unittest.TestCase):
     def test_device_array_interface(self):
         dary = cuda.device_array(shape=100)

--- a/numba/cuda/tests/cudadrv/test_host_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_host_alloc.py
@@ -3,8 +3,10 @@ import numpy as np
 from numba.cuda.cudadrv import driver
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 class TestHostAlloc(CUDATestCase):
     def test_host_alloc_driver(self):
         n = 32

--- a/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -3,8 +3,10 @@ from llvmlite.llvmpy.core import Module, Type, Builder, InlineAsm
 from llvmlite import binding as ll
 from numba.cuda.cudadrv import nvvm
 from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('Inline PTX cannot be used in the simulator')
 class TestCudaInlineAsm(CUDATestCase):
     def test_inline_rsqrt(self):
         mod = Module.new(__name__)

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -2,11 +2,12 @@ from __future__ import print_function, absolute_import, division
 import os.path
 import numpy as np
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 from numba.cuda.cudadrv.driver import Linker
 from numba.cuda import require_context
 from numba import cuda
 
-
+@skip_on_cudasim('Linking unsupported in the simulator')
 class TestLinker(unittest.TestCase):
 
     @require_context

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -7,10 +7,12 @@ from numba.cuda.cudadrv.nvvm import (NVVM, CompilationUnit, llvm_to_ptx,
 from ctypes import c_size_t, c_uint64, sizeof
 from numba.cuda.testing import unittest
 from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError
+from numba.cuda.testing import skip_on_cudasim
 
 is64bit = sizeof(c_size_t) == sizeof(c_uint64)
 
 
+@skip_on_cudasim('NVVM Driver unsupported in the simulator')
 class TestNvvmDriver(unittest.TestCase):
     def get_ptx(self):
         nvvm = NVVM()
@@ -79,6 +81,7 @@ class TestNvvmDriver(unittest.TestCase):
                 self.assertIn(pat, raises.msg)
 
 
+@skip_on_cudasim('NVVM Driver unsupported in the simulator')
 class TestArchOption(unittest.TestCase):
     def test_get_arch_option(self):
         self.assertEqual(get_arch_option(2, 0), 'compute_20')
@@ -94,6 +97,7 @@ class TestArchOption(unittest.TestCase):
                          'compute_%d%d' % SUPPORTED_CC[-1])
 
 
+@skip_on_cudasim('NVVM Driver unsupported in the simulator')
 class TestLibDevice(unittest.TestCase):
     def _libdevice_load(self, arch, expect):
         libdevice = LibDevice(arch=arch)

--- a/numba/cuda/tests/cudadrv/test_profiler.py
+++ b/numba/cuda/tests/cudadrv/test_profiler.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, print_function
 import numba.unittest_support as unittest
 from numba.cuda.testing import CUDATestCase
 from numba import cuda
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('CUDA Profiler unsupported in the simulator')
 class TestProfiler(CUDATestCase):
     def test_profiling(self):
         with cuda._profiling():

--- a/numba/cuda/tests/cudapy/test_alignment.py
+++ b/numba/cuda/tests/cudapy/test_alignment.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numba import from_dtype, cuda
 from numba import unittest_support as unittest
-
+from numba.cuda.testing import skip_on_cudasim
 
 class TestAlignment(unittest.TestCase):
     def test_record_alignment(self):
@@ -23,6 +23,7 @@ class TestAlignment(unittest.TestCase):
 
         self.assertTrue(np.all(a_recarray.a == a_recarray.b))
 
+    @skip_on_cudasim('Simulator does not check alignment')
     def test_record_alignment_error(self):
         rec_dtype = np.dtype([('a', 'int32'), ('b', 'float64')])
         rec = from_dtype(rec_dtype)

--- a/numba/cuda/tests/cudapy/test_autojit.py
+++ b/numba/cuda/tests/cudapy/test_autojit.py
@@ -2,8 +2,10 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 from numba import cuda
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 
 
+@skip_on_cudasim('Simulator does not have definitions attribute')
 class TestCudaAutoJit(unittest.TestCase):
     def test_autojit(self):
         @cuda.autojit

--- a/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba/cuda/tests/cudapy/test_debug.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 
 import numpy as np
 
+from numba.cuda.testing import skip_on_cudasim
 from numba.tests.support import override_config, captured_stdout
 from numba import unittest_support as unittest
 from numba import cuda, float64
@@ -12,6 +13,7 @@ def simple_cuda(A, B):
     B[i] = A[i] + 1.5
 
 
+@skip_on_cudasim('Simulator does not produce debug dumps')
 class TestDebugOutput(unittest.TestCase):
 
     def compile_simple_cuda(self):

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, absolute_import
 import numpy
-from numba import jit, cuda
+from numba import config, cuda, jit
 from numba.cuda.testing import unittest
 
 
@@ -14,7 +14,10 @@ class TestException(unittest.TestCase):
         unsafe_foo = jit(target='cuda')(foo)
         safe_foo = jit(target='cuda', debug=True)(foo)
 
-        unsafe_foo[1, 2](numpy.array([0,1]))
+        if not config.ENABLE_CUDASIM:
+            # Simulator throws exceptions regardless of debug
+            # setting
+            unsafe_foo[1, 2](numpy.array([0,1]))
 
         with self.assertRaises(IndexError) as cm:
             safe_foo[1, 2](numpy.array([0,1]))

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, division, absolute_import
 from numba import cuda, float64, intp
 from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
 from numba.utils import StringIO
 
 
+@skip_on_cudasim('Simulator does not generate code to be inspected')
 class TestInspect(unittest.TestCase):
     def test_monotyped(self):
         @cuda.jit("(float32, int32)")

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -1,12 +1,15 @@
 from __future__ import print_function, absolute_import, division
 import numpy as np
 import time
-from numba import cuda, float64, void
+from numba import cuda, config, float64, void
 from numba.cuda.testing import unittest
 
 # NOTE: CUDA kernel does not return any value
 
-tpb = 16
+if config.ENABLE_CUDASIM:
+    tpb = 4
+else:
+    tpb = 16
 SM_SIZE = tpb, tpb
 
 
@@ -62,15 +65,18 @@ def jocabi_relax_core(A, Anew, error):
 
 class TestCudaLaplace(unittest.TestCase):
     def test_laplace_small(self):
-        NN = 256
-        NM = 256
+        if config.ENABLE_CUDASIM:
+            NN, NM = 4, 4
+            iter_max = 20
+        else:
+            NN, NM = 256, 256
+            iter_max = 1000
 
         A = np.zeros((NN, NM), dtype=np.float64)
         Anew = np.zeros((NN, NM), dtype=np.float64)
 
         n = NN
         m = NM
-        iter_max = 1000
 
         tol = 1.0e-6
         error = 1.0

--- a/numba/cuda/tests/cudapy/test_macro.py
+++ b/numba/cuda/tests/cudapy/test_macro.py
@@ -3,6 +3,7 @@ import numpy as np
 from numba import cuda, float32
 from numba.cuda.testing import unittest
 from numba.macro import MacroError
+from numba.cuda.testing import skip_on_cudasim
 
 GLOBAL_CONSTANT = 5
 GLOBAL_CONSTANT_2 = 6
@@ -62,6 +63,7 @@ class TestMacro(unittest.TestCase):
         udt = cuda.jit((float32[:, :],))(udt_global_build_tuple)
         udt(self.getarg2())
 
+    @skip_on_cudasim('Simulator does not perform macro expansion')
     def test_global_build_list(self):
         with self.assertRaises(MacroError) as raises:
             cuda.jit((float32[:, :],))(udt_global_build_list)
@@ -73,6 +75,7 @@ class TestMacro(unittest.TestCase):
         udt = cuda.jit((float32[:, :],))(udt_global_constant_tuple)
         udt(self.getarg2())
 
+    @skip_on_cudasim("Can't check for constants in simulator")
     def test_invalid_1(self):
         with self.assertRaises(ValueError) as raises:
             cuda.jit((float32[:],))(udt_invalid_1)
@@ -80,6 +83,7 @@ class TestMacro(unittest.TestCase):
         self.assertIn("Argument 'shape' must be a constant at",
                       str(raises.exception))
 
+    @skip_on_cudasim("Can't check for constants in simulator")
     def test_invalid_2(self):
         with self.assertRaises(ValueError) as raises:
             cuda.jit((float32[:, :],))(udt_invalid_2)

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -1,11 +1,15 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 from timeit import default_timer as time
-from numba import cuda, float32
+from numba import cuda, config, float32
 from numba.cuda.testing import unittest
 
-bpg = 50
-tpb = 32
+# Ensure the test takes a reasonable amount of time in the simulator
+if config.ENABLE_CUDASIM:
+    bpg, tpb = 2, 8
+else:
+    bpg, tpb = 50, 32
+
 n = bpg * tpb
 SM_SIZE = (tpb, tpb)
 

--- a/numba/cuda/tests/cudapy/test_multigpu.py
+++ b/numba/cuda/tests/cudapy/test_multigpu.py
@@ -1,6 +1,7 @@
 from numba import cuda
 import numpy as np
 from numba import unittest_support as unittest
+from numba.cuda.testing import skip_on_cudasim
 import threading
 
 
@@ -47,6 +48,7 @@ class TestMultiGPUContext(unittest.TestCase):
         copy_plus_1[1, N](A, B)
         check(A, B)
 
+    @skip_on_cudasim('Simulator does not support multiple threads')
     def test_multithreaded(self):
         def work(gpu, dA, results, ridx):
             try:

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 from numba import cuda, numpy_support, types
 from numba import unittest_support as unittest
+from numba.cuda.testing import skip_on_cudasim
 
 
 def set_a(ary, i, v):
@@ -264,6 +265,7 @@ class TestRecordDtype(unittest.TestCase):
 
         np.testing.assert_equal(rec['j'], arr)
 
+@skip_on_cudasim('Attribute access of structured arrays not supported in simulator')
 class TestRecordDtypeWithStructArrays(TestRecordDtype):
     '''
     Same as TestRecordDtype, but using structured arrays instead of recarrays.

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from numba.cuda.compiler import compile_kernel
 from numba.cuda.cudadrv import nvvm
+from numba.cuda.testing import skip_on_cudasim
 from numba import unittest_support as unittest
 from numba import types
 
@@ -14,6 +15,7 @@ def has_nvvm_lib():
         return True
 
 
+@skip_on_cudasim('libNVVM not supported in simulator')
 @unittest.skipIf(not has_nvvm_lib(), "No libNVVM")
 class TestNvvmWithoutCuda(unittest.TestCase):
     def test_nvvm_llvm_to_ptx(self):

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division, absolute_import
 import warnings
 from . import config, sigutils
 from .targets import registry
+from . import cuda
 
 # -----------------------------------------------------------------------------
 # Decorators
@@ -146,6 +147,8 @@ def jit(signature_or_function=None, locals={}, target='cpu', **options):
     else:
         # A function is passed
         pyfunc = signature_or_function
+        if config.ENABLE_CUDASIM and target == 'cuda':
+            return cuda.jit(pyfunc)
         if config.DISABLE_JIT and not target == 'npyufunc':
             return DisableJitWrapper(pyfunc)
         dispatcher = registry.target_registry[target]

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -31,6 +31,25 @@ FROM_DTYPE = {
     numpy.dtype('complex128'): types.complex128,
 }
 
+TO_DTYPE = {
+    types.boolean: numpy.bool,
+    types.int8: numpy.int8,
+    types.int16: numpy.int16,
+    types.int32: numpy.int32,
+    types.int64: numpy.int64,
+
+    types.uint8: numpy.uint8,
+    types.uint16: numpy.uint16,
+    types.uint32: numpy.uint32,
+    types.uint64: numpy.uint64,
+
+    types.float32: numpy.float32,
+    types.float64: numpy.float64,
+
+    types.complex64: numpy.complex64,
+    types.complex128: numpy.complex128,
+}
+
 re_typestr = re.compile(r'[<>=\|]([a-z])(\d+)?$', re.I)
 re_datetimestr = re.compile(r'[<>=\|]([mM])8?(\[([a-z]+)\])?$', re.I)
 
@@ -97,6 +116,16 @@ def from_dtype(dtype):
     else:
         return from_struct_dtype(dtype)
 
+def to_dtype(numba_type):
+    '''
+    Return a Numpy dtype corresponding to a given Numba type instance
+    '''
+    if isinstance(numba_type, numpy.dtype):
+        return numba_type
+    try:
+        return TO_DTYPE[numba_type]
+    except KeyError:
+        raise NotImplementedError(numba_type)
 
 _as_dtype_letters = {
     types.NPDatetime: 'M8',

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -31,25 +31,6 @@ FROM_DTYPE = {
     numpy.dtype('complex128'): types.complex128,
 }
 
-TO_DTYPE = {
-    types.boolean: numpy.bool,
-    types.int8: numpy.int8,
-    types.int16: numpy.int16,
-    types.int32: numpy.int32,
-    types.int64: numpy.int64,
-
-    types.uint8: numpy.uint8,
-    types.uint16: numpy.uint16,
-    types.uint32: numpy.uint32,
-    types.uint64: numpy.uint64,
-
-    types.float32: numpy.float32,
-    types.float64: numpy.float64,
-
-    types.complex64: numpy.complex64,
-    types.complex128: numpy.complex128,
-}
-
 re_typestr = re.compile(r'[<>=\|]([a-z])(\d+)?$', re.I)
 re_datetimestr = re.compile(r'[<>=\|]([mM])8?(\[([a-z]+)\])?$', re.I)
 
@@ -116,16 +97,6 @@ def from_dtype(dtype):
     else:
         return from_struct_dtype(dtype)
 
-def to_dtype(numba_type):
-    '''
-    Return a Numpy dtype corresponding to a given Numba type instance
-    '''
-    if isinstance(numba_type, numpy.dtype):
-        return numba_type
-    try:
-        return TO_DTYPE[numba_type]
-    except KeyError:
-        raise NotImplementedError(numba_type)
 
 _as_dtype_letters = {
     types.NPDatetime: 'M8',

--- a/numba/six.py
+++ b/numba/six.py
@@ -1,6 +1,6 @@
 """Utilities for writing code that runs on Python 2 and 3"""
 
-# Copyright (c) 2010-2014 Benjamin Peterson
+# Copyright (c) 2010-2015 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,16 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Numba addition to prevent importing of numba.types as types
 from __future__ import absolute_import
 
 import functools
+import itertools
 import operator
 import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.7.3"
+__version__ = "1.9.0"
 
 
 # Useful for very coarse version differentiation.
@@ -89,8 +89,12 @@ class _LazyDescr(object):
     def __get__(self, obj, tp):
         result = self._resolve()
         setattr(obj, self.name, result) # Invokes __set__.
-        # This is a bit ugly, but it avoids running this again.
-        delattr(obj.__class__, self.name)
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
         return result
 
 
@@ -228,10 +232,12 @@ _moved_attributes = [
     MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
     MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
     MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
     MovedAttribute("map", "itertools", "builtins", "imap", "map"),
     MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
     MovedAttribute("reload_module", "__builtin__", "imp", "reload"),
     MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
     MovedAttribute("StringIO", "StringIO", "io"),
     MovedAttribute("UserDict", "UserDict", "collections"),
     MovedAttribute("UserList", "UserList", "collections"),
@@ -323,6 +329,11 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("splitquery", "urllib", "urllib.parse"),
     MovedAttribute("splittag", "urllib", "urllib.parse"),
     MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
 ]
 for attr in _urllib_parse_moved_attributes:
     setattr(Module_six_moves_urllib_parse, attr.name, attr)
@@ -548,6 +559,12 @@ if PY3:
 
     def iterlists(d, **kw):
         return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
 else:
     def iterkeys(d, **kw):
         return iter(d.iterkeys(**kw))
@@ -560,6 +577,12 @@ else:
 
     def iterlists(d, **kw):
         return iter(d.iterlists(**kw))
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
 
 _add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
 _add_doc(itervalues, "Return an iterator over the values of a dictionary.")
@@ -587,6 +610,9 @@ if PY3:
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    _assertRaisesRegex = "assertRaisesRegex"
+    _assertRegex = "assertRegex"
 else:
     def b(s):
         return s
@@ -599,12 +625,26 @@ else:
         return ord(bs[0])
     def indexbytes(buf, i):
         return ord(buf[i])
-    def iterbytes(buf):
-        return (ord(byte) for byte in buf)
+    iterbytes = functools.partial(itertools.imap, ord)
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
 
 
 if PY3:
@@ -635,6 +675,21 @@ else:
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    if from_value is None:
+        raise value
+    raise value from from_value
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    raise value from from_value
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
 
 
 print_ = getattr(moves.builtins, "print", None)
@@ -691,6 +746,14 @@ if print_ is None:
                 write(sep)
             write(arg)
         write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
 
 _add_doc(reraise, """Reraise an exception.""")
 
@@ -698,7 +761,7 @@ if sys.version_info[0:2] < (3, 4):
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
               updated=functools.WRAPPER_UPDATES):
         def wrapper(f):
-            f = functools.wraps(wrapped)(f)
+            f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
             return f
         return wrapper
@@ -720,16 +783,35 @@ def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass."""
     def wrapper(cls):
         orig_vars = cls.__dict__.copy()
-        orig_vars.pop('__dict__', None)
-        orig_vars.pop('__weakref__', None)
         slots = orig_vars.get('__slots__')
         if slots is not None:
             if isinstance(slots, str):
                 slots = [slots]
             for slots_var in slots:
                 orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
 
 # Complete the moves implementation.
 # This code is at the end of this module to speed up module loading.

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,8 @@ packages = [
     "numba.datamodel",
     "numba.cuda",
     "numba.cuda.cudadrv",
+    "numba.cuda.simulator",
+    "numba.cuda.simulator.cudadrv",
     "numba.cuda.tests",
     "numba.cuda.tests.cudadrv",
     "numba.cuda.tests.cudadrv.data",


### PR DESCRIPTION
This adds a CUDA simulator for debugging, which is enabled by setting `NUMBA_ENABLE_CUDASIM=1`. I had previously mentioned my intent to have the simulator enabled when `NUMBA_DISABLE_JIT`, but I came to the conclusion that this is a bad idea because it slows everything down in codes where the CPU and CUDA targets are both used.

This is intended to be as much of a "drop-in" replacement for the real CUDA Python implementation as is possible, so some of the driver functions are also simulated, in order to get as many tests as possible to pass - the aim is to minimise the amount of changes a user is required to make to use of the simulator, with the ideal case being that they only need to set the aforementioned environment variable.

The simulator runtime executes GPU kernels one block at a time, using one CPU thread per kernel thread. There are some opportunities for making the context switching work a bit faster, as I think the present mechanism that deals with syncthreads wastes time doing things it doesn't always need to do. However, I think it would be more straightforward to get this initial working version in then look at optimisations separately.