### PR TITLE
Gather exception classes in a "numba.errors" module

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -3,12 +3,14 @@ Expose top-level symbols that are safe for import *
 """
 from __future__ import print_function, division, absolute_import
 import re
+
 from . import testing, decorators
 from ._version import get_versions
-from . import special, types, config
+from . import errors, special, types, config
 
 # Re-export typeof
 from .special import *
+from .errors import *
 from .pycc.decorators import export, exportmany
 
 # Version
@@ -45,7 +47,7 @@ export
 exportmany
 cuda
 from_dtype
-""".split() + types.__all__ + special.__all__
+""".split() + types.__all__ + special.__all__ + errors.__all__
 
 
 def _sentry_llvm_version():

--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -9,7 +9,7 @@ import sys
 import inspect
 from collections import namedtuple
 
-from numba import utils
+from numba import errors, utils
 from numba.config import PYVERSION
 
 opcode_info = namedtuple('opcode_info', ['argsize'])
@@ -255,10 +255,6 @@ class ByteCodeOperation(object):
         self.args = args
 
 
-class ByteCodeSupportError(Exception):
-    pass
-
-
 class ByteCodeBase(object):
     __slots__ = (
         'func', 'func_name', 'func_qualname', 'filename',
@@ -325,10 +321,10 @@ class ByteCode(ByteCodeBase):
         code = get_code_object(func)
         pysig = utils.pysignature(func)
         if not code:
-            raise ByteCodeSupportError("%s does not provide its bytecode" %
-                                       func)
+            raise errors.ByteCodeSupportError(
+                "%s does not provide its bytecode" % func)
         if code.co_cellvars:
-            raise ByteCodeSupportError("does not support cellvars")
+            raise NotImplementedError("cell vars are not supported")
 
         table = utils.SortedMap(ByteCodeIter(code))
         labels = set(dis.findlabels(code.co_code))

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -218,10 +218,6 @@ class _PipelineManager(object):
         raise CompilerError("All pipelines have failed")
 
 
-class CompilerError(Exception):
-    pass
-
-
 class Pipeline(object):
     """
     Stores and manages states for the compiler pipeline

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -3,7 +3,9 @@ Contains function decorators and target_registry
 """
 from __future__ import print_function, division, absolute_import
 import warnings
+
 from . import config, sigutils
+from .errors import DeprecationError
 from .targets import registry
 from . import cuda
 
@@ -20,9 +22,6 @@ def autojit(*args, **kws):
                   "the same functionality", DeprecationWarning)
     return jit(*args, **kws)
 
-
-class DeprecationError(Exception):
-    pass
 
 class DisableJitWrapper(object):
     def __init__(self, py_func):

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -71,6 +71,13 @@ class TypingError(NumbaError):
             super(TypingError, self).__init__("%s" % (msg,))
 
 
+class UntypedAttributeError(TypingError):
+    def __init__(self, value, attr):
+        msg = 'Unknown attribute "{attr}" of type {type}'.format(type=value,
+                                                              attr=attr)
+        super(UntypedAttributeError, self).__init__(msg)
+
+
 class ByteCodeSupportError(NumbaError):
     """
     Failure to extract the bytecode of the user's function.

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -1,0 +1,83 @@
+
+__all__ = []
+
+__all__ += [name for (name, value) in globals().items()
+            if not name.startswith('_') and issubclass(value, Exception)]
+
+
+class NumbaError(Exception):
+    pass
+
+
+class IRError(NumbaError):
+    """
+    An error occurred during Numba IR generation.
+    """
+
+class RedefinedError(IRError):
+    pass
+
+class NotDefinedError(IRError):
+    def __init__(self, name, loc=None):
+        self.name = name
+        self.loc = loc
+
+    def __str__(self):
+        loc = "?" if self.loc is None else self.loc
+        return "{name!r} is not defined in {loc}".format(name=self.name,
+                                                         loc=self.loc)
+
+class VerificationError(IRError):
+    pass
+
+
+class MacroError(NumbaError):
+    """
+    An error occurred during macro expansion.
+    """
+
+
+class DeprecationError(NumbaError):
+    pass
+
+
+class LoweringError(NumbaError):
+    """
+    An error occurred during lowering.
+    """
+
+    def __init__(self, msg, loc):
+        self.msg = msg
+        self.loc = loc
+        super(LoweringError, self).__init__("%s\n%s" % (msg, loc.strformat()))
+
+
+class ForbiddenConstruct(LoweringError):
+    """
+    A forbidden Python construct was encountered (e.g. use of locals()).
+    """
+
+
+class TypingError(NumbaError):
+    """
+    A type inference failure.
+    """
+    def __init__(self, msg, loc=None):
+        self.msg = msg
+        self.loc = loc
+        if loc:
+            super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
+        else:
+            super(TypingError, self).__init__("%s" % (msg,))
+
+
+class ByteCodeSupportError(NumbaError):
+    """
+    Failure to extract the bytecode of the user's function.
+    """
+
+
+class CompilerError(NumbaError):
+    """
+    Some high-level error in the compiler.
+    """

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -1,9 +1,6 @@
 
 __all__ = []
 
