### PR TITLE
Optimize power with a static integer exponent

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -143,13 +143,15 @@ class Expr(Inst):
     @classmethod
     def binop(cls, fn, lhs, rhs, loc):
         op = 'binop'
-        return cls(op=op, loc=loc, fn=fn, lhs=lhs, rhs=rhs)
+        return cls(op=op, loc=loc, fn=fn, lhs=lhs, rhs=rhs,
+                   static_lhs=UNDEFINED, static_rhs=UNDEFINED)
 
     @classmethod
     def inplace_binop(cls, fn, immutable_fn, lhs, rhs, loc):
         op = 'inplace_binop'
         return cls(op=op, loc=loc, fn=fn, immutable_fn=immutable_fn,
-                   lhs=lhs, rhs=rhs)
+                   lhs=lhs, rhs=rhs,
+                   static_lhs=UNDEFINED, static_rhs=UNDEFINED)
 
     @classmethod
     def unary(cls, fn, value, loc):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -434,19 +434,52 @@ class Lower(BaseLower):
     def lower_binop(self, resty, expr, op):
         lhs = expr.lhs
         rhs = expr.rhs
+        static_lhs = expr.static_lhs
+        static_rhs = expr.static_rhs
         lty = self.typeof(lhs.name)
         rty = self.typeof(rhs.name)
         lhs = self.loadvar(lhs.name)
         rhs = self.loadvar(rhs.name)
-        # Get function
-        signature = self.fndesc.calltypes[expr]
-        impl = self.context.get_function(op, signature)
+
         # Convert argument to match
+        signature = self.fndesc.calltypes[expr]
         lhs = self.context.cast(self.builder, lhs, lty, signature.args[0])
         rhs = self.context.cast(self.builder, rhs, rty, signature.args[1])
+
+        def cast_result(res):
+            return self.context.cast(self.builder, res,
+                                     signature.return_type, resty)
+
+        # First try with static operands, if known
+        def try_static_impl(tys, args):
+            if any(a is ir.UNDEFINED for a in args):
+                return None
+            static_sig = typing.signature(signature.return_type, *tys)
+            try:
+                static_impl = self.context.get_function(op, static_sig)
+                return static_impl(self.builder, args)
+            except NotImplementedError:
+                return None
+
+        res = try_static_impl((types.Const(static_lhs), types.Const(static_rhs)),
+                              (static_lhs, static_rhs))
+        if res is not None:
+            return cast_result(res)
+
+        res = try_static_impl((types.Const(static_lhs), rty),
+                              (static_lhs, rhs))
+        if res is not None:
+            return cast_result(res)
+
+        res = try_static_impl((lty, types.Const(static_rhs)),
+                              (lhs, static_rhs))
+        if res is not None:
+            return cast_result(res)
+
+        # Normal implementation for generic arguments
+        impl = self.context.get_function(op, signature)
         res = impl(self.builder, (lhs, rhs))
-        return self.context.cast(self.builder, res,
-                                 signature.return_type, resty)
+        return cast_result(res)
 
     def lower_getitem(self, resty, expr, value, index, signature):
         baseval = self.loadvar(value.name)

--- a/numba/rewrites/__init__.py
+++ b/numba/rewrites/__init__.py
@@ -5,4 +5,4 @@ A subpackage hosting Numba IR rewrite passes.
 from .registry import register_rewrite, rewrite_registry, Rewrite
 
 # Register various built-in rewrite passes
-from . import static_getitem, static_raise, ir_print, macros
+from . import static_getitem, static_raise, static_binop, ir_print, macros

--- a/numba/rewrites/static_binop.py
+++ b/numba/rewrites/static_binop.py
@@ -1,0 +1,35 @@
+from numba import ir, errors
+from . import register_rewrite, Rewrite
+
+
+@register_rewrite('before-inference')
+class DetectStaticBinops(Rewrite):
+    """
+    Detect constant arguments to select binops.
+    """
+
+    # Those operators can benefit from a constant-inferred argument
+    rhs_operators = {'**'}
+
+    def match(self, interp, block, typemap, calltypes):
+        self.static_lhs = {}
+        self.static_rhs = {}
+        self.block = block
+        # Find binop expressions with a constant lhs or rhs
+        for expr in block.find_exprs(op='binop'):
+            try:
+                if (expr.fn in self.rhs_operators
+                    and expr.static_rhs is ir.UNDEFINED):
+                    self.static_rhs[expr] = interp.infer_constant(expr.rhs)
+            except errors.ConstantInferenceError:
+                continue
+
+        return len(self.static_lhs) > 0 or len(self.static_rhs) > 0
+
+    def apply(self):
+        """
+        Store constant arguments that were detected in match().
+        """
+        for expr, rhs in self.static_rhs.items():
+            expr.static_rhs = rhs
+        return self.block

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -166,7 +166,7 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where='input operand'):
     elif tyinp in types.number_domain | set([types.boolean]):
         return _ScalarHelper(ctxt, bld, inp, tyinp)
     else:
-        raise TypeError('unknown type for {0}: {1}'.format(where, str(tyinp)))
+        raise TypeError('unsupported type for {0}: {1}'.format(where, str(tyinp)))
 
 
 _broadcast_onto_sig = types.intp(types.intp, types.CPointer(types.intp),

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -166,7 +166,7 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where='input operand'):
     elif tyinp in types.number_domain | set([types.boolean]):
         return _ScalarHelper(ctxt, bld, inp, tyinp)
     else:
-        raise TypeError('unsupported type for {0}: {1}'.format(where, str(tyinp)))
+        raise NotImplementedError('unsupported type for {0}: {1}'.format(where, str(tyinp)))
 
 
 _broadcast_onto_sig = types.intp(types.intp, types.CPointer(types.intp),

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -191,7 +191,6 @@ def int_power_impl(context, builder, sig, args):
     is_integer = isinstance(sig.args[0], types.Integer)
     tp = sig.return_type
     zerodiv_return = _get_power_zerodiv_return(context, tp)
-    print("int_power_impl:", tp, zerodiv_return)
 
     def int_power(a, b):
         # Ensure computations are done with a large enough width

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import math
+import numbers
 
 import numpy as np
 
@@ -174,16 +175,23 @@ def int_rem_impl(context, builder, sig, args):
                               builder.load(res))
 
 
+def _get_power_zerodiv_return(context, return_type):
+    if (isinstance(return_type, types.Integer)
+        and not context.error_model.raise_on_fp_zero_division):
+        # If not raising, return 0x8000... when computing 0 ** <negative number>
+        return -1 << (return_type.bitwidth - 1)
+    else:
+        return False
+
+
 def int_power_impl(context, builder, sig, args):
     """
     a ^ b, where a is an integer or real, and b an integer
     """
     is_integer = isinstance(sig.args[0], types.Integer)
     tp = sig.return_type
-    zerodiv_return = False
-    if is_integer and not context.error_model.raise_on_fp_zero_division:
-        # If not raising, return 0x8000... when computing 0 ** <negative number>
-        zerodiv_return = -1 << (tp.bitwidth - 1)
+    zerodiv_return = _get_power_zerodiv_return(context, tp)
+    print("int_power_impl:", tp, zerodiv_return)
 
     def int_power(a, b):
         # Ensure computations are done with a large enough width
@@ -218,6 +226,69 @@ def int_power_impl(context, builder, sig, args):
 
     res = context.compile_internal(builder, int_power, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@lower_builtin('**', types.Integer, types.Const)
+@lower_builtin('**', types.Float, types.Const)
+def static_power_impl(context, builder, sig, args):
+    """
+    a ^ b, where a is an integer or real, and b a constant integer
+    """
+    exp = sig.args[1].value
+    if not isinstance(exp, numbers.Integral):
+        raise NotImplementedError
+    if abs(exp) > 0x10000:
+        # Optimization cutoff: fallback on the generic algorithm above
+        raise NotImplementedError
+    invert = exp < 0
+    exp = abs(exp)
+
+    tp = sig.return_type
+    is_integer = isinstance(tp, types.Integer)
+    zerodiv_return = _get_power_zerodiv_return(context, tp)
+
+    val = context.cast(builder, args[0], sig.args[0], tp)
+    lty = val.type
+
+    def mul(a, b):
+        if is_integer:
+            return builder.mul(a, b)
+        else:
+            return builder.fmul(a, b)
+
+    # Unroll the exponentiation loop
+    res = lty(1)
+    a = val
+    while exp != 0:
+        if exp & 1:
+            res = mul(res, val)
+        exp >>= 1
+        val = mul(val, val)
+
+    if invert:
+        # If the exponent was negative, fix the result by inverting it
+        if is_integer:
+            # Integer inversion
+            def invert_impl(a):
+                if a == 0:
+                    if zerodiv_return:
+                        return zerodiv_return
+                    else:
+                        raise ZeroDivisionError("0 cannot be raised to a negative power")
+                if a != 1 and a != -1:
+                    return 0
+                else:
+                    return a
+
+        else:
+            # Real inversion
+            def invert_impl(a):
+                return 1.0 / a
+
+        res = context.compile_internal(builder, invert_impl,
+                                       typing.signature(tp, tp), (res,))
+
+    return res
 
 
 def int_slt_impl(context, builder, sig, args):


### PR DESCRIPTION
This ensures that scalar expressions such as `x ** 3` are always optimized properly, regardless of whether LLVM is able to loop-unroll the dynamic version of the implementation.