### PR TITLE
Add numpy array constructors

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -116,6 +116,7 @@ The following top-level functions are supported:
 * :func:`numpy.arange`
 * :func:`numpy.empty`
 * :func:`numpy.empty_like`
+* :func:`numpy.eye`
 * :func:`numpy.full`
 * :func:`numpy.full_like`
 * :func:`numpy.identity`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -113,13 +113,22 @@ Functions
 
 The following top-level functions are supported:
 
+* :func:`numpy.empty`
+* :func:`numpy.empty_like`
+* :func:`numpy.full`
+* :func:`numpy.full_like`
+* :func:`numpy.identity`
 * :class:`numpy.ndenumerate`
 * :class:`numpy.ndindex`
+* :func:`numpy.ones`
+* :func:`numpy.ones_like`
 * :func:`numpy.round_`
-* :func:`numpy.empty`
+* :func:`numpy.zeros`
+* :func:`numpy.zeros_like`
 
 The following constructors are supported, only with a numeric input:
 
+* :class:`numpy.bool_`
 * :class:`numpy.complex64`
 * :class:`numpy.complex128`
 * :class:`numpy.float32`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -113,6 +113,7 @@ Functions
 
 The following top-level functions are supported:
 
+* :func:`numpy.arange`
 * :func:`numpy.empty`
 * :func:`numpy.empty_like`
 * :func:`numpy.full`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -119,6 +119,7 @@ The following top-level functions are supported:
 * :func:`numpy.full`
 * :func:`numpy.full_like`
 * :func:`numpy.identity`
+* :func:`numpy.linspace` (only the 3-argument form)
 * :class:`numpy.ndenumerate`
 * :class:`numpy.ndindex`
 * :func:`numpy.ones`

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -402,19 +402,12 @@ class Lower(BaseLower):
                                               "when calling %s" % (fnty,))
                 args = expr.args
             else:
-                ba = pysig.bind(*expr.args, **dict(expr.kws))
-                for i, param in enumerate(pysig.parameters.values()):
-                    name = param.name
-                    default = param.default
-                    if (default is not param.empty and
-                        name not in ba.arguments):
-                        value = self.context.get_constant_generic(
-                            self.builder, signature.args[i], default)
-                        ba.arguments[name] = value
-                        defargs.add(i)
-                # This is ensured in Dispatcher.get_call_template()
-                assert not ba.kwargs
-                args = ba.args
+                def default_handler(index, default):
+                    return self.context.get_constant_generic(
+                                self.builder, signature.args[index], default)
+                args, defargs = typing.fold_arguments(pysig,
+                                                      expr.args, dict(expr.kws),
+                                                      default_handler)
 
             # Fetch and cast non-default arguments
             argvals = list(args)

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -85,17 +85,17 @@ void nrt_meminfo_call_dtor(MemInfo *mi) {
 }
 
 static
