### PR TITLE
Fix #2029: make default arguments fast

### DIFF
--- a/numba/_dispatcherimpl.cpp
+++ b/numba/_dispatcherimpl.cpp
@@ -24,16 +24,19 @@ public:
         int selected;
         matches = 0;
         if (0 == ovct) {
+            // No overloads registered
             return NULL;
         }
-        if (overloads.size() > 0) {
-            matches = tm->selectOverload(sig, &overloads[0], selected, argct,
-                                         ovct, allow_unsafe);
-        } else if (argct == 0){
+        if (argct == 0) {
+            // Nullary function: trivial match on first overload
             matches = 1;
             selected = 0;
         }
-        if (matches == 1){
+        else {
+            matches = tm->selectOverload(sig, &overloads[0], selected, argct,
+                                         ovct, allow_unsafe);
+        }
+        if (matches == 1) {
             return functions[selected];
         }
         return NULL;
@@ -49,8 +52,11 @@ public:
 private:
     const int argct;
     TypeManager *tm;
-    TypeTable overloads;
+    // An array of overloads
     Functions functions;
+    // A flattened array of argument types to all overloads
+    // (invariant: sizeof(overloads) == argct * sizeof(functions))
+    TypeTable overloads;
 };
 
 


### PR DESCRIPTION
Omitted arguments with a default value would fail on typeof(), and `Dispatcher.__call__` would then follow a slow path to get the appropriate overload.

This fixes the slowness issue by making function calls as fast when omitted arguments are not specified as when they are specified.
Also, by pushing the `_numba_type_` later in the fallback chain, other argument types are also sped up (such as booleans and tuples).

Also added some benchmarks for this.

(NOTE: the added complication in this PR may be an argument to rethink our way of handling default arguments, as per @sklam )