### PR TITLE
Fix reshape(int, ...)

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1138,7 +1138,7 @@ def array_reshape_vararg(context, builder, sig, args):
     # make a tuple
     shape = cgutils.pack_array(builder, dims, dims[0].type)
 
-    shapety = types.UniTuple(dtype=types.uintp, count=len(dims))
+    shapety = types.UniTuple(dtype=types.intp, count=len(dims))
     new_sig = typing.signature(sig.return_type, aryty, shapety)
     new_args = ary, shape
     return array_reshape(context, builder, new_sig, new_args)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1078,6 +1078,12 @@ def array_reshape(context, builder, sig, args):
     ary = make_array(aryty)(context, builder, args[0])
 
     # XXX unknown dimension (-1) is unhandled
+    msg = "negative shape is not handled, yet"
+    for s in cgutils.unpack_tuple(builder, shape):
+        is_neg = builder.icmp_signed('<', s, lc.Constant.int(ll_intp, 0))
+        with cgutils.if_unlikely(builder, is_neg):
+            context.call_conv.return_user_exc(builder, NotImplementedError,
+                                              (msg,))
 
     # Check requested size
     newsize = lc.Constant.int(ll_intp, 1)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1126,8 +1126,8 @@ def array_reshape_vararg(context, builder, sig, args):
     # values
     ary = args[0]
     dims = args[1:]
