### PR TITLE
Implement numpy.linalg.matrix_rank().

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -176,6 +176,7 @@ floating-point and complex numbers:
   output, complex input -> complex output).
 * :func:`numpy.linalg.inv`
 * :func:`numpy.linalg.lstsq`
+* :func:`numpy.linalg.matrix_rank`
 * :func:`numpy.linalg.norm` (only the 2 first arguments and only non string
   values in ``ord``).
 * :func:`numpy.linalg.pinv`

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -2150,7 +2150,7 @@ def matrix_rank_impl(a, tol=None):
                 # replicate numpy default tolerance calculation
                 r = a.shape[0]
                 c = a.shape[1]
-                l = r if r > c else c
+                l = max(r, c)
                 t = s[0] * l * eps_val
                 return get_rank(s, t)
             return _2d_tol_none_impl
@@ -2178,7 +2178,10 @@ def matrix_rank_impl(a, tol=None):
             # The code below replicates the numpy behaviour.
             @jit(nopython=True)
             def _1d_matrix_rank_impl(a, tol):
-                return int(np.all(a != 0.))
+                for k in range(len(a)):
+                    if a[k] != 0.:
+                        return 1
+                return 0
             return _1d_matrix_rank_impl
         elif ndim == 2:
             return _2d_matrix_rank_impl(a, tol)


### PR DESCRIPTION
This patch implements `numpy.linalg.matrix_rank()` and adds
tests for the implementation.