### PR TITLE
Optimize datamodel traversal

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
 
+from functools import partial
+
 from llvmlite import ir
 
 from numba import cgutils, types, numpy_support
@@ -84,10 +86,11 @@ class DataModel(object):
         """
         return self.from_data(builder, builder.load(ptr, align=align))
 
-    def traverse(self, builder, value):
+    def traverse(self, builder):
         """
-        Traverse contained values
-        Returns a iterable of contained (types, values)
+        Traverse contained members.
+        Returns a iterable of contained (types, getters).
+        Each getter is a one-argument function accepting a LLVM value.
         """
         return []
 
@@ -386,9 +389,11 @@ class UniTupleModel(DataModel):
     def from_return(self, builder, value):
         return value
 
-    def traverse(self, builder, value):
-        values = cgutils.unpack_tuple(builder, value, count=self._count)
-        return zip([self._fe_type.dtype] * len(values), values)
+    def traverse(self, builder):
+        def getter(i, value):
+            return builder.extract_value(value, i)
+        return [(self._fe_type.dtype, partial(getter, i))
+                for i in range(self._count)]
 
     def inner_types(self):
         return self._elem_model.traverse_types()
@@ -596,13 +601,14 @@ class StructModel(CompositeModel):
         """
         return self._models[pos]
 
-    def traverse(self, builder, value):
-        if value.type != self.get_value_type():
-            args = self.get_value_type(), value.type
-            raise TypeError("expecting {0} but got {1}".format(*args))
-        out = [(self.get_type(k), self.get(builder, value, k))
-                for k in self._fields]
-        return out
+    def traverse(self, builder):
+        def getter(k, value):
+            if value.type != self.get_value_type():
+                args = self.get_value_type(), value.type
+                raise TypeError("expecting {0} but got {1}".format(*args))
+            return self.get(builder, value, k)
+
+        return [(self.get_type(k), partial(getter, k)) for k in self._fields]
 
     def inner_types(self):
         types = []
@@ -797,12 +803,16 @@ class OptionalModel(StructModel):
     def from_return(self, builder, value):
         return self._value_model.from_return(builder, value)
 
-    def traverse(self, builder, value):
-        data = self.get(builder, value, "data")
-        valid = self.get(builder, value, "valid")
-        data = builder.select(valid, data, ir.Constant(data.type, None))
-        return [(self.get_type("data"), data),
-                (self.get_type("valid"), valid)]
+    def traverse(self, builder):
+        def get_data(value):
+            valid = get_valid(value)
+            data = self.get(builder, value, "data")
+            return builder.select(valid, data, ir.Constant(data.type, None))
+        def get_valid(value):
+            return self.get(builder, value, "valid")
+
+        return [(self.get_type("data"), get_data),
+                (self.get_type("valid"), get_valid)]
 
 
 @register_default(types.Record)
@@ -1167,5 +1177,6 @@ class DeferredStructModel(CompositeModel):
     def _actual_model(self):
         return self._dmm.lookup(self.actual_fe_type)
 
-    def traverse(self, builder, value):
-        return [(self.actual_fe_type, builder.extract_value(value, [0]))]
+    def traverse(self, builder):
+        return [(self.actual_fe_type,
+                 lambda value: builder.extract_value(value, [0]))]

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1043,22 +1043,28 @@ class BaseContext(object):
                                         name="NRT_MemInfo_data_fast")
         return builder.call(fn, [meminfo])
 
-    def _call_nrt_incref_decref(self, builder, root_type, typ, value, funcname):
+    def _call_nrt_incref_decref(self, builder, root_type, typ, value,
+                                funcname, getters=()):
         self._require_nrt()
 
         from numba.runtime.atomicops import incref_decref_ty
 
         data_model = self.data_model_manager[typ]
 
-        members = data_model.traverse(builder, value)
-        for mt, mv in members:
-            self._call_nrt_incref_decref(builder, root_type, mt, mv, funcname)
+        members = data_model.traverse(builder)
+        for mtyp, getter in members:
+            self._call_nrt_incref_decref(builder, root_type, mtyp, value,
+                                         funcname, getters + (getter,))
 
-        try:
-            meminfo = data_model.get_nrt_meminfo(builder, value)
-        except NotImplementedError as e:
-            raise NotImplementedError("%s: %s" % (root_type, str(e)))
-        if meminfo:
+        if data_model.has_nrt_meminfo():
+            # Call the chain of getters to compute the member value
+            for getter in getters:
+                value = getter(value)
+            try:
+                meminfo = data_model.get_nrt_meminfo(builder, value)
+            except NotImplementedError as e:
+                raise NotImplementedError("%s: %s" % (root_type, str(e)))
+            assert meminfo is not None  # since has_nrt_meminfo()
             mod = builder.module
             fn = mod.get_or_insert_function(incref_decref_ty, name=funcname)
             # XXX "nonnull" causes a crash in test_dyn_array: can this


### PR DESCRIPTION
Traversing a datamodel tree looking for NRT fields would reify every member as a new LLVM instruction.  Instead, only access fields as necessary.

This removes some boilerplate from the generated LLVM IR, and can shorten compilation times a bit.

Based on PR #1724.