### PR TITLE
Fix #1245: make power with an integer exponent faster

### DIFF
--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -158,77 +158,35 @@ def int_urem_impl(context, builder, sig, args):
     return builder.urem(x, y)
 
 
-def int_spower_impl(context, builder, sig, args):
-    module = builder.module
-    x, y = args
+def int_power_impl(context, builder, sig, args):
+    """
+    a ^ b, where a is an integer or real, and b an integer
+    """
+    def int_power(a, b):
+        r = 1
+        if b < 0:
+            invert = True
+            exp = -b
+            if exp < 0:
+                raise OverflowError
+        else:
+            invert = False
+            exp = b
+        if b > 0x10000:
+            # Optimization cutoff: fallback on the generic algorithm
+            return math.pow(a, float(b))
+        while True:
+            if exp & 1:
+                r *= a
+            exp >>= 1
+            if exp == 0:
+                break
+            a *= a
 
-    # Cast x to float64 to ensure enough precision for the result
-    x = context.cast(builder, x, sig.args[0], types.float64)
-    # Cast y to int32
-    y = context.cast(builder, y, sig.args[1], types.int32)
+        return 1.0 / r if invert else r
 
-    if context.implement_powi_as_math_call:
-        undersig = typing.signature(sig.return_type, types.float64,
-                                    types.int32)
-        impl = context.get_function(math.pow, undersig)
-        res = impl(builder, (x, y))
-    else:
-        powerfn = lc.Function.intrinsic(module, lc.INTR_POWI, [x.type])
-        res = builder.call(powerfn, (x, y))
-
-    # Cast result back
-    return context.cast(builder, res, types.float64, sig.return_type)
-
-
-def int_upower_impl(context, builder, sig, args):
-    module = builder.module
-    x, y = args
-    if y.type.width > 32:
-        y = builder.trunc(y, Type.int(32))
-    elif y.type.width < 32:
-        y = builder.zext(y, Type.int(32))
-
-    if context.implement_powi_as_math_call:
-        undersig = typing.signature(sig.return_type, sig.args[0], types.int32)
-        impl = context.get_function(math.pow, undersig)
-        return impl(builder, (x, y))
-    else:
-        powerfn = lc.Function.intrinsic(module, lc.INTR_POWI, [x.type])
-        return builder.call(powerfn, (x, y))
-
-
-def int_power_func_body(context, builder, x, y):
-    pcounter = cgutils.alloca_once(builder, y.type)
-    presult = cgutils.alloca_once(builder, x.type)
-    result = Constant.int(x.type, 1)
-    counter = y
-    builder.store(counter, pcounter)
-    builder.store(result, presult)
-
-    bbcond = builder.append_basic_block(".cond")
-    bbbody = builder.append_basic_block(".body")
-    bbexit = builder.append_basic_block(".exit")
-
-    del counter
-    del result
-
-    builder.branch(bbcond)
-
-    with builder.goto_block(bbcond):
-        counter = builder.load(pcounter)
-        ONE = Constant.int(counter.type, 1)
-        ZERO = Constant.null(counter.type)
-        builder.store(builder.sub(counter, ONE), pcounter)
-        pred = builder.icmp(lc.ICMP_SGT, counter, ZERO)
-        builder.cbranch(pred, bbbody, bbexit)
-
-    with builder.goto_block(bbbody):
-        result = builder.load(presult)
-        builder.store(builder.mul(result, x), presult)
-        builder.branch(bbcond)
-
-    builder.position_at_end(bbexit)
-    return builder.load(presult)
+    return context.compile_internal(builder, int_power, sig, args,
+                                    locals={'r': sig.return_type})
 
 
 def int_slt_impl(context, builder, sig, args):
@@ -429,8 +387,8 @@ def _implement_integer_operators():
     builtin(implement('~', ty)(int_invert_impl))
     builtin(implement(types.sign_type, ty)(int_sign_impl))
 
-    builtin(implement('**', ty, ty)(int_spower_impl))
-    builtin(implement(pow, ty, ty)(int_spower_impl))
+    builtin(implement('**', ty, ty)(int_power_impl))
+    builtin(implement(pow, ty, ty)(int_power_impl))
 
     for ty in types.unsigned_domain:
         builtin(implement('/?', ty, ty)(int_udiv_impl))
@@ -441,8 +399,8 @@ def _implement_integer_operators():
         builtin(implement('<=', ty, ty)(int_ule_impl))
         builtin(implement('>', ty, ty)(int_ugt_impl))
         builtin(implement('>=', ty, ty)(int_uge_impl))