-__all__ += [name for (name, value) in globals().items()
-            if not name.startswith('_') and issubclass(value, Exception)]
-
 
 class NumbaError(Exception):
     pass
@@ -88,3 +85,7 @@ class CompilerError(NumbaError):
     """
     Some high-level error in the compiler.
     """
+
+
+__all__ += [name for (name, value) in globals().items()
+            if not name.startswith('_') and issubclass(value, Exception)]

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -4,7 +4,7 @@ import collections
 import dis
 import sys
 
-from numba import ir, controlflow, dataflow, utils
+from numba import ir, controlflow, dataflow, utils, errors
 from numba.utils import builtins
 
 
@@ -467,7 +467,7 @@ class Interpreter(object):
         else:
             try:
                 return fn(inst, **kws)
-            except ir.NotDefinedError as e:
+            except errors.NotDefinedError as e:
                 if e.loc is None:
                     e.loc = self.loc
                 raise e

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -4,24 +4,7 @@ import os
 import pprint
 from collections import defaultdict
 
-
-class RedefinedError(NameError):
-    pass
-
-
-class NotDefinedError(NameError):
-    def __init__(self, name, loc=None):
-        self.name = name
-        self.loc = loc
-
-    def __str__(self):
-        loc = "?" if self.loc is None else self.loc
-        return "{name!r} is not defined in {loc}".format(name=self.name,
-                                                         loc=self.loc)
-
-
-class VerificationError(Exception):
-    pass
+from .errors import NotDefinedError, RedefinedError, VerificationError
 
 
 class Loc(object):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -9,17 +9,7 @@ from llvmlite.llvmpy.core import Constant, Type, Builder
 
 from . import (_dynfunc, cgutils, config, funcdesc, generators, ir, types,
                typing, utils)
-
-
-class LoweringError(Exception):
-    def __init__(self, msg, loc):
-        self.msg = msg
-        self.loc = loc
-        super(LoweringError, self).__init__("%s\n%s" % (msg, loc.strformat()))
-
-
-class ForbiddenConstruct(LoweringError):
-    pass
+from .errors import LoweringError
 
 
 _VarArgItem = namedtuple("_VarArgItem", ("vararg", "index"))

