### PR TITLE
Refactor type unification

### DIFF
--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -203,9 +203,10 @@ Dispatcher_Insert(DispatcherObject *self, PyObject *args)
 
 static PyObject *str_typeof_pyval = NULL;
 
-/* For void types, we need to keep a reference to the returned type object so
-   that it cannot be deleted. This is because of the following events occurring
-   when first using a @jit function for a given set of types:
+/* When we want to cache the type's typecode for later lookup, we need to
+   keep a reference to the returned type object so that it cannot be
+   deleted. This is because of the following events occurring when first
+   using a @jit function for a given set of types:
 
     1. typecode_fallback requests a new typecode for an arbitrary Python value;
        this implies creating a Numba type object (on the first dispatcher call);
@@ -215,14 +216,15 @@ static PyObject *str_typeof_pyval = NULL;
     3. we have to compile: compile_and_invoke() is called, it will invoke
        Dispatcher_Insert to register the new signature.
 
-   The reference returned in step 1 is deleted as soon as we call Py_DECREF() on
-   it, since we are holding the only reference. If this happens and we use the
-   typecode we got to populate the cache, then the cache won't ever return the
-   correct typecode, and the dispatcher will never successfully match the typecodes
-   with those of some already-compiled instance. So we need to make sure that we
-   don't call Py_DECREF() on objects whose typecode will be used to populate the
-   cache. This is ensured by calling _typecode_fallback with retain_reference ==
-   0.
+   The reference to the Numba type object returned in step 1 is deleted as
+   soon as we call Py_DECREF() on it, since we are holding the only
+   reference. If this happens and we use the typecode we got to populate the
+   cache, then the cache won't ever return the correct typecode, and the
+   dispatcher will never successfully match the typecodes with those of
+   some already-compiled instance. So we need to make sure that we don't
+   call Py_DECREF() on objects whose typecode will be used to populate the
+   cache. This is ensured by calling _typecode_fallback with
+   retain_reference == 0.
 
    Note that technically we are leaking the reference, since we do not continue
    to hold a pointer to the type object that we get back from typeof_pyval.
@@ -266,11 +268,16 @@ int typecode_fallback_keep_ref(DispatcherObject *dispatcher, PyObject *val) {
     return _typecode_fallback(dispatcher, val, 1);
 }
 
+/*
+ * Direct lookup table for extra-fast typecode resolution of simple array types.
+ */
+
 #define N_DTYPES 12
 #define N_NDIM 5    /* Fast path for up to 5D array */
 #define N_LAYOUT 3
 static int cached_arycode[N_NDIM][N_LAYOUT][N_DTYPES];
 
