### PR TITLE
Fixes and improvement to HSA driver initialization and finalization

### DIFF
--- a/numba/hsa/__init__.py
+++ b/numba/hsa/__init__.py
@@ -6,10 +6,12 @@ from __future__ import print_function, absolute_import, division
 from .api import *
 from .stubs import atomic
 
+
 def is_available():
     """Returns a boolean to indicate the availability of a HSA runtime.
 
     This will force initialization of the driver if it hasn't been
     initialized.
     """
-    pass
+    from .hsadrv.driver import hsa
+    return hsa.is_available

--- a/numba/hsa/hlc/libhlc.py
+++ b/numba/hsa/hlc/libhlc.py
@@ -18,16 +18,22 @@ class OpaqueModuleRef(Structure):
 
 moduleref_ptr = POINTER(OpaqueModuleRef)
 
-hlc = CDLL(os.path.join(sys.prefix, 'lib', 'libHLC.so'))
-hlc.HLC_ParseModule.restype = moduleref_ptr
-hlc.HLC_ModuleEmitBRIG.restype = c_size_t
-hlc.HLC_Initialize()
-utils.finalize(hlc, hlc.HLC_Finalize)
+try:
+    hlc = CDLL(os.path.join(sys.prefix, 'lib', 'libHLC.so'))
+except OSError:
+    raise ImportError("libHLC.so cannot be found.  Please install the libhlc "
+                      "package by: conda install -c numba libhlc")
 
-hlc.HLC_SetCommandLineOption.argtypes = [
-    c_int,
-    c_void_p,
-]
+else:
+    hlc.HLC_ParseModule.restype = moduleref_ptr
+    hlc.HLC_ModuleEmitBRIG.restype = c_size_t
+    hlc.HLC_Initialize()
+    utils.finalize(hlc, hlc.HLC_Finalize)
+
+    hlc.HLC_SetCommandLineOption.argtypes = [
+        c_int,
+        c_void_p,
+    ]
 
 
 def set_option(*opt):

--- a/numba/hsa/hsadrv/driver.py
+++ b/numba/hsa/hsadrv/driver.py
@@ -201,14 +201,11 @@ class Driver(object):
             self.initialization_error = e
             raise HsaDriverError("Error at driver init: \n%s:" % e)
         else:
-            hsa_shut_down = self.hsa_shut_down
-
             @atexit.register
             def shutdown():
                 for agent in self.agents:
                     agent.release()
                 self._recycler.drain()
-                hsa_shut_down()
 
     def _initialize_agents(self):
         if self._agent_map is not None:


### PR DESCRIPTION
* proper error message when libHLC is not available
* proper implementation of ``hsa.is_available()``
* skip ``hsa_shut_down()``: unnecessary and some hsa object may be removed at a later point.