### PR TITLE
Adjust tolerance in sinc() test for osx.

### DIFF
--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -201,13 +201,14 @@ class TestNPFunctions(TestCase):
                     ]
         x_types = [types.complex64, types.complex128] * (len(x_values) // 2)
         self.run_unary_complex(pyfunc, x_types, x_values, flags=flags,
-                               ignore_sign_on_zero=isoz, abs_tol=tol)
+                               ignore_sign_on_zero=isoz, abs_tol=tol, ulps=2)
+
 
         # complex domain vector context
         x_values = np.array(x_values)
         x_types = [types.complex64, types.complex128]
         self.run_unary_complex(pyfunc, x_types, x_values, flags=flags,
-                               ignore_sign_on_zero=isoz, abs_tol=tol)
+                               ignore_sign_on_zero=isoz, abs_tol=tol, ulps=2)
 
 
     def test_angle(self, flags=no_pyobj_flags):


### PR DESCRIPTION
OSX fails with a 2ULP error between numpy and numba.
This slackens the tolerance.

Manual testing on OSX: python {2.7.x,3.4.x} with numpy 1.9.3, now seems to pass.