### PR TITLE
Support for *args

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -40,7 +40,7 @@ Function calls
 --------------
 
 Numba supports function calls using positional and named arguments, as well
-as arguments with default values.  Explicit ``*args`` and ``**kwargs`` are
+as arguments with default values and ``*args``.  Explicit ``**kwargs`` are
 not supported.
 
 Generators

--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifndef Py_MAX
-#define Py_MAX(x, y) (((x) > (y)) ? (y) : (x))
+#define Py_MAX(x, y) (((x) < (y)) ? (y) : (x))
 #endif
 
 #endif /* NUMBA_PY_MODULE_H_ */

--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -32,5 +32,14 @@
     #define PyInt_Type PyLong_Type
 #endif
 
+
+#ifndef Py_MIN
+#define Py_MIN(x, y) (((x) > (y)) ? (y) : (x))
+#endif
+
+#ifndef Py_MAX
+#define Py_MAX(x, y) (((x) > (y)) ? (y) : (x))
+#endif
+
 #endif /* NUMBA_PY_MODULE_H_ */
 

--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -90,6 +90,7 @@ def _make_bytecode_table():
                     ('BUILD_SLICE', 2),
                     ('BUILD_TUPLE', 2),
                     ('CALL_FUNCTION', 2),
+                    ('CALL_FUNCTION_VAR', 2),
                     ('COMPARE_OP', 2),
                     ('DELETE_ATTR', 2),
                     ('DUP_TOP', 0),

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -332,7 +332,7 @@ class Pipeline(object):
         Analyze bytecode and translating to Numba IR
         """
         self.interp = translate_stage(self.bc)
-        self.nargs = len(self.interp.argspec.args)
+        self.nargs = self.interp.arg_count
         if not self.args and self.flags.force_pyobject:
             # Allow an empty argument types specification when object mode
             # is explicitly requested.
@@ -666,13 +666,13 @@ def translate_stage(bytecode):
 
 
 def type_inference_stage(typingctx, interp, args, return_type, locals={}):
-    if len(args) != len(interp.argspec.args):
+    if len(args) != interp.arg_count:
         raise TypeError("Mismatch number of argument types")
 
     infer = typeinfer.TypeInferer(typingctx, interp)
 
     # Seed argument types
-    for index, (name, ty) in enumerate(zip(interp.argspec.args, args)):
+    for index, (name, ty) in enumerate(zip(interp.bytecode.arg_names, args)):
         infer.seed_argument(name, index, ty)
 
     # Seed return type

--- a/numba/datamodel/argpacker.py
+++ b/numba/datamodel/argpacker.py
@@ -21,7 +21,6 @@ class ArgPacker(object):
         self._nargs = len(fe_args)
         self._dm_args = [self._dmm.lookup(ty) for ty in fe_args]
         argtys = [bt.get_argument_type() for bt in self._dm_args]
-        #flattened = list()
         if argtys:
             self._be_args, self._posmap = zip(*_flatten(argtys, mark_empty=True))
         else:

--- a/numba/datamodel/argpacker.py
+++ b/numba/datamodel/argpacker.py
@@ -21,8 +21,9 @@ class ArgPacker(object):
         self._nargs = len(fe_args)
         self._dm_args = [self._dmm.lookup(ty) for ty in fe_args]
         argtys = [bt.get_argument_type() for bt in self._dm_args]
-        if len(argtys):
-            self._be_args, self._posmap = zip(*_flatten(argtys))
+        #flattened = list()
+        if argtys:
+            self._be_args, self._posmap = zip(*_flatten(argtys, mark_empty=True))
         else:
             self._be_args = self._posmap = ()
 
@@ -38,18 +39,16 @@ class ArgPacker(object):
         args = [dm.as_argument(builder, val)
                 for dm, val in zip(self._dm_args, values)]
 
-        args, _ = zip(*_flatten(args))
+        flattened = list(_flatten(args))
+        if flattened:
+            args, _ = zip(*flattened)
+        else:
+            args = ()
         return args
 
     def from_arguments(self, builder, args):
         """Unflatten all argument values
         """
-
-        if len(args) != len(self._posmap):
-            raise TypeError("invalid number of args")
-
-        if not args:
-            return ()
 
         valtree = _unflatten(self._posmap, args)
         values = [dm.from_argument(builder, val)
@@ -60,11 +59,6 @@ class ArgPacker(object):
     def assign_names(self, args, names):
         """Assign names for each flattened argument values.
         """
-        if len(args) != len(self._posmap):
-            raise TypeError("invalid number of args")
-
-        if not args:
-            return ()
 
         valtree = _unflatten(self._posmap, args)
         for aval, aname in zip(valtree, names):
@@ -84,7 +78,7 @@ class ArgPacker(object):
         """Return a list of LLVM types that are results of flattening
         composite types.
         """
-        return tuple(self._be_args)
+        return tuple(ty for ty in self._be_args if ty != ())
 
 
 def _unflatten(posmap, flatiter):
@@ -95,7 +89,6 @@ def _unflatten(posmap, flatiter):
 
     res = []
     while poss:
-        assert len(poss) == len(vals)
         cur = poss.popleft()
         ptr = res
         for loc in cur[:-1]:
@@ -103,22 +96,32 @@ def _unflatten(posmap, flatiter):
                 ptr.append([])
             ptr = ptr[loc]
 
-        assert len(ptr) == cur[-1]
-        ptr.append(vals.popleft())
+        if cur == ():
+            ptr.append(())
+        else:
+            assert len(ptr) == cur[-1]
+            ptr.append(vals.popleft())
+
+    assert not vals
 
     return res
 
 
-def _flatten(iterable, indices=(0,)):
+def _flatten(iterable, mark_empty=False):
     """
     Flatten nested iterable of (tuple, list) with position information
     """
-    for i in iterable:
-        if isinstance(i, (tuple, list)):
-            inner = indices + (0,)
-            for j, k in _flatten(i, indices=inner):
-                yield j, k
-        else:
-            yield i, indices
-        indices = indices[:-1] + (indices[-1] + 1,)
+    def rec(iterable, indices):
+        for i in iterable:
+            if isinstance(i, (tuple, list)):
+                if len(i) > 0:
+                    inner = indices + (0,)
+                    for j, k in rec(i, indices=inner):
+                        yield j, k
+                elif mark_empty:
+                    yield i, ()
+            else:
+                yield i, indices
+            indices = indices[:-1] + (indices[-1] + 1,)
+    return rec(iterable, indices=(0,))
 

--- a/numba/funcdesc.py
+++ b/numba/funcdesc.py
@@ -113,7 +113,7 @@ class FunctionDescriptor(object):
         qualname = interp.bytecode.func_qualname
         modname = func.__module__
         doc = func.__doc__ or ''
-        args = interp.argspec.args
+        args = tuple(interp.arg_names)
         kws = ()        # TODO
 
         if modname is None:

--- a/numba/generators.py
+++ b/numba/generators.py
@@ -200,7 +200,7 @@ class PyGeneratorLower(BaseGeneratorLower):
         return types.Generator(
             gen_func=self.interp.bytecode.func,
             yield_type=types.pyobject,
-            arg_types=(types.pyobject,) * len(self.interp.argspec.args),
+            arg_types=(types.pyobject,) * self.interp.arg_count,
             state_types=(types.pyobject,) * len(self.geninfo.state_vars),
             has_finalizer=True,
             )

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -93,7 +93,8 @@ class Interpreter(object):
         self.bytecode = bytecode
         self.scopes = []
         self.loc = ir.Loc(filename=bytecode.filename, line=1)
-        self.argspec = bytecode.argspec
+        self.arg_count = bytecode.arg_count
+        self.arg_names = bytecode.arg_names
         # Control flow analysis
         self.cfa = controlflow.ControlFlowAnalysis(bytecode)
         self.cfa.run()
@@ -357,7 +358,7 @@ class Interpreter(object):
 
     def init_first_block(self):
         # Define variables receiving the function arguments
-        for index, name in enumerate(self.argspec.args):
+        for index, name in enumerate(self.arg_names):
             val = ir.Arg(index=index, name=name, loc=self.loc)
             self.store(val, name)
 

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -791,9 +791,11 @@ class Interpreter(object):
         loop = ir.Loop(inst.offset, exit=(inst.next + inst.arg))
         self.syntax_blocks.append(loop)
 
-    def op_CALL_FUNCTION(self, inst, func, args, kws, res):
+    def op_CALL_FUNCTION(self, inst, func, args, kws, res, vararg):
         func = self.get(func)
         args = [self.get(x) for x in args]
+        if vararg is not None:
+            vararg = self.get(vararg)
 
         # Process keywords
         keyvalues = []
@@ -809,8 +811,11 @@ class Interpreter(object):
         for inst in removethese:
             self.current_block.remove(inst)
 
-        expr = ir.Expr.call(func, args, keyvalues, loc=self.loc)
+        expr = ir.Expr.call(func, args, keyvalues, loc=self.loc,
+                            vararg=vararg)
         self.store(expr, res)
+
+    op_CALL_FUNCTION_VAR = op_CALL_FUNCTION
 
     def op_GET_ITER(self, inst, value, res):
         expr = ir.Expr.getiter(value=self.get(value), loc=self.loc)

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -165,9 +165,10 @@ class Expr(Inst):
         return cls(op=op, loc=loc, fn=fn, value=value)
 
     @classmethod
-    def call(cls, func, args, kws, loc):
+    def call(cls, func, args, kws, loc, vararg=None):
         op = 'call'
-        return cls(op=op, loc=loc, func=func, args=args, kws=kws)
+        return cls(op=op, loc=loc, func=func, args=args, kws=kws,
+                   vararg=vararg)
 
     @classmethod
     def build_tuple(cls, items, loc):
@@ -241,7 +242,9 @@ class Expr(Inst):
         if self.op == 'call':
             args = ', '.join(str(a) for a in self.args)
             kws = ', '.join('%s=%s' % (k, v) for k, v in self.kws)
-            return 'call %s(%s, %s)' % (self.func, args, kws)
+            vararg = '*%s' % (self.vararg,) if self.vararg is not None else ''
+            arglist = ', '.join(filter(None, [args, vararg, kws]))
+            return 'call %s(%s)' % (self.func, arglist)
         elif self.op == 'binop':
             return '%s %s %s' % (self.lhs, self.fn, self.rhs)
         else:

--- a/numba/looplifting.py
+++ b/numba/looplifting.py
@@ -21,7 +21,7 @@ def lift_loop(bytecode, dispatcher_factory):
     separate_loops(bytecode, outer, loops)
 
     # Prepend arguments as negative bytecode offset
-    for a in bytecode.argspec.args:
+    for a in bytecode.pysig.parameters:
         outer_wrs[a] = [-1] + outer_wrs[a]
 
     dispatchers = []
@@ -42,7 +42,7 @@ def lift_loop(bytecode, dispatcher_factory):
     outerbc = CustomByteCode(func=bytecode.func,
                              func_qualname=bytecode.func_qualname,
                              is_generator=bytecode.is_generator,
-                             argspec=bytecode.argspec,
+                             pysig=bytecode.pysig,
                              filename=bytecode.filename,
                              co_names=outernames,
                              co_varnames=bytecode.co_varnames,
@@ -231,10 +231,6 @@ def make_loop_bytecode(bytecode, loop, args, returns):
     # Function name
     loop_qualname = bytecode.func_qualname + ".__numba__loop%d__" % loop[0].offset
 
-    # Argspec
-    argspectype = type(bytecode.argspec)
-    argspec = argspectype(args=args, varargs=(), keywords=(), defaults=())
-
     # Code table
     codetable = utils.SortedMap((i.offset, i) for i in loop)
 
@@ -243,7 +239,9 @@ def make_loop_bytecode(bytecode, loop, args, returns):
                          func_qualname=loop_qualname,
                          # Enforced in separate_loops()
                          is_generator=False,
-                         argspec=argspec,
+                         pysig=bytecode.pysig,
+                         arg_count=len(args),
+                         arg_names=args,
                          filename=bytecode.filename,
                          co_names=bytecode.co_names,
                          co_varnames=bytecode.co_varnames,

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -128,6 +128,9 @@ class TestArgInfo(unittest.TestCase):
 
         self.assertEqual(expect_types, got_types)
 
+        # Assign names (check this doesn't raise)
+        fi.assign_names(values, ["arg%i" for i in range(len(fe_args))])
+
         builder.ret_void()
 
         ll.parse_assembly(str(module))
@@ -153,6 +156,11 @@ class TestArgInfo(unittest.TestCase):
         self._test_as_arguments(fe_args)
         # Nested tuple
         fe_args = [types.UniTuple(types.UniTuple(types.int32, 2), 3)]
+        self._test_as_arguments(fe_args)
+        # Empty tuple
+        fe_args = [types.UniTuple(types.int16, 0),
+                   types.int32,
+                   types.UniTuple(types.int64, 0)]
         self._test_as_arguments(fe_args)
 
 

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -184,10 +184,13 @@ class TestDispatcher(TestCase):
         check(4, y=5)
         with self.assertRaises(TypeError) as cm:
             f(4, 5, y=6)
-        self.assertIn("too many arguments", str(cm.exception))
+        self.assertIn("some keyword arguments unexpected", str(cm.exception))
         with self.assertRaises(TypeError) as cm:
             f(4, 5, z=6)
-        self.assertIn("too many arguments", str(cm.exception))
+        self.assertIn("some keyword arguments unexpected", str(cm.exception))
+        with self.assertRaises(TypeError) as cm:
+            f(4, x=6)
+        self.assertIn("some keyword arguments unexpected", str(cm.exception))
 
     def test_explicit_signatures(self):
         f = jit("(int64,int64)")(add)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -25,13 +25,18 @@ def addsub_defaults(x, y=2, z=3):
     return x - y + z
 
 
+def star_defaults(x, y=2, *z):
+    return x, y, z
+
+
 class TestDispatcher(TestCase):
 
     def compile_func(self, pyfunc):
         def check(*args, **kwargs):
+            expected = pyfunc(*args, **kwargs)
             result = f(*args, **kwargs)
-            self.assertPreciseEqual(result, pyfunc(*args, **kwargs))
-        f = jit(pyfunc)
+            self.assertPreciseEqual(result, expected)
+        f = jit(nopython=True)(pyfunc)
         return f, check
 
     def test_numba_interface(self):
@@ -163,6 +168,26 @@ class TestDispatcher(TestCase):
         with self.assertRaises(TypeError) as cm:
             f(y=6, z=7)
         self.assertIn("missing argument 'x'", str(cm.exception))
+
+    def test_star_args(self):
+        """
+        Test a compiled function with starargs in the signature.
+        """
+        f, check = self.compile_func(star_defaults)
+        check(4)
+        check(4, 5)
+        check(4, 5, 6)
+        check(4, 5, 6, 7)
+        check(4, 5, 6, 7, 8)
+        check(x=4)
+        check(x=4, y=5)
+        check(4, y=5)
+        with self.assertRaises(TypeError) as cm:
+            f(4, 5, y=6)
+        self.assertIn("too many arguments", str(cm.exception))
+        with self.assertRaises(TypeError) as cm:
+            f(4, 5, z=6)
+        self.assertIn("too many arguments", str(cm.exception))
 
     def test_explicit_signatures(self):
         f = jit("(int64,int64)")(add)

--- a/numba/tests/test_nested_calls.py
+++ b/numba/tests/test_nested_calls.py
@@ -23,6 +23,14 @@ def g_inner(a, b=2, c=3):
 def g(x, y, z):
     return g_inner(x, b=y), g_inner(a=z, c=x)
 
+@njit
+def star_inner(a=5, *b):
+    return a, b
+
+def star(x, y, z):
+    #return star_inner(x, y, z)
+    return star_inner(a=x), star_inner(x, y, z)
+
 
 
 class TestNestedCall(unittest.TestCase):
@@ -57,6 +65,13 @@ class TestNestedCall(unittest.TestCase):
         cfunc = njit(g)
         self.assertEqual(cfunc(1, 2, 3), g(1, 2, 3))
         self.assertEqual(cfunc(1, y=2, z=3), g(1, 2, 3))
+
+    def test_star_args(self):
+        """
+        Test a nested function call to a function with *args in its signature.
+        """
+        cfunc = njit(star)
+        self.assertEqual(cfunc(1, 2, 3), star(1, 2, 3))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_nested_calls.py
+++ b/numba/tests/test_nested_calls.py
@@ -7,6 +7,7 @@ from __future__ import print_function, division, absolute_import
 
 from numba import njit
 from numba import unittest_support as unittest
+from .support import TestCase
 
 
 @njit
@@ -28,12 +29,21 @@ def star_inner(a=5, *b):
     return a, b
 
 def star(x, y, z):
-    #return star_inner(x, y, z)
     return star_inner(a=x), star_inner(x, y, z)
 
+def star_call(x, y, z):
+    return star_inner(x, *y), star_inner(*z)
 
 
-class TestNestedCall(unittest.TestCase):
+class TestNestedCall(TestCase):
+
+    def compile_func(self, pyfunc):
+        def check(*args, **kwargs):
+            expected = pyfunc(*args, **kwargs)
+            result = f(*args, **kwargs)
+            self.assertPreciseEqual(result, expected)
+        f = njit(pyfunc)
+        return f, check
 
     def test_boolean_return(self):
         @njit
@@ -54,24 +64,31 @@ class TestNestedCall(unittest.TestCase):
         """
         Test a nested function call with named (keyword) arguments.
         """
-        cfunc = njit(f)
-        self.assertEqual(cfunc(1, 2, 3), f(1, 2, 3))
-        self.assertEqual(cfunc(1, y=2, z=3), f(1, 2, 3))
+        cfunc, check = self.compile_func(f)
+        check(1, 2, 3)
+        check(1, y=2, z=3)
 
     def test_default_args(self):
         """
         Test a nested function call using default argument values.
         """
-        cfunc = njit(g)
-        self.assertEqual(cfunc(1, 2, 3), g(1, 2, 3))
-        self.assertEqual(cfunc(1, y=2, z=3), g(1, 2, 3))
+        cfunc, check = self.compile_func(g)
+        check(1, 2, 3)
+        check(1, y=2, z=3)
 
     def test_star_args(self):
         """
         Test a nested function call to a function with *args in its signature.
         """
-        cfunc = njit(star)
-        self.assertEqual(cfunc(1, 2, 3), star(1, 2, 3))
+        cfunc, check = self.compile_func(star)
+        check(1, 2, 3)
+
+    def test_star_call(self):
+        """
+        Test a function call with a *args.
+        """
+        cfunc, check = self.compile_func(star_call)
+        check(1, (2,), (3,))
 
 
 if __name__ == '__main__':

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -213,11 +213,12 @@ class CallConstrain(object):
     Perform case analysis foreach combinations of argument types.
     """
 