-    # coerce all types to uintp
-    dims = [context.cast(builder, val, ty, types.uintp)
+    # coerce all types to intp
+    dims = [context.cast(builder, val, ty, types.intp)
             for ty, val in zip(dimtys, dims)]
     # make a tuple
     shape = cgutils.pack_array(builder, dims, dims[0].type)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1101,6 +1101,8 @@ def array_reshape(context, builder, sig, args):
     fail = builder.icmp_unsigned('==', ok, lc.Constant.int(ok.type, 0))
 
     with builder.if_then(fail):
+        # Release allocated array if the function error out
+        context.nrt_decref(builder, aryty, args[0])
         msg = "incompatible shape for array"
         context.call_conv.return_user_exc(builder, NotImplementedError, (msg,))
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1107,8 +1107,6 @@ def array_reshape(context, builder, sig, args):
     fail = builder.icmp_unsigned('==', ok, lc.Constant.int(ok.type, 0))
 
     with builder.if_then(fail):
-        # Release allocated array if the function error out
-        context.nrt_decref(builder, aryty, args[0])
         msg = "incompatible shape for array"
         context.call_conv.return_user_exc(builder, NotImplementedError, (msg,))
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -420,14 +420,17 @@ class MemoryLeak(object):
 
     def memory_leak_teardown(self):
         if self.__enable_leak_check:
-            old = self.__init_stats
-            new = rtsys.get_allocation_stats()
-            total_alloc = new.alloc - old.alloc
-            total_free = new.free - old.free
-            total_mi_alloc = new.mi_alloc - old.mi_alloc
-            total_mi_free = new.mi_free - old.mi_free
-            self.assertEqual(total_alloc, total_free)
-            self.assertEqual(total_mi_alloc, total_mi_free)
+            self.assert_no_memory_leak()
+
+    def assert_no_memory_leak(self):
+        old = self.__init_stats
+        new = rtsys.get_allocation_stats()
+        total_alloc = new.alloc - old.alloc
+        total_free = new.free - old.free
+        total_mi_alloc = new.mi_alloc - old.mi_alloc
+        total_mi_free = new.mi_free - old.mi_free
+        self.assertEqual(total_alloc, total_free)
+        self.assertEqual(total_mi_alloc, total_mi_free)
 
     def disable_leak_check(self):
         # For per-test use when MemoryLeakMixin is injected into a TestCase

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -216,7 +216,7 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
         expected = pyfunc(a)
         got = cfunc(a)
-        np.testing.assert_equal(expected, got)
+        self.assertPreciseEqual(expected, got)
 
     def test_convert_array_str_npm(self):
         with self.assertRaises(errors.UntypedAttributeError) as raises:

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import numpy as np
 
 from numba.compiler import compile_isolated, Flags
-from numba import types, from_dtype, errors
+from numba import types, from_dtype, errors, typeof
 import numba.unittest_support as unittest
 from numba.tests.support import TestCase, MemoryLeakMixin
 
@@ -74,12 +74,13 @@ def bad_float_index(arr):
 
 class TestArrayManipulation(MemoryLeakMixin, TestCase):
     def test_reshape_array(self, flags=enable_pyobj_flags):
+        a = np.arange(9)
+
         pyfunc = reshape_array
-        arraytype1 = types.Array(types.int32, 1, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -89,12 +90,12 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
     def test_reshape_array_to_1d(self, flags=enable_pyobj_flags,
                                  layout='C'):
+        a = np.arange(9).reshape(3, 3)
         pyfunc = reshape_array_to_1d
-        arraytype1 = types.Array(types.int32, 2, layout)
+        arraytype1 = typeof(a).copy(layout=layout)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         self.assertEqual(got.ndim, 1)
@@ -109,12 +110,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
                       str(raises.exception))
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = flatten_array
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -126,23 +128,25 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("flatten", str(raises.exception))
 
     def test_ravel_array(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = ravel_array
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
 
     def test_ravel_array_size(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = ravel_array_size
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -160,12 +164,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("ravel", str(raises.exception))
 
     def test_transpose_array(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = transpose_array
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -174,12 +179,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.test_transpose_array(flags=no_pyobj_flags)
 
     def test_squeeze_array(self, flags=enable_pyobj_flags):
+        a = np.arange(2 * 1 * 3 * 1 * 4).reshape(2, 1, 3, 1, 4)
+
         pyfunc = squeeze_array
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(2 * 1 * 3 * 1 * 4).reshape(2, 1, 3, 1, 4)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -191,12 +197,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("squeeze", str(raises.exception))
 
     def test_convert_array_str(self, flags=enable_pyobj_flags):
+        a = np.arange(9, dtype='i4')
+
         pyfunc = convert_array_str
-        arraytype1 = types.Array(types.int32, 1, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9, dtype='i4')
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -208,12 +215,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("astype", str(raises.exception))
 
     def test_convert_array(self, flags=enable_pyobj_flags):
+        a = np.arange(9, dtype='i4')
+
         pyfunc = convert_array_dtype
-        arraytype1 = types.Array(types.int32, 1, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9, dtype='i4')
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -225,12 +233,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("astype", str(raises.exception))
 
     def test_add_axis1(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = add_axis1
-        arraytype1 = types.Array(types.int32, 1, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -242,12 +251,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("expand_dims", str(raises.exception))
 
     def test_add_axis2(self, flags=enable_pyobj_flags):
+        a = np.arange(9).reshape(3, 3)
+
         pyfunc = add_axis2
-        arraytype1 = types.Array(types.int32, 1, 'C')
+        arraytype1 = typeof(a)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3, 3)
         expected = pyfunc(a)
         got = cfunc(a)
         np.testing.assert_equal(expected, got)
@@ -256,7 +266,7 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         with self.assertTypingError() as raises:
             self.test_add_axis2(flags=no_pyobj_flags)
         self.assertIn("unsupported array index type none in",
-                         str(raises.exception))
+                      str(raises.exception))
 
     def test_bad_index_npm(self):
         with self.assertTypingError() as raises:

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -111,14 +111,13 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
     def test_reshape_array_to_1d_npm(self):
         self.test_reshape_array_to_1d(flags=no_pyobj_flags)
-        # Test unsupported layout
-        message = "reshape() supports C-contiguous array only"
-        with self.assertTypingError() as raises:
+        with self.assertRaises(NotImplementedError) as raises:
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='F')
-        self.assertIn(message, str(raises.exception))
+        self.assertIn("incompatible shape for array", str(raises.exception))
         with self.assertTypingError() as raises:
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='A')
-        self.assertIn(message, str(raises.exception))
+        self.assertIn("reshape() supports contiguous array only",
+                      str(raises.exception))
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
         a = np.arange(9).reshape(3, 3)

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -17,6 +17,10 @@ def reshape_array(a):
     return a.reshape(3, 3)
 
 
+def reshape_array_to_1d(a):
+    return a.reshape(a.size)
+
+
 def flatten_array(a):
     return a.flatten()
 
@@ -82,6 +86,21 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
     def test_reshape_array_npm(self):
         self.test_reshape_array(flags=no_pyobj_flags)
+
+    def test_reshape_array_to_1d(self, flags=enable_pyobj_flags):
+        pyfunc = reshape_array_to_1d
+        arraytype1 = types.Array(types.int32, 2, 'C')
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
+        cfunc = cr.entry_point
+
+        a = np.arange(9).reshape(3, 3)
+        expected = pyfunc(a)
+        got = cfunc(a)
+        self.assertEqual(got.ndim, 1)
+        np.testing.assert_equal(expected, got)
+
+    def test_reshape_array_to_1d_npm(self):
+        self.test_reshape_array_to_1d(flags=no_pyobj_flags)
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
         pyfunc = flatten_array
@@ -183,7 +202,7 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         self.assertIn("astype", str(raises.exception))
 
     def test_convert_array(self, flags=enable_pyobj_flags):
-        pyfunc = convert_array_str
+        pyfunc = convert_array_dtype
         arraytype1 = types.Array(types.int32, 1, 'C')
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import numpy as np
 
 from numba.compiler import compile_isolated, Flags
-from numba import types, from_dtype
+from numba import types, from_dtype, errors
 import numba.unittest_support as unittest
 from numba.tests.support import TestCase, MemoryLeakMixin
 
@@ -10,40 +10,57 @@ enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
 
 no_pyobj_flags = Flags()
+no_pyobj_flags.set('nrt')
 
 
-def reshape_array(a, expected):
-    return (a.reshape(3, 3) == expected).all()
+def reshape_array(a):
+    return a.reshape(3, 3)
 
-def flatten_array(a, expected):
-    return (a.flatten() == expected).all()
 
-def ravel_array(a, expected):
-    return (a.ravel() == expected).all()
+def flatten_array(a):
+    return a.flatten()
 
-def ravel_array_size(a, expected):
-    return (a.ravel().size == expected.size)
 
-def transpose_array(a, expected):
-    return (a.transpose() == expected).all()
+def ravel_array(a):
+    return a.ravel()
 
-def squeeze_array(a, expected):
-    return (a.squeeze() == expected).all()
 
-def convert_array(a, expected):
+def ravel_array_size(a):
+    return a.ravel().size
+
+
+def transpose_array(a):
+    return a.transpose()
+
+
+def squeeze_array(a):
+    return a.squeeze()
+
+
+def convert_array_str(a):
     # astype takes no kws argument in numpy1.6
-    return (a.astype('f4') == expected).all()
+    return a.astype('f4')
 
-def add_axis1(a, expected):
-    return np.expand_dims(a, axis=0).shape == expected.shape
 
-def add_axis2(a, expected):
-    return a[np.newaxis,:].shape == expected.shape
+def convert_array_dtype(a):
+    # astype takes no kws argument in numpy1.6
+    return a.astype(np.float32)
+
+
+def add_axis1(a):
+    return np.expand_dims(a, axis=0)
+
+
+def add_axis2(a):
+    return a[np.newaxis, :]
+
 
 def bad_index(arr, arr2d):
     x = arr.x,
     y = arr.y
+    # note that `x` is a tuple, which causes a new axis to be created.
     arr2d[x, y] = 1.0
+
 
 def bad_float_index(arr):
     # 2D index required for this function because 1D index
@@ -52,146 +69,169 @@ def bad_float_index(arr):
 
 
 class TestArrayManipulation(MemoryLeakMixin, TestCase):
-
     def test_reshape_array(self, flags=enable_pyobj_flags):
         pyfunc = reshape_array
         arraytype1 = types.Array(types.int32, 1, 'C')
-        arraytype2 = types.Array(types.int32, 2, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9)
-        expected = np.arange(9).reshape(3, 3)
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_reshape_array_npm(self):
-        with self.assertTypingError():
-            self.test_reshape_array(flags=no_pyobj_flags)
+        self.test_reshape_array(flags=no_pyobj_flags)
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
         pyfunc = flatten_array
         arraytype1 = types.Array(types.int32, 2, 'C')
-        arraytype2 = types.Array(types.int32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9).reshape(3, 3)
-        expected = np.arange(9).reshape(3, 3).flatten()
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_flatten_array_npm(self):
-        with self.assertTypingError():
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
             self.test_flatten_array(flags=no_pyobj_flags)
+
+        self.assertIn("flatten", str(raises.exception))
 
     def test_ravel_array(self, flags=enable_pyobj_flags):
         pyfunc = ravel_array
         arraytype1 = types.Array(types.int32, 2, 'C')
-        arraytype2 = types.Array(types.int32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9).reshape(3, 3)
-        expected = np.arange(9).reshape(3, 3).ravel()
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_ravel_array_size(self, flags=enable_pyobj_flags):
         pyfunc = ravel_array_size
         arraytype1 = types.Array(types.int32, 2, 'C')
-        arraytype2 = types.Array(types.int32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9).reshape(3, 3)
-        expected = np.arange(9).reshape(3, 3).ravel()
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_ravel_array_npm(self):
-        with self.assertTypingError():
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
             self.test_ravel_array(flags=no_pyobj_flags)
+
+        self.assertIn("ravel", str(raises.exception))
+
+    def test_ravel_array_size_npm(self):
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
+            self.test_ravel_array_size(flags=no_pyobj_flags)
+
+        self.assertIn("ravel", str(raises.exception))
 
     def test_transpose_array(self, flags=enable_pyobj_flags):
         pyfunc = transpose_array
         arraytype1 = types.Array(types.int32, 2, 'C')
-        arraytype2 = types.Array(types.int32, 2, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9).reshape(3, 3)
-        expected = np.arange(9).reshape(3, 3).transpose()
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_transpose_array_npm(self):
-        with self.assertTypingError():
-            self.test_transpose_array(flags=no_pyobj_flags)
+        self.test_transpose_array(flags=no_pyobj_flags)
 
     def test_squeeze_array(self, flags=enable_pyobj_flags):
         pyfunc = squeeze_array
         arraytype1 = types.Array(types.int32, 2, 'C')
-        arraytype2 = types.Array(types.int32, 2, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(2*1*3*1*4).reshape(2,1,3,1,4)
-        expected = np.arange(2*1*3*1*4).reshape(2,1,3,1,4).squeeze()
-        self.assertTrue(cfunc(a, expected))
+        a = np.arange(2 * 1 * 3 * 1 * 4).reshape(2, 1, 3, 1, 4)
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_squeeze_array_npm(self):
-        with self.assertTypingError():
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
             self.test_squeeze_array(flags=no_pyobj_flags)
 
-    def test_convert_array(self, flags=enable_pyobj_flags):
-        pyfunc = convert_array
+        self.assertIn("squeeze", str(raises.exception))
+
+    def test_convert_array_str(self, flags=enable_pyobj_flags):
+        pyfunc = convert_array_str
         arraytype1 = types.Array(types.int32, 1, 'C')
-        arraytype2 = types.Array(types.float32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
         a = np.arange(9, dtype='i4')
-        expected = np.arange(9, dtype='f4')
-        self.assertTrue(cfunc(a, expected))
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
+
+    def test_convert_array_str_npm(self):
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
+            self.test_convert_array_str(flags=no_pyobj_flags)
+
+        self.assertIn("astype", str(raises.exception))
+
+    def test_convert_array(self, flags=enable_pyobj_flags):
+        pyfunc = convert_array_str
+        arraytype1 = types.Array(types.int32, 1, 'C')
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
+        cfunc = cr.entry_point
+
+        a = np.arange(9, dtype='i4')
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_convert_array_npm(self):
-        with self.assertTypingError():
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
             self.test_convert_array(flags=no_pyobj_flags)
+
+        self.assertIn("astype", str(raises.exception))
 
     def test_add_axis1(self, flags=enable_pyobj_flags):
         pyfunc = add_axis1
         arraytype1 = types.Array(types.int32, 1, 'C')
-        arraytype2 = types.Array(types.float32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3,3)
-        expected = np.arange(9).reshape(1,3,3)
-        self.assertTrue(cfunc(a, expected))
+        a = np.arange(9).reshape(3, 3)
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_add_axis1_npm(self):
-        with self.assertTypingError():
+        with self.assertRaises(errors.UntypedAttributeError) as raises:
             self.test_add_axis1(flags=no_pyobj_flags)
+
+        self.assertIn("expand_dims", str(raises.exception))
 
     def test_add_axis2(self, flags=enable_pyobj_flags):
         pyfunc = add_axis2
         arraytype1 = types.Array(types.int32, 1, 'C')
-        arraytype2 = types.Array(types.float32, 1, 'C')
-        cr = compile_isolated(pyfunc, (arraytype1, arraytype2),
-                              flags=flags)
+        cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
-        a = np.arange(9).reshape(3,3)
-        expected = np.arange(9).reshape(1,3,3)
-        self.assertTrue(cfunc(a, expected))
+        a = np.arange(9).reshape(3, 3)
+        expected = pyfunc(a)
+        got = cfunc(a)
+        np.testing.assert_equal(expected, got)
 
     def test_add_axis2_npm(self):
-        with self.assertTypingError():
+        with self.assertTypingError() as raises:
             self.test_add_axis2(flags=no_pyobj_flags)
+        self.assertIn("unsupported array index type none in",
+                         str(raises.exception))
 
     def test_bad_index_npm(self):
         with self.assertTypingError() as raises:
@@ -206,9 +246,9 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         with self.assertTypingError() as raises:
             compile_isolated(bad_float_index,
                              (types.Array(types.float64, 2, 'C'),))
-        self.assertIn('unsupported array index type float64', str(raises.exception))
+        self.assertIn('unsupported array index type float64',
+                      str(raises.exception))
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -118,6 +118,19 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='A')
         self.assertIn("reshape() supports contiguous array only",
                       str(raises.exception))
+        self.disable_leak_check()
+
+    @unittest.expectedFailure
+    def test_reshape_array_to_1d_leak_error_npm(self):
+        """
+        Rerun the test in ``test_reshape_array_to_1d_npm`` that will cause
+        a leak error.
+        """
+        with self.assertRaises(NotImplementedError) as raises:
+            self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='F')
+        self.assertIn("incompatible shape for array", str(raises.exception))
+        self.disable_leak_check()
+        self.assert_no_memory_leak()
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
         a = np.arange(9).reshape(3, 3)

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -115,9 +115,11 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='F')
         self.assertIn("incompatible shape for array", str(raises.exception))
         with self.assertTypingError() as raises:
+            # The following will leak due to lack of post exception cleanup
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='A')
         self.assertIn("reshape() supports contiguous array only",
                       str(raises.exception))
