### PR TITLE
Add user-controllable thread pool limits for parallel CPU target.

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -149,3 +149,16 @@ GPU support
 
    If set, don't compile and execute code for the GPU, but use the CUDA
    Simulator instead. For debugging purposes.
+
+Threading Control
+-----------------
+
+.. envvar:: NUMBA_NUM_THREADS
+
+   If set, the number of threads in the thread pool for the parallel CPU target 
+   will take this value. Must be greater than zero. This value is independent
+   of ``OMP_NUM_THREADS`` and ``MKL_NUM_THREADS``.
+
+   *Default value:* The number of CPU cores on the system as determined at run
+   time, this can be accessed via ``numba.config.NUMBA_DEFAULT_NUM_THREADS``.
+

--- a/numba/config.py
+++ b/numba/config.py
@@ -6,6 +6,7 @@ import sys
 import os
 import re
 import warnings
+import multiprocessing
 
 import llvmlite.binding as ll
 
@@ -197,6 +198,14 @@ class _EnvReloader(object):
 
         # Disable HSA support
         DISABLE_HSA = _readenv("NUMBA_DISABLE_HSA", int, 0)
+
+        # The default number of threads to use.
+        NUMBA_DEFAULT_NUM_THREADS = max(1, multiprocessing.cpu_count())
+
+        # Numba thread pool size (defaults to number of CPUs on the system).
+        NUMBA_NUM_THREADS = _readenv("NUMBA_NUM_THREADS", int, 
+                                     NUMBA_DEFAULT_NUM_THREADS)
+
         # Inject the configuration values into the module globals
         for name, value in locals().copy().items():
             if name.isupper():

--- a/numba/tests/npyufunc/test_parallel_env_variable.py
+++ b/numba/tests/npyufunc/test_parallel_env_variable.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, print_function, division
+from numba import unittest_support as unittest
+from numba.npyufunc.parallel import get_thread_count
+from os import environ as env
+from numba import config
+
+
+class TestParallelEnvVariable(unittest.TestCase):
+    """
+    Tests environment variables related to the underlying "parallel"
+    functions for npyufuncs.
+    """
+
+    def test_num_threads_variable(self):
+        """
+        Tests the NUMBA_NUM_THREADS env variable behaves as expected.
+        """
+        key = 'NUMBA_NUM_THREADS'
+        current = str(getattr(env, key, config.NUMBA_DEFAULT_NUM_THREADS))
+        threads = "3154"
+        env[key] = threads
+        config.reload_config()
+        try:
+            self.assertEqual(threads, str(get_thread_count()))
+            self.assertEqual(threads, str(config.NUMBA_NUM_THREADS))
+        finally:
+            # reset the env variable/set to default
+            env[key] = current
+            config.reload_config()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds the capacity to set an environment variable to control
the size of the thread pool used for CPU parallel targets used
by `@vectorize` and `@guvectorize`.