### PR TITLE
Make CI tests less verbose

### DIFF
--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -10,9 +10,9 @@ python -m numba.tests.test_runtests
 @rem directive in .coveragerc
 if "%RUN_COVERAGE%" == "yes" (
     coverage erase
-    coverage run runtests.py -b -m -v numba.tests
+    coverage run runtests.py -b -m numba.tests
 ) else (
     set NUMBA_ENABLE_CUDASIM=1
-    python -m numba.runtests -b -m -v numba.tests
+    python -m numba.runtests -b -m numba.tests
 )
 

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -13,7 +13,7 @@ python -m numba.tests.test_runtests
 # directive in .coveragerc
 if [ "$RUN_COVERAGE" == "yes" ]; then
     coverage erase
-    coverage run runtests.py -b -m -v numba.tests
+    coverage run runtests.py -b -m numba.tests
 else
-    NUMBA_ENABLE_CUDASIM=1 python -m numba.runtests -b -m -v numba.tests
+    NUMBA_ENABLE_CUDASIM=1 python -m numba.runtests -b -m numba.tests
 fi


### PR DESCRIPTION
Since we have 6000+ individual test cases, the full verbose printout
is quite painful to display and skim through.