+        # Disable leak check for the last `test_reshape_array_to_1d` call.
         self.disable_leak_check()
 
     @unittest.expectedFailure
@@ -129,7 +131,12 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         with self.assertRaises(NotImplementedError) as raises:
             self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='F')
         self.assertIn("incompatible shape for array", str(raises.exception))
+        # The leak check is not captured by the expectedFailure.
+        # We need to disable it because `test_reshape_array_to_1d` will leak
+        # due to the lack of post exception cleanup
         self.disable_leak_check()
+        # The following checks for memory leak and it will fail.
+        # This will trigger the expectedFailure
         self.assert_no_memory_leak()
 
     def test_flatten_array(self, flags=enable_pyobj_flags):

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -87,9 +87,10 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
     def test_reshape_array_npm(self):
         self.test_reshape_array(flags=no_pyobj_flags)
 
-    def test_reshape_array_to_1d(self, flags=enable_pyobj_flags):
+    def test_reshape_array_to_1d(self, flags=enable_pyobj_flags,
+                                 layout='C'):
         pyfunc = reshape_array_to_1d
-        arraytype1 = types.Array(types.int32, 2, 'C')
+        arraytype1 = types.Array(types.int32, 2, layout)
         cr = compile_isolated(pyfunc, (arraytype1,), flags=flags)
         cfunc = cr.entry_point
 
