### PR TITLE
Expose extension API (step 1 for pandas.Index-like functionality)

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -90,6 +90,7 @@ operations:
 
 * comparison between tuples
 * iteration and indexing over homogenous tuples
+* addition (concatenation) between tuples
 
 list
 ----

--- a/numba/abstracttypes.py
+++ b/numba/abstracttypes.py
@@ -140,6 +140,13 @@ class Type(object):
         """
         return True
 
+    def augment(self, other):
+        """
+        Augment this type with the *other*.  Return the augmented type,
+        or None if not supported.
+        """
+        return None
+
     # User-facing helpers.  These are not part of the core Type API but
     # are provided so that users can write e.g. `numba.boolean(1.5)`
     # (returns True) or `types.int32(types.int32[:])` (returns something
@@ -224,14 +231,13 @@ class Callable(Type):
         Using the typing *context*, resolve the callable's signature for
         the given arguments.  A signature object is returned, or None.
         """
-        pass
 
     @abstractmethod
     def get_call_signatures(self):
         """
-        Returns a tuple of (signatures, parameterized)
+        Returns a tuple of (list of signatures, parameterized)
         """
-        pass
+
 
 class DTypeSpec(Type):
     """
@@ -292,3 +298,21 @@ class MutableSequence(Sequence):
     Base class for 1d mutable sequence types.  Instances should have the
     *dtype* attribute.
     """
+
+
+class ArrayCompatible(Type):
+    """
+    Type class for Numpy array-compatible objects (typically, objects
+    exposing an __array__ method).
+    Derived classes should implement the *as_array* attribute.
+    """
+    # If overriden by a subclass, it should also implement typing
+    # for '__array_wrap__' with arguments (input, formal result).
+    array_priority = 0.0
+
+    @abstractproperty
+    def as_array(self):
+        """
+        The equivalent array type, for operations supporting array-compatible
+        objects (such as ufuncs).
+        """

--- a/numba/annotations/type_annotations.py
+++ b/numba/annotations/type_annotations.py
@@ -147,7 +147,7 @@ class TypeAnnotation(object):
                               file=io)
                         print("# Has %d overloads" % len(loop.overloads),
                               file=io)
-                        for cres in loop._compileinfos.values():
+                        for cres in loop.overloads.values():
                             print(cres.type_annotation, file=io)
             else:
                 print("# Source code unavailable", file=io)

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -117,7 +117,7 @@ _LowerResult = namedtuple("_LowerResult", [
 def get_function_attributes(func):
     '''
     Extract the function attributes from a Python function or object with
-    *py_func* attribute, such as CPUOverloaded.
+    *py_func* attribute, such as CPUDispatcher.
 
     Returns an instance of FunctionAttributes.
     '''

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -268,6 +268,8 @@ class Pipeline(object):
                  locals):
         # Make sure the environment is reloaded
         config.reload_config()
+        typingctx.refresh()
+        targetctx.refresh()
 
         self.typingctx = typingctx
 

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import, print_function
-from numba.targets.registry import target_registry
+
 
 def init_jit():
     from numba.cuda.dispatcher import CUDADispatcher
     return CUDADispatcher
 
 def initialize_all():
-    target_registry.ondemand['gpu'] = init_jit
-    target_registry.ondemand['cuda'] = init_jit
+    from numba.targets.registry import dispatcher_registry
+    dispatcher_registry.ondemand['gpu'] = init_jit
+    dispatcher_registry.ondemand['cuda'] = init_jit

--- a/numba/cuda/printimpl.py
+++ b/numba/cuda/printimpl.py
@@ -10,7 +10,7 @@ register = registry.register
 voidptr = Type.pointer(Type.int(8))
 
 @register
-@implement(types.print_item_type, types.Integer)
+@implement("print_item", types.Integer)
 def int_print_impl(context, builder, sig, args):
     [x] = args
     [srctype] = sig.args
@@ -31,7 +31,7 @@ def int_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Float)
+@implement("print_item", types.Float)
 def real_print_impl(context, builder, sig, args):
     [x] = args
     [srctype] = sig.args
@@ -48,7 +48,7 @@ def real_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_type, types.VarArg(types.Any))
+@implement(print, types.VarArg(types.Any))
 def print_varargs(context, builder, sig, args):
     """This function is a generic 'print' wrapper for arbitrary types.
     It dispatches to the appropriate 'print' implementations above
@@ -61,7 +61,7 @@ def print_varargs(context, builder, sig, args):
 
     for i, (argtype, argval) in enumerate(zip(sig.args, args)):
         signature = typing.signature(types.none, argtype)
-        imp = context.get_function(types.print_item_type, signature)
+        imp = context.get_function("print_item", signature)
         imp(builder, [argval])
         if i < len(args) - 1:
             builder.call(vprint, (sep, Constant.null(voidptr)))

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -21,13 +21,13 @@ from . import codegen, nvvmutils
 
 
 class CUDATypingContext(typing.BaseContext):
-    def init(self):
+    def load_additional_registries(self):
         from . import cudadecl, cudamath
 
-        self.install(cudadecl.registry)
-        self.install(cudamath.registry)
-        self.install(cmathdecl.registry)
-        self.install(operatordecl.registry)
+        self.install_registry(cudadecl.registry)
+        self.install_registry(cudamath.registry)
+        self.install_registry(cmathdecl.registry)
+        self.install_registry(operatordecl.registry)
 
 # -----------------------------------------------------------------------------
 # Implementation
@@ -44,16 +44,16 @@ class CUDATargetContext(BaseContext):
         return self._internal_codegen._create_empty_module(name)
 
     def init(self):
-        from . import cudaimpl, printimpl, libdevice
-
         self._internal_codegen = codegen.JITCUDACodegen("numba.cuda.jit")
+        self._target_data = ll.create_target_data(nvvm.default_data_layout)
 
+    def load_additional_registries(self):
+        from . import cudaimpl, printimpl, libdevice
         self.install_registry(cudaimpl.registry)
         self.install_registry(printimpl.registry)
         self.install_registry(libdevice.registry)
         self.install_registry(cmathimpl.registry)
         self.install_registry(operatorimpl.registry)
-        self._target_data = ll.create_target_data(nvvm.default_data_layout)
 
     def codegen(self):
         return self._internal_codegen

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -399,6 +399,13 @@ class StructModel(CompositeModel):
             self._fields = self._members = ()
         self._models = tuple([self._dmm.lookup(t) for t in self._members])
 
+    def get_member_fe_type(self, name):
+        """
+        StructModel-specific: get the Numba type of the field named *name*.
+        """
+        pos = self.get_field_position(name)
+        return self._members[pos]
+
     def get_value_type(self):
         elems = [t.get_value_type() for t in self._models]
         return ir.LiteralStructType(elems)

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -35,10 +35,8 @@ class _OverloadedBase(_dispatcher.Dispatcher):
     def __init__(self, arg_count, py_func, pysig):
         self._tm = default_type_manager
 
-        # A mapping of signatures to entry points
-        self.overloads = utils.OrderedDict()
         # A mapping of signatures to compile results
-        self._compileinfos = utils.OrderedDict()
+        self.overloads = utils.OrderedDict()
 
         self.py_func = py_func
         # other parts of Numba assume the old Python 2 name for code object
@@ -68,7 +66,6 @@ class _OverloadedBase(_dispatcher.Dispatcher):
     def _reset_overloads(self):
         self._clear()
         self.overloads.clear()
-        self._compileinfos.clear()
 
     def _make_finalizer(self):
         """
@@ -87,9 +84,9 @@ class _OverloadedBase(_dispatcher.Dispatcher):
                 return
             # This function must *not* hold any reference to self:
             # we take care to bind the necessary objects in the closure.
-            for func in overloads.values():
+            for cres in overloads.values():
                 try:
-                    targetctx.remove_user_function(func)
+                    targetctx.remove_user_function(cres.entry_point)
                 except KeyError:
                     pass
 
@@ -104,7 +101,7 @@ class _OverloadedBase(_dispatcher.Dispatcher):
 
     @property
     def nopython_signatures(self):
