### PR TITLE
Fix #1297: invalid lowering of decref for var defined in loops.

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -704,17 +704,8 @@ class Lower(BaseLower):
 
     def storevar(self, value, name):
         fetype = self.typeof(name)
-        # Clean up existing value stored in the variable
-        try:
-            # Load original value in variable
-            old = self.loadvar(name)
-        except KeyError:
-            # If it has not been defined, don't do anything
-            pass
-        else:
-            # Else, dereference the old value
-            self.decref(fetype, old)
-        # Store variable
+
+        # Define if not already
         if name not in self.varmap:
             # If not already defined, allocate it
             llty = self.context.get_value_type(fetype)
@@ -722,6 +713,11 @@ class Lower(BaseLower):
             # Remember the pointer
             self.varmap[name] = ptr
 
+        # Clean up existing value stored in the variable
+        old = self.loadvar(name)
+        self.decref(fetype, old)
+
+        # Store variable
         ptr = self.getvar(name)
         if value.type != ptr.type.pointee:
             msg = ("Storing {value.type} to ptr of {ptr.type.pointee}. "


### PR DESCRIPTION
This fixes https://github.com/numba/numba/issues/1297.

**Problem description**

```python
@njit
def g(n):
    x = f(n)
    for i in range(n):
        y = x[i]

    for i in range(n):
        y = x[i]

    return 0
```
When lowering reach the first definition of `y`, it did not emit a decref because it is defined for the first time.  That is incorrect because the line is in a loop.  

Interestingly, this bug will not occur without the second loop that redefine `y`.  Without the second definition, a explicit Del instruction will be inserted into the loop of the first loop body to indicate the end of lifetime of `y`.  The problem will also not occur if `y` is defined before the first loop.

**The Fix**

Lowering needs to always emit a decref even if it is the first definition site.  It cannot tell (should not need to tell) if it is inside a loop.  The extra decref should not be a problem because all definition are zero initialized and LLVM is able to infer that the decref is never going to be called when not in a loop.
