### PR TITLE
Add numpy.linalg.qr

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -173,6 +173,7 @@ floating-point and complex numbers:
   change is supported e.g. real input -> real
   output, complex input -> complex output).
 * :func:`numpy.linalg.inv`
+* :func:`numpy.linalg.qr` (only the first argument).
 * :func:`numpy.linalg.svd` (only the 2 first arguments).
 
 .. note::

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -89,6 +89,8 @@ build_c_helpers_dict(void)
     declmethod(ez_rgeev);
     declmethod(ez_cgeev);
     declmethod(ez_gesdd);
+    declmethod(ez_geqrf);
+    declmethod(ez_xxgqr);
 
     declpointer(py_random_state);
     declpointer(np_random_state);

--- a/numba/_lapack.c
+++ b/numba/_lapack.c
@@ -693,14 +693,6 @@ numba_raw_rgeev(char kind, char jobvl, char jobvr,
         case 'd':
             raw_func = get_clapack_dgeev();
             break;
-        default:
-        {
-            PyGILState_STATE st = PyGILState_Ensure();
-            PyErr_SetString(PyExc_ValueError,
-                            "invalid kind of real space *geev call");
-            PyGILState_Release(st);
-        }
-        return -1;
     }
     if (raw_func == NULL)
         return -1;
@@ -788,14 +780,6 @@ numba_raw_cgeev(char kind, char jobvl, char jobvr,
         case 'z':
             raw_func = get_clapack_zgeev();
             break;
-        default:
-        {
-            PyGILState_STATE st = PyGILState_Ensure();
-            PyErr_SetString(PyExc_ValueError,\
-                            "invalid kind of complex space *geev call");
-            PyGILState_Release(st);
-        }
-        return -1;
     }
     if (raw_func == NULL)
         return -1;
@@ -902,14 +886,6 @@ numba_raw_rgesdd(char kind, char jobz, Py_ssize_t m, Py_ssize_t n, void *a,
         case 'd':
             raw_func = get_clapack_dgesdd();
             break;
-        default:
-        {
-            PyGILState_STATE st = PyGILState_Ensure();
-            PyErr_SetString(PyExc_ValueError,\
-                            "invalid kind of real space *gesdd call");
-            PyGILState_Release(st);
-        }
-        return -1;
     }
     if (raw_func == NULL)
         return -1;
@@ -996,14 +972,6 @@ numba_raw_cgesdd(char kind, char jobz, Py_ssize_t m, Py_ssize_t n, void *a,
         case 'z':
             raw_func = get_clapack_zgesdd();
             break;
-        default:
-        {
-            PyGILState_STATE st = PyGILState_Ensure();
-            PyErr_SetString(PyExc_ValueError,\
-                            "invalid kind of complex space *gesdd call");
-            PyGILState_Release(st);
-        }
-        return -1;
     }
     if (raw_func == NULL)
         return -1;

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1077,15 +1077,19 @@ def qr_impl(a):
             fatal_error_func()
             assert 0   # unreachable
 
-        # pull out R, there is undoubtedly a more elegant way
-        # this is transposed in memory because Fortran
-        r = numpy.zeros((minmn, n), dtype=a.dtype)
+        # pull out R, this is transposed because of Fortran
+        r = numpy.zeros((n, minmn), dtype=a.dtype).T
 
+        # the triangle in R
         for i in range(minmn):
-            for j in range(i, n):
-                r[i, j] = q[i, j]
+            for j in range(i + 1):
+                r[j, i] = q[j, i]
 
-        # create Q in A.
+        # and the possible square in R
+        for i in range(minmn, n):
+            for j in range(minmn):
+                r[j, i] = q[j, i]
+
         ret = numba_ez_xxgqr(
             kind,  # kind
             m,  # m

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -786,23 +786,7 @@ class TestLinalgQr(TestLinalgBase):
     """
     Tests for np.linalg.qr.
     """
-
-    def sample_matrix(self, size, dtype, order):
-        break_at = 10
-        jmp = 0
-        # have a few attempts at shuffling to get the condition number down
-        # else not worry about it
-        mn = size[0] * size[1]
-        np.random.seed(0)  # repeatable seed
-        while jmp < break_at:
-            v = self.sample_vector(mn, dtype)
-            # shuffle to improve conditioning
-            np.random.shuffle(v)
-            A = np.reshape(v, size)
-            if np.linalg.cond(A) < mn:
-                return np.array(A, order=order, dtype=dtype)
-            jmp += 1
-
+    
     @needs_lapack
     def test_linalg_qr(self):
         """

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -345,6 +345,15 @@ class TestLinalgBase(TestCase):
             return (base * 0.5 + 1).astype(dtype)
 
     def orth_fact_sample_matrix(self, size, dtype, order):
+        """
+        Provides a sample matrix for use in orthogonal factorization tests.
+
+        size: (rows, columns), the dimensions of the returned matrix.
+        dtype: the dtype for the returned matrix.
+        order: the memory layout for the returned matrix, 'F' or 'C'.
+        """
+        # May be worth just explicitly constructing this system at some point
+        # with a kwarg for condition number?
         break_at = 10
         jmp = 0
         # have a few attempts at shuffling to get the condition number down
@@ -395,22 +404,15 @@ class TestLinalgBase(TestCase):
                         contiguousness across all input values
                         (and therefore tests).
         """
-        flgc = "C_CONTIGUOUS"
-        flgf = "F_CONTIGUOUS"
 
         if isinstance(got, tuple):
             # tuple present, check all results
-            # find the contiguousness of the first result
-            c_contig = got[0].flags[flgc]
-            f_contig = got[0].flags[flgf]
-            # AND in the flags from other possible results
-            for k in range(1, len(got)):
-                c_contig &= got[k].flags[flgc]
-                f_contig &= got[k].flags[flgf]
+            c_contig = {a.flags.c_contiguous for a in got} == {True}
+            f_contig = {a.flags.f_contiguous for a in got} == {True}
         else:
             # else a single array is present
-            c_contig = got.flags[flgc]
-            f_contig = got.flags[flgf]
+            c_contig = got.flags.c_contiguous
+            f_contig = got.flags.f_contiguous
 
         # check that the result (possible set of) is at least one of
         # C or F contiguous.


### PR DESCRIPTION
This adds support for `numpy.linalg.qr`, the QR decomposition.

Only the first argument is supported as the kwarg is a string,
which is not supported yet. This means `qr()` follows the default
behaviour of operating in the `'reduced'` mode (see notes in
numpy, the behavior changed in 1.8 leading to `"reduced"` and
`"full"` aliasing).

The testing compares the implementation to numpy and falls back to
testing via reconstruction.