### PR TITLE
Support cffi.FFI.from_buffer

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -391,9 +391,15 @@ functions, using the following C types:
 * :c:type:`char *`
 * :c:type:`void *`
 * :c:type:`uint8_t *`
+* :c:type:`float *`
+* :c:type:`double *`
 * :c:type:`ssize_t`
 * :c:type:`size_t`
 * :c:type:`void`
+
+The ``from_buffer`` method of ``cffi.FFI`` and ``CompiledFFI`` objects is
+supported for passing NumPy arrays of ``float32`` and ``float64`` values to C
+function parameters of type ``float *`` and ``double *`` respectively.
 
 Out-of-line cffi modules must be registered with Numba prior to the use of any
 of their functions from within Numba-compiled functions:

--- a/numba/targets/cffiimpl.py
+++ b/numba/targets/cffiimpl.py
@@ -4,7 +4,6 @@ Implementation of some CFFI functions
 
 from __future__ import print_function, absolute_import, division
 
-import cffi
 from numba.targets.imputils import implement, Registry
 from numba import types
 from . import arrayobj
@@ -12,7 +11,7 @@ from . import arrayobj
 registry = Registry()
 
 @registry.register
-@implement(cffi.FFI.from_buffer, types.Kind(types.Array))
+@implement('ffi.from_buffer', types.Kind(types.Array))
 def from_buffer(context, builder, sig, args):
     assert len(sig.args) == 1
     assert len(args) == 1

--- a/numba/targets/cffiimpl.py
+++ b/numba/targets/cffiimpl.py
@@ -1,0 +1,25 @@
+"""
+Implementation of some CFFI functions
+"""
+
+from __future__ import print_function, absolute_import, division
+
+import cffi
+from numba.targets.imputils import implement, Registry
+from numba import types
+from . import arrayobj
+
+registry = Registry()
+
+@registry.register
+@implement(cffi.FFI.from_buffer, types.Kind(types.Array))
+def from_buffer(context, builder, sig, args):
+    assert len(sig.args) == 1
+    assert len(args) == 1
+    [fromty] = sig.args
+    [val] = args
+    # Type inference should have prevented passing a buffer from an
+    # array to a pointer of the wrong type
+    assert fromty.dtype == sig.return_type.dtype
+    ary = arrayobj.make_array(fromty)(context, builder, val)
+    return ary.data

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -12,8 +12,8 @@ from .base import BaseContext, PYOBJECT
 from numba import utils, cgutils, types
 from numba.utils import cached_property
 from numba.targets import (
-    callconv, codegen, externals, intrinsics, listobj, cmathimpl, mathimpl,
-    npyimpl, operatorimpl, printimpl, randomimpl)
+    callconv, cffiimpl, codegen, externals, intrinsics, listobj, cmathimpl,
+    mathimpl, npyimpl, operatorimpl, printimpl, randomimpl)
 from .options import TargetOptions
 from numba.runtime import rtsys
 
@@ -48,6 +48,7 @@ class CPUContext(BaseContext):
 
         # Add target specific implementations
         self.install_registry(cmathimpl.registry)
+        self.install_registry(cffiimpl.registry)
         self.install_registry(mathimpl.registry)
         self.install_registry(npyimpl.registry)
         self.install_registry(operatorimpl.registry)

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from numba import cffi_support
+import numpy as np
 
 
 if cffi_support.SUPPORTED:
@@ -28,6 +29,25 @@ if cffi_support.SUPPORTED:
 
     # Compile out-of-line module and load it
 
+    defs += """
+    void vsSin(int n, float* x, float* y);
+    void vdSin(int n, double* x, double* y);
+    """
+
+    source += """
+    void vsSin(int n, float* x, float* y) {
+        int i;
+        for (i=0; i<n; i++)
+            y[i] = sin(x[i]);
+    }
+
+    void vdSin(int n, double* x, double* y) {
+        int i;
+        for (i=0; i<n; i++)
+            y[i] = sin(x[i]);
+    }
+    """
+
     ffi_ool = FFI()
     ffi.set_source('cffi_usecases_ool', source)
     ffi.cdef(defs, override=True)
@@ -38,6 +58,9 @@ if cffi_support.SUPPORTED:
     cffi_sin_ool = cffi_usecases_ool.lib.sin
     cffi_cos_ool = cffi_usecases_ool.lib.cos
     cffi_foo = cffi_usecases_ool.lib.foo
+    vsSin = cffi_usecases_ool.lib.vsSin
+    vdSin = cffi_usecases_ool.lib.vdSin
+
 
 def use_cffi_sin(x):
     return cffi_sin(x) * 2
@@ -59,3 +82,19 @@ def use_func_pointer(fa, fb, x):
 
 def use_user_defined_symbols():
     return cffi_foo(1, 2, 3)