-    def __init__(self, target, func, args, kws, loc):
+    def __init__(self, target, func, args, kws, vararg, loc):
         self.target = target
         self.func = func
         self.args = args
-        self.kws = kws
+        self.kws = kws or {}
+        self.vararg = vararg
         self.loc = loc
 
     def __call__(self, context, typevars):
@@ -230,10 +231,19 @@ class CallConstrain(object):
         kwds = [kw for (kw, var) in self.kws]
         argtypes = [typevars[a.name].get() for a in self.args]
         argtypes += [typevars[var.name].get() for (kw, var) in self.kws]
+        if self.vararg is not None:
+            argtypes.append(typevars[self.vararg.name].get())
         restypes = []
         # Case analysis for each combination of argument types.
         for args in itertools.product(*argtypes):
             pos_args = args[:n_pos_args]
+            if self.vararg is not None:
+                if not isinstance(args[-1], types.BaseTuple):
+                    # Unsuitable for *args
+                    # (Python is more lenient and accepts all iterables)
+                    continue
+                pos_args += args[-1].types
+                args = args[:-1]
             kw_args = dict(zip(kwds, args[n_pos_args:]))
             sig = context.resolve_function_type(fnty, pos_args, kw_args)
             if sig is None:
@@ -444,16 +454,20 @@ class TypeInferer(object):
             assert signature is not None, (fnty, args)
             calltypes[call] = signature
 
