### PR TITLE
Remove separate _npymath_exports module

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1262,3 +1262,8 @@ Define bridge for all math functions
  */
 
 #include "_lapack.c"
+
+/*
+ * Numpy C math function exports
+ */
+#include "_npymath_exports.c"

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -108,6 +108,37 @@ error:
     return NULL;
 }
 
+static int
+register_npymath_exports(PyObject *dct)
+{
+    size_t count = sizeof(npymath_exports) / sizeof(npymath_exports[0]);
+    size_t i;
+
+    for (i = 0; i < count; ++i) {
+        PyObject *ptr = PyLong_FromVoidPtr(npymath_exports[i].func);
+        if (ptr == NULL)
+            return -1;
+        if (PyDict_SetItemString(dct, npymath_exports[i].name, ptr) < 0) {
+            Py_DECREF(ptr);
+            return -1;
+        }
+        Py_DECREF(ptr);
+    }
+
+    return 0;
+}
+
+static PyObject *
+build_npymath_exports_dict(void)
+{
+    PyObject *dct = PyDict_New();
+    if (dct != NULL) {
+        if (register_npymath_exports(dct) < 0)
+            Py_CLEAR(dct);
+    }
+    return dct;
+}
+
 static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },
     { "rnd_seed", (PyCFunction) _numba_rnd_seed, METH_VARARGS, NULL },
@@ -171,6 +202,7 @@ MOD_INIT(_helperlib) {
     import_array();
 
     PyModule_AddObject(m, "c_helpers", build_c_helpers_dict());
+    PyModule_AddObject(m, "npymath_exports", build_npymath_exports_dict());
     PyModule_AddIntConstant(m, "long_min", LONG_MIN);
     PyModule_AddIntConstant(m, "long_max", LONG_MAX);
     PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer));

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -157,10 +157,10 @@ def _load_global_helpers():
     ll.add_symbol("_Py_NoneStruct", id(None))
 
     # Add C helper functions
-    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers):
-        for py_name in c_helpers:
+    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers,
+                      _helperlib.npymath_exports):
+        for py_name, c_address in c_helpers.items():
             c_name = "numba_" + py_name
-            c_address = c_helpers[py_name]
             ll.add_symbol(c_name, c_address)
 
     # Add all built-in exception classes

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -41,7 +41,6 @@ class CPUContext(BaseContext):
 
         # Map external C functions.
         externals.c_math_functions.install(self)
-        externals.c_numpy_functions.install(self)
 
         # Initialize NRT runtime
         rtsys.initialize(self)

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -8,7 +8,7 @@ from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba import utils
-from numba import _helperlib, _npymath_exports
+from numba import _helperlib
 from . import intrinsics
 
 
@@ -125,8 +125,6 @@ class _ExternalMathFunctions(_Installer):
     def _do_install(self, context):
         is32bit = utils.MACHINE_BITS == 32
         c_helpers = _helperlib.c_helpers
-        for name in ['cpow', 'sdiv', 'srem', 'udiv', 'urem']:
-            ll.add_symbol("numba.math.%s" % name, c_helpers[name])
 
         if sys.platform.startswith('win32') and is32bit:
             # For Windows XP _ftol2 is not defined, we will just use
@@ -155,16 +153,4 @@ class _ExternalMathFunctions(_Installer):
             ll.add_symbol(fname, c_helpers[fname])
 
 
-class _ExternalNumpyFunctions(_Installer):
-    """
-    Map Numpy's C math functions into the LLVM execution environment.
-    """
-
-    def _do_install(self, context):
-        # add the symbols for numpy math to the execution environment.
-        for sym in _npymath_exports.symbols:
-            ll.add_symbol(*sym)
-
-
 c_math_functions = _ExternalMathFunctions()
-c_numpy_functions = _ExternalNumpyFunctions()

--- a/numba/targets/intrinsics.py
+++ b/numba/targets/intrinsics.py
@@ -10,7 +10,7 @@ class _DivmodFixer(ir.Visitor):
     def visit_Instruction(self, instr):
         if instr.type == ir.IntType(64):
             if instr.opname in ['srem', 'urem', 'sdiv', 'udiv']:
-                name = 'numba.math.{op}'.format(op=instr.opname)
+                name = 'numba_{op}'.format(op=instr.opname)
                 fn = self.module.globals.get(name)
                 # Declare the function if it doesn't already exist
                 if fn is None:

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -352,8 +352,8 @@ def np_real_logaddexp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logaddexpf',
-        types.float64: 'numba.npymath.logaddexp',
+        types.float32: 'numba_npymath_logaddexpf',
+        types.float64: 'numba_npymath_logaddexp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -366,8 +366,8 @@ def np_real_logaddexp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logaddexp2f',
-        types.float64: 'numba.npymath.logaddexp2',
+        types.float32: 'numba_npymath_logaddexp2f',
+        types.float64: 'numba_npymath_logaddexp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -459,8 +459,8 @@ def np_complex_power_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.cpowf',
-        types.complex128: 'numba.npymath.cpow',
+        types.complex64: 'numba_npymath_cpowf',
+        types.complex128: 'numba_npymath_cpow',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -531,8 +531,8 @@ def np_real_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.expf',
-        types.float64: 'numba.npymath.exp',
+        types.float32: 'numba_npymath_expf',
+        types.float64: 'numba_npymath_exp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -543,8 +543,8 @@ def np_complex_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.cexpf',
-        types.complex128: 'numba.npymath.cexp',
+        types.complex64: 'numba_npymath_cexpf',
+        types.complex128: 'numba_npymath_cexp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -557,8 +557,8 @@ def np_real_exp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.exp2f',
-        types.float64: 'numba.npymath.exp2',
+        types.float32: 'numba_npymath_exp2f',
+        types.float64: 'numba_npymath_exp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -584,8 +584,8 @@ def np_real_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logf',
-        types.float64: 'numba.npymath.log',
+        types.float32: 'numba_npymath_logf',
+        types.float64: 'numba_npymath_log',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -596,8 +596,8 @@ def np_complex_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.clogf',
-        types.complex128: 'numba.npymath.clog',
+        types.complex64: 'numba_npymath_clogf',
+        types.complex128: 'numba_npymath_clog',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -610,8 +610,8 @@ def np_real_log2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log2f',
-        types.float64: 'numba.npymath.log2',
+        types.float32: 'numba_npymath_log2f',
+        types.float64: 'numba_npymath_log2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -637,8 +637,8 @@ def np_real_log10_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log10f',
-        types.float64: 'numba.npymath.log10',
+        types.float32: 'numba_npymath_log10f',
+        types.float64: 'numba_npymath_log10',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -665,8 +665,8 @@ def np_real_expm1_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.expm1f',
-        types.float64: 'numba.npymath.expm1',
+        types.float32: 'numba_npymath_expm1f',
+        types.float64: 'numba_npymath_expm1',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -700,8 +700,8 @@ def np_real_log1p_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log1pf',
-        types.float64: 'numba.npymath.log1p',
+        types.float32: 'numba_npymath_log1pf',
+        types.float64: 'numba_npymath_log1p',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -736,8 +736,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sqrtf',
-        types.float64: 'numba.npymath.sqrt',
+        types.float32: 'numba_npymath_sqrtf',
+        types.float64: 'numba_npymath_sqrt',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -746,8 +746,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
 
 def np_complex_sqrt_impl(context, builder, sig, args):
     dispatch_table = {
-        types.complex64: 'numba.npymath.csqrtf',
-        types.complex128: 'numba.npymath.csqrt',
+        types.complex64: 'numba_npymath_csqrtf',
+        types.complex128: 'numba_npymath_csqrt',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -842,8 +842,8 @@ def np_real_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sinf',
-        types.float64: 'numba.npymath.sin',
+        types.float32: 'numba_npymath_sinf',
+        types.float64: 'numba_npymath_sin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -854,8 +854,8 @@ def np_complex_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.csinf',
-        types.complex128: 'numba.npymath.csin',
+        types.complex64: 'numba_npymath_csinf',
+        types.complex128: 'numba_npymath_csin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -869,8 +869,8 @@ def np_real_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.cosf',
-        types.float64: 'numba.npymath.cos',
+        types.float32: 'numba_npymath_cosf',
+        types.float64: 'numba_npymath_cos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -881,8 +881,8 @@ def np_complex_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.ccosf',
-        types.complex128: 'numba.npymath.ccos',
+        types.complex64: 'numba_npymath_ccosf',
+        types.complex128: 'numba_npymath_ccos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -896,8 +896,8 @@ def np_real_tan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.tanf',
-        types.float64: 'numba.npymath.tan',
+        types.float32: 'numba_npymath_tanf',
+        types.float64: 'numba_npymath_tan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -949,8 +949,8 @@ def np_real_asin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.asinf',
-        types.float64: 'numba.npymath.asin',
+        types.float32: 'numba_npymath_asinf',
+        types.float64: 'numba_npymath_asin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1047,8 +1047,8 @@ def np_real_acos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.acosf',
-        types.float64: 'numba.npymath.acos',
+        types.float32: 'numba_npymath_acosf',
+        types.float64: 'numba_npymath_acos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1062,8 +1062,8 @@ def np_real_atan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atanf',
-        types.float64: 'numba.npymath.atan',
+        types.float32: 'numba_npymath_atanf',
+        types.float64: 'numba_npymath_atan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1131,8 +1131,8 @@ def np_real_atan2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atan2f',
-        types.float64: 'numba.npymath.atan2',
+        types.float32: 'numba_npymath_atan2f',
+        types.float64: 'numba_npymath_atan2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1146,8 +1146,8 @@ def np_real_hypot_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.hypotf',
-        types.float64: 'numba.npymath.hypot',
+        types.float32: 'numba_npymath_hypotf',
+        types.float64: 'numba_npymath_hypot',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1161,8 +1161,8 @@ def np_real_sinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sinhf',
-        types.float64: 'numba.npymath.sinh',
+        types.float32: 'numba_npymath_sinhf',
+        types.float64: 'numba_npymath_sinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1201,8 +1201,8 @@ def np_real_cosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.coshf',
-        types.float64: 'numba.npymath.cosh',
+        types.float32: 'numba_npymath_coshf',
+        types.float64: 'numba_npymath_cosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1240,8 +1240,8 @@ def np_real_tanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.tanhf',
-        types.float64: 'numba.npymath.tanh',
+        types.float32: 'numba_npymath_tanhf',
+        types.float64: 'numba_npymath_tanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1293,8 +1293,8 @@ def np_real_asinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.asinhf',
-        types.float64: 'numba.npymath.asinh',
+        types.float32: 'numba_npymath_asinhf',
+        types.float64: 'numba_npymath_asinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1359,8 +1359,8 @@ def np_real_acosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.acoshf',
-        types.float64: 'numba.npymath.acosh',
+        types.float32: 'numba_npymath_acoshf',
+        types.float64: 'numba_npymath_acosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1401,8 +1401,8 @@ def np_real_atanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atanhf',
-        types.float64: 'numba.npymath.atanh',
+        types.float32: 'numba_npymath_atanhf',
+        types.float64: 'numba_npymath_atanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1950,8 +1950,8 @@ def np_real_signbit_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.signbitf',
-        types.float64: 'numba.npymath.signbit',
+        types.float32: 'numba_npymath_signbitf',
+        types.float64: 'numba_npymath_signbit',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1967,8 +1967,8 @@ def np_real_nextafter_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.nextafterf',
-        types.float64: 'numba.npymath.nextafter',
+        types.float32: 'numba_npymath_nextafterf',
+        types.float64: 'numba_npymath_nextafter',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1978,8 +1978,8 @@ def np_real_spacing_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.spacingf',
-        types.float64: 'numba.npymath.spacing',
+        types.float32: 'numba_npymath_spacingf',
+        types.float64: 'numba_npymath_spacing',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1992,8 +1992,8 @@ def np_real_ldexp_impl(context, builder, sig, args):
     # an 'i' or an 'l'.
 
     dispatch_table = {
-        types.float32: 'numba.npymath.ldexpf',
-        types.float64: 'numba.npymath.ldexp',
+        types.float32: 'numba_npymath_ldexpf',
+        types.float64: 'numba_npymath_ldexp',
     }
 
     # the functions expect the second argument to be have a C int type

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -835,7 +835,7 @@ def complex_power_impl(context, builder, sig, args):
         with otherwise:
             # Lower with call to external function
             fnty = Type.function(Type.void(), [pa.type] * 3)
-            cpow = module.get_or_insert_function(fnty, name="numba.math.cpow")
+            cpow = module.get_or_insert_function(fnty, name="numba_cpow")
             builder.call(cpow, (pa, pb, pc))
 
     res = builder.load(pc)

--- a/setup.py
+++ b/setup.py
@@ -62,14 +62,6 @@ ext_dynfunc = Extension(name='numba._dynfunc',
                         depends=['numba/_pymodule.h',
                                  'numba/_dynfunc.c'])
 
-ext_npymath_exports = Extension(name='numba._npymath_exports',
-                                sources=['numba/_npymath_exports.c'],
-                                include_dirs=npymath_info['include_dirs'],
-                                libraries=npymath_info['libraries'],
-                                library_dirs=npymath_info['library_dirs'],
-                                define_macros=npymath_info['define_macros'])
-
-
 ext_dispatcher = Extension(name="numba._dispatcher",
                            include_dirs=[np.get_include()],
                            sources=['numba/_dispatcher.c',
@@ -92,6 +84,7 @@ ext_helperlib = Extension(name="numba._helperlib",
                                    "numba/_math_c99.h",
                                    "numba/_helperlib.c",
                                    "numba/_lapack.c",
+                                   "numba/_npymath_exports.c",
                                    "numba/mathnames.inc"])
 
 ext_typeconv = Extension(name="numba.typeconv._typeconv",
@@ -129,7 +122,7 @@ ext_jitclass_box = Extension(name='numba.jitclass._box',
                              depends=['numba/_pymodule.h'],
                              include_dirs=['numba'])
 
-ext_modules = [ext_dynfunc, ext_npymath_exports, ext_dispatcher,
+ext_modules = [ext_dynfunc, ext_dispatcher,
                ext_helperlib, ext_typeconv,
                ext_npyufunc_ufunc, ext_npyufunc_workqueue, ext_mviewbuf,
                ext_nrt_python, ext_jitclass_box]

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,10 @@ ext_dispatcher = Extension(name="numba._dispatcher",
                            extra_link_args=cpp_link_args)
 
 ext_helperlib = Extension(name="numba._helperlib",
-                          include_dirs=[np.get_include()],
+                          include_dirs=npymath_info['include_dirs'],
+                          libraries=npymath_info['libraries'],
+                          library_dirs=npymath_info['library_dirs'],
+                          define_macros=npymath_info['define_macros'],
                           sources=["numba/_helpermod.c", "numba/_math_c99.c"],
                           extra_compile_args=CFLAGS,
                           extra_link_args=install_name_tool_fixer,


### PR DESCRIPTION
The registration logic for npymath functions is factored into _helperlib.