### PR TITLE
Issue #1916: fix documentation example

### DIFF
--- a/docs/source/user/generated-jit.rst
+++ b/docs/source/user/generated-jit.rst
@@ -57,6 +57,10 @@ There are several things to note here:
 * It is possible to pre-compute some data at compile-time (the ``missing``
   variable above) to have them reused inside the compiled implementation.
 
+* The function definitions use the same names for arguments as in the
+  decorated function, this is required to ensure passing arguments by
+  name works as expected.
+
 
 Compilation options
 ===================

--- a/docs/source/user/generated-jit.rst
+++ b/docs/source/user/generated-jit.rst
@@ -31,15 +31,15 @@ That compile-time logic is easily implemented using the
    from numba import generated_jit, types
 
    @generated_jit(nopython=True)
-   def is_missing(value):
+   def is_missing(x):
        """
        Return True if the value is missing, False otherwise.
        """
-       if isinstance(value, types.Float):
+       if isinstance(x, types.Float):
            return lambda x: np.isnan(x)
-       elif isinstance(value, (types.NPDatetime, types.NPTimedelta)):
+       elif isinstance(x, (types.NPDatetime, types.NPTimedelta)):
            # The corresponding Not-a-Time value
-           missing = value('NaT')
+           missing = x('NaT')
            return lambda x: x == missing
        else:
            return lambda x: False


### PR DESCRIPTION
The argument names have to be the same in the generating function and
in each of the implementations, due to the way named arguments are
currently handled.