### PR TITLE
Fix _shutting_down not set before finalize._exitfunc

### DIFF
--- a/numba/utils.py
+++ b/numba/utils.py
@@ -166,7 +166,6 @@ def _at_shutdown():
     global _shutting_down
     _shutting_down = True
 
-atexit.register(_at_shutdown)
 
 def shutting_down(globals=globals):
     """
@@ -561,6 +560,7 @@ class finalize:
             import atexit
             atexit.register(self._exitfunc)
             finalize._registered_with_atexit = True
+            atexit.register(_at_shutdown)
         info = self._Info()
         info.weakref = ref(obj, self)
         info.func = func

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -661,3 +661,8 @@ class finalize:
             finalize._shutdown = True
             if reenable_gc:
                 gc.enable()
+
+
+# dummy invocation to force _at_shutdown() to be registered
+finalize(lambda: None, lambda: None)
+assert finalize._registered_with_atexit


### PR DESCRIPTION
`atexit.register` is like a stack (last-in first-out).  This ensures that the shutting down flag is set for use in finalize, which seems to be the only consumer of this flag for now.