### PR TITLE
Add support for listing tests (without running them).

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -111,23 +111,29 @@ Numba is validated using a test suite comprised of various kind of tests
 (unit tests, functional tests). The test suite is written using the
 standard :py:mod:`unittest` framework.
 
-The various test modules are inside the ``numba/tests`` directory. There
-are two entry points to run the test suite:
+The tests can be executed using the `runtests.py` script. It accepts various
+options to influence test running and reporting. Pass ``-h``
+or ``--help`` to get a glimpse at those options. Examples:
 
-* if you want to run the whole test suite (which will take a couple of
-  minutes), call the ``runtests.py`` script; in particular, the ``-m`` flag
-  will parallelize the test suite into several processes::
+* to list all available tests::
 
-  $ python runtests.py -m
+    $ runtests.py -l
 
-* if you want to run an individual test module, invoke it as a python
-  module, for example::
+* to list tests from a specific (sub-)suite::
 
-  $ python -m numba.tests.test_closure
+    $ runtests.py -l numba.tests.test_usecases
 
-Both the global test runner ``runtests.py`` and individual modules allow you
-to pass various options to influence test running and report.  Pass ``-h``
-or ``--help`` to get a glimpse at those options.
+* to run those tests::
+
+    $ runtests.py numba.tests.test_usecases
+
+* to run all tests in parallel, using multiple sub-processes::
+
+    $ runtests.py -m
+    
+* For a detailed list of all options::
+
+    $ runtests.py -h
 
 
 Development rules

--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -1,0 +1,5 @@
+from numba.tests import SerialSuite
+
+def load_tests(loader, tests, pattern):
+    suite = loader.discover("numba.cuda.tests")
+    return SerialSuite(suite)

--- a/numba/cuda/tests/cudadrv/__init__.py
+++ b/numba/cuda/tests/cudadrv/__init__.py
@@ -1,0 +1,5 @@
+from numba.tests import SerialSuite
+
+def load_tests(loader, tests, pattern):
+    suite = loader.discover("numba.cuda.tests.cudadrv")
+    return SerialSuite(suite)

--- a/numba/cuda/tests/cudapy/__init__.py
+++ b/numba/cuda/tests/cudapy/__init__.py
@@ -1,0 +1,5 @@
+from numba.tests import SerialSuite
+
+def load_tests(loader, tests, pattern):
+    suite = loader.discover("numba.cuda.tests.cudapy")
+    return SerialSuite(suite)

--- a/numba/cuda/tests/cudapy/test_array.py
+++ b/numba/cuda/tests/cudapy/test_array.py
@@ -4,21 +4,6 @@ from numba.cuda.testing import unittest
 from numba import cuda
 
 
-@cuda.jit('void(double[:])')
-def kernel(x):
-    i = cuda.grid(1)
-    if i < x.shape[0]:
-        x[i] = i
-
-
-@cuda.jit('void(double[:], double[:])')
-def copykernel(x, y):
-    i = cuda.grid(1)
-    if i < x.shape[0]:
-        x[i] = i
-        y[i] = i
-
-
 class TestCudaArray(unittest.TestCase):
     def test_gpu_array_zero_length(self):
         x = numpy.arange(0)
@@ -30,6 +15,13 @@ class TestCudaArray(unittest.TestCase):
         self.assertEqual(x.size, hx.size)
 
     def test_gpu_array_strided(self):
+
+        @cuda.jit('void(double[:])')
+        def kernel(x):
+            i = cuda.grid(1)
+            if i < x.shape[0]:
+                x[i] = i
+
         x = numpy.arange(10, dtype=numpy.double)
         y = numpy.ndarray(shape=10 * 8, buffer=x, dtype=numpy.byte)
         z = numpy.ndarray(9, buffer=y[4:-4], dtype=numpy.double)
@@ -37,6 +29,14 @@ class TestCudaArray(unittest.TestCase):
         self.assertTrue(numpy.allclose(z, list(range(9))))
 
     def test_gpu_array_interleaved(self):
