### PR TITLE
Fix flat indexing of boolean arrays

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1636,11 +1636,11 @@ def _make_flattening_iter_cls(flatiterty, kind):
 
             def getitem(self, context, builder, arrty, arr, index):
                 ptr = builder.gep(arr.data, [index])
-                return builder.load(ptr)
+                return load_item(context, builder, arrty, ptr)
 
             def setitem(self, context, builder, arrty, arr, index, value):
                 ptr = builder.gep(arr.data, [index])
-                builder.store(value, ptr)
+                store_item(context, builder, arrty, value, ptr)
 
         return CContiguousFlatIter
 
@@ -1769,11 +1769,11 @@ def _make_flattening_iter_cls(flatiterty, kind):
 
             def getitem(self, context, builder, arrty, arr, index):
                 ptr = self._ptr_for_index(context, builder, arrty, arr, index)
-                return builder.load(ptr)
+                return load_item(context, builder, arrty, ptr)
 
             def setitem(self, context, builder, arrty, arr, index, value):
                 ptr = self._ptr_for_index(context, builder, arrty, arr, index)
-                builder.store(value, ptr)
+                store_item(context, builder, arrty, value, ptr)
 
         return FlatIter
 

--- a/numba/tests/test_array_iterators.py
+++ b/numba/tests/test_array_iterators.py
@@ -120,6 +120,8 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         self.assertFalse(arr.flags.c_contiguous)
         self.assertFalse(arr.flags.f_contiguous)
         self.check_array_iter(arr)
+        arr = np.bool_([1, 0, 0, 1])
+        self.check_array_iter(arr)
 
     def test_array_view_iter(self):
         # Test iterating over a 1d view over a 2d array
@@ -127,6 +129,8 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         self.check_array_view_iter(arr, 1)
         self.check_array_view_iter(arr.T, 1)
         arr = arr[::2]
+        self.check_array_view_iter(arr, 1)
+        arr = np.bool_([1, 0, 0, 1]).reshape((2, 2))
         self.check_array_view_iter(arr, 1)
 
     def test_array_flat_3d(self):
@@ -149,6 +153,9 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         self.assertFalse(arr.flags.c_contiguous)
         self.assertFalse(arr.flags.f_contiguous)
         self.assertEqual(typeof(arr).layout, 'A')
+        self.check_array_flat(arr)
+        # Boolean array
+        arr = np.bool_([1, 0, 0, 1] * 2).reshape((2, 2, 2))
         self.check_array_flat(arr)
 
     def test_array_flat_empty(self):
@@ -190,6 +197,13 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         arr = np.array([42]).reshape(())
         for i in range(arr.size):
             check(arr, i)
+        # Boolean array
+        arr = np.bool_([1, 0, 0, 1])
+        for i in range(arr.size):
+            check(arr, i)
+        arr = arr[::2]
+        for i in range(arr.size):
+            check(arr, i)
 
     def test_array_flat_setitem(self):
         # Test indexing of array.flat object
@@ -216,6 +230,13 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         arr = np.array([42]).reshape(())
         for i in range(arr.size):
             check(arr, i)
+        # Boolean array
+        arr = np.bool_([1, 0, 0, 1])
+        for i in range(arr.size):
+            check(arr, i)
+        arr = arr[::2]
+        for i in range(arr.size):
+            check(arr, i)
 
     def test_array_ndenumerate_2d(self):
         arr = np.arange(12).reshape(4, 3)
@@ -239,6 +260,9 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         arrty = typeof(arr)
         self.assertEqual(arrty.layout, 'A')
         self.check_array_ndenumerate_sum(arr, arrty)
+        # Boolean array
+        arr = np.bool_([1, 0, 0, 1]).reshape((2, 2))
+        self.check_array_ndenumerate_sum(arr, typeof(arr))
 
     def test_array_ndenumerate_empty(self):
         arr = np.zeros(0, dtype=np.int32)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -507,6 +507,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             self.assertEqual(got.dtype, expected.dtype)
             np.testing.assert_array_equal(got, expected)
 
+        arr = np.int16([1, 0, -1, 0])
+        check_arr(arr)
+        arr = np.bool_([1, 0, 1])
+        check_arr(arr)
+
         arr = fac(24)
         check_arr(arr)
         check_arr(arr.reshape((3, 8)))


### PR DESCRIPTION
This would produce invalid LLVM IR (the usual i1 <-> i8 conversion issues).