### PR TITLE
implement aligned allocator

### DIFF
--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -536,6 +536,8 @@ declmethod(decref);
 declmethod(MemInfo_data);
 declmethod(MemInfo_alloc);
 declmethod(MemInfo_alloc_safe);
+declmethod(MemInfo_alloc_aligned);
+declmethod(MemInfo_alloc_safe_aligned);
 declmethod(MemInfo_call_dtor);
 
 

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -340,7 +340,7 @@ void* NRT_MemAlign(void **ptr, size_t size, unsigned align) {
     unsigned remainder;
 
     /* Allocate extra space for padding and book keeping */
-    size_t total_size = size + align + sizeof(AlignHeader);
+    size_t total_size = size + 2 * align + sizeof(AlignHeader);
     base = (AlignHeader*) NRT_Allocate(total_size);
 
     /* The AlignHeader goes first, so skip sizeof(AlignHeader) */

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -40,6 +40,11 @@ struct MemSys{
 static MemSys TheMSys;
 
 
+typedef struct {
+    size_t total_size;
+} AlignHeader;
+
+
 static
 MemInfo *nrt_pop_meminfo_list(MemInfo * volatile *list) {
     MemInfo *old, *repl, *head;
@@ -226,6 +231,39 @@ MemInfo* NRT_MemInfo_alloc_safe(size_t size) {
     return NRT_MemInfo_new(data, size, nrt_internal_dtor, (void*)size);
 }
 
+static
+void nrt_internal_aligned_dtor(void *ptr, void *info) {
+    NRT_Debug(nrt_debug_print("nrt_internal_aligned_dtor %p, %p\n", ptr, info));
+    NRT_Free(info);
+}
+
+static
+void nrt_internal_aligned_safe_dtor(void *ptr, void *info) {
+    AlignHeader *header = info;
+    NRT_Debug(nrt_debug_print("nrt_internal_aligned_safe_dtor %p, %p\n", ptr,
+                              info));
+    if (header->total_size) {
+        memset(header, 0xDE, header->total_size);  /* for safety */
+    }
+    NRT_Free(info);
+}
+
+MemInfo* NRT_MemInfo_alloc_aligned(size_t size, unsigned align) {
+    void *data = NULL;
+    void *base = NRT_MemAlign(&data, size, align);
+    NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_aligned %p\n", data));
+    return NRT_MemInfo_new(data, size, nrt_internal_aligned_dtor, base);
+}
+
+MemInfo* NRT_MemInfo_alloc_safe_aligned(size_t size, unsigned align) {
+    void *data = NULL;
+    void *base = NRT_MemAlign(&data, size, align);
+    memset(data, 0xCB, size);
+    NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_safe_aligned %p %llu\n",
+                              data, size));
+    return NRT_MemInfo_new(data, size, nrt_internal_aligned_safe_dtor, base);
+}
+
 void NRT_MemInfo_destroy(MemInfo *mi) {
     NRT_MemSys_insert_meminfo(mi);
 }
@@ -281,4 +319,37 @@ void* NRT_Allocate(size_t size) {
 void NRT_Free(void *ptr) {
     NRT_Debug(nrt_debug_print("NRT_Free %p\n", ptr));
     free(ptr);
+}
+
+void* NRT_MemAlign(void **ptr, size_t size, unsigned align) {
+    AlignHeader *base;
+    size_t intptr;
+    unsigned offset;
+    unsigned remainder;
+
+    /* Allocate extra space for padding and book keeping */
+    size_t total_size = size + align + sizeof(AlignHeader);
+    base = (AlignHeader*) NRT_Allocate(total_size);
+
+    /* The AlignHeader goes first, so skip sizeof(AlignHeader) */
+    intptr = (size_t) (base + 1);
+
+    /* See if we are aligned */
+    remainder = intptr % align;
+    if (remainder == 0){
+        /* Yes */
+        offset = 0;
+    } else {
+        /* No, move forward `offset` bytes */
+        offset = align - remainder;
+    }
+
+    /* Store the aligned pointer to the output parameter */
+    *ptr = (void*) (intptr + offset);
+
+    /* Remember the total allocated size */
+    base->total_size = total_size;
+
+    /* Return the pointer for deallocation with NRT_Free() */
+    return base;
 }

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -103,6 +103,7 @@ MemInfo* NRT_MemInfo_new(void *data, size_t size, dtor_function dtor,
  */
 MemInfo* NRT_MemInfo_alloc(size_t size);
 
+
 /*
  * The "safe" NRT_MemInfo_alloc performs additional steps to help debug
  * memory errors.
@@ -111,6 +112,13 @@ MemInfo* NRT_MemInfo_alloc(size_t size);
  *   - may do more in the future
  */
 MemInfo* NRT_MemInfo_alloc_safe(size_t size);
+
+/*
+ * Aligned versions of the NRT_MemInfo_alloc and NRT_MemInfo_alloc_safe.
+ * These take an additional argument `align` for number of bytes to align to.
+ */
+MemInfo* NRT_MemInfo_alloc_aligned(size_t size, unsigned align);
+MemInfo* NRT_MemInfo_alloc_safe_aligned(size_t size, unsigned align);
 
 /*
  * Internal API.
@@ -169,3 +177,11 @@ void* NRT_Allocate(size_t size);
  * Deallocate memory pointed by `ptr`.
  */
 void NRT_Free(void *ptr);
+
+/*
+ * Allocate memory of `size` bytes on the given `align` byte boundary
+ * The allocated output is stored to `ptr`.
+ * The return value is the base pointer to be passed to NRT_Free
+ */
+void* NRT_MemAlign(void **ptr, size_t size, unsigned align);
+

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1581,8 +1581,11 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
             "Don't know how to allocate array with layout '{0}'.".format(
                 arrtype.layout))
 
-    meminfo = context.nrt_meminfo_alloc(builder,
-                                        size=builder.mul(itemsize, arrlen))
+    allocsize = builder.mul(itemsize, arrlen)
+    # NOTE: AVX prefer 32-byte alignment
+    meminfo = context.nrt_meminfo_alloc_aligned(builder, size=allocsize,
+                                                align=32)
+
     data = context.nrt_meminfo_data(builder, meminfo)
 
     intp_t = context.get_value_type(types.intp)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1003,23 +1003,30 @@ class BaseContext(object):
             raise Exception("Require NRT")
         mod = builder.module
         fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
-            [self.get_value_type(types.intp)])
+                                   [self.get_value_type(types.intp)])
         # NOTE: safe alloc really slows allocations down
         fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
         return builder.call(fn, [size])
 
