### PR TITLE
Improve undeclared function msg

### DIFF
--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -202,6 +202,12 @@ class Callable(Type):
         """
         pass
 
+    @abstractmethod
+    def get_call_signatures(self):
+        """
+        Returns a tuple of (signatures, parameterized)
+        """
+        pass
 
 class DTypeSpec(Type):
     """

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -56,7 +56,7 @@ class TestTypingError(unittest.TestCase):
         try:
             compile_isolated(issue_868, (types.Array(types.int32, 1, 'C'),))
         except TypingError as e:
-            self.assertTrue(e.msg.startswith('Undeclared'))
+            self.assertTrue(e.msg.startswith('Invalid usage of * '))
         else:
             self.fail('Should raise error')
 

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -4,6 +4,7 @@ import numba.unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types
 from numba.errors import TypingError
+import math
 
 
 def what():
@@ -23,6 +24,9 @@ def impossible_return_type(x):
         return ()
     else:
         return 1j
+
+def bad_hypot_usage():
+    return math.hypot(1)
 
 
 class TestTypingError(unittest.TestCase):
@@ -61,6 +65,15 @@ class TestTypingError(unittest.TestCase):
             compile_isolated(impossible_return_type, (types.int32,))
         self.assertIn("Can't unify return type from the following types: (), complex128",
                       str(raises.exception))
+
+    def test_bad_hypot_usage(self):
+        with self.assertRaises(TypingError) as raises:
+            compile_isolated(bad_hypot_usage, ())
+
+        errmsg = str(raises.exception)
+        # Make sure it listed the known signatures.
+        # This is sensitive to the formatting of the error message.
+        self.assertIn(" * (float64, float64) -> float64", errmsg)
 
 
 if __name__ == '__main__':

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -18,7 +18,6 @@ from pprint import pprint
 import itertools
 
 from numba import ir, types, utils, config, six
-from numba.utils import RANGE_ITER_OBJECTS
 from .errors import TypingError
 
 
@@ -239,7 +238,10 @@ class CallConstrain(object):
             kw_args = dict(zip(kwds, args[n_pos_args:]))
             sig = context.resolve_function_type(fnty, pos_args, kw_args)
             if sig is None:
-                msg = "Undeclared %s%s" % (fnty, args)
+                desc = context.explain_function_type(fnty)
+                headtemp = "Invalid usage of {0} with parameters ({1})"
+                head = headtemp.format(fnty, '\n'.join(map(str, args)))
+                msg = '\n'.join([head, desc])
                 raise TypingError(msg, loc=self.loc)
             restypes.append(sig.return_type)
         typevars[self.target].add_types(*restypes)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -240,7 +240,7 @@ class CallConstrain(object):
             if sig is None:
                 desc = context.explain_function_type(fnty)
                 headtemp = "Invalid usage of {0} with parameters ({1})"
-                head = headtemp.format(fnty, '\n'.join(map(str, args)))
+                head = headtemp.format(fnty, ', '.join(map(str, args)))
                 msg = '\n'.join([head, desc])
                 raise TypingError(msg, loc=self.loc)
             restypes.append(sig.return_type)

--- a/numba/types.py
+++ b/numba/types.py
@@ -201,6 +201,10 @@ class Function(Callable, Opaque):
     def get_call_type(self, context, args, kws):
         return self.template(context).apply(args, kws)
 
+    def get_call_signatures(self):
+        sigs = getattr(self.template, 'cases')
+        return sigs, hasattr(self.template, 'generic')
+
 
 class NumberClass(Callable, DTypeSpec, Opaque):
     """
@@ -215,6 +219,10 @@ class NumberClass(Callable, DTypeSpec, Opaque):
 
     def get_call_type(self, context, args, kws):
         return self.template(context).apply(args, kws)
+
+    def get_call_signatures(self):
+        sigs = getattr(self.template, 'cases')
+        return sigs, hasattr(self.template, 'generic')
 
     @property
     def key(self):
@@ -284,6 +292,10 @@ class Dispatcher(WeakType, Callable, Dummy):
         sig = template(context).apply(args, kws)
         sig.pysig = self.pysig
         return sig
+
+    def get_call_signatures(self):
+        sigs = self.overloaded.nopython_signatures
+        return sigs, True
 
     @property
     def overloaded(self):
@@ -1089,9 +1101,12 @@ class ExceptionType(Callable, Phantom):
         super(ExceptionType, self).__init__(name, param=True)
 
     def get_call_type(self, context, args, kws):
+        return self.get_call_signatures()[0][0]
+
+    def get_call_signatures(self):
         from . import typing
         return_type = ExceptionInstance(self.exc_class)
-        return typing.signature(return_type)
+        return [typing.signature(return_type)], False
 
     @property
     def key(self):


### PR DESCRIPTION
The current error message for incorrect usage of a function is not informative and it is confusing.
This patch tries to make it clearer to numba user what is wrong.

A sample of old message:
```
numba.errors.TypingError: Failed at nopython (nopython frontend)
Undeclared Function(<built-in function hypot>)(float64,)
File "testhypot.py", line 10
```

The message says the function ``hypot`` is "undeclared".  But the actual error is that ``hypot`` takes two parameters but the user has only given it one.

With this patch, the new error message is:
```
Invalid usage of Function(<built-in function hypot>) with parameters (float64)
Known signatures:
 * (int64, int64) -> float64
 * (uint64, uint64) -> float64
 * (float32, float32) -> float32
 * (float64, float64) -> float64
File "testhypot.py", line 10
```

For generic functions that do not have a straight forward list of signatures, it will print "parameterized" as one of the signature.  In the future, we can make the "definition" provide some useful description of the usage.