-        return [cres.signature for cres in self._compileinfos.values()
+        return [cres.signature for cres in self.overloads.values()
                 if not cres.objectmode and not cres.interpmode]
 
     def disable_compile(self, val=True):
@@ -118,8 +115,7 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         args = tuple(cres.signature.args)
         sig = [a._code for a in args]
         self._insert(sig, cres.entry_point, cres.objectmode, cres.interpmode)
-        self.overloads[args] = cres.entry_point
-        self._compileinfos[args] = cres
+        self.overloads[args] = cres
 
     def get_call_template(self, args, kws):
         """
@@ -152,8 +148,11 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         return call_template, args, kws
 
     def get_overload(self, sig):
+        """
+        Return the compiled function for the given signature.
+        """
         args, return_type = sigutils.normalize_signature(sig)
-        return self.overloads[tuple(args)]
+        return self.overloads[tuple(args)].entry_point
 
     @property
     def is_compiling(self):
@@ -173,14 +172,14 @@ class _OverloadedBase(_dispatcher.Dispatcher):
 
     def inspect_llvm(self, signature=None):
         if signature is not None:
-            lib = self._compileinfos[signature].library
+            lib = self.overloads[signature].library
             return lib.get_llvm_str()
 
         return dict((sig, self.inspect_llvm(sig)) for sig in self.signatures)
 
     def inspect_asm(self, signature=None):
         if signature is not None:
-            lib = self._compileinfos[signature].library
+            lib = self.overloads[signature].library
             return lib.get_asm_str()
 
         return dict((sig, self.inspect_asm(sig)) for sig in self.signatures)
@@ -189,7 +188,7 @@ class _OverloadedBase(_dispatcher.Dispatcher):
         if file is None:
             file = sys.stdout
 
-        for ver, res in utils.iteritems(self._compileinfos):
+        for ver, res in utils.iteritems(self.overloads):
             print("%s %s" % (self.py_func.__name__, ver), file=file)
             print('-' * 80, file=file)
             print(res.type_annotation, file=file)
@@ -306,7 +305,7 @@ class Overloaded(_OverloadedBase):
         if self._can_compile:
             sigs = []
         else:
-            sigs = [cr.signature for cr in self._compileinfos.values()]
+            sigs = [cr.signature for cr in self.overloads.values()]
         return (serialize._rebuild_reduction,
                 (self.__class__, serialize._reduce_function(self.py_func),
                  self.locals, self.targetoptions, self._can_compile, sigs))
@@ -329,7 +328,7 @@ class Overloaded(_OverloadedBase):
             # Don't recompile if signature already exists
             existing = self.overloads.get(tuple(args))
             if existing is not None:
-                return existing
+                return existing.entry_point
 
             # Try to load from disk cache
             cres = self._cache.load_overload(sig, self.targetctx)
@@ -361,9 +360,6 @@ class Overloaded(_OverloadedBase):
         """
         Recompile all signatures afresh.
         """
-        # A subtle point: self.overloads has argument type tuples, while
-        # while self._compileinfos has full signatures including return
-        # types.  This has an effect on cache lookups...
         sigs = list(self.overloads)
         old_can_compile = self._can_compile
         # Ensure the old overloads are disposed of, including compiled functions.

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -69,10 +69,10 @@ class TypingError(NumbaError):
 
 
 class UntypedAttributeError(TypingError):
-    def __init__(self, value, attr):
+    def __init__(self, value, attr, loc=None):
         msg = 'Unknown attribute "{attr}" of type {type}'.format(type=value,
-                                                              attr=attr)
-        super(UntypedAttributeError, self).__init__(msg)
+                                                                 attr=attr)
+        super(UntypedAttributeError, self).__init__(msg, loc=loc)
 
 
 class ByteCodeSupportError(NumbaError):

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -1,0 +1,117 @@
+
+import inspect
+
+from numba import types
+
+# Exported symbols
+from .typing.typeof import typeof_impl
+from .targets.imputils import builtin, builtin_cast, implement, impl_attribute
+from .datamodel import models, register_default as register_model
+from .pythonapi import box, unbox, reflect, NativeValue
+
+
+def type_callable(func):
+    """
+    Decorate a function as implementing typing for the callable *func*.
+    *func* can be a callable object (probably a global) or a string
+    denoting a built-in operation (such 'getitem' or '__array_wrap__')
+    """
+    from .typing.templates import CallableTemplate, builtin, builtin_global
+    if not callable(func) and not isinstance(func, str):
+        raise TypeError("`func` should be a function or string")
+    try:
+        func_name = func.__name__
+    except AttributeError:
+        func_name = str(func)
+
+    def decorate(typing_func):
+        def generic(self):
+            return typing_func(self.context)
+
+        name = "%s_CallableTemplate" % (func_name,)
+        bases = (CallableTemplate,)
+        class_dict = dict(key=func, generic=generic)
+        template = type(name, bases, class_dict)
+        builtin(template)
+        if hasattr(func, '__module__'):
+            builtin_global(func, types.Function(template))
+
+    return decorate
+
+
+def overlay(func):
+    """
+    TODO docstring
+    """
+    # XXX Should overlay() return a jitted wrapper calling the
+    # function?  This way it would also be usable from pure Python
+    # code, like a regular jitted function
+    from .typing.templates import make_overlay_template, builtin_global
+
+    def decorate(overlay_func):
+        template = make_overlay_template(func, overlay_func)
+        ty = types.Function(template)
+        if hasattr(func, '__module__'):
+            builtin_global(func, ty)
+        return overlay_func
+
+    return decorate
+
+
+def overlay_attribute(typ, attr):
+    """
+    TODO docstring
+    """
+    from .typing.templates import make_overlay_attribute_template, builtin_attr
+
+    def decorate(overlay_func):
+        template = make_overlay_attribute_template(typ, attr, overlay_func)
+        builtin_attr(template)
+        return overlay_func
+
+    return decorate
+
+
+def make_attribute_wrapper(typeclass, struct_attr, python_attr):
+    """
+    Make an automatic attribute wrapper exposing member named *struct_attr*
+    as a read-only attribute named *python_attr*.
+    The given *typeclass*'s model must be a StructModel subclass.
+    """
+    # XXX should this work for setters as well?
+    from .typing.templates import builtin_attr, AttributeTemplate
+    from .datamodel import default_manager
+    from .datamodel.models import StructModel
+    from .targets.imputils import (builtin_attr as target_attr,
+                                   impl_attribute, impl_ret_borrowed)
+    from . import cgutils
+
+    if not isinstance(typeclass, type) or not issubclass(typeclass, types.Type):
+        raise TypeError("typeclass should be a Type subclass, got %s"
+                        % (typeclass,))
+
+    def get_attr_fe_type(typ):
+        """
+        Get the Numba type of member *struct_attr* in *typ*.
+        """
+        model = default_manager.lookup(typ)
+        if not isinstance(model, StructModel):
+            raise TypeError("make_struct_attribute_wrapper() needs a type "
+                            "with a StructModel, but got %s" % (model,))
+        return model.get_member_fe_type(struct_attr)
+
+    @builtin_attr
+    class StructAttribute(AttributeTemplate):
+        key = typeclass
+
+        def generic_resolve(self, typ, attr):
+            if attr == python_attr:
+                return get_attr_fe_type(typ)
+
+    @target_attr
+    @impl_attribute(typeclass, python_attr)
+    def struct_getattr_impl(context, builder, typ, val):
+        val = cgutils.create_struct_proxy(typ)(context, builder, value=val)
+        attrty = get_attr_fe_type(typ)
+        attrval = getattr(val, struct_attr)
+        return impl_ret_borrowed(context, builder, attrty, attrval)

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -39,35 +39,35 @@ def type_callable(func):
     return decorate
 
 
-def overlay(func):
+def overload(func):
     """
     TODO docstring
     """
-    # XXX Should overlay() return a jitted wrapper calling the
+    # XXX Should overload() return a jitted wrapper calling the
     # function?  This way it would also be usable from pure Python
     # code, like a regular jitted function
-    from .typing.templates import make_overlay_template, builtin_global
+    from .typing.templates import make_overload_template, builtin_global
 
-    def decorate(overlay_func):
-        template = make_overlay_template(func, overlay_func)
+    def decorate(overload_func):
+        template = make_overload_template(func, overload_func)
         ty = types.Function(template)
         if hasattr(func, '__module__'):
             builtin_global(func, ty)
-        return overlay_func
+        return overload_func
 
     return decorate
 
 
-def overlay_attribute(typ, attr):
+def overload_attribute(typ, attr):
     """
     TODO docstring
     """
-    from .typing.templates import make_overlay_attribute_template, builtin_attr
+    from .typing.templates import make_overload_attribute_template, builtin_attr
 
-    def decorate(overlay_func):
-        template = make_overlay_attribute_template(typ, attr, overlay_func)
+    def decorate(overload_func):
+        template = make_overload_attribute_template(typ, attr, overload_func)
         builtin_attr(template)
-        return overlay_func
+        return overload_func
 
     return decorate
 

--- a/numba/hsa/target.py
+++ b/numba/hsa/target.py
@@ -20,11 +20,11 @@ CC_SPIR_FUNC = "spir_func"
 
 
 class HSATypingContext(typing.BaseContext):
-    def init(self):
+    def load_additional_registries(self):
         from . import hsadecl, mathdecl
 
-        self.install(hsadecl.registry)
-        self.install(mathdecl.registry)
+        self.install_registry(hsadecl.registry)
+        self.install_registry(mathdecl.registry)
 
 
 # -----------------------------------------------------------------------------
@@ -64,14 +64,16 @@ class HSATargetContext(BaseContext):
     generic_addrspace = SPIR_GENERIC_ADDRSPACE
 
     def init(self):
-        from . import hsaimpl, mathimpl
-
-        self.insert_func_defn(hsaimpl.registry.functions)
-        self.insert_func_defn(mathimpl.registry.functions)
         self._internal_codegen = codegen.JITHSACodegen("numba.hsa.jit")
         self._target_data = DATALAYOUT[utils.MACHINE_BITS]
         # Override data model manager
         self.data_model_manager = hsa_data_model_manager
+
+    def load_additional_registries(self):
+        from . import hsaimpl, mathimpl
+
+        self.insert_func_defn(hsaimpl.registry.functions)
+        self.insert_func_defn(mathimpl.registry.functions)
 
     @cached_property
     def call_conv(self):

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -398,17 +398,12 @@ def ctor_impl(context, builder, sig, args):
     init_sig = (sig.return_type,) + sig.args
 
     init = inst_typ.jitmethods['__init__']
-    init.compile(init_sig)
-    cres = init._compileinfos[init_sig]
+    disp_type = types.Dispatcher(init)
+    call = context.get_function(disp_type, types.void(*init_sig))
     realargs = [inst_struct._getvalue()] + list(args)
-    context.call_internal(builder, cres.fndesc, types.void(*init_sig),
-                          realargs)
+    call(builder, realargs)
 
-    # Prepare reutrn value
+    # Prepare return value
     ret = inst_struct._getvalue()
-
-    # Add function to link
-    codegen = context.codegen()
-    codegen.add_linking_library(cres.library)
 
     return imputils.impl_ret_new_ref(context, builder, inst_typ, ret)

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -62,8 +62,8 @@ class RewriteArrayExprs(rewrites.Rewrite):
                         func_type = typemap[expr.func.name]
                         # Note: func_type can be a types.Dispatcher, which
                         #       doesn't have the `.template` attribute.
-                        if hasattr(func_type, 'template'):
-                            func_key = getattr(func_type.template, 'key', None)
+                        if isinstance(func_type, types.Function):
+                            func_key = func_type.typing_key
                             if isinstance(func_key, (ufunc, DUFunc)):
                                 # If so, match it as a potential subexpression.
                                 array_assigns[target_name] = instr
@@ -89,7 +89,7 @@ class RewriteArrayExprs(rewrites.Rewrite):
         if ir_op in ('unary', 'binop'):
             return ir_expr.fn
         elif ir_op == 'call':
-            return self.typemap[ir_expr.func.name].template.key
+            return self.typemap[ir_expr.func.name].typing_key
         raise NotImplementedError(
             "Don't know how to find the operator for '{0}' expressions.".format(
                 ir_op))

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import
+
 import warnings
 import inspect
+
 import numpy as np
 
 from numba.decorators import jit
-from numba.targets.registry import target_registry
+from numba.targets.registry import dispatcher_registry
 from numba.targets.options import TargetOptions
 from numba import utils, compiler, types, sigutils
 from numba.numpy_support import as_dtype
@@ -66,7 +68,7 @@ class UFuncDispatcher(object):
         return cres
 
 
-target_registry['npyufunc'] = UFuncDispatcher
+dispatcher_registry['npyufunc'] = UFuncDispatcher
 
 # Utility functions
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -17,7 +17,7 @@ from numba import _dynfunc, _helperlib
 from numba.pythonapi import PythonAPI
 from numba.targets.imputils import (user_function, user_generator,
                                     builtin_registry, impl_attribute,
-                                    impl_ret_borrowed)
+                                    impl_ret_borrowed, RegistryLoader)
 from . import (
     arrayobj, arraymath, builtins, iterators, rangeobj, optional, slicing,
     tupleobj, imputils)
@@ -139,17 +139,19 @@ class BaseContext(object):
 
     def __init__(self, typing_context):
         _load_global_helpers()
+
         self.address_size = utils.MACHINE_BITS
         self.typing_context = typing_context
 
+        # A list of installed registries
+        self._registries = {}
+        # Declarations loaded from registries and other sources
         self._defns = defaultdict(Overloads)
         self._attrs = defaultdict(Overloads)
         self._casts = Overloads()
+        # Other declarations
         self._generators = {}
         self.special_ops = {}
-
-        self.install_registry(builtin_registry)
-
         self.cached_internal_func = {}
 
         self.data_model_manager = datamodel.default_manager
@@ -161,7 +163,19 @@ class BaseContext(object):
         """
         For subclasses to add initializer
         """
-        pass
+
+    def refresh(self):
+        """
+        Refresh context with new declarations from known registries.
+        Useful for third-party extensions.
+        """
+        self.install_registry(builtin_registry)
+        self.load_additional_registries()
+
+    def load_additional_registries(self):
+        """
+        Load target-specific registries.  Can be overriden by subclasses.
+        """
 
     def get_arg_packer(self, fe_args):
         return datamodel.ArgPacker(self.data_model_manager, fe_args)
@@ -186,9 +200,14 @@ class BaseContext(object):
         Install a *registry* (a imputils.Registry instance) of function
         and attribute implementations.
         """
-        self.insert_func_defn(registry.functions)
-        self.insert_attr_defn(registry.attributes)
-        self._insert_cast_defn(registry.casts)
+        try:
+            loader = self._registries[registry]
+        except KeyError:
+            loader = RegistryLoader(registry)
+            self._registries[registry] = loader
+        self.insert_func_defn(loader.new_functions())
+        self.insert_attr_defn(loader.new_attributes())
+        self._insert_cast_defn(loader.new_casts())
 
     def insert_func_defn(self, defns):
         for impl, func_sigs in defns:
@@ -429,6 +448,7 @@ class BaseContext(object):
         elif isinstance(typ, types.ClassInstanceType):
             def imp(context, builder, sig, args):
                 if attr in typ.struct:
+                    # It's a struct member
                     instance_struct = cgutils.create_struct_proxy(typ)
                     [this, val] = args
                     inst = instance_struct(context, builder, value=this)
@@ -448,13 +468,13 @@ class BaseContext(object):
                     # Delete old value
                     context.nrt_decref(builder, attr_type, oldvalue)
                 elif attr in typ.jitprops:
+                    # It's a user-defined property, compile its setter
                     setter = typ.jitprops[attr]['set']
-                    setter.compile(sig)
-                    cres = setter._compileinfos[sig.args]
-                    out = context.call_internal(builder, cres.fndesc,
-                                                cres.signature, args)
-                    return imputils.impl_ret_new_ref(context, builder,
-                                                     cres.signature, out)
+                    disp_type = types.Dispatcher(setter)
+                    sig = disp_type.get_call_type(self.typing_context,
+                                                  sig.args, {})
+                    call = self.get_function(disp_type, sig)
+                    return call(builder, args)
 
                 else:
                     msg = 'attribute {0!r} not implemented'.format(attr)
@@ -467,8 +487,9 @@ class BaseContext(object):
         Return the implementation of function *fn* for signature *sig*.
         The return value is a callable with the signature (builder, args).
         """
-        if isinstance(fn, (types.Function)):
-            key = fn.template.key
+        if isinstance(fn, (types.Function, types.BoundFunction,
+                           types.Dispatcher)):
+            key = fn.get_impl_key(sig)
 
             if isinstance(key, MethodType):
                 overloads = self._defns[key.im_func]
@@ -480,9 +501,6 @@ class BaseContext(object):
             else:
                 overloads = self._defns[key]
 
-        elif isinstance(fn, types.Dispatcher):
-            key = fn.overloaded.get_overload(sig.args)
-            overloads = self._defns[key]
         else:
             key = fn
             overloads = self._defns[key]

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -34,9 +34,18 @@ PYOBJECT = GENERIC_POINTER
 void_ptr = GENERIC_POINTER
 
 
-class Overloads(object):
+class OverloadSelector(object):
+    """
+    An object matching an actual signature against a registry of formal
+    signatures and choosing the best candidate, if any.
+
+    In the current implementation:
+    - a "signature" is a tuple of type classes or type instances
+    - the "best candidate" is simply the first match
+    """
+
     def __init__(self):
-        # A list of (args tuple, implementation)
+        # A list of (formal args tuple, value)
         self.versions = []
 
     def find(self, sig):
@@ -78,8 +87,11 @@ class Overloads(object):
             assert issubclass(formal, types.Type)
             return True
 
-    def append(self, impl, sig):
-        self.versions.append((sig, impl))
+    def append(self, value, sig):
+        """
+        Add a formal signature and its associated value.
+        """
+        self.versions.append((sig, value))
 
 
 @utils.runonce
@@ -146,9 +158,9 @@ class BaseContext(object):
         # A list of installed registries
         self._registries = {}
         # Declarations loaded from registries and other sources
-        self._defns = defaultdict(Overloads)
-        self._attrs = defaultdict(Overloads)
-        self._casts = Overloads()
+        self._defns = defaultdict(OverloadSelector)
+        self._attrs = defaultdict(OverloadSelector)
+        self._casts = OverloadSelector()
         # Other declarations
         self._generators = {}
         self.special_ops = {}

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -378,6 +378,9 @@ def bool_invert_impl(context, builder, sig, args):
 
 
 def int_sign_impl(context, builder, sig, args):
+    """
+    np.sign(int)
+    """
     [x] = args
     POS = Constant.int(x.type, 1)
     NEG = Constant.int(x.type, -1)
@@ -443,9 +446,7 @@ def _implement_integer_operators():
 
     builtin(implement('-', ty)(int_negate_impl))
     builtin(implement('+', ty)(int_positive_impl))
-    builtin(implement(types.neg_type, ty)(int_negate_impl))
     builtin(implement('~', ty)(int_invert_impl))
-    builtin(implement(types.sign_type, ty)(int_sign_impl))
 
     builtin(implement('**', ty, ty)(int_power_impl))
     builtin(implement(pow, ty, ty)(int_power_impl))
@@ -457,16 +458,16 @@ def _implement_integer_operators():
         builtin(implement('>=', ty, ty)(int_uge_impl))
         builtin(implement('**', types.float64, ty)(int_power_impl))
         builtin(implement(pow, types.float64, ty)(int_power_impl))
-        builtin(implement(types.abs_type, ty)(uint_abs_impl))
+        builtin(implement(abs, ty)(uint_abs_impl))
 
     for ty in types.signed_domain:
         builtin(implement('<', ty, ty)(int_slt_impl))
         builtin(implement('<=', ty, ty)(int_sle_impl))
         builtin(implement('>', ty, ty)(int_sgt_impl))
         builtin(implement('>=', ty, ty)(int_sge_impl))
-        builtin(implement(types.abs_type, ty)(int_abs_impl))
         builtin(implement('**', types.float64, ty)(int_power_impl))
         builtin(implement(pow, types.float64, ty)(int_power_impl))
+        builtin(implement(abs, ty)(int_abs_impl))
 
 _implement_integer_operators()
 
@@ -795,6 +796,9 @@ def real_positive_impl(context, builder, sig, args):
 
 
 def real_sign_impl(context, builder, sig, args):
+    """
+    np.sign(float)
+    """
     [x] = args
     POS = Constant.real(x.type, 1)
     NEG = Constant.real(x.type, -1)
@@ -840,12 +844,10 @@ builtin(implement('<=', ty, ty)(real_le_impl))
 builtin(implement('>', ty, ty)(real_gt_impl))
 builtin(implement('>=', ty, ty)(real_ge_impl))
 
-builtin(implement(types.abs_type, ty)(real_abs_impl))
+builtin(implement(abs, ty)(real_abs_impl))
 
 builtin(implement('-', ty)(real_negate_impl))
 builtin(implement('+', ty)(real_positive_impl))
-builtin(implement(types.neg_type, ty)(real_negate_impl))
-builtin(implement(types.sign_type, ty)(real_sign_impl))
 
 del ty
 
@@ -1107,7 +1109,7 @@ builtin(implement("+", ty)(complex_positive_impl))
 builtin(implement('==', ty, ty)(complex_eq_impl))
 builtin(implement('!=', ty, ty)(complex_ne_impl))
 
-builtin(implement(types.abs_type, ty)(complex_abs_impl))
+builtin(implement(abs, ty)(complex_abs_impl))
 
 del ty
 

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -46,6 +46,10 @@ class CPUContext(BaseContext):
         externals.c_math_functions.install(self)
         externals.c_numpy_functions.install(self)
 
+        # Initialize NRT runtime
+        rtsys.initialize(self)
+
+    def load_additional_registries(self):
         # Add target specific implementations
         self.install_registry(cmathimpl.registry)
         self.install_registry(cffiimpl.registry)
@@ -54,9 +58,6 @@ class CPUContext(BaseContext):
         self.install_registry(operatorimpl.registry)
         self.install_registry(printimpl.registry)
         self.install_registry(randomimpl.registry)
-
-        # Initialize NRT runtime
-        rtsys.initialize(self)
 
     @property
     def target_data(self):

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -395,7 +395,7 @@ def list_constructor(context, builder, sig, args):
 # Various operations
 
 @builtin
-@implement(types.len_type, types.List)
+@implement(len, types.List)
 def list_len(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     return inst.size

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -124,7 +124,7 @@ def timedelta_neg_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @builtin
-@implement(types.abs_type, types.NPTimedelta)
+@implement(abs, types.NPTimedelta)
 def timedelta_abs_impl(context, builder, sig, args):
     val, = args
     ret = alloc_timedelta_result(builder)
@@ -136,9 +136,10 @@ def timedelta_abs_impl(context, builder, sig, args):
     res = builder.load(ret)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
-@builtin
-@implement(types.sign_type, types.NPTimedelta)
 def timedelta_sign_impl(context, builder, sig, args):
+    """
+    np.sign(timedelta64)
+    """
     val, = args
     ret = alloc_timedelta_result(builder)
     zero = Constant.int(TIMEDELTA64, 0)

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -156,7 +156,7 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where='input operand'):
     _ScalarHelper or _ArrayHelper) class to handle the argument.
     using the polymorphic interface of the Helper classes, scalar
     and array cases can be handled with the same code"""
-    if isinstance(tyinp, types.Array):
+    if isinstance(tyinp, types.ArrayCompatible):
         ary     = ctxt.make_array(tyinp)(ctxt, bld, inp)
         shape   = cgutils.unpack_tuple(bld, ary.shape, tyinp.ndim)
         strides = cgutils.unpack_tuple(bld, ary.strides, tyinp.ndim)
@@ -279,7 +279,7 @@ def numpy_ufunc_kernel(context, builder, sig, args, kernel_class,
                  for arg, tyarg in zip(args, sig.args)]
     if not explicit_output:
         ret_ty = sig.return_type
-        if isinstance(ret_ty, types.Array):
+        if isinstance(ret_ty, types.ArrayCompatible):
             output = _build_array(context, builder, ret_ty, arguments)
         else:
             output = _prepare_argument(

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -15,7 +15,7 @@ register = registry.register
 
 
 @register
-@implement(types.print_item_type, types.Integer)
+@implement("print_item", types.Integer)
 def int_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
@@ -30,7 +30,7 @@ def int_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Float)
+@implement("print_item", types.Float)
 def real_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
@@ -43,7 +43,7 @@ def real_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.Boolean)
+@implement("print_item", types.Boolean)
 def bool_print_impl(context, builder, sig, args):
     [x] = args
     py = context.get_python_api(builder)