+
+        @cuda.jit('void(double[:], double[:])')
+        def copykernel(x, y):
+            i = cuda.grid(1)
+            if i < x.shape[0]:
+                x[i] = i
+                y[i] = i
+
         x = numpy.arange(10, dtype=numpy.double)
         y = x[:-1:2]
         # z = x[1::2]

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -4,19 +4,19 @@ from numba import cuda
 from numba.cuda.testing import unittest
 
 
-@cuda.jit('double(double[:],int64)', device=True, inline=True)
-def device_function(a, c):
-    return a[c]
-
-
-@cuda.jit('void(double[:],double[:])')
-def kernel(x, y):
-    i = cuda.grid(1)
-    y[i] = device_function(x, i)
-
-
 class TestCudaArrayArg(unittest.TestCase):
     def test_array_ary(self):
+
+        @cuda.jit('double(double[:],int64)', device=True, inline=True)
+        def device_function(a, c):
+            return a[c]
+
+
+        @cuda.jit('void(double[:],double[:])')
+        def kernel(x, y):
+            i = cuda.grid(1)
+            y[i] = device_function(x, i)
+
         x = numpy.arange(10, dtype=numpy.double)
         y = numpy.zeros_like(x)
         kernel[10, 1](x, y)

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -43,33 +43,6 @@ def black_scholes(callResult, putResult, stockPrice, optionStrike, optionYears,
     putResult[:] = (X * expRT * (1.0 - cndd2) - S * (1.0 - cndd1))
 
 
-@cuda.jit(argtypes=(double,), restype=double, device=True, inline=True)
-def cnd_cuda(d):
-    K = 1.0 / (1.0 + 0.2316419 * math.fabs(d))
-    ret_val = (RSQRT2PI * math.exp(-0.5 * d * d) *
-               (K * (A1 + K * (A2 + K * (A3 + K * (A4 + K * A5))))))
-    if d > 0:
-        ret_val = 1.0 - ret_val
-    return ret_val
-
-
-@cuda.jit(argtypes=(double[:], double[:], double[:], double[:], double[:],
-                    double, double))
-def black_scholes_cuda(callResult, putResult, S, X, T, R, V):
-    i = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-    if i >= S.shape[0]:
-        return
-    sqrtT = math.sqrt(T[i])
-    d1 = (math.log(S[i] / X[i]) + (R + 0.5 * V * V) * T[i]) / (V * sqrtT)
-    d2 = d1 - V * sqrtT
-    cndd1 = cnd_cuda(d1)
-    cndd2 = cnd_cuda(d2)
-
-    expRT = math.exp((-1. * R) * T[i])
-    callResult[i] = (S[i] * cndd1 - X[i] * expRT * cndd2)
-    putResult[i] = (X[i] * expRT * (1.0 - cndd2) - S[i] * (1.0 - cndd1))
-
-
 def randfloat(rand_var, low, high):
     return (1.0 - rand_var) * low + rand_var * high
 
@@ -93,6 +66,34 @@ class TestBlackScholes(unittest.TestCase):
         for i in range(iterations):
             black_scholes(callResultNumpy, putResultNumpy, stockPrice,
                           optionStrike, optionYears, RISKFREE, VOLATILITY)
+
+
+
+        @cuda.jit(argtypes=(double,), restype=double, device=True, inline=True)
+        def cnd_cuda(d):
+            K = 1.0 / (1.0 + 0.2316419 * math.fabs(d))
+            ret_val = (RSQRT2PI * math.exp(-0.5 * d * d) *
+                       (K * (A1 + K * (A2 + K * (A3 + K * (A4 + K * A5))))))
+            if d > 0:
+                ret_val = 1.0 - ret_val
+            return ret_val
+
+
+        @cuda.jit(argtypes=(double[:], double[:], double[:], double[:], double[:],
+                            double, double))
+        def black_scholes_cuda(callResult, putResult, S, X, T, R, V):
+            i = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
+            if i >= S.shape[0]:
+                return
+            sqrtT = math.sqrt(T[i])
+            d1 = (math.log(S[i] / X[i]) + (R + 0.5 * V * V) * T[i]) / (V * sqrtT)
+            d2 = d1 - V * sqrtT
+            cndd1 = cnd_cuda(d1)
+            cndd2 = cnd_cuda(d2)
+
+            expRT = math.exp((-1. * R) * T[i])
+            callResult[i] = (S[i] * cndd1 - X[i] * expRT * cndd2)
+            putResult[i] = (X[i] * expRT * (1.0 - cndd2) - S[i] * (1.0 - cndd1))
 
         # numbapro
         time0 = time.time()

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -4,28 +4,19 @@ from numba.cuda.testing import unittest
 from numba import cuda
 
 
-@cuda.jit("float32(float32, float32)", device=True)
-def add2f(a, b):
-    return a + b
-
-
-@cuda.jit("float32(float32, float32)", device=True)
-def indirect(a, b):
-    return add2f(a, b)
-
-
-def use_add2f(ary):
-    i = cuda.grid(1)
-    ary[i] = add2f(ary[i], ary[i])
-
-
-def indirect_add2f(ary):
-    i = cuda.grid(1)
-    ary[i] = indirect(ary[i], ary[i])
-
-
 class TestDeviceFunc(unittest.TestCase):
+
+
     def test_use_add2f(self):
+
+        @cuda.jit("float32(float32, float32)", device=True)
+        def add2f(a, b):
+            return a + b
+
+        def use_add2f(ary):
+            i = cuda.grid(1)
+            ary[i] = add2f(ary[i], ary[i])
+
         compiled = cuda.jit("void(float32[:])")(use_add2f)
 
         nelem = 10
@@ -36,6 +27,19 @@ class TestDeviceFunc(unittest.TestCase):
         self.assertTrue(np.all(ary == exp), (ary, exp))
 
     def test_indirect_add2f(self):
+
+        @cuda.jit("float32(float32, float32)", device=True)
+        def add2f(a, b):
+            return a + b
+
+        @cuda.jit("float32(float32, float32)", device=True)
+        def indirect(a, b):
+            return add2f(a, b)
+
+        def indirect_add2f(ary):
+            i = cuda.grid(1)
+            ary[i] = indirect(ary[i], ary[i])
+
         compiled = cuda.jit("void(float32[:])")(indirect_add2f)
 
         nelem = 10

--- a/numba/cuda/tests/cudapy/test_forall.py
+++ b/numba/cuda/tests/cudapy/test_forall.py
@@ -4,30 +4,29 @@ import numba.unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
 import numpy
 
-
-@cuda.jit
-def foo(x):
-    i = cuda.grid(1)
-    if i < x.size:
-        x[i] += 1
-
-
-@cuda.jit("void(float32, float32[:], float32[:])")
-def bar(a, x, y):
-    i = cuda.grid(1)
-    if i < x.size:
-        y[i] = a * x[i] + y[i]
-
-
 @skip_on_cudasim('forall API unsupported in the simulator')
 class TestForAll(unittest.TestCase):
     def test_forall_1(self):
+
+        @cuda.jit
+        def foo(x):
+            i = cuda.grid(1)
+            if i < x.size:
+                x[i] += 1
+
         arr = numpy.arange(11)
         orig = arr.copy()
         foo.forall(arr.size)(arr)
         self.assertTrue(numpy.all(arr == orig + 1))
 
     def test_forall_2(self):
+
+        @cuda.jit("void(float32, float32[:], float32[:])")
+        def bar(a, x, y):
+            i = cuda.grid(1)
+            if i < x.size:
+                y[i] = a * x[i] + y[i]
+
         x = numpy.arange(13, dtype=numpy.float32)
         y = numpy.arange(13, dtype=numpy.float32)
         oldy = y.copy()

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -9,46 +9,31 @@ from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
 
 
-@guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
-             '(m,n),(n,p)->(m,p)',
-             target='cuda')
-def matmulcore(A, B, C):
-    m, n = A.shape
-    n, p = B.shape
-    for i in range(m):
-        for j in range(p):
-            C[i, j] = 0
-            for k in range(n):
-                C[i, j] += A[i, k] * B[k, j]
-
-
-gufunc = matmulcore
-gufunc.max_blocksize = 512
-
 non_stream_speedups = []
 stream_speedups = []
 
 
