### PR TITLE
Fix #1945: allow using Numpy ufuncs in AOT compiled code

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -476,7 +476,7 @@ numba_cpowf(npy_cfloat *a, npy_cfloat *b, npy_cfloat *out) {
     _b.real = npy_crealf(*b);
     _b.imag = npy_cimagf(*b);
     numba_cpow(&_a, &_b, &_out);
-    *out = npy_cpackf(_out.real, _out.imag);
+    *out = npy_cpackf((float) _out.real, (float) _out.imag);
 }
 
 /* C99 math functions: redirect to system implementations

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1262,3 +1262,8 @@ Define bridge for all math functions
  */
 
 #include "_lapack.c"
+
+/*
+ * Numpy C math function exports
+ */
+#include "_npymath_exports.c"

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -17,6 +17,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>
 #include <numpy/arrayscalars.h>
+#include <numpy/npy_math.h>
 
 #include "_arraystruct.h"
 
@@ -457,8 +458,25 @@ numba_ldexpf(float x, int exp)
 
 /* provide complex power */
 NUMBA_EXPORT_FUNC(void)
-numba_cpow(Py_complex *a, Py_complex *b, Py_complex *c) {
-    *c = _Py_c_pow(*a, *b);
+numba_cpow(Py_complex *a, Py_complex *b, Py_complex *out) {
+    errno = 0;
+    *out = _Py_c_pow(*a, *b);
+    if (errno == EDOM) {
+        /* _Py_c_pow() doesn't bother returning the right value
+           in this case, as Python raises ZeroDivisionError */
+        out->real = out->imag = Py_NAN;
+    }
+}
+
+NUMBA_EXPORT_FUNC(void)
+numba_cpowf(npy_cfloat *a, npy_cfloat *b, npy_cfloat *out) {
+    Py_complex _a, _b, _out;
+    _a.real = npy_crealf(*a);
+    _a.imag = npy_cimagf(*a);
+    _b.real = npy_crealf(*b);
+    _b.imag = npy_cimagf(*b);
+    numba_cpow(&_a, &_b, &_out);
+    *out = npy_cpackf(_out.real, _out.imag);
 }
 
 /* C99 math functions: redirect to system implementations
@@ -512,7 +530,21 @@ numba_erfcf(float x)
     return erfcf(x);
 }
 
+/* Note npy_signbit() is actually a polymorphic macro */
+NUMBA_EXPORT_FUNC(int)
+numba_signbitf(float a)
+{
+    return npy_signbit(a);
+}
 
+NUMBA_EXPORT_FUNC(int)
+numba_signbit(npy_double a)
+{
+    return npy_signbit(a);
+}
+
+
+/* Unpack any Python complex-like object into a Py_complex structure */
 NUMBA_EXPORT_FUNC(int)
 numba_complex_adaptor(PyObject* obj, Py_complex *out) {
     PyObject* fobj;
@@ -1244,8 +1276,8 @@ numba_unpickle(const char *data, int n)
 
 
 /*
-Define bridge for all math functions
-*/
+ * Define bridge for all math functions
+ */
 
 #define MATH_UNARY(F, R, A) \
     NUMBA_EXPORT_FUNC(R) numba_##F(A a) { return F(a); }
@@ -1262,8 +1294,3 @@ Define bridge for all math functions
  */
 
 #include "_lapack.c"
-
-/*
- * Numpy C math function exports
- */
-#include "_npymath_exports.c"

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -8,7 +8,12 @@ Expose all functions as pointers in a dedicated C extension.
 /* Import _pymodule.h first, for a recent _POSIX_C_SOURCE */
 #include "_pymodule.h"
 #include <math.h>
+
+/* Numba C helpers */
 #include "_helperlib.c"
+
+/* Numpy C math function exports */
+#include "_npymath_exports.c"
 
 static PyObject *
 build_c_helpers_dict(void)
@@ -40,6 +45,7 @@ build_c_helpers_dict(void)
     declmethod(ldexp);
     declmethod(ldexpf);
     declmethod(cpow);
+    declmethod(cpowf);
     declmethod(erf);
     declmethod(erff);
     declmethod(erfc);
@@ -48,6 +54,8 @@ build_c_helpers_dict(void)
     declmethod(gammaf);
     declmethod(lgamma);
     declmethod(lgammaf);
+    declmethod(signbit);
+    declmethod(signbitf);
     declmethod(complex_adaptor);
     declmethod(adapt_ndarray);
     declmethod(ndarray_new);

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -108,6 +108,37 @@ error:
     return NULL;
 }
 
+static int
+register_npymath_exports(PyObject *dct)
+{
+    size_t count = sizeof(npymath_exports) / sizeof(npymath_exports[0]);
+    size_t i;
+
+    for (i = 0; i < count; ++i) {
+        PyObject *ptr = PyLong_FromVoidPtr(npymath_exports[i].func);
+        if (ptr == NULL)
+            return -1;
+        if (PyDict_SetItemString(dct, npymath_exports[i].name, ptr) < 0) {
+            Py_DECREF(ptr);
+            return -1;
+        }
+        Py_DECREF(ptr);
+    }
+
+    return 0;
+}
+
+static PyObject *
+build_npymath_exports_dict(void)
+{
+    PyObject *dct = PyDict_New();
+    if (dct != NULL) {
+        if (register_npymath_exports(dct) < 0)
+            Py_CLEAR(dct);
+    }
+    return dct;
+}
+
 static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },
     { "rnd_seed", (PyCFunction) _numba_rnd_seed, METH_VARARGS, NULL },
