### PR TITLE
Patch Numpy's exec_command() to avoid crashes on Windows in test_pycc

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -5,6 +5,8 @@ set PIP_INSTALL=pip install -q
 
 @echo on
 
+@rem Deactivate any environment
+call deactivate
 @rem Display root environment (for debugging)
 conda list
 @rem Clean up any left-over from a previous build

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -5,6 +5,8 @@ set -v
 CONDA_INSTALL="conda install -q -y"
 PIP_INSTALL="pip install -q"
 
+# Deactivate any environment
+source deactivate
 # Display root environment (for debugging)
 conda list
 # Clean up any left-over from a previous build

--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -123,3 +123,87 @@ class Toolchain(object):
         Given a C extension's module name, return its intended filename.
         """
         return self._build_ext.get_ext_filename(ext_name)
+
+
+#
+# Patch Numpy's exec_command() to avoid random crashes on Windows in test_pycc
+# see https://github.com/numpy/numpy/pull/7614
+# and https://github.com/numpy/numpy/pull/7862
+#
+
+def _patch_exec_command():
+    # Patch the internal worker _exec_command()
+    import numpy.distutils.exec_command as mod
+    orig_exec_command = mod._exec_command
+    mod._exec_command = _exec_command
+
+def _exec_command(command, use_shell=None, use_tee = None, **env):
+    """
+    Internal workhorse for exec_command().
+    Code from https://github.com/numpy/numpy/pull/7862
+    """
+    if use_shell is None:
+        use_shell = os.name=='posix'
+    if use_tee is None:
+        use_tee = os.name=='posix'
+
+    executable = None
+
+    if os.name == 'posix' and use_shell:
+        # On POSIX, subprocess always uses /bin/sh, override
+        sh = os.environ.get('SHELL', '/bin/sh')
+        if is_sequence(command):
+            command = [sh, '-c', ' '.join(command)]
+        else:
+            command = [sh, '-c', command]
+        use_shell = False
+
+    elif os.name == 'nt' and _is_sequence(command):
+        # On Windows, join the string for CreateProcess() ourselves as
+        # subprocess does it a bit differently
+        command = ' '.join(_quote_arg(arg) for arg in command)
+
+    # Inherit environment by default
+    env = env or None
+    try:
+        proc = subprocess.Popen(command, shell=use_shell, env=env,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True)
+    except EnvironmentError:
+        # Return 127, as os.spawn*() and /bin/sh do
+        return '', 127
+    text, err = proc.communicate()
+    # Only append stderr if the command failed, as otherwise
+    # the output may become garbled for parsing
+    if proc.returncode:
+        if text:
+            text += "\n"
+        text += err
+    # Another historical oddity
+    if text[-1:] == '\n':
+        text = text[:-1]
+    if use_tee:
+        print(text)
+    return proc.returncode, text
+
+
+def _quote_arg(arg):
+    """
+    Quote the argument for safe use in a shell command line.
+    """
+    # If there is a quote in the string, assume relevants parts of the
+    # string are already quoted (e.g. '-I"C:\\Program Files\\..."')
+    if '"' not in arg and ' ' in arg:
+        return '"%s"' % arg
+    return arg
+
+
+def _is_sequence(arg):
+    if isinstance(arg, (str, bytes)):
+        return False
+    try:
+        len(arg)
+        return True
+    except Exception:
+        return False

--- a/numba/tests/pycc_distutils_usecase/setup_distutils.py
+++ b/numba/tests/pycc_distutils_usecase/setup_distutils.py
@@ -2,8 +2,12 @@ from distutils.core import setup
 
 from source_module import cc
 
+from numba.pycc.platform import _patch_exec_command
+
 
 def run_setup():
+    # Avoid sporadic crashes on Windows due to MSVCRT spawnve()
+    _patch_exec_command()
     setup(ext_modules=[cc.distutils_extension()])
 
 

--- a/numba/tests/pycc_distutils_usecase/setup_setuptools.py
+++ b/numba/tests/pycc_distutils_usecase/setup_setuptools.py
@@ -2,8 +2,12 @@ from setuptools import setup
 
 from source_module import cc
 
+from numba.pycc.platform import _patch_exec_command
+
 
 def run_setup():
+    # Avoid sporadic crashes on Windows due to MSVCRT spawnve()
+    _patch_exec_command()
     setup(ext_modules=[cc.distutils_extension()])
 
 


### PR DESCRIPTION
See https://github.com/numpy/numpy/pull/7614 for context,
and https://github.com/numpy/numpy/pull/7862 for the patch submitted upstream.
This should fix random failures on our Windows CI builders.

Based on PR #2002.