### PR TITLE
Small fixes for debug mode

### DIFF
--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -5,9 +5,9 @@ All functions described here are threadsafe.
 #include <stdlib.h>
 #include <stdio.h>
 
-/* Debugging facilities */
+/* Debugging facilities - enabled at compile-time */
 /* #undef NDEBUG */
-#ifndef NDEBUG
+#if 0
 #   define NRT_Debug(X) X
 #else
 #   define NRT_Debug(X)

--- a/numba/tests/test_annotations.py
+++ b/numba/tests/test_annotations.py
@@ -5,8 +5,15 @@ from numba.compiler import compile_isolated
 from numba import types
 from numba.io_support import StringIO
 
+try:
+    import jinja2
+except ImportError:
+    jinja2 = None
 
+
+@unittest.skipIf(jinja2 is None, "please install the 'jinja2' package")
 class TestAnnotation(unittest.TestCase):
+
     def test_exercise_code_path(self):
         """
         Ensures template.html is available
@@ -31,4 +38,3 @@ class TestAnnotation(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Two small fixes:
- disable NRT debug by default, instead of making it conditional on NDEBUG (otherwise, a debug-enabled Python makes Numba insanely chatty)
- fix the annotations test when jinja2 isn't installed (conda-provided jinja2 installs a C extension, which isn't compatible with a debug-enabled Python)