### PR TITLE
Fix refcount pruning bug due to hidden alias

### DIFF
--- a/numba/runtime/atomicops.py
+++ b/numba/runtime/atomicops.py
@@ -167,6 +167,7 @@ def create_nrt_module(ctx):
 
     return ir_mod, library
 
+
 def compile_nrt_functions(ctx):
     """
     Compile all LLVM NRT functions and return a library containing them.
@@ -190,11 +191,13 @@ def remove_redundant_nrt_refct(ll_module):
     Remove redundant reference count operations from the
     `llvmlite.binding.ModuleRef`. This parses the ll_module as a string and
     line by line to remove the unnecessary nrt refct pairs within each block.
-
-    Note
-    -----
-    Should replace this.  Not efficient.
+    Decref calls are moved after the last incref call in the block to avoid
+    temporarily decref'ing to zero (which can happen due to hidden decref from
+    alias).
     """
+    # Note: As soon as we have better utility in analyzing materialized LLVM
+    #       module in llvmlite, we can redo this without so much string
+    #       processing.
 
     def _extract_functions(module):
         cur = []

--- a/numba/runtime/atomicops.py
+++ b/numba/runtime/atomicops.py
@@ -264,8 +264,8 @@ def remove_redundant_nrt_refct(ll_module):
             yield ln, None, None
 
     def _prune_redundant_refct_ops(bb_lines):
-        incref_map = defaultdict(list)
-        decref_map = defaultdict(list)
+        incref_map = defaultdict(deque)
+        decref_map = defaultdict(deque)
         for num, incref_var, decref_var in _examine_refct_op(bb_lines):
             assert not (incref_var and decref_var)
             if incref_var:
@@ -279,7 +279,7 @@ def remove_redundant_nrt_refct(ll_module):
             ct = min(len(incops), len(decops))
             for _ in range(ct):
                 to_remove.add(incops.pop())
-                to_remove.add(decops.pop())
+                to_remove.add(decops.popleft())
 
         return [ln for num, ln in enumerate(bb_lines)
                 if num not in to_remove]

--- a/numba/runtime/atomicops.py
+++ b/numba/runtime/atomicops.py
@@ -241,7 +241,7 @@ def remove_redundant_nrt_refct(ll_module):
             elif ln:
                 cur.append(ln)
 
-        yield False, cur
+        yield True, cur
         yield False, [func_lines[-1]]
 
     def _process_basic_block(bb_lines):

--- a/numba/runtime/atomicops.py
+++ b/numba/runtime/atomicops.py
@@ -7,6 +7,8 @@ from numba.config import MACHINE_BITS
 from numba import cgutils
 from llvmlite import ir, binding as llvm
 
+# Flag to enable debug print in NRT_incref and NRT_decref
+_debug_print = True
 
 _word_type = ir.IntType(MACHINE_BITS)
 _pointer_type = ir.PointerType(ir.IntType(8))
@@ -49,6 +51,10 @@ def _define_nrt_incref(module, atomic_incr):
     is_null = builder.icmp_unsigned("==", ptr, cgutils.get_null_value(ptr.type))
     with cgutils.if_unlikely(builder, is_null):
         builder.ret_void()
+
+    if _debug_print:
+        cgutils.printf(builder, "*** NRT_Incref %zu [%p]\n", builder.load(ptr),
+                       ptr)
     builder.call(atomic_incr, [builder.bitcast(ptr, atomic_incr.args[0].type)])
     builder.ret_void()
 
@@ -67,6 +73,10 @@ def _define_nrt_decref(module, atomic_decr):
     is_null = builder.icmp_unsigned("==", ptr, cgutils.get_null_value(ptr.type))
     with cgutils.if_unlikely(builder, is_null):
         builder.ret_void()
+
+    if _debug_print:
+        cgutils.printf(builder, "*** NRT_Decref %zu [%p]\n", builder.load(ptr),
+                       ptr)
     newrefct = builder.call(atomic_decr,
                             [builder.bitcast(ptr, atomic_decr.args[0].type)])
 

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -295,6 +295,17 @@ class TestNRTIssue(MemoryLeakMixin, TestCase):
         self.assertPreciseEqual(z, 0j)
         self.assertPreciseEqual(arr, np.zeros(1, dtype=np.int32))
 
+    def test_refct_pruning_issue_1511(self):
+        @njit
+        def f():
+            a = np.ones(10, dtype=np.float64)
+            b = np.ones(10, dtype=np.float64)
+            return a, b[:]
+
+        a, b = f()
+        np.testing.assert_equal(a, b)
+        np.testing.assert_equal(a, np.ones(10, dtype=np.float64))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The refcount pruning can incorrectly remove incref operations that result in refct temporarily reaching zero (and deleted) because it does not keep track of potential alias.  This patch fixes the issue with alias by reordering decref instructions so that they all occur after the last incref in each basicblock.