### PR TITLE
Avoid spurious output in cuda.tests.cudapy.test_debug

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -116,6 +116,8 @@ Calculation
 The following methods of Numpy arrays are supported in their basic form
 (without any optional arguments):
 
+* :meth:`~numpy.ndarray.all`
+* :meth:`~numpy.ndarray.any`
 * :meth:`~numpy.ndarray.argmax`
 * :meth:`~numpy.ndarray.argmin`
 * :meth:`~numpy.ndarray.cumprod`

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -170,10 +170,13 @@ def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
     Compile the function in an isolated environment (typing and target context).
     Good for testing.
     """
+    from .targets.registry import cpu_target
     typingctx = typing.Context()
     targetctx = cpu.CPUContext(typingctx)
-    return compile_extra(typingctx, targetctx, func, args, return_type, flags,
-                         locals)
+    # Register the contexts in case for nested @jit or @overload calls
+    with cpu_target.nested_context(typingctx, targetctx):
+        return compile_extra(typingctx, targetctx, func, args, return_type,
+                             flags, locals)
 
 
 class _CompileStatus(object):

--- a/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba/cuda/tests/cudapy/test_debug.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import
 import numpy as np
 
 from numba.cuda.testing import skip_on_cudasim
-from numba.tests.support import override_config, captured_stdout
+from numba.tests.support import override_config, captured_stderr, captured_stdout
 from numba import unittest_support as unittest
 from numba import cuda, float64
 
@@ -17,14 +17,17 @@ def simple_cuda(A, B):
 class TestDebugOutput(unittest.TestCase):
 
     def compile_simple_cuda(self):
-        with captured_stdout() as out:
-            cfunc = cuda.jit((float64[:], float64[:]))(simple_cuda)
-            # Call compiled function (to ensure PTX is generated)
-            # and sanity-check results.
-            A = np.linspace(0, 1, 10).astype(np.float64)
-            B = np.zeros_like(A)
-            cfunc[1, 10](A, B)
-            self.assertTrue(np.allclose(A + 1.5, B))
+        with captured_stderr() as err:
+            with captured_stdout() as out:
+                cfunc = cuda.jit((float64[:], float64[:]))(simple_cuda)
+                # Call compiled function (to ensure PTX is generated)
+                # and sanity-check results.
+                A = np.linspace(0, 1, 10).astype(np.float64)
+                B = np.zeros_like(A)
+                cfunc[1, 10](A, B)
+                self.assertTrue(np.allclose(A + 1.5, B))
+        # stderr shouldn't be affected by debug output
+        self.assertFalse(err.getvalue())
         return out.getvalue()
 
     def assert_fails(self, *args, **kwargs):
@@ -52,6 +55,7 @@ class TestDebugOutput(unittest.TestCase):
 
     def _check_dump_ir(self, out):
         self.assertIn('--IR DUMP: simple_cuda--', out)
+        self.assertIn('const(float, 1.5)', out)
 
     def _check_dump_llvm(self, out):
         self.assertIn('--LLVM DUMP', out)

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -555,6 +555,7 @@ class Interpreter(object):
                 raise e
 
     def dump(self, file=None):
+        # Avoid early bind of sys.stdout as default value
         file = file or sys.stdout
         for offset, block in sorted(self.blocks.items()):
             print('label %s:' % (offset,), file=file)

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -673,7 +673,9 @@ class Block(object):
     def clear(self):
         del self.body[:]
 
-    def dump(self, file=sys.stdout):
+    def dump(self, file=None):
+        # Avoid early bind of sys.stdout as default value
+        file = file or sys.stdout
         for inst in self.body:
             inst_vars = sorted(str(v) for v in inst.list_vars())
             print('    %-40s %s' % (inst, inst_vars), file=file)

--- a/numba/rewrites/registry.py
+++ b/numba/rewrites/registry.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict
+import sys
 
 from numba import config
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -186,6 +186,9 @@ class BaseContext(object):
             pass
         self.install_registry(builtin_registry)
         self.load_additional_registries()
+        # Also refresh typing context, since @overload declarations can
+        # affect it.
+        self.typing_context.refresh()
 
     def load_additional_registries(self):
         """

--- a/numba/targets/registry.py
+++ b/numba/targets/registry.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+import contextlib
+import threading
+
 from . import cpu
 from .descriptors import TargetDescriptor
 from .. import dispatcher, utils, typing
@@ -7,17 +10,66 @@ from .. import dispatcher, utils, typing
 # -----------------------------------------------------------------------------
 # Default CPU target descriptors
 
