### PR TITLE
Report JIT-compiled functions as Python functions.

### DIFF
--- a/numba/tests/test_profiler.py
+++ b/numba/tests/test_profiler.py
@@ -47,10 +47,6 @@ class TestProfiler(unittest.TestCase):
                         )
         self.assertIn(expected_key, stats.stats)
 
-    # The feature is currently broken.  We merely run the code to check
-    # Numba doesn't crash.
-
-    @unittest.expectedFailure
     def test_profiler(self):
         self.check_profiler_dot(dot)
 


### PR DESCRIPTION
With this change the cProfiler module will report the source location for JIT-compiled functions as for ordinary Python functions.