### PR TITLE
Speed up some math functions

### DIFF
--- a/numba/_npymath_exports.c
+++ b/numba/_npymath_exports.c
@@ -206,23 +206,13 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(log10),
     NPYMATH_SYMBOL(log1p),
 
-    NPYMATH_SYMBOL(floor),
-    NPYMATH_SYMBOL(ceil),
-    NPYMATH_SYMBOL(trunc),
-
     NPYMATH_SYMBOL(pow),
     NPYMATH_SYMBOL(sqrt),
-
-    NPYMATH_SYMBOL(deg2rad),
-    NPYMATH_SYMBOL(rad2deg),
 
     NPYMATH_SYMBOL(atan2),
 
     NPYMATH_SYMBOL(logaddexp),
     NPYMATH_SYMBOL(logaddexp2),
-    NPYMATH_SYMBOL(rint),
-    NPYMATH_SYMBOL(fabs),
-    NPYMATH_SYMBOL(copysign),
     NPYMATH_SYMBOL(nextafter),
     NPYMATH_SYMBOL(spacing),
     /* npy_ldexp and npy_frexp appear in npy_math.h past NumPy 1.9, so link
@@ -233,9 +223,7 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(modf),
 
     /* float functions */
-    NPYMATH_SYMBOL(floorf),
     NPYMATH_SYMBOL(powf),
-    NPYMATH_SYMBOL(rintf),
     NPYMATH_SYMBOL(expf),
     NPYMATH_SYMBOL(exp2f),
     NPYMATH_SYMBOL(logf),
@@ -264,11 +252,6 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(atanhf),
     NPYMATH_SYMBOL(logaddexpf),
     NPYMATH_SYMBOL(logaddexp2f),
