### PR TITLE
fix jinja git templates in jenkins and local recipes

### DIFF
--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: numba
-  version: {{ environ.get('GIT_DESCRIBE_TAG','') }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   git_url: https://github.com/numba/numba
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.numba_entry:main

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -1,13 +1,13 @@
 package:
    name: numba
    # We need to provide a default version
-   version: {{ environ.get('GIT_DESCRIBE_TAG','devel') }}
+   version: {{ GIT_DESCRIBE_TAG }}
 
 source:
    path: ../..
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  number: {{ GIT_DESCRIBE_NUMBER|int }}
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.numba_entry:main


### PR DESCRIPTION
@stefanseefeld - you had some confusion in the jinja templates.  You need to use the variables directly rather than environ.get('GIT_DESCRIBE_VAR').

I have tested these as working correctly, but note that there is a confusing message at build start that doesn't show the version number.  That is because the source hasn't been downloaded yet.  The output of conda build --output should always show correct values, and may download source if it needs it.