### PR TITLE
Remove benchmarks from test suite

### DIFF
--- a/numba/cuda/tests/cudadrv/test_pinned.py
+++ b/numba/cuda/tests/cudadrv/test_pinned.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
-from timeit import default_timer as timer
+
 import numpy as np
+
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
 
@@ -10,37 +11,25 @@ REPEAT = 25
 
 class TestPinned(CUDATestCase):
 
-    def _template(self, name, A):
+    def _run_copies(self, A):
         A0 = np.copy(A)
 
-        s = timer()
         stream = cuda.stream()
         ptr = cuda.to_device(A, copy=False, stream=stream)
-
         ptr.copy_to_device(A, stream=stream)
-
         ptr.copy_to_host(A, stream=stream)
         stream.synchronize()
 
-        e = timer()
-
         self.assertTrue(np.allclose(A, A0))
-
-        elapsed = e - s
-        return elapsed
 
     def test_pinned(self):
         A = np.arange(2*1024*1024) # 16 MB
-        total = 0
         with cuda.pinned(A):
-            for i in range(REPEAT):
-                total += self._template('pinned', A)
+            self._run_copies(A)
 
     def test_unpinned(self):
         A = np.arange(2*1024*1024) # 16 MB
-        total = 0
-        for i in range(REPEAT):
-            total += self._template('unpinned', A)
+        self._run_copies(A)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, absolute_import
 
-from timeit import default_timer as time
-
 import numpy as np
 import numpy.core.umath_tests as ut
 
@@ -10,10 +8,6 @@ from numba import guvectorize
 from numba import cuda
 from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
-
-
-non_stream_speedups = []
-stream_speedups = []
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
@@ -43,18 +37,8 @@ class TestCUDAGufunc(unittest.TestCase):
         B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(matrix_ct, 4,
                                                                    5)
 
-        ts = time()
         C = gufunc(A, B)
-        tcuda = time() - ts
-
-        ts = time()
         Gold = ut.matrix_multiply(A, B)
-        tcpu = time() - ts
-
-        non_stream_speedups.append(tcpu / tcuda)
-
-        print(C, Gold)
-
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_auto_transfer(self):
@@ -82,18 +66,8 @@ class TestCUDAGufunc(unittest.TestCase):
 
         dB = cuda.to_device(B)
 
-        ts = time()
         C = gufunc(A, dB).copy_to_host()
-        tcuda = time() - ts
-
-        ts = time()
         Gold = ut.matrix_multiply(A, B)
-        tcpu = time() - ts
-
-        non_stream_speedups.append(tcpu / tcuda)
-
-        print(C, Gold)
-
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc(self):
@@ -119,16 +93,8 @@ class TestCUDAGufunc(unittest.TestCase):
         B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(matrix_ct, 4,
                                                                    5)
 
-        ts = time()
         C = gufunc(A, B)
-        tcuda = time() - ts
-
-        ts = time()
         Gold = ut.matrix_multiply(A, B)
-        tcpu = time() - ts
-
-        non_stream_speedups.append(tcpu / tcuda)
-
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_hidim(self):
@@ -152,16 +118,8 @@ class TestCUDAGufunc(unittest.TestCase):
         A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(4, 25, 2, 4)
         B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(4, 25, 4, 5)
 
-        ts = time()
         C = gufunc(A, B)
-        tcuda = time() - ts
-
-        ts = time()
         Gold = ut.matrix_multiply(A, B)
-        tcpu = time() - ts
-
-        non_stream_speedups.append(tcpu / tcuda)
-
         self.assertTrue(np.allclose(C, Gold))
 
     def test_gufunc_new_axis(self):
@@ -243,7 +201,6 @@ class TestCUDAGufunc(unittest.TestCase):
         B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(matrix_ct, 4,
                                                                    5)
 
-        ts = time()
         stream = cuda.stream()
         dA = cuda.to_device(A, stream)
         dB = cuda.to_device(B, stream)
@@ -253,13 +210,7 @@ class TestCUDAGufunc(unittest.TestCase):
         C = dC.copy_to_host(stream=stream)
         stream.synchronize()
 
