### PR TITLE
Add abs tol support to comparison. Fix `sinc()`.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -314,9 +314,8 @@ class TestCase(unittest.TestCase):
             elif isinstance(abs_tol, float):
                 rtol = abs_tol
             else:
-                self.fail(
-                    self._formatMessage(
-                        msg, "abs_tol is not \"eps\" or a float"))
+                raise ValueError("abs_tol is not \"eps\" or a float, found %s"
+                    % abs_tol)
             if abs(first - second) < rtol:
                 return
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -167,7 +167,7 @@ class TestNPFunctions(TestCase):
         # Testing sinc(1.) leads to sin(pi)/pi, which is below machine
         # precision in practice on most machines. Small floating point
         # differences in sin() etc. may lead to large differences in the result
-        # that are at a range that in accessible using standard width
+        # that are at a range that is inaccessible using standard width
         # floating point representations.
         # e.g. Assume float64 type.
         # sin(pi) ~= 1e-16, but should be zero

--- a/numba/tests/test_support.py
+++ b/numba/tests/test_support.py
@@ -85,9 +85,9 @@ class TestAssertPreciseEqual(TestCase):
 
     def test_abs_tol_parse(self):
         # check invalid values in abs_tol kwarg raises
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.eq(np.float64(1e-17), np.float64(1e-17), abs_tol="invalid")
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.eq(np.float64(1), np.float64(2), abs_tol=int(7))
 
     def test_float_values(self):

--- a/numba/tests/test_support.py
+++ b/numba/tests/test_support.py
@@ -8,7 +8,6 @@ from numba import utils
 from numba import unittest_support as unittest
 from .support import TestCase, skip_on_numpy_16
 
-
 DBL_EPSILON = 2**-52
 FLT_EPSILON = 2**-23
 
@@ -84,6 +83,13 @@ class TestAssertPreciseEqual(TestCase):
                 self.ne(tp(-1), tp(1), prec=prec)
                 self.ne(tp(2**80), tp(1+2**80), prec=prec)
 
+    def test_abs_tol_parse(self):
+        # check invalid values in abs_tol kwarg raises
+        with self.assertRaises(AssertionError):
+            self.eq(np.float64(1e-17), np.float64(1e-17), abs_tol="invalid")
+        with self.assertRaises(AssertionError):
+            self.eq(np.float64(1), np.float64(2), abs_tol=int(7))
+
     def test_float_values(self):
         for tp in self.float_types:
             for prec in ['exact', 'single', 'double']:
@@ -128,6 +134,12 @@ class TestAssertPreciseEqual(TestCase):
                 self.ne(tp(a), tp(d), prec='double', ulps=2)
                 self.eq(tp(a), tp(c), prec='double', ulps=3)
                 self.eq(tp(a), tp(d), prec='double', ulps=3)
+            # test absolute tolerance based on eps
+            self.eq(tp(1e-16), tp(3e-16), prec='double', abs_tol="eps")
+            self.ne(tp(1e-16), tp(4e-16), prec='double', abs_tol="eps")
+            # test absolute tolerance based on value
+            self.eq(tp(1e-17), tp(1e-18), prec='double', abs_tol=1e-17)
+            self.ne(tp(1e-17), tp(3e-17), prec='double', abs_tol=1e-17)
 
     def test_float32_values_inexact(self):
         tp = np.float32
@@ -147,6 +159,13 @@ class TestAssertPreciseEqual(TestCase):
             self.ne(tp(a), tp(d), prec='single', ulps=2)
             self.eq(tp(a), tp(c), prec='single', ulps=3)
             self.eq(tp(a), tp(d), prec='single', ulps=3)
+        # test absolute tolerance based on eps
+        self.eq(tp(1e-7), tp(2e-7), prec='single', abs_tol="eps")
+        self.ne(tp(1e-7), tp(3e-7), prec='single', abs_tol="eps")
+        # test absolute tolerance based on value
+        self.eq(tp(1e-7), tp(1e-8), prec='single', abs_tol=1e-7)
+        self.ne(tp(1e-7), tp(3e-7), prec='single', abs_tol=1e-7)
+
 
     def test_complex_values(self):
         # Complex literals with signed zeros are confusing, better use


### PR DESCRIPTION
`sinc()` was failing on a test machine via a bizarre numerical problem, it was
decided that supporting comparison by absolute tolerance may be useful
especially for values near zero, this patch introduces this feature. It also
fixes `sinc()` tests as a result. `sinc()` was failing for the value 1.e0 which
lead to `sin(pi)/pi` being evaluated, which naturally, due to numerical methods,
does not come out as 0.e0. The specific result value is below machine precision
and as demonstrated by failing code, somewhat machine/compiler/libm specific.