### PR TITLE
Workaround conda-build issue #1001

### DIFF
--- a/buildscripts/condarecipe.buildbot/bld.bat
+++ b/buildscripts/condarecipe.buildbot/bld.bat
@@ -1,4 +1,4 @@
-@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-%PYTHON% -m pip install ordereddict
-%PYTHON% setup.py install
-if errorlevel 1 exit 1
+%PYTHON% buildscripts/remove_unwanted_files.py
+%PYTHON% setup.py build install
+
+exit /b %errorlevel%

--- a/buildscripts/condarecipe.buildbot/build.sh
+++ b/buildscripts/condarecipe.buildbot/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-$PYTHON -m pip install ordereddict
-$PYTHON setup.py install
+$PYTHON buildscripts/remove_unwanted_files.py
+$PYTHON setup.py build install

--- a/buildscripts/condarecipe.hsa/bld.bat
+++ b/buildscripts/condarecipe.hsa/bld.bat
@@ -1,8 +1,4 @@
-@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-%PYTHON% -m pip install ordereddict
-%PYTHON% setup.py install
-if errorlevel 1 exit 1
+%PYTHON% buildscripts/remove_unwanted_files.py
+%PYTHON% setup.py build install
 
-if "%PY3K%"=="1" (
-    rd /s /q %SP_DIR%\numpy
-)
+exit /b %errorlevel%

--- a/buildscripts/condarecipe.hsa/build.sh
+++ b/buildscripts/condarecipe.hsa/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-$PYTHON -m pip install ordereddict
-$PYTHON setup.py install
+$PYTHON buildscripts/remove_unwanted_files.py
+$PYTHON setup.py build install

--- a/buildscripts/condarecipe.jenkins/bld.bat
+++ b/buildscripts/condarecipe.jenkins/bld.bat
@@ -1,8 +1,4 @@
-@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-%PYTHON% -m pip install ordereddict
+%PYTHON% buildscripts/remove_unwanted_files.py
 %PYTHON% setup.py build install
-if errorlevel 1 exit 1
 
-if "%PY3K%"=="1" (
-    rd /s /q %SP_DIR%\numpy
-)
+exit /b %errorlevel%

--- a/buildscripts/condarecipe.jenkins/build.sh
+++ b/buildscripts/condarecipe.jenkins/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-$PYTHON -m pip install ordereddict
+$PYTHON buildscripts/remove_unwanted_files.py
 $PYTHON setup.py build install

--- a/buildscripts/condarecipe.local/bld.bat
+++ b/buildscripts/condarecipe.local/bld.bat
@@ -1,4 +1,4 @@
-@rem Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-%PYTHON% -m pip install ordereddict
-%PYTHON% setup.py install
-if errorlevel 1 exit 1
+%PYTHON% buildscripts/remove_unwanted_files.py
+%PYTHON% setup.py build install
+
+exit /b %errorlevel%

--- a/buildscripts/condarecipe.local/build.sh
+++ b/buildscripts/condarecipe.local/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-# Hack to workaround https://github.com/testing-cabal/funcsigs/issues/18
-$PYTHON -m pip install ordereddict
-$PYTHON setup.py install
+$PYTHON buildscripts/remove_unwanted_files.py
+$PYTHON setup.py build install

--- a/buildscripts/remove_unwanted_files.py
+++ b/buildscripts/remove_unwanted_files.py
@@ -1,0 +1,36 @@
+"""
+Workaround for a conda-build bug where failing to compile some Python files
+results in a build failure.
+
+See https://github.com/conda/conda-build/issues/1001
+"""
+
+import os
+import sys
+
+
+py2_only_files = []
+
+py3_only_files = [
+    'numba/tests/annotation_usecases.py',
+    ]
+
+
+def remove_files(basedir):
+    """
+    Remove unwanted files from the current source tree
+    """
+    if sys.version_info >= (3,):
+        removelist = py2_only_files
+        msg = "Python 2-only file"
+    else:
+        removelist = py3_only_files
+        msg = "Python 3-only file"
+    for relpath in removelist:
+        path = os.path.join(basedir, relpath)
+        print("Removing %s %r" % (msg, relpath))
+        os.remove(path)
+
+
+if __name__ == "__main__":
+    remove_files('.')


### PR DESCRIPTION
Our conda recipes currently fail on Python 2 builds because of https://github.com/conda/conda-build/issues/1001

I tested this patch on Linux and Windows.