### PR TITLE
Fix #1616: use system-provided versions of C99 math where possible

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -459,490 +459,55 @@ numba_cpow(Py_complex *a, Py_complex *b, Py_complex *c) {
     *c = _Py_c_pow(*a, *b);
 }
 
-/* provide gamma() and lgamma(); code borrowed from CPython */
-
-/*
-   sin(pi*x), giving accurate results for all finite x (especially x
-   integral or close to an integer).  This is here for use in the
-   reflection formula for the gamma function.  It conforms to IEEE
-   754-2008 for finite arguments, but not for infinities or nans.
-*/
-
-static const double pi = 3.141592653589793238462643383279502884197;
-static const double sqrtpi = 1.772453850905516027298167483341145182798;
-static const double logpi = 1.144729885849400174143427351353058711647;
-
-static double
-sinpi(double x)
-{
-    double y, r;
-    int n;
-    /* this function should only ever be called for finite arguments */
-    assert(Py_IS_FINITE(x));
-    y = fmod(fabs(x), 2.0);
-    n = (int)round(2.0*y);
-    assert(0 <= n && n <= 4);
-    switch (n) {
-    case 0:
-        r = sin(pi*y);
-        break;
-    case 1:
-        r = cos(pi*(y-0.5));
-        break;
-    case 2:
-        /* N.B. -sin(pi*(y-1.0)) is *not* equivalent: it would give
-           -0.0 instead of 0.0 when y == 1.0. */
-        r = sin(pi*(1.0-y));
-        break;
-    case 3:
-        r = -cos(pi*(y-1.5));
-        break;
-    case 4:
-        r = sin(pi*(y-2.0));
-        break;
-    default:
-        assert(0);  /* should never get here */
-        r = -1.23e200; /* silence gcc warning */
-    }
-    return copysign(1.0, x)*r;
-}
-
-/* Implementation of the real gamma function.  In extensive but non-exhaustive
-   random tests, this function proved accurate to within <= 10 ulps across the
-   entire float domain.  Note that accuracy may depend on the quality of the
-   system math functions, the pow function in particular.  Special cases
-   follow C99 annex F.  The parameters and method are tailored to platforms
-   whose double format is the IEEE 754 binary64 format.
-
-   Method: for x > 0.0 we use the Lanczos approximation with parameters N=13
-   and g=6.024680040776729583740234375; these parameters are amongst those
-   used by the Boost library.  Following Boost (again), we re-express the
-   Lanczos sum as a rational function, and compute it that way.  The
-   coefficients below were computed independently using MPFR, and have been
-   double-checked against the coefficients in the Boost source code.
-
-   For x < 0.0 we use the reflection formula.
-
-   There's one minor tweak that deserves explanation: Lanczos' formula for
-   Gamma(x) involves computing pow(x+g-0.5, x-0.5) / exp(x+g-0.5).  For many x
-   values, x+g-0.5 can be represented exactly.  However, in cases where it
-   can't be represented exactly the small error in x+g-0.5 can be magnified
-   significantly by the pow and exp calls, especially for large x.  A cheap
-   correction is to multiply by (1 + e*g/(x+g-0.5)), where e is the error
-   involved in the computation of x+g-0.5 (that is, e = computed value of
-   x+g-0.5 - exact value of x+g-0.5).  Here's the proof:
-
-   Correction factor
-   -----------------
-   Write x+g-0.5 = y-e, where y is exactly representable as an IEEE 754
-   double, and e is tiny.  Then:
-
-     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) = pow(y-e, x-0.5)/exp(y-e)
-     = pow(y, x-0.5)/exp(y) * C,
-
-   where the correction_factor C is given by
-
-     C = pow(1-e/y, x-0.5) * exp(e)
-
-   Since e is tiny, pow(1-e/y, x-0.5) ~ 1-(x-0.5)*e/y, and exp(x) ~ 1+e, so:
-
-     C ~ (1-(x-0.5)*e/y) * (1+e) ~ 1 + e*(y-(x-0.5))/y
-
-   But y-(x-0.5) = g+e, and g+e ~ g.  So we get C ~ 1 + e*g/y, and
-
-     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) ~ pow(y, x-0.5)/exp(y) * (1 + e*g/y),
-
-   Note that for accuracy, when computing r*C it's better to do
-
-     r + e*g/y*r;
-
-   than
-
-     r * (1 + e*g/y);
-
-   since the addition in the latter throws away most of the bits of
-   information in e*g/y.
-*/
-
-#define LANCZOS_N 13
-static const double lanczos_g = 6.024680040776729583740234375;
-static const double lanczos_g_minus_half = 5.524680040776729583740234375;
-static const double lanczos_num_coeffs[LANCZOS_N] = {
-    23531376880.410759688572007674451636754734846804940,
-    42919803642.649098768957899047001988850926355848959,
-    35711959237.355668049440185451547166705960488635843,
-    17921034426.037209699919755754458931112671403265390,
-    6039542586.3520280050642916443072979210699388420708,
-    1439720407.3117216736632230727949123939715485786772,
-    248874557.86205415651146038641322942321632125127801,
-    31426415.585400194380614231628318205362874684987640,
-    2876370.6289353724412254090516208496135991145378768,
-    186056.26539522349504029498971604569928220784236328,
-    8071.6720023658162106380029022722506138218516325024,
-    210.82427775157934587250973392071336271166969580291,
-    2.5066282746310002701649081771338373386264310793408
-};
-
-/* denominator is x*(x+1)*...*(x+LANCZOS_N-2) */
-static const double lanczos_den_coeffs[LANCZOS_N] = {
-    0.0, 39916800.0, 120543840.0, 150917976.0, 105258076.0, 45995730.0,
-    13339535.0, 2637558.0, 357423.0, 32670.0, 1925.0, 66.0, 1.0};
-
-/* gamma values for small positive integers, 1 though NGAMMA_INTEGRAL */
-#define NGAMMA_INTEGRAL 23
-static const double gamma_integral[NGAMMA_INTEGRAL] = {
-    1.0, 1.0, 2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0, 362880.0,
-    3628800.0, 39916800.0, 479001600.0, 6227020800.0, 87178291200.0,
-    1307674368000.0, 20922789888000.0, 355687428096000.0,
-    6402373705728000.0, 121645100408832000.0, 2432902008176640000.0,
-    51090942171709440000.0, 1124000727777607680000.0,
-};
-
-/* Lanczos' sum L_g(x), for positive x */
-
-static double
-lanczos_sum(double x)
-{
-    double num = 0.0, den = 0.0;
-    int i;
-    assert(x > 0.0);
-    /* evaluate the rational function lanczos_sum(x).  For large
-       x, the obvious algorithm risks overflow, so we instead
-       rescale the denominator and numerator of the rational
-       function by x**(1-LANCZOS_N) and treat this as a
-       rational function in 1/x.  This also reduces the error for
-       larger x values.  The choice of cutoff point (5.0 below) is
-       somewhat arbitrary; in tests, smaller cutoff values than
-       this resulted in lower accuracy. */
-    if (x < 5.0) {
-        for (i = LANCZOS_N; --i >= 0; ) {
-            num = num * x + lanczos_num_coeffs[i];
-            den = den * x + lanczos_den_coeffs[i];
-        }
-    }
-    else {
-        for (i = 0; i < LANCZOS_N; i++) {
-            num = num / x + lanczos_num_coeffs[i];
-            den = den / x + lanczos_den_coeffs[i];
-        }
-    }
-    return num/den;
-}
+/* C99 math functions: redirect to system implementations
+   (but see _math_c99.h for Windows) */
 
 NUMBA_EXPORT_FUNC(double)
 numba_gamma(double x)
 {
-    double absx, r, y, z, sqrtpow;
-
-    /* special cases */
-    if (!Py_IS_FINITE(x)) {
-        if (Py_IS_NAN(x) || x > 0.0)
-            return x;  /* tgamma(nan) = nan, tgamma(inf) = inf */
-        else {
-            /*errno = EDOM;*/
-            return Py_NAN;  /* tgamma(-inf) = nan, invalid */
-        }
-    }
-    if (x == 0.0) {
-        /*errno = EDOM;*/
-        /* tgamma(+-0.0) = +-inf, divide-by-zero */
-        return copysign(Py_HUGE_VAL, x);
-    }
-
-    /* integer arguments */
-    if (x == floor(x)) {
-        if (x < 0.0) {
-            /*errno = EDOM;*/  /* tgamma(n) = nan, invalid for */
-            return Py_NAN; /* negative integers n */
-        }
-        if (x <= NGAMMA_INTEGRAL)
-            return gamma_integral[(int)x - 1];
-    }
-    absx = fabs(x);
-
-    /* tiny arguments:  tgamma(x) ~ 1/x for x near 0 */
-    if (absx < 1e-20) {
-        r = 1.0/x;
-        /*if (Py_IS_INFINITY(r))
-            errno = ERANGE;*/
-        return r;
-    }
-
-    /* large arguments: assuming IEEE 754 doubles, tgamma(x) overflows for
-       x > 200, and underflows to +-0.0 for x < -200, not a negative
-       integer. */
-    if (absx > 200.0) {
-        if (x < 0.0) {
-            return 0.0/sinpi(x);
-        }
-        else {
-            /*errno = ERANGE;*/
-            return Py_HUGE_VAL;
-        }
-    }
-
-    y = absx + lanczos_g_minus_half;
-    /* compute error in sum */
-    if (absx > lanczos_g_minus_half) {
-        /* note: the correction can be foiled by an optimizing
-           compiler that (incorrectly) thinks that an expression like
-           a + b - a - b can be optimized to 0.0.  This shouldn't
-           happen in a standards-conforming compiler. */
-        double q = y - absx;
-        z = q - lanczos_g_minus_half;
-    }
-    else {
-        double q = y - lanczos_g_minus_half;
-        z = q - absx;
-    }
-    z = z * lanczos_g / y;
-    if (x < 0.0) {
-        r = -pi / sinpi(absx) / absx * exp(y) / lanczos_sum(absx);
-        r -= z * r;
-        if (absx < 140.0) {
-            r /= pow(y, absx - 0.5);
-        }
-        else {
-            sqrtpow = pow(y, absx / 2.0 - 0.25);
-            r /= sqrtpow;
-            r /= sqrtpow;
-        }
-    }
-    else {
-        r = lanczos_sum(absx) / exp(y);
-        r += z * r;
-        if (absx < 140.0) {
-            r *= pow(y, absx - 0.5);
-        }
-        else {
-            sqrtpow = pow(y, absx / 2.0 - 0.25);
-            r *= sqrtpow;
-            r *= sqrtpow;
-        }
-    }
-    /*if (Py_IS_INFINITY(r))
-        errno = ERANGE;*/
-    return r;
+    return tgamma(x);
 }
 
 NUMBA_EXPORT_FUNC(float)
 numba_gammaf(float x)
 {
-    return (float) numba_gamma(x);
+    return tgammaf(x);
 }
