### PR TITLE
Fix #1570: use overflow-immune algorithm in hypot()

### DIFF
--- a/numba/_npymath_exports.c
+++ b/numba/_npymath_exports.c
@@ -195,7 +195,6 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(asinh),
     NPYMATH_SYMBOL(acosh),
     NPYMATH_SYMBOL(atanh),
-    NPYMATH_SYMBOL(hypot),
 
     NPYMATH_SYMBOL(exp),
     NPYMATH_SYMBOL(exp2),
@@ -235,7 +234,6 @@ struct npy_math_entry exports[] = {
     NPYMATH_SYMBOL(cosf),
     NPYMATH_SYMBOL(tanf),
     NPYMATH_SYMBOL(atan2f),
-    NPYMATH_SYMBOL(hypotf),
     NPYMATH_SYMBOL(sqrtf),
     NPYMATH_SYMBOL(sinhf),
     NPYMATH_SYMBOL(coshf),

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -355,11 +355,24 @@ def hypot_u64_impl(context, builder, sig, args):
 @lower(math.hypot, types.Float, types.Float)
 def hypot_float_impl(context, builder, sig, args):
     def hypot(x, y):
+        # This particular algorithm avoids intermediate overflow in the
+        # computation.  See
+        # http://www.johndcook.com/blog/2010/06/02/whats-so-hard-about-finding-a-hypotenuse/
+        x, y = abs(x), abs(y)
+        if x < y:
+            x, y = y, x
         if math.isinf(x):
-            return abs(x)
-        elif math.isinf(y):
-            return abs(y)
-        return math.sqrt(x * x + y * y)
+            return x
+        if math.isinf(y):
+            return y
+        if math.isnan(x):
+            return x
+        if math.isnan(y):
+            return y
+        if x == 0.0:
+            return 0.0
+        r = y / x
+        return x * math.sqrt(1.0 + r * r)
 
     res = context.compile_internal(builder, hypot, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -753,8 +753,8 @@ def np_complex_log1p_impl(context, builder, sig, args):
     in1 = complex_class(context, builder, value=args[0])
     out = complex_class(context, builder)
     real_plus_one = builder.fadd(in1.real, ONE)
-    l = np_real_hypot_impl(context, builder, float_binary_sig,
-                           [real_plus_one, in1.imag])
+    l = mathimpl.hypot_float_impl(context, builder, float_binary_sig,
+                                  [real_plus_one, in1.imag])
     out.imag = np_real_atan2_impl(context, builder, float_binary_sig,
                                   [in1.imag, real_plus_one])
     out.real = np_real_log_impl(context, builder, float_unary_sig, [l])
@@ -1175,21 +1175,6 @@ def np_real_atan2_impl(context, builder, sig, args):
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
                                        dispatch_table, 'arctan2')
-
-
-########################################################################
-# NumPy hypot
-
-def np_real_hypot_impl(context, builder, sig, args):
-    _check_arity_and_homogeneity(sig, args, 2)
-
-    dispatch_table = {
-        types.float32: 'numba.npymath.hypotf',
-        types.float64: 'numba.npymath.hypot',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'hypot')
 
 
 ########################################################################

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -436,8 +436,8 @@ def _fill_ufunc_db(ufunc_db):
     }
 
     ufunc_db[np.hypot] = {
-        'ff->f': npyfuncs.np_real_hypot_impl,
-        'dd->d': npyfuncs.np_real_hypot_impl,
+        'ff->f': mathimpl.hypot_float_impl,
+        'dd->d': mathimpl.hypot_float_impl,
     }
 
     ufunc_db[np.sinh] = {

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -503,8 +503,15 @@ class TestMathLib(TestCase):
         x_values = [1, 2, 3, 4, 5, 6, .21, .34]
         y_values = [x + 2 for x in x_values]
         # Issue #563: precision issues with math.hypot() under Windows.
-        prec = 'single' if sys.platform == 'win32' else 'exact'
+        prec = 'single' if sys.platform == 'win32' else 'double'
         self.run_binary(pyfunc, x_types, x_values, y_values, prec=prec)
+        # Test that hypot() is immune to internal overflow
+        for ty, bigval in [(types.float32, 1e38), (types.float64, 5e307)]:
+            values = [0, 1.5, bigval, -bigval,
+                      float('inf'), float('-inf'), float('nan')]
+            x_values, y_values = zip(*itertools.product(values, values))
+            x_types = y_types = [ty] * len(x_values)
+            self.run_binary(pyfunc, x_types, x_values, y_values, prec=prec)
 
     def test_hypot_npm(self):
         self.test_hypot(flags=no_pyobj_flags)


### PR DESCRIPTION
This has the side effect of slowing down math.hypot() by 2x, and speeding up np.hypot() by 30%