### PR TITLE
Improve typing of array indexing

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -722,13 +722,6 @@ def guard_null(context, builder, value, exc_tuple):
         exc_args = exc_tuple[1:] or None
         context.call_conv.return_user_exc(builder, exc, exc_args)
 
-def guard_invalid_slice(context, builder, slicestruct):
-    """
-    Guard against *slicestruct* having a zero step (and raise ValueError).
-    """
-    guard_null(context, builder, slicestruct.step,
-               (ValueError, "slice step cannot be zero"))
-
 def guard_memory_error(context, builder, pointer, msg=None):
     """
     Guard against *pointer* being NULL (and raise a MemoryError).

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -840,13 +840,14 @@ class UniTupleIter(StructModel):
         super(UniTupleIter, self).__init__(dmm, fe_type, members)
 
 
-@register_default(types.Slice3Type)
-class Slice3(StructModel):
+@register_default(types.SliceType)
+class SliceModel(StructModel):
     def __init__(self, dmm, fe_type):
         members = [('start', types.intp),
                    ('stop', types.intp),
-                   ('step', types.intp)]
-        super(Slice3, self).__init__(dmm, fe_type, members)
+                   ('step', types.intp),
+                   ]
+        super(SliceModel, self).__init__(dmm, fe_type, members)
 
 
 @register_default(types.NPDatetime)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -300,9 +300,9 @@ def basic_indexing(context, builder, aryty, ary, index_types, indices):
                 ax += 1
             continue
         # Regular index value
-        if idxty == types.slice3_type:
-            slice = slicing.Slice(context, builder, value=indexval)
-            cgutils.guard_invalid_slice(context, builder, slice)
+        if isinstance(idxty, types.SliceType):
+            slice = slicing.make_slice(context, builder, idxty, value=indexval)
+            slicing.guard_invalid_slice(context, builder, idxty, slice)
             slicing.fix_slice(builder, slice, shapes[ax])
             output_indices.append(slice.start)
             sh = slicing.get_slice_length(builder, slice)
@@ -389,7 +389,7 @@ def getitem_arraynd_intp(context, builder, sig, args):
 
 
 @builtin
-@implement('getitem', types.Buffer, types.slice3_type)
+@implement('getitem', types.Buffer, types.SliceType)
 def getitem_array1d_slice(context, builder, sig, args):
     aryty, idxty = sig.args
     ary, idx = args
@@ -737,12 +737,13 @@ class SliceIndexer(Indexer):
     Compute indices along a slice.
     """
 
-    def __init__(self, context, builder, aryty, ary, dim, slice):
+    def __init__(self, context, builder, aryty, ary, dim, idxty, slice):
         self.context = context
         self.builder = builder
         self.aryty = aryty
         self.ary = ary
         self.dim = dim
+        self.idxty = idxty
         self.slice = slice
         self.ll_intp = self.context.get_value_type(types.intp)
         self.zero = Constant.int(self.ll_intp, 0)
@@ -752,7 +753,8 @@ class SliceIndexer(Indexer):
         builder = self.builder
         # Fix slice for the dimension's size
         self.dim_size = builder.extract_value(self.ary.shape, self.dim)
-        cgutils.guard_invalid_slice(self.context, builder, self.slice)
+        slicing.guard_invalid_slice(self.context, builder, self.idxty,
+                                    self.slice)
         slicing.fix_slice(builder, self.slice, self.dim_size)
         self.is_step_negative = cgutils.is_neg_int(builder, self.slice.step)
         # Create loop entities
@@ -821,9 +823,10 @@ class FancyIndexer(object):
                 continue
 
             # Regular index value
