### PR TITLE
Add a reference section for CUDA Python

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -1,0 +1,150 @@
+CUDA Host API
+=============
+
+Device Management
+-----------------
+
+Device detection and enquiry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following functions are available for querying the available hardware:
+
+.. autofunction:: numba.cuda.is_available
+
+.. autofunction:: numba.cuda.detect
+
+Context management
+~~~~~~~~~~~~~~~~~~
+
+CUDA Python functions execute within a CUDA context. Each CUDA device in a
+system has an associated CUDA context, and Numba presently allows only one context
+per thread. For further details on CUDA Contexts, refer to the `CUDA Driver API
+Documentation on Context Management
+<http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html>`_ and the
+`CUDA C Programming Guide Context Documentation
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#context>`_. CUDA Contexts
+are instances of the :class:`Context` class:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Context
+   :members: reset, get_memory_info, push, pop
+
+The following functions can be used to get or select the context:
+
+.. autofunction:: numba.cuda.current_context
+.. autofunction:: numba.cuda.require_context
+
+The following functions affect the current context:
+
+.. autofunction:: numba.cuda.synchronize
+.. autofunction:: numba.cuda.close
+
+Device management
+~~~~~~~~~~~~~~~~~
+
+Numba maintains a list of supported CUDA-capable devices:
+
+.. attribute:: numba.cuda.gpus
+
+   An indexable list of supported CUDA devices. This list is indexed by integer
+   device ID.
+
+Alternatively, the current device can be obtained:
+
+.. function:: numba.cuda.gpus.current
+
+   Return the currently-selected device.
+
+Getting a device through :attr:`numba.cuda.gpus` always provides an instance of
+:class:`numba.cuda.cudadrv.devices._DeviceContextManager`, which acts as a
+context manager for the selected device:
+
+.. autoclass:: numba.cuda.cudadrv.devices._DeviceContextManager
+
+One may also select a context and device or get the current device using the
+following three functions:
+
+.. autofunction:: numba.cuda.select_device
+.. autofunction:: numba.cuda.get_current_device
+.. autofunction:: numba.cuda.list_devices
+
+The :class:`numba.cuda.cudadrv.driver.Device` class can be used to enquire about
+the functionality of the selected device:
+
+.. class:: numba.cuda.cudadrv.driver.Device
+
+   The device associated with a particular context.
+
+   .. attribute:: compute_capability
+
+      A tuple, *(major, minor)* indicating the supported compute capability.
+
+   .. attribute:: id
+
+      The integer ID of the device.
+
+   .. attribute:: name
+
+      The name of the device (e.g. "GeForce GTX 970")
+
+   .. method:: reset
+
+      Delete the context for the device. This will destroy all memory
+      allocations, events, and streams created within the context.
+
+Measurement
+-----------
+
+Profiling
+~~~~~~~~~
+
+The NVidia Visual Profiler can be used directly on executing CUDA Python code -
+it is not a requirement to insert calls to these functions into user code.
+However, these functions can be used to allow profiling to be performed
+selectively on specific portions of the code. For further information on
+profiling, see the `NVidia Profiler User's Guide
+<docs.nvidia.com/cuda/profiler-users-guide/>`_.
+
+.. autofunction:: numba.cuda.profile_start
+.. autofunction:: numba.cuda.profile_stop
+.. autofunction:: numba.cuda.profiling
+
+Events
+~~~~~~
+
+Events can be used to monitor the progress of execution and to record the
+timestamps of specific points being reached. Event creation returns immediately,
+and the created event can be queried to determine if it has been reached. For
+further information, see the `CUDA C Programming Guide Events section
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#events>`_.
+
+The following functions are used for creating and measuring the time between
+events:
+
+.. autofunction:: numba.cuda.event
+.. autofunction:: numba.cuda.event_elapsed_time
+
+Events are instances of the :class:`numba.cuda.cudadrv.driver.Event` class:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Event
+   :members: query, record, synchronize, wait
+
+Stream Management
+-----------------
+
+Streams allow concurrency of execution on a single device within a given
+context. Queued work items in the same stream execute sequentially, but work
+items in different streams may execute concurrently. Most operations involving a
+CUDA device can be performed asynchronously using streams, including data
+transfers and kernel execution. For further details on streams, see the `CUDA C
+Programming Guide Streams section
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#streams>`_.
+
+To create a stream:
+
+.. autofunction:: numba.cuda.stream
+
+Streams are instances of :class:`numba.cuda.cudadrv.driver.Stream`:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Stream
+   :members: synchronize, auto_synchronize
+

