### PR TITLE
recipe for buildbot use.

### DIFF
--- a/buildscripts/condarecipe.buildbot/bld.bat
+++ b/buildscripts/condarecipe.buildbot/bld.bat
@@ -1,0 +1,4 @@
+@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+%PYTHON% -m pip install ordereddict
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/buildscripts/condarecipe.buildbot/build.sh
+++ b/buildscripts/condarecipe.buildbot/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
+$PYTHON -m pip install ordereddict
+$PYTHON setup.py install

--- a/buildscripts/condarecipe.buildbot/license.txt
+++ b/buildscripts/condarecipe.buildbot/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2012, Continuum Analytics, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/buildscripts/condarecipe.buildbot/mandel.py
+++ b/buildscripts/condarecipe.buildbot/mandel.py
@@ -1,0 +1,43 @@
+from numba import autojit
+import numpy as np
+#from pylab import imshow, jet, show, ion
+
+@autojit
+def mandel(x, y, max_iters):
+    """
+    Given the real and imaginary parts of a complex number,
+    determine if it is a candidate for membership in the Mandelbrot
+    set given a fixed number of iterations.
+    """
+    i = 0
+    c = complex(x,y)
+    z = 0.0j
+    for i in range(max_iters):
+        z = z*z + c
+        if (z.real*z.real + z.imag*z.imag) >= 4:
+            return i
+
+    return 255
+
+@autojit
+def create_fractal(min_x, max_x, min_y, max_y, image, iters):
+    height = image.shape[0]
+    width = image.shape[1]
+
+    pixel_size_x = (max_x - min_x) / width
+    pixel_size_y = (max_y - min_y) / height
+    for x in range(width):
+        real = min_x + x * pixel_size_x
+        for y in range(height):
+            imag = min_y + y * pixel_size_y
+            color = mandel(real, imag, iters)
+            image[y, x] = color
+
+    return image
+
+image = np.zeros((500, 750), dtype=np.uint8)
+create_fractal(-2.0, 1.0, -1.0, 1.0, image, 20)
+#jet()
+#ion()
+#show()
+print("mandel OK")

--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -1,0 +1,44 @@
+package:
+   name: numba
+   # We need to provide a default version
+   version: {{ environ.get('GIT_DESCRIBE_TAG','devel') }}
+
+source:
+   path: ../..
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  entry_points:
+    - pycc = numba.pycc:main
+    - numba = numba.numba_entry:main
+
+requirements:
+  # build and run dependencies are duplicated to avoid setuptools issues
+  # when we also set install_requires in setup.py
+  build:
+    - python
+    - numpy x.x
+    # On channel https://anaconda.org/numba/
+    - llvmlite 0.11.*
+    - funcsigs       [py27]
+    - singledispatch [py27]
+  run:
+    - python
+    - numpy x.x
+    # On channel https://anaconda.org/numba/
+    - llvmlite 0.11.*
+    - funcsigs       [py27]
+    - singledispatch [py27]
+test:
+  requires:
+    - jinja2
+    # Required to test optional Numba features
+    - cffi
+    - scipy
+    - cudatoolkit
+  files:
+    - mandel.py
+  commands:
+    - pycc -h
+    - numba -h
+    - python -m numba.runtests -v -m -b numba.cuda.tests


### PR DESCRIPTION
This recipe is a clone of buildscripts/condarecipe.local, with cudatoolkit added to the test prerequisites, to enable CUDA testing.