### PR TITLE
List all lowering implementation in developer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov/
 .ipynb_checkpoints/
 __pycache__/
 
+docs/source/developer/autogen*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -283,3 +283,16 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'llvmlite': ('http://llvmlite.pydata.org/en/latest/', None),
     }
+
+
+# -- Custom autogeneration ------------------------------------------------
+
+def _autogenerate():
+    from numba.scripts.generate_lower_listing import gen_lower_listing
+
+    basedir = os.path.dirname(__file__)
+    gen_lower_listing(os.path.join(basedir,
+                                   'developer/autogen_lower_listing.rst'))
+
+
+_autogenerate()

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -5,6 +5,7 @@ Developer Manual
 ================
 
 .. toctree::
+   :maxdepth: 2
 
    contributing.rst
    architecture.rst
@@ -13,3 +14,4 @@ Developer Manual
    numba-runtime.rst
    rewrites.rst
    live_variable_analysis.rst
+   listings.rst

--- a/docs/source/developer/listings.rst
+++ b/docs/source/developer/listings.rst
@@ -1,6 +1,10 @@
 Listings
 ========
 
+This shows listings from compiler internal registries  (e.g. lowering
+definitions).  The information is provided as developer reference.
+When possible, links to source code are provided via github links.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/developer/listings.rst
+++ b/docs/source/developer/listings.rst
@@ -1,0 +1,7 @@
+Listings
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   autogen_lower_listing.rst

--- a/numba/scripts/generate_lower_listing.py
+++ b/numba/scripts/generate_lower_listing.py
@@ -5,16 +5,21 @@ using reStructured text.
 
 from __future__ import print_function
 
+from subprocess import check_output
+
 import os.path
 from io import StringIO
 from collections import defaultdict
 import inspect
 from functools import partial
-import textwrap
-
 
 import numba
 from numba.targets.registry import cpu_target
+
+
+def git_hash():
+    out = check_output(['git', 'log', "--pretty=format:'%H'", '-n', '1'])
+    return out.decode('ascii').strip("'\"")
 
 
 def gather_function_info(backend):
@@ -32,7 +37,6 @@ def gather_function_info(backend):
                 'name': impl.__qualname__,
                 'filename': os.path.relpath(path, start=basepath),
                 'lines': (firstlineno, firstlineno + len(code) - 1),
-                'source': textwrap.dedent(''.join(code)),
                 'docstring': impl.__doc__
             }
 
@@ -53,6 +57,17 @@ def format_signature(sig):
     return '`({0})`'.format(', '.join(out))
 
 
+github_url = 'https://github.com/numba/numba/blob/{commit}/{path}#L{firstline}-L{lastline}'
+
+description = """
+This lists all lowering definition registered to the CPU target.
+Each subsection corresponds to a Python function that is supported by numba
+nopython mode. These functions have one or more lower implementation with
+different signatures. The compiler chooses the most specific implementation
+from all overloads.
+"""
+
+
 def format_function_infos(fninfos):
     with StringIO() as buf:
         print = bind_file_to_print(buf)
@@ -60,6 +75,10 @@ def format_function_infos(fninfos):
         title_line = "Lowering Listing"
         print(title_line)
         print('=' * len(title_line))
+
+        print(description)
+
+        commit = git_hash()
 
         def format_fname(fn):
             try:
@@ -70,37 +89,49 @@ def format_function_infos(fninfos):
 
         for fn, fname in sorted(map(format_fname, fninfos), key=lambda x: x[1]):
             impinfos = fninfos[fn]
-            header_line = "Lower Impl ``{0}``".format(fname)
+            header_line = "``{0}``".format(fname)
             print(header_line)
             print('-' * len(header_line))
             print()
 
-            formatted_sigs = map(lambda x: format_signature(x['sig']), impinfos)
+            formatted_sigs = map(
+                lambda x: format_signature(x['sig']), impinfos)
             sorted_impinfos = sorted(zip(formatted_sigs, impinfos),
                                      key=lambda x: x[0])
 
