### PR TITLE
Fix complex ufuncs lowering and all ufuncs tests

### DIFF
--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1262,11 +1262,12 @@ class TestLoopTypes(TestCase):
         # fail in no python mode. Usually the last loop in ufuncs is an all
         # object fallback
         supported_types = getattr(self, '_supported_types', [])
-        skip_types = getattr(self, '_skip_types', [])
-        if any(l not in supported_types or l in skip_types
-               for l in letter_types):
+        if (supported_types and
+            any(l not in supported_types for l in letter_types)):
             return
-
+        skip_types = getattr(self, '_skip_types', [])
+        if any(l in skip_types for l in letter_types):
+            return
         # if the test case requires some types to be present, skip loops
         # not involving any of those types.
         required_types = getattr(self, '_required_types', [])

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1318,7 +1318,7 @@ class _TestLoopTypes(TestCase):
                 # If one is NaN and the other is zero
                 msg = "mismatch for nan values: expected {0}; got {1}"
                 print(msg.format(py, c))
-                return True
+                # This is not occurring any more
 
         elif np.abs(c) == 0 and np.abs(py) == np.abs(c):
             # If both are zeros and they are differ by sign

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -166,8 +166,8 @@ _floating_functions = [ "isfinite", "isinf", "isnan", "signbit",
 # implemented.
 #
 # It also works as a nice TODO list for ufunc support :)
-_unsupported = set([ numpy.frexp, # this one is tricky, as it has 2 returns
-                     numpy.modf,  # this one also has 2 returns
+_unsupported = set([ 'frexp', # this one is tricky, as it has 2 returns
+                     'modf',  # this one also has 2 returns
                  ])
 
 # a list of ufuncs that are in fact aliases of other ufuncs. They need to insert the


### PR DESCRIPTION
- fixes #1125 
- fixes accidental skipping for the ufunc tests
- make error due to differing error handling acceptable:
   - `0 != -0` is acceptable  (#1131)
- all tests in test_ufuncs are auto injected into the TestCase classes as test function.
   - can easily pinpoint a test now.