@@ -55,7 +55,7 @@ def bool_print_impl(context, builder, sig, args):
 
 
 @register
-@implement(types.print_item_type, types.CharSeq)
+@implement("print_item", types.CharSeq)
 def print_charseq(context, builder, sig, args):
     [tx] = sig.args
     [x] = args
@@ -72,12 +72,12 @@ def print_charseq(context, builder, sig, args):
 
 
 @register
-@implement(types.print_type, types.VarArg(types.Any))
+@implement(print, types.VarArg(types.Any))
 def print_varargs(context, builder, sig, args):
     py = context.get_python_api(builder)
     for i, (argtype, argval) in enumerate(zip(sig.args, args)):
         signature = typing.signature(types.none, argtype)
-        imp = context.get_function(types.print_item_type, signature)
+        imp = context.get_function("print_item", signature)
         imp(builder, [argval])
         if i < len(args) - 1:
             py.print_string(' ')

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -21,7 +21,7 @@ def make_range_impl(range_state_type, range_iter_type, int_type):
     RangeState = cgutils.create_struct_proxy(range_state_type)
 
     @builtin
-    @implement(types.range_type, int_type)
+    @implement(range, int_type)
     def range1_impl(context, builder, sig, args):
         """
         range(stop: int) -> range object
@@ -37,7 +37,7 @@ def make_range_impl(range_state_type, range_iter_type, int_type):
                                   state._getvalue())
 
     @builtin
-    @implement(types.range_type, int_type, int_type)
+    @implement(range, int_type, int_type)
     def range2_impl(context, builder, sig, args):
         """
         range(start: int, stop: int) -> range object