@@ -171,6 +202,7 @@ MOD_INIT(_helperlib) {
     import_array();
 
     PyModule_AddObject(m, "c_helpers", build_c_helpers_dict());
+    PyModule_AddObject(m, "npymath_exports", build_npymath_exports_dict());
     PyModule_AddIntConstant(m, "long_min", LONG_MIN);
     PyModule_AddIntConstant(m, "long_max", LONG_MAX);
     PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer));

--- a/numba/_npymath_exports.c
+++ b/numba/_npymath_exports.c
@@ -2,180 +2,22 @@
  * This file contains exports of Numpy math functions needed by numba.
  */
 
-
 #include "_pymodule.h"
 #include <numpy/npy_math.h>
 #include <math.h>
 
 
-/* Missing math function on windows prior to VS2015 */
-#if defined(_WIN32) && _MSC_VER < 1900
-    /* undef windows macros for the following */
-    #undef ldexpf
-    #undef frexpf
-
-    static
-    float ldexpf(float x, int exp) {
-        return (float)ldexp(x, exp);
-    }
-
-    static
-    float frexpf(float x, int *exp) {
-        return (float)frexp(x, exp);
-    }
-#endif /* WIN32 and _MSC_VER < 1900 */
-
-/* signbit is actually a macro, two versions will be exported as to let the
-   macro do whatever magic it does for floats and for doubles */
-
-static npy_bool
-ufunc_signbitf(npy_float a)
-{
-    return npy_signbit(a) != 0;
-}
-
-static npy_bool
-ufunc_signbit(npy_double a)
-{
-    return npy_signbit(a) != 0;
-}
-
-/* Some functions require being adapted from the ones in npymath for
-   use in numpy loops. It is easier to do this at this point than having
-   to write code generation for the equivalent code.
-
-   The code here usually reflect what can be found in NumPy's
-   funcs.inc.src.
-*/
-
-static void
-ufunc_cpowf(npy_cfloat *dst, npy_cfloat *a, npy_cfloat *b)
-{
-    float br = npy_crealf(*b);
-    float bi = npy_cimagf(*b);
-    float ar = npy_crealf(*a);
-    float ai = npy_cimagf(*b);
-
-    if (br == 0.0f && bi == 0.0f) {
-        /* on a 0 exponent, result is 1.0 + 0.0i */
-        *dst = npy_cpackf(1.0f, 0.0f);
-        return;
-    }
-
-    if (ar == 0.0f && ai == 0.0f) {
-        if (br > 0 && bi == 0) {
-            *dst = npy_cpackf(0.0f, 0.0f);
-        }
-        else {
-            /* NB: there are four complex zeros; c0 = (+-0, +-0), so that unlike
-             *     for reals, c0**p, with `p` negative is in general
-             *     ill-defined.
-             *
-             *     c0**z with z complex is also ill-defined.
-             */
-            *dst = npy_cpackf(NPY_NAN, NPY_NAN);
-
-            /* Raise invalid */
-            npy_set_floatstatus_invalid();
-        }
-        return;
-    }
-
-    /* note: in NumPy there are optimizations for integer
-    *exponents. These are not present here...
-    */
-
-    *dst = npy_cpowf(*a, *b);
-    return;
-}
-
-
-static void
-ufunc_cpow(npy_cdouble *dst, npy_cdouble *a, npy_cdouble *b)
-{
-    double br = npy_creal(*b);
-    double bi = npy_cimag(*b);
-    double ar = npy_creal(*a);
-    double ai = npy_cimag(*b);
-
-    if (br == 0.0 && bi == 0.0) {
-        /* on a 0 exponent, result is 1.0 + 0.0i */
-        *dst = npy_cpack(1.0, 0.0);
-        return;
-    }
-
-    if (ar == 0.0 && ai == 0.0) {
-        if (br > 0 && bi == 0) {
-            *dst = npy_cpack(0.0, 0.0);
-        }
-        else {
-            /* NB: there are four complex zeros; c0 = (+-0, +-0), so that unlike
-             *     for reals, c0**p, with `p` negative is in general
-             *     ill-defined.
-             *
-             *     c0**z with z complex is also ill-defined.
-             */
-            *dst = npy_cpack(NPY_NAN, NPY_NAN);
-
-            /* Raise invalid */
-            npy_set_floatstatus_invalid();
-        }
-        return;
-    }
-
-    /* note: in NumPy there are optimizations for integer
-    *exponents. These are not present here...
-    */
-
-    *dst = npy_cpow(*a, *b);
-    return;
-}
-
-
-/* Use this macros to wrap functions that on C have complex arguments.
-   In numba complex numbers are passed by reference, and the return
-   value is passed as a first arg. This is different in npy_math */
-
-#define NUMBA_UNARY_FUNC_WRAP(func, type)                               \
-    void npy_ ## func ## _wrapped(type* dst, type* op1)                 \
-    {                                                                   \
-        *dst = npy_ ## func(*op1);                                      \
-    }
-
-#define NUMBA_BINARY_FUNC_WRAP(func, type)                          \
-    void npy_ ## func ## _wrapped(type* dst, type* op1, type* op2)  \
-    {                                                               \
-        *dst = npy_ ## func(*op1, *op2);                            \
-    }
-
-
-NUMBA_UNARY_FUNC_WRAP(cexpf, npy_cfloat);
-NUMBA_UNARY_FUNC_WRAP(cexp, npy_cdouble);
-NUMBA_UNARY_FUNC_WRAP(clogf, npy_cfloat);
-NUMBA_UNARY_FUNC_WRAP(clog, npy_cdouble);
-NUMBA_UNARY_FUNC_WRAP(csqrtf, npy_cfloat);
-NUMBA_UNARY_FUNC_WRAP(csqrt, npy_cdouble);
-
-NUMBA_UNARY_FUNC_WRAP(csinf, npy_cfloat);
-NUMBA_UNARY_FUNC_WRAP(csin, npy_cdouble);
-NUMBA_UNARY_FUNC_WRAP(ccosf, npy_cfloat);
-NUMBA_UNARY_FUNC_WRAP(ccos, npy_cdouble);
-
+/*
+ * Map Numpy C function symbols to their addresses.
+ */
 
 struct npymath_entry {
-    const char* name;
-    void* func;
+    const char *name;
+    void *func;
 };
 
