### PR TITLE
Smartarray API improvements.

### DIFF
--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -123,7 +123,7 @@ and from the device automatically. It can be used as drop-in replacement for
                                shape=None, dtype=None, order=None, where='host')
 
 .. autoclass:: numba.SmartArray
-   :members: __init__, host, host_changed, gpu, gpu_changed
+   :members: __init__, get, mark_changed
 	       
 
 Thus, `SmartArray` objects may be passed as function arguments to jit-compiled

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -604,8 +604,8 @@ class CUDAKernel(CUDAKernelBase):
         """
         if isinstance(ty, types.Array):
             if isinstance(ty, types.SmartArrayType):
-                devary = val.gpu()
-                retr.append(lambda: val.gpu_changed())
+                devary = val.get('gpu')
+                retr.append(lambda: val.mark_changed('gpu'))
                 outer_parent = ctypes.c_void_p(0)
                 kernelargs.append(outer_parent)
             else:

--- a/numba/cuda/tests/cudapy/test_smart_array.py
+++ b/numba/cuda/tests/cudapy/test_smart_array.py
@@ -27,7 +27,7 @@ class TestJIT(unittest.TestCase):
         event("checkpoint")
         transpose(b, c)
         event("done")
-        self.assertTrue((c.host() == a.host()).all())
+        self.assertTrue((c.get('host') == a.get('host')).all())
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -36,7 +36,7 @@ def deprecated(arg):
 
         return wraps(func)(wrapper)
 
-    if callable(arg) or type(arg) in (classmethod, staticmethod):
+    if not subst:
         return decorator(arg)
     else:
         return decorator

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -13,17 +13,33 @@ from functools import wraps
 # Filled at the end
 __all__ = []
 
-def deprecated(subst):
+def deprecated(arg):
+    """Define a deprecation decorator.
+    An optional string should refer to the new API to be used instead.
 