-            # generate summary
-            print('Signatures\n')
+            col_signatures = ['Signature']
+            col_urls = ['Definition']
 
             for fmtsig, info in sorted_impinfos:
-                print('* `{0}`'.format(fmtsig))
-            print()
-
-            for fmtsig, info in sorted_impinfos:
-                sig_line = 'signature {0}'.format(fmtsig)
-                print(sig_line)
-                print('~' * len(sig_line))
-                print()
-
                 impl = info['impl']
-                print('by', '``{0}``'.format(impl['name']),
-                      '`{0}`'.format(impl['filename']),
-                      'lines {0}-{1}'.format(*impl['lines']))
-                print()
-                print(".. code-block:: python")
-                print()
-                print(textwrap.indent(impl['source'], prefix=' ' * 4))
-                print()
+
+                filename = impl['filename']
+                lines = impl['lines']
+                fname = impl['name']
+
+                source = '{0} lines {1}-{2}'.format(filename, *lines)
+                link = github_url.format(commit=commit, path=filename,
+                                         firstline=lines[0], lastline=lines[1])
+                url = '``{0}`` `{1} <{2}>`_'.format(fname, source, link)
+
+                col_signatures.append(fmtsig)
+                col_urls.append(url)
+
+            # table formatting
+            max_width_col_sig = max(map(len, col_signatures))
+            max_width_col_url = max(map(len, col_urls))
+            padding = 2
+            width_col_sig = padding * 2 + max_width_col_sig
+            width_col_url = padding * 2 + max_width_col_url
+            line_format = "{{0:^{0}}}  {{1:^{1}}}".format(width_col_sig,
+                                                          width_col_url)
+            print(line_format.format('=' * width_col_sig, '=' * width_col_url))
+            print(line_format.format(col_signatures[0], col_urls[0]))
+            print(line_format.format('=' * width_col_sig, '=' * width_col_url))
+            for sig, url in zip(col_signatures[1:], col_urls[1:]):
+                print(line_format.format(sig, url))
+            print(line_format.format('=' * width_col_sig, '=' * width_col_url))
+            print()
 
         return buf.getvalue()
 

--- a/numba/scripts/generate_lower_listing.py
+++ b/numba/scripts/generate_lower_listing.py
@@ -75,9 +75,11 @@ def format_function_infos(fninfos):
             print('-' * len(header_line))
             print()
 
-            for info in impinfos:
-                sig_line = 'signature {0}'.format(
-                    format_signature(info['sig']))
+            formatted_sigs = map(lambda x: format_signature(x['sig']), impinfos)
+            sorted_impinfos = zip(formatted_sigs, impinfos)
+
+            for fmtsig, info in sorted(sorted_impinfos, key=lambda x: x[0]):
+                sig_line = 'signature {0}'.format(fmtsig)
                 print(sig_line)
                 print('~' * len(sig_line))
                 print()

