### PR TITLE
Use system hypot/hypotf where possible.

### DIFF
--- a/numba/_math_c99.c
+++ b/numba/_math_c99.c
@@ -301,6 +301,11 @@ float m_atan2f(float y, float x) {
     return (float) m_atan2(y, x);
 }
 
+/* Map to double version directly */
+float m_hypotf(float x, float y) {
+    return (float) m_hypotf(x, y);
+}
+
 
 /* provide gamma() and lgamma(); code borrowed from CPython */
 

--- a/numba/_math_c99.h
+++ b/numba/_math_c99.h
@@ -49,6 +49,8 @@ VISIBILITY_HIDDEN float m_truncf(float x);
 VISIBILITY_HIDDEN double m_atan2(double y, double x);
 VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 
+VISIBILITY_HIDDEN float m_hypotf(float x, float y);
+
 #if !HAVE_C99_MATH
 
 /* Define missing math functions */
@@ -80,8 +82,10 @@ VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 #define trunc(x) m_trunc(x)
 #define truncf(x) m_truncf(x)
 
-
 #define atan2f(x, y) m_atan2f(x, y)
+
+/* float version of hypot missing in < VS2013 */
+#define hypotf(x, y) m_hypotf(x, y)
 
 #endif /* !HAVE_C99_MATH */
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -539,7 +539,7 @@ class TestMathLib(TestCase):
             self.assertTrue(np.isfinite(nb_ans))
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
-                self.assertRaisesRegex(RuntimeWarning,
+                self.assertRaisesRegexp(RuntimeWarning,
                 'overflow encountered in .*_scalars',
                 naive_hypot, val, val)
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -3,14 +3,14 @@ from __future__ import print_function, absolute_import, division
 import itertools
 import math
 import sys
+import warnings
 
 import numpy as np
 
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated, Flags, utils
-from numba import types
+from numba import types, numpy_support
 from .support import TestCase, CompilationCache, tag
-
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
@@ -518,14 +518,30 @@ class TestMathLib(TestCase):
 
     def test_hypot(self, flags=enable_pyobj_flags):
         pyfunc = hypot
-        x_types = [types.int16, types.int32, types.int64,
-                   types.uint16, types.uint32, types.uint64,
+        x_types = [types.int64, types.uint64,
                    types.float32, types.float64]
         x_values = [1, 2, 3, 4, 5, 6, .21, .34]
         y_values = [x + 2 for x in x_values]
         # Issue #563: precision issues with math.hypot() under Windows.
         prec = 'single' if sys.platform == 'win32' else 'exact'
-        self.run_binary(pyfunc, x_types, x_values, y_values, prec=prec)
+        self.run_binary(pyfunc, x_types, x_values, y_values, flags, prec)
+        # Check that values that overflow in naive implementations do not
+        # in the numba impl
+        def naive_hypot(x, y):
+            return math.sqrt(x * x + y * y)
+        for fltty in (types.float32, types.float64):
+            cr = self.ccache.compile(pyfunc, (fltty, fltty), flags=flags)
+            cfunc = cr.entry_point
+            dt = numpy_support.as_dtype(fltty).type
+            val = dt(np.finfo(dt).max / 10.)
+            nb_ans = cfunc(val, val)
+            self.assertPreciseEqual(nb_ans, pyfunc(val, val), prec='single')
+            self.assertTrue(np.isfinite(nb_ans))
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                self.assertRaisesRegex(RuntimeWarning,
+                'overflow encountered in .*_scalars',
+                naive_hypot, val, val)
 
     @tag('important')
     def test_hypot_npm(self):


### PR DESCRIPTION
This is an attempt at fixing the known overflow problems in the
`hypot()` impl in numba by delegating all hypot calls to the
local system maths library. For platforms with C99 both float
and double variants exist, for those which don't have the float
variant (some windows) floats are cast to doubles and the double
implementation used, with a cast back to float on return.

This also fixes a bug in the hypot unit test which meant it was
not running the no-python-mode variant of the test.

Relevant issues/PRs:
 * https://github.com/numba/numba/issues/1877
 * https://github.com/numba/numba/pull/1619
 * https://github.com/numba/numba/issues/1570