-
-/*
-   lgamma:  natural log of the absolute value of the Gamma function.
-   For large arguments, Lanczos' formula works extremely well here.
-*/
 
 NUMBA_EXPORT_FUNC(double)
 numba_lgamma(double x)
 {
-    double r, absx;
-
-    /* special cases */
-    if (!Py_IS_FINITE(x)) {
-        if (Py_IS_NAN(x))
-            return x;  /* lgamma(nan) = nan */
-        else
-            return Py_HUGE_VAL; /* lgamma(+-inf) = +inf */
-    }
-
-    /* integer arguments */
-    if (x == floor(x) && x <= 2.0) {
-        if (x <= 0.0) {
-            /*errno = EDOM;*/  /* lgamma(n) = inf, divide-by-zero for */
-            return Py_HUGE_VAL; /* integers n <= 0 */
-        }
-        else {
-            return 0.0; /* lgamma(1) = lgamma(2) = 0.0 */
-        }
-    }
-
-    absx = fabs(x);
-    /* tiny arguments: lgamma(x) ~ -log(fabs(x)) for small x */
-    if (absx < 1e-20)
-        return -log(absx);
-
-    /* Lanczos' formula.  We could save a fraction of a ulp in accuracy by
-       having a second set of numerator coefficients for lanczos_sum that
-       absorbed the exp(-lanczos_g) term, and throwing out the lanczos_g
-       subtraction below; it's probably not worth it. */
-    r = log(lanczos_sum(absx)) - lanczos_g;
-    r += (absx - 0.5) * (log(absx + lanczos_g - 0.5) - 1);
-    if (x < 0.0)
-        /* Use reflection formula to get value for negative x. */
-        r = logpi - log(fabs(sinpi(absx))) - log(absx) - r;
-    /*if (Py_IS_INFINITY(r))
-        errno = ERANGE;*/
-    return r;
+    return lgamma(x);
 }
 
 NUMBA_EXPORT_FUNC(float)
 numba_lgammaf(float x)
 {
-    return (float) numba_lgamma(x);
+    return lgammaf(x);
 }
