### PR TITLE
Avoid unwilling testing negative zeros in test_ufuncs

### DIFF
--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1562,7 +1562,8 @@ class _TestLoopTypes(TestCase):
             return np.array([1.5, -3.5, 0.0, float('nan')], dtype=a_letter_type)
         elif a_letter_type in 'FD':
             # complex
-            return np.array([-1.0j, 1.5 + 1.5j, 1j * float('nan'), 0j],
+            # Note `-1j` is different on 2.x and 3.x, hence the explicit spelling
+            return np.array([0.0-1.0j, 1.5 + 1.5j, 1j * float('nan'), 0j],
                             dtype=a_letter_type)
         else:
             raise RuntimeError("type %r not understood" % (a_letter_type,))

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1563,8 +1563,12 @@ class _TestLoopTypes(TestCase):
         elif a_letter_type in 'FD':
             # complex
             # Note `-1j` is different on 2.x and 3.x, hence the explicit spelling
-            return np.array([0.0-1.0j, 1.5 + 1.5j, 1j * float('nan'), 0j],
-                            dtype=a_letter_type)
+            vals = [0.0-1.0j, 1.5 + 1.5j, 1j * float('nan'), 0j]
+            if sys.platform != 'win32':
+                # Other platforms have better handling of negative zeros,
+                # test them
+                vals.append(-(0.0+1.0j))
+            return np.array(vals, dtype=a_letter_type)
         else:
             raise RuntimeError("type %r not understood" % (a_letter_type,))
 

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1539,27 +1539,30 @@ class _TestLoopTypes(TestCase):
 
     def _arg_for_type(self, a_letter_type, index=0):
         """return a suitable array argument for testing the letter type"""
+        # Note all possible arrays must have the same size, since they
+        # may be used as inputs to the same func.
         if a_letter_type in 'bhilq':
             # an integral
-            return np.array([1, 4, 0, -2], dtype=a_letter_type)
+            return np.array([1, 4, 0, -2, 3], dtype=a_letter_type)
         if a_letter_type in 'BHILQ':
-            return np.array([1, 2, 4, 0], dtype=a_letter_type)
+            return np.array([1, 2, 4, 0, 2], dtype=a_letter_type)
         elif a_letter_type in '?':
             # a boolean
-            return np.array([True, False, False, True], dtype=a_letter_type)
+            return np.array([True, False, False, True, True], dtype=a_letter_type)
         elif a_letter_type[0] == 'm':
             # timedelta64
             if len(a_letter_type) == 1:
                 a_letter_type = 'm8[D]'
-            return np.array([2, -3, 'NaT', 0], dtype=a_letter_type)
+            return np.array([2, -3, 'NaT', 0, 1], dtype=a_letter_type)
         elif a_letter_type[0] == 'M':
             # datetime64
             if len(a_letter_type) == 1:
                 a_letter_type = 'M8[D]'
-            return np.array(['Nat', 1, 25, 0], dtype=a_letter_type)
+            return np.array(['Nat', 1, 25, 0, 10], dtype=a_letter_type)
         elif a_letter_type in 'fd':
             # floating point
-            return np.array([1.5, -3.5, 0.0, float('nan')], dtype=a_letter_type)
+            return np.array([1.5, -3.5, 0.0, float('nan'), float('inf')],
+                            dtype=a_letter_type)
         elif a_letter_type in 'FD':
             # complex
             # Note `-1j` is different on 2.x and 3.x, hence the explicit spelling
@@ -1568,6 +1571,8 @@ class _TestLoopTypes(TestCase):
                 # Other platforms have better handling of negative zeros,
                 # test them
                 vals.append(-(0.0+1.0j))
+            else:
+                vals.append(0.0+1.0j)
             return np.array(vals, dtype=a_letter_type)
         else:
             raise RuntimeError("type %r not understood" % (a_letter_type,))


### PR DESCRIPTION
This and a rint() bug on win32 were the cause of the Jenkins failures.