### PR TITLE
Added support for PyInstaller frozen caching

### DIFF
--- a/numba/caching.py
+++ b/numba/caching.py
@@ -188,8 +188,8 @@ class _InTreeCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
 
 class _UserWideCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
     """
-    A locator for functions backed by a regular Python module, cached
-    into a user-wide cache directory.
+    A locator for functions backed by a regular Python module or a 
+    frozen executable, cached into a user-wide cache directory. 
     """
 
     def __init__(self, py_func, py_file):

--- a/numba/caching.py
+++ b/numba/caching.py
@@ -146,7 +146,10 @@ class _SourceFileBackedLocatorMixin(object):
     """
 
     def get_source_stamp(self):
-        st = os.stat(self._py_file)
+        if getattr(sys, 'frozen', False):
+            st = os.stat(sys.executable)
+        else:
+            st = os.stat(self._py_file)
         # We use both timestamp and size as some filesystems only have second
         # granularity.
         return st.st_mtime, st.st_size
@@ -195,16 +198,33 @@ class _UserWideCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
         appdirs = AppDirs(appname="numba", appauthor=False)
         cache_dir = appdirs.user_cache_dir
         cache_subpath = os.path.dirname(py_file)
-        if os.name != "nt":
+        if not (os.name == "nt" or getattr(sys, 'frozen', False)):
             # On non-Windows, further disambiguate by appending the entire
             # absolute source path to the cache dir, e.g.
             # "$HOME/.cache/numba/usr/lib/.../mypkg/mysubpkg"
             # On Windows, this is undesirable because of path length limitations
+
+            # For frozen applications, there is no existing "full path"
+            # directory, and depends on a relocatable executable.
             cache_subpath = os.path.abspath(cache_subpath).lstrip(os.path.sep)
         self._cache_path = os.path.join(cache_dir, cache_subpath)
 
     def get_cache_path(self):
         return self._cache_path
+
+    @classmethod
+    def from_function(cls, py_func, py_file):
+        if not (os.path.exists(py_file) or getattr(sys, 'frozen', False)):
+            # Perhaps a placeholder (e.g. "<ipython-XXX>")
+            # stop function exit if frozen, since it uses a temp placeholder
+            return
+        self = cls(py_func, py_file)
+        try:
+            self.ensure_cache_path()
+        except OSError:
+            # Cannot ensure the cache directory exists or is writable
+            return
+        return self
 
 
 class _IPythonCacheLocator(_CacheLocator):


### PR DESCRIPTION
Previously, attempts to use caching with a frozen application raised a RuntimeError, with the following code:

```
RuntimeError("cannot cache function %r: no locator available "
                               "for file %r" % (qualname, self._source_path))
```

This is due to the frozen application architecture, where a frozen application uses a bootloader which either identifies resources from a stable folder (one-folder), or a temporary directory (one-file), and this has the added advantage of working with both.

**Patch 1**

In both the one-folder and one-file example, `os.path.exists(py_file)` will return False, since the file is either bundled into an executable within a folder or provided as an extension of site-packages inside a temporary folder (prefixed with 'site-packages'). Therefore, a simple check if `os.path.exists(py_file) and not getattr(sys, 'frozen', False)` is enough to override the function exit. I therefore redefined the `_SourceFileBackedLocatorMixin.from_function` for `_UserWideCacheLocator`, so the in-tree compilation is not attempted, but user-wide cache is only if the function is frozen.

**Patch 2**

Normally, not on Windows systems, the numba compiler looks for the abspath to the file, to avoid conflicting installations of the same module, doing:

```
if os.name != 'nt':
    cache_subpath = os.path.abspath(cache_subpath).lstrip(os.path.sep)
```

Since there is no real path to the file, and `os.abspath` returns a location that is specific to a relocatable executable, I skipped this code block if the code is frozen.

```
 if not (os.name == "nt" or getattr(sys, 'frozen', False)):
    cache_subpath = os.path.abspath(cache_subpath).lstrip(os.path.sep)
```

**Patch 3**

Finally, since `self._pyfile` does not point to a real file, it's important to look at the source time stamp of the executable, and not the virtual file. I therefore redefined `get_source_stamp` to get file metadata from the executable and not the virtual file.

Original:

```
def get_source_stamp(self):
    st = os.stat(self._py_file)
```

New:

```
def get_source_stamp(self):
    if getattr(sys, 'frozen', False):
        st = os.stat(sys.executable)
    else:
        st = os.stat(self._py_file)
```

Finally, this should minimally conflict with any other installs, since in-tree caching is favored for user installs or running from source, global installs use the system path or a local path, and iPython uses a separate cache, and frozen applications preface all imported functions with "site-packages", and all frozen functions using solely the executable name:

```
>>> inspect.getfile(package.function)
'site-packages/package/function.py'
>>> inspect.getfile(local_function)
'myscript.py'
```
