### PR TITLE
[WIP] array internalization rewrite pass

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -32,6 +32,9 @@ test = testing.test
 # Try to initialize cuda
 from . import cuda
 
+# Initialize array internization rewrite pass
+import numba.array_intern   # import time side-effects
+
 
 __all__ = """
 jit

--- a/numba/array_intern.py
+++ b/numba/array_intern.py
@@ -1,0 +1,84 @@
+from __future__ import print_function, division, absolute_import
+import numpy as np
+from numba import cgutils, ir, types, rewrites
+from numba.typing.templates import FunctionTemplate
+
+
+@rewrites.register_rewrite
+class InternArrayAlloc(rewrites.Rewrite):
+    def __init__(self, *args, **kwargs):
+        super(InternArrayAlloc, self).__init__(*args, **kwargs)
+        self._block = None
+        self._matches = None
+        # Install a lowering hook if we are using this rewrite.
+        special_ops = self.pipeline.targetctx.special_ops
+        if 'interned_alloc' not in special_ops:
+            special_ops['interned_alloc'] = _lower_interned_alloc
+
+    def match(self, label, block, typemap, calltypes):
+        # Match only the first block
+        if label == 0 and block.body and len(calltypes) > 1:
+            self._matches = {}
+            self._block = block
+            for i, tar, expr in self._iter_call(block.body):
+                fnty = typemap.get(expr.func.name)
+                if isinstance(fnty, types.Function):
+                    if issubclass(fnty.key, FunctionTemplate):
+                        if fnty.key.key == np.empty:
+                            self._matches[i] = expr, typemap[tar.name]
+            return bool(self._matches)
+        return False
+
+    def _iter_call(self, body):
+        for i, stmt in enumerate(body):
+            if isinstance(stmt, ir.Assign):
+                if isinstance(stmt.value, ir.Expr):
+                    expr = stmt.value
+                    if expr.op == 'call':
+                        yield i, stmt.target, expr
+
+    def apply(self):
+        newstmts = {}
+        for i, (expr, ty) in self._matches.items():
+            expr = ir.Expr(op="interned_alloc",
+                           loc=expr.loc,
+                           args=expr.args,
+                           ty=ty)
+            orig = self._block.body[i]
+            newstmts[i] = ir.Assign(value=expr, target=orig.target,
+                                    loc=orig.loc)
+        repls = [newstmts.get(i, stmt)
+                 for i, stmt in enumerate(self._block.body)]
+        newblk = ir.Block(scope=self._block.scope, loc=self._block.loc)
+        newblk.body.extend(repls)
+        return newblk
+
+
+def _lower_interned_alloc(lower, expr):
+    context = lower.context
+    builder = lower.builder
+
+    elemcount = lower.loadvar(expr.args[0].name)
+    elemcount_type = lower.typeof(expr.args[0].name)
+    assert isinstance(elemcount_type, types.Integer)  # XXX handle tuples
+    lldtype = context.get_data_type(expr.ty.dtype)
+    stackptr = builder.alloca(lldtype, size=elemcount)
+
+    arycls = context.make_array(expr.ty)
+    ary = arycls(context, builder)
+
+    shape_values = [context.cast(builder, elemcount, elemcount_type,
+                                 types.intp)]
+    shape = cgutils.pack_array(builder, shape_values)
+
+    itemsize = context.get_constant(types.intp,
+                                    context.get_abi_sizeof(lldtype) * 8)
+
+    context.populate_array(ary,
+                           data=stackptr,
+                           shape=shape,
+                           strides=cgutils.pack_array(builder, [itemsize]),
+                           itemsize=itemsize,
+                           meminfo=None)
+
+    return ary._getvalue()

--- a/numba/array_intern.py
+++ b/numba/array_intern.py
@@ -10,7 +10,7 @@ class InternArrayAlloc(rewrites.Rewrite):
         super(InternArrayAlloc, self).__init__(*args, **kwargs)
         self._block = None
         self._matches = None
-        self._enabled = self.pipeline.targetctx.enable_nrt == False
+        self._enabled = self.pipeline.targetctx.enable_array_intern
         if self._enabled:
             # Install a lowering hook if we are using this rewrite.
             special_ops = self.pipeline.targetctx.special_ops

--- a/numba/cuda/npydecl.py
+++ b/numba/cuda/npydecl.py
@@ -1,0 +1,24 @@
+from __future__ import print_function, division, absolute_import
+from numba import types
+from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
+                                    AbstractTemplate, MacroTemplate,
+                                    signature, Registry)
+import numpy
+from numba.typing.npydecl import NdEmpty
+
+registry = Registry()
+intrinsic = registry.register
+intrinsic_attr = registry.register_attr
+intrinsic_global = registry.register_global
+
+
+@intrinsic_attr
+class NumpyModuleAttribute(AttributeTemplate):
+    key = types.Module(numpy)
+
+    def resolve_empty(self, mod):
+        return types.Function(NdEmpty)
+
+
+intrinsic_global(numpy.empty, types.Function(NdEmpty))
+intrinsic_global(numpy, types.Module(numpy))

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -13,7 +13,7 @@ from numba.targets import cmathimpl, operatorimpl
 from numba.typing import cmathdecl, operatordecl
 from numba.funcdesc import transform_arg_name
 from .cudadrv import nvvm
-from . import codegen, nvvmutils
+from . import codegen, nvvmutils, npydecl
 
 
 # -----------------------------------------------------------------------------
@@ -28,6 +28,7 @@ class CUDATypingContext(typing.BaseContext):
         self.install(cudamath.registry)
         self.install(cmathdecl.registry)
         self.install(operatordecl.registry)
+        self.install(npydecl.registry)
 
 # -----------------------------------------------------------------------------
 # Implementation

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -39,6 +39,7 @@ VALID_CHARS = re.compile(r'[^a-z0-9]', re.I)
 class CUDATargetContext(BaseContext):
     implement_powi_as_math_call = True
     strict_alignment = True
+    enable_array_intern = True
 
     # Overrides
     def create_module(self, name):

--- a/numba/cuda/tests/cudapy/test_rewrites.py
+++ b/numba/cuda/tests/cudapy/test_rewrites.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import numpy as np
+from numba import cuda
+from numba import unittest_support as unittest
+
+
+class TestRewriteArray(unittest.TestCase):
+    def test_rewrite_numpy_empty(self):
+        size = 10
+
+        @cuda.jit
+        def foo(out):
+            arr = np.empty(size, dtype=np.int32)
+            for i in range(size):
+                arr[i] = cuda.threadIdx.x + i
+
+            for i in range(size):
+                out[cuda.threadIdx.x, i] = arr[i]
+
+        threads = 4
+        out = np.zeros((threads, size), dtype=np.int32)
+
+        foo[1, threads](out)
+
+        np.testing.assert_equal(out[0], np.arange(size, dtype=np.int32))
+
+        for i in range(1, out.shape[0]):
+            np.testing.assert_equal(out[i], 1 + out[i - 1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_rewrites.py
+++ b/numba/cuda/tests/cudapy/test_rewrites.py
@@ -9,7 +9,7 @@ class TestRewriteArray(unittest.TestCase):
         size = 10
 
         @cuda.jit
-        def foo(out):
+        def foo(out, out_strides):
             arr = np.empty(size, dtype=np.int32)
             for i in range(size):
                 arr[i] = cuda.threadIdx.x + i
@@ -17,12 +17,54 @@ class TestRewriteArray(unittest.TestCase):
             for i in range(size):
                 out[cuda.threadIdx.x, i] = arr[i]
 
+            if cuda.threadIdx.x == 0:
+                for i, s in enumerate(arr.strides):
+                    out_strides[i] = s
+
         threads = 4
         out = np.zeros((threads, size), dtype=np.int32)
+        out_strides = np.zeros(1, dtype=np.intp)
 
-        foo[1, threads](out)
+        foo[1, threads](out, out_strides)
+
+        self.assertEqual(out_strides[0], out.itemsize)
 
         np.testing.assert_equal(out[0], np.arange(size, dtype=np.int32))
+
+        for i in range(1, out.shape[0]):
+            np.testing.assert_equal(out[i], 1 + out[i - 1])
+
+    def test_rewrite_numpy_empty_nd(self):
+
+        @cuda.jit
+        def foo(out, out_strides):
+            arr = np.empty((2, 3, 6), dtype=np.int32)
+            c = 0
+            for x in range(arr.shape[0]):
+                for y in range(arr.shape[1]):
+                    for z in range(arr.shape[2]):
+                        arr[x, y, z] = cuda.threadIdx.x + c
+                        c += 1
+
+            for x in range(arr.shape[0]):
+                for y in range(arr.shape[1]):
+                    for z in range(arr.shape[2]):
+                        out[cuda.threadIdx.x, x, y, z] = arr[x, y, z]
+
+            if cuda.threadIdx.x == 0:
+                for i, s in enumerate(arr.strides):
+                    out_strides[i] = s
+
+        threads = 4
+        out = np.zeros((threads, 2, 3, 6), dtype=np.int32)
+        out_strides = np.zeros(3, dtype=np.intp)
+
+        foo[1, threads](out, out_strides)
+
+        self.assertEqual(out.strides[1:], tuple(out_strides))
+
+        np.testing.assert_equal(out[0].ravel(), np.arange(out[0].size,
+                                                          dtype=np.int32))
 
         for i in range(1, out.shape[0]):
             np.testing.assert_equal(out[i], 1 + out[i - 1])

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -26,7 +26,7 @@ class RewriteArrayExprs(rewrites.Rewrite):
         if 'arrayexpr' not in special_ops:
             special_ops['arrayexpr'] = _lower_array_expr
 
-    def match(self, block, typemap, calltypes):
+    def match(self, label, block, typemap, calltypes):
         '''Using typing and a basic block, search the basic block for array
         expressions.  Returns True when one or more matches were
         found, False otherwise.

--- a/numba/rewrites.py
+++ b/numba/rewrites.py
@@ -14,7 +14,7 @@ class Rewrite(object):
         self.args = args
         self.kws = kws
 
-    def match(self, block, typemap, calltypes):
+    def match(self, label, block, typemap, calltypes):
         '''Overload this method to check an IR block for matching terms in the
         rewrite.
         '''
@@ -57,7 +57,7 @@ class RewriteRegistry(object):
             work_list = list(blocks.items())
             while work_list:
                 key, block = work_list.pop()
-                matches = rewrite.match(block, pipeline.typemap,
+                matches = rewrite.match(key, block, pipeline.typemap,
                                         pipeline.calltypes)
                 if matches:
                     if config.DUMP_IR:

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -161,6 +161,9 @@ class BaseContext(object):
     # Error model for various operations (only FP exceptions currently)
     error_model = None
 
+    # Rewrite passes
+    enable_array_intern = False
+
     def __init__(self, typing_context):
         _load_global_helpers()
         self.address_size = utils.MACHINE_BITS


### PR DESCRIPTION
Implement rewrite for CUDA backend to rewrite array allocations into per-thread static local memory of the function.  This allows the use of `np.empty` to be used inside the CUDA backend.  

Limitations:
- only rewrite the array allocations in the entry block
- the shape must be compile-time constant.
