### PR TITLE
Implement parallel target for gufunc

### DIFF
--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -3,9 +3,9 @@ import inspect
 
 from . import _internal, dufunc
 from .ufuncbuilder import UFuncBuilder, GUFuncBuilder
-from .parallel import ParallelUFuncBuilder
+from .parallel import ParallelUFuncBuilder, ParallelGUFuncBuilder
 
-from numba.cuda.vectorizers import CUDAVectorize, CUDAGUFuncVectorize 
+from numba.cuda.vectorizers import CUDAVectorize, CUDAGUFuncVectorize
 from numba.targets.registry import TargetRegistry
 
 
@@ -26,7 +26,7 @@ class _BaseVectorize(object):
 
 class Vectorize(_BaseVectorize):
     target_registry = TargetRegistry({'cpu': UFuncBuilder,
-                                      'parallel': ParallelUFuncBuilder})
+                                      'parallel': ParallelUFuncBuilder,})
 
     def __new__(cls, func, **kws):
         identity = cls.get_identity(kws)
@@ -35,7 +35,8 @@ class Vectorize(_BaseVectorize):
 
 
 class GUVectorize(_BaseVectorize):
-    target_registry = TargetRegistry({'cpu': GUFuncBuilder})
+    target_registry = TargetRegistry({'cpu': GUFuncBuilder,
+                                      'parallel': ParallelGUFuncBuilder,})
 
     def __new__(cls, func, signature, **kws):
         identity = cls.get_identity(kws)

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -13,13 +13,12 @@ from __future__ import print_function, absolute_import
 import sys
 import os
 import multiprocessing
-
 import numpy as np
 import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
 from numba.npyufunc import ufuncbuilder
-from numba import types, utils
-
+from numba.numpy_support import as_dtype
+from numba import types, utils, cgutils
 
 NUM_CPU = max(1, multiprocessing.cpu_count())
 
@@ -176,6 +175,193 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
     return lfunc
 
 
