### PR TITLE
Fix #1530: accept scalar inputs in np.where()

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -510,6 +510,14 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             self.assertEqual(got.dtype, expected.dtype)
             np.testing.assert_array_equal(got, expected)
 
+        def check_scal(scal):
+            x = 4
+            y = 5
+            cres = compile_isolated(pyfunc, (typeof(scal), typeof(x), typeof(y)))
+            expected = pyfunc(scal, x, y)
+            got = cres.entry_point(scal, x, y)
+            self.assertPreciseEqual(got, expected)
+
         arr = np.int16([1, 0, -1, 0])
         check_arr(arr)
         arr = np.bool_([1, 0, 1])
@@ -526,6 +534,9 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         for v in (0.0, 1.5, float('nan')):
             arr = np.array([v]).reshape(())
             check_arr(arr)
+
+        for x in (0, 1, True, False, 2.5, 0j):
+            check_scal(x)
 
 
 class TestArrayComparisons(TestCase):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -672,6 +672,9 @@ class ConstructorLikeBaseTest(object):
             if arr.ndim > 0:
                 check_arr(arr[::2])
 
+        # Scalar argument => should produce a 0-d array
+        check_arr(orig[0])
+
 
 class TestNdEmptyLike(ConstructorLikeBaseTest, TestCase):
 


### PR DESCRIPTION
Also allow np.empty_like() and friends with a scalar argument (creates a 0-d array).