### PR TITLE
Fix error in test_pycc in single-process mode

### DIFF
--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -12,8 +12,6 @@ import os
 import subprocess
 import sys
 
-from numba.utils import finalize
-
 
 _configs = {
     # DLL suffix, Python C extension suffix

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -38,8 +38,12 @@ class BasePYCCTest(TestCase):
 
     def setUp(self):
         self.tmpdir = static_temp_directory('test_pycc')
+        # Make sure temporary files and directories created by
+        # distutils don't clutter the top-level /tmp
+        tempfile.tempdir = self.tmpdir
 
     def tearDown(self):
+        tempfile.tempdir = None
         # Since we're executing the module-under-test several times
         # from the same process, we must clear the exports registry
         # between invocations.


### PR DESCRIPTION
Fix the following error in test_pycc:
```
[...]
  File "/home/antoine/34/lib/python3.4/tempfile.py", line 200, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmps0e8jvnk/z_e0ztq4'
```
