### PR TITLE
Support for more array methods

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -91,15 +91,6 @@ The following attributes of Numpy arrays are supported:
 * :attr:`~numpy.ndarray.strides`
 * :attr:`~numpy.ndarray.T`
 
-Type and shape manipulation
----------------------------
-
-The following methods of Numpy arrays are supported:
-
-* :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
-* :meth:`~numpy.ndarray.transpose` (without arguments)
-* :meth:`~numpy.ndarray.view` (only the 1-argument form)
-
 Calculation
 -----------
 
@@ -120,6 +111,16 @@ The following methods of Numpy arrays are supported in their basic form
 
 The corresponding top-level Numpy functions (such as :func:`numpy.sum`)
 are similarly supported.
+
+Other methods
+-------------
+
+The following methods of Numpy arrays are supported:
+
+* :meth:`~numpy.ndarray.copy` (without arguments)
+* :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
+* :meth:`~numpy.ndarray.transpose` (without arguments, and without copying)
+* :meth:`~numpy.ndarray.view` (only the 1-argument form)
 
 
 Functions

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -82,6 +82,7 @@ Attributes
 
 The following attributes of Numpy arrays are supported:
 
+* :attr:`~numpy.ndarray.dtype`
 * :attr:`~numpy.ndarray.flat`
 * :attr:`~numpy.ndarray.itemsize`
 * :attr:`~numpy.ndarray.ndim`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -65,7 +65,8 @@ Structured scalars support attribute getting and setting.
 Array types
 ===========
 
-Arrays of any of the scalar types above are supported, regardless of the shape
+`Numpy arrays <http://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html>`_
+of any of the scalar types above are supported, regardless of the shape
 or layout.
 
 Operations
@@ -87,9 +88,19 @@ The following attributes of Numpy arrays are supported:
 * :attr:`~numpy.ndarray.shape`
 * :attr:`~numpy.ndarray.size`
 * :attr:`~numpy.ndarray.strides`
+* :attr:`~numpy.ndarray.T`
 
-Methods
--------
+Type and shape manipulation
+---------------------------
+
+The following methods of Numpy arrays are supported:
+
+* :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
+* :meth:`~numpy.ndarray.transpose` (without arguments)
+* :meth:`~numpy.ndarray.view` (only the 1-argument form)
+
+Calculation
+-----------
 
 The following methods of Numpy arrays are supported in their basic form
 (without any optional arguments):

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1197,6 +1197,134 @@ PyObject* Numba_ndarray_new(int nd,
     return ndary;
 }
 
