### PR TITLE
Slice assignment of sequence to array

### DIFF
--- a/numba/consts.py
+++ b/numba/consts.py
@@ -1,4 +1,6 @@
 
+import weakref
+
 from . import ir
 from .errors import ConstantInferenceError
 
@@ -11,7 +13,9 @@ class ConstantInference(object):
     """
 
     def __init__(self, interp):
-        self._interp = interp
+        # Avoid cyclic references as some user-visible objects may be
+        # held alive in the cache
+        self._interp = weakref.proxy(interp)
         self._cache = {}
 
     def infer_constant(self, name):

--- a/numba/consts.py
+++ b/numba/consts.py
@@ -1,0 +1,72 @@
+
+from . import ir
+from .errors import ConstantInferenceError
+
+
+class ConstantInference(object):
+    """
+    A constant inference object for a given interpreter.
+
+    This shouldn't be used directly, instead call Interpreter.infer_constant().
+    """
+
+    def __init__(self, interp):
+        self._interp = interp
+        self._cache = {}
+
+    def infer_constant(self, name):
+        """
+        Infer a constant value for the given variable *name*.
+        If no value can be inferred, numba.errors.ConstantInferenceError
+        is raised.
+        """
+        if name not in self._cache:
+            try:
+                self._cache[name] = (True, self._do_infer(name))
+            except ConstantInferenceError as exc:
+                # Store the exception args only, to avoid keeping
+                # a whole traceback alive.
+                self._cache[name] = (False, (exc.__class__, exc.args))
+        success, val = self._cache[name]
+        if success:
+            return val
+        else:
+            exc, args = val
+            raise exc(*args)
+
+    def _fail(self, val):
+        raise ConstantInferenceError(
+            "constant inference not possible for %s" % (val,))
+
+    def _do_infer(self, name):
+        if not isinstance(name, str):
+            raise TypeError("infer_constant() called with non-str %r"
+                            % (name,))
+        try:
+            defn = self._interp.get_definition(name)
+        except KeyError:
+            raise ConstantInferenceError(
+                "no single definition for %r" % (name,))
+        try:
+            const = defn.infer_constant()
+        except ConstantInferenceError:
+            if isinstance(defn, ir.Expr):
+                return self._infer_expr(defn)
+            self._fail(defn)
+        return const
+
+    def _infer_expr(self, expr):
+        if expr.op == 'call':
+            if not expr.kws and not expr.vararg:
+                func = self.infer_constant(expr.func.name)
+                return self._infer_call(func, expr)
+        self._fail(expr)
+
+    def _infer_call(self, func, expr):
+        if expr.kws or expr.vararg:
+            self._fail(expr)
+        if (func in (slice,) or
+            (isinstance(func, type) and issubclass(func, BaseException))):
+            args = [self.infer_constant(a.name) for a in expr.args]
+            return func(*args)
+        self._fail(expr)

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -87,5 +87,11 @@ class CompilerError(NumbaError):
     """
 
 
+class ConstantInferenceError(NumbaError):
+    """
+    Failure during constant inference.
+    """
+
+
 __all__ += [name for (name, value) in globals().items()
             if not name.startswith('_') and issubclass(value, Exception)]

--- a/numba/rewrites/registry.py
+++ b/numba/rewrites/registry.py
@@ -69,7 +69,7 @@ class RewriteRegistry(object):
                 matches = rewrite.match(interp, block, pipeline.typemap,
                                         pipeline.calltypes)
                 if matches:
-                    if config.DUMP_IR:
+                    if config.DEBUG or config.DUMP_IR:
                         print("_" * 70)
                         print("REWRITING:")
                         block.dump()
@@ -77,7 +77,7 @@ class RewriteRegistry(object):
                     new_block = rewrite.apply()
                     blocks[key] = new_block
                     work_list.append((key, new_block))
-                    if config.DUMP_IR:
+                    if config.DEBUG or config.DUMP_IR:
                         new_block.dump()
                         print("_" * 70)
         # If any blocks were changed, perform a sanity check.

--- a/numba/rewrites/static_getitem.py
+++ b/numba/rewrites/static_getitem.py
@@ -21,10 +21,12 @@ class RewriteConstGetitems(Rewrite):
                     defn = interp.get_definition(expr.index)
                 except KeyError:
                     continue
+                print("defn =", defn)
                 try:
-                    const = defn.infer_constant()
+                    const = defn.infer_constant(interp)
                 except TypeError:
                     continue
+                print("-> const =", const)
                 getitems.append((expr, const))
 
         return len(getitems) > 0
@@ -59,7 +61,7 @@ class RewriteConstSetitems(Rewrite):
             except KeyError:
                 continue
             try:
-                const = defn.infer_constant()
+                const = defn.infer_constant(interp)
             except TypeError:
                 continue
             setitems[inst] = const

--- a/numba/rewrites/static_raise.py
+++ b/numba/rewrites/static_raise.py
@@ -35,8 +35,8 @@ class RewriteConstRaises(Rewrite):
         if call.kws or call.vararg:
             raise NotImplementedError
         try:
-            exc_type = interp.get_definition(call.func).infer_constant()
-            exc_args = tuple(interp.get_definition(arg).infer_constant()
+            exc_type = interp.get_definition(call.func).infer_constant(interp)
+            exc_args = tuple(interp.get_definition(arg).infer_constant(interp)
                              for arg in call.args)
         except (KeyError, TypeError):
             # Not all exception arguments are constants
@@ -67,7 +67,7 @@ class RewriteConstRaises(Rewrite):
                 else:
                     # Is it a compile-time constant?
                     try:
-                        const = excdef.infer_constant()
+                        const = excdef.infer_constant(interp)
                     except TypeError:
                         continue
                     try:

--- a/numba/rewrites/static_raise.py
+++ b/numba/rewrites/static_raise.py
@@ -21,27 +21,13 @@ class RewriteConstRaises(Rewrite):
         """
         Break down constant exception.
         """
-        if isinstance(const, Exception):
+        if isinstance(const, BaseException):
             return const.__class__, const.args
         elif self._is_exception_type(const):
             return const, None
         else:
-            raise NotImplementedError
-
-    def _break_call(self, interp, call):
-        """
-        Break down call expression giving an exception instance.
-        """
-        if call.kws or call.vararg:
-            raise NotImplementedError
-        try:
-            exc_type = interp.get_definition(call.func).infer_constant(interp)
-            exc_args = tuple(interp.get_definition(arg).infer_constant(interp)
-                             for arg in call.args)
-        except (KeyError, TypeError):
-            # Not all exception arguments are constants
-            raise NotImplementedError
-        return exc_type, exc_args
+            raise NotImplementedError("unsupported exception constant %r"
+                                      % (const,))
 
     def match(self, interp, block, typemap, calltypes):
         self.raises = raises = {}
@@ -54,26 +40,8 @@ class RewriteConstRaises(Rewrite):
                 exc_type, exc_args = None, None
             else:
                 # raise <something> => find the definition site for <something>
-                try:
-                    excdef = interp.get_definition(inst.exception)
-                except KeyError:
-                    continue
-                if isinstance(excdef, ir.Expr) and excdef.op == 'call':
-                    # Is it the result of calling a constant?
-                    try:
-                        exc_type, exc_args = self._break_call(interp, excdef)
-                    except NotImplementedError:
-                        continue
-                else:
-                    # Is it a compile-time constant?
-                    try:
-                        const = excdef.infer_constant(interp)
-                    except TypeError:
-                        continue
-                    try:
-                        exc_type, exc_args = self._break_constant(interp, const)
-                    except NotImplementedError:
-                        continue
+                const = interp.infer_constant(inst.exception)
+                exc_type, exc_args = self._break_constant(interp, const)
             raises[inst] = exc_type, exc_args
 
         return len(raises) > 0

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -997,27 +997,26 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
                                                 wraparound=False)
             return load_item(context, builder, srcty, src_ptr)
 
-    elif isinstance(srcty, types.UniTuple):
-        # Store the value in a slot to use getelementptr over it
-        # (extract_value only accepts constant indices)
-        src_slot = cgutils.alloca_once_value(builder, src)
+    elif isinstance(srcty, types.Sequence):
         src_dtype = srcty.dtype
 
-        # Check shape is equal to tuple length
+        # Check shape is equal to sequence length
         index_shape = indexer.get_shape()
         assert len(index_shape) == 1
+        len_impl = context.get_function(len, signature(types.intp, srcty))
+        seq_len = len_impl(builder, (src,))
 
