### PR TITLE
Fix nonzero() on a boolean array.

### DIFF
--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1039,6 +1039,12 @@ def number_not_impl(context, builder, sig, args):
 
 
 @builtin
+@implement(bool, types.boolean)
+def bool_as_bool(context, builder, sig, args):
+    [val] = args
+    return val
+
+@builtin
 @implement(bool, types.Kind(types.Integer))
 def int_as_bool(context, builder, sig, args):
     [val] = args

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -459,6 +459,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             expected = [a.copy() for a in expected]
             self.assertPreciseEqual(cres.entry_point(arr), expected)
 
+        arr = np.int16([1, 0, -1, 0])
+        check_arr(arr)
+        arr = np.bool_([1, 0, 1])
+        check_arr(arr)
+
         arr = fac(24)
         check_arr(arr)
         check_arr(arr.reshape((3, 8)))

--- a/numba/tests/test_numberctor.py
+++ b/numba/tests/test_numberctor.py
@@ -9,6 +9,10 @@ from numba import jit, types
 from .support import TestCase
 
 
+def dobool(a):
+    return bool(a)
+
+
 def doint(a):
     return int(a)
 
@@ -42,18 +46,23 @@ def converter(tp):
 
 
 class TestNumberCtor(TestCase):
-    def test_int(self):
-        pyfunc = doint
 
+    def check_int_constructor(self, pyfunc):
         x_types = [
-            types.int32, types.int64, types.float32, types.float64
+            types.boolean, types.int32, types.int64, types.float32, types.float64
         ]
-        x_values = [1, 1000, 12.2, 23.4]
+        x_values = [1, 0, 1000, 12.2, 23.4]
 
         for ty, x in zip(x_types, x_values):
             cres = compile_isolated(pyfunc, [ty])
             cfunc = cres.entry_point
             self.assertPreciseEqual(pyfunc(x), cfunc(x))
+
+    def test_bool(self):
+        self.check_int_constructor(dobool)
+
+    def test_int(self):
+        self.check_int_constructor(doint)
 
     def test_float(self):
         pyfunc = dofloat

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -658,7 +658,7 @@ class Bool(AbstractTemplate):
     def generic(self, args, kws):
         assert not kws
         [arg] = args
-        if arg in types.number_domain:
+        if isinstance(arg, (types.Boolean, types.Number)):
             return signature(types.boolean, arg)
         # XXX typing for bool cannot be polymorphic because of the
         # types.Function thing, so we redirect to the "is_true"
@@ -674,16 +674,9 @@ class Int(AbstractTemplate):
 
         [arg] = args
 
-        if arg not in types.number_domain:
-            raise TypeError("int() only support for numbers")
-
-        if arg in types.complex_domain:
-            raise TypeError("int() does not support complex")
-
-        if arg in types.integer_domain:
+        if isinstance(arg, types.Integer):
             return signature(arg, arg)
-
-        if arg in types.real_domain:
+        if isinstance(arg, (types.Float, types.Boolean)):
             return signature(types.intp, arg)
 
 


### PR DESCRIPTION
Also support more cases of calling the int() and bool() constructors.