### PR TITLE
Allow MemInfo structure to be inlined with the data buffer

### DIFF
--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -52,13 +52,6 @@ memsys_set_atomic_cas(PyObject *self, PyObject *args) {
 
 static
 PyObject*
-memsys_process_defer_dtor(PyObject *self, PyObject *args) {
-    NRT_MemSys_process_defer_dtor();
-    Py_RETURN_NONE;
-}
-
-static
-PyObject*
 memsys_get_stats_alloc(PyObject *self, PyObject *args) {
     return PyLong_FromSize_t(NRT_MemSys_get_stats_alloc());
 }
@@ -153,7 +146,6 @@ meminfo_alloc_safe(PyObject *self, PyObject *args) {
 typedef struct {
     PyObject_HEAD
     MemInfo *meminfo;
-    int      defer;
 } MemInfoObject;
 
 static
@@ -167,7 +159,6 @@ int MemInfo_init(MemInfoObject *self, PyObject *args, PyObject *kwds) {
     raw_ptr = PyLong_AsVoidPtr(raw_ptr_obj);
     if(PyErr_Occurred()) return -1;
     self->meminfo = (MemInfo*)raw_ptr;
-    self->defer = 0;
     assert (NRT_MemInfo_refcount(self->meminfo) > 0 && "0 refcount");
     return 0;
 }
@@ -226,32 +217,9 @@ MemInfo_acquire(MemInfoObject *self) {
 static
 PyObject*
 MemInfo_release(MemInfoObject *self) {
-    NRT_MemInfo_release(self->meminfo, self->defer);
+    NRT_MemInfo_release(self->meminfo);
     Py_RETURN_NONE;
 }
-
-static
-int
-MemInfo_set_defer(MemInfoObject *self, PyObject *value, void *closure) {
-    int defer = PyObject_IsTrue(value);
-    if (defer == -1) {
-        return -1;
-    }
-    self->defer = defer;
-    return 0;
-}
-
-
-static
-PyObject*
-MemInfo_get_defer(MemInfoObject *self, void *closure) {
-    if (self->defer) {
-        Py_RETURN_TRUE;
-    } else {
-        Py_RETURN_FALSE;
-    }
-}
-
 
 static
 PyObject*
@@ -273,7 +241,7 @@ MemInfo_get_refcount(MemInfoObject *self, void *closure) {
 static void
 MemInfo_dealloc(MemInfoObject *self)
 {
-    NRT_MemInfo_release(self->meminfo, self->defer);
+    NRT_MemInfo_release(self->meminfo);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -289,10 +257,6 @@ static PyMethodDef MemInfo_methods[] = {
 
 
 static PyGetSetDef MemInfo_getsets[] = {
-    {"defer",
-     (getter)MemInfo_get_defer, (setter)MemInfo_set_defer,
-     "Boolean flag for the defer attribute",
-     NULL},
     {"data",
      (getter)MemInfo_get_data, NULL,
      "Get the data pointer as an integer",
@@ -445,7 +409,7 @@ PyObject* NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
         PyObject *obj = try_to_return_parent(arystruct, ndim, descr);
         if (obj){
             /* Release NRT reference to the numpy array */
-            NRT_MemInfo_release(arystruct->meminfo, 0);
+            NRT_MemInfo_release(arystruct->meminfo);
             return obj;
         }
     }
@@ -546,7 +510,7 @@ NRT_incref(MemInfo* mi) {
 static void
 NRT_decref(MemInfo* mi) {
     if (mi) {
-        NRT_MemInfo_release(mi, 0);
+        NRT_MemInfo_release(mi);
     }
 }
 
@@ -556,7 +520,6 @@ static PyMethodDef ext_methods[] = {
     declmethod_noargs(memsys_shutdown),
     declmethod(memsys_set_atomic_inc_dec),
     declmethod(memsys_set_atomic_cas),
-    declmethod_noargs(memsys_process_defer_dtor),
     declmethod_noargs(memsys_get_stats_alloc),
     declmethod_noargs(memsys_get_stats_free),
     declmethod_noargs(memsys_get_stats_mi_alloc),

--- a/numba/runtime/atomicops.py
+++ b/numba/runtime/atomicops.py
@@ -37,7 +37,7 @@ def _define_decref(module, atomic_decr):
     fn_decref = module.get_global_variable_named("NRT_decref")
     fn_decref.linkage = 'linkonce_odr'
     calldtor = module.add_function(ir.FunctionType(ir.VoidType(),
-        [ir.IntType(8).as_pointer(), ir.IntType(32)]),
+        [ir.IntType(8).as_pointer()]),
         name="NRT_MemInfo_call_dtor")
 
     builder = ir.IRBuilder(fn_decref.append_basic_block())
@@ -51,8 +51,7 @@ def _define_decref(module, atomic_decr):
     refct_eq_0 = builder.icmp_unsigned("==", newrefct,
                                        ir.Constant(newrefct.type, 0))
     with cgutils.if_unlikely(builder, refct_eq_0):
-        do_defer = ir.Constant(ir.IntType(32), 0)
-        builder.call(calldtor, [ptr, do_defer])
+        builder.call(calldtor, [ptr])
     builder.ret_void()
 
 

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -197,7 +197,7 @@ void* nrt_allocate_meminfo_and_data_align(size_t size, unsigned align,
                                          MemInfo **mi)
 {
     size_t offset, intptr, remainder;
-    char *base = nrt_allocate_meminfo_and_data(size + align, mi);
+    char *base = nrt_allocate_meminfo_and_data(size + 2 * align, mi);
     intptr = (size_t) base;
     /* See if we are aligned */
     remainder = intptr % align;

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -7,11 +7,6 @@
 #define MIN(a, b) ((a) < (b)) ? (a) : (b)
 #endif
 
-#ifdef IS_FLAG_SET
-#  error "IS_FLAG_SET redefined"
-#else
-#  define IS_FLAG_SET(X, M) ( (X & M) == M )
-#endif
 
 typedef int (*atomic_meminfo_cas_func)(void **ptr, void *cmp,
                                        void *repl, void **oldptr);
@@ -133,7 +128,7 @@ void NRT_MemSys_set_atomic_cas_stub(void) {
 }
 
 void NRT_MemInfo_init(MemInfo *mi,void *data, size_t size, dtor_function dtor,
-                      void *dtor_info, int flags)
+                      void *dtor_info)
 {
     mi->refct = 1;  /* starts with 1 refct */
     mi->dtor = dtor;
@@ -148,7 +143,7 @@ MemInfo* NRT_MemInfo_new(void *data, size_t size, dtor_function dtor,
                          void *dtor_info)
 {
     MemInfo * mi = NRT_Allocate(sizeof(MemInfo));
-    NRT_MemInfo_init(mi, data, size, dtor, dtor_info, 0);
+    NRT_MemInfo_init(mi, data, size, dtor, dtor_info);
     return mi;
 }
 
@@ -182,7 +177,7 @@ MemInfo* NRT_MemInfo_alloc(size_t size) {
     MemInfo *mi;
     void *data = nrt_allocate_meminfo_and_data(size, &mi);
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc %p\n", data));
-    NRT_MemInfo_init(mi, data, size, NULL, NULL, 0);
+    NRT_MemInfo_init(mi, data, size, NULL, NULL);
     return mi;
 }
 
@@ -193,8 +188,7 @@ MemInfo* NRT_MemInfo_alloc_safe(size_t size) {
        overhead. */
     memset(data, 0xCB, MIN(size, 256));
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_safe %p %zu\n", data, size));
-    NRT_MemInfo_init(mi, data, size, nrt_internal_dtor_safe,
-                     (void*)size, 0);
+    NRT_MemInfo_init(mi, data, size, nrt_internal_dtor_safe, (void*)size);
     return mi;
 }
 
@@ -219,7 +213,7 @@ MemInfo* NRT_MemInfo_alloc_aligned(size_t size, unsigned align) {
     MemInfo *mi;
     void *data = nrt_allocate_meminfo_and_data_align(size, align, &mi);
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_aligned %p\n", data));
-    NRT_MemInfo_init(mi, data, size, NULL, NULL, 0);
+    NRT_MemInfo_init(mi, data, size, NULL, NULL);
     return mi;
 }
 
@@ -231,8 +225,7 @@ MemInfo* NRT_MemInfo_alloc_safe_aligned(size_t size, unsigned align) {
     memset(data, 0xCB, MIN(size, 256));
     NRT_Debug(nrt_debug_print("NRT_MemInfo_alloc_safe_aligned %p %zu\n",
                               data, size));
-    NRT_MemInfo_init(mi, data, size, nrt_internal_dtor_safe,
-                     (void*)size, 0);
+    NRT_MemInfo_init(mi, data, size, nrt_internal_dtor_safe, (void*)size);
     return mi;
 }
 

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -90,7 +90,8 @@ static
 void nrt_meminfo_call_dtor(MemInfo *mi) {
     NRT_Debug(nrt_debug_print("nrt_meminfo_call_dtor %p\n", mi));
     /* call dtor */
-    mi->payload.dtor(mi->payload.data, mi->payload.dtor_info);
+    if (mi->payload.dtor)
+        mi->payload.dtor(mi->payload.data, mi->payload.dtor_info);
     /* Clear and release MemInfo */
     NRT_MemInfo_destroy(mi);
 }
@@ -318,12 +319,10 @@ void NRT_MemInfo_acquire(MemInfo *mi) {
 
 void NRT_MemInfo_call_dtor(MemInfo *mi, int defer) {
     /* We have a destructor */
-    if (mi->payload.dtor) {
-        if (defer) {
-            NRT_MemInfo_defer_dtor(mi);
-        } else {
-            nrt_meminfo_call_dtor(mi);
-        }
+    if (defer) {
+        NRT_MemInfo_defer_dtor(mi);
+    } else {
+        nrt_meminfo_call_dtor(mi);
     }
 }
 

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -19,6 +19,10 @@ typedef int (*atomic_meminfo_cas_func)(MemInfo * volatile *ptr, MemInfo *cmp,
 
 enum MEMINFO_FLAGS{
     MEMINFO_FLAGS_NONE = 0,
+    /*
+     *  If set, the MemInfo and the data buffer are in the same allocated
+     *  region.  Freeing the MemInfo pointer will free the data.
+     */
     MEMINFO_FLAGS_INLINED = 1
 };
 
@@ -29,7 +33,7 @@ union MemInfo{
         void          *dtor_info;
         void          *data;
         size_t         size;    /* only used for NRT allocated memory */
-        int            flags;
+        int            flags;   /* See enum MEMINFO_FLAGS */
     } payload;
 
     /* Freelist or Deferred-dtor-list */

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -105,6 +105,9 @@ size_t NRT_MemSys_get_stats_mi_free();
 MemInfo* NRT_MemInfo_new(void *data, size_t size, dtor_function dtor,
                          void *dtor_info);
 
+void NRT_MemInfo_init(MemInfo *mi, void *data, size_t size, dtor_function dtor,
+                      void *dtor_info, int flags);
+
 /*
  * Returns the refcount of a MemInfo or (size_t)-1 if error.
  */
@@ -190,11 +193,4 @@ void* NRT_Allocate(size_t size);
  * Deallocate memory pointed by `ptr`.
  */
 void NRT_Free(void *ptr);
-
-/*
- * Allocate memory of `size` bytes on the given `align` byte boundary
- * The allocated output is stored to `ptr`.
- * The return value is the base pointer to be passed to NRT_Free
- */
-void* NRT_MemAlign(void **ptr, size_t size, unsigned align);
 

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -82,11 +82,6 @@ void NRT_MemSys_set_atomic_inc_dec_stub(void);
 void NRT_MemSys_set_atomic_cas_stub(void);
 
 /*
- * Process all pending deferred dtors
- */
-void NRT_MemSys_process_defer_dtor(void);
-
-/*
  * The following functions get internal statistics of the memory subsystem.
  */
 size_t NRT_MemSys_get_stats_alloc();
@@ -150,15 +145,13 @@ void NRT_MemInfo_acquire(MemInfo* mi);
 /*
  * Release a reference to a MemInfo
  */
-void NRT_MemInfo_release(MemInfo* mi, int defer);
+void NRT_MemInfo_release(MemInfo* mi);
 
 /*
  * Internal/Compiler API.
  * Invoke the registered destructor of a MemInfo.
- * if `defer` is true, the MemInfo is added to the deferred dtor list.
- * Calls NRT_MemInfo_defer_dtor.
  */
-void NRT_MemInfo_call_dtor(MemInfo *mi, int defer);
+void NRT_MemInfo_call_dtor(MemInfo *mi);
 
 /*
  * Returns the data pointer
@@ -169,12 +162,6 @@ void* NRT_MemInfo_data(MemInfo* mi);
  * Returns the allocated size
  */
 size_t NRT_MemInfo_size(MemInfo* mi);
-
-/*
- * Internal API.
- * Append the MemInfo to the deferred dtor list.
- */
-void NRT_MemInfo_defer_dtor(MemInfo* mi);
 
 
 /*

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -34,7 +34,7 @@ typedef size_t (*atomic_inc_dec_func)(size_t *ptr);
 typedef int (*atomic_cas_func)(void * volatile *ptr, void *cmp, void *repl,
                                void **oldptr);
 
-typedef union MemInfo MemInfo;
+typedef struct MemInfo MemInfo;
 typedef struct MemSys MemSys;
 
 /* Memory System API */

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -87,7 +87,7 @@ MemInfo* NRT_MemInfo_new(void *data, size_t size, dtor_function dtor,
                          void *dtor_info);
 
 void NRT_MemInfo_init(MemInfo *mi, void *data, size_t size, dtor_function dtor,
-                      void *dtor_info, int flags);
+                      void *dtor_info);
 
 /*
  * Returns the refcount of a MemInfo or (size_t)-1 if error.

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -46,20 +46,6 @@ void NRT_MemSys_init(void);
 void NRT_MemSys_shutdown(void);
 
 /*
- * Internal API
- * Add a new MemInfo to the freelist (available MemInfo for use).
- * If `newnode` is NULL, a new MemInfo is created.
- */
-void NRT_MemSys_insert_meminfo(MemInfo *newnode);
-
-
-/*
- * Internal API
- * Pop a MemInfo from the freelist.
- */
-MemInfo* NRT_MemSys_pop_meminfo(void);
-
-/*
  * Register the atomic increment and decrement functions
  */
 void NRT_MemSys_set_atomic_inc_dec(atomic_inc_dec_func inc,

--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -73,11 +73,6 @@ class _Runtime(object):
             mi = _nrt.meminfo_alloc(size)
         return MemInfo(mi)
 
-    def process_defer_dtor(self):
-        """Process all deferred dtors.
-        """
-        _nrt.memsys_process_defer_dtor()
-
     def get_allocation_stats(self):
         """
         Returns a namedtuple of (alloc, free, mi_alloc, mi_free) for count of

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -62,26 +62,6 @@ class TestNrtMemInfo(unittest.TestCase):
         del mi
         self.assertEqual(Dummy.alive, 0)
 
-    def test_defer_dtor(self):
-        d = Dummy()
-        self.assertEqual(Dummy.alive, 1)
-        addr = 0xdeadcafe  # some made up location
-
-        mi = rtsys.meminfo_new(addr, d)
-        self.assertEqual(mi.refcount, 1)
-        # Set defer flag
-        mi.defer = True
-        del d
-        self.assertEqual(Dummy.alive, 1)
-        mi.acquire()
-        self.assertEqual(Dummy.alive, 1)
-        mi.release()
-        del mi
-        # mi refct is zero but not yet removed due to deferring
-        self.assertEqual(Dummy.alive, 1)
-        rtsys.process_defer_dtor()
-        self.assertEqual(Dummy.alive, 0)
-
     @unittest.skipIf(PYVERSION <= (2, 7), "memoryview not supported")
     def test_fake_memoryview(self):
         d = Dummy()


### PR DESCRIPTION
Implements Antoine's suggestion  https://github.com/numba/numba/pull/1331#issuecomment-126386182

Fixes #1330.
Closes #1331 as an alternative.

The ABA issue in MemInfo list is fixed by reverting to using a locked based implementation.  We don't need the performance of a lockfree implementation because MemInfo freelist is now only used for CPython allocated objects.  There will not be any concurrent operation to the freelist due to CPython GIL.  When allocating inside nopython function, a fresh MemInfo is allocated inline with the data buffer.


