### PR TITLE
Fix test failure on Numpy 1.9 and Python 3.5

### DIFF
--- a/numba/tests/matmul_usecase.py
+++ b/numba/tests/matmul_usecase.py
@@ -7,10 +7,12 @@ except ImportError:
     has_blas = False
 
 import numba.unittest_support as unittest
+from numba.numpy_support import version as numpy_version
 
 
 # The "@" operator only compiles on Python 3.5+.
-has_matmul = sys.version_info >= (3, 5)
+# It is only supported by Numpy 1.10+.
+has_matmul = sys.version_info >= (3, 5) and numpy_version >= (1, 10)
 
 if has_matmul:
     code = """if 1:
@@ -32,7 +34,8 @@ else:
     imatmul_usecase = None
 
 needs_matmul = unittest.skipUnless(
-    has_matmul, "the matrix multiplication operator needs Python 3.5+")
+    has_matmul,
+    "the matrix multiplication operator needs Python 3.5+ and Numpy 1.10+")
 
 needs_blas = unittest.skipUnless(has_blas, "BLAS needs Scipy 0.16+")
 


### PR DESCRIPTION
The "@" operator between arrays is only supported by Numpy 1.10+. This should fix the failure on the OS X builder.