### PR TITLE
Adds the `angle()` function and patches error in `sinc()`.

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1719,7 +1719,7 @@ def scalar_angle(context, builder, sig, args):
 @implement(numpy.angle, types.Kind(types.Number), types.Kind(types.Boolean))
 def scalar_angle_kwarg(context, builder, sig, args):
     def scalar_angle_impl(val, deg=False):
-        if(deg):
+        if deg:
             scal = 180/numpy.pi
             return numpy.arctan2(val.imag, val.real) * scal
         else:
@@ -1730,25 +1730,9 @@ def scalar_angle_kwarg(context, builder, sig, args):
 
 @builtin
 @implement(numpy.angle, types.Kind(types.Array))
-def array_angle(context, builder, sig, args):
-    arg=sig.args[0]
-    if isinstance(arg.dtype, types.Complex):
-        retty = arg.dtype.underlying_float
-    else:
-        retty = arg.dtype
-    def array_angle_impl(arr):
-        out = numpy.zeros_like(arr, dtype=retty)
-        for index, val in numpy.ndenumerate(arr):
-            out[index] = numpy.angle(val)
-        return out
-    res = context.compile_internal(builder, array_angle_impl, sig, args)
-    return impl_ret_new_ref(context, builder, sig.return_type, res)
-
-
-@builtin
 @implement(numpy.angle, types.Kind(types.Array), types.Kind(types.Boolean))
 def array_angle_kwarg(context, builder, sig, args):
-    arg=sig.args[0]
+    arg = sig.args[0]
     if isinstance(arg.dtype, types.Complex):
         retty = arg.dtype.underlying_float
     else:

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -219,7 +219,7 @@ class TestCase(unittest.TestCase):
                 or math.isinf(first) or math.isinf(second)):
                 self.assertEqual(first, second, msg=msg)
                 # For signed zeros
-                if(not ignore_sign_on_zero):
+                if not ignore_sign_on_zero:
                     try:
                         if math.copysign(1, first) != math.copysign(1, second):
                             self.fail(

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -172,7 +172,7 @@ class TestCase(unittest.TestCase):
                          "strides differ")
 
     def assertPreciseEqual(self, first, second, prec='exact', ulps=1,
-                           msg=None):
+                           msg=None, ignore_sign_on_zero=False):
         """
         Versatile equality testing function with more built-in checks than
         standard assertEqual().
@@ -192,12 +192,15 @@ class TestCase(unittest.TestCase):
         is computed according to the value of *prec*: 53 bits if *prec*
         is 'double', 24 bits if *prec* is single.  This number of bits
         can be lowered by raising the *ulps* value.
+        ignore_sign_on_zero can be set to True if zeros are to be considered
+        equal regardless of their sign bit.
 
         Any value of *prec* other than 'exact', 'single' or 'double'
         will raise an error.
         """
         try:
-            self._assertPreciseEqual(first, second, prec, ulps, msg)
+            self._assertPreciseEqual(first, second, prec, ulps, msg,
+                ignore_sign_on_zero)
         except AssertionError as exc:
             failure_msg = str(exc)
             # Fall off of the 'except' scope to avoid Python 3 exception
@@ -208,7 +211,7 @@ class TestCase(unittest.TestCase):
         self.fail("when comparing %s and %s: %s" % (first, second, failure_msg))
 
     def _assertPreciseEqual(self, first, second, prec='exact', ulps=1,
-                            msg=None):
+                            msg=None, ignore_sign_on_zero=False):
         """Recursive workhorse for assertPreciseEqual()."""
 
         def _assertNumberEqual(first, second, delta=None):
@@ -216,13 +219,15 @@ class TestCase(unittest.TestCase):
                 or math.isinf(first) or math.isinf(second)):
                 self.assertEqual(first, second, msg=msg)
                 # For signed zeros
