### PR TITLE
Use Numpy error model in array expressions

### DIFF
--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -6,7 +6,7 @@ import sys
 
 from numpy import ufunc
 
-from .. import ir, types, rewrites, six
+from .. import compiler, ir, types, rewrites, six
 from ..typing import npydecl
 from .dufunc import DUFunc
 
@@ -336,7 +336,11 @@ def _lower_array_expr(lowerer, expr):
             inner_sig_args.append(argty)
     inner_sig = outer_sig.return_type.dtype(*inner_sig_args)
 
-    cres = context.compile_only_no_cache(builder, impl, inner_sig)
+    # Follow the Numpy error model.  Note this also allows e.g. vectorizing
+    # division (issue #1223).
+    flags = compiler.Flags()
+    flags.set('error_model', 'numpy')
+    cres = context.compile_only_no_cache(builder, impl, inner_sig, flags=flags)
 
     # Create kernel subclass calling our native function
     from ..targets import npyimpl

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -709,7 +709,7 @@ class BaseContext(object):
     def get_dummy_type(self):
         return GENERIC_POINTER
 
-    def compile_only_no_cache(self, builder, impl, sig, locals={}):
+    def compile_only_no_cache(self, builder, impl, sig, locals={}, flags=None):
         """Invoke the compiler to compile a function to be used inside a
         nopython function, but without generating code to call that
         function.
@@ -719,7 +719,8 @@ class BaseContext(object):
 
         codegen = self.codegen()
         library = codegen.create_library(impl.__name__)
-        flags = compiler.Flags()
+        if flags is None:
+            flags = compiler.Flags()
         flags.set('no_compile')
         flags.set('no_cpython_wrapper')
         cres = compiler.compile_internal(self.typing_context, self,


### PR DESCRIPTION
This is more correct, and also allows speeding up divisions (2x faster by vectorizing).
Fix #1223.