### PR TITLE
Support inplace array operators (supersedes #1242)

### DIFF
--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -149,6 +149,10 @@ class ListInstance(_ListPayloadMixin):
         self._itemsize = get_itemsize(context, list_type)
 
     @property
+    def dtype(self):
+        return self._ty.dtype
+
+    @property
     def _payload(self):
         # This cannot be cached as it can be reallocated
         return get_list_payload(self._context, self._builder, self._ty, self._list)
@@ -532,9 +536,11 @@ def list_add(context, builder, sig, args):
 
     with cgutils.for_range(builder, a_size) as loop:
         value = a.getitem(loop.index)
+        value = context.cast(builder, value, a.dtype, dest.dtype)
         dest.setitem(loop.index, value)
     with cgutils.for_range(builder, b_size) as loop:
         value = b.getitem(loop.index)
+        value = context.cast(builder, value, b.dtype, dest.dtype)
         dest.setitem(builder.add(loop.index, a_size), value)
 
     return impl_ret_new_ref(context, builder, sig.return_type, dest.value)
@@ -542,7 +548,7 @@ def list_add(context, builder, sig, args):
 @builtin
 @implement("+=", types.Kind(types.List), types.Kind(types.List))
 def list_add_inplace(context, builder, sig, args):
-    assert sig.args[0].dtype == sig.args[1].dtype
+    assert sig.args[0].dtype == sig.return_type.dtype
     dest = _list_extend_list(context, builder, sig, args)
 
     return impl_ret_borrowed(context, builder, sig.return_type, dest.value)
@@ -743,6 +749,7 @@ def _list_extend_list(context, builder, sig, args):
 
     with cgutils.for_range(builder, src_size) as loop:
         value = src.getitem(loop.index)
+        value = context.cast(builder, value, src.dtype, dest.dtype)
         dest.setitem(builder.add(loop.index, dest_size), value)
 
     return dest

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -757,8 +757,8 @@ def _list_extend_list(context, builder, sig, args):
 @builtin
 @implement("list.extend", types.Kind(types.List), types.Kind(types.IterableType))
 def list_extend(context, builder, sig, args):
-    if isinstance(sig.args[1], types.List) and sig.args[0].dtype == sig.args[1].dtype:
-        # Specialize for same-type list operands, for speed
+    if isinstance(sig.args[1], types.List):
+        # Specialize for list operands, for speed.
         _list_extend_list(context, builder, sig, args)
         return context.get_dummy_value()
 

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -226,10 +226,27 @@ def list_add(m, n):
     res.append(42)   # check result is a copy
     return a, b, res
 
+def list_add_heterogenous():
+    a = [1]
+    b = [2.0]
+    c = a + b
+    d = b + a
+    # check result is a copy
+    a.append(3)
+    b.append(4.0)
+    return a, b, c, d
+
 def list_add_inplace(m, n):
     a = list(range(0, m))
     b = list(range(100, 100 + n))
     a += b
+    return a, b
+
+def list_add_inplace_heterogenous():
+    a = [1]
+    b = [2.0]
+    a += b
+    b += a
     return a, b
 
 def list_mul(n, v):
@@ -529,8 +546,20 @@ class TestLists(MemoryLeakMixin, TestCase):
     def test_add(self):
         self.check_add(list_add)
 
+    def test_add_heterogenous(self):
+        pyfunc = list_add_heterogenous
+        cfunc = jit(nopython=True)(pyfunc)
+        expected = pyfunc()
+        self.assertEqual(cfunc(), expected)
+
     def test_add_inplace(self):
         self.check_add(list_add_inplace)
+
+    def test_add_inplace_heterogenous(self):
+        pyfunc = list_add_inplace_heterogenous
+        cfunc = jit(nopython=True)(pyfunc)
+        expected = pyfunc()
+        self.assertEqual(cfunc(), expected)
 
     def check_mul(self, pyfunc):
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -86,16 +86,25 @@ def _make_binary_ufunc_op_usecase(ufunc_op):
     return fn
 
 
+def _make_inplace_ufunc_op_usecase(ufunc_op):
+    ldict = {}
+    exec("def fn(x,y):\n    x{0}y".format(ufunc_op), globals(), ldict)
+    fn = ldict["fn"]
+    fn.__name__ = "usecase_{0}".format(hash(ufunc_op))
+    return fn
+
+
 def _as_dtype_value(tyargs, args):
     """Convert python values into numpy scalar objects.
     """
     return [np.dtype(str(ty)).type(val) for ty, val in zip(tyargs, args)]
 
 
-class TestUFuncs(MemoryLeakMixin, TestCase):
+
+class BaseUFuncTest(MemoryLeakMixin):
 
     def setUp(self):
-        super(TestUFuncs, self).setUp()
+        super(BaseUFuncTest, self).setUp()
         self.inputs = [
             (np.uint32(0), types.uint32),
             (np.uint32(1), types.uint32),
@@ -147,6 +156,9 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
             else:
                 output_type = types.Array(ty, 1, 'C')
         return output_type
+
+
+class TestUFuncs(BaseUFuncTest, TestCase):
 
     def unary_ufunc_test(self, ufunc, flags=enable_pyobj_flags,
                          skip_inputs=[], additional_inputs=[],
@@ -225,27 +237,6 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
                                                expected.dtype, expected)
                         self.fail(msg)
 
-    def unary_op_test(self, operator, flags=enable_nrt_flags,
-                      skip_inputs=[], additional_inputs=[],
-                      int_output_type=None, float_output_type=None):
-        operator_func = _make_unary_ufunc_op_usecase(operator)
-        inputs = list(self.inputs)
-        inputs.extend(additional_inputs)
-        pyfunc = operator_func
-        for input_tuple in inputs:
-            input_operand, input_type = input_tuple
-
-            if ((input_type in skip_inputs) or
-                (not isinstance(input_type, types.Array))):
-                continue
-
-            cr = self.cache.compile(pyfunc, (input_type,),
-                                    flags=flags)
-            cfunc = cr.entry_point
-            expected = pyfunc(input_operand)
-            result = cfunc(input_operand)
-            np.testing.assert_array_almost_equal(expected, result)
-
     def binary_ufunc_test(self, ufunc, flags=enable_pyobj_flags,
                          skip_inputs=[], additional_inputs=[],
                          int_output_type=None, float_output_type=None):
@@ -280,55 +271,6 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
             cfunc(input_operand, input_operand, result)
             pyfunc(input_operand, input_operand, expected)
             np.testing.assert_array_almost_equal(expected, result)
-
-    def binary_op_test(self, operator, flags=enable_nrt_flags,
-                       skip_inputs=[], additional_inputs=[],
-                       int_output_type=None, float_output_type=None,
-                       positive_rhs=False):
-        operator_func = _make_binary_ufunc_op_usecase(operator)
-        inputs = list(self.inputs)
-        inputs.extend(additional_inputs)
-        pyfunc = operator_func
-        for input_tuple in inputs:
-            input_operand1, input_type = input_tuple
-            input_dtype = numpy_support.as_dtype(
-                getattr(input_type, "dtype", input_type))
-            input_type1 = input_type
-
-            if input_type in skip_inputs:
-                continue
-
-            if positive_rhs:
-                zero = np.zeros(1, dtype=input_dtype)[0]
-            # If we only use two scalars, the code generator will not
-            # select the ufunctionalized operator, so we mix it up.
-            if isinstance(input_type, types.Array):
-                input_operand0 = input_operand1
-                input_type0 = input_type
-                if positive_rhs and np.any(input_operand1 < zero):
-                    continue
-            else:
-                input_operand0 = (np.random.random(10) * 100).astype(
-                    input_dtype)
-                input_type0 = typeof(input_operand0)
-                if positive_rhs and input_operand1 < zero:
-                    continue
-
-            cr = self.cache.compile(pyfunc, (input_type0, input_type1),
-                                    flags=flags)
-            cfunc = cr.entry_point
-            expected = pyfunc(input_operand0, input_operand1)
-            result = cfunc(input_operand0, input_operand1)
-            np.testing.assert_array_almost_equal(expected, result)
-
-    def binary_int_op_test(self, *args, **kws):
-        if 'skip_inputs' not in kws:
-            kws['skip_inputs'] = []
-        kws['skip_inputs'].extend([
-            types.float32, types.float64,
-            types.Array(types.float32, 1, 'C'),
-            types.Array(types.float64, 1, 'C')])
-        return self.binary_op_test(*args, **kws)
 
     def unary_int_ufunc_test(self, name=None, flags=enable_pyobj_flags):
         self.unary_ufunc_test(name, flags=flags,
@@ -1170,8 +1112,126 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
                              result.flags.f_contiguous)
             np.testing.assert_array_equal(expected, result)
 
+
+
+class TestArrayOperators(BaseUFuncTest, TestCase):
+
+    def unary_op_test(self, operator, flags=enable_nrt_flags,
+                      skip_inputs=[], additional_inputs=[],
+                      int_output_type=None, float_output_type=None):
+        operator_func = _make_unary_ufunc_op_usecase(operator)
+        inputs = list(self.inputs)
+        inputs.extend(additional_inputs)
+        pyfunc = operator_func
+        for input_tuple in inputs:
+            input_operand, input_type = input_tuple
+
+            if ((input_type in skip_inputs) or
+                (not isinstance(input_type, types.Array))):
+                continue
+
+            cr = self.cache.compile(pyfunc, (input_type,),
+                                    flags=flags)
+            cfunc = cr.entry_point
+            expected = pyfunc(input_operand)
+            result = cfunc(input_operand)
+            np.testing.assert_array_almost_equal(expected, result)
+
+    def binary_op_test(self, operator, flags=enable_nrt_flags,
+                       skip_inputs=[], additional_inputs=[],
+                       int_output_type=None, float_output_type=None,
+                       positive_rhs=False):
+        operator_func = _make_binary_ufunc_op_usecase(operator)
+        inputs = list(self.inputs)
+        inputs.extend(additional_inputs)
+        pyfunc = operator_func
+        for input_tuple in inputs:
+            input_operand1, input_type = input_tuple
+            input_dtype = numpy_support.as_dtype(
+                getattr(input_type, "dtype", input_type))
+            input_type1 = input_type
+
+            if input_type in skip_inputs:
+                continue
+
+            if positive_rhs:
+                zero = np.zeros(1, dtype=input_dtype)[0]
+            # If we only use two scalars, the code generator will not
+            # select the ufunctionalized operator, so we mix it up.
+            if isinstance(input_type, types.Array):
+                input_operand0 = input_operand1
+                input_type0 = input_type
+                if positive_rhs and np.any(input_operand1 < zero):
+                    continue
+            else:
+                input_operand0 = (np.random.random(10) * 100).astype(
+                    input_dtype)
+                input_type0 = typeof(input_operand0)
+                if positive_rhs and input_operand1 < zero:
+                    continue
+
+            cr = self.cache.compile(pyfunc, (input_type0, input_type1),
+                                    flags=flags)
+            cfunc = cr.entry_point
+            expected = pyfunc(input_operand0, input_operand1)
+            result = cfunc(input_operand0, input_operand1)
+            np.testing.assert_array_almost_equal(expected, result)
+
+    def binary_int_op_test(self, *args, **kws):
+        if 'skip_inputs' not in kws:
+            kws['skip_inputs'] = []
+        kws['skip_inputs'].extend([
+            types.float32, types.float64,
+            types.Array(types.float32, 1, 'C'),
+            types.Array(types.float64, 1, 'C')])
+        return self.binary_op_test(*args, **kws)
+
+    def _make_arrays(self, dtypes):
+        for dtype in dtypes:
+            yield np.linspace(0, 5, 3).astype(dtype)
+            yield np.linspace(1, 6, 3).astype(dtype)
+
+    def inplace_op_test(self, operator, lhs_values, rhs_values,
+                        lhs_dtypes, rhs_dtypes):
+        operator_func = _make_inplace_ufunc_op_usecase(operator)
+        pyfunc = operator_func
+
+        # The left operand can only be an array, while the right operand
+        # can be either an array or a scalar
+        lhs_inputs = [np.array(lhs_values, dtype=dtype)
+                      for dtype in lhs_dtypes]
+
+        rhs_arrays = [np.array(rhs_values, dtype=dtype)
+                      for dtype in rhs_dtypes]
+        rhs_scalars = [dtype(v) for v in rhs_values for dtype in rhs_dtypes]
+        rhs_inputs = rhs_arrays + rhs_scalars
+
+        for lhs, rhs in itertools.product(lhs_inputs, rhs_inputs):
+            lhs_type = typeof(lhs)
+            rhs_type = typeof(rhs)
+            cr = self.cache.compile(pyfunc, (lhs_type, rhs_type),
+                                    flags=no_pyobj_flags)
+            cfunc = cr.entry_point
+            expected = lhs.copy()
+            pyfunc(expected, rhs)
+            got = lhs.copy()
+            cfunc(got, rhs)
+            self.assertPreciseEqual(got, expected)
+
+    def inplace_float_op_test(self, operator, lhs_values, rhs_values):
+        # Also accept integer inputs for the right operand (they should
+        # be converted to float).
+        return self.inplace_op_test(operator, lhs_values, rhs_values,
+                                    (np.float32, np.float64),
+                                    (np.float32, np.float64, np.int64))
+
+    def inplace_int_op_test(self, operator, lhs_values, rhs_values):
+        return self.inplace_op_test(operator, lhs_values, rhs_values,
+                                    (np.int16, np.int32, np.int64),
+                                    (np.int16, np.uint32))
+
     # ____________________________________________________________
-    # Array operators
+    # Unary operators
 
     def test_unary_positive_array_op(self):
         self.unary_op_test('+')
@@ -1184,6 +1244,70 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
             types.float32, types.float64,
             types.Array(types.float32, 1, 'C'),
             types.Array(types.float64, 1, 'C')])