--- a/docs/source/cuda-reference/index.rst
+++ b/docs/source/cuda-reference/index.rst
@@ -1,0 +1,8 @@
+CUDA Python Reference
+=====================
+
+.. toctree::
+
+   host.rst
+   kernel.rst
+   memory.rst

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -1,0 +1,77 @@
+CUDA Kernel API
+===============
+
+Kernel declaration
+------------------
+
+The ``@cuda.jit`` decorator is used to create a CUDA kernel:
+
+.. autofunction:: numba.cuda.jit
+
+.. autoclass:: numba.cuda.compiler.AutoJitCUDAKernel
+   :members: inspect_asm, inspect_llvm, inspect_types, specialize
+
+Individual specialized kernels are instances of
+:class:`numba.cuda.compiler.CUDAKernel`:
+
+.. autoclass:: numba.cuda.compiler.CUDAKernel
+   :members: bind, ptx, device, inspect_llvm, inspect_asm, inspect_types
+
+Intrinsic Attributes and Functions
+----------------------------------
+
+The remainder of the attributes and functions in this section may only be called
+from within a CUDA Kernel.
+
+Thread Indexing
+~~~~~~~~~~~~~~~
+
+.. autofunction:: numba.cuda.threadIdx
+.. autofunction:: numba.cuda.blockIdx
+.. autofunction:: numba.cuda.blockDim
+.. autofunction:: numba.cuda.gridDim
+
+.. function:: numba.cuda.grid(ndim)
+
+   Return the absolute position of the current thread in the entire
+   grid of blocks.  *ndim* should correspond to the number of dimensions
+   declared when instantiating the kernel.  If *ndim* is 1, a single integer
+   is returned.  If *ndim* is 2 or 3, a tuple of the given number of
+   integers is returned.
+
+   Computation of the first integer is as follows::
+
+      cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
+
+   and is similar for the other two indices, but using the ``y`` and ``z``
+   attributes.
+
+.. function:: numba.cuda.gridsize(ndim)
+
+   Return the absolute size (or shape) in threads of the entire grid of
+   blocks. *ndim* should correspond to the number of dimensions declared when
+   instantiating the kernel.
+
+   Computation of the first integer is as follows::
+
+       cuda.blockDim.x * cuda.gridDim.x
+
+   and is similar for the other two indices, but using the ``y`` and ``z``
+   attributes.
+
+Memory Management
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: numba.cuda.shared
+   :members: array
+.. autoclass:: numba.cuda.local
+   :members: array
+.. autoclass:: numba.cuda.const
+   :members: array_like
+
+Synchronization and Atomic Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: numba.cuda.atomic
+   :members: add, max
+.. autofunction:: numba.cuda.syncthreads

--- a/docs/source/cuda-reference/memory.rst
+++ b/docs/source/cuda-reference/memory.rst
@@ -1,0 +1,21 @@
+Memory Management
+=================
+
+.. autofunction:: numba.cuda.to_device
+.. autofunction:: numba.cuda.device_array
+.. autofunction:: numba.cuda.device_array_like
+.. autofunction:: numba.cuda.pinned_array
+.. autofunction:: numba.cuda.mapped_array
+.. autofunction:: numba.cuda.pinned
+.. autofunction:: numba.cuda.mapped
+
+Device Objects
+--------------
+
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceNDArray
+   :members: copy_to_device, copy_to_host, is_c_contiguous, is_f_contiguous,
+              ravel, reshape, split
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceRecord
+   :members: copy_to_device, copy_to_host
+.. autoclass:: numba.cuda.cudadrv.devicearray.MappedNDArray
+   :members: copy_to_device, copy_to_host, split

--- a/docs/source/cuda/device-management.rst
+++ b/docs/source/cuda/device-management.rst
@@ -34,6 +34,7 @@ Users can then create a new context with another device.
 
 
 .. function:: numba.cuda.select_device(device_id)
