### PR TITLE
Issue #1226: help LLVM make integer power faster

### DIFF
--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -175,12 +175,10 @@ def int_power_impl(context, builder, sig, args):
         if exp > 0x10000:
             # Optimization cutoff: fallback on the generic algorithm
             return math.pow(a, float(b))
-        while True:
+        while exp != 0:
             if exp & 1:
                 r *= a
             exp >>= 1
-            if exp == 0:
-                break
             a *= a
 
         return 1.0 / r if invert else r

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -329,14 +329,23 @@ class CPUCallConv(BaseCallConv):
 
     def decorate_function(self, fn, args, fe_argtypes):
         """
-        Set names of function arguments.
+        Set names of function arguments, and add useful attributes to them.
         """
         arginfo = self.context.get_arg_packer(fe_argtypes)
         arginfo.assign_names(self.get_arguments(fn),
                              ['arg.' + a for a in args])
-        self._get_return_argument(fn).name = "retptr"
-        self._get_excinfo_argument(fn).name = "excinfo"
-        self.get_env_argument(fn).name = "env"
+        retarg = self._get_return_argument(fn)
+        retarg.name = "retptr"
+        retarg.add_attribute("nocapture")
+        retarg.add_attribute("noalias")
+        excarg = self._get_excinfo_argument(fn)
+        excarg.name = "excinfo"
+        excarg.add_attribute("nocapture")
+        excarg.add_attribute("noalias")
+        envarg = self.get_env_argument(fn)
+        envarg.name = "env"
+        envarg.add_attribute("nocapture")
+        envarg.add_attribute("noalias")
         return fn
 
     def get_arguments(self, func):


### PR DESCRIPTION
When the exponent is a constant, as in `x ** 2`, this new form helps LLVM unroll the implementation's loop and simplify it down to a multiplication.

Also add attributes to our calling convention's function arguments.

(performance fix courtesy of @sklam )