### PR TITLE
Allow dtype instances to np.empty() and friends

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -6,7 +6,6 @@ import llvmlite.llvmpy.core as lc
 import llvmlite.llvmpy.ee as le
 import llvmlite.binding as ll
 from numba.targets.imputils import implement, Registry
-from numba.targets.npyimpl import register_casters
 from numba import cgutils
 from numba import types
 from .cudadrv import nvvm
@@ -15,7 +14,6 @@ from . import nvvmutils, stubs
 registry = Registry()
 register = registry.register
 
-register_casters(register)
 
 @register
 @implement('ptx.grid.1d', types.intp)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -193,6 +193,8 @@ class PrimitiveModel(DataModel):
 @register_default(types.ExternalFunction)
 @register_default(types.Method)
 @register_default(types.Macro)
+@register_default(types.NumberClass)
+@register_default(types.DType)
 class OpaqueModel(PrimitiveModel):
     """
     Passed as opaque pointers
@@ -205,6 +207,7 @@ class OpaqueModel(PrimitiveModel):
     def get_nrt_meminfo(self, builder, value):
         if self._fe_type == types.meminfo_pointer:
             return value
+
 
 @register_default(types.Integer)
 class IntegerModel(PrimitiveModel):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -322,10 +322,7 @@ class Lower(BaseLower):
                 return self.context.get_constant_generic(self.builder, ty,
                                                          value.value)
 
-            elif (isinstance(ty, types.Dummy) or
-                    isinstance(ty, types.Module) or
-                    isinstance(ty, types.Function) or
-                    isinstance(ty, types.Dispatcher)):
+            elif isinstance(ty, types.Dummy):
                 return self.context.get_dummy_value()
 
             elif isinstance(ty, types.Array):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1337,7 +1337,7 @@ def numpy_empty_nd(context, builder, sig, args):
 
 @builtin
 @implement(numpy.empty_like, types.Kind(types.Array))
-@implement(numpy.empty_like, types.Kind(types.Array), types.Kind(types.Function))
+@implement(numpy.empty_like, types.Kind(types.Array), types.Kind(types.DTypeSpec))
 def numpy_zeros_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -1356,7 +1356,7 @@ def numpy_zeros_nd(context, builder, sig, args):
 
 @builtin
 @implement(numpy.zeros_like, types.Kind(types.Array))
-@implement(numpy.zeros_like, types.Kind(types.Array), types.Kind(types.Function))
+@implement(numpy.zeros_like, types.Kind(types.Array), types.Kind(types.DTypeSpec))
 def numpy_zeros_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -1378,7 +1378,7 @@ if numpy_version >= (1, 8):
         return context.compile_internal(builder, full, sig, args)
 
     @builtin
-    @implement(numpy.full, types.Any, types.Any, types.Kind(types.Function))
+    @implement(numpy.full, types.Any, types.Any, types.Kind(types.DTypeSpec))
     def numpy_full_dtype_nd(context, builder, sig, args):
 
         def full(shape, value, dtype):
@@ -1404,7 +1404,7 @@ if numpy_version >= (1, 8):
 
 
     @builtin
-    @implement(numpy.full_like, types.Kind(types.Array), types.Any, types.Kind(types.Function))
+    @implement(numpy.full_like, types.Kind(types.Array), types.Any, types.Kind(types.DTypeSpec))
     def numpy_full_like_nd(context, builder, sig, args):
 
         def full_like(arr, value, dtype):
@@ -1431,7 +1431,7 @@ def numpy_ones_nd(context, builder, sig, args):
                                     locals={'c': valty})
 
 @builtin
-@implement(numpy.ones, types.Any, types.Kind(types.Function))
+@implement(numpy.ones, types.Any, types.Kind(types.DTypeSpec))
 def numpy_ones_dtype_nd(context, builder, sig, args):
 
     def ones(shape, dtype):
@@ -1455,7 +1455,7 @@ def numpy_ones_like_nd(context, builder, sig, args):
     return context.compile_internal(builder, ones_like, sig, args)
 
 @builtin
-@implement(numpy.ones_like, types.Kind(types.Array), types.Kind(types.Function))
+@implement(numpy.ones_like, types.Kind(types.Array), types.Kind(types.DTypeSpec))
 def numpy_ones_like_dtype_nd(context, builder, sig, args):
 
     def ones_like(arr, dtype):
@@ -1480,7 +1480,7 @@ def numpy_identity(context, builder, sig, args):
     return context.compile_internal(builder, identity, sig, args)
 
 @builtin
-@implement(numpy.identity, types.Kind(types.Integer), types.Kind(types.Function))
+@implement(numpy.identity, types.Kind(types.Integer), types.Kind(types.DTypeSpec))
 def numpy_identity(context, builder, sig, args):
 
     def identity(n, dtype):
@@ -1522,7 +1522,7 @@ def numpy_eye(context, builder, sig, args):
 
 @builtin
 @implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer),
-           types.Kind(types.Integer), types.Kind(types.Function))
+           types.Kind(types.Integer), types.Kind(types.DTypeSpec))
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m, k, dtype):
@@ -1574,7 +1574,7 @@ def numpy_arange_3(context, builder, sig, args):
 
 @builtin
 @implement(numpy.arange, types.Kind(types.Number), types.Kind(types.Number),
-           types.Kind(types.Number), types.Kind(types.Function))
+           types.Kind(types.Number), types.Kind(types.DTypeSpec))
 def numpy_arange_4(context, builder, sig, args):
 
     if any(isinstance(a, types.Complex) for a in sig.args):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -434,7 +434,7 @@ class BaseContext(object):
         Return the implementation of function *fn* for signature *sig*.
         The return value is a callable with the signature (builder, args).
         """