-@guvectorize([void(float32[:], float32[:])],
-             '(x)->(x)',
-             target='cuda')
-def copy(A, B):
-    for i in range(B.size):
-        B[i] = A[i]
-
-
-@guvectorize([void(float32[:, :], float32[:, :])],
-             '(x, y)->(x, y)',
-             target='cuda')
-def copy2d(A, B):
-    for x in range(B.shape[0]):
-        for y in range(B.shape[1]):
-            B[x, y] = A[x, y]
-
-
 @skip_on_cudasim('ufunc API unsupported in the simulator')
 class TestCUDAGufunc(unittest.TestCase):
+
     def test_gufunc_small(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         matrix_ct = 2
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2,
                                                                    4)
@@ -70,6 +55,22 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_auto_transfer(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         matrix_ct = 2
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2,
                                                                    4)
@@ -93,6 +94,22 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         matrix_ct = 1001 # an odd number to test thread/block division in CUDA
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2,
                                                                    4)
@@ -112,6 +129,22 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_hidim(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         matrix_ct = 100 # an odd number to test thread/block division in CUDA
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(4, 25, 2, 4)
         B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(4, 25, 4, 5)
@@ -129,6 +162,22 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_adjust_blocksize(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         matrix_ct = 1001 # an odd number to test thread/block division in CUDA
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2,
                                                                    4)
@@ -141,6 +190,22 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_stream(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :], float32[:, :])],
+                     '(m,n),(n,p)->(m,p)',
+                     target='cuda')
+        def matmulcore(A, B, C):
+            m, n = A.shape
+            n, p = B.shape
+            for i in range(m):
+                for j in range(p):
+                    C[i, j] = 0
+                    for k in range(n):
+                        C[i, j] += A[i, k] * B[k, j]
+
+        gufunc = matmulcore
+        gufunc.max_blocksize = 512
+
         #cuda.driver.flush_pending_free()
         matrix_ct = 1001 # an odd number to test thread/block division in CUDA
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2,
@@ -169,18 +234,43 @@ class TestCUDAGufunc(unittest.TestCase):
         self.assertTrue(np.allclose(C, Gold))
 
     def test_copy(self):
