### PR TITLE
Fix #1884: support np.lib.stride_tricks.as_strided()

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -359,6 +359,16 @@ Distributions
    and later).
 
 
+``stride_tricks``
+-----------------
+
+The following function from the :mod:`numpy.lib.stride_tricks` module
+is supported:
+
+* :func:`~numpy.lib.stride_tricks.as_strided` (the *strides* argument
+  is mandatory, the *subok* argument is not supported)
+
+
 Standard ufuncs
 ===============
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -147,6 +147,7 @@ class OverloadSelector(object):
         self.versions.append((sig, value))
         self._cache.clear()
 
+
 @utils.runonce
 def _load_global_helpers():
     """


### PR DESCRIPTION
The *strides* argument is mandatory, which corresponds to all use cases I've found in the wild.