### PR TITLE
Pin setuptools version in conda-build recipes

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -24,6 +24,8 @@ requirements:
   build:
     - python
     - numpy x.x
+    # Avoid https://github.com/pypa/setuptools/issues/728
+    - setuptools 23.*
     # On channel https://anaconda.org/numba/
     - llvmlite 0.13.*
     - funcsigs       [py27]
@@ -31,6 +33,8 @@ requirements:
   run:
     - python
     - numpy x.x
+    # Avoid https://github.com/pypa/setuptools/issues/728
+    - setuptools 23.*
     # On channel https://anaconda.org/numba/
     - llvmlite 0.13.*
     - funcsigs       [py27]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -17,6 +17,8 @@ requirements:
   build:
     - python
     - numpy x.x
+    # Avoid https://github.com/pypa/setuptools/issues/728
+    - setuptools 23.*
     # On channel https://anaconda.org/numba/
     - llvmlite 0.13.*
     - funcsigs       [py27]
@@ -24,6 +26,8 @@ requirements:
   run:
     - python
     - numpy x.x
+    # Avoid https://github.com/pypa/setuptools/issues/728
+    - setuptools 23.*
     # On channel https://anaconda.org/numba/
     - llvmlite 0.13.*
     - funcsigs       [py27]


### PR DESCRIPTION
This was overlooked in #2022. Hopefully this will fix the "full" buildbot builds.