-                try:
-                    if math.copysign(1, first) != math.copysign(1, second):
-                        self.fail(
-                            self._formatMessage(msg,
-                                                "%s != %s" % (first, second)))
-                except TypeError:
-                    pass
+                if(not ignore_sign_on_zero):
+                    try:
+                        if math.copysign(1, first) != math.copysign(1, second):
+                            self.fail(
+                                self._formatMessage(msg,
+                                                    "%s != %s" %
+                                                    (first, second)))
+                    except TypeError:
+                        pass
             else:
                 self.assertAlmostEqual(first, second, delta=delta, msg=msg)
 
@@ -255,13 +260,15 @@ class TestCase(unittest.TestCase):
             if second.dtype != dtype:
                 second = second.astype(dtype)
             for a, b in zip(first.flat, second.flat):
-                self._assertPreciseEqual(a, b, prec, ulps, msg)
+                self._assertPreciseEqual(a, b, prec, ulps, msg,
+                                         ignore_sign_on_zero)
             return
 
         if compare_family == "sequence":
             self.assertEqual(len(first), len(second), msg=msg)
             for a, b in zip(first, second):
-                self._assertPreciseEqual(a, b, prec, ulps, msg)
+                self._assertPreciseEqual(a, b, prec, ulps, msg,
+                                         ignore_sign_on_zero)
             return
 
         if compare_family == "exact":

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -12,14 +12,9 @@ from numba.compiler import compile_isolated, Flags, utils
 from numba import types
 from .support import TestCase, CompilationCache
 
-enable_pyobj_flags = Flags()
-enable_pyobj_flags.set("enable_pyobject")
 no_pyobj_flags = Flags()
 no_pyobj_flags.set("nrt")
-
 no_pyobj_flags = [no_pyobj_flags]
-enable_pyobj_flags = [enable_pyobj_flags]
-all_flags = enable_pyobj_flags + no_pyobj_flags
 
 def sinc(x):
     return np.sinc(x)
@@ -37,7 +32,7 @@ class TestNPFunctions(TestCase):
         self.ccache = CompilationCache()
 
     def run_unary_real(self, pyfunc, x_types, x_values,
-        flags=enable_pyobj_flags, prec='exact',
+        flags=no_pyobj_flags, prec='exact',
         func_extra_types=None, func_extra_args=None,
         ignore_sign_on_zero=False, **kwargs):
         """
@@ -49,7 +44,7 @@ class TestNPFunctions(TestCase):
                  functions to be tested.
         x_types: the types of the values being tested, see numba.types
         x_values: the numerical values of the values to be tested
-        flags: flags to pass to the ComplicationCache::ccache::compile function
+        flags: flags to pass to the CompilationCache::ccache::compile function
         func_extra_types: the types of additional arguments to the numpy
                           function
         func_extra_args:  additional arguments to the numpy function
@@ -64,7 +59,7 @@ class TestNPFunctions(TestCase):
         """
         for f in flags:
             for tx, vx in zip(x_types, x_values):
-                if(func_extra_args == None):
+                if func_extra_args == None:
                     cr = self.ccache.compile(pyfunc, (tx,), flags=f)
                     cfunc = cr.entry_point
                     got = cfunc(vx)
@@ -92,7 +87,7 @@ class TestNPFunctions(TestCase):
     def run_unary_complex(self, pyfunc, x_types, x_values, ulps=1,
                   func_extra_types=None, func_extra_args=None,
                   ignore_sign_on_zero=False,
-                  flags=enable_pyobj_flags):
+                  flags=no_pyobj_flags):
         """
         Runs tests for a unary function operating in the numerical complex
         space.
@@ -104,7 +99,7 @@ class TestNPFunctions(TestCase):
         x_types: the types of the values being tested, see numba.types
         x_values: the numerical values of the values to be tested
         ulps: the number of ulps in error considered acceptable
-        flags: flags to pass to the ComplicationCache::ccache::compile function
+        flags: flags to pass to the CompilationCache::ccache::compile function
         func_extra_types: the types of additional arguments to the numpy
                           function
         func_extra_args:  additional arguments to the numpy function
@@ -154,7 +149,7 @@ class TestNPFunctions(TestCase):
                                                     ignore_sign_on_zero=
                                                     ignore_sign_on_zero)
 
-    def test_sinc(self, flags=all_flags):
+    def test_sinc(self, flags=no_pyobj_flags):
         """
         Tests the sinc() function.
         This test is purely to assert numerical computations are correct.