+
+    # ____________________________________________________________
+    # Inplace operators
+
+    def test_inplace_add(self):
+        self.inplace_float_op_test('+=', [-1, 1.5, 3], [-5, 0, 2.5])
+
+    def test_inplace_sub(self):
+        self.inplace_float_op_test('-=', [-1, 1.5, 3], [-5, 0, 2.5])
+
+    def test_inplace_mul(self):
+        self.inplace_float_op_test('*=', [-1, 1.5, 3], [-5, 0, 2.5])
+
+    def test_inplace_floordiv(self):
+        self.inplace_float_op_test('//=', [-1, 1.5, 3], [-5, 0, 2.5])
+
+    def test_inplace_div(self):
+        self.inplace_float_op_test('/=', [-1, 1.5, 3], [-5, 0, 2.5])
+
+    def test_inplace_remainder(self):
+        self.inplace_float_op_test('%=', [-1, 1.5, 3], [-5, 2, 2.5])
+
+    def test_inplace_pow(self):
+        self.inplace_float_op_test('**=', [-1, 1.5, 3], [-5, 2, 2.5])
+
+    def test_inplace_and(self):
+        self.inplace_int_op_test('&=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+
+    def test_inplace_or(self):
+        self.inplace_int_op_test('|=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+
+    def test_inplace_xor(self):
+        self.inplace_int_op_test('^=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+
+    def test_inplace_lshift(self):
+        self.inplace_int_op_test('<<=', [0, 5, -10, -51], [0, 1, 4, 14])
+
+    def test_inplace_rshift(self):
+        self.inplace_int_op_test('>>=', [0, 5, -10, -51], [0, 1, 4, 14])
+
+    def test_unary_positive_array_op(self):
+        '''
+        Verify that the unary positive operator copies values, and doesn't
+        just alias to the input array (mirrors normal Numpy/Python
+        interaction behavior).
+        '''
+        # Test originally from @gmarkall
+        def f(a1):
+            a2 = +a1
+            a1[0] = 3
+            a2[1] = 4
+            return a2
+
+        a1 = np.zeros(10)
+        a2 = f(a1)
+        self.assertTrue(a1[0] != a2[0] and a1[1] != a2[1])
+        a3 = np.zeros(10)
+        a4 = njit(f)(a3)
+        self.assertTrue(a3[0] != a4[0] and a3[1] != a4[1])
+        np.testing.assert_array_equal(a1, a3)
+        np.testing.assert_array_equal(a2, a4)
+
+    # ____________________________________________________________
+    # Binary operators
 
     def test_add_array_op(self):
         self.binary_op_test('+')
@@ -1241,28 +1365,6 @@ class TestUFuncs(MemoryLeakMixin, TestCase):
 
     def test_not_equal_array_op(self):
         self.binary_op_test('!=')
-
-    def test_unary_positive_array_op(self):
-        '''
-        Verify that the unary positive operator copies values, and doesn't
-        just alias to the input array (mirrors normal Numpy/Python
-        interaction behavior).
-        '''
-        # Test originally from @gmarkall
-        def f(a1):
-            a2 = +a1
-            a1[0] = 3
-            a2[1] = 4
-            return a2
-
-        a1 = np.zeros(10)
-        a2 = f(a1)
-        self.assertTrue(a1[0] != a2[0] and a1[1] != a2[1])
-        a3 = np.zeros(10)
-        a4 = njit(f)(a3)
-        self.assertTrue(a3[0] != a4[0] and a3[1] != a4[1])
-        np.testing.assert_array_equal(a1, a3)
-        np.testing.assert_array_equal(a2, a4)
 
 
 class TestScalarUFuncs(TestCase):

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -781,10 +781,7 @@ class TypeInferer(object):
         elif expr.op == 'binop':
             self.typeof_intrinsic_call(inst, target, expr.fn, expr.lhs, expr.rhs)
         elif expr.op == 'inplace_binop':
-            # We assume type constraints for inplace operators to be the
-            # same as for normal operators.  This may have to be refined in
-            # the future.
-            self.typeof_intrinsic_call(inst, target, expr.immutable_fn,
+            self.typeof_intrinsic_call(inst, target, expr.fn,
                                        expr.lhs, expr.rhs)
         elif expr.op == 'unary':
             self.typeof_intrinsic_call(inst, target, expr.fn, expr.value)

--- a/numba/typing/listdecl.py
+++ b/numba/typing/listdecl.py
@@ -175,7 +175,7 @@ class InplaceAddList(AbstractTemplate):
             a, b = args
             if isinstance(a, types.List) and isinstance(b, types.List):
                 if self.context.can_convert(b.dtype, a.dtype):
-                    return signature(a, b, a)
+                    return signature(a, a, b)
 
 
 @builtin

--- a/numba/typing/listdecl.py
+++ b/numba/typing/listdecl.py
@@ -165,14 +165,32 @@ class AddList(AbstractTemplate):
                 unified = self.context.unify_pairs(a, b)
                 return signature(unified, a, b)
 
+
 @builtin
-class AddList(AbstractTemplate):
+class InplaceAddList(AbstractTemplate):
+    key = "+="
+
+    def generic(self, args, kws):
+        if len(args) == 2:
+            a, b = args
+            if isinstance(a, types.List) and isinstance(b, types.List):
+                if self.context.can_convert(b.dtype, a.dtype):
+                    return signature(a, b, a)
+
+
+@builtin
+class MulList(AbstractTemplate):
     key = "*"
 
     def generic(self, args, kws):
         a, b = args
         if isinstance(a, types.List) and isinstance(b, types.Integer):
             return signature(a, a, types.intp)
+
+
+@builtin
+class InplaceMulList(MulList):
+    key = "*="
 
 
 class ListCompare(AbstractTemplate):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import numpy
-from .. import types
+from .. import types, utils
 from .templates import (AttributeTemplate, AbstractTemplate, CallableTemplate,
                         Registry, signature)
 
@@ -203,6 +203,29 @@ class NumpyRulesArrayOperator(Numpy_rules_ufunc):
         return sig
 
 
+_binop_map = NumpyRulesArrayOperator._op_map
+
+class NumpyRulesInplaceArrayOperator(NumpyRulesArrayOperator):
+    _op_map = dict((inp, _binop_map[binop])
+                   for (inp, binop) in utils.inplace_map.items()
+                   if binop in _binop_map)
+
+    def generic(self, args, kws):
+        # Type the inplace operator as if an explicit output was passed,
+        # to handle type resolution correctly.
+        # (for example int8[:] += int16[:] should use an int8[:] output,
+        #  not int16[:])
+        lhs, rhs = args
+        if not isinstance(lhs, types.Array):
+            return
+        args = args + (lhs,)
+        sig = super(NumpyRulesInplaceArrayOperator, self).generic(args, kws)
+        # Strip off the fake explicit output
+        assert len(sig.args) == 3
+        real_sig = signature(sig.return_type, *sig.args[:2])
+        return real_sig
+
+
 class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
     _op_map = {
         # Positive is a special case since there is no Numpy ufunc
@@ -216,7 +239,6 @@ class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
         assert not kws
         if len(args) == 1 and isinstance(args[0], types.Array):
             return super(NumpyRulesUnaryArrayOperator, self).generic(args, kws)
-
 
 
 # list of unary ufuncs to register
@@ -298,6 +320,7 @@ supported_ufuncs = [getattr(numpy, name) for name in supported_ufuncs]
 
 NumpyRulesUnaryArrayOperator.install_operations()
 NumpyRulesArrayOperator.install_operations()
+NumpyRulesInplaceArrayOperator.install_operations()
 
 supported_array_operators = set(
     NumpyRulesUnaryArrayOperator._op_map.keys()).union(

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -96,6 +96,11 @@ operator_map = [
 if not IS_PY3:
     operator_map.append(('div', 'idiv', '/?'))
 
+# Map of known in-place operators to their corresponding copying operators
+inplace_map = dict((op + '=', op)
+                   for (_bin, _inp, op) in operator_map
+                   if _inp)
+
 
 _shutting_down = False
 


### PR DESCRIPTION
Also fix `+` and `+=` on lists of different but compatible types.