### PR TITLE
Support np.nditer()

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -141,12 +141,14 @@ The following methods of Numpy arrays are supported:
 
 * :meth:`~numpy.ndarray.astype` (only the 1-argument form)
 * :meth:`~numpy.ndarray.copy` (without arguments)
+* :meth:`~numpy.ndarray.flatten` (no order argument; 'C' order only)
+* :meth:`~numpy.ndarray.item` (without arguments)
+* :meth:`~numpy.ndarray.itemset` (only the 1-argument form)
+* :meth:`~numpy.ndarray.ravel` (no order argument; 'C' order only)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
 * :meth:`~numpy.ndarray.sort` (without arguments)
 * :meth:`~numpy.ndarray.transpose` (without arguments, and without copying)
 * :meth:`~numpy.ndarray.view` (only the 1-argument form)
-* :meth:`~numpy.ndarray.ravel` (no order argument; 'C' order only)
-* :meth:`~numpy.ndarray.flatten` (no order argument; 'C' order only)
 
 
 .. warning::
@@ -182,6 +184,7 @@ The following top-level functions are supported:
 * :func:`numpy.empty`
 * :func:`numpy.empty_like`
 * :func:`numpy.eye`
+* :func:`numpy.flatten` (no order argument; 'C' order only)
 * :func:`numpy.frombuffer` (only the 2 first arguments)
 * :func:`numpy.full`
 * :func:`numpy.full_like`
@@ -190,16 +193,16 @@ The following top-level functions are supported:
 * :func:`numpy.median` (only the first argument)
 * :class:`numpy.ndenumerate`
 * :class:`numpy.ndindex`
+* :class:`numpy.nditer` (only the first argument)
 * :func:`numpy.ones`
 * :func:`numpy.ones_like`
+* :func:`numpy.ravel` (no order argument; 'C' order only)
 * :func:`numpy.round_`
 * :func:`numpy.sinc`
 * :func:`numpy.sort` (no optional arguments)
 * :func:`numpy.where`
 * :func:`numpy.zeros`
 * :func:`numpy.zeros_like`
