### PR TITLE
Parametrize conda build environment for improved parallelism.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ dist: trusty
 matrix:
     include:
         # Longest build first
-        - env: PYTHON=3.5 NUMPY=1.11 RUN_COVERAGE=yes ENV=travisci
-        - env: PYTHON=3.4 NUMPY=1.9 BUILD_DOC=yes ENV=travisci
-        - env: PYTHON=2.7 NUMPY=1.7 ENV=travisci
+        # Parametrize the conda env name so multiple builds can
+        # work with multiple environments on the same machine in parallel.
+        - env: PYTHON=3.5 NUMPY=1.11 RUN_COVERAGE=yes CONDA_ENV=travisci
+        - env: PYTHON=3.4 NUMPY=1.9 BUILD_DOC=yes CONDA_ENV=travisci
+        - env: PYTHON=2.7 NUMPY=1.7 CONDA_ENV=travisci
 
 branches:
     only:
@@ -21,7 +23,7 @@ before_install:
     - buildscripts/incremental/create_conda_environment.sh
     - buildscripts/incremental/setup_conda_environment.sh
 install:
-    - source activate $ENV
+    - source activate $CONDA_ENV
     # Build numba extensions without silencing compile errors
     - python setup.py build_ext -q --inplace
     # Install numba

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ dist: trusty
 matrix:
     include:
         # Longest build first
-        - env: PYTHON=3.5 NUMPY=1.11 RUN_COVERAGE=yes
-        - env: PYTHON=3.4 NUMPY=1.9 BUILD_DOC=yes
-        - env: PYTHON=2.7 NUMPY=1.7
+        - env: PYTHON=3.5 NUMPY=1.11 RUN_COVERAGE=yes ENV=travisci
+        - env: PYTHON=3.4 NUMPY=1.9 BUILD_DOC=yes ENV=travisci
+        - env: PYTHON=2.7 NUMPY=1.7 ENV=travisci
 
 branches:
     only:
@@ -21,7 +21,7 @@ before_install:
     - buildscripts/incremental/create_conda_environment.sh
     - buildscripts/incremental/setup_conda_environment.sh
 install:
-    - source activate travisci
+    - source activate $ENV
     # Build numba extensions without silencing compile errors
     - python setup.py build_ext -q --inplace
     # Install numba

--- a/buildscripts/incremental/create_conda_environment.sh
+++ b/buildscripts/incremental/create_conda_environment.sh
@@ -3,4 +3,4 @@
 # Setup environment
 conda update --yes conda
 # Scipy, CFFI and jinja2 are optional dependencies, but exercised in the test suite
-conda create -n $ENV --yes python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2
+conda create -n $CONDA_ENV --yes python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2

--- a/buildscripts/incremental/create_conda_environment.sh
+++ b/buildscripts/incremental/create_conda_environment.sh
@@ -3,4 +3,4 @@
 # Setup environment
 conda update --yes conda
 # Scipy, CFFI and jinja2 are optional dependencies, but exercised in the test suite
-conda create -n travisci --yes python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2
+conda create -n $ENV --yes python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source activate $ENV
+source activate $CONDA_ENV
 set -v
 # Setup environment
 CONDA_INSTALL="conda install --yes -q"

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source activate travisci
+source activate $ENV
 set -v
 # Setup environment
 CONDA_INSTALL="conda install --yes -q"

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source activate $ENV
+source activate $CONDA_ENV
 set -v
 # Ensure that the documentation builds without warnings
 pushd docs

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source activate travisci
+source activate $ENV
 set -v
 # Ensure that the documentation builds without warnings
 pushd docs


### PR DESCRIPTION
Using an environment variable for the name of the conda environment allows multiple (buildbot) builders to build in parallel, each using a different environment (rather than the shared 'travisci' that was used before).