### PR TITLE
Make source package re-distributable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include MANIFEST.in
 include README.rst setup.py runtests.py versioneer.py CHANGE_LOG AUTHORS LICENSE
 
 recursive-include numba *.c *.cpp *.h *.hpp *.inc


### PR DESCRIPTION
v0.22.0 source package is missing important metafiles because it was built from the result of a `python setup.py sdist` and it does not contain the MANIFEST.in.  This patch adds MANIFEST.in in MANIFEST.in so that sdist inside another sdist'ed tarball works.


Related issue #1513.