-        for call, args, kws in self.usercalls:
-            args = tuple(typemap[a.name] for a in args)
-            kws = dict((kw, typemap[var.name]) for (kw, var) in kws)
-
+        for call, args, kws, vararg in self.usercalls:
             if isinstance(call.func, ir.Intrinsic):
                 signature = call.func.type
             else:
                 fnty = typemap[call.func.name]
+
+                args = tuple(typemap[a.name] for a in args)
+                kws = dict((kw, typemap[var.name]) for (kw, var) in kws)
+                if vararg is not None:
+                    tp = typemap[vararg.name]
+                    assert isinstance(tp, types.BaseTuple)
+                    args = args + tp.types
                 signature = self.context.resolve_function_type(fnty, args, kws)
-                assert signature is not None, (fnty, args, kws)
+                assert signature is not None, (fnty, args, kws, vararg)
             calltypes[call] = signature
 
         for inst in self.setitemcalls:
@@ -606,7 +620,7 @@ class TypeInferer(object):
             if isinstance(expr.func, ir.Intrinsic):
                 restype = expr.func.type.return_type
                 self.typevars[target.name].add_types(restype)
-                self.usercalls.append((inst.value, expr.args, expr.kws))
+                self.usercalls.append((inst.value, expr.args, expr.kws, None))
             else:
                 self.typeof_call(inst, target, expr)
         elif expr.op in ('getiter', 'iternext'):