-            if idxty == types.slice3_type:
-                slice = slicing.Slice(context, builder, value=indexval)
-                indexer = SliceIndexer(context, builder, aryty, ary, ax, slice)
+            if isinstance(idxty, types.SliceType):
+                slice = slicing.make_slice(context, builder, idxty, indexval)
+                indexer = SliceIndexer(context, builder, aryty, ary, ax,
+                                       idxty, slice)
                 indexers.append(indexer)
             elif isinstance(idxty, types.Integer):
                 ind = fix_integer_index(context, builder, idxty, indexval,

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -33,31 +33,6 @@ GENERIC_POINTER = Type.pointer(Type.int(8))
 PYOBJECT = GENERIC_POINTER
 void_ptr = GENERIC_POINTER
 
-LTYPEMAP = {
-    types.pyobject: PYOBJECT,
-
-    types.boolean: Type.int(8),
-
-    types.uint8: Type.int(8),
-    types.uint16: Type.int(16),
-    types.uint32: Type.int(32),
-    types.uint64: Type.int(64),
-
-    types.int8: Type.int(8),
-    types.int16: Type.int(16),
-    types.int32: Type.int(32),
-    types.int64: Type.int(64),
-
-    types.float32: Type.float(),
-    types.float64: Type.double(),
-}
-
-STRUCT_TYPES = {
-    types.complex64: builtins.Complex64,
-    types.complex128: builtins.Complex128,
-    types.slice3_type: slicing.Slice,
-}
-
 
 class Overloads(object):
     def __init__(self):

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -273,7 +273,7 @@ def unbox_optional(typ, obj, c):
                        cleanup=cleanup)
 
 
