### PR TITLE
Fix #2028: ignore filesystem errors when caching from multiple processes

### DIFF
--- a/numba/tests/cache_usecases.py
+++ b/numba/tests/cache_usecases.py
@@ -17,6 +17,14 @@ from numba.tests.support import TestCase, captured_stderr
 
 
 @jit(cache=True, nopython=True)
+def simple_usecase(x):
+    return x
+
+def simple_usecase_caller(x):
+    return simple_usecase(x)
+
+
+@jit(cache=True, nopython=True)
 def add_usecase(x, y):
     return x + y + Z
 


### PR DESCRIPTION
On Windows, replacing a file with another when the file being replaced is being read by another process raises a permission error.
Since we can't do anything reasonable to ensure they don't happen, we simply let these errors pass silently.