-
-/* provide erf() and erfc(); code borrowed from CPython */
-
-/*
-   Implementations of the error function erf(x) and the complementary error
-   function erfc(x).
-
-   Method: following 'Numerical Recipes' by Flannery, Press et. al. (2nd ed.,
-   Cambridge University Press), we use a series approximation for erf for
-   small x, and a continued fraction approximation for erfc(x) for larger x;
-   combined with the relations erf(-x) = -erf(x) and erfc(x) = 1.0 - erf(x),
-   this gives us erf(x) and erfc(x) for all x.
-
-   The series expansion used is:
-
-      erf(x) = x*exp(-x*x)/sqrt(pi) * [
-                     2/1 + 4/3 x**2 + 8/15 x**4 + 16/105 x**6 + ...]
-
-   The coefficient of x**(2k-2) here is 4**k*factorial(k)/factorial(2*k).
-   This series converges well for smallish x, but slowly for larger x.
-
-   The continued fraction expansion used is:
-
-      erfc(x) = x*exp(-x*x)/sqrt(pi) * [1/(0.5 + x**2 -) 0.5/(2.5 + x**2 - )
-                              3.0/(4.5 + x**2 - ) 7.5/(6.5 + x**2 - ) ...]
-
-   after the first term, the general term has the form:
-
-      k*(k-0.5)/(2*k+0.5 + x**2 - ...).
-
-   This expansion converges fast for larger x, but convergence becomes
-   infinitely slow as x approaches 0.0.  The (somewhat naive) continued
-   fraction evaluation algorithm used below also risks overflow for large x;
-   but for large x, erfc(x) == 0.0 to within machine precision.  (For
-   example, erfc(30.0) is approximately 2.56e-393).
-
-   Parameters: use series expansion for abs(x) < ERF_SERIES_CUTOFF and
-   continued fraction expansion for ERF_SERIES_CUTOFF <= abs(x) <
-   ERFC_CONTFRAC_CUTOFF.  ERFC_SERIES_TERMS and ERFC_CONTFRAC_TERMS are the
-   numbers of terms to use for the relevant expansions.  */
-
-#define ERF_SERIES_CUTOFF 1.5
-#define ERF_SERIES_TERMS 25
-#define ERFC_CONTFRAC_CUTOFF 30.0
-#define ERFC_CONTFRAC_TERMS 50
-
-/*
-   Error function, via power series.
-
-   Given a finite float x, return an approximation to erf(x).
-   Converges reasonably fast for small x.
-*/
-
-static double
-m_erf_series(double x)
-{
-    double x2, acc, fk, result;
-    int i, saved_errno;
-
-    x2 = x * x;
-    acc = 0.0;
-    fk = (double)ERF_SERIES_TERMS + 0.5;
-    for (i = 0; i < ERF_SERIES_TERMS; i++) {
-        acc = 2.0 + x2 * acc / fk;
-        fk -= 1.0;
-    }
-    /* Make sure the exp call doesn't affect errno;
-       see m_erfc_contfrac for more. */
-    saved_errno = errno;
-    result = acc * x * exp(-x2) / sqrtpi;
-    errno = saved_errno;
-    return result;
-}
-
-/*
-   Complementary error function, via continued fraction expansion.
-
-   Given a positive float x, return an approximation to erfc(x).  Converges
-   reasonably fast for x large (say, x > 2.0), and should be safe from
-   overflow if x and nterms are not too large.  On an IEEE 754 machine, with x
-   <= 30.0, we're safe up to nterms = 100.  For x >= 30.0, erfc(x) is smaller
-   than the smallest representable nonzero float.  */
-
-static double
-m_erfc_contfrac(double x)
-{
-    double x2, a, da, p, p_last, q, q_last, b, result;
-    int i, saved_errno;
-
-    if (x >= ERFC_CONTFRAC_CUTOFF)
-        return 0.0;
-
-    x2 = x*x;
-    a = 0.0;
-    da = 0.5;
-    p = 1.0; p_last = 0.0;
-    q = da + x2; q_last = 1.0;
-    for (i = 0; i < ERFC_CONTFRAC_TERMS; i++) {
-        double temp;
-        a += da;
-        da += 2.0;
-        b = da + x2;
-        temp = p; p = b*p - a*p_last; p_last = temp;
-        temp = q; q = b*q - a*q_last; q_last = temp;
-    }
-    /* Issue #8986: On some platforms, exp sets errno on underflow to zero;
-       save the current errno value so that we can restore it later. */
-    saved_errno = errno;
-    result = p / q * x * exp(-x2) / sqrtpi;
-    errno = saved_errno;
-    return result;
-}
-
-/* Error function erf(x), for general x */
 
 NUMBA_EXPORT_FUNC(double)
 numba_erf(double x)
 {
-    double absx, cf;
-
-    if (Py_IS_NAN(x))
-        return x;
-    absx = fabs(x);
-    if (absx < ERF_SERIES_CUTOFF)
-        return m_erf_series(x);
-    else {
-        cf = m_erfc_contfrac(absx);
-        return x > 0.0 ? 1.0 - cf : cf - 1.0;
-    }
+    return erf(x);
 }
 
 NUMBA_EXPORT_FUNC(float)
 numba_erff(float x)
 {
-    return (float) numba_erf(x);
+    return erff(x);
 }
