### PR TITLE
Improve overload selector

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1072,21 +1072,6 @@ class BaseContext(object):
             fn.args[0].add_attribute("nocapture")
             builder.call(fn, [meminfo])
 
-    def get_nrt_meminfo_recur(self, builder, typ, val):
-        """
-        Returns a list of MemInfo pointers (i8*) from the given value by
-        traversing recursively in nested structures.
-        """
-        data_model = self.data_model_manager[typ]
-        members = data_model.traverse(builder)
-        out = []
-        if data_model.has_nrt_meminfo():
-            mi = data_model.get_nrt_meminfo(builder, val)
-            out.append(mi)
-        for mtyp, getter in members:
-            out += self.get_nrt_meminfo_recur(builder, mtyp, getter(val))
-        return out
-
     def nrt_incref(self, builder, typ, value):
         """
         Recursively incref the given *value* and its members.

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -1072,6 +1072,21 @@ class BaseContext(object):
             fn.args[0].add_attribute("nocapture")
             builder.call(fn, [meminfo])
 
+    def get_nrt_meminfo_recur(self, builder, typ, val):
+        """
+        Returns a list of MemInfo pointers (i8*) from the given value by
+        traversing recursively in nested structures.
+        """
+        data_model = self.data_model_manager[typ]
+        members = data_model.traverse(builder)
+        out = []
+        if data_model.has_nrt_meminfo():
+            mi = data_model.get_nrt_meminfo(builder, val)
+            out.append(mi)
+        for mtyp, getter in members:
+            out += self.get_nrt_meminfo_recur(builder, mtyp, getter(val))
+        return out
+
     def nrt_incref(self, builder, typ, value):
         """
         Recursively incref the given *value* and its members.

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -86,9 +86,8 @@ class OverloadSelector(object):
         or if the formal signature is a compatible generic signature.
         """
         if formal_args and isinstance(formal_args[-1], types.VarArg):
-            formal_args = (
-                formal_args[:-1] +
-                (formal_args[-1].dtype,) * (len(actual_args) - len(formal_args) + 1))
+            ndiff = len(actual_args) - len(formal_args) + 1
+            formal_args = formal_args[:-1] + (formal_args[-1].dtype,) * ndiff
 
         if len(formal_args) != len(actual_args):
             return False
@@ -106,11 +105,13 @@ class OverloadSelector(object):
         elif types.Any == formal:
             # formal argument is any
             return True
-        elif (isinstance(formal, type) and
-              isinstance(actual, formal)):
-            # formal argument is a type class matching actual argument
-            assert issubclass(formal, types.Type)
-            return True
+        elif isinstance(formal, type) and issubclass(formal, types.Type):
+            if isinstance(actual, type) and issubclass(actual, formal):
+                # formal arg is a type class and actual arg is a subclass
+                return True
+            elif isinstance(actual, formal):
+                # formal arg is a type class of which actual arg is an instance
+                return True
 
     def append(self, value, sig):
         """

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -35,7 +35,7 @@ class OverloadSelector(object):
 
     In the current implementation:
     - a "signature" is a tuple of type classes or type instances
-    - the "best candidate" is simply the first match
+    - the "best candidate" is the most specific match
     """
 
     def __init__(self):
@@ -71,7 +71,13 @@ class OverloadSelector(object):
                 # increase genericity score everything another signature
                 # is compatible
                 scoring[this] += 1
-        return sorted(candidates, key=lambda x: scoring[x])
+        ordered = sorted(candidates, key=lambda x: scoring[x])
+        if len(ordered) > 1:
+            x, y = map(scoring.get, ordered[:2])
+            if x == y:
+                msg = "ambiguous signatures {0}".format(ordered[:2])
+                raise TypeError(msg)
+        return ordered
 
     def _match_arglist(self, formal_args, actual_args):
         """

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -41,8 +41,16 @@ class OverloadSelector(object):
     def __init__(self):
         # A list of (formal args tuple, value)
         self.versions = []
+        self._cache = {}
 
     def find(self, sig):
+        out = self._cache.get(sig)
+        if out is None:
+            out = self._find(sig)
+            self._cache[sig] = out
+        return out
+
+    def _find(self, sig):
         candidates = self._select_compatible(sig)
         if candidates:
             return candidates[self._best_signature(candidates)]