+    Example:
+      @deprecated
+      def old_func(): ...
+
+      @deprecated('new_func')
+      def old_func(): ..."""
+
+    subst = arg if isinstance(arg, str) else None
     def decorator(func):
         def wrapper(*args, **kwargs):
-            warnings.warn("Call to deprecated function \"{}\".\n Use \"{}\" instead.".format(func.__name__, subst),
+            msg = "Call to deprecated function \"{}\"."
+            if subst:
+                msg += "\n Use \"{}\" instead."
+            warnings.warn(msg.format(func.__name__, subst),
                           category=DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wraps(func)(wrapper)
 
-    return decorator
+    if callable(arg) or type(arg) in (classmethod, staticmethod):
+        return decorator(arg)
+    else:
+        return decorator
 
 
 class NumbaWarning(Warning):

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -7,10 +7,23 @@ from __future__ import print_function, division, absolute_import
 import contextlib
 from collections import defaultdict
 import warnings
+from functools import wraps
 
 
 # Filled at the end
 __all__ = []
+
+def deprecated(subst):
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            warnings.warn("Call to deprecated function \"{}\".\n Use \"{}\" instead.".format(func.__name__, subst),
+                          category=DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wraps(func)(wrapper)
+
+    return decorator
 
 
 class NumbaWarning(Warning):

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -948,11 +948,14 @@ class PythonAPI(object):
         args.append(self.context.get_constant_null(types.pyobject))
         return self.builder.call(fn, args)
 
-    def call_method(self, callee, method, objargs = None):
-        cstr = self.context.insert_const_string(self.module, method)
-        fnty = Type.function(self.pyobj, [self.pyobj, self.cstring], var_arg=True)
+    def call_method(self, callee, method, objargs=()):
+        cname = self.context.insert_const_string(self.module, method)
+        fnty = Type.function(self.pyobj, [self.pyobj, self.cstring, self.cstring],
+                             var_arg=True)
         fn = self._get_function(fnty, name="PyObject_CallMethod")
-        args = [callee, cstr]
+        fmt = 'O' * len(objargs)
+        cfmt = self.context.insert_const_string(self.module, fmt)
+        args = [callee, cname, cfmt]
         if objargs:
             args.extend(objargs)
         args.append(self.context.get_constant_null(types.pyobject))

--- a/numba/smartarray.py
+++ b/numba/smartarray.py
@@ -1,4 +1,5 @@
 from numba.tracing import trace
+from numba.errors import deprecated
 
 import sys
 
@@ -105,6 +106,11 @@ class SmartArray(object):
         elif where == 'gpu': return self._gpu
         else: raise ValueError('unknown memory space "%s"'%where)
 
+    @deprecated("get('host')")
+    def host(self): return self.get('host')
+    @deprecated("get('gpu')")
+    def gpu(self): return self.get('gpu')
+
     def mark_changed(self, where='host'):
         """Mark the given location as changed, broadcast updates if needed."""
 
@@ -120,6 +126,11 @@ class SmartArray(object):
             # only sync if there are active views
             if self._host is not None and sys.getrefcount(self._host) > 2:
                 self._sync('host')
+
+    @deprecated("mark_changed('host')")
+    def host_changed(self): return self.mark_changed('host')
+    @deprecated("mark_changed('gpu')")
+    def gpu_changed(self): return self.mark_changed('gpu')
 
     def __array__(self, *args):
 

--- a/numba/smartarray.py
+++ b/numba/smartarray.py
@@ -206,3 +206,5 @@ class SmartArray(object):
         return self._maybe_wrap(self.get('host').__getitem__(*args))
     def __setitem__(self, *args):
         return self._maybe_wrap(self.get('host').__setitem__(*args))
+    def astype(self, *args):
+        return self._maybe_wrap(self.get('host').astype(*args))

--- a/numba/smartarray.py
+++ b/numba/smartarray.py
@@ -40,6 +40,8 @@ def _s2o(dtype, shape, strides):
 class SmartArray(object):
     """An array type that supports host and GPU storage."""
 
+    _targets = ('host', 'gpu')
+
     def __init__(self, obj=None, copy=True,
                  shape=None, dtype=None, order=None, where='host'):
         """Construct a SmartArray in the memory space defined by 'where'.