-        builtin(implement('**', types.float64, ty)(int_upower_impl))
-        builtin(implement(pow, types.float64, ty)(int_upower_impl))
+        builtin(implement('**', types.float64, ty)(int_power_impl))
+        builtin(implement(pow, types.float64, ty)(int_power_impl))
         # logical shift for unsigned
         builtin(implement('>>', ty, types.uint32)(int_lshr_impl))
         builtin(implement(types.abs_type, ty)(uint_abs_impl))
@@ -457,8 +415,8 @@ def _implement_integer_operators():
         builtin(implement('>', ty, ty)(int_sgt_impl))
         builtin(implement('>=', ty, ty)(int_sge_impl))
         builtin(implement(types.abs_type, ty)(int_abs_impl))
-        builtin(implement('**', types.float64, ty)(int_spower_impl))
-        builtin(implement(pow, types.float64, ty)(int_spower_impl))
+        builtin(implement('**', types.float64, ty)(int_power_impl))
+        builtin(implement(pow, types.float64, ty)(int_power_impl))
         # arithmetic shift for signed
         builtin(implement('>>', ty, types.uint32)(int_ashr_impl))
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -172,7 +172,7 @@ def int_power_impl(context, builder, sig, args):
         else:
             invert = False
             exp = b
-        if b > 0x10000:
+        if exp > 0x10000:
             # Optimization cutoff: fallback on the generic algorithm
             return math.pow(a, float(b))
         while True:

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -108,10 +108,6 @@ class CPUContext(BaseContext):
     def post_lowering(self, func):
         mod = func.module
 
-        if (sys.platform.startswith('linux') or
-                sys.platform.startswith('win32')):
-            intrinsics.fix_powi_calls(mod)
-
         if self.is32bit:
             # 32-bit machine needs to replace all 64-bit div/rem to avoid
             # calls to compiler-rt

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -441,9 +441,9 @@ unary_math_int_impl(math.degrees, degrees_f64_impl)
 # -----------------------------------------------------------------------------
 
 for ty in types.unsigned_domain:
-    register(implement(math.pow, types.float64, ty)(builtins.int_upower_impl))
+    register(implement(math.pow, types.float64, ty)(builtins.int_power_impl))
 for ty in types.signed_domain:
-    register(implement(math.pow, types.float64, ty)(builtins.int_spower_impl))
+    register(implement(math.pow, types.float64, ty)(builtins.int_power_impl))
 
 ty = types.Kind(types.Float)
 register(implement(math.pow, ty, ty)(builtins.real_power_impl))

--- a/numba/targets/operatorimpl.py
+++ b/numba/targets/operatorimpl.py
@@ -48,8 +48,8 @@ def _implement_integer_operators():
         register(implement(operator.le, ty, ty)(builtins.int_ule_impl))
         register(implement(operator.gt, ty, ty)(builtins.int_ugt_impl))
         register(implement(operator.ge, ty, ty)(builtins.int_uge_impl))
-        register(implement(operator.pow, types.float64, ty)(builtins.int_upower_impl))
-        register(implement(operator.ipow, types.float64, ty)(builtins.int_upower_impl))
+        register(implement(operator.pow, types.float64, ty)(builtins.int_power_impl))
+        register(implement(operator.ipow, types.float64, ty)(builtins.int_power_impl))
         register(implement(operator.rshift, ty, ty)(builtins.int_lshr_impl))
         register(implement(operator.irshift, ty, ty)(builtins.int_lshr_impl))
 
@@ -67,8 +67,8 @@ def _implement_integer_operators():
         register(implement(operator.le, ty, ty)(builtins.int_sle_impl))
         register(implement(operator.gt, ty, ty)(builtins.int_sgt_impl))
         register(implement(operator.ge, ty, ty)(builtins.int_sge_impl))
-        register(implement(operator.pow, types.float64, ty)(builtins.int_spower_impl))
-        register(implement(operator.ipow, types.float64, ty)(builtins.int_spower_impl))
+        register(implement(operator.pow, types.float64, ty)(builtins.int_power_impl))
+        register(implement(operator.ipow, types.float64, ty)(builtins.int_power_impl))
         register(implement(operator.rshift, ty, ty)(builtins.int_ashr_impl))
         register(implement(operator.irshift, ty, ty)(builtins.int_ashr_impl))
 


### PR DESCRIPTION
Typical runtime falls from 60 µs (before) to 5-20 µs (after, depending on the exponent's magnitude).
Large exponents fall back on the generic version.