### PR TITLE
Refactor lowering of constants

### DIFF
--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -134,6 +134,19 @@ Native operations
    must return a value compatible with the type ``toty``.
 
 
+Constants
+'''''''''
+
+.. decorator:: lower_constant(typespec)
+
+   Register the decorated function as implementing the creation of
+   constants for the Numba *typespec*.  The decorated function
+   is called with four arguments ``(context, builder, ty, pyval)``.
+   *ty* is the concrete type to create a constant for.  *pyval*
+   is the Python value to convert into a LLVM constant.
+   The function must return a value compatible with the type ``ty``.
+
+
 Boxing and unboxing
 '''''''''''''''''''
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -244,6 +244,11 @@ and return types:
 * :class:`ctypes.c_double`
 * :class:`ctypes.c_void_p`
 
+``enum``
+--------
+
+Both :class:`enum.Enum` and :class:`enum.IntEnum` subclasses are supported.
+
 ``math``
 --------
 

--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -33,6 +33,7 @@
     #define PyString_InternFromString PyUnicode_InternFromString
     #define PyInt_Type PyLong_Type
     #define PyInt_Check PyLong_Check
+    #define PyInt_CheckExact PyLong_CheckExact
 #else
     #define Py_hash_t long
     #define Py_uhash_t unsigned long

--- a/numba/_typeof.c
+++ b/numba/_typeof.c
@@ -236,7 +236,8 @@ compute_fingerprint(string_writer_t *w, PyObject *val)
         return string_writer_put_char(w, OP_NONE);
     if (PyBool_Check(val))
         return string_writer_put_char(w, OP_BOOL);
-    if (PyInt_Check(val) || PyLong_Check(val))
+    /* Note we avoid matching int subclasses such as IntEnum */
+    if (PyInt_CheckExact(val) || PyLong_CheckExact(val))
         return string_writer_put_char(w, OP_INT);
     if (PyFloat_Check(val))
         return string_writer_put_char(w, OP_FLOAT);

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -236,6 +236,7 @@ class ProxyModel(DataModel):
 
 
 @register_default(types.EnumMember)
+@register_default(types.IntEnumMember)
 class EnumModel(ProxyModel):
     """
     Enum members are represented exactly like their values.
@@ -263,6 +264,7 @@ class EnumModel(ProxyModel):
 @register_default(types.NumbaFunction)
 @register_default(types.Macro)
 @register_default(types.EnumClass)
+@register_default(types.IntEnumClass)
 @register_default(types.NumberClass)
 @register_default(types.NamedTupleClass)
 @register_default(types.DType)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -199,6 +199,52 @@ class PrimitiveModel(DataModel):
         return value
 
 
+class ProxyModel(DataModel):
+    """
+    Helper class for models which delegate to another model.
+    """
+
+    def get_value_type(self):
+        return self._proxied_model.get_value_type()
+
+    def get_data_type(self):
+        return self._proxied_model.get_data_type()
+
+    def get_return_type(self):
+        return self._proxied_model.get_return_type()
+
+    def get_argument_type(self):
+        return self._proxied_model.get_argument_type()
+
+    def as_data(self, builder, value):
+        return self._proxied_model.as_data(builder, value)
+
+    def as_argument(self, builder, value):
+        return self._proxied_model.as_argument(builder, value)
+
+    def as_return(self, builder, value):
+        return self._proxied_model.as_return(builder, value)
+
+    def from_data(self, builder, value):
+        return self._proxied_model.from_data(builder, value)
+
+    def from_argument(self, builder, value):
+        return self._proxied_model.from_argument(builder, value)
+
+    def from_return(self, builder, value):
+        return self._proxied_model.from_return(builder, value)
+
+
+@register_default(types.EnumMember)
+class EnumModel(ProxyModel):
+    """
+    Enum members are represented exactly like their values.
+    """
+    def __init__(self, dmm, fe_type):
+        super(EnumModel, self).__init__(dmm, fe_type)
+        self._proxied_model = dmm.lookup(fe_type.dtype)
+
+
 @register_default(types.Opaque)
 @register_default(types.PyObject)
 @register_default(types.RawPointer)
@@ -216,6 +262,7 @@ class PrimitiveModel(DataModel):
 @register_default(types.ExternalFunction)
 @register_default(types.NumbaFunction)
 @register_default(types.Macro)
+@register_default(types.EnumClass)
 @register_default(types.NumberClass)
 @register_default(types.NamedTupleClass)
 @register_default(types.DType)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -156,6 +156,7 @@ class BaseContext(object):
         self._getattrs = defaultdict(OverloadSelector)
         self._setattrs = defaultdict(OverloadSelector)
         self._casts = OverloadSelector()
+        self._get_constants = OverloadSelector()
         # Other declarations
         self._generators = {}
         self.special_ops = {}
@@ -227,6 +228,7 @@ class BaseContext(object):
         self._insert_getattr_defn(loader.new_registrations('getattrs'))
         self._insert_setattr_defn(loader.new_registrations('setattrs'))
         self._insert_cast_defn(loader.new_registrations('casts'))
+        self._insert_get_constant_defn(loader.new_registrations('constants'))
 
     def insert_func_defn(self, defns):
         for impl, func, sig in defns:
@@ -243,6 +245,10 @@ class BaseContext(object):
     def _insert_cast_defn(self, defns):
         for impl, sig in defns:
             self._casts.append(impl, sig)
+
+    def _insert_get_constant_defn(self, defns):
+        for impl, sig in defns:
+            self._get_constants.append(impl, sig)
 
     def insert_user_function(self, func, fndesc, libs=()):
         impl = user_function(fndesc, libs)
@@ -350,100 +356,23 @@ class BaseContext(object):
         dm = self.data_model_manager[ty]
         return dm.load_from_data_pointer(builder, ptr, align)
 
-    def is_struct_type(self, ty):
-        return isinstance(self.data_model_manager[ty], datamodel.CompositeModel)
-
-    # XXX we need an extensible API for this
-
     def get_constant_generic(self, builder, ty, val):
         """
         Return a LLVM constant representing value *val* of Numba type *ty*.
         """
-        if isinstance(ty, types.ExternalFunctionPointer):
-            ptrty = self.get_function_pointer_type(ty)
-            ptrval = ty.get_pointer(val)
-            return builder.inttoptr(self.get_constant(types.intp, ptrval),
-                                    ptrty)
-
-        elif isinstance(ty, types.Array):
-            return self.make_constant_array(builder, ty, val)
-
-        elif isinstance(ty, types.Dummy):
-            return self.get_dummy_value()
-
-        elif self.is_struct_type(ty):
-            struct = self.get_constant_struct(builder, ty, val)
-            if isinstance(ty, types.Record):
-                ptrty = self.data_model_manager[ty].get_data_type()
-                ptr = cgutils.alloca_once(builder, ptrty)
-                builder.store(struct, ptr)
-                return ptr
-            return struct
-
-        else:
-            return self.get_constant(ty, val)
-
-    def get_constant_struct(self, builder, ty, val):
-        assert self.is_struct_type(ty)
-
-        if ty in types.complex_domain:
-            if ty == types.complex64:
-                innertype = types.float32
-            elif ty == types.complex128:
-                innertype = types.float64
-            else:
-                raise Exception("unreachable")
-
-            real = self.get_constant(innertype, val.real)
-            imag = self.get_constant(innertype, val.imag)
-            const = Constant.struct([real, imag])
-            return const
-
-        elif isinstance(ty, (types.Tuple, types.NamedTuple)):
-            consts = [self.get_constant_generic(builder, ty.types[i], v)
-                      for i, v in enumerate(val)]
-            return Constant.struct(consts)
-
-        elif isinstance(ty, types.Record):
-            consts = [self.get_constant(types.int8, b)
-                      for b in bytearray(val.tostring())]
-            return Constant.array(consts[0].type, consts)
-
-        else:
-            raise NotImplementedError("%s as constant unsupported" % ty)
+        try:
+            impl = self._get_constants.find((ty,))
+            return impl(self, builder, ty, val)
+        except NotImplementedError:
+            raise NotImplementedError("cannot lower constant of type '%s'" % (ty,))
 
     def get_constant(self, ty, val):
-        assert not self.is_struct_type(ty)
-
-        lty = self.get_value_type(ty)
-
-        if ty == types.none:
-            assert val is None
-            return self.get_dummy_value()
-
-        elif ty == types.boolean:
-            return Constant.int(Type.int(1), int(val))
-
-        elif ty in types.signed_domain:
-            return Constant.int_signextend(lty, val)
-
-        elif ty in types.unsigned_domain:
-            return Constant.int(lty, val)
-
-        elif ty in types.real_domain:
-            return Constant.real(lty, val)
-
-        elif isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
-            return Constant.real(lty, val.astype(numpy.int64))
-
-        elif isinstance(ty, (types.UniTuple, types.NamedUniTuple)):
-            consts = [self.get_constant(ty.dtype, v) for v in val]
-            return Constant.array(consts[0].type, consts)
-
-        elif isinstance(ty, types.EnumMember):
-            return self.get_constant(ty.dtype, val.value)
-
-        raise NotImplementedError("cannot lower constant of type '%s'" % (ty,))
+        """
+        Same as get_constant_generic(), but without specifying *builder*.
+        Works only for simple types.
+        """
+        # HACK: pass builder=None to preserve get_constant() API
+        return self.get_constant_generic(None, ty, val)
 
     def get_constant_undef(self, ty):
         lty = self.get_value_type(ty)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -178,8 +178,8 @@ class BaseContext(object):
         Useful for third-party extensions.
         """
         # Populate built-in registry
-        from . import (arraymath, iterators, linalg, rangeobj, slicing,
-                       smartarray, tupleobj)
+        from . import (arraymath, enumimpl, iterators, linalg, rangeobj,
+                       slicing, smartarray, tupleobj)
         try:
             from . import npdatetime
         except NotImplementedError:

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -151,6 +151,25 @@ def box_raw_pointer(typ, val, c):
     return c.box(types.uintp, addr)
 
 
+@box(types.EnumMember)
+def box_enum(typ, val, c):
+    """
+    Fetch an enum member given its native value.
+    """
+    valobj = c.box(typ.dtype, val)
+    # Call the enum class with the value object
+    cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    return c.pyapi.call_function_objargs(cls_obj, (valobj,))
+
+@unbox(types.EnumMember)
+def unbox_enum(typ, obj, c):
+    """
+    Convert an enum member's value to its native value.
+    """
+    valobj = c.pyapi.object_getattr_string(obj, "value")
+    return c.unbox(typ.dtype, valobj)
+
+
 #
 # Composite types
 #

--- a/numba/targets/enumimpl.py
+++ b/numba/targets/enumimpl.py
@@ -5,7 +5,7 @@ Implementation of enums.
 from llvmlite import ir
 
 from .imputils import (lower_builtin, lower_getattr, lower_getattr_generic,
-                       iternext_impl, impl_ret_borrowed, impl_ret_untracked)
+                       lower_cast, impl_ret_borrowed, impl_ret_untracked)
 from .. import typing, types, cgutils
 
 
@@ -31,6 +31,14 @@ def enum_eq(context, builder, sig, args):
 @lower_getattr(types.EnumMember, 'value')
 def enum_value(context, builder, ty, val):
     return val
+
+@lower_cast(types.IntEnumMember, types.Integer)
+def int_enum_to_int(context, builder, fromty, toty, val):
+    """
+    Convert an IntEnum member to its raw integer value.
+    """
+    return context.cast(builder, val, fromty.dtype, toty)
+
 
 @lower_getattr_generic(types.EnumClass)
 def enum_class_lookup(context, builder, ty, val, attr):

--- a/numba/targets/enumimpl.py
+++ b/numba/targets/enumimpl.py
@@ -5,7 +5,7 @@ Implementation of enums.
 from llvmlite import ir
 
 from .imputils import (lower_builtin, lower_getattr, lower_getattr_generic,
-                       lower_cast, impl_ret_borrowed, impl_ret_untracked)
+                       lower_cast, lower_constant, impl_ret_untracked)
 from .. import typing, types, cgutils
 
 
@@ -49,6 +49,12 @@ def int_enum_to_int(context, builder, fromty, toty, val):
     """
     return context.cast(builder, val, fromty.dtype, toty)
 
+@lower_constant(types.EnumMember)
+def enum_constant(context, builder, ty, pyval):
+    """
+    Return a LLVM constant representing enum member *pyval*.
+    """
+    return context.get_constant_generic(builder, ty.dtype, pyval.value)
 
 @lower_getattr_generic(types.EnumClass)
 def enum_class_lookup(context, builder, ty, val, attr):

--- a/numba/targets/enumimpl.py
+++ b/numba/targets/enumimpl.py
@@ -1,0 +1,41 @@
+"""
+Implementation of enums.
+"""
+
+from llvmlite import ir
+
+from .imputils import (lower_builtin, lower_getattr, lower_getattr_generic,
+                       iternext_impl, impl_ret_borrowed, impl_ret_untracked)
+from .. import typing, types, cgutils
+
+
+@lower_builtin('==', types.EnumMember, types.EnumMember)
+@lower_builtin('is', types.EnumMember, types.EnumMember)
+def enum_eq(context, builder, sig, args):
+    tu, tv = sig.args
+    u, v = args
+    res = context.generic_compare(builder, "==",
+                                  (tu.dtype, tv.dtype), (u, v))
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@lower_builtin('!=', types.EnumMember, types.EnumMember)
+def enum_eq(context, builder, sig, args):
+    tu, tv = sig.args
+    u, v = args
+    res = context.generic_compare(builder, "!=",
+                                  (tu.dtype, tv.dtype), (u, v))
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@lower_getattr(types.EnumMember, 'value')
+def enum_value(context, builder, ty, val):
+    return val
+
+@lower_getattr_generic(types.EnumClass)
+def enum_class_lookup(context, builder, ty, val, attr):
+    """
+    Return an enum member by name.
+    """
+    member = getattr(ty.instance_class, attr)
+    return context.get_constant_generic(builder, ty.dtype, member.value)

--- a/numba/targets/enumimpl.py
+++ b/numba/targets/enumimpl.py
@@ -10,12 +10,22 @@ from .. import typing, types, cgutils
 
 
 @lower_builtin('==', types.EnumMember, types.EnumMember)
-@lower_builtin('is', types.EnumMember, types.EnumMember)
 def enum_eq(context, builder, sig, args):
     tu, tv = sig.args
     u, v = args
     res = context.generic_compare(builder, "==",
                                   (tu.dtype, tv.dtype), (u, v))
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+@lower_builtin('is', types.EnumMember, types.EnumMember)
+def enum_is(context, builder, sig, args):
+    tu, tv = sig.args
+    u, v = args
+    if tu == tv:
+        res = context.generic_compare(builder, "==",
+                                      (tu.dtype, tv.dtype), (u, v))
+    else:
+        res = context.get_constant(sig.return_type, False)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -22,6 +22,7 @@ class Registry(object):
         self.getattrs = []
         self.setattrs = []
         self.casts = []
+        self.constants = []
 
     def lower(self, func, *argtys):
         """
@@ -103,12 +104,24 @@ class Registry(object):
             return impl
         return decorate
 
+    def lower_constant(self, ty):
+        """
+        Decorate the implementation for creating a constant of type *ty*.
+
+        The decorated implementation will have the signature
+        (context, builder, ty, pyval).
+        """
+        def decorate(impl):
+            self.constants.append((impl, (ty,)))
+            return impl
+        return decorate
+
 
 class RegistryLoader(BaseRegistryLoader):
     """
     An incremental loader for a target registry.
     """
-    registry_items = ('functions', 'getattrs', 'setattrs', 'casts')
+    registry_items = ('functions', 'getattrs', 'setattrs', 'casts', 'constants')
 
 
 # Global registry for implementations of builtin operations
@@ -121,6 +134,7 @@ lower_getattr_generic = builtin_registry.lower_getattr_generic
 lower_setattr = builtin_registry.lower_setattr
 lower_setattr_generic = builtin_registry.lower_setattr_generic
 lower_cast = builtin_registry.lower_cast
+lower_constant = builtin_registry.lower_constant
 
 
 def _decorate_getattr(impl, ty, attr):

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -2,11 +2,13 @@
 Implementation of operations on numpy timedelta64.
 """
 
+import numpy as np
+
 from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
 from numba import npdatetime, types, cgutils
-from numba.targets.imputils import lower_builtin, impl_ret_untracked
+from .imputils import lower_builtin, lower_constant, impl_ret_untracked
 
 
 # datetime64 and timedelta64 use the same internal representation
@@ -104,6 +106,13 @@ normal_year_months_acc = make_constant_array(
     [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334])
 leap_year_months_acc = make_constant_array(
     [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335])
+
+
+@lower_constant(types.NPDatetime)
+@lower_constant(types.NPTimedelta)
+def datetime_constant(context, builder, ty, pyval):
+    return DATETIME64(pyval.astype(np.int64))
+
 
 # Arithmetic operators on timedelta64
 

--- a/numba/tests/enum_usecases.py
+++ b/numba/tests/enum_usecases.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+
+from enum import Enum
+
+
+class Color(Enum):
+    red = 1
+    green = 2
+    blue = 3
+
+
+class Shake(Enum):
+    vanilla = 7
+    chocolate = 4
+    cookies = 9
+    mint = 3
+
+
+class Planet(Enum):
+    MERCURY = (3.303e+23, 2.4397e6)
+    VENUS   = (4.869e+24, 6.0518e6)
+    EARTH   = (5.976e+24, 6.37814e6)
+    MARS    = (6.421e+23, 3.3972e6)
+    JUPITER = (1.9e+27,   7.1492e7)
+    SATURN  = (5.688e+26, 6.0268e7)
+    URANUS  = (8.686e+25, 2.5559e7)
+    NEPTUNE = (1.024e+26, 2.4746e7)
+
+
+class HeterogenousEnum(Enum):
+    red = 1
+    green = 2
+    blue = 3j

--- a/numba/tests/enum_usecases.py
+++ b/numba/tests/enum_usecases.py
@@ -13,6 +13,7 @@ class Shake(Enum):
     vanilla = 7
     chocolate = 4
     cookies = 9
+    # Same as Color.blue
     mint = 3
 
 
@@ -34,11 +35,14 @@ class HeterogenousEnum(Enum):
 
 
 class Shape(IntEnum):
-    circle = 10
-    square = 20
+    # Same as Color.green
+    circle = 2
+    # Same as RequestError.internal_error
+    square = 500
 
 
 class RequestError(IntEnum):
+    dummy = 2
     not_found = 404
     internal_error = 500
 

--- a/numba/tests/enum_usecases.py
+++ b/numba/tests/enum_usecases.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 class Color(Enum):
@@ -28,6 +28,17 @@ class Planet(Enum):
 
 
 class HeterogenousEnum(Enum):
-    red = 1
-    green = 2
+    red = 1.0
+    green = 2.0
     blue = 3j
+
+
+class Shape(IntEnum):
+    circle = 10
+    square = 20
+
+
+class RequestError(IntEnum):
+    not_found = 404
+    internal_error = 500
+

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -1,0 +1,63 @@
+"""
+Tests for enum support.
+"""
+
+from __future__ import print_function
+
+import enum
+
+import numba.unittest_support as unittest
+from numba import jit
+
+from .support import TestCase, tag
+from .enum_usecases import *
+
+
+def compare_usecase(a, b):
+    return a == b, a != b, a is b
+
+def constant_usecase(a):
+    return a is Color.red
+
+def return_usecase(a, b, pred):
+    return a if pred else b
+
+
+class TestEnum(TestCase):
+    pairs = [
+        (Color.red, Color.red),
+        (Color.red, Color.green),
+        (Shake.mint, Shake.vanilla),
+        (Planet.VENUS, Planet.MARS),
+        (Planet.EARTH, Planet.EARTH),
+        ]
+
+    def test_compare(self):
+        pyfunc = compare_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for args in self.pairs:
+            self.assertPreciseEqual(pyfunc(*args), cfunc(*args))
+
+    def test_return(self):
+        """
+        Passing and returning enum members.
+        """
+        pyfunc = return_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for pair in self.pairs:
+            for pred in (True, False):
+                args = pair + (pred,)
+                self.assertIs(pyfunc(*args), cfunc(*args))
+
+    def test_constant(self):
+        pyfunc = constant_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for arg in [Color.red, Color.green]:
+            self.assertPreciseEqual(pyfunc(arg), cfunc(arg))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -20,6 +20,12 @@ def global_usecase(a):
     # Lookup of a enum member on its class
     return a is Color.red
 
+def identity_usecase(a, b, c):
+    return (a is Shake.mint,
+            b is Shape.circle,
+            c is RequestError.internal_error,
+            )
+
 def make_constant_usecase(const):
     def constant_usecase(a):
         return a is const
@@ -36,16 +42,7 @@ def int_coerce_usecase(x):
         return x + Shape.circle
 
 
-class TestEnum(TestCase):
-    values = [Color.red, Color.green]
-
-    pairs = [
-        (Color.red, Color.red),
-        (Color.red, Color.green),
-        (Shake.mint, Shake.vanilla),
-        (Planet.VENUS, Planet.MARS),
-        (Planet.EARTH, Planet.EARTH),
-        ]
+class BaseEnumTest(object):
 
     def test_compare(self):
         pyfunc = compare_usecase
@@ -77,7 +74,34 @@ class TestEnum(TestCase):
         self.check_constant_usecase(make_constant_usecase(self.values[0]))
 
 
-class TestIntEnum(TestEnum):
+class TestEnum(BaseEnumTest, TestCase):
+    """
+    Tests for Enum classes and members.
+    """
+    values = [Color.red, Color.green]
+
+    pairs = [
+        (Color.red, Color.red),
+        (Color.red, Color.green),
+        (Shake.mint, Shake.vanilla),
+        (Planet.VENUS, Planet.MARS),
+        (Planet.EARTH, Planet.EARTH),
+        ]
+
+    def test_identity(self):
+        """
+        Enum with equal values should not compare identical
+        """
+        pyfunc = identity_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+        args = (Color.blue, Color.green, Shape.square)
+        self.assertPreciseEqual(pyfunc(*args), cfunc(*args))
+
+
+class TestIntEnum(BaseEnumTest, TestCase):
+    """
+    Tests for IntEnum classes and members.
+    """
     values = [Shape.circle, Shape.square]
 
     pairs = [

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -14,16 +14,31 @@ from .enum_usecases import *
 
 
 def compare_usecase(a, b):
-    return a == b, a != b, a is b
+    return a == b, a != b, a is b, a is not b
 
-def constant_usecase(a):
+def global_usecase(a):
+    # Lookup of a enum member on its class
     return a is Color.red
+
+def make_constant_usecase(const):
+    def constant_usecase(a):
+        return a is const
+    return constant_usecase
 
 def return_usecase(a, b, pred):
     return a if pred else b
 
+def int_coerce_usecase(x):
+    # Implicit coercion of intenums to ints
+    if x > RequestError.internal_error:
+        return x - RequestError.not_found
+    else:
+        return x + Shape.circle
+
 
 class TestEnum(TestCase):
+    values = [Color.red, Color.green]
+
     pairs = [
         (Color.red, Color.red),
         (Color.red, Color.green),
@@ -51,11 +66,32 @@ class TestEnum(TestCase):
                 args = pair + (pred,)
                 self.assertIs(pyfunc(*args), cfunc(*args))
 
-    def test_constant(self):
-        pyfunc = constant_usecase
+    def check_constant_usecase(self, pyfunc):
         cfunc = jit(nopython=True)(pyfunc)
 
-        for arg in [Color.red, Color.green]:
+        for arg in self.values:
+            self.assertPreciseEqual(pyfunc(arg), cfunc(arg))
+
+    def test_constant(self):
+        self.check_constant_usecase(global_usecase)
+        self.check_constant_usecase(make_constant_usecase(self.values[0]))
+
+
+class TestIntEnum(TestEnum):
+    values = [Shape.circle, Shape.square]
+
+    pairs = [
+        (Shape.circle, Shape.circle),
+        (Shape.circle, Shape.square),
+        (RequestError.not_found, RequestError.not_found),
+        (RequestError.internal_error, RequestError.not_found),
+        ]
+
+    def test_int_coerce(self):
+        pyfunc = int_coerce_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for arg in [300, 450, 550]:
             self.assertPreciseEqual(pyfunc(arg), cfunc(arg))
 
 

--- a/numba/tests/test_support.py
+++ b/numba/tests/test_support.py
@@ -7,6 +7,7 @@ import numpy as np
 from numba import jit, utils
 from numba import unittest_support as unittest
 from .support import TestCase, forbid_codegen
+from .enum_usecases import *
 
 DBL_EPSILON = 2**-52
 FLT_EPSILON = 2**-23
@@ -257,6 +258,15 @@ class TestAssertPreciseEqual(TestCase):
             self.eq(tp(aa), tp(ac), prec='single', ulps=2)
             self.eq(tp(ac), tp(cc), prec='single', ulps=2)
             self.eq(tp(aa), tp(cc), prec='single', ulps=2)
+
+    def test_enums(self):
+        values = [Color.red, Color.green, Color.blue, Shake.mint,
+                  Shape.circle, Shape.square, Planet.EARTH, Planet.MERCURY]
+        for val in values:
+            self.eq(val, val)
+            self.ne(val, val.value)
+        for a, b in itertools.combinations(values, 2):
+            self.ne(a, b)
 
     def test_arrays(self):
         a = np.arange(1, 7, dtype=np.int16).reshape((2, 3))

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -223,11 +223,14 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         self.assertEqual(tp_choc, types.EnumMember(Shake, types.intp))
         self.assertEqual(tp_choc, typeof(Shake.mint))
         self.assertNotEqual(tp_choc, tp_red)
+        tp_404 = typeof(RequestError.not_found)
+        self.assertEqual(tp_404, types.IntEnumMember(RequestError, types.intp))
+        self.assertEqual(tp_404, typeof(RequestError.internal_error))
 
         with self.assertRaises(ValueError) as raises:
             typeof(HeterogenousEnum.red)
         self.assertEqual(str(raises.exception),
-                         "Cannot type heterogenous enum: got value types complex128, int64")
+                         "Cannot type heterogenous enum: got value types complex128, float64")
 
     @tag('important')
     def test_enum_class(self):
@@ -236,11 +239,17 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         tp_shake = typeof(Shake)
         self.assertEqual(tp_shake, types.EnumClass(Shake, types.intp))
         self.assertNotEqual(tp_shake, tp_color)
+        tp_shape = typeof(Shape)
+        self.assertEqual(tp_shape, types.IntEnumClass(Shape, types.intp))
+        tp_error = typeof(RequestError)
+        self.assertEqual(tp_error,
+                         types.IntEnumClass(RequestError, types.intp))
+        self.assertNotEqual(tp_error, tp_shape)
 
         with self.assertRaises(ValueError) as raises:
             typeof(HeterogenousEnum)
         self.assertEqual(str(raises.exception),
-                         "Cannot type heterogenous enum: got value types complex128, int64")
+                         "Cannot type heterogenous enum: got value types complex128, float64")
 
     @tag('important')
     def test_dtype(self):
@@ -339,6 +348,13 @@ class TestFingerprint(TestCase):
 
     def test_none(self):
         compute_fingerprint(None)
+
+    def test_enums(self):
+        # Enums should fail fingerprinting, even IntEnums
+        with self.assertRaises(NotImplementedError):
+            compute_fingerprint(Color.red)
+        with self.assertRaises(NotImplementedError):
+            compute_fingerprint(RequestError.not_found)
 
     def test_records(self):
         d1 = np.dtype([('m', np.int32), ('n', np.int64)])

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -419,6 +419,8 @@ class TestPickling(TestCase):
         self.check_pickling(ty1)
         ty2 = types.EnumMember(Shake, types.int64)
         self.check_pickling(ty2)
+        ty3 = types.IntEnumMember(Shape, types.int64)
+        self.check_pickling(ty3)
 
     def test_lists(self):
         ty = types.List(types.int32)

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -4,6 +4,7 @@ Tests for numba.types.
 
 from __future__ import print_function, absolute_import
 
+from collections import namedtuple
 import gc
 try:
     import cPickle as pickle
@@ -19,11 +20,15 @@ from numba.types.abstract import _typecache
 from numba import jit, numpy_support
 from numba import unittest_support as unittest
 from .support import TestCase, tag
+from .enum_usecases import *
 
+
+Point = namedtuple('Point', ('x', 'y'))
+
+Rect = namedtuple('Rect', ('width', 'height'))
 
 def gen(x):
     yield x + 1
-
 
 class Dummy(object):
     pass
@@ -401,6 +406,18 @@ class TestPickling(TestCase):
         ty1 = types.UniTuple(types.int32, 3)
         self.check_pickling(ty1)
         ty2 = types.Tuple((types.int32, ty1))
+        self.check_pickling(ty2)
+
+    def test_namedtuples(self):
+        ty1 = types.NamedUniTuple(types.intp, 2, Point)
+        self.check_pickling(ty1)
+        ty2 = types.NamedTuple((types.intp, types.float64), Point)
+        self.check_pickling(ty2)
+
+    def test_enums(self):
+        ty1 = types.EnumMember(Color, types.int32)
+        self.check_pickling(ty1)
+        ty2 = types.EnumMember(Shake, types.int64)
         self.check_pickling(ty2)
 
     def test_lists(self):

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -194,6 +194,10 @@ class Type(object):
         raise NotImplementedError
 
 
+# XXX we should distinguish between Dummy (no meaningful
+# representation, e.g. None or a builtin function) and Opaque (has a
+# meaningful representation, e.g. ExternalFunctionPointer)
+
 class Dummy(Type):
     """
     Base class for types that do not really have a representation and are

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -276,7 +276,10 @@ class NamedUniTuple(_HomogenousTuple, BaseNamedTuple):
         self.instance_class = cls
         name = "%s(%s x %d)" % (cls.__name__, dtype, count)
         super(NamedUniTuple, self).__init__(name)
-        self._iterator_type = UniTupleIter(self)
+
+    @property
+    def iterator_type(self):
+        return UniTupleIter(self)
 
     @property
     def key(self):

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -4,7 +4,7 @@ from .abstract import *
 from .common import *
 
 
-class Function(Callable, Opaque):
+class BaseFunction(Callable):
     """
     Base type class for some function types.
     """
@@ -22,7 +22,7 @@ class Function(Callable, Opaque):
             self.typing_key = template.key
         self._impl_keys = {}
         name = "%s(%s)" % (self.__class__.__name__, self.typing_key)
-        super(Function, self).__init__(name)
+        super(BaseFunction, self).__init__(name)
 
     @property
     def key(self):
@@ -58,6 +58,12 @@ class Function(Callable, Opaque):
             sigs += getattr(temp, 'cases', [])
             is_param = is_param or hasattr(temp, 'generic')
         return sigs, is_param
+
+
+class Function(BaseFunction, Opaque):
+    """
+    Type class for builtin functions implemented by Numba.
+    """
 
 
 class BoundFunction(Callable, Opaque):
@@ -179,7 +185,7 @@ class Dispatcher(WeakType, Callable, Dummy):
         return self.get_overload(sig)
 
 
-class ExternalFunctionPointer(Function):
+class ExternalFunctionPointer(BaseFunction):
     """
     A pointer to a native function (e.g. exported via ctypes or cffi).
     *get_pointer* is a Python function taking an object

--- a/numba/types/scalars.py
+++ b/numba/types/scalars.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
+import enum
+
 import numpy
 
 from .abstract import *
@@ -110,3 +112,53 @@ class NPTimedelta(_NPDatetimeBase):
 @utils.total_ordering
 class NPDatetime(_NPDatetimeBase):
     type_name = 'datetime64'
+
+
+class EnumClass(Dummy):
+    """
+    Type class for enum classes.
+    """
+
+    def __init__(self, cls, dtype):
+        assert isinstance(cls, type)
+        assert isinstance(dtype, Type)
+        self.instance_class = cls
+        self.dtype = dtype
+        name = "enum class<%s>(%s)" % (self.dtype, self.instance_class.__name__)
+        super(EnumClass, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.instance_class, self.dtype
+
+    @utils.cached_property
+    def member_type(self):
+        """
+        The type of this class' members.
+        """
+        return EnumMember(self.instance_class, self.dtype)
+
+
+class EnumMember(Type):
+    """
+    Type class for enum members.
+    """
+
+    def __init__(self, cls, dtype):
+        assert isinstance(cls, type)
+        assert isinstance(dtype, Type)
+        self.instance_class = cls
+        self.dtype = dtype
+        name = "enum<%s>(%s)" % (self.dtype, self.instance_class.__name__)
+        super(EnumMember, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.instance_class, self.dtype
+
+    @property
+    def class_type(self):
+        """
+        The type of this member's class.
+        """
+        return EnumClass(self.instance_class, self.dtype)

--- a/numba/types/scalars.py
+++ b/numba/types/scalars.py
@@ -194,4 +194,5 @@ class IntEnumMember(EnumMember):
         Convert IntEnum members to plain integers.
         """
         if issubclass(self.instance_class, enum.IntEnum):
-            return typingctx.can_convert(self.dtype, other)
+            conv = typingctx.can_convert(self.dtype, other)
+            return max(conv, Conversion.safe)

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -508,10 +508,11 @@ class BaseContext(object):
 class Context(BaseContext):
 
     def load_additional_registries(self):
-        from . import (cffi_utils, cmathdecl, listdecl, mathdecl,
+        from . import (cffi_utils, cmathdecl, enumdecl, listdecl, mathdecl,
                        npydecl, operatordecl, randomdecl, setdecl)
         self.install_registry(cffi_utils.registry)
         self.install_registry(cmathdecl.registry)
+        self.install_registry(enumdecl.registry)
         self.install_registry(listdecl.registry)
         self.install_registry(mathdecl.registry)
         self.install_registry(npydecl.registry)

--- a/numba/typing/enumdecl.py
+++ b/numba/typing/enumdecl.py
@@ -1,0 +1,52 @@
+"""
+Typing for enums.
+"""
+
+import enum
+
+from numba import types, utils
+from numba.typing.templates import (AbstractTemplate, AttributeTemplate,
+                                    signature, Registry, bound_function)
+
+registry = Registry()
+infer = registry.register
+infer_global = registry.register_global
+infer_getattr = registry.register_attr
+
+
+@infer_getattr
+class EnumAttribute(AttributeTemplate):
+    key = types.EnumMember
+
+    def resolve_value(self, ty):
+        return ty.dtype
+
+
+@infer_getattr
+class EnumClassAttribute(AttributeTemplate):
+    key = types.EnumClass
+
+    def generic_resolve(self, ty, attr):
+        """
+        Resolve attributes of an enum class as enum members.
+        """
+        if attr in ty.instance_class.__members__:
+            return ty.member_type
+
+
+class EnumCompare(AbstractTemplate):
+
+    def generic(self, args, kws):
+        [lhs, rhs] = args
+        if (isinstance(lhs, types.EnumMember)
+            and isinstance(rhs, types.EnumMember)
+            and lhs == rhs):
+            return signature(types.boolean, lhs, rhs)
+
+@infer
+class EnumEq(EnumCompare):
+    key = '=='
+
+@infer
+class EnumNe(EnumCompare):
+    key = '!='

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -146,6 +146,7 @@ def _typeof_slice(val, c):
     return types.slice2_type if val.step in (None, 1) else types.slice3_type
 
 @typeof_impl.register(enum.Enum)
+@typeof_impl.register(enum.IntEnum)
 def _typeof_enum(val, c):
     clsty = typeof_impl(type(val), c)
     return clsty.member_type
@@ -161,7 +162,11 @@ def _typeof_enum_class(val, c):
         raise ValueError("Cannot type heterogenous enum: "
                          "got value types %s"
                          % ", ".join(sorted(str(ty) for ty in dtypes)))
-    return types.EnumClass(cls, dtypes.pop())
+    if issubclass(val, enum.IntEnum):
+        typecls = types.IntEnumClass
+    else:
+        typecls = types.EnumClass
+    return typecls(cls, dtypes.pop())
 
 @typeof_impl.register(np.dtype)
 def _typeof_dtype(val, c):

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -57,10 +57,42 @@ try:
     from functools import singledispatch
 except ImportError:
     try:
-        from singledispatch import singledispatch
+        import singledispatch
     except ImportError:
         raise ImportError("please install the 'singledispatch' package "
                           "('pip install singledispatch')")
+    else:
+        # Hotfix for https://bitbucket.org/ambv/singledispatch/issues/8/inconsistent-hierarchy-with-enum
+        def _c3_merge(sequences):
+            """Merges MROs in *sequences* to a single MRO using the C3 algorithm.
+
+            Adapted from http://www.python.org/download/releases/2.3/mro/.
+
+            """
+            result = []
+            while True:
+                sequences = [s for s in sequences if s]   # purge empty sequences
+                if not sequences:
+                    return result
+                for s1 in sequences:   # find merge candidates among seq heads
+                    candidate = s1[0]
+                    for s2 in sequences:
+                        if candidate in s2[1:]:
+                            candidate = None
+                            break      # reject the current head, it appears later
+                    else:
+                        break
+                if candidate is None:
+                    raise RuntimeError("Inconsistent hierarchy")
+                result.append(candidate)
+                # remove the chosen candidate
+                for seq in sequences:
+                    if seq[0] == candidate:
+                        del seq[0]
+
+        singledispatch._c3_merge = _c3_merge
+
+        singledispatch = singledispatch.singledispatch
 
 
 # Mapping between operator module functions and the corresponding built-in


### PR DESCRIPTION
This introduces a `@lower_constant` decorator that allow extending creation of low-level constants for arbitrary types.

Based on PR #1829.