### PR TITLE
FIX: linalg.inv() failure on py26np19

### DIFF
--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -303,7 +303,7 @@ class TestLinalgInv(TestCase):
             got = cfunc(a)
             # XXX add to use that function otherwise comparison fails
             # because of +0, -0 discrepancies
-            np.testing.assert_array_almost_equal_nulp(got, expected)
+            np.testing.assert_array_almost_equal_nulp(got, expected, nulp=2)
 
         for order in 'CF':
             a = np.array(((2, 1), (2, 3)), dtype=np.float64, order=order)


### PR DESCRIPTION
Adjusts test tolerance to allow small differences in the inversion
of matrices with `dtype=complex64` to be accepted.