### PR TITLE
Fix cuda 7 conststring name

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -344,7 +344,7 @@ class CUDAKernel(CUDAKernelBase):
         '''
         Returns the PTX code for this kernel.
         '''
-        return str(self._func.ptx.get())
+        return self._func.ptx.get().decode('ascii')
 
     def inspect_types(self, file=None):
         '''

--- a/numba/cuda/tests/cudapy/test_const_string.py
+++ b/numba/cuda/tests/cudapy/test_const_string.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+
+import re
+from numba.cuda.testing import unittest
+from numba.cuda.descriptor import CUDATargetDesc
+from numba.cuda.cudadrv.nvvm import llvm_to_ptx, ADDRSPACE_CONSTANT
+from llvmlite import ir
+
+
+class TestCudaConstString(unittest.TestCase):
+    def test_const_string(self):
+        targetctx = CUDATargetDesc.targetctx
+        mod = targetctx.create_module("")
+        textstring = 'A Little Brown Fox'
+        gv0 = targetctx.insert_const_string(mod, textstring)
+        gv1 = targetctx.insert_const_string(mod, textstring)
+
+        res = re.findall(r"@\"__conststring__.*internal.*constant.*\["
+                         r"19\s+x\s+i8\]", str(mod))
+        self.assertEqual(len(res), 1)
+
+        fnty = ir.FunctionType(ir.IntType(8).as_pointer(), [])
+
+        # Using insert_const_string
+        fn = mod.add_function(fnty, name="test_insert_const_string")
+        builder = ir.IRBuilder(fn.append_basic_block())
+        res = targetctx.insert_addrspace_conv(builder, gv0,
+                                              addrspace=ADDRSPACE_CONSTANT)
+        builder.ret(res)
+
+        matches = re.findall(r"@\"__conststring__.*internal.*constant.*\["
+                             r"19\s+x\s+i8\]", str(mod))
+        self.assertEqual(len(matches), 1)
+
+        # Using insert_string_const_addrspace
+        fn = mod.add_function(fnty, name="test_insert_string_const_addrspace")
+        builder = ir.IRBuilder(fn.append_basic_block())
+        res = targetctx.insert_string_const_addrspace(builder, textstring)
+        builder.ret(res)
+
+        matches = re.findall(r"@\"__conststring__.*internal.*constant.*\["
+                             r"19\s+x\s+i8\]", str(mod))
+        self.assertEqual(len(matches), 1)
+
+        ptx = llvm_to_ptx(str(mod)).decode('ascii')
+        matches = list(re.findall(r"\.const.*__conststring__", ptx))
+
+        self.assertEqual(len(matches), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_const_string.py
+++ b/numba/cuda/tests/cudapy/test_const_string.py
@@ -1,14 +1,17 @@
 from __future__ import print_function
 
 import re
-from numba.cuda.testing import unittest
-from numba.cuda.descriptor import CUDATargetDesc
-from numba.cuda.cudadrv.nvvm import llvm_to_ptx, ADDRSPACE_CONSTANT
+from numba.cuda.testing import unittest, skip_on_cudasim
 from llvmlite import ir
 
 
+@skip_on_cudasim("This is testing CUDA backend code generation")
 class TestCudaConstString(unittest.TestCase):
     def test_const_string(self):
+        # These imports is incompatible with CUDASIM
+        from numba.cuda.descriptor import CUDATargetDesc
+        from numba.cuda.cudadrv.nvvm import llvm_to_ptx, ADDRSPACE_CONSTANT
+
         targetctx = CUDATargetDesc.targetctx
         mod = targetctx.create_module("")
         textstring = 'A Little Brown Fox'


### PR DESCRIPTION
CUDA 7 have problem with '%' character is the name of global variable.  NVVM passes it to the PTX directly without mangling.
