### PR TITLE
Improve array indexing

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -159,8 +159,8 @@ class _StructProxy(object):
                                                     value,
                                                     ptr.type.pointee.addrspace)
             else:
-                raise TypeError("Invalid store {value.type} {"
-                                "ptr.type.pointee} in "
+                raise TypeError("Invalid store of {value.type} to "
+                                "{ptr.type.pointee} in "
                                 "{self._datamodel}".format(value=value,
                                                            ptr=ptr,
                                                            self=self))

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -197,6 +197,7 @@ class PrimitiveModel(DataModel):
 @register_default(types.PyObject)
 @register_default(types.RawPointer)
 @register_default(types.NoneType)
+@register_default(types.EllipsisType)
 @register_default(types.Function)
 @register_default(types.Type)
 @register_default(types.Object)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -117,7 +117,7 @@ def populate_array(array, data, shape, strides, itemsize, meminfo,
     Helper function for populating array structures.
     This avoids forgetting to set fields.
 
-    *shape* and *strides* get be Python tuples or LLVM arrays.
+    *shape* and *strides* can be Python tuples or LLVM arrays.
     """
     context = array._context
     builder = array._builder
@@ -260,7 +260,7 @@ def iternext_array(context, builder, sig, args, result):
 
 def basic_indexing(context, builder, aryty, ary, index_types, indices):
     """
-    Perform basic indexing on the given indexing.
+    Perform basic indexing on the given array.
     A (data pointer, shapes, strides) tuple is returned describing
     the corresponding view.
     """
@@ -420,9 +420,7 @@ def setitem_array1d(context, builder, sig, args):
     """
     aryty, idxty, valty = sig.args
     ary, idx, val = args
-
-    arystty = make_array(aryty)
-    ary = arystty(context, builder, ary)
+    ary = make_array(aryty)(context, builder, ary)
 
     ptr = cgutils.get_item_pointer(builder, aryty, ary, [idx],
                                    wraparound=idxty.signed)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -409,9 +409,12 @@ def setitem_array1d(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.Buffer),
-           types.Kind(types.UniTuple), types.Any)
+@implement('setitem', types.Kind(types.Buffer), types.Kind(types.BaseTuple),
+           types.Any)
 def setitem_array_unituple(context, builder, sig, args):
+    """
+    array[a,..,b] = scalar
+    """
     aryty, idxty, valty = sig.args
     ary, idx, val = args
 
@@ -428,26 +431,8 @@ def setitem_array_unituple(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.Buffer),
-           types.Kind(types.Tuple), types.Any)
-def setitem_array_tuple(context, builder, sig, args):
-    aryty, idxty, valty = sig.args
-    ary, idx, val = args
-
-    arystty = make_array(aryty)
-    ary = arystty(context, builder, ary)
-
-    # TODO: other than layout
-    indices = cgutils.unpack_tuple(builder, idx, count=len(idxty))
-    indices = [context.cast(builder, i, t, types.intp)
-               for t, i in zip(idxty, indices)]
-    ptr = cgutils.get_item_pointer(builder, aryty, ary, indices,
-                                   wraparound=True)
-    store_item(context, builder, aryty, val, ptr)
-
-@builtin
-@implement('setitem', types.Kind(types.Buffer),
-           types.slice3_type, types.Any)
+@implement('setitem', types.Kind(types.Buffer), types.slice3_type,
+           types.Any)
 def setitem_array1d_slice(context, builder, sig, args):
     aryty, idxty, valty = sig.args
     ary, idx, val = args

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -2,8 +2,11 @@
 Implement slices and various slice computations.
 """
 
+import itertools
+
 from llvmlite import ir
 
+from numba.six.moves import zip_longest
 from numba import cgutils, types, typing
 from .imputils import (builtin, builtin_attr, implement,
                        impl_attribute, impl_attribute_generic,
@@ -118,9 +121,18 @@ class Slice(cgutils.Structure):
 
 
 @builtin
-@implement(types.slice_type, types.intp, types.intp, types.intp)
-def slice3_impl(context, builder, sig, args):
-    start, stop, step = args
+@implement(types.slice_type, types.VarArg(types.Any))
+def slice_constructor_impl(context, builder, sig, args):
+    maxint = (1 << (context.address_size - 1)) - 1
+
+    slice_args = []
+    for ty, val, default in zip_longest(sig.args, args, (0, maxint, 1)):
+        if ty in (types.none, None):
+            # Omitted or None
+            slice_args.append(context.get_constant(types.intp, default))
+        else:
+            slice_args.append(val)
+    start, stop, step = slice_args
 
     slice3 = Slice(context, builder)
     slice3.start = start
@@ -129,69 +141,3 @@ def slice3_impl(context, builder, sig, args):
 
     res = slice3._getvalue()
     return impl_ret_untracked(context, builder, sig.return_type, res)
-
-
-@builtin
-@implement(types.slice_type, types.intp, types.intp)
-def slice2_impl(context, builder, sig, args):
-    start, stop = args
-
-    slice3 = Slice(context, builder)
-    slice3.start = start
-    slice3.stop = stop
-    slice3.step = context.get_constant(types.intp, 1)
-
-    res = slice3._getvalue()
-    return impl_ret_untracked(context, builder, sig.return_type, res)
-
-
-@builtin
-@implement(types.slice_type, types.intp, types.none)
-def slice1_start_impl(context, builder, sig, args):
-    start, stop = args
-
-    slice3 = Slice(context, builder)
-    slice3.start = start
-    maxint = (1 << (context.address_size - 1)) - 1
-    slice3.stop = context.get_constant(types.intp, maxint)
-    slice3.step = context.get_constant(types.intp, 1)
-
-    res = slice3._getvalue()
-    return impl_ret_untracked(context, builder, sig.return_type, res)
-
-
-@builtin
-@implement(types.slice_type, types.none, types.intp)
-def slice1_stop_impl(context, builder, sig, args):
-    start, stop = args
-
-    slice3 = Slice(context, builder)
-    slice3.start = context.get_constant(types.intp, 0)
-    slice3.stop = stop
-    slice3.step = context.get_constant(types.intp, 1)
-
-    res = slice3._getvalue()
-    return impl_ret_untracked(context, builder, sig.return_type, res)
-
-
-@builtin
-@implement(types.slice_type)
-def slice0_empty_impl(context, builder, sig, args):
-    assert not args
-
-    slice3 = Slice(context, builder)
-    slice3.start = context.get_constant(types.intp, 0)
-    maxint = (1 << (context.address_size - 1)) - 1
-    slice3.stop = context.get_constant(types.intp, maxint)
-    slice3.step = context.get_constant(types.intp, 1)
-
-    res = slice3._getvalue()
-    return impl_ret_untracked(context, builder, sig.return_type, res)
-
-
-@builtin
-@implement(types.slice_type, types.none, types.none)
-def slice0_none_none_impl(context, builder, sig, args):
-    assert len(args) == 2
-    newsig = typing.signature(types.slice_type)
-    return slice0_empty_impl(context, builder, newsig, ())

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -200,14 +200,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
             arraytype2 = types.Array(types.int32, 2, 'C')
             compile_isolated(bad_index, (arraytype1, arraytype2),
                              flags=no_pyobj_flags)
-        self.assertIn('is unsupported for indexing', str(raises.exception))
+        self.assertIn('unsupported array index type', str(raises.exception))
 
     def test_bad_float_index_npm(self):
         with self.assertTypingError() as raises:
             compile_isolated(bad_float_index,
                              (types.Array(types.float64, 2, 'C'),))
-        self.assertIn('Type float', str(raises.exception))
-        self.assertIn('is unsupported for indexing', str(raises.exception))
+        self.assertIn('unsupported array index type float64', str(raises.exception))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import types, utils, njit, errors
+from numba import types, utils, njit, errors, typeof
 from numba.tests import usecases
 from .support import TestCase
 
@@ -95,8 +95,14 @@ def integer_indexing_2d_usecase(a, i1, i2):
 def integer_indexing_2d_usecase2(a, i1, i2):
     return a[i1][i2]
 
-def ellipse_usecase(a):
-    return a[...,0]
+def ellipsis_usecase1(a, i, j):
+    return a[i:j, ...]
+
+def ellipsis_usecase2(a, i, j):
+    return a[..., i:j]
+
+def ellipsis_usecase3(a, i, j):
+    return a[i, ..., j]
 
 def none_index_usecase(a):
     return a[None]
@@ -593,19 +599,39 @@ class TestIndexing(TestCase):
         arraytype = types.Array(types.int32, 2, 'A')
         check(a, arraytype)
 
-    def test_ellipse(self, flags=enable_pyobj_flags):
-        pyfunc = ellipse_usecase
-        arraytype = types.Array(types.int32, 2, 'C')
-        # TODO should be enable to handle this in NoPython mode
-        cr = compile_isolated(pyfunc, (arraytype,), flags=flags)
-        cfunc = cr.entry_point
+    def check_ellipsis(self, pyfunc, flags):
+        def compile_func(arr):
+            cr = compile_isolated(pyfunc, (typeof(arr), types.intp, types.intp),
+                                  flags=flags)
+            return cr.entry_point
 
-        a = np.arange(100, dtype='i4').reshape(10, 10)
-        self.assertTrue((pyfunc(a) == cfunc(a)).all())
+        def run(a):
+            bounds = (0, 1, 2, -1, -2)
+            cfunc = compile_func(a)
+            for i, j in itertools.product(bounds, bounds):
+                x = cfunc(a, i, j)
+                self.assertPreciseEqual(pyfunc(a, i, j), cfunc(a, i, j))
 
-    def test_ellipse_npm(self):
-        with self.assertTypingError():
-            self.test_ellipse(flags=Noflags)
+        run(np.arange(16, dtype='i4').reshape(4, 4))
+        run(np.arange(27, dtype='i4').reshape(3, 3, 3))
+
+    def test_ellipsis1(self, flags=enable_pyobj_flags):
+        self.check_ellipsis(ellipsis_usecase1, flags)
+
+    def test_ellipsis1_npm(self):
+        self.test_ellipsis1(flags=Noflags)
+
+    def test_ellipsis2(self, flags=enable_pyobj_flags):
+        self.check_ellipsis(ellipsis_usecase2, flags)
+
+    def test_ellipsis2_npm(self):
+        self.test_ellipsis2(flags=Noflags)
+
+    def test_ellipsis3(self, flags=enable_pyobj_flags):
+        self.check_ellipsis(ellipsis_usecase3, flags)
+
+    def test_ellipsis3_npm(self):
+        self.test_ellipsis3(flags=Noflags)
 
     def test_none_index(self, flags=enable_pyobj_flags):
         pyfunc = none_index_usecase

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -303,8 +303,7 @@ class TestIndexing(TestCase):
         self.assertTrue((pyfunc(a, 0, 10, 2) == cfunc(a, 0, 10, 2)).all())
 
     def test_2d_slicing_npm(self):
-        with self.assertTypingError():
-            self.test_2d_slicing(flags=Noflags)
+        self.test_2d_slicing(flags=Noflags)
 
     def test_2d_slicing2(self, flags=enable_pyobj_flags):
         """

