### PR TITLE
CUDA: Improve memory management

### DIFF
--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -124,7 +124,7 @@ and from the device automatically. It can be used as drop-in replacement for
 
 .. autoclass:: numba.SmartArray
    :members: __init__, get, mark_changed
-	       
+
 
 Thus, `SmartArray` objects may be passed as function arguments to jit-compiled
 functions. Whenever a cuda.jit-compiled function is being executed, it will
@@ -135,3 +135,46 @@ references to that.
 Thus, if the next operation is another invocation of a cuda.jit-compiled function,
 the data does not need to be transferred again, making the compound operation more
 efficient (and making the use of the GPU advantagous even for smaller data sizes).
+
+Deallocation Behavior
+=====================
+
+Deallocation of all CUDA resources are tracked on a per-context basis.
+When the last reference to a device memory is dropped, the underlying memory
+is scheduled to be deallocated.  The deallocation does not occur immediately.
+It is added to a queue of pending deallocations.  This design has two benefits:
+
+1. Resource deallocation API may cause the device to synchronize; thus, breaking
+   any asynchronous execution.  Deferring the deallocation could avoid latency
+   in performance critical code section.
+2. Some deallocation errors may cause all the remaining deallocations to fail.
+   Continued deallocation errors can cause critical errors at the CUDA driver
+   level.  In some cases, this could mean a segmentation fault in the CUDA
+   driver. In the worst case, this could cause the system GUI to freeze and
+   could only recover with a system reset.  When an error occurs during a
+   deallocation, the remaining pending deallocations are cancelled.  Any
+   deallocation error will be reported.  When the process is terminated, the
+   CUDA driver is able to release all allocated resources by the terminated
+   process.
+
+The deallocation queue is flushed automatically as soon as the following events
+occur:
+
+- An allocation failed due to out-of-memory error.  Allocation is retried after
+  flushing all deallocations.
+- The deallocation queue has reached its maximum size, which is default to 10.
+  User can override by setting the environment variable
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT`.  For example,
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT=20`, increases the limit to 20.
+- The maximum accumulated byte size of resources that are pending deallocation
+  is reached.  This is default to 20% of the device memory capacity.
+  User can override by setting the environment variable
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO`. For example,
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO=0.5` sets the limit to 50% of the
+  capacity.
+
+Sometimes, it is desired to defer resource deallocation until a code section
+ends.  Most often, users want to avoid any implicit synchronization due to
+deallocation.  This can be done by using the following context manager:
+
+.. autofunction:: numba.cuda.defer_cleanup

--- a/numba/config.py
+++ b/numba/config.py
@@ -158,16 +158,10 @@ class _EnvReloader(object):
         # Dump type annotation in html format
         HTML = _readenv("NUMBA_DUMP_HTML", str, None)
 
-        # Disable CUDA support
-        DISABLE_CUDA = _readenv("NUMBA_DISABLE_CUDA", int, int(MACHINE_BITS==32))
-
         # Allow interpreter fallback so that Numba @jit decorator will never fail
         # Use for migrating from old numba (<0.12) which supported closure, and other
         # yet-to-be-supported features.
         COMPATIBILITY_MODE = _readenv("NUMBA_COMPATIBILITY_MODE", int, 0)
-
-        # Force CUDA compute capability to a specific version
-        FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _parse_cc, None)
 
         # x86-64 specific
         # Enable AVX on supported platforms where it won't degrade performance.
@@ -191,8 +185,24 @@ class _EnvReloader(object):
         # Disable jit for debugging
         DISABLE_JIT = _readenv("NUMBA_DISABLE_JIT", int, 0)
 
+        # CUDA Configs
+
+        # Force CUDA compute capability to a specific version
+        FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _parse_cc, None)
+
+        # Disable CUDA support
+        DISABLE_CUDA = _readenv("NUMBA_DISABLE_CUDA", int, int(MACHINE_BITS==32))
+
         # Enable CUDA simulator
         ENABLE_CUDASIM = _readenv("NUMBA_ENABLE_CUDASIM", int, 0)
+
+        # Maximum number of pending CUDA deallocations (default: 10)
+        CUDA_DEALLOCS_COUNT = _readenv("NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT",
+                                       int, 10)
+
+        # Maximum ratio of pending CUDA deallocations to capacity (default: 0.2)
+        CUDA_DEALLOCS_RATIO = _readenv("NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO",
+                                       float, 0.2)
 
         # HSA Configs
 