-
-#define NPYMATH_SYMBOL_EXPLICIT(name, function) \
-    { "npymath_" #name, (void*) function }
-
 #define NPYMATH_SYMBOL(name) \
-    { "npymath_" #name, (void*) npy_##name }
-
-#define NPYMATH_SYMBOL_WRAPPED(name) \
-    { "npymath_" #name, (void*) npy_##name##_wrapped }
+    { "npy_" #name, (void*) npy_##name }
 
 static struct npymath_entry npymath_exports[] = {
     /* double functions */
@@ -212,11 +54,6 @@ static struct npymath_entry npymath_exports[] = {
     NPYMATH_SYMBOL(logaddexp2),
     NPYMATH_SYMBOL(nextafter),
     NPYMATH_SYMBOL(spacing),
-    /* npy_ldexp and npy_frexp appear in npy_math.h past NumPy 1.9, so link
-       directly to the math.h versions. */
-    NPYMATH_SYMBOL_EXPLICIT(ldexp, ldexp),
-    NPYMATH_SYMBOL_EXPLICIT(frexp, frexp),
-    NPYMATH_SYMBOL_EXPLICIT(signbit, ufunc_signbit),
 
     NPYMATH_SYMBOL(modf),
 
@@ -254,30 +91,8 @@ static struct npymath_entry npymath_exports[] = {
     NPYMATH_SYMBOL(logaddexp2f),
     NPYMATH_SYMBOL(nextafterf),
     NPYMATH_SYMBOL(spacingf),
-    /* npy_ldexpf and npy_frexpf appear in npy_math.h past NumPy 1.9, so link
-       directly to the math.h versions. */
-    NPYMATH_SYMBOL_EXPLICIT(ldexpf, ldexpf),
-    NPYMATH_SYMBOL_EXPLICIT(frexpf, frexpf),
-    NPYMATH_SYMBOL_EXPLICIT(signbitf, ufunc_signbitf),
 
     NPYMATH_SYMBOL(modff),
-
-    /* complex128 functions */
-    NPYMATH_SYMBOL_EXPLICIT(cpow, ufunc_cpow),
-    NPYMATH_SYMBOL_WRAPPED(cexp),
-    NPYMATH_SYMBOL_WRAPPED(clog),
-    NPYMATH_SYMBOL_WRAPPED(csqrt),
-    NPYMATH_SYMBOL_WRAPPED(csin),
-    NPYMATH_SYMBOL_WRAPPED(ccos),
-
-    /* complex64 functions */
-    NPYMATH_SYMBOL_EXPLICIT(cpowf, ufunc_cpowf),
-    NPYMATH_SYMBOL_WRAPPED(cexpf),
-    NPYMATH_SYMBOL_WRAPPED(clogf),
-    NPYMATH_SYMBOL_WRAPPED(csqrtf),
-    NPYMATH_SYMBOL_WRAPPED(csinf),
-    NPYMATH_SYMBOL_WRAPPED(ccosf),
 };
+
 #undef NPYMATH_SYMBOL
-#undef NPYMATH_SYMBOL_EXPLICIT
-#undef NPYMATH_SYMBOL_WRAPPED

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -163,7 +163,7 @@ def _load_global_helpers():
             ll.add_symbol(c_name, c_address)
 
     # Add Numpy C helpers (npy_XXX)
-    for c_name, c_address in c_helpers.items():
+    for c_name, c_address in _helperlib.npymath_exports.items():
         ll.add_symbol(c_name, c_address)
 
     # Add all built-in exception classes

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -157,10 +157,10 @@ def _load_global_helpers():
     ll.add_symbol("_Py_NoneStruct", id(None))
 
     # Add C helper functions
-    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers):
-        for py_name in c_helpers:
+    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers,
+                      _helperlib.npymath_exports):
+        for py_name, c_address in c_helpers.items():
             c_name = "numba_" + py_name
-            c_address = c_helpers[py_name]
             ll.add_symbol(c_name, c_address)
 
     # Add all built-in exception classes

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -156,12 +156,15 @@ def _load_global_helpers():
     # This is Py_None's real C name
     ll.add_symbol("_Py_NoneStruct", id(None))
 
-    # Add C helper functions
-    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers,
-                      _helperlib.npymath_exports):
+    # Add Numba C helper functions
+    for c_helpers in (_helperlib.c_helpers, _dynfunc.c_helpers):
         for py_name, c_address in c_helpers.items():
             c_name = "numba_" + py_name
             ll.add_symbol(c_name, c_address)
+
+    # Add Numpy C helpers (npy_XXX)
+    for c_name, c_address in c_helpers.items():
+        ll.add_symbol(c_name, c_address)
 
     # Add all built-in exception classes
     for obj in utils.builtins.__dict__.values():

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -41,7 +41,6 @@ class CPUContext(BaseContext):
 
         # Map external C functions.
         externals.c_math_functions.install(self)
-        externals.c_numpy_functions.install(self)
 
         # Initialize NRT runtime
         rtsys.initialize(self)

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -8,7 +8,7 @@ from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba import utils
-from numba import _helperlib, _npymath_exports
+from numba import _helperlib
 from . import intrinsics
 
 
@@ -125,8 +125,6 @@ class _ExternalMathFunctions(_Installer):
     def _do_install(self, context):
         is32bit = utils.MACHINE_BITS == 32
         c_helpers = _helperlib.c_helpers
-        for name in ['cpow', 'sdiv', 'srem', 'udiv', 'urem']:
-            ll.add_symbol("numba.math.%s" % name, c_helpers[name])
 
         if sys.platform.startswith('win32') and is32bit:
             # For Windows XP _ftol2 is not defined, we will just use
@@ -155,16 +153,4 @@ class _ExternalMathFunctions(_Installer):
             ll.add_symbol(fname, c_helpers[fname])
 
 
-class _ExternalNumpyFunctions(_Installer):
-    """
-    Map Numpy's C math functions into the LLVM execution environment.
-    """
-
-    def _do_install(self, context):
-        # add the symbols for numpy math to the execution environment.
-        for sym in _npymath_exports.symbols:
-            ll.add_symbol(*sym)
-
-
 c_math_functions = _ExternalMathFunctions()
-c_numpy_functions = _ExternalNumpyFunctions()

--- a/numba/targets/intrinsics.py
+++ b/numba/targets/intrinsics.py
@@ -10,7 +10,7 @@ class _DivmodFixer(ir.Visitor):
     def visit_Instruction(self, instr):
         if instr.type == ir.IntType(64):
             if instr.opname in ['srem', 'urem', 'sdiv', 'udiv']:
-                name = 'numba.math.{op}'.format(op=instr.opname)
+                name = 'numba_{op}'.format(op=instr.opname)
                 fn = self.module.globals.get(name)
                 # Declare the function if it doesn't already exist
                 if fn is None:

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -352,8 +352,8 @@ def np_real_logaddexp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logaddexpf',
-        types.float64: 'numba.npymath.logaddexp',
+        types.float32: 'numba_npymath_logaddexpf',
+        types.float64: 'numba_npymath_logaddexp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -366,8 +366,8 @@ def np_real_logaddexp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logaddexp2f',
-        types.float64: 'numba.npymath.logaddexp2',
+        types.float32: 'numba_npymath_logaddexp2f',
+        types.float64: 'numba_npymath_logaddexp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -459,8 +459,8 @@ def np_complex_power_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.cpowf',
-        types.complex128: 'numba.npymath.cpow',
+        types.complex64: 'numba_npymath_cpowf',
+        types.complex128: 'numba_npymath_cpow',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -531,8 +531,8 @@ def np_real_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.expf',
-        types.float64: 'numba.npymath.exp',
+        types.float32: 'numba_npymath_expf',
+        types.float64: 'numba_npymath_exp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -543,8 +543,8 @@ def np_complex_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.cexpf',
-        types.complex128: 'numba.npymath.cexp',
+        types.complex64: 'numba_npymath_cexpf',
+        types.complex128: 'numba_npymath_cexp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -557,8 +557,8 @@ def np_real_exp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.exp2f',
-        types.float64: 'numba.npymath.exp2',
+        types.float32: 'numba_npymath_exp2f',
+        types.float64: 'numba_npymath_exp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -584,8 +584,8 @@ def np_real_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.logf',
-        types.float64: 'numba.npymath.log',
+        types.float32: 'numba_npymath_logf',
+        types.float64: 'numba_npymath_log',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -596,8 +596,8 @@ def np_complex_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.clogf',
-        types.complex128: 'numba.npymath.clog',
+        types.complex64: 'numba_npymath_clogf',
+        types.complex128: 'numba_npymath_clog',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -610,8 +610,8 @@ def np_real_log2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log2f',
-        types.float64: 'numba.npymath.log2',
+        types.float32: 'numba_npymath_log2f',
+        types.float64: 'numba_npymath_log2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -637,8 +637,8 @@ def np_real_log10_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log10f',
-        types.float64: 'numba.npymath.log10',
+        types.float32: 'numba_npymath_log10f',
+        types.float64: 'numba_npymath_log10',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -665,8 +665,8 @@ def np_real_expm1_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.expm1f',
-        types.float64: 'numba.npymath.expm1',
+        types.float32: 'numba_npymath_expm1f',
+        types.float64: 'numba_npymath_expm1',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -700,8 +700,8 @@ def np_real_log1p_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.log1pf',
-        types.float64: 'numba.npymath.log1p',
+        types.float32: 'numba_npymath_log1pf',
+        types.float64: 'numba_npymath_log1p',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -736,8 +736,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sqrtf',
-        types.float64: 'numba.npymath.sqrt',
+        types.float32: 'numba_npymath_sqrtf',
+        types.float64: 'numba_npymath_sqrt',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -746,8 +746,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
 
 def np_complex_sqrt_impl(context, builder, sig, args):
     dispatch_table = {
-        types.complex64: 'numba.npymath.csqrtf',
-        types.complex128: 'numba.npymath.csqrt',
+        types.complex64: 'numba_npymath_csqrtf',
+        types.complex128: 'numba_npymath_csqrt',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -842,8 +842,8 @@ def np_real_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sinf',
-        types.float64: 'numba.npymath.sin',
+        types.float32: 'numba_npymath_sinf',
+        types.float64: 'numba_npymath_sin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -854,8 +854,8 @@ def np_complex_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.csinf',
-        types.complex128: 'numba.npymath.csin',
+        types.complex64: 'numba_npymath_csinf',
+        types.complex128: 'numba_npymath_csin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -869,8 +869,8 @@ def np_real_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.cosf',
-        types.float64: 'numba.npymath.cos',
+        types.float32: 'numba_npymath_cosf',
+        types.float64: 'numba_npymath_cos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -881,8 +881,8 @@ def np_complex_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.complex64: 'numba.npymath.ccosf',
-        types.complex128: 'numba.npymath.ccos',
+        types.complex64: 'numba_npymath_ccosf',
+        types.complex128: 'numba_npymath_ccos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -896,8 +896,8 @@ def np_real_tan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.tanf',
-        types.float64: 'numba.npymath.tan',
+        types.float32: 'numba_npymath_tanf',
+        types.float64: 'numba_npymath_tan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -949,8 +949,8 @@ def np_real_asin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.asinf',
-        types.float64: 'numba.npymath.asin',
+        types.float32: 'numba_npymath_asinf',
+        types.float64: 'numba_npymath_asin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1047,8 +1047,8 @@ def np_real_acos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.acosf',
-        types.float64: 'numba.npymath.acos',
+        types.float32: 'numba_npymath_acosf',
+        types.float64: 'numba_npymath_acos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1062,8 +1062,8 @@ def np_real_atan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atanf',
-        types.float64: 'numba.npymath.atan',
+        types.float32: 'numba_npymath_atanf',
+        types.float64: 'numba_npymath_atan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1131,8 +1131,8 @@ def np_real_atan2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atan2f',
-        types.float64: 'numba.npymath.atan2',
+        types.float32: 'numba_npymath_atan2f',
+        types.float64: 'numba_npymath_atan2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1146,8 +1146,8 @@ def np_real_hypot_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.hypotf',
-        types.float64: 'numba.npymath.hypot',
+        types.float32: 'numba_npymath_hypotf',
+        types.float64: 'numba_npymath_hypot',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1161,8 +1161,8 @@ def np_real_sinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.sinhf',
-        types.float64: 'numba.npymath.sinh',
+        types.float32: 'numba_npymath_sinhf',
+        types.float64: 'numba_npymath_sinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1201,8 +1201,8 @@ def np_real_cosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.coshf',
-        types.float64: 'numba.npymath.cosh',
+        types.float32: 'numba_npymath_coshf',
+        types.float64: 'numba_npymath_cosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1240,8 +1240,8 @@ def np_real_tanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.tanhf',
-        types.float64: 'numba.npymath.tanh',
+        types.float32: 'numba_npymath_tanhf',
+        types.float64: 'numba_npymath_tanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1293,8 +1293,8 @@ def np_real_asinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.asinhf',
-        types.float64: 'numba.npymath.asinh',
+        types.float32: 'numba_npymath_asinhf',
+        types.float64: 'numba_npymath_asinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1359,8 +1359,8 @@ def np_real_acosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.acoshf',
-        types.float64: 'numba.npymath.acosh',
+        types.float32: 'numba_npymath_acoshf',
+        types.float64: 'numba_npymath_acosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1401,8 +1401,8 @@ def np_real_atanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.atanhf',
-        types.float64: 'numba.npymath.atanh',
+        types.float32: 'numba_npymath_atanhf',
+        types.float64: 'numba_npymath_atanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1950,8 +1950,8 @@ def np_real_signbit_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.signbitf',
-        types.float64: 'numba.npymath.signbit',
+        types.float32: 'numba_npymath_signbitf',
+        types.float64: 'numba_npymath_signbit',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1967,8 +1967,8 @@ def np_real_nextafter_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.nextafterf',
-        types.float64: 'numba.npymath.nextafter',
+        types.float32: 'numba_npymath_nextafterf',
+        types.float64: 'numba_npymath_nextafter',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1978,8 +1978,8 @@ def np_real_spacing_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba.npymath.spacingf',
-        types.float64: 'numba.npymath.spacing',
+        types.float32: 'numba_npymath_spacingf',
+        types.float64: 'numba_npymath_spacing',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1992,8 +1992,8 @@ def np_real_ldexp_impl(context, builder, sig, args):
     # an 'i' or an 'l'.
 
     dispatch_table = {
-        types.float32: 'numba.npymath.ldexpf',
-        types.float64: 'numba.npymath.ldexp',
+        types.float32: 'numba_npymath_ldexpf',
+        types.float64: 'numba_npymath_ldexp',
     }
 
     # the functions expect the second argument to be have a C int type

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -11,7 +11,7 @@ import math
 from llvmlite.llvmpy import core as lc
 
 from .. import cgutils, typing, types, lowering, errors
-from . import mathimpl, numbers
+from . import cmathimpl, mathimpl, numbers
 
 # some NumPy constants. Note that we could generate some of them using
 # the math library, but having the values copied from npy_math seems to
@@ -352,8 +352,8 @@ def np_real_logaddexp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_logaddexpf',
-        types.float64: 'numba_npymath_logaddexp',
+        types.float32: 'npy_logaddexpf',
+        types.float64: 'npy_logaddexp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -366,8 +366,8 @@ def np_real_logaddexp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_logaddexp2f',
-        types.float64: 'numba_npymath_logaddexp2',
+        types.float32: 'npy_logaddexp2f',
+        types.float64: 'npy_logaddexp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -458,13 +458,14 @@ def np_complex_floor_div_impl(context, builder, sig, args):
 def np_complex_power_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
-    dispatch_table = {
-        types.complex64: 'numba_npymath_cpowf',
-        types.complex128: 'numba_npymath_cpow',
-    }
+    return numbers.complex_power_impl(context, builder, sig, args)
+    #dispatch_table = {
+        #types.complex64: 'npy_cpowf',
+        #types.complex128: 'npy_cpow',
+    #}
 
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'power')
+    #return _dispatch_func_by_name_type(context, builder, sig, args,
+                                       #dispatch_table, 'power')
 
 
 ########################################################################
@@ -531,8 +532,8 @@ def np_real_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_expf',
-        types.float64: 'numba_npymath_exp',
+        types.float32: 'npy_expf',
+        types.float64: 'npy_exp',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -541,14 +542,7 @@ def np_real_exp_impl(context, builder, sig, args):
 
 def np_complex_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.complex64: 'numba_npymath_cexpf',
-        types.complex128: 'numba_npymath_cexp',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'exp')
+    return cmathimpl.exp_impl(context, builder, sig, args)
 
 ########################################################################
 # NumPy exp2
@@ -557,8 +551,8 @@ def np_real_exp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_exp2f',
-        types.float64: 'numba_npymath_exp2',
+        types.float32: 'npy_exp2f',
+        types.float64: 'npy_exp2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -584,8 +578,8 @@ def np_real_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_logf',
-        types.float64: 'numba_npymath_log',
+        types.float32: 'npy_logf',
+        types.float64: 'npy_log',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -594,14 +588,7 @@ def np_real_log_impl(context, builder, sig, args):
 
 def np_complex_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.complex64: 'numba_npymath_clogf',
-        types.complex128: 'numba_npymath_clog',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'log')
+    return cmathimpl.log_impl(context, builder, sig, args)
 
 ########################################################################
 # NumPy log2
@@ -610,8 +597,8 @@ def np_real_log2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_log2f',
-        types.float64: 'numba_npymath_log2',
+        types.float32: 'npy_log2f',
+        types.float64: 'npy_log2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -637,8 +624,8 @@ def np_real_log10_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_log10f',
-        types.float64: 'numba_npymath_log10',
+        types.float32: 'npy_log10f',
+        types.float64: 'npy_log10',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -665,8 +652,8 @@ def np_real_expm1_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_expm1f',
-        types.float64: 'numba_npymath_expm1',
+        types.float32: 'npy_expm1f',
+        types.float64: 'npy_expm1',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -700,8 +687,8 @@ def np_real_log1p_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_log1pf',
-        types.float64: 'numba_npymath_log1p',
+        types.float32: 'npy_log1pf',
+        types.float64: 'npy_log1p',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -736,8 +723,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_sqrtf',
-        types.float64: 'numba_npymath_sqrt',
+        types.float32: 'npy_sqrtf',
+        types.float64: 'npy_sqrt',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -745,13 +732,8 @@ def np_real_sqrt_impl(context, builder, sig, args):
 
 
 def np_complex_sqrt_impl(context, builder, sig, args):
-    dispatch_table = {
-        types.complex64: 'numba_npymath_csqrtf',
-        types.complex128: 'numba_npymath_csqrt',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'sqrt')
+    _check_arity_and_homogeneity(sig, args, 1)
+    return cmathimpl.sqrt_impl(context, builder, sig, args)
 
 
 ########################################################################
@@ -842,8 +824,8 @@ def np_real_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_sinf',
-        types.float64: 'numba_npymath_sin',
+        types.float32: 'npy_sinf',
+        types.float64: 'npy_sin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -852,14 +834,7 @@ def np_real_sin_impl(context, builder, sig, args):
 
 def np_complex_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.complex64: 'numba_npymath_csinf',
-        types.complex128: 'numba_npymath_csin',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'sin')
+    return cmathimpl.sin_impl(context, builder, sig, args)
 
 
 ########################################################################