--- a/numba/tests/test_storeslice.py
+++ b/numba/tests/test_storeslice.py
@@ -66,17 +66,6 @@ class TestStoreSlice(unittest.TestCase):
             cres.entry_point(a, 3, 6, 0, 88)
         self.assertEqual(str(cm.exception), "slice step cannot be zero")
 
-    def test_array_assign_slice_error(self):
-        """Ensure that we have a meaning error message"""
-        def pyfunc(inp, out):
-            out[:] = out
-
-        with self.assertRaises(errors.TypingError) as cm:
-            cres = compile_isolated(pyfunc, (types.int64[:], types.int64[:]))
-
-        # Test the error message
-        errmsg = "Storing array into array slice is not supported, yet"
-        self.assertIn(errmsg, str(cm.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -214,6 +214,9 @@ class TestUnify(unittest.TestCase):
         aty = types.UniTuple(i32, 2)
         bty = types.Tuple((i16, i64))
         self.assert_unify(aty, bty, types.Tuple((i32, i64)))
+        aty = types.UniTuple(i64, 0)
+        bty = types.Tuple(())
+        self.assert_unify(aty, bty, bty)
         # (Tuple, Tuple) -> Tuple
         aty = types.Tuple((i8, i16, i32))
         bty = types.Tuple((i32, i16, i8))
@@ -328,6 +331,7 @@ class TestTypeConversion(CompatibilityTestMixin, unittest.TestCase):
         self.check_number_compatibility(ctx.can_convert)
 
     def test_tuple(self):
+        # UniTuple -> UniTuple
         aty = types.UniTuple(i32, 3)
         bty = types.UniTuple(i64, 3)
         self.assert_can_convert(aty, aty, Conversion.exact)
@@ -335,9 +339,23 @@ class TestTypeConversion(CompatibilityTestMixin, unittest.TestCase):
         aty = types.UniTuple(i32, 3)
         bty = types.UniTuple(f64, 3)
         self.assert_can_convert(aty, bty, Conversion.safe)
+        # Tuple -> Tuple
         aty = types.Tuple((i32, i32))
         bty = types.Tuple((i32, i64))
         self.assert_can_convert(aty, bty, Conversion.promote)
+        # UniTuple <-> Tuple
+        aty = types.UniTuple(i32, 2)
+        bty = types.Tuple((i32, i64))
+        self.assert_can_convert(aty, bty, Conversion.promote)
+        self.assert_can_convert(bty, aty, Conversion.unsafe)
+        # Empty tuples
+        aty = types.UniTuple(i64, 0)
+        bty = types.UniTuple(i32, 0)
+        cty = types.Tuple(())
+        self.assert_can_convert(aty, bty, Conversion.safe)
+        self.assert_can_convert(bty, aty, Conversion.safe)
+        self.assert_can_convert(aty, cty, Conversion.safe)
+        self.assert_can_convert(cty, aty, Conversion.safe)
         # Failures
         aty = types.UniTuple(i64, 3)
         bty = types.UniTuple(types.none, 3)

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -154,6 +154,10 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         ty = typeof(None)
         self.assertEqual(ty, types.none)
 
+    def test_ellipsis(self):
+        ty = typeof(Ellipsis)
+        self.assertEqual(ty, types.ellipsis)
+
     def test_str(self):
         ty = typeof("abc")
         self.assertEqual(ty, types.string)

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -87,13 +87,13 @@ class SetItemBuffer(AbstractTemplate):
             out = get_array_index_type(ary, idx)
             if out is not None:
                 ary, idx, res = out
-                # Allow for broadcasting.
                 if isinstance(res, types.Array):
+                    if res.ndim > 1:
+                        raise NotImplementedError(
+                            "Cannot store slice on array of more than one dimension")
+                    # Allow for broadcasting.
                     if not isinstance(val, types.Array):
                         res = res.dtype
-                    else:
-                        raise TypeError("Storing array into array slice is not "
-                                        "supported, yet")
                 return signature(types.none, ary, idx, res)
 
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -32,6 +32,9 @@ def get_array_index_type(ary, idx):
     # Walk indices
     for ty in idx:
         if ty is types.ellipsis:
+            if ellipsis_met:
+                raise TypeError("only one ellipsis allowed in array index "
+                                "(got %s)" % (idx,))
             ellipsis_met = True
         elif ty is types.slice3_type:
             pass

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -4,7 +4,6 @@ import itertools
 
 from numba import types, intrinsics
 from numba.utils import PYVERSION
-from .builtins import normalize_nd_index
 from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
                                     AbstractTemplate, builtin_global, builtin,
                                     builtin_attr, signature, bound_function,
@@ -21,42 +20,88 @@ def get_array_index_type(ary, idx):
     if not isinstance(ary, types.Buffer):
         return
 
-    idx = normalize_nd_index(idx)
-    if idx is None:
-        return
+    ndim = ary.ndim
 
-    if idx == types.slice3_type:
-        res = ary.copy(layout='A')
-    elif isinstance(idx, (types.UniTuple, types.Tuple)):
-        if ary.ndim > len(idx):
-            return
-        elif ary.ndim < len(idx):
-            return
-        elif any(i == types.slice3_type for i in idx):
-            ndim = ary.ndim
-            for i in idx:
-                if i != types.slice3_type:
-                    ndim -= 1
-            res = ary.copy(ndim=ndim, layout='A')
-        else:
-            res = ary.dtype
-    elif isinstance(idx, types.Integer):
-        if ary.ndim == 1:
-            res = ary.dtype
-        elif not ary.slice_is_copy and ary.ndim > 1:
-            # Left-index into a F-contiguous array gives a non-contiguous view
-            layout = 'C' if ary.layout == 'C' else 'A'
-            res = ary.copy(ndim=ary.ndim - 1, layout=layout)
-        else:
-            return
+    left_indices = []
+    right_indices = []
+    ellipsis_met = False
 
+    if not isinstance(idx, types.BaseTuple):
+        idx = [idx]
+
+    # Walk indices
+    for ty in idx:
+        if ty is types.ellipsis:
+            ellipsis_met = True
+        elif ty is types.slice3_type:
+            pass
+        elif isinstance(ty, types.Integer):
+            # Normalize integer index
+            ty = types.intp if ty.signed else types.uintp
+            # Integer indexing removes the given dimension
+            ndim -= 1
+        else:
+            raise TypeError("unsupported array index type %s in %s"
+                            % (ty, idx))
+        (right_indices if ellipsis_met else left_indices).append(ty)
+
+    # Check indices and result dimensionality
+    all_indices = left_indices + right_indices
+    n_indices = len(all_indices) - ellipsis_met
+    if n_indices > ary.ndim:
+        raise TypeError("cannot index %s with %d indices: %s"
+                        % (ary, n_indices, idx))
+    if (n_indices == ary.ndim
+        and all(isinstance(ty, types.Integer) for ty in all_indices)
+        and not ellipsis_met):
+        # Full integer indexing => scalar result
+        # (note if ellipsis is present, a 0-d view is returned instead)
+        res = ary.dtype
     else:
-        raise Exception("unreachable: index type of %s" % idx)
+        # Result is a view
+        if ary.slice_is_copy:
+            # Avoid view semantics when the original type creates a copy
+            # when slicing.
+            return
 
-    if isinstance(res, types.Buffer) and res.slice_is_copy:
-        # Avoid view semantics when the original type creates a copy
-        # when slicing.
-        return
+        # Infer layout
+        layout = ary.layout
+        if layout == 'C':
+            # Integer indexing on the left keeps the array C-contiguous
+            if len(left_indices) + len(right_indices) == ary.ndim:
+                # If all indices are there, ellipsis's place is indifferent
+                left_indices = left_indices + right_indices
+                right_indices = []
+            if right_indices:
+                layout = 'A'
+            else:
+                for ty in left_indices:
+                    if ty is not types.ellipsis and not isinstance(ty, types.Integer):
+                        # Slicing cannot guarantee to keep the array contiguous
+                        layout = 'A'
+                        break
+        elif layout == 'F':
+            # Integer indexing on the right keeps the array F-contiguous
+            if len(left_indices) + len(right_indices) == ary.ndim:
+                # If all indices are there, ellipsis's place is indifferent
+                right_indices = left_indices + right_indices
+                left_indices = []
+            if left_indices:
+                layout = 'A'
+            else:
+                for ty in right_indices:
+                    if ty is not types.ellipsis and not isinstance(ty, types.Integer):
+                        # Slicing cannot guarantee to keep the array contiguous
+                        layout = 'A'
+                        break
+
+        res = ary.copy(ndim=ndim, layout=layout)
+
+    # Re-wrap indices
+    if isinstance(idx, types.BaseTuple):
+        idx = types.BaseTuple.from_types(all_indices)
+    else:
+        idx, = all_indices
 
     return ary, idx, res
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -429,27 +429,6 @@ def normalize_1d_index(index):
     elif isinstance(index, types.Integer):
         return types.intp if index.signed else types.uintp
 
-def normalize_nd_index(index):
-    """
-    Normalize the *index* type (an integer, slice or tuple thereof) for
-    indexing a N-D sequence.
-    """
-    if isinstance(index, types.UniTuple):
-        if index.dtype in types.integer_domain:
-            idxtype = types.intp if index.dtype.signed else types.uintp
-            return types.UniTuple(idxtype, len(index))
-        elif index.dtype == types.slice3_type:
-            return index
-
-    elif isinstance(index, types.Tuple):
-        for ty in index:
-            if (ty not in types.integer_domain and ty != types.slice3_type):
-                raise TypeError('Type %s of index %s is unsupported for indexing'
-                                 % (ty, index))
-        return index
-
-    return normalize_1d_index(index)
-
 
 @builtin
 class GetItemCPointer(AbstractTemplate):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -64,6 +64,9 @@ class Slice(ConcreteTemplate):
         signature(types.slice3_type, types.intp, types.none),
         signature(types.slice3_type, types.intp, types.intp),
         signature(types.slice3_type, types.intp, types.intp, types.intp),
+        signature(types.slice3_type, types.none, types.intp, types.intp),
+        signature(types.slice3_type, types.intp, types.none, types.intp),
+        signature(types.slice3_type, types.none, types.none, types.intp),
     ]
 
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -106,6 +106,10 @@ def _typeof_str(val, c):
 def _typeof_none(val, c):
     return types.none
 
+@typeof_impl.register(type(Ellipsis))
+def _typeof_none(val, c):
+    return types.ellipsis
+
 @typeof_impl.register(tuple)
 def _typeof_tuple(val, c):
     tys = [typeof_impl(v, c) for v in val]

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -107,7 +107,7 @@ def _typeof_none(val, c):
     return types.none
 
 @typeof_impl.register(type(Ellipsis))
-def _typeof_none(val, c):
+def _typeof_ellipsis(val, c):
     return types.ellipsis
 
 @typeof_impl.register(tuple)


### PR DESCRIPTION
Supersedes #1441. This PR allows assigning an array to a 1d array slice (issue #422) and also allows using ellipsis (`...`) in array indices. Note this doesn't solve the more general N-d slice assignment use case.