-MemInfo* meminfo_malloc() {
+MemInfo* meminfo_malloc(void) {
     void *p = malloc(sizeof(MemInfo));;
     NRT_Debug(nrt_debug_print("meminfo_malloc %p\n", p));
     return p;
 }
 
-void NRT_MemSys_init() {
+void NRT_MemSys_init(void) {
     memset(&TheMSys, 0, sizeof(MemSys));
 }
 
-void NRT_MemSys_shutdown() {
+void NRT_MemSys_shutdown(void) {
     TheMSys.shutting = 1;
     /* Revert to use our non-atomic stub for all atomic operations
        because the JIT-ed version will be removed.
@@ -105,7 +105,7 @@ void NRT_MemSys_shutdown() {
     NRT_MemSys_set_atomic_cas_stub();
 }
 
-void NRT_MemSys_process_defer_dtor() {
+void NRT_MemSys_process_defer_dtor(void) {
     MemInfo *mi;
     while ((mi = nrt_pop_meminfo_list(&TheMSys.mi_deferlist))) {
         NRT_Debug(nrt_debug_print("Defer dtor %p\n", mi));
@@ -125,7 +125,7 @@ void NRT_MemSys_insert_meminfo(MemInfo *newnode) {
     nrt_push_meminfo_list(&TheMSys.mi_freelist, newnode);
 }
 
-MemInfo* NRT_MemSys_pop_meminfo() {
+MemInfo* NRT_MemSys_pop_meminfo(void) {
     MemInfo *node = nrt_pop_meminfo_list(&TheMSys.mi_freelist);
     if (NULL == node) {
         node = meminfo_malloc();
@@ -179,12 +179,12 @@ int nrt_testing_atomic_cas(void* volatile *ptr, void *cmp, void *val,
 
 }
 
-void NRT_MemSys_set_atomic_inc_dec_stub(){
+void NRT_MemSys_set_atomic_inc_dec_stub(void){
     NRT_MemSys_set_atomic_inc_dec(nrt_testing_atomic_inc,
                                   nrt_testing_atomic_dec);
 }
 
-void NRT_MemSys_set_atomic_cas_stub() {
+void NRT_MemSys_set_atomic_cas_stub(void) {
     NRT_MemSys_set_atomic_cas(nrt_testing_atomic_cas);
 }
 
@@ -208,7 +208,7 @@ static
 void nrt_internal_dtor(void *ptr, void *info) {
     NRT_Debug(nrt_debug_print("nrt_internal_dtor %p, %p\n", ptr, info));
     if (info != NULL) {
-        memset(ptr, 0, (size_t)info);  /* for safety */
+        memset(ptr, 0xDE, (size_t)info);  /* for safety */
     }
     NRT_Free(ptr);
 }
@@ -221,7 +221,7 @@ MemInfo* NRT_MemInfo_alloc(size_t size) {
 
 MemInfo* NRT_MemInfo_alloc_safe(size_t size) {
     void *data = NRT_Allocate(size);
-    memset(data, 0, size);
+    memset(data, 0xCB, size);
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_safe %p %llu\n", data, size));
     return NRT_MemInfo_new(data, size, nrt_internal_dtor, (void*)size);
 }

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1346,10 +1346,8 @@ def _parse_empty_like_args(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.empty, types.Kind(types.Integer))
-@implement(numpy.empty, types.Kind(types.BaseTuple))
-@implement(numpy.empty, types.Kind(types.Integer), types.Kind(types.Function))
-@implement(numpy.empty, types.Kind(types.BaseTuple), types.Kind(types.Function))
+@implement(numpy.empty, types.Any)
+@implement(numpy.empty, types.Any, types.Any)
 def numpy_empty_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -1365,10 +1363,8 @@ def numpy_zeros_like_nd(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.zeros, types.Kind(types.Integer))
-@implement(numpy.zeros, types.Kind(types.BaseTuple))
-@implement(numpy.zeros, types.Kind(types.Integer), types.Kind(types.Function))
-@implement(numpy.zeros, types.Kind(types.BaseTuple), types.Kind(types.Function))
+@implement(numpy.zeros, types.Any)
+@implement(numpy.zeros, types.Any, types.Any)
 def numpy_zeros_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -1387,29 +1383,48 @@ def numpy_zeros_like_nd(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.ones, types.Kind(types.Integer))
-@implement(numpy.ones, types.Kind(types.BaseTuple))
-def numpy_ones_nd(context, builder, sig, args):
+@implement(numpy.full, types.Any, types.Any)
+def numpy_full_nd(context, builder, sig, args):
 
-    def ones(shape):
+    def full(shape, value):
         arr = numpy.empty(shape)
         for idx in numpy.ndindex(arr.shape):
-            arr[idx] = 1
+            arr[idx] = value
         return arr
 
-    return context.compile_internal(builder, ones, sig, args)
+    return context.compile_internal(builder, full, sig, args)
+
+@builtin
+@implement(numpy.full, types.Any, types.Any, types.Kind(types.Function))
+def numpy_full_dtype_nd(context, builder, sig, args):
+
+    def full(shape, value, dtype):
+        arr = numpy.empty(shape, dtype)
+        for idx in numpy.ndindex(arr.shape):
+            arr[idx] = value
+        return arr
+
+    return context.compile_internal(builder, full, sig, args)
 
 
 @builtin
-@implement(numpy.ones, types.Kind(types.Integer), types.Kind(types.Function))
-@implement(numpy.ones, types.Kind(types.BaseTuple), types.Kind(types.Function))
+@implement(numpy.ones, types.Any)
+def numpy_ones_nd(context, builder, sig, args):
+
+    def ones(shape):
+        c = 1
+        return numpy.full(shape, c)
+
+    valty = sig.return_type.dtype
+    return context.compile_internal(builder, ones, sig, args,
+                                    locals={'c': valty})
+
+@builtin
+@implement(numpy.ones, types.Any, types.Kind(types.Function))
 def numpy_ones_dtype_nd(context, builder, sig, args):
 
     def ones(shape, dtype):
-        arr = numpy.empty(shape, dtype)
-        for idx in numpy.ndindex(arr.shape):
-            arr[idx] = 1
-        return arr
+        return numpy.full(shape, 1, dtype)
 
     return context.compile_internal(builder, ones, sig, args)
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1286,23 +1286,7 @@ def _zero_fill_array(context, builder, ary):
     """
     Zero-fill an array.  The array must be contiguous.
     """
-    memset = "llvm.memset.p0i8.i%d" % (types.intp.bitwidth)
-    module = cgutils.get_module(builder)
-    ll_intp = context.get_value_type(types.intp)
-    i32 = lc.Type.int(32)
-    i8 = lc.Type.int(8)
-    i1 = lc.Type.int(1)
-    # void @llvm.memset.p0i8.i32(i8* <dest>, i8 <val>,
-    #                            i32 <len>, i32 <align>, i1 <isvolatile>)
-    ptr = builder.bitcast(ary.data, lc.Type.pointer(i8))
-    fnty = lc.Type.function(lc.Type.void(),
-                            [ptr.type, i8,
-                             context.get_value_type(types.intp),
-                             i32, i1])
-    fn = module.get_or_insert_function(fnty, name=memset)
-    builder.call(fn, [ptr, Constant.int(i8, 0),
-                      builder.mul(ary.itemsize, ary.nitems),
-                      Constant.int(i32, 0), Constant.int(i1, 0)])
+    cgutils.memset(builder, ary.data, builder.mul(ary.itemsize, ary.nitems), 0)
 
 
 def _parse_empty_args(context, builder, sig, args):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1573,3 +1573,30 @@ def numpy_arange_4(context, builder, sig, args):
     return context.compile_internal(builder, arange, sig, args,
                                     locals={'nitems': types.intp})
 
+
+@builtin
+@implement(numpy.linspace, types.Kind(types.Number), types.Kind(types.Number))
+def numpy_linspace_2(context, builder, sig, args):
+
+    def linspace(start, stop):
+        return numpy.linspace(start, stop, 50)
+
+    return context.compile_internal(builder, linspace, sig, args)
+
+@builtin
+@implement(numpy.linspace, types.Kind(types.Number), types.Kind(types.Number),
+           types.Kind(types.Integer))
+def numpy_linspace_3(context, builder, sig, args):
+    dtype = getattr(numpy, str(sig.return_type.dtype))
+
+    def linspace(start, stop, num):
+        arr = numpy.empty(num, dtype)
+        div = num - 1
+        delta = stop - start
+        arr[0] = start
+        for i in range(1, num):
+            arr[i] = start + delta * (i / div)
+        return arr
+
+    return context.compile_internal(builder, linspace, sig, args)
+

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1248,6 +1248,9 @@ def iternext_numpy_ndindex(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, result)
 
 
+# -----------------------------------------------------------------------------
+# Numpy array constructors
+
 def _empty_nd_impl(context, builder, arrtype, shapes):
     """Utility function used for allocating a new array during LLVM code
     generation (lowering).  Given a target context, builder, array
@@ -1460,10 +1463,7 @@ def numpy_ones_dtype_nd(context, builder, sig, args):
 def numpy_ones_like_nd(context, builder, sig, args):
 
     def ones_like(arr):
-        arr = numpy.empty_like(arr)
-        for idx in numpy.ndindex(arr.shape):
-            arr[idx] = 1
-        return arr
+        return numpy.full_like(arr, 1)
 
     return context.compile_internal(builder, ones_like, sig, args)
 
@@ -1472,10 +1472,32 @@ def numpy_ones_like_nd(context, builder, sig, args):
 def numpy_ones_like_dtype_nd(context, builder, sig, args):
 
     def ones_like(arr, dtype):
-        arr = numpy.empty_like(arr, dtype)
-        for idx in numpy.ndindex(arr.shape):
-            arr[idx] = 1
-        return arr
+        return numpy.full_like(arr, 1, dtype)
 
     return context.compile_internal(builder, ones_like, sig, args)
 
+
+@builtin
+@implement(numpy.identity, types.Kind(types.Integer))
+def numpy_identity(context, builder, sig, args):
+
+    def identity(n):
+        arr = numpy.zeros((n, n))
+        for i in range(n):
+            arr[i, i] = 1
+        return arr
+
+    return context.compile_internal(builder, identity, sig, args)
+
+
+@builtin
+@implement(numpy.identity, types.Kind(types.Integer), types.Kind(types.Function))
+def numpy_identity(context, builder, sig, args):
+
+    def identity(n, dtype):
+        arr = numpy.zeros((n, n), dtype)
+        for i in range(n):
+            arr[i, i] = 1
+        return arr
+
+    return context.compile_internal(builder, identity, sig, args)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1408,6 +1408,32 @@ def numpy_full_dtype_nd(context, builder, sig, args):
 
 
 @builtin
+@implement(numpy.full_like, types.Kind(types.Array), types.Any)
+def numpy_full_like_nd(context, builder, sig, args):
+
+    def full_like(arr, value):
+        arr = numpy.empty_like(arr)
+        for idx in numpy.ndindex(arr.shape):
+            arr[idx] = value
+        return arr
+
+    return context.compile_internal(builder, full_like, sig, args)
+
+
+@builtin
+@implement(numpy.full_like, types.Kind(types.Array), types.Any, types.Kind(types.Function))
+def numpy_full_like_nd(context, builder, sig, args):
+
+    def full_like(arr, value, dtype):
+        arr = numpy.empty_like(arr, dtype)
+        for idx in numpy.ndindex(arr.shape):
+            arr[idx] = value
+        return arr
+
+    return context.compile_internal(builder, full_like, sig, args)
+
+
+@builtin
 @implement(numpy.ones, types.Any)
 def numpy_ones_nd(context, builder, sig, args):
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1480,6 +1480,54 @@ def numpy_identity(context, builder, sig, args):
 
 
 @builtin
+@implement(numpy.eye, types.Kind(types.Integer))
+def numpy_eye(context, builder, sig, args):
+
+    def eye(n):
+        return numpy.identity(n)
+
+    return context.compile_internal(builder, eye, sig, args)
+
+@builtin
+@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer))
+def numpy_eye(context, builder, sig, args):
+
+    def eye(n, m):
+        return numpy.eye(n, m, 0, numpy.float64)
+
+    return context.compile_internal(builder, eye, sig, args)
+
+@builtin
+@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer),
+           types.Kind(types.Integer))
+def numpy_eye(context, builder, sig, args):
+
+    def eye(n, m, k):
+        return numpy.eye(n, m, k, numpy.float64)
+
+    return context.compile_internal(builder, eye, sig, args)
+
+@builtin
+@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer),
+           types.Kind(types.Integer), types.Kind(types.Function))
+def numpy_eye(context, builder, sig, args):
+
+    def eye(n, m, k, dtype):
+        arr = numpy.zeros((n, m), dtype)
+        if k >= 0:
+            d = min(n, m - k)
+            for i in range(d):
+                arr[i, i + k] = 1
+        else:
+            d = min(n + k, m)
+            for i in range(d):
+                arr[i - k, i] = 1
+        return arr
+
+    return context.compile_internal(builder, eye, sig, args)
+
+
+@builtin
 @implement(numpy.arange, types.Kind(types.Number))
 def numpy_arange_1(context, builder, sig, args):
     dtype = getattr(numpy, str(sig.return_type.dtype))

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1243,7 +1243,9 @@ def caster(restype):
 
     return _cast
 
-for tp in types.number_domain:
+cast_types = set(types.number_domain)
+cast_types.add(types.bool_)
+for tp in cast_types:
     builtin(caster(tp))
 
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -929,7 +929,7 @@ def complex_div_impl(context, builder, sig, args):
         if abs(breal) >= abs(bimag):
             # Divide tops and bottom by b.real
             if not breal:
-                return complex(NAN, NAN)
+                raise ZeroDivisionError("complex division by zero")
             ratio = bimag / breal
             denom = breal + bimag * ratio
             return complex(

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -926,10 +926,12 @@ def complex_div_impl(context, builder, sig, args):
         aimag = a.imag
         breal = b.real
         bimag = b.imag
+        if not breal and not bimag:
+            raise ZeroDivisionError("complex division by zero")
         if abs(breal) >= abs(bimag):
             # Divide tops and bottom by b.real
             if not breal:
-                raise ZeroDivisionError("complex division by zero")
+                return complex(NAN, NAN)
             ratio = bimag / breal
             denom = breal + bimag * ratio
             return complex(

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -280,7 +280,7 @@ def _build_array(context, builder, array_ty, arg_arrays):
                            for dest_shape_addr in dest_shape_addrs)
     array_val = arrayobj._empty_nd_impl(context, builder, array_ty,
                                         dest_shape_tup)
-    return _prepare_argument(context, builder, array_val, array_ty,
+    return _prepare_argument(context, builder, array_val._getvalue(), array_ty,
                              where='implicit output argument')
 
 

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -39,6 +39,7 @@ def register_casters(register_function):
     for tp in types.number_domain:
         register_function(caster(tp, getattr(numpy, str(tp))))
 
+    register_function(caster(types.bool_, numpy.bool_))
     register_function(caster(types.intc, numpy.intc))
     register_function(caster(types.uintc, numpy.uintc))
     register_function(caster(types.intp, numpy.intp))

--- a/numba/tests/test_chained_assign.py
+++ b/numba/tests/test_chained_assign.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 from numba import jit
 import numba.unittest_support as unittest
 import numpy as np
@@ -86,8 +87,8 @@ class TestChainedAssign(unittest.TestCase):
 
     def test_chain2(self):
         args = [
-            [3.0],
             [3],
+            [3.0],
         ]
         self._test_template(chain2, args)
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -666,6 +666,37 @@ class TestNdIdentity(BaseTest):
             self.check_identity(func)
 
 
+class TestNdEye(BaseTest):
+
+    def test_eye_n(self):
+        def func(n):
+            return np.eye(n)
+        self.check_outputs(func, [(1,), (3,)])
+
+    def test_eye_n_m(self):
+        def func(n, m):
+            return np.eye(n, m)
+        self.check_outputs(func, [(1, 2), (3, 2), (0, 3)])
+
+    def check_eye_n_m_k(self, func):
+        self.check_outputs(func, [(1, 2, 0),
+                                  (3, 4, 1),
+                                  (3, 4, -1),
+                                  (4, 3, -2),
+                                  (4, 3, -5),
+                                  (4, 3, 5)])
+
+    def test_eye_n_m_k(self):
+        def func(n, m, k):
+            return np.eye(n, m, k)
+        self.check_eye_n_m_k(func)
+
+    def test_eye_n_m_k_dtype(self):
+        def func(n, m, k):
+            return np.eye(N=n, M=m, k=k, dtype=np.int16)
+        self.check_eye_n_m_k(func)
+
+
 class TestNdArange(BaseTest):
 
     def test_linspace_2(self):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -436,8 +436,10 @@ class ConstructorBaseTest(object):
         self.assertEqual(ret.dtype, expected.dtype)
         self.assertEqual(ret.strides, expected.strides)
         self.check_result_value(ret, expected)
-        ret.fill(123)  # test writability
-        np.testing.assert_equal(123, ret)
+        # test writability
+        expected = np.full_like(ret, 123)
+        ret.fill(123)
+        np.testing.assert_equal(ret, expected)
 
     def check_2d(self, pyfunc, dtype):
         cfunc = nrtjit(pyfunc)
@@ -449,8 +451,10 @@ class ConstructorBaseTest(object):
         self.assertEqual(ret.dtype, expected.dtype)
         self.assertEqual(ret.strides, expected.strides)
         self.check_result_value(ret, expected)
-        ret.fill(123)  # test writability
-        np.testing.assert_equal(123, ret)
+        # test writability
+        expected = np.full_like(ret, 123)
+        ret.fill(123)
+        np.testing.assert_equal(ret, expected)
 
 
 class TestNdZeros(ConstructorBaseTest, unittest.TestCase):
@@ -504,7 +508,7 @@ class TestNdFull(ConstructorBaseTest, unittest.TestCase):
 
     def test_1d_dtype(self):
         def func(n):
-            return np.full(n, 4.5, np.int32)
+            return np.full(n, 4.5, np.bool_)
         self.check_1d(func, np.int32)
 
     def test_2d(self):
@@ -605,8 +609,33 @@ class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
 
     def test_like_dtype(self):
         def func(arr):
-            return np.full_like(arr, 4.5, np.int32)
-        self.check_like(func, np.float64, np.int32)
+            return np.full_like(arr, 4.5, np.bool_)
+        self.check_like(func, np.float64, np.bool_)
+
+
+class TestNdIdentity(unittest.TestCase):
+
+    def check_identity(self, pyfunc):
+        cfunc = nrtjit(pyfunc)
+        n = 3
+        expected = pyfunc(n)
+        ret = cfunc(n)
+        self.assertEqual(ret.size, expected.size)
+        self.assertEqual(ret.shape, expected.shape)
+        self.assertEqual(ret.dtype, expected.dtype)
+        self.assertEqual(ret.strides, expected.strides)
+        np.testing.assert_equal(expected, ret)
+
+    def test_identity(self):
+        def func(n):
+            return np.identity(n)
+        self.check_identity(func)
+
+    def test_identity_dtype(self):
+        for dtype in (np.complex64, np.int16, np.bool_):
+            def func(n):
+                return np.identity(n, dtype)
+            self.check_identity(func)
 
 
 def benchmark_refct_speed():

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -646,6 +646,39 @@ class TestNdIdentity(unittest.TestCase):
             self.check_identity(func)
 
 
+class TestNdArange(unittest.TestCase):
+
+    def check_outputs(self, pyfunc, argslist):
+        cfunc = nrtjit(pyfunc)
+        for args in argslist:
+            expected = pyfunc(*args)
+            ret = cfunc(*args)
+            self.assertEqual(ret.size, expected.size)
+            self.assertEqual(ret.shape, expected.shape)
+            self.assertEqual(ret.dtype, expected.dtype)
+            self.assertEqual(ret.strides, expected.strides)
+            np.testing.assert_equal(expected, ret, verbose=True)
+
+    def test_arange_1(self):
+        def pyfunc(n):
+            return np.arange(n)
+        self.check_outputs(pyfunc, [(0,), (1,), (2.5,), (2+3j,), (-1,), (1.5j,)])
+
+    def test_arange_2(self):
+        def pyfunc(n, m):
+            return np.arange(n, m)
+        self.check_outputs(pyfunc,
+                           [(0, 4), (1, 4), (-3.5, 2.5), (-3j, 2+3j),
+                            (2, 1), (1+0.5j, 1.5j)])
+
+    def test_arange_3(self):
+        def pyfunc(n, m, p):
+            return np.arange(n, m, p)
+        self.check_outputs(pyfunc,
+                           [(0, 5, 2), (9, 1, -1.5), (-13., 2.5, 0.25),
+                            (-3j, 2+3j, 1j), (1, 3, -1), (0.5j, 1+1.5j, 1-1j)])
+
+
 def benchmark_refct_speed():
     def pyfunc(x, y, t):
         """Swap array x and y for t number of times

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -585,6 +585,30 @@ class TestNdOnesLike(TestNdZerosLike):
         self.expected_value = 1
 
 
+class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
+
+    def check_result_value(self, ret, expected):
+        np.testing.assert_equal(ret, expected)
+
+    def test_like(self):
+        def func(arr):
+            return np.full_like(arr, 3.5)
+        self.check_like(func, np.float64, np.float64)
+
+    # Not supported yet.
+    @unittest.expectedFailure
+    def test_like_structured(self):
+        dtype = np.dtype([('a', np.int16), ('b', np.float32)])
+        def func(arr):
+            return np.full_like(arr, 4.5)
+        self.check_like(func, dtype, dtype)
+
+    def test_like_dtype(self):
+        def func(arr):
+            return np.full_like(arr, 4.5, np.int32)
+        self.check_like(func, np.float64, np.int32)
+
+
 def benchmark_refct_speed():
     def pyfunc(x, y, t):
         """Swap array x and y for t number of times

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -14,6 +14,23 @@ from numba import utils
 nrtjit = njit(_nrt=True, nogil=True)
 
 
+class BaseTest(unittest.TestCase):
+
+    def check_outputs(self, pyfunc, argslist, exact=True):
+        cfunc = nrtjit(pyfunc)
+        for args in argslist:
+            expected = pyfunc(*args)
+            ret = cfunc(*args)
+            self.assertEqual(ret.size, expected.size)
+            self.assertEqual(ret.shape, expected.shape)
+            self.assertEqual(ret.dtype, expected.dtype)
+            self.assertEqual(ret.strides, expected.strides)
+            if exact:
+                np.testing.assert_equal(expected, ret)
+            else:
+                np.testing.assert_allclose(expected, ret)
+
+
 class TestDynArray(unittest.TestCase):
     def test_empty_1d(self):
         @nrtjit
@@ -621,18 +638,10 @@ class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
         self.check_like(func, np.float64, np.bool_)
 
 
-class TestNdIdentity(unittest.TestCase):
+class TestNdIdentity(BaseTest):
 
     def check_identity(self, pyfunc):
-        cfunc = nrtjit(pyfunc)
-        n = 3
-        expected = pyfunc(n)
-        ret = cfunc(n)
-        self.assertEqual(ret.size, expected.size)
-        self.assertEqual(ret.shape, expected.shape)
-        self.assertEqual(ret.dtype, expected.dtype)
-        self.assertEqual(ret.strides, expected.strides)
-        np.testing.assert_equal(expected, ret)
+        self.check_outputs(pyfunc, [(3,)])
 
     def test_identity(self):
         def func(n):
@@ -646,37 +655,23 @@ class TestNdIdentity(unittest.TestCase):
             self.check_identity(func)
 
 
-class TestNdArange(unittest.TestCase):
+class TestNdArange(BaseTest):
 
-    def check_outputs(self, pyfunc, argslist):
-        cfunc = nrtjit(pyfunc)
-        for args in argslist:
-            expected = pyfunc(*args)
-            ret = cfunc(*args)
-            self.assertEqual(ret.size, expected.size)
-            self.assertEqual(ret.shape, expected.shape)
-            self.assertEqual(ret.dtype, expected.dtype)
-            self.assertEqual(ret.strides, expected.strides)
-            np.testing.assert_equal(expected, ret, verbose=True)
-
-    def test_arange_1(self):
-        def pyfunc(n):
-            return np.arange(n)
-        self.check_outputs(pyfunc, [(0,), (1,), (2.5,), (2+3j,), (-1,), (1.5j,)])
-
-    def test_arange_2(self):
+    def test_linspace_2(self):
         def pyfunc(n, m):
-            return np.arange(n, m)
+            return np.linspace(n, m)
         self.check_outputs(pyfunc,
-                           [(0, 4), (1, 4), (-3.5, 2.5), (-3j, 2+3j),
-                            (2, 1), (1+0.5j, 1.5j)])
+                           [(0, 4), (1, 100), (-3.5, 2.5), (-3j, 2+3j),
+                            (2, 1), (1+0.5j, 1.5j)], exact=False)
 
-    def test_arange_3(self):
+    def test_linspace_3(self):
         def pyfunc(n, m, p):
-            return np.arange(n, m, p)
+            return np.linspace(n, m, p)
         self.check_outputs(pyfunc,
-                           [(0, 5, 2), (9, 1, -1.5), (-13., 2.5, 0.25),
-                            (-3j, 2+3j, 1j), (1, 3, -1), (0.5j, 1+1.5j, 1-1j)])
+                           [(0, 4, 9), (1, 4, 3), (-3.5, 2.5, 8),
+                            (-3j, 2+3j, 7), (2, 1, 0),
+                            (1+0.5j, 1.5j, 5), (1, 1e100, 1)],
+                           exact=False)
 
 
 def benchmark_refct_speed():

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -440,6 +440,10 @@ class ConstructorBaseTest(object):
         expected = np.full_like(ret, 123)
         ret.fill(123)
         np.testing.assert_equal(ret, expected)
+        # errors
+        with self.assertRaises(ValueError) as cm:
+            cfunc(-1)
+        self.assertEqual(str(cm.exception), "negative dimensions not allowed")
 
     def check_2d(self, pyfunc, dtype):
         cfunc = nrtjit(pyfunc)
@@ -455,6 +459,10 @@ class ConstructorBaseTest(object):
         expected = np.full_like(ret, 123)
         ret.fill(123)
         np.testing.assert_equal(ret, expected)
+        # errors
+        with self.assertRaises(ValueError) as cm:
+            cfunc(2, -1)
+        self.assertEqual(str(cm.exception), "negative dimensions not allowed")
 
 
 class TestNdZeros(ConstructorBaseTest, unittest.TestCase):

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -97,16 +97,16 @@ class TestNrtMemInfo(unittest.TestCase):
 
     @unittest.skipIf(PYVERSION <= (2, 7), "memoryview not supported")
     def test_memoryview(self):
-        from ctypes import c_int32, c_void_p, POINTER, cast
+        from ctypes import c_uint32, c_void_p, POINTER, cast
 
-        dtype = np.dtype(np.int32)
+        dtype = np.dtype(np.uint32)
         bytesize = dtype.itemsize * 10
         mi = rtsys.meminfo_alloc(bytesize, safe=True)
         addr = mi.data
-        c_arr = cast(c_void_p(mi.data), POINTER(c_int32 * 10))
-        # Check zero-filling
+        c_arr = cast(c_void_p(mi.data), POINTER(c_uint32 * 10))
+        # Check 0xCB-filling
         for i in range(10):
-            self.assertEqual(c_arr.contents[i], 0)
+            self.assertEqual(c_arr.contents[i], 0xcbcbcbcb)
 
         # Init array with ctypes
         for i in range(10):
@@ -138,16 +138,16 @@ class TestNrtMemInfo(unittest.TestCase):
         # consumed by another thread.
 
     def test_buffer(self):
-        from ctypes import c_int32, c_void_p, POINTER, cast
+        from ctypes import c_uint32, c_void_p, POINTER, cast
 
-        dtype = np.dtype(np.int32)
+        dtype = np.dtype(np.uint32)
         bytesize = dtype.itemsize * 10
         mi = rtsys.meminfo_alloc(bytesize, safe=True)
         addr = mi.data
-        c_arr = cast(c_void_p(addr), POINTER(c_int32 * 10))
-        # Check zero-filling
+        c_arr = cast(c_void_p(addr), POINTER(c_uint32 * 10))
+        # Check 0xCB-filling
         for i in range(10):
-            self.assertEqual(c_arr.contents[i], 0)
+            self.assertEqual(c_arr.contents[i], 0xcbcbcbcb)
 
         # Init array with ctypes
         for i in range(10):

--- a/numba/tests/test_numberctor.py
+++ b/numba/tests/test_numberctor.py
@@ -142,12 +142,12 @@ class TestNumberCtor(TestCase):
             self.assertPreciseEqual(got, expected)
 
     def check_number_types(self, tp_factory):
-        values = [1, -1, 100003, 10000000000007, -100003, -10000000000007,
+        values = [0, 1, -1, 100003, 10000000000007, -100003, -10000000000007,
                   1.5, -3.5]
         for tp_name in ('int8', 'int16', 'int32', 'int64',
                         'uint8', 'uint16', 'uint32', 'uint64',
                         'intc', 'uintc', 'intp', 'uintp',
-                        'float32', 'float64'):
+                        'float32', 'float64', 'bool_'):
             np_type = getattr(np, tp_name)
             tp = tp_factory(tp_name)
             self.check_type_converter(tp, np_type, values)

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -651,13 +651,17 @@ class TestOperators(TestCase):
                           'floats_array': 'run_binop_array_floats',
                           })
 
-    def check_div_errors(self, usecase_name, msg, flags=force_pyobj_flags):
+    def check_div_errors(self, usecase_name, msg, flags=force_pyobj_flags,
+                         allow_complex=False):
         pyfunc = getattr(self.op, usecase_name)
         if pyfunc is NotImplemented:
             self.skipTest("%r not implemented" % (usecase_name,))
         # Signed and unsigned division can take different code paths,
         # test them both.
-        for tp in (types.int32, types.uint32, types.float64):
+        arg_types = [types.int32, types.uint32, types.float64]
+        if allow_complex:
+            arg_types.append(types.complex128)
+        for tp in arg_types:
             cr = compile_isolated(pyfunc, (tp, tp), flags=flags)
             cfunc = cr.entry_point
             with self.assertRaises(ZeroDivisionError) as cm:
@@ -667,7 +671,8 @@ class TestOperators(TestCase):
                 self.assertIn(msg, str(cm.exception))
 
     def test_truediv_errors(self, flags=force_pyobj_flags):
-        self.check_div_errors("truediv_usecase", "division by zero", flags=flags)
+        self.check_div_errors("truediv_usecase", "division by zero", flags=flags,
+                              allow_complex=True)
 
     def test_truediv_errors_npm(self):
         self.test_truediv_errors(flags=Noflags)

--- a/numba/types.py
+++ b/numba/types.py
@@ -155,7 +155,9 @@ class OpaqueType(Type):
 
 
 class Boolean(Type):
-    pass
+
+    def cast_python_value(self, value):
+        return bool(value)
 
 
 @utils.total_ordering

--- a/numba/types.py
+++ b/numba/types.py
@@ -160,8 +160,14 @@ class Boolean(Type):
         return bool(value)
 
 
+class Number(Type):
+    """
+    Base class for number types.
+    """
+
+
 @utils.total_ordering
-class Integer(Type):
+class Integer(Number):
     def __init__(self, *args, **kws):
         super(Integer, self).__init__(*args, **kws)
         # Determine bitwidth
@@ -183,7 +189,7 @@ class Integer(Type):
 
 
 @utils.total_ordering
-class Float(Type):
+class Float(Number):
     def __init__(self, *args, **kws):
         super(Float, self).__init__(*args, **kws)
         # Determine bitwidth
@@ -201,7 +207,7 @@ class Float(Type):
 
 
 @utils.total_ordering
-class Complex(Type):
+class Complex(Number):
     def __init__(self, name, underlying_float, **kwargs):
         super(Complex, self).__init__(name, **kwargs)
         self.underlying_float = underlying_float

--- a/numba/typing/__init__.py
+++ b/numba/typing/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
 from .context import BaseContext, Context, new_method
-from .templates import signature, make_concrete_template, Signature
+from .templates import (signature, make_concrete_template, Signature,
+                        fold_arguments)
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -689,50 +689,6 @@ for ty in types.number_domain:
 
 #-------------------------------------------------------------------------------
 
-#@builtin_attr
-class NumbaTypesModuleAttribute(AttributeTemplate):
-    key = types.Module(types)
-
-    def resolve_int8(self, mod):
-        return types.Function(ToInt8)
-
-    def resolve_int16(self, mod):
-        return types.Function(ToInt16)
-
-    def resolve_int32(self, mod):
-        return types.Function(ToInt32)
-
-    def resolve_int64(self, mod):
-        return types.Function(ToInt64)
-
-    def resolve_uint8(self, mod):
-        return types.Function(ToUint8)
-
-    def resolve_uint16(self, mod):
-        return types.Function(ToUint16)
-
-    def resolve_uint32(self, mod):
-        return types.Function(ToUint32)
-
-    def resolve_uint64(self, mod):
-        return types.Function(ToUint64)
-
-    def resolve_float32(self, mod):
-        return types.Function(ToFloat32)
-
-    def resolve_float64(self, mod):
-        return types.Function(ToFloat64)
-
-    def resolve_complex64(self, mod):
-        return types.Function(ToComplex64)
-
-    def resolve_complex128(self, mod):
-        return types.Function(ToComplex128)
-
-
-builtin_global(types, types.Module(types))
-
-
 def register_casters(register_global):
     nb_types = set(types.number_domain)
     nb_types.add(types.bool_)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -689,7 +689,7 @@ for ty in types.number_domain:
 
 #-------------------------------------------------------------------------------
 
-@builtin_attr
+#@builtin_attr
 class NumbaTypesModuleAttribute(AttributeTemplate):
     key = types.Module(types)
 
@@ -730,75 +730,26 @@ class NumbaTypesModuleAttribute(AttributeTemplate):
         return types.Function(ToComplex128)
 
 
-class Caster(AbstractTemplate):
-    def generic(self, args, kws):
-        assert not kws
-        [a] = args
-        if a in types.number_domain:
-            return signature(self.key, a)
-
-
-class ToInt8(Caster):
-    key = types.int8
-
-
-class ToInt16(Caster):
-    key = types.int16
-
-
-class ToInt32(Caster):
-    key = types.int32
-
-
-class ToInt64(Caster):
-    key = types.int64
-
-
-class ToUint8(Caster):
-    key = types.uint8
-
-
-class ToUint16(Caster):
-    key = types.uint16
-
-
-class ToUint32(Caster):
-    key = types.uint32
-
-
-class ToUint64(Caster):
-    key = types.uint64
-
-
-class ToFloat32(Caster):
-    key = types.float32
-
-
-class ToFloat64(Caster):
-    key = types.float64
-
-
-class ToComplex64(Caster):
-    key = types.complex64
-
-
-class ToComplex128(Caster):
-    key = types.complex128
-
-
 builtin_global(types, types.Module(types))
-builtin_global(types.int8, types.Function(ToInt8))
-builtin_global(types.int16, types.Function(ToInt16))
-builtin_global(types.int32, types.Function(ToInt32))
-builtin_global(types.int64, types.Function(ToInt64))
-builtin_global(types.uint8, types.Function(ToUint8))
-builtin_global(types.uint16, types.Function(ToUint16))
-builtin_global(types.uint32, types.Function(ToUint32))
-builtin_global(types.uint64, types.Function(ToUint64))
-builtin_global(types.float32, types.Function(ToFloat32))
-builtin_global(types.float64, types.Function(ToFloat64))
-builtin_global(types.complex64, types.Function(ToComplex64))
-builtin_global(types.complex128, types.Function(ToComplex128))
+
+
+def register_casters(register_global):
+    nb_types = set(types.number_domain)
+    nb_types.add(types.bool_)
+
+    for restype in nb_types:
+        class Caster(AbstractTemplate):
+            key = restype
+
+            def generic(self, args, kws):
+                assert not kws
+                [a] = args
+                if a in nb_types:
+                    return signature(self.key, a)
+
+        register_global(restype, types.Function(Caster))
+
+register_casters(builtin_global)
 
 #------------------------------------------------------------------------------
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -491,13 +491,32 @@ class NdConstructorLike(AbstractTemplate):
         if not isinstance(arr, types.Array):
             return
         if len(args) >= 2:
-            npy_dtype = args[1]
-            dtype = _parse_dtype(npy_dtype)
+            dtype = _parse_dtype(args[1])
         else:
             dtype = arr.dtype
 
         return_type = arr.copy(dtype=dtype)
         return signature(return_type, *args)
+
+
+@builtin
+class NdFullLike(AbstractTemplate):
+    key = numpy.full_like
+
+    def generic(self, args, kws):
+        assert not kws
+        arr = args[0]
+        if not isinstance(arr, types.Array):
+            return
+        value = args[1]
+        if len(args) >= 3:
+            dtype = _parse_dtype(args[2])
+        else:
+            dtype = arr.dtype
+
+        return_type = arr.copy(dtype=dtype)
+        return signature(return_type, *args)
+
 
 @builtin
 class NdEmpty(NdConstructor):
@@ -533,6 +552,7 @@ builtin_global(numpy.full, types.Function(NdFull))
 builtin_global(numpy.empty_like, types.Function(NdEmptyLike))
 builtin_global(numpy.zeros_like, types.Function(NdZerosLike))
 builtin_global(numpy.ones_like, types.Function(NdOnesLike))
+builtin_global(numpy.full_like, types.Function(NdFullLike))
 
 
 @builtin

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -425,9 +425,7 @@ class NdIndex(AbstractTemplate):
 
 builtin_global(numpy.ndindex, types.Function(NdIndex))
 
-@builtin
-class NdEmpty(AbstractTemplate):
-    key = numpy.empty
+class NdConstructor(AbstractTemplate):
 
     def generic(self, args, kws):
         assert not kws
@@ -441,16 +439,28 @@ class NdEmpty(AbstractTemplate):
             dtype = from_dtype(numpy.dtype(npy_dtype.template.key))
 
         if isinstance(shape, types.Integer):
-            return signature(types.double[::1], *args)
+            ndim = 1
         elif isinstance(shape, (types.Tuple, types.UniTuple)):
-            if all(isinstance(s, types.Integer) for s in shape):
-                aryty = types.Array(dtype=dtype,
-                                    ndim=len(shape),
-                                    layout='C')
-                return signature(aryty, *args)
+            if not all(isinstance(s, types.Integer) for s in shape):
+                return
+            ndim = len(shape)
+        else:
+            return
 
+        aryty = types.Array(dtype=dtype, ndim=ndim, layout='C')
+        return signature(aryty, *args)
+
+@builtin
+class NdEmpty(NdConstructor):
+    key = numpy.empty
+
+@builtin
+class NdZeros(NdConstructor):
+    key = numpy.zeros
 
 builtin_global(numpy.empty, types.Function(NdEmpty))
+builtin_global(numpy.zeros, types.Function(NdZeros))
+
 
 @builtin
 class Round(AbstractTemplate):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -537,6 +537,23 @@ def _infer_dtype_from_inputs(inputs):
 
 
 @builtin
+class NdEye(CallableTemplate):
+    key = numpy.eye
+
+    def generic(self):
+        def typer(N, M=None, k=None, dtype=None):
+            if dtype is None:
+                nb_dtype = types.float64
+            else:
+                nb_dtype = _parse_dtype(dtype)
+            return types.Array(ndim=2, dtype=nb_dtype, layout='C')
+
+        return typer
+
+builtin_global(numpy.eye, types.Function(NdEye))
+
+
+@builtin
 class NdArange(AbstractTemplate):
     key = numpy.arange
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -539,6 +539,32 @@ class NdIdentity(AbstractTemplate):
 builtin_global(numpy.identity, types.Function(NdIdentity))
 
 
+@builtin
+class NdArange(AbstractTemplate):
+    key = numpy.arange
+
+    def generic(self, args, kws):
+        assert not kws
+        if len(args) >= 4:
+            dtype = _parse_dtype(args[3])
+            bounds = args[:3]
+        else:
+            bounds = args
+            # Infer dtypes from inputs
+            if any(isinstance(arg, types.Complex) for arg in bounds):
+                dtype = types.complex128
+            elif any(isinstance(arg, types.Float) for arg in bounds):
+                dtype = types.float64
+            else:
+                dtype = max(bounds)
+        if not all(isinstance(arg, types.Number) for arg in bounds):
+            return
+        return_type = types.Array(ndim=1, dtype=dtype, layout='C')
+        return signature(return_type, *args)
+
+builtin_global(numpy.arange, types.Function(NdArange))
+
+
 # -----------------------------------------------------------------------------
 # Miscellaneous functions
 

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -62,6 +62,31 @@ def signature(return_type, *args, **kws):
     return Signature(return_type, args, recvr=recvr)
 
 
+def fold_arguments(pysig, args, kws, default_handler):
+    """
+    Given the signature *pysig*, explicit *args* and *kws*, resolve
+    omitted arguments (by calling default_handler(index, default))
+    and keyword arguments.  A tuple (arguments, defaults) is returned
+    where *arguments* is a tuple of positional arguments and *defaults*
+    is the list of indices of omitted arguments.
+    """
+    ba = pysig.bind(*args, **kws)
+    defargs = []
+    for i, param in enumerate(pysig.parameters.values()):
+        name = param.name
+        default = param.default
+        if (default is not param.empty and
+            name not in ba.arguments):
+            ba.arguments[name] = default_handler(i, default)
+            defargs.append(i)
+    if ba.kwargs:
+        # There's a remaining keyword argument, e.g. if omitting
+        # some argument with a default value before it.
+        raise NotImplementedError("unhandled keyword argument: %s"
+                                  % list(ba.kwargs))
+    return ba.args, defargs
+
+
 def _uses_downcast(dists):
     for d in dists:
         if d < 0:


### PR DESCRIPTION
Add support for several array constructors (the zeros(), zeros_like() etc. series as well as arange() and linspace()).
Also allow casting to np.bool_ and numba.types.bool_ (as with integer and real types).
Also, complex division now raises ZeroDivisionError when necessary.