-    NPYMATH_SYMBOL(floorf),
-    NPYMATH_SYMBOL(ceilf),
-    NPYMATH_SYMBOL(truncf),
-    NPYMATH_SYMBOL(fabsf),
-    NPYMATH_SYMBOL(copysignf),
     NPYMATH_SYMBOL(nextafterf),
     NPYMATH_SYMBOL(spacingf),
     /* npy_ldexpf and npy_frexpf appear in npy_math.h past NumPy 1.9, so link

--- a/numba/_npymath_exports.c
+++ b/numba/_npymath_exports.c
@@ -264,8 +264,6 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(atanhf),
     NPYMATH_SYMBOL(logaddexpf),
     NPYMATH_SYMBOL(logaddexp2f),
-    NPYMATH_SYMBOL(deg2radf),
-    NPYMATH_SYMBOL(rad2degf),
     NPYMATH_SYMBOL(floorf),
     NPYMATH_SYMBOL(ceilf),
     NPYMATH_SYMBOL(truncf),

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -11,7 +11,7 @@ import math
 from llvmlite.llvmpy import core as lc
 
 from .. import cgutils, typing, types, lowering, errors
-from . import builtins
+from . import builtins, mathimpl
 
 # some NumPy constants. Note that we could generate some of them using
 # the math library, but having the values copied from npy_math seems to
@@ -493,24 +493,6 @@ def np_complex_power_impl(context, builder, sig, args):
                                        dispatch_table, 'power')
 
 
-def np_real_floor_impl(context, builder, sig, args):
-    assert len(args) == 1
-    assert len(sig.args) == 1
-    ty = sig.args[0]
-    assert ty == sig.return_type, "must have homogeneous types"
-    mod = builder.module
-    if ty == types.float64:
-        fnty = lc.Type.function(lc.Type.double(), [lc.Type.double()])
-        fn = cgutils.insert_pure_function(mod, fnty, name="numba.npymath.floor")
-    elif ty == types.float32:
-        fnty = lc.Type.function(lc.Type.float(), [lc.Type.float()])
-        fn = cgutils.insert_pure_function(mod, fnty, name="numba.npymath.floorf")
-    else:
-        raise errors.LoweringError("No floor function for real type {0}".format(str(ty)))
-
-    return builder.call(fn, args)
-
-
 ########################################################################
 # Numpy style complex sign
 
@@ -550,13 +532,7 @@ def np_complex_sign_impl(context, builder, sig, args):
 def np_real_rint_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.rintf',
-        types.float64: 'numba.npymath.rint',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'rint')
+    return mathimpl.call_fp_intrinsic(builder, 'llvm.rint', args)
 
 
 def np_complex_rint_impl(context, builder, sig, args):
@@ -1530,19 +1506,14 @@ def np_complex_atanh_impl(context, builder, sig, args):
     return out._getvalue()
 
 
+
 ########################################################################
 # NumPy floor
 
 def np_real_floor_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.floorf',
-        types.float64: 'numba.npymath.floor',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'floor')
+    return mathimpl.call_fp_intrinsic(builder, 'llvm.floor', args)
 
 
 ########################################################################
@@ -1551,13 +1522,7 @@ def np_real_floor_impl(context, builder, sig, args):
 def np_real_ceil_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.ceilf',
-        types.float64: 'numba.npymath.ceil',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'ceil')
+    return mathimpl.call_fp_intrinsic(builder, 'llvm.ceil', args)
 
 
 ########################################################################
@@ -1566,13 +1531,7 @@ def np_real_ceil_impl(context, builder, sig, args):
 def np_real_trunc_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.truncf',
-        types.float64: 'numba.npymath.trunc',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'trunc')
+    return mathimpl.call_fp_intrinsic(builder, 'llvm.trunc', args)
 
 
 ########################################################################
@@ -1581,13 +1540,7 @@ def np_real_trunc_impl(context, builder, sig, args):
 def np_real_fabs_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.fabsf',
-        types.float64: 'numba.npymath.fabs',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'fabs')
+    return mathimpl.call_fp_intrinsic(builder, 'llvm.fabs', args)
 
 
 ########################################################################
@@ -2055,13 +2008,7 @@ def np_real_signbit_impl(context, builder, sig, args):
 def np_real_copysign_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
-    dispatch_table = {
-        types.float32: 'numba.npymath.copysignf',
-        types.float64: 'numba.npymath.copysign',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'copysign')
+    return mathimpl.copysign_float_impl(context, builder, sig, args)
 
 def np_real_nextafter_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -1531,36 +1531,6 @@ def np_complex_atanh_impl(context, builder, sig, args):
 
 
 ########################################################################
-# NumPy deg2rad (radians)
-
-def np_real_deg2rad_impl(context, builder, sig, args):
-    _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.float32: 'numba.npymath.deg2radf',
-        types.float64: 'numba.npymath.deg2rad',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'deg2rad')
-
-
-########################################################################
-# NumPy rad2deg (degrees)
-
-def np_real_rad2deg_impl(context, builder, sig, args):
-    _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.float32: 'numba.npymath.rad2degf',
-        types.float64: 'numba.npymath.rad2deg',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'rad2deg')
-
-
-########################################################################
 # NumPy floor
 
 def np_real_floor_impl(context, builder, sig, args):

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -47,7 +47,7 @@ def _fill_ufunc_db(ufunc_db):
     # some of these imports would cause a problem of circular
     # imports if done at global scope when importing the numba
     # module.
-    from . import builtins, npyfuncs, cmathimpl
+    from . import builtins, npyfuncs, mathimpl, cmathimpl
     from numba import numpy_support
 
     v = numpy_support.version
@@ -487,15 +487,15 @@ def _fill_ufunc_db(ufunc_db):
     }
 
     ufunc_db[np.deg2rad] = {
-        'f->f': npyfuncs.np_real_deg2rad_impl,
-        'd->d': npyfuncs.np_real_deg2rad_impl,
+        'f->f': mathimpl.radians_float_impl,
+        'd->d': mathimpl.radians_float_impl,
     }
 
     ufunc_db[np.radians] = ufunc_db[np.deg2rad]
 
     ufunc_db[np.rad2deg] = {
-        'f->f': npyfuncs.np_real_rad2deg_impl,
-        'd->d': npyfuncs.np_real_rad2deg_impl,
+        'f->f': mathimpl.degrees_float_impl,
+        'd->d': mathimpl.degrees_float_impl,
     }
 
     ufunc_db[np.degrees] = ufunc_db[np.rad2deg]

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -205,8 +205,11 @@ class TestMathLib(TestCase):
     def check_predicate_func(self, pyfunc, flags=enable_pyobj_flags):
         x_types = [types.int16, types.int32, types.int64,
                    types.uint16, types.uint32, types.uint64,
-                   types.float32, types.float32, types.float64, types.float64]
-        x_values = [0, 0, 0, 0, 0, 0, float('inf'), 0.0, float('inf'), 0.0]
+                   types.float32, types.float32, types.float32,
+                   types.float64, types.float64, types.float64]
+        x_values = [0, 0, 0, 0, 0, 0,
+                    float('inf'), 0.0, float('nan'),
+                    float('inf'), 0.0, float('nan')]
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     def test_sin(self, flags=enable_pyobj_flags):


### PR DESCRIPTION
This patch speeds up the following function in nopythno mode: math.isfinite(), math.degrees(), math.radians(), np.degrees(), np.radians(), np.floor(), np.rint(), np.ceil(), np.trunc(), np.copysign(), np.fabs().