### PR TITLE
CUDA simulator device function may not have the right "cuda" module

### DIFF
--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -9,8 +9,8 @@ def load_tests(loader, tests, pattern):
     suite = SerialSuite()
     this_dir = dirname(__file__)
     suite.addTests(load_testsuite(loader, join(this_dir, 'nocuda')))
-    suite.addTests(load_testsuite(loader, join(this_dir, 'cudasim')))
     if cuda.is_available():
+        suite.addTests(load_testsuite(loader, join(this_dir, 'cudasim')))
         gpus = cuda.list_devices()
         if gpus and gpus[0].compute_capability >= (2, 0):
             suite.addTests(load_testsuite(loader, join(this_dir, 'cudadrv')))

--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -3,11 +3,13 @@ from numba.testing import load_testsuite
 from numba import cuda
 from os.path import dirname, join
 
+
 def load_tests(loader, tests, pattern):
 
     suite = SerialSuite()
     this_dir = dirname(__file__)
     suite.addTests(load_testsuite(loader, join(this_dir, 'nocuda')))
+    suite.addTests(load_testsuite(loader, join(this_dir, 'cudasim')))
     if cuda.is_available():
         gpus = cuda.list_devices()
         if gpus and gpus[0].compute_capability >= (2, 0):

--- a/numba/cuda/tests/cudasim/__init__.py
+++ b/numba/cuda/tests/cudasim/__init__.py
@@ -1,0 +1,8 @@
+from numba.testing import SerialSuite
+from numba.testing import load_testsuite
+import os
+from numba import config
+
+
+def load_tests(loader, tests, pattern):
+    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/cuda/tests/cudasim/support.py
+++ b/numba/cuda/tests/cudasim/support.py
@@ -1,0 +1,6 @@
+from numba import cuda
+
+
+@cuda.jit(device=True)
+def cuda_module_in_device_function():
+    return cuda.threadIdx.x

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba import cuda
+
+
+class TestCudaSimIssues(unittest.TestCase):
+
+    def test_cuda_module_in_device_function(self):
+        """
+        Discovered in https://github.com/numba/numba/issues/1837.
+        When the `cuda` module is referenced in a device function,
+        it does not have the kernel API (e.g. cuda.threadIdx, cuda.shared)
+        """
+        from .support import cuda_module_in_device_function as inner
+
+        @cuda.jit
+        def outer(out):
+            tid = inner()
+            if tid < out.size:
+                out[tid] = tid
+
+        arr = np.zeros(10, dtype=np.int32)
+        outer[1, 11](arr)
+        expected = np.arange(arr.size, dtype=np.int32)
+        np.testing.assert_equal(expected, arr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix issue #1837.

The CUDA simulator injects/monkeypatches the global dictionary of the kernel function to replace the "cuda" module with a FakeCudaModule instance that has all the kernel api (e.g. cuda.shared, cuda.threadIdx, etc..).  However, this was not performed on device functions.  Problem occurs when the device function is imported from another module, which has a unpatched global dictionary.  This PR fixes it.

In additional to the fix, the monkeypatching of global will not replaces globals that are referencing the "cuda" module object; instead of just replacing the variable with the name "cuda".  