@@ -101,6 +102,11 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
     def test_reshape_array_to_1d_npm(self):
         self.test_reshape_array_to_1d(flags=no_pyobj_flags)
+        self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='F')
+        with self.assertTypingError() as raises:
+            self.test_reshape_array_to_1d(flags=no_pyobj_flags, layout='A')
+        self.assertIn("reshape() supports contiguous array only",
+                      str(raises.exception))
 
     def test_flatten_array(self, flags=enable_pyobj_flags):
         pyfunc = flatten_array

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -198,6 +198,12 @@ class TestArrayMethodsCustom(MemoryLeak, TestCase):
             self.assertEqual(str(raises.exception),
                              "total size of new array must be unchanged")
 
+        def check_err_negative(arr, shape):
+            with self.assertRaises(NotImplementedError) as raises:
+                run(arr, shape)
+            self.assertEqual(str(raises.exception),
+                             "negative shape is not handled, yet")
+
         # C-contiguous
         arr = np.arange(24)
         check(arr, (24,))
@@ -226,6 +232,12 @@ class TestArrayMethodsCustom(MemoryLeak, TestCase):
         check_err_shape(arr, (2, 3, 4))
         check_err_shape(arr, (6, 4))
         check_err_shape(arr, (2, 12))
+
+        # Test unhandled value (negative shape)
+        arr = np.arange(25).reshape(5,5)
+        check_err_negative(arr, -1)
+        check_err_negative(arr, (-1,))
+        check_err_negative(arr, (-1, -2, 5, 5))
 
     def test_array_view(self):
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -253,9 +253,9 @@ class ArrayAttribute(AttributeTemplate):
     @bound_function("array.reshape")
     def resolve_reshape(self, ary, args, kws):
         assert not kws