@@ -53,7 +53,7 @@ def make_range_impl(range_state_type, range_iter_type, int_type):
                                   state._getvalue())
 
     @builtin
-    @implement(types.range_type, int_type, int_type, int_type)
+    @implement(range, int_type, int_type, int_type)
     def range3_impl(context, builder, sig, args):
         """
         range(start: int, stop: int, step: int) -> range object

--- a/numba/targets/registry.py
+++ b/numba/targets/registry.py
@@ -14,12 +14,14 @@ class CPUTarget(TargetDescriptor):
     target_context = cpu.CPUContext(typing_context)
 
 
-class CPUOverloaded(dispatcher.Overloaded):
+class CPUDispatcher(dispatcher.Dispatcher):
     targetdescr = CPUTarget()
 
 
 class TargetRegistry(utils.UniqueDict):
     """
+    A registry of API implementations for various backends.
+
     Attributes
     ----------
     ondemand:
@@ -39,5 +41,5 @@ class TargetRegistry(utils.UniqueDict):
         return super(TargetRegistry, self).__getitem__(item)
 
 
-target_registry = TargetRegistry()
-target_registry['cpu'] = CPUOverloaded
+dispatcher_registry = TargetRegistry()
+dispatcher_registry['cpu'] = CPUDispatcher

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -140,7 +140,7 @@ def make_slice(context, builder, typ, value=None):
 
 
 @builtin
-@implement(types.slice_type, types.VarArg(types.Any))
+@implement(slice, types.VarArg(types.Any))
 def slice_constructor_impl(context, builder, sig, args):
     slice_args = []
     for ty, val, default in zip_longest(sig.args, args, get_defaults(context)):

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -20,7 +20,7 @@ def namedtuple_constructor(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @builtin
-@implement(types.len_type, types.BaseTuple)
+@implement(len, types.BaseTuple)
 def tuple_len(context, builder, sig, args):
     tupty, = sig.args
     retty = sig.return_type
@@ -35,6 +35,12 @@ def tuple_bool(context, builder, sig, args):
         return cgutils.true_bit
     else:
         return cgutils.false_bit
+
+@builtin
+@implement('+', types.BaseTuple, types.BaseTuple)
+def tuple_add(context, builder, sig, args):
+    left, right = [cgutils.unpack_tuple(builder, x) for x in args]
+    return context.make_tuple(builder, sig.return_type, left + right)
 
 def tuple_cmp_ordered(context, builder, op, sig, args):
     tu, tv = sig.args

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -15,11 +15,11 @@ from .support import TestCase, captured_stdout
 
 from numba.extending import (typeof_impl, type_callable,
                              builtin, builtin_cast,
-                             implement, overlay,
+                             implement, overload,
                              models, register_model,
                              box, unbox, NativeValue,
                              make_attribute_wrapper,
-                             overlay_attribute)
+                             overload_attribute)
 from numba.typing.templates import (
     ConcreteTemplate, signature, builtin as typing_builtin)
 
@@ -115,8 +115,8 @@ def call_where(cond, x, y):
     return where(cond, y=y, x=x)
 
 
-@overlay(where)
-def overlay_where_arrays(cond, x, y):
+@overload(where)
+def overload_where_arrays(cond, x, y):
     """
     Implement where() for arrays.
     """
@@ -157,11 +157,11 @@ def overlay_where_arrays(cond, x, y):
 
         return where_impl
 
-# We can define another overlay function for the same function, they
+# We can define another overload function for the same function, they
 # will be tried in turn until one succeeds.
 
-@overlay(where)
-def overlay_where_scalars(cond, x, y):
+@overload(where)
+def overload_where_scalars(cond, x, y):
     """
     Implement where() for scalars.
     """
@@ -183,8 +183,8 @@ def overlay_where_scalars(cond, x, y):
 
 # Overlay an already defined built-in function
 
-@overlay(len)
-def overlay_len_dummy(arg):
+@overload(len)
+def overload_len_dummy(arg):
     if isinstance(arg, MyDummyType):
         def len_impl(arg):
             return 13
@@ -317,7 +317,7 @@ def box_index(typ, val, c):
     indexobj = c.pyapi.call_function_objargs(classobj, (arrayobj,))
     return indexobj
 
-@overlay_attribute(IndexType, 'is_monotonic_increasing')
+@overload_attribute(IndexType, 'is_monotonic_increasing')
 def index_is_monotonic_increasing(typ):
     def getter(index):
         data = index._data
@@ -420,7 +420,7 @@ class TestPandasLike(TestCase):
 
     def test_is_monotonic(self):
         # The is_monotonic_increasing attribute is exposed with
