### PR TITLE
numba 0.21 is not compatible with llvmlite 0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.6
-llvmlite>=0.6
+llvmlite>=0.7
 argparse


### PR DESCRIPTION
solves this the simple way: https://github.com/numba/numba/issues/1422