### PR TITLE
Support implicit casting in device gufunc

### DIFF
--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -96,10 +96,21 @@ class TestGUFuncScalr(unittest.TestCase):
             for i in range(b.size):
                 out[i] = a * b[i]
 
-        a = np.int64(2)
+        a = np.int64(2)  # type does not match signature (int32)
         b = np.arange(10).astype(np.int32)
         out = foo(a, b)
         np.testing.assert_equal(out, a * b)
+
+        # test error
+        a = np.array(a)
+        da = cuda.to_device(a)
+        self.assertEqual(da.dtype, np.int64)
+        with self.assertRaises(TypeError) as raises:
+            foo(da, b)
+
+        self.assertIn("does not support .astype()", str(raises.exception))
+
+
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -89,6 +89,18 @@ class TestGUFuncScalr(unittest.TestCase):
                 exp = A[j] * X[j, i] + Y[j, i]
                 self.assertTrue(exp == out[j, i], (exp, out[j, i]))
 
+    def test_gufunc_scalar_cast(self):
+        @guvectorize(['void(int32, int32[:], int32[:])'], '(),(t)->(t)',
+                     target='cuda')
+        def foo(a, b, out):
+            for i in range(b.size):
+                out[i] = a * b[i]
+
+        a = np.int64(2)
+        b = np.arange(10).astype(np.int32)
+        out = foo(a, b)
+        np.testing.assert_equal(out, a * b)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/npyufunc/deviceufunc.py
+++ b/numba/npyufunc/deviceufunc.py
@@ -6,13 +6,12 @@ import operator
 import warnings
 from functools import reduce
 import numpy as np
-from numba.utils import longint
+from numba.utils import longint, OrderedDict
 from numba.utils import IS_PY3
 from numba.npyufunc.ufuncbuilder import _BaseUFuncBuilder
 from numba import sigutils, types
 from numba.typing import signature
 from numba.npyufunc.sigparse import parse_signature
-from collections import OrderedDict
 
 if IS_PY3:
     def _exec(codestr, glbls):


### PR DESCRIPTION
When the type of an argument to a device (e.g. cuda) gufunc does not match exactly to any specified types, implicit casting is performed to match the first compatible signature.  This does not match numpy behavior exactly because:
* we prefer exact match (in the future, we may just jit a new version)
* we search for first compatible signature only if no exact signature match is found.
* device array is not casted (unless `.astype()` method is available)

The most useful case for the implicit casting is for scalar argument.