-        # overlay_attribute()
+        # overload_attribute()
         cfunc = jit(nopython=True)(is_monotonic_usecase)
         for values, expected in [([8, 42, 5], False),
                                  ([5, 8, 42], True),
@@ -437,7 +437,7 @@ class TestHighLevelExtending(TestCase):
 
     def test_where(self):
         """
-        Test implementing a function with @overlay.
+        Test implementing a function with @overload.
         """
         pyfunc = call_where
         cfunc = jit(nopython=True)(pyfunc)
@@ -460,7 +460,7 @@ class TestHighLevelExtending(TestCase):
 
     def test_len(self):
         """
-        Test re-implementing len() for a custom type with @overlay.
+        Test re-implementing len() for a custom type with @overload.
         """
         cfunc = jit(nopython=True)(len_usecase)
         self.assertPreciseEqual(cfunc(MyDummy()), 13)
@@ -468,7 +468,7 @@ class TestHighLevelExtending(TestCase):
 
     def test_print(self):
         """
-        Test re-implementing print() for a custom type with @overlay.
+        Test re-implementing print() for a custom type with @overload.
         """
         cfunc = jit(nopython=True)(print_usecase)
         with captured_stdout():

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1,0 +1,480 @@
+from __future__ import print_function, division, absolute_import
+
+from collections import namedtuple
+import math
+import sys
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba import jit, types, errors, typeof, numpy_support, cgutils
+from numba.compiler import compile_isolated
+from .support import TestCase, captured_stdout
+
+# XXX target @builtin and typing @builtin conflict!
+
+from numba.extending import (typeof_impl, type_callable,
+                             builtin, builtin_cast,
+                             implement, overlay,
+                             models, register_model,
+                             box, unbox, NativeValue,
+                             make_attribute_wrapper,
+                             overlay_attribute)
+from numba.typing.templates import (
+    ConcreteTemplate, signature, builtin as typing_builtin)
+
+
+# Define a function's typing and implementation using the classical
+# two-step API
+
+def func1(x=None):
+    raise NotImplementedError
+
+@type_callable(func1)
+def type_func1(context):
+    def typer(x=None):
+        if x in (None, types.none):
+            # 0-arg or 1-arg with None
+            return types.int32
+        elif isinstance(x, types.Float):
+            # 1-arg with float
+            return x
+
+    return typer
+
+@builtin
+@implement(func1)
+@implement(func1, types.none)
+def func1_nullary(context, builder, sig, args):
+    return context.get_constant(sig.return_type, 42)
+
+@builtin
+@implement(func1, types.Float)
+def func1_unary(context, builder, sig, args):
+    def func1_impl(x):
+        return math.sqrt(2 * x)
+    return context.compile_internal(builder, func1_impl, sig, args)
+
+def call_func1_nullary():
+    return func1()
+
+def call_func1_unary(x):
+    return func1(x)
+
+
+# Define a custom type and an implicit cast on it
+
+class MyDummy(object):
+    pass
+
+class MyDummyType(types.Opaque):
+
+    def can_convert_to(self, context, toty):
+        if isinstance(toty, types.Number):
+            from numba.typeconv import Conversion
+            return Conversion.safe
+
+mydummy_type = MyDummyType('mydummy')
+mydummy = MyDummy()
+
+@typeof_impl.register(MyDummy)
+def typeof_mydummy(val, c):
+    return mydummy_type
+
+@builtin_cast(MyDummyType, types.Number)
+def mydummy_to_number(context, builder, fromty, toty, val):
+    """
+    Implicit conversion from MyDummy to int.
+    """
+    return context.get_constant(toty, 42)
+
+def get_dummy():
+    return mydummy
+
+register_model(MyDummyType)(models.OpaqueModel)
+
+@unbox(MyDummyType)
+def unbox_index(typ, obj, c):
+    return NativeValue(c.context.get_dummy_value())
+
+
+#
+# Define an overlaid function (combined API)
+#
+
+def where(cond, x, y):
+    raise NotImplementedError
+
+def np_where(cond, x, y):
+    """
+    Wrap np.where() to allow for keyword arguments
+    """
+    return np.where(cond, x, y)
+
+def call_where(cond, x, y):
+    return where(cond, y=y, x=x)
+
+
+@overlay(where)
+def overlay_where_arrays(cond, x, y):
+    """
+    Implement where() for arrays.
+    """
+    # Choose implementation based on argument types.
+    if isinstance(cond, types.Array):
+        if x.dtype != y.dtype:
+            raise errors.TypingError("x and y should have the same dtype")
+
+        # Array where() => return an array of the same shape
+        if all(ty.layout == 'C' for ty in (cond, x, y)):
+            def where_impl(cond, x, y):
+                """
+                Fast implementation for C-contiguous arrays
+                """
+                shape = cond.shape
+                if x.shape != shape or y.shape != shape:
+                    raise ValueError("all inputs should have the same shape")
+                res = np.empty_like(x)
+                cf = cond.flat
+                xf = x.flat
+                yf = y.flat
+                rf = res.flat
+                for i in range(cond.size):
+                    rf[i] = xf[i] if cf[i] else yf[i]
+                return res
+        else:
+            def where_impl(cond, x, y):
+                """
+                Generic implementation for other arrays
+                """
+                shape = cond.shape
+                if x.shape != shape or y.shape != shape:
+                    raise ValueError("all inputs should have the same shape")
+                res = np.empty_like(x)
+                for idx, c in np.ndenumerate(cond):
+                    res[idx] = x[idx] if c else y[idx]
+                return res
+
+        return where_impl
+
+# We can define another overlay function for the same function, they
+# will be tried in turn until one succeeds.
+
+@overlay(where)
+def overlay_where_scalars(cond, x, y):
+    """
+    Implement where() for scalars.
+    """
+    if not isinstance(cond, types.Array):
+        if x != y:
+            raise errors.TypingError("x and y should have the same type")
+
+        def where_impl(cond, x, y):
+            """
+            Scalar where() => return a 0-dim array
+            """
+            scal = x if cond else y
+            # Can't use full_like() on Numpy < 1.8
+            arr = np.empty_like(scal)
+            arr[()] = scal
+            return arr
+
+        return where_impl
+
+# Overlay an already defined built-in function
+
+@overlay(len)
+def overlay_len_dummy(arg):
+    if isinstance(arg, MyDummyType):
+        def len_impl(arg):
+            return 13
+
+        return len_impl
+
+@typing_builtin
+class PrintDummy(ConcreteTemplate):
+    key = "print_item"
+    cases = [signature(types.none, mydummy_type)]
+
+@builtin
+@implement("print_item", MyDummyType)
+def print_dummy(context, builder, sig, args):
+    [x] = args
+    pyapi = context.get_python_api(builder)
+    strobj = pyapi.unserialize(pyapi.serialize_object("hello!"))
+    pyapi.print_object(strobj)
+    pyapi.decref(strobj)
+    return context.get_dummy_value()
+
+
+#
+# Minimal Pandas-inspired example
+#
+
+class Index(object):
+    """
+    A minimal pandas.Index-like object.
+    """
+
+    def __init__(self, data):
+        assert isinstance(data, np.ndarray)
+        assert data.ndim == 1
+        self._data = data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def flags(self):
+        return self._data.flags
+
+
+class IndexType(types.Buffer):
+    """
+    The type class for Index objects.
+    """
+
+    def __init__(self, dtype, layout, pyclass):
+        self.pyclass = pyclass
+        super(IndexType, self).__init__(dtype, 1, layout)
+
+    @property
+    def key(self):
+        return self.pyclass, self.dtype, self.layout
+
+    @property
+    def as_array(self):
+        return types.Array(self.dtype, 1, self.layout)
+
+    def copy(self, dtype=None, ndim=1, layout=None):
+        assert ndim == 1
+        if dtype is None:
+            dtype = self.dtype
+        layout = layout or self.layout
+        return type(self)(dtype, layout, self.pyclass)
+
+
+@typeof_impl.register(Index)
+def typeof_index(val, c):
+    dtype = numpy_support.from_dtype(val.dtype)
+    layout = numpy_support.map_layout(val)
+    return IndexType(dtype, layout, type(val))
+
+@type_callable('__array_wrap__')
+def type_array_wrap(context):
+    def typer(input_type, result):
+        if isinstance(input_type, IndexType):
+            return input_type.copy(dtype=result.dtype,
+                                   ndim=result.ndim,
+                                   layout=result.layout)
+
+    return typer
+
+
+# Backend extensions for Index
+
+@register_model(IndexType)
+class IndexModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('data', fe_type.as_array)]
+        models.StructModel.__init__(self, dmm, fe_type, members)
+
+make_attribute_wrapper(IndexType, 'data', '_data')
+
+def make_index(context, builder, typ, **kwargs):
+    return cgutils.create_struct_proxy(typ)(context, builder, **kwargs)
+
+@builtin
+@implement('__array__', IndexType)
+def index_as_array(context, builder, sig, args):
+    val = make_index(context, builder, sig.args[0], ref=args[0])
+    return val._get_ptr_by_name('data')
+
+@unbox(IndexType)
+def unbox_index(typ, obj, c):
+    """
+    Convert a Index object to a native index structure.
+    """
+    data = c.pyapi.object_getattr_string(obj, "_data")
+    index = make_index(c.context, c.builder, typ)
+    index.data = c.unbox(typ.as_array, data).value
+
+    return NativeValue(index._getvalue())
+
+@box(IndexType)
+def box_index(typ, val, c):
+    """
+    Convert a native index structure to a Index object.
+    """
+    # First build a Numpy array object, then wrap it in a Index
+    index = make_index(c.context, c.builder, typ, value=val)
+    classobj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.pyclass))
+    arrayobj = c.box(typ.as_array, index.data)
+    indexobj = c.pyapi.call_function_objargs(classobj, (arrayobj,))
+    return indexobj
+
+@overlay_attribute(IndexType, 'is_monotonic_increasing')
+def index_is_monotonic_increasing(typ):
+    def getter(index):
+        data = index._data
+        if len(data) == 0:
+            return True
+        u = data[0]
+        for v in data:
+            if v < u:
+                return False
+            v = u
+        return True
+
+    return getter
+
+
+def len_usecase(x):
+    return len(x)
+
+def print_usecase(x):
+    print(x)
+
+def getitem_usecase(x, key):
+    return x[key]
+
+def npyufunc_usecase(x):
+    return np.cos(np.sin(x))
+
+def get_data_usecase(x):
+    return x._data
+
+def is_monotonic_usecase(x):
+    return x.is_monotonic_increasing
+
+
+class TestLowLevelExtending(TestCase):
+    """
+    Test the low-level two-tier extension API.
+    """
+
+    # We check with both @jit and compile_isolated(), to exercise the
+    # registration logic.
+
+    def test_func1(self):
+        pyfunc = call_func1_nullary
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(), 42)
+        pyfunc = call_func1_unary
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(None), 42)
+        self.assertPreciseEqual(cfunc(18.0), 6.0)
+
+    def test_func1_isolated(self):
+        pyfunc = call_func1_nullary
+        cr = compile_isolated(pyfunc, ())
+        self.assertPreciseEqual(cr.entry_point(), 42)
+        pyfunc = call_func1_unary
+        cr = compile_isolated(pyfunc, (types.float64,))
+        self.assertPreciseEqual(cr.entry_point(18.0), 6.0)
+
+    def test_cast_mydummy(self):
+        pyfunc = get_dummy
+        cr = compile_isolated(pyfunc, (), types.float64)
+        self.assertPreciseEqual(cr.entry_point(), 42.0)
+
+
+class TestPandasLike(TestCase):
+    """
+    Test implementing a pandas-like Index object.
+    """
+
+    def test_index_len(self):
+        i = Index(np.arange(3))
+        cfunc = jit(nopython=True)(len_usecase)
+        self.assertPreciseEqual(cfunc(i), 3)
+
+    def test_index_getitem(self):
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(getitem_usecase)
+        self.assertPreciseEqual(cfunc(i, 1), 8)
+        ii = cfunc(i, slice(1, None))
+        self.assertIsInstance(ii, Index)
+        self.assertEqual(list(ii), [8, -5])
+
+    def test_index_ufunc(self):
+        """
+        Check Numpy ufunc on an Index object.
+        """
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(npyufunc_usecase)
+        ii = cfunc(i)
+        self.assertIsInstance(ii, Index)
+        self.assertPreciseEqual(ii._data, np.cos(np.sin(i._data)))
+
+    def test_get_data(self):
+        # The _data attribute is exposed with make_attribute_wrapper()
+        i = Index(np.int32([42, 8, -5]))
+        cfunc = jit(nopython=True)(get_data_usecase)
+        data = cfunc(i)
+        self.assertIs(data, i._data)
+
+    def test_is_monotonic(self):
+        # The is_monotonic_increasing attribute is exposed with
+        # overlay_attribute()
+        cfunc = jit(nopython=True)(is_monotonic_usecase)
+        for values, expected in [([8, 42, 5], False),
+                                 ([5, 8, 42], True),
+                                 ([], True)]:
+            i = Index(np.int32(values))
+            got = cfunc(i)
+            self.assertEqual(got, expected)
+
+
+class TestHighLevelExtending(TestCase):
+    """
+    Test the high-level combined API.
+    """
+
+    def test_where(self):
+        """
+        Test implementing a function with @overlay.
+        """
+        pyfunc = call_where
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(*args, **kwargs):
+            expected = np_where(*args, **kwargs)
+            got = cfunc(*args, **kwargs)
+            self.assertPreciseEqual
+
+        check(x=3, cond=True, y=8)
+        check(True, 3, 8)
+        check(np.bool_([True, False, True]), np.int32([1, 2, 3]),
+              np.int32([4, 5, 5]))
+
+        # The typing error is propagated
+        with self.assertRaises(errors.TypingError) as raises:
+            cfunc(np.bool_([]), np.int32([]), np.int64([]))
+        self.assertIn("x and y should have the same dtype",
+                      str(raises.exception))
+
+    def test_len(self):
+        """
+        Test re-implementing len() for a custom type with @overlay.
+        """
+        cfunc = jit(nopython=True)(len_usecase)
+        self.assertPreciseEqual(cfunc(MyDummy()), 13)
+        self.assertPreciseEqual(cfunc([4, 5]), 2)
+
+    def test_print(self):
+        """
+        Test re-implementing print() for a custom type with @overlay.
+        """
+        cfunc = jit(nopython=True)(print_usecase)
+        with captured_stdout():
+            cfunc(MyDummy())
+            self.assertEqual(sys.stdout.getvalue(), "hello!\n")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_func_lifetime.py
+++ b/numba/tests/test_func_lifetime.py
@@ -33,7 +33,8 @@ class TestFuncLifetime(TestCase):
         Get the single implementation (a C function object) of a dispatcher.
         """
         self.assertEqual(len(dispatcher.overloads), 1)
-        return list(dispatcher.overloads.values())[0]
+        cres = list(dispatcher.overloads.values())[0]
+        return cres.entry_point
 
     def check_local_func_lifetime(self, **jitargs):
         def f(x):

--- a/numba/tests/test_jitmethod.py
+++ b/numba/tests/test_jitmethod.py
@@ -1,9 +1,11 @@
 import numba.unittest_support as unittest
+
+import numpy as np
+
 from numba import config, jit, types
 from numba.compiler import compile_isolated
-from numba.decorators import DisableJitWrapper
+from numba.decorators import _DisableJitWrapper
 from numba.tests.support import override_config
-import numpy as np
 
 
 class TestJITMethod(unittest.TestCase):
@@ -51,7 +53,7 @@ class TestDisabledJIT(unittest.TestCase):
             def method(x):
                 return x
 
-        self.assertIsInstance(method, DisableJitWrapper)
+        self.assertIsInstance(method, _DisableJitWrapper)
         self.assertIsNotNone(method.py_func)
         self.assertEqual(10, method(10))
 
@@ -61,7 +63,7 @@ class TestDisabledJIT(unittest.TestCase):
             def method(x):
                 return x
 
-        self.assertIsInstance(method, DisableJitWrapper)
+        self.assertIsInstance(method, _DisableJitWrapper)
         self.assertIsNotNone(method.py_func)
         self.assertEqual(10, method(10))
 

--- a/numba/tests/test_jitmethod.py
+++ b/numba/tests/test_jitmethod.py
@@ -27,9 +27,9 @@ class TestJITMethod(unittest.TestCase):
             np.array([15, 15, 15, 15, 15], dtype=np.float32))
 
         # Check that loop lifting in nopython mode was successful
-        [cres] = something.method._compileinfos.values()
+        [cres] = something.method.overloads.values()
         jitloop = cres.lifted[0]
-        [loopcres] = jitloop._compileinfos.values()
+        [loopcres] = jitloop.overloads.values()
         self.assertTrue(loopcres.fndesc.native)
 
     def test_unbound_jit_method(self):

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -118,7 +118,7 @@ class TestLoopLifting(TestCase):
     def assert_lifted_native(self, cres):
         # Check if we have lifted in nopython mode
         jitloop = cres.lifted[0]
-        [loopcres] = jitloop._compileinfos.values()
+        [loopcres] = jitloop.overloads.values()
         self.assertTrue(loopcres.fndesc.native)  # Lifted function is native
 
     def check_lift_ok(self, pyfunc, argtypes, args):

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -18,7 +18,7 @@ class TestDispatcherPickling(TestCase):
             meth(proto, *args, **kwargs)
 
     def simulate_fresh_target(self):
-        dispatcher_cls = registry.target_registry['cpu']
+        dispatcher_cls = registry.dispatcher_registry['cpu']
         # Simulate fresh targetdescr
         dispatcher_cls.targetdescr = type(dispatcher_cls.targetdescr)()
 

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -34,6 +34,9 @@ def tuple_index(tup, idx):
 def len_usecase(tup):
     return len(tup)
 
+def add_usecase(a, b):
+    return a + b
+
 def eq_usecase(a, b):
     return a == b
 
@@ -165,6 +168,19 @@ class TestOperations(TestCase):
         cr = compile_isolated(pyfunc,
                               [types.Tuple(())])
         self.assertPreciseEqual(cr.entry_point(()), pyfunc(()))
+
+    def test_add(self):
+        pyfunc = add_usecase
+        samples = [(types.Tuple(()), ()),
+                   (types.UniTuple(types.int32, 0), ()),
+                   (types.UniTuple(types.int32, 1), (42,)),
+                   (types.Tuple((types.int64, types.float32)), (3, 4.5)),
+                   ]
+        for (ta, a), (tb, b) in itertools.product(samples, samples):
+            cr = compile_isolated(pyfunc, (ta, tb))
+            expected = pyfunc(a, b)
+            got = cr.entry_point(a, b)
+            self.assertPreciseEqual(got, expected, msg=(ta, tb))
 
     def _test_compare(self, pyfunc):
         def eq(pyfunc, cfunc, args):

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -203,7 +203,7 @@ class TestUnify(unittest.TestCase):
         self.assert_unify(aty, bty, types.Optional(i64))
         # Failure
         aty = types.Optional(i32)
-        bty = types.Optional(types.len_type)
+        bty = types.Optional(types.slice3_type)
         self.assert_unify_failure(aty, bty)
 
     def test_tuple(self):
@@ -238,12 +238,12 @@ class TestUnify(unittest.TestCase):
                           types.UniTuple(types.Tuple((i64, f32)), 2))
         # Failures
         aty = types.UniTuple(i32, 1)
-        bty = types.UniTuple(types.len_type, 1)
+        bty = types.UniTuple(types.slice3_type, 1)
         self.assert_unify_failure(aty, bty)
         aty = types.UniTuple(i32, 1)
         bty = types.UniTuple(i32, 2)
         self.assert_unify_failure(aty, bty)
-        aty = types.Tuple((i8, types.len_type))
+        aty = types.Tuple((i8, types.slice3_type))
         bty = types.Tuple((i32, i8))
         self.assert_unify_failure(aty, bty)
 

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -111,9 +111,9 @@ class TestTypes(TestCase):
         a = types.Dispatcher(d)
         b = types.Dispatcher(d)
         c = types.Dispatcher(e)
-        self.assertIs(a.overloaded, d)
-        self.assertIs(b.overloaded, d)
-        self.assertIs(c.overloaded, e)
+        self.assertIs(a.dispatcher, d)
+        self.assertIs(b.dispatcher, d)
+        self.assertIs(c.dispatcher, e)
         # Equality of alive references
         self.assertTrue(a == b)
         self.assertFalse(a != b)
@@ -136,11 +136,11 @@ class TestTypes(TestCase):
         d = e = None
         gc.collect()
         with self.assertRaises(ReferenceError):
-            a.overloaded
+            a.dispatcher
         with self.assertRaises(ReferenceError):
-            b.overloaded
+            b.dispatcher
         with self.assertRaises(ReferenceError):
-            c.overloaded
+            c.dispatcher
         # Dead references are always unequal
         self.assertFalse(a == b)
         self.assertFalse(a == c)

--- a/numba/tests/test_wrapper.py
+++ b/numba/tests/test_wrapper.py
@@ -25,7 +25,7 @@ class TestWrapper(unittest.TestCase):
         """
         cr = compiler.compile_isolated(overhead, [types.int32])
         cfunc = cr.entry_point
