### PR TITLE
Remove old jit usage on windows

### DIFF
--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -253,13 +253,7 @@ class BaseCPUCodegen(object):
         tm_options = dict(cpu='', features='', opt=config.OPT)
         self._customize_tm_options(tm_options)
         tm = target.create_target_machine(**tm_options)
-
-        # MCJIT is still defective under Windows
-        if sys.platform.startswith('win32'):
-            engine = ll.create_jit_compiler_with_tm(llvm_module, tm)
-        else:
-            engine = ll.create_mcjit_compiler(llvm_module, tm)
-
+        engine = ll.create_mcjit_compiler(llvm_module, tm)
         tli = ll.create_target_library_info(llvm_module.triple)
 
         self._tli = tli


### PR DESCRIPTION
LLVM 3.6* and llvmlite 0.6* has removed the legacy jit.