### PR TITLE
Fix refcount leak in compile_internal calls

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -198,8 +198,12 @@ class Lower(BaseLower):
                 if isinstance(inst.value, ir.Expr) and inst.value.op == 'call':
                     callexpr = inst.value
                     # NPM function returns new reference
-                    if isinstance(self.typeof(callexpr.func.name),
-                                  types.Dispatcher):
+                    fnty = self.typeof(callexpr.func.name)
+                    if (isinstance(fnty, types.Dispatcher)
+                        or (isinstance(fnty, types.Function)
+                            and getattr(fnty.template,
+                                        'return_new_reference',
+                                        False))):
                         self.decref(ty, val)
 
         elif isinstance(inst, ir.Branch):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1325,6 +1325,8 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
                    strides=cgutils.pack_array(builder, strides),
                    itemsize=itemsize,
                    meminfo=meminfo)
+
+    context.nrt_incref(builder, arrtype, ary._getvalue())
     return ary
 
 def _zero_fill_array(context, builder, ary):
@@ -1382,7 +1384,7 @@ def numpy_empty_nd(context, builder, sig, args):
 @builtin
 @implement(numpy.empty_like, types.Kind(types.Array))
 @implement(numpy.empty_like, types.Kind(types.Array), types.Kind(types.DTypeSpec))
-def numpy_zeros_like_nd(context, builder, sig, args):
+def numpy_empty_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
     return ary._getvalue()

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1326,7 +1326,6 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
                    itemsize=itemsize,
                    meminfo=meminfo)
 
-    context.nrt_incref(builder, arrtype, ary._getvalue())
     return ary
 
 def _zero_fill_array(context, builder, ary):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -390,6 +390,7 @@ class NdConstructor(CallableTemplate):
     """
     Typing template for np.empty(), .zeros(), .ones().
     """
+    return_new_reference = True
 
     def generic(self):
         def typer(shape, dtype=None):
@@ -409,6 +410,7 @@ class NdConstructorLike(CallableTemplate):
     """
     Typing template for np.empty_like(), .zeros_like(), .ones_like().
     """
+    return_new_reference = True
 
     def generic(self):
         def typer(arr, dtype=None):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -390,7 +390,6 @@ class NdConstructor(CallableTemplate):
     """
     Typing template for np.empty(), .zeros(), .ones().
     """
-    return_new_reference = True
 
     def generic(self):
         def typer(shape, dtype=None):
@@ -410,7 +409,6 @@ class NdConstructorLike(CallableTemplate):
     """
     Typing template for np.empty_like(), .zeros_like(), .ones_like().
     """
-    return_new_reference = True
 
     def generic(self):
         def typer(arr, dtype=None):
@@ -435,6 +433,7 @@ class NdZeros(NdConstructor):
 @builtin
 class NdOnes(NdConstructor):
     key = numpy.ones
+    return_new_reference = True
 
 @builtin
 class NdEmptyLike(NdConstructorLike):
@@ -464,6 +463,8 @@ if numpy_version >= (1, 8):
     @builtin
     class NdFull(CallableTemplate):
         key = numpy.full
+        return_new_reference = True
+
 
         def generic(self):
             def typer(shape, fill_value, dtype=None):
@@ -481,6 +482,7 @@ if numpy_version >= (1, 8):
     @builtin
     class NdFullLike(CallableTemplate):
         key = numpy.full_like
+        return_new_reference = True
 
         def generic(self):
             def typer(arr, fill_value, dtype=None):
@@ -500,6 +502,7 @@ if numpy_version >= (1, 8):
 @builtin
 class NdIdentity(AbstractTemplate):
     key = numpy.identity
+    return_new_reference = True
 
     def generic(self, args, kws):
         assert not kws
@@ -525,6 +528,7 @@ def _infer_dtype_from_inputs(inputs):
 @builtin
 class NdEye(CallableTemplate):
     key = numpy.eye
+    return_new_reference = True
 
     def generic(self):
         def typer(N, M=None, k=None, dtype=None):
@@ -543,6 +547,7 @@ builtin_global(numpy.eye, types.Function(NdEye))
 @builtin
 class NdArange(AbstractTemplate):
     key = numpy.arange
+    return_new_reference = True
 
     def generic(self, args, kws):
         assert not kws
@@ -568,6 +573,7 @@ builtin_global(numpy.arange, types.Function(NdArange))
 @builtin
 class NdLinspace(AbstractTemplate):
     key = numpy.linspace
+    return_new_reference = True
 
     def generic(self, args, kws):
         assert not kws


### PR DESCRIPTION
The fix require this kind of function must define a
`return_new_reference` attribute for the call template.

We are not able to unittest this kind of error because we can't see the refcount in MemInfo.