-        disp = registry.CPUOverloaded(overhead)
+        disp = registry.CPUDispatcher(overhead)
         disp.add_overload(cr)
 
         x = 321
@@ -51,7 +51,7 @@ class TestWrapper(unittest.TestCase):
         """
         cr = compiler.compile_isolated(array_overhead, [types.int32[::1]])
         cfunc = cr.entry_point
-        disp = registry.CPUOverloaded(array_overhead)
+        disp = registry.CPUDispatcher(array_overhead)
         disp.add_overload(cr)
 
         self.assertEqual(cr.signature.args[0].layout, 'C')
@@ -80,7 +80,7 @@ class TestWrapper(unittest.TestCase):
         """
         cr = compiler.compile_isolated(add, [types.int32])
         cfunc = cr.entry_point
-        disp = registry.CPUOverloaded(add)
+        disp = registry.CPUDispatcher(add)
         disp.add_overload(cr)
 
         x = 321

--- a/numba/types.py
+++ b/numba/types.py
@@ -415,24 +415,24 @@ class Dispatcher(WeakType, Callable, Dummy):
     Type class for @jit-compiled functions.
     """
 
-    def __init__(self, overloaded):
-        self._store_object(overloaded)
-        super(Dispatcher, self).__init__("Dispatcher(%s)" % overloaded)
+    def __init__(self, dispatcher):
+        self._store_object(dispatcher)
+        super(Dispatcher, self).__init__("Dispatcher(%s)" % dispatcher)
 
     def get_call_type(self, context, args, kws):
-        template, args, kws = self.overloaded.get_call_template(args, kws)
+        template, args, kws = self.dispatcher.get_call_template(args, kws)
         sig = template(context).apply(args, kws)
         sig.pysig = self.pysig
         return sig
 
     def get_call_signatures(self):
-        sigs = self.overloaded.nopython_signatures
+        sigs = self.dispatcher.nopython_signatures
         return sigs, True
 
     @property
-    def overloaded(self):
+    def dispatcher(self):
         """
