### PR TITLE
Support one-argument type()

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -147,6 +147,8 @@ The following built-in functions are supported:
 * :class:`range`: semantics are similar to those of Python 3 even in Python 2:
   a range object is returned instead of an array of values.
 * :func:`round`
+* :func:`type`: only the one-argument form, and only on some types
+  (e.g. numbers and named tuples)
 * :func:`zip`
 
 

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from numba import types
-from numba.typing.npydecl import register_casters
+from numba.typing.npydecl import register_number_classes
 from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                     AbstractTemplate, MacroTemplate,
                                     signature, Registry)
@@ -12,7 +12,8 @@ intrinsic = registry.register
 intrinsic_attr = registry.register_attr
 intrinsic_global = registry.register_global
 
-register_casters(intrinsic_global)
+register_number_classes(intrinsic_global)
+
 
 class Cuda_grid(MacroTemplate):
     key = cuda.grid

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1332,3 +1332,14 @@ def array_ravel_impl(context, builder, sig, args):
 
     res = flatarr._getvalue()
     return impl_ret_borrowed(context, builder, sig.return_type, res)
+
+
+# -----------------------------------------------------------------------------
+
+@builtin
+@implement(type, types.Any)
+def type_impl(context, builder, sig, args):
+    """
+    One-argument type() builtin.
+    """
+    return context.get_dummy_value()

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -129,6 +129,9 @@ def round_usecase2(x, n):
 def sum_usecase(x):
     return sum(x)
 
+def type_unary_usecase(a, b):
+    return type(a)(b)
+
 def unichr_usecase(x):
     return unichr(x)
 
@@ -691,6 +694,21 @@ class TestBuiltins(TestCase):
     def test_sum_npm(self):
         with self.assertTypingError():
             self.test_sum(flags=no_pyobj_flags)
+
+    def test_type_unary(self):
+        # Test type(val) and type(val)(other_val)
+        pyfunc = type_unary_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(*args):
+            expected = pyfunc(*args)
+            self.assertPreciseEqual(cfunc(*args), expected)
+
+        check(1.5, 2)
+        check(1, 2.5)
+        check(1.5j, 2)
+        check(True, 2)
+        check(2.5j, False)
 
     @unittest.skipIf(utils.IS_PY3, "cmp not available as global is Py3")
     def test_unichr(self, flags=enable_pyobj_flags):

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -70,6 +70,9 @@ def make_point_nrt(n):
     p = Point(r, len(r.width), len(r.height))
     return p
 
+def type_usecase(tup, *args):
+    return type(tup)(*args)
+
 
 class TestTupleReturn(TestCase):
 
@@ -308,6 +311,19 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
 
         check(make_point)
         check(make_point_kws)
+
+    def test_type(self):
+        # Test the type() built-in on named tuples
+        pyfunc = type_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        arg_tuples = [(4, 5, 6), (4, 5.5, 6j)]
+        for tup_args, args in itertools.product(arg_tuples, arg_tuples):
+            tup = Point(*tup_args)
+            expected = pyfunc(tup, *args)
+            got = cfunc(tup, *args)
+            self.assertIs(type(got), type(expected))
+            self.assertPreciseEqual(got, expected)
 
 
 class TestNamedTupleNRT(TestCase, MemoryLeakMixin):

