### PR TITLE
Issue #1691: cffi.from_buffer() improvements

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -374,7 +374,7 @@ Third-party modules
 --------
 
 Similarly to ctypes, Numba is able to call into `cffi`_-declared external
-functions, using the following C types:
+functions, using the following C types and any derived pointer types:
 
 * :c:type:`char`
 * :c:type:`short`
@@ -396,18 +396,15 @@ functions, using the following C types:
 * :c:type:`uint64_t`
 * :c:type:`float`
 * :c:type:`double`
-* :c:type:`char *`
-* :c:type:`void *`
-* :c:type:`uint8_t *`
-* :c:type:`float *`
-* :c:type:`double *`
 * :c:type:`ssize_t`
 * :c:type:`size_t`
 * :c:type:`void`
 
-The ``from_buffer`` method of ``cffi.FFI`` and ``CompiledFFI`` objects is
-supported for passing NumPy arrays of ``float32`` and ``float64`` values to C
-function parameters of type ``float *`` and ``double *`` respectively.
+The ``from_buffer()`` method of ``cffi.FFI`` and ``CompiledFFI`` objects is
+supported for passing Numpy arrays and other buffer-like objects.  Only
+*contiguous* arguments are accepted.  The argument to ``from_buffer()``
+is converted to a raw pointer of the appropriate C type (for example a
+``double *`` for a ``float64`` array).
 
 Out-of-line cffi modules must be registered with Numba prior to the use of any
 of their functions from within Numba-compiled functions:

--- a/numba/targets/cffiimpl.py
+++ b/numba/targets/cffiimpl.py
@@ -10,7 +10,7 @@ from . import arrayobj
 
 registry = Registry()
 
-@registry.lower('ffi.from_buffer', types.Array)
+@registry.lower('ffi.from_buffer', types.Buffer)
 def from_buffer(context, builder, sig, args):
     assert len(sig.args) == 1
     assert len(args) == 1

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -141,12 +141,8 @@ def use_user_defined_symbols():
 # (cffi_usecases_ool.ffi is a CompiledFFI object) so we use both in these
 # functions.
 
-def vector_sin_float32(x):
-    y = np.empty_like(x)
+def vector_sin_float32(x, y):
     vsSin(len(x), ffi.from_buffer(x), ffi_ool.from_buffer(y))
-    return y
 
-def vector_sin_float64(x):
-    y = np.empty_like(x)
+def vector_sin_float64(x, y):
     vdSin(len(x), ffi.from_buffer(x), ffi_ool.from_buffer(y))
-    return y


### PR DESCRIPTION
- Improve error message when using a non-contiguous array (fix #1691)
- Allow more pointer types
- Allow non-Numpy buffer objects