### PR TITLE
Attempt to fix CUDA print test failures by flushing stdout before capturing it

### DIFF
--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -61,6 +61,9 @@ def captured_cuda_stdout():
     Return a minimal stream-like object capturing the text output of
     either CUDA or the simulator.
     """
+    # Prevent accidentally capturing previously output text
+    sys.stdout.flush()
+
     if config.ENABLE_CUDASIM:
         # The simulator calls print() on Python stdout
         with captured_stdout() as stream:


### PR DESCRIPTION
Failure only seems to happen with Python 2.x on Jenkins, so I can't reproduce it, but this change does seem like a good idea anyway.