### PR TITLE
Fix #1642: implement np.diag()

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -171,6 +171,7 @@ The following top-level functions are supported:
 
 * :func:`numpy.arange`
 * :func:`numpy.array` (only the 2 first arguments)
+* :func:`numpy.diag`
 * :func:`numpy.empty`
 * :func:`numpy.empty_like`
 * :func:`numpy.eye`

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -2459,9 +2459,7 @@ def numpy_diag_kwarg(context, builder, sig, args):
         # matrix context
         def diag_impl(arr, k=0):
             #Will return arr.diagonal(v, k) when axis args are supported
-            s = arr.shape
-            rows = s[0]
-            cols = s[1]
+            rows, cols = arr.shape
             r = rows
             c = cols
             if k < 0:
@@ -2470,13 +2468,12 @@ def numpy_diag_kwarg(context, builder, sig, args):
                 cols = cols - k
             n = max(min(rows, cols), 0)
             ret = numpy.empty(n, arr.dtype)
-            flt = arr.flat
             if k >= 0:
                 for i in range(n):
-                    ret[i] = flt[i * c + k + i]
+                    ret[i] = arr[i, k + i]
             else:
                 for i in range(n):
-                    ret[i] = flt[(i - k) * c + i]
+                    ret[i] = arr[i - k, i]
             return ret
     else:
         #invalid input

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -2433,6 +2433,57 @@ def numpy_eye(context, builder, sig, args):
     res = context.compile_internal(builder, eye, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
+@lower_builtin(numpy.diag, types.Array)
+def numpy_diag(context, builder, sig, args):
+    def diag_impl(val):
+        return numpy.diag(val, k=0)
+    return context.compile_internal(builder, diag_impl, sig, args)
+
+@lower_builtin(numpy.diag, types.Array, types.Integer)
+def numpy_diag_kwarg(context, builder, sig, args):
+    arg = sig.args[0]
+    if arg.ndim == 1:
+        # vector context
+        def diag_impl(arr, k=0):
+            s = arr.shape
+            n = s[0] + abs(k)
+            ret = numpy.zeros((n, n), arr.dtype)
+            if k >= 0:
+                for i in range(n - k):
+                    ret[i, k + i] = arr[i]
+            else:
+                for i in range(n + k):
+                    ret[i - k, i] = arr[i]
+            return ret
+    elif arg.ndim == 2:
+        # matrix context
+        def diag_impl(arr, k=0):
+            #Will return arr.diagonal(v, k) when axis args are supported
+            s = arr.shape
+            rows = s[0]
+            cols = s[1]
+            r = rows
+            c = cols
+            if k < 0:
+                rows = rows + k
+            if k > 0:
+                cols = cols - k
+            n = max(min(rows, cols), 0)
+            ret = numpy.empty(n, arr.dtype)
+            flt = arr.flat
+            if k >= 0:
+                for i in range(n):
+                    ret[i] = flt[i * c + k + i]
+            else:
+                for i in range(n):
+                    ret[i] = flt[(i - k) * c + i]
+            return ret
+    else:
+        #invalid input
+        raise ValueError("Input must be 1- or 2-d.")
+
+    res = context.compile_internal(builder, diag_impl, sig, args)
+    return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin(numpy.arange, types.Number)
 def numpy_arange_1(context, builder, sig, args):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -852,6 +852,67 @@ class TestNdEye(BaseTest):
         self.check_eye_n_m_k(func)
 
 
+class TestNdDiag(TestCase):
+
+    def setUp(self):
+        v = np.array([1, 2, 3])
+        hv = np.array([[1, 2, 3]])
+        vv = np.transpose(hv)
+        self.vectors = [v, hv, vv]
+        a3x4 = np.arange(12).reshape(3, 4)
+        a4x3 = np.arange(12).reshape(4, 3)
+        self.matricies = [a3x4, a4x3]
+        def func(q):
+            return np.diag(q)
+        self.f_diag = func
+
+        def func_kwarg(q, k=0):
+            return np.diag(q, k=k)
+        self.f_diag_kwarg = func_kwarg
+
+    def check_diag(self, pyfunc, *args, **kwargs):
+        cfunc = nrtjit(pyfunc)
+        expected = pyfunc(*args, **kwargs)
+        computed = cfunc(*args, **kwargs)
+        self.assertEqual(computed.size, expected.size)
+        self.assertEqual(computed.dtype, expected.dtype)
+        # NOTE: stride not tested as np returns a RO view, nb returns new data
+        np.testing.assert_equal(expected, computed)
+
+    # create a diag matrix from a vector
+    def test_diag_vect_create(self):
+        for d in self.vectors:
+            self.check_diag(self.f_diag, d)
+
+    # create a diag matrix from a vector at a given offset
+    def test_diag_vect_create_kwarg(self):
+        for k in range(-10, 10):
+            for d in self.vectors:
+                self.check_diag(self.f_diag_kwarg, d, k=k)
+
+    # extract the diagonal
+    def test_diag_extract(self):
+        for d in self.matricies:
+            self.check_diag(self.f_diag, d)
+
+    # extract a diagonal at a given offset
+    def test_diag_extract_kwarg(self):
+        for k in range(-4, 4):
+            for d in self.matricies:
+                self.check_diag(self.f_diag_kwarg, d, k=k)
+
+    # check error handling
+    def test_error_handling(self):
+      # missing arg
+      with self.assertRaises(TypeError):
+          cfunc = nrtjit(self.f_diag())
+
+      # > 2d
+      with self.assertRaises(ValueError):
+          d = np.array([[[1]]])
+          cfunc = nrtjit(self.f_diag(d))
+
+
 class TestNdArange(BaseTest):
 
     def test_linspace_2(self):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -904,3 +904,20 @@ class Angle(CallableTemplate):
             else:
                 return types.float64
         return typer
+
+@infer_global(numpy.diag)
+class DiagCtor(CallableTemplate):
+    """
+    Typing template for np.diag()
+    """
+    def generic(self):
+        def typer(ref, k = 0):
+            if(isinstance(ref, types.Array)):
+                if ref.ndim == 1:
+                    rdim = 2
+                elif ref.ndim == 2:
+                    rdim = 1
+                else:
+                    return None
+                return types.Array(ndim=rdim, dtype=ref.dtype, layout='C')
+        return typer


### PR DESCRIPTION
This patch implements `np.diag()` functionality. Tests aim to check
vector and matrix context with and without a kwarg to specified an
offset.

NOTE: the implementation returns new data whereas numpy returns
a RO view. This detail is purely for implementation simplicity on
the numba side.