### PR TITLE
Add a config variable NUMBA_DEBUG_TYPEINFER

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -36,6 +36,10 @@ These variables influence what is printed out during compilation of
    of the compiler frontend, up to and including generation of the Numba
    Intermediate Representation.
 
+.. envvar:: NUMBA_DEBUG_TYPEINFER
+
+   If set to non-zero, print out debugging information about type inference.
+
 .. envvar:: NUMBA_DUMP_BYTECODE
 
    If set to non-zero, print out the Python :py:term:`bytecode` of

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -709,11 +709,6 @@ def type_inference_stage(typingctx, interp, args, return_type, locals={}):
     infer.propagate()
     typemap, restype, calltypes = infer.unify()
 
-    if config.DEBUG:
-        pprint(typemap)
-        pprint(restype)
-        pprint(calltypes)
-
     return typemap, restype, calltypes
 
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -97,6 +97,9 @@ class _EnvReloader(object):
         # Enable debugging of front-end operation (up to and including IR generation)
         DEBUG_FRONTEND = _readenv("NUMBA_DEBUG_FRONTEND", int, 0)
 
+        # Enable debugging of type inference
+        DEBUG_TYPEINFER = _readenv("NUMBA_DEBUG_TYPEINFER", int, 0)
+
         # Optimization level
         OPT = _readenv("NUMBA_OPT", int, 3)
 
@@ -107,7 +110,8 @@ class _EnvReloader(object):
         DUMP_CFG = _readenv("NUMBA_DUMP_CFG", int, DEBUG_FRONTEND)
 
         # Force dump of Numba IR
-        DUMP_IR = _readenv("NUMBA_DUMP_IR", int, DEBUG_FRONTEND)
+        DUMP_IR = _readenv("NUMBA_DUMP_IR", int,
+                           DEBUG_FRONTEND or DEBUG_TYPEINFER)
 
         # Force dump of LLVM IR
         DUMP_LLVM = _readenv("NUMBA_DUMP_LLVM", int, DEBUG)

--- a/numba/tests/test_debug.py
+++ b/numba/tests/test_debug.py
@@ -21,8 +21,8 @@ def simple_gen(x, y):
 
 class DebugTestBase(TestCase):
 
-    all_dumps = set(['bytecode', 'cfg', 'ir', 'llvm', 'func_opt_llvm',
-                     'optimized_llvm', 'assembly'])
+    all_dumps = set(['bytecode', 'cfg', 'ir', 'typeinfer', 'llvm',
+                     'func_opt_llvm', 'optimized_llvm', 'assembly'])
 
     def assert_fails(self, *args, **kwargs):
         self.assertRaises(AssertionError, *args, **kwargs)
@@ -47,6 +47,9 @@ class DebugTestBase(TestCase):
 
     def _check_dump_ir(self, out):
         self.assertIn('--IR DUMP: %s--' % self.func_name, out)
+
+    def _check_dump_typeinfer(self, out):
+        self.assertIn('--propagate--', out)
 
     def _check_dump_llvm(self, out):
         self.assertIn('--LLVM DUMP', out)
@@ -154,7 +157,8 @@ class TestEnvironmentOverride(FunctionDebugTestBase):
             out = self.compile_simple_nopython()
             # Note that all variables dependent on NUMBA_DEBUG are
             # updated too.
