### PR TITLE
Add a facility to compile subroutines

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -193,6 +193,7 @@ class PrimitiveModel(DataModel):
 @register_default(types.Dummy)
 @register_default(types.ExceptionInstance)
 @register_default(types.ExternalFunction)
+@register_default(types.NumbaFunction)
 @register_default(types.Method)
 @register_default(types.Macro)
 @register_default(types.NumberClass)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -473,6 +473,11 @@ class Lower(BaseLower):
             res = self.context.call_external_function(
                 self.builder, func, fndesc.argtypes, argvals)
 
+        elif isinstance(fnty, types.NumbaFunction):
+            # Handle a compiled Numba function
+            res = self.context.call_internal(self.builder, fnty.fndesc,
+                                             fnty.sig, argvals)
+
         elif isinstance(fnty, types.Method):
             # Method of objects are handled differently
             fnobj = self.loadvar(expr.func.name)

--- a/numba/types.py
+++ b/numba/types.py
@@ -327,6 +327,7 @@ class ExternalFunctionPointer(Function):
 class ExternalFunction(Function):
     """
     A named native function (resolvable by LLVM).
+    For internal use only.
     """
 
     def __init__(self, symbol, sig):
@@ -335,6 +336,30 @@ class ExternalFunction(Function):
         self.sig = sig
         template = typing.make_concrete_template(symbol, symbol, [sig])
         super(ExternalFunction, self).__init__(template)
+
+    @property
+    def key(self):
+        return self.symbol, self.sig
+
+
+class NumbaFunction(Function):
+    """
+    A named native function with the Numba calling convention
+    (resolvable by LLVM).
+    For internal use only.
+    """
+
+    def __init__(self, fndesc, sig):
+        from . import typing
+        self.fndesc = fndesc
+        self.sig = sig
+        template = typing.make_concrete_template(fndesc.qualname,
+                                                 fndesc.qualname, [sig])
+        super(NumbaFunction, self).__init__(template)
+
+    @property
+    def key(self):
+        return self.fndesc.unique_name, self.sig
 
 
 class BoundFunction(Function):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -244,7 +244,7 @@ class BaseContext(object):
         if tp is not None:
             return tp
 
-        if isinstance(val, types.ExternalFunction):
+        if isinstance(val, (types.ExternalFunction, types.NumbaFunction)):
             return val
 
         if isinstance(val, type) and issubclass(val, BaseException):


### PR DESCRIPTION
Useful for complex implementations (e.g. the median() implementation in PR #1250).
The new `compile_subroutine()` method is like the existing `compile_internal()`, except that it doesn't call the resulting function: instead, it returns an object that can be called from another nopython mode function.