@@ -869,8 +844,8 @@ def np_real_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_cosf',
-        types.float64: 'numba_npymath_cos',
+        types.float32: 'npy_cosf',
+        types.float64: 'npy_cos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -879,14 +854,7 @@ def np_real_cos_impl(context, builder, sig, args):
 
 def np_complex_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-
-    dispatch_table = {
-        types.complex64: 'numba_npymath_ccosf',
-        types.complex128: 'numba_npymath_ccos',
-    }
-
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'cos')
+    return cmathimpl.cos_impl(context, builder, sig, args)
 
 
 ########################################################################
@@ -896,8 +864,8 @@ def np_real_tan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_tanf',
-        types.float64: 'numba_npymath_tan',
+        types.float32: 'npy_tanf',
+        types.float64: 'npy_tan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -949,8 +917,8 @@ def np_real_asin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_asinf',
-        types.float64: 'numba_npymath_asin',
+        types.float32: 'npy_asinf',
+        types.float64: 'npy_asin',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1047,8 +1015,8 @@ def np_real_acos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_acosf',
-        types.float64: 'numba_npymath_acos',
+        types.float32: 'npy_acosf',
+        types.float64: 'npy_acos',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1062,8 +1030,8 @@ def np_real_atan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_atanf',
-        types.float64: 'numba_npymath_atan',
+        types.float32: 'npy_atanf',
+        types.float64: 'npy_atan',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1131,8 +1099,8 @@ def np_real_atan2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_atan2f',
-        types.float64: 'numba_npymath_atan2',
+        types.float32: 'npy_atan2f',
+        types.float64: 'npy_atan2',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1146,8 +1114,8 @@ def np_real_hypot_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_hypotf',
-        types.float64: 'numba_npymath_hypot',
+        types.float32: 'npy_hypotf',
+        types.float64: 'npy_hypot',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1161,8 +1129,8 @@ def np_real_sinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_sinhf',
-        types.float64: 'numba_npymath_sinh',
+        types.float32: 'npy_sinhf',
+        types.float64: 'npy_sinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1201,8 +1169,8 @@ def np_real_cosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_coshf',
-        types.float64: 'numba_npymath_cosh',
+        types.float32: 'npy_coshf',
+        types.float64: 'npy_cosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1240,8 +1208,8 @@ def np_real_tanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_tanhf',
-        types.float64: 'numba_npymath_tanh',
+        types.float32: 'npy_tanhf',
+        types.float64: 'npy_tanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1293,8 +1261,8 @@ def np_real_asinh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_asinhf',
-        types.float64: 'numba_npymath_asinh',
+        types.float32: 'npy_asinhf',
+        types.float64: 'npy_asinh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1359,8 +1327,8 @@ def np_real_acosh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_acoshf',
-        types.float64: 'numba_npymath_acosh',
+        types.float32: 'npy_acoshf',
+        types.float64: 'npy_acosh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1401,8 +1369,8 @@ def np_real_atanh_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_atanhf',
-        types.float64: 'numba_npymath_atanh',
+        types.float32: 'npy_atanhf',
+        types.float64: 'npy_atanh',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1950,12 +1918,15 @@ def np_real_signbit_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_signbitf',
-        types.float64: 'numba_npymath_signbit',
+        types.float32: 'numba_signbitf',
+        types.float64: 'numba_signbit',
     }
