### PR TITLE
HSA: Coarse grained allocation and BRIG load for dGPU (supersedes PR #1582)

### DIFF
--- a/numba/hsa/compiler.py
+++ b/numba/hsa/compiler.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from numba.typing.templates import ConcreteTemplate
 from numba import types, compiler
 from .hlc import hlc
-from .hsadrv import devices, driver
+from .hsadrv import devices, driver, enums
 from numba.typing.templates import AbstractTemplate
 from numba import ctypes_support as ctypes
 
@@ -222,7 +222,7 @@ class _CachedProgram(object):
             ex.freeze()
             symobj = ex.get_symbol(agent, symbol)
             kernarg_region = [r for r in agent.regions.globals
-                              if r.supports_kernargs][0]
+                        if r.supports(enums.HSA_REGION_GLOBAL_FLAG_KERNARG)][0]
 
             # Cache the finalized program
             result = _CacheEntry(symbol=symobj, executable=ex,

--- a/numba/hsa/hsadrv/driver.py
+++ b/numba/hsa/hsadrv/driver.py
@@ -15,7 +15,7 @@ from numba.utils import total_ordering
 from numba import utils
 from numba import config
 from .error import HsaSupportError, HsaDriverError, HsaApiError
-from . import enums, drvapi
+from . import enums, enums_ext, drvapi
 
 
 class HsaKernelTimedOut(HsaDriverError):
@@ -553,8 +553,10 @@ class MemRegion(HsaWrapper):
         ),
         '_flags': (
             enums.HSA_REGION_INFO_GLOBAL_FLAGS,
-            drvapi.hsa_region_flag_t
+            drvapi.hsa_region_global_flag_t
         ),