@@ -659,12 +673,12 @@ class TypeInferer(object):
 
     def typeof_call(self, inst, target, call):
         constrain = CallConstrain(target.name, call.func.name, call.args,
-                                  call.kws, loc=inst.loc)
+                                  call.kws, call.vararg, loc=inst.loc)
         self.constrains.append(constrain)
-        self.usercalls.append((inst.value, call.args, call.kws))
+        self.usercalls.append((inst.value, call.args, call.kws, call.vararg))
 
     def typeof_intrinsic_call(self, inst, target, func, *args):
-        constrain = IntrinsicCallConstrain(target.name, func, args, (),
-                                           loc=inst.loc)
+        constrain = IntrinsicCallConstrain(target.name, func, args,
+                                           kws=(), vararg=None, loc=inst.loc)
         self.constrains.append(constrain)
         self.intrcalls.append((inst.value, args, ()))

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -62,29 +62,43 @@ def signature(return_type, *args, **kws):
     return Signature(return_type, args, recvr=recvr)
 
 
-def fold_arguments(pysig, args, kws, default_handler):
+def fold_arguments(pysig, args, kws, normal_handler, default_handler,
+                   stararg_handler):
     """
     Given the signature *pysig*, explicit *args* and *kws*, resolve
-    omitted arguments (by calling default_handler(index, default))
-    and keyword arguments.  A tuple (arguments, defaults) is returned
-    where *arguments* is a tuple of positional arguments and *defaults*
-    is the list of indices of omitted arguments.
+    omitted arguments and keyword arguments. A tuple of positional
+    arguments is returned.
+    Various handlers allow to process arguments:
+    - normal_handler(index, param, value) is called for normal arguments
+    - default_handler(index, param, default) is called for omitted arguments
+    - stararg_handler(index, param, values) is called for a "*args" argument
     """
     ba = pysig.bind(*args, **kws)
     defargs = []
     for i, param in enumerate(pysig.parameters.values()):
         name = param.name
         default = param.default
-        if (default is not param.empty and
-            name not in ba.arguments):
-            ba.arguments[name] = default_handler(i, default)
-            defargs.append(i)
+        if param.kind == param.VAR_POSITIONAL:
+            # stararg may be omitted, in which case its "default" value
+            # is simply the empty tuple
+            ba.arguments[name] = stararg_handler(i, param,
+                                                 ba.arguments.get(name, ()))
+        elif name in ba.arguments:
+            # Non-stararg, present
+            ba.arguments[name] = normal_handler(i, param, ba.arguments[name])
+        else:
+            # Non-stararg, omitted
+            assert default is not param.empty
+            ba.arguments[name] = default_handler(i, param, default)
     if ba.kwargs:
         # There's a remaining keyword argument, e.g. if omitting
         # some argument with a default value before it.
         raise NotImplementedError("unhandled keyword argument: %s"
                                   % list(ba.kwargs))
-    return ba.args, defargs
+    # Collect args in the right order
+    args = tuple(ba.arguments[param.name]
+                 for param in pysig.parameters.values())
+    return args
 
 
 def _uses_downcast(dists):


### PR DESCRIPTION
Based on PR #1136 . This adds support for `*args` in compiled function signatures as well as in compiled function calls.