### PR TITLE
Precision update for erf, erfc, and linalg.inv tests

### DIFF
--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -303,7 +303,7 @@ class TestLinalgInv(TestCase):
             got = cfunc(a)
             # XXX add to use that function otherwise comparison fails
             # because of +0, -0 discrepancies
-            np.testing.assert_array_almost_equal_nulp(got, expected, nulp=2)
+            np.testing.assert_array_almost_equal_nulp(got, expected, nulp=3)
 
         for order in 'CF':
             a = np.array(((2, 1), (2, 3)), dtype=np.float64, order=order)

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -537,7 +537,7 @@ class TestMathLib(TestCase):
         x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
         self.run_unary(pyfunc, x_types, x_values, flags,
-                       prec='double')
+                       prec='double', ulps=2)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erf_npm(self):
@@ -549,7 +549,7 @@ class TestMathLib(TestCase):
         x_values = [1., 1., -1., -0.0, 0.0, 0.5, 5, float('inf')]
         x_types = [types.float32, types.float64] * (len(x_values) // 2)
         self.run_unary(pyfunc, x_types, x_values, flags,
-                       prec='double', ulps=3)
+                       prec='double', ulps=4)
 
     @unittest.skipIf(not PY27_AND_ABOVE, "Only support for 2.7+")
     def test_erfc_npm(self):


### PR DESCRIPTION
Adjust the required precision to permit one extra ULP of difference for these three functions to account for differences on OS X.