@@ -162,7 +157,8 @@ class TestNPFunctions(TestCase):
 
         # Ignore sign of zeros, this will need masking depending on numpy
         # version once the fix to numpy complex division is in upstream
-        isoz=True
+        # See: https://github.com/numpy/numpy/pull/6699
+        isoz = True
 
         pyfunc = sinc
 
@@ -176,7 +172,7 @@ class TestNPFunctions(TestCase):
         x_values = np.array(x_values)
         x_types = [types.float32, types.float64]
         self.run_unary_real(pyfunc, x_types, x_values, flags=flags,
-                               ignore_sign_on_zero=True)
+                               ignore_sign_on_zero=isoz)
 
         # complex domain scalar context
         x_values = [1.+0j, -1+0j, 0.0+0.0j, -0.0+0.0j, 0+1j, 0-1j, 0.5+0.0j,
@@ -195,7 +191,7 @@ class TestNPFunctions(TestCase):
                                ignore_sign_on_zero=isoz)
 
 
-    def test_angle(self, flags=all_flags):
+    def test_angle(self, flags=no_pyobj_flags):
         """
         Tests the angle() function.
         This test is purely to assert numerical computations are correct.

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -14,11 +14,18 @@ from .support import TestCase, CompilationCache
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
-
 no_pyobj_flags = Flags()
+no_pyobj_flags.set("nrt")
+
+no_pyobj_flags = [no_pyobj_flags]
+enable_pyobj_flags = [enable_pyobj_flags]
+all_flags = enable_pyobj_flags + no_pyobj_flags
 
 def sinc(x):
     return np.sinc(x)
+
+def angle(x, deg):
+    return np.angle(x, deg)
 
 class TestNPFunctions(TestCase):
     """
@@ -30,7 +37,9 @@ class TestNPFunctions(TestCase):
         self.ccache = CompilationCache()
 
     def run_unary_real(self, pyfunc, x_types, x_values,
-        flags=enable_pyobj_flags, prec='exact', **kwargs):
+        flags=enable_pyobj_flags, prec='exact',
+        func_extra_types=None, func_extra_args=None,
+        ignore_sign_on_zero=False, **kwargs):
         """
         Runs tests for a unary function operating in the numerical real space.
 
@@ -40,7 +49,12 @@ class TestNPFunctions(TestCase):
                  functions to be tested.
         x_types: the types of the values being tested, see numba.types
         x_values: the numerical values of the values to be tested
-        flags: flags to pass to the ComplicationnCache::ccache::compile function
+        flags: flags to pass to the ComplicationCache::ccache::compile function
+        func_extra_types: the types of additional arguments to the numpy
+                          function
+        func_extra_args:  additional arguments to the numpy function
+        ignore_sign_on_zero: boolean as to whether to allow zero values
+        with incorrect signs to be considered equal
         prec: the required precision match, see assertPreciseEqual
 
         Notes:
@@ -48,17 +62,36 @@ class TestNPFunctions(TestCase):
         x_types and x_values must have the same length
 
         """
