### PR TITLE
Fix invalid usage of heterogenous tuple for zip and enumerate

### DIFF
--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -73,7 +73,8 @@ def iternext_enumerate(context, builder, sig, args, result):
 
     with builder.if_then(is_valid):
         srcval = srcres.yielded_value()
-        result.yield_(cgutils.make_anonymous_struct(builder, [count, srcval]))
+        result.yield_(context.make_tuple(builder, enumty.yield_type,
+                                         [count, srcval]))
 
 
 #-------------------------------------------------------------------------------

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -127,7 +127,7 @@ def iternext_zip(context, builder, sig, args, result):
 
     result.set_valid(is_valid)
     with builder.if_then(is_valid):
-        result.yield_(cgutils.make_anonymous_struct(builder, values))
+        result.yield_(context.make_tuple(builder, zip_type.yield_type, values))
 
 
 #-------------------------------------------------------------------------------

--- a/numba/tests/test_iteration.py
+++ b/numba/tests/test_iteration.py
@@ -171,6 +171,23 @@ class IterationTest(TestCase):
     def test_array_1d_record_mutate(self):
         self.test_array_1d_record_mutate_npm(flags=force_pyobj_flags)
 
+    def test_tuple_iter_issue1504(self):
+        # The issue is due to `row` being typed as heterogeneous tuple.
+        def bar(x, y):
+            total = 0
+            for row in zip(x, y):
+                total += row[0] + row[1]
+
+            return total
+
+        x = y = np.arange(3, dtype=np.int32)
+        aryty = types.Array(types.int32, 1, 'C')
+        cres = compile_isolated(bar, (aryty, aryty))
+
+        expect = bar(x, y)
+        got = cres.entry_point(x, y)
+        self.assertEqual(expect, got)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types.py
+++ b/numba/types.py
@@ -1078,7 +1078,7 @@ class _HeterogenousTuple(BaseTuple):
 class Tuple(BaseAnonymousTuple, _HeterogenousTuple):
 
     def __new__(cls, types):
-        if all(t == types[0] for t in types[1:]):
+        if types and all(t == types[0] for t in types[1:]):
             return UniTuple(dtype=types[0], count=len(types))
         else:
             return object.__new__(Tuple)

--- a/numba/types.py
+++ b/numba/types.py
@@ -622,7 +622,7 @@ class ZipType(SimpleIteratorType):
 
     def __init__(self, iterable_types):
         self.source_types = tuple(tp.iterator_type for tp in iterable_types)
-        yield_type = Tuple(tp.yield_type for tp in self.source_types)
+        yield_type = Tuple([tp.yield_type for tp in self.source_types])
         name = 'zip(%s)' % ', '.join(str(tp) for tp in self.source_types)
         super(ZipType, self).__init__(name, yield_type)
 
@@ -1076,6 +1076,12 @@ class _HeterogenousTuple(BaseTuple):
 
 
 class Tuple(BaseAnonymousTuple, _HeterogenousTuple):
+
+    def __new__(cls, types):
+        if all(t == types[0] for t in types[1:]):
+            return UniTuple(dtype=types[0], count=len(types))
+        else:
+            return object.__new__(Tuple)
 
     def __init__(self, types):
         self.types = tuple(types)


### PR DESCRIPTION
`zip` and `enumerate` can produce homogeneous tuples but the typing and the lowering is not correct.