### PR TITLE
Use 'double' precision in lgamma test.

### DIFF
--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -562,7 +562,7 @@ class TestMathLib(TestCase):
         pyfunc = lgamma
         x_values = [1., -0.9, -0.1, 0.1, 200., 1e10, 1e30, float('inf')]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
-        self.run_unary(pyfunc, x_types, x_values, flags)
+        self.run_unary(pyfunc, x_types, x_values, flags, prec='double')
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_lgamma_npm(self):


### PR DESCRIPTION
On linux 32-bit x86, x87 FPU is used for the double return value in
cdecl calling convention.  This leads probably the cause of the mismatch
in precision.