### PR TITLE
Do not compile CFFI code when importing the test suite

### DIFF
--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -85,19 +85,35 @@ def load_ool_module():
         sys.path.remove(tmpdir)
 
 
-if cffi_support.SUPPORTED:
-    ffi, dll = load_inline_module()
-    cffi_sin = dll._numba_test_sin
-    cffi_cos = dll._numba_test_cos
-    del dll
+def init():
+    """
+    Initialize module globals.  This can invoke external utilities, hence not
+    being executed implicitly at module import.
+    """
+    global ffi, cffi_sin, cffi_cos
 
-    ffi_ool, mod = load_ool_module()
-    cffi_sin_ool = mod.lib.sin
-    cffi_cos_ool = mod.lib.cos
-    cffi_foo = mod.lib.foo
-    vsSin = mod.lib.vsSin
-    vdSin = mod.lib.vdSin
-    del mod
+    if ffi is None:
+        ffi, dll = load_inline_module()
+        cffi_sin = dll._numba_test_sin
+        cffi_cos = dll._numba_test_cos
+        del dll
+
+def init_ool():
+    """
+    Same as init() for OOL mode.
+    """
+    global ffi_ool, cffi_sin_ool, cffi_cos_ool, cffi_foo, vsSin, vdSin
+
+    if ffi_ool is None:
+        ffi_ool, mod = load_ool_module()
+        cffi_sin_ool = mod.lib.sin
+        cffi_cos_ool = mod.lib.cos
+        cffi_foo = mod.lib.foo
+        vsSin = mod.lib.vsSin
+        vdSin = mod.lib.vdSin
+        del mod
+
+ffi = ffi_ool = None
 
 
 def use_cffi_sin(x):

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -20,9 +20,9 @@ no_pyobj_flags = Flags()
                      "CFFI not supported -- please install the cffi module")
 class TestCFFI(TestCase):
 
-    # Need to run the test serially because of race conditions with
+    # Need to run the tests serially because of race conditions in
     # cffi's OOL mode.
-    _numba_parallel_test_ = True
+    _numba_parallel_test_ = False
 
     def setUp(self):
         mod.init()

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -1,12 +1,14 @@
 from __future__ import print_function, division, absolute_import
 
+import numpy as np
+
 from numba import unittest_support as unittest
 from numba import jit, cffi_support, types
 from numba.compiler import compile_isolated, Flags
 from numba.tests.support import TestCase
-from numba.tests.cffi_usecases import *
 
-import numpy as np
+import numba.tests.cffi_usecases as mod
+
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
@@ -18,8 +20,16 @@ no_pyobj_flags = Flags()
                      "CFFI not supported -- please install the cffi module")
 class TestCFFI(TestCase):
 
+    # Need to run the test serially because of race conditions with
+    # cffi's OOL mode.
+    _numba_parallel_test_ = True
+
+    def setUp(self):
+        mod.init()
+        mod.init_ool()
+
     def test_type_map(self):
-        signature = cffi_support.map_type(ffi.typeof(cffi_sin))
+        signature = cffi_support.map_type(mod.ffi.typeof(mod.cffi_sin))
         self.assertEqual(len(signature.args), 1)
         self.assertEqual(signature.args[0], types.double)
 
@@ -31,48 +41,48 @@ class TestCFFI(TestCase):
             self.assertPreciseEqual(pyfunc(x), cfunc(x))
 
     def test_sin_function(self):
-        self._test_function(use_cffi_sin)
+        self._test_function(mod.use_cffi_sin)
 
     def test_sin_function_npm(self):
-        self._test_function(use_cffi_sin, flags=no_pyobj_flags)
+        self._test_function(mod.use_cffi_sin, flags=no_pyobj_flags)
 
     def test_sin_function_ool(self, flags=enable_pyobj_flags):
-        self._test_function(use_cffi_sin_ool)
+        self._test_function(mod.use_cffi_sin_ool)
 
     def test_sin_function_npm_ool(self):
-        self._test_function(use_cffi_sin_ool, flags=no_pyobj_flags)
+        self._test_function(mod.use_cffi_sin_ool, flags=no_pyobj_flags)
 
     def test_two_funcs(self):
         # Check that two constant functions don't get mixed up.
-        self._test_function(use_two_funcs)
+        self._test_function(mod.use_two_funcs)
 
     def test_two_funcs_ool(self):
-        self._test_function(use_two_funcs_ool)
+        self._test_function(mod.use_two_funcs_ool)
 
     def test_function_pointer(self):