+/*
+ * Straight from Numpy's _attempt_nocopy_reshape()
+ * (np/core/src/multiarray/shape.c).
+ * Attempt to reshape an array without copying data
+ *
+ * This function should correctly handle all reshapes, including
+ * axes of length 1. Zero strides should work but are untested.
+ *
+ * If a copy is needed, returns 0
+ * If no copy is needed, returns 1 and fills newstrides
+ *     with appropriate strides
+ */
+static int
+Numba_attempt_nocopy_reshape(npy_intp nd, npy_intp *dims, npy_intp *strides,
+                             npy_intp newnd, npy_intp *newdims,
+                             npy_intp *newstrides, npy_intp itemsize,
+                             int is_f_order)
+{
+    int oldnd;
+    npy_intp olddims[NPY_MAXDIMS];
+    npy_intp oldstrides[NPY_MAXDIMS];
+    npy_intp np, op, last_stride;
+    int oi, oj, ok, ni, nj, nk;
+
+    oldnd = 0;
+    /*
+     * Remove axes with dimension 1 from the old array. They have no effect
+     * but would need special cases since their strides do not matter.
+     */
+    for (oi = 0; oi < nd; oi++) {
+        if (dims[oi]!= 1) {
+            olddims[oldnd] = dims[oi];
+            oldstrides[oldnd] = strides[oi];
+            oldnd++;
+        }
+    }
+
+    np = 1;
+    for (ni = 0; ni < newnd; ni++) {
+        np *= newdims[ni];
+    }
+    op = 1;
+    for (oi = 0; oi < oldnd; oi++) {
+        op *= olddims[oi];
+    }
+    if (np != op) {
+        /* different total sizes; no hope */
+        return 0;
+    }
+
+    if (np == 0) {
+        /* the current code does not handle 0-sized arrays, so give up */
+        return 0;
+    }
+
+    /* oi to oj and ni to nj give the axis ranges currently worked with */
+    oi = 0;
+    oj = 1;
+    ni = 0;
+    nj = 1;
+    while (ni < newnd && oi < oldnd) {
+        np = newdims[ni];
+        op = olddims[oi];
+
+        while (np != op) {
+            if (np < op) {
+                /* Misses trailing 1s, these are handled later */
+                np *= newdims[nj++];
+            } else {
+                op *= olddims[oj++];
+            }
+        }
+
+        /* Check whether the original axes can be combined */
+        for (ok = oi; ok < oj - 1; ok++) {
+            if (is_f_order) {
+                if (oldstrides[ok+1] != olddims[ok]*oldstrides[ok]) {
+                     /* not contiguous enough */
+                    return 0;
+                }
+            }
+            else {
+                /* C order */
+                if (oldstrides[ok] != olddims[ok+1]*oldstrides[ok+1]) {
+                    /* not contiguous enough */
+                    return 0;
+                }
+            }
+        }
+
+        /* Calculate new strides for all axes currently worked with */
+        if (is_f_order) {
+            newstrides[ni] = oldstrides[oi];
+            for (nk = ni + 1; nk < nj; nk++) {
+                newstrides[nk] = newstrides[nk - 1]*newdims[nk - 1];
+            }
+        }
+        else {
+            /* C order */
+            newstrides[nj - 1] = oldstrides[oj - 1];
+            for (nk = nj - 1; nk > ni; nk--) {
+                newstrides[nk - 1] = newstrides[nk]*newdims[nk];
+            }
+        }
+        ni = nj++;
+        oi = oj++;
+    }
+
+    /*
+     * Set strides corresponding to trailing 1s of the new shape.
+     */
+    if (ni >= 1) {
+        last_stride = newstrides[ni - 1];
+    }
+    else {
+        last_stride = itemsize;
+    }
+    if (is_f_order) {
+        last_stride *= newdims[ni - 1];
+    }
+    for (nk = ni; nk < newnd; nk++) {
+        newstrides[nk] = last_stride;
+    }
+
+    return 1;
+}
+
+
 /* We use separate functions for datetime64 and timedelta64, to ensure
  * proper type checking.
  */
@@ -1414,7 +1542,8 @@ build_c_helpers_dict(void)
 #define declmethod(func) _declpointer(#func, &Numba_##func)
 
 #define declpointer(ptr) _declpointer(#ptr, &ptr)
-	declmethod(multi3);
+
+    declmethod(multi3);
     declmethod(sdiv);
     declmethod(srem);
     declmethod(udiv);
@@ -1453,6 +1582,7 @@ build_c_helpers_dict(void)
     declmethod(rnd_shuffle);
     declmethod(rnd_init);
     declmethod(poisson_ptrs);
