### PR TITLE
Use `import numpy as np` throughout

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -66,7 +66,7 @@ def to_device(obj, stream=0, copy=True, to=None):
 def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
     """device_array(shape, dtype=np.float, strides=None, order='C', stream=0)
 
-    Allocate an empty device ndarray. Similar to :meth:`np.empty`.
+    Allocate an empty device ndarray. Similar to :meth:`numpy.empty`.
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -3,8 +3,11 @@ API that are reported to numba.cuda
 """
 
 from __future__ import print_function, absolute_import
+
 import contextlib
+
 import numpy as np
+
 from .cudadrv import devicearray, devices, driver
 
 
@@ -28,7 +31,7 @@ def to_device(obj, stream=0, copy=True, to=None):
 
     To copy host->device a numpy array::
 
-        ary = numpy.arange(10)
+        ary = np.arange(10)
         d_ary = cuda.to_device(ary)
 
     To enqueue the transfer to a stream::
@@ -44,7 +47,7 @@ def to_device(obj, stream=0, copy=True, to=None):
 
     To copy device->host to an existing array::
 
-        ary = numpy.empty(shape=d_ary.shape, dtype=d_ary.dtype)
+        ary = np.empty(shape=d_ary.shape, dtype=d_ary.dtype)
         d_ary.copy_to_host(ary)
 
     To enqueue the transfer to a stream::
@@ -63,7 +66,7 @@ def to_device(obj, stream=0, copy=True, to=None):
 def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
     """device_array(shape, dtype=np.float, strides=None, order='C', stream=0)
 
-    Allocate an empty device ndarray. Similar to :meth:`numpy.empty`.
+    Allocate an empty device ndarray. Similar to :meth:`np.empty`.
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)
@@ -75,8 +78,8 @@ def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
 def pinned_array(shape, dtype=np.float, strides=None, order='C'):
     """pinned_array(shape, dtype=np.float, strides=None, order='C')
 
