### PR TITLE
Fix dispatcher._DispatcherBase.disable_compile()

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -213,7 +213,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         """Disable the compilation of new signatures at call time.
         """
         # If disabling compilation then there must be at least one signature
-        assert val or len(self.signatures) > 0
+        assert (not val) or len(self.signatures) > 0
         self._can_compile = not val
 
     def add_overload(self, cres):


### PR DESCRIPTION
Compilation can be disabled only if there is at least one signature already.

`disable_compile(val)` would like to change `_can_compile` flag to `not val`.
This should raise an error if `val == True` and `len(signatures) == 0`.
Therefore we should put the assertion
```python
    assert (not val) or len(signatures) > 0
```