### PR TITLE
Fix np.prod() tests on 64-bit Windows

### DIFF
--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -91,7 +91,9 @@ def base_test_arrays(dtype):
 
     a1 = factory(10)
     a2 = factory(10).reshape(2, 5)
-    a3 = (factory(60))[::2].reshape((2, 5, 3), order='A')
+    # The prod() of this array fits in a 32-bit int
+    a3 = (factory(12))[::-1].reshape((2, 3, 2), order='A')
+    assert not (a3.flags.c_contiguous or a3.flags.f_contiguous)
 
     return [a1, a2, a3]
 


### PR DESCRIPTION
The failure is due to prod() overflowing a 32-bit int and Numpy and Numba handling the overflow differently.