### PR TITLE
Correctly set the error model when compiling a Numpy ufunc

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -278,16 +278,7 @@ class Pipeline(object):
         targetctx.refresh()
 
         self.typingctx = typingctx
-
-        subtargetoptions = {}
-        if flags.boundcheck:
-            subtargetoptions['enable_boundcheck'] = True
-        if flags.nrt:
-            subtargetoptions['enable_nrt'] = True
-        error_model = callconv.error_models[flags.error_model](targetctx.call_conv)
-        subtargetoptions['error_model'] = error_model
-
-        self.targetctx = targetctx.subtarget(**subtargetoptions)
+        self.targetctx = _make_subtarget(targetctx, flags)
         self.library = library
         self.args = args
         self.return_type = return_type
@@ -677,6 +668,21 @@ class Pipeline(object):
             return self.cr
 
 
+def _make_subtarget(targetctx, flags):
+    """
+    Make a new target context from the given target context and flags.
+    """
+    subtargetoptions = {}
+    if flags.boundcheck:
+        subtargetoptions['enable_boundcheck'] = True
+    if flags.nrt:
+        subtargetoptions['enable_nrt'] = True
+    error_model = callconv.create_error_model(flags.error_model, targetctx)
+    subtargetoptions['error_model'] = error_model
+
+    return targetctx.subtarget(**subtargetoptions)
+
+
 def compile_extra(typingctx, targetctx, func, args, return_type, flags,
                   locals, library=None):
     """
@@ -701,7 +707,9 @@ def compile_bytecode(typingctx, targetctx, bc, args, return_type, flags,
 
 def compile_internal(typingctx, targetctx, library,
                      func, args, return_type, flags, locals):
-    # For now this is the same thing as compile_extra().
+    """
+    For internal use only.
+    """
     pipeline = Pipeline(typingctx, targetctx, library,
                         args, return_type, flags, locals)
     return pipeline.compile_extra(func)

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -340,7 +340,7 @@ def _lower_array_expr(lowerer, expr):
     # division (issue #1223).
     flags = compiler.Flags()
     flags.set('error_model', 'numpy')
-    cres = context.compile_only_no_cache(builder, impl, inner_sig, flags=flags)
+    cres = context.compile_subroutine_no_cache(builder, impl, inner_sig, flags=flags)
 
     # Create kernel subclass calling our native function
     from ..targets import npyimpl

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -491,3 +491,10 @@ error_models = {
     'python': PythonErrorModel,
     'numpy': NumpyErrorModel,
     }
+
+
+def create_error_model(model_name, context):
+    """
+    Create an error model instance for the given target context.
+    """
+    return error_models[model_name](context.call_conv)

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -405,3 +405,18 @@ def impl_ret_untracked(ctx, builder, retty, ret):
     The return type is not a NRT object.
     """
     return ret
+
+
+@contextlib.contextmanager
+def force_error_model(context, model_name='numpy'):
+    """
+    Temporarily change the context's error model.
+    """
+    from . import callconv
+
+    old_error_model = context.error_model
+    context.error_model = callconv.create_error_model(model_name, context)
+    try:
+        yield
+    finally:
+        context.error_model = old_error_model

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -12,8 +12,8 @@ from collections import namedtuple
 
 from llvmlite.llvmpy import core as lc
 
-from . import builtins, ufunc_db, arrayobj
-from .imputils import Registry, impl_ret_new_ref
+from . import builtins, callconv, ufunc_db, arrayobj
+from .imputils import Registry, impl_ret_new_ref, force_error_model
 from .. import typing, types, cgutils, numpy_support, utils
 from ..config import PYVERSION
 from ..numpy_support import ufunc_find_matching_loop, select_array_wrapper
@@ -409,7 +409,8 @@ def _ufunc_db_function(ufunc):
             cast_args = [self.cast(val, inty, outty)
                          for val, inty, outty in zip(args, osig.args,
                                                      isig.args)]
-            res = self.fn(self.context, self.builder, isig, cast_args)
+            with force_error_model(self.context, 'numpy'):
+                res = self.fn(self.context, self.builder, isig, cast_args)
             dmm = self.context.data_model_manager
             res = dmm[isig.return_type].from_return(self.builder, res)
             return self.cast(res, isig.return_type, osig.return_type)

--- a/numba/tests/test_compile_cache.py
+++ b/numba/tests/test_compile_cache.py
@@ -1,11 +1,13 @@
+from __future__ import division
+
 import numba.unittest_support as unittest
 
 import llvmlite.llvmpy.core as lc
 
 import numpy as np
 