+
+        @guvectorize([void(float32[:], float32[:])],
+                     '(x)->(x)',
+                     target='cuda')
+        def copy(A, B):
+            for i in range(B.size):
+                B[i] = A[i]
+
         A = np.arange(10, dtype=np.float32) + 1
         B = np.zeros_like(A)
         copy(A, out=B)
         self.assertTrue(np.allclose(A, B))
 
     def test_copy_odd(self):
+
+        @guvectorize([void(float32[:], float32[:])],
+                     '(x)->(x)',
+                     target='cuda')
+        def copy(A, B):
+            for i in range(B.size):
+                B[i] = A[i]
+
         A = np.arange(11, dtype=np.float32) + 1
         B = np.zeros_like(A)
         copy(A, out=B)
         self.assertTrue(np.allclose(A, B))
 
     def test_copy2d(self):
+
+        @guvectorize([void(float32[:, :], float32[:, :])],
+                     '(x, y)->(x, y)',
+                     target='cuda')
+        def copy2d(A, B):
+            for x in range(B.shape[0]):
+                for y in range(B.shape[1]):
+                    B[x, y] = A[x, y]
+
         A = np.arange(30, dtype=np.float32).reshape(5, 6) + 1
         B = np.zeros_like(A)
         copy2d(A, out=B)

