### PR TITLE
Fix #1488: implicitly casting an argument variable should not break nested calls

### DIFF
--- a/numba/funcdesc.py
+++ b/numba/funcdesc.py
@@ -60,7 +60,10 @@ class FunctionDescriptor(object):
         self.kws = kws
         self.restype = restype
         # Argument types
-        self.argtypes = argtypes or [self.typemap[a] for a in args]
+        if argtypes is not None:
+            self.argtypes = argtypes
+        else:
+            self.argtypes = [self.typemap['arg.' + a] for a in args]
         mangler = default_mangler if mangler is None else mangler
         # The mangled name *must* be unique, else the wrong function can
         # be chosen at link time.

--- a/numba/funcdesc.py
+++ b/numba/funcdesc.py
@@ -63,6 +63,8 @@ class FunctionDescriptor(object):
         if argtypes is not None:
             self.argtypes = argtypes
         else:
+            # Get argument types from the type inference result
+            # (note the "arg.FOO" convention as used in typeinfer
             self.argtypes = [self.typemap['arg.' + a] for a in args]
         mangler = default_mangler if mangler is None else mangler
         # The mangled name *must* be unique, else the wrong function can

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -402,7 +402,9 @@ class Lower(BaseLower):
             return res
 
         elif isinstance(value, ir.Arg):
-            res = self.fnargs[value.index]
+            val = self.fnargs[value.index]
+            oty = self.typeof("arg." + value.name)
+            res = self.context.cast(self.builder, val, oty, ty)
             self.incref(ty, res)
             return res
 

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -403,6 +403,8 @@ class Lower(BaseLower):
 
         elif isinstance(value, ir.Arg):
             val = self.fnargs[value.index]
+            # Cast from the argument type to the local variable type
+            # (note the "arg.FOO" convention as used in typeinfer)
             oty = self.typeof("arg." + value.name)
             res = self.context.cast(self.builder, val, oty, ty)
             self.incref(ty, res)


### PR DESCRIPTION
Note the `arg.name` convention is now hardcoded in several places...