### PR TITLE
Use an object code-based JIT compilation cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,8 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -v -b -m
+    #- cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -v -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.tests.test_dispatcher -v -b -m
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,8 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
+    #- cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.tests.test_npdatetime -v -b -m
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,7 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    #- cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.tests.test_npdatetime -v -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,7 @@ script:
     # Ensure that the documentation builds without warnings
     - cd $TRAVIS_BUILD_DIR/docs ; make SPHINXOPTS=-W clean html
     # Run the Numba test suite
-    #- cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -v -b -m
-    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.tests.test_dispatcher -v -b -m
+    - cd ~ ; NUMBA_ENABLE_CUDASIM=1 python -m numba.testing -b -m
     #- if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then cd $HOME; py.test --udf $HOME/impyla/impala/tests/test_udf_compile.py; fi
 
 notifications:

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -65,7 +65,7 @@ class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
         """
         Reduce a CompileResult to picklable components.
         """
-        libdata = self.library.serialize()
+        libdata = self.library.serialize_using_object_code()
         # Make it (un)picklable efficiently
         typeann = str(self.type_annotation)
         fndesc = self.fndesc
@@ -527,6 +527,10 @@ class Pipeline(object):
         if self.library is None:
             codegen = self.targetctx.jit_codegen()
             self.library = codegen.create_library(self.bc.func_qualname)
+            # Enable object caching upfront, so that the library can
+            # be later serialized.
+            self.library.enable_object_caching()
+
         lowered = lowerfn()
         signature = typing.signature(self.return_type, *self.args)
         cr = compile_result(typing_context=self.typingctx,

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -324,6 +324,14 @@ class Overloaded(_OverloadedBase):
 
     def compile(self, sig):
         with self._compile_lock:
+            args, return_type = sigutils.normalize_signature(sig)
+            # Don't recompile if signature already exists
+            # (e.g. if another thread compiled it before we got the lock)
+            existing = self.overloads.get(tuple(args))
+            if existing is not None:
+                return existing
+
+            # Try to load from disk cache
             cres = self._cache.load_overload(sig, self.targetctx)
             if cres is not None:
                 # XXX fold this in add_overload()? (also see compiler.py)
@@ -332,13 +340,6 @@ class Overloaded(_OverloadedBase):
                                                    cres.fndesc, [cres.library])
                 self.add_overload(cres)
                 return cres.entry_point
-
-            args, return_type = sigutils.normalize_signature(sig)
-            # Don't recompile if signature already exists
-            # (e.g. if another thread compiled it before we got the lock)
-            existing = self.overloads.get(tuple(args))
-            if existing is not None:
-                return existing
 
             flags = compiler.Flags()
             self.targetdescr.options.parse_as_flags(flags, self.targetoptions)

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import functools
 import sys
+import weakref
 
 import llvmlite.llvmpy.core as lc
 import llvmlite.llvmpy.passes as lp
@@ -43,7 +44,7 @@ class CodeLibrary(object):
             str(self._codegen._create_empty_module(self._name)))
         self._final_module.name = self._name
         # Remember this on the module, for the object cache hooks
-        self._final_module.__library = self
+        self._final_module.__library = weakref.proxy(self)
         self._shared_module = None
 
     @property

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -33,6 +33,7 @@ class CodeLibrary(object):
     """
 
     _finalized = False
+    _object_caching_enabled = False
 
     def __init__(self, codegen, name):
         self._codegen = codegen
@@ -40,6 +41,9 @@ class CodeLibrary(object):
         self._linking_libraries = set()
         self._final_module = ll.parse_assembly(
             str(self._codegen._create_empty_module(self._name)))
+        self._final_module.name = self._name
+        # Remember this on the module, for the object cache hooks
+        self._final_module.__library = self
         self._shared_module = None
 
     @property
@@ -87,18 +91,30 @@ class CodeLibrary(object):
         into another library.  Exported functions are made "linkonce_odr"
         to allow for multiple definitions, inlining, and removal of
         unused exports.
+
         See discussion in https://github.com/numba/numba/pull/890
         """
         if self._shared_module is not None:
             return self._shared_module
         mod = self._final_module
         to_fix = []
+        nfuncs = 0
         for fn in mod.functions:
+            nfuncs += 1
             if not fn.is_declaration and fn.linkage == ll.Linkage.external:
                 to_fix.append(fn.name)
+        if nfuncs == 0:
+            # This is an issue which can occur if loading a module
+            # from an object file and trying to link with it, so detect it
+            # here to make debugging easier.
+            raise RuntimeError("library unfit for linking: "
+                               "no available functions in %s"
+                               % (self,))
         if to_fix:
             mod = mod.clone()
             for name in to_fix:
+                # NOTE: this will mark the symbol WEAK if serialized
+                # to an ELF file
                 mod.get_function(name).linkage = 'linkonce_odr'
         self._shared_module = mod
         return mod
@@ -126,6 +142,7 @@ class CodeLibrary(object):
         self._raise_if_finalized()
         assert isinstance(ir_module, llvmir.Module)
         ll_module = ll.parse_assembly(str(ir_module))
+        ll_module.name = ir_module.name
         ll_module.verify()
         self.add_llvm_module(ll_module)
 
@@ -188,20 +205,6 @@ class CodeLibrary(object):
     def get_function(self, name):
         return self._final_module.get_function(name)
 
-    def serialize(self):
-        self._ensure_finalized()
-        return (self._name, self._final_module.as_bitcode())
-
-    @classmethod
-    def _unserialize(cls, codegen, state):
-        name, bitcode = state
-        self = codegen.create_library(name)
-        assert isinstance(self, cls)
-        # No need to re-run optimizations, just make the module ready
-        self._final_module = ll.parse_bitcode(bitcode)
-        self._finalize_final_module()
-        return self
-
     def get_llvm_str(self):
         """
         Get the human-readable form of the LLVM module.
@@ -213,6 +216,117 @@ class CodeLibrary(object):
         Get the human-readable assembly.
         """
         return str(self._codegen._tm.emit_assembly(self._final_module))
+
+    #
+    # Object cache hooks and serialization
+    #
+
+    def enable_object_caching(self):
+        self._object_caching_enabled = True
+        self._compiled_object = None
+        self._compiled = False
+
+    def _get_compiled_object(self):
+        if not self._object_caching_enabled:
+            raise ValueError("object caching not enabled in %s" % (self,))
+        if self._compiled_object is None:
+            raise RuntimeError("no compiled object yet for %s" % (self,))
+        return self._compiled_object
+
+    def _set_compiled_object(self, value):
+        if not self._object_caching_enabled:
+            raise ValueError("object caching not enabled in %s" % (self,))
+        if self._compiled:
+            raise ValueError("library already compiled: %s" % (self,))
+        self._compiled_object = value
+
+    @classmethod
+    def _dump_elf(cls, buf):
+        """
+        Dump the symbol table of an ELF file.
+        Needs pyelftools (https://github.com/eliben/pyelftools)
+        """
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf import descriptions
+        from io import BytesIO
+        f = ELFFile(BytesIO(buf))
+        print("ELF file:")
+        for sec in f.iter_sections():
+            if sec['sh_type'] == 'SHT_SYMTAB':
+                symbols = sorted(sec.iter_symbols(), key=lambda sym: sym.name)
+                print("    symbols:")
+                for sym in symbols:
+                    if not sym.name:
+                        continue
+                    print("    - %r: size=%d, value=0x%x, type=%s, bind=%s"
+                          % (sym.name.decode(),
+                             sym['st_size'],
+                             sym['st_value'],
+                             descriptions.describe_symbol_type(sym['st_info']['type']),
+                             descriptions.describe_symbol_bind(sym['st_info']['bind']),
+                             ))
+        print()
+
+    @classmethod
+    def _object_compiled_hook(cls, ll_module, buf):
+        """
+        `ll_module` was compiled into object code `buf`.
+        """
+        try:
+            self = ll_module.__library
+        except AttributeError:
+            return
+        if self._object_caching_enabled:
+            self._compiled = True
+            self._compiled_object = buf
+
+    @classmethod
+    def _object_getbuffer_hook(cls, ll_module):
+        """
+        Return a cached object code for `ll_module`.
+        """
+        try:
+            self = ll_module.__library
+        except AttributeError:
+            return
+        if self._object_caching_enabled and self._compiled_object:
+            buf = self._compiled_object
+            self._compiled_object = None
+            return buf
+
+    def serialize_using_bitcode(self):
+        """
+        Serialize this library using its bitcode as the cached representation.
+        """
+        self._ensure_finalized()
+        return (self._name, 'bitcode', self._final_module.as_bitcode())
+
+    def serialize_using_object_code(self):
+        """
+        Serialize this library using its object code as the cached
+        representation.
+        """
+        self._ensure_finalized()
+        ll_module = self._final_module
+        return (self._name, 'object', self._get_compiled_object())
+
+    @classmethod
+    def _unserialize(cls, codegen, state):
+        name, kind, data = state
+        self = codegen.create_library(name)
+        assert isinstance(self, cls)
+        if kind == 'bitcode':
+            # No need to re-run optimizations, just make the module ready
+            self._final_module = ll.parse_bitcode(data)
+            self._finalize_final_module()
+            return self
+        elif kind == 'object':
+            self.enable_object_caching()
+            self._set_compiled_object(data)
+            self._finalize_final_module()
+            return self
+        else:
+            raise ValueError("unsupported serialization kind %r" % (kind,))
 
 
 class AOTCodeLibrary(CodeLibrary):
