### PR TITLE
Fixes for armv7l (rpi2)

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -386,91 +386,6 @@ Numba_poisson_ptrs(rnd_state_t *state, double lam)
  * Other helpers.
  */
 
-/* provide 128-bit multiplication inplace for __multi3
- * on 32-bit platform */
-
-/* NOTE only with a proper 128-bit integer type is this guaranteed
- * to work.  Only clang is known to offer a 128-bit integer on 32-bit
- * architectures.  On x86 the fallback works anyway, but it crashes on
- * ARMv7 (test_multi3), so on ARMv7 you need to compile with clang.
- * (`CC=clang python setup.py build_ext`).
- */
-
-#if defined(__clang__)
-#define HAVE_I128 1
-#else
-#define HAVE_I128 0
-#endif
-
-#if HAVE_I128
-typedef int i128 __attribute__ ((mode (TI)));
-#endif
-
-/* XXX little-endian only */
-typedef struct {
-    uint64_t low;
-    int64_t high;
-} s128;
-
-typedef union {
-    s128 s;
-#if HAVE_I128
-    i128 value;
-#endif
-} _i128;
-
-
-static _i128
-umul64(uint64_t a, uint64_t b) {
-    /* Adapted from __mulddi in compiler-rt */
-    _i128 r;
-    uint64_t t;
-    const int bits_in_dword_2 = 32;
-    const uint64_t lower_mask = (uint64_t)~0 >> bits_in_dword_2;
-
-    r.s.low = (a & lower_mask) * (b & lower_mask);
-    t = r.s.low >> bits_in_dword_2;
-    r.s.low &= lower_mask;
-    t += (a >> bits_in_dword_2) * (b & lower_mask);
-    r.s.low += (t & lower_mask) << bits_in_dword_2;
-    r.s.high = t >> bits_in_dword_2;
-    t = r.s.low >> bits_in_dword_2;
-    r.s.low &= lower_mask;
-    t += (b >> bits_in_dword_2) * (a & lower_mask);
-    r.s.low += (t & lower_mask) << bits_in_dword_2;
-    r.s.high += t >> bits_in_dword_2;
-    r.s.high += (a >> bits_in_dword_2) * (b >> bits_in_dword_2);
-    return r;
-}
-
-static _i128
-mul128(_i128 a, _i128 b) {
-    /* Adapted from __multi3 in compiler-rt */
-    _i128 r = umul64(a.s.low, b.s.low);
-    r.s.high += a.s.high * b.s.low + a.s.low * b.s.high;
-    return r;
-}
-
-#if HAVE_I128
-static i128
-Numba_multi3(i128 x, i128 y) {
-    _i128 _x, _y, r;
-    _x.value = x;
-    _y.value = y;
-    r = mul128(_x, _y);
-    return r.value;
-}
-#else
-/* Fallback for when no 128-bit integer type is available.
- * We pretend passing the union type is equivalent - which it isn't
- * necessarily.
- */
-static _i128
-Numba_multi3(_i128 x, _i128 y) {
-    return mul128(x, y);
-}
-#endif
-
 /* provide 64-bit division function to 32-bit platforms */
 static
 int64_t Numba_sdiv(int64_t a, int64_t b) {
@@ -1585,7 +1500,6 @@ build_c_helpers_dict(void)
 
 #define declpointer(ptr) _declpointer(#ptr, &ptr)
 
-    declmethod(multi3);
     declmethod(sdiv);
     declmethod(srem);
     declmethod(udiv);

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -889,41 +889,6 @@ def memmove(builder, dst, src, count, itemsize, align=1):
                            is_volatile])
 
 
-def memcpy2(builder, dst, src, count, itemsize, align=1):
-    """
-    Emit a memcpy() call for `count` items of size `itemsize`
-    from `src` to `dest`.
-    """
-    ptr_t = ir.IntType(8).as_pointer()
-    size_t = count.type
-
-    memmove = builder.module.declare_intrinsic('llvm.memcpy',
-                                               [ptr_t, ptr_t, size_t])
-    align = ir.Constant(ir.IntType(32), align)
-    is_volatile = false_bit
-    builder.call(memmove, [builder.bitcast(dst, ptr_t),
-                           builder.bitcast(src, ptr_t),
-                           builder.mul(count, ir.Constant(size_t, itemsize)),
-                           align,
-                           is_volatile])
-
-
-def copy_from_unaligned(context, builder, ptr):
-    llty = ptr.type.pointee
-    datasize = context.get_abi_sizeof(llty)
-    tmp = alloca_once(builder, llty)
-    count = ir.Constant(intp_t, 1)
-    memcpy2(builder, tmp, ptr, count, datasize)
-    return tmp
-
-def copy_to_unaligned(context, builder, destptr, srcptr):
-    assert srcptr.type == destptr.type
-    llty = srcptr.type.pointee
-    datasize = context.get_abi_sizeof(llty)
-    count = ir.Constant(intp_t, 1)
-    memcpy2(builder, destptr, srcptr, count, datasize)
-
-
 def muladd_with_overflow(builder, a, b, c):
     """
     Compute (a * b + c) and return a (result, overflow bit) pair.

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -77,12 +77,12 @@ class DataModel(object):
     def from_return(self, builder, value):
         raise NotImplementedError
 
-    def load_from_data_pointer(self, builder, ptr):
+    def load_from_data_pointer(self, builder, ptr, align=None):
         """
         Load value from a pointer to data.
         This is the default implementation, sufficient for most purposes.
         """
-        return self.from_data(builder, builder.load(ptr))
+        return self.from_data(builder, builder.load(ptr, align=align))
 
     def traverse(self, builder, value):
         """