@@ -203,7 +213,7 @@ class _EnvReloader(object):
         NUMBA_DEFAULT_NUM_THREADS = max(1, multiprocessing.cpu_count())
 
         # Numba thread pool size (defaults to number of CPUs on the system).
-        NUMBA_NUM_THREADS = _readenv("NUMBA_NUM_THREADS", int, 
+        NUMBA_NUM_THREADS = _readenv("NUMBA_NUM_THREADS", int,
                                      NUMBA_DEFAULT_NUM_THREADS)
 
         # Inject the configuration values into the module globals

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -282,8 +282,12 @@ def detect():
 
 @contextlib.contextmanager
 def defer_cleanup():
-    tserv = get_current_device().trashing
-    with tserv.defer_cleanup:
+    """
+    Temporarily disable memory deallocation.
+    Use this to prevent resource deallocation brekaing asynchronous execution.
+    """
+    deallocs = current_context().deallocations
+    with deallocs.disable():
         yield
 
 

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -284,7 +284,16 @@ def detect():
 def defer_cleanup():
     """
     Temporarily disable memory deallocation.
-    Use this to prevent resource deallocation brekaing asynchronous execution.
+    Use this to prevent resource deallocation breaking asynchronous execution.
+
+    For example::
+
+        with defer_cleanup():
+            # all cleanup is deferred in here
+            do_speed_critical_code()
+        # cleanup will occur here
+
+    Note: this context manager can be nested.
     """
     deallocs = current_context().deallocations
     with deallocs.disable():

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -291,7 +291,7 @@ def defer_cleanup():
         with defer_cleanup():
             # all cleanup is deferred in here
             do_speed_critical_code()
-        # cleanup will occur here
+        # cleanup can occur here
 
     Note: this context manager can be nested.
     """

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -474,9 +474,11 @@ class _PendingDeallocs(object):
         This can be nested.
         """
         self._disable_count += 1
-        yield
-        self._disable_count -= 1
-        assert self._disable_count >= 0
+        try:
+            yield
+        finally:
+            self._disable_count -= 1
+            assert self._disable_count >= 0
 
     @property
     def is_disabled(self):

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -2,7 +2,7 @@
 CUDA driver bridge implementation
 
 NOTE:
-The new driver implementation uses a "trashing service" that help prevents a
+The new driver implementation uses a *_PendingDeallocs* that help prevents a
 crashing the system (particularly OSX) when the CUDA context is corrupted at
 resource deallocation.  The old approach ties resource management directly
 into the object destructor; thus, at corruption of the CUDA context,
@@ -23,9 +23,9 @@ from ctypes import (c_int, byref, c_size_t, c_char, c_char_p, addressof,
                     c_void_p, c_float)
 import contextlib
 import numpy as np
-from collections import namedtuple
+from collections import namedtuple, deque
 
-from numba import utils, servicelib, mviewbuf
+from numba import utils, mviewbuf
 from .error import CudaSupportError, CudaDriverError
 from .drvapi import API_PROTOTYPES
 from .drvapi import cu_occupancy_b2d_size
@@ -298,45 +298,6 @@ class Driver(object):
 driver = Driver()
 
 
-class TrashService(servicelib.Service):
-    """
-    We need this to enqueue things to be removed.  There are times when you
-    want to disable deallocation because that would break asynchronous work
-    queues.
-    """
-    CLEAN_LIMIT = 20
-
-    def add_trash(self, item):
-        self.trash.append(item)
-
-    def process(self, _arg):
-        self.trash = []
-        yield
-        while True:
-            count = 0
-            # Clean the trash
-            assert self.CLEAN_LIMIT > count
-            while self.trash and count < self.CLEAN_LIMIT:
-                cb = self.trash.pop()
-                # Invoke callback
-                cb()
-                count += 1
-            yield
-
-    def clear(self):
-        while self.trash:
-            cb = self.trash.pop()
-            cb()
-
-    @contextlib.contextmanager
-    def defer_cleanup(self):
-        orig = self.enabled
-        self.enabled = False
-        yield
-        self.enabled = orig
-        self.service()
-
-
 def _build_reverse_device_attrs():
     prefix = "CU_DEVICE_ATTRIBUTE_"
     map = utils.UniqueDict()
@@ -360,7 +321,6 @@ class Device(object):
         driver.cuDeviceGet(byref(got_devnum), devnum)
         assert devnum == got_devnum.value, "Driver returned another device"
         self.id = got_devnum.value
-        self.trashing = trashing = TrashService("cuda.device%d.trash" % self.id)
         self.attributes = {}
         # Read compute capability
         cc_major = c_int()
@@ -373,11 +333,6 @@ class Device(object):
         buf = (c_char * bufsz)()
         driver.cuDeviceGetName(buf, bufsz, self.id)
         self.name = buf.value
-
-        def finalizer():
-            trashing.clear()
-
-        utils.finalize(self, finalizer)
         self.primary_context = None
 
     @property
@@ -458,6 +413,55 @@ def met_requirement_for_device(device):
                                (device, MIN_REQUIRED_CC))
 
 