@@ -137,7 +145,7 @@ class OverloadSelector(object):
         """
         assert isinstance(sig, tuple), (value, sig)
         self.versions.append((sig, value))
-
+        self._cache.clear()
 
 @utils.runonce
 def _load_global_helpers():

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -47,12 +47,15 @@ def deferred_getattr(context, builder, typ, value, attr):
 
 @lower_cast(types.Any, types.DeferredType)
 @lower_cast(types.Optional, types.DeferredType)
+@lower_cast(types.Boolean, types.DeferredType)
 def any_to_deferred(context, builder, fromty, toty, val):
     actual = context.cast(builder, val, fromty, toty.get())
     model = context.data_model_manager[toty]
     return model.set(builder, model.make_uninitialized(), actual)
 
 @lower_cast(types.DeferredType, types.Any)
+@lower_cast(types.DeferredType, types.Boolean)
+@lower_cast(types.DeferredType, types.Optional)
 def deferred_to_any(context, builder, fromty, toty, val):
     model = context.data_model_manager[fromty]
     val = model.get(builder, val)

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -25,6 +25,14 @@ def generic_is_not(context, builder, sig, args):
     return builder.not_(is_impl(builder, args))
 
 
+@lower_builtin('is', types.Any, types.Any)
+def generic_is(context, builder, sig, args):
+    """
+    Default implementation for `x is y`
+    """
+    return cgutils.false_bit
+
+
 #-------------------------------------------------------------------------------
 
 @lower_getattr_generic(types.DeferredType)

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -295,3 +295,22 @@ def not_in(context, builder, sig, args):
 
     res = context.compile_internal(builder, in_impl, sig, args)
     return builder.not_(res)
+
+
+# -----------------------------------------------------------------------------
+
+@lower_builtin(len, types.ConstSized)
+def constsized_len(context, builder, sig, args):
+    [ty] = sig.args
+    retty = sig.return_type
+    res = context.get_constant(retty, len(ty.types))
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@lower_builtin(bool, types.Sized)
+def sized_bool(context, builder, sig, args):
+    [ty] = sig.args
+    if len(ty):
+        return cgutils.true_bit
+    else:
+        return cgutils.false_bit

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -45,6 +45,11 @@ def deferred_getattr(context, builder, typ, value, attr):
     imp = context.get_getattr(inner_type, attr)
     return imp(context, builder, inner_type, val, attr)
 
+@lower_cast(types.Any, types.DeferredType)
+def any_to_deferred(context, builder, fromty, toty, val):
+    actual = context.cast(builder, val, fromty, toty.get())
+    model = context.data_model_manager[toty]
+    return model.set(builder, model.make_uninitialized(), actual)
 
 @lower_cast(types.DeferredType, types.Any)
 def deferred_to_any(context, builder, fromty, toty, val):

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -45,11 +45,6 @@ def deferred_getattr(context, builder, typ, value, attr):
     imp = context.get_getattr(inner_type, attr)
     return imp(context, builder, inner_type, val, attr)
 
-@lower_cast(types.Any, types.DeferredType)
-def any_to_deferred(context, builder, fromty, toty, val):
-    actual = context.cast(builder, val, fromty, toty.get())
-    model = context.data_model_manager[toty]
-    return model.set(builder, model.make_uninitialized(), actual)
 
 @lower_cast(types.DeferredType, types.Any)
 def deferred_to_any(context, builder, fromty, toty, val):

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -31,29 +31,21 @@ def generic_is(context, builder, sig, args):
     Default implementation for `x is y`
     """
     lhs_type, rhs_type = sig.args
-    lhs, rhs = args
     # the lhs and rhs have the same type
     if lhs_type == rhs_type:
-        lhs_mis = context.get_nrt_meminfo_recur(builder, lhs_type, lhs)
-        rhs_mis = context.get_nrt_meminfo_recur(builder, rhs_type, rhs)
-        if context.enable_nrt and lhs_mis and rhs_mis:
-            # check that the meminfo pointer matches
-            assert len(lhs_mis) == len(rhs_mis)
-            matches = [builder.icmp_unsigned('==', a, b)
-                       for a, b in zip(lhs_mis, rhs_mis)]
-            res = matches[0]
-            for m in matches[1:]:
-                res = builder.and_(res, m)
-            return res
-        else:
-            # non NRT managed object fallbacks to `==`
-            try:
-                eq_impl = context.get_function('==', sig)
-            except NotImplementedError:
-                # no `==` implemented for this type
-                return cgutils.false_bit
+            # mutable types
+            if lhs_type.mutable:
+                raise NotImplementedError('no default `is` implementation')
+            # immutable types
             else:
-                return eq_impl(builder, args)
+                # fallbacks to `==`
+                try:
+                    eq_impl = context.get_function('==', sig)
+                except NotImplementedError:
+                    # no `==` implemented for this type
+                    return cgutils.false_bit
+                else:
+                    return eq_impl(builder, args)
     else:
         return cgutils.false_bit
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -46,6 +46,7 @@ def deferred_getattr(context, builder, typ, value, attr):
     return imp(context, builder, inner_type, val, attr)
 
 @lower_cast(types.Any, types.DeferredType)
+@lower_cast(types.Optional, types.DeferredType)
 def any_to_deferred(context, builder, fromty, toty, val):
     actual = context.cast(builder, val, fromty, toty.get())
     model = context.data_model_manager[toty]

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -1194,7 +1194,7 @@ def complex_to_complex(context, builder, fromty, toty, val):
 def any_to_boolean(context, builder, fromty, toty, val):
     return context.is_true(builder, fromty, val)
 
-@lower_cast(types.Boolean, types.Any)
+@lower_cast(types.Boolean, types.Number)
 def boolean_to_any(context, builder, fromty, toty, val):
     # Casting from boolean to anything first casts to int32
     asint = builder.zext(val, Type.int())

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -85,7 +85,6 @@ def optional_to_optional(context, builder, fromty, toty, val):
 
 
 @lower_cast(types.Any, types.Optional)
-@lower_cast(types.Boolean, types.Optional)
 def any_to_optional(context, builder, fromty, toty, val):
     if fromty == types.none:
         return context.make_optional_none(builder, toty.type)

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -85,6 +85,7 @@ def optional_to_optional(context, builder, fromty, toty, val):
 
 
 @lower_cast(types.Any, types.Optional)
+@lower_cast(types.Boolean, types.Optional)
 def any_to_optional(context, builder, fromty, toty, val):
     if fromty == types.none:
         return context.make_optional_none(builder, toty.type)

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -95,6 +95,7 @@ def any_to_optional(context, builder, fromty, toty, val):
 
 
 @lower_cast(types.Optional, types.Any)
+@lower_cast(types.Optional, types.Boolean)
 def optional_to_any(context, builder, fromty, toty, val):
     optval = context.make_helper(builder, fromty, value=val)
     validbit = cgutils.as_bool_bit(builder, optval.valid)

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -41,10 +41,6 @@ lower_builtin('is', types.none, types.none)(always_return_true_impl)
 lower_builtin('is', types.Optional, types.none)(optional_is_none)
 lower_builtin('is', types.none, types.Optional)(optional_is_none)
 
-# Comparing none type to any other types result in False
-lower_builtin('is', types.none, types.Any)(always_return_false_impl)
-lower_builtin('is', types.Any, types.none)(always_return_false_impl)
-
 
 @lower_getattr_generic(types.Optional)
 def optional_getattr(context, builder, typ, value, attr):

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -25,7 +25,7 @@ def tuple_len(context, builder, sig, args):
     res = context.get_constant(retty, len(tupty.types))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
-@lower_builtin(bool, types.BaseTuple)
+@lower_builtin(bool, types.Sized)
 def tuple_bool(context, builder, sig, args):
     tupty, = sig.args
     if len(tupty):

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -18,21 +18,6 @@ def namedtuple_constructor(context, builder, sig, args):
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
-@lower_builtin(len, types.BaseTuple)
-def tuple_len(context, builder, sig, args):
-    tupty, = sig.args
-    retty = sig.return_type
-    res = context.get_constant(retty, len(tupty.types))
-    return impl_ret_untracked(context, builder, sig.return_type, res)
-
-@lower_builtin(bool, types.Sized)
-def tuple_bool(context, builder, sig, args):
-    tupty, = sig.args
-    if len(tupty):
-        return cgutils.true_bit
-    else:
-        return cgutils.false_bit
-
 @lower_builtin('+', types.BaseTuple, types.BaseTuple)
 def tuple_add(context, builder, sig, args):
     left, right = [cgutils.unpack_tuple(builder, x) for x in args]

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -13,6 +13,7 @@ from numba import jitclass
 from .support import TestCase, MemoryLeakMixin, tag
 from numba.jitclass import _box
 from numba.runtime.nrt import MemInfo