-        shape_error = builder.icmp_signed('!=', index_shape[0],
-                                          Constant.int(index_shape[0].type, len(srcty)))
+        shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
 
         with builder.if_then(shape_error, likely=False):
             msg = "cannot assign slice from input of different size"
             context.call_conv.return_user_exc(builder, ValueError, (msg,))
 
         def src_getitem(source_indices):
-            assert len(source_indices) == 1
-            src_ptr = cgutils.gep_inbounds(builder, src_slot, 0, source_indices[0])
-            return builder.load(src_ptr)
+            idx, = source_indices
+            getitem_impl = context.get_function('getitem',
+                                                signature(src_dtype, srcty, types.intp))
+            return getitem_impl(builder, (src, idx))
 
     else:
         # Source is a scalar (broadcast or not, depending on destination

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -208,7 +208,6 @@ def static_getitem_tuple(context, builder, sig, args):
         res = builder.extract_value(tup, idx)
     elif isinstance(idx, slice):
         items = cgutils.unpack_tuple(builder, tup)[idx]
-        print("items =", items, tupty, sig.return_type)
         res = context.make_tuple(builder, sig.return_type, items)
     else:
         raise NotImplementedError("unexpected index %r for %s"

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -202,9 +202,17 @@ def getitem_unituple(context, builder, sig, args):
 
 @lower_builtin('static_getitem', types.BaseTuple, types.Const)
 def static_getitem_tuple(context, builder, sig, args):
+    tupty, _ = sig.args
     tup, idx = args
-    assert isinstance(idx, int)
-    res = builder.extract_value(tup, idx)
+    if isinstance(idx, int):
+        res = builder.extract_value(tup, idx)
+    elif isinstance(idx, slice):
+        items = cgutils.unpack_tuple(builder, tup)[idx]
+        print("items =", items, tupty, sig.return_type)
+        res = context.make_tuple(builder, sig.return_type, items)
+    else:
+        raise NotImplementedError("unexpected index %r for %s"
+                                  % (idx, sig.args[0]))
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -743,30 +743,41 @@ class TestSetItem(TestCase):
         with self.assertRaises(ValueError):
             cfunc(np.zeros_like(arg), arg, 0, 0, 1)
 
-    def test_1d_slicing_set_tuple(self, flags=enable_pyobj_flags):
+    def check_1d_slicing_set_sequence(self, flags, seqty, seq):
         """
-        Tuple to 1d slice assignment
+        Generic sequence to 1d slice assignment
         """
         pyfunc = slicing_1d_usecase_set
-        # Note heterogenous types for the source and destination arrays
         dest_type = types.Array(types.int32, 1, 'C')
-        src_type = types.UniTuple(types.int16, 2)
-        argtys = (dest_type, src_type, types.int32, types.int32, types.int32)
+        argtys = (dest_type, seqty, types.int32, types.int32, types.int32)
         cr = compile_isolated(pyfunc, argtys, flags=flags)
         cfunc = cr.entry_point
 
         N = 10
+        k = len(seq)
         arg = np.arange(N, dtype=np.int32)
-        args = ((8, -42), 1, -N+3, 1)
+        args = (seq, 1, -N + k + 1, 1)
         expected = pyfunc(arg.copy(), *args)
         got = cfunc(arg.copy(), *args)
         self.assertPreciseEqual(expected, got)
 
-        args = ((8, -42), 1, -N+2, 1)
+        args = (seq, 1, -N + k, 1)
         with self.assertRaises(ValueError) as raises:
             cfunc(arg.copy(), *args)
-        self.assertEqual(str(raises.exception),
-                         "cannot assign slice from input of different size")
+
+    def test_1d_slicing_set_tuple(self, flags=enable_pyobj_flags):
+        """
+        Tuple to 1d slice assignment
+        """
+        self.check_1d_slicing_set_sequence(
+            flags, types.UniTuple(types.int16, 2), (8, -42))
+
+    def test_1d_slicing_set_list(self, flags=enable_pyobj_flags):
+        """
+        List to 1d slice assignment
+        """
+        self.check_1d_slicing_set_sequence(
+            flags, types.List(types.int16), [8, -42])
 
     def test_1d_slicing_broadcast(self, flags=enable_pyobj_flags):
         """
@@ -807,6 +818,9 @@ class TestSetItem(TestCase):
 
     def test_1d_slicing_set_npm(self):
         self.test_1d_slicing_set(flags=Noflags)
+
+    def test_1d_slicing_set_list_npm(self):
+        self.test_1d_slicing_set_list(flags=Noflags)
 
     def test_1d_slicing_set_tuple_npm(self):
         self.test_1d_slicing_set_tuple(flags=Noflags)

--- a/numba/tests/test_indexing.py
+++ b/numba/tests/test_indexing.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import types, utils, njit, errors, typeof
+from numba import types, utils, njit, errors, typeof, numpy_support
 from .support import TestCase
 
 
@@ -761,9 +761,11 @@ class TestSetItem(TestCase):
         got = cfunc(arg.copy(), *args)
         self.assertPreciseEqual(expected, got)
 
-        args = (seq, 1, -N + k, 1)
-        with self.assertRaises(ValueError) as raises:
-            cfunc(arg.copy(), *args)
+        if numpy_support.version != (1, 7):
+            # Numpy 1.7 doesn't always raise an error here (object mode)
+            args = (seq, 1, -N + k, 1)
+            with self.assertRaises(ValueError) as raises:
+                cfunc(arg.copy(), *args)
 
     def test_1d_slicing_set_tuple(self, flags=enable_pyobj_flags):
         """

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -31,6 +31,12 @@ def tuple_second(tup):
 def tuple_index(tup, idx):
     return tup[idx]
 
+def tuple_slice2(tup):
+    return tup[1:-1]
+
+def tuple_slice3(tup):
+    return tup[1::2]
+
 def len_usecase(tup):
     return len(tup)
 
@@ -154,6 +160,22 @@ class TestOperations(TestCase):
         tup = (4, 5, 6)
         for i in range(len(tup)):
             self.assertPreciseEqual(cr.entry_point(tup, i), tup[i])
+
+    def check_slice(self, pyfunc):
+        tup = (4, 5, 6, 7)
+        cr = compile_isolated(pyfunc,
+                              [types.UniTuple(types.int64, 4)])
+        self.assertPreciseEqual(cr.entry_point(tup), pyfunc(tup))
+        cr = compile_isolated(
+            pyfunc,
+            [types.Tuple((types.int64, types.int32, types.int64, types.int32))])
+        self.assertPreciseEqual(cr.entry_point(tup), pyfunc(tup))
+
+    def test_slice2(self):
+        self.check_slice(tuple_slice2)
+
+    def test_slice3(self):
+        self.check_slice(tuple_slice3)
 
     def test_bool(self):
         pyfunc = bool_usecase

--- a/numba/types.py
+++ b/numba/types.py
@@ -167,11 +167,17 @@ class Const(Dummy):
 
     def __init__(self, value):
         self.value = value
+        try:
+            hash(value)
+        except TypeError:
+            self._key = id(value)
+        else:
+            self._key = value
         super(Const, self).__init__("const(%r)" % (value,))
 
     @property
     def key(self):
-        return type(self.value), self.value
+        return type(self.value), self._key
 
 
 class VarArg(Type):

--- a/numba/types.py
+++ b/numba/types.py
@@ -167,6 +167,8 @@ class Const(Dummy):
 
     def __init__(self, value):
         self.value = value
+        # We want to support constants of non-hashable values, therefore
+        # fall back on the value's id() if necessary.
         try:
             hash(value)
         except TypeError:

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -482,8 +482,12 @@ class StaticGetItemTuple(AbstractTemplate):
 
     def generic(self, args, kws):
         tup, idx = args
-        if isinstance(tup, types.BaseTuple) and isinstance(idx, int):
+        if not isinstance(tup, types.BaseTuple):
+            return
+        if isinstance(idx, int):
             return tup.types[idx]
+        elif isinstance(idx, slice):
+            return types.BaseTuple.from_types(tup.types[idx])
 
 
 #-------------------------------------------------------------------------------

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -48,7 +48,9 @@ class GetItemSequence(AbstractTemplate):
         if isinstance(seq, types.Sequence):
             idx = normalize_1d_index(idx)
             if isinstance(idx, types.SliceType):
-                return signature(seq, seq, idx)
+                # Slicing a tuple only supported with static_getitem
+                if not isinstance(seq, types.BaseTuple):
+                    return signature(seq, seq, idx)
             elif isinstance(idx, types.Integer):
                 return signature(seq.dtype, seq, idx)
 


### PR DESCRIPTION
This allows things like `array[:] = (1, 2, 3)`.
Lists and homogenous tuples are supported on the right-hand side. Based on PR #1622.