### PR TITLE
Export BLAS and LAPACK wrappers for pycc use

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1249,3 +1249,9 @@ Define bridge for all math functions
 
 #undef MATH_UNARY
 #undef MATH_BINARY
+
+/*
+ * BLAS and LAPACK wrappers
+ */
+
+#include "_lapack.c"

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -9,7 +9,6 @@ Expose all functions as pointers in a dedicated C extension.
 #include "_pymodule.h"
 #include <math.h>
 #include "_helperlib.c"
-#include "_lapack.c"
 
 static PyObject *
 build_c_helpers_dict(void)

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from numba import float32
 from numba.pycc import CC, exportmany, export
+from numba.tests.matmul_usecase import has_blas
 
 
 #
@@ -51,6 +52,7 @@ def sqrt(u):
 def size(arr):
     return arr.size
 
+
 # This one clashes with libc random() unless pycc is careful with naming.
 @cc_helperlib.export('random', 'f8(i4)')
 def random_impl(seed):
@@ -65,6 +67,13 @@ cc_nrt = CC('pycc_test_nrt')
 def zero_scalar(n):
     arr = np.zeros(n)
     return arr[-1]
+
+if has_blas:
+    # This one also needs BLAS
+    @cc_nrt.export('vector_dot', 'f8(i4)')
+    def vector_dot(n):
+        a = np.linspace(1, n, n)
+        return np.dot(a, a)
 
 # This one needs an environment
 @cc_nrt.export('zeros', 'f8[:](i4)')

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -21,6 +21,7 @@ from numba import unittest_support as unittest
 from numba.pycc import main
 from numba.pycc.decorators import clear_export_registry
 from numba.pycc.platform import find_shared_ending, find_pyext_ending
+from .matmul_usecase import has_blas
 from .support import TestCase, tag, import_dynamic, temp_directory
 
 
@@ -244,13 +245,19 @@ class TestCC(BasePYCCTest):
             self.assertPreciseEqual(lib.zero_scalar(1), 0.0)
             res = lib.zeros(3)
             self.assertEqual(list(res), [0, 0, 0])
+            if has_blas:
+                res = lib.vector_dot(4)
+                self.assertPreciseEqual(res, 30.0)
 
             code = """if 1:
                 res = lib.zero_scalar(1)
                 assert res == 0.0
                 res = lib.zeros(3)
                 assert list(res) == [0, 0, 0]
-                """
+                if %(has_blas)s:
+                    res = lib.vector_dot(4)
+                    assert res == 30.0
+                """ % dict(has_blas=has_blas)
             self.check_cc_compiled_in_subprocess(lib, code)
 
 


### PR DESCRIPTION
The BLAS and LAPACK wrappers were left out of pycc-compiled extensions, which made it impossible to call BLAS- and LAPACK-backed functions from AOT-compiled functions.