### PR TITLE
llvm_call() for inserting LLVM IR

### DIFF
--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -16,7 +16,8 @@ for use in :term:`nopython mode` functions.  The function decorated with
 runtime arguments.  It should return a callable representing the
 *implementation* of the function for the given types.  The returned
 implementation is compiled by Numba as if it were a normal function
-decorated with ``@jit``.
+decorated with ``@jit``.  Additional options to ``@jit`` can be passed as
+dictionary using the ``jit_options`` argument.
 
 For example, let's pretend Numba doesn't support the :func:`len` function
 on tuples yet.  Here is how to implement it using ``@overload``::

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -42,7 +42,7 @@ def type_callable(func):
     return decorate
 
 
-def overload(func):
+def overload(func, jit_options={}):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode.
@@ -61,11 +61,13 @@ def overload(func):
                     return n
                 return len_impl
 
+    Compiler options can be passed as an dictionary using the **jit_options**
+    argument.
     """
     from .typing.templates import make_overload_template, infer_global
 
     def decorate(overload_func):
-        template = make_overload_template(func, overload_func)
+        template = make_overload_template(func, overload_func, jit_options)
         infer(template)
         if hasattr(func, '__module__'):
             infer_global(func, types.Function(template))

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -43,6 +43,11 @@ def type_callable(func):
     return decorate
 
 
+# By default, an *overload* does not have a cpython wrapper because it is not
+# callable from python.
+_overload_default_jit_options = {'no_cpython_wrapper': True}
+
+
 def overload(func, jit_options={}):
     """
     A decorator marking the decorated function as typing and implementing
@@ -67,8 +72,12 @@ def overload(func, jit_options={}):
     """
     from .typing.templates import make_overload_template, infer_global
 
+    # set default options
+    opts = _overload_default_jit_options.copy()
+    opts.update(jit_options)  # let user options override
+
     def decorate(overload_func):
-        template = make_overload_template(func, overload_func, jit_options)
+        template = make_overload_template(func, overload_func, opts)
         infer(template)
         if hasattr(func, '__module__'):
             infer_global(func, types.Function(template))

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -180,9 +180,9 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
         return impl_ret_borrowed(context, builder, attrty, attrval)
 
 
-class _LLVMCall(object):
+class _Intrinsic(object):
     """
-    Dummy callable for llvm_call
+    Dummy callable for intrinsic
     """
     _memo = weakref.WeakValueDictionary()
     __uuid = None
@@ -211,9 +211,9 @@ class _LLVMCall(object):
         self._memo[u] = self
 
     def _register(self):
-        from .typing.templates import make_llvm_call_template, infer_global
+        from .typing.templates import make_intrinsic_template, infer_global
 
-        template = make_llvm_call_template(self, self._defn, self._name)
+        template = make_intrinsic_template(self, self._defn, self._name)
         infer(template)
         infer_global(self, types.Function(template))
 
@@ -225,7 +225,7 @@ class _LLVMCall(object):
         raise NotImplementedError(msg)
 
     def __repr__(self):
-        return "<llvm_call {0}>".format(self._name)
+        return "<intrinsic {0}>".format(self._name)
 
     def __reduce__(self):
         from numba import serialize
@@ -253,7 +253,7 @@ class _LLVMCall(object):
             return llc
 
 
-def llvm_call(func):
+def intrinsic(func):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode using the llvmlite IRBuilder API.  This is an escape
@@ -273,7 +273,7 @@ def llvm_call(func):
     Here is an example implementing a ``cast_int_to_byte_ptr`` that cast
     any integer to a byte pointer::
 
-        @llvm_call
+        @intrinsic
         def cast_int_to_byte_ptr(typingctx, src):
             # check for accepted types
             if isinstance(src, types.Integer):
@@ -290,6 +290,6 @@ def llvm_call(func):
                 return sig, codegen
     """
     name = getattr(func, '__name__', str(func))
-    llc = _LLVMCall(name, func)
+    llc = _Intrinsic(name, func)
     llc._register()
     return llc

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -452,7 +452,7 @@ class BaseContext(object):
         lty = self.get_value_type(ty)
         return Constant.null(lty)
 