-        A strong reference to the underlying Dispatcher instance.
+        A strong reference to the underlying numba.dispatcher.Dispatcher instance.
         """
         return self._get_object()
 
@@ -441,13 +441,13 @@ class Dispatcher(WeakType, Callable, Dummy):
         """
         A inspect.Signature object corresponding to this type.
         """
-        return self.overloaded._pysig
+        return self.dispatcher._pysig
 
     def get_overload(self, sig):
         """
         Get the compiled overload for the given signature.
         """
-        return self.overloaded.get_overload(sig.args)
+        return self.dispatcher.get_overload(sig.args)
 
     def get_impl_key(self, sig):
         """

--- a/numba/types.py
+++ b/numba/types.py
@@ -212,21 +212,106 @@ class Macro(Type):
 
 
 class Function(Callable, Opaque):
+    """
+    Base type class for some function types.
+    """
+
     def __init__(self, template):
-        self.template = template
-        name = "%s(%s)" % (self.__class__.__name__, template.key)
+        if isinstance(template, (list, tuple)):
+            self.templates = tuple(template)
+            keys = set(temp.key for temp in self.templates)
+            if len(keys) != 1:
+                raise ValueError("incompatible templates: keys = %s"
+                                 % (this,))
+            self.typing_key, = keys
+        else:
+            self.templates = (template,)
+            self.typing_key = template.key
+        self._impl_keys = {}
+        name = "%s(%s)" % (self.__class__.__name__, self.typing_key)
         super(Function, self).__init__(name)
 
     @property
     def key(self):
-        return self.template
+        return self.typing_key, self.templates
+
+    def augment(self, other):
+        """
+        Augment this function type with the other function types' templates,
+        so as to support more input types.
+        """
+        if type(other) is type(self) and other.typing_key == self.typing_key:
+            return type(self)(self.templates + other.templates)
+
+    def get_impl_key(self, sig):
+        """
+        Get the implementation key (used by the target context) for the
+        given signature.
+        """
+        return self._impl_keys[sig.args]
+
+    def get_call_type(self, context, args, kws):
+        for temp_cls in self.templates:
+            temp = temp_cls(context)
+            sig = temp.apply(args, kws)
+            if sig is not None:
+                self._impl_keys[sig.args] = temp.get_impl_key(sig)
+                return sig
+
+    def get_call_signatures(self):
+        sigs = []
+        is_param = False
+        for temp in self.templates:
+            sigs += getattr(temp, 'cases', [])
+            is_param = is_param or hasattr(temp, 'generic')
+        return sigs, is_param
+
+
+class BoundFunction(Callable, Opaque):
+    """
+    A function with an implicit first argument (denoted as *this* below).
+    """
+
+    def __init__(self, template, this):
+        # Create a derived template with an attribute *this*
+        newcls = type(template.__name__ + '.' + str(this), (template,),
+                      dict(this=this))
+        self.template = newcls
+        self.typing_key = self.template.key
+        self.this = this
+        name = "%s(%s for %s)" % (self.__class__.__name__,
+                                  self.typing_key, self.this)
+        super(BoundFunction, self).__init__(name)
+
+    def unify(self, typingctx, other):
+        if (isinstance(other, BoundFunction) and
+            self.typing_key == other.typing_key):
+            this = typingctx.unify_pairs(self.this, other.this)
+            if this != pyobject:
+                # XXX is it right that both template instances are distinct?
+                return self.copy(this=this)
+
+    def copy(self, this):
+        return type(self)(self.template, this)
+
+    @property
+    def key(self):
+        return self.typing_key, self.this
+
+    def get_impl_key(self, sig):
+        """
+        Get the implementation key (used by the target context) for the
+        given signature.
+        """
+        return self.typing_key
 
     def get_call_type(self, context, args, kws):
         return self.template(context).apply(args, kws)
 
     def get_call_signatures(self):
         sigs = getattr(self.template, 'cases', [])
-        return sigs, hasattr(self.template, 'generic')
+        is_param = hasattr(self.template, 'generic')
+        return sigs, is_param
 
 
 class NamedTupleClass(Callable, Opaque):
@@ -326,6 +411,9 @@ class WeakType(Type):
 
 
 class Dispatcher(WeakType, Callable, Dummy):
+    """
+    Type class for @jit-compiled functions.
+    """
 
     def __init__(self, overloaded):
         self._store_object(overloaded)
@@ -354,6 +442,18 @@ class Dispatcher(WeakType, Callable, Dummy):
         A inspect.Signature object corresponding to this type.
         """
         return self.overloaded._pysig
+
+    def get_overload(self, sig):
+        """
+        Get the compiled overload for the given signature.
+        """
+        return self.overloaded.get_overload(sig.args)
+
+    def get_impl_key(self, sig):
+        """
+        Get the implementation key for the given signature.
+        """
+        return self.get_overload(sig)
 
 
 class ExternalFunctionPointer(Function):
@@ -397,7 +497,7 @@ class ExternalFunctionPointer(Function):
 
 class ExternalFunction(Function):
     """
-    A named native function (resolvable by LLVM).
+    A named native function (resolvable by LLVM) accepting an explicit signature.
     For internal use only.
     """
 
@@ -431,27 +531,6 @@ class NumbaFunction(Function):
     @property
     def key(self):
         return self.fndesc.unique_name, self.sig
-
-
-class BoundFunction(Function):
-    def __init__(self, template, this):
-        self.this = this
-        # Create a derived template with an attribute *this*
-        newcls = type(template.__name__ + '.' + str(this), (template,),
-                      dict(this=this))
-        super(BoundFunction, self).__init__(newcls)
-
-    def unify(self, typingctx, other):
-        if (isinstance(other, BoundFunction) and
-            self.template.key == other.template.key):
-            this = typingctx.unify_pairs(self.this, other.this)
-            if this != pyobject:
-                # XXX is it right that both template instances are distinct?
-                return BoundFunction(self.template, this)
-
-    @property
-    def key(self):
-        return self.template.key, self.this
 
 
 class Pair(Type):
@@ -715,7 +794,7 @@ class ArrayIterator(SimpleIteratorType):
         super(ArrayIterator, self).__init__(name, yield_type)
 
 
-class Buffer(IterableType):
+class Buffer(IterableType, ArrayCompatible):
     """
     Type class for objects providing the buffer protocol.
     Derived classes exist for more specific cases.
@@ -747,6 +826,10 @@ class Buffer(IterableType):
     @property
     def iterator_type(self):
         return ArrayIterator(self)
+
+    @property
+    def as_array(self):
+        return self
 
     def copy(self, dtype=None, ndim=None, layout=None):
         if dtype is None:
@@ -1545,15 +1628,6 @@ float64 = Float('float64')
 
 complex64 = Complex('complex64', float32)
 complex128 = Complex('complex128', float64)
-
-len_type = Phantom('len')
-range_type = Phantom('range')
-slice_type = Phantom('slice')
-abs_type = Phantom('abs')
-neg_type = Phantom('neg')
-print_type = Phantom('print')
-print_item_type = Phantom('print-item')
-sign_type = Phantom('sign')
 
 range_iter32_type = RangeIteratorType(int32)
 range_iter64_type = RangeIteratorType(int64)

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -21,13 +21,16 @@ class InSequence(AbstractTemplate):
 
 @builtin
 class SequenceLen(AbstractTemplate):
-    key = types.len_type
+    key = len
 
     def generic(self, args, kws):
         assert not kws
         (val,) = args
         if isinstance(val, (types.Sequence)):
             return signature(types.intp, val)
