### PR TITLE
Fix #1998 ufunc deadlock

### DIFF
--- a/numba/tests/npyufunc/test_parallel_ufunc_issues.py
+++ b/numba/tests/npyufunc/test_parallel_ufunc_issues.py
@@ -64,11 +64,11 @@ class TestParUfuncIssues(unittest.TestCase):
             stdout = buf.getvalue()
             buf.close()
             # process outputs from print
-            got_output = ''.join(sorted(map(lambda x: x.strip(), stdout)))
+            got_output = sorted(map(lambda x: x.strip(), stdout.splitlines()))
             # build expected output
             expected_output = [str(x % 10) for x in range(nelem)]
             expected_output += [characters[x % 10] for x in range(nelem)]
-            expected_output = ''.join(sorted(expected_output))
+            expected_output = sorted(expected_output)
             # verify
             self.assertEqual(got_output, expected_output)
             np.testing.assert_equal(got, 2 * acopy)

--- a/numba/tests/npyufunc/test_parallel_ufunc_issues.py
+++ b/numba/tests/npyufunc/test_parallel_ufunc_issues.py
@@ -1,9 +1,14 @@
 from __future__ import print_function, absolute_import, division
 
-from numba import unittest_support as unittest
-from numba import vectorize
-import numpy as np
 import time
+import ctypes
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba.tests.support import captured_output
+from numba import vectorize
+
 
 class TestParUfuncIssues(unittest.TestCase):
     def test_thread_response(self):
@@ -25,6 +30,46 @@ class TestParUfuncIssues(unittest.TestCase):
             np.testing.assert_equal(a + b, fnv(a, b))
             # Reduce sleep time
             sleep_time /= 2
+
+    def test_gil_reacquire_deadlock(self):
+        """
+        Testing issue #1998 due to GIL reacquiring
+        """
+        # make a ctypes callback that requires the GIL
+        proto = ctypes.CFUNCTYPE(None, ctypes.c_int32)
+
+        def bar(x):
+            print('c', x)
+
+        cbar = proto(bar)
+
+        # our unit under test
+        @vectorize(['int32(int32)'], target='parallel', nopython=True)
+        def foo(x):
+            print('p', x)  # this reacquires the GIL
+            cbar(x)        # this reacquires the GIL
+            return x
+
+        # Numpy ufunc has a heuristic to determine whether to release the GIL
+        # during execution.  Small input size (10) seems to not release the GIL.
+        # Large input size (1000) seems to release the GIL.
+        for nelem in [1, 10, 100, 1000]:
+            # inputs
+            a = np.arange(nelem, dtype=np.int32)
+            acopy = a.copy()
+            # run and capture stdout
+            with captured_output('stdout') as buf:
+                got = foo(a)
+            stdout = buf.getvalue()
+            buf.close()
+            got_output = sorted(stdout.splitlines())
+            # build expected output
+            expected_output = list(map('c {0}'.format, range(nelem)))
+            expected_output += list(map('p {0}'.format, range(nelem)))
+            expected_output = sorted(expected_output)
+            # verify
+            self.assertEqual(got_output, expected_output)
+            np.testing.assert_equal(got, acopy)
 
 
 if __name__ == '__main__':

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -15,8 +15,8 @@ import sys
 import tempfile
 import time
 try:
-    # prefered over pure-python StringIO due to threadsafety
-    # note: parallel write to StringIO could cause data to went missing
+    # preferred over pure-python StringIO due to threadsafety
+    # note: parallel write to StringIO could cause data to go missing
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -14,12 +14,6 @@ import subprocess
 import sys
 import tempfile
 import time
-try:
-    # preferred over pure-python StringIO due to threadsafety
-    # note: parallel write to StringIO could cause data to go missing
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 import numpy as np
 
@@ -541,7 +535,7 @@ def captured_output(stream_name):
     """Return a context manager used by captured_stdout/stdin/stderr
     that temporarily replaces the sys stream *stream_name* with a StringIO."""
     orig_stdout = getattr(sys, stream_name)
-    setattr(sys, stream_name, StringIO())
+    setattr(sys, stream_name, utils.StringIO())
     try:
         yield getattr(sys, stream_name)
     finally:

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -14,6 +14,12 @@ import subprocess
 import sys
 import tempfile
 import time
+try:
+    # prefered over pure-python StringIO due to threadsafety
+    # note: parallel write to StringIO could cause data to went missing
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import numpy as np
 
@@ -535,7 +541,7 @@ def captured_output(stream_name):
     """Return a context manager used by captured_stdout/stdin/stderr
     that temporarily replaces the sys stream *stream_name* with a StringIO."""
     orig_stdout = getattr(sys, stream_name)
-    setattr(sys, stream_name, utils.StringIO())
+    setattr(sys, stream_name, StringIO())
     try:
         yield getattr(sys, stream_name)
     finally:

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -14,6 +14,12 @@ import sys
 import numpy as np
 
 from .six import *
+try:
+    # preferred over pure-python StringIO due to threadsafety
+    # note: parallel write to StringIO could cause data to go missing
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 from numba.config import PYVERSION, MACHINE_BITS
 
 


### PR DESCRIPTION
Note: numpy ufunc may or may not release the GIL in due to some heuristic on the size of the input array.