### PR TITLE
Fix Numba for LLVM 3.8

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -432,7 +432,7 @@ def llvm_to_ptx(llvmir, **opts):
     for decl, fn in replacements:
         llvmir = llvmir.replace(decl, fn)
 
-    llvmir = llvm37_to_34_ir(llvmir)
+    llvmir = llvm38_to_34_ir(llvmir)
 
     cu.add_module(llvmir.encode('utf8'))
     cu.add_module(libdevice.get())
@@ -442,6 +442,10 @@ def llvm_to_ptx(llvmir, **opts):
 
 re_metadata_def = re.compile(r"\!\d+\s*=")
 re_metadata_correct_usage = re.compile(r"metadata\s*\![{'\"]")
+
+re_attributes_def = re.compile(r"^attributes #\d+ = \{ ([\w\s]+)\ }")
+unsupported_attributes = {'argmemonly', 'inaccessiblememonly',
+                          'inaccessiblemem_or_argmemonly', 'norecurse'}
 
 re_getelementptr = re.compile(r"\Wgetelementptr\s(?:inbounds )?\(?")
 
@@ -454,9 +458,9 @@ re_type_tok = re.compile(r"[,{}()[\]]")
 re_annotations = re.compile(r"\Wnonnull\W")
 
 
-def llvm37_to_34_ir(ir):
+def llvm38_to_34_ir(ir):
     """
-    Convert LLVM 3.7 IR for LLVM 3.4.
+    Convert LLVM 3.8 IR for LLVM 3.4.
     """
     def parse_out_leading_type(s):
         par_level = 0
@@ -488,6 +492,12 @@ def llvm37_to_34_ir(ir):
             if None is re_metadata_correct_usage.search(line):
                 line = line.replace('!{', 'metadata !{')
                 line = line.replace('!"', 'metadata !"')
+        if line.startswith('attributes #'):
+            # Remove function attributes unsupported pre-3.8
+            m = re_attributes_def.match(line)
+            attrs = m.group(1).split()
+            attrs = ' '.join(a for a in attrs if a not in unsupported_attributes)
+            line = line.replace(m.group(1), attrs)
         if 'getelementptr ' in line:
             # Rewrite "getelementptr ty, ty* ptr, ..."
             # to "getelementptr ty *ptr, ..."


### PR DESCRIPTION
Followup to https://github.com/numba/llvmlite/pull/176.

One test outputs a LLVM optimization warning that https://github.com/numba/llvmlite/pull/190 will silence:
```
$ ./runtests.py -v numba.tests.test_globals.TestGlobals.test_two_global_rec_arrs_npm
test_two_global_rec_arrs_npm (numba.tests.test_globals.TestGlobals) ... remark: <unknown>:0:0: loop not vectorized: cannot prove it is safe to reorder memory operations
```