-        tcuda = time() - ts
-
-        ts = time()
         Gold = ut.matrix_multiply(A, B)
-        tcpu = time() - ts
-
-        stream_speedups.append(tcpu / tcuda)
 
         self.assertTrue(np.allclose(C, Gold))
 

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -1,7 +1,5 @@
 from __future__ import print_function, division, absolute_import
 
-from timeit import default_timer as time
-
 import numpy as np
 
 from numba import cuda, config, float32
@@ -58,7 +56,6 @@ class TestCudaMatMul(unittest.TestCase):
         B = np.array(np.random.random((n, n)), dtype=np.float32)
         C = np.empty_like(A)
 
-        s = time()
         stream = cuda.stream()
         with stream.auto_synchronize():
             dA = cuda.to_device(A, stream)
@@ -67,14 +64,8 @@ class TestCudaMatMul(unittest.TestCase):
             cu_square_matrix_mul[(bpg, bpg), (tpb, tpb), stream](dA, dB, dC)
             dC.copy_to_host(C, stream)
 
-        e = time()
-        tcuda = e - s
-
         # Host compute
-        s = time()
         Cans = np.dot(A, B)
-        e = time()
-        tcpu = e - s
 
         # Check result
         np.testing.assert_allclose(C, Cans, rtol=1e-5)

--- a/numba/tests/npyufunc/test_parallel_low_work.py
+++ b/numba/tests/npyufunc/test_parallel_low_work.py
@@ -2,11 +2,13 @@
 There was a deadlock problem when work count is smaller than number of threads.
 """
 from __future__ import absolute_import, print_function, division
+
 from numba import unittest_support as unittest
+
 import numpy as np
+
 from numba import float32, float64, int32, uint32
 from numba.npyufunc import Vectorize
-from timeit import default_timer as time
 
 
 def vector_add(a, b):

--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division, absolute_import
-from timeit import Timer
 
 import numpy as np
 

--- a/numba/tests/test_blackscholes.py
+++ b/numba/tests/test_blackscholes.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import math
-from timeit import default_timer as timer
 
 import numpy as np
 
@@ -146,21 +145,8 @@ class TestBlackScholes(TestCase):
 
         args = stockPrice, optionStrike, optionYears, RISKFREE, VOLATILITY
 
-        ts = timer()
-        for i in range(iterations):
-            callResultGold, putResultGold = blackscholes_arrayexpr(*args)
-        te = timer()
-        pytime = te - ts
-
-        ts = timer()
-        for i in range(iterations):
-            callResultNumba, putResultNumba = jitted_bs(*args)
-        te = timer()
-        jittime = te - ts
-
-        print("Python", pytime)
-        print("Numba", jittime)
-        print("Speedup: %s" % (pytime / jittime))
+        callResultGold, putResultGold = blackscholes_arrayexpr(*args)
+        callResultNumba, putResultNumba = jitted_bs(*args)
 
         delta = np.abs(callResultGold - callResultNumba)
         L1norm = delta.sum() / np.abs(callResultGold).sum()
@@ -205,21 +191,8 @@ class TestBlackScholes(TestCase):
 
         args = stockPrice, optionStrike, optionYears, RISKFREE, VOLATILITY
 
-        ts = timer()
-        for i in range(iterations):
-             blackscholes_scalar(callResultGold, putResultGold, *args)
-        te = timer()
-        pytime = te - ts
-
-        ts = timer()
-        for i in range(iterations):
-            jitted_bs(callResultNumba, putResultNumba, *args)
-        te = timer()
-        jittime = te - ts
-
-        print("Python", pytime)
-        print("Numba", jittime)
-        print("Speedup: %s" % (pytime / jittime))
+        blackscholes_scalar(callResultGold, putResultGold, *args)
+        jitted_bs(callResultNumba, putResultNumba, *args)
 
         delta = np.abs(callResultGold - callResultNumba)
         L1norm = delta.sum() / np.abs(callResultGold).sum()


### PR DESCRIPTION
Remove benchmark measurements and printouts (that nobody probably ever reads) from the test suite, now we have a benchmark suite where they should belong.