### PR TITLE
Implement implicit output layout for 'A' layout

### DIFF
--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -73,14 +73,11 @@ class Numpy_rules_ufunc(AbstractTemplate):
             layouts = [x.layout if isinstance(x, types.Array) else ''
                        for x in args]
 
-            # Prefer C contig if any array is C contig
-            if 'C' not in layouts:
-                # Next, prefer F contig
-                if 'F' in layouts:
-                    layout = 'F'
-                # If none of the arrays are C or F, default to C
-                elif 'A' in layouts:
-                    layout = 'C'
+            # Prefer C contig if any array is C contig.
+            # Next, prefer F contig.
+            # Defaults to C contig if not layouts are C/F.
+            if 'C' not in layouts and 'F' in layouts:
+                layout = 'F'
 
         return base_types, explicit_outputs, ndims, layout
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -72,14 +72,15 @@ class Numpy_rules_ufunc(AbstractTemplate):
             layout = 'C'
             layouts = [x.layout if isinstance(x, types.Array) else ''
                        for x in args]
+
+            # Prefer C contig if any array is C contig
             if 'C' not in layouts:
+                # Next, prefer F contig
                 if 'F' in layouts:
                     layout = 'F'
+                # If none of the arrays are C or F, default to C
                 elif 'A' in layouts:
-                    # See also _empty_nd_impl() in numba.targets.arrayobj.
-                    raise NotImplementedError(
-                        "Don't know how to create implicit output array "
-                        "with 'A' layout.")
+                    layout = 'C'
 
         return base_types, explicit_outputs, ndims, layout
 


### PR DESCRIPTION
This fixes issue #1418.

This completes the ufunc layout handling for A layout.
The numpy logic appears to prefer 'C' if any input is it, then, 'F' layout if any input is it.  Otherwise, default to 'C' layout if all inputs are of 'A' layout.