+    declmethod(attempt_nocopy_reshape);
 
     declpointer(py_random_state);
     declpointer(np_random_state);

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1206,12 +1206,12 @@ PyObject* Numba_ndarray_new(int nd,
  * axes of length 1. Zero strides should work but are untested.
  *
  * If a copy is needed, returns 0
- * If no copy is needed, returns 1 and fills newstrides
+ * If no copy is needed, returns 1 and fills `npy_intp *newstrides`
  *     with appropriate strides
  */
 static int
-Numba_attempt_nocopy_reshape(npy_intp nd, npy_intp *dims, npy_intp *strides,
-                             npy_intp newnd, npy_intp *newdims,
+Numba_attempt_nocopy_reshape(npy_intp nd, const npy_intp *dims, const npy_intp *strides,
+                             npy_intp newnd, const npy_intp *newdims,
                              npy_intp *newstrides, npy_intp itemsize,
                              int is_f_order)
 {

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -528,16 +528,24 @@ def _loop_nest(builder, shape, intp):
             yield (ind,)
 
 
-def pack_array(builder, values):
+def pack_array(builder, values, ty=None):
+    """
+    Pack an array of values.  *ty* should be given if the array may be empty,
+    in which case the type can't be inferred from the values.
+    """
     n = len(values)
-    ty = values[0].type
+    if ty is None:
+        ty = values[0].type
     ary = Constant.undef(Type.array(ty, n))
     for i, v in enumerate(values):
         ary = builder.insert_value(ary, v, i)
     return ary
 
 
-def unpack_tuple(builder, tup, count):
+def unpack_tuple(builder, tup, count=None):
+    if count is None:
+        # Assuming *tup* is an aggregate
+        count = len(tup.type.elements)
     vals = [builder.extract_value(tup, i)
             for i in range(count)]
     return vals

--- a/numba/datamodel/argpacker.py
+++ b/numba/datamodel/argpacker.py
@@ -76,7 +76,7 @@ class ArgPacker(object):
 
 def _flatten(iterable):
     """
-    Flatten nested iterable of (tuple, list)n
+    Flatten nested iterable of (tuple, list).
     """
     def rec(iterable):
         for i in iterable:

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -1095,6 +1095,9 @@ class PythonAPI(object):
         elif isinstance(typ, types.CharSeq):
             return self.from_native_charseq(val, typ)
 
+        elif isinstance(typ, types.DType):
+            return self.from_native_dtype(val, typ)
+
         elif typ == types.voidptr:
             ll_intp = self.context.get_value_type(types.uintp)
             addr = self.builder.ptrtoint(val, ll_intp)
@@ -1163,6 +1166,10 @@ class PythonAPI(object):
             parent = nativeary.parent
             self.incref(parent)
             return parent
+
+    def from_native_dtype(self, val, typ):
+        np_dtype = numpy_support.as_dtype(typ.dtype)
+        return self.unserialize(self.serialize_object(np_dtype))
 
     def to_native_optional(self, obj, typ):
         """

--- a/numba/special.py
+++ b/numba/special.py
@@ -9,5 +9,5 @@ def typeof(val):
     Used outside of Numba code, infers the type for the object.
     """
     from .targets.registry import CPUTarget
-    return CPUTarget.typing_context.resolve_data_type(val)
+    return CPUTarget.typing_context.resolve_argument_type(val)
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -101,13 +101,8 @@ def update_array_info(aryty, array):
     # Calc num of items from shape
     nitems = context.get_constant(types.intp, 1)
     unpacked_shape = cgutils.unpack_tuple(builder, array.shape, aryty.ndim)
-    if unpacked_shape:
-        # Shape is not empty
-        for axlen in unpacked_shape:
-            nitems = builder.mul(nitems, axlen)
-    else:
-        # Shape is empty
-        nitems = context.get_constant(types.intp, 1)
+    for axlen in unpacked_shape:
+        nitems = builder.mul(nitems, axlen)
     array.nitems = nitems
 
     array.itemsize = context.get_constant(types.intp,

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -938,6 +938,11 @@ def array_round(context, builder, sig, args):
 # Array attributes
 
 @builtin_attr
+@impl_attribute(types.Kind(types.Array), "dtype", types.Kind(types.DType))
+def array_dtype(context, builder, typ, value):
+    return context.get_dummy_value()
+
+@builtin_attr
 @impl_attribute(types.Kind(types.Array), "shape", types.Kind(types.UniTuple))
 @impl_attribute(types.Kind(types.MemoryView), "shape", types.Kind(types.UniTuple))
 def array_shape(context, builder, typ, value):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1001,6 +1001,7 @@ class BaseContext(object):
         mod = cgutils.get_module(builder)
         fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
             [self.get_value_type(types.intp)])
+        # NOTE: safe alloc really slows allocations down
         fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
         return builder.call(fn, [size])
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -135,6 +135,15 @@ class TestCase(unittest.TestCase):
         else:
             return dtype
 
+    def _fix_strides(self, arr):
+        """
+        Return the strides of the given array, fixed for comparison.
+        Strides for 0- or 1-sized dimensions are ignored.
+        """
+        return [stride / arr.itemsize
+                for (stride, shape) in zip(arr.strides, arr.shape)
+                if shape > 1]
+
     def assertPreciseEqual(self, first, second, prec='exact', ulps=1,
                            msg=None):
         """
@@ -198,8 +207,8 @@ class TestCase(unittest.TestCase):
             self.assertEqual(dtype, self._fix_dtype(second.dtype))
             self.assertEqual(first.ndim, second.ndim)
             self.assertEqual(first.shape, second.shape)
-            self.assertEqual([x / first.itemsize for x in first.strides],
-                             [x / second.itemsize for x in second.strides])
+            self.assertEqual(first.itemsize, second.itemsize)
+            self.assertEqual(self._fix_strides(first), self._fix_strides(second))
             if first.dtype != dtype:
                 first = first.astype(dtype)
             if second.dtype != dtype:

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -153,6 +153,12 @@ def array_argmax(arr):
 def array_argmax_global(arr):
     return np.argmax(arr)
 
+def array_T(arr):
+    return arr.T
+
+def array_transpose(arr):
+    return arr.transpose()
+
 
 def base_test_arrays(dtype):
     a1 = np.arange(10, dtype=dtype) + 1
@@ -553,6 +559,25 @@ class TestArrayMethods(TestCase):
 
     def test_around_scalar(self):
         self.check_round_scalar(np_around_unary, np_around_binary)
+
+    def check_transpose(self, pyfunc):
+        def check_arr(arr):
+            cres = compile_isolated(pyfunc, (typeof(arr),))
+            self.assertPreciseEqual(cres.entry_point(arr), pyfunc(arr))
+        arr = np.arange(24)
+        check_arr(arr)
+        check_arr(arr.reshape((3, 8)))
+        check_arr(arr.reshape((3, 8))[::2])
+        check_arr(arr.reshape((2, 3, 4)))
+        check_arr(arr.reshape((2, 3, 4))[::2])
+        arr = np.array([0]).reshape(())
+        check_arr(arr)
+
+    def test_array_transpose(self):
+        self.check_transpose(array_transpose)
+
+    def test_array_T(self):
+        self.check_transpose(array_T)
 
 
 # These form a testing product where each of the combinations are tested

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -27,6 +27,12 @@ def array_ndenumerate_sum(arr):
         s = s + (i + 1) * (j + 1) * v
     return s
 
+def np_ndindex_empty():
+    s = 0
+    for ind in np.ndindex(()):
+        s += s + len(ind) + 1
+    return s
+
 def np_ndindex(x, y):
     s = 0
     n = 0
@@ -158,6 +164,9 @@ def array_T(arr):
 
 def array_transpose(arr):
     return arr.transpose()
+
+def array_copy(arr):
+    return arr.copy()
 
 
 def base_test_arrays(dtype):
@@ -371,6 +380,12 @@ class TestArrayMethods(TestCase):
         arr = arr.reshape((2, 2, 3))
         self.check_array_unary(arr, typeof(arr), func)
 
+    def test_np_ndindex_empty(self):
+        func = np_ndindex_empty
+        cres = compile_isolated(func, [])
+        cfunc = cres.entry_point
+        self.assertPreciseEqual(cfunc(), func())
+
     def test_array_sum_global(self):
         arr = np.arange(10, dtype=np.int32)
         arrty = typeof(arr)
@@ -560,24 +575,29 @@ class TestArrayMethods(TestCase):
     def test_around_scalar(self):
         self.check_round_scalar(np_around_unary, np_around_binary)
 
-    def check_transpose(self, pyfunc):
+    def check_layout_dependent_func(self, pyfunc):
         def check_arr(arr):
             cres = compile_isolated(pyfunc, (typeof(arr),))
             self.assertPreciseEqual(cres.entry_point(arr), pyfunc(arr))
         arr = np.arange(24)
         check_arr(arr)
         check_arr(arr.reshape((3, 8)))
+        check_arr(arr.reshape((3, 8)).T)
         check_arr(arr.reshape((3, 8))[::2])
         check_arr(arr.reshape((2, 3, 4)))
+        check_arr(arr.reshape((2, 3, 4)).T)
         check_arr(arr.reshape((2, 3, 4))[::2])
         arr = np.array([0]).reshape(())
         check_arr(arr)
 
     def test_array_transpose(self):
-        self.check_transpose(array_transpose)
+        self.check_layout_dependent_func(array_transpose)
 
     def test_array_T(self):
-        self.check_transpose(array_T)
+        self.check_layout_dependent_func(array_T)
+
+    def test_array_copy(self):
+        self.check_layout_dependent_func(array_copy)
 
 
 # These form a testing product where each of the combinations are tested

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -171,6 +171,9 @@ def array_copy(arr):
 def array_reshape(arr, newshape):
     return arr.reshape(newshape)
 
+def array_view(arr, newtype):
+    return arr.view(newtype)
+
 # XXX Can't pass a dtype as a Dispatcher argument for now
 def make_array_view(newtype):
     def array_view(arr):

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -145,6 +145,11 @@ class TestArgInfo(unittest.TestCase):
         fe_args = [types.Array(types.int32, 1, 'C')] * 2
         self._test_as_arguments(fe_args)
 
+    @unittest.expectedFailure
+    def test_two_0d_arrays(self):
+        fe_args = [types.Array(types.int32, 0, 'C')] * 2
+        self._test_as_arguments(fe_args)
+
     def test_tuples(self):
         fe_args = [types.UniTuple(types.int32, 2),
                    types.UniTuple(types.int32, 3)]
@@ -157,10 +162,19 @@ class TestArgInfo(unittest.TestCase):
         # Nested tuple
         fe_args = [types.UniTuple(types.UniTuple(types.int32, 2), 3)]
         self._test_as_arguments(fe_args)
+
+    def test_empty_tuples(self):
         # Empty tuple
         fe_args = [types.UniTuple(types.int16, 0),
-                   types.int32,
-                   types.UniTuple(types.int64, 0)]
+                   types.Tuple(()),
+                   types.int32]
+        self._test_as_arguments(fe_args)
+
+    @unittest.expectedFailure
+    def test_nested_empty_tuples(self):
+        fe_args = [types.int32,
+                   types.UniTuple(types.Tuple(()), 2),
+                   types.int64]
         self._test_as_arguments(fe_args)
 
 

--- a/numba/tests/test_datamodel.py
+++ b/numba/tests/test_datamodel.py
@@ -145,7 +145,6 @@ class TestArgInfo(unittest.TestCase):
         fe_args = [types.Array(types.int32, 1, 'C')] * 2
         self._test_as_arguments(fe_args)
 
-    @unittest.expectedFailure
     def test_two_0d_arrays(self):
         fe_args = [types.Array(types.int32, 0, 'C')] * 2
         self._test_as_arguments(fe_args)
@@ -170,7 +169,6 @@ class TestArgInfo(unittest.TestCase):
                    types.int32]
         self._test_as_arguments(fe_args)
 
-    @unittest.expectedFailure
     def test_nested_empty_tuples(self):
         fe_args = [types.int32,
                    types.UniTuple(types.Tuple(()), 2),

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -625,9 +625,6 @@ class ConstructorLikeBaseTest(object):
         for shape in (6, (2, 3), (1, 2, 3), (3, 1, 2), ()):
             if shape == ():
                 arr = orig[-1:].reshape(())
-                # FIXME: fails because of argpacker issues with nested
-                # empty tuples.
-                continue
             else:
                 arr = orig.reshape(shape)
             expected = pyfunc(arr)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -529,6 +529,9 @@ def normalize_shape(shape):
 class ArrayAttribute(AttributeTemplate):
     key = types.Array
 
+    def resolve_dtype(self, ary):
+        return types.DType(ary.dtype)
+
     def resolve_itemsize(self, ary):
         return types.intp
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -588,7 +588,17 @@ class ArrayAttribute(AttributeTemplate):
         retty = ary.copy(ndim=ndim)
         return signature(retty, shape)
 
+    @bound_function("array.view")
+    def resolve_view(self, ary, args, kws):
+        from .npydecl import _parse_dtype
+        assert not kws
+        dtype, = args
+        dtype = _parse_dtype(dtype)
+        retty = ary.copy(dtype=dtype)
+        return signature(retty, *args)
+
     def generic_resolve(self, ary, attr):
+        # Resolution of other attributes, for record arrays
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:
                 return types.Array(ary.dtype.typeof(attr), ndim=ary.ndim,

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -554,6 +554,13 @@ class ArrayAttribute(AttributeTemplate):
         assert not kws
         return signature(self.resolve_T(ary))
 
+    @bound_function("array.copy")
+    def resolve_copy(self, ary, args, kws):
+        assert not args
+        assert not kws
+        retty = ary.copy(layout="C")
+        return signature(retty)
+
     def generic_resolve(self, ary, attr):
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -540,6 +540,20 @@ class ArrayAttribute(AttributeTemplate):
     def resolve_ctypes(self, ary):
         return types.ArrayCTypes(ary)
 
+    def resolve_T(self, ary):
+        if ary.ndim <= 1:
+            retty = ary
+        else:
+            layout = {"C": "F", "F": "C"}.get(ary.layout, "A")
+            retty = ary.copy(layout=layout)
+        return retty
+
+    @bound_function("array.transpose")
+    def resolve_transpose(self, ary, args, kws):
+        assert not args
+        assert not kws
+        return signature(self.resolve_T(ary))
+
     def generic_resolve(self, ary, attr):
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -195,6 +195,10 @@ class BaseContext(object):
                     return type_class(dtype, m.ndim, layout=layout,
                                       readonly=m.readonly)
 
+        if isinstance(val, numpy.dtype):
+            tp = numpy_support.from_dtype(val)
+            return types.DType(tp)
+
         else:
             # Matching here is quite broad, so we have to do it after
             # the more specific matches above.
@@ -219,10 +223,6 @@ class BaseContext(object):
 
         if isinstance(val, type) and issubclass(val, BaseException):
             return types.ExceptionType(val)
-
-        if isinstance(val, numpy.dtype):
-            tp = numpy_support.from_dtype(val)
-            return types.DType(tp)
 
         try:
             # Try to look up target specific typing information

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -615,12 +615,16 @@ class NdIndex(AbstractTemplate):
         assert not kws
 
         # Either ndindex(shape) or ndindex(*shape)
-        if len(args) == 1 and isinstance(args[0], types.UniTuple):
-            shape = list(args[0])
+        if len(args) == 1 and isinstance(args[0], types.BaseTuple):
+            tup = args[0]
+            if tup.count > 0 and not isinstance(tup, types.UniTuple):
+                # Heterogenous tuple
+                return
+            shape = list(tup)
         else:
             shape = args
 
-        if shape and all(isinstance(x, types.Integer) for x in shape):
+        if all(isinstance(x, types.Integer) for x in shape):
             iterator_type = types.NumpyNdIndexType(len(shape))
             return signature(iterator_type, *args)
 

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -275,15 +275,16 @@ class CallableTemplate(FunctionTemplate):
         sig = typer(*args, **kws)
 
         # Unpack optional type if no matching signature
-        if sig is None and any(isinstance(x, types.Optional) for x in args):
-            def unpack_opt(x):
-                if isinstance(x, types.Optional):
-                    return x.type
-                else:
-                    return x
+        if sig is None:
+            if any(isinstance(x, types.Optional) for x in args):
+                def unpack_opt(x):
+                    if isinstance(x, types.Optional):
+                        return x.type
+                    else:
+                        return x
 
-            args = list(map(unpack_opt, args))
-            sig = typer(*args, **kws)
+                args = list(map(unpack_opt, args))
+                sig = typer(*args, **kws)
             if sig is None:
                 return
 


### PR DESCRIPTION
Support for array.transpose(), array.T, array.copy(), array.reshape() (without any arguments), array.view() (with a single argument), as well as the array.dtype attribute.
reshape() is only supported in the non-copying version.

Also allow 0-d shapes and arrays with empty(), empty_like(), etc. -- as well as ndindex().