### PR TITLE
Fix double-free due to extra ir.Del inserted 

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -272,6 +272,7 @@ class Lower(BaseLower):
                 pass
             else:
                 self.decref(self.typeof(inst.value), val)
+                self._delete_variable(inst.value)
 
         elif isinstance(inst, ir.SetAttr):
             target = self.loadvar(inst.target.name)
@@ -725,3 +726,10 @@ class Lower(BaseLower):
             return
 
         self.context.nrt_decref(self.builder, typ, val)
+
+    def _delete_variable(self, varname):
+        """
+        Zero-fill variable to avoid crashing due to extra ir.Del
+        """
+        storage = self.getvar(varname)
+        self.builder.store(Constant.null(storage.type.pointee), storage)


### PR DESCRIPTION
* Fix #1195: double-free by zero-filling variables at ir.Del
* Fix bug in arrayexpr rewrite: using already deleted variable

This is a minimal fix for the double-free problem.  A better solution is to improve the automatic variable disposal logic.  The current problem is due to ir.Del inserted at a branch that may not be entered (B) and at the exit branch (C):

```
 A
 |__
 |  |
 |  B
 |__|
 |
 C
```

Del should be inserted at the first common postdominator of all blocks that used the variable.