-    Allocate a numpy.ndarray with a buffer that is pinned (pagelocked).
-    Similar to numpy.empty().
+    Allocate a np.ndarray with a buffer that is pinned (pagelocked).
+    Similar to np.empty().
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)
@@ -93,7 +96,7 @@ def mapped_array(shape, dtype=np.float, strides=None, order='C', stream=0,
     """mapped_array(shape, dtype=np.float, strides=None, order='C', stream=0, portable=False, wc=False)
 
     Allocate a mapped ndarray with a buffer that is pinned and mapped on
-    to the device. Similar to numpy.empty()
+    to the device. Similar to np.empty()
 
     :param portable: a boolean flag to allow the allocated device memory to be
               usable in multiple devices.

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -4,11 +4,14 @@ on the object.  If it exists and evaluate to True, it must define shape,
 strides, dtype and size attributes similar to a NumPy ndarray.
 """
 from __future__ import print_function, absolute_import, division
+
 import warnings
 import math
 import copy
 from ctypes import c_void_p
+
 import numpy as np
+
 from . import driver as _driver
 from . import devices
 from numba import dummyarray, types, numpy_support
@@ -63,7 +66,7 @@ class DeviceNDArrayBase(object):
         strides
             array strides.
         dtype
-            data type as numpy.dtype.
+            data type as np.dtype.
         stream
             cuda stream.
         writeback
@@ -276,7 +279,7 @@ class DeviceNDArray(DeviceNDArrayBase):
     def reshape(self, *newshape, **kws):
         """
         Reshape the array without changing its contents, similarly to
-        :meth:`numpy.ndarray.reshape`. Example::
+        :meth:`np.ndarray.reshape`. Example::
 
             d_arr = d_arr.reshape(20, 50, order='F')
         """
@@ -300,7 +303,7 @@ class DeviceNDArray(DeviceNDArrayBase):
     def ravel(self, order='C', stream=0):
         '''
         Flatten the array without changing its contents, similar to
-        :meth:`numpy.ndarray.ravel`.
+        :meth:`np.ndarray.ravel`.
         '''
         stream = self._default_stream(stream)
         cls = type(self)

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -279,7 +279,7 @@ class DeviceNDArray(DeviceNDArrayBase):
     def reshape(self, *newshape, **kws):
         """
         Reshape the array without changing its contents, similarly to
-        :meth:`np.ndarray.reshape`. Example::
+        :meth:`numpy.ndarray.reshape`. Example::
 
             d_arr = d_arr.reshape(20, 50, order='F')
         """
@@ -303,7 +303,7 @@ class DeviceNDArray(DeviceNDArrayBase):
     def ravel(self, order='C', stream=0):
         '''
         Flatten the array without changing its contents, similar to
-        :meth:`np.ndarray.ravel`.
+        :meth:`numpy.ndarray.ravel`.
         '''
         stream = self._default_stream(stream)
         cls = type(self)

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -1,5 +1,7 @@
 import ctypes
-import numpy
+
+import numpy as np
+
 from numba.cuda.cudadrv import driver, drvapi, devices
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.utils import IS_PY3
@@ -33,7 +35,7 @@ class TestCudaMemory(CUDATestCase):
         self._template(devmem)
 
     def test_pinned_memory(self):
-        ary = numpy.arange(10)
+        ary = np.arange(10)
         arybuf = ary if IS_PY3 else buffer(ary)
         devmem = self.context.mempin(arybuf, ary.ctypes.data,
                                      ary.size * ary.dtype.itemsize,
@@ -74,59 +76,59 @@ class TestCudaMemoryFunctions(CUDATestCase):
         del self.context
 
     def test_memcpy(self):
-        hstary = numpy.arange(100, dtype=numpy.uint32)
-        hstary2 = numpy.arange(100, dtype=numpy.uint32)
+        hstary = np.arange(100, dtype=np.uint32)
+        hstary2 = np.arange(100, dtype=np.uint32)
         sz = hstary.size * hstary.dtype.itemsize
         devary = self.context.memalloc(sz)
 
         driver.host_to_device(devary, hstary, sz)
         driver.device_to_host(hstary2, devary, sz)
 
-        self.assertTrue(numpy.all(hstary == hstary2))
+        self.assertTrue(np.all(hstary == hstary2))
 
     def test_memset(self):
-        dtype = numpy.dtype('uint32')
+        dtype = np.dtype('uint32')
         n = 10
         sz = dtype.itemsize * 10
         devary = self.context.memalloc(sz)
         driver.device_memset(devary, 0xab, sz)
 
-        hstary = numpy.empty(n, dtype=dtype)
+        hstary = np.empty(n, dtype=dtype)
         driver.device_to_host(hstary, devary, sz)
 
-        hstary2 = numpy.array([0xabababab] * n, dtype=numpy.dtype('uint32'))
-        self.assertTrue(numpy.all(hstary == hstary2))
+        hstary2 = np.array([0xabababab] * n, dtype=np.dtype('uint32'))
+        self.assertTrue(np.all(hstary == hstary2))
 
     def test_d2d(self):
-        hst = numpy.arange(100, dtype=numpy.uint32)
-        hst2 = numpy.empty_like(hst)
+        hst = np.arange(100, dtype=np.uint32)
+        hst2 = np.empty_like(hst)
         sz = hst.size * hst.dtype.itemsize
         dev1 = self.context.memalloc(sz)
         dev2 = self.context.memalloc(sz)
         driver.host_to_device(dev1, hst, sz)
         driver.device_to_device(dev2, dev1, sz)
         driver.device_to_host(hst2, dev2, sz)
-        self.assertTrue(numpy.all(hst == hst2))
+        self.assertTrue(np.all(hst == hst2))
 
 
 @skip_on_cudasim('CUDA Memory API unsupported in the simulator')
 class TestMVExtent(CUDATestCase):
     def test_c_contiguous_array(self):
-        ary = numpy.arange(100)
+        ary = np.arange(100)
         arysz = ary.dtype.itemsize * ary.size
         s, e = driver.host_memory_extents(ary)
         self.assertTrue(ary.ctypes.data == s)
         self.assertTrue(arysz == driver.host_memory_size(ary))
 
     def test_f_contiguous_array(self):
-        ary = numpy.asfortranarray(numpy.arange(100).reshape(2, 50))
-        arysz = ary.dtype.itemsize * numpy.prod(ary.shape)
+        ary = np.asfortranarray(np.arange(100).reshape(2, 50))
+        arysz = ary.dtype.itemsize * np.prod(ary.shape)
         s, e = driver.host_memory_extents(ary)
         self.assertTrue(ary.ctypes.data == s)
         self.assertTrue(arysz == driver.host_memory_size(ary))
 
     def test_single_element_array(self):
-        ary = numpy.asarray(numpy.uint32(1234))
+        ary = np.asarray(np.uint32(1234))
         arysz = ary.dtype.itemsize
         s, e = driver.host_memory_extents(ary)
         self.assertTrue(ary.ctypes.data == s)

--- a/numba/cuda/tests/cudapy/test_array.py
+++ b/numba/cuda/tests/cudapy/test_array.py
@@ -1,12 +1,14 @@
 from __future__ import print_function, division, absolute_import
-import numpy
+
+import numpy as np
+
 from numba.cuda.testing import unittest
 from numba import cuda
 
 
 class TestCudaArray(unittest.TestCase):
     def test_gpu_array_zero_length(self):
-        x = numpy.arange(0)
+        x = np.arange(0)
         dx = cuda.to_device(x)
         hx = dx.copy_to_host()
         self.assertEqual(x.shape, dx.shape)
@@ -22,11 +24,11 @@ class TestCudaArray(unittest.TestCase):
             if i < x.shape[0]:
                 x[i] = i
 
-        x = numpy.arange(10, dtype=numpy.double)
-        y = numpy.ndarray(shape=10 * 8, buffer=x, dtype=numpy.byte)
-        z = numpy.ndarray(9, buffer=y[4:-4], dtype=numpy.double)
+        x = np.arange(10, dtype=np.double)
+        y = np.ndarray(shape=10 * 8, buffer=x, dtype=np.byte)
+        z = np.ndarray(9, buffer=y[4:-4], dtype=np.double)
         kernel[10, 10](z)
-        self.assertTrue(numpy.allclose(z, list(range(9))))
+        self.assertTrue(np.allclose(z, list(range(9))))
 
     def test_gpu_array_interleaved(self):
 
@@ -37,7 +39,7 @@ class TestCudaArray(unittest.TestCase):
                 x[i] = i
                 y[i] = i
 
-        x = numpy.arange(10, dtype=numpy.double)
+        x = np.arange(10, dtype=np.double)
         y = x[:-1:2]
         # z = x[1::2]
         # n = y.size
@@ -52,8 +54,8 @@ class TestCudaArray(unittest.TestCase):
             # assert z.size == y.size
             # copykernel[1, n](y, x)
             # print(y, z)
-            # assert numpy.all(y == z)
-            # assert numpy.all(y == list(range(n)))
+            # assert np.all(y == z)
+            # assert np.all(y == list(range(n)))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
-import numpy
+
+import numpy as np
+
 from numba import cuda
 from numba.cuda.testing import unittest
 
@@ -17,10 +19,10 @@ class TestCudaArrayArg(unittest.TestCase):
             i = cuda.grid(1)
             y[i] = device_function(x, i)
 
-        x = numpy.arange(10, dtype=numpy.double)
-        y = numpy.zeros_like(x)
+        x = np.arange(10, dtype=np.double)
+        y = np.zeros_like(x)
         kernel[10, 1](x, y)
-        self.assertTrue(numpy.all(x == y))
+        self.assertTrue(np.all(x == y))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -1,13 +1,15 @@
 from __future__ import print_function
-import numpy
+
+import numpy as np
+
 from numba import cuda
 from numba.cuda.testing import unittest
 
 
-CONST1D = numpy.arange(10, dtype=numpy.float64) / 2.
-CONST2D = numpy.asfortranarray(
-                numpy.arange(100, dtype=numpy.int32).reshape(10, 10))
-CONST3D = ((numpy.arange(5*5*5, dtype=numpy.complex64).reshape(5, 5, 5) + 1j) /
+CONST1D = np.arange(10, dtype=np.float64) / 2.
+CONST2D = np.asfortranarray(
+                np.arange(100, dtype=np.int32).reshape(10, 10))
+CONST3D = ((np.arange(5*5*5, dtype=np.complex64).reshape(5, 5, 5) + 1j) /
             2j)
 
 
@@ -35,23 +37,23 @@ class TestCudaConstantMemory(unittest.TestCase):
     def test_const_array(self):
         jcuconst = cuda.jit('void(float64[:])')(cuconst)
         self.assertTrue('.const' in jcuconst.ptx)
-        A = numpy.empty_like(CONST1D)
+        A = np.empty_like(CONST1D)
         jcuconst[2, 5](A)
-        self.assertTrue(numpy.all(A == CONST1D))
+        self.assertTrue(np.all(A == CONST1D))
 
     def test_const_array_2d(self):
         jcuconst2d = cuda.jit('void(int32[:,:])')(cuconst2d)
         self.assertTrue('.const' in jcuconst2d.ptx)
-        A = numpy.empty_like(CONST2D, order='C')
+        A = np.empty_like(CONST2D, order='C')
         jcuconst2d[(2,2), (5,5)](A)
-        self.assertTrue(numpy.all(A == CONST2D))
+        self.assertTrue(np.all(A == CONST2D))
 
     def test_const_array_3d(self):
         jcuconst3d = cuda.jit('void(complex64[:,:,:])')(cuconst3d)
         self.assertTrue('.const' in jcuconst3d.ptx)
-        A = numpy.empty_like(CONST3D, order='F')
+        A = np.empty_like(CONST3D, order='F')
         jcuconst3d[1, (5, 5, 5)](A)
-        self.assertTrue(numpy.all(A == CONST3D))
+        self.assertTrue(np.all(A == CONST3D))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
-import numpy
+
+import numpy as np
+
 from numba import config, cuda, jit
 from numba.cuda.testing import unittest
 
@@ -21,10 +23,10 @@ class TestException(unittest.TestCase):
         if not config.ENABLE_CUDASIM:
             # Simulator throws exceptions regardless of debug
             # setting
-            unsafe_foo[1, 2](numpy.array([0, 1]))
+            unsafe_foo[1, 2](np.array([0, 1]))
 
         with self.assertRaises(IndexError) as cm:
-            safe_foo[1, 2](numpy.array([0, 1]))
+            safe_foo[1, 2](np.array([0, 1]))
         self.assertIn("tuple index out of range", str(cm.exception))
 
     def test_user_raise(self):

--- a/numba/cuda/tests/cudapy/test_forall.py
+++ b/numba/cuda/tests/cudapy/test_forall.py
@@ -1,8 +1,10 @@
 from __future__ import print_function, absolute_import
+
+import numpy as np
+
 from numba import cuda
 import numba.unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
-import numpy
 
 @skip_on_cudasim('forall API unsupported in the simulator')
 class TestForAll(unittest.TestCase):
@@ -14,10 +16,10 @@ class TestForAll(unittest.TestCase):
             if i < x.size:
                 x[i] += 1
 
-        arr = numpy.arange(11)
+        arr = np.arange(11)
         orig = arr.copy()
         foo.forall(arr.size)(arr)
-        self.assertTrue(numpy.all(arr == orig + 1))
+        self.assertTrue(np.all(arr == orig + 1))
 
     def test_forall_2(self):
 
@@ -27,12 +29,12 @@ class TestForAll(unittest.TestCase):
             if i < x.size:
                 y[i] = a * x[i] + y[i]
 
-        x = numpy.arange(13, dtype=numpy.float32)
-        y = numpy.arange(13, dtype=numpy.float32)
+        x = np.arange(13, dtype=np.float32)
+        y = np.arange(13, dtype=np.float32)
         oldy = y.copy()
         a = 1.234
         bar.forall(y.size)(a, x, y)
-        self.assertTrue(numpy.all(y == (a * x + oldy)))
+        self.assertTrue(np.all(y == (a * x + oldy)))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_freevar.py
+++ b/numba/cuda/tests/cudapy/test_freevar.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
-import numpy
+
+import numpy as np
+
 from numba import cuda
 from numba.cuda.testing import unittest
 
@@ -20,7 +22,7 @@ class TestFreeVar(unittest.TestCase):
                                       dtype=nbtype)  # nbtype is freevar
             A[i] = sdata[i]
 
-        A = numpy.arange(2, dtype="float32")
+        A = np.arange(2, dtype="float32")
         foo(A, 0)
 
 

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -1,10 +1,13 @@
 from __future__ import print_function, absolute_import
-from numba import void, float32, float64
+
+from timeit import default_timer as time
+
 import numpy as np
 import numpy.core.umath_tests as ut
+
+from numba import void, float32, float64
 from numba import guvectorize
 from numba import cuda
-from timeit import default_timer as time
 from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
 

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import, division
-import numpy
+
+import numpy as np
+
 from numba import cuda, int32, complex128
 from numba.cuda.testing import unittest
 
@@ -32,10 +34,10 @@ class TestCudaLocalMem(unittest.TestCase):
     def test_local_array(self):
         jculocal = cuda.jit('void(int32[:], int32[:])')(culocal)
         self.assertTrue('.local' in jculocal.ptx)
-        A = numpy.arange(1000, dtype='int32')
-        B = numpy.zeros_like(A)
+        A = np.arange(1000, dtype='int32')
+        B = np.zeros_like(A)
         jculocal(A, B)
-        self.assertTrue(numpy.all(A == B))
+        self.assertTrue(np.all(A == B))
 
     def test_local_array_1_tuple(self):
         """Ensure that the macro can be use with 1-tuple
@@ -43,20 +45,20 @@ class TestCudaLocalMem(unittest.TestCase):
         jculocal = cuda.jit('void(int32[:], int32[:])')(culocal1tuple)
         # Don't check if .local is in the ptx because the optimizer
         # may reduce it to registers.
-        A = numpy.arange(5, dtype='int32')
-        B = numpy.zeros_like(A)
+        A = np.arange(5, dtype='int32')
+        B = np.zeros_like(A)
         jculocal(A, B)
-        self.assertTrue(numpy.all(A == B))
+        self.assertTrue(np.all(A == B))
 
     def test_local_array_complex(self):
         sig = 'void(complex128[:], complex128[:])'
         jculocalcomplex = cuda.jit(sig)(culocalcomplex)
         # The local memory would be turned into register
         # self.assertTrue('.local' in jculocalcomplex.ptx)
-        A = (numpy.arange(100, dtype='complex128') - 1) / 2j
-        B = numpy.zeros_like(A)
+        A = (np.arange(100, dtype='complex128') - 1) / 2j
+        B = np.zeros_like(A)
         jculocalcomplex(A, B)
-        self.assertTrue(numpy.all(A == B))
+        self.assertTrue(np.all(A == B))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import numpy
+import numpy as np
 
 from numba import cuda
 from numba import unittest_support as unittest
@@ -57,7 +57,7 @@ class TestPrint(unittest.TestCase):
         Eyeballing required
         """
         jcuprintary = cuda.jit('void(float32[:])')(cuprintary)
-        A = numpy.arange(10, dtype=numpy.float32)
+        A = np.arange(10, dtype=np.float32)
         jcuprintary[2, 5](A)
         cuda.synchronize()
 

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -1,9 +1,12 @@
 from __future__ import print_function, division
+
+from collections import namedtuple
 import itertools
 import functools
 import operator
-import numpy
-from collections import namedtuple
+
+import numpy as np
+
 
 Extent = namedtuple("Extent", ["begin", "end"])
 
@@ -160,7 +163,7 @@ class Array(object):
         self.shape = tuple(dim.size for dim in self.dims)
         self.strides = tuple(dim.stride for dim in self.dims)
         self.itemsize = itemsize
-        self.size = numpy.prod(self.shape)
+        self.size = np.prod(self.shape)
         self.extent = self._compute_extent()
         self.flags = self._compute_layout()
 

--- a/numba/npdatetime.py
+++ b/numba/npdatetime.py
@@ -1,5 +1,5 @@
 """
-Helper functions for numpy.timedelta64 and numpy.datetime64.
+Helper functions for np.timedelta64 and np.datetime64.
 For now, multiples-of-units (for example timedeltas expressed in tens
 of seconds) are not supported.
 """

--- a/numba/npyufunc/deviceufunc.py
+++ b/numba/npyufunc/deviceufunc.py
@@ -166,7 +166,7 @@ class UFuncMechanism(object):
 
     def _get_actual_args(self):
         """Return the actual arguments
-        Casts scalar arguments to numpy.array.
+        Casts scalar arguments to np.array.
         """
         for i in self.scalarpos:
             self.arrays[i] = np.array([self.args[i]], dtype=self.argtypes[i])

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function, division
-import numpy
+
+import numpy as np
 
 from .. import jit, typeof, utils, types, numpy_support, sigutils
 from ..typing import npydecl
@@ -147,7 +148,7 @@ class DUFunc(_internal._DUFunc):
         # To avoid a mismatch in how Numba types values as opposed to
         # Numpy, we need to first check for scalars.  For example, on
         # 64-bit systems, numba.typeof(3) => int32, but
-        # numpy.array(3).dtype => int64.
+        # np.array(3).dtype => int64.
         for arg in args[:nin]:
             if numpy_support.is_arrayscalar(arg):
                 argtys.append(numpy_support.map_arrayscalar_type(arg))

--- a/numba/smartarray.py
+++ b/numba/smartarray.py
@@ -1,6 +1,8 @@
 from numba.tracing import trace
-import numpy
+
 import sys
+
+import numpy as np
 
 def _o2s(dtype, shape, order):
     # convert order parameter to strides
@@ -121,7 +123,7 @@ class SmartArray(object):
     def __array__(self, *args):
 
         self._sync('host')
-        return numpy.array(self._host, *args)
+        return np.array(self._host, *args)
 
     def _sync(self, where):
         """Sync the data in one memory space with the other."""
@@ -150,12 +152,12 @@ class SmartArray(object):
     def _allocate(self, where, obj=None, dtype=None, shape=None, strides=None,
                   copy=True):
         if dtype:
-            dtype = numpy.dtype(dtype)
+            dtype = np.dtype(dtype)
         if where == 'host':
             if obj is not None:
-                self._host = numpy.array(obj, dtype, copy=copy)
+                self._host = np.array(obj, dtype, copy=copy)
             else:
-                self._host = numpy.empty(shape, dtype, _s2o(dtype, shape, strides))
+                self._host = np.empty(shape, dtype, _s2o(dtype, shape, strides))
         else:
             # Don't import this at module-scope as it may not be available
             # in all environments (e.g., CUDASIM)
@@ -163,8 +165,8 @@ class SmartArray(object):
             if obj is not None:
                 # If 'obj' is an array-like object but not an ndarray,
                 # construct an ndarray first to extract all the parameters we need.
-                if not isinstance(obj, numpy.ndarray):
-                    obj = numpy.array(obj, copy=False)
+                if not isinstance(obj, np.ndarray):
+                    obj = np.array(obj, copy=False)
                 self._gpu = da.from_array_like(obj)
             else:
                 if strides is None:
@@ -186,7 +188,7 @@ class SmartArray(object):
         """If `value` is an ndarray, wrap it in a SmartArray,
         otherwise return `value` itself."""
 
-        if isinstance(value, numpy.ndarray):
+        if isinstance(value, np.ndarray):
             return SmartArray(value, copy=False)
         else:
             return value

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -12,7 +12,8 @@ from llvmlite import ir
 import llvmlite.llvmpy.core as lc
 from llvmlite.llvmpy.core import Constant
 
-import numpy
+import numpy as np
+
 from numba import types, cgutils, typing, utils
 from numba.numpy_support import as_dtype, carray, farray
 from numba.numpy_support import version as numpy_version
@@ -1271,7 +1272,7 @@ def array_ravel(context, builder, sig, args):
     return res
 
 
-@lower_builtin(numpy.ravel, types.Array)
+@lower_builtin(np.ravel, types.Array)
 def np_ravel(context, builder, sig, args):
     def np_ravel_impl(a):
         return a.ravel()
@@ -1749,7 +1750,7 @@ def array_is(context, builder, sig, args):
 
 
 #-------------------------------------------------------------------------------
-# builtin `numpy.flat` implementation
+# builtin `np.flat` implementation
 
 def make_array_flat_cls(flatiterty):
     """
@@ -2474,7 +2475,7 @@ def iternext_numpy_getitem(context, builder, sig, args):
     return arr.nitems
 
 
-@lower_builtin(numpy.ndenumerate, types.Array)
+@lower_builtin(np.ndenumerate, types.Array)
 def make_array_ndenumerate(context, builder, sig, args):
     arrty, = sig.args
     arr, = args
@@ -2509,7 +2510,7 @@ def iternext_numpy_nditer(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, arrty, arr, result)
 
 
-@lower_builtin(numpy.ndindex, types.VarArg(types.Integer))
+@lower_builtin(np.ndindex, types.VarArg(types.Integer))
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(*shape)"""
     shape = [context.cast(builder, arg, argty, types.intp)
@@ -2522,7 +2523,7 @@ def make_array_ndindex(context, builder, sig, args):
     res = nditer._getvalue()
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.ndindex, types.BaseTuple)
+@lower_builtin(np.ndindex, types.BaseTuple)
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(shape)"""
     ndim = sig.return_type.ndim
@@ -2555,7 +2556,7 @@ def iternext_numpy_ndindex(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, result)
 
 
-@lower_builtin(numpy.nditer, types.Any)
+@lower_builtin(np.nditer, types.Any)
 def make_array_nditer(context, builder, sig, args):
     """
     nditer(...)
@@ -2696,23 +2697,23 @@ def _parse_empty_like_args(context, builder, sig, args):
         return sig.return_type, ()
 
 
-@lower_builtin(numpy.empty, types.Any)
-@lower_builtin(numpy.empty, types.Any, types.Any)
+@lower_builtin(np.empty, types.Any)
+@lower_builtin(np.empty, types.Any, types.Any)
 def numpy_empty_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
     return impl_ret_new_ref(context, builder, sig.return_type, ary._getvalue())
 
-@lower_builtin(numpy.empty_like, types.Any)
-@lower_builtin(numpy.empty_like, types.Any, types.DTypeSpec)
+@lower_builtin(np.empty_like, types.Any)
+@lower_builtin(np.empty_like, types.Any, types.DTypeSpec)
 def numpy_empty_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
     return impl_ret_new_ref(context, builder, sig.return_type, ary._getvalue())
 
 
-@lower_builtin(numpy.zeros, types.Any)
-@lower_builtin(numpy.zeros, types.Any, types.Any)
+@lower_builtin(np.zeros, types.Any)
+@lower_builtin(np.zeros, types.Any, types.Any)
 def numpy_zeros_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -2720,8 +2721,8 @@ def numpy_zeros_nd(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, ary._getvalue())
 
 
-@lower_builtin(numpy.zeros_like, types.Any)
-@lower_builtin(numpy.zeros_like, types.Any, types.DTypeSpec)
+@lower_builtin(np.zeros_like, types.Any)
+@lower_builtin(np.zeros_like, types.Any, types.DTypeSpec)
 def numpy_zeros_like_nd(context, builder, sig, args):
     arrtype, shapes = _parse_empty_like_args(context, builder, sig, args)
     ary = _empty_nd_impl(context, builder, arrtype, shapes)
@@ -2730,24 +2731,24 @@ def numpy_zeros_like_nd(context, builder, sig, args):
 
 
 if numpy_version >= (1, 8):
-    @lower_builtin(numpy.full, types.Any, types.Any)
+    @lower_builtin(np.full, types.Any, types.Any)
     def numpy_full_nd(context, builder, sig, args):
 
         def full(shape, value):
-            arr = numpy.empty(shape)
-            for idx in numpy.ndindex(arr.shape):
+            arr = np.empty(shape)
+            for idx in np.ndindex(arr.shape):
                 arr[idx] = value
             return arr
 
         res = context.compile_internal(builder, full, sig, args)
         return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-    @lower_builtin(numpy.full, types.Any, types.Any, types.DTypeSpec)
+    @lower_builtin(np.full, types.Any, types.Any, types.DTypeSpec)
     def numpy_full_dtype_nd(context, builder, sig, args):
 
         def full(shape, value, dtype):
-            arr = numpy.empty(shape, dtype)
-            for idx in numpy.ndindex(arr.shape):
+            arr = np.empty(shape, dtype)
+            for idx in np.ndindex(arr.shape):
                 arr[idx] = value
             return arr
 
@@ -2755,12 +2756,12 @@ if numpy_version >= (1, 8):
         return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-    @lower_builtin(numpy.full_like, types.Any, types.Any)
+    @lower_builtin(np.full_like, types.Any, types.Any)
     def numpy_full_like_nd(context, builder, sig, args):
 
         def full_like(arr, value):
-            arr = numpy.empty_like(arr)
-            for idx in numpy.ndindex(arr.shape):
+            arr = np.empty_like(arr)
+            for idx in np.ndindex(arr.shape):
                 arr[idx] = value
             return arr
 
@@ -2768,12 +2769,12 @@ if numpy_version >= (1, 8):
         return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-    @lower_builtin(numpy.full_like, types.Any, types.Any, types.DTypeSpec)
+    @lower_builtin(np.full_like, types.Any, types.Any, types.DTypeSpec)
     def numpy_full_like_nd(context, builder, sig, args):
 
         def full_like(arr, value, dtype):
-            arr = numpy.empty_like(arr, dtype)
-            for idx in numpy.ndindex(arr.shape):
+            arr = np.empty_like(arr, dtype)
+            for idx in np.ndindex(arr.shape):
                 arr[idx] = value
             return arr
 
@@ -2781,12 +2782,12 @@ if numpy_version >= (1, 8):
         return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-@lower_builtin(numpy.ones, types.Any)
+@lower_builtin(np.ones, types.Any)
 def numpy_ones_nd(context, builder, sig, args):
 
     def ones(shape):
-        arr = numpy.empty(shape)
-        for idx in numpy.ndindex(arr.shape):
+        arr = np.empty(shape)
+        for idx in np.ndindex(arr.shape):
             arr[idx] = 1
         return arr
 
@@ -2795,36 +2796,36 @@ def numpy_ones_nd(context, builder, sig, args):
                                    locals={'c': valty})
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.ones, types.Any, types.DTypeSpec)
+@lower_builtin(np.ones, types.Any, types.DTypeSpec)
 def numpy_ones_dtype_nd(context, builder, sig, args):
 
     def ones(shape, dtype):