-* :func:`numpy.ravel` (no order argument; 'C' order only)
-* :func:`numpy.flatten` (no order argument; 'C' order only)
 
 
 The following constructors are supported, both with a numeric input (to

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -352,6 +352,8 @@ def alloca_once(builder, ty, size=None, name='', zfill=False):
     ``name`` arg set the symbol name inside the llvm IR for debugging.
     If ``zfill`` is set, also filling zeros to the memory.
     """
+    if isinstance(size, int):
+        size = ir.Constant(intp_t, size)
     with builder.goto_entry_block():
         ptr = builder.alloca(ty, size=size, name=name)
         if zfill:

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -352,7 +352,7 @@ def alloca_once(builder, ty, size=None, name='', zfill=False):
     ``name`` arg set the symbol name inside the llvm IR for debugging.
     If ``zfill`` is set, also filling zeros to the memory.
     """
-    if isinstance(size, int):
+    if isinstance(size, utils.INT_TYPES):
         size = ir.Constant(intp_t, size)
     with builder.goto_entry_block():
         ptr = builder.alloca(ty, size=size, name=name)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1110,10 +1110,11 @@ class NdIter(StructModel):
     def __init__(self, dmm, fe_type):
         array_types = fe_type.arrays
         ndim = fe_type.ndim
-        members = [('shape', types.UniTuple(types.intp, ndim)),
-                   ('indices', types.EphemeralArray(types.intp, ndim)),
-                   ('exhausted', types.EphemeralPointer(types.boolean)),
+        shape_len = ndim if fe_type.need_shaped_indexing else 1
+        members = [('exhausted', types.EphemeralPointer(types.boolean)),
                    ('arrays', types.Tuple(array_types)),
+                   ('shape', types.UniTuple(types.intp, shape_len)),
+                   ('indices', types.EphemeralArray(types.intp, shape_len)),
                    ]
         for i, sub in enumerate(fe_type.indexers):
             kind, start_dim, end_dim, _ = sub

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1864,6 +1864,9 @@ def make_nditer_cls(nditerty):
     class NdIter(cgutils.create_struct_proxy(nditerty)):
         """
         .nditer() implementation.
+
+        Note: 'F' layout means the shape is iterated in reverse logical order,
+        so indices and shapes arrays have to be reversed as well.
         """
 
         @utils.cached_property
@@ -2023,6 +2026,8 @@ def make_nditer_cls(nditerty):
             for sub, subiter in zip(indexers, subiters):
                 _, _, _, array_indices = sub
                 sub_indices = indices[subiter.start_dim:subiter.end_dim]
+                if layout == 'F':
+                    sub_indices = sub_indices[::-1]
                 for i in array_indices:
                     assert views[i] is None
                     views[i] = self._make_view(context, builder, sub_indices,

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1794,6 +1794,9 @@ def make_nditer_cls(nditerty):
     nshapes = ndim if nditerty.need_shaped_indexing else 1
 
     class BaseSubIter(object):
+        """
+        Base class for sub-iterators of a nditer() instance.
+        """
 
         def __init__(self, nditer, member_name, start_dim, end_dim):
             self.nditer = nditer
@@ -1820,6 +1823,10 @@ def make_nditer_cls(nditerty):
 
 
     class FlatSubIter(BaseSubIter):
+        """
+        Sub-iterator walking a contiguous array in physical order, with
+        support for broadcasting (the index is reset on the outer dimension).
+        """
 
         def init_specific(self, context, builder):
             zero = context.get_constant(types.intp, 0)
@@ -1849,6 +1856,10 @@ def make_nditer_cls(nditerty):
 
 
     class TrivialFlatSubIter(BaseSubIter):
+        """
+        Sub-iterator walking a contiguous array in physical order,
+        *without* support for broadcasting.
+        """
 
         def init_specific(self, context, builder):
             assert not nditerty.need_shaped_indexing
@@ -1859,6 +1870,9 @@ def make_nditer_cls(nditerty):
 
 
     class IndexedSubIter(BaseSubIter):
+        """
+        Sub-iterator walking an array in logical order.
+        """
 
         def compute_pointer(self, context, builder, indices, arrty, arr):
             assert len(indices) == self.ndim
@@ -1867,12 +1881,18 @@ def make_nditer_cls(nditerty):
 
 
     class ZeroDimSubIter(BaseSubIter):
+        """
+        Sub-iterator "walking" a 0-d array.
+        """
 
         def compute_pointer(self, context, builder, indices, arrty, arr):
             return arr.data
 
 
     class ScalarSubIter(BaseSubIter):
+        """
+        Sub-iterator "walking" a scalar value.
+        """
 
         def compute_pointer(self, context, builder, indices, arrty, arr):
             return arr
@@ -1903,6 +1923,9 @@ def make_nditer_cls(nditerty):
             return l
 
         def init_specific(self, context, builder, arrtys, arrays):
+            """
+            Initialize the nditer() instance for the specific array inputs.
+            """
             zero = context.get_constant(types.intp, 0)
 
             # Store inputs
@@ -1979,6 +2002,9 @@ def make_nditer_cls(nditerty):
                 subiter.init_specific(context, builder)
 
         def iternext_specific(self, context, builder, result):
+            """
+            Compute next iteration of the nditer() instance.
+            """
             zero = context.get_constant(types.intp, 0)
             one = context.get_constant(types.intp, 1)
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1085,6 +1085,15 @@ lower_builtin(abs, ty)(complex_abs_impl)
 del ty
 
 
+@lower_builtin("number.item", types.Boolean)
+@lower_builtin("number.item", types.Number)
+def number_item_impl(context, builder, sig, args):
+    """
+    The no-op .item() method on booleans and numbers.
+    """
+    return args[0]
+
+
 #------------------------------------------------------------------------------
 
 

--- a/numba/tests/test_array_iterators.py
+++ b/numba/tests/test_array_iterators.py
@@ -1,9 +1,11 @@
 from __future__ import division
 
+import itertools
+
 import numpy as np
 
 from numba import unittest_support as unittest
-from numba import typeof, types
+from numba import jit, typeof, types
 from numba.compiler import compile_isolated
 from .support import TestCase, CompilationCache, MemoryLeakMixin, tag
 
@@ -65,6 +67,24 @@ def np_ndindex_array(arr):
         for i, j in enumerate(indices):
             s = s + (i + 1) * (j + 1)
     return s
+
+def np_nditer1(a):
+    res = []
+    for u in np.nditer(a):
+        res.append(u.item())
+    return res
+
+def np_nditer2(a, b):
+    res = []
+    for u, v in np.nditer((a, b)):
+        res.append((u.item(), v.item()))
+    return res
+
+def np_nditer3(a, b, c):
+    res = []
+    for u, v, w in np.nditer((a, b, c)):
+        res.append((u.item(), v.item(), w.item()))
+    return res
 
 
 class TestArrayIterators(MemoryLeakMixin, TestCase):
@@ -328,6 +348,87 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         cres = compile_isolated(func, [])
         cfunc = cres.entry_point
         self.assertPreciseEqual(cfunc(), func())
+
+
+class TestNdIter(MemoryLeakMixin, TestCase):
+    """
+    Test np.nditer()
+    """
+
+    def inputs(self):
+        # All those inputs are compatible with a (3, 4) main shape
+
+        # scalars
+        yield np.float32(100)
+
+        # 0-d arrays
+        yield np.array(102, dtype=np.int16)
+
+        # 1-d arrays
+        yield np.arange(4).astype(np.complex64)
+        yield np.arange(8)[::2]
+
+        # 2-d arrays
+        a = np.arange(12).reshape((3, 4))
+        yield a
+        yield a.copy(order='F')
+        a = np.arange(24).reshape((6, 4))[::2]
+        yield a
+
+    def basic_inputs(self):
+        yield np.arange(4).astype(np.complex64)
+        yield np.arange(8)[::2]
+        a = np.arange(12).reshape((3, 4))
+        yield a
+        yield a.copy(order='F')
+
+    def check_result(self, got, expected):
+        self.assertEqual(set(got), set(expected), (got, expected))
+
+    def test_nditer1(self):
+        pyfunc = np_nditer1
+        cfunc = jit(nopython=True)(pyfunc)
+        for a in self.inputs():
+            expected = pyfunc(a)
+            got = cfunc(a)
+            self.check_result(got, expected)
+
+    @tag('important')
+    def test_nditer2(self):
+        pyfunc = np_nditer2
+        cfunc = jit(nopython=True)(pyfunc)
+        for a, b in itertools.product(self.inputs(), self.inputs()):
+            expected = pyfunc(a, b)
+            got = cfunc(a, b)
+            self.check_result(got, expected)
+
+    def test_nditer3(self):
+        pyfunc = np_nditer3
+        cfunc = jit(nopython=True)(pyfunc)
+        # Use a restricted set of inputs, to shorten test time
+        inputs = self.basic_inputs
+        for a, b, c in itertools.product(inputs(), inputs(), inputs()):
+            expected = pyfunc(a, b, c)
+            got = cfunc(a, b, c)
+            self.check_result(got, expected)
+
+    def test_errors(self):
+        # Incompatible shapes
+        pyfunc = np_nditer2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.disable_leak_check()
+
+        def check_incompatible(a, b):
+            with self.assertRaises(ValueError) as raises:
+                cfunc(a, b)
+            self.assertIn("operands could not be broadcast together",
+                          str(raises.exception))
+
+        check_incompatible(np.arange(2), np.arange(3))
+        a = np.arange(12).reshape((3, 4))
+        b = np.arange(3)
+        check_incompatible(a, b)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -241,6 +241,7 @@ class TestNdIter(TestCase):
         def check(ty, dtypes, ndim, layout, indexers=None):
             self.assertEqual(ty.ndim, ndim)
             self.assertEqual(ty.layout, layout)
+            self.assertEqual(ty.dtypes, dtypes)
             views = [types.Array(dtype, 0, "C") for dtype in dtypes]
             if len(views) > 1:
                 self.assertEqual(ty.yield_type, types.BaseTuple.from_types(views))
@@ -267,6 +268,10 @@ class TestNdIter(TestCase):
         ty = types.NumpyNdIterType((e, g))
         check(ty, (i16, f32), 0, "C", [('0d', 0, 0, [0, 1])])
         self.assertFalse(ty.need_shaped_indexing)
+        ty = types.NumpyNdIterType((e, c64))
+        check(ty, (i16, c64), 0, "C",
+              [('0d', 0, 0, [0]), ('scalar', 0, 0, [1])])
+        self.assertFalse(ty.need_shaped_indexing)
 
         # 1-dim iterator
         ty = types.NumpyNdIterType((a,))
@@ -277,9 +282,12 @@ class TestNdIter(TestCase):
         check(ty, (f32, f32), 1, "C",
               [('flat', 0, 1, [0, 1])])
         self.assertFalse(ty.need_shaped_indexing)
-        ty = types.NumpyNdIterType((a, e, e))
-        check(ty, (f32, i16, i16), 1, "C",
-              [('flat', 0, 1, [0]), ('0d', 0, 0, [1, 2])])
+        ty = types.NumpyNdIterType((a, e, e, c64))
+        check(ty, (f32, i16, i16, c64), 1, "C",
+              [('flat', 0, 1, [0]), # a
+               ('0d', 0, 0, [1, 2]), # e, e
+               ('scalar', 0, 0, [3]), # c64
+               ])
         self.assertFalse(ty.need_shaped_indexing)
         ty = types.NumpyNdIterType((a, f))
         check(ty, (f32, f32), 1, "C",

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -235,6 +235,81 @@ class TestTypes(TestCase):
         self.assertIs(f(8, signed=False), types.uint8)
 
 
+class TestNdIter(TestCase):
+
+    def test_homogenous(self):
+        def check(ty, dtype, ndim, layout, indexers=None):
+            self.assertEqual(ty.ndim, ndim)
+            self.assertEqual(ty.layout, layout)
+            self.assertEqual(ty.dtype, dtype)
+            if indexers is not None:
+                self.assertEqual(ty.indexers, indexers)
+
+        f32 = types.float32
+        a = types.Array(f32, 1, "C")
+        b = types.Array(f32, 2, "C")
+        c = types.Array(f32, 2, "F")
+        d = types.Array(f32, 2, "A")
+        e = types.Array(f32, 0, "C")
+        f = types.Array(f32, 1, "A")
+        # 1-dim iterator
+        ty = types.NumpyNdIterType((a,))
+        check(ty, f32, 1, "C", [('flat', 0, 1, [0])])
+        ty = types.NumpyNdIterType((a, a))
+        check(ty, f32, 1, "C", [('flat', 0, 1, [0, 1])])
+        ty = types.NumpyNdIterType((a, e, e))
+        check(ty, f32, 1, "C", [('flat', 0, 1, [0]), ('0d', 0, 0, [1, 2])])
+        ty = types.NumpyNdIterType((a, f))
+        check(ty, f32, 1, "C", [('flat', 0, 1, [0]), ('indexed', 0, 1, [1])])
+        ty = types.NumpyNdIterType((f,))
+        check(ty, f32, 1, "C", [('indexed', 0, 1, [0])])
+        # 2-dim C-order iterator
+        ty = types.NumpyNdIterType((b,))
+        check(ty, f32, 2, "C", [('flat', 0, 2, [0])])
+        ty = types.NumpyNdIterType((b, c))
+        check(ty, f32, 2, "C", [('flat', 0, 2, [0]), ('indexed', 0, 2, [1])])
+        ty = types.NumpyNdIterType((d,))
+        check(ty, f32, 2, "C", [('indexed', 0, 2, [0])])
+        ty = types.NumpyNdIterType((b, c, d, d, e))
+        check(ty, f32, 2, "C",
+              [('flat', 0, 2, [0]), # b
+               ('indexed', 0, 2, [1, 2, 3]), # c, d, d
+               ('0d', 0, 0, [4]), # e
+               ])
+        ty = types.NumpyNdIterType((a, b, c, d, d, f))
+        check(ty, f32, 2, "C",
+              [('flat', 1, 2, [0]), # a
+               ('flat', 0, 2, [1]), # b
+               ('indexed', 0, 2, [2, 3, 4]), # c, d, d
+               ('indexed', 1, 2, [5]), # f
+               ])
+        # 2-dim F-order iterator
+        ty = types.NumpyNdIterType((c,))
+        check(ty, f32, 2, "F", [('flat', 0, 2, [0])])
+        ty = types.NumpyNdIterType((c, b, c, f))
+        check(ty, f32, 2, "F",
+              [('flat', 0, 2, [0, 2]), # c, c
+               ('indexed', 0, 2, [1]), # b
+               ('indexed', 0, 1, [3]), # f
+               ])
+        ty = types.NumpyNdIterType((b, c, c, d, d, a, e))
+        check(ty, f32, 2, "F",
+              [('indexed', 0, 2, [0, 3, 4]), # b, d, d
+               ('flat', 0, 2, [1, 2]), # c, c
+               ('flat', 0, 1, [5]), # a
+               ('0d', 0, 0, [6]), # e
+              ])
+
+    def test_heterogenous(self):
+        a = types.Array(types.float32, 1, "C")
+        b = types.Array(types.float64, 1, "C")
+        with self.assertRaises(TypeError) as raises:
+            types.NumpyNdIterType((a, b))
+        self.assertIn("nditer() arguments must have the same dtypes, "
+                      "got (array(float32, 1d, C), array(float64, 1d, C))",
+                      str(raises.exception))
+
+
 class TestPickling(TestCase):
     """
     Pickling and unpickling should preserve type identity (singleton-ness)

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -233,7 +233,7 @@ class NumpyNdIterType(IteratorType):
                 pass
             elif kind == 'flat':
                 if (start_dim, end_dim) != (0, self.ndim):
-                    # Broadcasted flat iteration needs shaped indexing
+                    # Broadcast flat iteration needs shaped indexing
                     # to know when to restart iteration.
                     return True
             else:

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -1,10 +1,13 @@
 from __future__ import print_function, division, absolute_import
 
+import collections
+
 import numpy
 
 from .abstract import *
 from .common import *
 from ..typeconv import Conversion
+from .. import utils
 
 
 class CharSeq(Type):
@@ -132,6 +135,95 @@ class NumpyNdEnumerateType(SimpleIteratorType):
         return self.array_type
 
 
+class NumpyNdIterType(IteratorType):
+    """
+    Type class for `np.nditer()` objects.
+    """
+
+    def __init__(self, arrays):
+        self.arrays = tuple(arrays)
+        assert all(isinstance(a, Array) for a in arrays)
+        dtypes = set(a.dtype for a in self.arrays)
+        if len(dtypes) > 1:
+            raise TypeError("nditer() arguments must have the same dtypes, got %s" % (self.arrays,))
+        self.dtype, = dtypes
+        self.layout = self._compute_layout(self.arrays)
+        self.ndim = max(a.ndim for a in self.arrays)
+        name = "nditer(ndim={ndim}, layout={layout}, arrays={arrays})".format(
+            ndim=self.ndim, layout=self.layout, arrays=self.arrays)
+        super(NumpyNdIterType, self).__init__(name)
+
+    @classmethod
+    def _compute_layout(cls, arrays):
+        c = collections.Counter()
+        for a in arrays:
+            if a.layout in 'CF' and a.ndim == 1:
+                c['C'] += 1
+                c['F'] += 1
+            elif a.ndim >= 1:
+                c[a.layout] += 1
+        return 'F' if c['F'] > c['C'] else 'C'
+
+    @property
+    def key(self):
+        return self.arrays
+
+    @property
+    def yield_type(self):
+        from . import UniTuple
+        n = len(self.arrays)
+        arrty = Array(self.dtype, 0, 'C')
+        if n > 1:
+            return UniTuple(arrty, n)
+        else:
+            return arrty
+
+    @utils.cached_property
+    def indexers(self):
+        """
+        A list of (kind, ndim, indices) where:
+        - `kind` is either "flat" or "indexed"
+        - `ndim` is the indexed arrays number of dimensions
+        - `indices` is the indices of the indexed arrays in self.arrays
+        """
+        d = collections.OrderedDict()
+        layout = self.layout
+        for i, a in enumerate(self.arrays):
+            kind = 'flat' if a.layout == layout else 'indexed'
+            indexer = (kind, a.ndim)
+            d.setdefault(indexer, []).append(i)
+        return list(k + (v,) for k, v in d.items())
+
+    @utils.cached_property
+    def indexers(self):
+        """
+        A list of (kind, start_dim, end_dim, indices) where:
+        - `kind` is either "flat" or "indexed"
+        - `start_dim` and `end_dim` are the dimension numbers at which
+          this indexing takes place
+        - `indices` is the indices of the indexed arrays in self.arrays
+        """
+        d = collections.OrderedDict()
+        layout = self.layout
+        ndim = self.ndim
+        assert layout in 'CF'
+        for i, a in enumerate(self.arrays):
+            if a.ndim == 0:
+                indexer = ('0d', 0, 0)
+            else:
+                if a.layout == layout or (a.ndim == 1 and a.layout in 'CF'):
+                    kind = 'flat'
+                else:
+                    kind = 'indexed'
+                if layout == 'C':
+                    # If iterating in C order, broadcasting is done on the outer indices
+                    indexer = (kind, ndim - a.ndim, ndim)
+                else:
+                    indexer = (kind, 0, a.ndim)
+            d.setdefault(indexer, []).append(i)
+        return list(k + (v,) for k, v in d.items())
+
+
 class NumpyNdIndexType(SimpleIteratorType):
     """
     Type class for `np.ndindex()` objects.
@@ -141,7 +233,7 @@ class NumpyNdIndexType(SimpleIteratorType):
         from . import UniTuple, intp
         self.ndim = ndim
         yield_type = UniTuple(intp, self.ndim)
-        name = "ndindex(dims={ndim})".format(ndim=ndim)
+        name = "ndindex(ndim={ndim})".format(ndim=ndim)
         super(NumpyNdIndexType, self).__init__(name, yield_type)
 
     @property

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -275,12 +275,18 @@ class ArrayAttribute(AttributeTemplate):
     @bound_function("array.item")
     def resolve_item(self, ary, args, kws):
         assert not kws
+        # We don't support explicit arguments as that's exactly equivalent
+        # to regular indexing.  The no-argument form is interesting to
+        # allow some degree of genericity when writing functions.
         if not args:
             return signature(ary.dtype)
 
     @bound_function("array.itemset")
     def resolve_itemset(self, ary, args, kws):
         assert not kws
+        # We don't support explicit arguments as that's exactly equivalent
+        # to regular indexing.  The no-argument form is interesting to
+        # allow some degree of genericity when writing functions.
         if len(args) == 1:
             return signature(types.none, ary.dtype)
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -272,6 +272,12 @@ class ArrayAttribute(AttributeTemplate):
         retty = ary.copy(layout="C")
         return signature(retty)
 
+    @bound_function("array.item")
+    def resolve_item(self, ary, args, kws):
+        assert not kws
+        if not args:
+            return signature(ary.dtype)
+
     @bound_function("array.nonzero")
     def resolve_nonzero(self, ary, args, kws):
         assert not args

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -278,6 +278,12 @@ class ArrayAttribute(AttributeTemplate):
         if not args:
             return signature(ary.dtype)
 
+    @bound_function("array.itemset")
+    def resolve_itemset(self, ary, args, kws):
+        assert not kws
+        if len(args) == 1:
+            return signature(types.none, ary.dtype)
+
     @bound_function("array.nonzero")
     def resolve_nonzero(self, ary, args, kws):
         assert not args

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -550,6 +550,12 @@ class BooleanAttribute(AttributeTemplate):
     def resolve___class__(self, ty):
         return types.NumberClass(ty)
 
+    @bound_function("number.item")
+    def resolve_item(self, ty, args, kws):
+        assert not kws
+        if not args:
+            return signature(ty)
+
 
 @infer_getattr
 class NumberAttribute(AttributeTemplate):
@@ -569,6 +575,12 @@ class NumberAttribute(AttributeTemplate):
         assert not args
         assert not kws
         return signature(ty)
+
+    @bound_function("number.item")
+    def resolve_item(self, ty, args, kws):
+        assert not kws
+        if not args:
+            return signature(ty)
 
 
 @infer_getattr

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -807,6 +807,23 @@ class NdEnumerate(AbstractTemplate):
             return signature(enumerate_type, *args)
 
 
+@infer_global(numpy.nditer)
+class NdIter(AbstractTemplate):
+
+    def generic(self, args, kws):
+        assert not kws
+        arrays, = args
+
+        if isinstance(arrays, types.BaseTuple) and len(arrays) >= 1:
+            arrays = list(arrays)
+        elif isinstance(arrays, types.Array):
+            arrays = [arrays]
+        else:
+            return
+        nditerty = types.NumpyNdIterType(arrays)
+        return signature(nditerty, *args)
+
+
 @infer_global(numpy.ndindex)
 class NdIndex(AbstractTemplate):
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -814,12 +814,12 @@ class NdIter(AbstractTemplate):
         assert not kws
         arrays, = args
 
-        if isinstance(arrays, types.BaseTuple) and len(arrays) >= 1:
+        if isinstance(arrays, types.BaseTuple):
+            if not arrays:
+                return
             arrays = list(arrays)
-        elif isinstance(arrays, types.Array):
-            arrays = [arrays]
         else:
-            return
+            arrays = [arrays]
         nditerty = types.NumpyNdIterType(arrays)
         return signature(nditerty, *args)
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -812,6 +812,8 @@ class NdIter(AbstractTemplate):
 
     def generic(self, args, kws):
         assert not kws
+        if len(args) != 1:
+            return
         arrays, = args
 
         if isinstance(arrays, types.BaseTuple):


### PR DESCRIPTION
Only the first argument is supported. `nditer()` provides an efficient unordered multi-array iterator (also suitable for a single array), including broadcasting. This can allow vectorizing iteration of F-order arrays, for example.

(note there is a hack to disable memory management on the yielded 0d views, otherwise performance falls to dismal levels)

The PR also provides the `.item()` and `.itemset()` method, which access the element of a one-element array (work on any one-element array: 0d, 1d, etc., as well as on scalars -- `.item()` only).

Based on PR #1782.