### PR TITLE
Implement np.linalg.{det, slogdet}.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -169,6 +169,7 @@ floating-point and complex numbers:
 * On Python 3.5 and above, the matrix multiplication operator from
   :pep:`465` (i.e. ``a @ b`` where ``a`` and ``b`` are 1-D or 2-D arrays).
 * :func:`numpy.linalg.cholesky`
+* :func:`numpy.linalg.det`
 * :func:`numpy.linalg.eig` (only running with data that does not cause a domain
   change is supported e.g. real input -> real
   output, complex input -> complex output).
@@ -176,6 +177,7 @@ floating-point and complex numbers:
 * :func:`numpy.linalg.lstsq`
 * :func:`numpy.linalg.pinv`
 * :func:`numpy.linalg.qr` (only the first argument).
+* :func:`numpy.linalg.slogdet`
 * :func:`numpy.linalg.solve`
 * :func:`numpy.linalg.svd` (only the 2 first arguments).
 

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1660,6 +1660,8 @@ def slogdet_impl(a):
         # The following, prior to the call to diag_walker, is present
         # to account for the effect of possible permutations to the
         # sign of the determinant.
+        # This is the same idea as in numpy:
+        # https://github.com/numpy/numpy/blob/master/numpy/linalg/umath_linalg.c.src#L1099-L1110
         sgn = 1
         for k in range(n):
             sgn = sgn + (ipiv[k] != (k + 1))

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1574,3 +1574,112 @@ def pinv_impl(a, rcond=1.e-15):
         return acpy.T.ravel().reshape(a.shape).T
 
     return pinv_impl
+
+# Walks the diag of a LUP decomposed matrix
+# uses that det(A) = prod(diag(lup(A)))
+# and also that log(a)+log(b) = log(a*b)
+# The return sign is adjusted based on the values found
+# such that the log(value) stays in the real domain.
+
+
+def _get_slogdet_diag_walker(a):
+    if isinstance(a.dtype, types.scalars.Complex):
+        @jit(nopython=True)
+        def cmplx_diag_walker(n, a, sgn):
+            # walk diagonal
+            csgn = sgn + 0.j
+            acc = 0.
+            for k in range(n):
+                absel = np.abs(a[k, k])
+                csgn = csgn * (a[k, k] / absel)
+                acc = acc + np.log(absel)
+            return (csgn, acc)
+        return cmplx_diag_walker
+    else:
+        @jit(nopython=True)
+        def real_diag_walker(n, a, sgn):
+            # walk diagonal
+            acc = 0.
+            for k in range(n):
+                v = a[k, k]
+                if v < 0.:
+                    sgn = -sgn
+                    v = -v
+                acc = acc + np.log(v)
+            # sgn is a float dtype
+            return (sgn + 0., acc)
+        return real_diag_walker
+
+
+@overload(np.linalg.slogdet)
+def slogdet_impl(a):
+    ensure_lapack()
+
+    _check_linalg_matrix(a, "slogdet")
+
+    numba_xxgetrf_sig = types.intc(types.char,   # kind
+                                   types.intp,  # m
+                                   types.intp,  # n
+                                   types.CPointer(a.dtype),  # a
+                                   types.intp,  # lda
+                                   types.CPointer(F_INT_nbtype)  # ipiv
+                                   )
+
+    numba_xxgetrf = types.ExternalFunction("numba_xxgetrf",
+                                           numba_xxgetrf_sig)
+
+    kind = ord(get_blas_kind(a.dtype, "slogdet"))
+
+    F_layout = a.layout == 'F'
+
+    diag_walker = _get_slogdet_diag_walker(a)
+
+    def slogdet_impl(a):
+        n = a.shape[-1]
+        if a.shape[-2] != n:
+            msg = "Last 2 dimensions of the array must be square."
+            raise np.linalg.LinAlgError(msg)
+
+        _check_finite_matrix(a)
+
+        if F_layout:
+            acpy = np.copy(a)
+        else:
+            acpy = np.asfortranarray(a)
+
+        ipiv = np.empty(n, dtype=F_INT_nptype)
+
+        r = numba_xxgetrf(kind, n, n, acpy.ctypes, n, ipiv.ctypes)
+
+        if r > 0:
+            # factorisation failed, return same defaults as np
+            return (0., -np.inf)
+        _inv_err_handler(r)  # catch input-to-lapack problem
+
+        sgn = 1
+        for k in range(n):
+            sgn = sgn + (ipiv[k] != (k + 1))
+
+        sgn = np.mod(sgn, 2)
+        if sgn == 0:
+            sgn = -1
+
+        # help liveness analysis
+        ipiv.size
+        return diag_walker(n, acpy, sgn)
+
+    return slogdet_impl
+
+
+@overload(np.linalg.det)
+def det_impl(a):
+
+    ensure_lapack()
+
+    _check_linalg_matrix(a, "det")
+
+    def det_impl(a):
+        (sgn, slogdet) = np.linalg.slogdet(a)
+        return sgn * np.exp(slogdet)
+
+    return det_impl

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1661,7 +1661,9 @@ def slogdet_impl(a):
         # to account for the effect of possible permutations to the
         # sign of the determinant.
         # This is the same idea as in numpy:
-        # https://github.com/numpy/numpy/blob/master/numpy/linalg/umath_linalg.c.src#L1099-L1110
+        # File name `umath_linalg.c.src` e.g.
+        # https://github.com/numpy/numpy/blob/master/numpy/linalg/umath_linalg.c.src
+        # in function `@TYPE@_slogdet_single_element`.
         sgn = 1
         for k in range(n):
             sgn = sgn + (ipiv[k] != (k + 1))

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -1605,7 +1605,7 @@ class TestLinalgSlogdet(TestLinalgBase):
                 got_conv, expected[0], nulp=10)
             # compare log determinant magnitude with a more fuzzy value
             # as numpy values come from higher precision lapack routines
-            resolution = 5 * np.finfo(expected[1]).resolution
+            resolution = 5 * np.finfo(a.dtype).resolution
             np.testing.assert_allclose(
                 got[1], expected[1], rtol=resolution, atol=resolution)
 
@@ -1659,8 +1659,11 @@ class TestLinalgDet(TestLinalgBase):
         def check(a, **kwargs):
             expected = det_matrix(a, **kwargs)
             got = cfunc(a, **kwargs)
+
+            resolution = 5 * np.finfo(a.dtype).resolution
+
             # check the determinants are the same
-            np.testing.assert_allclose(got, expected)
+            np.testing.assert_allclose(got, expected, rtol=resolution)
 
             # Ensure proper resource management
             with self.assertNoNRTLeak():

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -1566,52 +1566,63 @@ class TestLinalgPinv(TestLinalgBase):
                                             dtype=np.float64),))
 
 
-class TestLinalgSlogdet(TestLinalgBase):
+class TestLinalgDetAndSlogdet(TestLinalgBase):
     """
-    Tests for np.linalg.slogdet.
+    Tests for np.linalg.det. and np.linalg.slogdet.
+    Exactly the same inputs are used for both tests as
+    det() is a trivial function of slogdet(), the tests
+    are therefore combined.
     """
 
-    @needs_lapack
-    def test_linalg_slogdet(self):
-        """
-        Test np.linalg.slogdet
-        """
-        cfunc = jit(nopython=True)(slogdet_matrix)
+    def check_det(self, cfunc, a, **kwargs):
+        expected = det_matrix(a, **kwargs)
+        got = cfunc(a, **kwargs)
 
-        def check(a, **kwargs):
-            expected = slogdet_matrix(a, **kwargs)
-            got = cfunc(a, **kwargs)
+        resolution = 5 * np.finfo(a.dtype).resolution
 
-            # As numba returns python floats types and numpy returns
-            # numpy float types, some more adjustment and different
-            # types of comparison than those used with array based
-            # results is required.
+        # check the determinants are the same
+        np.testing.assert_allclose(got, expected, rtol=resolution)
 
-            # check that the returned tuple is same length
-            self.assertEqual(len(expected), len(got))
-            # and that length is 2
-            self.assertEqual(len(got), 2)
+        # Ensure proper resource management
+        with self.assertNoNRTLeak():
+            cfunc(a, **kwargs)
 
-            # check that the domain of the results match
-            for k in range(2):
-                self.assertEqual(
-                    np.iscomplexobj(got[k]),
-                    np.iscomplexobj(expected[k]))
+    def check_slogdet(self, cfunc, a, **kwargs):
+        expected = slogdet_matrix(a, **kwargs)
+        got = cfunc(a, **kwargs)
 
-            # turn got[0] into the same dtype as `a`
-            # this is so checking with nulp will work
-            got_conv = a.dtype.type(got[0])
-            np.testing.assert_array_almost_equal_nulp(
-                got_conv, expected[0], nulp=10)
-            # compare log determinant magnitude with a more fuzzy value
-            # as numpy values come from higher precision lapack routines
-            resolution = 5 * np.finfo(a.dtype).resolution
-            np.testing.assert_allclose(
-                got[1], expected[1], rtol=resolution, atol=resolution)
+        # As numba returns python floats types and numpy returns
+        # numpy float types, some more adjustment and different
+        # types of comparison than those used with array based
+        # results is required.
 