+
+# The from_buffer method is member of cffi.FFI, and also of CompiledFFI objects
+# (cffi_usecases_ool.ffi is a CompiledFFI object) so we use both in these
+# functions.
+
+def vector_sin_float32(x):
+    y = np.empty_like(x)
+    vsSin(len(x), ffi.from_buffer(x),
+        cffi_usecases_ool.ffi.from_buffer(y))
+    return y
+
+def vector_sin_float64(x):
+    y = np.empty_like(x)
+    vdSin(len(x), ffi.from_buffer(x),
+        cffi_usecases_ool.ffi.from_buffer(y))
+    return y

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -75,15 +75,16 @@ class TestCFFI(TestCase):
         cfunc = jit(nopython=True)(pyfunc)
         self.assertEqual(pyfunc(), cfunc())
 
+    def _test_pass_numpy_array(self, pyfunc, dtype):
+        x = np.arange(10).astype(dtype)
+        cfunc = jit(nopython=True)(pyfunc)
+        np.testing.assert_equal(pyfunc(x), cfunc(x))
+
     def test_pass_numpy_array_float32(self):
-        x = np.arange(10).astype(np.float32)
-        cfunc = jit(nopython=True)(vector_sin_float32)
-        np.testing.assert_equal(np.sin(x), cfunc(x))
+        self._test_pass_numpy_array(vector_sin_float32, np.float32)
 
     def test_pass_numpy_array_float64(self):
-        x = np.arange(10).astype(np.float64)
-        cfunc = jit(nopython=True)(vector_sin_float64)
-        np.testing.assert_equal(np.sin(x), cfunc(x))
+        self._test_pass_numpy_array(vector_sin_float64, np.float64)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -6,6 +6,7 @@ from numba.compiler import compile_isolated, Flags
 from numba.tests.support import TestCase
 from numba.tests.cffi_usecases import *
 
+import numpy as np
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
@@ -73,6 +74,17 @@ class TestCFFI(TestCase):
         pyfunc = use_user_defined_symbols
         cfunc = jit(nopython=True)(pyfunc)
         self.assertEqual(pyfunc(), cfunc())
+
+    def test_pass_numpy_array_float32(self):
+        x = np.arange(10).astype(np.float32)
+        cfunc = jit(nopython=True)(vector_sin_float32)
+        np.testing.assert_equal(np.sin(x), cfunc(x))
+
+    def test_pass_numpy_array_float64(self):
+        x = np.arange(10).astype(np.float64)
+        cfunc = jit(nopython=True)(vector_sin_float64)
+        np.testing.assert_equal(np.sin(x), cfunc(x))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -1385,6 +1385,7 @@ class Slice3Type(Type):
 
 pyobject = PyObject('pyobject')
 ffi_forced_object = Opaque('ffi_forced_object')
+ffi = Opaque('ffi')
 none = NoneType('none')
 ellipsis = EllipsisType('...')
 Any = Phantom('any')
@@ -1562,4 +1563,5 @@ c8
 c16
 optional
 ffi_forced_object
