### PR TITLE
Fix test_ufuncs failures depending on libm with Numpy 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
     - python: 3.4
       env: NUMPY="numpy=1.9"
     - python: 3.5-dev
-      env: NUMPY="numpy=1.10"
+      # TODO: change this to 1.10 when we're ok
+      env: NUMPY="numpy=1.9"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ matrix:
     - python: 3.4
       env: NUMPY="numpy=1.9"
     - python: 3.5-dev
-      # TODO: change this to 1.10 when we're ok
-      env: NUMPY="numpy=1.9"
+      env: NUMPY="numpy=1.10"
 
 branches:
   only:

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1534,6 +1534,10 @@ class _TestLoopTypes(TestCase):
     if is_on_numpy_16:
         _skip_types += 'Mm'
 
+    _ulps = {('arccos', 'F'): 2,
+             ('tanh', 'F'): 2,
+             }
+
     def _arg_for_type(self, a_letter_type, index=0):
         """return a suitable array argument for testing the letter type"""
         if a_letter_type in 'bhilq':
@@ -1587,10 +1591,6 @@ class _TestLoopTypes(TestCase):
 
         self._check_ufunc_with_dtypes(fn, ufunc, letter_types)
 
-    ulps = {('arccos', 'F'): 2,
-            ('tanh', 'F'): 2,
-            }
-
     def _check_ufunc_with_dtypes(self, fn, ufunc, dtypes):
         arg_dty = [np.dtype(t) for t in dtypes]
         arg_nbty = [types.Array(from_dtype(t), 1, 'C') for t in arg_dty]
@@ -1610,7 +1610,7 @@ class _TestLoopTypes(TestCase):
         # mutated).
         for c_arg, py_arg in zip(c_args, py_args):
             typechar = c_arg.dtype.char
-            ulps = self.ulps.get((ufunc.__name__, typechar), 1)
+            ulps = self._ulps.get((ufunc.__name__, typechar), 1)
             prec = 'single' if typechar in 'fF' else 'exact'
             prec = 'double' if typechar in 'dD' else prec
             msg = '\n'.join(["ufunc '{0}' arrays differ ({1}):",


### PR DESCRIPTION
This should fix the failures on our OS X and CentOS Jenkins machines.