+        'host_accessible': (enums_ext.HSA_AMD_REGION_INFO_HOST_ACCESSIBLE,
+                            ctypes.c_bool),
         'size': (enums.HSA_REGION_INFO_SIZE,
                  ctypes.c_size_t),
         'alloc_max_size': (enums.HSA_REGION_INFO_ALLOC_MAX_SIZE,
@@ -589,10 +591,16 @@ class MemRegion(HsaWrapper):
     def agent(self):
         return self._owner_agent
 
-    @property
-    def supports_kernargs(self):
+    def supports(self, check_flag):
+        """
+            Determines if a given feature is supported by this MemRegion.
+            Feature flags are found in "./enums.py" under:
+                * hsa_region_global_flag_t
+             Params:
+                check_flag: Feature flag to test
+        """
         if self.kind == 'global':
-            return self._flags & enums.HSA_REGION_GLOBAL_FLAG_KERNARG
+            return self._flags & check_flag
         else:
             return False
 

--- a/numba/hsa/hsadrv/drvapi.py
+++ b/numba/hsa/hsadrv/drvapi.py
@@ -25,7 +25,7 @@ hsa_device_type_t = ctypes.c_int # enum
 hsa_system_info_t = ctypes.c_int # enum
 hsa_agent_info_t = ctypes.c_int # enum
 hsa_region_segment_t = ctypes.c_int # enum
-hsa_region_flag_t = ctypes.c_int # enum
+hsa_region_global_flag_t = ctypes.c_int # enum
 hsa_region_info_t = ctypes.c_int # enum
 hsa_executable_state_t = ctypes.c_int # enum
 hsa_executable_symbol_info_t = ctypes.c_int # enum
@@ -573,6 +573,17 @@ API_PROTOTYPES = {
         'argtypes': [ctypes.c_void_p],
         'errcheck': _check_error
     },
+
+    # hsa_status_t HSA_API hsa_memory_copy(
+    #     void * dst,
+    #     const void * src,
+    #     size_t size);
+    'hsa_memory_copy': {
+        'restype': hsa_status_t,
+        'argtypes': [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t],
+        'errcheck': _check_error
+    },
+
 
 
     # Signals ##################################################################

--- a/numba/hsa/hsadrv/enums_ext.py
+++ b/numba/hsa/hsadrv/enums_ext.py
@@ -1,0 +1,60 @@
+"""Enum values for HSA from the HSA extension header
+
+Note that Python namespacing could be used to avoid the C-like
+prefixing, but we choose to keep the same names as found in the C
+enums, in order to match the documentation.
+"""
+
+import ctypes
+
+#
+# Agent attributes
+#
+# Enums of the type hsa_amd_agent_info_t
+#
+
+# Chip identifier. The type of this attribute is uint32_t.
+HSA_AMD_AGENT_INFO_CHIP_ID = 0xA000
+
+# Size of a cacheline in bytes. The type of this attribute is uint32_t.
+HSA_AMD_AGENT_INFO_CACHELINE_SIZE = 0xA001
+
+# The number of compute unit available in the agent. The type of this
+# attribute is uint32_t.
+HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT = 0xA002
+
+# The maximum clock frequency of the agent in MHz. The type of this
+# attribute is uint32_t.
+HSA_AMD_AGENT_INFO_MAX_CLOCK_FREQUENCY = 0xA003
+
+# Internal driver node identifier. The type of this attribute is uint32_t.
+HSA_AMD_AGENT_INFO_DRIVER_NODE_ID = 0xA004
+
+# Max number of watch points on memory address ranges to generate exception
+# events when the watched addresses are accessed.
+HSA_AMD_AGENT_INFO_MAX_ADDRESS_WATCH_POINTS = 0xA005
+
+#
+# Region attributes
+#
+# Enums of the type hsa_amd_region_info_t
+#
+
+# Determine if host can access the region. The type of this attribute is bool.
+HSA_AMD_REGION_INFO_HOST_ACCESSIBLE = 0xA000
+
+# Base address of the region in flat address space.
+HSA_AMD_REGION_INFO_BASE = 0xA001
+
+#
+# Coherency attributes of a fine grained region
+#
+# Enums of the type hsa_amd_coherency_type_t
+#
+
+# Coherent region.
+HSA_AMD_COHERENCY_TYPE_COHERENT = 0
+
+# Non coherent region.
+HSA_AMD_COHERENCY_TYPE_NONCOHERENT = 1
+

--- a/numba/hsa/tests/__init__.py
+++ b/numba/hsa/tests/__init__.py
@@ -1,5 +1,17 @@
-from numba.tests import SerialSuite
+from numba.testing import SerialSuite
+from numba.testing import load_testsuite
+from numba import hsa
+from os.path import dirname, join
 
 def load_tests(loader, tests, pattern):
-    suite = loader.discover("numba.hsa.tests")
-    return SerialSuite(suite)
+
+    suite = SerialSuite()
+    this_dir = dirname(__file__)
+
+    if hsa.is_available():
+        suite.addTests(load_testsuite(loader, join(this_dir, 'hsadrv')))
+        suite.addTests(load_testsuite(loader, join(this_dir, 'hsapy')))
+
+    else:
+        print("skipped HSA tests")
+    return suite

--- a/numba/hsa/tests/hsadrv/__init__.py
+++ b/numba/hsa/tests/hsadrv/__init__.py
@@ -1,6 +1,6 @@
-from numba.tests import SerialSuite
-
+from numba.testing import SerialSuite
+from numba.testing import load_testsuite
+import os
 
 def load_tests(loader, tests, pattern):
-    suite = loader.discover("numba.hsa.tests.hsadrv")
-    return SerialSuite(suite)
+    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/hsa/tests/hsadrv/test_hlc.py
+++ b/numba/hsa/tests/hsadrv/test_hlc.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import
 
 import numba.unittest_support as unittest
 from numba.hsa.hlc import hlc
+from numba.hsa.hsadrv import enums
 
 SPIR_SAMPLE = """
 ; ModuleID = 'kernel.out.bc'
@@ -72,7 +73,8 @@ class TestHLC(unittest.TestCase):
 
         sig = hsa.create_signal(1)
 
-        kernarg_region = [r for r in agent.regions if r.supports_kernargs][0]
+        kernarg_region = [r for r in agent.regions
+                if r.supports(enums.HSA_REGION_GLOBAL_FLAG_KERNARG)][0]
 
         kernarg_types = (ctypes.c_void_p * 2)
         kernargs = kernarg_region.allocate(kernarg_types)

--- a/numba/hsa/tests/hsapy/__init__.py
+++ b/numba/hsa/tests/hsapy/__init__.py
@@ -1,6 +1,6 @@
-from numba.tests import SerialSuite
-
+from numba.testing import SerialSuite
+from numba.testing import load_testsuite
+import os
 
 def load_tests(loader, tests, pattern):
-    suite = loader.discover("numba.hsa.tests.hsapy")
-    return SerialSuite(suite)
+    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))


### PR DESCRIPTION
This patch:
 * Adds testing for coarse grained memory allocation with a dGPU.
 * Adds a test for the loading and running of a BRIG
   module from file. The BRIG module is run on a dGPU via coarse
   grained memory buffers.
 * Alters the driver API for MemRegion to support querying
   any flag of type `hsa_region_global_flag_t`
 * Adds the file `enums_ext.py` mimicking the C header of
   the same basename.
 * Minor typo fixes.