+ffi
 '''.split()

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -30,7 +30,10 @@ def is_ffi_module(obj):
     # CompiledFFI, which behaves similarly to an instance of cffi.FFI. In
     # order to simplify handling a CompiledFFI object, we treat them as
     # if they're cffi.FFI instances for typing and lowering purposes.
-    return obj in _ffi_modules or isinstance(obj, cffi.FFI)
+    try:
+        return obj in _ffi_modules or isinstance(obj, cffi.FFI)
+    except TypeError: # Unhashable type possible
+        return False
 
 def is_cffi_func(obj):
     """Check whether the obj is a CFFI function"""

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -20,18 +20,16 @@ except ImportError:
 SUPPORTED = ffi is not None
 _ool_func_types = {}
 _ool_func_ptr = {}
-_ffi_modules = set()
+_ffi_instances = set()
 
 
-ffi_module = types.Module(cffi.FFI)
-
-def is_ffi_module(obj):
+def is_ffi_instance(obj):
     # Compiled FFI modules have a member, ffi, which is an instance of
     # CompiledFFI, which behaves similarly to an instance of cffi.FFI. In
     # order to simplify handling a CompiledFFI object, we treat them as
     # if they're cffi.FFI instances for typing and lowering purposes.
     try:
-        return obj in _ffi_modules or isinstance(obj, cffi.FFI)
+        return obj in _ffi_instances or isinstance(obj, cffi.FFI)
     except TypeError: # Unhashable type possible
         return False
 
@@ -146,23 +144,23 @@ registry = templates.Registry()
 
 @registry.register
 class FFI_from_buffer(templates.AbstractTemplate):
-    key = cffi.FFI.from_buffer
+    key = 'ffi.from_buffer'
 
     def generic(self, args, kws):
         if kws or (len(args) != 1):
             return
         [ary] = args
-        if not (isinstance(ary, types.Array) or ary.layout in ('C', 'F')):
+        if not (isinstance(ary, types.Array) and ary.layout in ('C', 'F')):
             return
         ptr = types.CPointer(ary.dtype)
         return templates.signature(ptr, ary)
 
 @registry.register_attr
 class FFIAttribute(templates.AttributeTemplate):
-    key = ffi_module
+    key = types.ffi
 
     def resolve_from_buffer(self, ffi):
-        return types.Function(FFI_from_buffer)
+        return types.BoundFunction(FFI_from_buffer, types.ffi)
 
 
 def register_module(mod):
@@ -175,4 +173,4 @@ def register_module(mod):
             _ool_func_types[f] = mod.ffi.typeof(f)
             addr = mod.ffi.addressof(mod.lib, f.__name__)
             _ool_func_ptr[f] = int(mod.ffi.cast("uintptr_t", addr))
-        _ffi_modules.add(mod.ffi)
+        _ffi_instances.add(mod.ffi)

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -20,7 +20,17 @@ except ImportError:
 SUPPORTED = ffi is not None
 _ool_func_types = {}
 _ool_func_ptr = {}
+_ffi_modules = set()
 
+
+ffi_module = types.Module(cffi.FFI)
+
+def is_ffi_module(obj):
+    # Compiled FFI modules have a member, ffi, which is an instance of
+    # CompiledFFI, which behaves similarly to an instance of cffi.FFI. In
+    # order to simplify handling a CompiledFFI object, we treat them as
+    # if they're cffi.FFI instances for typing and lowering purposes.
+    return obj in _ffi_modules or isinstance(obj, cffi.FFI)
 
 def is_cffi_func(obj):
     """Check whether the obj is a CFFI function"""
@@ -72,10 +82,11 @@ def _type_map():
             ffi.typeof('uint64_t') :            types.ulonglong,
             ffi.typeof('float') :               types.float_,
             ffi.typeof('double') :              types.double,
-            # ffi.typeof('long double') :         longdouble,
             ffi.typeof('char *') :              types.voidptr,
             ffi.typeof('void *') :              types.voidptr,
             ffi.typeof('uint8_t *') :           types.CPointer(types.uint8),
+            ffi.typeof('float *') :             types.CPointer(types.float32),
+            ffi.typeof('double *') :            types.CPointer(types.float64),
             ffi.typeof('ssize_t') :             types.intp,
             ffi.typeof('size_t') :              types.uintp,
             ffi.typeof('void') :                types.void,
@@ -127,6 +138,30 @@ class ExternCFunction(types.ExternalFunction):
         signature = templates.signature(self.restype, *self.argtypes)
         super(ExternCFunction, self).__init__(symbol, signature)
 
+
+registry = templates.Registry()
+
+@registry.register
+class FFI_from_buffer(templates.AbstractTemplate):
+    key = cffi.FFI.from_buffer
+
+    def generic(self, args, kws):
+        if kws or (len(args) != 1):
+            return
+        [ary] = args
+        if not (isinstance(ary, types.Array) or ary.layout in ('C', 'F')):
+            return
+        ptr = types.CPointer(ary.dtype)
+        return templates.signature(ptr, ary)
+
+@registry.register_attr
+class FFIAttribute(templates.AttributeTemplate):
+    key = ffi_module
+
+    def resolve_from_buffer(self, ffi):
+        return types.Function(FFI_from_buffer)
+
+
 def register_module(mod):
     """
     Add typing for all functions in an out-of-line CFFI module to the typemap
@@ -137,3 +172,4 @@ def register_module(mod):
             _ool_func_types[f] = mod.ffi.typeof(f)
             addr = mod.ffi.addressof(mod.lib, f.__name__)
             _ool_func_ptr[f] = int(mod.ffi.cast("uintptr_t", addr))
+        _ffi_modules.add(mod.ffi)

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -444,4 +444,5 @@ class Context(BaseContext):
         self.install(npydecl.registry)
         self.install(operatordecl.registry)
         self.install(randomdecl.registry)
+        self.install(cffi_utils.registry)
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -39,12 +39,12 @@ def typeof_impl(val, c):
         return tp
 
     # cffi is handled here as it does not expose a public base class
-    # for exported functions.
+    # for exported functions or CompiledFFI instances.
     if cffi_utils.SUPPORTED:
         if cffi_utils.is_cffi_func(val):
             return cffi_utils.make_function_type(val)
-        if cffi_utils.is_ffi_module(val):
-            return cffi_utils.ffi_module
+        if cffi_utils.is_ffi_instance(val):
+            return types.ffi
 
     return getattr(val, "_numba_type_", None)
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -40,8 +40,11 @@ def typeof_impl(val, c):
 
     # cffi is handled here as it does not expose a public base class
     # for exported functions.
-    if cffi_utils.SUPPORTED and cffi_utils.is_cffi_func(val):
-        return cffi_utils.make_function_type(val)
+    if cffi_utils.SUPPORTED:
+        if cffi_utils.is_cffi_func(val):
+            return cffi_utils.make_function_type(val)
+        if cffi_utils.is_ffi_module(val):
+            return cffi_utils.ffi_module
 
     return getattr(val, "_numba_type_", None)
 


### PR DESCRIPTION
This can be used to pass contiguous Numpy arrays of float32 and
float64 to C function parameters of types float* and double*
respectively.

Some discussion/notes in #1443.