### PR TITLE
CUDA: Switch to use primary context

### DIFF
--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -44,6 +44,22 @@ API_PROTOTYPES = {
 'cuDeviceComputeCapability': (c_int, POINTER(c_int), POINTER(c_int),
                               cu_device),
 
+# CUresult cuDevicePrimaryCtxGetState ( CUdevice dev, unsigned int* flags, int* active )
+'cuDevicePrimaryCtxGetState': (c_int,
+                               cu_device, POINTER(c_uint), POINTER(c_int)),
+
+# CUresult cuDevicePrimaryCtxRelease ( CUdevice dev )
+'cuDevicePrimaryCtxRelease': (c_int, cu_device),
+
+# CUresult cuDevicePrimaryCtxReset ( CUdevice dev )
+'cuDevicePrimaryCtxReset': (c_int, cu_device),
+
+# CUresult cuDevicePrimaryCtxRetain ( CUcontext* pctx, CUdevice dev )
+'cuDevicePrimaryCtxRetain': (c_int, POINTER(cu_context), cu_device),
+
+# CUresult cuDevicePrimaryCtxSetFlags ( CUdevice dev, unsigned int  flags )
+'cuDevicePrimaryCtxSetFlags': (c_int, cu_device, c_uint),
+
 # CUresult cuCtxCreate(CUcontext *pctx, unsigned int flags,
 #                      CUdevice dev);
 'cuCtxCreate':          (c_int, POINTER(cu_context), c_uint, cu_device),

--- a/numba/cuda/cudadrv/enums.py
+++ b/numba/cuda/cudadrv/enums.py
@@ -164,7 +164,7 @@ CU_JIT_INPUT_LIBRARY = 4
 # Option type: unsigned int
 # Applies to: compiler only
 
-CU_JIT_MAX_REGISTERS = 0,
+CU_JIT_MAX_REGISTERS = 0
 
 
 # IN: Specifies minimum number of threads per block to target compilation


### PR DESCRIPTION
Base on #2039 .

This uses a newer API since CUDA 7.0.  A primary context is unique per device and shares with the CUDA runtime API.  This allows seamless integration with other CUDA libraries.

In numba, the switch simplifies CUDA context management because we can always assume to have one context per device.