@@ -281,7 +281,7 @@ class EphemeralPointerModel(PointerModel):
     def from_data(self, builder, value):
         raise NotImplementedError("use load_from_data_pointer() instead")
 
-    def load_from_data_pointer(self, builder, ptr):
+    def load_from_data_pointer(self, builder, ptr, align=None):
         return builder.bitcast(ptr, self.get_value_type())
 
 
@@ -299,7 +299,7 @@ class EphemeralArrayModel(PointerModel):
     def from_data(self, builder, value):
         raise NotImplementedError("use load_from_data_pointer() instead")
 
-    def load_from_data_pointer(self, builder, ptr):
+    def load_from_data_pointer(self, builder, ptr, align=None):
         return builder.bitcast(ptr, self.get_value_type())
 
 
@@ -461,11 +461,11 @@ class StructModel(CompositeModel):
                 for i in range(len(self._members))]
         return self._from("from_data", builder, vals)
 
-    def load_from_data_pointer(self, builder, ptr):
+    def load_from_data_pointer(self, builder, ptr, align=None):
         values = []
         for i, model in enumerate(self._models):
             elem_ptr = cgutils.gep_inbounds(builder, ptr, 0, i)
-            val = model.load_from_data_pointer(builder, elem_ptr)
+            val = model.load_from_data_pointer(builder, elem_ptr, align)
             values.append(val)
 
         struct = ir.Constant(self.get_value_type(), ir.Undefined)
@@ -738,7 +738,7 @@ class RecordModel(CompositeModel):
     def from_return(self, builder, value):
         return value
 
-    def load_from_data_pointer(self, builder, ptr):
+    def load_from_data_pointer(self, builder, ptr, align=None):
         return builder.bitcast(ptr, self.get_value_type())
 
 

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -287,9 +287,11 @@ if numpy.__version__ <= '1.7':
     # for dtype.  We implement the behavior of the function here.
     def _is_aligned_struct(struct):
         for (dtype, offset) in struct.fields.values():
-            # Make sure all attributes have offset equal to the alignment of
-            # the attribute dtype.
+            # Make sure all attributes can only appear at offsets equal
+            # to the alignment of the attribute dtype.
             if offset % dtype.alignment:
+                return False
+            if struct.itemsize % dtype.alignment:
                 return False
         return True
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -104,6 +104,13 @@ def load_item(context, builder, arrayty, ptr):
     return context.unpack_value(builder, arrayty.dtype, ptr,
                                 align=align)
 
+def store_item(context, builder, arrayty, ptr, val):
+    """
+    Store the item at the given array pointer.
+    """
+    align = None if arrayty.aligned else 1
+    return context.pack_value(builder, arrayty.dtype, ptr, val,  align=align)
+
 
 def populate_array(array, data, shape, strides, itemsize, meminfo,
                    parent=None):
@@ -379,7 +386,7 @@ def setitem_array1d(context, builder, sig, args):
 
     val = context.cast(builder, val, valty, aryty.dtype)
 
-    context.pack_value(builder, aryty.dtype, val, ptr)
+    store_item(context, builder, aryty, val, ptr)
 
 
 @builtin
@@ -398,7 +405,7 @@ def setitem_array_unituple(context, builder, sig, args):
                for t, i in zip(idxty, indices)]
     ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
                                    wraparound=idxty.dtype.signed)
-    context.pack_value(builder, aryty.dtype, val, ptr)
+    store_item(context, builder, aryty, val, ptr)
 
 
 @builtin
@@ -417,7 +424,7 @@ def setitem_array_tuple(context, builder, sig, args):
                for t, i in zip(idxty, indices)]
     ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
                                    wraparound=True)