+
+builtin_global(len, types.Function(SequenceLen))
+
 
 @builtin
 class SequenceBool(AbstractTemplate):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -46,15 +46,28 @@ class BaseContext(object):
     """
 
     def __init__(self):
-        self.functions = defaultdict(list)
-        self.attributes = {}
+        # A list of installed registries
+        self._registries = {}
+        # Typing declarations extracted from the registries or other sources
+        self._functions = defaultdict(list)
+        self._attributes = defaultdict(list)
         self._globals = utils.UniqueDict()
         self.tm = rules.default_type_manager
-        self._load_builtins()
+        # Initialize
         self.init()
 
     def init(self):
-        pass
+        """
+        Initialize the typing context.  Can be overriden by subclasses.
+        """
+
+    def refresh(self):
+        """
+        Refresh context with new declarations from known registries.
+        Useful for third-party extensions.
+        """
+        self._load_builtins()
+        self.load_additional_registries()
 
     def explain_function_type(self, func):
         """
@@ -67,8 +80,8 @@ class BaseContext(object):
             sigs, param = func.get_call_signatures()
             defns.extend(sigs)
 
-        elif func in self.functions:
-            for tpl in self.functions[func]:
+        elif func in self._functions:
+            for tpl in self._functions[func]:
                 param = param or hasattr(tpl, 'generic')
                 defns.extend(getattr(tpl, 'cases', []))
 
@@ -92,7 +105,7 @@ class BaseContext(object):
         Resolve function type *func* for argument types *args* and *kws*.
         A signature is returned.
         """
-        defns = self.functions[func]
+        defns = self._functions[func]
         for defn in defns:
             res = defn.apply(args, kws)
             if res is not None:
@@ -100,11 +113,8 @@ class BaseContext(object):
 
         if isinstance(func, types.Type):
             # If it's a type, it may support a __call__ method
-            try:
-                func_type = self.resolve_getattr(func, "__call__")
-            except KeyError:
-                pass
-            else:
+            func_type = self.resolve_getattr(func, "__call__")
+            if func_type is not None:
                 # The function has a __call__ method, type its call.
                 return self.resolve_function_type(func_type, args, kws)
 
@@ -112,43 +122,46 @@ class BaseContext(object):
             # XXX fold this into the __call__ attribute logic?
             return func.get_call_type(self, args, kws)
 
-    def resolve_getattr(self, value, attr):
-        try:
-            attrinfo = self.attributes[value]
-        except KeyError:
-            for cls in type(value).__mro__:
-                if cls in self.attributes:
-                    attrinfo = self.attributes[cls]
-                    break
-            else:
-                if isinstance(value, types.Module):
-                    attrty = self.resolve_module_constants(value, attr)
-                    if attrty is not None:
-                        return attrty
-                raise
+    def _get_attribute_templates(self, typ):
+        """
+        Get matching AttributeTemplates for the Numba type.
+        """
+        if typ in self._attributes:
+            for attrinfo in self._attributes[typ]:
+                yield attrinfo
+        else:
+            for cls in type(typ).__mro__:
+                if cls in self._attributes:
+                    for attrinfo in self._attributes[cls]:
+                        yield attrinfo
 
-        ret = attrinfo.resolve(value, attr)
-        if ret is None:
-            raise KeyError(attr)
-        return ret
+    def resolve_getattr(self, typ, attr):
+        """
+        Resolve getting the attribute *attr* (a string) on the Numba type.
+        The attribute's type is returned, or None if resolution failed.
+        """
+        for attrinfo in self._get_attribute_templates(typ):
+            ret = attrinfo.resolve(typ, attr)
+            if ret is not None:
+                return ret
+
+        if isinstance(typ, types.Module):
+            attrty = self.resolve_module_constants(typ, attr)
+            if attrty is not None:
+                return attrty
 
     def resolve_setattr(self, target, attr, value):
-        if isinstance(target, types.Record):
-            expectedty = target.typeof(attr)
-            if self.can_convert(value, expectedty) is not None:
-                return templates.signature(types.void, target, value)
-        elif target in self.attributes:
-            expectedty = self.attributes[target].resolve(target, attr)
-            return templates.signature(types.void, target, expectedty)
-        else:
-            for cls in type(target).__mro__:
-                if cls in self.attributes:
-                    try:
-                        expectedty = self.attributes[cls].resolve(target, attr)
-                    except errors.UntypedAttributeError:
-                        pass
-                    else:
-                        return templates.signature(types.void, target, expectedty)
+        """
+        Resolve setting the attribute *attr* (a string) on the *target* type
+        to the given *value* type.
+        A function signature is returned, or None if resolution failed.
+        """
+        for attrinfo in self._get_attribute_templates(target):
+            expectedty = attrinfo.resolve(target, attr)
+            # NOTE: convertibility from *value* to *expectedty* is left to
+            # the caller.
+            if expectedty is not None:
+                return templates.signature(types.void, target, expectedty)
 
     def resolve_static_getitem(self, value, index):
         assert not isinstance(index, types.Type), index
@@ -229,15 +242,40 @@ class BaseContext(object):
                 raise
 
     def _load_builtins(self):
-        self.install(templates.builtin_registry)
+        self.install_registry(templates.builtin_registry)
 
-    def install(self, registry):
-        for ftcls in registry.functions:
+    def load_additional_registries(self):
+        """
+        Load target-specific registries.  Can be overriden by subclasses.
+        """
+
+    def install_registry(self, registry):
+        """
+        Install a *registry* (a templates.Registry instance) of function,
+        attribute and global declarations.
+        """
+        try:
+            loader = self._registries[registry]
+        except KeyError:
+            loader = templates.RegistryLoader(registry)
+            self._registries[registry] = loader
+        for ftcls in loader.new_functions():
             self.insert_function(ftcls(self))
-        for ftcls in registry.attributes:
+        for ftcls in loader.new_attributes():
             self.insert_attributes(ftcls(self))
-        for gv, gty in registry.globals:
-            self.insert_global(gv, gty)
+        for gv, gty in loader.new_globals():
+            try:
+                existing = self._lookup_global(gv)
+            except KeyError:
+                self.insert_global(gv, gty)
+            else:
+                # A type was already inserted, see if we can add to it
+                newty = existing.augment(gty)
+                if newty is None:
+                    raise TypeError("cannot augment %s with %s"
+                                    % (existing, gty))
+                self._remove_global(gv)
+                self._insert_global(gv, newty)
 
     def _lookup_global(self, gv):
         """
@@ -264,17 +302,26 @@ class BaseContext(object):
             pass
         self._globals[gv] = gty
 
+    def _remove_global(self, gv):
+        """
+        Remove the registered type for global value *gv*.
+        """
+        try:
+            gv = weakref.ref(gv)
+        except TypeError:
+            pass
+        del self._globals[gv]
+
     def insert_global(self, gv, gty):
         self._insert_global(gv, gty)
 
     def insert_attributes(self, at):
         key = at.key
-        assert key not in self.attributes, "Duplicated attributes template %r" % (key,)
-        self.attributes[key] = at
+        self._attributes[key].append(at)
 
     def insert_function(self, ft):
         key = ft.key
-        self.functions[key].append(ft)
+        self._functions[key].append(ft)
 
     def insert_overloaded(self, overloaded):
         self._insert_global(overloaded, types.Dispatcher(overloaded))
@@ -457,11 +504,12 @@ class BaseContext(object):
 
 
 class Context(BaseContext):
-    def init(self):
-        self.install(cmathdecl.registry)
-        self.install(listdecl.registry)
-        self.install(mathdecl.registry)
-        self.install(npydecl.registry)
-        self.install(operatordecl.registry)
-        self.install(randomdecl.registry)
-        self.install(cffi_utils.registry)
+
+    def load_additional_registries(self):
+        self.install_registry(cmathdecl.registry)
+        self.install_registry(listdecl.registry)
+        self.install_registry(mathdecl.registry)
+        self.install_registry(npydecl.registry)
+        self.install_registry(operatordecl.registry)
+        self.install_registry(randomdecl.registry)
+        self.install_registry(cffi_utils.registry)

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -323,9 +323,6 @@ class BaseContext(object):
         key = ft.key
         self._functions[key].append(ft)
 
-    def insert_overloaded(self, overloaded):
-        self._insert_global(overloaded, types.Dispatcher(overloaded))
-
     def insert_user_function(self, fn, ft):
         """Insert a user function.
 

--- a/numba/typing/npdatetime.py
+++ b/numba/typing/npdatetime.py
@@ -170,7 +170,9 @@ class TimedeltaCmpGE(TimedeltaOrderedCmpOp):
 
 @builtin
 class TimedeltaAbs(TimedeltaUnaryOp):
-    key = types.abs_type
+    key = abs
+
+builtin_global(abs, types.Function(TimedeltaAbs))
 
 
 # datetime64 operations

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -287,6 +287,25 @@ def bit_length(intval):
         return len(bin(-intval - 1)) - 2
 
 
+def stream_list(lst):
+    """
+    Given a list, return an infinite iterator of iterators.
+    Each iterator iterates over the list from the last seen point up to
+    the current end-of-list.
+
+    In effect, each iterator will give the newly appended elements from the
+    previous iterator instantiation time.
+    """
+    def sublist_iterator(start, stop):
+        return iter(lst[start:stop])
+
+    start = 0
+    while True:
+        stop = len(lst)
+        yield sublist_iterator(start, stop)
+        start = stop
+
+
 class BenchmarkResult(object):
     def __init__(self, func, records, loop):
         self.func = func


### PR DESCRIPTION
Based on PR #1578.
* make available a subset of the low-level registrations we use internally
* also simpler APIs `type_callable`, `overload`, `overload_attribute`, `make_attribute_wrapper` (some of them proposed in NBEP 2)
* add facilities to allow extending Numba with a small subset of Pandas(-like) functionality

Things I've left for a next step:
* handle a Series-like object
* add simple API to implement a method
* add / enhance API for setting an attribute
* allow typing a global using `@builtin` without having to call `builtin_global()`?
* disambiguate `@builtin`, `@builtin_attr` from typing and targets subpackages?
