### PR TITLE
Fix #2006: `array(float32) ** int` should return array(float32)

### DIFF
--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -500,8 +500,8 @@ def _implement_integer_operators():
         lower_builtin('<=', ty, ty)(int_ule_impl)
         lower_builtin('>', ty, ty)(int_ugt_impl)
         lower_builtin('>=', ty, ty)(int_uge_impl)
-        lower_builtin('**', types.float64, ty)(int_power_impl)
-        lower_builtin(pow, types.float64, ty)(int_power_impl)
+        lower_builtin('**', types.Float, ty)(int_power_impl)
+        lower_builtin(pow, types.Float, ty)(int_power_impl)
         lower_builtin(abs, ty)(uint_abs_impl)
 
     for ty in types.signed_domain:
@@ -509,8 +509,8 @@ def _implement_integer_operators():
         lower_builtin('<=', ty, ty)(int_sle_impl)
         lower_builtin('>', ty, ty)(int_sgt_impl)
         lower_builtin('>=', ty, ty)(int_sge_impl)
-        lower_builtin('**', types.float64, ty)(int_power_impl)
-        lower_builtin(pow, types.float64, ty)(int_power_impl)
+        lower_builtin('**', types.Float, ty)(int_power_impl)
+        lower_builtin(pow, types.Float, ty)(int_power_impl)
         lower_builtin(abs, ty)(int_abs_impl)
 
 def _implement_bitwise_operators():

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -1432,7 +1432,7 @@ class TestStaticPower(TestCase):
 
     def test_real_values(self):
         exponents = [1, 2, 3, 5, 17, 0, -1, -2, -3, 0x111111, -0x111112]
-        vals = [1.5, 3.25, -1.25, np.float32(-1.5), float('inf'), float('nan')]
+        vals = [1.5, 3.25, -1.25, np.float32(-2.0), float('inf'), float('nan')]
 
         self._check_pow(exponents, vals)
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -217,10 +217,11 @@ class BinOpFloorDiv(ConcreteTemplate):
 class BinOpPower(ConcreteTemplate):
     key = "**"
     cases = list(integer_binop_cases)
+    # Ensure that float32 ** int doesn't go through DP computations
+    cases += [signature(types.float32, types.float32, op)
+              for op in (types.int32, types.int64, types.uint64)]
     cases += [signature(types.float64, types.float64, op)
-              for op in sorted(types.signed_domain)]
-    cases += [signature(types.float64, types.float64, op)
-              for op in sorted(types.unsigned_domain)]
+              for op in (types.int32, types.int64, types.uint64)]
     cases += [signature(op, op, op)
               for op in sorted(types.real_domain)]
     cases += [signature(op, op, op)


### PR DESCRIPTION
Also make `float32 ** int` faster when vectorized (e.g. `float32 ** 3` can now be vectorized as FP32 SIMD, becoming twice faster than `float64 ** 3`).