### PR TITLE
Fix signature normalization for pycc

### DIFF
--- a/numba/pycc/cc.py
+++ b/numba/pycc/cc.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from collections import defaultdict
 from distutils import dir_util, log
 from distutils.command import build_ext
 from distutils.extension import Extension
@@ -9,7 +8,7 @@ import shutil
 import sys
 import tempfile
 
-from numba import sigutils
+from numba import sigutils, typing
 from .compiler import ModuleCompiler, ExportEntry
 from .platform import Toolchain
 
@@ -117,7 +116,8 @@ class CC(object):
         """
         Mark a function for exporting in the extension module.
         """
-        sig = sigutils.parse_signature(sig)
+        fn_args, fn_retty = sigutils.normalize_signature(sig)
+        sig = typing.signature(fn_retty, *fn_args)
         if exported_name in self._exported_functions:
             raise KeyError("duplicated export symbol %s" % (exported_name))
 

--- a/numba/pycc/decorators.py
+++ b/numba/pycc/decorators.py
@@ -1,11 +1,10 @@
 from __future__ import print_function, absolute_import
 
-import inspect
-import os
+
 import re
 import warnings
 
-from numba import sigutils
+from numba import sigutils, typing
 from .compiler import ExportEntry
 
 # Registry is okay to be a global because we are using pycc as a standalone
@@ -20,7 +19,8 @@ def export(prototype):
     sym, sig = parse_prototype(prototype)
 
     def wrappped(func):
-        signature = sigutils.parse_signature(sig)
+        fn_argtys, fn_retty = sigutils.normalize_signature(sig)
+        signature = typing.signature(fn_retty, *fn_argtys)
         entry = ExportEntry(symbol=sym, signature=signature, function=func)
         export_registry.append(entry)
 

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -3,6 +3,7 @@ import cmath
 import numpy as np
 
 from numba import exportmany, export
+from numba import float32
 from numba.pycc import CC
 
 
@@ -13,7 +14,7 @@ from numba.pycc import CC
 cc = CC('pycc_test_simple')
 cc.use_nrt = False
 
-@cc.export('multf', 'f4(f4, f4)')
+@cc.export('multf', (float32, float32))
 @cc.export('multi', 'i4(i4, i4)')
 def mult(a, b):
     return a * b


### PR DESCRIPTION
So that `export("foo", (int32, int32))`  would work