### PR TITLE
Fix tuple getitem regression for cuda target

### DIFF
--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -6,6 +6,9 @@ from numba import types
 from numba.typing.templates import (AttributeTemplate, AbstractTemplate,
                                     infer, infer_getattr, signature,
                                     bound_function)
+# import time side effect: array operations requires typing support of sequence
+# defined in collections: e.g. array.shape[i]
+from numba.typing import collections
 
 Indexing = namedtuple("Indexing", ("index", "result", "advanced"))
 


### PR DESCRIPTION
The error is observed when running ``numba.cuda.tests.cudapy.test_exception.TestException.test_exception``