+class _ThreadLocalContext(threading.local):
+    """
+    Thread-local helper for CPUTarget.
+    """
+    _nested_typing_context = None
+    _nested_target_context = None
+
+    @contextlib.contextmanager
+    def nested(self, typing_context, target_context):
+        old_nested = self._nested_typing_context, self._nested_target_context
+        try:
+            self._nested_typing_context = typing_context
+            self._nested_target_context = target_context
+            yield
+        finally:
+            self._nested_typing_context, self._nested_target_context = old_nested
+
 
 class CPUTarget(TargetDescriptor):
     options = cpu.CPUTargetOptions
+    _tls = _ThreadLocalContext()
 
     @utils.cached_property
-    def target_context(self):
+    def _toplevel_target_context(self):
+        # Lazily-initialized top-level target context, for all threads
         return cpu.CPUContext(self.typing_context)
 
     @utils.cached_property
-    def typing_context(self):
+    def _toplevel_typing_context(self):
+        # Lazily-initialized top-level typing context, for all threads
         return typing.Context()
+
+    @property
+    def target_context(self):
+        """
+        The target context for CPU targets.
+        """
+        nested = self._tls._nested_target_context
+        if nested is not None:
+            return nested
+        else:
+            return self._toplevel_target_context
+
+    @property
+    def typing_context(self):
+        """
+        The typing context for CPU targets.
+        """
+        nested = self._tls._nested_typing_context
+        if nested is not None:
+            return nested
+        else:
+            return self._toplevel_typing_context
+
+    def nested_context(self, typing_context, target_context):
+        """
+        A context manager temporarily replacing the contexts with the
+        given ones, for the current thread of execution.
+        """
+        return self._tls.nested(typing_context, target_context)
 
 
 # The global CPU target

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -546,8 +546,11 @@ class ParallelTestRunner(runner.TextTestRunner):
             # On exception, kill still active workers immediately
             pool.terminate()
         else:
-            # On success, close the pool cleanly
-            pool.close()
+            # Close the pool cleanly unless asked to early out
+            if result.shouldStop:
+                pool.terminate()
+            else:
+                pool.close()
         finally:
             # Always join the pool (this is necessary for coverage.py)
             pool.join()

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -5,10 +5,22 @@ from itertools import product
 import numpy as np
 
 from numba import unittest_support as unittest
-from numba import typeof
+from numba import jit, typeof
 from numba.compiler import compile_isolated
 from .support import TestCase, MemoryLeakMixin, tag
 
+
+def array_all(arr):
+    return arr.all()
+
+def array_all_global(arr):
+    return np.all(arr)
+
+def array_any(arr):
+    return arr.any()
+
+def array_any_global(arr):
+    return np.any(arr)
 
 def array_cumprod(arr):
     return arr.cumprod()
@@ -121,6 +133,40 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
     """
     Test array reduction methods and functions such as .sum(), .max(), etc.
     """
+
+    @tag('important')
+    def test_all_basic(self, pyfunc=array_all):
+        cfunc = jit(nopython=True)(pyfunc)
+        def check(arr):
+            self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+
+        arr = np.float64([1.0, 0.0, float('inf'), float('nan')])
+        check(arr)
+        arr[1] = -0.0
+        check(arr)
+        arr[1] = 1.5
+        check(arr)
+        arr = arr.reshape((2, 2))
+        check(arr)
+        check(arr[::-1])
+
+    @tag('important')
+    def test_any_basic(self, pyfunc=array_any):
+        cfunc = jit(nopython=True)(pyfunc)
+        def check(arr):
+            self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+
+        arr = np.float64([0.0, -0.0, 0.0, 0.0])
+        check(arr)
+        arr[2] = float('nan')
+        check(arr)
+        arr[2] = float('inf')
+        check(arr)
+        arr[2] = 1.5
+        check(arr)
+        arr = arr.reshape((2, 2))
+        check(arr)
+        check(arr[::-1])
 
     @tag('important')
     def test_sum_basic(self):
@@ -381,7 +427,10 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
                            array_min, array_min_global,
                            array_max, array_max_global,
                            array_argmin, array_argmin_global,
-                           array_argmax, array_argmax_global]
+                           array_argmax, array_argmax_global,
+                           array_all, array_all_global,
+                           array_any, array_any_global,
+                           ]
         dtypes_to_test = [np.int32, np.float32, np.bool_]
 
         # Install tests on class

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -327,16 +327,24 @@ class AttributeTemplate(object):
     _initialized = False
 
     def __init__(self, context):
+        self._lazy_class_init()
         self.context = context
 
     def resolve(self, value, attr):
-        if not self._initialized:
-            self._do_init()
-            self._initialized = True
         return self._resolve(value, attr)
 