--- a/numba/cuda/tests/cudapy/test_idiv.py
+++ b/numba/cuda/tests/cudapy/test_idiv.py
@@ -4,22 +4,15 @@ from numba import cuda, float32, float64, int32
 from numba.cuda.testing import unittest
 
 
-@cuda.jit(argtypes=[float32[:, :], int32, int32])
-def div(grid, l_x, l_y):
-    for x in range(l_x):
-        for y in range(l_y):
-            grid[x, y] /= 2.0
-
-
-@cuda.jit(argtypes=[float64[:, :], int32, int32])
-def div_double(grid, l_x, l_y):
-    for x in range(l_x):
-        for y in range(l_y):
-            grid[x, y] /= 2.0
-
-
 class TestCudaIDiv(unittest.TestCase):
     def test_inplace_div(self):
+
+        @cuda.jit(argtypes=[float32[:, :], int32, int32])
+        def div(grid, l_x, l_y):
+            for x in range(l_x):
+                for y in range(l_y):
+                    grid[x, y] /= 2.0
+
         x = np.ones((2, 2), dtype=np.float32)
         grid = cuda.to_device(x)
         div(grid, 2, 2)
@@ -28,6 +21,13 @@ class TestCudaIDiv(unittest.TestCase):
 
 
     def test_inplace_div_double(self):
+
+        @cuda.jit(argtypes=[float64[:, :], int32, int32])
+        def div_double(grid, l_x, l_y):
+            for x in range(l_x):
+                for y in range(l_y):
+                    grid[x, y] /= 2.0
+
         x = np.ones((2, 2), dtype=np.float64)
         grid = cuda.to_device(x)
         div_double(grid, 2, 2)

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -12,59 +12,59 @@ else:
     tpb = 16
 SM_SIZE = tpb, tpb
 
-
-@cuda.jit(float64(float64, float64), device=True, inline=True)
-def get_max(a, b):
-    if a > b:
-        return a
-    else:
-        return b
-
-
-@cuda.jit(void(float64[:, :], float64[:, :], float64[:, :]))
-def jocabi_relax_core(A, Anew, error):
-    err_sm = cuda.shared.array(SM_SIZE, dtype=float64)
-
-    ty = cuda.threadIdx.x
-    tx = cuda.threadIdx.y
-    bx = cuda.blockIdx.x
-    by = cuda.blockIdx.y
-
-    n = A.shape[0]
-    m = A.shape[1]
-
-    i, j = cuda.grid(2)
-
-    err_sm[ty, tx] = 0
-    if j >= 1 and j < n - 1 and i >= 1 and i < m - 1:
-        Anew[j, i] = 0.25 * ( A[j, i + 1] + A[j, i - 1] \
-                              + A[j - 1, i] + A[j + 1, i])
-        err_sm[ty, tx] = Anew[j, i] - A[j, i]
-
-    cuda.syncthreads()
-
-    # max-reduce err_sm vertically
-    t = tpb // 2
-    while t > 0:
-        if ty < t:
-            err_sm[ty, tx] = get_max(err_sm[ty, tx], err_sm[ty + t, tx])
-        t //= 2
-        cuda.syncthreads()
-
-    # max-reduce err_sm horizontally
-    t = tpb // 2
-    while t > 0:
-        if tx < t and ty == 0:
-            err_sm[ty, tx] = get_max(err_sm[ty, tx], err_sm[ty, tx + t])
-        t //= 2
-        cuda.syncthreads()
-
-    if tx == 0 and ty == 0:
-        error[by, bx] = err_sm[0, 0]
-
-
 class TestCudaLaplace(unittest.TestCase):
     def test_laplace_small(self):
