### PR TITLE
Fix typo.

### DIFF
--- a/numba/testing/__init__.py
+++ b/numba/testing/__init__.py
@@ -41,7 +41,8 @@ def allow_interpreter_mode(fn):
     return _core
 
 
-def run_tests(argv=None, defaultTest=None, xmloutput=None, verbosity=1, nomultiproc=False):
+def run_tests(argv=None, defaultTest=None, topleveldir=None,
+              xmloutput=None, verbosity=1, nomultiproc=False):
     """
     args
     ----
@@ -61,6 +62,7 @@ def run_tests(argv=None, defaultTest=None, xmloutput=None, verbosity=1, nomultip
     prog = NumbaTestProgram(argv=argv,
                             module=None,
                             defaultTest=defaultTest,
+                            topleveldir=topleveldir,
                             testRunner=runner, exit=False,
                             verbosity=verbosity,
                             nomultiproc=nomultiproc)

--- a/numba/testing/loader.py
+++ b/numba/testing/loader.py
@@ -5,10 +5,10 @@ from os.path import isdir, isfile, join, dirname, basename
 
 class TestLoader(loader.TestLoader):
 
-    # Unfortunately there is right now no other way to set
-    # the top-level directory.
-    # ('-t' only works after the 'discover' command).
-    _top_level_dir = dirname(dirname(dirname(__file__)))
+
+    def __init__(self, topleveldir=None):
+        super(TestLoader, self).__init__()
+        self._top_level_dir = topleveldir or dirname(dirname(dirname(__file__)))
 
     def _find_tests(self, start_dir, pattern, namespace=False):
         # Upstream doesn't look for 'load_tests' in start_dir.

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import unittest
+import subprocess
+
+def check_output(*popenargs, **kwargs):
+    # Provide this for backward-compatibility until we drop Python 2.6 support.
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise subprocess.CalledProcessError(retcode, cmd)
+    return output
+
+
+class TestCase(unittest.TestCase):
+    """These test cases are meant to test the Numba test infrastructure itself.
+    Therefore, the logic used here shouldn't use numba.testing, but only the upstream
+    unittest, and run the numba test suite only in a subprocess."""
+    
+
+    def check_testsuite_size(self, id, minsize, maxsize = None):
+        """Check that the reported numbers of tests in 'id' are 
+        in the (minsize, maxsize) range, or are equal to minsize if maxsize is None."""
+
+        cmd = ['python', '-m', 'numba.runtests', '-l']
+        if id:
+            cmd.append(id)
+        last_line = check_output(cmd).decode().split('\n')[-2]
+        self.assertTrue(last_line.endswith('tests found'))
+        number = int(last_line.split(' ')[0])
+        if maxsize is None:
+            self.assertEqual(number, minsize)
+        else:
+            self.assertGreaterEqual(number, minsize)
+            self.assertLessEqual(number, maxsize)
+
+    def test_default(self):
+        self.check_testsuite_size('', 7000, 8000)
+    def test_all(self):
+        self.check_testsuite_size('numba.tests', 7000, 8000)
+    def test_cuda(self):
+        self.check_testsuite_size('numba.cuda.tests', 0, 400)
+    def test_module(self):
+        self.check_testsuite_size('numba.tests.test_builtins', 82)
+        
+if __name__ == '__main__':
+    unittest.main()
+    


### PR DESCRIPTION
This PR fixes a Python 2.7 incompatibility. We used to test for the existence of 'self.tests' as a measure of whether tests were successfully instantiated. However, that member only exists in Python 3.
Testing for 'self.test' instead will work for Python 2 and Python 3.