### PR TITLE
Fix Linux checks on Python 2

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -44,7 +44,7 @@ def _os_supports_avx():
     This is necessary because the user may be running a very old Linux
     kernel (e.g. CentOS 5) on a recent CPU.
     """
-    if (sys.platform != 'linux'
+    if (not sys.platform.startswith('linux')
         or platform.machine() not in ('i386', 'i586', 'i686', 'x86_64')):
         return True
     # Executing the CPUID instruction may report AVX available even though

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -176,7 +176,7 @@ class TestCC(BasePYCCTest):
         f = self._test_module.cc.output_file
         self.assertFalse(os.path.exists(f), f)
         self.assertTrue(os.path.basename(f).startswith('pycc_test_simple.'), f)
-        if sys.platform == 'linux':
+        if sys.platform.startswith('linux'):
             self.assertTrue(f.endswith('.so'), f)
             if sys.version_info >= (3,):
                 self.assertIn('.cpython', f)


### PR DESCRIPTION
This should finally fix crashes on the CentOS builders