-        arr = numpy.empty(shape, dtype)
-        for idx in numpy.ndindex(arr.shape):
+        arr = np.empty(shape, dtype)
+        for idx in np.ndindex(arr.shape):
             arr[idx] = 1
         return arr
 
     res = context.compile_internal(builder, ones, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.ones_like, types.Any)
+@lower_builtin(np.ones_like, types.Any)
 def numpy_ones_like_nd(context, builder, sig, args):
 
     def ones_like(arr):
-        arr = numpy.empty_like(arr)
-        for idx in numpy.ndindex(arr.shape):
+        arr = np.empty_like(arr)
+        for idx in np.ndindex(arr.shape):
             arr[idx] = 1
         return arr
 
     res = context.compile_internal(builder, ones_like, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.ones_like, types.Any, types.DTypeSpec)
+@lower_builtin(np.ones_like, types.Any, types.DTypeSpec)
 def numpy_ones_like_dtype_nd(context, builder, sig, args):
 
     def ones_like(arr, dtype):
-        arr = numpy.empty_like(arr, dtype)
-        for idx in numpy.ndindex(arr.shape):
+        arr = np.empty_like(arr, dtype)
+        for idx in np.ndindex(arr.shape):
             arr[idx] = 1
         return arr
 
@@ -2832,11 +2833,11 @@ def numpy_ones_like_dtype_nd(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-@lower_builtin(numpy.identity, types.Integer)
+@lower_builtin(np.identity, types.Integer)
 def numpy_identity(context, builder, sig, args):
 
     def identity(n):
-        arr = numpy.zeros((n, n))
+        arr = np.zeros((n, n))
         for i in range(n):
             arr[i, i] = 1
         return arr
@@ -2844,11 +2845,11 @@ def numpy_identity(context, builder, sig, args):
     res = context.compile_internal(builder, identity, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.identity, types.Integer, types.DTypeSpec)
+@lower_builtin(np.identity, types.Integer, types.DTypeSpec)
 def numpy_identity(context, builder, sig, args):
 
     def identity(n, dtype):
-        arr = numpy.zeros((n, n), dtype)
+        arr = np.zeros((n, n), dtype)
         for i in range(n):
             arr[i, i] = 1
         return arr
@@ -2857,40 +2858,40 @@ def numpy_identity(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-@lower_builtin(numpy.eye, types.Integer)
+@lower_builtin(np.eye, types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n):
-        return numpy.identity(n)
+        return np.identity(n)
 
     res = context.compile_internal(builder, eye, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.eye, types.Integer, types.Integer)
+@lower_builtin(np.eye, types.Integer, types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m):
-        return numpy.eye(n, m, 0, numpy.float64)
+        return np.eye(n, m, 0, np.float64)
 
     res = context.compile_internal(builder, eye, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.eye, types.Integer, types.Integer,
+@lower_builtin(np.eye, types.Integer, types.Integer,
            types.Integer)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m, k):
-        return numpy.eye(n, m, k, numpy.float64)
+        return np.eye(n, m, k, np.float64)
 
     res = context.compile_internal(builder, eye, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.eye, types.Integer, types.Integer,
+@lower_builtin(np.eye, types.Integer, types.Integer,
            types.Integer, types.DTypeSpec)
 def numpy_eye(context, builder, sig, args):
 
     def eye(n, m, k, dtype):
-        arr = numpy.zeros((n, m), dtype)
+        arr = np.zeros((n, m), dtype)
         if k >= 0:
             d = min(n, m - k)
             for i in range(d):
@@ -2904,13 +2905,13 @@ def numpy_eye(context, builder, sig, args):
     res = context.compile_internal(builder, eye, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.diag, types.Array)
+@lower_builtin(np.diag, types.Array)
 def numpy_diag(context, builder, sig, args):
     def diag_impl(val):
-        return numpy.diag(val, k=0)
+        return np.diag(val, k=0)
     return context.compile_internal(builder, diag_impl, sig, args)
 
-@lower_builtin(numpy.diag, types.Array, types.Integer)
+@lower_builtin(np.diag, types.Array, types.Integer)
 def numpy_diag_kwarg(context, builder, sig, args):
     arg = sig.args[0]
     if arg.ndim == 1:
@@ -2918,7 +2919,7 @@ def numpy_diag_kwarg(context, builder, sig, args):
         def diag_impl(arr, k=0):
             s = arr.shape
             n = s[0] + abs(k)
-            ret = numpy.zeros((n, n), arr.dtype)
+            ret = np.zeros((n, n), arr.dtype)
             if k >= 0:
                 for i in range(n - k):
                     ret[i, k + i] = arr[i]
@@ -2938,7 +2939,7 @@ def numpy_diag_kwarg(context, builder, sig, args):
             if k > 0:
                 cols = cols - k
             n = max(min(rows, cols), 0)
-            ret = numpy.empty(n, arr.dtype)
+            ret = np.empty(n, arr.dtype)
             if k >= 0:
                 for i in range(n):
                     ret[i] = arr[i, k + i]
@@ -2953,39 +2954,39 @@ def numpy_diag_kwarg(context, builder, sig, args):
     res = context.compile_internal(builder, diag_impl, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.arange, types.Number)
+@lower_builtin(np.arange, types.Number)
 def numpy_arange_1(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
     def arange(stop):
-        return numpy.arange(0, stop, 1, dtype)
+        return np.arange(0, stop, 1, dtype)
 
     res = context.compile_internal(builder, arange, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.arange, types.Number, types.Number)
+@lower_builtin(np.arange, types.Number, types.Number)
 def numpy_arange_2(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
     def arange(start, stop):
-        return numpy.arange(start, stop, 1, dtype)
+        return np.arange(start, stop, 1, dtype)
 
     res = context.compile_internal(builder, arange, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-@lower_builtin(numpy.arange, types.Number, types.Number,
+@lower_builtin(np.arange, types.Number, types.Number,
            types.Number)
 def numpy_arange_3(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
     def arange(start, stop, step):
-        return numpy.arange(start, stop, step, dtype)
+        return np.arange(start, stop, step, dtype)
 
     res = context.compile_internal(builder, arange, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.arange, types.Number, types.Number,
+@lower_builtin(np.arange, types.Number, types.Number,
            types.Number, types.DTypeSpec)
 def numpy_arange_4(context, builder, sig, args):
 
@@ -2995,7 +2996,7 @@ def numpy_arange_4(context, builder, sig, args):
             nitems_r = math.ceil(nitems_c.real)
             nitems_i = math.ceil(nitems_c.imag)
             nitems = max(min(nitems_i, nitems_r), 0)
-            arr = numpy.empty(nitems, dtype)
+            arr = np.empty(nitems, dtype)
             val = start
             for i in range(nitems):
                 arr[i] = val
@@ -3005,7 +3006,7 @@ def numpy_arange_4(context, builder, sig, args):
         def arange(start, stop, step, dtype):
             nitems_r = math.ceil((stop - start) / step)
             nitems = max(nitems_r, 0)
-            arr = numpy.empty(nitems, dtype)
+            arr = np.empty(nitems, dtype)
             val = start
             for i in range(nitems):
                 arr[i] = val
@@ -3016,22 +3017,22 @@ def numpy_arange_4(context, builder, sig, args):
                                    locals={'nitems': types.intp})
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.linspace, types.Number, types.Number)
+@lower_builtin(np.linspace, types.Number, types.Number)
 def numpy_linspace_2(context, builder, sig, args):
 
     def linspace(start, stop):
-        return numpy.linspace(start, stop, 50)
+        return np.linspace(start, stop, 50)
 
     res = context.compile_internal(builder, linspace, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin(numpy.linspace, types.Number, types.Number,
+@lower_builtin(np.linspace, types.Number, types.Number,
            types.Integer)
 def numpy_linspace_3(context, builder, sig, args):
     dtype = as_dtype(sig.return_type.dtype)
 
     def linspace(start, stop, num):
-        arr = numpy.empty(num, dtype)
+        arr = np.empty(num, dtype)
         div = num - 1
         delta = stop - start
         arr[0] = start
@@ -3084,11 +3085,11 @@ def _array_copy(context, builder, sig, args):
 def array_copy(context, builder, sig, args):
     return _array_copy(context, builder, sig, args)
 
-@lower_builtin(numpy.copy, types.Array)
+@lower_builtin(np.copy, types.Array)
 def numpy_copy(context, builder, sig, args):
     return _array_copy(context, builder, sig, args)
 
-@lower_builtin(numpy.asfortranarray, types.Array)
+@lower_builtin(np.asfortranarray, types.Array)
 def array_asfortranarray(context, builder, sig, args):
     retty = sig.return_type
     aryty = sig.args[0]
@@ -3148,8 +3149,8 @@ def array_astype(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, ret._getvalue())
 
 
-@lower_builtin(numpy.frombuffer, types.Buffer)
-@lower_builtin(numpy.frombuffer, types.Buffer, types.DTypeSpec)
+@lower_builtin(np.frombuffer, types.Buffer)
+@lower_builtin(np.frombuffer, types.Buffer, types.DTypeSpec)
 def np_frombuffer(context, builder, sig, args):
     bufty = sig.args[0]
     aryty = sig.return_type
@@ -3378,8 +3379,8 @@ def assign_sequence_to_array(context, builder, data, shapes, strides,
     assign(seqty, seq, shapes, ())
 
 
-@lower_builtin(numpy.array, types.Any)
-@lower_builtin(numpy.array, types.Any, types.DTypeSpec)
+@lower_builtin(np.array, types.Any)
+@lower_builtin(np.array, types.Any, types.DTypeSpec)
 def np_array(context, builder, sig, args):
     arrty = sig.return_type
     ndim = arrty.ndim
@@ -3437,7 +3438,7 @@ def array_sort(context, builder, sig, args):
     return context.compile_internal(builder, array_sort_impl, sig, args)
 
 
-@lower_builtin(numpy.sort, types.Array)
+@lower_builtin(np.sort, types.Array)
 def np_sort(context, builder, sig, args):
 
     def np_sort_impl(a):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -5,7 +5,7 @@ import copy
 import os
 import sys
 
-import numpy
+import numpy as np
 
 from llvmlite import ir as llvmir
 import llvmlite.llvmpy.core as lc
@@ -805,7 +805,7 @@ class BaseContext(object):
         cshape = Constant.array(llintp, shapevals)
 
         # Handle strides: use strides of the equivalent C-contiguous array.
-        contig = numpy.ascontiguousarray(ary)
+        contig = np.ascontiguousarray(ary)
         stridevals = [self.get_constant(types.intp, s) for s in contig.strides]
         cstrides = Constant.array(llintp, stridevals)
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 import math
 from functools import reduce
 
-import numpy
+import numpy as np
 
 from llvmlite import ir
 from llvmlite.llvmpy.core import Type, Constant
@@ -221,7 +221,7 @@ def number_constructor(context, builder, sig, args):
     """
     if isinstance(sig.return_type, types.Array):
         # Array constructor
-        impl = context.get_function(numpy.array, sig)
+        impl = context.get_function(np.array, sig)
         return impl(builder, args)
     else:
         # Scalar constructor

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -115,7 +115,7 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
 # In NumPy, a division by zero does not raise an exception, but instead
 # generated a known value. Note that a division by zero in any of the
 # operations of a vector may raise an exception or issue a warning
-# depending on the numpy.seterr configuration. This is not supported
+# depending on the np.seterr configuration. This is not supported
 # right now (and in any case, it won't be handled by these functions
 # either)
 

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -4,13 +4,14 @@ Implementation of functions in the Numpy package.
 
 from __future__ import print_function, division, absolute_import
 
-import numpy
 import math
 import sys
 import itertools
 from collections import namedtuple
 
 from llvmlite.llvmpy import core as lc
+
+import numpy as np
 
 from . import builtins, ufunc_db, arrayobj
 from .imputils import Registry, impl_ret_new_ref
@@ -520,7 +521,7 @@ def array_positive_impl(context, builder, sig, args):
 for _op_map in (npydecl.NumpyRulesUnaryArrayOperator._op_map,
                 npydecl.NumpyRulesArrayOperator._op_map):
     for operator, ufunc_name in _op_map.items():
-        ufunc = getattr(numpy, ufunc_name)
+        ufunc = getattr(np, ufunc_name)
         kernel = _kernels[ufunc]
         if ufunc.nin == 1:
             register_unary_operator_kernel(operator, kernel)

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import math
 
-import numpy
+import numpy as np
 
 from llvmlite import ir
 from llvmlite.llvmpy.core import Type, Constant

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -1,5 +1,5 @@
 """
-Implement the random and numpy.random module functions.
+Implement the random and np.random module functions.
 """
 
 from __future__ import print_function, absolute_import, division

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import sys
 
-import numpy
+import numpy as np
 
 from numba import config, unittest_support as unittest
 from numba.npyufunc.ufuncbuilder import GUFuncBuilder
@@ -84,10 +84,10 @@ class TestUfuncBuilding(TestCase):
 
         def check(a):
             b = ufunc(a, a)
-            self.assertTrue(numpy.all(a + a == b))
+            self.assertTrue(np.all(a + a == b))
             self.assertEqual(b.dtype, a.dtype)
 
-        a = numpy.arange(12, dtype='int32')
+        a = np.arange(12, dtype='int32')
         check(a)
         # Non-contiguous dimension
         a = a[::2]
@@ -107,10 +107,10 @@ class TestUfuncBuilding(TestCase):
 
         def check(a):
             b = ufunc(a, a)
-            self.assertTrue(numpy.all(a + a == b))
+            self.assertTrue(np.all(a + a == b))
             self.assertEqual(b.dtype, a.dtype)
 
-        a = numpy.arange(12, dtype='complex64') + 1j
+        a = np.arange(12, dtype='complex64') + 1j
         check(a)
         # Non-contiguous dimension
         a = a[::2]
@@ -124,9 +124,9 @@ class TestUfuncBuilding(TestCase):
         self.assertTrue(cres.objectmode)
         ufunc = ufb.build_ufunc()
 
-        a = numpy.arange(10, dtype='int32')
+        a = np.arange(10, dtype='int32')
         b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
+        self.assertTrue(np.all(a + a == b))
 
     def test_nested_call(self):
         """
@@ -167,11 +167,11 @@ class TestGUfuncBuilding(TestCase):
         self.assertFalse(cres.objectmode)
         ufunc = gufb.build_ufunc()
 
-        a = numpy.arange(10, dtype="int32").reshape(2, 5)
+        a = np.arange(10, dtype="int32").reshape(2, 5)
         b = ufunc(a, a)
 
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('int32'))
+        self.assertTrue(np.all(a + a == b))
+        self.assertEqual(b.dtype, np.dtype('int32'))
 
         # Metadata
         self.assertEqual(ufunc.__name__, "guadd")
@@ -184,10 +184,10 @@ class TestGUfuncBuilding(TestCase):
         self.assertFalse(cres.objectmode)
         ufunc = gufb.build_ufunc()
 
-        a = numpy.arange(10, dtype="complex64").reshape(2, 5) + 1j
+        a = np.arange(10, dtype="complex64").reshape(2, 5) + 1j
         b = ufunc(a, a)
 
-        self.assertTrue(numpy.all(a + a == b))
+        self.assertTrue(np.all(a + a == b))
 
     def test_gufunc_struct_forceobj(self):
         gufb = GUFuncBuilder(guadd, "(x, y),(x, y)->(x, y)",
@@ -197,11 +197,11 @@ class TestGUfuncBuilding(TestCase):
         self.assertTrue(cres.objectmode)
         ufunc = gufb.build_ufunc()
 
-        a = numpy.arange(10, dtype="complex64").reshape(2, 5) + 1j
+        a = np.arange(10, dtype="complex64").reshape(2, 5) + 1j
         b = ufunc(a, a)
 
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('complex64'))
+        self.assertTrue(np.all(a + a == b))
+        self.assertEqual(b.dtype, np.dtype('complex64'))
 
 
 class TestGUfuncBuildingJitDisabled(TestGUfuncBuilding):
@@ -220,25 +220,25 @@ class TestVectorizeDecor(TestCase):
 
     def test_vectorize(self):
         ufunc = vectorize(['int32(int32, int32)'])(add)
-        a = numpy.arange(10, dtype='int32')
+        a = np.arange(10, dtype='int32')
         b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('int32'))
+        self.assertTrue(np.all(a + a == b))
+        self.assertEqual(b.dtype, np.dtype('int32'))
 
     def test_vectorize_objmode(self):
         ufunc = vectorize(['int32(int32, int32)'], forceobj=True)(add)
-        a = numpy.arange(10, dtype='int32')
+        a = np.arange(10, dtype='int32')
         b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('int32'))
+        self.assertTrue(np.all(a + a == b))
+        self.assertEqual(b.dtype, np.dtype('int32'))
 
     @tag('important')
     def test_vectorize_bool_return(self):
         ufunc = vectorize(['bool_(int32, int32)'])(equals)
-        a = numpy.arange(10, dtype='int32')
+        a = np.arange(10, dtype='int32')
         r = ufunc(a,a)
-        self.assertTrue(numpy.all(r))
-        self.assertEqual(r.dtype, numpy.dtype('bool_'))
+        self.assertTrue(np.all(r))
+        self.assertEqual(r.dtype, np.dtype('bool_'))
 
     @tag('important')
     def test_vectorize_identity(self):
@@ -257,28 +257,28 @@ class TestVectorizeDecor(TestCase):
             vectorize([sig], identity=2)(add)
 
     def test_vectorize_no_args(self):
-        a = numpy.linspace(0,1,10)
-        b = numpy.linspace(1,2,10)
+        a = np.linspace(0,1,10)
+        b = np.linspace(1,2,10)
         ufunc = vectorize(add)
-        self.assertTrue(numpy.all(ufunc(a,b) == (a + b)))
+        self.assertTrue(np.all(ufunc(a,b) == (a + b)))
         ufunc2 = vectorize(add)
-        c = numpy.empty(10)
+        c = np.empty(10)
         ufunc2(a, b, c)
-        self.assertTrue(numpy.all(c == (a + b)))
+        self.assertTrue(np.all(c == (a + b)))
 
     def test_vectorize_only_kws(self):
-        a = numpy.linspace(0,1,10)
-        b = numpy.linspace(1,2,10)
+        a = np.linspace(0,1,10)
+        b = np.linspace(1,2,10)
         ufunc = vectorize(identity=PyUFunc_One, nopython=True)(mul)
-        self.assertTrue(numpy.all(ufunc(a,b) == (a * b)))
+        self.assertTrue(np.all(ufunc(a,b) == (a * b)))
 
     def test_vectorize_output_kwarg(self):
         """
         Passing the output array as a keyword argument (issue #1867).
         """
         def check(ufunc):
-            a = numpy.arange(10, 16, dtype='int32')
-            out = numpy.zeros_like(a)
+            a = np.arange(10, 16, dtype='int32')
+            out = np.zeros_like(a)
             got = ufunc(a, a, out=out)
             self.assertIs(got, out)
             self.assertPreciseEqual(out, a + a)
@@ -297,26 +297,26 @@ class TestVectorizeDecor(TestCase):
     def test_guvectorize(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)")(guadd)
-        a = numpy.arange(10, dtype='int32').reshape(2, 5)
+        a = np.arange(10, dtype='int32').reshape(2, 5)
         b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
-        self.assertEqual(b.dtype, numpy.dtype('int32'))
+        self.assertTrue(np.all(a + a == b))
+        self.assertEqual(b.dtype, np.dtype('int32'))
 
     @tag('important')
     def test_guvectorize_no_output(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y),(x,y)")(guadd)
-        a = numpy.arange(10, dtype='int32').reshape(2, 5)
-        out = numpy.zeros_like(a)
+        a = np.arange(10, dtype='int32').reshape(2, 5)
+        out = np.zeros_like(a)
         ufunc(a, a, out)
-        self.assertTrue(numpy.all(a + a == out))
+        self.assertTrue(np.all(a + a == out))
 
     def test_guvectorize_objectmode(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)")(guadd_obj)
-        a = numpy.arange(10, dtype='int32').reshape(2, 5)
+        a = np.arange(10, dtype='int32').reshape(2, 5)
         b = ufunc(a, a)
-        self.assertTrue(numpy.all(a + a == b))
+        self.assertTrue(np.all(a + a == b))
 
     def test_guvectorize_scalar_objectmode(self):
         """
@@ -324,14 +324,14 @@ class TestVectorizeDecor(TestCase):
         """
         ufunc = guvectorize(['(int32[:,:], int32, int32[:,:])'],
                             "(x,y),()->(x,y)")(guadd_scalar_obj)
-        a = numpy.arange(10, dtype='int32').reshape(2, 5)
+        a = np.arange(10, dtype='int32').reshape(2, 5)
         b = ufunc(a, 3)
-        self.assertTrue(numpy.all(a + 3 == b))
+        self.assertTrue(np.all(a + 3 == b))
 
     def test_guvectorize_error_in_objectmode(self):
         ufunc = guvectorize(['(int32[:,:], int32[:,:], int32[:,:])'],
                             "(x,y),(x,y)->(x,y)", forceobj=True)(guerror)
-        a = numpy.arange(10, dtype='int32').reshape(2, 5)
+        a = np.arange(10, dtype='int32').reshape(2, 5)
         with self.assertRaises(MyException):
             ufunc(a, a)
 

--- a/numba/tests/test_array_return.py
+++ b/numba/tests/test_array_return.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
-import numpy
+
+import numpy as np
+
 from numba.compiler import compile_isolated
 from numba import typeof
 from numba import unittest_support as unittest
@@ -19,7 +21,7 @@ def array_return_start_with_loop(a):
 
 class TestArrayReturn(MemoryLeakMixin, unittest.TestCase):
     def test_array_return(self):
-        a = numpy.arange(10)
+        a = np.arange(10)
         i = 2
         at, it = typeof(a), typeof(i)
         cres = compile_isolated(array_return, (at, it))
@@ -30,7 +32,7 @@ class TestArrayReturn(MemoryLeakMixin, unittest.TestCase):
         """
         A bug breaks array return if the function starts with a loop
         """
-        a = numpy.arange(10)
+        a = np.arange(10)
         at = typeof(a)
         cres = compile_isolated(array_return_start_with_loop, [at])
         cfunc = cres.entry_point

--- a/numba/tests/test_auto_constants.py
+++ b/numba/tests/test_auto_constants.py
@@ -1,15 +1,18 @@
 from __future__ import print_function, division, absolute_import
-from numba import unittest_support as unittest
-from numba.compiler import compile_isolated
-import numpy
+
 import math
 import sys
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba.compiler import compile_isolated
 
 
 class TestAutoConstants(unittest.TestCase):
     def test_numpy_nan(self):
         def pyfunc():
-            return numpy.nan
+            return np.nan
 
         cres = compile_isolated(pyfunc, ())
         cfunc = cres.entry_point

--- a/numba/tests/test_bubblesort.py
+++ b/numba/tests/test_bubblesort.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import numpy
+
+import numpy as np
+
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types
@@ -23,7 +25,7 @@ class TestBubbleSort(unittest.TestCase):
         cr = compile_isolated(pyfunc, (aryty,))
         cfunc = cr.entry_point
 
-        array = numpy.array(list(reversed(range(8))), dtype="int64")
+        array = np.array(list(reversed(range(8))), dtype="int64")
         control = array.copy()
 
         cfunc(array)

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -2,7 +2,8 @@ from __future__ import print_function, absolute_import, division
 
 import sys
 import threading
-import numpy
+
+import numpy as np
 
 from numba.ctypes_support import *
 
@@ -138,7 +139,7 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
             return what
 
         cfunc = jit(nopython=True, nogil=True)(pyfunc)
-        arr = numpy.array(["what"], dtype='S10')
+        arr = np.array(["what"], dtype='S10')
         self.assertEqual(pyfunc(arr), cfunc(arr))
 
     def test_python_call_back_threaded(self):
@@ -150,7 +151,7 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
 
         cfunc = jit(nopython=True, nogil=True)(pyfunc)
 
-        arr = numpy.array(["what"], dtype='S10')
+        arr = np.array(["what"], dtype='S10')
         repeat = 1000
 
         expected = pyfunc(arr, repeat)
@@ -191,7 +192,7 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
 
         cfunc = jit(nopython=True, nogil=True)(pyfunc)
 
-        arr = numpy.arange(5)
+        arr = np.arange(5)
 
         expected = pyfunc(arr)
         got = cfunc(arr)
@@ -201,7 +202,7 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
     def check_array_ctypes(self, pyfunc):
         cfunc = jit(nopython=True)(pyfunc)
 
-        arr = numpy.linspace(0, 10, 5)
+        arr = np.linspace(0, 10, 5)
         expected = arr ** 2.0
         got = cfunc(arr)
         self.assertPreciseEqual(expected, got)
@@ -225,7 +226,7 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
 
         # Non-compatible pointers are not accepted (here float32* vs. float64*)
         with self.assertRaises(errors.TypingError) as raises:
-            cfunc(numpy.float32([0.0]))
+            cfunc(np.float32([0.0]))
         self.assertIn("Invalid usage of ExternalFunctionPointer",
                       str(raises.exception))
 

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -1,5 +1,5 @@
 """
-Test numpy.datetime64 and numpy.timedelta64 support.
+Test np.datetime64 and np.timedelta64 support.
 """
 
 # NOTE: datetime64 and timedelta64 ufuncs are tested in test_ufuncs.

--- a/numba/tests/test_numpyadapt.py
+++ b/numba/tests/test_numpyadapt.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import numpy
+import numpy as np
 
 import numba.unittest_support as unittest
 from numba.ctypes_support import *
@@ -27,7 +27,7 @@ class TestArrayAdaptor(unittest.TestCase):
         adaptorptr = _helperlib.c_helpers['adapt_ndarray']
         adaptor = PYFUNCTYPE(c_int, py_object, c_void_p)(adaptorptr)
 
-        ary = numpy.arange(60).reshape(2, 3, 10)
+        ary = np.arange(60).reshape(2, 3, 10)
         status = adaptor(ary, byref(arystruct))
         self.assertEqual(status, 0)
         self.assertEqual(arystruct.data, ary.ctypes.data)

--- a/numba/tests/test_object_mode.py
+++ b/numba/tests/test_object_mode.py
@@ -4,7 +4,7 @@ Testing object mode specifics.
 """
 from __future__ import print_function
 
-import numpy
+import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
@@ -73,7 +73,7 @@ class TestObjectMode(TestCase):
 
     def test_array_of_object(self):
         cfunc = jit(array_of_object)
-        objarr = numpy.array([object()] * 10)
+        objarr = np.array([object()] * 10)
         self.assertIs(cfunc(objarr), objarr)
 
     def test_sequence_contains(self):

--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import
 
 import itertools
 
-import numpy
+import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
@@ -145,10 +145,10 @@ class TestOptional(TestCase):
                 return y[0]
 
         cfunc = njit("(float32, optional(float32[:]))")(pyfunc)
-        cy = numpy.array([12.3], dtype=numpy.float32)
+        cy = np.array([12.3], dtype=np.float32)
         py = cy.copy()
         self.assertAlmostEqual(pyfunc(1., py), cfunc(1., cy))
-        numpy.testing.assert_almost_equal(py, cy)
+        np.testing.assert_almost_equal(py, cy)
         self.assertAlmostEqual(pyfunc(1., None), cfunc(1., None))
 
     def test_optional_array_error(self):
@@ -161,7 +161,7 @@ class TestOptional(TestCase):
         self.assertIn('expected array(int32, 1d, A), got None',
                       str(raised.exception))
 
-        y = numpy.array([0xabcd], dtype=numpy.int32)
+        y = np.array([0xabcd], dtype=np.int32)
         self.assertEqual(cfunc(y), pyfunc(y))
 
     def test_optional_array_attribute(self):
@@ -175,7 +175,7 @@ class TestOptional(TestCase):
             return opt.shape[0]
 
         cfunc = njit(pyfunc)
-        arr = numpy.arange(5)
+        arr = np.arange(5)
         self.assertEqual(pyfunc(arr, True), cfunc(arr, True))
 
     def test_assign_to_optional(self):

--- a/numba/tests/test_recarray_usecases.py
+++ b/numba/tests/test_recarray_usecases.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import sys
 
-import numpy
+import numpy as np
 
 from numba import numpy_support, types
 from numba.compiler import compile_isolated
@@ -66,32 +66,32 @@ class TestRecordUsecase(unittest.TestCase):
 
     def setUp(self):
         fields = [('f1', '<f8'), ('s1', '|S3'), ('f2', '<f8')]
-        self.unaligned_dtype = numpy.dtype(fields)
-        self.aligned_dtype = numpy.dtype(fields, align=True)
+        self.unaligned_dtype = np.dtype(fields)
+        self.aligned_dtype = np.dtype(fields, align=True)
 
     @tag('important')
     def test_usecase1(self):
         pyfunc = usecase1
 
         # This is an unaligned dtype
-        mystruct_dt = numpy.dtype([('p', numpy.float64),
-                           ('row', numpy.float64),
-                           ('col', numpy.float64)])
+        mystruct_dt = np.dtype([('p', np.float64),
+                           ('row', np.float64),
+                           ('col', np.float64)])
         mystruct = numpy_support.from_dtype(mystruct_dt)
 
         cres = compile_isolated(pyfunc, (mystruct[:], mystruct[:]))
         cfunc = cres.entry_point
 
-        st1 = numpy.recarray(3, dtype=mystruct_dt)
-        st2 = numpy.recarray(3, dtype=mystruct_dt)
+        st1 = np.recarray(3, dtype=mystruct_dt)
+        st2 = np.recarray(3, dtype=mystruct_dt)
 
-        st1.p = numpy.arange(st1.size) + 1
-        st1.row = numpy.arange(st1.size) + 1
-        st1.col = numpy.arange(st1.size) + 1
+        st1.p = np.arange(st1.size) + 1
+        st1.row = np.arange(st1.size) + 1
+        st1.col = np.arange(st1.size) + 1
 
-        st2.p = numpy.arange(st2.size) + 1
-        st2.row = numpy.arange(st2.size) + 1
-        st2.col = numpy.arange(st2.size) + 1
+        st2.p = np.arange(st2.size) + 1
+        st2.row = np.arange(st2.size) + 1
+        st2.col = np.arange(st2.size) + 1
 
         expect1 = st1.copy()
         expect2 = st2.copy()
@@ -102,15 +102,15 @@ class TestRecordUsecase(unittest.TestCase):
         pyfunc(expect1, expect2)
         cfunc(got1, got2)
 
-        self.assertTrue(numpy.all(expect1 == got1))
-        self.assertTrue(numpy.all(expect2 == got2))
+        self.assertTrue(np.all(expect1 == got1))
+        self.assertTrue(np.all(expect2 == got2))
 
     def _setup_usecase2to5(self, dtype):
         N = 5
-        a = numpy.recarray(N, dtype=dtype)
-        a.f1 = numpy.arange(N)
-        a.f2 = numpy.arange(2, N + 2)
-        a.s1 = numpy.array(['abc'] * a.shape[0], dtype='|S3')
+        a = np.recarray(N, dtype=dtype)
+        a.f1 = np.arange(N)
+        a.f2 = np.arange(2, N + 2)
+        a.s1 = np.array(['abc'] * a.shape[0], dtype='|S3')
         return a
 
     def _test_usecase2to5(self, pyfunc, dtype):

--- a/numba/tests/test_typenames.py
+++ b/numba/tests/test_typenames.py
@@ -1,15 +1,17 @@
 from __future__ import print_function, absolute_import
-import numpy
+
+import numpy as np
+
 from numba import types
 from numba import unittest_support as unittest
 
 
 class TestTypeNames(unittest.TestCase):
     def test_numpy_integers(self):
-        expect = getattr(types, "int%d" % (numpy.dtype("int").itemsize * 8))
+        expect = getattr(types, "int%d" % (np.dtype("int").itemsize * 8))
         self.assertEqual(types.int_, expect)
 
-        expect = getattr(types, "uint%d" % (numpy.dtype("uint").itemsize * 8))
+        expect = getattr(types, "uint%d" % (np.dtype("uint").itemsize * 8))
         self.assertEqual(types.uint, expect)
 
 

--- a/numba/tests/test_unpack_sequence.py
+++ b/numba/tests/test_unpack_sequence.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import numpy
+import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
@@ -83,8 +83,8 @@ def unpack_arbitrary(seq):
 
 
 def unpack_nrt():
-    a = numpy.zeros(1)
-    b = numpy.zeros(2)
+    a = np.zeros(1)
+    b = np.zeros(2)
     tup = b, a
     alpha, beta = tup
     return alpha, beta
@@ -120,7 +120,7 @@ class TestUnpack(MemoryLeakMixin, TestCase):
                                                         layout='C')],
                               flags=flags)
         cfunc = cr.entry_point
-        a = numpy.zeros(shape=(1, 2, 3))
+        a = np.zeros(shape=(1, 2, 3))
         self.assertPreciseEqual(cfunc(a), pyfunc(a))
 
     @tag('important')
@@ -218,7 +218,7 @@ class TestUnpack(MemoryLeakMixin, TestCase):
         self.check_conditional_swap(no_pyobj_flags)
 
     def test_unpack_tuple_of_arrays(self):
-        tup = tuple(numpy.zeros(i + 1) for i in range(2))
+        tup = tuple(np.zeros(i + 1) for i in range(2))
         tupty = typeof(tup)
         pyfunc = unpack_arbitrary
         cr = compile_isolated(pyfunc, (tupty,),

--- a/numba/tests/test_wrapper.py
+++ b/numba/tests/test_wrapper.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
+
+import numpy as np
+
 import numba.unittest_support as unittest
 from numba import compiler, types, utils
 from numba.targets import registry
-import numpy
 
 
 def overhead(x):
@@ -56,7 +58,7 @@ class TestWrapper(unittest.TestCase):
 
         self.assertEqual(cr.signature.args[0].layout, 'C')
 
-        x = numpy.zeros(shape=2, dtype='int32')
+        x = np.zeros(shape=2, dtype='int32')
 
         def python():
             array_overhead(x)

--- a/numba/types/__init__.py
+++ b/numba/types/__init__.py
@@ -2,6 +2,8 @@ from __future__ import print_function, division, absolute_import
 
 import struct
 
+import numpy as np
+
 from .abstract import *
 from .containers import *
 from .functions import *
@@ -87,21 +89,21 @@ float_ = float32
 double = float64
 void = none
 
-_make_signed = lambda x: globals()["int%d" % (numpy.dtype(x).itemsize * 8)]
-_make_unsigned = lambda x: globals()["uint%d" % (numpy.dtype(x).itemsize * 8)]
+_make_signed = lambda x: globals()["int%d" % (np.dtype(x).itemsize * 8)]
+_make_unsigned = lambda x: globals()["uint%d" % (np.dtype(x).itemsize * 8)]
 
-char = _make_signed(numpy.byte)
-uchar = byte = _make_unsigned(numpy.byte)
-short = _make_signed(numpy.short)
-ushort = _make_unsigned(numpy.short)
-int_ = _make_signed(numpy.int_)
-uint = _make_unsigned(numpy.int_)
-intc = _make_signed(numpy.intc) # C-compat int
-uintc = _make_unsigned(numpy.uintc) # C-compat uint
-long_ = _make_signed(numpy.long)
-ulong = _make_unsigned(numpy.long)
-longlong = _make_signed(numpy.longlong)
-ulonglong = _make_unsigned(numpy.longlong)
+char = _make_signed(np.byte)
+uchar = byte = _make_unsigned(np.byte)
+short = _make_signed(np.short)
+ushort = _make_unsigned(np.short)
+int_ = _make_signed(np.int_)
+uint = _make_unsigned(np.int_)
+intc = _make_signed(np.intc) # C-compat int
+uintc = _make_unsigned(np.uintc) # C-compat uint
+long_ = _make_signed(np.long)
+ulong = _make_unsigned(np.long)
+longlong = _make_signed(np.longlong)
+ulonglong = _make_unsigned(np.longlong)
 
 # optional types
 optional = Optional

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import itertools
 import weakref
 
-import numpy
+import numpy as np
 
 from ..six import add_metaclass
 from ..utils import cached_property
@@ -226,7 +226,7 @@ class Number(Hashable):
             # e.g. would unify {int64, uint64} to float64
             a = numpy_support.as_dtype(self)
             b = numpy_support.as_dtype(other)
-            sel = numpy.promote_types(a, b)
+            sel = np.promote_types(a, b)
             return numpy_support.from_dtype(sel)
 
 

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import collections
 
-import numpy
+import numpy as np
 
 from .abstract import *
 from .common import *
@@ -344,7 +344,7 @@ class SmartArrayType(Array):
 
 class ArrayCTypes(Type):
     """
-    This is the type for `numpy.ndarray.ctypes`.
+    This is the type for `np.ndarray.ctypes`.
     """
     def __init__(self, arytype):
         # This depends on the ndim for the shape and strides attributes,
@@ -378,7 +378,7 @@ class ArrayCTypes(Type):
 
 class ArrayFlags(Type):
     """
-    This is the type for `numpy.ndarray.flags`.
+    This is the type for `np.ndarray.flags`.
     """
     def __init__(self, arytype):
         self.array_type = arytype

--- a/numba/types/scalars.py
+++ b/numba/types/scalars.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import enum
 
-import numpy
+import numpy as np
 
 from .abstract import *
 from .. import npdatetime, utils
@@ -32,7 +32,7 @@ class Integer(Number):
         return cls(name)
 
     def cast_python_value(self, value):
-        return getattr(numpy, self.name)(value)
+        return getattr(np, self.name)(value)
 
     def __lt__(self, other):
         if self.__class__ is not other.__class__:
@@ -52,7 +52,7 @@ class Float(Number):
         self.bitwidth = bitwidth
 
     def cast_python_value(self, value):
-        return getattr(numpy, self.name)(value)
+        return getattr(np, self.name)(value)
 
     def __lt__(self, other):
         if self.__class__ is not other.__class__:
@@ -71,7 +71,7 @@ class Complex(Number):
         self.bitwidth = bitwidth
 
     def cast_python_value(self, value):
-        return getattr(numpy, self.name)(value)
+        return getattr(np, self.name)(value)
 
     def __lt__(self, other):
         if self.__class__ is not other.__class__:
@@ -81,7 +81,7 @@ class Complex(Number):
 
 class _NPDatetimeBase(Type):
     """
-    Common base class for numpy.datetime64 and numpy.timedelta64.
+    Common base class for np.datetime64 and np.timedelta64.
     """
 
     def __init__(self, unit, *args, **kws):
@@ -99,7 +99,7 @@ class _NPDatetimeBase(Type):
         return self.unit_code < other.unit_code
 
     def cast_python_value(self, value):
-        cls = getattr(numpy, self.type_name)
+        cls = getattr(np, self.type_name)
         if self.unit:
             return cls(value, self.unit)
         else:

--- a/numba/typing/bufproto.py
+++ b/numba/typing/bufproto.py
@@ -32,7 +32,7 @@ def decode_pep3118_format(fmt, itemsize):
     Return the Numba type for an item with format string *fmt* and size
     *itemsize* (in bytes).
     """
-    # XXX reuse _dtype_from_pep3118() from numpy.core._internal?
+    # XXX reuse _dtype_from_pep3118() from np.core._internal?
     if fmt in _pep3118_int_types:
         # Determine int width and signedness
         name = 'int%d' % (itemsize * 8,)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import itertools
 
-import numpy
+import numpy as np
 
 from numba import types
 
@@ -618,7 +618,7 @@ class NumberClassAttribute(AttributeTemplate):
             if isinstance(val, (types.BaseTuple, types.Sequence)):
                 # Array constructor, e.g. np.int32([1, 2])
                 sig = self.context.resolve_function_type(
-                    numpy.array, (val,), {'dtype': types.DType(ty)})
+                    np.array, (val,), {'dtype': types.DType(ty)})
                 return sig.return_type
             else:
                 # Scalar constructor, e.g. np.int32(42)

--- a/numba/typing/npdatetime.py
+++ b/numba/typing/npdatetime.py
@@ -1,5 +1,5 @@
 """
-Typing declarations for numpy.timedelta64.
+Typing declarations for np.timedelta64.
 """
 
 from __future__ import print_function, division, absolute_import

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -11,7 +11,7 @@ import timeit
 import math
 import sys
 
-import numpy
+import numpy as np
 
 from .six import *
 from numba.config import PYVERSION, MACHINE_BITS
@@ -329,8 +329,8 @@ class BenchmarkResult(object):
     def __init__(self, func, records, loop):
         self.func = func
         self.loop = loop
-        self.records = numpy.array(records) / loop
-        self.best = numpy.min(self.records)
+        self.records = np.array(records) / loop
+        self.best = np.min(self.records)
 
     def __repr__(self):
         name = getattr(self.func, "__name__", self.func)

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,12 @@ from distutils.command import build
 from distutils.spawn import spawn
 import sys
 import os
-import numpy
+
+import numpy as np
 import numpy.distutils.misc_util as np_misc
+
 import versioneer
+
 
 class build_doc(build.build):
     description = "build documentation"
@@ -68,7 +71,7 @@ ext_npymath_exports = Extension(name='numba._npymath_exports',
 
 
 ext_dispatcher = Extension(name="numba._dispatcher",
-                           include_dirs=[numpy.get_include()],
+                           include_dirs=[np.get_include()],
                            sources=['numba/_dispatcher.c',
                                     'numba/_typeof.c',
                                     'numba/_hashtable.c',
@@ -81,7 +84,7 @@ ext_dispatcher = Extension(name="numba._dispatcher",
                            extra_link_args=cpp_link_args)
 
 ext_helperlib = Extension(name="numba._helperlib",
-                          include_dirs=[numpy.get_include()],
+                          include_dirs=[np.get_include()],
                           sources=["numba/_helpermod.c", "numba/_math_c99.c"],
                           extra_compile_args=CFLAGS,
                           extra_link_args=install_name_tool_fixer,
@@ -98,7 +101,7 @@ ext_typeconv = Extension(name="numba.typeconv._typeconv",
 
 ext_npyufunc_ufunc = Extension(name="numba.npyufunc._internal",
                                sources=["numba/npyufunc/_internal.c"],
-                               include_dirs=[numpy.get_include()],
+                               include_dirs=[np.get_include()],
                                depends=["numba/npyufunc/_ufunc.c",
                                         "numba/npyufunc/_internal.h",
                                         "numba/_pymodule.h"])


### PR DESCRIPTION
This harmonizes the code base and makes it easier to move code around.
Also, this is the convention used by many people and documents, including Numpy's own documentation.

I recommend merging early to minimize conflicts.