@@ -263,6 +377,7 @@ class BaseCPUCodegen(object):
         self._data_layout = None
         self._llvm_module = ll.parse_assembly(
             str(self._create_empty_module(module_name)))
+        self._llvm_module.name = "global_codegen_module"
         self._init(self._llvm_module)
 
     def _init(self, llvm_module):
@@ -281,6 +396,9 @@ class BaseCPUCodegen(object):
         self._target_data = engine.target_data
         self._data_layout = str(self._target_data)
         self._mpm = self._module_pass_manager()
+
+        self._engine.set_object_cache(self._library_class._object_compiled_hook,
+                                      self._library_class._object_getbuffer_hook)
 
     def _create_empty_module(self, name):
         ir_module = lc.Module.new(name)

--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -354,17 +354,18 @@ class _MinimalRunner(object):
         result.buffer = runner.buffer
         # Install faulthandler hook to dump tracebacks just before the
         # timeout, to get a better view of where the test is hanging.
-        if self.timeout is not None and faulthandler is not None:
-            faulthandler.dump_traceback_later(self.timeout, exit=True)
-        try:
+        #if self.timeout is not None and faulthandler is not None:
+            #faulthandler.dump_traceback_later(self.timeout, exit=True)
+        #try:
+        if 1:
             with self.cleanup_object(test):
                 test(result)
             # HACK as cStringIO.StringIO isn't picklable in 2.x
             result.stream = _FakeStringIO(result.stream.getvalue())
             return _MinimalResult(result, test.id())
-        finally:
-            if self.timeout is not None and faulthandler is not None:
-                faulthandler.cancel_dump_traceback_later()
+        #finally:
+            #if self.timeout is not None and faulthandler is not None:
+                #faulthandler.cancel_dump_traceback_later()
 
     @contextlib.contextmanager
     def cleanup_object(self, test):
@@ -388,8 +389,8 @@ class ParallelTestRunner(runner.TextTestRunner):
     """
 
     resultclass = ParallelTestResult
-    # A test can't run longer than 3 minutes
-    timeout = 180
+    # A test can't run longer than 2 minutes
+    timeout = 120
 
     def __init__(self, runner_cls, **kwargs):
         runner.TextTestRunner.__init__(self, **kwargs)

--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -388,8 +388,8 @@ class ParallelTestRunner(runner.TextTestRunner):
     """
 
     resultclass = ParallelTestResult
-    # A test can't run longer than 2 minutes
-    timeout = 120
+    # A test can't run longer than 3 minutes
+    timeout = 180
 
     def __init__(self, runner_cls, **kwargs):
         runner.TextTestRunner.__init__(self, **kwargs)

--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -389,7 +389,7 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     resultclass = ParallelTestResult
     # A test can't run longer than 2 minutes
-    timeout = 120
+    timeout = 150
 
     def __init__(self, runner_cls, **kwargs):
         runner.TextTestRunner.__init__(self, **kwargs)

--- a/numba/tests/__init__.py
+++ b/numba/tests/__init__.py
@@ -389,7 +389,7 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     resultclass = ParallelTestResult
     # A test can't run longer than 2 minutes
-    timeout = 150
+    timeout = 120
 
     def __init__(self, runner_cls, **kwargs):
         runner.TextTestRunner.__init__(self, **kwargs)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -394,6 +394,7 @@ class TestCache(TestCase):
         self.modfile = os.path.join(self.tempdir, self.modname + ".py")
         self.cache_dir = os.path.join(self.tempdir, "__pycache__")
         shutil.copy(self.usecases_file, self.modfile)
+        self.maxDiff = None
 
     def tearDown(self):
         sys.modules.pop(self.modname, None)


### PR DESCRIPTION
*Note*: I'd rather hold this until after 0.21 is released.

This is based on PR #1051 and saves the object code instead of the LLVM bitcode, which makes it more than 10x faster on loading than PR #1051 (and overall more than 100x faster than without caching).
