### PR TITLE
Support for out-of-line CFFI modules

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -395,4 +395,13 @@ functions, using the following C types:
 * :c:type:`size_t`
 * :c:type:`void`
 
+Out-of-line cffi modules must be registered with Numba prior to the use of any
+of their functions from within Numba-compiled functions:
+
+.. function:: numba.cffi_support.register_module(mod)
+
+   Register the cffi out-of-line module ``mod`` with Numba.
+
+Inline cffi modules require no registration.
+
 .. _cffi: https://cffi.readthedocs.org/

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -8,6 +8,14 @@ if cffi_support.SUPPORTED:
     defs = """
     double sin(double x);
     double cos(double x);
+    int foo(int a, int b, int c);
+    """
+
+    source = """
+    static int foo(int a, int b, int c)
+    {
+        return a + b * c;
+    }
     """
 
     # Create inline module
@@ -21,7 +29,7 @@ if cffi_support.SUPPORTED:
     # Compile out-of-line module and load it
 
     ffi_ool = FFI()
-    ffi.set_source('cffi_usecases_ool', defs)
+    ffi.set_source('cffi_usecases_ool', source)
     ffi.cdef(defs, override=True)
     ffi.compile()
 
@@ -29,7 +37,7 @@ if cffi_support.SUPPORTED:
     cffi_support.register_module(cffi_usecases_ool)
     cffi_sin_ool = cffi_usecases_ool.lib.sin
     cffi_cos_ool = cffi_usecases_ool.lib.cos
-
+    cffi_foo = cffi_usecases_ool.lib.foo
 
 def use_cffi_sin(x):
     return cffi_sin(x) * 2
@@ -48,3 +56,6 @@ def use_func_pointer(fa, fb, x):
         return fa(x)
     else:
         return fb(x)
+
+def use_user_defined_symbols():
+    return cffi_foo(1, 2, 3)

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -5,14 +5,30 @@ from numba import cffi_support
 
 if cffi_support.SUPPORTED:
     from cffi import FFI
-    ffi = FFI()
-    ffi.cdef("""
+    defs = """
     double sin(double x);
     double cos(double x);
-    """)
-    C = ffi.dlopen(None)                     # loads the entire C namespace
+    """
+
+    # Create inline module
+
+    ffi = FFI()
+    ffi.cdef(defs)
+    C = ffi.dlopen(None) # loads the entire C namespace
     cffi_sin = C.sin
     cffi_cos = C.cos
+
+    # Compile out-of-line module and load it
+
+    ffi_ool = FFI()
+    ffi.set_source('cffi_usecases_ool', defs)
+    ffi.cdef(defs, override=True)
+    ffi.compile()
+
+    import cffi_usecases_ool
+    cffi_support.register_module(cffi_usecases_ool)
+    cffi_sin_ool = cffi_usecases_ool.lib.sin
+    cffi_cos_ool = cffi_usecases_ool.lib.cos
 
 
 def use_cffi_sin(x):
@@ -20,6 +36,12 @@ def use_cffi_sin(x):
 
 def use_two_funcs(x):
     return cffi_sin(x) - cffi_cos(x)
+
+def use_cffi_sin_ool(x):
+    return cffi_sin_ool(x) * 2
+
+def use_two_funcs_ool(x):
+    return cffi_sin_ool(x) - cffi_cos_ool(x)
 
 def use_func_pointer(fa, fb, x):
     if x > 0:

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -69,6 +69,10 @@ class TestCFFI(TestCase):
         # A single specialization was compiled for all calls
         self.assertEqual(len(cfunc.overloads), 1, cfunc.overloads)
 
+    def test_user_defined_sybols(self):
+        pyfunc = use_user_defined_symbols
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertEqual(pyfunc(), cfunc())
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -3,8 +3,8 @@ from __future__ import print_function, division, absolute_import
 from numba import unittest_support as unittest
 from numba import jit, cffi_support, types
 from numba.compiler import compile_isolated, Flags
-from .support import TestCase
-from .cffi_usecases import *
+from numba.tests.support import TestCase
+from numba.tests.cffi_usecases import *
 
 
 enable_pyobj_flags = Flags()
@@ -16,28 +16,36 @@ no_pyobj_flags = Flags()
 @unittest.skipUnless(cffi_support.SUPPORTED, "CFFI not supported")
 class TestCFFI(TestCase):
 
-    def test_sin_function(self, flags=enable_pyobj_flags):
+    def test_type_map(self):
         signature = cffi_support.map_type(ffi.typeof(cffi_sin))
         self.assertEqual(len(signature.args), 1)
         self.assertEqual(signature.args[0], types.double)
 
-        pyfunc = use_cffi_sin
+    def _test_function(self, pyfunc, flags=enable_pyobj_flags):
         cres = compile_isolated(pyfunc, [types.double], flags=flags)
         cfunc = cres.entry_point
 
-        for x in [-1.2, -1, 0, 0.1]:
+        for x in [-1.2, -1, 0, 0.1, 3.14]:
             self.assertPreciseEqual(pyfunc(x), cfunc(x))
 
+    def test_sin_function(self):
+        self._test_function(use_cffi_sin)
+
     def test_sin_function_npm(self):
-        self.test_sin_function(flags=no_pyobj_flags)
+        self._test_function(use_cffi_sin, flags=no_pyobj_flags)
+
+    def test_sin_function_ool(self, flags=enable_pyobj_flags):
+        self._test_function(use_cffi_sin_ool)
+
+    def test_sin_function_npm_ool(self):
+        self._test_function(use_cffi_sin_ool, flags=no_pyobj_flags)
 
     def test_two_funcs(self):
         # Check that two constant functions don't get mixed up.
-        pyfunc = use_two_funcs
-        cres = compile_isolated(pyfunc, [types.double])
-        cfunc = cres.entry_point
-        x = 3.14
-        self.assertEqual(pyfunc(x), cfunc(x))
+        self._test_function(use_two_funcs)
+
+    def test_two_funcs_ool(self):
+        self._test_function(use_two_funcs_ool)
 
     def test_function_pointer(self):
         pyfunc = use_func_pointer
@@ -46,7 +54,15 @@ class TestCFFI(TestCase):
             (cffi_sin, cffi_cos, 1.0),
             (cffi_sin, cffi_cos, -1.0),
             (cffi_cos, cffi_sin, 1.0),
-            (cffi_cos, cffi_sin, -1.0)]:
+            (cffi_cos, cffi_sin, -1.0),
+            (cffi_sin_ool, cffi_cos_ool, 1.0),
+            (cffi_sin_ool, cffi_cos_ool, -1.0),
+            (cffi_cos_ool, cffi_sin_ool, 1.0),
+            (cffi_cos_ool, cffi_sin_ool, -1.0),
+            (cffi_sin, cffi_cos_ool, 1.0),
+            (cffi_sin, cffi_cos_ool, -1.0),
+            (cffi_cos, cffi_sin_ool, 1.0),
+            (cffi_cos, cffi_sin_ool, -1.0)]:
             expected = pyfunc(fa, fb, x)
             got = cfunc(fa, fb, x)
             self.assertEqual(got, expected)


### PR DESCRIPTION
Out-of-line CFFI modules appear differently to inline ones - they are all of type `builtin_function_or_method`. This PR allows registering an out-of-line CFFI module with Numba so that it can build a mapping of types for all functions in the module, and therefore compile calls to them in jitted functions.