--- a/numba/macro.py
+++ b/numba/macro.py
@@ -4,14 +4,9 @@ Macro handling passes
 Macros are expanded on block-by-block
 """
 from __future__ import absolute_import, print_function, division
-from numba import ir
 
-
-class MacroError(Exception):
-    '''
-    An exception thrown during macro expansion
-    '''
-    pass
+from . import ir
+from .errors import MacroError
 
 
 def expand_macros(blocks):

--- a/numba/objmode.py
+++ b/numba/objmode.py
@@ -8,7 +8,8 @@ from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
 from . import cgutils, generators, ir, types, utils
-from .lowering import BaseLower, ForbiddenConstruct
+from .errors import ForbiddenConstruct
+from .lowering import BaseLower
 from .utils import builtins
 
 

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -10,7 +10,7 @@ import math
 
 from llvmlite.llvmpy import core as lc
 
-from .. import cgutils, typing, types, lowering
+from .. import cgutils, typing, types, lowering, errors
 from . import builtins
 
 # some NumPy constants. Note that we could generate some of them using
@@ -71,7 +71,7 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
         func_name = table[ty]
     except KeyError as e:
         msg = "No {0} function for real type {1}".format(user_name, str(e))
-        raise lowering.LoweringError(msg)
+        raise errors.LoweringError(msg)
 
     mod = cgutils.get_module(builder)
     if ty in types.complex_domain:
@@ -514,7 +514,7 @@ def np_real_floor_impl(context, builder, sig, args):
         fnty = lc.Type.function(lc.Type.float(), [lc.Type.float()])
         fn = mod.get_or_insert_function(fnty, name="numba.npymath.floorf")
     else:
-        raise LoweringError("No floor function for real type {0}".format(str(ty)))
+        raise errors.LoweringError("No floor function for real type {0}".format(str(ty)))
 
     return builder.call(fn, args)
 

--- a/numba/testing.py
+++ b/numba/testing.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division, absolute_import
+
 import sys
 import functools
+
 from numba import config
 
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -9,11 +9,9 @@ import sys
 
 import numpy as np
 
-from numba import config, typing, utils
+from numba import config, errors, typing, utils
 from numba.compiler import compile_extra, compile_isolated, Flags, DEFAULT_FLAGS
-from numba.lowering import LoweringError
 from numba.targets import cpu
-from numba.typeinfer import TypingError
 import numba.unittest_support as unittest
 
 
@@ -86,8 +84,9 @@ class TestCase(unittest.TestCase):
         A context manager that asserts the enclosed code block fails
         compiling in nopython mode.
         """
-        with self.assertRaises(
-            (LoweringError, TypingError, TypeError, NotImplementedError)) as cm:
+        _accepted_errors = (errors.LoweringError, errors.TypingError,
+                            TypeError, NotImplementedError)
+        with self.assertRaises(_accepted_errors) as cm:
             yield cm
 
     _exact_typesets = [(bool, np.bool_), utils.INT_TYPES, (str,), (np.integer,), (utils.text_type), ]

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -1,0 +1,38 @@
+from __future__ import division
+
+import numba
+
+from numba import unittest_support as unittest
+from .support import TestCase
+
+
+class TestNumbaModule(TestCase):
+    """
+    Test the APIs exposed by the top-level `numba` module.
+    """
+
+    def check_member(self, name):
+        self.assertTrue(hasattr(numba, name), name)
+        self.assertIn(name, numba.__all__)
+
+    def test_numba_module(self):
+        # jit
+        self.check_member("jit")
+        self.check_member("vectorize")
+        self.check_member("guvectorize")
+        self.check_member("njit")
+        self.check_member("autojit")
+        # errors
+        self.check_member("NumbaError")
+        self.check_member("TypingError")
+        # pycc
+        self.check_member("export")
+        self.check_member("exportmany")
+        # types
+        self.check_member("int32")
+        # misc
+        numba.__version__  # not in __all__
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_arrayconst.py
+++ b/numba/tests/test_arrayconst.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
-import numba.unittest_support as unittest
+
 import numpy as np
+
+import numba.unittest_support as unittest
 from numba.compiler import compile_isolated
-from numba.typeinfer import TypingError
+from numba.errors import TypingError
 from numba import types
 
 myarray = np.arange(5)

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -6,7 +6,7 @@ import sys
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import jit, typeof, lowering, types, utils
+from numba import jit, typeof, errors, types, utils
 from .support import TestCase
 
 enable_pyobj_flags = Flags()
@@ -438,7 +438,7 @@ class TestBuiltins(TestCase):
 
     def test_locals(self, flags=enable_pyobj_flags):
         pyfunc = locals_usecase
-        with self.assertRaises(lowering.ForbiddenConstruct):
+        with self.assertRaises(errors.ForbiddenConstruct):
             cr = compile_isolated(pyfunc, (types.int64,), flags=flags)
 
     def test_locals_forceobj(self):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -806,11 +806,10 @@ class TestNpyEmptyKeyword(unittest.TestCase):
             self._test_with_shape_and_dtype_kw(dtype)
 
     def test_empty_no_args(self):
-        from numba.typeinfer import TypingError
+        from numba.errors import TypingError
 
         def pyfunc():
             return np.empty()
-
 
         cfunc = nrtjit(pyfunc)
 

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -13,8 +13,8 @@ import warnings
 import numpy as np
 
 import numba.unittest_support as unittest
-from numba.typeinfer import TypingError
 from numba import config, jit, npdatetime, types, vectorize
