### PR TITLE
Add ufunc properties to DUFunc.

### DIFF
--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -83,6 +83,30 @@ class DUFunc(_internal._DUFunc):
         self._lower_me = DUFuncLowerer(self)
         self._install_cg()
 
+    @property
+    def nin(self):
+        return self.ufunc.nin
+
+    @property
+    def nout(self):
+        return self.ufunc.nout
+
+    @property
+    def nargs(self):
+        return self.ufunc.nargs
+
+    @property
+    def ntypes(self):
+        return self.ufunc.ntypes
+
+    @property
+    def types(self):
+        return self.ufunc.types
+
+    @property
+    def identity(self):
+        return self.ufunc.identity
+
     def _compile_for_args(self, *args, **kws):
         nin = self.ufunc.nin
         args_len = len(args)

--- a/numba/tests/test_dufunc.py
+++ b/numba/tests/test_dufunc.py
@@ -66,5 +66,17 @@ class TestDUFunc(unittest.TestCase):
         out3 = npmadd(1.,2.)
         self.assertEqual(out3, 3.)
 
+    def test_ufunc_props(self):
+        duadd = dufunc.DUFunc(pyuadd, nopython=True)
+        self.assertEqual(duadd.nin, 2)
+        self.assertEqual(duadd.nout, 1)
+        self.assertEqual(duadd.nargs, duadd.nin + duadd.nout)
+        self.assertEqual(duadd.ntypes, 0)
+        self.assertEqual(duadd.types, [])
+        self.assertEqual(duadd.identity, None)
+        duadd(1, 2)
+        self.assertEqual(duadd.ntypes, 1)
+        self.assertEqual(duadd.ntypes, len(duadd.types))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adding these properties should make DUFunc instances behaviorally interchangeable with ufunc's.