-        for tx, vx in zip(x_types, x_values):
-            cr = self.ccache.compile(pyfunc, (tx,), flags=flags)
-            cfunc = cr.entry_point
-            got = cfunc(vx)
-            expected = pyfunc(vx)
-            actual_prec = 'single' if tx is types.float32 else prec
-            msg = 'for input %r with prec %r' % (vx, prec)
-            self.assertPreciseEqual(got, expected, prec=actual_prec, msg=msg,
-                                    **kwargs)
+        for f in flags:
+            for tx, vx in zip(x_types, x_values):
+                if(func_extra_args == None):
+                    cr = self.ccache.compile(pyfunc, (tx,), flags=f)
+                    cfunc = cr.entry_point
+                    got = cfunc(vx)
+                    expected = pyfunc(vx)
+                    actual_prec = 'single' if tx is types.float32 else prec
+                    msg = 'for input %r with prec %r' % (vx, prec)
+                    self.assertPreciseEqual(got, expected,
+                                            prec=actual_prec, msg=msg,
+                                            ignore_sign_on_zero=
+                                            ignore_sign_on_zero, **kwargs)
+                else:
+                    for xtype, xargs in zip(func_extra_types, func_extra_args):
+                        cr = self.ccache.compile(pyfunc, (tx,xtype), flags=f)
+                        cfunc = cr.entry_point
+                        got = cfunc(vx, xargs)
+                        expected = pyfunc(vx, xargs)
+                        actual_prec = 'single' if tx is types.float32 else prec
+                        msg = 'for input %r with prec %r' % (vx, prec)
+                        self.assertPreciseEqual(got, expected,
+                                                prec=actual_prec,
+                                                msg=msg,
+                                                ignore_sign_on_zero=
+                                                ignore_sign_on_zero, **kwargs)
 
     def run_unary_complex(self, pyfunc, x_types, x_values, ulps=1,
+                  func_extra_types=None, func_extra_args=None,
+                  ignore_sign_on_zero=False,
                   flags=enable_pyobj_flags):
         """
         Runs tests for a unary function operating in the numerical complex
@@ -71,43 +104,128 @@ class TestNPFunctions(TestCase):
         x_types: the types of the values being tested, see numba.types
         x_values: the numerical values of the values to be tested
         ulps: the number of ulps in error considered acceptable
-        flags: flags to pass to the ComplicationnCache::ccache::compile function
+        flags: flags to pass to the ComplicationCache::ccache::compile function
+        func_extra_types: the types of additional arguments to the numpy
+                          function
+        func_extra_args:  additional arguments to the numpy function
+        ignore_sign_on_zero: boolean as to whether to allow zero values
+        with incorrect signs to be considered equal
         prec: the required precision match, see assertPreciseEqual
 
         Notes:
         ------
         x_types and x_values must have the same length
         """
-        for tx in x_types:
-            cr = self.ccache.compile(pyfunc, (tx,), flags=flags)
-            cfunc = cr.entry_point
-            prec = 'single' if tx in (types.float32, types.complex64) else \
-            'double'
-            for vx in x_values:
-                try:
-                    expected = pyfunc(vx)
-                except ValueError as e:
-                    self.assertIn("math domain error", str(e))
-                    continue
-                got = cfunc(vx)
-                msg = 'for input %r with prec %r' % (vx, prec)
-                self.assertPreciseEqual(got, expected, prec=prec,
-                                        ulps=ulps, msg=msg)
+        for f in flags:
+            for tx in x_types:
+                if(func_extra_args == None):
+                    cr = self.ccache.compile(pyfunc, (tx,), flags=f)
+                    cfunc = cr.entry_point
+                    prec = 'single' if tx in (types.float32, types.complex64) \
+                        else 'double'
+                    for vx in x_values:
+                        try:
+                            expected = pyfunc(vx)
+                        except ValueError as e:
+                            self.assertIn("math domain error", str(e))
+                            continue
+                        got = cfunc(vx)
+                        msg = 'for input %r with prec %r' % (vx, prec)
+                        self.assertPreciseEqual(got, expected, prec=prec,
+                                                ulps=ulps, msg=msg,
+                                                ignore_sign_on_zero=
+                                                ignore_sign_on_zero)
+                else:
+                    for xtype, xargs in zip(func_extra_types, func_extra_args):
+                        cr = self.ccache.compile(pyfunc, (tx,xtype), flags=f)
+                        cfunc = cr.entry_point
+                        prec = 'single' if tx in (types.float32,\
+                            types.complex64) else 'double'
+                        for vx in x_values:
+                            try:
+                                expected = pyfunc(vx, xargs)
+                            except ValueError as e:
+                                self.assertIn("math domain error", str(e))
+                                continue
+                            got = cfunc(vx, xargs)
+                            msg = 'for input %r with prec %r' % (vx, prec)
+                            self.assertPreciseEqual(got, expected, prec=prec,
+                                                    ulps=ulps, msg=msg,
+                                                    ignore_sign_on_zero=
+                                                    ignore_sign_on_zero)
 