-        pyfunc = use_func_pointer
+        pyfunc = mod.use_func_pointer
         cfunc = jit(nopython=True)(pyfunc)
         for (fa, fb, x) in [
-            (cffi_sin, cffi_cos, 1.0),
-            (cffi_sin, cffi_cos, -1.0),
-            (cffi_cos, cffi_sin, 1.0),
-            (cffi_cos, cffi_sin, -1.0),
-            (cffi_sin_ool, cffi_cos_ool, 1.0),
-            (cffi_sin_ool, cffi_cos_ool, -1.0),
-            (cffi_cos_ool, cffi_sin_ool, 1.0),
-            (cffi_cos_ool, cffi_sin_ool, -1.0),
-            (cffi_sin, cffi_cos_ool, 1.0),
-            (cffi_sin, cffi_cos_ool, -1.0),
-            (cffi_cos, cffi_sin_ool, 1.0),
-            (cffi_cos, cffi_sin_ool, -1.0)]:
+            (mod.cffi_sin, mod.cffi_cos, 1.0),
+            (mod.cffi_sin, mod.cffi_cos, -1.0),
+            (mod.cffi_cos, mod.cffi_sin, 1.0),
+            (mod.cffi_cos, mod.cffi_sin, -1.0),
+            (mod.cffi_sin_ool, mod.cffi_cos_ool, 1.0),
+            (mod.cffi_sin_ool, mod.cffi_cos_ool, -1.0),
+            (mod.cffi_cos_ool, mod.cffi_sin_ool, 1.0),
+            (mod.cffi_cos_ool, mod.cffi_sin_ool, -1.0),
+            (mod.cffi_sin, mod.cffi_cos_ool, 1.0),
+            (mod.cffi_sin, mod.cffi_cos_ool, -1.0),
+            (mod.cffi_cos, mod.cffi_sin_ool, 1.0),
+            (mod.cffi_cos, mod.cffi_sin_ool, -1.0)]:
             expected = pyfunc(fa, fb, x)
             got = cfunc(fa, fb, x)
             self.assertEqual(got, expected)
         # A single specialization was compiled for all calls
         self.assertEqual(len(cfunc.overloads), 1, cfunc.overloads)
 
-    def test_user_defined_sybols(self):
-        pyfunc = use_user_defined_symbols
+    def test_user_defined_symbols(self):
+        pyfunc = mod.use_user_defined_symbols
         cfunc = jit(nopython=True)(pyfunc)
         self.assertEqual(pyfunc(), cfunc())
 
@@ -82,10 +92,10 @@ class TestCFFI(TestCase):
         np.testing.assert_equal(pyfunc(x), cfunc(x))
 
     def test_pass_numpy_array_float32(self):
-        self._test_pass_numpy_array(vector_sin_float32, np.float32)
+        self._test_pass_numpy_array(mod.vector_sin_float32, np.float32)
 
     def test_pass_numpy_array_float64(self):
-        self._test_pass_numpy_array(vector_sin_float64, np.float64)
+        self._test_pass_numpy_array(mod.vector_sin_float64, np.float64)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -51,7 +51,7 @@ class TestCase(unittest.TestCase):
         self.check_testsuite_size('numba.cuda.tests', 0, 400)
     def test_module(self):
         self.check_testsuite_size('numba.tests.test_builtins', 82)
-        
+
 if __name__ == '__main__':
     unittest.main()
     

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -220,18 +220,19 @@ class TestTypeof(ValueTypingTestBase, TestCase):
 
     @unittest.skipUnless(cffi_support.SUPPORTED, "CFFI not supported")
     def test_cffi(self):
-        from .cffi_usecases import cffi_cos, cffi_sin
-        ty_cffi_cos = typeof(cffi_cos)
-        ty_cffi_sin = typeof(cffi_sin)
+        from . import cffi_usecases as mod
+        mod.init()
+        ty_cffi_cos = typeof(mod.cffi_cos)
+        ty_cffi_sin = typeof(mod.cffi_sin)
         self.assertIsInstance(ty_cffi_cos, types.ExternalFunctionPointer)
         self.assertEqual(ty_cffi_cos.sig.args, (types.float64,))
         self.assertEqual(ty_cffi_cos.sig.return_type, types.float64)
         self.assertEqual(ty_cffi_cos, ty_cffi_sin)
         ty_ctypes_cos = typeof(c_cos)
         self.assertNotEqual(ty_cffi_cos, ty_ctypes_cos)
-        self.assertNotEqual(ty_cffi_cos.get_pointer(cffi_cos),
-                            ty_cffi_sin.get_pointer(cffi_sin))
-        self.assertEqual(ty_cffi_cos.get_pointer(cffi_cos),
+        self.assertNotEqual(ty_cffi_cos.get_pointer(mod.cffi_cos),
+                            ty_cffi_sin.get_pointer(mod.cffi_sin))
+        self.assertEqual(ty_cffi_cos.get_pointer(mod.cffi_cos),
                          ty_ctypes_cos.get_pointer(c_cos))
 
     def test_custom(self):


### PR DESCRIPTION
Hopefully this will fix the test failures on Jenkins Windows builders