### PR TITLE
charseq support

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -887,3 +887,21 @@ def add_postfix(name, postfix):
         return "{head}{ct}".format(head=head, ct=ct)
     return name + postfix
 
+
+def memcpy(builder, dst, src, count):
+    """
+    Emit a memcpy to the builder.
+
+    Copies each element of dst to src. Unlike the C equivalent, each element
+    can be any LLVM type.
+
+    Assumes
+    -------
+    * dst.type == src.type
+    * count is positive
+    """
+    assert dst.type == src.type
+    with for_range(builder, count, count.type) as idx:
+        out_ptr = builder.gep(dst, [idx])
+        in_ptr = builder.gep(src, [idx])
+        builder.store(builder.load(in_ptr), out_ptr)

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -6,6 +6,7 @@ from collections import namedtuple, defaultdict
 from pprint import pprint
 import sys
 import warnings
+import traceback
 
 from numba import (bytecode, interpreter, funcdesc, typing, typeinfer,
                    lowering, objmode, irpasses, utils, config,
@@ -180,6 +181,12 @@ class _PipelineManager(object):
         Patches the error to show the stage that it arose in.
         """
         newmsg = "{desc}\n{exc}".format(desc=desc, exc=exc)
+
+        # For python2, attach the traceback of the previous exception.
+        if not utils.IS_PY3:
+            fmt = "Caused By:\n{tb}\n{newmsg}"
+            newmsg = fmt.format(tb=traceback.format_exc(), newmsg=newmsg)
+
         exc.args = (newmsg,)
         return exc
 

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -59,20 +59,20 @@ class DataModel(object):
         Takes one LLVM value
         Return a LLVM value or nested tuple of LLVM value
         """
-        raise NotImplementedError
+        raise NotImplementedError(self)
 
     def as_return(self, builder, value):
-        raise NotImplementedError
+        raise NotImplementedError(self)
 
     def from_data(self, builder, value):
-        raise NotImplementedError
+        raise NotImplementedError(self)
 
     def from_argument(self, builder, value):
         """
         Takes a LLVM value or nested tuple of LLVM value
         Returns one LLVM value
         """
-        raise NotImplementedError
+        raise NotImplementedError(self)
 
     def from_return(self, builder, value):
         raise NotImplementedError

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -676,6 +676,12 @@ class CharSeq(DataModel):
     def from_return(self, builder, value):
         return value
 
+    def as_argument(self, builder, value):
+        return value
+
+    def from_argument(self, builder, value):
+        return value
+
 
 class CContiguousFlatIter(StructModel):
     def __init__(self, dmm, fe_type):

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -691,6 +691,42 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [strobj])
 
+    def string_as_string_and_size(self, strobj):
+        """
+        Returns a tuple of ``(ok, buffer, length)``.
+        The ``ok`` is i1 value that is set if ok.
+        The ``buffer`` is a i8* of the output buffer.
+        The ``length`` is a i32/i64 (py_ssize_t) of the length of the buffer.
+        """
+
+        p_length = cgutils.alloca_once(self.builder, self.py_ssize_t)
+        if PYVERSION >= (3, 0):
+            fnty = Type.function(self.cstring, [self.pyobj,
+                                                self.py_ssize_t.as_pointer()])
+            fname = "PyUnicode_AsUTF8AndSize"
+            fn = self._get_function(fnty, name=fname)
+
+            buffer = self.builder.call(fn, [strobj, p_length])
+            ok = self.builder.icmp_unsigned('!=',
+                                            ir.Constant(buffer.type, None),
+                                            buffer)
+        else:
+            fnty = Type.function(lc.Type.int(), [self.pyobj,
+                                                 self.cstring.as_pointer(),
+                                                 self.py_ssize_t.as_pointer()])
+            fname = "PyString_AsStringAndSize"
+            fn = self._get_function(fnty, name=fname)
+            # Allocate space for the output parameters
+            p_buffer = cgutils.alloca_once(self.builder, self.cstring)
+
+            status = self.builder.call(fn, [strobj, p_buffer, p_length])
+
+            negone = ir.Constant(status.type, -1)
+            ok = builder.icmp_signed("!=", status, negone)
+            buffer = self.builder.load(p_buffer)
+
+        return (ok, buffer, self.builder.load(p_length))
+
     def string_from_string_and_size(self, string, size):
         fnty = Type.function(self.pyobj, [self.cstring, self.py_ssize_t])
         if PYVERSION >= (3, 0):

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -722,7 +722,7 @@ class PythonAPI(object):
             status = self.builder.call(fn, [strobj, p_buffer, p_length])
 
             negone = ir.Constant(status.type, -1)
-            ok = builder.icmp_signed("!=", status, negone)
+            ok = self.builder.icmp_signed("!=", status, negone)
             buffer = self.builder.load(p_buffer)
 
         return (ok, buffer, self.builder.load(p_length))


### PR DESCRIPTION
* allow CharSeq as_argument/from_argument 
* allow CharSeq to pass from interpreter to npm function

TODO:
* [x] add test
* [x] charseq to_native_value needs to check for string length.