--- a/numba/types.py
+++ b/numba/types.py
@@ -248,18 +248,17 @@ class NumberClass(Callable, DTypeSpec, Opaque):
     Type class for number classes (e.g. "np.float64").
     """
 
-    def __init__(self, instance_type, template):
+    def __init__(self, instance_type):
         self.instance_type = instance_type
-        self.template = template
-        name = "type(%s)" % (instance_type,)
-        super(NumberClass, self).__init__(name)
+        name = "class(%s)" % (instance_type,)
+        super(NumberClass, self).__init__(name, param=True)
 
     def get_call_type(self, context, args, kws):
-        return self.template(context).apply(args, kws)
+        # Overriden by the __call__ constructor resolution in typing.builtins
+        return None
 
     def get_call_signatures(self):
-        sigs = getattr(self.template, 'cases')
-        return sigs, hasattr(self.template, 'generic')
+        return (), True
 
     @property
     def key(self):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -5,7 +5,8 @@ from numba import types, intrinsics
 from numba.utils import PYVERSION, RANGE_ITER_OBJECTS
 from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                     AbstractTemplate, builtin_global, builtin,
-                                    builtin_attr, signature, bound_function)
+                                    builtin_attr, signature, bound_function,
+                                    make_callable_template)
 
 for obj in RANGE_ITER_OBJECTS:
     builtin_global(obj, types.range_type)
@@ -767,13 +768,28 @@ class MemoryViewAttribute(AttributeTemplate):
 
 
 #-------------------------------------------------------------------------------
-class ComplexAttribute(AttributeTemplate):
+
+
+@builtin_attr
+class BooleanAttribute(AttributeTemplate):
+    key = types.Boolean
+
+    def resolve___class__(self, ty):
+        return types.NumberClass(ty)
+
+
+@builtin_attr
+class NumberAttribute(AttributeTemplate):
+    key = types.Number
+
+    def resolve___class__(self, ty):
+        return types.NumberClass(ty)
 
     def resolve_real(self, ty):
-        return self.innertype
+        return getattr(ty, "underlying_float", ty)
 
     def resolve_imag(self, ty):
-        return self.innertype
+        return getattr(ty, "underlying_float", ty)
 
     @bound_function("complex.conjugate")
     def resolve_conjugate(self, ty, args, kws):
@@ -782,37 +798,34 @@ class ComplexAttribute(AttributeTemplate):
         return signature(ty)
 
 
-def register_complex_attributes(ty):
-    @builtin_attr
-    class ConcreteComplexAttribute(ComplexAttribute):
-        key = ty
-        try:
-            innertype = ty.underlying_float
-        except AttributeError:
-            innertype = ty
-
-for ty in types.number_domain:
-    register_complex_attributes(ty)
-
 #-------------------------------------------------------------------------------
 
-def register_casters(register_global):
+
+@builtin_attr
+class NumberClassAttribute(AttributeTemplate):
+    key = types.NumberClass
+
+    def resolve___call__(self, classty):
+        """
+        Resolve a number class's constructor (e.g. calling int(...))
+        """
+        ty = classty.instance_type
+
+        def typer(val):
+            return ty
+
+        return types.Function(make_callable_template(key=ty, typer=typer))
+
+
+def register_number_classes(register_global):
     nb_types = set(types.number_domain)
     nb_types.add(types.bool_)
 
-    for restype in nb_types:
-        class Caster(AbstractTemplate):
-            key = restype
+    for ty in nb_types:
+        register_global(ty, types.NumberClass(ty))
 
-            def generic(self, args, kws):
-                assert not kws
-                [a] = args
-                if a in nb_types:
-                    return signature(self.key, a)
 
-        register_global(restype, types.NumberClass(restype, Caster))
-
-register_casters(builtin_global)
+register_number_classes(builtin_global)
 
 #------------------------------------------------------------------------------
 
@@ -1016,3 +1029,24 @@ class Intrinsic_array_ravel(AbstractTemplate):
             return signature(arr.copy(ndim=1), arr)
 
 builtin_global(intrinsics.array_ravel, types.Function(Intrinsic_array_ravel))
+
+
+#------------------------------------------------------------------------------
+
+@builtin
+class TypeBuiltin(AbstractTemplate):
+    key = type
+
+    def generic(self, args, kws):
+        assert not kws
+        if len(args) == 1:
+            # One-argument type() -> return the __class__
+            try:
+                classty = self.context.resolve_getattr(args[0], "__class__")
+            except KeyError:
+                return
+            else:
+                return signature(classty, *args)
+
+
+builtin_global(type, types.Function(TypeBuiltin))

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -83,6 +83,9 @@ class DelItemSequence(AbstractTemplate):
 class NamedTupleAttribute(AttributeTemplate):
     key = types.BaseNamedTuple
 
+    def resolve___class__(self, tup):
+        return types.NamedTupleClass(tup.instance_class)
+
     def generic_resolve(self, tup, attr):
         # Resolution of other attributes
         try:

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -138,19 +138,15 @@ class BaseContext(object):
         try:
             attrinfo = self.attributes[value]
         except KeyError:
-            if value.is_parametric:
-                for cls in type(value).__mro__:
-                    if cls in self.attributes:
-                        attrinfo = self.attributes[cls]
-                        break
-                else:
-                    raise
-            elif isinstance(value, types.Module):
-                attrty = self.resolve_module_constants(value, attr)
-                if attrty is not None:
-                    return attrty
-                raise
+            for cls in type(value).__mro__:
+                if cls in self.attributes:
+                    attrinfo = self.attributes[cls]
+                    break
             else:
+                if isinstance(value, types.Module):
+                    attrty = self.resolve_module_constants(value, attr)
+                    if attrty is not None:
+                        return attrty
                 raise
 
         ret = attrinfo.resolve(value, attr)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -350,23 +350,14 @@ np_types.add(numpy.uintc)
 np_types.add(numpy.uintp)
 
 
-def register_casters(register_global):
+def register_number_classes(register_global):
     for np_type in np_types:
         nb_type = getattr(types, np_type.__name__)
 
-        class Caster(AbstractTemplate):
-            key = np_type
-            restype = nb_type
+        register_global(np_type, types.NumberClass(nb_type))
 
-            def generic(self, args, kws):
-                assert not kws
-                [a] = args
-                if a in types.number_domain:
-                    return signature(self.restype, a)
 
-        register_global(np_type, types.NumberClass(nb_type, Caster))
-
-register_casters(builtin_global)
+register_number_classes(builtin_global)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Based on PR #1379. The main usecase is to instantiate the right type in a polymorphic function, e.g. calls `type(some_argument)(some_value)`.  This PR only supports type() on numbers, booleans and named tuples.