### PR TITLE
Also rewrite trivial array expressions

### DIFF
--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -4,11 +4,15 @@ import ast
 from collections import defaultdict
 import sys
 
-from numpy import ufunc
+import numpy as np
 
 from .. import compiler, ir, types, rewrites, six
 from ..typing import npydecl
 from .dufunc import DUFunc
+
+
+def _is_ufunc(func):
+    return isinstance(func, (np.ufunc, DUFunc))
 
 
 @rewrites.register_rewrite('after-inference')
@@ -26,62 +30,78 @@ class RewriteArrayExprs(rewrites.Rewrite):
             special_ops['arrayexpr'] = _lower_array_expr
 
     def match(self, interp, block, typemap, calltypes):
-        '''Using typing and a basic block, search the basic block for array
-        expressions.  Returns True when one or more matches were
-        found, False otherwise.
-        '''
+        """
+        Using typing and a basic block, search the basic block for array
+        expressions.
+        Return True when one or more matches were found, False otherwise.
+        """
         matches = []
-        # We can trivially reject everything if there are fewer than 2
-        # calls in the type results since we'll only rewrite when
-        # there are two or more calls.
-        if len(calltypes) > 1:
+        # We can trivially reject everything if there are no
+        # calls in the type results.
+        if len(calltypes) > 0:
             self.crnt_block = block
             self.typemap = typemap
             self.matches = matches
-            array_assigns = {}
-            self.array_assigns = array_assigns
-            const_assigns = {}
-            self.const_assigns = const_assigns
+            self.array_assigns = {}
+            self.const_assigns = {}
+
             assignments = block.find_insts(ir.Assign)
             for instr in assignments:
                 target_name = instr.target.name
                 expr = instr.value
-                if isinstance(expr, ir.Expr) and isinstance(
-                        typemap.get(target_name, None), types.Array):
-                    # We've matched a subexpression assignment to an
-                    # array variable.  Now see if the expression is an
-                    # array expression.
-                    expr_op = expr.op
-                    if ((expr_op in ('unary', 'binop')) and (
-                            expr.fn in npydecl.supported_array_operators)):
-                        # Matches an array operation that maps to a ufunc.
-                        array_assigns[target_name] = instr
-                    elif ((expr_op == 'call') and (expr.func.name in typemap)):
-                        # Could be a match for a ufunc or DUFunc call.
-                        func_type = typemap[expr.func.name]
-                        # Note: func_type can be a types.Dispatcher, which
-                        #       doesn't have the `.template` attribute.
-                        if isinstance(func_type, types.Function):
-                            func_key = func_type.typing_key
-                            if isinstance(func_key, (ufunc, DUFunc)):
-                                # If so, match it as a potential subexpression.
-                                array_assigns[target_name] = instr
-                    # Now check to see if we matched anything of
-                    # interest; if so, check to see if one of the
-                    # expression's dependencies isn't also a matching
-                    # expression.
-                    if target_name in array_assigns:
-                        operands = set(var.name
-                                       for var in expr.list_vars())
-                        if operands.intersection(array_assigns.keys()):
-                            # We've identified a nested array
-                            # expression.  Rewrite it.
-                            matches.append(target_name)
+                # Does it assign an expression to an array variable?
+                if (isinstance(expr, ir.Expr) and
+                    isinstance(typemap.get(target_name, None), types.Array)):
+                    self._match_array_expr(instr, expr, target_name)
                 elif isinstance(expr, ir.Const):
                     # Track constants since we might need them for an
                     # array expression.
-                    const_assigns[target_name] = expr
+                    self.const_assigns[target_name] = expr
+
         return len(matches) > 0
+
+    def _match_array_expr(self, instr, expr, target_name):
+        """
+        Find whether the given assignment (*instr*) of an expression (*expr*)
+        to variable *target_name* is an array expression.
+        """
+        # We've matched a subexpression assignment to an
+        # array variable.  Now see if the expression is an
+        # array expression.
+        expr_op = expr.op
+        array_assigns = self.array_assigns
+
+        if ((expr_op in ('unary', 'binop')) and (
+                expr.fn in npydecl.supported_array_operators)):
+            # It is an array operator that maps to a ufunc.
+            array_assigns[target_name] = instr
+
+        elif ((expr_op == 'call') and (expr.func.name in self.typemap)):
+            # It could be a match for a known ufunc call.
+            func_type = self.typemap[expr.func.name]
+            if isinstance(func_type, types.Function):
+                func_key = func_type.typing_key
+                if _is_ufunc(func_key):
+                    # If so, check whether an explicit output is passed.
+                    if not self._has_explicit_output(expr, func_key):
+                        # If not, match it as a potential (sub)expression.
+                        array_assigns[target_name] = instr
+
+        # If we matched anything of interest, record it.
+        if target_name in array_assigns:
+            self.matches.append(target_name)
+
+    def _has_explicit_output(self, expr, func):
+        """
+        Return whether the *expr* call to *func* (a ufunc) features an
+        explicit output argument.
+        """
+        nargs = len(expr.args) + len(expr.kws)
+        if expr.vararg is not None:
+            # XXX *args unsupported here, assume there may be an explicit
+            # output
+            return True
+        return nargs > func.nin
 
     def _get_array_operator(self, ir_expr):
         ir_op = ir_expr.op
@@ -265,7 +285,7 @@ def _arr_expr_to_ast(expr):
             else:
                 assert op in _unaryops
                 return ast.UnaryOp(_unaryops[op](), ast_args[0]), env
-        elif isinstance(op, (ufunc, DUFunc)):
+        elif _is_ufunc(op):
             fn_name = "__ufunc_or_dufunc_{0}".format(
                 hex(hash(op)).replace("-", "_"))
             fn_ast_name = ast.Name(fn_name, ast.Load())

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -22,13 +22,19 @@ from numba.typing.npydecl import supported_ufuncs, all_ufuncs
 is32bits = tuple.__itemsize__ == 4
 iswindows = sys.platform.startswith('win32')
 
+# NOTE: to test the implementation of Numpy ufuncs, we disable rewriting
+# of array expressions.
+
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
+enable_pyobj_flags.set("no_rewrites")
 
 no_pyobj_flags = Flags()
+no_pyobj_flags.set("no_rewrites")
 
 enable_nrt_flags = Flags()
 enable_nrt_flags.set("nrt")
+enable_nrt_flags.set("no_rewrites")
 
 
 def _unimplemented(func):

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -172,10 +172,20 @@ class ConfigOptions(object):
     def unset(self, name):
         self.set(name, False)
 
-    def __getattr__(self, name):
+    def _check_attr(self, name):
         if name not in self.OPTIONS:
-            raise NameError("Invalid flag: %s" % name)
+            raise AttributeError("Invalid flag: %s" % name)
+
+    def __getattr__(self, name):
+        self._check_attr(name)
         return self._values[name]
+
+    def __setattr__(self, name, value):
+        if name.startswith('_'):
+            super(ConfigOptions, self).__setattr__(name, value)
+        else:
+            self._check_attr(name)
+            self._values[name] = value
 
     def __repr__(self):
         return "Flags(%s)" % ', '.join('%s=%s' % (k, v)


### PR DESCRIPTION
Simple non-nested array expressions need to be rewritten in order to enable scalar optimizations on them.  For example, this PR speeds up `x ** 3` on arrays by 100x.