-@unbox(types.Slice3Type)
+@unbox(types.SliceType)
 def unbox_slice(typ, obj, c):
     """
     Convert object *obj* to a native slice structure.
@@ -281,11 +281,11 @@ def unbox_slice(typ, obj, c):
     from . import slicing
     ok, start, stop, step = \
         c.pyapi.slice_as_ints(obj, slicing.get_defaults(c.context))
-    slice3 = slicing.Slice(c.context, c.builder)
-    slice3.start = start
-    slice3.stop = stop
-    slice3.step = step
-    return NativeValue(slice3._getvalue(), is_error=c.builder.not_(ok))
+    sli = slicing.make_slice(c.context, c.builder, typ)
+    sli.start = start
+    sli.stop = stop
+    sli.step = step
+    return NativeValue(sli._getvalue(), is_error=c.builder.not_(ok))
 
 
 #

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -453,11 +453,11 @@ def setitem_list(context, builder, sig, args):
 
 
 @builtin
-@implement('getitem', types.List, types.slice3_type)
+@implement('getitem', types.List, types.SliceType)
 def getslice_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
-    slice = slicing.Slice(context, builder, value=args[1])
-    cgutils.guard_invalid_slice(context, builder, slice)
+    slice = slicing.make_slice(context, builder, sig.args[1], args[1])
+    slicing.guard_invalid_slice(context, builder, sig.args[1], slice)
     inst.fix_slice(slice)
 
     # Allocate result and populate it
@@ -477,13 +477,13 @@ def getslice_list(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, result.value)
 
 @builtin
-@implement('setitem', types.List, types.slice3_type, types.Any)
+@implement('setitem', types.List, types.SliceType, types.Any)
 def setitem_list(context, builder, sig, args):
     dest = ListInstance(context, builder, sig.args[0], args[0])
-    slice = slicing.Slice(context, builder, value=args[1])
     src = ListInstance(context, builder, sig.args[2], args[2])
 
-    cgutils.guard_invalid_slice(context, builder, slice)
+    slice = slicing.make_slice(context, builder, sig.args[1], args[1])
+    slicing.guard_invalid_slice(context, builder, sig.args[1], slice)
     dest.fix_slice(slice)
 
     src_size = src.size
@@ -538,12 +538,12 @@ def setitem_list(context, builder, sig, args):
 
 
 @builtin
-@implement('delitem', types.List, types.slice3_type)
+@implement('delitem', types.List, types.SliceType)
 def setitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
-    slice = slicing.Slice(context, builder, value=args[1])
+    slice = slicing.make_slice(context, builder, sig.args[1], args[1])
 
-    cgutils.guard_invalid_slice(context, builder, slice)
+    slicing.guard_invalid_slice(context, builder, sig.args[1], slice)
     inst.fix_slice(slice)
 
     slice_len = slicing.get_slice_length(builder, slice)

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -864,5 +864,86 @@ class TestSetItem(TestCase):
                       str(raises.exception))
 
 
+class TestTyping(TestCase):
+    """
+    Check typing of basic indexing operations
+    """
+
+    def test_layout(self):
+        """
+        Check an appropriate layout is inferred for the result of array
+        indexing.
+        """
+        from numba.typing import arraydecl
+        from numba.types import intp, ellipsis, slice2_type, slice3_type
+
+        func = arraydecl.get_array_index_type
+
+        cty = types.Array(types.float64, 3, 'C')
+        fty = types.Array(types.float64, 3, 'F')
+        aty = types.Array(types.float64, 3, 'A')
+
+        indices = [
+            # Tuples of (indexing arguments, keeps "C" layout, keeps "F" layout)
+            ((), True, True),
+            ((ellipsis,), True, True),
+
+            # Indexing from the left => can sometimes keep "C" layout
+            ((intp,), True, False),
+            ((slice2_type,), True, False),
+            ((intp, slice2_type), True, False),
+            ((slice2_type, intp), False, False),
+            ((slice2_type, slice2_type), False, False),
+            # Strided slices = > "A" layout
+            ((intp, slice3_type), False, False),
+            ((slice3_type,), False, False),
+
+            # Indexing from the right => can sometimes keep "F" layout
+            ((ellipsis, intp,), False, True),
+            ((ellipsis, slice2_type,), False, True),
+            ((ellipsis, intp, slice2_type,), False, False),
+            ((ellipsis, slice2_type, intp,), False, True),
+            ((ellipsis, slice2_type, slice2_type,), False, False),
+            # Strided slices = > "A" layout
+            ((ellipsis, slice3_type,), False, False),
+            ((ellipsis, slice3_type, intp,), False, False),
+
+            # Indexing from both sides => only if all dimensions are indexed
+            ((intp, ellipsis, intp,), False, False),
+            ((slice2_type, ellipsis, slice2_type,), False, False),
+            ((intp, intp, slice2_type,), True, False),
+            ((intp, ellipsis, intp, slice2_type,), True, False),
+            ((slice2_type, intp, intp,), False, True),
+            ((slice2_type, intp, ellipsis, intp,), False, True),
+            ((intp, slice2_type, intp,), False, False),
+            # Strided slices = > "A" layout
+            ((slice3_type, intp, intp,), False, False),
+            ((intp, intp, slice3_type,), False, False),
+            ]
+
+        for index_tuple, keep_c, _ in indices:
+            index = types.Tuple(index_tuple)
+            r = func(cty, index)
+            self.assertEqual(tuple(r.index), index_tuple)
+            self.assertEqual(r.result.layout, 'C' if keep_c else 'A',
+                             index_tuple)
+            self.assertFalse(r.advanced)
+
+        for index_tuple, _, keep_f in indices:
+            index = types.Tuple(index_tuple)
+            r = func(fty, index)
+            self.assertEqual(tuple(r.index), index_tuple)
+            self.assertEqual(r.result.layout, 'F' if keep_f else 'A',
+                             index_tuple)
+            self.assertFalse(r.advanced)
+
+        for index_tuple, _, _ in indices:
+            index = types.Tuple(index_tuple)
+            r = func(aty, index)
+            self.assertEqual(tuple(r.index), index_tuple)
+            self.assertEqual(r.result.layout, 'A')
+            self.assertFalse(r.advanced)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -11,10 +11,17 @@ from .support import TestCase
 def slice_passing(sl):
     return sl.start, sl.stop, sl.step
 
+def slice_constructor(*args):
+    sl = slice(*args)
+    return sl.start, sl.stop, sl.step
+
 
 class TestSlices(TestCase):
 
     def test_slice_passing(self):
+        """
+        Check passing a slice object to a Numba function.
+        """
         # NOTE this also checks slice attributes
         def check(a, b, c, d, e, f):
             sl = slice(a, b, c)
@@ -34,6 +41,25 @@ class TestSlices(TestCase):
         # Some member is neither integer nor None
         with self.assertRaises(TypeError):
             cfunc(slice(1.5, 1, 1))
+
+    def test_slice_constructor(self):
+        """
+        Test the slice() constructor in nopython mode.
+        """
+        maxint = sys.maxsize
+        cfunc = jit(nopython=True)(slice_constructor)
+        for args, expected in [((), (0, maxint, 1)),
+                               ((None, None), (0, maxint, 1)),
+                               ((1, None), (1, maxint, 1)),
+                               ((None, 2), (0, 2, 1)),
+                               ((1, 2), (1, 2, 1)),
+                               ((None, None, 3), (0, maxint, 3)),
+                               ((None, 2, 3), (0, 2, 3)),
+                               ((1, None, 3), (1, maxint, 3)),
+                               ((1, 2, 3), (1, 2, 3)),
+                               ]:
+            got = cfunc(*args)
+            self.assertPreciseEqual(got, expected)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -164,6 +164,14 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         ty = typeof("abc")
         self.assertEqual(ty, types.string)
 
+    def test_slices(self):
+        for args in [(1,), (1, 2), (1, 2, 1), (1, 2, None)]:
+            v = slice(*args)
+            self.assertIs(typeof(v), types.slice2_type)
+        for args in [(1, 2, 2), (1, 2, -1), (None, None, -2)]:
+            v = slice(*args)
+            self.assertIs(typeof(v), types.slice3_type)
+
     def test_tuples(self):
         v = (1, 2)
         self.assertEqual(typeof(v), types.UniTuple(types.intp, 2))

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -759,7 +759,8 @@ class TypeInferer(object):
         self.add_type(target.name, types.none)
 
     def sentry_modified_builtin(self, inst, gvar):
-        """Ensure that builtins are modified.
+        """
+        Ensure that builtins are not modified.
         """
         if (gvar.name in ('range', 'xrange') and
                     gvar.value not in utils.RANGE_ITER_OBJECTS):

