### PR TITLE
Fix problem with matching CUDA IR code in array_exprs.

### DIFF
--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -58,9 +58,9 @@ class RewriteArrayExprs(rewrites.Rewrite):
                             expr.fn in npydecl.supported_array_operators)):
                         # Matches an array operation that maps to a ufunc.
                         array_assigns[target_name] = instr
-                    elif expr_op == 'call':
+                    elif ((expr_op == 'call') and (expr.func.name in typemap)):
                         # Could be a match for a ufunc or DUFunc call.
-                        func_type = typemap.get(expr.func.name)
+                        func_type = typemap[expr.func.name]
                         func_key = getattr(func_type.template, 'key', None)
                         if isinstance(func_key, (ufunc, DUFunc)):
                             # If so, match it as a potential subexpression.


### PR DESCRIPTION
Added additional guards to make sure the call matching logic in array_exprs doesn't chase after calls to functions with no type information (which won't be ufunc's or DUFunc's).  Should fix problem with running numba.cuda.tests.cudapy.test_lang.TestLang.test_issue_872 on a system with CUDA support.