### PR TITLE
Make cuda print() tests programmatic

### DIFF
--- a/numba/cuda/printimpl.py
+++ b/numba/cuda/printimpl.py
@@ -56,15 +56,16 @@ def print_varargs(context, builder, sig, args):
 
     mod = builder.module
     vprint = nvvmutils.declare_vprint(mod)
+    sep = context.insert_string_const_addrspace(builder, " ")
+    eol = context.insert_string_const_addrspace(builder, "\n")
+
     for i, (argtype, argval) in enumerate(zip(sig.args, args)):
         signature = typing.signature(types.none, argtype)
         imp = context.get_function(types.print_item_type, signature)
         imp(builder, [argval])
-        if i == len(args) - 1:
-            eos = context.insert_string_const_addrspace(builder, "\n")
-        else:
-            eos = context.insert_string_const_addrspace(builder, " ")
+        if i < len(args) - 1:
+            builder.call(vprint, (sep, Constant.null(voidptr)))
 
-        builder.call(vprint, (eos, Constant.null(voidptr)))
+    builder.call(vprint, (eol, Constant.null(voidptr)))
 
     return context.get_dummy_value()

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, absolute_import, division
 
-import collections
 import contextlib
 import io
 import os

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -44,10 +44,6 @@ class CUDATextCapture(object):
     def getvalue(self):
         return self._stream.read()
 
-    def sync(self):
-        from numba import cuda
-        cuda.synchronize()
-
 
 class PythonTextCapture(object):
 
@@ -56,9 +52,6 @@ class PythonTextCapture(object):
 
     def getvalue(self):
         return self._stream.getvalue()
-
-    def sync(self):
-        pass
 
 
 @contextlib.contextmanager
@@ -73,5 +66,7 @@ def captured_cuda_stdout():
             yield PythonTextCapture(stream)
     else:
         # The CUDA runtime writes onto the system stdout
+        from numba import cuda
         with redirect_fd(1) as stream:
             yield CUDATextCapture(stream)
+            cuda.synchronize()

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,5 +1,12 @@
 from __future__ import print_function, absolute_import, division
+
+import collections
+import contextlib
+import io
+import os
+
 from numba import config, unittest_support as unittest
+from numba.tests.support import captured_stdout
 
 
 class CUDATestCase(unittest.TestCase):
@@ -11,3 +18,61 @@ class CUDATestCase(unittest.TestCase):
 
 def skip_on_cudasim(reason):
     return unittest.skipIf(config.ENABLE_CUDASIM, reason)
+
+
+@contextlib.contextmanager
+def redirect_fd(fd):
+    """
+    Temporarily redirect *fd* to a pipe's write end and return a file object
+    wrapping the pipe's read end.
+    """
+    save = os.dup(fd)
+    r, w = os.pipe()
+    try:
+        os.dup2(w, fd)
+        yield io.open(r, "r")
+    finally:
+        os.close(w)
+        os.dup2(save, fd)
+        os.close(save)
+
+
+class CUDATextCapture(object):
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def getvalue(self):
+        return self._stream.read()
+
+    def sync(self):
+        from numba import cuda
+        cuda.synchronize()
+
+
+class PythonTextCapture(object):
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def getvalue(self):
+        return self._stream.getvalue()
+
+    def sync(self):
+        pass
+
+
+@contextlib.contextmanager
+def captured_cuda_stdout():
+    """
+    Return a minimal stream-like object capturing the text output of
+    either CUDA or the simulator.
+    """
+    if config.ENABLE_CUDASIM:
+        # The simulator calls print() on Python stdout
+        with captured_stdout() as stream:
+            yield PythonTextCapture(stream)
+    else:
+        # The CUDA runtime writes onto the system stdout
+        with redirect_fd(1) as stream:
+            yield CUDATextCapture(stream)

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -32,7 +32,6 @@ class TestPrint(unittest.TestCase):
         jcuhello = cuda.jit('void()', debug=False)(cuhello)
         with captured_cuda_stdout() as stdout:
             jcuhello[2, 3]()
-            stdout.sync()
         # The output of GPU threads is intermingled, just sanity check it
         out = stdout.getvalue()
         expected = ''.join('%d 999\n' % i for i in range(6))
@@ -42,7 +41,6 @@ class TestPrint(unittest.TestCase):
         jprintfloat = cuda.jit('void()', debug=False)(printfloat)
         with captured_cuda_stdout() as stdout:
             jprintfloat()
-            stdout.sync()
         # CUDA and the simulator use different formats for float formatting
         self.assertIn(stdout.getvalue(), ["0 23 34.750000 321\n",
                                           "0 23 34.75 321\n"])
@@ -51,7 +49,6 @@ class TestPrint(unittest.TestCase):
         cufunc = cuda.jit('void()', debug=False)(printempty)
         with captured_cuda_stdout() as stdout:
             cufunc()
-            stdout.sync()
         self.assertEqual(stdout.getvalue(), "\n")
 
     @unittest.skipIf(True, "Print string not implemented yet")

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -22,6 +22,10 @@ def cuprintary(A):
     print("A[", i, "]", A[i])
 
 
