### PR TITLE
Avoid overly broad operator typing

### DIFF
--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -61,8 +61,9 @@ class BaseContext(object):
         Refresh context with new declarations from known registries.
         Useful for third-party extensions.
         """
-        self._load_builtins()
         self.load_additional_registries()
+        # Some extensions may have augmented the builtin registry
+        self._load_builtins()
 
     def explain_function_type(self, func):
         """

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -200,17 +200,25 @@ class NumpyRulesArrayOperator(Numpy_rules_ufunc):
         '''
         try:
             sig = super(NumpyRulesArrayOperator, self).generic(args, kws)
-            # Stay out of the timedelta64 range and domain; already
-            # handled elsewhere.
-            if sig is not None:
-                timedelta_test = (
-                    isinstance(sig.return_type, types.NPTimedelta) or
-                    (all(isinstance(argty, types.NPTimedelta)
-                         for argty in sig.args)))
-                if timedelta_test:
-                    sig = None
         except TypingError:
-            sig = None
+            return None
+        if sig is None:
+            return None
+        args = sig.args
+        # Only accept at least one array argument, otherwise it needn't
+        # obey Numpy's ufunc rules.
+        if not any(isinstance(arg, types.ArrayCompatible)
+                   for arg in args):
+            return None
+        # Stay out of the timedelta64 range and domain; already
+        # handled elsewhere.
+        if sig is not None:
+            timedelta_test = (
+                isinstance(sig.return_type, types.NPTimedelta) or
+                (all(isinstance(argty, types.NPTimedelta)
+                     for argty in sig.args)))
+            if timedelta_test:
+                return None
         return sig
 
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -205,20 +205,11 @@ class NumpyRulesArrayOperator(Numpy_rules_ufunc):
         if sig is None:
             return None
         args = sig.args
-        # Only accept at least one array argument, otherwise it needn't
-        # obey Numpy's ufunc rules.
+        # Only accept at least one array argument, otherwise the operator
+        # doesn't involve Numpy's ufunc machinery.
         if not any(isinstance(arg, types.ArrayCompatible)
                    for arg in args):
             return None
-        # Stay out of the timedelta64 range and domain; already
-        # handled elsewhere.
-        if sig is not None:
-            timedelta_test = (
-                isinstance(sig.return_type, types.NPTimedelta) or
-                (all(isinstance(argty, types.NPTimedelta)
-                     for argty in sig.args)))
-            if timedelta_test:
-                return None
         return sig
 
 


### PR DESCRIPTION
The ufunc machinery could type operators even between scalars, though in pure Python it wouldn't apply