-from numba import types, typing
-from numba.targets import cpu
+from numba import compiler, types, typing
+from numba.targets import callconv, cpu
 
 
 class TestCompileCache(unittest.TestCase):
@@ -14,18 +16,7 @@ class TestCompileCache(unittest.TestCase):
     checking the state of the cache when it is used by the CPUContext.
     '''
 
-    def test_cache(self):
-        def times2(i):
-            return 2*i
-
-        def times3(i):
-            return i*3
-
-        def make_closure(x, y):
-            def f(z):
-                return y + z
-            return f
-
+    def _context_builder_sig_args(self):
         typing_context = typing.Context()
         context = cpu.CPUContext(typing_context)
         module = lc.Module("test_module")
@@ -38,6 +29,17 @@ class TestCompileCache(unittest.TestCase):
         assert function.is_declaration
         entry_block = function.append_basic_block('entry')
         builder = lc.Builder(entry_block)
+
+        return context, builder, sig, args
+
+    def test_cache(self):
+        def times2(i):
+            return 2*i
+
+        def times3(i):
+            return i*3
+
+        context, builder, sig, args = self._context_builder_sig_args()
 
         # Ensure the cache is empty to begin with
         self.assertEqual(0, len(context.cached_internal_func))
@@ -59,7 +61,8 @@ class TestCompileCache(unittest.TestCase):
         sig2 = typing.signature(types.float64, types.float64)
         llvm_fnty2 = context.call_conv.get_function_type(sig2.return_type,
                                                          sig2.args)
-        function2 = module.get_or_insert_function(llvm_fnty2, name='test_fn_2')
+        function2 = builder.module.get_or_insert_function(llvm_fnty2,
+                                                          name='test_fn_2')
         args2 = context.call_conv.get_arguments(function2)
         assert function2.is_declaration
         entry_block2 = function2.append_basic_block('entry')
@@ -70,19 +73,61 @@ class TestCompileCache(unittest.TestCase):
         context.compile_internal(builder2, times3, sig2, args2)
         self.assertEqual(3, len(context.cached_internal_func))
 
+    def test_closures(self):
+        """
+        Caching must not mix up closures reusing the same code object.
+        """
+        def make_closure(x, y):
+            def f(z):
+                return y + z
+            return f
+
+        context, builder, sig, args = self._context_builder_sig_args()
+
         # Closures with distinct cell contents must each be compiled.
         clo11 = make_closure(1, 1)
         clo12 = make_closure(1, 2)
         clo22 = make_closure(2, 2)
         res1 = context.compile_internal(builder, clo11, sig, args)
-        self.assertEqual(4, len(context.cached_internal_func))
+        self.assertEqual(1, len(context.cached_internal_func))
         res2 = context.compile_internal(builder, clo12, sig, args)
-        self.assertEqual(5, len(context.cached_internal_func))
+        self.assertEqual(2, len(context.cached_internal_func))
         # Same cell contents as above (first parameter isn't captured)
         res3 = context.compile_internal(builder, clo22, sig, args)
-        self.assertEqual(5, len(context.cached_internal_func))
+        self.assertEqual(2, len(context.cached_internal_func))
+
+    def test_error_model(self):
+        """
+        Caching must not mix up different error models.
+        """
+        def inv(x):
+            return 1.0 / x
+
+        inv_sig = typing.signature(types.float64, types.float64)
+
+        def compile_inv(context):
+            return context.compile_subroutine(builder, inv, inv_sig)
+
+        context, builder, sig, args = self._context_builder_sig_args()
+
+        py_error_model = callconv.create_error_model('python', context)
+        np_error_model = callconv.create_error_model('numpy', context)
+
+        py_context1 = context.subtarget(error_model=py_error_model)
+        py_context2 = context.subtarget(error_model=py_error_model)
+        np_context = context.subtarget(error_model=np_error_model)
+
+        # Note the parent context's cache is shared by subtargets
+        self.assertEqual(0, len(context.cached_internal_func))
+        # Compiling with the same error model reuses the same cache slot
+        compile_inv(py_context1)
+        self.assertEqual(1, len(context.cached_internal_func))
+        compile_inv(py_context2)
+        self.assertEqual(1, len(context.cached_internal_func))
+        # Compiling with another error model creates a new cache slot
+        compile_inv(np_context)
+        self.assertEqual(2, len(context.cached_internal_func))
 
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Also sanitize the handling of the error model in the target context cache.

Hopefully this will fix the non-deterministic errors in `test_power_array_op` on the Jenkins builders.