+from numba.errors import TypingError
 from .support import TestCase, skip_on_numpy_16
 
 

--- a/numba/tests/test_return_values.py
+++ b/numba/tests/test_return_values.py
@@ -4,12 +4,13 @@ Test return values
 
 from __future__ import print_function
 
+import math
+
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
 from numba.utils import PYVERSION
 from numba import types
-from numba.typeinfer import TypingError
-import math
+from numba.errors import TypingError
 
 
 enable_pyobj_flags = Flags()

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 
 from numba import unittest_support as unittest
+from numba.errors import TypingError
 from numba.targets import registry
-from numba.typeinfer import TypingError
 from .support import TestCase
 from .serialize_usecases import *
 

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -4,7 +4,7 @@ import itertools
 import numpy as np
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
-from numba import types, typeinfer, typing, jit
+from numba import types, typeinfer, typing, jit, errors
 
 
 class TestArgRetCasting(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestArgRetCasting(unittest.TestCase):
         return_type = types.float32
         try:
             cres = compile_isolated(foo, args, return_type)
-        except typeinfer.TypingError as e:
+        except errors.TypingError as e:
             pass
         else:
             self.fail("Should complain about array casting to float32")

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
+
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types
-from numba.typeinfer import TypingError
+from numba.errors import TypingError
 
 
 def what():
@@ -18,6 +19,7 @@ def bar(x):
 
 def issue_868(a):
     return a.shape * 2
+
 
 class TestTypingError(unittest.TestCase):
     def test_unknown_function(self):
@@ -48,6 +50,7 @@ class TestTypingError(unittest.TestCase):
             self.assertTrue(e.msg.startswith('Undeclared'))
         else:
             self.fail('Should raise error')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -14,9 +14,8 @@ from numba.compiler import compile_isolated, Flags, DEFAULT_FLAGS
 from numba.numpy_support import from_dtype
 from numba import vectorize
 from numba.config import PYVERSION
-from numba.typeinfer import TypingError
+from numba.errors import LoweringError, TypingError
 from numba.targets import cpu
-from numba.lowering import LoweringError
 from .support import (TestCase, CompilationCache, skip_on_numpy_16,
                       is_on_numpy_16)
 

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -19,16 +19,7 @@ import itertools
 
 from numba import ir, types, utils, config, six
 from numba.utils import RANGE_ITER_OBJECTS
-
-
-class TypingError(Exception):
-    def __init__(self, msg, loc=None):
-        self.msg = msg
-        self.loc = loc
-        if loc:
-            super(TypingError, self).__init__("%s\n%s" % (msg, loc.strformat()))
-        else:
-            super(TypingError, self).__init__("%s" % (msg,))
+from .errors import TypingError
 
 
 class TypeVar(object):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -10,7 +10,7 @@ from ..numpy_support import (ufunc_find_matching_loop,
                              from_dtype)
 from ..numpy_support import version as numpy_version
 
-from ..typeinfer import TypingError
+from ..errors import TypingError
 
 registry = Registry()
 builtin = registry.register

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -4,10 +4,11 @@ Define typing templates
 from __future__ import print_function, division, absolute_import
 
 import functools
-from .. import types, utils
-from ..typeinfer import TypingError
 from functools import reduce
 import operator
+
+from .. import types, utils
+from ..errors import TypingError
 
 
 class Signature(object):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -8,7 +8,7 @@ from functools import reduce
 import operator
 
 from .. import types, utils
-from ..errors import TypingError
+from ..errors import TypingError, UntypedAttributeError
 
 
 class Signature(object):
@@ -317,13 +317,6 @@ class ConcreteTemplate(FunctionTemplate):
         cases = getattr(self, 'cases')
         assert cases
         return self._select(cases, args, kws)
-
-
-class UntypedAttributeError(TypingError):
-    def __init__(self, value, attr):
-        msg = 'Unknown attribute "{attr}" of type {type}'.format(type=value,
-                                                              attr=attr)
-        super(UntypedAttributeError, self).__init__(msg)
 
 
 class AttributeTemplate(object):


### PR DESCRIPTION
Perhaps we may also reorganize the exception hierarchy. I'm not sure it makes much sense from a user's point of view, currently. OTOH, some of it is useful internally.