### PR TITLE
CFFI type registration

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -406,6 +406,13 @@ supported for passing Numpy arrays and other buffer-like objects.  Only
 is converted to a raw pointer of the appropriate C type (for example a
 ``double *`` for a ``float64`` array).
 
+Additional type mappings for the conversion from a buffer to the appropriate C
+type may be registered with Numba. This may include struct types, though it is
+only permitted to call functions that accept pointers to structs - passing a
+struct by value is unsupported. For registering a mapping, use:
+
+.. function:: numba.cffi_support.register_type(cffi_type, numba_type)
+
 Out-of-line cffi modules must be registered with Numba prior to the use of any
 of their functions from within Numba-compiled functions:
 

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -104,6 +104,18 @@ class TestCFFI(TestCase):
     def test_from_buffer_float64(self):
         self._test_from_buffer_numpy_array(mod.vector_sin_float64, np.float64)
 
+    def test_from_buffer_struct(self):
+        n = 10
+        x = np.arange(n) + np.arange(n * 2, n * 3) * 1j
+        y = np.zeros(n)
+        real_cfunc = jit(nopython=True)(mod.vector_extract_real)
+        real_cfunc(x, y)
+        np.testing.assert_equal(x.real, y)
+        imag_cfunc = jit(nopython=True)(mod.vector_extract_imag)
+        imag_cfunc(x, y)
+        np.testing.assert_equal(x.imag, y)
+
+
     @unittest.skipIf(sys.version_info < (3,),
                      "buffer protocol on array.array needs Python 3+")
     def test_from_buffer_pyarray(self):


### PR DESCRIPTION
This PR allows registration of additional type mappings into Numba's type map. These type mappings may involve pointers to structs - however, calling a function that accepts struct values is not presently supported as there is no implementation of marshalling for this kind of argument.

An example usecase for this functionality is to interoperate with C libraries that use a struct consisting of two members to store a complex numba, as demonstrated in the test.