### PR TITLE
Changes to support CUDA 7.0

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -240,7 +240,7 @@ class CompilationUnit(object):
             err = self.driver.nvvmGetProgramLog(self._handle, logbuf)
             self.driver.check_error(err, 'Failed to get compilation log.')
 
-            return logbuf.value.decode('utf8')  # popluate log attribute
+            return logbuf.value.decode('utf8')  # populate log attribute
 
         return ''
 

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -68,17 +68,19 @@ class TestNvvmDriver(unittest.TestCase):
         for arch in SUPPORTED_CC:
             self._test_nvvm_support(arch=arch)
 
+    @unittest.skipIf(True, "No new CC unknown to NVVM yet")
     def test_nvvm_future_support(self):
         """Test unsupported CC to help track the feature support
         """
+        # List known CC but unsupported by NVVM
         future_archs = [
-            (5, 2),
+            # (5, 2),  # for example
         ]
         for arch in future_archs:
             pat = r"-arch=compute_{0}{1}".format(*arch)
             with self.assertRaises(NvvmError) as raises:
                 self._test_nvvm_support(arch=arch)
-                self.assertIn(pat, raises.msg)
+            self.assertIn(pat, raises.msg)
 
 
 @skip_on_cudasim('NVVM Driver unsupported in the simulator')
@@ -112,6 +114,7 @@ class TestLibDevice(unittest.TestCase):
 
 
 gpu64 = '''
+target triple="nvptx64-"
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
 
 define i32 @ave(i32 %a, i32 %b) {
@@ -146,6 +149,7 @@ declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() nounwind readnone
 '''
 
 gpu32 = '''
+target triple="nvptx-"
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
 
 define i32 @ave(i32 %a, i32 %b) {

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -32,7 +32,7 @@ class TestCudaLocalMem(unittest.TestCase):
     def test_local_array(self):
         jculocal = cuda.jit('void(int32[:], int32[:])')(culocal)
         self.assertTrue('.local' in jculocal.ptx)
-        A = numpy.arange(100, dtype='int32')
+        A = numpy.arange(1000, dtype='int32')
         B = numpy.zeros_like(A)
         jculocal(A, B)
         self.assertTrue(numpy.all(A == B))

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -5,7 +5,7 @@ from numba.cuda.testing import unittest
 
 
 def culocal(A, B):
-    C = cuda.local.array(100, dtype=int32)
+    C = cuda.local.array(1000, dtype=int32)
     for i in range(C.shape[0]):
         C[i] = A[i]
     for i in range(C.shape[0]):


### PR DESCRIPTION
This requires llvmlite with llvm 3.6 even though CUDA 7.0 uses LLVM 3.4.