-    def _do_init(self):
-        pass
+    @classmethod
+    def _lazy_class_init(cls):
+        if not cls._initialized:
+            cls.do_class_init()
+            cls._initialized = True
+
+    @classmethod
+    def do_class_init(cls):
+        """
+        Class-wide initialization.  Can be overriden by subclasses to
+        register permanent typing or target hooks.
+        """
 
     def _resolve(self, value, attr):
         fn = getattr(self, "resolve_%s" % attr, None)
@@ -357,48 +365,55 @@ class _OverloadAttributeTemplate(AttributeTemplate):
     A base class of templates for @overload_attribute functions.
     """
 
-    def _do_init(self):
+    def __init__(self, context):
+        super(_OverloadAttributeTemplate, self).__init__(context)
+        self.context = context
+
+    @classmethod
+    def do_class_init(cls):
         """
         Register attribute implementation.
         """
         from numba.targets.imputils import lower_getattr
-        attr = self._attr
+        attr = cls._attr
 
-        @lower_getattr(self.key, attr)
+        @lower_getattr(cls.key, attr)
         def getattr_impl(context, builder, typ, value):
             sig_args = (typ,)
             sig_kws = {}
-            disp = self._get_dispatcher(typ, attr, sig_args, sig_kws)
+            typing_context = context.typing_context
+            disp = cls._get_dispatcher(typing_context, typ, attr, sig_args, sig_kws)
             disp_type = types.Dispatcher(disp)
-            sig = disp_type.get_call_type(self.context, sig_args, sig_kws)
+            sig = disp_type.get_call_type(typing_context, sig_args, sig_kws)
             call = context.get_function(disp_type, sig)
             return call(builder, (value,))
 
-    def _get_dispatcher(self, typ, attr, sig_args, sig_kws):
+    @classmethod
+    def _get_dispatcher(cls, context, typ, attr, sig_args, sig_kws):
         """
         Get the compiled dispatcher implementing the attribute for
         the given formal signature.
         """
-        cache_key = self.context, typ, attr
+        cache_key = context, typ, attr
         try:
-            disp = self._impl_cache[cache_key]
+            disp = cls._impl_cache[cache_key]
         except KeyError:
             # Get the overload implementation for the given type
-            pyfunc = self._overload_func(*sig_args, **sig_kws)
+            pyfunc = cls._overload_func(*sig_args, **sig_kws)
             if pyfunc is None:
                 # No implementation => fail typing
-                self._impl_cache[cache_key] = None
+                cls._impl_cache[cache_key] = None
                 return
 
             from numba import jit
-            disp = self._impl_cache[cache_key] = jit(nopython=True)(pyfunc)
+            disp = cls._impl_cache[cache_key] = jit(nopython=True)(pyfunc)
         return disp
 
     def _resolve_impl_sig(self, typ, attr, sig_args, sig_kws):
         """
         Compute the actual implementation sig for the given formal argument types.
         """
-        disp = self._get_dispatcher(typ, attr, sig_args, sig_kws)
+        disp = self._get_dispatcher(self.context, typ, attr, sig_args, sig_kws)
         if disp is None:
             return None
 
@@ -420,19 +435,21 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
     A base class of templates for @overload_method functions.
     """
 
-    def _do_init(self):
+    @classmethod
+    def do_class_init(cls):
         """
         Register generic method implementation.
         """
         from numba.targets.imputils import lower_builtin
-        attr = self._attr
+        attr = cls._attr
 
-        @lower_builtin((self.key, attr), self.key, types.VarArg(types.Any))
+        @lower_builtin((cls.key, attr), cls.key, types.VarArg(types.Any))
         def method_impl(context, builder, sig, args):
             typ = sig.args[0]
-            disp = self._get_dispatcher(typ, attr, sig.args, {})
+            typing_context = context.typing_context
+            disp = cls._get_dispatcher(typing_context, typ, attr, sig.args, {})
             disp_type = types.Dispatcher(disp)
-            sig = disp_type.get_call_type(self.context, sig.args, {})
+            sig = disp_type.get_call_type(typing_context, sig.args, {})
             call = context.get_function(disp_type, sig)
             return call(builder, args)
 
@@ -461,6 +478,7 @@ def make_overload_attribute_template(typ, attr, overload_func,
     """
     assert isinstance(typ, types.Type) or issubclass(typ, types.Type)
     name = "OverloadTemplate_%s_%s" % (typ, attr)
+    # Note the implementation cache is subclass-specific
     dct = dict(key=typ, _attr=attr, _impl_cache={},
                _overload_func=staticmethod(overload_func),
                )


### PR DESCRIPTION
This was caused by early-binding to sys.stdout, which ignored the redirection done by the test.
Based on PR #1782.