### PR TITLE
Fancy indexing

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -69,13 +69,17 @@ Array types
 of any of the scalar types above are supported, regardless of the shape
 or layout.
 
-Operations
-----------
+Array access
+------------
 
-Arrays support iteration and full indexing (i.e. indexing that yields scalar
-values).  Partial indexing by a single integer is supported, but other kinds of
-partial indexing (for example indexing a 3-d array with a 2-tuple) are not
-supported.
+Arrays support normal iteration.  Full basic indexing and slicing is
+supported.  A subset of advanced indexing is also supported: only one
+advanced index is allowed, and it has to be a one-dimensional array
+(it can be combined with an arbitrary number of basic indices as well).
+
+.. seealso::
+   `Numpy indexing <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
+   reference.
 
 Attributes
 ----------

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -585,6 +585,9 @@ def pack_array(builder, values, ty=None):
 
 
 def unpack_tuple(builder, tup, count=None):
+    """
+    Unpack an array or structure of values, return a Python tuple.
+    """
     if count is None:
         # Assuming *tup* is an aggregate
         count = len(tup.type.elements)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -579,6 +579,29 @@ class PythonAPI(object):
         return self.builder.call(fn, [cobj])
 
     #
+    # Concrete slice API
+    #
+
+    def slice_as_ints(self, obj, defaults):
+        """
+        Read the members of a slice of integers.
+        Returns a (ok, start, stop, step) tuple where ok is a boolean and
+        the following members are pointer-sized ints.
+        """
+        defaults = [ir.Constant(self.py_ssize_t, v) for v in defaults]
+        pstart = cgutils.alloca_once_value(self.builder, defaults[0])
+        pstop = cgutils.alloca_once_value(self.builder, defaults[1])
+        pstep = cgutils.alloca_once_value(self.builder, defaults[2])
+        fnty = Type.function(Type.int(),
+                             [self.pyobj] + [self.py_ssize_t.as_pointer()] * 3)
+        fn = self._get_function(fnty, name="numba_unpack_slice")
+        res = self.builder.call(fn, (obj, pstart, pstop, pstep))
+        start = self.builder.load(pstart)
+        stop = self.builder.load(pstop)
+        step = self.builder.load(pstep)
+        return cgutils.is_null(self.builder, res), start, stop, step
+
+    #
     # List and sequence APIs
     #
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -902,7 +902,7 @@ def fancy_getitem(context, builder, sig, args,
     # a positive index is returned.
     ptr = cgutils.get_item_pointer2(builder, data, shapes, strides,
                                     aryty.layout, indices, wraparound=False)
-    val = builder.load(ptr)
+    val = load_item(context, builder, aryty, ptr)
 
     # Since the destination is C-contiguous, no need for multi-dimensional
     # indexing.
@@ -974,7 +974,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                                 src_shapes, src_strides,
                                                 srcty.layout, source_indices,
                                                 wraparound=False)
-            return builder.load(src_ptr)
+            return load_item(context, builder, srcty, src_ptr)
 
     else:
         # Source is a scalar (broadcast or not, depending on destination
@@ -1000,7 +1000,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                          dest_shapes, dest_strides,
                                          aryty.layout, dest_indices,
                                          wraparound=False)
-    builder.store(val, dest_ptr)
+    store_item(context, builder, aryty, val, dest_ptr)
 
     indexer.end_loops()
 

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -274,6 +274,20 @@ def unbox_optional(c, typ, obj):
                        cleanup=cleanup)
 
 
+@unbox(types.Slice3Type)
+def unbox_slice(c, typ, obj):
+    """
+    """
+    from . import slicing
+    ok, start, stop, step = \
+        c.pyapi.slice_as_ints(obj, slicing.get_defaults(c.context))
+    slice3 = slicing.Slice(c.context, c.builder)
+    slice3.start = start
+    slice3.stop = stop
+    slice3.step = step
+    return NativeValue(slice3._getvalue(), is_error=c.builder.not_(ok))
+
+
 #
 # Collections
 #

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -113,8 +113,14 @@ def unbox_complex(c, typ, obj):
 
 
 @box(types.NoneType)
+@box(types.EllipsisType)
 def box_none(c, typ, val):
     return c.pyapi.make_none()
+
+@unbox(types.NoneType)
+@unbox(types.EllipsisType)
+def unbox_none(c, typ, val):
+    return NativeValue(c.context.get_dummy_value())
 
 
 @box(types.NPDatetime)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -113,7 +113,6 @@ def unbox_complex(c, typ, obj):
 
 
 @box(types.NoneType)
-@box(types.EllipsisType)
 def box_none(c, typ, val):
     return c.pyapi.make_none()
 

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -276,6 +276,7 @@ def unbox_optional(c, typ, obj):
 @unbox(types.Slice3Type)
 def unbox_slice(c, typ, obj):
     """
+    Convert object *obj* to a native slice structure.
     """
     from . import slicing
     ok, start, stop, step = \

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -111,6 +111,14 @@ def fix_stride(builder, slice, stride):
     return builder.mul(slice.step, stride)
 
 
+def get_defaults(context):
+    """
+    Get the default values for a slice's three members.
+    """
+    maxint = (1 << (context.address_size - 1)) - 1
+    return (0, maxint, 1)
+
+
 #---------------------------------------------------------------------------
 # The slice structure
 
@@ -141,3 +149,22 @@ def slice_constructor_impl(context, builder, sig, args):
 
     res = slice3._getvalue()
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@builtin_attr
+@impl_attribute(types.slice3_type, "start")
+def slice_start_impl(context, builder, typ, value):
+    slice3 = Slice(context, builder, value)
+    return slice3.start
+
+@builtin_attr
+@impl_attribute(types.slice3_type, "stop")
+def slice_stop_impl(context, builder, typ, value):
+    slice3 = Slice(context, builder, value)
+    return slice3.stop
+
+@builtin_attr
+@impl_attribute(types.slice3_type, "step")
+def slice_step_impl(context, builder, typ, value):
+    slice3 = Slice(context, builder, value)
+    return slice3.step

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -15,6 +15,13 @@ def getitem_usecase(a, b):
 
 class TestFancyIndexing(TestCase):
 
+    def generate_advanced_indices(self, N, many=True):
+        choices = [np.int16([0, N - 1, -2])]
+        if many:
+            choices += [np.uint16([0, 1, N - 1]),
+                        np.bool_([0, 1, 1, 0])]
+        return choices
+
     def generate_basic_index_tuples(self, N, maxdim, many=True):
         """
         Generate basic index tuples with 0 to *maxdim* items.
@@ -44,10 +51,7 @@ class TestFancyIndexing(TestCase):
         """
         # (Note Numba doesn't support advanced indices with more than
         #  one advanced index array at the moment)
-        choices = [np.int16([0, N - 1, -2])]
-        if many:
-            choices += [np.uint16([0, 1, N - 1]),
-                        np.bool_([0, 1, 1, 0])]
+        choices = list(self.generate_advanced_indices(N, many=many))
         for i in range(maxdim + 1):
             for tup in self.generate_basic_index_tuples(N, maxdim - 1, many):
                 for adv in choices:
@@ -83,6 +87,7 @@ class TestFancyIndexing(TestCase):
                 np.testing.assert_equal(arr, orig)
 
     def test_getitem_tuple(self):
+        # Test many variations of advanced indexing with a tuple index
         N = 4
         ndim = 3
         arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
@@ -100,7 +105,13 @@ class TestFancyIndexing(TestCase):
 
         self.check_getitem_indices(arr, indices)
 
-    # TODO: write tests with a non-tuple index
+    def test_getitem_array(self):
+        # Test advanced indexing with a single array index
+        N = 4
+        ndim = 3
+        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
+        indices = self.generate_advanced_indices(N)
+        self.check_getitem_indices(arr, indices)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -1,0 +1,105 @@
+from __future__ import print_function
+
+import itertools
+
+import numpy as np
+
+import numba.unittest_support as unittest
+from numba import types, jit, typeof
+from .support import TestCase
+
+
+def getitem_usecase(a, b):
+    return a[b]
+
+
+class TestFancyIndexing(TestCase):
+
+    def generate_basic_index_tuples(self, N, maxdim, many=True):
+        """
+        Generate basic index tuples with 0 to *maxdim* items.
+        """
+        # Note integers can be considered advanced indices in certain
+        # cases, so we avoid them here.
+        # See "Combining advanced and basic indexing"
+        # in http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+        if many:
+            choices = [slice(None, None, None),
+                       slice(1, N - 1, None),
+                       slice(0, None, 2),
+                       slice(-N + 1, -1, None),
+                       slice(-1, -N, -2),
+                       ]
+        else:
+            choices = [slice(0, N - 1, None),
+                       slice(-1, -N, -2)]
+        for ndim in range(maxdim + 1):
+            for tup in itertools.product(choices, repeat=ndim):
+                yield tup
+
+    def generate_advanced_index_tuples(self, N, maxdim, many=True):
+        """
+        Generate advanced index tuples by generating basic index tuples
+        and adding a single advanced index item.
+        """
+        # (Note Numba doesn't support advanced indices with more than
+        #  one advanced index array at the moment)
+        choices = [np.int16([0, N - 1, -2])]
+        if many:
+            choices += [np.uint16([0, 1, N - 1]),
+                        np.bool_([0, 1, 1, 0])]
+        for i in range(maxdim + 1):
+            for tup in self.generate_basic_index_tuples(N, maxdim - 1, many):
+                for adv in choices:
+                    yield tup[:i] + (adv,) + tup[i:]
+
+    def generate_advanced_index_tuples_with_ellipsis(self, N, maxdim, many=True):
+        """
+        Same as generate_advanced_index_tuples(), but also insert an
+        ellipsis at various points.
+        """
+        for tup in self.generate_advanced_index_tuples(N, maxdim, many):
+            for i in range(len(tup) + 1):
+                yield tup[:i] + (Ellipsis,) + tup[i:]
+
+    def check_getitem_indices(self, arr, indices):
+        pyfunc = getitem_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+        orig = arr.copy()
+        orig_base = arr.base or arr
+
+        for index in indices:
+            expected = pyfunc(arr, index)
+            # Sanity check: if a copy wasn't made, this wasn't advanced
+            # but basic indexing, and shouldn't be tested here.
+            assert expected.base is not orig_base
+            got = cfunc(arr, index)
+            self.assertEqual(got.shape, expected.shape)
+            self.assertEqual(got.dtype, expected.dtype)
+            np.testing.assert_equal(got, expected)
+            # Check a copy was *really* returned by Numba
+            if got.size:
+                got.fill(42)
+                np.testing.assert_equal(arr, orig)
+
+    def test_getitem_tuple(self):
+        N = 4
+        ndim = 3
+        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
+        indices = self.generate_advanced_index_tuples(N, ndim)
+
+        self.check_getitem_indices(arr, indices)
+
+    def test_getitem_tuple_and_ellipsis(self):
+        # Same, but also insert an ellipsis at a random point
+        N = 4
+        ndim = 3
+        arr = np.arange(N ** ndim).reshape((N,) * ndim).astype(np.int32)
+        indices = self.generate_advanced_index_tuples_with_ellipsis(N, ndim,
+                                                                    many=False)
+
+        self.check_getitem_indices(arr, indices)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -100,6 +100,8 @@ class TestFancyIndexing(TestCase):
 
         self.check_getitem_indices(arr, indices)
 
+    # TODO: write tests with a non-tuple index
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -729,15 +729,10 @@ class TestIndexing(TestCase):
         for test in tests:
             pyleft = pyfunc(np.zeros_like(arg), arg[slice(*test[0:3]), slice(*test[3:6])], *test)
             cleft = cfunc(np.zeros_like(arg), arg[slice(*test[0:3]), slice(*test[3:6])], *test)
-            self.assertTrue((pyleft == cleft).all())
+            self.assertPreciseEqual(cleft, pyleft)
 
     def test_2d_slicing_set_npm(self):
-        """
-        TypingError: TypingError: Cannot resolve setitem: array(int32, 2d, C)[(slice3_type x 2)] = array(int32, 2d, C)
-        setitem on slices not yet supported.
-        """
-        with self.assertTypingError():
-            self.test_2d_slicing_set(flags=Noflags)
+        self.test_2d_slicing_set(flags=Noflags)
 
     def test_setitem(self):
         arr = np.arange(5)

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -687,7 +687,7 @@ class TestSetItem(TestCase):
         # Note heterogenous types for the source and destination arrays
         # (int16[:] -> int32[:])
         dest_type = types.Array(types.int32, 1, 'C')
-        src_type = types.Array(types.int16, 1, 'C')
+        src_type = types.Array(types.int16, 1, 'A')
         argtys = (dest_type, src_type, types.int32, types.int32, types.int32)
         cr = compile_isolated(pyfunc, argtys, flags=flags)
         cfunc = cr.entry_point
@@ -761,7 +761,7 @@ class TestSetItem(TestCase):
         2d to 2d slice assignment
         """
         pyfunc = slicing_2d_usecase_set
-        arraytype = types.Array(types.int32, 2, 'C')
+        arraytype = types.Array(types.int32, 2, 'A')
         argtys = (arraytype, arraytype, types.int32, types.int32, types.int32,
                   types.int32, types.int32, types.int32)
         cr = compile_isolated(pyfunc, argtys, flags=flags)

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -129,7 +129,11 @@ def slicing_2d_usecase_set(a, b, start, stop, step, start2, stop2, step2):
     return a
 
 
-class TestIndexing(TestCase):
+class TestGetItem(TestCase):
+    """
+    Test basic indexed load from an array (returning a view or a scalar).
+    Note fancy indexing is tested in test_fancy_indexing.
+    """
 
     def test_1d_slicing(self, flags=enable_pyobj_flags):
         pyfunc = slicing_1d_usecase
@@ -651,6 +655,13 @@ class TestIndexing(TestCase):
 
     def test_empty_tuple_indexing_npm(self):
         self.test_empty_tuple_indexing(flags=Noflags)
+
+
+class TestSetItem(TestCase):
+    """
+    Test basic indexed store into an array.
+    Note fancy indexing is tested in test_fancy_indexing.
+    """
 
     def test_conversion_setitem(self, flags=enable_pyobj_flags):
         """ this used to work, and was used in one of the tutorials """

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -8,7 +8,6 @@ import numpy as np
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
 from numba import types, utils, njit, errors, typeof
-from numba.tests import usecases
 from .support import TestCase
 
 
@@ -106,12 +105,6 @@ def ellipsis_usecase3(a, i, j):
 
 def none_index_usecase(a):
     return a[None]
-
-def fancy_index_usecase(a, index):
-    return a[index]
-
-def boolean_indexing_usecase(a, mask):
-    return a[mask]
 
 def empty_tuple_usecase(a):
     return a[()]
@@ -646,42 +639,6 @@ class TestIndexing(TestCase):
     def test_none_index_npm(self):
         with self.assertTypingError():
             self.test_none_index(flags=Noflags)
-
-    def test_fancy_index(self, flags=enable_pyobj_flags):
-        pyfunc = fancy_index_usecase
-        arraytype = types.Array(types.int32, 2, 'C')
-        indextype = types.Array(types.int32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype, indextype), flags=flags)
-        cfunc = cr.entry_point
-
-        a = np.arange(100, dtype='i4').reshape(10, 10)
-        index = np.array([], dtype='i4')
-        self.assertTrue((pyfunc(a, index) == cfunc(a, index)).all())
-        index = np.array([0], dtype='i4')
-        self.assertTrue((pyfunc(a, index) == cfunc(a, index)).all())
-        index = np.array([1,2], dtype='i4')
-        self.assertTrue((pyfunc(a, index) == cfunc(a, index)).all())
-        index = np.array([-1], dtype='i4')
-        self.assertTrue((pyfunc(a, index) == cfunc(a, index)).all())
-
-    def test_fancy_index_npm(self):
-        with self.assertTypingError():
-            self.test_fancy_index(flags=Noflags)
-
-    def test_boolean_indexing(self, flags=enable_pyobj_flags):
-        pyfunc = boolean_indexing_usecase
-        arraytype = types.Array(types.int32, 2, 'C')
-        masktype = types.Array(types.boolean, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype, masktype), flags=flags)
-        cfunc = cr.entry_point
-
-        a = np.arange(100, dtype='i4').reshape(10, 10)
-        mask = np.array([True, False, True])
-        self.assertTrue((pyfunc(a, mask) == cfunc(a, mask)).all())
-
-    def test_boolean_indexing_npm(self):
-        with self.assertTypingError():
-            self.test_boolean_indexing(flags=Noflags)
 
     def test_empty_tuple_indexing(self, flags=enable_pyobj_flags):
         pyfunc = empty_tuple_usecase

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -1,0 +1,40 @@
+from __future__ import print_function, division, absolute_import
+
+import itertools
+import sys
+
+from numba import unittest_support as unittest
+from numba import jit, typeof
+from .support import TestCase
+
+
+def slice_passing(sl):
+    return sl.start, sl.stop, sl.step
+
+
+class TestSlices(TestCase):
+
+    def test_slice_passing(self):
+        # NOTE this also checks slice attributes
+        def check(a, b, c, d, e, f):
+            sl = slice(a, b, c)
+            got = cfunc(sl)
+            self.assertPreciseEqual(got, (d, e, f))
+
+        maxint = sys.maxsize
+        cfunc = jit(nopython=True)(slice_passing)
+        start_cases = [(None, 0), (42, 42), (-1, -1)]
+        stop_cases = [(None, maxint), (9, 9), (-11, -11)]
+        step_cases = [(None, 1), (12, 12), (-33, -33)]
+        for (a, d), (b, e), (c, f) in itertools.product(start_cases,
+                                                        stop_cases,
+                                                        step_cases):
+            check(a, b, c, d, e, f)
+
+        # Some member is neither integer nor None
+        with self.assertRaises(TypeError):
+            cfunc(slice(1.5, 1, 1))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_storeslice.py
+++ b/numba/tests/test_storeslice.py
@@ -12,7 +12,7 @@ def setitem_slice(a, start, stop, step, scalar):
 
 
 def usecase(obs, nPoints):
-    center = nPoints / 2
+    center = nPoints // 2
     obs[0:center] = np.arange(center)
     obs[center] = 321
     obs[(center + 1):] = np.arange(nPoints - center - 1)
@@ -26,7 +26,7 @@ class TestStoreSlice(unittest.TestCase):
         obs_expected = obs_got.copy()
 
         flags = Flags()
-        flags.set("enable_pyobject")
+        flags.set("nrt")
         cres = compile_isolated(usecase, (types.float64[:], types.intp),
                                 flags=flags)
         cres.entry_point(obs_got, n)

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -162,12 +162,12 @@ class SetItemBuffer(AbstractTemplate):
         if isinstance(res, types.Array):
             # Indexing produces an array
             if not isinstance(val, types.Array):
-                # Allow for scalar broadcasting
+                # Allow scalar broadcasting
                 res = res.dtype
             elif (val.ndim == res.ndim and
                   self.context.can_convert(val.dtype, res.dtype)):
-                # Allow for assignement of compatible-dtype array
-                res = res.copy(dtype=val.dtype)
+                # Allow assignement of same-dimensionality compatible-dtype array
+                res = val
             else:
                 # Unexpected dimensionality of assignment source
                 # (array broadcasting is unsupported)

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -30,6 +30,7 @@ def get_array_index_type(ary, idx):
     right_indices = []
     ellipsis_met = False
     advanced = False
+    has_integer = False
 
     if not isinstance(idx, types.BaseTuple):
         idx = [idx]
@@ -45,10 +46,14 @@ def get_array_index_type(ary, idx):
             ty = types.intp if ty.signed else types.uintp
             # Integer indexing removes the given dimension
             ndim -= 1
+            has_integer = True
         elif (isinstance(ty, types.Array)
               and ty.ndim == 1
               and isinstance(ty.dtype, (types.Integer, types.Boolean))):
-            if advanced:
+            if advanced or has_integer:
+                # We don't support the complicated combination of
+                # advanced indices (and integers are considered part
+                # of them by Numpy).
                 raise NotImplementedError("only one advanced index supported")
             advanced = True
         else:

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -540,6 +540,20 @@ class NumberAttribute(AttributeTemplate):
         return signature(ty)
 
 
+@builtin_attr
+class SliceAttribute(AttributeTemplate):
+    key = types.slice3_type
+
+    def resolve_start(self, ty):
+        return types.intp
+
+    def resolve_stop(self, ty):
+        return types.intp
+
+    def resolve_step(self, ty):
+        return types.intp
+
+
 #-------------------------------------------------------------------------------
 
 
@@ -568,6 +582,7 @@ def register_number_classes(register_global):
 
 
 register_number_classes(builtin_global)
+
 
 #------------------------------------------------------------------------------
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -117,6 +117,10 @@ def _typeof_tuple(val, c):
         return
     return types.BaseTuple.from_types(tys, type(val))
 
+@typeof_impl.register(slice)
+def _typeof_slice(val, c):
+    return types.slice3_type
+
 @typeof_impl.register(np.dtype)
 def _typeof_dtype(val, c):
     tp = numpy_support.from_dtype(val)


### PR DESCRIPTION
Based on PR #1442. This PR implements a subset of fancy (or "advanced") indexing. Advanced indexing is described in http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html

Generic slice assignment is enabled by this PR, as the fancy indexing machinery can be favorably reused for it. Also, this PR adds support for passing slice objects into Numba functions, to ease testing.

The case where several (> 1) advanced indices are present in the index tuple is not handled, as the combination rules are still a bit over my head.