+class _SizeNotSet(object):
+    def __str__(self):
+        return '?'
+
+    def __int__(self):
+        return 0
+
+_SizeNotSet = _SizeNotSet()
+
+
+class _PendingDeallocs(object):
+    MAX_PENDING_DEALLOCS_COUNT = config.CUDA_DEALLOCS_COUNT
+    PENDING_DEALLOCS_RATIO = config.CUDA_DEALLOCS_RATIO
+
+    def __init__(self, capacity):
+        self._cons = deque()
+        self._disable_count = 0
+        self._size = 0
+        self._max_pending_bytes = int(capacity * self.PENDING_DEALLOCS_RATIO)
+
+    def add_item(self, dtor, handle, size=_SizeNotSet):
+        self._cons.append((dtor, handle, size))
+        self._size += int(size)
+        if (len(self._cons) > self.MAX_PENDING_DEALLOCS_COUNT or
+                self._size > self._max_pending_bytes):
+            self.clear()
+
+    def clear(self):
+        if not self.is_disabled:
+            while self._cons:
+                [dtor, handle, size] = self._cons.popleft()
+                dtor(handle)
+            self._size = 0
+
+    @contextlib.contextmanager
+    def disable(self):
+        self._disable_count += 1
+        yield
+        self._disable_count -= 1
+        assert self._disable_count >= 0
+
+    @property
+    def is_disabled(self):
+        return self._disable_count > 0
+
+    def __len__(self):
+        return len(self._cons)
+
+
 _MemoryInfo = namedtuple("_MemoryInfo", "free,total")
 
 
@@ -468,34 +472,15 @@ class Context(object):
     Contexts should not be constructed directly by user code.
     """
 
-    def __init__(self, device, handle, finalizer=None):
+    def __init__(self, device, handle):
         self.device = device
         self.handle = handle
-        self.external_finalizer = finalizer
-        self.trashing = TrashService("cuda.device%d.context%x.trash" %
-                                     (self.device.id, self.handle.value))
         self.allocations = utils.UniqueDict()
+        # *deallocations* is lazily initialized on context push
+        self.deallocations = None
         self.modules = utils.UniqueDict()
-        utils.finalize(self, self._make_finalizer())
         # For storing context specific data
         self.extras = {}
-
-    def _make_finalizer(self):
-        """
-        Make a finalizer function that doesn't keep a reference to this object.
-        """
-        allocations = self.allocations
-        modules = self.modules
-        trashing = self.trashing
-        external_finalizer = self.external_finalizer
-
-        def finalize():
-            allocations.clear()
-            modules.clear()
-            trashing.clear()
-            if external_finalizer is not None:
-                external_finalizer()
-        return finalize
 
     def reset(self):
         """
@@ -505,7 +490,7 @@ class Context(object):
         self.allocations.clear()
         self.modules.clear()
         # Clear trash
-        self.trashing.clear()
+        self.deallocations.clear()
 
     def get_memory_info(self):
         """Returns (free, total) memory in bytes in the context.
@@ -555,6 +540,9 @@ class Context(object):
         Pushes this context on the current CPU Thread.
         """
         driver.cuCtxPushCurrent(self.handle)
