### PR TITLE
Rewrite variable liveness analysis

### DIFF
--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -244,6 +244,17 @@ class Interpreter(object):
         Insert del statements for each variable.
         Returns a 2-tuple of (variable definition map, variable deletion map)
         which indicates variables defined and deleted in each block.
+
+        The algorithm avoids relying on explicit knowledge on loops and
+        distinguish between variables that are defined locally vs variables that
+        come from incoming blocks.
+        We start with simple usage (variable reference) and definition (variable
+        creation) maps on each block. Propagate the liveness info to predecessor
+        blocks until it stabilize, at which point we know which variables must
+        exist before entering each block. Then, we compute the end of variable
+        lives and insert del statements accordingly. Variables are deleted after
+        the last use. Variable referenced by terminators (e.g. conditional
+        branch and return) are deleted by the successors or the caller.
         """
         var_use_map, var_def_map = self._compute_use_defs()
         live_map = self._compute_live_map(var_use_map, var_def_map)

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -382,19 +382,16 @@ class Interpreter(object):
         """
         for offset, ir_block in self.blocks.items():
             # for each internal var, insert delete after the last use
-            internal_set = internal_dead_map[offset]
-            # all non escaping live varibles at the terminator
-            live_set = set(v.name for v in ir_block.terminator.list_vars())
-            live_set &= internal_set
+            internal_dead_set = internal_dead_map[offset]
             delete_pts = []
             # for each statement in reverse order
             for stmt in reversed(ir_block.body[:-1]):
                 # internal vars that are used here
-                use_set = set(v.name for v in stmt.list_vars()) & internal_set
+                live_set = set(v.name for v in stmt.list_vars())
+                dead_set = live_set & internal_dead_set
                 # used here but not afterwards
-                dead_set = use_set - live_set
                 delete_pts.append((stmt, dead_set))
-                live_set |= use_set
+                internal_dead_set -= dead_set
 
             # rewrite body and insert dels
             body = []

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -397,7 +397,9 @@ class Interpreter(object):
             body = []
             for stmt, delete_set in reversed(delete_pts):
                 body.append(stmt)
-                for var_name in sorted(delete_set):
+                # note: the reverse sort is not necessary for correctness
+                #       it is just to minimize changes to test for now
+                for var_name in sorted(delete_set, reverse=True):
                     body.append(ir.Del(var_name, loc=ir_block.loc))
             body.append(ir_block.body[-1])  # terminator
             ir_block.body = body

--- a/numba/tests/test_nrt_refct.py
+++ b/numba/tests/test_nrt_refct.py
@@ -53,6 +53,30 @@ class TestNrtRefCt(unittest.TestCase):
         self.assertEqual(cur_stats.alloc - init_stats.alloc, 1)
         self.assertEqual(cur_stats.free - init_stats.free, 1)
 
+    def test_invalid_computation_of_lifetime(self):
+        """
+        Test issue #1573
+        """
+        @njit
+        def if_with_allocation_and_initialization(arr1, test1):
+            tmp_arr = np.ones_like(arr1)
+
+            for i in range(tmp_arr.shape[0]):
+                pass
+
+            if test1:
+                np.zeros_like(arr1)
+
+            return tmp_arr
+
+        arr = np.random.choice([0, 1, 2], (1000, 1000))
+
+        init_stats = rtsys.get_allocation_stats()
+        if_with_allocation_and_initialization(arr, False)
+        cur_stats = rtsys.get_allocation_stats()
+        self.assertEqual(cur_stats.alloc - init_stats.alloc,
+                         cur_stats.free - init_stats.free)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_nrt_refct.py
+++ b/numba/tests/test_nrt_refct.py
@@ -59,7 +59,7 @@ class TestNrtRefCt(unittest.TestCase):
         """
         @njit
         def if_with_allocation_and_initialization(arr1, test1):
-            tmp_arr = np.ones_like(arr1)
+            tmp_arr = np.zeros_like(arr1)
 
             for i in range(tmp_arr.shape[0]):
                 pass
@@ -69,7 +69,7 @@ class TestNrtRefCt(unittest.TestCase):
 
             return tmp_arr
 
-        arr = np.random.choice([0, 1, 2], (1000, 1000))
+        arr = np.random.random((5, 5))  # the values are not consumed
 
         init_stats = rtsys.get_allocation_stats()
         if_with_allocation_and_initialization(arr, False)


### PR DESCRIPTION
This fixes #1573.

The new algorithm:
* avoids relying on explicit knowledge on loops
* distinguish between variables that are defined locally vs variables that come from incoming blocks

We start with simple usage (variable reference) and definition (variable creation) maps on each block.  Propagate the liveness info to predecessor blocks until it stabilize, at which point we know which variables must exist before entering each block.  Then, we compute the end of variable lives and insert `del` statements accordingly.  Variables are deleted after the last use.  Variable referened by terminators (e.g. conditional branch and return) are deleted by the successor or the caller.

Potential enhancement once this is accepted:
* ~~Merge with ``Interpreter._compute_live_variables``.  Some work is duplicated.~~ (Edit: done)
* Provide warning for undefined variables: `live_map` for the entry block will contain all required variables.  Subtracting that from the available arguments gives all potentially undefined variables.  (With "potentially", I mean some variables that are defined only if a particular path is visited; and is undefined in another.  ``raising_usecase1`` and ``raising_usecase2`` in ``test_obj_lifetime.py`` are examples.)
