### PR TITLE
Fix test fragility on second-granularity filesystems

### DIFF
--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 
 from numba import cffi_support
-from numba.tests.support import temp_directory
+from numba.tests.support import import_dynamic, temp_directory
 from numba.types import complex128
 
 
@@ -100,7 +100,7 @@ def load_ool_module():
     ffi.compile(tmpdir=tmpdir)
     sys.path.append(tmpdir)
     try:
-        import cffi_usecases_ool as mod
+        mod = import_dynamic('cffi_usecases_ool')
         cffi_support.register_module(mod)
         cffi_support.register_type(mod.ffi.typeof('struct _numba_complex'),
                                    complex128)

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -469,6 +469,18 @@ def temp_directory(prefix):
     return _create_trashcan_subdir(prefix)
 
 
+def import_dynamic(modname):
+    """
+    Import and return a module of the given name.  Care is taken to
+    avoid issues due to Python's internal directory caching.
+    """
+    if sys.version_info >= (3, 3):
+        import importlib
+        importlib.invalidate_caches()
+    __import__(modname)
+    return sys.modules[modname]
+
+
 # From CPython
 
 @contextlib.contextmanager

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -15,7 +15,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import utils, vectorize, jit, generated_jit, types
 from numba.errors import NumbaWarning
-from .support import TestCase, tag, temp_directory
+from .support import TestCase, tag, temp_directory, import_dynamic
 
 
 def dummy(x):
@@ -522,7 +522,7 @@ class TestCache(TestCase):
                 except OSError as e:
                     if e.errno != errno.ENOENT:
                         raise
-        mod = __import__(self.modname)
+        mod = import_dynamic(self.modname)
         self.assertEqual(mod.__file__.rstrip('co'), self.modfile)
         return mod
 

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -18,9 +18,7 @@ except ImportError:
 from numba import unittest_support as unittest
 from numba.pycc import find_shared_ending, find_pyext_ending, main
 from numba.pycc.decorators import clear_export_registry
-from .support import TestCase, tag
-
-from numba.tests.support import temp_directory
+from .support import TestCase, tag, import_dynamic, temp_directory
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -53,7 +51,7 @@ class BasePYCCTest(TestCase):
     def check_c_ext(self, extdir, name):
         sys.path.append(extdir)
         try:
-            lib = __import__(name)
+            lib = import_dynamic(name)
             yield lib
         finally:
             sys.path.remove(extdir)


### PR DESCRIPTION
This should fix any sporadic failures in test_pycc on Jenkins builders