-    context.pack_value(builder, aryty.dtype, val, ptr)
+    store_item(context, builder, aryty, val, ptr)
 
 @builtin
 @implement('setitem', types.Kind(types.Buffer),
@@ -488,12 +495,12 @@ def setitem_array1d_slice(context, builder, sig, args):
             ptr = cgutils.get_item_pointer(builder, aryty, ary,
                                 [loop_idx1],
                                 wraparound=True)
-            context.pack_value(builder, aryty.dtype, val, ptr)
+            store_item(context, builder, aryty, val, ptr)
         with neg_range as (loop_idx2, _):
             ptr = cgutils.get_item_pointer(builder, aryty, ary,
                                 [loop_idx2],
                                 wraparound=True)
-            context.pack_value(builder, aryty.dtype, val, ptr)
+            store_item(context, builder, aryty, val, ptr)
 
 
 @builtin

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -96,6 +96,14 @@ def get_itemsize(context, array_type):
     return context.get_abi_sizeof(llty)
 
 
+def load_item(context, builder, arrayty, ptr):
+    """
+    """
+    align = None if arrayty.aligned else 1
+    return context.unpack_value(builder, arrayty.dtype, ptr,
+                                align=align)
+
+
 def populate_array(array, data, shape, strides, itemsize, meminfo,
                    parent=None):
     """
@@ -202,7 +210,7 @@ def getiter_array(context, builder, sig, args):
 def _getitem_array1d(context, builder, arrayty, array, idx, wraparound):
     ptr = cgutils.get_item_pointer(builder, arrayty, array, [idx],
                                    wraparound=wraparound)
-    return context.unpack_value(builder, arrayty.dtype, ptr)
+    return load_item(context, builder, arrayty, ptr)
 
 @builtin
 @implement('iternext', types.Kind(types.ArrayIterator))
@@ -350,7 +358,7 @@ def getitem_array_tuple(context, builder, sig, args):
         ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
                                        wraparound=True)
 
-        res = context.unpack_value(builder, aryty.dtype, ptr)
+        res = load_item(context, builder, aryty, ptr)
 
     return impl_ret_borrowed(context, builder ,sig.return_type, res)
 
@@ -1305,7 +1313,8 @@ def array_record_getattr(context, builder, typ, value, attr):
     dtype = rectype.typeof(attr)
     offset = rectype.offset(attr)
 
-    resty = types.Array(dtype, ndim=typ.ndim, layout='A')
+    resty = types.Array(dtype, ndim=typ.ndim, layout='A', aligned=rectype.aligned)
+    resty = typ.copy(dtype=dtype, layout='A')
 
     raryty = make_array(resty)
 
@@ -1495,7 +1504,7 @@ def _make_flattening_iter_cls(flatiterty, kind):
 
                 with cgutils.if_likely(builder, is_valid):
                     ptr = builder.gep(arr.data, [index])
-                    value = context.unpack_value(builder, arrty.dtype, ptr)
+                    value = load_item(context, builder, arrty, ptr)
                     if kind == 'flat':
                         result.yield_(value)
                     else:
@@ -1583,7 +1592,7 @@ def _make_flattening_iter_cls(flatiterty, kind):
                 # Current pointer inside last dimension
                 last_ptr = cgutils.gep_inbounds(builder, pointers, ndim - 1)
                 ptr = builder.load(last_ptr)
-                value = context.unpack_value(builder, arrty.dtype, ptr)
+                value = load_item(context, builder, arrty, ptr)
                 if kind == 'flat':
                     result.yield_(value)
                 else:

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -98,6 +98,7 @@ def get_itemsize(context, array_type):
 
 def load_item(context, builder, arrayty, ptr):
     """
+    Load the item at the given array pointer.
     """
     align = None if arrayty.aligned else 1
     return context.unpack_value(builder, arrayty.dtype, ptr,
@@ -1313,7 +1314,6 @@ def array_record_getattr(context, builder, typ, value, attr):
     dtype = rectype.typeof(attr)
     offset = rectype.offset(attr)
 
-    resty = types.Array(dtype, ndim=typ.ndim, layout='A', aligned=rectype.aligned)
     resty = typ.copy(dtype=dtype, layout='A')
 
     raryty = make_array(resty)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1294,7 +1294,7 @@ def array_ctypes_data(context, builder, typ, value):
 def array_record_getattr(context, builder, typ, value, attr):
     """
     Generic getattr() implementation for record arrays: fetch the given
-    record member.
+    record member, i.e. a subarray.
     """
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -515,10 +515,6 @@ class BaseContext(object):
                 def imp(context, builder, typ, val):
                     dptr = cgutils.get_record_member(builder, val, offset,
                                                      context.get_data_type(elemty))
-                    #if not typ.aligned:
-                        ## Make an aligned copy on the stack
-                        #dptr = cgutils.copy_from_unaligned(context, builder,
-                                                           #dptr)
                     align = None if typ.aligned else 1
                     res = self.unpack_value(builder, elemty, dptr, align)
                     return impl_ret_borrowed(context, builder, typ, res)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -309,13 +309,19 @@ class BaseContext(object):
         return self.data_model_manager[ty].get_value_type()
 
     def pack_value(self, builder, ty, value, ptr, align=None):
-        """Pack data for array storage
+        """
+        Pack value into the array storage at *ptr*.
+        If *align* is given, it is the guaranteed alignment for *ptr*
+        (by default, the standard ABI alignment).
         """
         dataval = self.data_model_manager[ty].as_data(builder, value)
         builder.store(dataval, ptr, align=align)
 
     def unpack_value(self, builder, ty, ptr, align=None):
-        """Unpack data from array storage
+        """
+        Unpack value from the array storage at *ptr*.
+        If *align* is given, it is the guaranteed alignment for *ptr*
+        (by default, the standard ABI alignment).
         """
         dm = self.data_model_manager[ty]
         return dm.load_from_data_pointer(builder, ptr, align)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -40,10 +40,11 @@ class CPUContext(BaseContext):
 
     def init(self):
         self.is32bit = (utils.MACHINE_BITS == 32)
+        self._internal_codegen = codegen.JITCPUCodegen("numba.exec")
 
         # Map external C functions.
-        externals.c_math_functions.install()
-        externals.c_numpy_functions.install()
+        externals.c_math_functions.install(self)
+        externals.c_numpy_functions.install(self)
 
         # Add target specific implementations
         self.install_registry(cmathimpl.registry)
@@ -52,8 +53,6 @@ class CPUContext(BaseContext):
         self.install_registry(operatorimpl.registry)
         self.install_registry(printimpl.registry)
         self.install_registry(randomimpl.registry)
-
-        self._internal_codegen = codegen.JITCPUCodegen("numba.exec")
 
         # Initialize NRT runtime
         rtsys.initialize(self)

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -31,7 +31,8 @@ def _get_msvcrt_symbol(symbol):
 
 def compile_multi3(context):
     """
-    Compile the multi3() helper function used by LLVM.
+    Compile the multi3() helper function used by LLVM
+    for 128-bit multiplication on 32-bit platforms.
     """
     codegen = context.jit_codegen()
     library = codegen.create_library("multi3")

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -4,6 +4,7 @@ Register external C functions necessary for Numba code generation.
 
 import sys
 
+from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba import utils
@@ -28,17 +29,89 @@ def _get_msvcrt_symbol(symbol):
     return cast(f, c_void_p).value
 
 
+def compile_multi3(context):
+    """
+    Compile the multi3() helper function used by LLVM.
+    """
+    codegen = context.jit_codegen()
+    library = codegen.create_library("multi3")
+
+    ir_mod = library.create_ir_module("multi3")
+
+    i64 = ir.IntType(64)
+    i128 = ir.IntType(128)
+    lower_mask = ir.Constant(i64, 0xffffffff)
+    _32 = ir.Constant(i64, 32)
+    _64 = ir.Constant(i128, 64)
+
+    fn_type = ir.FunctionType(i128, [i128, i128])
+    fn = ir.Function(ir_mod, fn_type, name="multi3")
+
+    a, b = fn.args
+    bb = fn.append_basic_block()
+    builder = ir.IRBuilder(bb)
+
+    # This implementation mimicks compiler-rt's.
+    al = builder.trunc(a, i64)
+    bl = builder.trunc(b, i64)
+    ah = builder.trunc(builder.ashr(a, _64), i64)
+    bh = builder.trunc(builder.ashr(b, _64), i64)
+
+    # Compute {rh, rl} = al * bl   (unsigned 64-bit multiplication)
+    # rl = (al & 0xffffffff) * (bl & 0xffffffff)
+    rl = builder.mul(builder.and_(al, lower_mask), builder.and_(bl, lower_mask))
+    # t = rl >> 32
+    t = builder.lshr(rl, _32)
+    # rl &= 0xffffffff
+    rl = builder.and_(rl, lower_mask)
+    # t += (al >> 32) * (bl & 0xffffffff)
+    t = builder.add(t, builder.mul(builder.lshr(al, _32),
+                                   builder.and_(bl, lower_mask)))
+    # rl += t << 32
+    rl = builder.add(rl, builder.shl(t, _32))
+    # rh = t >> 32
+    rh = builder.lshr(t, _32)
+    # t = rl >> 32
+    t = builder.lshr(rl, _32)
+    # rl &= 0xffffffff
+    rl = builder.and_(rl, lower_mask)
+    # t += (bl >> 32) * (al & 0xffffffff)
+    t = builder.add(t, builder.mul(builder.lshr(bl, _32),
+                                   builder.and_(al, lower_mask)))
+    # rl += t << 32
+    rl = builder.add(rl, builder.shl(t, _32))
+    # rh += t >> 32
+    rh = builder.add(rh, builder.lshr(t, _32))
+    # rh += (al >> 32) * (bl >> 32)
+    rh = builder.add(rh, builder.mul(builder.lshr(al, _32),
+                                     builder.lshr(bl, _32)))
+
+    # rh += (bh * al) + (bl * ah)
+    rh = builder.add(rh, builder.mul(bh, al))
+    rh = builder.add(rh, builder.mul(bl, ah))
+
+    # r = rl + (rh << 64)
+    r = builder.zext(rl, i128)
+    r = builder.add(r, builder.shl(builder.zext(rh, i128), _64))
+    builder.ret(r)
+
+    library.add_ir_module(ir_mod)
+    library.finalize()
+
+    return library
+
+
 class _Installer(object):
 
     _installed = False
 
-    def install(self):
+    def install(self, context):
         """
         Install the functions into LLVM.  This only needs to be done once,
         as the mappings are persistent during the process lifetime.
         """
         if not self._installed:
-            self._do_install()
+            self._do_install(context)
             self._installed = True
 
 
@@ -48,7 +121,7 @@ class _ExternalMathFunctions(_Installer):
     execution environment.
     """
 
-    def _do_install(self):
+    def _do_install(self, context):
         is32bit = utils.MACHINE_BITS == 32
         c_helpers = _helperlib.c_helpers
         for name in ['cpow', 'sdiv', 'srem', 'udiv', 'urem']:
@@ -66,7 +139,11 @@ class _ExternalMathFunctions(_Installer):
             _add_missing_symbol("__fixunssfdi", c_helpers["fptouif"])
 
         if is32bit:
-            _add_missing_symbol("__multi3", c_helpers["multi3"])
+            # Make the library immortal
+            self._multi3_lib = compile_multi3(context)
+            ptr = self._multi3_lib.get_pointer_to_function("multi3")
+            assert ptr
+            _add_missing_symbol("__multi3", ptr)
 
         # List available C-math
         for fname in intrinsics.INTR_MATH:
@@ -82,7 +159,7 @@ class _ExternalNumpyFunctions(_Installer):
     Map Numpy's C math functions into the LLVM execution environment.
     """
 
-    def _do_install(self):
+    def _do_install(self, context):
         # add the symbols for numpy math to the execution environment.
         for sym in _npymath_exports.symbols:
             ll.add_symbol(*sym)

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -19,8 +19,10 @@ register = registry.register
 def int_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
-    szval = context.cast(builder, x, sig.args[0], types.intp)
-    intobj = py.long_from_ssize_t(szval)
+    if sig.args[0].signed:
+        intobj = py.long_from_signed_int(x)
+    else:
+        intobj = py.long_from_unsigned_int(x)
     py.print_object(intobj)
     py.decref(intobj)
     res = context.get_dummy_value()

--- a/numba/tests/test_multi3.py
+++ b/numba/tests/test_multi3.py
@@ -9,7 +9,7 @@ from numba import unittest_support as unittest
 
 class TestMulti3(unittest.TestCase):
     """
-    This test is only valid for x86-32.
+    This test is only relevant for 32-bit architectures.
 
     Test __multi3 implementation in _helperlib.c.
     The symbol defines a i128 multiplication.
@@ -26,13 +26,14 @@ class TestMulti3(unittest.TestCase):
                 res += i
             return res
 
-        x_cases = [-1, 0, 1, 0xffffffff - 1, 0xffffffff, 0xffffffff + 1]
+        x_cases = [-1, 0, 1, 0xffffffff - 1, 0xffffffff, 0xffffffff + 1,
+                   0x123456789abcdef, -0x123456789abcdef]
         for _ in range(500):
             x_cases.append(random.randint(0, 0xffffffff))
 
         def expected(x):
             if x <= 0: return 0
-            return (x * (x - 1)) // 2
+            return ((x * (x - 1)) // 2) & (2**64 - 1)
 
         for x in x_cases:
             self.assertEqual(expected(x), func(x))

--- a/numba/tests/test_multi3.py
+++ b/numba/tests/test_multi3.py
@@ -26,7 +26,8 @@ class TestMulti3(unittest.TestCase):
                 res += i
             return res
 
-        x_cases = [-1, 0, 1, 0xffffffff - 1, 0xffffffff, 0xffffffff + 1,
+        x_cases = [-1, 0, 1, 3, 4, 8,
+                   0xffffffff - 1, 0xffffffff, 0xffffffff + 1,
                    0x123456789abcdef, -0x123456789abcdef]
         for _ in range(500):
             x_cases.append(random.randint(0, 0xffffffff))

--- a/numba/tests/test_numberctor.py
+++ b/numba/tests/test_numberctor.py
@@ -136,7 +136,12 @@ class TestNumberCtor(TestCase):
             np_converter = lambda x: np_type(np.int64(x))
         else:
             np_converter = np_type
+        dtype = np.dtype(np_type)
         for val in values:
+            if dtype.kind == 'u' and isinstance(val, float) and val < 0.0:
+                # Converting negative float to unsigned int yields undefined
+                # behaviour (and concretely different on ARM vs. x86)
+                continue
             expected = np_converter(val)
             got = cfunc(val)
             self.assertPreciseEqual(got, expected,

--- a/numba/tests/test_numpy_support.py
+++ b/numba/tests/test_numpy_support.py
@@ -127,12 +127,10 @@ class TestFromDtype(TestCase):
               size=8, aligned=True)
 
         dtype = np.dtype([('m', np.int32), ('n', 'S5')])
-        # A heuristic is used on Numpy 1.6
-        aligned = False if np.__version__ >= '1.7' else True
         check(dtype,
               fields={'m': (types.int32, 0),
                       'n': (types.CharSeq(5), 4)},
-              size=9, aligned=aligned)
+              size=9, aligned=False)
 
 
 class ValueTypingTestBase(object):

--- a/numba/tests/test_print.py
+++ b/numba/tests/test_print.py
@@ -32,22 +32,30 @@ class TestPrint(unittest.TestCase):
 
         cr = compile_isolated(pyfunc, (types.int32,))
         cfunc = cr.entry_point
-
-        with swap_stdout():
-            cfunc(1)
-            self.assertEqual(sys.stdout.getvalue().strip(), '1')
+        for val in (1, -234):
+            with swap_stdout():
+                cfunc(val)
+                self.assertEqual(sys.stdout.getvalue().strip(), str(val))
 
         cr = compile_isolated(pyfunc, (types.int64,))
         cfunc = cr.entry_point
-        with swap_stdout():
-            cfunc(1)
-            self.assertEqual(sys.stdout.getvalue().strip(), '1')
+        for val in (1, -234, 123456789876543210, -123456789876543210):
+            with swap_stdout():
+                cfunc(val)
+                self.assertEqual(sys.stdout.getvalue().strip(), str(val))
+
+        cr = compile_isolated(pyfunc, (types.uint64,))
+        cfunc = cr.entry_point
+        for val in (1, 234, 123456789876543210, 2**63 + 123):
+            with swap_stdout():
+                cfunc(val)
+                self.assertEqual(sys.stdout.getvalue().strip(), str(val))
 
         cr = compile_isolated(pyfunc, (types.float32,))
         cfunc = cr.entry_point
         with swap_stdout():
             cfunc(1.1)
-            # Float32 will loose precision
+            # Float32 will lose precision
             got = sys.stdout.getvalue().strip()
             expect = '1.10000002384'
             self.assertTrue(got.startswith(expect))

--- a/numba/tests/test_recarray_usecases.py
+++ b/numba/tests/test_recarray_usecases.py
@@ -71,9 +71,16 @@ def usecase5(x, N):
 
 
 class TestRecordUsecase(unittest.TestCase):
+
+    def setUp(self):
+        fields = [('f1', '<f8'), ('s1', '|S3'), ('f2', '<f8')]
+        self.unaligned_dtype = numpy.dtype(fields)
+        self.aligned_dtype = numpy.dtype(fields, align=True)
+
     def test_usecase1(self):
         pyfunc = usecase1
 
+        # This is an unaligned dtype
         mystruct_dt = numpy.dtype([('p', numpy.float64),
                            ('row', numpy.float64),
                            ('col', numpy.float64)])
@@ -105,42 +112,45 @@ class TestRecordUsecase(unittest.TestCase):
         self.assertTrue(numpy.all(expect1 == got1))
         self.assertTrue(numpy.all(expect2 == got2))
 
-    def _setup_usecase2to5(self):
-        dtype = numpy.dtype([('f1', '<f8'), ('s1', '|S3'), ('f2', '<f8')])
+    def _setup_usecase2to5(self, dtype):
         N = 5
         a = numpy.recarray(N, dtype=dtype)
         a.f1 = numpy.arange(N)
         a.f2 = numpy.arange(2, N + 2)
         a.s1 = numpy.array(['abc'] * a.shape[0], dtype='|S3')
-        return a, dtype, N
+        return a
 
-    def _test_usecase2to5(self, pyfunc):
-        array, dtype, N = self._setup_usecase2to5()
+    def _test_usecase2to5(self, pyfunc, dtype):
+        array = self._setup_usecase2to5(dtype)
         record_type = numpy_support.from_dtype(dtype)
         cres = compile_isolated(pyfunc, (record_type[:], types.intp))
         cfunc = cres.entry_point
 
         with swap_stdout():
-            pyfunc(array, N)
+            pyfunc(array, len(array))
             expect = sys.stdout.getvalue()
 
         with swap_stdout():
-            cfunc(array, N)
+            cfunc(array, len(array))
             got = sys.stdout.getvalue()
 
         self.assertEqual(expect, got)
 
     def test_usecase2(self):
-        self._test_usecase2to5(usecase2)
+        self._test_usecase2to5(usecase2, self.unaligned_dtype)
+        self._test_usecase2to5(usecase2, self.aligned_dtype)
 
     def test_usecase3(self):
-        self._test_usecase2to5(usecase3)
+        self._test_usecase2to5(usecase3, self.unaligned_dtype)
+        self._test_usecase2to5(usecase3, self.aligned_dtype)
 
     def test_usecase4(self):
-        self._test_usecase2to5(usecase4)
+        self._test_usecase2to5(usecase4, self.unaligned_dtype)
+        self._test_usecase2to5(usecase4, self.aligned_dtype)
 
     def test_usecase5(self):
-        self._test_usecase2to5(usecase5)
+        self._test_usecase2to5(usecase5, self.unaligned_dtype)
+        self._test_usecase2to5(usecase5, self.aligned_dtype)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -162,15 +162,13 @@ def get_charseq_tuple(ary, i):
     return ary[i].m, ary[i].n
 
 
-# Note: these record types are unaligned
-
 recordtype = np.dtype([('a', np.float64),
                        ('b', np.int16),
                        ('c', np.complex64),
                        ('d', (np.str, 5))])
 
 recordtype2 = np.dtype([('e', np.int32),
-                        ('f', np.float64)])
+                        ('f', np.float64)], align=True)
 
 recordtype3 = np.dtype([('first', np.float32),
                         ('second', np.float64)])

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -163,7 +163,7 @@ def get_charseq_tuple(ary, i):
 
 
 recordtype = np.dtype([('a', np.float64),
-                       ('b', np.int32),
+                       ('b', np.int16),
                        ('c', np.complex64),
                        ('d', (np.str, 5))])
 