--- a/numba/types.py
+++ b/numba/types.py
@@ -1396,8 +1396,17 @@ class ExceptionInstance(Phantom):
         return self.exc_class
 
 
-class Slice3Type(Type):
-    pass
+class SliceType(Type):
+
+    def __init__(self, name, members):
+        assert members in (2, 3)
+        self.members = members
+        self.has_step = members >= 3
+        super(SliceType, self).__init__(name, param=True)
+
+    @property
+    def key(self):
+        return self.members
 
 
 # Short names
@@ -1453,8 +1462,8 @@ range_state32_type = RangeType(int32)
 range_state64_type = RangeType(int64)
 unsigned_range_state64_type = RangeType(uint64)
 
-# slice2_type = Type('slice2_type')
-slice3_type = Slice3Type('slice3_type')
+slice2_type = SliceType('slice<a:b>', 2)
+slice3_type = SliceType('slice<a:b:c>', 3)
 
 signed_domain = frozenset([int8, int16, int32, int64])
 unsigned_domain = frozenset([uint8, uint16, uint32, uint64])

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -96,15 +96,17 @@ def get_array_index_type(ary, idx):
         layout = ary.layout
 
         def keeps_contiguity(ty, is_innermost):
-            """
-            Whether indexing with the given type keeps an array contiguous.
-            """
-            # Slicing can only keep an array contiguous if the innermost index
+            # A slice can only keep an array contiguous if it is the
+            # innermost index and it is not strided
             return (ty is types.ellipsis or isinstance(ty, types.Integer)
                     or (is_innermost and isinstance(ty, types.SliceType)
                         and not ty.has_step))
 
         def check_contiguity(outer_indices):
+            """
+            Whether indexing with the given indices (from outer to inner in
+            physical layout order) can keep an array contiguous.
+            """
             for ty in outer_indices[:-1]:
                 if not keeps_contiguity(ty, False):
                     return False

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -38,7 +38,7 @@ def get_array_index_type(ary, idx):
                 raise TypeError("only one ellipsis allowed in array index "
                                 "(got %s)" % (idx,))
             ellipsis_met = True
-        elif ty is types.slice3_type:
+        elif isinstance(ty, types.SliceType):
             pass
         elif isinstance(ty, types.Integer):
             # Normalize integer index

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -66,6 +66,10 @@ def get_array_index_type(ary, idx):
 
     # Check indices and result dimensionality
     all_indices = left_indices + right_indices