-    def nrt_meminfo_alloc(self, builder, size):
+    def nrt_meminfo_alloc_aligned(self, builder, size, align):
+        """
+        Allocate a new MemInfo of `size` bytes and and align the data pointer
+        to `align` bytes.  The `align` arg can be either a Python int or a LLVM
+        uint32 value.
+        """
         if not self.enable_nrt:
             raise Exception("Require NRT")
         mod = builder.module
-        fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
-            [self.get_value_type(types.intp),
-             self.get_value_type(types.uint32)])
-
+        intp = self.get_value_type(types.intp)
+        u32 = self.get_value_type(types.uint32)
+        fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(), [intp, u32])
+        # NOTE: safe alloc really slows allocations down
         fn = mod.get_or_insert_function(fnty,
                                         name="NRT_MemInfo_alloc_safe_aligned")
-
-        align = self.get_constant(types.uint32, 16)
+        if isinstance(align, int):
+            align = self.get_constant(types.uint32, align)
+        else:
+            assert align.type == u32, "align must be a uint32"
         return builder.call(fn, [size, align])
 
     def nrt_meminfo_data(self, builder, meminfo):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1008,6 +1008,20 @@ class BaseContext(object):
         fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
         return builder.call(fn, [size])
 
+    def nrt_meminfo_alloc(self, builder, size):
+        if not self.enable_nrt:
+            raise Exception("Require NRT")
+        mod = builder.module
+        fnty = llvmir.FunctionType(llvmir.IntType(8).as_pointer(),
+            [self.get_value_type(types.intp),
+             self.get_value_type(types.uint32)])
+
+        fn = mod.get_or_insert_function(fnty,
+                                        name="NRT_MemInfo_alloc_safe_aligned")
+
+        align = self.get_constant(types.uint32, 16)
+        return builder.call(fn, [size, align])
+
     def nrt_meminfo_data(self, builder, meminfo):
         if not self.enable_nrt:
             raise Exception("Require NRT")


### PR DESCRIPTION
* Implement memalign in nrt
* Align array data buffer to 32-bytes as recommended for AVX (see https://software.intel.com/en-us/articles/practical-intel-avx-optimization-on-2nd-generation-intel-core-processors)
