### PR TITLE
Do not update conda in CI builds

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -1,18 +1,23 @@
-set CONDA_INSTALL=conda install -q -y
+@rem The cmd /C hack circumvents a regression where conda installs a conda.bat
+@rem script in non-root environments.
+set CONDA_INSTALL=cmd /C conda install -q -y
 set PIP_INSTALL=pip install -q
 
-conda update -q -y conda
+@echo on
+
+@rem Display root environment (for debugging)
+conda list
 @rem Clean up any left-over from a previous build
-conda env remove -q -y -n %CONDA_ENV%
+conda remove --all -q -y -n %CONDA_ENV%
 @rem Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
 conda create -n %CONDA_ENV% -q -y python=%PYTHON% numpy=%NUMPY% cffi pip scipy jinja2 ipython
+
 call activate %CONDA_ENV%
 @rem Install llvmdev (separate channel, for now)
-%CONDA_INSTALL% -c numba llvmdev="3.7*" llvmlite
-@rem Install enum34 and singledispatch for Python < 3.4
+%CONDA_INSTALL% -c numba -n %CONDA_ENV% llvmdev="3.7*" llvmlite
+@rem Install required backports for older Pythons
 if %PYTHON% LSS 3.4 (%CONDA_INSTALL% enum34)
 if %PYTHON% LSS 3.4 (%PIP_INSTALL% singledispatch)
-@rem Install funcsigs for Python < 3.3
 if %PYTHON% LSS 3.3 (%CONDA_INSTALL% -c numba funcsigs)
 @rem Install dependencies for building the documentation
 if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx pygments)

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
+set -v
+
 CONDA_INSTALL="conda install -q -y"
 PIP_INSTALL="pip install -q"
 
-conda update -q -y conda
+# Display root environment (for debugging)
+conda list
 # Clean up any left-over from a previous build
-conda env remove -q -y -n $CONDA_ENV
+# (note workaround for https://github.com/conda/conda/issues/2679:
+#  `conda env remove` issue)
+conda remove --all -q -y -n $CONDA_ENV
 # Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
 conda create -n $CONDA_ENV -q -y python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2 ipython
 
+set +v
 source activate $CONDA_ENV
 set -v
+
 # Install llvmdev (separate channel, for now)
 $CONDA_INSTALL -c numba llvmdev="3.7*" llvmlite
 # Install enum34 and singledispatch for Python < 3.4

--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -15,4 +15,3 @@ if "%RUN_COVERAGE%" == "yes" (
     set NUMBA_ENABLE_CUDASIM=1
     python -m numba.runtests -b -m numba.tests
 )
-

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 source activate $CONDA_ENV
-set -v
+
+# Make sure any error below is reported as such
+set -v -e
+
 # Ensure that the documentation builds without warnings
 pushd docs
 if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi


### PR DESCRIPTION
Also fix a regression that went unnoticed in Windows build scripts (due to a breaking change in conda 4.1.x), as well as a general regression due to `conda env remove` being broken in conda 4.1.x.