### PR TITLE
Fix hypot() on Windows

### DIFF
--- a/numba/_math_c99.c
+++ b/numba/_math_c99.c
@@ -301,11 +301,6 @@ float m_atan2f(float y, float x) {
     return (float) m_atan2(y, x);
 }
 
-/* Map to double version directly */
-float m_hypotf(float x, float y) {
-    return (float) m_hypotf(x, y);
-}
-
 
 /* provide gamma() and lgamma(); code borrowed from CPython */
 

--- a/numba/_math_c99.h
+++ b/numba/_math_c99.h
@@ -49,7 +49,6 @@ VISIBILITY_HIDDEN float m_truncf(float x);
 VISIBILITY_HIDDEN double m_atan2(double y, double x);
 VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 
-VISIBILITY_HIDDEN float m_hypotf(float x, float y);
 
 #if !HAVE_C99_MATH
 
@@ -83,9 +82,6 @@ VISIBILITY_HIDDEN float m_hypotf(float x, float y);
 #define truncf(x) m_truncf(x)
 
 #define atan2f(x, y) m_atan2f(x, y)
-
-/* float version of hypot missing in < VS2013 */
-#define hypotf(x, y) m_hypotf(x, y)
 
 #endif /* !HAVE_C99_MATH */
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -540,17 +540,11 @@ class TestMathLib(TestCase):
             self.assertPreciseEqual(nb_ans, pyfunc(val, val), prec='single')
             self.assertTrue(np.isfinite(nb_ans))
 
-            # select regex based assertion function (name changed in 2->3).
-            if PYVERSION < (3, 0):
-                regex_asserter = self.assertRaisesRegexp
-            else:
-                regex_asserter = self.assertRaisesRegex
-
             with warnings.catch_warnings():
-                warnings.simplefilter("error")
-                regex_asserter(RuntimeWarning,
-                               'overflow encountered in .*_scalars',
-                               naive_hypot, val, val)
+                warnings.simplefilter("error", RuntimeWarning)
+                self.assertRaisesRegexp(RuntimeWarning,
+                                        'overflow encountered in .*_scalars',
+                                        naive_hypot, val, val)
 
     @tag('important')
     def test_hypot_npm(self):

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -535,7 +535,7 @@ class TestMathLib(TestCase):
             cr = self.ccache.compile(pyfunc, (fltty, fltty), flags=flags)
             cfunc = cr.entry_point
             dt = numpy_support.as_dtype(fltty).type
-            val = dt(np.finfo(dt).max / 10.)
+            val = dt(np.finfo(dt).max / 30.)
             nb_ans = cfunc(val, val)
             self.assertPreciseEqual(nb_ans, pyfunc(val, val), prec='single')
             self.assertTrue(np.isfinite(nb_ans))


### PR DESCRIPTION
It seems _hypotf() exists on MSVC 2008 despite the documentation saying it doesn't.

Note there is still a `test_abs` failure on Windows 32, Python 2.7: `hypot(nan, inf)` should return `inf` but returns `nan` on that platform, and complex abs() uses hypot().