### PR TITLE
Fix #1594: ensure a list is homogenous when unboxing

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -96,7 +96,10 @@ list
 ----
 
 Creating and returning lists from JIT-compiled functions is supported,
-as well as all methods and operations.
+as well as all methods and operations.  Lists must be strictly homogenous:
+Numba will reject any list containing objects of different types, even if
+the types are compatible (for example, ``[1, 2.5]`` is rejected as it
+contains a :class:`int` and a :class:`float`).
 
 .. note::
    When passing a list into a JIT-compiled function, any modifications

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1592,6 +1592,11 @@ numba_gil_release(PyGILState_STATE *state) {
     PyGILState_Release(*state);
 }
 
+NUMBA_EXPORT_FUNC(PyObject *)
+numba_py_type(PyObject *obj) {
+    return (PyObject *) Py_TYPE(obj);
+}
+
 /* Pointer-stuffing functions for tagging a Python list object with an
  * arbitrary pointer.
  * Note a similar hack is used by Python itself, since

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -62,6 +62,7 @@ build_c_helpers_dict(void)
     declmethod(fptouif);
     declmethod(gil_ensure);
     declmethod(gil_release);
+    declmethod(py_type);
     declmethod(unpack_slice);
     declmethod(do_raise);
     declmethod(unpickle);

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -202,6 +202,11 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name="Py_DecRef")
         self.builder.call(fn, [obj])
 
+    def get_type(self, obj):
+        fnty = Type.function(self.pyobj, [self.pyobj])
+        fn = self._get_function(fnty, name="numba_py_type")
+        return self.builder.call(fn, [obj])
+
     #
     # Argument unpacking
     #


### PR DESCRIPTION
Also fix reflection happening even when the list wasn't modified by Numba.

This takes the radical approach that all objects in a Python list must have the exact same Python type. This allows for a fast and easy check at unboxing time.

Based on PR #1599.