-            # Ensure proper resource management
-            with self.assertNoNRTLeak():
-                cfunc(a, **kwargs)
+        # check that the returned tuple is same length
+        self.assertEqual(len(expected), len(got))
+        # and that length is 2
+        self.assertEqual(len(got), 2)
+
+        # check that the domain of the results match
+        for k in range(2):
+            self.assertEqual(
+                np.iscomplexobj(got[k]),
+                np.iscomplexobj(expected[k]))
+
+        # turn got[0] into the same dtype as `a`
+        # this is so checking with nulp will work
+        got_conv = a.dtype.type(got[0])
+        np.testing.assert_array_almost_equal_nulp(
+            got_conv, expected[0], nulp=10)
+        # compare log determinant magnitude with a more fuzzy value
+        # as numpy values come from higher precision lapack routines
+        resolution = 5 * np.finfo(a.dtype).resolution
+        np.testing.assert_allclose(
+            got[1], expected[1], rtol=resolution, atol=resolution)
+
+        # Ensure proper resource management
+        with self.assertNoNRTLeak():
+            cfunc(a, **kwargs)
+
+    def do_test(self, rn, check, cfunc):
 
         # test: 1x1 as it is unusual, 4x4 as it is even and 7x7 as is it odd!
         sizes = [(1, 1), (4, 4), (7, 7)]
@@ -1621,14 +1632,12 @@ class TestLinalgSlogdet(TestLinalgBase):
                 product(sizes, self.dtypes, 'FC'):
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
-            check(a)
+            check(cfunc, a)
 
         # use a matrix of zeros to trip xgetrf U(i,i)=0 singular test
         for dtype, order in product(self.dtypes, 'FC'):
             a = np.zeros((3, 3), dtype=dtype)
-            check(a)
-
-        rn = "slogdet"
+            check(cfunc, a)
 
         # Wrong dtype
         self.assert_wrong_dtype(rn, cfunc,
@@ -1642,63 +1651,16 @@ class TestLinalgSlogdet(TestLinalgBase):
         self.assert_no_nan_or_inf(cfunc,
                                   (np.array([[1., 2., ], [np.inf, np.nan]],
                                             dtype=np.float64),))
-
-
-class TestLinalgDet(TestLinalgBase):
-    """
-    Tests for np.linalg.det.
-    """
 
     @needs_lapack
     def test_linalg_det(self):
-        """
-        Test np.linalg.det
-        """
         cfunc = jit(nopython=True)(det_matrix)
+        self.do_test("det", self.check_det, cfunc)
 
-        def check(a, **kwargs):
-            expected = det_matrix(a, **kwargs)
-            got = cfunc(a, **kwargs)
-
-            resolution = 5 * np.finfo(a.dtype).resolution
-
-            # check the determinants are the same
-            np.testing.assert_allclose(got, expected, rtol=resolution)
-
-            # Ensure proper resource management
-            with self.assertNoNRTLeak():
-                cfunc(a, **kwargs)
-
-        # test: 1x1 as it is unusual, 4x4 as it is even and 7x7 as is it odd!
-        sizes = [(1, 1), (4, 4), (7, 7)]
-
-        # test loop
-        for size, dtype, order in \
-                product(sizes, self.dtypes, 'FC'):
-            # check a full rank matrix
-            a = self.specific_sample_matrix(size, dtype, order)
-            check(a)
-
-        # use a matrix of zeros to trip xgetrf U(i,i)=0 singular test
-        for dtype, order in product(self.dtypes, 'FC'):
-            a = np.zeros((3, 3), dtype=dtype)
-            check(a)
-
-        rn = "det"
-
-        # Wrong dtype
-        self.assert_wrong_dtype(rn, cfunc,
-                                (np.ones((2, 2), dtype=np.int32),))
-
-        # Dimension issue
-        self.assert_wrong_dimensions(rn, cfunc,
-                                     (np.ones(10, dtype=np.float64),))
-
-        # no nans or infs
-        self.assert_no_nan_or_inf(cfunc,
-                                  (np.array([[1., 2., ], [np.inf, np.nan]],
-                                            dtype=np.float64),))
-
+    @needs_lapack
+    def test_linalg_slogdet(self):
+        cfunc = jit(nopython=True)(slogdet_matrix)
+        self.do_test("slogdet", self.check_slogdet, cfunc)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch implements and tests:
 * `np.linalg.det`
 * `np.linalg.slogdet`