+
+        @cuda.jit(float64(float64, float64), device=True, inline=True)
+        def get_max(a, b):
+            if a > b:
+                return a
+            else:
+                return b
+
+        @cuda.jit(void(float64[:, :], float64[:, :], float64[:, :]))
+        def jocabi_relax_core(A, Anew, error):
+            err_sm = cuda.shared.array(SM_SIZE, dtype=float64)
+
+            ty = cuda.threadIdx.x
+            tx = cuda.threadIdx.y
+            bx = cuda.blockIdx.x
+            by = cuda.blockIdx.y
+
+            n = A.shape[0]
+            m = A.shape[1]
+
+            i, j = cuda.grid(2)
+
+            err_sm[ty, tx] = 0
+            if j >= 1 and j < n - 1 and i >= 1 and i < m - 1:
+                Anew[j, i] = 0.25 * ( A[j, i + 1] + A[j, i - 1] \
+                                      + A[j - 1, i] + A[j + 1, i])
+                err_sm[ty, tx] = Anew[j, i] - A[j, i]
+
+            cuda.syncthreads()
+
+            # max-reduce err_sm vertically
+            t = tpb // 2
+            while t > 0:
+                if ty < t:
+                    err_sm[ty, tx] = get_max(err_sm[ty, tx], err_sm[ty + t, tx])
+                t //= 2
+                cuda.syncthreads()
+
+            # max-reduce err_sm horizontally
+            t = tpb // 2
+            while t > 0:
+                if tx < t and ty == 0:
+                    err_sm[ty, tx] = get_max(err_sm[ty, tx], err_sm[ty, tx + t])
+                t //= 2
+                cuda.syncthreads()
+
+            if tx == 0 and ty == 0:
+                error[by, bx] = err_sm[0, 0]
+
+
+        
         if config.ENABLE_CUDASIM:
             NN, NM = 4, 4
             iter_max = 20

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -17,41 +17,42 @@ n = bpg * tpb
 SM_SIZE = (tpb, tpb)
 
 
-@cuda.jit(argtypes=[float32[:, ::1], float32[:, ::1], float32[:, ::1]])
-def cu_square_matrix_mul(A, B, C):
-    sA = cuda.shared.array(shape=SM_SIZE, dtype=float32)
-    sB = cuda.shared.array(shape=(tpb, tpb), dtype=float32)
-
-    tx = cuda.threadIdx.x
-    ty = cuda.threadIdx.y
-    bx = cuda.blockIdx.x
-    by = cuda.blockIdx.y
-    bw = cuda.blockDim.x
-    bh = cuda.blockDim.y
-
-    x = tx + bx * bw
-    y = ty + by * bh
-
-    acc = float32(0)  # forces all the math to be f32
-    for i in range(bpg):
-        if x < n and y < n:
-            sA[ty, tx] = A[y, tx + i * tpb]
-            sB[ty, tx] = B[ty + i * tpb, x]
-
-        cuda.syncthreads()
-
-        if x < n and y < n:
-            for j in range(tpb):
-                acc += sA[ty, j] * sB[j, tx]
-
-        cuda.syncthreads()
-
-    if x < n and y < n:
-        C[y, x] = acc
-
-
 class TestCudaMatMul(unittest.TestCase):
+
     def test_func(self):
+
+        @cuda.jit(argtypes=[float32[:, ::1], float32[:, ::1], float32[:, ::1]])
+        def cu_square_matrix_mul(A, B, C):
+            sA = cuda.shared.array(shape=SM_SIZE, dtype=float32)
+            sB = cuda.shared.array(shape=(tpb, tpb), dtype=float32)
+
+            tx = cuda.threadIdx.x
+            ty = cuda.threadIdx.y
+            bx = cuda.blockIdx.x
+            by = cuda.blockIdx.y
+            bw = cuda.blockDim.x
+            bh = cuda.blockDim.y
+
+            x = tx + bx * bw
+            y = ty + by * bh
+
+            acc = float32(0)  # forces all the math to be f32
+            for i in range(bpg):
+                if x < n and y < n:
+                    sA[ty, tx] = A[y, tx + i * tpb]
+                    sB[ty, tx] = B[ty + i * tpb, x]
+
+                cuda.syncthreads()
+
+                if x < n and y < n:
+                    for j in range(tpb):
+                        acc += sA[ty, j] * sB[j, tx]
+
+                cuda.syncthreads()
+
+            if x < n and y < n:
+                C[y, x] = acc
+
         np.random.seed(42)
         A = np.array(np.random.random((n, n)), dtype=np.float32)
         B = np.array(np.random.random((n, n)), dtype=np.float32)

