### PR TITLE
Add support for compute_50 in nvvm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ If you need CUDA support, you should also install the CUDA toolkit::
 
    $ conda install cudatoolkit
 
-This installs the CUDA Toolkit version 6.0, which requires driver version 331.00
+This installs the CUDA Toolkit version 7.5, which requires driver version 352.79
 or later to be installed.
 
 Custom Python Environments
@@ -92,7 +92,7 @@ or simply
 
    $ pip install numba
 
-If you want to enable CUDA support, you will need to install CUDA Toolkit 6.0.
+If you want to enable CUDA support, you will need to install CUDA Toolkit 7.5.
 After installing the toolkit, you might have to specify environment variables
 in order to override the standard search paths:
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -152,7 +152,7 @@ def _getpid():
 ERROR_MAP = _build_reverse_error_map()
 
 MISSING_FUNCTION_ERRMSG = """driver missing function: %s.
-Requires CUDA 5.5 or above.
+Requires CUDA 7.5 or above.
 """
 
 

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -66,7 +66,7 @@ def test(_platform=None):
                 # NOTE: ignore failure of dlopen on cuBlas on OSX 10.5
                 failed = True if not _if_osx_10_5() else False
 
-    archs = 'compute_20', 'compute_30', 'compute_35'
+    archs = 'compute_20', 'compute_30', 'compute_35', 'compute_50'
     for arch in archs:
         print('\tfinding libdevice for', arch, end='...')
         path = get_libdevice(arch)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -316,6 +316,7 @@ class LibDevice(object):
         "compute_20",
         "compute_30",
         "compute_35",
+        "compute_50",
     ]
 
     def __init__(self, arch):

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -8,7 +8,7 @@ from ctypes import (c_void_p, c_int, POINTER, c_char_p, c_size_t, byref,
 import threading
 from numba import config
 from .error import NvvmError, NvvmSupportError
-from .libs import open_libdevice, open_cudalib
+from .libs import get_libdevice, open_libdevice, open_cudalib
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +306,14 @@ def get_arch_option(major, minor):
 MISSING_LIBDEVICE_MSG = '''
 Please define environment variable NUMBAPRO_LIBDEVICE=/path/to/libdevice
 /path/to/libdevice -- is the path to the directory containing the libdevice.*.bc
-files in the installation of CUDA.  (requires CUDA >=5.5)
+files in the installation of CUDA.  (requires CUDA >=7.5)
+'''
+
+MISSING_LIBDEVICE_FILE_MSG = '''Missing libdevice file for {arch}.
+Please ensure you have package cudatoolkit 7.5.
+Install package by:
+
+    conda install cudatoolkit=7.5
 '''
 
 
@@ -325,6 +332,8 @@ class LibDevice(object):
         """
         if arch not in self._cache_:
             arch = self._get_closest_arch(arch)
+            if get_libdevice(arch) is None:
+                raise RuntimeError(MISSING_LIBDEVICE_FILE_MSG.format(arch=arch))
             self._cache_[arch] = open_libdevice(arch)
 
         self.arch = arch

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -101,7 +101,7 @@ class TestLibDevice(unittest.TestCase):
         self._libdevice_load('compute_21', 'compute_20')
         self._libdevice_load('compute_30', 'compute_30')
         self._libdevice_load('compute_35', 'compute_35')
-        self._libdevice_load('compute_52', 'compute_35')
+        self._libdevice_load('compute_52', 'compute_50')
 
 
 gpu64 = '''


### PR DESCRIPTION
Small change to numba to recognize newly supported "compute_50" in the CUDA 7.5.
Packages for ``cudatoolkit=7.5`` is currently available at https://anaconda.org/sklam/cudatoolkit for testing.  

Install with: ``conda install -c sklam cudatoolkit``.
