### PR TITLE
Robustify check for TLS variable.

### DIFF
--- a/numba/tracing.py
+++ b/numba/tracing.py
@@ -90,7 +90,7 @@ def dotrace(*args, **kwds):
         spec = None
         logger = logging.getLogger('trace')
         def wrapper(*args, **kwds):
-            if not logger.isEnabledFor(logging.INFO) or tls.tracing:
+            if not logger.isEnabledFor(logging.INFO) or getattr(tls, 'tracing', False):
                 return func(*args, **kwds)
 
             fname, ftype = find_function_info(func, spec, args)


### PR DESCRIPTION
This patch fixes a runtime failure where the `tls.tracing` variable is accessed without being defined (which may happen if the given code is run in a thread that wasn't the first to import this module, there by not initializing the TLS variable.