+from numba.errors import LoweringError
 
 
 def _get_meminfo(box):
@@ -273,8 +274,10 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         def do_is(a, b):
             return a is b
 
-        self.assertTrue(do_is(vec_a, vec_a))
-        self.assertFalse(do_is(vec_a, vec_b))
+        with self.assertRaises(LoweringError) as raises:
+            # trigger compilation
+            do_is(vec_a, vec_a)
+        self.assertIn('no default `is` implementation', str(raises.exception))
 
     def test_isinstance(self):
         Vector2 = self._make_Vector2()

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -264,6 +264,18 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(cstruct.b, st.b)
         self.assertEqual(cstruct.c, st.c)
 
+    def test_is(self):
+        Vector = self._make_Vector2()
+        vec_a = Vector(1, 2)
+        vec_b = Vector(1, 2)
+
+        @njit
+        def do_is(a, b):
+            return a is b
+
+        self.assertTrue(do_is(vec_a, vec_a))
+        self.assertFalse(do_is(vec_a, vec_b))
+
     def test_isinstance(self):
         Vector2 = self._make_Vector2()
         vec = Vector2(1, 2)

--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -117,13 +117,17 @@ class TestOptional(TestCase):
 
     def test_a_is_b_intp(self):
         pyfunc = a_is_b
-        with self.assertRaises(lowering.LoweringError):
-            cres = compile_isolated(pyfunc, [types.intp, types.intp])
+        cres = compile_isolated(pyfunc, [types.intp, types.intp])
+        cfunc = cres.entry_point
+        # object identity is not the same in numba
+        self.assertFalse(cfunc(1, 1))
 
     def test_a_is_not_b_intp(self):
         pyfunc = a_is_not_b
-        with self.assertRaises(lowering.LoweringError):
-            cres = compile_isolated(pyfunc, [types.intp, types.intp])
+        cres = compile_isolated(pyfunc, [types.intp, types.intp])
+        cfunc = cres.entry_point
+        # object identity is not the same in numba
+        self.assertTrue(cfunc(1, 1))
 
     def test_optional_float(self):
         def pyfunc(x, y):

--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -119,15 +119,17 @@ class TestOptional(TestCase):
         pyfunc = a_is_b
         cres = compile_isolated(pyfunc, [types.intp, types.intp])
         cfunc = cres.entry_point
-        # object identity is not the same in numba
-        self.assertFalse(cfunc(1, 1))
+        # integer identity relies on `==`
+        self.assertTrue(cfunc(1, 1))
+        self.assertFalse(cfunc(1, 2))
 
     def test_a_is_not_b_intp(self):
         pyfunc = a_is_not_b
         cres = compile_isolated(pyfunc, [types.intp, types.intp])
         cfunc = cres.entry_point
-        # object identity is not the same in numba
-        self.assertTrue(cfunc(1, 1))
+        # integer identity relies on `==`
+        self.assertFalse(cfunc(1, 1))
+        self.assertTrue(cfunc(1, 2))
 
     def test_optional_float(self):
         def pyfunc(x, y):

--- a/numba/tests/test_target_overloadselector.py
+++ b/numba/tests/test_target_overloadselector.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
-from itertools import product
+from itertools import product, permutations
+from collections import defaultdict
 
 import numba.unittest_support as unittest
 from numba.targets.base import OverloadSelector
@@ -108,7 +109,7 @@ class TestValidateOverloads(unittest.TestCase):
         os = self.create_overload_selector(kind='casts')
         all_types = set(t for sig, impl in os.versions for t in sig)
         # ensure there are no ambiguous cast overloads
-        for sig in product(all_types, all_types):
+        for sig in permutations(all_types, r=2):
             try:
                 os.find(sig)
             except NotImplementedError:

--- a/numba/tests/test_target_overloadselector.py
+++ b/numba/tests/test_target_overloadselector.py
@@ -1,0 +1,120 @@
+from __future__ import print_function
+
+from itertools import product
+
+import numba.unittest_support as unittest
+from numba.targets.base import OverloadSelector
+from numba.targets.registry import cpu_target
+from numba.targets.imputils import builtin_registry, RegistryLoader
+from numba import types
+
+
+class TestOverloadSelector(unittest.TestCase):
+    def test_select_and_sort_1(self):
+        os = OverloadSelector()
+        os.append(1, (types.Any, types.Boolean))
+        os.append(2, (types.Boolean, types.Integer))
+        os.append(3, (types.Boolean, types.Any))
+        os.append(4, (types.Boolean, types.Boolean))
+        compats = os._select_compatible((types.boolean, types.boolean))
+        self.assertEqual(len(compats), 3)
+        ordered, scoring = os._sort_signatures(compats)
+        self.assertEqual(len(ordered), 3)
+        self.assertEqual(len(scoring), 3)
+        self.assertEqual(ordered[0], (types.Boolean, types.Boolean))
+        self.assertEqual(scoring[types.Boolean, types.Boolean], 0)
+        self.assertEqual(scoring[types.Boolean, types.Any], 1)
+        self.assertEqual(scoring[types.Any, types.Boolean], 1)
+
+    def test_select_and_sort_2(self):
+        os = OverloadSelector()
+        os.append(1, (types.Container,))
+        os.append(2, (types.Sequence,))
+        os.append(3, (types.MutableSequence,))
+        os.append(4, (types.List,))
+        compats = os._select_compatible((types.List,))
+        self.assertEqual(len(compats), 4)
+        ordered, scoring = os._sort_signatures(compats)
+        self.assertEqual(len(ordered), 4)
+        self.assertEqual(len(scoring), 4)
+        self.assertEqual(ordered[0], (types.List,))
+        self.assertEqual(scoring[(types.List,)], 0)
+        self.assertEqual(scoring[(types.MutableSequence,)], 1)
+        self.assertEqual(scoring[(types.Sequence,)], 2)
+        self.assertEqual(scoring[(types.Container,)], 3)
+
+    def test_match(self):
+        os = OverloadSelector()
+        self.assertTrue(os._match(formal=types.Boolean, actual=types.boolean))
+        self.assertTrue(os._match(formal=types.Boolean, actual=types.Boolean))
+        # test subclass
+        self.assertTrue(issubclass(types.Sequence, types.Container))
+        self.assertTrue(os._match(formal=types.Container,
+                                  actual=types.Sequence))
+        self.assertFalse(os._match(formal=types.Sequence,
+                                   actual=types.Container))
+        # test any
+        self.assertTrue(os._match(formal=types.Any, actual=types.Any))
+        self.assertTrue(os._match(formal=types.Any, actual=types.Container))
+        self.assertFalse(os._match(formal=types.Container, actual=types.Any))
+
+    def test_ambiguous_detection(self):
+        os = OverloadSelector()
+        # unambiguous signatures
+        os.append(1, (types.Any, types.Boolean))
+        os.append(2, (types.Integer, types.Boolean))
+        self.assertEqual(os.find((types.boolean, types.boolean)), 1)
+        # not implemented
+        with self.assertRaises(NotImplementedError) as raises:
+            os.find((types.boolean, types.int32))
+        # generic
+        os.append(3, (types.Any, types.Any))
+        self.assertEqual(os.find((types.boolean, types.int32)), 3)
+        self.assertEqual(os.find((types.boolean, types.boolean)), 1)
+        # add ambiguous signature; can match (bool, any) and (any, bool)
+        os.append(4, (types.Boolean, types.Any))
+        with self.assertRaises(TypeError) as raises:
+            os.find((types.boolean, types.boolean))
+        self.assertIn('2 ambiguous signatures', str(raises.exception))
+        # disambiguous
+        os.append(5, (types.boolean, types.boolean))
+        self.assertEqual(os.find((types.boolean, types.boolean)), 5)
+
+    def test_subclass_specialization(self):
+        os = OverloadSelector()
+        self.assertTrue(issubclass(types.Sequence, types.Container))
+        os.append(1, (types.Container, types.Container,))
+        lstty = types.List(types.boolean)
+        self.assertEqual(os.find((lstty, lstty)), 1)
+        os.append(2, (types.Container, types.Sequence,))
+        self.assertEqual(os.find((lstty, lstty)), 2)
+
+
+class TestValidateOverloads(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # ensure all impls are loaded
+        cpu_target.target_context.refresh()
+
+    def create_overload_selector(self, kind):
+        os = OverloadSelector()
+        loader = RegistryLoader(builtin_registry)
+        for impl, sig in loader.new_registrations(kind):
+            os.append(impl, sig)
+        return os
+
+    def test_ambiguous_casts(self):
+        os = self.create_overload_selector(kind='casts')
+        all_types = set(t for sig, impl in os.versions for t in sig)
+        # ensure there are no ambiguous cast overloads
+        for sig in product(all_types, all_types):
+            try:
+                os.find(sig)
+            except NotImplementedError:
+                pass   # ignore not implemented cast
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_target_overloadselector.py
+++ b/numba/tests/test_target_overloadselector.py
@@ -90,6 +90,17 @@ class TestOverloadSelector(unittest.TestCase):
         os.append(2, (types.Container, types.Sequence,))
         self.assertEqual(os.find((lstty, lstty)), 2)
 
+    def test_cache(self):
+        os = OverloadSelector()
+        self.assertEqual(len(os._cache), 0)
+        os.append(1, (types.Any,))
+        self.assertEqual(os.find((types.int32,)), 1)
+        self.assertEqual(len(os._cache), 1)
+        os.append(2, (types.Integer,))
+        self.assertEqual(len(os._cache), 0)
+        self.assertEqual(os.find((types.int32,)), 2)
+        self.assertEqual(len(os._cache), 1)
+
 
 class TestAmbiguousOverloads(unittest.TestCase):
 

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -274,6 +274,12 @@ class IterableType(Type):
         """
 
 
+class Sized(Type):
+    """
+    Base class for object that supports len()
+    """
+
+
 class IteratorType(IterableType):
     """
     Base class for all iterator types.
@@ -296,7 +302,7 @@ class IteratorType(IterableType):
         return self
 
 
-class Container(IterableType):
+class Container(Sized, IterableType):
     """
     Base class for container types.
     """

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -276,13 +276,13 @@ class IterableType(Type):
 
 class Sized(Type):
     """
-    Base class for object that supports len()
+    Base class for objects that support len()
     """
 
 
 class ConstSized(Sized):
     """
-    For types that has a constant size
+    For types that have a constant size
     """
     @abstractmethod
     def __len__(self):

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -280,6 +280,15 @@ class Sized(Type):
     """
 
 
+class ConstSized(Sized):
+    """
+    For types that has a constant size
+    """
+    @abstractmethod
+    def __len__(self):
+        pass
+
+
 class IteratorType(IterableType):
     """
     Base class for all iterator types.

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -102,7 +102,7 @@ class MemoryView(Buffer):
     """
 
 
-class BaseTuple(Hashable):
+class BaseTuple(Sized, Hashable):
     """
     The base class for all tuple types (with a known size).
     """

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -102,7 +102,7 @@ class MemoryView(Buffer):
     """
 
 
-class BaseTuple(Sized, Hashable):
+class BaseTuple(ConstSized, Hashable):
     """
     The base class for all tuple types (with a known size).
     """

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -403,6 +403,15 @@ class DeferredType(Type):
             raise TypeError("arg is not a Type; got: {0}".format(type(typ)))
         self._define = typ
 
+        from numba.targets.imputils import lower_cast
+
+        @lower_cast(typ, DeferredType)
+        def any_to_deferred(context, builder, fromty, toty, val):
+            actual = context.cast(builder, val, fromty, toty.get())
+            model = context.data_model_manager[toty]
+            return model.set(builder, model.make_uninitialized(), actual)
+
+
     def unify(self, typingctx, other):
         return typingctx.unify_pairs(self.get(), other)
 

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -403,15 +403,6 @@ class DeferredType(Type):
             raise TypeError("arg is not a Type; got: {0}".format(type(typ)))
         self._define = typ
 
-        from numba.targets.imputils import lower_cast
-
-        @lower_cast(typ, DeferredType)
-        def any_to_deferred(context, builder, fromty, toty, val):
-            actual = context.cast(builder, val, fromty, toty.get())
-            model = context.data_model_manager[toty]
-            return model.set(builder, model.make_uninitialized(), actual)
-
-
     def unify(self, typingctx, other):
         return typingctx.unify_pairs(self.get(), other)
 


### PR DESCRIPTION
As noted in https://github.com/numba/numba/pull/1869#issuecomment-216665765, this improves the  overload selector so that the most specific signature is selected irrespective to the order in which signatures are added.  The old system picks the first matching definition, leading to difficulty to provide a generic (fallback) implementation.