### PR TITLE
Workaround test discovery bug when py.path is installed.

### DIFF
--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -40,4 +40,4 @@ test:
   commands:
     - pycc -h
     - numba -h
-    - python -m numba.runtests -m -b
+    - python -m numba.runtests -m -b numba.tests

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -40,4 +40,4 @@ test:
   commands:
     - pycc -h
     - numba -h
-    - python -m numba.runtests -m -b
+    - python -m numba.runtests -m -b numba.tests


### PR DESCRIPTION
When py.path (a IPython dependency) is installed, a `test_path` module
appears at the sys.path toplevel.  Test discovery by default tries to
run it (on Python 3), which fails because it needs py.test which isn't
installed.  This would lead into this perplexing failure:

```
$ python -m numba.runtests -m -b
E
======================================================================
ERROR: test_path (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_path
Traceback (most recent call last):
  File "/Users/jenkins/workspace/Numba-Builder-OSX/CONDA_NPY/1.11/CONDA_PY/35/label/numba-osx/miniconda/envs/_test/lib/python3.5/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Users/jenkins/workspace/Numba-Builder-OSX/CONDA_NPY/1.11/CONDA_PY/35/label/numba-osx/miniconda/envs/_test/lib/python3.5/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/Users/jenkins/workspace/Numba-Builder-OSX/CONDA_NPY/1.11/CONDA_PY/35/label/numba-osx/miniconda/envs/_test/lib/python3.5/site-packages/test_path.py", line 31, in <module>
    import pytest
ImportError: No module named 'pytest'

----------------------------------------------------------------------
Ran 1 test in 0.132s

FAILED (errors=1)
```