-
-/* Complementary error function erfc(x), for general x. */
 
 NUMBA_EXPORT_FUNC(double)
 numba_erfc(double x)
 {
-    double absx, cf;
-
-    if (Py_IS_NAN(x))
-        return x;
-    absx = fabs(x);
-    if (absx < ERF_SERIES_CUTOFF)
-        return 1.0 - m_erf_series(x);
-    else {
-        cf = m_erfc_contfrac(absx);
-        return x > 0.0 ? cf : 2.0 - cf;
-    }
+    return erfc(x);
 }
 
 NUMBA_EXPORT_FUNC(float)
 numba_erfcf(float x)
 {
-    return (float) numba_erfc(x);
+    return erfcf(x);
 }
 
 

--- a/numba/_math_c99.c
+++ b/numba/_math_c99.c
@@ -302,12 +302,478 @@ float m_atan2f(float y, float x) {
 }
 
 
+/* provide gamma() and lgamma(); code borrowed from CPython */
+
+/*
+   sin(pi*x), giving accurate results for all finite x (especially x
+   integral or close to an integer).  This is here for use in the
+   reflection formula for the gamma function.  It conforms to IEEE
+   754-2008 for finite arguments, but not for infinities or nans.
+*/
+
+static const double pi = 3.141592653589793238462643383279502884197;
+static const double sqrtpi = 1.772453850905516027298167483341145182798;
+static const double logpi = 1.144729885849400174143427351353058711647;
+
+static double
+sinpi(double x)
+{
+    double y, r;
+    int n;
+    /* this function should only ever be called for finite arguments */
+    assert(Py_IS_FINITE(x));
+    y = fmod(fabs(x), 2.0);
+    n = (int)round(2.0*y);
+    assert(0 <= n && n <= 4);
+    switch (n) {
+    case 0:
+        r = sin(pi*y);
+        break;
+    case 1:
+        r = cos(pi*(y-0.5));
+        break;
+    case 2:
+        /* N.B. -sin(pi*(y-1.0)) is *not* equivalent: it would give
+           -0.0 instead of 0.0 when y == 1.0. */
+        r = sin(pi*(1.0-y));
+        break;
+    case 3:
+        r = -cos(pi*(y-1.5));
+        break;
+    case 4:
+        r = sin(pi*(y-2.0));
+        break;
+    default:
+        assert(0);  /* should never get here */
+        r = -1.23e200; /* silence gcc warning */
+    }
+    return copysign(1.0, x)*r;
+}
+
+/* Implementation of the real gamma function.  In extensive but non-exhaustive
+   random tests, this function proved accurate to within <= 10 ulps across the
+   entire float domain.  Note that accuracy may depend on the quality of the
+   system math functions, the pow function in particular.  Special cases
+   follow C99 annex F.  The parameters and method are tailored to platforms
+   whose double format is the IEEE 754 binary64 format.
+
+   Method: for x > 0.0 we use the Lanczos approximation with parameters N=13
+   and g=6.024680040776729583740234375; these parameters are amongst those
+   used by the Boost library.  Following Boost (again), we re-express the
+   Lanczos sum as a rational function, and compute it that way.  The
+   coefficients below were computed independently using MPFR, and have been
+   double-checked against the coefficients in the Boost source code.
+
+   For x < 0.0 we use the reflection formula.
+
+   There's one minor tweak that deserves explanation: Lanczos' formula for
+   Gamma(x) involves computing pow(x+g-0.5, x-0.5) / exp(x+g-0.5).  For many x
+   values, x+g-0.5 can be represented exactly.  However, in cases where it
+   can't be represented exactly the small error in x+g-0.5 can be magnified
+   significantly by the pow and exp calls, especially for large x.  A cheap
+   correction is to multiply by (1 + e*g/(x+g-0.5)), where e is the error
+   involved in the computation of x+g-0.5 (that is, e = computed value of
+   x+g-0.5 - exact value of x+g-0.5).  Here's the proof:
+
+   Correction factor
+   -----------------
+   Write x+g-0.5 = y-e, where y is exactly representable as an IEEE 754
+   double, and e is tiny.  Then:
+
+     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) = pow(y-e, x-0.5)/exp(y-e)
+     = pow(y, x-0.5)/exp(y) * C,
+
+   where the correction_factor C is given by
+
+     C = pow(1-e/y, x-0.5) * exp(e)
+
+   Since e is tiny, pow(1-e/y, x-0.5) ~ 1-(x-0.5)*e/y, and exp(x) ~ 1+e, so:
+
+     C ~ (1-(x-0.5)*e/y) * (1+e) ~ 1 + e*(y-(x-0.5))/y
+
+   But y-(x-0.5) = g+e, and g+e ~ g.  So we get C ~ 1 + e*g/y, and
+
+     pow(x+g-0.5,x-0.5)/exp(x+g-0.5) ~ pow(y, x-0.5)/exp(y) * (1 + e*g/y),
+
+   Note that for accuracy, when computing r*C it's better to do
+
+     r + e*g/y*r;
+
+   than
+
+     r * (1 + e*g/y);
+
+   since the addition in the latter throws away most of the bits of
+   information in e*g/y.
+*/
+
+#define LANCZOS_N 13
+static const double lanczos_g = 6.024680040776729583740234375;
+static const double lanczos_g_minus_half = 5.524680040776729583740234375;
+static const double lanczos_num_coeffs[LANCZOS_N] = {
+    23531376880.410759688572007674451636754734846804940,
+    42919803642.649098768957899047001988850926355848959,
+    35711959237.355668049440185451547166705960488635843,
+    17921034426.037209699919755754458931112671403265390,
+    6039542586.3520280050642916443072979210699388420708,
+    1439720407.3117216736632230727949123939715485786772,
+    248874557.86205415651146038641322942321632125127801,
+    31426415.585400194380614231628318205362874684987640,
+    2876370.6289353724412254090516208496135991145378768,
+    186056.26539522349504029498971604569928220784236328,
+    8071.6720023658162106380029022722506138218516325024,
+    210.82427775157934587250973392071336271166969580291,
+    2.5066282746310002701649081771338373386264310793408
+};
+
+/* denominator is x*(x+1)*...*(x+LANCZOS_N-2) */
+static const double lanczos_den_coeffs[LANCZOS_N] = {
+    0.0, 39916800.0, 120543840.0, 150917976.0, 105258076.0, 45995730.0,
+    13339535.0, 2637558.0, 357423.0, 32670.0, 1925.0, 66.0, 1.0};
+
+/* gamma values for small positive integers, 1 though NGAMMA_INTEGRAL */
+#define NGAMMA_INTEGRAL 23
+static const double gamma_integral[NGAMMA_INTEGRAL] = {
+    1.0, 1.0, 2.0, 6.0, 24.0, 120.0, 720.0, 5040.0, 40320.0, 362880.0,
+    3628800.0, 39916800.0, 479001600.0, 6227020800.0, 87178291200.0,
+    1307674368000.0, 20922789888000.0, 355687428096000.0,
+    6402373705728000.0, 121645100408832000.0, 2432902008176640000.0,
+    51090942171709440000.0, 1124000727777607680000.0,
+};
+
+/* Lanczos' sum L_g(x), for positive x */
+
+static double
+lanczos_sum(double x)
+{
+    double num = 0.0, den = 0.0;
+    int i;
+    assert(x > 0.0);
+    /* evaluate the rational function lanczos_sum(x).  For large
+       x, the obvious algorithm risks overflow, so we instead
+       rescale the denominator and numerator of the rational
+       function by x**(1-LANCZOS_N) and treat this as a
+       rational function in 1/x.  This also reduces the error for
+       larger x values.  The choice of cutoff point (5.0 below) is
+       somewhat arbitrary; in tests, smaller cutoff values than
+       this resulted in lower accuracy. */
+    if (x < 5.0) {
+        for (i = LANCZOS_N; --i >= 0; ) {
+            num = num * x + lanczos_num_coeffs[i];
+            den = den * x + lanczos_den_coeffs[i];
+        }
+    }
+    else {
+        for (i = 0; i < LANCZOS_N; i++) {
+            num = num / x + lanczos_num_coeffs[i];
+            den = den / x + lanczos_den_coeffs[i];
+        }
+    }
+    return num/den;
+}
+
+double
+m_gamma(double x)
+{
+    double absx, r, y, z, sqrtpow;
+
+    /* special cases */
+    if (!Py_IS_FINITE(x)) {
+        if (Py_IS_NAN(x) || x > 0.0)
+            return x;  /* tgamma(nan) = nan, tgamma(inf) = inf */
+        else {
+            /*errno = EDOM;*/
+            return Py_NAN;  /* tgamma(-inf) = nan, invalid */
+        }
+    }
+    if (x == 0.0) {
+        /*errno = EDOM;*/
+        /* tgamma(+-0.0) = +-inf, divide-by-zero */
+        return copysign(Py_HUGE_VAL, x);
+    }
+
+    /* integer arguments */
+    if (x == floor(x)) {
+        if (x < 0.0) {
+            /*errno = EDOM;*/  /* tgamma(n) = nan, invalid for */
+            return Py_NAN; /* negative integers n */
+        }
+        if (x <= NGAMMA_INTEGRAL)
+            return gamma_integral[(int)x - 1];
+    }
+    absx = fabs(x);
+
+    /* tiny arguments:  tgamma(x) ~ 1/x for x near 0 */
+    if (absx < 1e-20) {
+        r = 1.0/x;
+        /*if (Py_IS_INFINITY(r))
+            errno = ERANGE;*/
+        return r;
+    }
+
+    /* large arguments: assuming IEEE 754 doubles, tgamma(x) overflows for
+       x > 200, and underflows to +-0.0 for x < -200, not a negative
+       integer. */
+    if (absx > 200.0) {
+        if (x < 0.0) {
+            return 0.0/sinpi(x);
+        }
+        else {
+            /*errno = ERANGE;*/
+            return Py_HUGE_VAL;
+        }
+    }
+
+    y = absx + lanczos_g_minus_half;
+    /* compute error in sum */
+    if (absx > lanczos_g_minus_half) {
+        /* note: the correction can be foiled by an optimizing
+           compiler that (incorrectly) thinks that an expression like
+           a + b - a - b can be optimized to 0.0.  This shouldn't
+           happen in a standards-conforming compiler. */
+        double q = y - absx;
+        z = q - lanczos_g_minus_half;
+    }
+    else {
+        double q = y - lanczos_g_minus_half;
+        z = q - absx;
+    }
+    z = z * lanczos_g / y;
+    if (x < 0.0) {
+        r = -pi / sinpi(absx) / absx * exp(y) / lanczos_sum(absx);
+        r -= z * r;
+        if (absx < 140.0) {
+            r /= pow(y, absx - 0.5);
+        }
+        else {
+            sqrtpow = pow(y, absx / 2.0 - 0.25);
+            r /= sqrtpow;
+            r /= sqrtpow;
+        }
+    }
+    else {
+        r = lanczos_sum(absx) / exp(y);
+        r += z * r;
+        if (absx < 140.0) {
+            r *= pow(y, absx - 0.5);
+        }
+        else {
+            sqrtpow = pow(y, absx / 2.0 - 0.25);
+            r *= sqrtpow;
+            r *= sqrtpow;
+        }
+    }
+    /*if (Py_IS_INFINITY(r))
+        errno = ERANGE;*/
+    return r;
+}
+
+/*
+   lgamma:  natural log of the absolute value of the Gamma function.
+   For large arguments, Lanczos' formula works extremely well here.
+*/
+
+double
+m_lgamma(double x)
+{
+    double r, absx;
+
+    /* special cases */
+    if (!Py_IS_FINITE(x)) {
+        if (Py_IS_NAN(x))
+            return x;  /* lgamma(nan) = nan */
+        else
+            return Py_HUGE_VAL; /* lgamma(+-inf) = +inf */
+    }
+
+    /* integer arguments */
+    if (x == floor(x) && x <= 2.0) {
+        if (x <= 0.0) {
+            /*errno = EDOM;*/  /* lgamma(n) = inf, divide-by-zero for */
+            return Py_HUGE_VAL; /* integers n <= 0 */
+        }
+        else {
+            return 0.0; /* lgamma(1) = lgamma(2) = 0.0 */
+        }
+    }
+
+    absx = fabs(x);
+    /* tiny arguments: lgamma(x) ~ -log(fabs(x)) for small x */
+    if (absx < 1e-20)
+        return -log(absx);
+
+    /* Lanczos' formula.  We could save a fraction of a ulp in accuracy by
+       having a second set of numerator coefficients for lanczos_sum that
+       absorbed the exp(-lanczos_g) term, and throwing out the lanczos_g
+       subtraction below; it's probably not worth it. */
+    r = log(lanczos_sum(absx)) - lanczos_g;
+    r += (absx - 0.5) * (log(absx + lanczos_g - 0.5) - 1);
+    if (x < 0.0)
+        /* Use reflection formula to get value for negative x. */
+        r = logpi - log(fabs(sinpi(absx))) - log(absx) - r;
+    /*if (Py_IS_INFINITY(r))
+        errno = ERANGE;*/
+    return r;
+}
+
+/* provide erf() and erfc(); code borrowed from CPython */
+
+/*
+   Implementations of the error function erf(x) and the complementary error
+   function erfc(x).
+
+   Method: following 'Numerical Recipes' by Flannery, Press et. al. (2nd ed.,
+   Cambridge University Press), we use a series approximation for erf for
+   small x, and a continued fraction approximation for erfc(x) for larger x;
+   combined with the relations erf(-x) = -erf(x) and erfc(x) = 1.0 - erf(x),
+   this gives us erf(x) and erfc(x) for all x.
+
+   The series expansion used is:
+
+      erf(x) = x*exp(-x*x)/sqrt(pi) * [
+                     2/1 + 4/3 x**2 + 8/15 x**4 + 16/105 x**6 + ...]
+
+   The coefficient of x**(2k-2) here is 4**k*factorial(k)/factorial(2*k).
+   This series converges well for smallish x, but slowly for larger x.
+
+   The continued fraction expansion used is:
+
+      erfc(x) = x*exp(-x*x)/sqrt(pi) * [1/(0.5 + x**2 -) 0.5/(2.5 + x**2 - )
+                              3.0/(4.5 + x**2 - ) 7.5/(6.5 + x**2 - ) ...]
+
+   after the first term, the general term has the form:
+
+      k*(k-0.5)/(2*k+0.5 + x**2 - ...).
+
+   This expansion converges fast for larger x, but convergence becomes
+   infinitely slow as x approaches 0.0.  The (somewhat naive) continued
+   fraction evaluation algorithm used below also risks overflow for large x;
+   but for large x, erfc(x) == 0.0 to within machine precision.  (For
+   example, erfc(30.0) is approximately 2.56e-393).
+
+   Parameters: use series expansion for abs(x) < ERF_SERIES_CUTOFF and
+   continued fraction expansion for ERF_SERIES_CUTOFF <= abs(x) <
+   ERFC_CONTFRAC_CUTOFF.  ERFC_SERIES_TERMS and ERFC_CONTFRAC_TERMS are the
+   numbers of terms to use for the relevant expansions.  */
+
+#define ERF_SERIES_CUTOFF 1.5
+#define ERF_SERIES_TERMS 25
+#define ERFC_CONTFRAC_CUTOFF 30.0
+#define ERFC_CONTFRAC_TERMS 50
+
+/*
+   Error function, via power series.
+
+   Given a finite float x, return an approximation to erf(x).
+   Converges reasonably fast for small x.
+*/
+
+static double
+m_erf_series(double x)
+{
+    double x2, acc, fk, result;
+    int i, saved_errno;
+
+    x2 = x * x;
+    acc = 0.0;
+    fk = (double)ERF_SERIES_TERMS + 0.5;
+    for (i = 0; i < ERF_SERIES_TERMS; i++) {
+        acc = 2.0 + x2 * acc / fk;
+        fk -= 1.0;
+    }
+    /* Make sure the exp call doesn't affect errno;
+       see m_erfc_contfrac for more. */
+    saved_errno = errno;
+    result = acc * x * exp(-x2) / sqrtpi;
+    errno = saved_errno;
+    return result;
+}
+
+/*
+   Complementary error function, via continued fraction expansion.
+
+   Given a positive float x, return an approximation to erfc(x).  Converges
+   reasonably fast for x large (say, x > 2.0), and should be safe from
+   overflow if x and nterms are not too large.  On an IEEE 754 machine, with x
+   <= 30.0, we're safe up to nterms = 100.  For x >= 30.0, erfc(x) is smaller
+   than the smallest representable nonzero float.  */
+
+static double
+m_erfc_contfrac(double x)
+{
+    double x2, a, da, p, p_last, q, q_last, b, result;
+    int i, saved_errno;
+
+    if (x >= ERFC_CONTFRAC_CUTOFF)
+        return 0.0;
+
+    x2 = x*x;
+    a = 0.0;
+    da = 0.5;
+    p = 1.0; p_last = 0.0;
+    q = da + x2; q_last = 1.0;
+    for (i = 0; i < ERFC_CONTFRAC_TERMS; i++) {
+        double temp;
+        a += da;
+        da += 2.0;
+        b = da + x2;
+        temp = p; p = b*p - a*p_last; p_last = temp;
+        temp = q; q = b*q - a*q_last; q_last = temp;
+    }
+    /* Issue #8986: On some platforms, exp sets errno on underflow to zero;
+       save the current errno value so that we can restore it later. */
+    saved_errno = errno;
+    result = p / q * x * exp(-x2) / sqrtpi;
+    errno = saved_errno;
+    return result;
+}
+
+/* Error function erf(x), for general x */
+
+double
+m_erf(double x)
+{
+    double absx, cf;
+
+    if (Py_IS_NAN(x))
+        return x;
+    absx = fabs(x);
+    if (absx < ERF_SERIES_CUTOFF)
+        return m_erf_series(x);
+    else {
+        cf = m_erfc_contfrac(absx);
+        return x > 0.0 ? 1.0 - cf : cf - 1.0;
+    }
+}
+
+/* Complementary error function erfc(x), for general x. */
+
+double
+m_erfc(double x)
+{
+    double absx, cf;
+
+    if (Py_IS_NAN(x))
+        return x;
+    absx = fabs(x);
+    if (absx < ERF_SERIES_CUTOFF)
+        return 1.0 - m_erf_series(x);
+    else {
+        cf = m_erfc_contfrac(absx);
+        return x > 0.0 ? cf : 2.0 - cf;
+    }
+}
+
 #define FLOATVER(Fn) float Fn##f(float x) { return (float)Fn(x); }
 
 FLOATVER(m_acosh);
 FLOATVER(m_asinh);
 FLOATVER(m_atanh);
