### PR TITLE
Fix #1610: allow nested calls between explicitly-typed ufuncs

### DIFF
--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -25,7 +25,8 @@ class _BaseVectorize(object):
 
 
 class Vectorize(_BaseVectorize):
-    target_registry = TargetRegistry({'cpu': UFuncBuilder,
+    target_registry = TargetRegistry({'cpu': dufunc.DUFunc,
+                                      #'cpu': UFuncBuilder,
                                       'parallel': ParallelUFuncBuilder,})
 
     def __new__(cls, func, **kws):
@@ -105,12 +106,12 @@ def vectorize(ftylist_or_function=(), **kws):
         ftylist = ftylist_or_function
 
     def wrap(func):
+        vec = Vectorize(func, **kws)
+        for sig in ftylist:
+            vec.add(sig)
         if len(ftylist) > 0:
-            vec = Vectorize(func, **kws)
-            for fty in ftylist:
-                vec.add(fty)
-            return vec.build_ufunc()
-        return dufunc.DUFunc(func, **kws)
+            vec.disable_compile()
+        return vec.build_ufunc()
 
     return wrap
 
@@ -167,5 +168,3 @@ def guvectorize(ftylist, signature, **kws):
         return guvec.build_ufunc()
 
     return wrap
-
-

--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 import inspect
 
 from . import _internal, dufunc
-from .ufuncbuilder import UFuncBuilder, GUFuncBuilder
+from .ufuncbuilder import GUFuncBuilder
 from .parallel import ParallelUFuncBuilder, ParallelGUFuncBuilder
 
 from numba.cuda.vectorizers import CUDAVectorize, CUDAGUFuncVectorize
@@ -26,7 +26,6 @@ class _BaseVectorize(object):
 
 class Vectorize(_BaseVectorize):
     target_registry = TargetRegistry({'cpu': dufunc.DUFunc,
-                                      #'cpu': UFuncBuilder,
                                       'parallel': ParallelUFuncBuilder,})
 
     def __new__(cls, func, **kws):

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -80,6 +80,8 @@ class DUFunc(_internal._DUFunc):
         self._install_type()
         self._lower_me = DUFuncLowerer(self)
         self._install_cg()
+        self.__name__ = py_func.__name__
+        self.__doc__ = py_func.__doc__
 
     def build_ufunc(self):
         """
@@ -124,7 +126,7 @@ class DUFunc(_internal._DUFunc):
         Compile the DUFunc for the given signature.
         """
         args, return_type = sigutils.normalize_signature(sig)
-        self._compile_for_argtys(args, return_type)
+        return self._compile_for_argtys(args, return_type)
 
     def _compile_for_args(self, *args, **kws):
         nin = self.ufunc.nin
@@ -170,6 +172,7 @@ class DUFunc(_internal._DUFunc):
         self._add_loop(utils.longint(ptr), dtypenums)
         self._keepalive.append((ptr, cres.library, env))
         self._lower_me.libs.append(cres.library)
+        return cres
 
     def _install_type(self, typingctx=None):
         """Constructs and installs a typing class for a DUFunc object in the

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, print_function, division
 import numpy
 
-from .. import jit, typeof, utils, types, numpy_support
+from .. import jit, typeof, utils, types, numpy_support, sigutils
 from ..typing import npydecl
 from ..typing.templates import AbstractTemplate, signature
 from ..targets import npyimpl
 from . import _internal, ufuncbuilder
+
 
 class DUFuncKernel(npyimpl._Kernel):
     '''npyimpl._Kernel subclass responsible for lowering a DUFunc kernel
@@ -59,29 +60,32 @@ class DUFuncLowerer(object):
 
 
 class DUFunc(_internal._DUFunc):
-    '''Dynamic universal funcion (DUFunc) intended to act like a normal
+    """
+    Dynamic universal function (DUFunc) intended to act like a normal
     Numpy ufunc, but capable of call-time (just-in-time) compilation
     of fast loops specialized to inputs.
-    '''
+    """
     # NOTE: __base_kwargs must be kept in synch with the kwlist in
     # _internal.c:dufunc_init()
     __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
-    def __init__(self, py_func, **kws):
+    def __init__(self, py_func, identity=None, targetoptions={}):
+        self.targetoptions = targetoptions.copy()
+        kws = {}
+        kws['identity'] = ufuncbuilder.parse_identity(identity)
         dispatcher = jit(target='npyufunc')(py_func)
-        self.targetoptions = {}
+        super(DUFunc, self).__init__(dispatcher, **kws)
         # Loop over a copy of the keys instead of the keys themselves,
         # since we're changing the dictionary while looping.
-        kws_keys = tuple(kws.keys())
-        for key in kws_keys:
-            if key not in self.__base_kwargs:
-                self.targetoptions[key] = kws.pop(key)
-        kws['identity'] = ufuncbuilder._BaseUFuncBuilder.parse_identity(
-            kws.pop('identity', None))
-        super(DUFunc, self).__init__(dispatcher, **kws)
         self._install_type()
         self._lower_me = DUFuncLowerer(self)
         self._install_cg()
+
+    def build_ufunc(self):
+        """
+        For compatibility with the various *UFuncBuilder classes.
+        """
+        return self
 
     @property
     def nin(self):
@@ -107,6 +111,21 @@ class DUFunc(_internal._DUFunc):
     def identity(self):
         return self.ufunc.identity
 
+    def disable_compile(self):
+        """
+        Disable the compilation of new signatures at call time.
+        """
+        # If disabling compilation then there must be at least one signature
+        assert len(self._dispatcher.overloads) > 0
+        self._frozen = True
+
+    def add(self, sig):
+        """
+        Compile the DUFunc for the given signature.
+        """
+        args, return_type = sigutils.normalize_signature(sig)
+        self._compile_for_argtys(args, return_type)
+
     def _compile_for_args(self, *args, **kws):
         nin = self.ufunc.nin
         args_len = len(args)
@@ -127,15 +146,23 @@ class DUFunc(_internal._DUFunc):
                 argtys.append(argty)
         return self._compile_for_argtys(tuple(argtys))
 
-    def _compile_for_argtys(self, argtys):
-        """Given a tuple of argument types (these should be the array
+    def _compile_for_argtys(self, argtys, return_type=None):
+        """
+        Given a tuple of argument types (these should be the array
         dtypes, and not the array types themselves), compile the
         element-wise function for those inputs, generate a UFunc loop
         wrapper, and register the loop with the Numpy ufunc object for
         this DUFunc.
         """
+        if self._frozen:
+            raise RuntimeError("compilation disabled for %s" % (self,))
+        assert isinstance(argtys, tuple)
+        if return_type is None:
+            sig = argtys
+        else:
+            sig = return_type(*argtys)
         cres, argtys, return_type = ufuncbuilder._compile_element_wise_function(
-            self._dispatcher, self.targetoptions, argtys)
+            self._dispatcher, self.targetoptions, sig)
         actual_sig = ufuncbuilder._finalize_ufunc_signature(
             cres, argtys, return_type)
         dtypenums, ptr, env = ufuncbuilder._build_element_wise_ufunc_wrapper(
@@ -159,23 +186,31 @@ class DUFunc(_internal._DUFunc):
         typingctx.insert_user_function(self, _ty_cls)
 
     def find_ewise_function(self, ewise_types):
-        """Given a tuple of element-wise argument types, find a matching
+        """
+        Given a tuple of element-wise argument types, find a matching
         signature in the dispatcher.
 
-        Returns a 2-tuple containing the matching signature, and
+        Return a 2-tuple containing the matching signature, and
         compilation result.  Will return two None's if no matching
         signature was found.
         """
+        if self._frozen:
+            # If we cannot compile, coerce to the best matching loop
+            loop = numpy_support.ufunc_find_matching_loop(self, ewise_types)
+            if loop is None:
+                return None, None
+            ewise_types = tuple(loop.inputs + loop.outputs)[:len(ewise_types)]
         for sig, cres in self._dispatcher.overloads.items():
             if sig.args == ewise_types:
                 return sig, cres
         return None, None
 
     def _type_me(self, argtys, kwtys):
-        """Overloads (defines) AbstractTemplate.generic() for the typing class
+        """
+        Implement AbstractTemplate.generic() for the typing class
         built by DUFunc._install_type().
 
-        Returns the call-site signature after either validating the
+        Return the call-site signature after either validating the
         element-wise signature or compiling for it.
         """
         assert not kwtys
@@ -192,6 +227,9 @@ class DUFunc(_internal._DUFunc):
         if sig is None:
             # Matching element-wise signature was not found; must
             # compile.
+            if self._frozen:
+                raise TypeError("cannot call %s with types %s"
+                                % (self, argtys))
             self._compile_for_argtys(ewise_types)
             sig, cres = self.find_ewise_function(ewise_types)
             assert sig is not None
@@ -208,9 +246,10 @@ class DUFunc(_internal._DUFunc):
         return signature(*outtys)
 
     def _install_cg(self, targetctx=None):
-        """Constructs and installs a typing class for a DUFunc object in the
-        input typing context.  If no typing context is given, then
-        _install_type() installs into the typing context of the
+        """
+        Install an implementation function for a DUFunc object in the
+        given target context.  If no target context is given, then
+        _install_cg() installs into the target context of the
         dispatcher object (should be same default context used by
         jit() and njit()).
         """

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -31,6 +31,9 @@ class UFuncTarget(registry.CPUTarget):
 
 
 class UFuncDispatcher(object):
+    """
+    An object handling compilation of various signatures for a ufunc.
+    """
     targetdescr = UFuncTarget()
 
     def __init__(self, py_func, locals={}, targetoptions={}):
@@ -70,25 +73,14 @@ class UFuncDispatcher(object):
 
 dispatcher_registry['npyufunc'] = UFuncDispatcher
 
+
 # Utility functions
 
-def _compile_element_wise_function(nb_func, targetoptions, sig=None,
-                                   argtypes=None, restype=None):
-    # Handle argtypes
-    if argtypes is not None:
-        warnings.warn("Keyword argument argtypes is deprecated",
-                      DeprecationWarning)
-        assert sig is None
-        if restype is None:
-            sig = tuple(argtypes)
-        else:
-            sig = restype(*argtypes)
-
+def _compile_element_wise_function(nb_func, targetoptions, sig):
     # Do compilation
     # Return CompileResult to test
     cres = nb_func.compile(sig, **targetoptions)
     args, return_type = sigutils.normalize_signature(sig)
-
     return cres, args, return_type
 
 def _finalize_ufunc_signature(cres, args, return_type):
@@ -134,43 +126,55 @@ def _build_element_wise_ufunc_wrapper(cres, signature):
     dtypenums.append(as_dtype(signature.return_type).num)
     return dtypenums, ptr, env
 
+
+_identities = {
+    0: _internal.PyUFunc_Zero,
+    1: _internal.PyUFunc_One,
+    None: _internal.PyUFunc_None,
+    }
+if np.__version__ >= '1.7':
+    _identities["reorderable"] = _internal.PyUFunc_ReorderableNone
+
+def parse_identity(identity):
+    """
+    Parse an identity value and return the corresponding low-level value
+    for Numpy.
+    """
+    try:
+        identity = _identities[identity]
+    except KeyError:
+        raise ValueError("Invalid identity value %r" % (identity,))
+    return identity
+
+
 # Class definitions
 
 class _BaseUFuncBuilder(object):
 
-    _identities = {
-        0: _internal.PyUFunc_Zero,
-        1: _internal.PyUFunc_One,
-        None: _internal.PyUFunc_None,
-        }
-    if np.__version__ >= '1.7':
-        _identities["reorderable"] = _internal.PyUFunc_ReorderableNone
-
-    @classmethod
-    def parse_identity(cls, identity):
-        try:
-            identity = cls._identities[identity]
-        except KeyError:
-            raise ValueError("Invalid identity value %r" % (identity,))
-        return identity
-
-    def add(self, sig=None, argtypes=None, restype=None):
+    def add(self, sig=None):
         if hasattr(self, 'targetoptions'):
             targetoptions = self.targetoptions
         else:
             targetoptions = self.nb_func.targetoptions
         cres, args, return_type = _compile_element_wise_function(
-            self.nb_func, targetoptions, sig, argtypes, restype)
+            self.nb_func, targetoptions, sig)
         sig = self._finalize_signature(cres, args, return_type)
         self._sigs.append(sig)
         self._cres[sig] = cres
         return cres
 
+    def disable_compile(self):
+        """
+        Disable the compilation of new signatures at call time.
+        """
+        # Override this for implementations that support lazy compilation
+
+
 class UFuncBuilder(_BaseUFuncBuilder):
 
     def __init__(self, py_func, identity=None, targetoptions={}):
         self.py_func = py_func
-        self.identity = self.parse_identity(identity)
+        self.identity = parse_identity(identity)
         self.nb_func = jit(target='npyufunc', **targetoptions)(py_func)
         self._sigs = []
         self._cres = {}
@@ -229,7 +233,7 @@ class GUFuncBuilder(_BaseUFuncBuilder):
     # TODO handle scalar
     def __init__(self, py_func, signature, identity=None, targetoptions={}):
         self.py_func = py_func
-        self.identity = self.parse_identity(identity)
+        self.identity = parse_identity(identity)
         self.nb_func = jit(target='npyufunc')(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
@@ -297,4 +301,3 @@ class GUFuncBuilder(_BaseUFuncBuilder):
                 ty = a
             dtypenums.append(as_dtype(ty).num)
         return dtypenums, ptr, env
-

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -249,8 +249,6 @@ class UFuncLoopSpec(collections.namedtuple('_UFuncLoopSpec',
     An object describing a ufunc loop's inner types.  Properties:
     - inputs: the inputs' Numba types
     - outputs: the outputs' Numba types
-    - numpy_inputs: the inputs' Numpy dtypes
-    - numpy_outputs: the outputs' Numpy dtypes
     - ufunc_sig: the string representing the ufunc's type signature, in
       Numpy format (e.g. "ii->i")
     """

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -36,7 +36,7 @@ class TestGUFunc(unittest.TestCase):
     def test_gufunc(self, target='cpu'):
         gufunc = GUVectorize(matmulcore, '(m,n),(n,p)->(m,p)',
                              target=self.target)
-        gufunc.add(argtypes=[float32[:, :], float32[:, :], float32[:, :]])
+        gufunc.add((float32[:, :], float32[:, :], float32[:, :]))
         gufunc = gufunc.build_ufunc()
 
         matrix_ct = 1001

--- a/numba/tests/npyufunc/test_parallel_low_work.py
+++ b/numba/tests/npyufunc/test_parallel_low_work.py
@@ -17,10 +17,8 @@ class TestParallelLowWorkCount(unittest.TestCase):
     def test_low_workcount(self):
         # build parallel native code ufunc
         pv = Vectorize(vector_add, target='parallel')
-        pv.add(restype=int32, argtypes=[int32, int32])
-        pv.add(restype=uint32, argtypes=[uint32, uint32])
-        pv.add(restype=float32, argtypes=[float32, float32])
-        pv.add(restype=float64, argtypes=[float64, float64])
+        for ty in (int32, uint32, float32, float64):
+            pv.add(ty(ty, ty))
         para_ufunc = pv.build_ufunc()
 
         # build python ufunc

--- a/numba/tests/npyufunc/test_ufunc.py
+++ b/numba/tests/npyufunc/test_ufunc.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, print_function, division
-from numba import unittest_support as unittest
+
 import numpy as np
+
+from numba import unittest_support as unittest
 from numba import float32
 from numba.npyufunc import Vectorize
 
@@ -46,7 +48,7 @@ class TestUFuncs(unittest.TestCase):
     def _test_ufunc_attributes(self, cls, a, b, *args):
         "Test ufunc attributes"
         vectorizer = cls(add, *args)
-        vectorizer.add(restype=float32, argtypes=[float32, float32])
+        vectorizer.add(float32(float32, float32))
         ufunc = vectorizer.build_ufunc()
 
         info = (cls, a.ndim)
@@ -58,8 +60,7 @@ class TestUFuncs(unittest.TestCase):
     def _test_broadcasting(self, cls, a, b, c, d):
         "Test multiple args"
         vectorizer = cls(add_multiple_args)
-        vectorizer.add(restype=float32,
-                       argtypes=[float32, float32, float32, float32])
+        vectorizer.add(float32(float32, float32, float32, float32))
         ufunc = vectorizer.build_ufunc()
 
         info = (cls, a.shape)
@@ -86,7 +87,7 @@ class TestUFuncs(unittest.TestCase):
     def test_implicit_broadcasting(self):
         for v in vectorizers:
             vectorizer = v(add)
-            vectorizer.add(restype=float32, argtypes=[float32, float32])
+            vectorizer.add(float32(float32, float32))
             ufunc = vectorizer.build_ufunc()
 
             broadcasting_b = b[np.newaxis, :, np.newaxis, np.newaxis, :]

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -5,9 +5,10 @@ import sys
 import numpy
 
 from numba import config, unittest_support as unittest
-from numba.npyufunc.ufuncbuilder import UFuncBuilder, GUFuncBuilder
+from numba.npyufunc.ufuncbuilder import GUFuncBuilder
 from numba import vectorize, guvectorize
 from numba.npyufunc import PyUFunc_One
+from numba.npyufunc.dufunc import DUFunc as UFuncBuilder
 from numba.tests import support
 
 
@@ -123,7 +124,8 @@ class TestUfuncBuilding(unittest.TestCase):
         """
         Check nested call to an implicitly-typed ufunc.
         """
-        builder = UFuncBuilder(outer)
+        builder = UFuncBuilder(outer,
+                               targetoptions={'nopython': True})
         builder.add("(int64, int64)")
         ufunc = builder.build_ufunc()
         self.assertEqual(ufunc(-1, 3), 2)
@@ -132,7 +134,8 @@ class TestUfuncBuilding(unittest.TestCase):
         """
         Check nested call to an explicitly-typed ufunc.
         """
-        builder = UFuncBuilder(outer_explicit, targetoptions={'nopython': True})
+        builder = UFuncBuilder(outer_explicit,
+                               targetoptions={'nopython': True})
         builder.add("(int64, int64)")
         ufunc = builder.build_ufunc()
         self.assertEqual(ufunc(-1, 3), 2)

--- a/numba/tests/npyufunc/test_vectorize.py
+++ b/numba/tests/npyufunc/test_vectorize.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, division
-from numba import unittest_support as unittest
+
 import numpy as np
+
+from numba import unittest_support as unittest
 from numba import int32, uint32, float32, float64
 from numba import vectorize
-from timeit import default_timer as time
 
 
 def vector_add(a, b):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -48,12 +48,6 @@ class TestDispatcher(TestCase):
         f = jit(nopython=True)(pyfunc)
         return f, check
 
-    def test_numba_interface(self):
-        """
-        Check that vectorize can accept a decorated object.
-        """
-        vectorize('f8(f8)')(jit(dummy))
-
     def test_no_argument(self):
         @jit
         def foo():


### PR DESCRIPTION
Now all CPU ufuncs use the DUfunc machinery. However, parallel ufuncs still use the old UFuncBuilder.