### PR TITLE
Fix segfault on linux32

### DIFF
--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -410,7 +410,9 @@ PyObject* NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
     if (arystruct->meminfo) {
         /* wrap into MemInfoObject */
         miobj = PyObject_New(MemInfoObject, &MemInfoType);
-        args = Py_BuildValue("(K)", (unsigned PY_LONG_LONG)arystruct->meminfo);
+        args = PyTuple_New(1);
+        /* SETITEM steals reference */
+        PyTuple_SET_ITEM(args, 0, PyLong_FromVoidPtr(arystruct->meminfo));
         if(MemInfo_init(miobj, args, NULL)) {
             return NULL;
         }

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -84,6 +84,21 @@ def use_func_pointer(fa, fb, x):
         return fb(x)
 
 
+mydct = {'what': 1232121}
+
+def call_me_maybe(arr):
+    return mydct[arr[0].decode('ascii')]
+
+# Create a callback into the python interpreter
+py_call_back = CFUNCTYPE(c_int, py_object)(call_me_maybe)
+
+
+def take_array_ptr(ptr):
+    return ptr
+
+c_take_array_ptr = CFUNCTYPE(c_void_p, c_void_p)(take_array_ptr)
+
+
 class TestCTypes(unittest.TestCase):
 
     def test_c_sin(self):
@@ -161,14 +176,6 @@ class TestCTypes(unittest.TestCase):
         self.assertEqual(pyfunc(arr), cfunc(arr))
 
     def test_python_call_back_threaded(self):
-        mydct = {'what': 1232121}
-
-        def call_me_maybe(arr):
-            return mydct[arr[0].decode('ascii')]
-
-        # Create a callback into the python interpreter
-        py_call_back = CFUNCTYPE(c_int, py_object)(call_me_maybe)
-
         def pyfunc(a, repeat):
             out = 0
             for _ in range(repeat):
@@ -208,12 +215,6 @@ class TestCTypes(unittest.TestCase):
             self.assertEqual(expected, got)
 
     def test_passing_array_ctypes_data(self):
-
-        def take_array_ptr(ptr):
-            return ptr
-
-        c_take_array_ptr = CFUNCTYPE(c_void_p, c_void_p)(take_array_ptr)
-
         def pyfunc(arr):
             return c_take_array_ptr(arr.ctypes.data)
 

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -183,6 +183,9 @@ class TestCTypes(unittest.TestCase):
         expected = pyfunc(arr, repeat)
         outputs = []
 
+        # Warm up
+        cfunc(arr, repeat)
+
         # Test the function in multiple threads to exercise the
         # GIL ensure/release code
 


### PR DESCRIPTION
Mainly fixes https://github.com/numba/numba/issues/1138.  The fix is to move the ``CFUNCTYPE`` declaration into the global scope of the module so that no ``CFUNCTYPE`` is used after forking by multiproc testing.

Additionally:
* Avoid an overflow error in "_nrt_python.c"
* Avoid hanging forever when a process is dead in multiproc testing.  Use ``Pool.apply_async`` and ``get(timeout)``.
