### PR TITLE
Issue #1288: add an import-time guard against restrictions on executable memory allocation

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -50,9 +50,9 @@ from_dtype
 """.split() + types.__all__ + special.__all__ + errors.__all__
 
 
-def _sentry_llvm_version():
+def _ensure_llvm():
     """
-    Make sure we meet min llvmlite version
+    Make sure llvmlite is operational.
     """
     import warnings
     import llvmlite
@@ -74,7 +74,11 @@ def _sentry_llvm_version():
         # Not matching?
         warnings.warn("llvmlite version format not recognized!")
 
-_sentry_llvm_version()
+    from llvmlite.binding import check_jit_execution
+    check_jit_execution()
+
+
+_ensure_llvm()
 
 
 # Process initialization


### PR DESCRIPTION
(note I don't have a SELinux system at hand to check that it raises, but trivially it should)