+/* Convert a Numpy dtype number to an internal index into cached_arycode */
 static int dtype_num_to_typecode(int type_num) {
     int dtype;
     switch(type_num) {
@@ -311,6 +318,7 @@ static int dtype_num_to_typecode(int type_num) {
         dtype = 11;
         break;
     default:
+        /* Type not included in the global lookup table */
         dtype = -1;
     }
     return dtype;
@@ -384,7 +392,7 @@ int typecode_ndarray(DispatcherObject *dispatcher, PyArrayObject *ary) {
     dtype = dtype_num_to_typecode(PyArray_TYPE(ary));
     if (dtype == -1) goto FALLBACK;
 
-    /* "Fast" path, using table lookup */
+    /* Fast path, using direct table lookup */
     assert(layout < N_LAYOUT);
     assert(ndim <= N_NDIM);
     assert(dtype < N_DTYPES);
@@ -392,13 +400,13 @@ int typecode_ndarray(DispatcherObject *dispatcher, PyArrayObject *ary) {
     typecode = cached_arycode[ndim - 1][layout][dtype];
     if (typecode == -1) {
         /* First use of this table entry, so it requires populating */
-        typecode = typecode_fallback(dispatcher, (PyObject*)ary);
+        typecode = typecode_fallback_keep_ref(dispatcher, (PyObject*)ary);
         cached_arycode[ndim - 1][layout][dtype] = typecode;
     }
     return typecode;
 
 FALLBACK:
-    /* "Slow" path */
+    /* Slower path, for non-trivial array types */
 
     /* If this isn't a structured array then we can't use the cache */
     if (PyArray_TYPE(ary) != NPY_VOID)

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -171,11 +171,6 @@ class Number(Type):
     Base class for number types.
     """
 
-    def can_convert_to(self, typingctx, other):
-        # Convertibility of numbers is checked with the type manager
-        # (the rules are predefined at startup there)
-        return typingctx.tm.check_compatible(self, other)
-
 
 class Callable(Type):
     """

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -96,12 +96,14 @@ class Type(object):
     def __ne__(self, other):
         return not (self == other)
 
-    def coerce(self, typingctx, other):
-        """Override this method to implement specialized coercion logic
-        for extending unify_pairs().  Only use this if the coercion logic cannot
-        be expressed as simple casting rules.
+    def unify(self, typingctx, other):
         """
-        return NotImplemented
+        Try to unify this type with the *other*.  A third type must
+        be returned, or None if unification is not possible.
+        Only override this if the coercion logic cannot be expressed
+        as simple casting rules.
+        """
+        return None
 
     # User-facing helpers.  These are not part of the core Type API but
     # are provided so that users can write e.g. `numba.boolean(1.5)`

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -4,6 +4,8 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import itertools
 import weakref
 
+import numpy
+
 from .six import add_metaclass
 
 
@@ -170,6 +172,19 @@ class Number(Type):
     """
     Base class for number types.
     """
+
+    def unify(self, typingctx, other):
+        """
+        Unify the two number types using Numpy's rules.
+        """
+        from . import numpy_support
+        if isinstance(other, Number):
+            # XXX: this can produce unsafe conversions,
+            # e.g. would unify {int64, uint64} to float64
+            a = numpy_support.as_dtype(self)
+            b = numpy_support.as_dtype(other)
+            sel = numpy.promote_types(a, b)
+            return numpy_support.from_dtype(sel)
 
 
 class Callable(Type):

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -50,7 +50,6 @@ class _TypeMetaclass(ABCMeta):
         else:
             inst._code = _autoincr()
             _typecache[wr] = wr
-            inst.post_init()
             return inst
 
 
@@ -68,13 +67,6 @@ class Type(object):
     def __init__(self, name, param=False):
         self.name = name
         self.is_parametric = param
-
-    def post_init(self):
-        """
-        A method called when the instance is fully initialized and has
-        a registered typecode in its _code attribute.  Does nothing by
-        default, but can be overriden.
-        """
 
     @property
     def key(self):
@@ -113,6 +105,13 @@ class Type(object):
         """
         # By default, convertibility is checked with the type manager
         return typingctx.tm.check_compatible(self, other)
+
+    def can_convert_from(self, typingctx, other):
+        """
+        Similar to *can_convert_to*, but in reverse.  Only needed if
+        the type provides conversion from other types.
+        """
+        return None
 
     # User-facing helpers.  These are not part of the core Type API but
     # are provided so that users can write e.g. `numba.boolean(1.5)`

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -14,6 +14,8 @@ from .six import add_metaclass
 # However, we also want types to be disposable, therefore we ensure
 # each type is interned as a weak reference, so that it lives only as
 # long as necessary to keep a stable type code.
+# NOTE: some types can still be made immortal elsewhere (for example
+# in _dispatcher.c's internal caches).
 _typecodes = itertools.count()
 
 def _autoincr():

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -105,6 +105,15 @@ class Type(object):
         """
         return None
 
+    def can_convert_to(self, typingctx, other):
+        """
+        Check whether this type can be converted to the *other*.
+        If successful, must return a string describing the conversion, e.g.
+        "exact", "promote", "unsafe", "safe"; otherwise None is returned.
+        """
+        # By default, convertibility is checked with the type manager
+        return typingctx.tm.check_compatible(self, other)
+
     # User-facing helpers.  These are not part of the core Type API but
     # are provided so that users can write e.g. `numba.boolean(1.5)`
     # (returns True) or `types.int32(types.int32[:])` (returns something

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -103,8 +103,7 @@ class Type(object):
         If successful, must return a string describing the conversion, e.g.
         "exact", "promote", "unsafe", "safe"; otherwise None is returned.
         """
-        # By default, convertibility is checked with the type manager
-        return typingctx.tm.check_compatible(self, other)
+        return None
 
     def can_convert_from(self, typingctx, other):
         """
@@ -171,6 +170,11 @@ class Number(Type):
     """
     Base class for number types.
     """
+
+    def can_convert_to(self, typingctx, other):
+        # Convertibility of numbers is checked with the type manager
+        # (the rules are predefined at startup there)
+        return typingctx.tm.check_compatible(self, other)
 
 
 class Callable(Type):

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -7,7 +7,7 @@ import sys
 from numba import _dispatcher, compiler, utils, types
 from numba.typeconv.rules import default_type_manager
 from numba import sigutils, serialize, types, typing
-from numba.typing.templates import resolve_overload, fold_arguments
+from numba.typing.templates import fold_arguments
 from numba.bytecode import get_code_object
 from numba.six import create_bound_method, next
 
@@ -192,8 +192,9 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         assert not kws, "kwargs not handled"
         args = tuple([self.typeof_pyval(a) for a in args])
         sigs = [cr.signature for cr in self._compileinfos.values()]
-        res = resolve_overload(self.typingctx, self.py_func, sigs, args, kws)
-        print("res =", res)
+        # This will raise
+        self.typingctx.resolve_overload(self.py_func, sigs, args, kws,
+                                        allow_ambiguous=False)
 
     def _explain_matching_error(self, *args, **kws):
         assert not kws, "kwargs not handled"

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -74,7 +74,6 @@ class TestDispatcher(TestCase):
     def test_ambiguous_new_version(self):
         """Test compiling new version in an ambiguous case
         """
-
         @jit
         def foo(a, b):
             return a + b
@@ -212,6 +211,22 @@ class TestDispatcher(TestCase):
         f = jit(["(float32,float32)", "(float64,float64)"])(add)
         self.assertPreciseEqual(f(np.float32(1), np.float32(2**-25)), 1.0)
         self.assertPreciseEqual(f(1, 2**-25), 1.0000000298023224)
+        # Fail to resolve ambiguity between the two best overloads
+        f = jit(["(float32,float64)",
+                 "(float64,float32)",
+                 "(int64,int64)"])(add)
+        with self.assertRaises(TypeError) as cm:
+            f(1.0, 2.0)
+        # The two best matches are output in the error message, as well
+        # as the actual argument types.
+        self.assertRegexpMatches(
+            str(cm.exception),
+            r"Ambiguous overloading for <function add [^>]*> \(float64, float64\)\n"
+            r"\(float32, float64\) -> float64\n"
+            r"\(float64, float32\) -> float64"
+            )
+        # The integer signature is not part of the best matches
+        self.assertNotIn("int64", str(cm.exception))
 
     def test_signature_mismatch(self):
         tmpl = "Signature mismatch: %d argument types given, but function takes 2 arguments"

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -221,7 +221,7 @@ class TestDispatcher(TestCase):
         # as the actual argument types.
         self.assertRegexpMatches(
             str(cm.exception),
-            r"Ambiguous overloading for <function add [^>]*> \(float64, float64\)\n"
+            r"Ambiguous overloading for <function add [^>]*> \(float64, float64\):\n"
             r"\(float32, float64\) -> float64\n"
             r"\(float64, float32\) -> float64"
             )

--- a/numba/tests/test_typeconv.py
+++ b/numba/tests/test_typeconv.py
@@ -33,11 +33,17 @@ class CompatibilityTestMixin(unittest.TestCase):
         self.assertEqual(check_compatible(u8, b), Conversion.unsafe)
 
         self.assertEqual(check_compatible(i32, i64), Conversion.promote)
-        self.assertEqual(check_compatible(i32, f32), Conversion.unsafe)
-        self.assertEqual(check_compatible(i32, f64), Conversion.safe)
         self.assertEqual(check_compatible(i32, u32), Conversion.unsafe)
         self.assertEqual(check_compatible(u32, i32), Conversion.unsafe)
         self.assertEqual(check_compatible(u32, i64), Conversion.safe)
+
+        self.assertEqual(check_compatible(i32, f32), Conversion.unsafe)
+        self.assertEqual(check_compatible(u32, f32), Conversion.unsafe)
+        self.assertEqual(check_compatible(i32, f64), Conversion.safe)
+        self.assertEqual(check_compatible(u32, f64), Conversion.safe)
+        # Note this is inconsistent with i32 -> f32...
+        self.assertEqual(check_compatible(i64, f64), Conversion.safe)
+        self.assertEqual(check_compatible(u64, f64), Conversion.safe)
 
         self.assertEqual(check_compatible(f32, c64), Conversion.safe)
         self.assertEqual(check_compatible(f64, c128), Conversion.safe)

--- a/numba/tests/test_typeconv.py
+++ b/numba/tests/test_typeconv.py
@@ -11,9 +11,12 @@ from numba.typeconv import castgraph, Conversion
 class CompatibilityTestMixin(unittest.TestCase):
 
     def check_number_compatibility(self, check_compatible):
+        b = types.boolean
+        i8 = types.int8
         i16 = types.int16
         i32 = types.int32
         i64 = types.int64
+        u8 = types.uint8
         u16 = types.uint16
         u32 = types.uint32
         u64 = types.uint64
@@ -23,6 +26,11 @@ class CompatibilityTestMixin(unittest.TestCase):
         c128 = types.complex128
 
         self.assertEqual(check_compatible(i32, i32), Conversion.exact)
+
+        self.assertEqual(check_compatible(b, i8), Conversion.safe)
+        self.assertEqual(check_compatible(b, u8), Conversion.safe)
+        self.assertEqual(check_compatible(i8, b), Conversion.unsafe)
+        self.assertEqual(check_compatible(u8, b), Conversion.unsafe)
 
         self.assertEqual(check_compatible(i32, i64), Conversion.promote)
         self.assertEqual(check_compatible(i32, f32), Conversion.unsafe)

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -175,11 +175,6 @@ class TestUnify(unittest.TestCase):
             # All results must be equal
             for res in results:
                 self.assertEqual(res, expected)
-            #res = set(res)
-            #first_result = res[0]
-            #self.assertIsInstance(first_result, types.Optional)
-            #for other in res[1:]:
-                #self.assertEqual(first_result, other)
 
     def test_none(self):
         aty = types.none

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -226,6 +226,28 @@ class TestUnify(unittest.TestCase):
         self.assert_unify(aty, bty, types.Tuple((types.Optional(types.int32),
                                                  types.Optional(types.int64))))
 
+    def test_arrays(self):
+        aty = types.Array(types.int32, 3, "C")
+        bty = types.Array(types.int32, 3, "A")
+        self.assert_unify(aty, bty, bty)
+        aty = types.Array(types.int32, 3, "C")
+        bty = types.Array(types.int32, 3, "F")
+        self.assert_unify(aty, bty, types.Array(types.int32, 3, "A"))
+        aty = types.Array(types.int32, 3, "C")
+        bty = types.Array(types.int32, 3, "C", readonly=True)
+        self.assert_unify(aty, bty, bty)
+        aty = types.Array(types.int32, 3, "A")
+        bty = types.Array(types.int32, 3, "C", readonly=True)
+        self.assert_unify(aty, bty,
+                          types.Array(types.int32, 3, "A", readonly=True))
+        # Failures
+        aty = types.Array(types.int32, 2, "C")
+        bty = types.Array(types.int32, 3, "C")
+        self.assert_unify_failure(aty, bty)
+        aty = types.Array(types.int32, 2, "C")
+        bty = types.Array(types.uint32, 2, "C")
+        self.assert_unify_failure(aty, bty)
+
 
 class TestUnifyUseCases(unittest.TestCase):
     """

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -17,7 +17,7 @@ class Dummy(object):
     pass
 
 
-class TestTypeNames(TestCase):
+class TestTypes(TestCase):
 
     def test_equality(self):
         self.assertEqual(types.int32, types.int32)
@@ -193,6 +193,13 @@ class TestTypeNames(TestCase):
         # Value cast
         self.assertPreciseEqual(i(42.5), 42)
         self.assertPreciseEqual(d(-5), -5.0)
+
+    def test_bitwidth_number_types(self):
+        """
+        All numeric types have bitwidth attribute
+        """
+        for ty in types.number_domain:
+            self.assertTrue(hasattr(ty, "bitwidth"))
 
 
 if __name__ == '__main__':

--- a/numba/typeconv/__init__.py
+++ b/numba/typeconv/__init__.py
@@ -1,0 +1,1 @@
+from .castgraph import Conversion

--- a/numba/typeconv/castgraph.py
+++ b/numba/typeconv/castgraph.py
@@ -11,10 +11,21 @@ class Conversion(enum.IntEnum):
     A conversion kind from one type to the other.  The enum members
     are ordered from stricter to looser.
     """
+    # The two types are identical
     exact = 1
+    # The two types are of the same kind, the destination type has more
+    # extension or precision than the source type (e.g. float32 -> float64,
+    # or int32 -> int64)
     promote = 2
+    # The source type can be converted to the destination type without loss
+    # of information (e.g. int32 -> int64).  Note that the conversion may
+    # still fail explicitly at runtime (e.g. Optional(int32) -> int32)
     safe = 3
+    # The conversion may appear to succeed at runtime while losing information
+    # or precision (e.g. int32 -> uint32, float64 -> float32, int64 -> int32,
+    # etc.)
     unsafe = 4
+
     # This value is only used internally
     nil = 99
 

--- a/numba/typeconv/castgraph.py
+++ b/numba/typeconv/castgraph.py
@@ -1,38 +1,22 @@
 from __future__ import print_function, absolute_import
+
 from collections import defaultdict
+import enum
+
 from numba.utils import total_ordering
 
 
-@total_ordering
-class _RelValue(object):
-    """Ordered categorical value
+class Conversion(enum.IntEnum):
     """
-
-    def __init__(self, name, precedence):
-        self._name = name
-        self._precedence = precedence
-
-    def __repr__(self):
-        return self._name
-
-    def __lt__(self, other):
-        if isinstance(other, _RelValue):
-            return self._precedence < other._precedence
-        else:
-            return NotImplemented
-
-    def __eq__(self, other):
-        if isinstance(other, _RelValue):
-            return self._precedence == other._precedence
-        else:
-            return NotImplemented
-
-
-# Define the casting relations
-Nil = _RelValue('Nil', 0)
-Promote = _RelValue('Promote', 1)
-Safe = _RelValue('Safe', 2)
-Unsafe = _RelValue('Unsafe', 3)
+    A conversion kind from one type to the other.  The enum members
+    are ordered from stricter to looser.
+    """
+    exact = 1
+    promote = 2
+    safe = 3
+    unsafe = 4
+    # This value is only used internally
+    nil = 99
 
 
 class CastSet(object):
@@ -45,11 +29,8 @@ class CastSet(object):
         self._rels = {}
 
     def insert(self, to, rel):
-        setrel = min(rel, self.get(to))
-        if setrel is Nil:
-            setrel = rel
-
-        old = self._rels.get(to)
+        old = self.get(to)
+        setrel = min(rel, old)
         self._rels[to] = setrel
         return old != setrel
 
@@ -57,7 +38,7 @@ class CastSet(object):
         return self._rels.items()
 
     def get(self, item):
-        return self._rels.get(item, Nil)
+        return self._rels.get(item, Conversion.nil)
 
     def __len__(self):
         return len(self._rels)
@@ -134,11 +115,11 @@ class TypeGraph(object):
         self.propagate(a, b, rel)
 
     def promote(self, a, b):
-        self.insert_rule(a, b, Promote)
+        self.insert_rule(a, b, Conversion.promote)
 
     def safe(self, a, b):
-        self.insert_rule(a, b, Safe)
+        self.insert_rule(a, b, Conversion.safe)
 
     def unsafe(self, a, b):
-        self.insert_rule(a, b, Unsafe)
+        self.insert_rule(a, b, Conversion.unsafe)
 

--- a/numba/typeconv/rules.py
+++ b/numba/typeconv/rules.py
@@ -16,6 +16,7 @@ def dump_number_rules():
 def _init_casting_rules(tm):
     tcr = TypeCastingRules(tm)
     tcr.safe_unsafe(types.boolean, types.int8)
+    tcr.safe_unsafe(types.boolean, types.uint8)
 
     tcr.promote_unsafe(types.int8, types.int16)
     tcr.promote_unsafe(types.uint8, types.uint16)

--- a/numba/typeconv/rules.py
+++ b/numba/typeconv/rules.py
@@ -34,6 +34,10 @@ def _init_casting_rules(tm):
     tcr.safe_unsafe(types.int32, types.float64)
 
     tcr.unsafe_unsafe(types.int32, types.float32)
+    # XXX this is inconsistent with the above; but we want to prefer
+    # float64 over int64 when typing a heterogenous operation,
+    # e.g. `float64 + int64`.  Perhaps we need more granularity in the
+    # conversion kinds.
     tcr.safe_unsafe(types.int64, types.float64)
     tcr.safe_unsafe(types.uint64, types.float64)
 

--- a/numba/typeconv/typeconv.py
+++ b/numba/typeconv/typeconv.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import
-from . import _typeconv, castgraph
+
+from . import _typeconv, castgraph, Conversion
 
 
 class TypeManager(object):
@@ -14,7 +15,10 @@ class TypeManager(object):
                                          allow_unsafe)
 
     def check_compatible(self, fromty, toty):
-        return _typeconv.check_compatible(self._ptr, fromty._code, toty._code)
+        name = _typeconv.check_compatible(self._ptr, fromty._code, toty._code)
+        conv = Conversion[name] if name is not None else None
+        assert conv is not Conversion.nil
+        return conv
 
     def set_compatible(self, fromty, toty, by):
         _typeconv.set_compatible(self._ptr, fromty._code, toty._code, by)
@@ -87,11 +91,11 @@ class TypeCastingRules(object):
         """
         Callback for updating.
         """
-        if rel == castgraph.Promote:
+        if rel == Conversion.promote:
             self._tm.set_promote(a, b)
-        elif rel == castgraph.Safe:
+        elif rel == Conversion.safe:
             self._tm.set_safe_convert(a, b)
-        elif rel == castgraph.Unsafe:
+        elif rel == Conversion.unsafe:
             self._tm.set_unsafe_convert(a, b)
         else:
             raise AssertionError(rel)

--- a/numba/typeconv/typeconv.py
+++ b/numba/typeconv/typeconv.py
@@ -4,6 +4,14 @@ from . import _typeconv, castgraph, Conversion
 
 
 class TypeManager(object):
+
+    # The character codes used by the C/C++ API (_typeconv.cpp)
+    _conversion_codes = {
+        Conversion.safe: ord("s"),
+        Conversion.unsafe: ord("u"),
+        Conversion.promote: ord("p"),
+        }
+
     def __init__(self):
         self._ptr = _typeconv.new_type_manager()
         self._types = set()
@@ -21,20 +29,21 @@ class TypeManager(object):
         return conv
 
     def set_compatible(self, fromty, toty, by):
-        _typeconv.set_compatible(self._ptr, fromty._code, toty._code, by)
+        code = self._conversion_codes[by]
+        _typeconv.set_compatible(self._ptr, fromty._code, toty._code, code)
         # Ensure the types don't die, otherwise they may be recreated with
         # other type codes and pollute the hash table.
         self._types.add(fromty)
         self._types.add(toty)
 
     def set_promote(self, fromty, toty):
-        self.set_compatible(fromty, toty, ord("p"))
+        self.set_compatible(fromty, toty, Conversion.promote)
 
     def set_unsafe_convert(self, fromty, toty):
-        self.set_compatible(fromty, toty, ord("u"))
+        self.set_compatible(fromty, toty, Conversion.unsafe)
 
     def set_safe_convert(self, fromty, toty):
-        self.set_compatible(fromty, toty, ord("s"))
+        self.set_compatible(fromty, toty, Conversion.safe)
 
     def get_pointer(self):
         return _typeconv.get_pointer(self._ptr)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -410,8 +410,8 @@ class TypeInferer(object):
                 raise TypeError("Variable %s has no type" % var)
             else:
                 unified = self.context.unify_types(*tv.get())
-            if unified == types.pyobject:
-                raise TypingError("Var '%s' unified to object: %s" % (var, tv))
+            if unified is types.pyobject:
+                raise TypingError("Can't unify types of variable '%s': %s" % (var, tv))
             typdict[var] = unified
         retty = self.get_return_type(typdict)
         fntys = self.get_function_types(typdict)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -484,17 +484,8 @@ class TypeInferer(object):
             if isinstance(term, ir.Return):
                 rettypes.add(typemap[term.value.name])
 
-        if types.none in rettypes:
-            # Special case None return
-            rettypes = rettypes - set([types.none])
-            if rettypes:
-                unified = self.context.unify_types(*rettypes)
-                return types.Optional(unified)
-            else:
-                return types.none
-        elif rettypes:
-            unified = self.context.unify_types(*rettypes)
-            return unified
+        if rettypes:
+            return self.context.unify_types(*rettypes)
         else:
             return types.none
 

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -44,7 +44,7 @@ class TypeVar(object):
             if set(types) != self.typeset:
                 [expect] = list(self.typeset)
                 for ty in types:
-                    if self.context.type_compatibility(ty, expect) is None:
+                    if self.context.can_convert(ty, expect) is None:
                         raise TypingError("No conversion from %s to %s for "
                                           "'%s'" % (ty, expect, self.var))
         else:
@@ -56,7 +56,7 @@ class TypeVar(object):
     def lock(self, typ):
         if self.locked:
             [expect] = list(self.typeset)
-            if self.context.type_compatibility(typ, expect) is None:
+            if self.context.can_convert(typ, expect) is None:
                 raise TypingError("No conversion from %s to %s for "
                                   "'%s'" % (typ, expect, self.var))
         else:

--- a/numba/types.py
+++ b/numba/types.py
@@ -700,6 +700,17 @@ class Array(Buffer):
     def key(self):
         return self.dtype, self.ndim, self.layout, self.mutable
 
+    def unify(self, typingctx, other):
+        if (isinstance(other, Array) and other.ndim == self.ndim
+            and other.dtype == self.dtype):
+            if self.layout == other.layout:
+                layout = self.layout
+            else:
+                layout = 'A'
+            readonly = not (self.mutable and other.mutable)
+            return Array(dtype=self.dtype, ndim=self.ndim, layout=layout,
+                         readonly=readonly)
+
 
 class ArrayCTypes(Type):
     """

--- a/numba/types.py
+++ b/numba/types.py
@@ -817,7 +817,7 @@ class UniTuple(IterableType, BaseTuple):
     def types(self):
         return (self.dtype,) * self.count
 
-    def coerce(self, typingctx, other):
+    def unify(self, typingctx, other):
         """
         Unify UniTuples with their dtype
         """
@@ -825,7 +825,7 @@ class UniTuple(IterableType, BaseTuple):
             dtype = typingctx.unify_pairs(self.dtype, other.dtype)
             return UniTuple(dtype=dtype, count=self.count)
 
-        return NotImplemented
+        return None
 
 
 class UniTupleIter(SimpleIteratorType):
@@ -866,7 +866,7 @@ class Tuple(BaseTuple):
     def __iter__(self):
         return iter(self.types)
 
-    def coerce(self, typingctx, other):
+    def unify(self, typingctx, other):
         """
         Unify elements of Tuples/UniTuples
         """
@@ -876,11 +876,11 @@ class Tuple(BaseTuple):
                        for ta, tb in zip(self, other)]
 
             if any(t == pyobject for t in unified):
-                return NotImplemented
+                return None
 
             return Tuple(unified)
 
-        return NotImplemented
+        return None
 
 
 class CPointer(Type):
@@ -958,7 +958,7 @@ class Optional(Type):
     def key(self):
         return self.type
 
-    def coerce(self, typingctx, other):
+    def unify(self, typingctx, other):
         if isinstance(other, Optional):
             unified = typingctx.unify_pairs(self.type, other.type)
 
@@ -968,11 +968,11 @@ class Optional(Type):
         if unified != pyobject:
             return Optional(unified)
 
-        return NotImplemented
+        return None
 
 
 class NoneType(Opaque):
-    def coerce(self, typingctx, other):
+    def unify(self, typingctx, other):
         """Turns anything to a Optional type
         """
         if isinstance(other, Optional):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -831,7 +831,8 @@ class Max(AbstractTemplate):
                 return
 
         retty = self.context.unify_types(*args)
-        return signature(retty, *args)
+        if retty is not None:
+            return signature(retty, *args)
 
 
 class Min(AbstractTemplate):
@@ -848,7 +849,8 @@ class Min(AbstractTemplate):
                 return
 
         retty = self.context.unify_types(*args)
-        return signature(retty, *args)
+        if retty is not None:
+            return signature(retty, *args)
 
 
 class Round(ConcreteTemplate):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -342,6 +342,12 @@ class BaseContext(object):
         if fromty == toty:
             return Conversion.exact
         else:
+            # First check with the type manager (some rules are predefined
+            # at startup there, see n.typeconv.rules)
+            conv = self.tm.check_compatible(fromty, toty)
+            if conv is not None:
+                return conv
+
             forward = fromty.can_convert_to(self, toty)
             backward = toty.can_convert_from(self, fromty)
             if backward is None:
@@ -381,7 +387,7 @@ class BaseContext(object):
         """
         Install possible conversions from the actual argument types to
         the formal argument types in the C++ type manager.
-        Returns True if all conversions are possible.
+        Return True if all arguments can be converted.
         """
         if len(actualargs) != len(formalargs):
             return False

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -394,6 +394,7 @@ class BaseContext(object):
             return False
         for actual, formal in zip(actualargs, formalargs):
             if self.tm.check_compatible(actual, formal) is not None:
+                # This conversion is already known
                 continue
             conv = self.can_convert(actual, formal)
             if conv is None:
@@ -425,7 +426,7 @@ class BaseContext(object):
         if candidates:
             best_rate, best = candidates[0]
             if not allow_ambiguous:
-                # Find whether there is a tie
+                # Find whether there is a tie and if so, raise an error
                 tied = []
                 for rate, case in candidates:
                     if rate != best_rate:
@@ -441,7 +442,7 @@ class BaseContext(object):
             # (this can happen if e.g. a function template exposes
             #  (int32, int32) -> int32 and (int64, int64) -> int64,
             #  and you call it with (int16, int16) arguments)
-            return candidates[0][1]
+            return best
 
     def unify_types(self, *typelist):
         # Sort the type list according to bit width before doing

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -434,7 +434,7 @@ class BaseContext(object):
                     tied.append(case)
                 if len(tied) > 1:
                     args = (key, args, '\n'.join(map(str, tied)))
-                    msg = "Ambiguous overloading for %s %s\n%s" % args
+                    msg = "Ambiguous overloading for %s %s:\n%s" % args
                     raise TypeError(msg)
             # Simply return the best matching candidate in order.
             # If there is a tie, since list.sort() is stable, the first case

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -121,113 +121,12 @@ def _sum_downcast(dists):
     return c
 
 
-class Rating(object):
-    __slots__ = 'promote', 'safe_convert', "unsafe_convert"
-
-    def __init__(self):
-        self.promote = 0
-        self.safe_convert = 0
-        self.unsafe_convert = 0
-
-    def astuple(self):
-        """Returns a tuple suitable for comparing with the worse situation
-        start first.
-        """
-        return (self.unsafe_convert, self.safe_convert, self.promote)
-
-    def __add__(self, other):
-        if type(self) is not type(other):
-            return NotImplemented
-        rsum = Rating()
-        rsum.promote = self.promote + other.promote
-        rsum.safe_convert = self.safe_convert + other.safe_convert
-        rsum.unsafe_convert = self.unsafe_convert + other.unsafe_convert
-        return rsum
-
-
-def _rate_arguments(context, actualargs, formalargs):
-    ratings = [Rating()]
-    for actual, formal in zip(actualargs, formalargs):
-        rate = Rating()
-        by = context.type_compatibility(actual, formal)
-        if by is None:
-            return None
-
-        if by == 'promote':
-            rate.promote += 1
-        elif by == 'safe':
-            rate.safe_convert += 1
-        elif by == 'unsafe':
-            rate.unsafe_convert += 1
-        elif by == 'exact':
-            pass
-        else:
-            raise Exception("unreachable", by)
-
-        ratings.append(rate)
-    return ratings
-
-
-def resolve_overload(context, key, cases, args, kws):
-    assert not kws, "Keyword arguments are not supported, yet"
-    # Rate each cases
-    candids = []
-    symm_ratings = []
-    for case in cases:
-        if len(args) == len(case.args):
-            ratings = _rate_arguments(context, args, case.args)
-            if ratings is not None:
-                combined = reduce(operator.add, ratings)
-                symm_ratings.append(combined.astuple())
-                candids.append(case)
-
-    # Find the best case
-    ordered = sorted(zip(symm_ratings, candids), key=lambda i: i[0])
-    if ordered:
-        if len(ordered) > 1:
-            (first, case1), (second, case2) = ordered[:2]
-            # Ambiguous overloading
-            # NOTE: we can have duplicate overloadings if e.g. some type
-            # aliases were used when declaring the supported signatures
-            # (typical example being "intp" and "int64" on a 64-bit build)
-            if first == second and case1 != case2:
-                ambiguous = []
-                for rate, case in ordered:
-                    if rate == first:
-                        ambiguous.append(case)
-
-                # Try to resolve promotion
-                # TODO: need to match this to the C overloading dispatcher
-                resolvable = resolve_ambiguous_resolution(context, ambiguous,
-                                                          args)
-                if resolvable:
-                    return resolvable
-
-                # Failed to resolve promotion
-                args = (key, args, '\n'.join(map(str, ambiguous)))
-                msg = "Ambiguous overloading for %s %s\n%s" % args
-                raise TypeError(msg)
-
-        return ordered[0][1]
-
-
-def resolve_ambiguous_resolution(context, cases, args):
-    """Uses asymmetric resolution to find the best version
-    """
-    ratings = []
-    for case in cases:
-        rates = _rate_arguments(context, args, case.args)
-        ratings.append((tuple(r.astuple() for r in rates), case))
-
-    return max(ratings, key=lambda x: x[0])[1]
-
-
 class FunctionTemplate(object):
     def __init__(self, context):
         self.context = context
 
     def _select(self, cases, args, kws):
-        selected = resolve_overload(self.context, self.key, cases, args, kws)
+        selected = self.context.resolve_overload(self.key, cases, args, kws)
         return selected
 
 

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -526,3 +526,268 @@ class finalize:
             finalize._shutdown = True
             if reenable_gc:
                 gc.enable()
+
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Copied from http://code.activestate.com/recipes/576693/
+
+    # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
+    # Passes Python2.7's test suite and incorporates all the latest updates.
+
+    try:
+        from thread import get_ident as _get_ident
+    except ImportError:
+        from dummy_thread import get_ident as _get_ident
+
+    try:
+        from _abcoll import KeysView, ValuesView, ItemsView
+    except ImportError:
+        pass
+
+
+    class OrderedDict(dict):
+        'Dictionary that remembers insertion order'
+        # An inherited dict maps keys to values.
+        # The inherited dict provides __getitem__, __len__, __contains__, and get.
+        # The remaining methods are order-aware.
+        # Big-O running times for all methods are the same as for regular dictionaries.
+
+        # The internal self.__map dictionary maps keys to links in a doubly linked list.
+        # The circular doubly linked list starts and ends with a sentinel element.
+        # The sentinel element never gets deleted (this simplifies the algorithm).
+        # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+
+        def __init__(self, *args, **kwds):
+            '''Initialize an ordered dictionary.  Signature is the same as for
+            regular dictionaries, but keyword arguments are not recommended
+            because their insertion order is arbitrary.
+
+            '''
+            if len(args) > 1:
+                raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            try:
+                self.__root
+            except AttributeError:
+                self.__root = root = []                     # sentinel node
+                root[:] = [root, root, None]
+                self.__map = {}
+            self.__update(*args, **kwds)
+
+        def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+            'od.__setitem__(i, y) <==> od[i]=y'
+            # Setting a new item creates a new link which goes at the end of the linked
+            # list, and the inherited dictionary is updated with the new key/value pair.
+            if key not in self:
+                root = self.__root
+                last = root[0]
+                last[1] = root[0] = self.__map[key] = [last, root, key]
+            dict_setitem(self, key, value)
+
+        def __delitem__(self, key, dict_delitem=dict.__delitem__):
+            'od.__delitem__(y) <==> del od[y]'
+            # Deleting an existing item uses self.__map to find the link which is
+            # then removed by updating the links in the predecessor and successor nodes.
+            dict_delitem(self, key)
+            link_prev, link_next, key = self.__map.pop(key)
+            link_prev[1] = link_next
+            link_next[0] = link_prev
+
+        def __iter__(self):
+            'od.__iter__() <==> iter(od)'
+            root = self.__root
+            curr = root[1]
+            while curr is not root:
+                yield curr[2]
+                curr = curr[1]
+
+        def __reversed__(self):
+            'od.__reversed__() <==> reversed(od)'
+            root = self.__root
+            curr = root[0]
+            while curr is not root:
+                yield curr[2]
+                curr = curr[0]
+
+        def clear(self):
+            'od.clear() -> None.  Remove all items from od.'
+            try:
+                for node in self.__map.itervalues():
+                    del node[:]
+                root = self.__root
+                root[:] = [root, root, None]
+                self.__map.clear()
+            except AttributeError:
+                pass
+            dict.clear(self)
+
+        def popitem(self, last=True):
+            '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+            Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+            '''
+            if not self:
+                raise KeyError('dictionary is empty')
+            root = self.__root
+            if last:
+                link = root[0]
+                link_prev = link[0]
+                link_prev[1] = root
+                root[0] = link_prev
+            else:
+                link = root[1]
+                link_next = link[1]
+                root[1] = link_next
+                link_next[0] = root
+            key = link[2]
+            del self.__map[key]
+            value = dict.pop(self, key)
+            return key, value
+
+        # -- the following methods do not depend on the internal structure --
+
+        def keys(self):
+            'od.keys() -> list of keys in od'
+            return list(self)
+
+        def values(self):
+            'od.values() -> list of values in od'
+            return [self[key] for key in self]
+
+        def items(self):
+            'od.items() -> list of (key, value) pairs in od'
+            return [(key, self[key]) for key in self]
+
+        def iterkeys(self):
+            'od.iterkeys() -> an iterator over the keys in od'
+            return iter(self)
+
+        def itervalues(self):
+            'od.itervalues -> an iterator over the values in od'
+            for k in self:
+                yield self[k]
+
+        def iteritems(self):
+            'od.iteritems -> an iterator over the (key, value) items in od'
+            for k in self:
+                yield (k, self[k])
+
+        def update(*args, **kwds):
+            '''od.update(E, **F) -> None.  Update od from dict/iterable E and F.
+
+            If E is a dict instance, does:           for k in E: od[k] = E[k]
+            If E has a .keys() method, does:         for k in E.keys(): od[k] = E[k]
+            Or if E is an iterable of items, does:   for k, v in E: od[k] = v
+            In either case, this is followed by:     for k, v in F.items(): od[k] = v
+
+            '''
+            if len(args) > 2:
+                raise TypeError('update() takes at most 2 positional '
+                                'arguments (%d given)' % (len(args),))
+            elif not args:
+                raise TypeError('update() takes at least 1 argument (0 given)')
+            self = args[0]
+            # Make progressively weaker assumptions about "other"
+            other = ()
+            if len(args) == 2:
+                other = args[1]
+            if isinstance(other, dict):
+                for key in other:
+                    self[key] = other[key]
+            elif hasattr(other, 'keys'):
+                for key in other.keys():
+                    self[key] = other[key]
+            else:
+                for key, value in other:
+                    self[key] = value
+            for key, value in kwds.items():
+                self[key] = value
+
+        __update = update  # let subclasses override update without breaking __init__
+
+        __marker = object()
+
+        def pop(self, key, default=__marker):
+            '''od.pop(k[,d]) -> v, remove specified key and return the corresponding value.
+            If key is not found, d is returned if given, otherwise KeyError is raised.
+
+            '''
+            if key in self:
+                result = self[key]
+                del self[key]
+                return result
+            if default is self.__marker:
+                raise KeyError(key)
+            return default
+
+        def setdefault(self, key, default=None):
+            'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+            if key in self:
+                return self[key]
+            self[key] = default
+            return default
+
+        def __repr__(self, _repr_running={}):
+            'od.__repr__() <==> repr(od)'
+            call_key = id(self), _get_ident()
+            if call_key in _repr_running:
+                return '...'
+            _repr_running[call_key] = 1
+            try:
+                if not self:
+                    return '%s()' % (self.__class__.__name__,)
+                return '%s(%r)' % (self.__class__.__name__, self.items())
+            finally:
+                del _repr_running[call_key]
+
+        def __reduce__(self):
+            'Return state information for pickling'
+            items = [[k, self[k]] for k in self]
+            inst_dict = vars(self).copy()
+            for k in vars(OrderedDict()):
+                inst_dict.pop(k, None)
+            if inst_dict:
+                return (self.__class__, (items,), inst_dict)
+            return self.__class__, (items,)
+
+        def copy(self):
+            'od.copy() -> a shallow copy of od'
+            return self.__class__(self)
+
+        @classmethod
+        def fromkeys(cls, iterable, value=None):
+            '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
+            and values equal to v (which defaults to None).
+
+            '''
+            d = cls()
+            for key in iterable:
+                d[key] = value
+            return d
+
+        def __eq__(self, other):
+            '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+            while comparison to a regular mapping is order-insensitive.
+
+            '''
+            if isinstance(other, OrderedDict):
+                return len(self)==len(other) and self.items() == other.items()
+            return dict.__eq__(self, other)
+
+        def __ne__(self, other):
+            return not self == other
+
+        # -- the following methods are only used in Python 2.7 --
+
+        def viewkeys(self):
+            "od.viewkeys() -> a set-like object providing a view on od's keys"
+            return KeysView(self)
+
+        def viewvalues(self):
+            "od.viewvalues() -> an object providing a view on od's values"
+            return ValuesView(self)
+
+        def viewitems(self):
+            "od.viewitems() -> a set-like object providing a view on od's items"
+            return ItemsView(self)


### PR DESCRIPTION
Amongst other things:
- add tests for type unification and conversion
- add a OrderedDict backport in numba.utils (for Python 2.6)
- remove ad-hoc registration of types in post_init()
- simply resolution of ambiguous signature matches
- make the machinery more generic and easier to extend
- should fix the issue reported on the ML ("Cannot unify {array(float64, 1d, A), array(float64, 1d, C)}")