@@ -59,7 +61,8 @@ class SmartArray(object):
         initially. (Default: 'host')
         """
 
-        assert where in ('host', 'gpu')
+        if where not in self._targets:
+            raise ValueError('"%s" is not a valid target'%where)
         # we need either a prototype or proper type info
         assert obj is not None or (shape and dtype)
         self._host = self._gpu = None
@@ -95,6 +98,8 @@ class SmartArray(object):
     def get(self, where='host'):
         """Return the representation of 'self' in the given memory space."""
 
+        if where not in self._targets:
+            raise ValueError('"%s" is not a valid target'%where)
         self._sync(where)
         if where == 'host': return self._host
         elif where == 'gpu': return self._gpu
@@ -103,6 +108,8 @@ class SmartArray(object):
     def mark_changed(self, where='host'):
         """Mark the given location as changed, broadcast updates if needed."""
 
+        if where not in self._targets:
+            raise ValueError('"%s" is not a valid target'%where)
         if where == 'host':
             self._invalidate('gpu')
             # only sync if there are active views

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -23,9 +23,6 @@ def shape_usecase(x):
 def npyufunc_usecase(x):
     return np.cos(np.sin(x))
 
-def astype_usecase(x, dtype):
-    return x.astype(dtype)
-
 def identity(x): return x
 
 class TestJIT(TestCase):

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -23,6 +23,8 @@ def shape_usecase(x):
 def npyufunc_usecase(x):
     return np.cos(np.sin(x))
 
+def astype_usecase(x, dtype):
+    return x.astype(dtype)
 
 def identity(x): return x
 
@@ -59,6 +61,12 @@ class TestJIT(TestCase):
         self.assertIsInstance(aa, SmartArray)
         self.assertPreciseEqual(aa.get('host'), np.cos(np.sin(a.get('host'))))
 
+    def test_astype(self):
+        a = SmartArray(np.int32([42, 8, -5]))
+        #cfunc = jit(nopython=True)(astype_usecase)
+        aa = a.astype(np.float64)
+        self.assertIsInstance(aa, SmartArray)
+        self.assertPreciseEqual(aa.get('host'), a.get('host').astype(np.float64))
 
 class TestInterface(TestCase):
 

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -63,7 +63,6 @@ class TestJIT(TestCase):
 
     def test_astype(self):
         a = SmartArray(np.int32([42, 8, -5]))
-        #cfunc = jit(nopython=True)(astype_usecase)
         aa = a.astype(np.float64)
         self.assertIsInstance(aa, SmartArray)
         self.assertPreciseEqual(aa.get('host'), a.get('host').astype(np.float64))

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -63,6 +63,7 @@ class TestJIT(TestCase):
         aa = a.astype(np.float64)
         self.assertIsInstance(aa, SmartArray)
         self.assertPreciseEqual(aa.get('host'), a.get('host').astype(np.float64))
+        self.assertIs(aa.dtype.type, np.float64)
 
 class TestInterface(TestCase):
 

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -62,7 +62,10 @@ class TestJIT(TestCase):
         a = SmartArray(np.int32([42, 8, -5]))
         aa = a.astype(np.float64)
         self.assertIsInstance(aa, SmartArray)
+        # verify that SmartArray.astype() operates like ndarray.astype()...
         self.assertPreciseEqual(aa.get('host'), a.get('host').astype(np.float64))
+        # ...and that both actually yield the expected dtype.
+        self.assertPreciseEqual(aa.get('host').dtype.type, np.float64)
         self.assertIs(aa.dtype.type, np.float64)
 
 class TestInterface(TestCase):

--- a/numba/tests/test_smart_array.py
+++ b/numba/tests/test_smart_array.py
@@ -57,7 +57,7 @@ class TestJIT(TestCase):
         cfunc = jit(nopython=True)(npyufunc_usecase)
         aa = cfunc(a)
         self.assertIsInstance(aa, SmartArray)
-        self.assertPreciseEqual(aa.host(), np.cos(np.sin(a.host())))
+        self.assertPreciseEqual(aa.get('host'), np.cos(np.sin(a.get('host'))))
 
 
 class TestInterface(TestCase):

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -4,8 +4,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba import jit
-from numba.errors import NumbaWarning
-
+from numba.errors import NumbaWarning, deprecated
 
 class TestBuiltins(unittest.TestCase):
     def test_type_infer_warning(self):
@@ -106,6 +105,19 @@ class TestBuiltins(unittest.TestCase):
             self.assertIn('object mode', str(w[2].message))
             self.assertIn('lifted loops', str(w[2].message))
 
+
+    def test_deprecated(self):
+        @deprecated('foo')
+        def bar(): pass
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            bar()
+
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].category, DeprecationWarning)
+            self.assertIn('bar', str(w[0].message))
+            self.assertIn('foo', str(w[0].message))
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -185,6 +185,6 @@ def _typeof_ndarray(val, c):
 
 @typeof_impl.register(smartarray.SmartArray)
 def typeof_array(val, c):
-    arrty = typeof_impl(val.host(), c)
+    arrty = typeof_impl(val.get('host'), c)
     return types.SmartArrayType(arrty.dtype, arrty.ndim, arrty.layout, type(val))
 


### PR DESCRIPTION
This PR generalizes the SmartArray API by replacing methods `host()` and `gpu()` by `get(where)`, and likewise replaces `host_changed()` and `gpu_changed()` by `mark_changed(where)`. (Thus there is nothing GPU-specific in the API any longer.)
The PR further adds support for NumPy's `astype` functionality, which we use elsewhere for type promotion. (How to deal with type promotion in device memory has yet to be decided...)