@@ -235,7 +235,7 @@ class TestRecordDtype(unittest.TestCase):
     def test_from_dtype(self):
         rec = numpy_support.from_dtype(recordtype)
         self.assertEqual(rec.typeof('a'), types.float64)
-        self.assertEqual(rec.typeof('b'), types.int32)
+        self.assertEqual(rec.typeof('b'), types.int16)
         self.assertEqual(rec.typeof('c'), types.complex64)
         if IS_PY3:
             self.assertEqual(rec.typeof('d'), types.UnicodeCharSeq(5))
@@ -349,8 +349,8 @@ class TestRecordDtype(unittest.TestCase):
         npval = self.refsample1d.copy()[0]
         nbval = self.nbsample1d.copy()[0]
         attrs = 'abc'
-        valtypes = types.float64, types.int32, types.complex64
-        values = 1.23, 123432, 132j
+        valtypes = types.float64, types.int16, types.complex64
+        values = 1.23, 12345, 123+456j
         old_refcnt = sys.getrefcount(nbval)
 
         for attr, valtyp, val in zip(attrs, valtypes, values):
@@ -373,7 +373,7 @@ class TestRecordDtype(unittest.TestCase):
 
             got = cfunc(*args)
             self.assertEqual(expected, got)
-            self.assertNotEqual(nbval['a'], got)
+            self.assertNotEqual(nbval[attr], got)
             del got, expected, args
 
         # Check for potential leaks (issue #441)

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -162,6 +162,8 @@ def get_charseq_tuple(ary, i):
     return ary[i].m, ary[i].n
 
 
