### PR TITLE
Fix conda test invocation and remove obsolete test API.

### DIFF
--- a/buildscripts/condarecipe.hsa/run_test.py
+++ b/buildscripts/condarecipe.hsa/run_test.py
@@ -6,8 +6,9 @@ if sys.platform.startswith('win32'):
     args += ['-b']
 else:
     args += ['-m', '-b']
+args += ['numba.tests']
 
-if not numba.test(*args):
+if not numba.runtests.main(*args):
     print("Test failed")
     sys.exit(1)
 print('numba.__version__: %s' % numba.__version__)

--- a/buildscripts/condarecipe.jenkins/run_test.py
+++ b/buildscripts/condarecipe.jenkins/run_test.py
@@ -1,13 +1,15 @@
 import sys
 import numba
+import numba.runtests
 
 args = []
 if sys.platform.startswith('win32'):
     args += ['-b']
 else:
     args += ['-m', '-b']
+args += ['numba.tests']
 
-if not numba.test(*args):
+if not numba.runtests.main(*args):
     print("Test failed")
     sys.exit(1)
 print('numba.__version__: %s' % numba.__version__)

--- a/buildscripts/condarecipe.local/run_test.py
+++ b/buildscripts/condarecipe.local/run_test.py
@@ -6,8 +6,9 @@ if sys.platform.startswith('win32'):
     args += ['-b']
 else:
     args += ['-m', '-b']
+args += ['numba.tests']
 
-if not numba.test(*args):
+if not numba.runtests.main(*args):
     print("Test failed")
     sys.exit(1)
 print('numba.__version__: %s' % numba.__version__)

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -4,7 +4,7 @@ Expose top-level symbols that are safe for import *
 from __future__ import print_function, division, absolute_import
 import re
 
-from . import testing, decorators
+from . import runtests, decorators
 from . import errors, special, types, config
 
 # Re-export typeof
@@ -29,8 +29,8 @@ from .numpy_support import from_dtype
 # Re export jitclass
 from .jitclass import jitclass
 
-# Re-export test entrypoint
-test = testing.test
+# Keep this for backward compatibility.
+test = runtests.main
 
 # Try to initialize cuda
 from . import cuda

--- a/numba/runtests.py
+++ b/numba/runtests.py
@@ -1,5 +1,18 @@
 import sys
 from numba.testing import run_tests
 
+def _main(argv, **kwds):
+    # This helper function assumes the first element of argv
+    # is the name of the calling program.
+    # The 'main' API function is invoked in-process, and thus
+    # will synthesize that name.
+    return run_tests(argv, **kwds).wasSuccessful()
+
+def main(*argv, **kwds):
+    """keyword arguments are accepted for backward compatiblity only.
+    See `numba.testing.run_tests()` documentation for details."""
+
+    return _main(['<main>'] + list(argv), **kwds)
+
 if __name__ == '__main__':
-    sys.exit(0 if run_tests(sys.argv).wasSuccessful() else 1)
+    sys.exit(0 if _main(sys.argv) else 1)

--- a/numba/testing/__init__.py
+++ b/numba/testing/__init__.py
@@ -64,11 +64,3 @@ def run_tests(argv=None, xmloutput=None, verbosity=1, nomultiproc=False):
                             verbosity=verbosity,
                             nomultiproc=nomultiproc)
     return prog.result
-
-
-def test(*args, **kwargs):
-    return run_tests(argv=['<main>'] + list(args), **kwargs).wasSuccessful()
-
-
-if __name__ == "__main__":
-    sys.exit(0 if run_tests(sys.argv).wasSuccessful() else 1)

--- a/numba/testing/loader.py
+++ b/numba/testing/loader.py
@@ -24,5 +24,5 @@ class TestLoader(loader.TestLoader):
                 except Exception as e:
                     yield loader._make_failed_load_tests(package.__name__, e, self.suiteClass)
         else:
-            for t in super(TestLoader, self)._find_tests(start_dir, pattern, namespace):
+            for t in super(TestLoader, self)._find_tests(start_dir, pattern):
                 yield t

--- a/runtests.py
+++ b/runtests.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function, division, absolute_import
-import sys
 
-import numba.testing as testing
+import runpy
 
-if __name__ == "__main__":
-    result = testing.run_tests(sys.argv)
-    sys.exit(0 if result.wasSuccessful() else 1)
+runpy.run_module('numba.runtests', run_name='__main__')


### PR DESCRIPTION
The important change in this PR is the adjustment of the conda test scripts for a recent change in the build logic.
At the same time it takes the opportunity to reduce the number of entry points to running our test suite:
The top-level `./runtests.py` script is removed (use `python -m numba.runtests` instead), and the `numba.test()` function is essentially a backward-compatible proxy to `numba.runtests.main()`.
At this point the two supported (and functionally equivalent) ways to run the tests are:

* `python -m numba.runtests <args>`
* `python -c "from numba import runtests; runtests.main(<args>)"`

Note that the last element in the `args` argument vector needs to be a test (or test suite) ID. To run all standard tests, use 'numba.tests'. E.g.:

  `python -m numba.runtests -l numba.tests`

will list all tests under numba.tests. (Example and notebooks are not included there yet.)