### PR TITLE
Various speed hacks

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -291,6 +291,17 @@ def alloca_once_value(builder, value, name=''):
     return storage
 
 
+def insert_pure_function(module, fnty, name):
+    """
+    Insert a pure function (in the functional programming sense) in the
+    given module.
+    """
+    fn = module.get_or_insert_function(fnty, name=name)
+    fn.attributes.add("readonly")
+    fn.attributes.add("nounwind")
+    return fn
+
+
 def terminate(builder, bbend):
     bb = builder.basic_block
     if bb.terminator is None:

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -652,10 +652,17 @@ def is_neg_int(builder, val):
 
 
 def gep_inbounds(builder, ptr, *inds, **kws):
+    """
+    Same as *gep*, but add the `inbounds` keyword.
+    """
     return gep(builder, ptr, *inds, inbounds=True, **kws)
 
 
 def gep(builder, ptr, *inds, **kws):
+    """
+    Emit a getelementptr instruction for the given pointer and indices.
+    The indices can be LLVM values or Python int constants.
+    """
     name = kws.pop('name', '')
     inbounds = kws.pop('inbounds', False)
     assert not kws

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -712,7 +712,6 @@ class CContiguousFlatIter(StructModel):
         ndim = array_type.ndim
         members = [('array', types.EphemeralPointer(array_type)),
                    ('stride', types.intp),
-                   ('pointer', types.EphemeralPointer(types.CPointer(dtype))),
                    ('index', types.EphemeralPointer(types.intp)),
                    ]
         if need_indices:

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -262,7 +262,7 @@ class EphemeralArrayModel(PointerModel):
         return ir.ArrayType(self._pointee_be_type, self._fe_type.count)
 
     def as_data(self, builder, value):