-    def get_function(self, fn, sig):
+    def get_function(self, fn, sig, _firstcall=True):
         """
         Return the implementation of function *fn* for signature *sig*.
         The return value is a callable with the signature (builder, args).
@@ -477,6 +477,13 @@ class BaseContext(object):
             except NotImplementedError:
                 # Raise exception for the type instance, for a better error message
                 pass
+
+        # Automatically refresh the context to load new registries if we are
+        # calling the first time.
+        if _firstcall:
+            self.refresh()
+            return self.get_function(fn, sig, _firstcall=False)
+
         raise NotImplementedError("No definition for lowering %s%s" % (key, sig))
 
     def get_generator_desc(self, genty):

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -187,6 +187,7 @@ class CPUTargetOptions(TargetOptions):
         "boundcheck": bool,
         "_nrt": bool,
         "no_rewrites": bool,
+        "no_cpython_wrapper": bool,
     }
 
 

--- a/numba/targets/options.py
+++ b/numba/targets/options.py
@@ -58,6 +58,9 @@ class TargetOptions(object):
         if kws.pop('no_rewrites', False):
             flags.set('no_rewrites')
 
+        if kws.pop('no_cpython_wrapper', False):
+            flags.set('no_cpython_wrapper')
+
         flags.set("enable_pyobject_looplift")
 
         if kws:

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -247,7 +247,7 @@ def return_non_boxable():
     return np
 
 
-@overload(return_non_boxable, jit_options={'no_cpython_wrapper': True})
+@overload(return_non_boxable)
 def overload_return_non_boxable():
     def imp():
         return np

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -492,7 +492,7 @@ class TestLLVMCall(TestCase):
         def unsafe_get_ctypes_pointer(src):
             raise NotImplementedError("not callable from python")
 
-        @overload(unsafe_get_ctypes_pointer, {'no_cpython_wrapper': True})
+        @overload(unsafe_get_ctypes_pointer)
         def array_impl_unsafe_get_ctypes_pointer(arrtype):
             if isinstance(arrtype, types.Array):
                 unsafe_cast = unsafe_caster(types.CPointer(arrtype.dtype))

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -325,14 +325,14 @@ def make_overload_template(func, overload_func, jit_options):
     return type(base)(name, (base,), dct)
 
 
-class _LLVMCallTemplate(AbstractTemplate):
+class _IntrinsicTemplate(AbstractTemplate):
     """
-    A base class of templates for llvm_call intrinsic definition
+    A base class of templates for intrinsic intrinsic definition
     """
 
     def generic(self, args, kws):
         """
-        Type the llvm_call intrinsic by the arguments.
+        Type the intrinsic intrinsic by the arguments.
         """
         from numba.targets.imputils import lower_builtin
 
@@ -363,13 +363,13 @@ class _LLVMCallTemplate(AbstractTemplate):
         return self._overload_cache[sig.args]
 
 
-def make_llvm_call_template(handle, defn, name):
+def make_intrinsic_template(handle, defn, name):
     """
-    Make a template class for a llvm_call handle *handle* defined by the
+    Make a template class for a intrinsic handle *handle* defined by the
     function *defn*.  The *name* is used for naming the new template class.
     """
-    base = _LLVMCallTemplate
-    name = "_LLVMCallTemplate_%s" % (name)
+    base = _IntrinsicTemplate
+    name = "_IntrinsicTemplate_%s" % (name)
     dct = dict(key=handle, _definition_func=staticmethod(defn),
                _impl_cache={}, _overload_cache={})
     return type(base)(name, (base,), dct)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -327,12 +327,12 @@ def make_overload_template(func, overload_func, jit_options):
 
 class _IntrinsicTemplate(AbstractTemplate):
     """
-    A base class of templates for intrinsic intrinsic definition
+    A base class of templates for intrinsic definition
     """
 
     def generic(self, args, kws):
         """
-        Type the intrinsic intrinsic by the arguments.
+        Type the intrinsic by the arguments.
         """
         from numba.targets.imputils import lower_builtin
 
@@ -351,8 +351,7 @@ class _IntrinsicTemplate(AbstractTemplate):
             self._impl_cache[cache_key] = sig
             self._overload_cache[sig.args] = imp
             # register the lowering
-            typespec = types.VarArg(types.Any)
-            lower_builtin(imp, typespec)(imp)
+            lower_builtin(imp, *sig.args)(imp)
             return sig
 
     def get_impl_key(self, sig):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -291,7 +291,8 @@ class _OverloadFunctionTemplate(AbstractTemplate):
                 self._impl_cache[cache_key] = None
                 return
             from numba import jit
-            disp = self._impl_cache[cache_key] = jit(nopython=True)(pyfunc)
+            jitdecor = jit(nopython=True, **self._jit_options)
+            disp = self._impl_cache[cache_key] = jitdecor(pyfunc)
         else:
             if disp is None:
                 return
@@ -311,15 +312,16 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         return self._compiled_overloads[sig.args]
 
 
-def make_overload_template(func, overload_func):
+def make_overload_template(func, overload_func, jit_options):
     """
     Make a template class for function *func* overloaded by *overload_func*.
+    Compiler options are passed as a dictionary to *jit_options*.
     """
     func_name = getattr(func, '__name__', str(func))
     name = "OverloadTemplate_%s" % (func_name,)
     base = _OverloadFunctionTemplate
     dct = dict(key=func, _overload_func=staticmethod(overload_func),
-               _impl_cache={}, _compiled_overloads={})
+               _impl_cache={}, _compiled_overloads={}, _jit_options=jit_options)
     return type(base)(name, (base,), dct)
 
 


### PR DESCRIPTION
Inspired by Julia's `llvmcall()` which allows the insertion of LLVM IR text into the code, the ``llvm_call()`` allows user to do custom LLVM IRBuilder logic inside of nopython mode.

The goal is to have a way for users and numba developers to drop to LLVM IR level in the middle of a nopython function.  Internally, numba should have more of the implementation be written in nopython code.  The occasional need for IRBuilder can be isolated in the ``llvm_call()``.  Imagine an ``unsafe`` module for internal use and occasional external use for some special cases and needs.

In addition, this adds `no_cpython_wrapper` flag for `@jit` and `@overload` for functions that returns a value that cannot be boxed and returned to CPython; e.g. `int*` (a pointer to integer).