-        if isinstance(fn, types.Function):
+        if isinstance(fn, (types.NumberClass, types.Function)):
             key = fn.template.key
 
             if isinstance(key, MethodType):
@@ -516,7 +516,8 @@ class BaseContext(object):
             # We are treating them as constants.
             # XXX We shouldn't have to retype this
             attrty = self.typing_context.resolve_module_constants(typ, attr)
-            if attrty is not None and not isinstance(attrty, (types.Dispatcher,
+            if attrty is not None and not isinstance(attrty, (types.Dummy,
+                                                              types.Dispatcher,
                                                               types.Function,
                                                               types.Module)):
                 pyval = getattr(typ.pymod, attr)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -516,18 +516,15 @@ class BaseContext(object):
             # We are treating them as constants.
             # XXX We shouldn't have to retype this
             attrty = self.typing_context.resolve_module_constants(typ, attr)
-            if attrty is not None and not isinstance(attrty, (types.Dummy,
-                                                              types.Dispatcher,
-                                                              types.Function,
-                                                              types.Module)):
+            if attrty is not None and not isinstance(attrty, types.Dummy):
                 pyval = getattr(typ.pymod, attr)
                 llval = self.get_constant(attrty, pyval)
                 @impl_attribute(typ, attr, attrty)
                 def imp(context, builder, typ, val):
                     return llval
                 return imp
-            # No implementation required for functions/modules, which are
-            # dealt with later
+            # No implementation required for dummies (functions, modules...),
+            # which are dealt with later
             return None
 
         # Lookup specific attribute implementation for this type

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -23,30 +23,6 @@ registry = Registry()
 register = registry.register
 
 
-def caster(restype, constructor):
-    """
-    Implement explicit calls to Numpy type *constructor* (e.g. np.int16).
-    """
-    @implement(constructor, types.Any)
-    def _cast(context, builder, sig, args):
-        [val] = args
-        [valty] = sig.args
-        return context.cast(builder, val, valty, restype)
-
-    return _cast
-
-def register_casters(register_function):
-    for tp in types.number_domain:
-        register_function(caster(tp, getattr(numpy, str(tp))))
-
-    register_function(caster(types.bool_, numpy.bool_))
-    register_function(caster(types.intc, numpy.intc))
-    register_function(caster(types.uintc, numpy.uintc))
-    register_function(caster(types.intp, numpy.intp))
-    register_function(caster(types.uintp, numpy.uintp))
-
-register_casters(register)
-
 ########################################################################
 
 # In the way we generate code, ufuncs work with scalar as well as

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -444,7 +444,7 @@ class TestDynArray(unittest.TestCase):
 
 class ConstructorBaseTest(object):
 
-    def check_1d(self, pyfunc, dtype):
+    def check_1d(self, pyfunc):
         cfunc = nrtjit(pyfunc)
         n = 3
         expected = pyfunc(n)
@@ -464,7 +464,7 @@ class ConstructorBaseTest(object):
             cfunc(-1)
         self.assertEqual(str(cm.exception), "negative dimensions not allowed")
 
-    def check_2d(self, pyfunc, dtype):
+    def check_2d(self, pyfunc):
         cfunc = nrtjit(pyfunc)
         m, n = 2, 3
         expected = pyfunc(m, n)
@@ -497,25 +497,33 @@ class TestNdZeros(ConstructorBaseTest, unittest.TestCase):
         pyfunc = self.pyfunc
         def func(n):
             return pyfunc(n)
-        self.check_1d(func, np.float64)
+        self.check_1d(func)
 
     def test_1d_dtype(self):
         pyfunc = self.pyfunc
         def func(n):
             return pyfunc(n, np.int32)
-        self.check_1d(func, np.int32)
+        self.check_1d(func)
+
+    def test_1d_dtype_instance(self):
+        # dtype as numpy dtype, not as scalar class
+        pyfunc = self.pyfunc
+        _dtype = np.dtype('int32')
+        def func(n):
+            return pyfunc(n, _dtype)
+        self.check_1d(func)
 
     def test_2d(self):
         pyfunc = self.pyfunc
         def func(m, n):
             return pyfunc((m, n))
-        self.check_2d(func, np.float64)
+        self.check_2d(func)
 
     def test_2d_dtype_kwarg(self):
         pyfunc = self.pyfunc
         def func(m, n):
             return pyfunc((m, n), dtype=np.complex64)
-        self.check_2d(func, np.complex64)
+        self.check_2d(func)
 
 
 class TestNdOnes(TestNdZeros):
@@ -533,22 +541,28 @@ class TestNdFull(ConstructorBaseTest, unittest.TestCase):
     def test_1d(self):
         def func(n):
             return np.full(n, 4.5)
-        self.check_1d(func, np.float64)
+        self.check_1d(func)
 
     def test_1d_dtype(self):
         def func(n):
             return np.full(n, 4.5, np.bool_)
-        self.check_1d(func, np.int32)
+        self.check_1d(func)
+
+    def test_1d_dtype_instance(self):
+        dtype = np.dtype('bool')
+        def func(n):
+            return np.full(n, 4.5, dtype)
+        self.check_1d(func)
 
     def test_2d(self):
         def func(m, n):
             return np.full((m, n), 4.5)
-        self.check_2d(func, np.float64)
+        self.check_2d(func)
 
     def test_2d_dtype_kwarg(self):
         def func(m, n):
             return np.full((m, n), 1 + 4.5j, dtype=np.complex64)
-        self.check_2d(func, np.complex64)
+        self.check_2d(func)
 
 
 class ConstructorLikeBaseTest(object):
@@ -601,6 +615,13 @@ class TestNdEmptyLike(ConstructorLikeBaseTest, unittest.TestCase):
             return pyfunc(arr, np.int32)
         self.check_like(func, np.float64, np.int32)
 
+    def test_like_dtype_instance(self):
+        dtype = np.dtype('int32')
+        pyfunc = self.pyfunc
+        def func(arr):
+            return pyfunc(arr, dtype)
+        self.check_like(func, np.float64, np.int32)
+
     def test_like_dtype_kwarg(self):
         pyfunc = self.pyfunc
         def func(arr):
@@ -649,6 +670,12 @@ class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
             return np.full_like(arr, 4.5, np.bool_)
         self.check_like(func, np.float64, np.bool_)
 
+    def test_like_dtype_instance(self):
+        dtype = np.dtype('bool')
+        def func(arr):
+            return np.full_like(arr, 4.5, dtype)
+        self.check_like(func, np.float64, np.bool_)
+
     def test_like_dtype_kwarg(self):
         def func(arr):
             return np.full_like(arr, 4.5, dtype=np.bool_)
@@ -666,7 +693,7 @@ class TestNdIdentity(BaseTest):
         self.check_identity(func)
 
     def test_identity_dtype(self):
-        for dtype in (np.complex64, np.int16, np.bool_):
+        for dtype in (np.complex64, np.int16, np.bool_, np.dtype('bool')):
             def func(n):
                 return np.identity(n, dtype)
             self.check_identity(func)
@@ -700,6 +727,12 @@ class TestNdEye(BaseTest):
     def test_eye_n_m_k_dtype(self):
         def func(n, m, k):
             return np.eye(N=n, M=m, k=k, dtype=np.int16)
+        self.check_eye_n_m_k(func)
+
+    def test_eye_n_m_k_dtype_instance(self):
+        dtype = np.dtype('int16')
+        def func(n, m, k):
+            return np.eye(N=n, M=m, k=k, dtype=dtype)
         self.check_eye_n_m_k(func)
 
 
@@ -737,7 +770,7 @@ class TestNpyEmptyKeyword(unittest.TestCase):
             self.assertEqual(expected.shape, got.shape)
 
     def test_with_dtype_kws(self):
-        for dtype in [np.int32, np.float32, np.complex64]:
+        for dtype in [np.int32, np.float32, np.complex64, np.dtype('complex64')]:
             self._test_with_dtype_kw(dtype)
 
     def _test_with_shape_and_dtype_kw(self, dtype):
@@ -754,8 +787,8 @@ class TestNpyEmptyKeyword(unittest.TestCase):
             self.assertEqual(expected.shape, got.shape)
 
     def test_with_shape_and_dtype_kws(self):
-        for dtype in [np.int32, np.float32, np.complex64]:
-            self._test_with_dtype_kw(dtype)
+        for dtype in [np.int32, np.float32, np.complex64, np.dtype('complex64')]:
+            self._test_with_shape_and_dtype_kw(dtype)
 
     def test_empty_no_args(self):
         from numba.typeinfer import TypingError

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -567,7 +567,7 @@ class TestNdFull(ConstructorBaseTest, unittest.TestCase):
 
 class ConstructorLikeBaseTest(object):
 
-    def check_like(self, pyfunc, dtype, ret_dtype):
+    def check_like(self, pyfunc, dtype):
         orig = np.linspace(0, 5, 6).astype(dtype)
         cfunc = nrtjit(pyfunc)
 
@@ -598,35 +598,40 @@ class TestNdEmptyLike(ConstructorLikeBaseTest, unittest.TestCase):
         pyfunc = self.pyfunc
         def func(arr):
             return pyfunc(arr)
-        self.check_like(func, np.float64, np.float64)
+        self.check_like(func, np.float64)
 
-    # Not supported yet.
-    @unittest.expectedFailure
     def test_like_structured(self):
         dtype = np.dtype([('a', np.int16), ('b', np.float32)])
         pyfunc = self.pyfunc
         def func(arr):
             return pyfunc(arr)
-        self.check_like(func, dtype, dtype)
+        self.check_like(func, dtype)
 
     def test_like_dtype(self):
         pyfunc = self.pyfunc
         def func(arr):
             return pyfunc(arr, np.int32)
-        self.check_like(func, np.float64, np.int32)
+        self.check_like(func, np.float64)
 
     def test_like_dtype_instance(self):
         dtype = np.dtype('int32')
         pyfunc = self.pyfunc
         def func(arr):
             return pyfunc(arr, dtype)
-        self.check_like(func, np.float64, np.int32)
+        self.check_like(func, np.float64)
+
+    def test_like_dtype_structured(self):
+        dtype = np.dtype([('a', np.int16), ('b', np.float32)])
+        pyfunc = self.pyfunc
+        def func(arr):
+            return pyfunc(arr, dtype)
+        self.check_like(func, np.float64)
 
     def test_like_dtype_kwarg(self):
         pyfunc = self.pyfunc
         def func(arr):
             return pyfunc(arr, dtype=np.int32)
-        self.check_like(func, np.float64, np.int32)
+        self.check_like(func, np.float64)
 
 
 class TestNdZerosLike(TestNdEmptyLike):
@@ -645,6 +650,16 @@ class TestNdOnesLike(TestNdZerosLike):
         self.pyfunc = np.ones_like
         self.expected_value = 1
 
+    # Not supported yet.
+
+    @unittest.expectedFailure
+    def test_like_structured(self):
+        super(TestNdOnesLike, self).test_like_structured()
+
+    @unittest.expectedFailure
+    def test_like_dtype_structured(self):
+        super(TestNdOnesLike, self).test_like_dtype_structured()
+
 
 @unittest.skipIf(numpy_version < (1, 8), "test requires Numpy 1.8 or later")
 class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
@@ -655,7 +670,7 @@ class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
     def test_like(self):
         def func(arr):
             return np.full_like(arr, 3.5)
-        self.check_like(func, np.float64, np.float64)
+        self.check_like(func, np.float64)
 
     # Not supported yet.
     @unittest.expectedFailure
@@ -663,23 +678,23 @@ class TestNdFullLike(ConstructorLikeBaseTest, unittest.TestCase):
         dtype = np.dtype([('a', np.int16), ('b', np.float32)])
         def func(arr):
             return np.full_like(arr, 4.5)
-        self.check_like(func, dtype, dtype)
+        self.check_like(func, dtype)
 
     def test_like_dtype(self):
         def func(arr):
             return np.full_like(arr, 4.5, np.bool_)
-        self.check_like(func, np.float64, np.bool_)
+        self.check_like(func, np.float64)
 
     def test_like_dtype_instance(self):
         dtype = np.dtype('bool')
         def func(arr):
             return np.full_like(arr, 4.5, dtype)
-        self.check_like(func, np.float64, np.bool_)
+        self.check_like(func, np.float64)
 
     def test_like_dtype_kwarg(self):
         def func(arr):
             return np.full_like(arr, 4.5, dtype=np.bool_)
-        self.check_like(func, np.float64, np.bool_)
+        self.check_like(func, np.float64)
 
 
 class TestNdIdentity(BaseTest):

--- a/numba/types.py
+++ b/numba/types.py
@@ -311,7 +311,7 @@ class VarArg(Type):
         return self.dtype
 
 
-class Module(Type):
+class Module(Dummy):
     def __init__(self, pymod):
         self.pymod = pymod
         super(Module, self).__init__("Module(%s)" % pymod)
@@ -345,7 +345,7 @@ class Callable(Type):
         raise NotImplementedError
 
 
-class Function(Callable):
+class Function(Callable, Opaque):
     def __init__(self, template):
         self.template = template
         name = "%s(%s)" % (self.__class__.__name__, template.key)
@@ -360,6 +360,10 @@ class Function(Callable):
 
 
 class DTypeSpec(Opaque):
+    """
+    Base class for types usable as "dtype" arguments to various Numpy APIs
+    (e.g. np.empty()).
+    """
 
     @property
     def dtype(self):
@@ -429,7 +433,7 @@ class WeakType(Type):
         return Type.__hash__(self)
 
 
-class Dispatcher(WeakType, Callable):
+class Dispatcher(WeakType, Callable, Dummy):
 
     def __init__(self, overloaded):
         self._store_object(overloaded)

--- a/numba/types.py
+++ b/numba/types.py
@@ -332,19 +332,73 @@ class Macro(Type):
         return self.template
 
 
-class Function(Type):
+class Callable(Type):
+    """
+    Base class for callables.
+    """
+
+    def get_call_type(self, context, args, kws):
+        """
+        Using the typing *context*, resolve the callable's signature for
+        the given arguments.  A signature object is returned, or None.
+        """
+        raise NotImplementedError
+
+
+class Function(Callable):
     def __init__(self, template):
         self.template = template
         name = "%s(%s)" % (self.__class__.__name__, template.key)
-        # TODO template is mutable.  Should use different naming scheme
         super(Function, self).__init__(name)
 
     @property
     def key(self):
         return self.template
 
-    def extend(self, template):
-        self.template.cases.extend(template.cases)
+    def get_call_type(self, context, args, kws):
+        return self.template(context).apply(args, kws)
+
+
+class DTypeSpec(Opaque):
+
+    @property
+    def dtype(self):
+        raise NotImplementedError
+
+
+class NumberClass(Callable, DTypeSpec):
+    """
+    Type class for number classes (e.g. "np.float64").
+    """
+
+    def __init__(self, instance_type, template):
+        self.instance_type = instance_type
+        self.template = template
+        name = "type(%s)" % (instance_type,)
+        super(NumberClass, self).__init__(name)
+
+    def get_call_type(self, context, args, kws):
+        return self.template(context).apply(args, kws)
+
+    @property
+    def dtype(self):
+        return self.instance_type
+
+
+class DType(DTypeSpec):
+    """
+    Type class for Numpy dtypes.
+    """
+
+    def __init__(self, dtype):
+        assert isinstance(dtype, Type)
+        self._dtype = dtype
+        name = "dtype(%s)" % (dtype,)
+        super(DTypeSpec, self).__init__(name)
+
+    @property
+    def dtype(self):
+        return self._dtype
 
 
 class WeakType(Type):
@@ -375,11 +429,17 @@ class WeakType(Type):
         return Type.__hash__(self)
 
 
-class Dispatcher(WeakType):
+class Dispatcher(WeakType, Callable):
 
     def __init__(self, overloaded):
         self._store_object(overloaded)
         super(Dispatcher, self).__init__("Dispatcher(%s)" % overloaded)
+
+    def get_call_type(self, context, args, kws):
+        template, args, kws = self.overloaded.get_call_template(args, kws)
+        sig = template(context).apply(args, kws)
+        sig.pysig = self.pysig
+        return sig
 
     @property
     def overloaded(self):
@@ -1075,7 +1135,7 @@ class NoneType(Opaque):
         return Optional(other)
 
 
-class ExceptionType(Phantom):
+class ExceptionType(Callable, Phantom):
     """
     The type of exception classes (not instances).
     """
@@ -1085,6 +1145,11 @@ class ExceptionType(Phantom):
         name = "%s" % (exc_class.__name__)
         self.exc_class = exc_class
         super(ExceptionType, self).__init__(name, param=True)
+
+    def get_call_type(self, context, args, kws):
+        from . import typing
+        return_type = ExceptionInstance(self.exc_class)
+        return typing.signature(return_type)
 
     @property
     def key(self):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -703,7 +703,7 @@ def register_casters(register_global):
                 if a in nb_types:
                     return signature(self.key, a)
 
-        register_global(restype, types.Function(Caster))
+        register_global(restype, types.NumberClass(restype, Caster))
 
 register_casters(builtin_global)
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -532,12 +532,12 @@ class NdIdentity(AbstractTemplate):
         if not isinstance(n, types.Integer):
             return
         if len(args) >= 2:
-            dtype = _parse_dtype(args[1])
+            nb_dtype = _parse_dtype(args[1])
         else:
-            dtype = types.float64
+            nb_dtype = types.float64
 
         if nb_dtype is not None:
-            return_type = types.Array(ndim=2, dtype=dtype, layout='C')
+            return_type = types.Array(ndim=2, dtype=nb_dtype, layout='C')
             return signature(return_type, *args)
 
 builtin_global(numpy.identity, types.Function(NdIdentity))

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -391,7 +391,7 @@ def register_casters(register_global):
                 if a in types.number_domain:
                     return signature(self.restype, a)
 
-        register_global(np_type, types.Function(Caster))
+        register_global(np_type, types.NumberClass(nb_type, Caster))
 
 register_casters(builtin_global)
 
@@ -409,10 +409,8 @@ def _parse_shape(shape):
     return ndim
 
 def _parse_dtype(dtype):
-    # numpy APIs allow dtype constructor to be used as `dtype`
-    # arguments.  Since, npy_dtype.template.key dtype or dtype
-    # ctor, we use numpy.dtype to force it into a dtype object.
-    return from_dtype(numpy.dtype(dtype.template.key))
+    if isinstance(dtype, types.DTypeSpec):
+        return dtype.dtype
 
 
 class NdConstructor(CallableTemplate):
@@ -428,7 +426,7 @@ class NdConstructor(CallableTemplate):
                 nb_dtype = _parse_dtype(dtype)
 
             ndim = _parse_shape(shape)
-            if ndim is not None:
+            if nb_dtype is not None and ndim is not None:
                 return types.Array(dtype=nb_dtype, ndim=ndim, layout='C')
 
         return typer
@@ -445,7 +443,8 @@ class NdConstructorLike(CallableTemplate):
                 nb_dtype = arr.dtype
             else:
                 nb_dtype = _parse_dtype(dtype)
-            return arr.copy(dtype=nb_dtype)
+            if nb_dtype is not None:
+                return arr.copy(dtype=nb_dtype)
 
         return typer
 
@@ -499,7 +498,7 @@ if numpy_version >= (1, 8):
                     nb_dtype = _parse_dtype(dtype)
 
                 ndim = _parse_shape(shape)
-                if ndim is not None:
+                if nb_dtype is not None and ndim is not None:
                     return types.Array(dtype=nb_dtype, ndim=ndim, layout='C')
 
             return typer
@@ -514,7 +513,8 @@ if numpy_version >= (1, 8):
                     nb_dtype = arr.dtype
                 else:
                     nb_dtype = _parse_dtype(dtype)
-                return arr.copy(dtype=nb_dtype)
+                if nb_dtype is not None:
+                    return arr.copy(dtype=nb_dtype)
 
             return typer
 
@@ -536,8 +536,9 @@ class NdIdentity(AbstractTemplate):
         else:
             dtype = types.float64
 
-        return_type = types.Array(ndim=2, dtype=dtype, layout='C')
-        return signature(return_type, *args)
+        if nb_dtype is not None:
+            return_type = types.Array(ndim=2, dtype=dtype, layout='C')
+            return signature(return_type, *args)
 
 builtin_global(numpy.identity, types.Function(NdIdentity))
 
@@ -556,7 +557,8 @@ class NdEye(CallableTemplate):
                 nb_dtype = types.float64
             else:
                 nb_dtype = _parse_dtype(dtype)
-            return types.Array(ndim=2, dtype=nb_dtype, layout='C')
+            if nb_dtype is not None:
+                return types.Array(ndim=2, dtype=nb_dtype, layout='C')
 
         return typer
 


### PR DESCRIPTION
Only Numpy constructors (`np.float64`, etc.) were until now supported. This PR adds support for actual dtype objects (such as `np.dtype('int64')`), and also enables support for structured dtypes.