### PR TITLE
Remove explicit itemsize check

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -206,7 +206,7 @@ class TestCase(unittest.TestCase):
             self.assertEqual(dtype, self._fix_dtype(second.dtype))
             self.assertEqual(first.ndim, second.ndim)
             self.assertEqual(first.shape, second.shape)
-            self.assertEqual(first.itemsize, second.itemsize)
+            # itemsize is already checked by the dtype test above
             self.assertEqual(self._fix_strides(first), self._fix_strides(second))
             if first.dtype != dtype:
                 first = first.astype(dtype)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -463,6 +463,12 @@ class TestArrayMethods(TestCase):
     def test_array_cumsum_global(self):
         self.check_cumulative(array_cumsum_global)
 
+    def test_array_cumprod(self):
+        self.check_cumulative(array_cumprod)
+
+    def test_array_cumprod_global(self):
+        self.check_cumulative(array_cumprod_global)
+
     def check_aggregation_magnitude(self, pyfunc, is_prod=False):
         """
         Check that integer overflows are avoided (issue #931).


### PR DESCRIPTION
The itemsize check is already covered by the dtype check, and we would have
to duplicate the same fixup for 32-bit int types on 64-bit Windows, so just
remove the redundant check instead.

This fixes the funny test failures on 64-bit Windows ("8 != 4").

(also adds basic tests for cumprod() which apparently were overlooked)