--- a/numba/scripts/generate_lower_listing.py
+++ b/numba/scripts/generate_lower_listing.py
@@ -1,0 +1,118 @@
+"""
+Generate documentation for all registered implementation for lowering
+using reStructured text.
+"""
+
+from __future__ import print_function
+
+import os.path
+from io import StringIO
+from collections import defaultdict
+import inspect
+from functools import partial
+import textwrap
+
+
+import numba
+from numba.targets.registry import cpu_target
+
+
+def gather_function_info(backend):
+    fninfos = defaultdict(list)
+    basepath = os.path.dirname(os.path.dirname(numba.__file__))
+    for fn, osel in backend._defns.items():
+        for sig, impl in osel.versions:
+            info = {}
+            fninfos[fn].append(info)
+            info['fn'] = fn
+            info['sig'] = sig
+            code, firstlineno = inspect.getsourcelines(impl)
+            path = inspect.getsourcefile(impl)
+            info['impl'] = {
+                'name': impl.__qualname__,
+                'filename': os.path.relpath(path, start=basepath),
+                'lines': (firstlineno, firstlineno + len(code) - 1),
+                'source': textwrap.dedent(''.join(code)),
+                'docstring': impl.__doc__
+            }
+
+    return fninfos
+
+
+def bind_file_to_print(fobj):
+    return partial(print, file=fobj)
+
+
+def format_signature(sig):
+    def fmt(c):
+        try:
+            return c.__name__
+        except AttributeError:
+            return repr(c).strip('\'"')
+    out = tuple(map(fmt, sig))
+    return '`({0})`'.format(', '.join(out))
+
+
+def format_function_infos(fninfos):
+    with StringIO() as buf:
+        print = bind_file_to_print(buf)
+
+        title_line = "Lowering Listing"
+        print(title_line)
+        print('=' * len(title_line))
+
+        def format_fname(fn):
+            try:
+                fname = "{0}.{1}".format(fn.__module__, fn.__qualname__)
+            except AttributeError:
+                fname = repr(fn)
+            return fn, fname
+
+        for fn, fname in sorted(map(format_fname, fninfos), key=lambda x: x[1]):
+            impinfos = fninfos[fn]
+            header_line = "Lower Impl ``{0}``".format(fname)
+            print(header_line)
+            print('-' * len(header_line))
+            print()
+
+            for info in impinfos:
+                sig_line = 'signature {0}'.format(
+                    format_signature(info['sig']))
+                print(sig_line)
+                print('~' * len(sig_line))
+                print()
+
+                impl = info['impl']
+                print('by', '``{0}``'.format(impl['name']),
+                      '`{0}`'.format(impl['filename']),
+                      'lines {0}-{1}'.format(*impl['lines']))
+                print()
+                print(".. code-block:: python")
+                print()
+                print(textwrap.indent(impl['source'], prefix=' ' * 4))
+                print()
+
+        return buf.getvalue()
+
+
+# Main routine for this module:
+
+def gen_lower_listing(path=None):
+    """
+    Generate lowering listing to ``path`` or (if None) to stdout.
+    """
+    cpu_backend = cpu_target.target_context
+    cpu_backend.refresh()
+
+    fninfos = gather_function_info(cpu_backend)
+    out = format_function_infos(fninfos)
+
+    if path is None:
+        print(out)
+    else:
+        with open(path, 'w') as fobj:
+            print(out, file=fobj)
+
+
+if __name__ == '__main__':
+    gen_lower_listing()

--- a/numba/scripts/generate_lower_listing.py
+++ b/numba/scripts/generate_lower_listing.py
@@ -76,9 +76,17 @@ def format_function_infos(fninfos):
             print()
 
             formatted_sigs = map(lambda x: format_signature(x['sig']), impinfos)
-            sorted_impinfos = zip(formatted_sigs, impinfos)
+            sorted_impinfos = sorted(zip(formatted_sigs, impinfos),
+                                     key=lambda x: x[0])
 
-            for fmtsig, info in sorted(sorted_impinfos, key=lambda x: x[0]):
+            # generate summary
+            print('Signatures\n')
+
+            for fmtsig, info in sorted_impinfos:
+                print('* `{0}`'.format(fmtsig))
+            print()
+
+            for fmtsig, info in sorted_impinfos:
                 sig_line = 'signature {0}'.format(fmtsig)
                 print(sig_line)
                 print('~' * len(sig_line))


### PR DESCRIPTION
With the growing number of implemented lowering and specializing overloads that can be in different source files, it becomes harder to find the definition location of the lowering of a supported nopython function.  This patch adds a autogeneration script that runs at documentation generation to add a section in the developer doc with a full listing of all lowering implementation.  In addition to help finding definition location of lowering implementation, this will also:

* show implemented nopython features and the supported signatures
* show how the lowering is implemented via source listing
* help understand the specialization/generialization for potential refactoring.