-            self.check_debug_output(out, ['ir', 'llvm', 'func_opt_llvm',
+            self.check_debug_output(out, ['ir', 'typeinfer',
+                                          'llvm', 'func_opt_llvm',
                                           'optimized_llvm', 'assembly'])
         finally:
             del os.environ['NUMBA_DEBUG']

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -448,9 +448,10 @@ class TypeInferer(object):
         # Target var -> constraint with refine hook
         self.refine_map = {}
 
-    def dump(self):
-        print('---- type variables ----')
-        pprint([v for k, v in sorted(self.typevars.items())])
+        if config.DEBUG or config.DEBUG_TYPEINFER:
+            self.debug = TypeInferDebug(self)
+        else:
+            self.debug = NullDebug()
 
     def _mangle_arg_name(self, name):
         # Disambiguise argument name
@@ -464,7 +465,7 @@ class TypeInferer(object):
     def seed_type(self, name, typ):
         """All arguments should be seeded.
         """
-        self.typevars[name].lock(typ)
+        self.lock_type(name, typ)
 
     def seed_return(self, typ):
         """Seeding of return value is optional.
@@ -472,7 +473,7 @@ class TypeInferer(object):
         for blk in utils.itervalues(self.blocks):
             inst = blk.terminator
             if isinstance(inst, ir.Return):
-                self.typevars[inst.value.name].lock(typ)
+                self.lock_type(inst.value.name, typ)
 
     def build_constrain(self):
         for blk in utils.itervalues(self.blocks):
@@ -482,20 +483,16 @@ class TypeInferer(object):
     def propagate(self):
         newtoken = self.get_state_token()
         oldtoken = None
-        if config.DEBUG:
-            self.dump()
         # Since the number of types are finite, the typesets will eventually
         # stop growing.
         while newtoken != oldtoken:
-            if config.DEBUG:
-                print("propagate".center(80, '-'))
+            self.debug.propagate_started()
             oldtoken = newtoken
             # Errors can appear when the type set is incomplete; only
             # raise them when there is no progress anymore.
             errors = self.constrains.propagate(self)
             newtoken = self.get_state_token()
-            if config.DEBUG:
-                self.dump()
+            self.debug.propagate_finished()
         if errors:
             raise errors[0]
 
@@ -509,6 +506,10 @@ class TypeInferer(object):
 
     def copy_type(self, src_var, dest_var):
         unified = self.typevars[dest_var].union(self.typevars[src_var])
+
+    def lock_type(self, var, tp):
+        tv = self.typevars[var]
+        tv.lock(tp)
 
     def propagate_refined_type(self, updated_var, updated_type):
         source_constraint = self.refine_map.get(updated_var)
@@ -544,6 +545,9 @@ class TypeInferer(object):
         fntys = self.get_function_types(typdict)
         if self.generator_info:
             retty = self.get_generator_type(typdict, retty)
+
+        self.debug.unify_finished(typdict, retty, fntys)
+
         return typdict, retty, fntys
 
     def get_generator_type(self, typdict, retty):
@@ -708,7 +712,7 @@ class TypeInferer(object):
                                          loc=inst.loc))
 
     def typeof_const(self, inst, target, const):
-        self.typevars[target.name].lock(self.resolve_value_type(inst, const))
+        self.lock_type(target.name, self.resolve_value_type(inst, const))
 
     def typeof_yield(self, inst, target, yield_):
         # Sending values into generators isn't supported.
@@ -740,7 +744,7 @@ class TypeInferer(object):
 
         if typ is not None:
             self.sentry_modified_builtin(inst, gvar)
-            self.typevars[target.name].lock(typ)
+            self.lock_type(target.name, typ)
             self.assumed_immutables.add(inst)
         else:
             raise TypingError("Untyped global name '%s'" % gvar.name,
@@ -817,3 +821,40 @@ class TypeInferer(object):
                                            kws=(), vararg=None, loc=inst.loc)
         self.constrains.append(constrain)
         self.intrcalls.append((inst.value, args, ()))
+
+
+
+class NullDebug(object):
+
+    def propagate_started(self):
+        pass
+
+    def propagate_finished(self):
+        pass
+
+    def unify_finished(self, typdict, retty, fntys):
+        pass
+
+
+class TypeInferDebug(object):
+
+    def __init__(self, typeinfer):
+        self.typeinfer = typeinfer
+
+    def _dump_state(self):
+        print('---- type variables ----')
+        pprint([v for k, v in sorted(self.typeinfer.typevars.items())])
+
+    def propagate_started(self):
+        print("propagate".center(80, '-'))
+
+    def propagate_finished(self):
+        self._dump_state()
+
+    def unify_finished(self, typdict, retty, fntys):
+        print("Variable types".center(80, "-"))
+        pprint(typdict)
+        print("Return type".center(80, "-"))
+        pprint(retty)
+        print("Call types".center(80, "-"))
+        pprint(fntys)


### PR DESCRIPTION
It enables printing out the typeinfer propagation without dumping unrelated
stuff such as the LLVM IR.