+        # setup *deallocations* as the context becomes active for the first time
+        if self.deallocations is None:
+            self.deallocations = _PendingDeallocs(self.get_memory_info().total)
 
     def pop(self):
         """
@@ -565,19 +553,39 @@ class Context(object):
         driver.cuCtxPopCurrent(byref(popped))
         assert popped.value == self.handle.value
 
+    def _attempt_allocation(self, allocator):
+        """
+        Attempt allocation by calling *allocator*.  If a out-of-memory error
+        is raised, the pending deallocations are flushed and the allocation
+        is retried.  If it fails in the second attempt, the error is reraised.
+        """
+        try:
+            allocator()
+        except CudaAPIError as e:
+            # is out-of-memory?
+            if e.code == enums.CUDA_ERROR_OUT_OF_MEMORY:
+                # clear pending deallocations
+                self.deallocations.clear()
+                # try again
+                allocator()
+            else:
+                raise
+
     def memalloc(self, bytesize):
-        self.trashing.service()
         ptr = drvapi.cu_device_ptr()
-        driver.cuMemAlloc(byref(ptr), bytesize)
-        _memory_finalizer = _make_mem_finalizer(driver.cuMemFree)
+
+        def allocator():
+            driver.cuMemAlloc(byref(ptr), bytesize)
+
+        self._attempt_allocation(allocator)
+
+        _memory_finalizer = _make_mem_finalizer(driver.cuMemFree, bytesize)
         mem = MemoryPointer(weakref.proxy(self), ptr, bytesize,
                             _memory_finalizer(self, ptr))
         self.allocations[ptr.value] = mem
         return mem.own()
 
     def memhostalloc(self, bytesize, mapped=False, portable=False, wc=False):
-        self.trashing.service()
-
         pointer = c_void_p()
         flags = 0
         if mapped:
@@ -587,11 +595,19 @@ class Context(object):
         if wc:
             flags |= enums.CU_MEMHOSTALLOC_WRITECOMBINED
 
-        driver.cuMemHostAlloc(byref(pointer), bytesize, flags)
+        def allocator():
+            driver.cuMemHostAlloc(byref(pointer), bytesize, flags)
+
+        if mapped:
+            self._attempt_allocation(allocator)
+        else:
+            allocator()
+
         owner = None
 
         if mapped:
-            _hostalloc_finalizer = _make_mem_finalizer(driver.cuMemFreeHost)
+            _hostalloc_finalizer = _make_mem_finalizer(driver.cuMemFreeHost,
+                                                       bytesize)
             finalizer = _hostalloc_finalizer(self, pointer)
             mem = MappedMemory(weakref.proxy(self), owner, pointer,
                                bytesize, finalizer=finalizer)
@@ -599,14 +615,12 @@ class Context(object):
             self.allocations[mem.handle.value] = mem
             return mem.own()
         else:
-            finalizer = _pinnedalloc_finalizer(self.trashing, pointer)
+            finalizer = _pinnedalloc_finalizer(self.deallocations, pointer)
             mem = PinnedMemory(weakref.proxy(self), owner, pointer, bytesize,
                                finalizer=finalizer)
             return mem
 
     def mempin(self, owner, pointer, size, mapped=False):
-        self.trashing.service()
-
         if isinstance(pointer, (int, long)):
             pointer = c_void_p(pointer)
 
@@ -621,10 +635,17 @@ class Context(object):
         if mapped:
             flags |= enums.CU_MEMHOSTREGISTER_DEVICEMAP
 
-        driver.cuMemHostRegister(pointer, size, flags)
+        def allocator():
+            driver.cuMemHostRegister(pointer, size, flags)
 
         if mapped:
-            _mapped_finalizer = _make_mem_finalizer(driver.cuMemHostUnregister)
+            self._attempt_allocation(allocator)
+        else:
+            allocator()
+
+        if mapped:
+            _mapped_finalizer = _make_mem_finalizer(driver.cuMemHostUnregister,
+                                                    size)
             finalizer = _mapped_finalizer(self, pointer)
             mem = MappedMemory(weakref.proxy(self), owner, pointer, size,
                                finalizer=finalizer)
@@ -632,7 +653,7 @@ class Context(object):
             return mem.own()
         else:
             mem = PinnedMemory(weakref.proxy(self), owner, pointer, size,
-                               finalizer=_pinned_finalizer(self.trashing,
+                               finalizer=_pinned_finalizer(self.deallocations,
                                                            pointer))
             return mem
 
@@ -646,32 +667,27 @@ class Context(object):
         return self.create_module_image(image)
 
     def create_module_image(self, image):
-        self.trashing.service()
         module = load_module_image(self, image)
         self.modules[module.handle.value] = module
         return weakref.proxy(module)
 
     def unload_module(self, module):
         del self.modules[module.handle.value]
-        self.trashing.service()
 
     def create_stream(self):
-        self.trashing.service()
         handle = drvapi.cu_stream()
         driver.cuStreamCreate(byref(handle), 0)
         return Stream(weakref.proxy(self), handle,
-                      _stream_finalizer(self.trashing, handle))
+                      _stream_finalizer(self.allocations, handle))
 
     def create_event(self, timing=True):
-        self.trashing.service()
-
         handle = drvapi.cu_event()
         flags = 0
         if not timing:
             flags |= enums.CU_EVENT_DISABLE_TIMING
         driver.cuEventCreate(byref(handle), flags)
         return Event(weakref.proxy(self), handle,
-                     finalizer=_event_finalizer(self.trashing, handle))
+                     finalizer=_event_finalizer(self.deallocations, handle))
 
     def synchronize(self):
         driver.cuCtxSynchronize()
@@ -723,71 +739,65 @@ def load_module_image(context, image):
                   _module_finalizer(context, handle))
 
 
-def _make_mem_finalizer(dtor):
+def _make_mem_finalizer(dtor, bytesize):
     def mem_finalize(context, handle):
-        trashing = context.trashing
         allocations = context.allocations
+        deallocations = context.deallocations
 
         def core():
-            def cleanup():
-                if allocations:
-                    del allocations[handle.value]
-                dtor(handle)
+            if allocations:
+                del allocations[handle.value]
 
-            trashing.add_trash(cleanup)
+            deallocations.add_item(dtor, handle, size=bytesize)
 
         return core
 
     return mem_finalize
 
 
-def _pinnedalloc_finalizer(trashing, handle):
+def _pinnedalloc_finalizer(deallocs, handle):
     def core():
-        trashing.add_trash(lambda: driver.cuMemFreeHost(handle))
+        deallocs.add_item(driver.cuMemFreeHost, handle)
 
     return core
 
 
-def _pinned_finalizer(trashing, handle):
+def _pinned_finalizer(deallocs, handle):
     def core():
-        trashing.add_trash(lambda: driver.cuMemHostUnregister(handle))
+        deallocs.add_item(driver.cuMemHostUnregister, handle)
 
     return core
 
 
-def _event_finalizer(trashing, handle):
+def _event_finalizer(deallocs, handle):
     def core():
-        trashing.add_trash(lambda: driver.cuEventDestroy(handle))
+        deallocs.add_item(driver.cuEventDestroy, handle)
 
     return core
 
 
-def _stream_finalizer(trashing, handle):
+def _stream_finalizer(deallocs, handle):
     def core():
-        trashing.add_trash(lambda: driver.cuStreamDestroy(handle))
+        deallocs.add_item(driver.cuStreamDestroy, handle)
 
     return core
 
 
 def _module_finalizer(context, handle):
-    trashing = context.trashing
+    dealloc = context.deallocations
     modules = context.modules
 
     def core():
-        def cleanup():
-            # All modules are owned by their parent Context.
-            # A Module is either released by a call to
-            # Context.unload_module, which clear the handle (pointer) mapping
-            # (checked by the following assertion), or, by Context.reset().
-            # Both releases the sole reference to the Module and trigger the
-            # finalizer for the Module instance.  The actual call to
-            # cuModuleUnload is deferred to the trashing service to avoid
-            # further corruption of the CUDA context if a fatal error has
-            # occurred in the CUDA driver.
-            assert handle.value not in modules
+        shutting_down = utils.shutting_down  # early bind
+
+        def module_unload(handle):
+            # If we are not shutting down, we must be called due to
+            # Context.reset() of Context.unload_module().  Both must have
+            # cleared the module reference from the context.
+            assert shutting_down() or handle.value not in modules
             driver.cuModuleUnload(handle)
 
-        trashing.add_trash(cleanup)
+        dealloc.add_item(module_unload, handle)
 
     return core
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -431,14 +431,15 @@ class _PendingDeallocs(object):
     Pending deallocations of a context (or device since we are using the primary
     context).
     """
