### PR TITLE
Add guards to .h files

### DIFF
--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -1,3 +1,6 @@
+#ifndef NUMBA_COMMON_H_
+#define NUMBA_COMMON_H_
+
 /* __has_attribute() is a clang / gcc-5 macro */
 #ifndef __has_attribute
 #   define __has_attribute(x) 0
@@ -13,3 +16,5 @@
 #else
 #define VISIBILITY_HIDDEN
 #endif
+
+#endif /* NUMBA_COMMON_H_ */

--- a/numba/runtime/nrt.h
+++ b/numba/runtime/nrt.h
@@ -2,6 +2,10 @@
 All functions described here are threadsafe.
 */
 
+#ifndef NUMBA_NRT_H_
+#define NUMBA_NRT_H_
+
+
 #include <stdlib.h>
 #include <stdio.h>
 #include "../_numba_common.h"
@@ -206,3 +210,6 @@ VISIBILITY_HIDDEN void *NRT_Reallocate(void *ptr, size_t size);
  * Debugging printf function used internally
  */
 VISIBILITY_HIDDEN void nrt_debug_print(char *fmt, ...);
+
+
+#endif /* NUMBA_NRT_H_ */


### PR DESCRIPTION
This hopes to fix the test_pycc_tresult failure on the py2.6 OS X jenkins builder