### PR TITLE
Workaround #1341

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -15,7 +15,18 @@ class CUDACodeLibrary(CodeLibrary):
         pass
 
     def _optimize_final_module(self):
-        pass
+        # Run some lightweight optimization to simplify the module.
+        # This seems to workaround a libnvvm compilation bug (see #1341)
+        pmb = ll.PassManagerBuilder()
+        pmb.opt_level = 1
+        pmb.disable_unit_at_a_time = False
+        pmb.disable_unroll_loops = True
+        pmb.loop_vectorize = False
+        pmb.slp_vectorize = False
+
+        pm = ll.ModulePassManager()
+        pmb.populate(pm)
+        pm.run(self._final_module)
 
     def _finalize_specific(self):
         # Fix global naming


### PR DESCRIPTION
Run O1 opt passes in cuda target before sending to nvvm.
Seems to workaround a libnvvm bug #1341.