### PR TITLE
Allow 0d constant arrays

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -171,9 +171,10 @@ class _StructProxy(object):
             else:
                 raise TypeError("Invalid store of {value.type} to "
                                 "{ptr.type.pointee} in "
-                                "{self._datamodel}".format(value=value,
-                                                           ptr=ptr,
-                                                           self=self))
+                                "{self._datamodel} "
+                                "(trying to write member #{index})"
+                                .format(value=value, ptr=ptr, self=self,
+                                        index=index))
         self._builder.store(value, ptr)
 
     def __len__(self):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -867,9 +867,13 @@ class BaseContext(object):
         shapevals = [self.get_constant(types.intp, s) for s in ary.shape]
         cshape = Constant.array(llintp, shapevals)
 
-        # Handle strides: use strides of the equivalent C-contiguous array.
-        contig = np.ascontiguousarray(ary)
-        stridevals = [self.get_constant(types.intp, s) for s in contig.strides]
+        # Handle strides
+        if ary.ndim > 0:
+            # Use strides of the equivalent C-contiguous array.
+            contig = np.ascontiguousarray(ary)
+            stridevals = [self.get_constant(types.intp, s) for s in contig.strides]
+        else:
+            stridevals = []
         cstrides = Constant.array(llintp, stridevals)
 
         # Create array structure

--- a/numba/tests/test_arrayconst.py
+++ b/numba/tests/test_arrayconst.py
@@ -8,6 +8,8 @@ from numba.errors import TypingError
 from numba import types
 
 
+a0 = np.array(42)
+
 s1 = np.int32(64)
 
 a1 = np.arange(12)
@@ -18,6 +20,10 @@ dt = np.dtype([('x', np.int8), ('y', 'S3')])
 
 a4 = np.arange(32, dtype=np.int8).view(dt)
 a5 = a4[::-2]
+
+
+def getitem0(i):
+    return a0[()]
 
 
 def getitem1(i):
@@ -55,6 +61,9 @@ class TestConstantArray(unittest.TestCase):
         cfunc = cres.entry_point
         for i in [0, 1, 2]:
             np.testing.assert_array_equal(pyfunc(i), cfunc(i))
+
+    def test_array_const_0d(self):
+        self.check_array_const(getitem0)
 
     def test_array_const_1d_contig(self):
         self.check_array_const(getitem1)


### PR DESCRIPTION
Fix bug where 0d constant arrays raise a `TypeError: Invalid store of [1 x i64] to [0 x i64]`.