### PR TITLE
Create cffi_usecases_ool in a tempdir

### DIFF
--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -56,15 +56,16 @@ if cffi_support.SUPPORTED:
     tmpdir = static_temp_directory('test_cffi')
     ffi.compile(tmpdir=tmpdir)
     sys.path.append(tmpdir)
-    import cffi_usecases_ool
-    sys.path.remove(tmpdir)
-
-    cffi_support.register_module(cffi_usecases_ool)
-    cffi_sin_ool = cffi_usecases_ool.lib.sin
-    cffi_cos_ool = cffi_usecases_ool.lib.cos
-    cffi_foo = cffi_usecases_ool.lib.foo
-    vsSin = cffi_usecases_ool.lib.vsSin
-    vdSin = cffi_usecases_ool.lib.vdSin
+    try:
+        import cffi_usecases_ool
+        cffi_support.register_module(cffi_usecases_ool)
+        cffi_sin_ool = cffi_usecases_ool.lib.sin
+        cffi_cos_ool = cffi_usecases_ool.lib.cos
+        cffi_foo = cffi_usecases_ool.lib.foo
+        vsSin = cffi_usecases_ool.lib.vsSin
+        vdSin = cffi_usecases_ool.lib.vdSin
+    finally:
+        sys.path.remove(tmpdir)
 
 
 def use_cffi_sin(x):

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
 from numba import cffi_support
+from numba.tests.support import static_temp_directory
+import sys
 import numpy as np
 
 
@@ -51,9 +53,12 @@ if cffi_support.SUPPORTED:
     ffi_ool = FFI()
     ffi.set_source('cffi_usecases_ool', source)
     ffi.cdef(defs, override=True)
-    ffi.compile()
-
+    tmpdir = static_temp_directory('test_cffi')
+    ffi.compile(tmpdir=tmpdir)
+    sys.path.append(tmpdir)
     import cffi_usecases_ool
+    sys.path.remove(tmpdir)
+
     cffi_support.register_module(cffi_usecases_ool)
     cffi_sin_ool = cffi_usecases_ool.lib.sin
     cffi_cos_ool = cffi_usecases_ool.lib.cos

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -4,8 +4,11 @@ Assorted utilities for use in tests.
 
 import cmath
 import contextlib
+import errno
 import math
+import os
 import sys
+import tempfile
 
 import numpy as np
 
@@ -337,6 +340,20 @@ def tweak_code(func, codestring=None, consts=None):
                       co.co_lnotab)
     func.__code__ = new_code
 
+def static_temp_directory(dirname):
+    """
+    Create a directory in the temp dir with a given name. Statically-named
+    temp dirs created using this function are needed because we can't delete a
+    DLL under Windows (this is a bit fragile if stale files can influence the
+    result of future test runs).
+    """
+    tmpdir = os.path.join(tempfile.gettempdir(), dirname)
+    try:
+        os.mkdir(tmpdir)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    return tmpdir
 
 # From CPython
 

--- a/numba/tests/test_pycc_tresult.py
+++ b/numba/tests/test_pycc_tresult.py
@@ -1,14 +1,12 @@
 from __future__ import print_function
 
-import errno
 import os
-import shutil
-import tempfile
 import sys
 from ctypes import *
 
 from numba import unittest_support as unittest
 from numba.pycc import find_shared_ending, find_pyext_ending, main
+from numba.tests.support import static_temp_directory
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -25,16 +23,7 @@ def unset_macosx_deployment_target():
 class TestPYCC(unittest.TestCase):
 
     def setUp(self):
-        # Note we use a permanent test directory as we can't delete
-        # a DLL that's in use under Windows.
-        # (this is a bit fragile if stale files can influence the result
-        #  of future test runs...)
-        self.tmpdir = os.path.join(tempfile.gettempdir(), "test_pycc")
-        try:
-            os.mkdir(self.tmpdir)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+        self.tmpdir = static_temp_directory('test_pycc')
 
     def test_pycc_ctypes_lib(self):
         """


### PR DESCRIPTION
... As opposed to creating .c and object files in whatever the current directory is, which was a little bit of a rude thing for a test to do.

Like the pycc tests, it will not be possible to delete these files on Windows, so a statically-named temp dir is used.