-        values = [builder.load(cgutils.gep(builder, value, i))
+        values = [builder.load(cgutils.gep_inbounds(builder, value, i))
                   for i in range(self._fe_type.count)]
         return cgutils.pack_array(builder, values)
 
@@ -430,7 +430,7 @@ class StructModel(CompositeModel):
     def load_from_data_pointer(self, builder, ptr):
         values = []
         for i, model in enumerate(self._models):
-            elem_ptr = cgutils.gep(builder, ptr, 0, i)
+            elem_ptr = cgutils.gep_inbounds(builder, ptr, 0, i)
             val = model.load_from_data_pointer(builder, elem_ptr)
             values.append(val)
 

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -235,11 +235,11 @@ class UArrayArg(object):
         self.is_unit_strided = builder.icmp(ICMP_EQ, self.abisize, self.step)
         self.builder = builder
 
-    def load(self, ind):
-        offset = self.builder.mul(self.step, ind)
-        return self.load_direct(offset)
-
     def load_direct(self, byteoffset):
+        """
+        Generic load from the given *byteoffset*.  load_aligned() is
+        preferred if possible.
+        """
         ptr = cgutils.pointer_add(self.builder, self.dataptr, byteoffset)
         return self.context.unpack_value(self.builder, self.fe_type, ptr)
 
@@ -248,10 +248,6 @@ class UArrayArg(object):
         # vectorize the loop.
         ptr = self.builder.gep(self.dataptr, [ind])
         return self.context.unpack_value(self.builder, self.fe_type, ptr)
-
-    def store(self, value, ind):
-        offset = self.builder.mul(self.step, ind)
-        self.store_direct(value, offset)
 
     def store_direct(self, value, byteoffset):
         ptr = cgutils.pointer_add(self.builder, self.dataptr, byteoffset)

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -225,9 +225,10 @@ class UArrayArg(object):
         self.fe_type = fe_type
         offset = self.context.get_constant(types.intp, i)
         offseted_args = self.builder.load(builder.gep(args, [offset]))
-        self.data_type = context.get_data_type(fe_type).as_pointer()
-        self.dataptr = self.builder.bitcast(offseted_args, self.data_type)
-        sizeof = self.context.get_abi_sizeof(self.data_type)
+        data_type = context.get_data_type(fe_type)
+        self.dataptr = self.builder.bitcast(offseted_args,
+                                            data_type.as_pointer())
+        sizeof = self.context.get_abi_sizeof(data_type)
         self.abisize = self.context.get_constant(types.intp, sizeof)
         offseted_step = self.builder.gep(steps, [offset])
         self.step = self.builder.load(offseted_step)
@@ -243,8 +244,10 @@ class UArrayArg(object):
         return self.context.unpack_value(self.builder, self.fe_type, ptr)
 
     def load_aligned(self, ind):
-        byteoffset = self.builder.mul(self.step, ind)
-        return self.load_direct(byteoffset)
+        # Using gep() instead of explicit pointer addition helps LLVM
+        # vectorize the loop.
+        ptr = self.builder.gep(self.dataptr, [ind])
+        return self.context.unpack_value(self.builder, self.fe_type, ptr)
 
     def store(self, value, ind):
         offset = self.builder.mul(self.step, ind)

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -232,7 +232,7 @@ MemInfo* NRT_MemInfo_alloc(size_t size) {
 MemInfo* NRT_MemInfo_alloc_safe(size_t size) {
     void *data = NRT_Allocate(size);
     /* Only fill up a couple cachelines with debug markers, to minimize
-       footprint. */
+       overhead. */
     memset(data, 0xCB, MIN(size, 256));
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_safe %p %llu\n", data, size));
     return NRT_MemInfo_new(data, size, nrt_internal_dtor_safe, (void*)size);

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -24,6 +24,8 @@ from .builtins import Slice
 
 
 def assume_positive(builder, val):
+    # NOTE: can't use range metadata as it may only be attached to a couple
+    # instruction kinds such as `load`.
     builder.assume(builder.icmp_signed('>=', val,
                                        cgutils.get_null_value(val.type)))
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -49,7 +49,7 @@ def mark_positive(builder, load):
     """
     Mark the result of a load instruction as positive (or zero).
     """
-    upper_bound = 1 << (load.type.width - 1) - 1
+    upper_bound = (1 << (load.type.width - 1)) - 1
     set_range_metadata(builder, load, 0, upper_bound)
 
 
@@ -1005,26 +1005,7 @@ def array_dtype(context, builder, typ, value):
 def array_shape(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
-    ndim = typ.ndim
-    if ndim == 0:
-        return array.shape
-    else:
-        ptr = array._get_ptr_by_name("shape")
-        shape = []
-        for i in range(ndim):
-            dimptr = cgutils.gep_inbounds(builder, ptr, 0, i)
-            load = builder.load(dimptr)
-            shape.append(load)
-
-            # Add range metadata to the load instruction
-            upper_bound = 1 << (load.type.width - 1) - 1
-            upper_bound = 2 ** 30
-            range_operands = [Constant.int(load.type, 0),
-                              Constant.int(load.type, upper_bound)]
-            md = builder.module.add_metadata(range_operands)
-            load.set_metadata("range", md)
-
-        return cgutils.pack_array(builder, shape)
+    return array.shape
 
 
 @builtin_attr

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -23,6 +23,11 @@ from numba.targets.imputils import (builtin, builtin_attr, implement,
 from .builtins import Slice
 
 
+def assume_positive(builder, val):
+    builder.assume(builder.icmp_signed('>=', val,
+                                       cgutils.get_null_value(val.type)))
+
+
 def make_array(array_type):
     """
     Return the Structure representation of the given *array_type*
@@ -38,8 +43,7 @@ def make_array(array_type):
             tup = base.__getattr__(self, "shape")
             builder = self._builder
             for val in cgutils.unpack_tuple(builder, tup, array_type.ndim):
-                builder.assume(builder.icmp_signed('>=', val,
-                                                   cgutils.get_null_value(val.type)))
+                assume_positive(builder, val)
             return tup
     return ArrayStruct
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1003,9 +1003,8 @@ class BaseContext(object):
             raise Exception("Require NRT")
         mod = builder.module
         fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
-            [self.get_value_type(types.intp)])
-        # NOTE: safe alloc really slows allocations down
-        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc")
+                                   [self.get_value_type(types.intp)])
+        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
         return builder.call(fn, [size])
 
     def nrt_meminfo_data(self, builder, meminfo):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1002,7 +1002,7 @@ class BaseContext(object):
         fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
             [self.get_value_type(types.intp)])
         # NOTE: safe alloc really slows allocations down
-        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
+        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc")
         return builder.call(fn, [size])
 
     def nrt_meminfo_data(self, builder, meminfo):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1005,6 +1005,7 @@ class BaseContext(object):
         fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
                                    [self.get_value_type(types.intp)])
         fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
+        fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
     def nrt_meminfo_data(self, builder, meminfo):
@@ -1014,43 +1015,37 @@ class BaseContext(object):
         voidptr = llvmir.IntType(8).as_pointer()
         fnty = llvmir.FunctionType(voidptr, [voidptr])
         fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_data")
+        fn.return_value.add_attribute("noalias")
         return builder.call(fn, [meminfo])
 
     def get_nrt_meminfo(self, builder, typ, value):
         return self.data_model_manager[typ].get_nrt_meminfo(builder, value)
 
-    def nrt_incref(self, builder, typ, value):
+    def _call_nrt_incref_decref(self, builder, typ, value, funcname):
         if not self.enable_nrt:
             raise Exception("Require NRT")
 
         members = self.data_model_manager[typ].traverse(builder, value)
         for mt, mv in members:
-            self.nrt_incref(builder, mt, mv)
+            self._call_nrt_incref_decref(builder, mt, mv, funcname)
 
         meminfo = self.get_nrt_meminfo(builder, typ, value)
         if meminfo:
             mod = builder.module
             fnty = llvmir.FunctionType(llvmir.VoidType(),
-                [llvmir.IntType(8).as_pointer()])
-            fn = mod.get_or_insert_function(fnty, name="NRT_incref")
-
+                                       [llvmir.IntType(8).as_pointer()])
+            fn = mod.get_or_insert_function(fnty, name=funcname)
+            # XXX "nonnull" causes a crash in test_dyn_array: can this
+            # function be called with a NULL pointer?
+            fn.args[0].add_attribute("noalias")
+            fn.args[0].add_attribute("nocapture")
             builder.call(fn, [meminfo])
+
+    def nrt_incref(self, builder, typ, value):
+        self._call_nrt_incref_decref(builder, typ, value, "NRT_incref")
 
     def nrt_decref(self, builder, typ, value):
-        if not self.enable_nrt:
-            raise Exception("Require NRT")
-
-        members = self.data_model_manager[typ].traverse(builder, value)
-        for mt, mv in members:
-            self.nrt_decref(builder, mt, mv)
-
-        meminfo = self.get_nrt_meminfo(builder, typ, value)
-        if meminfo:
-            mod = builder.module
-            fnty = llvmir.FunctionType(llvmir.VoidType(),
-                [llvmir.IntType(8).as_pointer()])
-            fn = mod.get_or_insert_function(fnty, name="NRT_decref")
-            builder.call(fn, [meminfo])
+        self._call_nrt_incref_decref(builder, typ, value, "NRT_decref")
 
 
 class _wrap_impl(object):

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -538,7 +538,7 @@ def real_divmod(context, builder, x, y):
     module = builder.module
     fname = ".numba.python.rem.%s" % x.type
     fnty = Type.function(floatty, (floatty, floatty, Type.pointer(floatty)))
-    fn = module.get_or_insert_function(fnty, fname)
+    fn = cgutils.insert_pure_function(mod, fnty, fname)
 
     if fn.is_declaration:
         fn.linkage = lc.LINKAGE_LINKONCE_ODR

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -538,7 +538,7 @@ def real_divmod(context, builder, x, y):
     module = builder.module
     fname = ".numba.python.rem.%s" % x.type
     fnty = Type.function(floatty, (floatty, floatty, Type.pointer(floatty)))
-    fn = cgutils.insert_pure_function(module, fnty, fname)
+    fn = module.get_or_insert_function(fnty, fname)
 
     if fn.is_declaration:
         fn.linkage = lc.LINKAGE_LINKONCE_ODR

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -538,7 +538,7 @@ def real_divmod(context, builder, x, y):
     module = builder.module
     fname = ".numba.python.rem.%s" % x.type
     fnty = Type.function(floatty, (floatty, floatty, Type.pointer(floatty)))
-    fn = cgutils.insert_pure_function(mod, fnty, fname)
+    fn = cgutils.insert_pure_function(module, fnty, fname)
 
     if fn.is_declaration:
         fn.linkage = lc.LINKAGE_LINKONCE_ODR

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -184,7 +184,6 @@ class MinimalCallConv(BaseCallConv):
         arginfo.assign_names(self.get_arguments(fn),
                              ['arg.' + a for a in args])
         fn.args[0].name = ".ret"
-        fn.args[0].add_attribute('sret')
         return fn
 
     def get_arguments(self, func):

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -178,12 +178,13 @@ class MinimalCallConv(BaseCallConv):
 
     def decorate_function(self, fn, args, fe_argtypes):
         """
-        Set names of function arguments.
+        Set names and attributes of function arguments.
         """
         arginfo = self.context.get_arg_packer(fe_argtypes)
         arginfo.assign_names(self.get_arguments(fn),
                              ['arg.' + a for a in args])
         fn.args[0].name = ".ret"
+        fn.args[0].add_attribute('sret')
         return fn
 
     def get_arguments(self, func):

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -145,7 +145,7 @@ def _float_input_unary_math_extern_impl(extern_func, input_type, restype=None):
         mod = builder.module
         lty = context.get_value_type(input_type)
         fnty = Type.function(lty, [lty])
-        fn = mod.get_or_insert_function(fnty, name=extern_func)
+        fn = cgutils.insert_pure_function(builder.module, fnty, name=extern_func)
         res = builder.call(fn, (val,))
         if restype is None:
             return res
@@ -308,7 +308,7 @@ def ldexp_impl(context, builder, sig, args):
         "float": "numba_ldexpf",
         "double": "numba_ldexp",
         }[str(fltty)]
-    fn = builder.module.get_or_insert_function(fnty, name=fname)
+    fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
     return builder.call(fn, (val, exp))
 
 
@@ -340,7 +340,7 @@ def atan2_f32_impl(context, builder, sig, args):
     assert len(args) == 2
     mod = builder.module
     fnty = Type.function(Type.float(), [Type.float(), Type.float()])
-    fn = mod.get_or_insert_function(fnty, name="atan2f")
+    fn = cgutils.insert_pure_function(builder.module, fnty, name="atan2f")
     return builder.call(fn, args)
 
 @register
@@ -351,7 +351,7 @@ def atan2_f64_impl(context, builder, sig, args):
     fnty = Type.function(Type.double(), [Type.double(), Type.double()])
     # Workaround atan2() issues under Windows
     fname = "atan2_fixed" if sys.platform == "win32" else "atan2"
-    fn = mod.get_or_insert_function(fnty, name=fname)
+    fn = cgutils.insert_pure_function(builder.module, fnty, name=fname)
     return builder.call(fn, args)
 
 

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -424,11 +424,11 @@ def reduce_datetime_for_unit(builder, dt_val, src_unit, dest_unit):
         with builder.if_else(is_leap_year(builder, year)) as (then, otherwise):
             with then:
                 addend = builder.load(cgutils.gep(builder, leap_array,
-                                                  0, month))
+                                                  0, month, inbounds=True))
                 builder.store(addend, days)
             with otherwise:
                 addend = builder.load(cgutils.gep(builder, normal_array,
-                                                  0, month))
+                                                  0, month, inbounds=True))
                 builder.store(addend, days)
 
         days_val = year_to_days(builder, year)

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -227,8 +227,8 @@ def _build_array(context, builder, array_ty, arg_arrays):
     dest_ndim = make_intp_const(array_ty.ndim)
     dest_shape = cgutils.alloca_once(builder, intp_ty, array_ty.ndim,
                                      "dest_shape")
-    dest_shape_addrs = tuple(builder.gep(dest_shape, [make_intp_const(index)])
-                           for index in range(array_ty.ndim))
+    dest_shape_addrs = tuple(cgutils.gep_inbounds(builder, dest_shape, index)
+                             for index in range(array_ty.ndim))
 
     # Initialize the destination shape with all ones.
     for dest_shape_addr in dest_shape_addrs:
@@ -243,7 +243,7 @@ def _build_array(context, builder, array_ty, arg_arrays):
         arg_ndim = make_intp_const(arg.ndim)
         for index in range(arg.ndim):
             builder.store(builder.extract_value(arg.ary.shape, index),
-                          builder.gep(src_shape, [make_intp_const(index)]))
+                          cgutils.gep_inbounds(builder, src_shape, index))
         arg_result = context.compile_internal(
             builder, _broadcast_onto, _broadcast_onto_sig,
             [arg_ndim, src_shape, dest_ndim, dest_shape])

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -47,16 +47,16 @@ rnd_state_ptr_t = ir.PointerType(rnd_state_t)
 
 # Accessors
 def get_index_ptr(builder, state_ptr):
-    return cgutils.gep(builder, state_ptr, 0, 0)
+    return cgutils.gep_inbounds(builder, state_ptr, 0, 0)
 
 def get_array_ptr(builder, state_ptr):
-    return cgutils.gep(builder, state_ptr, 0, 1)
+    return cgutils.gep_inbounds(builder, state_ptr, 0, 1)
 
 def get_has_gauss_ptr(builder, state_ptr):
-    return cgutils.gep(builder, state_ptr, 0, 2)
+    return cgutils.gep_inbounds(builder, state_ptr, 0, 2)
 
 def get_gauss_ptr(builder, state_ptr):
-    return cgutils.gep(builder, state_ptr, 0, 3)
+    return cgutils.gep_inbounds(builder, state_ptr, 0, 3)
 
 
 def get_next_int32(context, builder, state_ptr):
@@ -73,7 +73,7 @@ def get_next_int32(context, builder, state_ptr):
         builder.store(const_int(0), idxptr)
     idx = builder.load(idxptr)
     array_ptr = get_array_ptr(builder, state_ptr)
-    y = builder.load(cgutils.gep(builder, array_ptr, 0, idx))
+    y = builder.load(cgutils.gep_inbounds(builder, array_ptr, 0, idx))
     idx = builder.add(idx, const_int(1))
     builder.store(idx, idxptr)
     # Tempering

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -132,7 +132,7 @@ def make_range_impl(range_state_type, range_iter_type, int_type):
                 result.yield_(value)
                 one = context.get_constant(int_type, 1)
 
-                builder.store(builder.sub(count, one), countptr)
+                builder.store(builder.sub(count, one, flags=["nsw"]), countptr)
                 builder.store(builder.add(value, self.step), self.iter)
 
 

--- a/numba/tests/test_debug.py
+++ b/numba/tests/test_debug.py
@@ -54,11 +54,11 @@ class DebugTestBase(TestCase):
     def _check_dump_func_opt_llvm(self, out):
         self.assertIn('--FUNCTION OPTIMIZED DUMP %s' % self.func_name, out)
         # allocas have been optimized away
-        self.assertIn('add i64 %arg.somearg, 1', out)
+        self.assertIn('add nsw i64 %arg.somearg, 1', out)
 
     def _check_dump_optimized_llvm(self, out):
         self.assertIn('--OPTIMIZED DUMP %s' % self.func_name, out)
-        self.assertIn('add i64 %arg.somearg, 1', out)
+        self.assertIn('add nsw i64 %arg.somearg, 1', out)
 
     def _check_dump_assembly(self, out):
         self.assertIn('--ASSEMBLY %s' % self.func_name, out)

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -520,8 +520,8 @@ class TestOperators(TestCase):
     #
 
     def run_binop_ints(self, pyfunc, flags=force_pyobj_flags):
-        x_operands = [-2, 0, 1]
-        y_operands = [-1, 1, 3]
+        x_operands = [-5, 0, 1, 2]
+        y_operands = [-3, -1, 1, 3]
 
         types_list = [(types.int32, types.int32),
                       (types.int64, types.int64)]

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -81,10 +81,16 @@ class TestUfuncBuilding(unittest.TestCase):
         self.assertFalse(cres.objectmode)
         ufunc = ufb.build_ufunc()
 
+        def check(a):
+            b = ufunc(a, a)
+            self.assertTrue(numpy.all(a + a == b))
+            self.assertEqual(b.dtype, numpy.dtype('complex64'))
+
         a = numpy.arange(10, dtype='complex64') + 1j
-        b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('complex64'))
+        check(a)
+        # Non-contiguous dimension
+        a = a[::2]
+        check(a)
 
     def test_ufunc_forceobj(self):
         ufb = UFuncBuilder(add, targetoptions={'forceobj': True})

--- a/numba/tests/test_ufuncbuilding.py
+++ b/numba/tests/test_ufuncbuilding.py
@@ -67,9 +67,18 @@ class TestUfuncBuilding(unittest.TestCase):
         self.assertFalse(cres.objectmode)
         ufunc = ufb.build_ufunc()
 
-        a = numpy.arange(10, dtype='int32')
-        b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
+        def check(a):
+            b = ufunc(a, a)
+            self.assertTrue(numpy.all(a + a == b))
+            self.assertEqual(b.dtype, a.dtype)
+
+        a = numpy.arange(12, dtype='int32')
+        check(a)
+        # Non-contiguous dimension
+        a = a[::2]
+        check(a)
+        a = a.reshape((2, 3))
+        check(a)
 
         # Metadata
         self.assertEqual(ufunc.__name__, "add")
@@ -84,12 +93,14 @@ class TestUfuncBuilding(unittest.TestCase):
         def check(a):
             b = ufunc(a, a)
             self.assertTrue(numpy.all(a + a == b))
-            self.assertEqual(b.dtype, numpy.dtype('complex64'))
+            self.assertEqual(b.dtype, a.dtype)
 
-        a = numpy.arange(10, dtype='complex64') + 1j
+        a = numpy.arange(12, dtype='complex64') + 1j
         check(a)
         # Non-contiguous dimension
         a = a[::2]
+        check(a)
+        a = a.reshape((2, 3))
         check(a)
 
     def test_ufunc_forceobj(self):


### PR DESCRIPTION
- minimize the overhead of "safe" allocation
- encourage vectorization by using getelementpointer where possible, rather than pointer addition
- fix a bug in the "is_unit_strided" computation logic in ufuncs
- tell LLVM elements of an array shape are always positive or zero
- allow LLVM to ignore signed overflow on integer arithmetic
- add some attributes to declarations of various external functions (e.g. math or NRT)

Note: I've also added some benchmarks to the benchmark suite at https://github.com/numba/numba-benchmark
(graphs at http://numba.pydata.org/numba-benchmark/ -- probably not up to date)
