### PR TITLE
Implementation of np.linalg.inv using Lapack

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -160,6 +160,7 @@ floating-point and complex numbers.
 * :func:`numpy.vdot`
 * On Python 3.5 and above, the matrix multiplication operator from
   :pep:`465` (i.e. ``a @ b`` where ``a`` and ``b`` are 1-D or 2-D arrays).
+* :func:`numpy.linalg.inv`
 
 .. note::
    The implementation of these functions needs Scipy 0.16+ to be installed.

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -78,6 +78,8 @@ build_c_helpers_dict(void)
     declmethod(xxgemm);
     declmethod(xxgemv);
     declmethod(xxdot);
+    declmethod(xxgetrf);
+    declmethod(xxgetri);
 
     declpointer(py_random_state);
     declpointer(np_random_state);

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -779,6 +779,23 @@ class MatMul(MatMulTyperMixin, AbstractTemplate):
             return signature(restype, *args)
 
 
+@infer_global(numpy.linalg.inv)
+class LinalgInv(CallableTemplate):
+
+    def generic(self):
+        def typer(a):
+            if not isinstance(a, types.Array):
+                return
+            if not a.ndim == 2:
+                raise TypingError("np.linalg.inv() only supported on 2-D arrays")
+            if not isinstance(a.dtype, (types.Float, types.Complex)):
+                raise TypingError("np.linalg.inv() only supported on "
+                                  "float and complex arrays")
+            return a.copy(layout='C')
+
+        return typer
+
+
 # -----------------------------------------------------------------------------
 # Miscellaneous functions
 


### PR DESCRIPTION
I started working on implementing np.linalg.inv using the cython Lapack binding found in scipy. I am far from finished but I would like some advices as I am not at all familiar with the internals of numba.
I will summarize my main questions here (they also appear as inline comments in my changes) : 
-  in _helperlib.c integer seems to always be passed as Py_ssize_t. When calling LAPACK functions I need to provide integer pointers used as return values should I also use Py_ssize_t.
- to create new arrays for internal use I compiled functions calling numpy functions. Is this the right way to go ? If yes, what is the exact return type of the function ? should it be treated as the numpy arrays passed as input arguments ?
- for raising exceptions I am also using compile_internal, is that correct ?
- when using numba types (such as integer), how should those types be instantiated in signatures ?

Any other comment is of course welcomed !

Thanks
Matthieu