+# ---------------------------------------------------------------------------
+
+class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
+    def __init__(self, py_func, signature, identity=None, targetoptions={}):
+        # Force nopython mode
+        targetoptions.update(dict(nopython=True))
+        super(ParallelGUFuncBuilder, self).__init__(py_func=py_func,
+                                                    signature=signature,
+                                                    identity=identity,
+                                                    targetoptions=targetoptions)
+
+    def build(self, cres):
+        """
+        Returns (dtype numbers, function ptr, EnvironmentObject)
+        """
+        _launch_threads()
+        # Build wrapper for ufunc entry point
+        ctx = cres.target_context
+        library = cres.library
+        signature = cres.signature
+        llvm_func = library.get_function(cres.fndesc.llvm_func_name)
+        wrapper, env = build_gufunc_wrapper(library, ctx, llvm_func,
+                                            signature, self.sin, self.sout,
+                                            fndesc=cres.fndesc,
+                                            env=cres.environment)
+
+        ptr = library.get_pointer_to_function(wrapper.name)
+
+        # Get dtypes
+        dtypenums = []
+        for a in signature.args:
+            if isinstance(a, types.Array):
+                ty = a.dtype
+            else:
+                ty = a
+            dtypenums.append(as_dtype(ty).num)
+
+        return dtypenums, ptr, env
+
+
+def build_gufunc_wrapper(library, ctx, llvm_func, signature, sin, sout, fndesc,
+                         env):
+    innerfunc, env = ufuncbuilder.build_gufunc_wrapper(library, ctx, llvm_func,
+                                                       signature, sin, sout,
+                                                       fndesc=fndesc, env=env)
+    sym_in = set(sym for term in sin for sym in term)
+    sym_out = set(sym for term in sout for sym in term)
+    inner_ndim = len(sym_in | sym_out)
+
+    lfunc = build_gufunc_kernel(library, ctx, innerfunc, signature, inner_ndim)
+    library.add_ir_module(lfunc.module)
+    return lfunc, env
+
+
+def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
+    """Wrap the original CPU gufunc with a parallel dispatcher.
+
+    Args
+    ----
+    ctx
+        numba's codegen context
+
+    innerfunc
+        llvm function of the original CPU gufunc
+
+    sig
+        type signature of the gufunc
+
+    inner_ndim
+        inner dimension of the gufunc
+
+    Details
+    -------
+
+    Generate a function of the following signature:
+
+    void ufunc_kernel(char **args, npy_intp *dimensions, npy_intp* steps,
+                      void* data)
+
+    Divide the work equally across all threads and let the last thread take all
+    the left over.
+
+
+    """
+    # Declare types and function
+    byte_t = lc.Type.int(8)
+    byte_ptr_t = lc.Type.pointer(byte_t)
+
+    intp_t = ctx.get_value_type(types.intp)
+
+    fnty = lc.Type.function(lc.Type.void(), [lc.Type.pointer(byte_ptr_t),
+                                             lc.Type.pointer(intp_t),
+                                             lc.Type.pointer(intp_t),
+                                             byte_ptr_t])
+
+    mod = library.create_ir_module('parallel.gufunc.wrapper')
+    lfunc = mod.add_function(fnty, name=".kernel")
+    innerfunc = mod.add_function(fnty, name=innerfunc.name)
+
+    bb_entry = lfunc.append_basic_block('')
+
+    # Function body starts
+    builder = lc.Builder.new(bb_entry)
+
+    args, dimensions, steps, data = lfunc.args
+
+    # Distribute work
+    total = builder.load(dimensions)
+    ncpu = lc.Constant.int(total.type, NUM_CPU)
+
+    count = builder.udiv(total, ncpu)
+
+    count_list = []
+    remain = total
+
+    for i in range(NUM_CPU):
+        space = cgutils.alloca_once(builder, intp_t, size=inner_ndim + 1)
+        cgutils.memcpy(builder, space, dimensions,
+                       count=lc.Constant.int(intp_t, inner_ndim + 1))
+        count_list.append(space)
+
+        if i == NUM_CPU - 1:
+            # Last thread takes all leftover
+            builder.store(remain, space)
+        else:
+            builder.store(count, space)
+            remain = builder.sub(remain, count)
+
+    # Array count is input signature plus 1 (due to output array)
+    array_count = len(sig.args) + 1
+
+    # Get the increment step for each array
+    steps_list = []
+    for i in range(array_count):
+        ptr = builder.gep(steps, [lc.Constant.int(lc.Type.int(), i)])
+        step = builder.load(ptr)
+        steps_list.append(step)
+
+    # Get the array argument set for each thread
+    args_list = []
+    for i in range(NUM_CPU):
+        space = builder.alloca(byte_ptr_t,
+                               size=lc.Constant.int(lc.Type.int(), array_count))
+        args_list.append(space)
+
+        for j in range(array_count):
+            # For each array, compute subarray pointer
+            dst = builder.gep(space, [lc.Constant.int(lc.Type.int(), j)])
+            src = builder.gep(args, [lc.Constant.int(lc.Type.int(), j)])
+
+            baseptr = builder.load(src)
+            base = builder.ptrtoint(baseptr, intp_t)
+            multiplier = lc.Constant.int(count.type, i)
+            offset = builder.mul(steps_list[j], builder.mul(count, multiplier))
+            addr = builder.inttoptr(builder.add(base, offset), baseptr.type)
+
+            builder.store(addr, dst)
+
+    # Declare external functions
+    add_task_ty = lc.Type.function(lc.Type.void(), [byte_ptr_t] * 5)
+    empty_fnty = lc.Type.function(lc.Type.void(), ())
+    add_task = mod.get_or_insert_function(add_task_ty, name='numba_add_task')
+    synchronize = mod.get_or_insert_function(empty_fnty,
+                                             name='numba_synchronize')
+    ready = mod.get_or_insert_function(empty_fnty, name='numba_ready')
+
+    # Add tasks for queue; one per thread
+    as_void_ptr = lambda arg: builder.bitcast(arg, byte_ptr_t)
+
+    for each_args, each_dims in zip(args_list, count_list):
+        innerargs = [as_void_ptr(x) for x
+                     in [innerfunc, each_args, each_dims, steps, data]]
+        builder.call(add_task, innerargs)
+
+    # Signal worker that we are ready
+    builder.call(ready, ())
+    # Wait for workers
+    builder.call(synchronize, ())
+
+    builder.ret_void()
+
+    return lfunc
+
+
+# ---------------------------------------------------------------------------
+
+
 class _ProtectEngineDestroy(object):
     def __init__(self, set_cas, engine):
         self.set_cas = set_cas
@@ -260,8 +446,5 @@ elif not _DYLD_WORKAROUND_SET:
     # Do it automatically for python2.6 linux
     if (sys.version_info[:2] == (2, 6) and
             sys.platform.startswith('linux') and
-            utils.MACHINE_BITS == 64):
+                utils.MACHINE_BITS == 64):
         _launch_threads()
-
-
-

--- a/numba/npyufunc/workqueue.c
+++ b/numba/npyufunc/workqueue.c
@@ -173,7 +173,6 @@ void add_task(void *fn, void *args, void *dims, void *steps, void *data) {
     if ( ++queue_pivot == queue_count ) {
         queue_pivot = 0;
     }
-
 }
 
 static


### PR DESCRIPTION
This adds the minimum changes to enable parallel target for gufunc.  The code can use some refactoring to minimize duplication.

This also fixes some errors in the gufunc tests that are accidentally executing in object mode.