### PR TITLE
Complete removal of wraparound flag

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -74,11 +74,6 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **opti
                 mode. Any arrays that the tight loop uses should be created
                 before the loop is entered. Default value is True.
 
-            wraparound: bool
-                Set to True to enable array indexing wraparound for negative
-                indices, for a small performance penalty. Default value
-                is True.
-
     Returns
     --------
     A callable usable as a compiled function.  Actual compiling will be

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -173,7 +173,6 @@ class CPUTargetOptions(TargetOptions):
         "nogil": bool,
         "forceobj": bool,
         "looplift": bool,
-        "wraparound": bool,
         "boundcheck": bool,
         "_nrt": bool,
         "no_rewrites": bool,

--- a/numba/targets/options.py
+++ b/numba/targets/options.py
@@ -43,9 +43,6 @@ class TargetOptions(object):
         if kws.pop('looplift', True):
             flags.set("enable_looplift")
 
-        if kws.pop('wraparound', True) == False:
-            flags.set("no_wraparound")
-
         if kws.pop('boundcheck', False):
             flags.set("boundcheck")
 


### PR DESCRIPTION
The "wraparound" flag to the jit() decorator was removed some time ago,
but traces of it were left especially in the docstring.

Fixes #1533.