### PR TITLE
Enable pycc under Windows

### DIFF
--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division, absolute_import
 import logging
 import os
 import sys
-import functools
 
 import llvmlite.llvmpy.core as lc
 import llvmlite.llvmpy.ee as le
@@ -21,43 +20,12 @@ from numba.targets.registry import CPUTarget
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['which', 'find_linker', 'find_args', 'find_shared_ending', 'Compiler']
+__all__ = ['Compiler']
 
 NULL = lc.Constant.null(lt._void_star)
 ZERO = lc.Constant.int(lt._int32, 0)
 ONE = lc.Constant.int(lt._int32, 1)
 METH_VARARGS_AND_KEYWORDS = lc.Constant.int(lt._int32, 1|2)
-
-
-def which(program):
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, fname)
-            if is_exe(exe_file):
-                return exe_file
-    return None
-
-_configs = {
-    'win': ("link.exe", ("/dll",), '.dll'),
-    'dar': ("libtool", ("-dynamic", "-undefined", "dynamic_lookup"), '.so'),
-    'default': ("ld", ("-shared",), ".so")
-}
-
-
-def get_configs(arg):
-    return _configs.get(sys.platform[:3], _configs['default'])[arg]
-
-
-find_linker = functools.partial(get_configs, 0)
-find_args = functools.partial(get_configs, 1)
-find_shared_ending = functools.partial(get_configs, 2)
 
 
 def get_header():
@@ -124,6 +92,7 @@ class _Compiler(object):
         self.inputs = inputs
         self.module_name = module_name
         self.export_python_wrap = False
+        self.dll_exports = []
 
     def __enter__(self):
         return self
@@ -165,7 +134,6 @@ class _Compiler(object):
             llvm_func = cres.library.get_function(func_name)
 
             if self.export_python_wrap:
-                # XXX: unsupported (necessary?)
                 llvm_func.linkage = lc.LINKAGE_INTERNAL
                 wrappername = cres.fndesc.llvm_cpython_wrapper_name
                 wrapper = cres.library.get_function(wrappername)
@@ -175,8 +143,8 @@ class _Compiler(object):
                     cres.fndesc.restype, cres.fndesc.argtypes)
                 self.exported_function_types[entry] = fnty
             else:
-                llvm_func.linkage = lc.LINKAGE_EXTERNAL
                 llvm_func.name = entry.symbol
+                self.dll_exports.append(entry.symbol)
 
         if self.export_python_wrap:
             wrapper_module = library.create_ir_module("wrapper")
@@ -449,6 +417,8 @@ class CompilerPy3(_Compiler):
             builder.ret(NULL.bitcast(mod_init_fn.type.pointee.return_type))
 
         builder.ret(mod)
+
+        self.dll_exports.append(mod_init_fn.name)
 
 
 Compiler = CompilerPy3 if IS_PY3 else CompilerPy2

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -278,6 +278,8 @@ class CompilerPy2(_Compiler):
 
         builder.ret_void()
 
+        self.dll_exports.append(mod_init_fn.name)
+
 
 class CompilerPy3(_Compiler):
 

--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -1,0 +1,72 @@
+from __future__ import print_function, division, absolute_import
+
+from distutils.ccompiler import CCompiler, new_compiler
+from distutils.command.build_ext import build_ext
+from distutils.dist import Distribution
+from distutils.sysconfig import customize_compiler
+from distutils import log
+
+import functools
+import os
+import subprocess
+import sys
+
+
+_configs = {
+    # DLL suffix, Python C extension suffix
+    'win': ('.dll', '.pyd'),
+    'default': ('.so', '.so'),
+}
+
+
+def get_configs(arg):
+    return _configs.get(sys.platform[:3], _configs['default'])[arg]
+
+
+find_shared_ending = functools.partial(get_configs, 0)
+find_pyext_ending = functools.partial(get_configs, 1)
+
+
+class _DummyExtension(object):
+    libraries = []
+
+
+class Toolchain(object):
+
+    def __init__(self, debug=False):
+        self._compiler = new_compiler()
+        log.set_threshold(log.DEBUG if debug else log.INFO)
+        customize_compiler(self._compiler)
+        self._build_ext = build_ext(Distribution())
+        self._build_ext.finalize_options()
+        self._py_lib_dirs = self._build_ext.library_dirs
+
+    def link_shared(self, output, objects, libraries=(),
+                    library_dirs=(), export_symbols=()):
+        """
+        Create a shared library *output* linking the given *objects*
+        and *libraries* (all strings).
+        """
+        output_dir, output_filename = os.path.split(output)
+        self._compiler.link(CCompiler.SHARED_OBJECT, objects,
+                            output_filename, output_dir,
+                            libraries, library_dirs,
+                            export_symbols=export_symbols)
+
+    def get_python_libraries(self):
+        """
+        Get the library arguments necessary to link with Python.
+        """
+        libs = self._build_ext.get_libraries(_DummyExtension())
+        if sys.platform == 'win32':
+            # Under Windows, need to link explicitly against the CRT,
+            # as the MSVC compiler would implicitly do.
+            # (XXX msvcrtd in pydebug mode?)
+            libs = libs + ['msvcrt']
+        return libs
+
+    def get_python_library_dirs(self):
+        """
+        Get the library directories necessary to link with Python.
+        """
+        return list(self._py_lib_dirs)


### PR DESCRIPTION
This refactors the platform-specific parts of pycc to go through distutils. Note this needs the latest llvmlite to be able to write COFF files (rather than ELF) under Windows.

I have tested under Linux 64 and Windows 64, but have no way to verify it works on OS X...