### PR TITLE
Fix #1628: fix ctypes and cffi tests under Windows

### DIFF
--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -35,6 +35,9 @@ test:
     - argparse       [py26]
     - unittest2      [py26]
     - jinja2
+    # Required to test optional Numba features
+    - cffi
+    - scipy
   files:
     - mandel.py
   commands:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -36,6 +36,9 @@ test:
     - argparse       [py26]
     - unittest2      [py26]
     - jinja2
+    # Required to test optional Numba features
+    - cffi
+    - scipy
   files:
     - mandel.py
   commands:

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -5,8 +5,8 @@ Expose all functions as pointers in a dedicated C extension.
 #define NUMBA_EXPORT_FUNC(_rettype) static _rettype
 #define NUMBA_EXPORT_DATA(_vartype) static _vartype
 
+#include <math.h>
 #include "_helperlib.c"
-
 
 static PyObject *
 build_c_helpers_dict(void)
@@ -100,6 +100,30 @@ static PyMethodDef ext_methods[] = {
     { "rnd_shuffle", (PyCFunction) _numba_rnd_shuffle, METH_O, NULL },
     { NULL },
 };
+
+/*
+ * These functions are exported by the module's DLL, to exercise ctypes / cffi
+ * without relying on libc availability (see https://bugs.python.org/issue23606)
+ */
+
+PyAPI_FUNC(double) _numba_test_sin(double x);
+PyAPI_FUNC(double) _numba_test_cos(double x);
+PyAPI_FUNC(double) _numba_test_exp(double x);
+
+double _numba_test_sin(double x)
+{
+    return sin(x);
+}
+
+double _numba_test_cos(double x)
+{
+    return cos(x);
+}
+
+double _numba_test_exp(double x)
+{
+    return cos(x);
+}
 
 
 MOD_INIT(_helperlib) {

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -122,7 +122,7 @@ double _numba_test_cos(double x)
 
 double _numba_test_exp(double x)
 {
-    return cos(x);
+    return exp(x);
 }
 
 

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -14,6 +14,9 @@ def load_inline_module():
     """
     from cffi import FFI
 
+    # We can't rely on libc availability on Windows anymore, so we use our
+    # own compiled wrappers (see https://bugs.python.org/issue23606).
+
     defs = """
     double _numba_test_sin(double x);
     double _numba_test_cos(double x);

--- a/numba/tests/ctypes_usecases.py
+++ b/numba/tests/ctypes_usecases.py
@@ -6,6 +6,9 @@ import sys
 
 is_windows = sys.platform.startswith('win32')
 
+# We can't rely on libc availability on Windows anymore, so we use our
+# own compiled wrappers (see https://bugs.python.org/issue23606).
+
 from numba import _helperlib
 libnumba = CDLL(_helperlib.__file__)
 del _helperlib

--- a/numba/tests/ctypes_usecases.py
+++ b/numba/tests/ctypes_usecases.py
@@ -6,35 +6,34 @@ import sys
 
 is_windows = sys.platform.startswith('win32')
 
-if is_windows:
-    libc = cdll.msvcrt
-else:
-    libc = CDLL(None)
+from numba import _helperlib
+libnumba = CDLL(_helperlib.__file__)
+del _helperlib
 
-# A typed libc function (cdecl under Windows)
+# A typed C function (cdecl under Windows)
 
-c_sin = libc.sin
+c_sin = libnumba._numba_test_sin
 c_sin.argtypes = [c_double]
 c_sin.restype = c_double
 
 def use_c_sin(x):
     return c_sin(x)
 
-c_cos = libc.cos
+c_cos = libnumba._numba_test_cos
 c_cos.argtypes = [c_double]
 c_cos.restype = c_double
 
 def use_two_funcs(x):
     return c_sin(x) - c_cos(x)
 
-# An untyped libc function
+# An untyped C function
 
-c_untyped = libc.exp
+c_untyped = libnumba._numba_test_exp
 
 def use_c_untyped(x):
     return c_untyped(x)
 
-# A libc function wrapped in a CFUNCTYPE
+# A C function wrapped in a CFUNCTYPE
 
 ctype_wrapping = CFUNCTYPE(c_double, c_double)(use_c_sin)
 

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -68,7 +68,7 @@ class TestCTypes(MemoryLeakMixin, unittest.TestCase):
     def test_untyped_function(self):
         with self.assertRaises(TypeError) as raises:
             compile_isolated(use_c_untyped, [types.double])
-        self.assertIn("ctypes function 'exp' doesn't define its argument types",
+        self.assertIn("ctypes function '_numba_test_exp' doesn't define its argument types",
                       str(raises.exception))
 
     def test_python_call_back(self):


### PR DESCRIPTION
Also add cffi and scipy to the installed modules on the Jenkins builders.