### PR TITLE
Optimize jitclass usage in python interpreter

### DIFF
--- a/examples/linkedlist.py
+++ b/examples/linkedlist.py
@@ -3,7 +3,7 @@ This example demonstrates jitclasses and deferred types for writing a
 singly-linked-list.
 """
 from __future__ import print_function, absolute_import
-from numba.utils import OrderedDict
+from collections import OrderedDict
 import numpy as np
 from numba import njit
 from numba import jitclass
@@ -44,7 +44,7 @@ def fill_array(arr):
     into the array from the index.
     """
     head = make_linked_node(0)
-    for i in range(1, 1 + arr.size):
+    for i in range(1, arr.size):
         head = head.prepend(i)
 
     c = 0
@@ -60,7 +60,7 @@ def runme():
     print("== Result ==")
     print(arr)
     # Check answer
-    np.testing.assert_equal(arr, 1 + np.arange(arr.size, dtype=arr.dtype)[::-1])
+    np.testing.assert_equal(arr, np.arange(arr.size, dtype=arr.dtype)[::-1])
 
 
 if __name__ == '__main__':

--- a/numba/_typeof.c
+++ b/numba/_typeof.c
@@ -730,7 +730,7 @@ int typecode_arrayscalar(PyObject *dispatcher, PyObject* aryscalar) {
  */
 static
 int
-typeof_numba_type_shortcuit(PyObject *dispatcher, PyObject *val)
+typeof_numba_type_shortcut(PyObject *dispatcher, PyObject *val)
 {
     int typecode;
     PyObject *numba_type = NULL;
@@ -776,7 +776,7 @@ typeof_typecode(PyObject *dispatcher, PyObject *val)
     }
     /* Special case for "_numba_type_" attribute */
     else if (PyObject_HasAttrString(val, "_numba_type_")) {
-        return typeof_numba_type_shortcuit(dispatcher, val);
+        return typeof_numba_type_shortcut(dispatcher, val);
     }
 
     return typecode_using_fingerprint(dispatcher, val);

--- a/numba/jitclass/_box.c
+++ b/numba/jitclass/_box.c
@@ -129,8 +129,7 @@ cleanup:
 static
 PyObject* box_get_dataptr(PyObject *self, PyObject *args) {
     BoxObject *box;
-    /* no type checking */
-    if (!PyArg_ParseTuple(args, "O", (PyObject*)&box))
+    if (!PyArg_ParseTuple(args, "O!", &BoxType, (PyObject*)&box))
         return NULL;
     return PyLong_FromVoidPtr(box->dataptr);
 }
@@ -141,8 +140,7 @@ PyObject* box_get_dataptr(PyObject *self, PyObject *args) {
 static
 PyObject* box_get_meminfoptr(PyObject *self, PyObject *args) {
     BoxObject *box;
-    /* no type checking */
-    if (!PyArg_ParseTuple(args, "O", (PyObject*)&box))
+    if (!PyArg_ParseTuple(args, "O!", &BoxType, (PyObject*)&box))
         return NULL;
     return PyLong_FromVoidPtr(box->meminfoptr);
 }

--- a/numba/jitclass/_box.c
+++ b/numba/jitclass/_box.c
@@ -1,3 +1,6 @@
+/*
+Implements jitclass Box type in python c-api level.
+*/
 #include "_pymodule.h"
 
 typedef struct {
@@ -6,9 +9,18 @@ typedef struct {
 } BoxObject;
 
 
+/* Store function defined in numba.runtime._nrt_python for use in box_dealloc.
+ * It points to a function is code segment that does not need user deallocation
+ * and does not disappear while the process is stil running.
+ */
 static void (*MemInfo_release)(void*) = NULL;
 
 
+/*
+ * Box.__init__()
+ * Takes no arguments.
+ * meminfoptr and dataptr are set to NULL.
+ */
 static
 int Box_init(BoxObject *self, PyObject *args, PyObject *kwds) {
     static char *keywords[] = {NULL};
@@ -22,6 +34,11 @@ int Box_init(BoxObject *self, PyObject *args, PyObject *kwds) {
     return 0;
 }
 
+/*
+ * Box destructor
+ * Release MemInfo pointed by meminfoptr.
+ * Free the instance.
+ */
 static
 void box_dealloc(BoxObject *box)
 {
@@ -80,6 +97,9 @@ static PyTypeObject BoxType = {
 };
 
 
+/* Import MemInfo_Release from numba.runtime._nrt_python once for use in
+ * Box_dealloc.
+ */
 static
 void* import_meminfo_release() {
     PyObject *nrtmod = NULL;
@@ -103,6 +123,9 @@ cleanup:
     return fnptr;
 }
 
+/* Debug utils.
+ * Get internal dataptr field from Box.
+ */
 static
 PyObject* box_get_dataptr(PyObject *self, PyObject *args) {
     BoxObject *box;
@@ -112,6 +135,9 @@ PyObject* box_get_dataptr(PyObject *self, PyObject *args) {
     return PyLong_FromVoidPtr(box->dataptr);
 }
 
+/* Debug utils.
+ * Get internal meminfoptr field from Box.
+ */
 static
 PyObject* box_get_meminfoptr(PyObject *self, PyObject *args) {
     BoxObject *box;

--- a/numba/jitclass/_box.c
+++ b/numba/jitclass/_box.c
@@ -178,9 +178,9 @@ MOD_INIT(_box) {
 
     /* bind address to direct access utils */;
     PyModule_AddObject(m, "box_meminfoptr_offset",
-                       PyLong_FromLong(offsetof(BoxObject, meminfoptr)));
+                       PyLong_FromSsize_t(offsetof(BoxObject, meminfoptr)));
     PyModule_AddObject(m, "box_dataptr_offset",
-                       PyLong_FromLong(offsetof(BoxObject, dataptr)));
+                       PyLong_FromSsize_t(offsetof(BoxObject, dataptr)));
 
     return MOD_SUCCESS_VAL(m);
 }

--- a/numba/jitclass/_box.c
+++ b/numba/jitclass/_box.c
@@ -1,0 +1,146 @@
+#include "_pymodule.h"
+
+typedef struct {
+    PyObject_HEAD
+    PyObject *meminfo;
+    PyObject *meminfoptr;
+    PyObject *dataptr;
+} BoxObject;
+
+
+static PyMemberDef box_members[] = {
+    {"_meminfo",    T_OBJECT, offsetof(BoxObject, meminfo), READONLY},
+    {"_meminfoptr", T_OBJECT, offsetof(BoxObject, meminfoptr), READONLY},
+    {"_dataptr",    T_OBJECT, offsetof(BoxObject, dataptr), READONLY},
+    {NULL}  /* Sentinel */
+};
+
+static PyObject *MemInfoClass = NULL;
+
+static
+int Box_init(BoxObject *self, PyObject *args, PyObject *kwds) {
+    static char *keywords[] = {"meminfoptr", "dataptr", NULL};
+    PyObject *meminfo;
+    PyObject *meminfoptr;
+    PyObject *dataptr;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO", keywords,
+                                     &meminfoptr, &dataptr))
+    {
+        return -1;
+    }
+
+    /* MemInfo(meminfoptr) */
+    meminfo = PyObject_CallFunctionObjArgs(MemInfoClass, meminfoptr, NULL);
+    if (!meminfo) return -1;
+
+    /* Set attributes */
+    Py_INCREF(meminfoptr);
+    Py_INCREF(dataptr);
+    self->meminfo = meminfo;
+    self->meminfoptr = meminfoptr;
+    self->dataptr = dataptr;
+    return 0;
+}
+
+
+static void
+box_dealloc(BoxObject *box)
+{
+    Py_DECREF(box->meminfo);
+    Py_DECREF(box->meminfoptr);
+    Py_DECREF(box->dataptr);
+    Py_TYPE(box)->tp_free((PyObject *) box);
+}
+
+
+static const char Box_doc[] = "A box for numba created jit-class instance";
+
+
+static PyTypeObject BoxType = {
+#if (PY_MAJOR_VERSION < 3)
+    PyObject_HEAD_INIT(NULL)
+    0,                         /*ob_size*/
+#else
+    PyVarObject_HEAD_INIT(NULL, 0)
+#endif
+    "_box.Box",                /*tp_name*/
+    sizeof(BoxObject),         /*tp_basicsize*/
+    0,                         /*tp_itemsize*/
+    (destructor)box_dealloc,   /*tp_dealloc*/
+    0,                         /*tp_print*/
+    0,                         /*tp_getattr*/
+    0,                         /*tp_setattr*/
+    0,                         /*tp_compare*/
+    0,                         /*tp_repr*/
+    0,                         /*tp_as_number*/
+    0,                         /*tp_as_sequence*/
+    0,                         /*tp_as_mapping*/
+    0,                         /*tp_hash */
+    0,                         /*tp_call*/
+    0,                         /*tp_str*/
+    0,                         /*tp_getattro*/
+    0,                         /*tp_setattro*/
+    0,                         /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    Box_doc,                   /* tp_doc */
+    0,                         /* tp_traverse */
+    0,                         /* tp_clear */
+    0,                         /* tp_richcompare */
+    0,                         /* tp_weaklistoffset */
+    0,                         /* tp_iter */
+    0,                         /* tp_iternext */
+    0,                         /* tp_methods */
+    box_members,               /* tp_members */
+    0,                         /* tp_getset */
+    0,                         /* tp_base */
+    0,                         /* tp_dict */
+    0,                         /* tp_descr_get */
+    0,                         /* tp_descr_set */
+    0,                         /* tp_dictoffset */
+    (initproc)Box_init,        /* tp_init */
+    0,                         /* tp_alloc */
+    0,                         /* tp_new */
+};
+
+
+static
+PyObject * import_meminfo_class() {
+    PyObject *nrtmod;
+    PyObject *meminfocls;
+    /* from numba.runtime.nrt import MemInfo */
+    nrtmod = PyImport_ImportModule("numba.runtime.nrt");
+    if (!nrtmod) return NULL;
+    meminfocls = PyObject_GetAttrString(nrtmod, "MemInfo");
+    if (!meminfocls) {
+        Py_DECREF(nrtmod);
+        return NULL;
+    }
+    return meminfocls;
+}
+
+MOD_INIT(_box) {
+    PyObject *m;
+
+    MOD_DEF(m, "_box", "No docs", NULL)
+    if (m == NULL)
+        return MOD_ERROR_VAL;
+
+    /* init BoxType */
+    BoxType.tp_new = PyType_GenericNew;
+    if (PyType_Ready(&BoxType))
+        return MOD_ERROR_VAL;
+
+    /* import and cache numba.runtime.nrt.MemInfo
+       and keep it in the module */
+    MemInfoClass = import_meminfo_class();
+    if (!MemInfoClass) return MOD_ERROR_VAL;
+    Py_INCREF(MemInfoClass);
+    PyModule_AddObject(m, "_MemInfo", MemInfoClass);
+
+    /* bind BoxType */
+    Py_INCREF(&BoxType);
+    PyModule_AddObject(m, "Box", (PyObject *) (&BoxType));
+
+    return MOD_SUCCESS_VAL(m);
+}

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -14,7 +14,7 @@ from numba.datamodel import default_manager, models
 from numba.targets import imputils
 from numba import cgutils
 from numba.six import exec_
-from . import boxing
+from . import _box
 
 
 ##############################################################################
@@ -85,7 +85,7 @@ class JitClassType(type):
         cls._ctor = njit(ctor)
 
     def __instancecheck__(cls, instance):
-        if isinstance(instance, boxing.Box):
+        if isinstance(instance, _box.Box):
             return instance._numba_type_.class_type is cls.class_type
         return False
 

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -162,10 +162,9 @@ def _box_class_instance(typ, val, c):
 def _unbox_class_instance(typ, val, c):
     def access_member(member_offset):
         # Access member by byte offset
-        offset = c.context.get_constant(types.uint32, member_offset)
+        offset = c.context.get_constant(types.uintp, member_offset)
         llvoidptr = ir.IntType(8).as_pointer()
-        byte_ptr = c.builder.bitcast(val, llvoidptr)
-        ptr = c.builder.gep(byte_ptr, [offset])
+        ptr = cgutils.pointer_add(c.builder, val, offset)
         casted = c.builder.bitcast(ptr, llvoidptr.as_pointer())
         return c.builder.load(casted)
 

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -110,6 +110,19 @@ def _specialize_box(typ):
     # Store to cache
     _cache_specialized_box[typ] = subcls
 
+    # Pre-compile attribute getter.
+    # Note: This must be done after the "box" class is created because
+    #       compiling the getter requires the "box" class to be defined.
+    for k, v in dct.items():
+        if isinstance(v, property):
+            prop = getattr(subcls, k)
+            if prop.fget is not None:
+                fget = prop.fget
+                fast_fget = fget.compile((typ,))
+                fget.disable_compile()
+                setattr(subcls, k,
+                        property(fast_fget, prop.fset, prop.fdel))
+
     return subcls
 
 

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -148,9 +148,8 @@ def _box_class_instance(typ, val, c):
 
     def set_member(member_offset, value):
         # Access member by byte offset
-        offset = c.context.get_constant(types.uint32, member_offset)
-        byte_ptr = c.builder.bitcast(box, llvoidptr)
-        ptr = c.builder.gep(byte_ptr, [offset])
+        offset = c.context.get_constant(types.uintp, member_offset)
+        ptr = cgutils.pointer_add(c.builder, box, offset)
         casted = c.builder.bitcast(ptr, llvoidptr.as_pointer())
         c.builder.store(value, casted)
 

--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -41,24 +41,20 @@ meminfo_new_from_pyobject(void *data, PyObject *ownerobj) {
 typedef struct {
     PyObject_HEAD
     NRT_MemInfo *meminfo;
-    int owned;  /* if true (default) the release the memory at destruction */
 } MemInfoObject;
 
 static
 int MemInfo_init(MemInfoObject *self, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"ptr", "owned", NULL};
+    static char *keywords[] = {"ptr", NULL};
     PyObject *raw_ptr_obj;
-    int raw_owned = 1;
     void *raw_ptr;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|i", keywords, &raw_ptr_obj,
-                                     &raw_owned)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", keywords, &raw_ptr_obj)) {
         return -1;
     }
     raw_ptr = PyLong_AsVoidPtr(raw_ptr_obj);
     if(PyErr_Occurred()) return -1;
     self->meminfo = (NRT_MemInfo *)raw_ptr;
     assert (NRT_MemInfo_refcount(self->meminfo) > 0 && "0 refcount");
-    self->owned = (raw_owned? 1 : 0);
     return 0;
 }
 
@@ -147,7 +143,7 @@ MemInfo_get_refcount(MemInfoObject *self, void *closure) {
 static void
 MemInfo_dealloc(MemInfoObject *self)
 {
-    if (self->owned) NRT_MemInfo_release(self->meminfo);
+    NRT_MemInfo_release(self->meminfo);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 

--- a/numba/runtime/_nrt_pythonmod.c
+++ b/numba/runtime/_nrt_pythonmod.c
@@ -166,6 +166,7 @@ declmethod(MemInfo_new_varsize);
 declmethod(MemInfo_varsize_alloc);
 declmethod(MemInfo_varsize_free);
 declmethod(MemInfo_varsize_realloc);
+declmethod(MemInfo_release);
 
 
 #undef declmethod

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -17,7 +17,7 @@ from numba.runtime.nrt import MemInfo
 
 def _get_meminfo(box):
     ptr = _box.box_get_meminfoptr(box)
-    return MemInfo(ptr)
+    return MemInfo(ptr, owned=0)  # borrow ownership
 
 
 class TestJitClass(TestCase, MemoryLeakMixin):

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -17,7 +17,9 @@ from numba.runtime.nrt import MemInfo
 
 def _get_meminfo(box):
     ptr = _box.box_get_meminfoptr(box)
-    return MemInfo(ptr, owned=0)  # borrow ownership
+    mi = MemInfo(ptr)
+    mi.acquire()
+    return mi
 
 
 class TestJitClass(TestCase, MemoryLeakMixin):
@@ -135,21 +137,21 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         arr = np.arange(10, dtype=np.float32)
         obj = Float2AndArray(1, 2, arr)
         obj_meminfo = _get_meminfo(obj)
-        self.assertEqual(obj_meminfo.refcount, 1)
+        self.assertEqual(obj_meminfo.refcount, 2)
         self.assertEqual(obj_meminfo.data, _box.box_get_dataptr(obj))
         self.assertEqual(obj._numba_type_.class_type,
                          Float2AndArray.class_type)
         # Use jit class instance in numba
         other = identity(obj)
-        other_meminfo = _get_meminfo(other)
-        self.assertEqual(obj_meminfo.refcount, 2)
-        self.assertEqual(other_meminfo.refcount, 2)
+        other_meminfo = _get_meminfo(other)  # duplicates MemInfo object to obj
+        self.assertEqual(obj_meminfo.refcount, 4)
+        self.assertEqual(other_meminfo.refcount, 4)
         self.assertEqual(other_meminfo.data, _box.box_get_dataptr(other))
         self.assertEqual(other_meminfo.data, obj_meminfo.data)
 
         # Check dtor
-        del other
-        self.assertEqual(obj_meminfo.refcount, 1)
+        del other, other_meminfo
+        self.assertEqual(obj_meminfo.refcount, 2)
 
         # Check attributes
         out_x, out_y, out_arr = retrieve_attributes(obj)
@@ -220,19 +222,19 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
         first_meminfo = _get_meminfo(first)
         second_meminfo = _get_meminfo(second)
-        self.assertEqual(first_meminfo.refcount, 2)
+        self.assertEqual(first_meminfo.refcount, 3)
         self.assertEqual(second.next.data, first.data)
-        self.assertEqual(first_meminfo.refcount, 2)
-        self.assertEqual(second_meminfo.refcount, 1)
+        self.assertEqual(first_meminfo.refcount, 3)
+        self.assertEqual(second_meminfo.refcount, 2)
 
         # Test using deferred type as argument
         first_val = second.get_next_data()
         self.assertEqual(first_val, first.data)
 
         # Check ownership
+        self.assertEqual(first_meminfo.refcount, 3)
+        del second, second_meminfo
         self.assertEqual(first_meminfo.refcount, 2)
-        del second
-        self.assertEqual(first_meminfo.refcount, 1)
 
     def test_c_structure(self):
         spec = OrderedDict()

--- a/setup.py
+++ b/setup.py
@@ -111,10 +111,15 @@ ext_nrt_python = Extension(name='numba.runtime._nrt_python',
                                     'numba/runtime/_nrt_python.c'],
                            include_dirs=["numba"] + npymath_info['include_dirs'])
 
+ext_jitclass_box = Extension(name='numba.jitclass._box',
+                             sources=['numba/jitclass/_box.c'],
+                             depends=['numba/_pymodule.h'],
+                             include_dirs=['numba'])
+
 ext_modules = [ext_dynfunc, ext_npymath_exports, ext_dispatcher,
                ext_helperlib, ext_typeconv,
                ext_npyufunc_ufunc, ext_npyufunc_workqueue, ext_mviewbuf,
-               ext_nrt_python]
+               ext_nrt_python, ext_jitclass_box]
 
 
 def find_packages(root_dir, root_name):


### PR DESCRIPTION
* improves dispatch speed by handling `_numba_type_` attribute in the typeof C code
* turn ``Box`` class into C extension type for faster boxing and unboxing
    * this hides meminfoptr and dataptr attributes in Box
* optimize attribute/property getter by skipping dispatch