--- a/numba/cuda/tests/cudapy/test_vectorize.py
+++ b/numba/cuda/tests/cudapy/test_vectorize.py
@@ -5,6 +5,7 @@ from numba import cuda, int32, float32, float64
 from timeit import default_timer as time
 from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import CUDATestCase
 from numba import config
 
 sig = [int32(int32, int32),
@@ -17,25 +18,31 @@ if config.ENABLE_CUDASIM:
     target='cpu'
 
 
-@vectorize(sig, target=target)
-def vector_add(a, b):
-    return a + b
-
-
-cuda_ufunc = vector_add
-
 test_dtypes = np.float32, np.int32
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAVectorize(unittest.TestCase):
+class TestCUDAVectorize(CUDATestCase):
+
     def test_scalar(self):
+
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
         a = 1.2
         b = 2.3
         c = vector_add(a, b)
         self.assertEqual(c, a + b)
 
     def test_1d(self):
+
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         # build python ufunc
         np_ufunc = np.add
 
@@ -67,6 +74,13 @@ class TestCUDAVectorize(unittest.TestCase):
         test(np.int32)
 
     def test_1d_async(self):
+
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         # build python ufunc
         np_ufunc = np.add
 
@@ -102,6 +116,13 @@ class TestCUDAVectorize(unittest.TestCase):
         test(np.int32)
 
     def test_nd(self):
+
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         def test(dtype, order, nd, size=4):
             data = np.random.random((size,) * nd).astype(dtype)
             data[data != data] = 2.4
@@ -128,6 +149,10 @@ class TestCUDAVectorize(unittest.TestCase):
         self.reduce_test2(2 ** 10 + 1)
 
     def test_output_arg(self):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
         A = np.arange(10, dtype=np.float32)
         B = np.arange(10, dtype=np.float32)
         C = np.empty_like(A)
@@ -135,12 +160,24 @@ class TestCUDAVectorize(unittest.TestCase):
         self.assertTrue(np.allclose(A + B, C))
 
     def reduce_test(self, n):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
         x = np.arange(n, dtype=np.int32)
         gold = np.add.reduce(x)
         result = cuda_ufunc.reduce(x)
         self.assertEqual(result, gold)
 
     def reduce_test2(self, n):
+
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         x = np.arange(n, dtype=np.int32)
         gold = np.add.reduce(x)
         stream = cuda.stream()
@@ -149,6 +186,12 @@ class TestCUDAVectorize(unittest.TestCase):
         self.assertEqual(result, gold)
 
     def test_auto_transfer(self):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         n = 10
         x = np.arange(n, dtype=np.int32)
         dx = cuda.to_device(x)
@@ -156,6 +199,12 @@ class TestCUDAVectorize(unittest.TestCase):
         np.testing.assert_equal(y, x + x)
 
     def test_ufunc_output_ravel(self):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
+        cuda_ufunc = vector_add
+
         n = 10
         x = np.arange(n, dtype=np.int32).reshape(2, 5)
         dx = cuda.to_device(x)

--- a/numba/cuda/tests/cudapy/test_vectorize_device.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_device.py
@@ -6,18 +6,17 @@ from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
 
 
-@cuda.jit(float32(float32, float32, float32), device=True)
-def cu_device_fn(x, y, z):
-    return x ** y / z
-
-
-def cu_ufunc(x, y, z):
-    return cu_device_fn(x, y, z)
-
-
 @skip_on_cudasim('ufunc API unsupported in the simulator')
 class TestCudaVectorizeDeviceCall(unittest.TestCase):
     def test_cuda_vectorize_device_call(self):
+
+        @cuda.jit(float32(float32, float32, float32), device=True)
+        def cu_device_fn(x, y, z):
+            return x ** y / z
+
+        def cu_ufunc(x, y, z):
+            return cu_device_fn(x, y, z)
+
         ufunc = vectorize([float32(float32, float32, float32)], target='cuda')(
             cu_ufunc)
 

--- a/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
@@ -14,19 +14,23 @@ if config.ENABLE_CUDASIM:
     target='cpu'
 
 
-@vectorize(sig, target=target)
-def vector_add(a, b):
-    return a + b
-
-
 @skip_on_cudasim('ufunc API unsupported in the simulator')
 class TestCUDAVectorizeScalarArg(unittest.TestCase):
+
     def test_vectorize_scalar_arg(self):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+
         A = np.arange(10, dtype=np.float64)
         dA = cuda.to_device(A)
         vector_add(1.0, dA)
 
     def test_vectorize_all_scalars(self):
+        @vectorize(sig, target=target)
+        def vector_add(a, b):
+            return a + b
+        
         vector_add(1.0, 1.0)
 
 

--- a/numba/cuda/tests/nocuda/__init__.py
+++ b/numba/cuda/tests/nocuda/__init__.py
@@ -1,3 +1,9 @@
 """
 This subpackage contains CUDA tests that can be executed without a CUDA driver.
 """
+
+from numba.tests import SerialSuite
+
+def load_tests(loader, tests, pattern):
+    suite = loader.discover("numba.cuda.tests.nocuda")
+    return SerialSuite(suite)

--- a/numba/testing.py
+++ b/numba/testing.py
@@ -29,12 +29,10 @@ def discover_tests(startdir):
     return suite
 
 
-def run_tests(suite, xmloutput=None, verbosity=1, nomultiproc=False):
+def run_tests(xmloutput=None, verbosity=1, nomultiproc=False):
     """
     args
     ----
-    - suite [TestSuite]
-        A suite of all tests to run
     - xmloutput [str or None]
         Path of XML output directory (optional)
     - verbosity [int]
@@ -49,49 +47,15 @@ def run_tests(suite, xmloutput=None, verbosity=1, nomultiproc=False):
         runner = xmlrunner.XMLTestRunner(output=xmloutput)
     else:
         runner = None
-    prog = NumbaTestProgram(suite=suite, testRunner=runner, exit=False,
+    prog = NumbaTestProgram(module=None,
+                            testRunner=runner, exit=False,
                             verbosity=verbosity,
                             nomultiproc=nomultiproc)
     return prog.result
 
 
 def test(**kwargs):
-    """
-    Run all tests under ``numba.tests``.
-
-    kwargs
-    ------
-    - descriptions
-    - verbosity
-    - buffer
-    - failfast
-    - xmloutput [str]
-        Path of XML output directory
-    """
-    from numba import cuda
-
-    suite = discover_tests("numba.tests")
-    ok = run_tests(suite, **kwargs).wasSuccessful()
-    if not ok:
-        return ok
-
-    # Test no cuda tests
-    from numba.cuda.tests.nocuda.runtests import test as nocuda_test
-    ok = nocuda_test()
-
-    # Test CUDA
-    if ok:
-        if cuda.is_available():
-            gpus = cuda.list_devices()
-            if gpus and gpus[0].compute_capability >= (2, 0):
-                print("== Run CUDA tests ==")
-                ok = cuda.test()
-            else:
-                print("== Skipped CUDA tests because GPU CC < 2.0 ==")
-        else:
-            print("== Skipped CUDA tests ==")
-
-    return ok
+    return run_tests(**kwargs).wasSuccessful()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch adds support for listing tests without running them.
I occasionally run into test failures leading to the entire test run to fail, without a clear indication which test it was that caused the failure. Having the ability to list an (ordered) list of tests allows me to see the "current" test (i.e. the one following the last completed one) without hacking the code.

This isn't quite working yet, as the numba 'runtests.py' script invokes multiple instances of test suites, not all of them using a TestRunner. So this needs more work to be complete.
(I'm wondering whether this use-case is interesting enough in general for it to be submitted upstream.)