-    MAX_PENDING_DEALLOCS_COUNT = config.CUDA_DEALLOCS_COUNT
-    PENDING_DEALLOCS_RATIO = config.CUDA_DEALLOCS_RATIO
-
     def __init__(self, capacity):
         self._cons = deque()
         self._disable_count = 0
         self._size = 0
-        self._max_pending_bytes = int(capacity * self.PENDING_DEALLOCS_RATIO)
+        self._memory_capacity = capacity
+
+    @property
+    def _max_pending_bytes(self):
+        return int(self._memory_capacity * config.CUDA_DEALLOCS_RATIO)
 
     def add_item(self, dtor, handle, size=_SizeNotSet):
         """
@@ -451,7 +452,7 @@ class _PendingDeallocs(object):
         """
         self._cons.append((dtor, handle, size))
         self._size += int(size)
-        if (len(self._cons) > self.MAX_PENDING_DEALLOCS_COUNT or
+        if (len(self._cons) > config.CUDA_DEALLOCS_COUNT or
                 self._size > self._max_pending_bytes):
             self.clear()
 

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -86,3 +86,9 @@ def jit(fn_or_sig=None, device=False, debug=False, argtypes=None, inline=False, 
     return FakeCUDAKernel(fn_or_sig, device=device)
 
 autojit = jit
+
+
+@contextmanager
+def defer_cleanup():
+    # No effect for simulator
+    yield

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from numba import cuda, config
+from numba.cuda.testing import unittest, skip_on_cudasim
+
+
+@skip_on_cudasim('not supported on CUDASIM')
+class TestDeallocation(unittest.TestCase):
+    def test_max_pending_count(self):
+        # get deallocation manager and flush it
+        deallocs = cuda.current_context().deallocations
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+        # deallocate to maximum count
+        for i in range(config.CUDA_DEALLOCS_COUNT):
+            cuda.to_device(np.arange(1))
+            self.assertEqual(len(deallocs), i + 1)
+        # one more to trigger .clear()
+        cuda.to_device(np.arange(1))
+        self.assertEqual(len(deallocs), 0)
+
+    def test_max_pending_bytes(self):
+        # get deallocation manager and flush it
+        deallocs = cuda.current_context().deallocations
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+
+        max_pending = deallocs._max_pending_bytes
+
+        # deallocate half the max size
+        cuda.to_device(np.ones(max_pending // 2, dtype=np.int8))
+        self.assertEqual(len(deallocs), 1)
+
+        # deallocate another remaining
+        cuda.to_device(np.ones(max_pending - deallocs._size, dtype=np.int8))
+        self.assertEqual(len(deallocs), 2)
+
+        # another byte to trigger .clear()
+        cuda.to_device(np.ones(1, dtype=np.int8))
+        self.assertEqual(len(deallocs), 0)
+
+
+@skip_on_cudasim("defer_cleanup has no effect in CUDASIM")
+class TestDeferCleanup(unittest.TestCase):
+    def test_basic(self):
+        harr = np.arange(5)
+        darr1 = cuda.to_device(harr)
+        deallocs = cuda.current_context().deallocations
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+        with cuda.defer_cleanup():
+            darr2 = cuda.to_device(harr)
+            del darr1
+            self.assertEqual(len(deallocs), 1)
+            del darr2
+            self.assertEqual(len(deallocs), 2)
+            deallocs.clear()
+            self.assertEqual(len(deallocs), 2)
+
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+
+    def test_nested(self):
+        harr = np.arange(5)
+        darr1 = cuda.to_device(harr)
+        deallocs = cuda.current_context().deallocations
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+        with cuda.defer_cleanup():
+            with cuda.defer_cleanup():
+                darr2 = cuda.to_device(harr)
+                del darr1
+                self.assertEqual(len(deallocs), 1)
+                del darr2
+                self.assertEqual(len(deallocs), 2)
+                deallocs.clear()
+                self.assertEqual(len(deallocs), 2)
+            deallocs.clear()
+            self.assertEqual(len(deallocs), 2)
+
+        deallocs.clear()
+        self.assertEqual(len(deallocs), 0)
+
+
+class TestDeferCleanupAvail(unittest.TestCase):
+    def test_context_manager(self):
+        # just make sure the API is available
+        with cuda.defer_cleanup():
+            pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Improve memory management by:

* Retry an allocation if it fails with out-of-memory-error.  Before the retry, all pending deallocations are flushed.
* Pending deallocations are flushed if anyone of the below is true:
    * an allocation fails on out-of-memory;
    * a maximum limit of *pending deallocation count* is reached;
    * a maximum limit of *pending deallocation bytes* is reached.

Details:

* *pending deallocation count* limit is user configurable by `NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT`, which is set to 10 by default.
* *pending deallocation bytes* limt is user configurable by `NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO`, which is the max percentage of pending bytes to available device memory (deafult to 20%).
* These default limits could be adjusted in the future.
