### PR TITLE
[WIP] armv7 support

### DIFF
--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import
 
 import sys
+import platform
 
 import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
@@ -39,6 +40,10 @@ class CPUContext(BaseContext):
         self.is32bit = (utils.MACHINE_BITS == 32)
         self._internal_codegen = codegen.JITCPUCodegen("numba.exec")
 
+        # Add ARM ABI functions from libgcc_s
+        if platform.machine() == 'armv7l':
+            ll.load_library_permanently('libgcc_s.so.1')
+        
         # Map external C functions.
         externals.c_math_functions.install(self)
 


### PR DESCRIPTION
Once libgcc_s is loaded, ARM support basically 'just works'.  Tests that still fail:

* test_linalg_pinv: Generates a segfault due to a misaligned load 
* several datetime failures that appear to relate to casting of NaN to int
* several linalg tests where the differences seem disturbingly large.  Not sure if there is something wrong with Numba or the linear algebra library scipy was linked against.