+# Note: these record types are unaligned
+
 recordtype = np.dtype([('a', np.float64),
                        ('b', np.int16),
                        ('c', np.complex64),

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -13,13 +13,20 @@ from numba.utils import IS_PY3
 def get_a(ary, i):
     return ary[i].a
 
-
 def get_b(ary, i):
     return ary[i].b
 
-
 def get_c(ary, i):
     return ary[i].c
+
+def get_a_subarray(ary, i):
+    return ary.a[i]
+
+def get_b_subarray(ary, i):
+    return ary.b[i]
+
+def get_c_subarray(ary, i):
+    return ary.c[i]
 
 
 def get_two_arrays_a(ary1, ary2, i):
@@ -39,14 +46,20 @@ def get_two_arrays_distinct(ary1, ary2, i):
 def set_a(ary, i, v):
     ary[i].a = v
 
-
 def set_b(ary, i, v):
     ary[i].b = v
-
 
 def set_c(ary, i, v):
     ary[i].c = v
 
+def set_a_subarray(ary, i, v):
+    ary.a[i] = v
+
+def set_b_subarray(ary, i, v):
+    ary.b[i] = v
+
+def set_c_subarray(ary, i, v):
+    ary.c[i] = v
 
 def set_record(ary, i, j):
     ary[i] = ary[j]
@@ -255,12 +268,15 @@ class TestRecordDtype(unittest.TestCase):
 
     def test_get_a(self):
         self._test_get_equal(get_a)
+        self._test_get_equal(get_a_subarray)
 
     def test_get_b(self):
         self._test_get_equal(get_b)
+        self._test_get_equal(get_b_subarray)
 
     def test_get_c(self):
         self._test_get_equal(get_c)
+        self._test_get_equal(get_c_subarray)
 
     def _test_get_two_equal(self, pyfunc):
         '''
@@ -309,19 +325,28 @@ class TestRecordDtype(unittest.TestCase):
             self.assertTrue(np.all(expect == got))
 
     def test_set_a(self):
-        self._test_set_equal(set_a, 3.1415, types.float64)
-        # Test again to check if coercion works
-        self._test_set_equal(set_a, 3., types.float32)
+        def check(pyfunc):
+            self._test_set_equal(pyfunc, 3.1415, types.float64)
+            # Test again to check if coercion works
+            self._test_set_equal(pyfunc, 3., types.float32)
+        check(set_a)
+        check(set_a_subarray)
 
     def test_set_b(self):
-        self._test_set_equal(set_b, 123, types.int32)
-        # Test again to check if coercion works
-        self._test_set_equal(set_b, 123, types.float64)
+        def check(pyfunc):
+            self._test_set_equal(pyfunc, 123, types.int32)
+            # Test again to check if coercion works
+            self._test_set_equal(pyfunc, 123, types.float64)
+        check(set_b)
+        check(set_b_subarray)
 
     def test_set_c(self):
-        self._test_set_equal(set_c, 43j, types.complex64)
-        # Test again to check if coercion works
-        self._test_set_equal(set_c, 43j, types.complex128)
+        def check(pyfunc):
+            self._test_set_equal(pyfunc, 43j, types.complex64)
+            # Test again to check if coercion works
+            self._test_set_equal(pyfunc, 43j, types.complex128)
+        check(set_c)
+        check(set_c_subarray)
 
     def test_set_record(self):
         pyfunc = set_record

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -121,10 +121,13 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         dtype = np.dtype([('m', np.int32), ('n', 'S5')], align=True)
         rec_ty = numpy_support.from_struct_dtype(dtype)
 
+        # On Numpy 1.6, align=True doesn't align the itemsize
+        actual_aligned = numpy_support.version >= (1, 7)
+
         arr = np.empty(4, dtype=dtype)
-        check(arr, rec_ty, 1, "C", True)
+        check(arr, rec_ty, 1, "C", actual_aligned)
         arr = np.recarray(4, dtype=dtype)
-        check(arr, rec_ty, 1, "C", True)
+        check(arr, rec_ty, 1, "C", actual_aligned)
 
     @unittest.skipIf(sys.version_info < (2, 7),
                      "buffer protocol not supported on Python 2.6")

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1371,6 +1371,7 @@ class _TestLoopTypes(TestCase):
     _ufuncs = all_ufuncs[:]
     # Have their own test classes
     _ufuncs.remove(np.left_shift)
+    _ufuncs.remove(np.right_shift)
     _ufuncs.remove(np.reciprocal)
     _ufuncs.remove(np.power)
     _compile_flags = enable_pyobj_flags

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -631,8 +631,7 @@ class ArrayAttribute(AttributeTemplate):
         # Resolution of other attributes, for record arrays
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:
-                return types.Array(ary.dtype.typeof(attr), ndim=ary.ndim,
-                                   layout='A')
+                return ary.copy(dtype=ary.dtype.typeof(attr), layout='A')
 
 
 @builtin_attr


### PR DESCRIPTION
This PR fixes all the crashes and several failures when run on a Raspberry Pi 2 (armv7l).
The remaining failures are either:
* due to a Numpy bug: https://github.com/numpy/numpy/issues/6274
* due to what appears to be a LLVM optimization bug on `test_record_dtype:TestRecordDtype.test_record_args`: https://llvm.org/bugs/show_bug.cgi?id=24669

Note this needs the newest llvmlite from master, for the *align* argument to IRBuilder.load() and .store().