+FLOATVER(m_erf);
+FLOATVER(m_erfc);
 FLOATVER(m_expm1);
+FLOATVER(m_gamma);
+FLOATVER(m_lgamma);
 FLOATVER(m_log1p);
 FLOATVER(m_trunc);
 

--- a/numba/_math_c99.h
+++ b/numba/_math_c99.h
@@ -3,6 +3,16 @@
 
 #include "_numba_common.h"
 
+/* We require C99 on POSIX, but have to be tolerant on Windows since
+   Python < 3.5 is compiled with old MSVC versions */
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1800  /* Visual Studio 2013 */
+#define HAVE_C99_MATH 1
+#else
+#define HAVE_C99_MATH 0
+#endif
+
+
 VISIBILITY_HIDDEN double m_acosh(double x);
 VISIBILITY_HIDDEN float m_acoshf(float x);
 
@@ -12,8 +22,20 @@ VISIBILITY_HIDDEN float m_asinhf(float x);
 VISIBILITY_HIDDEN double m_atanh(double x);
 VISIBILITY_HIDDEN float m_atanhf(float x);
 
+VISIBILITY_HIDDEN double m_erf(double x);
+VISIBILITY_HIDDEN float m_erff(float x);
+
+VISIBILITY_HIDDEN double m_erfc(double x);
+VISIBILITY_HIDDEN float m_erfcf(float x);
+
 VISIBILITY_HIDDEN double m_expm1(double x);
 VISIBILITY_HIDDEN float m_expm1f(float x);