-    def test_sinc(self, flags=enable_pyobj_flags):
+    def test_sinc(self, flags=all_flags):
         """
-        Tests the sinc() function. The array context test for the sinc()
-        function is performed in the standard ufuncs test.
+        Tests the sinc() function.
         This test is purely to assert numerical computations are correct.
         """
+
+        # Ignore sign of zeros, this will need masking depending on numpy
+        # version once the fix to numpy complex division is in upstream
+        isoz=True
+
         pyfunc = sinc
+
+        # real domain scalar context
         x_values = [1., -1., 0.0, -0.0, 0.5, -0.5, 5, -5, 5e-21, -5e-21]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
-        self.run_unary_real(pyfunc, x_types, x_values, flags)
+        self.run_unary_real(pyfunc, x_types, x_values, flags,
+                            ignore_sign_on_zero=isoz)
 
-        x_values = [1.+0j, -1+0j, 0.0+0.0j, -0.0+0.0j, 1j, -1j, 0.5+0.0j,
+        # real domain vector context
+        x_values = np.array(x_values)
+        x_types = [types.float32, types.float64]
+        self.run_unary_real(pyfunc, x_types, x_values, flags=flags,
+                               ignore_sign_on_zero=True)
+
+        # complex domain scalar context
+        x_values = [1.+0j, -1+0j, 0.0+0.0j, -0.0+0.0j, 0+1j, 0-1j, 0.5+0.0j,
                     -0.5+0.0j, 0.5+0.5j, -0.5-0.5j, 5+5j, -5-5j,
                     # the following are to test sin(x)/x for small x
-                    5e-21+0j, -5e-21+0j, 5e-21j, -5e-21j]
+                    5e-21+0j, -5e-21+0j, 5e-21j, +(0-5e-21j)
+                    ]
         x_types = [types.complex64, types.complex128] * (len(x_values) // 2)
-        self.run_unary_complex(pyfunc, x_types, x_values, flags=flags)
+        self.run_unary_complex(pyfunc, x_types, x_values, flags=flags,
+                               ignore_sign_on_zero=isoz)
+
+        # complex domain vector context
+        x_values = np.array(x_values)
+        x_types = [types.complex64, types.complex128]
+        self.run_unary_complex(pyfunc, x_types, x_values, flags=flags,
+                               ignore_sign_on_zero=isoz)
+
+
+    def test_angle(self, flags=all_flags):
+        """
+        Tests the angle() function.
+        This test is purely to assert numerical computations are correct.
+        """
+        pyfunc = angle
+
+        # real domain scalar context
+        x_values = [1., -1., 0.0, -0.0, 0.5, -0.5, 5, -5]
+        x_types = [types.float32, types.float64] * (len(x_values) // 2)
+        xtra_values = [True, False]
+        xtra_types = [types.bool_, types.bool_]
+        self.run_unary_real(pyfunc, x_types, x_values,
+             flags, func_extra_types=xtra_types, func_extra_args=xtra_values)
+
+        # real domain vector context
+        x_values = np.array(x_values)
+        x_types = [types.float32, types.float64]
+        self.run_unary_real(pyfunc, x_types, x_values,
+             flags, func_extra_types=xtra_types, func_extra_args=xtra_values)
+
+        # complex domain scalar context
+        x_values = [1.+0j, -1+0j, 0.0+0.0j, -0.0+0.0j, 1j, -1j, 0.5+0.0j,
+                    -0.5+0.0j, 0.5+0.5j, -0.5-0.5j, 5+5j, -5-5j]
+        x_types = [types.complex64, types.complex128] * (len(x_values) // 2)
+        self.run_unary_complex(pyfunc, x_types, x_values,
+              func_extra_types=xtra_types, func_extra_args=xtra_values,
+              flags=flags)
+
+        # complex domain vector context
+        x_values = np.array(x_values)
+        x_types = [types.complex64, types.complex128]
+        self.run_unary_real(pyfunc, x_types, x_values,
+             flags, func_extra_types=xtra_types, func_extra_args=xtra_values)

--- a/numba/tests/test_support.py
+++ b/numba/tests/test_support.py
@@ -92,6 +92,7 @@ class TestAssertPreciseEqual(TestCase):
                 self.eq(tp(0.0), tp(0.0), prec=prec)
                 self.eq(tp(-0.0), tp(-0.0), prec=prec)
                 self.ne(tp(0.0), tp(-0.0), prec=prec)
+                self.eq(tp(0.0), tp(-0.0), prec=prec, ignore_sign_on_zero=True)
                 # Infinities
                 self.eq(tp(INF), tp(INF), prec=prec)
                 self.ne(tp(INF), tp(1e38), prec=prec)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -513,12 +513,6 @@ class TestUFuncs(BaseUFuncTest, TestCase):
     def test_sin_ufunc_npm(self):
         self.test_sin_ufunc(flags=no_pyobj_flags)
 
-    def test_sinc_ufunc(self, flags=enable_pyobj_flags):
-        self.unary_ufunc_test(np.sin, flags=flags, kinds='cf')
-
-    def test_sinc_ufunc_npm(self):
-        self.test_sin_ufunc(flags=no_pyobj_flags)
-
     def test_cos_ufunc(self, flags=enable_pyobj_flags):
         self.unary_ufunc_test(np.cos, flags=flags, kinds='cf')
 
@@ -634,7 +628,6 @@ class TestUFuncs(BaseUFuncTest, TestCase):
 
     def test_radians_ufunc_npm(self):
         self.test_radians_ufunc(flags=no_pyobj_flags)
-
 
     ############################################################################
     # Bit-twiddling Functions

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -774,14 +774,8 @@ class AngleCtor(CallableTemplate):
     """
     def generic(self):
         def typer(ref, deg = False):
-            if(isinstance(ref, types.Array)):
-                # type map
-                m = { types.complex128: types.float64,
-                      types.float64: types.float64,
-                      types.complex64: types.float32,
-                      types.float32: types.float32 }
-                dt=m[ref.dtype];
-                return ref.copy(dtype=dt)
+            if isinstance(ref, types.Array):
+                return ref.copy(dtype=ref.underlying_float)
             else:
                 return types.float64
         return typer

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -768,4 +768,30 @@ class Sinc(AbstractTemplate):
 builtin_global(numpy.sinc, types.Function(Sinc))
 
 
+class AngleCtor(CallableTemplate):
+    """
+    Typing template for np.angle()
+    """
+    def generic(self):
+        def typer(ref, deg = False):
+            if(isinstance(ref, types.Array)):
+                # type map
+                m = { types.complex128: types.float64,
+                      types.float64: types.float64,
+                      types.complex64: types.float32,
+                      types.float32: types.float32 }
+                dt=m[ref.dtype];
+                return ref.copy(dtype=dt)
+            else:
+                return types.float64
+        return typer
+
+@builtin
+class Angle(AngleCtor):
+    key = numpy.angle
+
+
+builtin_global(numpy.angle, types.Function(Angle))
+
+
 builtin_global(numpy, types.Module(numpy))


### PR DESCRIPTION
This patch:
 * Adds the `angle()` function and unit tests.
 * Fixes errors in the `sinc()` function implementation:
   * There is no need for `fabs()` if signed zeros are handled
     correctly in numpy complex scalar division, see:
     [https://github.com/numpy/numpy/pull/6699]
     (https://github.com/numpy/numpy/pull/6699)
 * Removes the `sinc()` ufunc test, it erroneously referred to
   `sin()` which should have been `sinc()`, however this change
    will not work in ufunc context so it is removed.
 * Adds array based test of `sinc()`.
 * Adds the option of `ignore_sign_of_zero` to `asssertPreciseEqual()`
   such that it is possible to flag in comparison based tests that
   zeros should be considered equal regardless of sign (needed for
   the `sinc()` function in complex space to match numpy).