### PR TITLE
CUDA memory fence

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -26,10 +26,30 @@ from within a CUDA Kernel.
 Thread Indexing
 ~~~~~~~~~~~~~~~
 
-.. autofunction:: numba.cuda.threadIdx
-.. autofunction:: numba.cuda.blockIdx
-.. autofunction:: numba.cuda.blockDim
-.. autofunction:: numba.cuda.gridDim
+.. attribute:: numba.cuda.threadIdx
+
+    The thread indices in the current thread block, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.blockDim` exclusive.
+
+.. attribute:: numba.cuda.blockIdx
+
+    The block indices in the grid of thread blocks, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.gridDim` exclusive.
+
+.. attribute:: numba.cuda.blockDim
+
+    The shape of a block of threads, as declared when instantiating the
+    kernel.  This value is the same for all threads in a given kernel, even
+    if they belong to different blocks (i.e. each block is "full").
+
+.. attribute:: numba.cuda.gridDim
+
+    The shape of the grid of blocks, accressed through the attributes ``x``,
+    ``y``, and ``z``.
 
 .. function:: numba.cuda.grid(ndim)
 
@@ -62,16 +82,89 @@ Thread Indexing
 Memory Management
 ~~~~~~~~~~~~~~~~~
 
-.. autoclass:: numba.cuda.shared
-   :members: array
-.. autoclass:: numba.cuda.local
-   :members: array
-.. autoclass:: numba.cuda.const
-   :members: array_like
+.. function:: numba.cuda.shared.array(shape, dtype)
+
+   Creates an array in the local memory space of the CUDA kernel with
+   the given ``shape`` and ``dtype``.
+
+   Returns an array with its content uninitialized.
+
+   .. note:: All threads in the same thread block sees the same array.
+
+.. function:: numba.cuda.local.array(shape, dtype)
+
+   Creates an array in the local memory space of the CUDA kernel with the
+   given ``shape`` and ``dtype``.
+
+   Returns an array with its content uninitialized.
+
+   .. note:: Each thread sees a unique array.
+
+.. function:: numba.cuda.const.array_like(ary)
+
+   Copies the ``ary`` into constant memory space on the CUDA kernel at compile
+   time.
+
+   Returns an array like the ``ary`` argument.
+
+   .. note:: All threads and blocks see the same array.
 
 Synchronization and Atomic Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: numba.cuda.atomic
-   :members: add, max
-.. autofunction:: numba.cuda.syncthreads
+.. function:: numba.cuda.atomic.add(array, idx, value)
+
+    Perform ``array[idx] += value``. Support int32, int64, float32 and
+    float64 only. The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multiple dimensional arrays. The number of element
+    in ``idx`` must match the number of dimension of ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.max(array, idx, value)
+
+    Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,
+    float32 and float64 only. The ``idx`` argument can be an integer or a
+    tuple of integer indices for indexing into multiple dimensional arrays.
+    The number of element in ``idx`` must match the number of dimension of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
+
+.. function:: numba.cuda.syncthreads
+
+    Synchronize all threads in the same thread block.  This function implements
+    the same pattern as barriers in traditional multi-threaded programming: this
+    function waits until all threads in the block call it, at which point it
+    returns control to all its callers.
+
+    .. warning:: Must be called by every thread in the thread-block. Falling to
+                 do so may result in undefined behavior.
+
+Memory Fences
+~~~~~~~~~~~~~~
+
+The memory fences are used to guarantee the effect of memory operations
+are visible by other threads within the same thread-block, the same GPU device,
+and the same system (across GPUs on global memory). Memory loads and stores
+are guaranteed to not move across the memory fences by optimization passes.
+
+.. warning:: The memory fences are considered to be advanced API and most
+             usercases should use the thread barrier (e.g. ``syncthreads()``).
+
+
+
+.. function:: numba.cuda.threadfence
+
+   A memory fence at thread block level
+
+.. function:: numba.cuda.threadfence_block
+
+   A memory fence at thread block level.
+
+.. function:: numba.cuda.threadfence_system
+
+   A memory fence at thread system level.

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -159,7 +159,7 @@ are guaranteed to not move across the memory fences by optimization passes.
 
 .. function:: numba.cuda.threadfence
 
-   A memory fence at thread block level
+   A memory fence at device level (within the GPU).
 
 .. function:: numba.cuda.threadfence_block
 
@@ -167,4 +167,4 @@ are guaranteed to not move across the memory fences by optimization passes.
 
 .. function:: numba.cuda.threadfence_system
 
-   A memory fence at thread system level.
+   A memory fence at system level (across GPUs)

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -90,6 +90,22 @@ class Cuda_syncthreads(ConcreteTemplate):
 
 
 @intrinsic
+class Cuda_threadfence_device(ConcreteTemplate):
+    key = cuda.threadfence
+    cases = [signature(types.none)]
+
+@intrinsic
+class Cuda_threadfence_block(ConcreteTemplate):
+    key = cuda.threadfence_block
+    cases = [signature(types.none)]
+
+@intrinsic
+class Cuda_threadfence_system(ConcreteTemplate):
+    key = cuda.threadfence_system
+    cases = [signature(types.none)]
+
+
+@intrinsic
 class Cuda_atomic_add(AbstractTemplate):
     key = cuda.atomic.add
 
@@ -240,6 +256,15 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_syncthreads(self, mod):
         return types.Function(Cuda_syncthreads)