+
+VISIBILITY_HIDDEN double m_gamma(double x);
+VISIBILITY_HIDDEN float m_gammaf(float x);
+
+VISIBILITY_HIDDEN double m_lgamma(double x);
+VISIBILITY_HIDDEN float m_lgammaf(float x);
 
 VISIBILITY_HIDDEN double m_log1p(double x);
 VISIBILITY_HIDDEN float m_log1pf(float x);
@@ -27,9 +49,9 @@ VISIBILITY_HIDDEN float m_truncf(float x);
 VISIBILITY_HIDDEN double m_atan2(double y, double x);
 VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 
-#ifdef _MSC_VER
+#if !HAVE_C99_MATH
 
-/* Define missing (C99) math functions for Windows */
+/* Define missing math functions */
 
 #define asinh(x) m_asinh(x)
 #define asinhf(x) m_asinhf(x)
@@ -38,19 +60,30 @@ VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 #define atanh(x) m_atanh(x)
 #define atanhf(x) m_atanhf(x)
 
+#define erf(x) m_erf(x)
+#define erfc(x) m_erfc(x)
+#define erfcf(x) m_erfcf(x)
+#define erff(x) m_erff(x)
+
 #define expm1(x) m_expm1(x)
 #define expm1f(x) m_expm1f(x)
 #define log1p(x) m_log1p(x)
 #define log1pf(x) m_log1pf(x)