+    inner_sig = typing.signature(types.intc, *sig.args)
 
-    return _dispatch_func_by_name_type(context, builder, sig, args,
-                                       dispatch_table, 'signbit')
+    int_res = _dispatch_func_by_name_type(context, builder, inner_sig, args,
+                                          dispatch_table, 'signbit')
+    bool_res = builder.icmp_unsigned('!=', int_res, int_res.type(0))
+    return bool_res
 
 
 def np_real_copysign_impl(context, builder, sig, args):
@@ -1967,8 +1938,8 @@ def np_real_nextafter_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_nextafterf',
-        types.float64: 'numba_npymath_nextafter',
+        types.float32: 'npy_nextafterf',
+        types.float64: 'npy_nextafter',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1978,8 +1949,8 @@ def np_real_spacing_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
     dispatch_table = {
-        types.float32: 'numba_npymath_spacingf',
-        types.float64: 'numba_npymath_spacing',
+        types.float32: 'npy_spacingf',
+        types.float64: 'npy_spacing',
     }
 
     return _dispatch_func_by_name_type(context, builder, sig, args,
@@ -1991,17 +1962,11 @@ def np_real_ldexp_impl(context, builder, sig, args):
     # arguments are not homogeneous and second arg may come as
     # an 'i' or an 'l'.
 
-    dispatch_table = {
-        types.float32: 'numba_npymath_ldexpf',
-        types.float64: 'numba_npymath_ldexp',
-    }
-
-    # the functions expect the second argument to be have a C int type
+    # the function expects the second argument to be have a C int type
     x1, x2 = args
     ty1, ty2 = sig.args
     # note that types.intc should be equivalent to int_ that is
     # 'NumPy's default int')
     x2 = context.cast(builder, x2, ty2, types.intc)
     f_fi_sig = typing.signature(ty1, ty1, types.intc)
-    return _dispatch_func_by_name_type(context, builder, f_fi_sig, [x1, x2],
-                                       dispatch_table, 'ldexp')
+    return mathimpl.ldexp_impl(context, builder, f_fi_sig, (x1, x2))

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -835,7 +835,7 @@ def complex_power_impl(context, builder, sig, args):
         with otherwise:
             # Lower with call to external function
             fnty = Type.function(Type.void(), [pa.type] * 3)
-            cpow = module.get_or_insert_function(fnty, name="numba.math.cpow")
+            cpow = module.get_or_insert_function(fnty, name="numba_cpow")
             builder.call(cpow, (pa, pb, pc))
 
     res = builder.load(pc)

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -820,8 +820,8 @@ def complex_power_impl(context, builder, sig, args):
     TWO = context.get_constant(fty, 2)
     ZERO = context.get_constant(fty, 0)
 
-    b_real_is_two = builder.fcmp(lc.FCMP_OEQ, b.real, TWO)
-    b_imag_is_zero = builder.fcmp(lc.FCMP_OEQ, b.imag, ZERO)
+    b_real_is_two = builder.fcmp_ordered('==', b.real, TWO)
+    b_imag_is_zero = builder.fcmp_ordered('==', b.imag, ZERO)
     b_is_two = builder.and_(b_real_is_two, b_imag_is_zero)
 
     with builder.if_else(b_is_two) as (then, otherwise):
@@ -834,8 +834,12 @@ def complex_power_impl(context, builder, sig, args):
 
         with otherwise:
             # Lower with call to external function
+            func_name = {
+                types.complex64: "numba_cpowf",
+                types.complex128: "numba_cpow",
+                }[ty]
             fnty = Type.function(Type.void(), [pa.type] * 3)
-            cpow = module.get_or_insert_function(fnty, name="numba_cpow")
+            cpow = module.get_or_insert_function(fnty, name=func_name)
             builder.call(cpow, (pa, pb, pc))
 
     res = builder.load(pc)

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -53,6 +53,15 @@ def sqrt(u):
 def size(arr):
     return arr.size
 
+# Exercise linking to Numpy math functions
+@cc_helperlib.export('np_sqrt', 'f8(f8)')
+def np_sqrt(u):
+    return np.sqrt(u)
+
+@cc_helperlib.export('spacing', 'f8(f8)')
+def np_spacing(u):
+    return np.spacing(u)
+
 
 # This one clashes with libc random() unless pycc is careful with naming.
 @cc_helperlib.export('random', 'f8(i4)')

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -220,6 +220,11 @@ class TestCC(BasePYCCTest):
             for val in (-1, -1 + 0j, np.complex128(-1)):
                 res = lib.sqrt(val)
                 self.assertPreciseEqual(res, 1j)
+            for val in (4, 4.0, np.float64(4)):
+                res = lib.np_sqrt(val)
+                self.assertPreciseEqual(res, 2.0)
+            res = lib.spacing(1.0)
+            self.assertPreciseEqual(res, 2**-52)
             # Implicit seeding at startup should guarantee a non-pathological
             # start state.
             self.assertNotEqual(lib.random(-1), lib.random(-1))
@@ -235,6 +240,8 @@ class TestCC(BasePYCCTest):
                 assert res == 128
                 res = lib.random(42)
                 assert_allclose(res, %(expected)s)
+                res = lib.spacing(1.0)
+                assert_allclose(res, 2**-52)
                 """ % {'expected': expected}
             self.check_cc_compiled_in_subprocess(lib, code)
 

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1396,8 +1396,10 @@ class _LoopTypesTester(TestCase):
     """
     _skip_types = 'OegG'
 
+    # Allowed deviation between Numpy and Numba results
     _ulps = {('arccos', 'F'): 2,
              ('arcsin', 'F'): 4,
+             ('log10', 'D'): 5,
              ('tanh', 'F'): 2,
              }
 

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1397,6 +1397,7 @@ class _LoopTypesTester(TestCase):
     _skip_types = 'OegG'
 
     _ulps = {('arccos', 'F'): 2,
+             ('arcsin', 'F'): 4,
              ('tanh', 'F'): 2,
              }
 

--- a/setup.py
+++ b/setup.py
@@ -62,14 +62,6 @@ ext_dynfunc = Extension(name='numba._dynfunc',
                         depends=['numba/_pymodule.h',
                                  'numba/_dynfunc.c'])
 
-ext_npymath_exports = Extension(name='numba._npymath_exports',
-                                sources=['numba/_npymath_exports.c'],
-                                include_dirs=npymath_info['include_dirs'],
-                                libraries=npymath_info['libraries'],
-                                library_dirs=npymath_info['library_dirs'],
-                                define_macros=npymath_info['define_macros'])
-
-
 ext_dispatcher = Extension(name="numba._dispatcher",
                            include_dirs=[np.get_include()],
                            sources=['numba/_dispatcher.c',
@@ -92,6 +84,7 @@ ext_helperlib = Extension(name="numba._helperlib",
                                    "numba/_math_c99.h",
                                    "numba/_helperlib.c",
                                    "numba/_lapack.c",
+                                   "numba/_npymath_exports.c",
                                    "numba/mathnames.inc"])
 
 ext_typeconv = Extension(name="numba.typeconv._typeconv",
@@ -129,7 +122,7 @@ ext_jitclass_box = Extension(name='numba.jitclass._box',
                              depends=['numba/_pymodule.h'],
                              include_dirs=['numba'])
 
-ext_modules = [ext_dynfunc, ext_npymath_exports, ext_dispatcher,
+ext_modules = [ext_dynfunc, ext_dispatcher,
                ext_helperlib, ext_typeconv,
                ext_npyufunc_ufunc, ext_npyufunc_workqueue, ext_mviewbuf,
                ext_nrt_python, ext_jitclass_box]

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,10 @@ ext_dispatcher = Extension(name="numba._dispatcher",
                            extra_link_args=cpp_link_args)
 
 ext_helperlib = Extension(name="numba._helperlib",
-                          include_dirs=[np.get_include()],
+                          include_dirs=npymath_info['include_dirs'],
+                          libraries=npymath_info['libraries'],
+                          library_dirs=npymath_info['library_dirs'],
+                          define_macros=npymath_info['define_macros'],
                           sources=["numba/_helpermod.c", "numba/_math_c99.c"],
                           extra_compile_args=CFLAGS,
                           extra_link_args=install_name_tool_fixer,


### PR DESCRIPTION
This minimizes our API contact surface with Numpy, and has the nice side-effect of standardizing on a single implementation for more math functions.

Note we could try to remove even more of our dependence on Numpy C functions (given it's most of time for redundant implementations of functions otherwise implemented for the `math` and `cmath` modules). I just did the minimum required to solve the AOT compilation issue.

Based on PR #1946.