+   :noindex:
 
    Create a new CUDA context for the selected *device_id*.  *device_id*
    should be the number of the device (starting from 0; the device order
@@ -46,6 +47,7 @@ Users can then create a new context with another device.
 
 
 .. function:: numba.cuda.close
+   :noindex:
 
    Explicitly close all contexts in the current thread.
 
@@ -62,6 +64,7 @@ The Device List is a list of all the GPUs in the system, and can be indexed to
 obtain a context manager that ensures execution on the selected GPU.
 
 .. attribute:: numba.cuda.gpus
+   :noindex:
 .. attribute:: numba.cuda.cudadrv.devices.gpus
 
 :py:data:`.gpus` is an instance of the :class:`_DeviceList` class, from which
@@ -69,4 +72,5 @@ the current GPU context can also be retrieved:
 
 .. autoclass:: numba.cuda.cudadrv.devices._DeviceList
     :members: current
+    :noindex:
 

--- a/docs/source/cuda/intrinsics.rst
+++ b/docs/source/cuda/intrinsics.rst
@@ -9,6 +9,7 @@ Those that are presently implemented are as follows:
 
 .. automodule:: numba.cuda
     :members: atomic
+    :noindex:
 
 Example
 '''''''

--- a/docs/source/cuda/kernels.rst
+++ b/docs/source/cuda/kernels.rst
@@ -141,6 +141,7 @@ dimension, use the ``x``, ``y`` and ``z`` attributes of these objects,
 respectively.
 
 .. attribute:: numba.cuda.threadIdx
+   :noindex:
 
    The thread indices in the current thread block.  For 1D blocks, the index
    (given by the ``x`` attribute) is an integer spanning the range from 0
@@ -148,12 +149,14 @@ respectively.
    exists for each dimension when more than one dimension is used.
 
 .. attribute:: numba.cuda.blockDim
+   :noindex:
 
    The shape of the block of threads, as declared when instantiating the
    kernel.  This value is the same for all threads in a given kernel, even
    if they belong to different blocks (i.e. each block is "full").
 
 .. attribute:: numba.cuda.blockIdx
+   :noindex:
 
    The block indices in the grid of threads launched a kernel.  For a 1D grid,
    the index (given by the ``x`` attribute) is an integer spanning the range
@@ -161,6 +164,7 @@ respectively.
    exists for each dimension when more than one dimension is used.
 
 .. attribute:: numba.cuda.gridDim
+   :noindex:
 
    The shape of the grid of blocks, i.e. the total number of blocks launched
    by this kernel invocation, as declared when instantiating the kernel.
@@ -173,6 +177,7 @@ same way as shown in the example above.  Numba provides additional facilities
 to automate such calculations:
 
 .. function:: numba.cuda.grid(ndim)
+   :noindex:
 
    Return the absolute position of the current thread in the entire
    grid of blocks.  *ndim* should correspond to the number of dimensions
@@ -181,6 +186,7 @@ to automate such calculations:
    integers is returned.
 
 .. function:: numba.cuda.gridsize(ndim)
+   :noindex:
 
    Return the absolute size (or shape) in threads of the entire grid of
    blocks.  *ndim* has the same meaning as in :func:`.grid` above.

--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -14,8 +14,11 @@ read-only arrays, you can use the following APIs to manually control the
 transfer:
 
 .. autofunction:: numba.cuda.device_array
+   :noindex:
 .. autofunction:: numba.cuda.device_array_like
+   :noindex:
 .. autofunction:: numba.cuda.to_device
+   :noindex:
 
 Device arrays
 -------------
@@ -25,22 +28,27 @@ called in host code, not within CUDA-jitted functions.
 
 .. autoclass:: numba.cuda.cudadrv.devicearray.DeviceNDArray
     :members: copy_to_host, is_c_contiguous, is_f_contiguous, ravel, reshape
+    :noindex:
 
 Pinned memory
 =============
 
 .. autofunction:: numba.cuda.pinned
+   :noindex:
 .. autofunction:: numba.cuda.pinned_array
+   :noindex:
 
 Streams
 =======
 
 .. autofunction:: numba.cuda.stream
+   :noindex:
 
 CUDA streams have the following methods:
 
 .. autoclass:: numba.cuda.cudadrv.driver.Stream
     :members: synchronize, auto_synchronize
+    :noindex:
 
 .. _cuda-shared-memory:
 
@@ -58,6 +66,7 @@ The memory is allocated once for the duration of the kernel, unlike
 traditional dynamic memory management.
 
 .. function:: numba.cuda.shared.array(shape, type)
+   :noindex:
 
    Allocate a shared array of the given *shape* and *type* on the device.
    This function must be called on the device (i.e. from a kernel or
@@ -71,7 +80,9 @@ traditional dynamic memory management.
    A common pattern is to have each thread populate one element in the
    shared array and then wait for all threads to finish using :func:`.syncthreads`.
 
+
 .. function:: numba.cuda.syncthreads()
+   :noindex:
 
    Synchronize all threads in the same thread block.  This function
    implements the same pattern as `barriers <http://en.wikipedia.org/wiki/Barrier_%28computer_science%29>`_
@@ -93,6 +104,7 @@ are not enough.  The memory is allocated once for the duration of the kernel,
 unlike traditional dynamic memory management.
 
 .. function:: numba.cuda.local.array(shape, type)
+   :noindex:
 
    Allocate a local array of the given *shape* and *type* on the device.
    The array is private to the current thread.  An array-like object is

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ with Numba, we suggest you start with the :doc:`User manual <user/index>`.
    user/index.rst
    reference/index.rst
    cuda/index.rst
+   cuda-reference/index.rst
    developer/index.rst
    glossary.rst
    release-notes.rst

--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -6,8 +6,7 @@ if config.ENABLE_CUDASIM:
     from .simulator_init import *
 else:
     from .device_init import *
-    from .device_init import (_auto_device, _profiling, _profile_start,
-                              _profile_stop)
+    from .device_init import _auto_device
 
 
 def test():

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -113,7 +113,7 @@ def mapped_array(shape, dtype=np.float, strides=None, order='C', stream=0,
 
 
 def synchronize():
-    "Synchronize current context"
+    "Synchronize the current context."
     return current_context().synchronize()
 
 
@@ -202,19 +202,22 @@ def mapped(*arylist, **kws):
 
 
 def event(timing=True):
-    """Create a CUDA event.
+    """
+    Create a CUDA event. Timing data is only recorded by the event if it is
+    created with ``timing=True``.
     """
     evt = current_context().create_event(timing=timing)
     return evt
 
+event_elapsed_time = driver.event_elapsed_time
+
 # Device selection
 
 def select_device(device_id):
-    """Creates a new CUDA context with the selected device.
-    The context is associated with the current thread.
-    Numba currently allows only one context per thread.
+    """
+    Make the context associated with device *device_id* the current context.
 
-    Returns a device instance
+    Returns a Device instance.
 
     Raises exception on error.
     """
@@ -228,14 +231,14 @@ def get_current_device():
 
 
 def list_devices():
-    "List all CUDA devices"
+    "Return a list of all detected devices"
     return devices.gpus
 
 
 def close():
-    """Explicitly closes the context.
-
-    Destroy the current context of the current thread
+    """
+    Explicitly clears all contexts in the current thread, and destroys all
+    contexts if the current thread is the main thread.
     """
     devices.reset()
 
@@ -245,7 +248,10 @@ def _auto_device(ary, stream=0, copy=True):
 
 
 def detect():
-    """Detect hardware support
+    """
+    Detect supported CUDA hardware and print a summary of the detected hardware.
+
+    Returns a boolean indicating whether any supported devices were detected.
     """
     devlist = list_devices()
     print('Found %d CUDA devices' % len(devlist))

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -278,12 +278,6 @@ def defer_cleanup():
         yield
 
 
-# TODO
-# Temporary entry-point to debug a failure for nvidia profiling tools to
-# record any kind of events.  Manually invocation of _profile_stop seems to be
-# necessary only on windows.
-# Should we make cuda.close() call _profile_stop()?
-_profiling = require_context(driver.profiling)
-_profile_start = require_context(driver.profile_start)
-_profile_stop = require_context(driver.profile_stop)
-
+profiling = require_context(driver.profiling)
+profile_start = require_context(driver.profile_start)
+profile_stop = require_context(driver.profile_stop)

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -323,7 +323,7 @@ class CUDAKernel(CUDAKernelBase):
     @property
     def ptx(self):
         '''
-        Returns the PTX code for this kernel encoded in UTF-8.
+        PTX code for this kernel.
         '''
         return self._func.ptx.get().decode('utf8')
 

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -239,6 +239,9 @@ class DeviceNDArrayBase(object):
 
 
 class DeviceRecord(DeviceNDArrayBase):
+    '''
+    An on-GPU record type
+    '''
     def __init__(self, dtype, stream=0, gpu_data=None):
         shape = ()
         strides = ()
@@ -255,6 +258,9 @@ class DeviceRecord(DeviceNDArrayBase):
 
 
 class DeviceNDArray(DeviceNDArrayBase):
+    '''
+    An on-GPU array type
+    '''
     def is_f_contiguous(self):
         '''
         Return true if the array is Fortran-contiguous.

--- a/numba/cuda/cudadrv/devices.py
+++ b/numba/cuda/cudadrv/devices.py
@@ -34,6 +34,9 @@ class _DeviceList(object):
         return super(_DeviceList, self).__getattr__(attr)
 
     def __getitem__(self, devnum):
+        '''
+        Returns the context manager for device *devnum*.
+        '''
         return self.lst[devnum]
 
     def __str__(self):
@@ -54,7 +57,15 @@ class _DeviceList(object):
 
 
 class _DeviceContextManager(object):
-    """Provides contextmanager functionality to Device objects
+    """
+    Provides a context manager for executing in the context of the chosen
+    device. The normal use of instances of this type is from
+    ``numba.cuda.gpus``. For example, to execute on device 2::
+
+       with numba.cuda.gpus[2]:
+           d_a = numba.cuda.to_device(a)
+
+    to copy the array *a* onto device 2, referred to by *d_a*.
     """
 
     def __init__(self, device):
@@ -230,7 +241,14 @@ def get_context(devnum=0):
 
 def require_context(fn):
     """
-    A decorator to ensure a context for the CUDA subsystem
+    A decorator that ensures a CUDA context is available when *fn* is executed.
+
+    Decorating *fn* is equivalent to writing::
+
+       get_context()
+       fn()
+
+    at each call site.
     """
 
     @functools.wraps(fn)

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -492,7 +492,7 @@ class Context(object):
 
     def pop(self):
         """
-        Pops this context on the current CPU thread. Note that this context must
+        Pops this context off the current CPU thread. Note that this context must
         be at the top of the context stack, otherwise an error will occur.
         """
         popped = drvapi.cu_context()

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -439,11 +439,10 @@ def met_requirement_for_device(device):
 
 
 class Context(object):
-    """This object is tied to the lifetime of the actual context resource.
+    """
+    This object wraps a CUDA Context resource.
 
-    This object is usually wrapped in a weakref proxy for user.  User seldom
-    owns this object.
-
+    Contexts should not be constructed directly by user code.
     """
 
     def __init__(self, device, handle, finalizer=None):
@@ -468,7 +467,8 @@ class Context(object):
             traceback.print_exc()
 
     def reset(self):
-        """Clean up all owned resources in this context
+        """
+        Clean up all owned resources in this context.
         """
         # Free owned resources
         self.allocations.clear()
@@ -485,12 +485,15 @@ class Context(object):
         return free.value, total.value
 
     def push(self):
-        """Push context
+        """
+        Pushes this context on the current CPU Thread.
         """
         driver.cuCtxPushCurrent(self.handle)
 
     def pop(self):
-        """Pop context
+        """
+        Pops this context on the current CPU thread. Note that this context must
+        be at the top of the context stack, otherwise an error will occur.
         """
         popped = drvapi.cu_context()
         driver.cuCtxPopCurrent(byref(popped))
@@ -918,7 +921,8 @@ class Event(object):
             traceback.print_exc()
 
     def query(self):
-        """Returns True if all work before the most recent record has completed;
+        """
+        Returns True if all work before the most recent record has completed;
         otherwise, returns False.
         """
         try:
@@ -932,19 +936,26 @@ class Event(object):
             return True
 
     def record(self, stream=0):
-        """Set the record state of the event at the stream.
+        """
+        Set the record point of the event to the current point in the given
+        stream.
+
+        The event will be considered to have occurred when all work that was
+        queued in the stream at the time of the call to ``record()`` has been
+        completed.
         """
         hstream = stream.handle if stream else 0
         driver.cuEventRecord(self.handle, hstream)
 
     def synchronize(self):
-        """Synchronize the host thread for the completion of the event.
+        """
+        Synchronize the host thread for the completion of the event.
         """
         driver.cuEventSynchronize(self.handle)
 
     def wait(self, stream=0):
-        """All future works submitted to stream will wait util the event
-        completes.
+        """
+        All future works submitted to stream will wait util the event completes.
         """
         hstream = stream.handle if stream else 0
         flags = 0
@@ -955,6 +966,9 @@ class Event(object):
 
 
 def event_elapsed_time(evtstart, evtend):
+    '''
+    Compute the elapsed time between two events in milliseconds.
+    '''
     msec = c_float()
     driver.cuEventElapsedTime(byref(msec), evtstart.handle, evtend.handle)
     return msec.value
@@ -1405,17 +1419,24 @@ def device_memset(dst, val, size, stream=0):
 
 
 def profile_start():
+    '''
+    Enable profile collection in the current context.
+    '''
     driver.cuProfilerStart()
 
 
 def profile_stop():
+    '''
+    Disable profile collection in the current context.
+    '''
     driver.cuProfilerStop()
 
 
 @contextlib.contextmanager
 def profiling():
     """
-    Experimental profiling context.
+    Context manager that enables profiling on entry and disables profiling on
+    exit.
     """
     profile_start()
     yield

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import, division
 from numba import config, sigutils, types
+from warnings import warn
 from .compiler import (compile_kernel, compile_device, declare_device_function,
                        AutoJitCUDAKernel, compile_device_template)
 from .simulator.kernel import FakeCUDAKernel
@@ -12,104 +13,61 @@ def jitdevice(func, link=[], debug=False, inline=False):
     return compile_device_template(func, debug=debug, inline=inline)
 
 
-def jit(restype=None, argtypes=None, device=False, inline=False, bind=True,
+def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
         link=[], debug=False, **kws):
-    """JIT compile a python function conforming to
-    the CUDA-Python specification.
+    """
+    JIT compile a python function conforming to the CUDA Python specification.
+    If a signature is supplied, then a function is returned that takes a
+    function to compile. If
 
-    To define a CUDA kernel that takes two int 1D-arrays::
+    :param func_or_sig: A function to JIT compile, or a signature of a function
+       to compile. If a function is supplied, then an :class:`AutoJitCUDAKernel`
+       is returned. If a signature is supplied, then a function which takes a
+       function to compile and returns an :class:`AutoJitCUDAKernel` is
+       returned.
 
-        @cuda.jit('void(int32[:], int32[:])')
-        def foo(aryA, aryB):
-            ...
-
-    .. note:: A kernel cannot have any return value.
-
-    To launch the cuda kernel::
-
-        griddim = 1, 2
-        blockdim = 3, 4
-        foo[griddim, blockdim](aryA, aryB)
-
-
-    ``griddim`` is the number of thread-block per grid.
-    It can be:
-
-    * an int;
-    * tuple-1 of ints;
-    * tuple-2 of ints.
-
-    ``blockdim`` is the number of threads per block.
-    It can be:
-
-    * an int;
-    * tuple-1 of ints;
-    * tuple-2 of ints;
-    * tuple-3 of ints.
-
-    The above code is equaivalent to the following CUDA-C.
-
-    .. code-block:: c
-
-        dim3 griddim(1, 2);
-        dim3 blockdim(3, 4);
-        foo<<<griddim, blockdim>>>(aryA, aryB);
-
-
-    To access the compiled PTX code::
-
-        print foo.ptx
-
-
-    To define a CUDA device function that takes two ints and returns a int::
-
-        @cuda.jit('int32(int32, int32)', device=True)
-        def bar(a, b):
-            ...
-
-    To force inline the device function::
-
-        @cuda.jit('int32(int32, int32)', device=True, inline=True)
-        def bar_forced_inline(a, b):
-            ...
-
-    A device function can only be used inside another kernel.
-    It cannot be called from the host.
-
-    Using ``bar`` in a CUDA kernel::
-
-        @cuda.jit('void(int32[:], int32[:], int32[:])')
-        def use_bar(aryA, aryB, aryOut):
-            i = cuda.grid(1) # global position of the thread for a 1D grid.
-            aryOut[i] = bar(aryA[i], aryB[i])
-
-    When the function signature is not given, this decorator behaves like
-    autojit.
-
-
-    The following addition options are available for kernel functions only.
-    They are ignored in device function.
-
-    - fastmath: bool
-        Enables flush-to-zero for denormal float;
-        Enables fused-multiply-add;
-        Disables precise division;
-        Disables precise square root.
+       .. note:: A kernel cannot have any return value.
+    :type func_or_sig: function or numba.typing.Signature
+    :param device: Indicates whether this is a device function.
+    :type device: bool
+    :param bind: Force binding to CUDA context immediately
+    :type bind: bool
+    :param link: A list of files containing PTX source to link with the function
+    :type link: list
+    :param debug: If True, check for exceptions thrown when executing the
+       kernel. Since this degrades performance, this should only be used for
+       debugging purposes.
+    :param fastmath: If true, enables flush-to-zero and fused-multiply-add,
+       disables precise division and square root. This parameter has no effect
+       on device function, whose fastmath setting depends on the kernel function
+       from which they are called.
     """
 
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')
 
-    if argtypes is None and not sigutils.is_signature(restype):
-        if restype is None:
-            return autojit(device=device, bind=bind, link=link, debug=debug,
-                           inline=inline, **kws)
+    if argtypes is None and not sigutils.is_signature(func_or_sig):
+        if func_or_sig is None:
+            if config.ENABLE_CUDASIM:
+                def autojitwrapper(func):
+                    return FakeCUDAKernel(func, device=device, fastmath=fastmath,
+                                          debug=debug)
+            else:
+                def autojitwrapper(func):
+                    return jit(func, device=device, bind=bind, **kws)
 
-        # restype is a function
+            return autojitwrapper
+        # func_or_sig is a function
         else:
-            decor = autojit(device=device, bind=bind, link=link, debug=debug,
-                            inline=inline, **kws)
-            return decor(restype)
+            if config.ENABLE_CUDASIM:
+                return FakeCUDAKernel(func_or_sig, device=device, fastmath=fastmath,
+                                       debug=debug)
+            elif device:
+                return jitdevice(func_or_sig, **kws)
+            else:
+                targetoptions = kws.copy()
+                targetoptions['debug'] = debug
+                return AutoJitCUDAKernel(func_or_sig, bind=bind, targetoptions=targetoptions)
 
     else:
         fastmath = kws.get('fastmath', False)
@@ -119,7 +77,7 @@ def jit(restype=None, argtypes=None, device=False, inline=False, bind=True,
                                       debug=debug)
             return jitwrapper
 
-        restype, argtypes = convert_types(restype, argtypes)
+        restype, argtypes = convert_types(func_or_sig, argtypes)
 
         if restype and not device and restype != types.void:
             raise TypeError("CUDA kernel must have void return type.")
@@ -144,53 +102,9 @@ def jit(restype=None, argtypes=None, device=False, inline=False, bind=True,
             return kernel_jit
 
 
-def autojit(func=None, device=False, bind=True, **kws):
-    """JIT at callsite.  Function signature is not needed as this
-    will capture the type at call time.  Each signature of the kernel
-    is cached for future use.
-
-    .. note:: Can only compile CUDA kernel.
-
-    Example::
-
-        import numpy
-
-        @cuda.autojit
-        def foo(aryA, aryB):
-            ...
-
-        aryA = numpy.arange(10, dtype=np.int32)
-        aryB = numpy.arange(10, dtype=np.float32)
-        foo[griddim, blockdim](aryA, aryB)
-
-    In the above code, a version of foo with the signature
-    "void(int32[:], float32[:])" is compiled.
-
-    A device function can be created as shown below::
-
-        @cuda.autojit(device=True)
-        def add(a, b):
-            return a + b
-
-    """
-    if func is None:
-        if config.ENABLE_CUDASIM:
-            def autojitwrapper(func):
-                return FakeCUDAKernel(func, device=device, fastmath=fastmath,
-                                      debug=debug)
-        else:
-            def autojitwrapper(func):
-                return autojit(func, device=device, bind=bind, **kws)
-
-        return autojitwrapper
-    else:
-        if config.ENABLE_CUDASIM:
-            return FakeCUDAKernel(func, device=device, fastmath=fastmath,
-                                  debug=debug)
-        elif device:
-            return jitdevice(func, **kws)
-        else:
-            return AutoJitCUDAKernel(func, bind=bind, targetoptions=kws)
+def autojit(*args, **kwargs):
+    warn('autojit is deprecated and will be removed in a future release. Use jit instead.')
+    return jit(*args, **kwargs)
 
 
 def declare_device(name, restype=None, argtypes=None):

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -9,7 +9,7 @@ from .errors import KernelRuntimeError
 
 from .decorators import jit, autojit, declare_device
 from .api import *
-from .api import _auto_device, _profiling, _profile_start, _profile_stop
+from .api import _auto_device
 
 
 def is_available():

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -29,7 +29,11 @@ SREG_SIGNATURE = typing.signature(types.int32)
 
 
 class threadIdx(Stub):
-    '''threadIdx.{x, y, z}
+    '''
+    The thread indices in the current thread block, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.blockDim` exclusive.
     '''
     _description_ = '<threadIdx.{x,y,z}>'
 
@@ -39,7 +43,11 @@ class threadIdx(Stub):
 
 
 class blockIdx(Stub):
-    '''blockIdx.{x, y, z}
+    '''
+    The block indices in the grid of thread blocks, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.gridDim` exclusive.
     '''
     _description_ = '<blockIdx.{x,y,z}>'
 
@@ -49,7 +57,10 @@ class blockIdx(Stub):
 
 
 class blockDim(Stub):
-    '''blockDim.{x, y, z}
+    '''
+    The shape of a block of threads, as declared when instantiating the
+    kernel.  This value is the same for all threads in a given kernel, even
+    if they belong to different blocks (i.e. each block is "full").
     '''
     x = macro.Macro('ntid.x', SREG_SIGNATURE)
     y = macro.Macro('ntid.y', SREG_SIGNATURE)
@@ -57,7 +68,9 @@ class blockDim(Stub):
 
 
 class gridDim(Stub):
-    '''gridDim.{x, y, z}
+    '''
+    The shape of the grid of blocks, accressed through the attributes ``x``,
+    ``y``, and ``z``.
     '''
     _description_ = '<gridDim.{x,y,z}>'
     x = macro.Macro('nctaid.x', SREG_SIGNATURE)
@@ -76,19 +89,18 @@ def _ptx_grid2d(): pass
 def grid_expand(ndim):
     """grid(ndim)
 
-    ndim: [int] 1, 2 or 3
+    Return the absolute position of the current thread in the entire
+    grid of blocks.  *ndim* should correspond to the number of dimensions
+    declared when instantiating the kernel.  If *ndim* is 1, a single integer
+    is returned.  If *ndim* is 2 or 3, a tuple of the given number of
+    integers is returned.
 
-        if ndim == 1:
-            return cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-        elif ndim == 2:
-            x = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-            y = cuda.threadIdx.y + cuda.blockIdx.y * cuda.blockDim.y
-            return x, y
-        elif ndim == 3:
-            x = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-            y = cuda.threadIdx.y + cuda.blockIdx.y * cuda.blockDim.y
-            z = cuda.threadIdx.z + cuda.blockIdx.z * cuda.blockDim.z
-            return x, y, z
+    Computation of the first integer is as follows::
+
+        cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
+
+    and is similar for the other two indices, but using the ``y`` and ``z``
+    attributes.
     """
     if ndim == 1:
         fname = "ptx.grid.1d"
@@ -105,28 +117,23 @@ def grid_expand(ndim):
     return ir.Intrinsic(fname, typing.signature(restype, types.intp),
                         args=[ndim])
 
-
 grid = macro.Macro('ptx.grid', grid_expand, callable=True)
 
 #-------------------------------------------------------------------------------
 # Gridsize Macro
 
 def gridsize_expand(ndim):
-    """gridsize(ndim)
+    """
+    Return the absolute size (or shape) in threads of the entire grid of
+    blocks. *ndim* should correspond to the number of dimensions declared when
+    instantiating the kernel. 
 
-    ndim: [int] 1, 2 or 3
+    Computation of the first integer is as follows::
 
-        if ndim == 1:
-            return cuda.blockDim.x * cuda.gridDim.x
-        elif ndim == 2:
-            x = cuda.blockDim.x * cuda.gridDim.x
-            y = cuda.blockDim.y * cuda.gridDim.y
-            return x, y
-        elif ndim == 3:
-            x = cuda.blockDim.x * cuda.gridDim.x
-            y = cuda.blockDim.y * cuda.gridDim.y
-            z = cuda.blockDim.z * cuda.gridDim.z
-            return x, y, z
+        cuda.blockDim.x * cuda.gridDim.x
+
+    and is similar for the other two indices, but using the ``y`` and ``z``
+    attributes.
     """
     if ndim == 1:
         fname = "ptx.gridsize.1d"
@@ -150,9 +157,11 @@ gridsize = macro.Macro('ptx.gridsize', gridsize_expand, callable=True)
 # synthreads
 
 class syncthreads(Stub):
-    '''syncthreads()
-
-    Synchronizes all threads in the thread block.
+    '''
+    Synchronize all threads in the same thread block.  This function implements
+    the same pattern as barriers in traditional multi-threaded programming: this
+    function waits until all threads in the block call it, at which point it
+    returns control to all its callers.
     '''
     _description_ = '<syncthread()>'
 
@@ -178,12 +187,22 @@ def shared_array(shape, dtype):
 
 
 class shared(Stub):
-    """shared namespace
+    """
+    Shared memory namespace.
     """
     _description_ = '<shared>'
 
     array = macro.Macro('shared.array', shared_array, callable=True,
                         argnames=['shape', 'dtype'])
+    '''
+    Allocate a shared array of the given *shape* and *type*. *shape* is either
+    an integer or a tuple of integers representing the array's dimensions.
+    *type* is a :ref:`Numba type <numba-types>` of the elements needing to be
+    stored in the array.
+
+    The returned array-like object can be read and written to like any normal
+    device array (e.g. through indexing).
+    '''
 
 
 #-------------------------------------------------------------------------------
@@ -200,12 +219,19 @@ def local_array(shape, dtype):
 
 
 class local(Stub):
-    '''shared namespace
+    '''
+    Local memory namespace.
     '''
     _description_ = '<local>'
 
     array = macro.Macro('local.array', local_array, callable=True,
                         argnames=['shape', 'dtype'])
+    '''
+    Allocate a local array of the given *shape* and *type*. The array is private
+    to the current thread, and resides in global memory. An array-like object is
+    returned which can be read and written to like any standard array (e.g.
+    through indexing).
+    '''
 
 #-------------------------------------------------------------------------------
 # const array
@@ -274,12 +300,17 @@ def const_array_like(ndarray):
 
 
 class const(Stub):
-    '''shared namespace
+    '''
+    Constant memory namespace.
     '''
     _description_ = '<const>'
 
     array_like = macro.Macro('const.array_like', const_array_like,
                              callable=True, argnames=['ary'])
+    '''
+    Create a const array from *ary*. The resulting const array will have the
+    same shape, type, and values as *ary*.
+    '''
 
 #-------------------------------------------------------------------------------
 # atomic

--- a/numba/cuda/tests/cudadrv/test_profiler.py
+++ b/numba/cuda/tests/cudadrv/test_profiler.py
@@ -8,11 +8,11 @@ from numba.cuda.testing import skip_on_cudasim
 @skip_on_cudasim('CUDA Profiler unsupported in the simulator')
 class TestProfiler(CUDATestCase):
     def test_profiling(self):
-        with cuda._profiling():
+        with cuda.profiling():
             a = cuda.device_array(10)
             del a
 
-        with cuda._profiling():
+        with cuda.profiling():
             a = cuda.device_array(100)
             del a
 


### PR DESCRIPTION
This is part of a reworking of the CUDA Python documentation. Still to come are an enumeration of all Numba supported features and functions, and a rewritten introduction to CUDA Python/user guide.

The reference section should cover everything that is part of an API that would be expected to be used by an end user that is CUDA-specific. I made the profiling functions public, since they seem to have a sensible use case (programatically controlling what gets profiled).

As much as possible of the manual is generated from docstrings, with the aim of making discovery at the interactive shell a bit easier. The style isn't 100% consistent, as I'm not really sure what the canonical way of documenting things with Sphinx/rst is, and there appears to be a mixture of styles across the manual and docstrings already.