+
+#define lgamma(x) m_lgamma(x)
+#define lgammaf(x) m_lgammaf(x)
+#define tgamma(x) m_gamma(x)
+#define tgammaf(x) m_gammaf(x)
 
 #define round(x) m_round(x)
 #define roundf(x) m_roundf(x)
 #define trunc(x) m_trunc(x)
 #define truncf(x) m_truncf(x)
 
+
 #define atan2f(x, y) m_atan2f(x, y)
 
-#endif /* _MSC_VER */
+#endif /* !HAVE_C99_MATH */
 
 #define atan2_fixed(x, y) m_atan2(x, y)
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -382,7 +382,7 @@ class TestMathLib(TestCase):
                    types.uint16, types.uint32, types.uint64,
                    types.float32, types.float64]
         x_values = [1, 1, 1, 1, 1, 1, 1., 1.]
-        self.run_unary(pyfunc, x_types, x_values, flags)
+        self.run_unary(pyfunc, x_types, x_values, flags, prec='double')
 
     def test_asinh_npm(self):
         self.test_asinh(flags=no_pyobj_flags)
@@ -404,7 +404,7 @@ class TestMathLib(TestCase):
                    types.uint16, types.uint32, types.uint64,
                    types.float32, types.float64]
         x_values = [0, 0, 0, 0, 0, 0, 0.1, 0.1]
