### PR TITLE
Fix #1332: support EXTENDED_ARG

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -312,6 +312,31 @@ def compile_function(name, code, globs):
     eval(co, globs, ns)
     return ns[name]
 
+def tweak_code(func, codestring=None, consts=None):
+    """
+    Tweak the code object of the given function by replacing its
+    *codestring* (a bytes object) and *consts* tuple, optionally.
+    """
+    co = func.__code__
+    tp = type(co)
+    if codestring is None:
+        codestring = co.co_code
+    if consts is None:
+        consts = co.co_consts
+    if sys.version_info >= (3,):
+        new_code = tp(co.co_argcount, co.co_kwonlyargcount, co.co_nlocals,
+                      co.co_stacksize, co.co_flags, codestring,
+                      consts, co.co_names, co.co_varnames,
+                      co.co_filename, co.co_name, co.co_firstlineno,
+                      co.co_lnotab)
+    else:
+        new_code = tp(co.co_argcount, co.co_nlocals,
+                      co.co_stacksize, co.co_flags, codestring,
+                      consts, co.co_names, co.co_varnames,
+                      co.co_filename, co.co_name, co.co_firstlineno,
+                      co.co_lnotab)
+    func.__code__ = new_code
+
 
 # From CPython
 

--- a/numba/tests/test_extended_arg.py
+++ b/numba/tests/test_extended_arg.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+
+import numba.unittest_support as unittest
+
+import dis
+import struct
+import sys
+
+from numba import jit
+from .support import TestCase, tweak_code
+
+
+class TestExtendedArg(TestCase):
+    """
+    Test support for the EXTENDED_ARG opcode.
+    """
+
+    def get_extended_arg_load_const(self):
+        """
+        Get a function with a EXTENDED_ARG opcode before a LOAD_CONST opcode.
+        """
+        def f():
+            x = 5
+            return x
+
+        b = bytearray(f.__code__.co_code)
+        consts = f.__code__.co_consts
+        consts = consts + (None,) * 65535 + (42,)
+        b[:0] = struct.pack("<BH", dis.EXTENDED_ARG, 1)
+
+        tweak_code(f, codestring=bytes(b), consts=consts)
+        return f
+
+    def test_extended_arg_load_const(self):
+        pyfunc = self.get_extended_arg_load_const()
+        self.assertPreciseEqual(pyfunc(), 42)
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(), 42)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR includes an artifical test devised by tweaking a function's bytecode.
A test with bytecode stemming from compilation of an actual function would take much too long (several seconds even for a trivial variant).