### PR TITLE
Make CudaAPIError picklable

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -49,7 +49,11 @@ class LinkerError(RuntimeError):
 class CudaAPIError(CudaDriverError):
     def __init__(self, code, msg):
         self.code = code
-        super(CudaAPIError, self).__init__(msg)
+        self.msg = msg
+        super(CudaAPIError, self).__init__(code, msg)
+
+    def __str__(self):
+        return "[%s] %s" % (self.code, self.msg)
 
 
 def find_driver():


### PR DESCRIPTION
This allows multiprocessing to correctly re-instantiate an error which occurred in a child process. Symptom:

```
>>> from numba.cuda.cudadrv.driver import CudaAPIError
>>> import pickle
>>> e = CudaAPIError(5, 'foo')
>>> pickle.loads(pickle.dumps(e))
Traceback (most recent call last):
  File "<ipython-input-4-7cb06eab7eff>", line 1, in <module>
    pickle.loads(pickle.dumps(e))
TypeError: __init__() missing 1 required positional argument: 'msg'
```
