### PR TITLE
numba config locals/globals context issue

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -166,7 +166,7 @@ class _EnvReloader(object):
         # Disable HSA support
         DISABLE_HSA = _readenv("NUMBA_DISABLE_HSA", int, 0)
         # Inject the configuration values into the module globals
-        for name, value in locals().items():
+        for name, value in locals().copy().items():
             if name.isupper():
                 globals()[name] = value
 


### PR DESCRIPTION
In some contexts, for example importing numba in a Python Visual Studio
(PTVS) script, during the debugging session locals() and globals() refer to the same datastructure.
and we can not modify a datastructure that we are iterating over. Hence I propose this minimal change to iterate over a copy.

This fixes this issue :
http://stackoverflow.com/questions/34069704/numba-exception-when-run-from-inside-ide-vs2015

and does not change the behaviour when operating on a copy of locals() is not required