-        self.run_unary(pyfunc, x_types, x_values, flags)
+        self.run_unary(pyfunc, x_types, x_values, flags, prec='double')
 
     def test_atanh_npm(self):
         self.test_atanh(flags=no_pyobj_flags)
@@ -536,7 +536,8 @@ class TestMathLib(TestCase):
         pyfunc = erf
         x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
-        self.run_unary(pyfunc, x_types, x_values, flags)
+        self.run_unary(pyfunc, x_types, x_values, flags,
+                       prec='double')
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erf_npm(self):
@@ -547,7 +548,8 @@ class TestMathLib(TestCase):
         pyfunc = erfc
         x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
-        self.run_unary(pyfunc, x_types, x_values, flags)
+        self.run_unary(pyfunc, x_types, x_values, flags,
+                       prec='double', ulps=3)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erfc_npm(self):

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -563,7 +563,8 @@ class TestMathLib(TestCase):
         self.run_unary(pyfunc, x_types, x_values, flags, prec='double', ulps=3)
         x_values = [-0.1, 0.1, 2.5, 10.1, 50., float('inf')]
         x_types = [types.float64] * len(x_values)
-        self.run_unary(pyfunc, x_types, x_values, flags, prec='double', ulps=3)
+        self.run_unary(pyfunc, x_types, x_values, flags,
+                       prec='double', ulps=8)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_gamma_npm(self):


### PR DESCRIPTION
Note the precision of some tests had to be lowered (especially test_gamma with the CentOS 5 libm).