### PR TITLE
Workaround missing dependency for funcsigs

### DIFF
--- a/buildscripts/condarecipe.hsa/bld.bat
+++ b/buildscripts/condarecipe.hsa/bld.bat
@@ -1,3 +1,5 @@
+@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+%PYTHON% -m pip install ordereddict
 %PYTHON% setup.py install
 if errorlevel 1 exit 1
 

--- a/buildscripts/condarecipe.hsa/build.sh
+++ b/buildscripts/condarecipe.hsa/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+$PYTHON -m pip install ordereddict
 $PYTHON setup.py install

--- a/buildscripts/condarecipe.jenkins/bld.bat
+++ b/buildscripts/condarecipe.jenkins/bld.bat
@@ -1,3 +1,5 @@
+@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+%PYTHON% -m pip install ordereddict
 %PYTHON% setup.py build install
 if errorlevel 1 exit 1
 

--- a/buildscripts/condarecipe.jenkins/build.sh
+++ b/buildscripts/condarecipe.jenkins/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+$PYTHON -m pip install ordereddict
 $PYTHON setup.py build install

--- a/buildscripts/condarecipe.local/bld.bat
+++ b/buildscripts/condarecipe.local/bld.bat
@@ -1,2 +1,4 @@
+@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+%PYTHON% -m pip install ordereddict
 %PYTHON% setup.py install
 if errorlevel 1 exit 1

--- a/buildscripts/condarecipe.local/build.sh
+++ b/buildscripts/condarecipe.local/build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+$PYTHON -m pip install ordereddict
 $PYTHON setup.py install


### PR DESCRIPTION
Workaround for https://github.com/testing-cabal/funcsigs/issues/18 and Anaconda providing ordereddict only for Python < 2.6.
Hopefully we'll be able to remove it quickly.