### PR TITLE
Fix #1353: make NRT-allocated memory visible to tracemalloc

### DIFF
--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -38,8 +38,9 @@
     #define Py_uhash_t unsigned long
 #endif
 
-#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && Py_MINOR_VERSION < 4)
+#if PY_MAJOR_VERSION < 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 4)
     #define PyMem_RawMalloc malloc
+    #define PyMem_RawRealloc realloc
     #define PyMem_RawFree free
 #endif
 

--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -20,6 +20,14 @@ memsys_shutdown(PyObject *self, PyObject *args) {
     Py_RETURN_NONE;
 }
 
+static PyObject *
+memsys_use_cpython_allocator(PyObject *self, PyObject *args) {
+    NRT_MemSys_set_allocator(PyMem_RawMalloc,
+                             PyMem_RawRealloc,
+                             PyMem_RawFree);
+    Py_RETURN_NONE;
+}
+
 static
 PyObject*
 memsys_set_atomic_inc_dec(PyObject *self, PyObject *args) {
@@ -518,6 +526,7 @@ NRT_decref(MemInfo* mi) {
 static PyMethodDef ext_methods[] = {
 #define declmethod(func) { #func , ( PyCFunction )func , METH_VARARGS , NULL }
 #define declmethod_noargs(func) { #func , ( PyCFunction )func , METH_NOARGS, NULL }
+    declmethod_noargs(memsys_use_cpython_allocator),
     declmethod_noargs(memsys_shutdown),
     declmethod(memsys_set_atomic_inc_dec),
     declmethod(memsys_set_atomic_cas),

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -83,11 +83,11 @@ void NRT_MemSys_set_allocator(NRT_malloc_func malloc_func,
                               NRT_realloc_func realloc_func,
                               NRT_free_func free_func)
 {
-    if (malloc_func != TheMSys.allocator.malloc &&
-        realloc_func != TheMSys.allocator.realloc &&
-        free_func != TheMSys.allocator.free &&
-        TheMSys.stats_alloc != TheMSys.stats_free &&
-        TheMSys.stats_mi_alloc != TheMSys.stats_mi_free) {
+    if ((malloc_func != TheMSys.allocator.malloc ||
+         realloc_func != TheMSys.allocator.realloc ||
+         free_func != TheMSys.allocator.free) &&
+         (TheMSys.stats_alloc != TheMSys.stats_free ||
+          TheMSys.stats_mi_alloc != TheMSys.stats_mi_free)) {
         nrt_fatal_error("cannot change allocator while blocks are allocated");
     }
     TheMSys.allocator.malloc = malloc_func;

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -23,6 +23,21 @@ struct MemInfo {
 
 
 /*
+ * Misc helpers.
+ */
+
+static void nrt_fatal_error(const char *msg)
+{
+    fprintf(stderr, "Fatal Numba error: %s\n", msg);
+    fflush(stderr); /* it helps in Windows debug build */
+
+#if defined(MS_WINDOWS) && defined(_DEBUG)
+    DebugBreak();
+#endif
+    abort();
+}
+
+/*
  * Global resources.
  */
 
@@ -35,6 +50,12 @@ struct MemSys{
     int shutting;
     /* Stats */
     size_t stats_alloc, stats_free, stats_mi_alloc, stats_mi_free;
+    /* System allocation functions */
+    struct {
+        NRT_malloc_func malloc;
+        NRT_realloc_func realloc;
+        NRT_free_func free;
+    } allocator;
 };
 
 /* The Memory System object */
@@ -42,6 +63,10 @@ static MemSys TheMSys;
 
 void NRT_MemSys_init(void) {
     memset(&TheMSys, 0, sizeof(MemSys));
+    /* Bind to libc allocator */
+    TheMSys.allocator.malloc = malloc;
+    TheMSys.allocator.realloc = realloc;
+    TheMSys.allocator.free = free;
 }
 
 void NRT_MemSys_shutdown(void) {
@@ -52,6 +77,22 @@ void NRT_MemSys_shutdown(void) {
        it cannot be running multiple threads anymore. */
     NRT_MemSys_set_atomic_inc_dec_stub();
     NRT_MemSys_set_atomic_cas_stub();
+}
+
+void NRT_MemSys_set_allocator(NRT_malloc_func malloc_func,
+                              NRT_realloc_func realloc_func,
+                              NRT_free_func free_func)
+{
+    if (malloc_func != TheMSys.allocator.malloc &&
+        realloc_func != TheMSys.allocator.realloc &&
+        free_func != TheMSys.allocator.free &&
+        TheMSys.stats_alloc != TheMSys.stats_free &&
+        TheMSys.stats_mi_alloc != TheMSys.stats_mi_free) {
+        nrt_fatal_error("cannot change allocator while blocks are allocated");
+    }
+    TheMSys.allocator.malloc = malloc_func;
+    TheMSys.allocator.realloc = realloc_func;
+    TheMSys.allocator.free = free_func;
 }
 
 void NRT_MemSys_set_atomic_inc_dec(atomic_inc_dec_func inc,
@@ -120,17 +161,6 @@ void NRT_MemSys_set_atomic_inc_dec_stub(void){
 
 void NRT_MemSys_set_atomic_cas_stub(void) {
     NRT_MemSys_set_atomic_cas(nrt_testing_atomic_cas);
-}
-
-static void nrt_fatal_error(const char *msg)
-{
-    fprintf(stderr, "Fatal Numba error: %s\n", msg);
-    fflush(stderr); /* it helps in Windows debug build */
-
-#if defined(MS_WINDOWS) && defined(_DEBUG)
-    DebugBreak();
-#endif
-    abort();
 }
 
 
@@ -328,14 +358,14 @@ void *NRT_MemInfo_varsize_realloc(MemInfo *mi, size_t size)
  */
 
 void* NRT_Allocate(size_t size) {
-    void *ptr = malloc(size);
+    void *ptr = TheMSys.allocator.malloc(size);
     NRT_Debug(nrt_debug_print("NRT_Allocate bytes=%zu ptr=%p\n", size, ptr));
     TheMSys.atomic_inc(&TheMSys.stats_alloc);
     return ptr;
 }
 
 void *NRT_Reallocate(void *ptr, size_t size) {
-    void *new_ptr = realloc(ptr, size);
+    void *new_ptr = TheMSys.allocator.realloc(ptr, size);
     NRT_Debug(nrt_debug_print("NRT_Reallocate bytes=%zu ptr=%p -> %p\n",
                               size, ptr, new_ptr));
     return new_ptr;
@@ -343,6 +373,6 @@ void *NRT_Reallocate(void *ptr, size_t size) {
 
 void NRT_Free(void *ptr) {
     NRT_Debug(nrt_debug_print("NRT_Free %p\n", ptr));
-    free(ptr);
+    TheMSys.allocator.free(ptr);
     TheMSys.atomic_inc(&TheMSys.stats_free);
 }

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -36,6 +36,11 @@ typedef int (*atomic_cas_func)(void * volatile *ptr, void *cmp, void *repl,
 typedef struct MemInfo MemInfo;
 typedef struct MemSys MemSys;
 
+typedef void *(*NRT_malloc_func)(size_t size);
+typedef void *(*NRT_realloc_func)(void *ptr, size_t new_size);
+typedef void (*NRT_free_func)(void *ptr);
+
+
 /* Memory System API */
 
 /* Initialize the memory system */
@@ -43,6 +48,11 @@ void NRT_MemSys_init(void);
 
 /* Shutdown the memory system */
 void NRT_MemSys_shutdown(void);
+
+/*
+ * Register the system allocation functions
+ */
+void NRT_MemSys_set_allocator(NRT_malloc_func, NRT_realloc_func, NRT_free_func);
 
 /*
  * Register the atomic increment and decrement functions

--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -98,7 +98,8 @@ class _Runtime(object):
 # Alias to _nrt_python._MemInfo
 MemInfo = _nrt._MemInfo
 
-# Create uninitialized runtime
+# Create runtime
+_nrt.memsys_use_cpython_allocator()
 rtsys = _Runtime()
 
 # Install finalizer

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -1,7 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+import math
+import os
+import sys
+
 import numpy as np
+
 from numba import unittest_support as unittest
+from numba import njit
 from numba.runtime import rtsys
 from numba.config import PYVERSION
 from .support import MemoryLeakMixin
@@ -164,15 +170,71 @@ class TestNrtMemInfo(unittest.TestCase):
         # consumed by another thread.
 
 
+@unittest.skipUnless(sys.version_info >= (3, 4),
+                     "need Python 3.4+ for the tracemalloc module")
+class TestTracemalloc(unittest.TestCase):
+    """
+    Test NRT-allocated memory can be tracked by tracemalloc.
+    """
+
+    def measure_memory_diff(self, func):
+        import tracemalloc
+        tracemalloc.start()
+        try:
+            before = tracemalloc.take_snapshot()
+            # Keep the result and only delete it after taking a snapshot
+            res = func()
+            after = tracemalloc.take_snapshot()
+            del res
+            return after.compare_to(before, 'lineno')
+        finally:
+            tracemalloc.stop()
+
+    def test_snapshot(self):
+        N = 1000000
+        dtype = np.int8
+
+        @njit
+        def alloc_nrt_memory():
+            """
+            Allocate and return a large array.
+            """
+            return np.empty(N, dtype)
+
+        def keep_memory():
+            return alloc_nrt_memory()
+
+        def release_memory():
+            alloc_nrt_memory()
+
+        alloc_lineno = keep_memory.__code__.co_firstlineno + 1
+
+        # Warmup JIT
+        alloc_nrt_memory()
+
+        # The large NRT-allocated array should appear topmost in the diff
+        diff = self.measure_memory_diff(keep_memory)
+        stat = diff[0]
+        # There is a slight overhead, so the allocated size won't exactly be N
+        self.assertGreaterEqual(stat.size, N)
+        self.assertLess(stat.size, N * 1.01)
+        frame = stat.traceback[0]
+        self.assertEqual(os.path.basename(frame.filename), "test_nrt.py")
+        self.assertEqual(frame.lineno, alloc_lineno)
+
+        # If NRT memory is released before taking a snapshot, it shouldn't
+        # appear.
+        diff = self.measure_memory_diff(release_memory)
+        stat = diff[0]
+        # Something else appears, but nothing the magnitude of N
+        self.assertLess(stat.size, N * 0.01)
+
+
 class TestNRTIssue(MemoryLeakMixin, unittest.TestCase):
     def test_issue_with_refct_op_pruning(self):
         """
         GitHub Issue #1244 https://github.com/numba/numba/issues/1244
         """
-        from numba import njit
-        import numpy as np
-        import math
-
         @njit
         def calculate_2D_vector_mag(vector):
             x, y = vector


### PR DESCRIPTION
Also fixes an embarrassing typo in _pymodule.h.