-        if ary.layout != 'C':
-            # only work for C-contiguous array
-            raise TypeError("reshape() supports C-contiguous array only")
+        if ary.layout not in 'CF':
+            # only work for contiguous array
+            raise TypeError("reshape() supports contiguous array only")
 
         if len(args) == 1:
             # single arg

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -1,15 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import namedtuple
-import itertools
 
-from numba import types, intrinsics
-from numba.utils import PYVERSION
-from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
-                                    AbstractTemplate, builtin_global, builtin,
-                                    builtin_attr, signature, bound_function,
-                                    make_callable_template)
-
+from numba import types
+from numba.typing.templates import (AttributeTemplate, AbstractTemplate,
+                                    builtin, builtin_attr, signature,
+                                    bound_function)
 
 Indexing = namedtuple("Indexing", ("index", "result", "advanced"))
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -257,7 +257,6 @@ class ArrayAttribute(AttributeTemplate):
     @bound_function("array.reshape")
     def resolve_reshape(self, ary, args, kws):
         assert not kws
-
         if ary.layout not in 'CF':
             # only work for contiguous array
             raise TypeError("reshape() supports contiguous array only")
@@ -265,11 +264,14 @@ class ArrayAttribute(AttributeTemplate):
         if len(args) == 1:
             # single arg
             shape, = args
-            shape = normalize_shape(shape)
-            if shape is None:
-                return
 
-            ndim = shape.count
+            if shape in types.number_domain:
+                ndim = 1
+            else:
+                shape = normalize_shape(shape)
+                if shape is None:
+                    return
+                ndim = shape.count
             retty = ary.copy(ndim=ndim)
             return signature(retty, shape)
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -253,9 +253,9 @@ class ArrayAttribute(AttributeTemplate):
     @bound_function("array.reshape")
     def resolve_reshape(self, ary, args, kws):
         assert not kws
-        if ary.layout not in 'CF':
-            # only work for contiguous array
-            raise TypeError("reshape() supports contiguous array only")
+        if ary.layout != 'C':
+            # only work for C-contiguous array
+            raise TypeError("reshape() supports C-contiguous array only")
 
         if len(args) == 1:
             # single arg


### PR DESCRIPTION
Fix for #1506 
* fixes the inability for reshape to accept scalar arguments
* make some related tests to be more precise in the feature under test.