+
+    def resolve_threadfence(self, mod):
+        return types.Function(Cuda_threadfence_device)
+
+    def resolve_threadfence_block(self, mod):
+        return types.Function(Cuda_threadfence_block)
+
+    def resolve_threadfence_system(self, mod):
+        return types.Function(Cuda_threadfence_system)
 
     def resolve_atomic(self, mod):
         return types.Module(cuda.atomic)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -222,6 +222,42 @@ def ptx_syncthreads(context, builder, sig, args):
 
 
 @register
+@implement(stubs.threadfence_block)
+def ptx_threadfence_block(context, builder, sig, args):
+    assert not args
+    fname = 'llvm.nvvm.membar.cta'
+    lmod = builder.module
+    fnty = Type.function(Type.void(), ())
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    builder.call(sync, ())
+    return context.get_dummy_value()
+
+
+@register
+@implement(stubs.threadfence_system)
+def ptx_threadfence_system(context, builder, sig, args):
+    assert not args
+    fname = 'llvm.nvvm.membar.sys'
+    lmod = builder.module
+    fnty = Type.function(Type.void(), ())
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    builder.call(sync, ())
+    return context.get_dummy_value()
+
+
+@register
+@implement(stubs.threadfence)
+def ptx_threadfence_device(context, builder, sig, args):
+    assert not args
+    fname = 'llvm.nvvm.membar.gl'
+    lmod = builder.module
+    fnty = Type.function(Type.void(), ())
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    builder.call(sync, ())
+    return context.get_dummy_value()
+
+
+@register
 @implement(stubs.atomic.add, types.Kind(types.Array), types.intp, types.Any)
 def ptx_atomic_add_intp(context, builder, sig, args):
     aryty, indty, valty = sig.args

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -2,7 +2,9 @@ from __future__ import print_function, absolute_import, division
 
 # Re export
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
-                    shared, local, const, grid, gridsize, atomic)
+                    shared, local, const, grid, gridsize, atomic,
+                    threadfence_block, threadfence_system,
+                    threadfence)
 from .cudadrv.error import CudaSupportError
 from .cudadrv import nvvm
 from . import initialize

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -154,6 +154,18 @@ class FakeCUDAModule(object):
     def syncthreads(self):
         threading.current_thread().syncthreads()
 
+    def threadfence(self):
+        # No-op
+        pass
+
+    def threadfence_block(self):
+        # No-op
+        pass
+
+    def threadfence_system(self):
+        # No-op
+        pass
+
     def grid(self, n):
         bdim = self.blockDim
         bid = self.blockIdx

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -126,7 +126,7 @@ def gridsize_expand(ndim):
     """
     Return the absolute size (or shape) in threads of the entire grid of
     blocks. *ndim* should correspond to the number of dimensions declared when
-    instantiating the kernel. 
+    instantiating the kernel.
 
     Computation of the first integer is as follows::
 
@@ -165,7 +165,32 @@ class syncthreads(Stub):
     '''
     _description_ = '<syncthread()>'
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
+# memory fences
+
+class threadfence_block(Stub):
+    '''
+    A memory fence at thread block level
+    '''
+    _description_ = '<threadfence_block()>'
+
+
+class threadfence_system(Stub):
+    '''
+    A memory fence at system level: across devices
+    '''
+    _description_ = '<threadfence_system()>'
+
+
+class threadfence(Stub):
+    '''
+    A memory fence at device level
+    '''
+    _description_ = '<threadfence()>'
+
+
+# -------------------------------------------------------------------------------
 # shared
 
 def _legalize_shape(shape):

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda, int32, float32
 from numba.cuda.testing import unittest
+from numba.config import ENABLE_CUDASIM
 
 
 def useless_sync(ary):
@@ -94,21 +95,24 @@ class TestCudaSync(unittest.TestCase):
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
-        self.assertIn("membar.gl;", compiled.ptx)
+        if not ENABLE_CUDASIM:
+            self.assertIn("membar.gl;", compiled.ptx)
 
     def test_threadfence_block_codegen(self):
         compiled = cuda.jit("void(int32[:])")(use_threadfence_block)
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
-        self.assertIn("membar.cta;", compiled.ptx)
+        if not ENABLE_CUDASIM:
+            self.assertIn("membar.cta;", compiled.ptx)
 
     def test_threadfence_system_codegen(self):
         compiled = cuda.jit("void(int32[:])")(use_threadfence_system)
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
-        self.assertIn("membar.sys;", compiled.ptx)
+        if not ENABLE_CUDASIM:
+            self.assertIn("membar.sys;", compiled.ptx)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -91,6 +91,7 @@ class TestCudaSync(unittest.TestCase):
         self.assertTrue(np.all(ary == 2 * np.arange(ary.size, dtype=np.int32)))
 
     def test_threadfence_codegen(self):
+        # Does not test runtime behavior, just the code generation.
         compiled = cuda.jit("void(int32[:])")(use_threadfence)
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)
@@ -99,6 +100,7 @@ class TestCudaSync(unittest.TestCase):
             self.assertIn("membar.gl;", compiled.ptx)
 
     def test_threadfence_block_codegen(self):
+        # Does not test runtime behavior, just the code generation.
         compiled = cuda.jit("void(int32[:])")(use_threadfence_block)
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)
@@ -107,6 +109,7 @@ class TestCudaSync(unittest.TestCase):
             self.assertIn("membar.cta;", compiled.ptx)
 
     def test_threadfence_system_codegen(self):
+        # Does not test runtime behavior, just the code generation.
         compiled = cuda.jit("void(int32[:])")(use_threadfence_system)
         ary = np.zeros(10, dtype=np.int32)
         compiled[1, 1](ary)


### PR DESCRIPTION
Implement CUDA memory fence
Note: usage of memory fence is preferred over volatile memory (not implemented) when thread synchronization is not needed