+def printempty():
+    print()
+
+
 class TestPrint(unittest.TestCase):
 
     def test_cuhello(self):
@@ -39,8 +43,16 @@ class TestPrint(unittest.TestCase):
         with captured_cuda_stdout() as stdout:
             jprintfloat()
             stdout.sync()
+        # CUDA and the simulator use different formats for float formatting
         self.assertIn(stdout.getvalue(), ["0 23 34.750000 321\n",
                                           "0 23 34.75 321\n"])
+
+    def test_printempty(self):
+        cufunc = cuda.jit('void()', debug=False)(printempty)
+        with captured_cuda_stdout() as stdout:
+            cufunc()
+            stdout.sync()
+        self.assertEqual(stdout.getvalue(), "\n")
 
     @unittest.skipIf(True, "Print string not implemented yet")
     def test_print_array(self):

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -1,12 +1,35 @@
 from __future__ import print_function
+
+import contextlib
+import io
+import os
+
 import numpy
+
 from numba import cuda
 from numba import unittest_support as unittest
 
 
+@contextlib.contextmanager
+def redirect_fd(fd):
+    """
+    Temporarily redirect *fd* to a pipe's write end and return a file object
+    wrapping the pipe's read end.
+    """
+    save = os.dup(fd)
+    r, w = os.pipe()
+    try:
+        os.dup2(w, fd)
+        yield io.open(r, "r")
+    finally:
+        os.close(w)
+        os.dup2(save, fd)
+        os.close(save)
+
+
 def cuhello():
     i = cuda.grid(1)
-    print(i, 1.234)
+    print(i, 999)
 
 
 def printfloat():
@@ -20,21 +43,23 @@ def cuprintary(A):
 
 
 class TestPrint(unittest.TestCase):
+
     def test_cuhello(self):
-        """
-        Eyeballing required
-        """
         jcuhello = cuda.jit('void()', debug=False)(cuhello)
-        jcuhello[2, 3]()
-        cuda.synchronize()
+        with redirect_fd(1) as stdout:
+            jcuhello[2, 3]()
+            cuda.synchronize()
+        # The output of GPU threads is intermingled, just sanity check it
+        out = stdout.read()
+        expected = ''.join('%d 999\n' % i for i in range(6))
+        self.assertEqual(sorted(out), sorted(expected))
 
     def test_printfloat(self):
-        """
-        Eyeballing required
-        """
         jprintfloat = cuda.jit('void()', debug=False)(printfloat)
-        jprintfloat()
-        cuda.synchronize()
+        with redirect_fd(1) as stdout:
+            jprintfloat()
+            cuda.synchronize()
+        self.assertEqual(stdout.read(), "0 23 34.300000 321\n")
 
     @unittest.skipIf(True, "Print string not implemented yet")
     def test_print_array(self):

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -1,30 +1,10 @@
 from __future__ import print_function
 
-import contextlib
-import io
-import os
-
 import numpy
 
 from numba import cuda
 from numba import unittest_support as unittest
-
-
-@contextlib.contextmanager
-def redirect_fd(fd):
-    """
-    Temporarily redirect *fd* to a pipe's write end and return a file object
-    wrapping the pipe's read end.
-    """
-    save = os.dup(fd)
-    r, w = os.pipe()
-    try:
-        os.dup2(w, fd)
-        yield io.open(r, "r")
-    finally:
-        os.close(w)
-        os.dup2(save, fd)
-        os.close(save)
+from numba.cuda.testing import captured_cuda_stdout
 
 
 def cuhello():
@@ -34,7 +14,7 @@ def cuhello():
 
 def printfloat():
     i = cuda.grid(1)
-    print(i, 23, 34.3, 321)
+    print(i, 23, 34.75, 321)
 
 
 def cuprintary(A):
@@ -46,20 +26,21 @@ class TestPrint(unittest.TestCase):
 
     def test_cuhello(self):
         jcuhello = cuda.jit('void()', debug=False)(cuhello)
-        with redirect_fd(1) as stdout:
+        with captured_cuda_stdout() as stdout:
             jcuhello[2, 3]()
-            cuda.synchronize()
+            stdout.sync()
         # The output of GPU threads is intermingled, just sanity check it
-        out = stdout.read()
+        out = stdout.getvalue()
         expected = ''.join('%d 999\n' % i for i in range(6))
         self.assertEqual(sorted(out), sorted(expected))
 
     def test_printfloat(self):
         jprintfloat = cuda.jit('void()', debug=False)(printfloat)
-        with redirect_fd(1) as stdout:
+        with captured_cuda_stdout() as stdout:
             jprintfloat()
-            cuda.synchronize()
-        self.assertEqual(stdout.read(), "0 23 34.300000 321\n")
+            stdout.sync()
+        self.assertIn(stdout.getvalue(), ["0 23 34.750000 321\n",
+                                          "0 23 34.75 321\n"])
 
     @unittest.skipIf(True, "Print string not implemented yet")
     def test_print_array(self):


### PR DESCRIPTION
This avoids requiring eyeballs and also makes the test output silent.
Also fixes `print()` printing nothing.