### PR TITLE
Implements `numpy.linalg.cond()`.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -169,6 +169,7 @@ floating-point and complex numbers:
 * On Python 3.5 and above, the matrix multiplication operator from
   :pep:`465` (i.e. ``a @ b`` where ``a`` and ``b`` are 1-D or 2-D arrays).
 * :func:`numpy.linalg.cholesky`
+* :func:`numpy.linalg.cond` (only non string values in ``p``).
 * :func:`numpy.linalg.det`
 * :func:`numpy.linalg.eig` (only running with data that does not cause a domain
   change is supported e.g. real input -> real

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -2086,6 +2086,8 @@ def cond_impl(a, p=None):
                 # `largest singular value/smallest singular value`, and for the
                 # case of `p==-2` the result is simply the
                 # `smallest singular value/largest singular value`.
+                # As a result of this, numba accepts non-square matrices as
+                # input when p==+/-2 as well as when p==None.
                 if p == 2 or p == -2:
                     s = sv_func(a)
                     if p == 2:

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1725,6 +1725,85 @@ def det_impl(a):
     return det_impl
 
 
+def _compute_singular_values(a):
+    """
+    Returns a function to compute singular values of `a`
+    """
+    numba_ez_gesdd = _LAPACK().numba_ez_gesdd(a.dtype)
+
+    kind = ord(get_blas_kind(a.dtype, "svd"))
+
+    # Flag for "only compute `S`" to give to xgesdd
+    JOBZ_N = ord('N')
+
+    nb_ret_type = getattr(a.dtype, "underlying_float", a.dtype)
+    np_ret_type = np_support.as_dtype(nb_ret_type)
+    np_dtype = np_support.as_dtype(a.dtype)
+
+    # This are not referenced in the computation but must be set
+    # for MKL.
+    u = np.empty((1, 1), dtype=np_dtype)
+    vt = np.empty((1, 1), dtype=np_dtype)
+
+    F_layout = a.layout == 'F'
+
+    @jit(nopython=True)
+    def sv_function(a):
+        """
+        Computes singular values.
+        """
+        # Don't use the np.linalg.svd impl instead
+        # call LAPACK to shortcut doing the "reconstruct
+        # singular vectors from reflectors" step and just
+        # get back the singular values.
+        _check_finite_matrix(a)
+        n = a.shape[-1]
+        m = a.shape[-2]
+        ldu = m
+        minmn = min(m, n)
+
+        # need to be >=1 but aren't referenced
+        ucol = 1
+        ldvt = 1
+
+        _check_finite_matrix(a)
+
+        if F_layout:
+            acpy = np.copy(a)
+        else:
+            acpy = np.asfortranarray(a)
+
+        # u and vt are not referenced however need to be
+        # allocated (as done above) for MKL as it
+        # checks for ref is nullptr.
+        s = np.empty(minmn, dtype=np_ret_type)
+
+        r = numba_ez_gesdd(
+            kind,        # kind
+            JOBZ_N,      # jobz
+            m,           # m
+            n,           # n
+            acpy.ctypes,  # a
+            m,           # lda
+            s.ctypes,    # s
+            u.ctypes,    # u
+            ldu,         # ldu
+            vt.ctypes,   # vt
+            ldvt         # ldvt
+        )
+        _handle_err_maybe_convergence_problem(r)
+
+        # help liveness analysis
+        acpy.size
+        vt.size
+        u.size
+        s.size
+
+        return s
+
+    return sv_function
+
+
 def _get_norm_impl(a, ord_flag):
     # This function is quite involved as norm supports a large
     # range of values to select different norm types via kwarg `ord`.
@@ -1847,71 +1926,7 @@ def _get_norm_impl(a, ord_flag):
     elif a.ndim == 2:
         # 2D cases
 
-        numba_ez_gesdd = _LAPACK().numba_ez_gesdd(a.dtype)
-
-        # Flag for "only compute `S`" to give to xgesdd
-        JOBZ_N = ord('N')
-
-        # This are not referenced in the computation but must be set
-        # for MKL.
-        u = np.empty((1, 1), dtype=np_dtype)
-        vt = np.empty((1, 1), dtype=np_dtype)
-
-        F_layout = a.layout == 'F'
-
-        # type based limit for use in min based functions
-        max_val = np.finfo(np_ret_type.type).max
-
-        @jit(nopython=True)
-        def twoD_norm_from_svd(a):
-            # Don't use the np.linalg.svd impl instead
-            # call LAPACK to shortcut doing the "reconstruct
-            # singular vectors from reflectors" step and just
-            # get back the singular values.
-            _check_finite_matrix(a)
-            n = a.shape[-1]
-            m = a.shape[-2]
-            ldu = m
-            minmn = min(m, n)
-
-            # need to be >=1 but aren't referenced
-            ucol = 1
-            ldvt = 1
-
-            _check_finite_matrix(a)
-
-            if F_layout:
-                acpy = np.copy(a)
-            else:
-                acpy = np.asfortranarray(a)
-
-            # u and vt are not referenced however need to be
-            # allocated (as done above) for MKL as it
-            # checks for ref is nullptr.
-            s = np.empty(minmn, dtype=np_ret_type)
-
-            r = numba_ez_gesdd(
-                kind,        # kind
-                JOBZ_N,      # jobz
-                m,           # m
-                n,           # n
-                acpy.ctypes,  # a
-                m,           # lda
-                s.ctypes,    # s
-                u.ctypes,    # u
-                ldu,         # ldu
-                vt.ctypes,   # vt
-                ldvt         # ldvt
-            )
-            _handle_err_maybe_convergence_problem(r)
-
-            # help liveness analysis
-            acpy.size
-            vt.size
-            u.size
-            s.size
-
-            return s
+        sv_func = _compute_singular_values(a)
 
         # handle "ord" being "None"
         if ord_flag in (None, types.none):
@@ -1944,6 +1959,9 @@ def _get_norm_impl(a, ord_flag):
 
                 return ret[0]
         else:
+            # max value for this dtype
+            max_val = np.finfo(np_ret_type.type).max
+
             @jit(nopython=True)
             def twoD_impl(a, order=None):
                 n = a.shape[-1]
@@ -2007,10 +2025,10 @@ def _get_norm_impl(a, ord_flag):
                 # by definition.
                 elif order == 2:
                     # max SV
-                    return twoD_norm_from_svd(a)[0]
+                    return sv_func(a)[0]
                 elif order == -2:
                     # min SV
-                    return twoD_norm_from_svd(a)[-1]
+                    return sv_func(a)[-1]
                 else:
                     # replicate numpy error
                     raise ValueError("Invalid norm order for matrices.")
@@ -2031,3 +2049,58 @@ def norm_impl(a, ord=None):
         return impl(a, ord)
 
     return norm_impl
+
+
+@overload(np.linalg.cond)
+def cond_impl(a, p=None):
+    ensure_lapack()
+
+    _check_linalg_matrix(a, "cond")
+
+    sv_func = _compute_singular_values(a)
+
+    def _get_cond_impl(a, p):
+        # handle the p==None case separately for type inference to work ok
+        if p in (None, types.none):
+            @jit(nopython=True)
+            def cond_none_impl(a, p):
+                s = sv_func(a)
+                return s[0] / s[-1]
+            return cond_none_impl
+        else:
+            @jit(nopython=True)
+            def cond_not_none_impl(a, p):
+                # This is extracted for performance, numpy does approximately:
+                # `condition = norm(a) * norm(inv(a))`
+                # in the cases of `p == 2` or `p ==-2` singular values are used
+                # for computing norms. This costs numpy an svd of `a` then an
+                # inversion of `a` and another svd of `a`.
+                # Below is a different approach, which also gives a more
+                # accurate answer as there is no inversion involved.
+                # Recall that the singular values of an inverted matrix are the
+                # reciprocal of singular values of the original matrix.
+                # Therefore calling `svd(a)` once yields all the information
+                # needed about both `a` and `inv(a)` without the cost or
+                # potential loss of accuracy incurred through inversion.
+                # For the case of `p == 2`, the result is just the ratio of
+                # `largest singular value/smallest singular value`, and for the
+                # case of `p==-2` the result is simply the
+                # `smallest singular value/largest singular value`.
+                if p == 2 or p == -2:
+                    s = sv_func(a)
+                    if p == 2:
+                        return s[0] / s[-1]
+                    else:
+                        return s[-1] / s[0]
+                else:  # cases np.inf, -np.inf, 1, -1
+                    norm_a = np.linalg.norm(a, p)
+                    norm_inv_a = np.linalg.norm(np.linalg.inv(a), p)
+                    return norm_a * norm_inv_a
+            return cond_not_none_impl
+
+    impl = _get_cond_impl(a, p)
+
+    def cond_impl(a, p=None):
+        return impl(a, p)
+
+    return cond_impl

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -1828,6 +1828,13 @@ class TestLinalgCond(TestLinalgBase):
             a = self.specific_sample_matrix(size, dtype, order)
             check(a, p=p)
 
+        # When p=None non-square matrices are accepted.
+        sizes = [(7, 1), (11, 5), (5, 11), (1, 7)]
+        for size, dtype, order in \
+                product(sizes, self.dtypes, 'FC'):
+            a = self.specific_sample_matrix(size, dtype, order)
+            check(a)
+
         # try an ill-conditioned system with 2-norm, make sure np raises an
         # overflow warning as the result is `+inf` and that the result from
         # numba matches.

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -349,6 +349,10 @@ def norm_matrix(a, ord=None):
     return np.linalg.norm(a, ord)
 
 
+def cond_matrix(a, p=None):
+    return np.linalg.cond(a, p)
+
+
 class TestLinalgBase(TestCase):
     """
     Provides setUp and common data/error modes for testing np.linalg functions.
@@ -531,6 +535,13 @@ class TestLinalgBase(TestCase):
             atol = 100 * resolution  # zeros tend to be fuzzy
         # check it matches
         np.testing.assert_allclose(got, eye, rtol, atol)
+
+    def assert_invalid_norm_kind(self, cfunc, args):
+        """
+        For use in norm() and cond() tests.
+        """
+        msg = "Invalid norm order for matrices."
+        self.assert_error(cfunc, args, msg, ValueError)
 
 
 class TestTestLinalgBase(TestCase):
@@ -1676,10 +1687,6 @@ class TestLinalgNorm(TestLinalgSystems):
     Tests for np.linalg.norm.
     """
 
-    def assert_invalid_norm_kind(self, cfunc, args):
-        msg = "Invalid norm order for matrices."
-        self.assert_error(cfunc, args, msg, ValueError)
-
     @needs_lapack
     def test_linalg_norm(self):
         """
@@ -1783,5 +1790,73 @@ class TestLinalgNorm(TestLinalgSystems):
                                                        dtype=np.float64), 6))
 
 
+class TestLinalgCond(TestLinalgBase):
+    """
+    Tests for np.linalg.cond.
+    """
+
+    @needs_lapack
+    def test_linalg_cond(self):
+        """
+        Test np.linalg.cond
+        """
+
+        cfunc = jit(nopython=True)(cond_matrix)
+
+        def check(a, **kwargs):
+            expected = cond_matrix(a, **kwargs)
+            got = cfunc(a, **kwargs)
+
+            # All results should be in the real domain
+            self.assertTrue(not np.iscomplexobj(got))
+
+            resolution = 5 * np.finfo(a.dtype).resolution
+
+            # check the cond is the same to the arg `a` precision
+            np.testing.assert_allclose(got, expected, rtol=resolution)
+
+            # Ensure proper resource management
+            with self.assertNoNRTLeak():
+                cfunc(a, **kwargs)
+
+        # valid p values (used to indicate norm type)
+        ps = [None, np.inf, -np.inf, 1, -1, 2, -2]
+        sizes = [(3, 3), (7, 7)]
+
+        for size, dtype, order, p in \
+                product(sizes, self.dtypes, 'FC', ps):
+            a = self.specific_sample_matrix(size, dtype, order)
+            check(a, p=p)
+
+        # try an ill-conditioned system with 2-norm, make sure np raises an
+        # overflow warning as the result is `+inf` and that the result from
+        # numba matches.
+        with warnings.catch_warnings():
+            a = np.array([[1.e308, 0], [0, 0.1]], dtype=np.float64)
+            warnings.simplefilter("error", RuntimeWarning)
+            self.assertRaisesRegexp(RuntimeWarning,
+                                    'overflow encountered in.*',
+                                    check, a)
+            warnings.simplefilter("ignore", RuntimeWarning)
+            check(a)
+
+        rn = "cond"
+
+        # Wrong dtype
+        self.assert_wrong_dtype(rn, cfunc,
+                                (np.ones((2, 2), dtype=np.int32),))
+
+        # Dimension issue
+        self.assert_wrong_dimensions(rn, cfunc,
+                                     (np.ones(10, dtype=np.float64),))
+
+        # no nans or infs when p="None" (default for kwarg).
+        self.assert_no_nan_or_inf(cfunc,
+                                  (np.array([[1., 2., ], [np.inf, np.nan]],
+                                            dtype=np.float64),))
+
+        # assert raises for an invalid norm kind kwarg
+        self.assert_invalid_norm_kind(cfunc, (np.array([[1., 2.], [3., 4.]],
+                                                       dtype=np.float64), 6))
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch adds an implementation of `numpy.linalg.cond`.
It also:
 * Refactors the code to pull out a function for computing
   singular values as these are used in multiple places.
 * Adds tests for `numpy.linalg.cond`.