### PR TITLE
Remove some codecov checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     include:
         # Longest build first
         - env: PYTHON=3.5 NUMPY="numpy=1.11" RUN_COVERAGE=yes
-        - env: PYTHON=3.4 NUMPY="numpy=1.9" BUILD_DOC=yes
-        - env: PYTHON=2.7 NUMPY="numpy=1.7"
+        #- env: PYTHON=3.4 NUMPY="numpy=1.9" BUILD_DOC=yes
+        #- env: PYTHON=2.7 NUMPY="numpy=1.7"
 
 branches:
     only:
@@ -57,7 +57,7 @@ script:
     # Run the Numba test suite
     # Note that coverage is run from the checkout dir to match the "source"
     # directive in .coveragerc
-    - if [ "$RUN_COVERAGE" == "yes" ]; then cd $TRAVIS_BUILD_DIR; coverage erase; coverage run runtests.py -b -m numba.tests; fi
+    - if [ "$RUN_COVERAGE" == "yes" ]; then cd $TRAVIS_BUILD_DIR; coverage erase; coverage run runtests.py --tags important -b -m numba.tests; fi
     - if [ "$RUN_COVERAGE" != "yes" ]; then NUMBA_ENABLE_CUDASIM=1 python -m numba.runtests -b -m numba.tests; fi
     # Also run test_runtests individually, to make sure test discovery didn't break
     - python -m numba.tests.test_runtests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
     include:
         # Longest build first
         - env: PYTHON=3.5 NUMPY="numpy=1.11" RUN_COVERAGE=yes
-        #- env: PYTHON=3.4 NUMPY="numpy=1.9" BUILD_DOC=yes
-        #- env: PYTHON=2.7 NUMPY="numpy=1.7"
+        - env: PYTHON=3.4 NUMPY="numpy=1.9" BUILD_DOC=yes
+        - env: PYTHON=2.7 NUMPY="numpy=1.7"
 
 branches:
     only:
@@ -57,7 +57,7 @@ script:
     # Run the Numba test suite
     # Note that coverage is run from the checkout dir to match the "source"
     # directive in .coveragerc
-    - if [ "$RUN_COVERAGE" == "yes" ]; then cd $TRAVIS_BUILD_DIR; coverage erase; coverage run runtests.py --tags important -b -m numba.tests; fi
+    - if [ "$RUN_COVERAGE" == "yes" ]; then cd $TRAVIS_BUILD_DIR; coverage erase; coverage run runtests.py -b -m numba.tests; fi
     - if [ "$RUN_COVERAGE" != "yes" ]; then NUMBA_ENABLE_CUDASIM=1 python -m numba.runtests -b -m numba.tests; fi
     # Also run test_runtests individually, to make sure test discovery didn't break
     - python -m numba.tests.test_runtests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 # Configuration for codecov.io
 
 comment:
-    layout: "header, changes, diff, suggestions, uncovered"
+    layout: "header, changes, diff"
 
 coverage:
     ignore:
@@ -9,11 +9,11 @@ coverage:
         - "numba/hsa/.*"
 
 status:
-    # Disable the "project" and "patch" statuses since they can mark
-    # a build as failed if too much code is not covered (which happens often
-    # with JITted functions).  The information is still available in
-    # the codecov.io UI.
     project:
-        enabled: no
+        # The build fails if total project coverage drops by more than 3%
+        target: auto
+        threshold: 3
     patch:
+        # This check can mark a build failed if too much new code
+        # is not covered (which happens often with JITted functions).
         enabled: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,19 @@
 # Configuration for codecov.io
 
 comment:
-    layout: "header, changes, diff"
+    layout: "header, changes, diff, suggestions, uncovered"
 
 coverage:
     ignore:
         - "numba/cuda/.*"
         - "numba/hsa/.*"
+
+status:
+    # Disable the "project" and "patch" statuses since they can mark
+    # a build as failed if too much code is not covered (which happens often
+    # with JITted functions).  The information is still available in
+    # the codecov.io UI.
+    project:
+        enabled: no
+    patch:
+        enabled: no

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,12 +8,12 @@ coverage:
         - "numba/cuda/.*"
         - "numba/hsa/.*"
 
-status:
-    patch:
+    status:
         # This check can mark a build failed if too much new code
         # is not covered (which happens often with JITted functions).
-        enabled: no
-    project:
-        # The build fails if total project coverage drops by more than 3%
-        target: auto
-        threshold: "3%"
+        patch: false
+        project:
+            default:
+                # The build fails if total project coverage drops by more than 3%
+                target: auto
+                threshold: "3%"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,11 +11,12 @@ coverage:
         - "numba/hsa/.*"
 
     status:
-        # This check can mark a build failed if too much new code
-        # is not covered (which happens often with JITted functions).
-        patch: false
         project:
             default:
                 # The build fails if total project coverage drops by more than 3%
                 target: auto
                 threshold: "3%"
+        # These checks can mark a build failed if too much new code
+        # is not covered (which happens often with JITted functions).
+        changes: false
+        patch: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,9 @@
 # Configuration for codecov.io
+# When editing this file, please validate its contents using:
+#   curl -X POST --data-binary @- https://codecov.io/validate < codecov.yml
 
 comment:
-    layout: "header, changes, diff"
+    layout: "header, diff, changes, uncovered"
 
 coverage:
     ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,11 +9,11 @@ coverage:
         - "numba/hsa/.*"
 
 status:
-    project:
-        # The build fails if total project coverage drops by more than 3%
-        target: auto
-        threshold: 3
     patch:
         # This check can mark a build failed if too much new code
         # is not covered (which happens often with JITted functions).
         enabled: no
+    project:
+        # The build fails if total project coverage drops by more than 3%
+        target: auto
+        threshold: "3%"

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -10,9 +10,9 @@ from .errors import DeprecationError
 from .targets import registry
 
 
+
 # -----------------------------------------------------------------------------
 # Decorators
-
 
 def autojit(*args, **kws):
     """Deprecated.
@@ -31,10 +31,10 @@ class _DisableJitWrapper(object):
     def __call__(self, *args, **kwargs):
         return self.py_func(*args, **kwargs)
 
+
 _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
-
 
 def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **options):
     """

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -35,6 +35,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
 
+
 def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **options):
     """
     This decorator is used to compile a Python function into native code.

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -9,6 +9,7 @@ from . import config, sigutils
 from .errors import DeprecationError
 from .targets import registry
 
+
 # -----------------------------------------------------------------------------
 # Decorators
 


### PR DESCRIPTION
This makes some of codecov's PR checks more lenient, so that adding a piece of code that appears poorly covered (for example because it's actually a `@jit` or `@overload` function) does not mark the build failed.