+    if ellipsis_met:
+        assert right_indices[0] is types.ellipsis
+        del right_indices[0]
+
     n_indices = len(all_indices) - ellipsis_met
     if n_indices > ary.ndim:
         raise TypeError("cannot index %s with %d indices: %s"
@@ -90,6 +94,24 @@ def get_array_index_type(ary, idx):
 
         # Infer layout
         layout = ary.layout
+
+        def keeps_contiguity(ty, is_innermost):
+            """
+            Whether indexing with the given type keeps an array contiguous.
+            """
+            # Slicing can only keep an array contiguous if the innermost index
+            return (ty is types.ellipsis or isinstance(ty, types.Integer)
+                    or (is_innermost and isinstance(ty, types.SliceType)
+                        and not ty.has_step))
+
+        def check_contiguity(outer_indices):
+            for ty in outer_indices[:-1]:
+                if not keeps_contiguity(ty, False):
+                    return False
+            if outer_indices and not keeps_contiguity(outer_indices[-1], True):
+                return False
+            return True
+
         if layout == 'C':
             # Integer indexing on the left keeps the array C-contiguous
             if n_indices == ary.ndim:
@@ -98,12 +120,8 @@ def get_array_index_type(ary, idx):
                 right_indices = []
             if right_indices:
                 layout = 'A'
-            else:
-                for ty in left_indices:
-                    if ty is not types.ellipsis and not isinstance(ty, types.Integer):
-                        # Slicing cannot guarantee to keep the array contiguous
-                        layout = 'A'
-                        break
+            elif not check_contiguity(left_indices):
+                layout = 'A'
         elif layout == 'F':
             # Integer indexing on the right keeps the array F-contiguous
             if n_indices == ary.ndim:
@@ -112,12 +130,8 @@ def get_array_index_type(ary, idx):
                 left_indices = []
             if left_indices:
                 layout = 'A'
-            else:
-                for ty in right_indices:
-                    if ty is not types.ellipsis and not isinstance(ty, types.Integer):
-                        # Slicing cannot guarantee to keep the array contiguous
-                        layout = 'A'
-                        break
+            elif not check_contiguity(right_indices[::-1]):
+                layout = 'A'
 
         res = ary.copy(ndim=ndim, layout=layout)
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -58,11 +58,11 @@ class Abs(ConcreteTemplate):
 class Slice(ConcreteTemplate):
     key = types.slice_type
     cases = [
-        signature(types.slice3_type),
-        signature(types.slice3_type, types.none, types.none),
-        signature(types.slice3_type, types.none, types.intp),
-        signature(types.slice3_type, types.intp, types.none),
-        signature(types.slice3_type, types.intp, types.intp),
+        signature(types.slice2_type),
+        signature(types.slice2_type, types.none, types.none),
+        signature(types.slice2_type, types.none, types.intp),
+        signature(types.slice2_type, types.intp, types.none),
+        signature(types.slice2_type, types.intp, types.intp),
         signature(types.slice3_type, types.intp, types.intp, types.intp),
         signature(types.slice3_type, types.none, types.intp, types.intp),
         signature(types.slice3_type, types.intp, types.none, types.intp),
@@ -423,8 +423,8 @@ def normalize_1d_index(index):
     Normalize the *index* type (an integer or slice) for indexing a 1D
     sequence.
     """
-    if index == types.slice3_type:
-        return types.slice3_type
+    if isinstance(index, types.SliceType):
+        return index
 
     elif isinstance(index, types.Integer):
         return types.intp if index.signed else types.uintp
@@ -552,7 +552,7 @@ class NumberAttribute(AttributeTemplate):
 
 @builtin_attr
 class SliceAttribute(AttributeTemplate):
-    key = types.slice3_type
+    key = types.SliceType
 
     def resolve_start(self, ty):
         return types.intp

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -47,7 +47,7 @@ class GetItemSequence(AbstractTemplate):
         seq, idx = args
         if isinstance(seq, types.Sequence):
             idx = normalize_1d_index(idx)
-            if idx == types.slice3_type:
+            if isinstance(idx, types.SliceType):
                 return signature(seq, seq, idx)
             elif isinstance(idx, types.Integer):
                 return signature(seq.dtype, seq, idx)
@@ -60,7 +60,7 @@ class SetItemSequence(AbstractTemplate):
         seq, idx, value = args
         if isinstance(seq, types.MutableSequence):
             idx = normalize_1d_index(idx)
-            if idx == types.slice3_type:
+            if isinstance(idx, types.SliceType):
                 return signature(types.none, seq, idx, seq)
             elif isinstance(idx, types.Integer):
                 return signature(types.none, seq, idx, seq.dtype)

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -129,7 +129,7 @@ def _typeof_list(val, c):
 
 @typeof_impl.register(slice)
 def _typeof_slice(val, c):
-    return types.slice3_type
+    return types.slice2_type if val.step in (None, 1) else types.slice3_type
 
 @typeof_impl.register(np.dtype)
 def _typeof_dtype(val, c):


### PR DESCRIPTION
This keeps the result array contiguous when there is a single innermost slice index (in physical dimension order) and the slice is not strided. This helps use `np.dot()` efficiently in more cases.