### PR TITLE
Fix precision on CUDA matmul test.

### DIFF
--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -76,7 +76,7 @@ class TestCudaMatMul(unittest.TestCase):
         tcpu = e - s
 
         # Check result
-        np.testing.assert_allclose(C, Cans)
+        np.testing.assert_allclose(C, Cans, rtol=1e-5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The test would succeed with the CUDA simulator but fail on actual hardware.

Here is the failure I got here:
```
======================================================================
FAIL: test_func (numba.cuda.tests.cudapy.test_matmul.TestCudaMatMul)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/antoine/numba/numba/cuda/tests/cudapy/test_matmul.py", line 79, in test_func
    np.testing.assert_allclose(C, Cans)
  File "/home/antoine/34/lib/python3.4/site-packages/numpy/testing/utils.py", line 1297, in assert_allclose
    verbose=verbose, header=header)
  File "/home/antoine/34/lib/python3.4/site-packages/numpy/testing/utils.py", line 665, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=0

(mismatch 100.0%)
 x: array([[ 406.321808,  391.100098,  394.007538, ...,  399.875702,
         388.311218,  392.593811],
       [ 407.188904,  395.627228,  398.176697, ...,  400.273621,...
 y: array([[ 406.321899,  391.099915,  394.00769 , ...,  399.87558 ,
         388.310974,  392.594025],
       [ 407.188965,  395.627075,  398.176208, ...,  400.273621,...
```

I'm assuming the discrepancy is due to the use of a different algorithm from `np.dot`. The issue wouldn't show up with the simulator as we compute on much smaller matrices then.