### PR TITLE
Add CUDA FAQ and first entry on flushing profiling results.

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -94,6 +94,8 @@ the functionality of the selected device:
 Measurement
 -----------
 
+.. _cuda-profiling:
+
 Profiling
 ~~~~~~~~~
 

--- a/docs/source/cuda/faq.rst
+++ b/docs/source/cuda/faq.rst
@@ -1,0 +1,20 @@
+
+.. _cudafaq:
+
+=================================================
+CUDA Frequently Asked Questions
+=================================================
+
+nvprof reports "No kernels were profiled"
+-----------------------------------------
+
+When using the ``nvprof`` tool to profile Numba jitted code for the CUDA
+target, the output contains ``No kernels were profiled`` but there are clearly
+running kernels present, what is going on?
+
+This is quite likely due to the profiling data not being flushed on program
+exit, see the `NVIDIA CUDA documentation
+<http://docs.nvidia.com/cuda/profiler-users-guide/#flush-profile-data>`_ for
+details. To fix this simply add a call to ``numba.cuda.profile_stop()`` prior
+to the exit point in your program (or whereever you want to stop profiling).
+For more on CUDA profiling support in Numba, see :ref:`cuda-profiling`.

--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -15,3 +15,4 @@ Numba for CUDA GPUs
    simulator.rst
    reduction.rst
    ufunc.rst
+   faq.rst


### PR DESCRIPTION
This patch adds a CUDA FAQ document to the toctree for CUDA, it
also adds in an entry explaining why `nvprof` sometimes reports
that no kernels were profiled and how to fix it.