### PR TITLE
Get rid of types.Kind

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -101,7 +101,7 @@ for sreg in nvvmutils.SREG_MAPPING.keys():
 # -----------------------------------------------------------------------------
 
 @register
-@implement('ptx.cmem.arylike', types.Kind(types.Array))
+@implement('ptx.cmem.arylike', types.Array)
 def ptx_cmem_arylike(context, builder, sig, args):
     lmod = builder.module
     [arr] = args
@@ -180,7 +180,7 @@ def ptx_smem_alloc_intp(context, builder, sig, args):
 
 
 @register
-@implement('ptx.smem.alloc', types.Kind(types.UniTuple), types.Any)
+@implement('ptx.smem.alloc', types.UniTuple, types.Any)
 def ptx_smem_alloc_array(context, builder, sig, args):
     shape, dtype = args
     return _generic_array(context, builder, shape=shape, dtype=dtype,
@@ -200,7 +200,7 @@ def ptx_lmem_alloc_intp(context, builder, sig, args):
 
 
 @register
-@implement('ptx.lmem.alloc', types.Kind(types.UniTuple), types.Any)
+@implement('ptx.lmem.alloc', types.UniTuple, types.Any)
 def ptx_lmem_alloc_array(context, builder, sig, args):
     shape, dtype = args
     return _generic_array(context, builder, shape=shape, dtype=dtype,
@@ -258,7 +258,7 @@ def ptx_threadfence_device(context, builder, sig, args):
 
 
 @register
-@implement(stubs.atomic.add, types.Kind(types.Array), types.intp, types.Any)
+@implement(stubs.atomic.add, types.Array, types.intp, types.Any)
 def ptx_atomic_add_intp(context, builder, sig, args):
     aryty, indty, valty = sig.args
     ary, ind, val = args
@@ -283,10 +283,10 @@ def ptx_atomic_add_intp(context, builder, sig, args):
 
 
 @register
-@implement(stubs.atomic.add, types.Kind(types.Array),
-           types.Kind(types.UniTuple), types.Any)
-@implement(stubs.atomic.add, types.Kind(types.Array),
-           types.Kind(types.Tuple), types.Any)
+@implement(stubs.atomic.add, types.Array,
+           types.UniTuple, types.Any)
+@implement(stubs.atomic.add, types.Array,
+           types.Tuple, types.Any)
 def ptx_atomic_add_tuple(context, builder, sig, args):
     aryty, indty, valty = sig.args
     ary, inds, val = args
@@ -317,7 +317,7 @@ def ptx_atomic_add_tuple(context, builder, sig, args):
 
 
 @register
-@implement(stubs.atomic.max, types.Kind(types.Array), types.intp, types.Any)
+@implement(stubs.atomic.max, types.Array, types.intp, types.Any)
 def ptx_atomic_max_intp(context, builder, sig, args):
     aryty, indty, valty = sig.args
     ary, ind, val = args
@@ -339,10 +339,10 @@ def ptx_atomic_max_intp(context, builder, sig, args):
 
 
 @register
-@implement(stubs.atomic.max, types.Kind(types.Array),
-           types.Kind(types.Tuple), types.Any)
-@implement(stubs.atomic.max, types.Kind(types.Array),
-           types.Kind(types.UniTuple), types.Any)
+@implement(stubs.atomic.max, types.Array,
+           types.Tuple, types.Any)
+@implement(stubs.atomic.max, types.Array,
+           types.UniTuple, types.Any)
 def ptx_atomic_max_tuple(context, builder, sig, args):
     aryty, indty, valty = sig.args
     ary, inds, val = args

--- a/numba/cuda/printimpl.py
+++ b/numba/cuda/printimpl.py
@@ -10,7 +10,7 @@ register = registry.register
 voidptr = Type.pointer(Type.int(8))
 
 @register
-@implement(types.print_item_type, types.Kind(types.Integer))
+@implement(types.print_item_type, types.Integer)
 def int_print_impl(context, builder, sig, args):
     [x] = args
     [srctype] = sig.args
@@ -31,7 +31,7 @@ def int_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Kind(types.Float))
+@implement(types.print_item_type, types.Float)
 def real_print_impl(context, builder, sig, args):
     [x] = args
     [srctype] = sig.args

--- a/numba/hsa/hsaimpl.py
+++ b/numba/hsa/hsaimpl.py
@@ -196,10 +196,10 @@ def activelanepermute_wavewidth_impl(context, builder, sig, args):
 
 
 @register
-@implement(stubs.atomic.add, types.Kind(types.Array), types.intp, types.Any)
-@implement(stubs.atomic.add, types.Kind(types.Array),
-           types.Kind(types.UniTuple), types.Any)
-@implement(stubs.atomic.add, types.Kind(types.Array), types.Kind(types.Tuple),
+@implement(stubs.atomic.add, types.Array, types.intp, types.Any)
+@implement(stubs.atomic.add, types.Array,
+           types.UniTuple, types.Any)
+@implement(stubs.atomic.add, types.Array, types.Tuple,
            types.Any)
 def hsail_atomic_add_tuple(context, builder, sig, args):
     aryty, indty, valty = sig.args
@@ -228,7 +228,7 @@ def hsail_atomic_add_tuple(context, builder, sig, args):
 
 
 @register
-@implement('hsail.smem.alloc', types.Kind(types.UniTuple), types.Any)
+@implement('hsail.smem.alloc', types.UniTuple, types.Any)
 def hsail_smem_alloc_array(context, builder, sig, args):
     shape, dtype = args
     return _generic_array(context, builder, shape=shape, dtype=dtype,

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -217,7 +217,7 @@ class DUFunc(_internal._DUFunc):
         if targetctx is None:
             targetctx = self._dispatcher.targetdescr.target_context
         _any = types.Any
-        _arr = types.Kind(types.Array)
+        _arr = types.Array
         sig0 = _any(*((_any,) * self.ufunc.nin + (_arr,) * self.ufunc.nout))
         sig1 = _any(*((_any,) * self.ufunc.nin))
         targetctx.insert_func_defn([(self._lower_me, [

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -24,8 +24,8 @@ from .arrayobj import make_array, load_item, store_item, _empty_nd_impl
 # Stats and aggregates
 
 @builtin
-@implement(numpy.sum, types.Kind(types.Array))
-@implement("array.sum", types.Kind(types.Array))
+@implement(numpy.sum, types.Array)
+@implement("array.sum", types.Array)
 def array_sum(context, builder, sig, args):
     zero = sig.return_type(0)
 
@@ -40,8 +40,8 @@ def array_sum(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.prod, types.Kind(types.Array))
-@implement("array.prod", types.Kind(types.Array))
+@implement(numpy.prod, types.Array)
+@implement("array.prod", types.Array)
 def array_prod(context, builder, sig, args):
 
     def array_prod_impl(arr):
@@ -55,8 +55,8 @@ def array_prod(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.cumsum, types.Kind(types.Array))
-@implement("array.cumsum", types.Kind(types.Array))
+@implement(numpy.cumsum, types.Array)
+@implement("array.cumsum", types.Array)
 def array_cumsum(context, builder, sig, args):
     scalar_dtype = sig.return_type.dtype
     dtype = as_dtype(scalar_dtype)
@@ -80,8 +80,8 @@ def array_cumsum(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.cumprod, types.Kind(types.Array))
-@implement("array.cumprod", types.Kind(types.Array))
+@implement(numpy.cumprod, types.Array)
+@implement("array.cumprod", types.Array)
 def array_cumprod(context, builder, sig, args):
     scalar_dtype = sig.return_type.dtype
     dtype = as_dtype(scalar_dtype)
@@ -102,8 +102,8 @@ def array_cumprod(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.mean, types.Kind(types.Array))
-@implement("array.mean", types.Kind(types.Array))
+@implement(numpy.mean, types.Array)
+@implement("array.mean", types.Array)
 def array_mean(context, builder, sig, args):
     zero = sig.return_type(0)
 
@@ -120,8 +120,8 @@ def array_mean(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.var, types.Kind(types.Array))
-@implement("array.var", types.Kind(types.Array))
+@implement(numpy.var, types.Array)
+@implement("array.var", types.Array)
 def array_var(context, builder, sig, args):
     def array_var_impl(arry):
         # Compute the mean
@@ -138,8 +138,8 @@ def array_var(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.std, types.Kind(types.Array))
-@implement("array.std", types.Kind(types.Array))
+@implement(numpy.std, types.Array)
+@implement("array.std", types.Array)
 def array_std(context, builder, sig, args):
     def array_std_impl(arry):
         return arry.var() ** 0.5
@@ -148,8 +148,8 @@ def array_std(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.min, types.Kind(types.Array))
-@implement("array.min", types.Kind(types.Array))
+@implement(numpy.min, types.Array)
+@implement("array.min", types.Array)
 def array_min(context, builder, sig, args):
     ty = sig.args[0].dtype
     if isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
@@ -185,8 +185,8 @@ def array_min(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.max, types.Kind(types.Array))
-@implement("array.max", types.Kind(types.Array))
+@implement(numpy.max, types.Array)
+@implement("array.max", types.Array)
 def array_max(context, builder, sig, args):
     def array_max_impl(arry):
         for v in arry.flat:
@@ -202,8 +202,8 @@ def array_max(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.argmin, types.Kind(types.Array))
-@implement("array.argmin", types.Kind(types.Array))
+@implement(numpy.argmin, types.Array)
+@implement("array.argmin", types.Array)
 def array_argmin(context, builder, sig, args):
     ty = sig.args[0].dtype
     # NOTE: Under Numpy < 1.10, argmin() is inconsistent with min() on NaT values:
@@ -254,8 +254,8 @@ def array_argmin(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.argmax, types.Kind(types.Array))
-@implement("array.argmax", types.Kind(types.Array))
+@implement(numpy.argmax, types.Array)
+@implement("array.argmax", types.Array)
 def array_argmax(context, builder, sig, args):
     def array_argmax_impl(arry):
         for v in arry.flat:
@@ -275,7 +275,7 @@ def array_argmax(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.median, types.Kind(types.Array))
+@implement(numpy.median, types.Array)
 def array_median(context, builder, sig, args):
 
     def partition(A, low, high):
@@ -354,19 +354,19 @@ def _np_round_float(context, builder, tp, val):
     return builder.call(fn, (val,))
 
 @builtin
-@implement(numpy.round, types.Kind(types.Float))
+@implement(numpy.round, types.Float)
 def scalar_round_unary(context, builder, sig, args):
     res =  _np_round_float(context, builder, sig.args[0], args[0])
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.round, types.Kind(types.Integer))
+@implement(numpy.round, types.Integer)
 def scalar_round_unary(context, builder, sig, args):
     res = args[0]
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.round, types.Kind(types.Complex))
+@implement(numpy.round, types.Complex)
 def scalar_round_unary_complex(context, builder, sig, args):
     fltty = sig.args[0].underlying_float
     cplx_cls = context.make_complex(sig.args[0])
@@ -377,8 +377,8 @@ def scalar_round_unary_complex(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.round, types.Kind(types.Float), types.Kind(types.Integer))
-@implement(numpy.round, types.Kind(types.Integer), types.Kind(types.Integer))
+@implement(numpy.round, types.Float, types.Integer)
+@implement(numpy.round, types.Integer, types.Integer)
 def scalar_round_binary_float(context, builder, sig, args):
     def round_ndigits(x, ndigits):
         if math.isinf(x) or math.isnan(x):
@@ -409,7 +409,7 @@ def scalar_round_binary_float(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.round, types.Kind(types.Complex), types.Kind(types.Integer))
+@implement(numpy.round, types.Complex, types.Integer)
 def scalar_round_binary_complex(context, builder, sig, args):
     def round_ndigits(z, ndigits):
         return complex(numpy.round(z.real, ndigits),
@@ -420,8 +420,8 @@ def scalar_round_binary_complex(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.round, types.Kind(types.Array), types.Kind(types.Integer),
-           types.Kind(types.Array))
+@implement(numpy.round, types.Array, types.Integer,
+           types.Array)
 def array_round(context, builder, sig, args):
     def array_round_impl(arr, decimals, out):
         if arr.shape != out.shape:
@@ -435,7 +435,7 @@ def array_round(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.sinc, types.Kind(types.Array))
+@implement(numpy.sinc, types.Array)
 def array_sinc(context, builder, sig, args):
     def array_sinc_impl(arr):
         out = numpy.zeros_like(arr)
@@ -446,7 +446,7 @@ def array_sinc(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.sinc, types.Kind(types.Number))
+@implement(numpy.sinc, types.Number)
 def scalar_sinc(context, builder, sig, args):
     scalar_dtype = sig.return_type
     def scalar_sinc_impl(val):
@@ -459,7 +459,7 @@ def scalar_sinc(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.angle, types.Kind(types.Number))
+@implement(numpy.angle, types.Number)
 def scalar_angle(context, builder, sig, args):
     def scalar_angle_impl(val):
           return numpy.arctan2(val.imag, val.real)
@@ -468,7 +468,7 @@ def scalar_angle(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.angle, types.Kind(types.Number), types.Kind(types.Boolean))
+@implement(numpy.angle, types.Number, types.Boolean)
 def scalar_angle_kwarg(context, builder, sig, args):
     def scalar_angle_impl(val, deg=False):
         if deg:
@@ -481,8 +481,8 @@ def scalar_angle_kwarg(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.angle, types.Kind(types.Array))
-@implement(numpy.angle, types.Kind(types.Array), types.Kind(types.Boolean))
+@implement(numpy.angle, types.Array)
+@implement(numpy.angle, types.Array, types.Boolean)
 def array_angle_kwarg(context, builder, sig, args):
     arg = sig.args[0]
     if isinstance(arg.dtype, types.Complex):
@@ -498,9 +498,9 @@ def array_angle_kwarg(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.nonzero, types.Kind(types.Array))
-@implement("array.nonzero", types.Kind(types.Array))
-@implement(numpy.where, types.Kind(types.Array))
+@implement(numpy.nonzero, types.Array)
+@implement("array.nonzero", types.Array)
+@implement(numpy.where, types.Array)
 def array_nonzero(context, builder, sig, args):
     aryty = sig.args[0]
     # Return type is a N-tuple of 1D C-contiguous arrays
@@ -741,8 +741,8 @@ def dot_2_vv(context, builder, sig, args, conjugate=False):
 
 
 @builtin
-@implement(numpy.dot, types.Kind(types.Array), types.Kind(types.Array))
-@implement('@', types.Kind(types.Array), types.Kind(types.Array))
+@implement(numpy.dot, types.Array, types.Array)
+@implement('@', types.Array, types.Array)
 def dot_2(context, builder, sig, args):
     """
     np.dot(a, b)
@@ -763,7 +763,7 @@ def dot_2(context, builder, sig, args):
         assert 0
 
 @builtin
-@implement(numpy.vdot, types.Kind(types.Array), types.Kind(types.Array))
+@implement(numpy.vdot, types.Array, types.Array)
 def vdot(context, builder, sig, args):
     """
     np.vdot(a, b)
@@ -940,8 +940,8 @@ def dot_3_mm(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.dot, types.Kind(types.Array), types.Kind(types.Array),
-           types.Kind(types.Array))
+@implement(numpy.dot, types.Array, types.Array,
+           types.Array)
 def dot_3(context, builder, sig, args):
     """
     np.dot(a, b, out)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -209,7 +209,7 @@ def make_arrayiter_cls(iterator_type):
     return cgutils.create_struct_proxy(iterator_type)
 
 @builtin
-@implement('getiter', types.Kind(types.Buffer))
+@implement('getiter', types.Buffer)
 def getiter_array(context, builder, sig, args):
     [arrayty] = sig.args
     [array] = args
@@ -242,7 +242,7 @@ def _getitem_array1d(context, builder, arrayty, array, idx, wraparound):
     return load_item(context, builder, arrayty, ptr)
 
 @builtin
-@implement('iternext', types.Kind(types.ArrayIterator))
+@implement('iternext', types.ArrayIterator)
 @iternext_impl
 def iternext_array(context, builder, sig, args, result):
     [iterty] = sig.args
@@ -364,7 +364,7 @@ def _getitem_array_generic(context, builder, return_type, aryty, ary,
 
 
 @builtin
-@implement('getitem', types.Kind(types.Buffer), types.Kind(types.Integer))
+@implement('getitem', types.Buffer, types.Integer)
 def getitem_arraynd_intp(context, builder, sig, args):
     aryty, idxty = sig.args
     ary, idx = args
@@ -389,7 +389,7 @@ def getitem_arraynd_intp(context, builder, sig, args):
 
 
 @builtin
-@implement('getitem', types.Kind(types.Buffer), types.slice3_type)
+@implement('getitem', types.Buffer, types.slice3_type)
 def getitem_array1d_slice(context, builder, sig, args):
     aryty, idxty = sig.args
     ary, idx = args
@@ -402,7 +402,7 @@ def getitem_array1d_slice(context, builder, sig, args):
 
 
 @builtin
-@implement('getitem', types.Kind(types.Buffer), types.Kind(types.BaseTuple))
+@implement('getitem', types.Buffer, types.BaseTuple)
 def getitem_array_tuple(context, builder, sig, args):
     aryty, tupty = sig.args
     ary, tup = args
@@ -433,7 +433,7 @@ def getitem_array_tuple(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.Buffer), types.Any, types.Any)
+@implement('setitem', types.Buffer, types.Any, types.Any)
 def setitem_array(context, builder, sig, args):
     """
     array[a] = scalar_or_array
@@ -472,7 +472,7 @@ def setitem_array(context, builder, sig, args):
 
 
 @builtin
-@implement(types.len_type, types.Kind(types.Buffer))
+@implement(types.len_type, types.Buffer)
 def array_len(context, builder, sig, args):
     (aryty,) = sig.args
     (ary,) = args
@@ -918,7 +918,7 @@ def fancy_getitem(context, builder, sig, args,
 
 
 @builtin
-@implement('getitem', types.Kind(types.Buffer), types.Kind(types.Array))
+@implement('getitem', types.Buffer, types.Array)
 def fancy_getitem_array(context, builder, sig, args):
     aryty, idxty = sig.args
     ary, idx = args
@@ -1011,7 +1011,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 # Shape / layout altering
 
 @builtin
-@implement('array.transpose', types.Kind(types.Array))
+@implement('array.transpose', types.Array)
 def array_transpose(context, builder, sig, args):
     return array_T(context, builder, sig.args[0], args[0])
 
@@ -1033,7 +1033,7 @@ def array_T(context, builder, typ, value):
         res = ret._getvalue()
     return impl_ret_borrowed(context, builder, typ, res)
 
-builtin_attr(impl_attribute(types.Kind(types.Array), 'T')(array_T))
+builtin_attr(impl_attribute(types.Array, 'T')(array_T))
 
 
 def _attempt_nocopy_reshape(context, builder, aryty, ary, newnd, newshape,
@@ -1065,7 +1065,7 @@ def _attempt_nocopy_reshape(context, builder, aryty, ary, newnd, newshape,
     return res
 
 @builtin
-@implement('array.reshape', types.Kind(types.Array), types.Kind(types.BaseTuple))
+@implement('array.reshape', types.Array, types.BaseTuple)
 def array_reshape(context, builder, sig, args):
     aryty = sig.args[0]
     retty = sig.return_type
@@ -1122,7 +1122,7 @@ def array_reshape(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement('array.reshape', types.Kind(types.Array), types.VarArg(types.Any))
+@implement('array.reshape', types.Array, types.VarArg(types.Any))
 def array_reshape_vararg(context, builder, sig, args):
     # types
     aryty = sig.args[0]
@@ -1269,7 +1269,7 @@ def _change_dtype(context, builder, oldty, newty, ary):
 
 
 @builtin
-@implement('array.view', types.Kind(types.Array), types.Kind(types.DTypeSpec))
+@implement('array.view', types.Array, types.DTypeSpec)
 def array_view(context, builder, sig, args):
     aryty = sig.args[0]
     retty = sig.return_type
@@ -1301,14 +1301,14 @@ def array_view(context, builder, sig, args):
 # Array attributes
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "dtype", types.Kind(types.DType))
+@impl_attribute(types.Array, "dtype", types.DType)
 def array_dtype(context, builder, typ, value):
     res = context.get_dummy_value()
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "shape", types.Kind(types.UniTuple))
-@impl_attribute(types.Kind(types.MemoryView), "shape", types.Kind(types.UniTuple))
+@impl_attribute(types.Array, "shape", types.UniTuple)
+@impl_attribute(types.MemoryView, "shape", types.UniTuple)
 def array_shape(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
@@ -1317,8 +1317,8 @@ def array_shape(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "strides", types.Kind(types.UniTuple))
-@impl_attribute(types.Kind(types.MemoryView), "strides", types.Kind(types.UniTuple))
+@impl_attribute(types.Array, "strides", types.UniTuple)
+@impl_attribute(types.MemoryView, "strides", types.UniTuple)
 def array_strides(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
@@ -1327,15 +1327,15 @@ def array_strides(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "ndim", types.intp)
-@impl_attribute(types.Kind(types.MemoryView), "ndim", types.intp)
+@impl_attribute(types.Array, "ndim", types.intp)
+@impl_attribute(types.MemoryView, "ndim", types.intp)
 def array_ndim(context, builder, typ, value):
     res = context.get_constant(types.intp, typ.ndim)
     return impl_ret_untracked(context, builder, typ, res)
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "size", types.intp)
+@impl_attribute(types.Array, "size", types.intp)
 def array_size(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
@@ -1344,8 +1344,8 @@ def array_size(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "itemsize", types.intp)
-@impl_attribute(types.Kind(types.MemoryView), "itemsize", types.intp)
+@impl_attribute(types.Array, "itemsize", types.intp)
+@impl_attribute(types.MemoryView, "itemsize", types.intp)
 def array_itemsize(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
@@ -1354,7 +1354,7 @@ def array_itemsize(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.MemoryView), "nbytes", types.intp)
+@impl_attribute(types.MemoryView, "nbytes", types.intp)
 def array_nbytes(context, builder, typ, value):
     """
     nbytes = size * itemsize
@@ -1367,34 +1367,34 @@ def array_nbytes(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.MemoryView), "contiguous", types.boolean)
+@impl_attribute(types.MemoryView, "contiguous", types.boolean)
 def array_contiguous(context, builder, typ, value):
     res = context.get_constant(types.boolean, typ.is_contig)
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin_attr
-@impl_attribute(types.Kind(types.MemoryView), "c_contiguous", types.boolean)
+@impl_attribute(types.MemoryView, "c_contiguous", types.boolean)
 def array_c_contiguous(context, builder, typ, value):
     res = context.get_constant(types.boolean, typ.is_c_contig)
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin_attr
-@impl_attribute(types.Kind(types.MemoryView), "f_contiguous", types.boolean)
+@impl_attribute(types.MemoryView, "f_contiguous", types.boolean)
 def array_f_contiguous(context, builder, typ, value):
     res = context.get_constant(types.boolean, typ.is_f_contig)
     return impl_ret_untracked(context, builder, typ, res)
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.MemoryView), "readonly", types.boolean)
+@impl_attribute(types.MemoryView, "readonly", types.boolean)
 def array_readonly(context, builder, typ, value):
     res = context.get_constant(types.boolean, not typ.mutable)
     return impl_ret_untracked(context, builder, typ, res)
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "ctypes",
-                types.Kind(types.ArrayCTypes))
+@impl_attribute(types.Array, "ctypes",
+                types.ArrayCTypes)
 def array_ctypes(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
@@ -1409,14 +1409,14 @@ def array_ctypes(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "flags", types.Kind(types.ArrayFlags))
+@impl_attribute(types.Array, "flags", types.ArrayFlags)
 def array_flags(context, builder, typ, value):
     res = context.get_dummy_value()
     return impl_ret_untracked(context, builder, typ, res)
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.ArrayCTypes), "data", types.uintp)
+@impl_attribute(types.ArrayCTypes, "data", types.uintp)
 def array_ctypes_data(context, builder, typ, value):
     ctinfo_type = cgutils.create_struct_proxy(typ)
     ctinfo = ctinfo_type(context, builder, value=value)
@@ -1425,15 +1425,15 @@ def array_ctypes_data(context, builder, typ, value):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.ArrayFlags), "contiguous", types.boolean)
-@impl_attribute(types.Kind(types.ArrayFlags), "c_contiguous", types.boolean)
+@impl_attribute(types.ArrayFlags, "contiguous", types.boolean)
+@impl_attribute(types.ArrayFlags, "c_contiguous", types.boolean)
 def array_ctypes_data(context, builder, typ, value):
     val = typ.array_type.layout == 'C'
     res = context.get_constant(types.boolean, val)
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin_attr
-@impl_attribute(types.Kind(types.ArrayFlags), "f_contiguous", types.boolean)
+@impl_attribute(types.ArrayFlags, "f_contiguous", types.boolean)
 def array_ctypes_data(context, builder, typ, value):
     layout = typ.array_type.layout
     val = layout == 'F' if typ.array_type.ndim > 1 else layout in 'CF'
@@ -1445,7 +1445,7 @@ def array_ctypes_data(context, builder, typ, value):
 # Structured / record lookup
 
 @builtin_attr
-@impl_attribute_generic(types.Kind(types.Array))
+@impl_attribute_generic(types.Array)
 def array_record_getattr(context, builder, typ, value, attr):
     """
     Generic getattr() implementation for record arrays: fetch the given
@@ -1484,13 +1484,13 @@ def array_record_getattr(context, builder, typ, value, attr):
     return impl_ret_borrowed(context, builder, typ, res)
 
 @builtin
-@implement('static_getitem', types.Kind(types.Array), types.Kind(types.Const))
+@implement('static_getitem', types.Array, types.Const)
 def array_record_getitem(context, builder, sig, args):
     return array_record_getattr(context, builder, sig.args[0], args[0], args[1])
 
 
 @builtin_attr
-@impl_attribute_generic(types.Kind(types.Record))
+@impl_attribute_generic(types.Record)
 def record_getattr(context, builder, typ, value, attr):
     """
     Generic getattr() implementation for records: fetch the given
@@ -1531,7 +1531,7 @@ def record_getattr(context, builder, typ, value, attr):
         return impl_ret_borrowed(context, builder, typ, res)
 
 @builtin
-@implement('static_getitem', types.Kind(types.Record), types.Kind(types.Const))
+@implement('static_getitem', types.Record, types.Const)
 def record_getitem(context, builder, sig, args):
     """
     Record.__getitem__ redirects to getattr()
@@ -1540,7 +1540,7 @@ def record_getitem(context, builder, sig, args):
     return impl(context, builder, sig.args[0], args[0], args[1])
 
 @builtin
-@implement('static_setitem', types.Kind(types.Record), types.Kind(types.Const), types.Any)
+@implement('static_setitem', types.Record, types.Const, types.Any)
 def record_setitem(context, builder, sig, args):
     """
     Record.__setitem__ redirects to setattr()
@@ -1557,7 +1557,7 @@ def record_setitem(context, builder, sig, args):
 # Comparisons
 
 @builtin
-@implement('is', types.Kind(types.Array), types.Kind(types.Array))
+@implement('is', types.Array, types.Array)
 def array_is(context, builder, sig, args):
     aty, bty = sig.args
     if aty != bty:
@@ -1895,7 +1895,7 @@ def _make_flattening_iter_cls(flatiterty, kind):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Array), "flat", types.Kind(types.NumpyFlatType))
+@impl_attribute(types.Array, "flat", types.NumpyFlatType)
 def make_array_flatiter(context, builder, arrty, arr):
     flatitercls = make_array_flat_cls(types.NumpyFlatType(arrty))
     flatiter = flatitercls(context, builder)
@@ -1913,7 +1913,7 @@ def make_array_flatiter(context, builder, arrty, arr):
 
 
 @builtin
-@implement('iternext', types.Kind(types.NumpyFlatType))
+@implement('iternext', types.NumpyFlatType)
 @iternext_impl
 def iternext_numpy_flatiter(context, builder, sig, args, result):
     [flatiterty] = sig.args
@@ -1930,7 +1930,7 @@ def iternext_numpy_flatiter(context, builder, sig, args, result):
 
 
 @builtin
-@implement('getitem', types.Kind(types.NumpyFlatType), types.Kind(types.Integer))
+@implement('getitem', types.NumpyFlatType, types.Integer)
 def iternext_numpy_getitem(context, builder, sig, args):
     flatiterty = sig.args[0]
     flatiter, index = args
@@ -1947,7 +1947,7 @@ def iternext_numpy_getitem(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.NumpyFlatType), types.Kind(types.Integer),
+@implement('setitem', types.NumpyFlatType, types.Integer,
            types.Any)
 def iternext_numpy_getitem(context, builder, sig, args):
     flatiterty = sig.args[0]
@@ -1965,7 +1965,7 @@ def iternext_numpy_getitem(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.ndenumerate, types.Kind(types.Array))
+@implement(numpy.ndenumerate, types.Array)
 def make_array_ndenumerate(context, builder, sig, args):
     arrty, = sig.args
     arr, = args
@@ -1985,7 +1985,7 @@ def make_array_ndenumerate(context, builder, sig, args):
 
 
 @builtin
-@implement('iternext', types.Kind(types.NumpyNdEnumerateType))
+@implement('iternext', types.NumpyNdEnumerateType)
 @iternext_impl
 def iternext_numpy_nditer(context, builder, sig, args, result):
     [nditerty] = sig.args
@@ -2002,7 +2002,7 @@ def iternext_numpy_nditer(context, builder, sig, args, result):
 
 
 @builtin
-@implement(numpy.ndindex, types.VarArg(types.Kind(types.Integer)))
+@implement(numpy.ndindex, types.VarArg(types.Integer))
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(*shape)"""
     shape = [context.cast(builder, arg, argty, types.intp)
@@ -2016,7 +2016,7 @@ def make_array_ndindex(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.ndindex, types.Kind(types.BaseTuple))
+@implement(numpy.ndindex, types.BaseTuple)
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(shape)"""
     ndim = sig.return_type.ndim
@@ -2038,7 +2038,7 @@ def make_array_ndindex(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement('iternext', types.Kind(types.NumpyNdIndexType))
+@implement('iternext', types.NumpyNdIndexType)
 @iternext_impl
 def iternext_numpy_ndindex(context, builder, sig, args, result):
     [nditerty] = sig.args
@@ -2165,7 +2165,7 @@ def numpy_empty_nd(context, builder, sig, args):
 
 @builtin
 @implement(numpy.empty_like, types.Any)
-@implement(numpy.empty_like, types.Any, types.Kind(types.DTypeSpec))
+@implement(numpy.empty_like, types.Any, types.DTypeSpec)
 def numpy_empty_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -2184,7 +2184,7 @@ def numpy_zeros_nd(context, builder, sig, args):
 
 @builtin
 @implement(numpy.zeros_like, types.Any)
-@implement(numpy.zeros_like, types.Any, types.Kind(types.DTypeSpec))
+@implement(numpy.zeros_like, types.Any, types.DTypeSpec)
 def numpy_zeros_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -2207,7 +2207,7 @@ if numpy_version >= (1, 8):
         return impl_ret_new_ref(context, builder, sig.return_type, res)
 
     @builtin
-    @implement(numpy.full, types.Any, types.Any, types.Kind(types.DTypeSpec))
+    @implement(numpy.full, types.Any, types.Any, types.DTypeSpec)
     def numpy_full_dtype_nd(context, builder, sig, args):
 
         def full(shape, value, dtype):
@@ -2235,7 +2235,7 @@ if numpy_version >= (1, 8):
 
 
     @builtin
-    @implement(numpy.full_like, types.Any, types.Any, types.Kind(types.DTypeSpec))
+    @implement(numpy.full_like, types.Any, types.Any, types.DTypeSpec)
     def numpy_full_like_nd(context, builder, sig, args):
 
         def full_like(arr, value, dtype):
@@ -2264,7 +2264,7 @@ def numpy_ones_nd(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.ones, types.Any, types.Kind(types.DTypeSpec))
+@implement(numpy.ones, types.Any, types.DTypeSpec)
 def numpy_ones_dtype_nd(context, builder, sig, args):
 
     def ones(shape, dtype):
@@ -2290,7 +2290,7 @@ def numpy_ones_like_nd(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.ones_like, types.Any, types.Kind(types.DTypeSpec))
+@implement(numpy.ones_like, types.Any, types.DTypeSpec)
 def numpy_ones_like_dtype_nd(context, builder, sig, args):
 
     def ones_like(arr, dtype):
@@ -2304,7 +2304,7 @@ def numpy_ones_like_dtype_nd(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.identity, types.Kind(types.Integer))
+@implement(numpy.identity, types.Integer)
 def numpy_identity(context, builder, sig, args):
 
     def identity(n):
@@ -2317,7 +2317,7 @@ def numpy_identity(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.identity, types.Kind(types.Integer), types.Kind(types.DTypeSpec))
+@implement(numpy.identity, types.Integer, types.DTypeSpec)
 def numpy_identity(context, builder, sig, args):
 
     def identity(n, dtype):
@@ -2331,7 +2331,7 @@ def numpy_identity(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.eye, types.Kind(types.Integer))
+@implement(numpy.eye, types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n):
@@ -2341,7 +2341,7 @@ def numpy_eye(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer))
+@implement(numpy.eye, types.Integer, types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m):
@@ -2351,8 +2351,8 @@ def numpy_eye(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer),
-           types.Kind(types.Integer))
+@implement(numpy.eye, types.Integer, types.Integer,
+           types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m, k):
@@ -2362,8 +2362,8 @@ def numpy_eye(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.eye, types.Kind(types.Integer), types.Kind(types.Integer),
-           types.Kind(types.Integer), types.Kind(types.DTypeSpec))
+@implement(numpy.eye, types.Integer, types.Integer,
+           types.Integer, types.DTypeSpec)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m, k, dtype):
@@ -2383,7 +2383,7 @@ def numpy_eye(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.arange, types.Kind(types.Number))
+@implement(numpy.arange, types.Number)
 def numpy_arange_1(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
@@ -2394,7 +2394,7 @@ def numpy_arange_1(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.arange, types.Kind(types.Number), types.Kind(types.Number))
+@implement(numpy.arange, types.Number, types.Number)
 def numpy_arange_2(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
@@ -2406,8 +2406,8 @@ def numpy_arange_2(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.arange, types.Kind(types.Number), types.Kind(types.Number),
-           types.Kind(types.Number))
+@implement(numpy.arange, types.Number, types.Number,
+           types.Number)
 def numpy_arange_3(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
@@ -2418,8 +2418,8 @@ def numpy_arange_3(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.arange, types.Kind(types.Number), types.Kind(types.Number),
-           types.Kind(types.Number), types.Kind(types.DTypeSpec))
+@implement(numpy.arange, types.Number, types.Number,
+           types.Number, types.DTypeSpec)
 def numpy_arange_4(context, builder, sig, args):
 
     if any(isinstance(a, types.Complex) for a in sig.args):
@@ -2450,7 +2450,7 @@ def numpy_arange_4(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.linspace, types.Kind(types.Number), types.Kind(types.Number))
+@implement(numpy.linspace, types.Number, types.Number)
 def numpy_linspace_2(context, builder, sig, args):
 
     def linspace(start, stop):
@@ -2460,8 +2460,8 @@ def numpy_linspace_2(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement(numpy.linspace, types.Kind(types.Number), types.Kind(types.Number),
-           types.Kind(types.Integer))
+@implement(numpy.linspace, types.Number, types.Number,
+           types.Integer)
 def numpy_linspace_3(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
@@ -2479,7 +2479,7 @@ def numpy_linspace_3(context, builder, sig, args):
 
 
 @builtin
-@implement("array.copy", types.Kind(types.Array))
+@implement("array.copy", types.Array)
 def array_copy(context, builder, sig, args):
     arytype = sig.args[0]
     ary = make_array(arytype)(context, builder, value=args[0])
@@ -2529,8 +2529,8 @@ def array_copy(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.frombuffer, types.Kind(types.Buffer))
-@implement(numpy.frombuffer, types.Kind(types.Buffer), types.Kind(types.DTypeSpec))
+@implement(numpy.frombuffer, types.Buffer)
+@implement(numpy.frombuffer, types.Buffer, types.DTypeSpec)
 def np_frombuffer(context, builder, sig, args):
     bufty = sig.args[0]
     aryty = sig.return_type
@@ -2592,7 +2592,7 @@ def load_sorts():
 
 
 @builtin
-@implement("array.sort", types.Kind(types.Array))
+@implement("array.sort", types.Array)
 def array_sort(context, builder, sig, args):
     load_sorts()
 
@@ -2610,7 +2610,7 @@ def array_sort(context, builder, sig, args):
 
 
 @builtin
-@implement(numpy.sort, types.Kind(types.Array))
+@implement(numpy.sort, types.Array)
 def np_sort(context, builder, sig, args):
 
     def np_sort_impl(a):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -97,10 +97,10 @@ class Overloads(object):
         elif types.Any == formal:
             # formal argument is any
             return True
-        elif (isinstance(formal, types.Kind) and
-                  isinstance(actual, formal.of)):
-            # formal argument is a kind and the actual argument
-            # is of that kind
+        elif (isinstance(formal, type) and
+              isinstance(actual, formal)):
+            # formal argument is a type class matching actual argument
+            assert issubclass(formal, types.Type)
             return True
 
     def append(self, impl, sig):
@@ -567,7 +567,7 @@ class BaseContext(object):
         return pair.second
 
     def cast(self, builder, val, fromty, toty):
-        if fromty == toty or toty == types.Any or isinstance(toty, types.Kind):
+        if fromty == toty or toty == types.Any:
             return val
 
         elif isinstance(fromty, types.Integer) and isinstance(toty, types.Integer):

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -116,8 +116,8 @@ def int_divmod(context, builder, x, y):
 
 
 @builtin
-@implement('/?', types.Kind(types.Integer), types.Kind(types.Integer))
-@implement('//', types.Kind(types.Integer), types.Kind(types.Integer))
+@implement('/?', types.Integer, types.Integer)
+@implement('//', types.Integer, types.Integer)
 def int_floordiv_impl(context, builder, sig, args):
     [va, vb] = args
     [ta, tb] = sig.args
@@ -146,7 +146,7 @@ def int_floordiv_impl(context, builder, sig, args):
 
 
 @builtin
-@implement('/', types.Kind(types.Integer), types.Kind(types.Integer))
+@implement('/', types.Integer, types.Integer)
 def int_truediv_impl(context, builder, sig, args):
     [va, vb] = args
     [ta, tb] = sig.args
@@ -159,7 +159,7 @@ def int_truediv_impl(context, builder, sig, args):
 
 
 @builtin
-@implement('%', types.Kind(types.Integer), types.Kind(types.Integer))
+@implement('%', types.Integer, types.Integer)
 def int_rem_impl(context, builder, sig, args):
     [va, vb] = args
     [ta, tb] = sig.args
@@ -426,7 +426,7 @@ builtin(implement('~', types.boolean)(bool_invert_impl))
 
 
 def _implement_integer_operators():
-    ty = types.Kind(types.Integer)
+    ty = types.Integer
 
     builtin(implement('+', ty, ty)(int_add_impl))
     builtin(implement('-', ty, ty)(int_sub_impl))
@@ -505,10 +505,10 @@ builtin(implement('is', types.none, types.none)(
 
 # Optional is None
 builtin(implement('is',
-                  types.Kind(types.Optional), types.none)(optional_is_none))
+                  types.Optional, types.none)(optional_is_none))
 
 builtin(implement('is',
-                  types.none, types.Kind(types.Optional))(optional_is_none))
+                  types.none, types.Optional)(optional_is_none))
 
 
 def real_add_impl(context, builder, sig, args):
@@ -791,7 +791,7 @@ def real_sign_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-ty = types.Kind(types.Float)
+ty = types.Float
 
 builtin(implement('+', ty, ty)(real_add_impl))
 builtin(implement('-', ty, ty)(real_sub_impl))
@@ -842,7 +842,7 @@ def get_complex_info(ty):
 
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Complex), "real")
+@impl_attribute(types.Complex, "real")
 def complex_real_impl(context, builder, typ, value):
     cplx_cls = context.make_complex(typ)
     cplx = cplx_cls(context, builder, value=value)
@@ -850,7 +850,7 @@ def complex_real_impl(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin_attr
-@impl_attribute(types.Kind(types.Complex), "imag")
+@impl_attribute(types.Complex, "imag")
 def complex_imag_impl(context, builder, typ, value):
     cplx_cls = context.make_complex(typ)
     cplx = cplx_cls(context, builder, value=value)
@@ -858,7 +858,7 @@ def complex_imag_impl(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 @builtin
-@implement("complex.conjugate", types.Kind(types.Complex))
+@implement("complex.conjugate", types.Complex)
 def complex_conjugate_impl(context, builder, sig, args):
     from . import mathimpl
     cplx_cls = context.make_complex(sig.args[0])
@@ -878,9 +878,9 @@ def real_conjugate_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, args[0])
 
 for cls in (types.Float, types.Integer):
-    builtin_attr(impl_attribute(types.Kind(cls), "real")(real_real_impl))
-    builtin_attr(impl_attribute(types.Kind(cls), "imag")(real_imag_impl))
-    builtin(implement("complex.conjugate", types.Kind(cls))(real_conjugate_impl))
+    builtin_attr(impl_attribute(cls, "real")(real_real_impl))
+    builtin_attr(impl_attribute(cls, "imag")(real_imag_impl))
+    builtin(implement("complex.conjugate", cls)(real_conjugate_impl))
 
 
 @builtin
@@ -1063,7 +1063,7 @@ def complex_abs_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-ty = types.Kind(types.Complex)
+ty = types.Complex
 
 builtin(implement("+", ty, ty)(complex_add_impl))
 builtin(implement("-", ty, ty)(complex_sub_impl))
@@ -1100,19 +1100,19 @@ def bool_as_bool(context, builder, sig, args):
     return val
 
 @builtin
-@implement(bool, types.Kind(types.Integer))
+@implement(bool, types.Integer)
 def int_as_bool(context, builder, sig, args):
     [val] = args
     return builder.icmp_unsigned('!=', val, ir.Constant(val.type, 0))
 
 @builtin
-@implement(bool, types.Kind(types.Float))
+@implement(bool, types.Float)
 def float_as_bool(context, builder, sig, args):
     [val] = args
     return builder.fcmp(lc.FCMP_UNE, val, ir.Constant(val.type, 0.0))
 
 @builtin
-@implement(bool, types.Kind(types.Complex))
+@implement(bool, types.Complex)
 def complex_as_bool(context, builder, sig, args):
     [typ] = sig.args
     [val] = args
@@ -1125,7 +1125,7 @@ def complex_as_bool(context, builder, sig, args):
 
 
 for ty in (types.Integer, types.Float, types.Complex):
-    builtin(implement('not', types.Kind(ty))(number_not_impl))
+    builtin(implement('not', ty)(number_not_impl))
 
 builtin(implement('not', types.boolean)(number_not_impl))
 
@@ -1136,7 +1136,7 @@ def make_pair(first_type, second_type):
 
 
 @builtin
-@implement('getitem', types.Kind(types.CPointer), types.Kind(types.Integer))
+@implement('getitem', types.CPointer, types.Integer)
 def getitem_cpointer(context, builder, sig, args):
     base_ptr, idx = args
     elem_ptr = builder.gep(base_ptr, [idx])
@@ -1145,7 +1145,7 @@ def getitem_cpointer(context, builder, sig, args):
 
 
 @builtin
-@implement('setitem', types.Kind(types.CPointer), types.Kind(types.Integer),
+@implement('setitem', types.CPointer, types.Integer,
            types.Any)
 def setitem_cpointer(context, builder, sig, args):
     base_ptr, idx, val = args
@@ -1226,7 +1226,7 @@ def _round_intrinsic(tp):
         return "llvm.round.f%d" % (tp.bitwidth,)
 
 @builtin
-@implement(round, types.Kind(types.Float))
+@implement(round, types.Float)
 def round_impl_unary(context, builder, sig, args):
     fltty = sig.args[0]
     llty = context.get_value_type(fltty)
@@ -1240,7 +1240,7 @@ def round_impl_unary(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(round, types.Kind(types.Float), types.Kind(types.Integer))
+@implement(round, types.Float, types.Integer)
 def round_impl_binary(context, builder, sig, args):
     fltty = sig.args[0]
     # Allow calling the intrinsic from the Python implementation below.
@@ -1342,7 +1342,7 @@ def math_e_impl(context, builder, typ, value):
 # -----------------------------------------------------------------------------
 
 @builtin
-@implement(intrinsics.array_ravel, types.Kind(types.Array))
+@implement(intrinsics.array_ravel, types.Array)
 def array_ravel_impl(context, builder, sig, args):
     [arrty] = sig.args
     [arr] = args

--- a/numba/targets/cffiimpl.py
+++ b/numba/targets/cffiimpl.py
@@ -11,7 +11,7 @@ from . import arrayobj
 registry = Registry()
 
 @registry.register
-@implement('ffi.from_buffer', types.Kind(types.Array))
+@implement('ffi.from_buffer', types.Array)
 def from_buffer(context, builder, sig, args):
     assert len(sig.args) == 1
     assert len(args) == 1

--- a/numba/targets/cmathimpl.py
+++ b/numba/targets/cmathimpl.py
@@ -33,7 +33,7 @@ def is_finite(builder, z):
 
 
 @register
-@implement(cmath.isnan, types.Kind(types.Complex))
+@implement(cmath.isnan, types.Complex)
 def isnan_float_impl(context, builder, sig, args):
     [typ] = sig.args
     [value] = args
@@ -43,7 +43,7 @@ def isnan_float_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement(cmath.isinf, types.Kind(types.Complex))
+@implement(cmath.isinf, types.Complex)
 def isinf_float_impl(context, builder, sig, args):
     [typ] = sig.args
     [value] = args
@@ -55,7 +55,7 @@ def isinf_float_impl(context, builder, sig, args):
 
 if utils.PYVERSION >= (3, 2):
     @register
-    @implement(cmath.isfinite, types.Kind(types.Complex))
+    @implement(cmath.isfinite, types.Complex)
     def isfinite_float_impl(context, builder, sig, args):
         [typ] = sig.args
         [value] = args
@@ -66,7 +66,7 @@ if utils.PYVERSION >= (3, 2):
 
 
 @register
-@implement(cmath.rect, types.Kind(types.Float), types.Kind(types.Float))
+@implement(cmath.rect, types.Float, types.Float)
 def rect_impl(context, builder, sig, args):
     [r, phi] = args
     # We can't call math.isfinite() inside rect() below because it
@@ -124,7 +124,7 @@ NAN = float('nan')
 INF = float('inf')
 
 @register
-@implement(cmath.exp, types.Kind(types.Complex))
+@implement(cmath.exp, types.Complex)
 @intrinsic_complex_unary
 def exp_impl(x, y, x_is_finite, y_is_finite):
     """cmath.exp(x + y j)"""
@@ -166,7 +166,7 @@ def exp_impl(x, y, x_is_finite, y_is_finite):
             return complex(r, r)
 
 @register
-@implement(cmath.log, types.Kind(types.Complex))
+@implement(cmath.log, types.Complex)
 @intrinsic_complex_unary
 def log_impl(x, y, x_is_finite, y_is_finite):
     """cmath.log(x + y j)"""
@@ -176,7 +176,7 @@ def log_impl(x, y, x_is_finite, y_is_finite):
 
 
 @register
-@implement(cmath.log, types.Kind(types.Complex), types.Kind(types.Complex))
+@implement(cmath.log, types.Complex, types.Complex)
 def log_base_impl(context, builder, sig, args):
     """cmath.log(z, base)"""
     [z, base] = args
@@ -189,7 +189,7 @@ def log_base_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.log10, types.Kind(types.Complex))
+@implement(cmath.log10, types.Complex)
 def log10_impl(context, builder, sig, args):
     LN_10 = 2.302585092994045684
 
@@ -205,14 +205,14 @@ def log10_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.phase, types.Kind(types.Complex))
+@implement(cmath.phase, types.Complex)
 @intrinsic_complex_unary
 def phase_impl(x, y, x_is_finite, y_is_finite):
     """cmath.phase(x + y j)"""
     return math.atan2(y, x)
 
 @register
-@implement(cmath.polar, types.Kind(types.Complex))
+@implement(cmath.polar, types.Complex)
 @intrinsic_complex_unary
 def polar_impl(x, y, x_is_finite, y_is_finite):
     """cmath.polar(x + y j)"""
@@ -220,7 +220,7 @@ def polar_impl(x, y, x_is_finite, y_is_finite):
 
 
 @register
-@implement(cmath.sqrt, types.Kind(types.Complex))
+@implement(cmath.sqrt, types.Complex)
 def sqrt_impl(context, builder, sig, args):
     # We risk spurious overflow for components >= FLT_MAX / (1 + sqrt(2)).
     THRES = mathimpl.FLT_MAX / (1 + math.sqrt(2))
@@ -272,7 +272,7 @@ def sqrt_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.cos, types.Kind(types.Complex))
+@implement(cmath.cos, types.Complex)
 def cos_impl(context, builder, sig, args):
     def cos_impl(z):
         """cmath.cos(z) = cmath.cosh(z j)"""
@@ -282,7 +282,7 @@ def cos_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.cosh, types.Kind(types.Complex))
+@implement(cmath.cosh, types.Complex)
 def cosh_impl(context, builder, sig, args):
     def cosh_impl(z):
         """cmath.cosh(z)"""
@@ -312,7 +312,7 @@ def cosh_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.sin, types.Kind(types.Complex))
+@implement(cmath.sin, types.Complex)
 def sin_impl(context, builder, sig, args):
     def sin_impl(z):
         """cmath.sin(z) = -j * cmath.sinh(z j)"""
@@ -323,7 +323,7 @@ def sin_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.sinh, types.Kind(types.Complex))
+@implement(cmath.sinh, types.Complex)
 def sinh_impl(context, builder, sig, args):
     def sinh_impl(z):
         """cmath.sinh(z)"""
@@ -350,7 +350,7 @@ def sinh_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.tan, types.Kind(types.Complex))
+@implement(cmath.tan, types.Complex)
 def tan_impl(context, builder, sig, args):
     def tan_impl(z):
         """cmath.tan(z) = -j * cmath.tanh(z j)"""
@@ -361,7 +361,7 @@ def tan_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.tanh, types.Kind(types.Complex))
+@implement(cmath.tanh, types.Complex)
 def tanh_impl(context, builder, sig, args):
     def tanh_impl(z):
         """cmath.tanh(z)"""
@@ -390,7 +390,7 @@ def tanh_impl(context, builder, sig, args):
 
 
 @register
-@implement(cmath.acos, types.Kind(types.Complex))
+@implement(cmath.acos, types.Complex)
 def acos_impl(context, builder, sig, args):
     LN_4 = math.log(4)
     THRES = mathimpl.FLT_MAX / 4
@@ -417,7 +417,7 @@ def acos_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.acosh, types.Kind(types.Complex))
+@implement(cmath.acosh, types.Complex)
 def acosh_impl(context, builder, sig, args):
     LN_4 = math.log(4)
     THRES = mathimpl.FLT_MAX / 4
@@ -444,7 +444,7 @@ def acosh_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.asinh, types.Kind(types.Complex))
+@implement(cmath.asinh, types.Complex)
 def asinh_impl(context, builder, sig, args):
     LN_4 = math.log(4)
     THRES = mathimpl.FLT_MAX / 4
@@ -469,7 +469,7 @@ def asinh_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.asin, types.Kind(types.Complex))
+@implement(cmath.asin, types.Complex)
 def asin_impl(context, builder, sig, args):
     def asin_impl(z):
         """cmath.asin(z) = -j * cmath.asinh(z j)"""
@@ -480,7 +480,7 @@ def asin_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.atan, types.Kind(types.Complex))
+@implement(cmath.atan, types.Complex)
 def atan_impl(context, builder, sig, args):
     def atan_impl(z):
         """cmath.atan(z) = -j * cmath.atanh(z j)"""
@@ -495,7 +495,7 @@ def atan_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 @register
-@implement(cmath.atanh, types.Kind(types.Complex))
+@implement(cmath.atanh, types.Complex)
 def atanh_impl(context, builder, sig, args):
     LN_4 = math.log(4)
     THRES_LARGE = math.sqrt(mathimpl.FLT_MAX / 4)

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -9,7 +9,7 @@ from numba.targets.imputils import (
 
 
 @builtin
-@implement('getiter', types.Kind(types.IteratorType))
+@implement('getiter', types.IteratorType)
 def iterator_getiter(context, builder, sig, args):
     [it] = args
     return impl_ret_borrowed(context, builder, sig.return_type, it)
@@ -26,8 +26,8 @@ def make_enumerate_cls(enum_type):
 
 
 @builtin
-@implement(enumerate, types.Kind(types.IterableType))
-@implement(enumerate, types.Kind(types.IterableType), types.Kind(types.Integer))
+@implement(enumerate, types.IterableType)
+@implement(enumerate, types.IterableType, types.Integer)
 def make_enumerate_object(context, builder, sig, args):
     assert len(args) == 1 or len(args) == 2 # enumerate(it) or enumerate(it, start)
     srcty = sig.args[0]
@@ -54,7 +54,7 @@ def make_enumerate_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement('iternext', types.Kind(types.EnumerateType))
+@implement('iternext', types.EnumerateType)
 @iternext_impl
 def iternext_enumerate(context, builder, sig, args, result):
     [enumty] = sig.args
@@ -104,7 +104,7 @@ def make_zip_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @builtin
-@implement('iternext', types.Kind(types.ZipType))
+@implement('iternext', types.ZipType)
 @iternext_impl
 def iternext_zip(context, builder, sig, args, result):
     [zip_type] = sig.args
@@ -135,7 +135,7 @@ def iternext_zip(context, builder, sig, args, result):
 # generator implementation
 
 @builtin
-@implement('iternext', types.Kind(types.Generator))
+@implement('iternext', types.Generator)
 @iternext_impl
 def iternext_zip(context, builder, sig, args, result):
     genty, = sig.args

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -379,7 +379,7 @@ def build_list(context, builder, list_type, items):
 
 
 @builtin
-@implement(list, types.Kind(types.IterableType))
+@implement(list, types.IterableType)
 def list_constructor(context, builder, sig, args):
 
     def list_impl(iterable):
@@ -394,7 +394,7 @@ def list_constructor(context, builder, sig, args):
 # Various operations
 
 @builtin
-@implement(types.len_type, types.Kind(types.List))
+@implement(types.len_type, types.List)
 def list_len(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     return inst.size
@@ -408,13 +408,13 @@ def make_listiter_cls(iterator_type):
     return cgutils.create_struct_proxy(iterator_type)
 
 @builtin
-@implement('getiter', types.Kind(types.List))
+@implement('getiter', types.List)
 def getiter_list(context, builder, sig, args):
     inst = ListIterInstance.from_list(context, builder, sig.return_type, args[0])
     return impl_ret_borrowed(context, builder, sig.return_type, inst.value)
 
 @builtin
-@implement('iternext', types.Kind(types.ListIter))
+@implement('iternext', types.ListIter)
 @iternext_impl
 def iternext_listiter(context, builder, sig, args, result):
     inst = ListIterInstance(context, builder, sig.args[0], args[0])
@@ -430,7 +430,7 @@ def iternext_listiter(context, builder, sig, args, result):
 
 
 @builtin
-@implement('getitem', types.Kind(types.List), types.Kind(types.Integer))
+@implement('getitem', types.List, types.Integer)
 def getitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     index = args[1]
@@ -441,7 +441,7 @@ def getitem_list(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, result)
 
 @builtin
-@implement('setitem', types.Kind(types.List), types.Kind(types.Integer), types.Any)
+@implement('setitem', types.List, types.Integer, types.Any)
 def setitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     index = args[1]
@@ -453,7 +453,7 @@ def setitem_list(context, builder, sig, args):
 
 
 @builtin
-@implement('getitem', types.Kind(types.List), types.slice3_type)
+@implement('getitem', types.List, types.slice3_type)
 def getslice_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     slice = slicing.Slice(context, builder, value=args[1])
@@ -477,7 +477,7 @@ def getslice_list(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, result.value)
 
 @builtin
-@implement('setitem', types.Kind(types.List), types.slice3_type, types.Any)
+@implement('setitem', types.List, types.slice3_type, types.Any)
 def setitem_list(context, builder, sig, args):
     dest = ListInstance(context, builder, sig.args[0], args[0])
     slice = slicing.Slice(context, builder, value=args[1])
@@ -538,7 +538,7 @@ def setitem_list(context, builder, sig, args):
 
 
 @builtin
-@implement('delitem', types.Kind(types.List), types.slice3_type)
+@implement('delitem', types.List, types.slice3_type)
 def setitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     slice = slicing.Slice(context, builder, value=args[1])
@@ -567,7 +567,7 @@ def setitem_list(context, builder, sig, args):
 
 
 @builtin
-@implement("in", types.Any, types.Kind(types.List))
+@implement("in", types.Any, types.List)
 def in_list(context, builder, sig, args):
     def list_contains_impl(value, lst):
         for elem in lst:
@@ -580,7 +580,7 @@ def in_list(context, builder, sig, args):
 
 # XXX should there be a specific module for Sequence or collection base classes?
 @builtin
-@implement(bool, types.Kind(types.Sequence))
+@implement(bool, types.Sequence)
 def sequence_bool(context, builder, sig, args):
     def sequence_bool_impl(seq):
         return len(seq) != 0
@@ -589,7 +589,7 @@ def sequence_bool(context, builder, sig, args):
 
 
 @builtin
-@implement("+", types.Kind(types.List), types.Kind(types.List))
+@implement("+", types.List, types.List)
 def list_add(context, builder, sig, args):
     a = ListInstance(context, builder, sig.args[0], args[0])
     b = ListInstance(context, builder, sig.args[1], args[1])
@@ -612,7 +612,7 @@ def list_add(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, dest.value)
 
 @builtin
-@implement("+=", types.Kind(types.List), types.Kind(types.List))
+@implement("+=", types.List, types.List)
 def list_add_inplace(context, builder, sig, args):
     assert sig.args[0].dtype == sig.return_type.dtype
     dest = _list_extend_list(context, builder, sig, args)
@@ -621,7 +621,7 @@ def list_add_inplace(context, builder, sig, args):
 
 
 @builtin
-@implement("*", types.Kind(types.List), types.Kind(types.Integer))
+@implement("*", types.List, types.Integer)
 def list_mul(context, builder, sig, args):
     src = ListInstance(context, builder, sig.args[0], args[0])
     src_size = src.size
@@ -642,7 +642,7 @@ def list_mul(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, dest.value)
 
 @builtin
-@implement("*=", types.Kind(types.List), types.Kind(types.Integer))
+@implement("*=", types.List, types.Integer)
 def list_mul_inplace(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     src_size = inst.size
@@ -666,7 +666,7 @@ def list_mul_inplace(context, builder, sig, args):
 # Comparisons
 
 @builtin
-@implement('is', types.Kind(types.List), types.Kind(types.List))
+@implement('is', types.List, types.List)
 def list_is(context, builder, sig, args):
     a = ListInstance(context, builder, sig.args[0], args[0])
     b = ListInstance(context, builder, sig.args[1], args[1])
@@ -675,7 +675,7 @@ def list_is(context, builder, sig, args):
     return builder.icmp_signed('==', ma, mb)
 
 @builtin
-@implement('==', types.Kind(types.List), types.Kind(types.List))
+@implement('==', types.List, types.List)
 def list_eq(context, builder, sig, args):
     aty, bty = sig.args
     a = ListInstance(context, builder, aty, args[0])
@@ -700,7 +700,7 @@ def list_eq(context, builder, sig, args):
     return builder.load(res)
 
 @builtin
-@implement('!=', types.Kind(types.List), types.Kind(types.List))
+@implement('!=', types.List, types.List)
 def list_ne(context, builder, sig, args):
 
     def list_ne_impl(a, b):
@@ -709,7 +709,7 @@ def list_ne(context, builder, sig, args):
     return context.compile_internal(builder, list_ne_impl, sig, args)
 
 @builtin
-@implement('<=', types.Kind(types.List), types.Kind(types.List))
+@implement('<=', types.List, types.List)
 def list_le(context, builder, sig, args):
 
     def list_le_impl(a, b):
@@ -725,7 +725,7 @@ def list_le(context, builder, sig, args):
     return context.compile_internal(builder, list_le_impl, sig, args)
 
 @builtin
-@implement('<', types.Kind(types.List), types.Kind(types.List))
+@implement('<', types.List, types.List)
 def list_lt(context, builder, sig, args):
 
     def list_lt_impl(a, b):
@@ -741,7 +741,7 @@ def list_lt(context, builder, sig, args):
     return context.compile_internal(builder, list_lt_impl, sig, args)
 
 @builtin
-@implement('>=', types.Kind(types.List), types.Kind(types.List))
+@implement('>=', types.List, types.List)
 def list_ge(context, builder, sig, args):
 
     def list_ge_impl(a, b):
@@ -750,7 +750,7 @@ def list_ge(context, builder, sig, args):
     return context.compile_internal(builder, list_ge_impl, sig, args)
 
 @builtin
-@implement('>', types.Kind(types.List), types.Kind(types.List))
+@implement('>', types.List, types.List)
 def list_gt(context, builder, sig, args):
 
     def list_gt_impl(a, b):
@@ -762,7 +762,7 @@ def list_gt(context, builder, sig, args):
 # Methods
 
 @builtin
-@implement("list.append", types.Kind(types.List), types.Any)
+@implement("list.append", types.List, types.Any)
 def list_append(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     item = args[1]
@@ -775,7 +775,7 @@ def list_append(context, builder, sig, args):
     return context.get_dummy_value()
 
 @builtin
-@implement("list.clear", types.Kind(types.List))
+@implement("list.clear", types.List)
 def list_clear(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     inst.resize(context.get_constant(types.intp, 0))
@@ -783,7 +783,7 @@ def list_clear(context, builder, sig, args):
     return context.get_dummy_value()
 
 @builtin
-@implement("list.copy", types.Kind(types.List))
+@implement("list.copy", types.List)
 def list_copy(context, builder, sig, args):
     def list_copy_impl(lst):
         return list(lst)
@@ -791,7 +791,7 @@ def list_copy(context, builder, sig, args):
     return context.compile_internal(builder, list_copy_impl, sig, args)
 
 @builtin
-@implement("list.count", types.Kind(types.List), types.Any)
+@implement("list.count", types.List, types.Any)
 def list_count(context, builder, sig, args):
 
     def list_count_impl(lst, value):
@@ -821,7 +821,7 @@ def _list_extend_list(context, builder, sig, args):
     return dest
 
 @builtin
-@implement("list.extend", types.Kind(types.List), types.Kind(types.IterableType))
+@implement("list.extend", types.List, types.IterableType)
 def list_extend(context, builder, sig, args):
     if isinstance(sig.args[1], types.List):
         # Specialize for list operands, for speed.
@@ -837,7 +837,7 @@ def list_extend(context, builder, sig, args):
     return context.compile_internal(builder, list_extend, sig, args)
 
 @builtin
-@implement("list.index", types.Kind(types.List), types.Any)
+@implement("list.index", types.List, types.Any)
 def list_index(context, builder, sig, args):
 
     def list_index_impl(lst, value):
@@ -850,8 +850,8 @@ def list_index(context, builder, sig, args):
     return context.compile_internal(builder, list_index_impl, sig, args)
 
 @builtin
-@implement("list.index", types.Kind(types.List), types.Any,
-           types.Kind(types.Integer))
+@implement("list.index", types.List, types.Any,
+           types.Integer)
 def list_index(context, builder, sig, args):
 
     def list_index_impl(lst, value, start):
@@ -869,8 +869,8 @@ def list_index(context, builder, sig, args):
     return context.compile_internal(builder, list_index_impl, sig, args)
 
 @builtin
-@implement("list.index", types.Kind(types.List), types.Any,
-           types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("list.index", types.List, types.Any,
+           types.Integer, types.Integer)
 def list_index(context, builder, sig, args):
 
     def list_index_impl(lst, value, start, stop):
@@ -892,7 +892,7 @@ def list_index(context, builder, sig, args):
     return context.compile_internal(builder, list_index_impl, sig, args)
 
 @builtin
-@implement("list.insert", types.Kind(types.List), types.Kind(types.Integer),
+@implement("list.insert", types.List, types.Integer,
            types.Any)
 def list_insert(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
@@ -910,7 +910,7 @@ def list_insert(context, builder, sig, args):
     return context.get_dummy_value()
 
 @builtin
-@implement("list.pop", types.Kind(types.List))
+@implement("list.pop", types.List)
 def list_pop(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
 
@@ -923,7 +923,7 @@ def list_pop(context, builder, sig, args):
     return res
 
 @builtin
-@implement("list.pop", types.Kind(types.List), types.Kind(types.Integer))
+@implement("list.pop", types.List, types.Integer)
 def list_pop(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     idx = inst.fix_index(args[1])
@@ -942,7 +942,7 @@ def list_pop(context, builder, sig, args):
     return res
 
 @builtin
-@implement("list.remove", types.Kind(types.List), types.Any)
+@implement("list.remove", types.List, types.Any)
 def list_remove(context, builder, sig, args):
 
     def list_remove_impl(lst, value):
@@ -956,7 +956,7 @@ def list_remove(context, builder, sig, args):
     return context.compile_internal(builder, list_remove_impl, sig, args)
 
 @builtin
-@implement("list.reverse", types.Kind(types.List))
+@implement("list.reverse", types.List)
 def list_reverse(context, builder, sig, args):
 
     def list_reverse_impl(lst):
@@ -991,8 +991,8 @@ def load_sorts():
 
 
 @builtin
-@implement("list.sort", types.Kind(types.List))
-@implement("list.sort", types.Kind(types.List), types.Kind(types.Boolean))
+@implement("list.sort", types.List)
+@implement("list.sort", types.List, types.Boolean)
 def list_sort(context, builder, sig, args):
     load_sorts()
 
@@ -1009,8 +1009,8 @@ def list_sort(context, builder, sig, args):
     return context.compile_internal(builder, list_sort_impl, sig, args)
 
 @builtin
-@implement(sorted, types.Kind(types.IterableType))
-@implement(sorted, types.Kind(types.IterableType), types.Kind(types.Boolean))
+@implement(sorted, types.IterableType)
+@implement(sorted, types.IterableType, types.Boolean)
 def sorted_impl(context, builder, sig, args):
     if len(args) == 1:
         sig = typing.signature(sig.return_type, *sig.args + (types.boolean,))

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -219,28 +219,28 @@ unary_math_extern(math.trunc, "truncf", "trunc", True)
 
 
 @register
-@implement(math.isnan, types.Kind(types.Float))
+@implement(math.isnan, types.Float)
 def isnan_float_impl(context, builder, sig, args):
     [val] = args
     res = is_nan(builder, val)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement(math.isnan, types.Kind(types.Integer))
+@implement(math.isnan, types.Integer)
 def isnan_int_impl(context, builder, sig, args):
     res = cgutils.false_bit
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
 @register
-@implement(math.isinf, types.Kind(types.Float))
+@implement(math.isinf, types.Float)
 def isinf_float_impl(context, builder, sig, args):
     [val] = args
     res = is_inf(builder, val)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement(math.isinf, types.Kind(types.Integer))
+@implement(math.isinf, types.Integer)
 def isinf_int_impl(context, builder, sig, args):
     res = cgutils.false_bit
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -248,14 +248,14 @@ def isinf_int_impl(context, builder, sig, args):
 
 if utils.PYVERSION >= (3, 2):
     @register
-    @implement(math.isfinite, types.Kind(types.Float))
+    @implement(math.isfinite, types.Float)
     def isfinite_float_impl(context, builder, sig, args):
         [val] = args
         res = is_finite(builder, val)
         return impl_ret_untracked(context, builder, sig.return_type, res)
 
     @register
-    @implement(math.isfinite, types.Kind(types.Integer))
+    @implement(math.isfinite, types.Integer)
     def isfinite_int_impl(context, builder, sig, args):
         res = cgutils.true_bit
         return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -290,7 +290,7 @@ def copysign_f64_impl(context, builder, sig, args):
 
 
 @register
-@implement(math.frexp, types.Kind(types.Float))
+@implement(math.frexp, types.Float)
 def frexp_impl(context, builder, sig, args):
     val, = args
     fltty = context.get_data_type(sig.args[0])
@@ -308,7 +308,7 @@ def frexp_impl(context, builder, sig, args):
 
 
 @register
-@implement(math.ldexp, types.Kind(types.Float), types.intc)
+@implement(math.ldexp, types.Float, types.intc)
 def ldexp_impl(context, builder, sig, args):
     val, exp = args
     fltty, intty = map(context.get_data_type, sig.args)
@@ -392,7 +392,7 @@ def hypot_u64_impl(context, builder, sig, args):
 
 
 @register
-@implement(math.hypot, types.Kind(types.Float), types.Kind(types.Float))
+@implement(math.hypot, types.Float, types.Float)
 def hypot_float_impl(context, builder, sig, args):
     def hypot(x, y):
         if math.isinf(x):
@@ -464,6 +464,6 @@ for ty in types.unsigned_domain:
 for ty in types.signed_domain:
     register(implement(math.pow, types.float64, ty)(builtins.int_power_impl))
 
-ty = types.Kind(types.Float)
+ty = types.Float
 register(implement(math.pow, ty, ty)(builtins.real_power_impl))
 

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -17,7 +17,7 @@ if not npdatetime.NPDATETIME_SUPPORTED:
 DATETIME64 = TIMEDELTA64 = Type.int(64)
 NAT = Constant.int(TIMEDELTA64, npdatetime.NAT)
 
-TIMEDELTA_BINOP_SIG = (types.Kind(types.NPTimedelta),) * 2
+TIMEDELTA_BINOP_SIG = (types.NPTimedelta,) * 2
 
 
 def scale_by_constant(builder, val, factor):
@@ -112,19 +112,19 @@ leap_year_months_acc = make_constant_array(
 # Arithmetic operators on timedelta64
 
 @builtin
-@implement('+', types.Kind(types.NPTimedelta))
+@implement('+', types.NPTimedelta)
 def timedelta_pos_impl(context, builder, sig, args):
     res =args[0]
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('-', types.Kind(types.NPTimedelta))
+@implement('-', types.NPTimedelta)
 def timedelta_neg_impl(context, builder, sig, args):
     res = builder.neg(args[0])
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(types.abs_type, types.Kind(types.NPTimedelta))
+@implement(types.abs_type, types.NPTimedelta)
 def timedelta_abs_impl(context, builder, sig, args):
     val, = args
     ret = alloc_timedelta_result(builder)
@@ -137,7 +137,7 @@ def timedelta_abs_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(types.sign_type, types.Kind(types.NPTimedelta))
+@implement(types.sign_type, types.NPTimedelta)
 def timedelta_sign_impl(context, builder, sig, args):
     val, = args
     ret = alloc_timedelta_result(builder)
@@ -201,8 +201,8 @@ def _timedelta_times_number(context, builder, td_arg, td_type,
 
 
 @builtin
-@implement('*', types.Kind(types.NPTimedelta), types.Kind(types.Integer))
-@implement('*', types.Kind(types.NPTimedelta), types.Kind(types.Float))
+@implement('*', types.NPTimedelta, types.Integer)
+@implement('*', types.NPTimedelta, types.Float)
 def timedelta_times_number(context, builder, sig, args):
     res = _timedelta_times_number(context, builder,
                                    args[0], sig.args[0], args[1], sig.args[1],
@@ -210,8 +210,8 @@ def timedelta_times_number(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('*', types.Kind(types.Integer), types.Kind(types.NPTimedelta))
-@implement('*', types.Kind(types.Float), types.Kind(types.NPTimedelta))
+@implement('*', types.Integer, types.NPTimedelta)
+@implement('*', types.Float, types.NPTimedelta)
 def number_times_timedelta(context, builder, sig, args):
     res = _timedelta_times_number(context, builder,
                                    args[1], sig.args[1], args[0], sig.args[0],
@@ -219,12 +219,12 @@ def number_times_timedelta(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('/', types.Kind(types.NPTimedelta), types.Kind(types.Integer))
-@implement('//', types.Kind(types.NPTimedelta), types.Kind(types.Integer))
-@implement('/?', types.Kind(types.NPTimedelta), types.Kind(types.Integer))
-@implement('/', types.Kind(types.NPTimedelta), types.Kind(types.Float))
-@implement('//', types.Kind(types.NPTimedelta), types.Kind(types.Float))
-@implement('/?', types.Kind(types.NPTimedelta), types.Kind(types.Float))
+@implement('/', types.NPTimedelta, types.Integer)
+@implement('//', types.NPTimedelta, types.Integer)
+@implement('/?', types.NPTimedelta, types.Integer)
+@implement('/', types.NPTimedelta, types.Float)
+@implement('//', types.NPTimedelta, types.Float)
+@implement('/?', types.NPTimedelta, types.Float)
 def timedelta_over_number(context, builder, sig, args):
     td_arg, number_arg = args
     number_type = sig.args[1]
@@ -477,7 +477,7 @@ _datetime_minus_timedelta = _datetime_timedelta_arith('sub')
 # datetime64 + timedelta64
 
 @builtin
-@implement('+', types.Kind(types.NPDatetime), types.Kind(types.NPTimedelta))
+@implement('+', types.NPDatetime, types.NPTimedelta)
 def datetime_plus_timedelta(context, builder, sig, args):
     dt_arg, td_arg = args
     dt_type, td_type = sig.args
@@ -488,7 +488,7 @@ def datetime_plus_timedelta(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('+', types.Kind(types.NPTimedelta), types.Kind(types.NPDatetime))
+@implement('+', types.NPTimedelta, types.NPDatetime)
 def timedelta_plus_datetime(context, builder, sig, args):
     td_arg, dt_arg = args
     td_type, dt_type = sig.args
@@ -501,7 +501,7 @@ def timedelta_plus_datetime(context, builder, sig, args):
 # datetime64 - timedelta64
 
 @builtin
-@implement('-', types.Kind(types.NPDatetime), types.Kind(types.NPTimedelta))
+@implement('-', types.NPDatetime, types.NPTimedelta)
 def datetime_minus_timedelta(context, builder, sig, args):
     dt_arg, td_arg = args
     dt_type, td_type = sig.args
@@ -514,7 +514,7 @@ def datetime_minus_timedelta(context, builder, sig, args):
 # datetime64 - datetime64
 
 @builtin
-@implement('-', types.Kind(types.NPDatetime), types.Kind(types.NPDatetime))
+@implement('-', types.NPDatetime, types.NPDatetime)
 def datetime_minus_datetime(context, builder, sig, args):
     va, vb = args
     ta, tb = sig.args
@@ -569,7 +569,7 @@ for op, func in [('==', datetime_eq_datetime_impl),
                  ('<=', datetime_le_datetime_impl),
                  ('>', datetime_gt_datetime_impl),
                  ('>=', datetime_ge_datetime_impl)]:
-    builtin(implement(op, *[types.Kind(types.NPDatetime)]*2)(func))
+    builtin(implement(op, *[types.NPDatetime]*2)(func))
 
 
 ########################################################################

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -404,7 +404,7 @@ def register_unary_ufunc_kernel(ufunc, kernel):
     _any = types.Any
 
     # (array or scalar, out=array)
-    register(implement(ufunc, _any, types.Kind(types.Array))(unary_ufunc))
+    register(implement(ufunc, _any, types.Array)(unary_ufunc))
     # (array or scalar)
     register(implement(ufunc, _any)(unary_ufunc_no_explicit_output))
 
@@ -422,7 +422,7 @@ def register_binary_ufunc_kernel(ufunc, kernel):
     _any = types.Any
 
     # (array or scalar, array o scalar, out=array)
-    register(implement(ufunc, _any, _any, types.Kind(types.Array))(binary_ufunc))
+    register(implement(ufunc, _any, _any, types.Array)(binary_ufunc))
     # (scalar, scalar)
     register(implement(ufunc, _any, _any)(binary_ufunc_no_explicit_output))
 
@@ -433,7 +433,7 @@ def register_unary_operator_kernel(operator, kernel):
     def lower_unary_operator(context, builder, sig, args):
         return numpy_ufunc_kernel(context, builder, sig, args, kernel,
                                   explicit_output=False)
-    _arr_kind = types.Kind(types.Array)
+    _arr_kind = types.Array
     register(implement(operator, _arr_kind)(lower_unary_operator))
 
 
@@ -452,7 +452,7 @@ def register_binary_operator_kernel(operator, kernel):
                                   explicit_output=True)
 
     _any = types.Any
-    _arr_kind = types.Kind(types.Array)
+    _arr_kind = types.Array
     formal_sigs = [(_arr_kind, _arr_kind), (_any, _arr_kind), (_arr_kind, _any)]
     for sig in formal_sigs:
         register(implement(operator, *sig)(lower_binary_operator))
@@ -474,7 +474,7 @@ for ufunc in ufunc_db.get_ufuncs():
 
 
 @register
-@implement('+', types.Kind(types.Array))
+@implement('+', types.Array)
 def array_positive_impl(context, builder, sig, args):
     '''Lowering function for +(array) expressions.  Defined here
     (numba.targets.npyimpl) since the remaining array-operator

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -15,7 +15,7 @@ register = registry.register
 
 
 @register
-@implement(types.print_item_type, types.Kind(types.Integer))
+@implement(types.print_item_type, types.Integer)
 def int_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
@@ -30,7 +30,7 @@ def int_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Kind(types.Float))
+@implement(types.print_item_type, types.Float)
 def real_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
@@ -43,7 +43,7 @@ def real_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Kind(types.CharSeq))
+@implement(types.print_item_type, types.CharSeq)
 def print_charseq(context, builder, sig, args):
     [tx] = sig.args
     [x] = args

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -202,8 +202,8 @@ def random_impl(context, builder, sig, args):
 
 
 @register
-@implement("random.gauss", types.Kind(types.Float), types.Kind(types.Float))
-@implement("random.normalvariate", types.Kind(types.Float), types.Kind(types.Float))
+@implement("random.gauss", types.Float, types.Float)
+@implement("random.normalvariate", types.Float, types.Float)
 def gauss_impl(context, builder, sig, args):
     res = _gauss_impl(context, builder, sig, args, "py")
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -213,8 +213,8 @@ def gauss_impl(context, builder, sig, args):
 @implement("np.random.randn")
 @implement("np.random.standard_normal")
 @implement("np.random.normal")
-@implement("np.random.normal", types.Kind(types.Float))
-@implement("np.random.normal", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.normal", types.Float)
+@implement("np.random.normal", types.Float, types.Float)
 def np_gauss_impl(context, builder, sig, args):
     sig, args = _fill_defaults(context, builder, sig, args, (0.0, 1.0))
     res = _gauss_impl(context, builder, sig, args, "np")
@@ -275,7 +275,7 @@ def _gauss_impl(context, builder, sig, args, state):
                         builder.fmul(sigma, builder.load(ret)))
 
 @register
-@implement("random.getrandbits", types.Kind(types.Integer))
+@implement("random.getrandbits", types.Integer)
 def getrandbits_impl(context, builder, sig, args):
     nbits, = args
     too_large = builder.icmp_unsigned(">=", nbits, const_int(65))
@@ -334,7 +334,7 @@ def _randrange_impl(context, builder, start, stop, step, state):
 
 
 @register
-@implement("random.randrange", types.Kind(types.Integer))
+@implement("random.randrange", types.Integer)
 def randrange_impl_1(context, builder, sig, args):
     stop, = args
     start = ir.Constant(stop.type, 0)
@@ -343,7 +343,7 @@ def randrange_impl_1(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("random.randrange", types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("random.randrange", types.Integer, types.Integer)
 def randrange_impl_2(context, builder, sig, args):
     start, stop = args
     step = ir.Constant(start.type, 1)
@@ -351,15 +351,15 @@ def randrange_impl_2(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("random.randrange", types.Kind(types.Integer),
-           types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("random.randrange", types.Integer,
+           types.Integer, types.Integer)
 def randrange_impl_3(context, builder, sig, args):
     start, stop, step = args
     res = _randrange_impl(context, builder, start, stop, step, "py")
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("random.randint", types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("random.randint", types.Integer, types.Integer)
 def randint_impl_1(context, builder, sig, args):
     start, stop = args
     step = ir.Constant(start.type, 1)
@@ -368,7 +368,7 @@ def randint_impl_1(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.randint", types.Kind(types.Integer))
+@implement("np.random.randint", types.Integer)
 def randint_impl_2(context, builder, sig, args):
     stop, = args
     start = ir.Constant(stop.type, 0)
@@ -377,7 +377,7 @@ def randint_impl_2(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.randint", types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("np.random.randint", types.Integer, types.Integer)
 def randrange_impl_2(context, builder, sig, args):
     start, stop = args
     step = ir.Constant(start.type, 1)
@@ -385,13 +385,13 @@ def randrange_impl_2(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("random.uniform", types.Kind(types.Float), types.Kind(types.Float))
+@implement("random.uniform", types.Float, types.Float)
 def uniform_impl(context, builder, sig, args):
     res = uniform_impl(context, builder, sig, args, "py")
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.uniform", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.uniform", types.Float, types.Float)
 def uniform_impl(context, builder, sig, args):
     res = uniform_impl(context, builder, sig, args, "np")
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -404,7 +404,7 @@ def uniform_impl(context, builder, sig, args, state):
     return builder.fadd(a, builder.fmul(width, r))
 
 @register
-@implement("random.triangular", types.Kind(types.Float), types.Kind(types.Float))
+@implement("random.triangular", types.Float, types.Float)
 def triangular_impl_2(context, builder, sig, args):
     fltty = sig.return_type
     low, high = args
@@ -425,16 +425,16 @@ def triangular_impl_2(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("random.triangular", types.Kind(types.Float),
-           types.Kind(types.Float), types.Kind(types.Float))
+@implement("random.triangular", types.Float,
+           types.Float, types.Float)
 def triangular_impl_3(context, builder, sig, args):
     low, high, mode = args
     res = _triangular_impl_3(context, builder, sig, low, high, mode, "py")
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.triangular", types.Kind(types.Float),
-           types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.triangular", types.Float,
+           types.Float, types.Float)
 def triangular_impl_3(context, builder, sig, args):
     low, mode, high = args
     res = _triangular_impl_3(context, builder, sig, low, high, mode, "np")
@@ -463,15 +463,15 @@ def _triangular_impl_3(context, builder, sig, low, high, mode, state):
 
 @register
 @implement("random.gammavariate",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def gammavariate_impl(context, builder, sig, args):
     res = _gammavariate_impl(context, builder, sig, args, random.random)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.standard_gamma", types.Kind(types.Float))
-@implement("np.random.gamma", types.Kind(types.Float))
-@implement("np.random.gamma", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.standard_gamma", types.Float)
+@implement("np.random.gamma", types.Float)
+@implement("np.random.gamma", types.Float, types.Float)
 def gammavariate_impl(context, builder, sig, args):
     sig, args = _fill_defaults(context, builder, sig, args, (None, 1.0))
     res = _gammavariate_impl(context, builder, sig, args, np.random.random)
@@ -548,7 +548,7 @@ def _gammavariate_impl(context, builder, sig, args, _random):
 
 @register
 @implement("random.betavariate",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def betavariate_impl(context, builder, sig, args):
     res = _betavariate_impl(context, builder, sig, args,
                              random.gammavariate)
@@ -556,7 +556,7 @@ def betavariate_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.beta",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def betavariate_impl(context, builder, sig, args):
     res = _betavariate_impl(context, builder, sig, args,
                              np.random.gamma)
@@ -581,7 +581,7 @@ def _betavariate_impl(context, builder, sig, args, gamma):
 
 @register
 @implement("random.expovariate",
-           types.Kind(types.Float))
+           types.Float)
 def expovariate_impl(context, builder, sig, args):
     _random = random.random
     _log = math.log
@@ -601,7 +601,7 @@ def expovariate_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.exponential", types.Kind(types.Float))
+@implement("np.random.exponential", types.Float)
 def exponential_impl(context, builder, sig, args):
     _random = np.random.random
     _log = math.log
@@ -629,8 +629,8 @@ def exponential_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.lognormal")
-@implement("np.random.lognormal", types.Kind(types.Float))
-@implement("np.random.lognormal", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.lognormal", types.Float)
+@implement("np.random.lognormal", types.Float, types.Float)
 def np_lognormal_impl(context, builder, sig, args):
     sig, args = _fill_defaults(context, builder, sig, args, (0.0, 1.0))
     res = _lognormvariate_impl(context, builder, sig, args,
@@ -639,7 +639,7 @@ def np_lognormal_impl(context, builder, sig, args):
 
 @register
 @implement("random.lognormvariate",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def lognormvariate_impl(context, builder, sig, args):
     res = _lognormvariate_impl(context, builder, sig, args, random.gauss)
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -655,7 +655,7 @@ def _lognormvariate_impl(context, builder, sig, args, _gauss):
 
 
 @register
-@implement("random.paretovariate", types.Kind(types.Float))
+@implement("random.paretovariate", types.Float)
 def paretovariate_impl(context, builder, sig, args):
     _random = random.random
 
@@ -670,7 +670,7 @@ def paretovariate_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.pareto", types.Kind(types.Float))
+@implement("np.random.pareto", types.Float)
 def pareto_impl(context, builder, sig, args):
     _random = np.random.random
 
@@ -684,7 +684,7 @@ def pareto_impl(context, builder, sig, args):
 
 @register
 @implement("random.weibullvariate",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def weibullvariate_impl(context, builder, sig, args):
     _random = random.random
     _log = math.log
@@ -700,7 +700,7 @@ def weibullvariate_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.weibull", types.Kind(types.Float))
+@implement("np.random.weibull", types.Float)
 def weibull_impl(context, builder, sig, args):
     _random = np.random.random
     _log = math.log
@@ -715,14 +715,14 @@ def weibull_impl(context, builder, sig, args):
 
 @register
 @implement("random.vonmisesvariate",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def vonmisesvariate_impl(context, builder, sig, args):
     res = _vonmisesvariate_impl(context, builder, sig, args, random.random)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
 @implement("np.random.vonmises",
-           types.Kind(types.Float), types.Kind(types.Float))
+           types.Float, types.Float)
 def vonmisesvariate_impl(context, builder, sig, args):
     res = _vonmisesvariate_impl(context, builder, sig, args, np.random.random)
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -780,7 +780,7 @@ def _vonmisesvariate_impl(context, builder, sig, args, _random):
 
 
 @register
-@implement("np.random.binomial", types.Kind(types.Integer), types.Kind(types.Float))
+@implement("np.random.binomial", types.Integer, types.Float)
 def binomial_impl(context, builder, sig, args):
     intty = sig.return_type
     _random = np.random.random
@@ -818,7 +818,7 @@ def binomial_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.chisquare", types.Kind(types.Float))
+@implement("np.random.chisquare", types.Float)
 def chisquare_impl(context, builder, sig, args):
 
     def chisquare_impl(df):
@@ -829,7 +829,7 @@ def chisquare_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.f", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.f", types.Float, types.Float)
 def f_impl(context, builder, sig, args):
 
     def f_impl(num, denom):
@@ -841,7 +841,7 @@ def f_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.geometric", types.Kind(types.Float))
+@implement("np.random.geometric", types.Float)
 def geometric_impl(context, builder, sig, args):
     _random = np.random.random
     intty = sig.return_type
@@ -868,7 +868,7 @@ def geometric_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.gumbel", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.gumbel", types.Float, types.Float)
 def gumbel_impl(context, builder, sig, args):
     _random = np.random.random
     _log = math.log
@@ -882,8 +882,8 @@ def gumbel_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.hypergeometric", types.Kind(types.Integer),
-           types.Kind(types.Integer), types.Kind(types.Integer))
+@implement("np.random.hypergeometric", types.Integer,
+           types.Integer, types.Integer)
 def hypergeometric_impl(context, builder, sig, args):
     _random = np.random.random
     _floor = math.floor
@@ -910,8 +910,8 @@ def hypergeometric_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.laplace")
-@implement("np.random.laplace", types.Kind(types.Float))
-@implement("np.random.laplace", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.laplace", types.Float)
+@implement("np.random.laplace", types.Float, types.Float)
 def laplace_impl(context, builder, sig, args):
     _random = np.random.random
     _log = math.log
@@ -930,8 +930,8 @@ def laplace_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.logistic")
-@implement("np.random.logistic", types.Kind(types.Float))
-@implement("np.random.logistic", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.logistic", types.Float)
+@implement("np.random.logistic", types.Float, types.Float)
 def logistic_impl(context, builder, sig, args):
     _random = np.random.random
     _log = math.log
@@ -945,7 +945,7 @@ def logistic_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.logseries", types.Kind(types.Float))
+@implement("np.random.logseries", types.Float)
 def logseries_impl(context, builder, sig, args):
     intty = sig.return_type
     _random = np.random.random
@@ -977,7 +977,7 @@ def logseries_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.negative_binomial", types.int64, types.Kind(types.Float))
+@implement("np.random.negative_binomial", types.int64, types.Float)
 def negative_binomial_impl(context, builder, sig, args):
     _gamma = np.random.gamma
     _poisson = np.random.poisson
@@ -996,7 +996,7 @@ def negative_binomial_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.poisson")
-@implement("np.random.poisson", types.Kind(types.Float))
+@implement("np.random.poisson", types.Float)
 def poisson_impl(context, builder, sig, args):
     state_ptr = get_np_state_ptr(context, builder)
 
@@ -1058,7 +1058,7 @@ def poisson_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.power", types.Kind(types.Float))
+@implement("np.random.power", types.Float)
 def power_impl(context, builder, sig, args):
 
     def power_impl(a):
@@ -1073,7 +1073,7 @@ def power_impl(context, builder, sig, args):
 
 @register
 @implement("np.random.rayleigh")
-@implement("np.random.rayleigh", types.Kind(types.Float))
+@implement("np.random.rayleigh", types.Float)
 def rayleigh_impl(context, builder, sig, args):
     _random = np.random.random
 
@@ -1100,7 +1100,7 @@ def cauchy_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.standard_t", types.Kind(types.Float))
+@implement("np.random.standard_t", types.Float)
 def standard_t_impl(context, builder, sig, args):
 
     def standard_t_impl(df):
@@ -1114,7 +1114,7 @@ def standard_t_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.wald", types.Kind(types.Float), types.Kind(types.Float))
+@implement("np.random.wald", types.Float, types.Float)
 def wald_impl(context, builder, sig, args):
 
     def wald_impl(mean, scale):
@@ -1137,7 +1137,7 @@ def wald_impl(context, builder, sig, args):
 
 
 @register
-@implement("np.random.zipf", types.Kind(types.Float))
+@implement("np.random.zipf", types.Float)
 def zipf_impl(context, builder, sig, args):
     _random = np.random.random
     intty = sig.return_type
@@ -1160,13 +1160,13 @@ def zipf_impl(context, builder, sig, args):
 
 
 @register
-@implement("random.shuffle", types.Kind(types.Buffer))
+@implement("random.shuffle", types.Buffer)
 def shuffle_impl(context, builder, sig, args):
     res = _shuffle_impl(context, builder, sig, args, random.randrange)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @register
-@implement("np.random.shuffle", types.Kind(types.Buffer))
+@implement("np.random.shuffle", types.Buffer)
 def shuffle_impl(context, builder, sig, args):
     res = _shuffle_impl(context, builder, sig, args, np.random.randint)
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -20,7 +20,7 @@ def namedtuple_constructor(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement(types.len_type, types.Kind(types.BaseTuple))
+@implement(types.len_type, types.BaseTuple)
 def tuple_len(context, builder, sig, args):
     tupty, = sig.args
     retty = sig.return_type
@@ -28,7 +28,7 @@ def tuple_len(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(bool, types.Kind(types.BaseTuple))
+@implement(bool, types.BaseTuple)
 def tuple_bool(context, builder, sig, args):
     tupty, = sig.args
     if len(tupty):
@@ -58,7 +58,7 @@ def tuple_cmp_ordered(context, builder, op, sig, args):
     return builder.load(res)
 
 @builtin
-@implement('==', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('==', types.BaseTuple, types.BaseTuple)
 def tuple_eq(context, builder, sig, args):
     tu, tv = sig.args
     u, v = args
@@ -74,38 +74,38 @@ def tuple_eq(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('!=', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('!=', types.BaseTuple, types.BaseTuple)
 def tuple_ne(context, builder, sig, args):
     res = builder.not_(tuple_eq(context, builder, sig, args))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('<', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('<', types.BaseTuple, types.BaseTuple)
 def tuple_lt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, '<', sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('<=', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('<=', types.BaseTuple, types.BaseTuple)
 def tuple_le(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, '<=', sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('>', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('>', types.BaseTuple, types.BaseTuple)
 def tuple_gt(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, '>', sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement('>=', types.Kind(types.BaseTuple), types.Kind(types.BaseTuple))
+@implement('>=', types.BaseTuple, types.BaseTuple)
 def tuple_ge(context, builder, sig, args):
     res = tuple_cmp_ordered(context, builder, '>=', sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
 @builtin_attr
-@impl_attribute_generic(types.Kind(types.BaseNamedTuple))
+@impl_attribute_generic(types.BaseNamedTuple)
 def namedtuple_getattr(context, builder, typ, value, attr):
     """
     Fetch a namedtuple's field.
@@ -127,8 +127,8 @@ def make_unituple_iter(tupiter):
 
 
 @builtin
-@implement('getiter', types.Kind(types.UniTuple))
-@implement('getiter', types.Kind(types.NamedUniTuple))
+@implement('getiter', types.UniTuple)
+@implement('getiter', types.NamedUniTuple)
 def getiter_unituple(context, builder, sig, args):
     [tupty] = sig.args
     [tup] = args
@@ -148,7 +148,7 @@ def getiter_unituple(context, builder, sig, args):
 
 
 @builtin
-@implement('iternext', types.Kind(types.UniTupleIter))
+@implement('iternext', types.UniTupleIter)
 @iternext_impl
 def iternext_unituple(context, builder, sig, args, result):
     [tupiterty] = sig.args
@@ -176,8 +176,8 @@ def iternext_unituple(context, builder, sig, args, result):
 
 
 @builtin
-@implement('getitem', types.Kind(types.UniTuple), types.intp)
-@implement('getitem', types.Kind(types.NamedUniTuple), types.intp)
+@implement('getitem', types.UniTuple, types.intp)
+@implement('getitem', types.NamedUniTuple, types.intp)
 def getitem_unituple(context, builder, sig, args):
     tupty, _ = sig.args
     tup, idx = args
@@ -210,7 +210,7 @@ def getitem_unituple(context, builder, sig, args):
 
 
 @builtin
-@implement('static_getitem', types.Kind(types.BaseTuple), types.Kind(types.Const))
+@implement('static_getitem', types.BaseTuple, types.Const)
 def static_getitem_tuple(context, builder, sig, args):
     tup, idx = args
     assert isinstance(idx, int)

--- a/numba/types.py
+++ b/numba/types.py
@@ -174,18 +174,6 @@ class Const(Dummy):
         return type(self.value), self.value
 
 
-class Kind(Type):
-    def __init__(self, of):
-        if not isinstance(of, type) or not issubclass(of, Type):
-            raise TypeError("expected a Type subclass, got %r" % (of,))
-        self.of = of
-        super(Kind, self).__init__("kind(%s)" % of)
-
-    @property
-    def key(self):
-        return self.of
-
-
 class VarArg(Type):
     """
     Special type representing a variable number of arguments at the


### PR DESCRIPTION
Refactor: allow `@implement` to take a type class without wrapping it in types.Kind.
(as proposed in NBEP 2)