### PR TITLE
Fork-safe thread-safe random generation

### DIFF
--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -225,9 +225,7 @@ MOD_INIT(_helperlib) {
     PyModule_AddIntConstant(m, "py_buffer_size", sizeof(Py_buffer));
     PyModule_AddIntConstant(m, "py_gil_state_size", sizeof(PyGILState_STATE));
 
-    if (_numba_rnd_random_seed(&numba_py_random_state) ||
-        _numba_rnd_random_seed(&numba_np_random_state))
-        return MOD_ERROR_VAL;
+    numba_rnd_ensure_global_init();
 
     return MOD_SUCCESS_VAL(m);
 }

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -77,9 +77,6 @@ build_c_helpers_dict(void)
     declmethod(unpack_slice);
     declmethod(do_raise);
     declmethod(unpickle);
-    declmethod(rnd_shuffle);
-    declmethod(rnd_init);
-    declmethod(poisson_ptrs);
     declmethod(attempt_nocopy_reshape);
     declmethod(get_list_private_data);
     declmethod(set_list_private_data);
@@ -87,6 +84,8 @@ build_c_helpers_dict(void)
     declmethod(get_pyobject_private_data);
     declmethod(set_pyobject_private_data);
     declmethod(reset_pyobject_private_data);
+
+    /* BLAS / LAPACK */
     declmethod(xxgemm);
     declmethod(xxgemv);
     declmethod(xxdot);
@@ -102,9 +101,12 @@ build_c_helpers_dict(void)
     declmethod(xgesv);
     declmethod(xxnrm2);
 
-    
-    declpointer(py_random_state);
-    declpointer(np_random_state);
+    /* PRNG support */
+    declmethod(get_py_random_state);
+    declmethod(get_np_random_state);
+    declmethod(rnd_shuffle);
+    declmethod(rnd_init);
+    declmethod(poisson_ptrs);
 
 #define MATH_UNARY(F, R, A) declmethod(F);
 #define MATH_BINARY(F, R, A, B) declmethod(F);
@@ -152,6 +154,9 @@ build_npymath_exports_dict(void)
 
 static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },
+    { "rnd_get_py_state_ptr", (PyCFunction) _numba_rnd_get_py_state_ptr, METH_NOARGS, NULL },
+    { "rnd_get_np_state_ptr", (PyCFunction) _numba_rnd_get_np_state_ptr, METH_NOARGS, NULL },
+    { "rnd_reset", (PyCFunction) _numba_rnd_reset, METH_VARARGS, NULL },
     { "rnd_seed", (PyCFunction) _numba_rnd_seed, METH_VARARGS, NULL },
     { "rnd_set_state", (PyCFunction) _numba_rnd_set_state, METH_VARARGS, NULL },
     { "rnd_shuffle", (PyCFunction) _numba_rnd_shuffle, METH_O, NULL },

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -156,8 +156,6 @@ static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },
     { "rnd_get_py_state_ptr", (PyCFunction) _numba_rnd_get_py_state_ptr, METH_NOARGS, NULL },
     { "rnd_get_np_state_ptr", (PyCFunction) _numba_rnd_get_np_state_ptr, METH_NOARGS, NULL },
-    { "rnd_global_init", (PyCFunction) _numba_rnd_global_init, METH_NOARGS, NULL },
-    { "rnd_reset", (PyCFunction) _numba_rnd_reset, METH_VARARGS, NULL },
     { "rnd_seed", (PyCFunction) _numba_rnd_seed, METH_VARARGS, NULL },
     { "rnd_set_state", (PyCFunction) _numba_rnd_set_state, METH_VARARGS, NULL },
     { "rnd_shuffle", (PyCFunction) _numba_rnd_shuffle, METH_O, NULL },

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -156,6 +156,7 @@ static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },
     { "rnd_get_py_state_ptr", (PyCFunction) _numba_rnd_get_py_state_ptr, METH_NOARGS, NULL },
     { "rnd_get_np_state_ptr", (PyCFunction) _numba_rnd_get_np_state_ptr, METH_NOARGS, NULL },
+    { "rnd_global_init", (PyCFunction) _numba_rnd_global_init, METH_NOARGS, NULL },
     { "rnd_reset", (PyCFunction) _numba_rnd_reset, METH_VARARGS, NULL },
     { "rnd_seed", (PyCFunction) _numba_rnd_seed, METH_VARARGS, NULL },
     { "rnd_set_state", (PyCFunction) _numba_rnd_set_state, METH_VARARGS, NULL },

--- a/numba/_random.c
+++ b/numba/_random.c
@@ -357,25 +357,6 @@ _numba_rnd_seed(PyObject *self, PyObject *args)
     }
 }
 
-NUMBA_EXPORT_FUNC(PyObject *)
-_numba_rnd_reset(PyObject *self, PyObject *args)
-{
-    rnd_state_t *state;
-
-    if (!PyArg_ParseTuple(args, "O&:rnd_reset",
-                          rnd_state_converter, &state))
-        return NULL;
-
-    state->is_initialized = 0;
-    Py_RETURN_NONE;
-}
-
-NUMBA_EXPORT_FUNC(PyObject *)
-_numba_rnd_global_init(PyObject *self)
-{
-    Py_RETURN_NONE;
-}
-
 /*
  * Random distribution helpers.
  * Most code straight from Numpy's distributions.c.

--- a/numba/_random.c
+++ b/numba/_random.c
@@ -154,10 +154,9 @@ static int rnd_globally_initialized;
 #ifdef _MSC_VER
 #define THREAD_LOCAL(ty) __declspec(thread) ty
 #else
+/* Non-standard C99 extension that's understood by gcc and clang */
 #define THREAD_LOCAL(ty) __thread ty
 #endif
-
-// #define THREAD_LOCAL(ty) ty
 
 static THREAD_LOCAL(rnd_state_t) numba_py_random_state;
 static THREAD_LOCAL(rnd_state_t) numba_np_random_state;
@@ -207,9 +206,9 @@ static void
 rnd_ensure_global_init(void)
 {
     if (!rnd_globally_initialized) {
-        #if HAVE_PTHREAD_ATFORK
+#if HAVE_PTHREAD_ATFORK
         pthread_atfork(NULL, NULL, rnd_atfork_child);
-        #endif
+#endif
         rnd_globally_initialized = 1;
     }
 }

--- a/numba/_random.c
+++ b/numba/_random.c
@@ -147,6 +147,7 @@ _numba_rnd_random_seed(rnd_state_t *state)
 
 static int rnd_globally_initialized;
 
+/* XXX __declspec(thread) for MSVC? */
 static __thread rnd_state_t numba_py_random_state;
 static __thread rnd_state_t numba_np_random_state;
 

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -128,10 +128,8 @@ PYCC(pycc_init_) (PyObject *module, PyMethodDef *defs,
     if (init_dynfunc_module(module)) {
         goto error;
     }
-    /* Initialize random state with non-zero data to avoid pathological
-       behaviour. */
-    _numba_rnd_random_seed(&numba_py_random_state);
-    _numba_rnd_random_seed(&numba_np_random_state);
+    /* Initialize random generation. */
+    numba_rnd_ensure_global_init();
 
 #if PYCC_USE_NRT
     NRT_MemSys_init();

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -56,8 +56,6 @@ class CPUContext(BaseContext):
         self.install_registry(operatorimpl.registry)
         self.install_registry(printimpl.registry)
         self.install_registry(randomimpl.registry)
-        # Initialize PRNG state
-        randomimpl.random_init()
 
     @property
     def target_data(self):

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -36,17 +36,20 @@ _pid = None
 
 def random_init():
     """
-    Reset the random states.
+    Routine ensuring the PRNG is properly initialized.
     """
     global _pid
     if _pid != os.getpid():
-        # Make sure the states are marked unitialized.
+        _helperlib.rnd_global_init()
+        # Note this only marks the states unitialized.
         # Actual initialization with system entropy, if needed,
         # is done lazily (see rnd_implicit_init() in _random.c).
         for state_ptr in [_helperlib.rnd_get_py_state_ptr(),
                           _helperlib.rnd_get_np_state_ptr()]:
             _helperlib.rnd_reset(state_ptr)
         _pid = os.getpid()
+
+random_init()
 
 
 # This is the same struct as rnd_state_t in _random.c.

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -41,7 +41,7 @@ def random_init():
     global _pid
     if _pid != os.getpid():
         # Make sure the states are marked unitialized.
-        # Actual initialization with system entropy (if needed)
+        # Actual initialization with system entropy, if needed,
         # is done lazily (see rnd_implicit_init() in _random.c).
         for state_ptr in [_helperlib.rnd_get_py_state_ptr(),
                           _helperlib.rnd_get_np_state_ptr()]:
@@ -49,11 +49,48 @@ def random_init():
         _pid = os.getpid()
 
 
-# This is the same struct as rnd_state_t in _helperlib.c.
-rnd_state_t = ir.LiteralStructType(
-    [int32_t, ir.ArrayType(int32_t, N),
-     int32_t, double])
+# This is the same struct as rnd_state_t in _random.c.
+rnd_state_t = ir.LiteralStructType([
+    # index
+    int32_t,
+    # mt[N]
+    ir.ArrayType(int32_t, N),
+    # has_gauss
+    int32_t,
+    # gauss
+    double,
+    # is_initialized
+    int32_t,
+    ])
 rnd_state_ptr_t = ir.PointerType(rnd_state_t)
+
+def get_state_ptr(context, builder, name):
+    """
+    Get a pointer to the given thread-local random state
+    (depending on *name*: "py" or "np").
+    If the state isn't initialized, it is lazily initialized with
+    system entropy.
+    """
+    assert name in ('py', 'np')
+    func_name = "numba_get_%s_random_state" % name
+    fnty = ir.FunctionType(rnd_state_ptr_t, ())
+    fn = builder.module.get_or_insert_function(fnty, func_name)
+    fn.attributes.add('readnone')
+    fn.attributes.add('nounwind')
+    return builder.call(fn, ())
+
+def get_py_state_ptr(context, builder):
+    """
+    Get a pointer to the thread-local Python random state.
+    """
+    return get_state_ptr(context, builder, 'py')
+
+def get_np_state_ptr(context, builder):
+    """
+    Get a pointer to the thread-local Numpy random state.
+    """
+    return get_state_ptr(context, builder, 'np')
+
 
 # Accessors
 def get_index_ptr(builder, state_ptr):
@@ -145,28 +182,6 @@ def get_next_int(context, builder, state_ptr, nbits):
             builder.store(total, ret)
 
     return builder.load(ret)
-
-
-def _get_state_ptr(context, builder, kind):
-    assert kind in ('py', 'np')
-    func_name = "numba_get_%s_random_state" % kind
-    fnty = ir.FunctionType(rnd_state_ptr_t, ())
-    fn = builder.module.get_or_insert_function(fnty, func_name)
-    fn.attributes.add('readnone')
-    fn.attributes.add('nounwind')
-    return builder.call(fn, ())
-
-def get_py_state_ptr(context, builder):
-    return _get_state_ptr(context, builder, 'py')
-
-def get_np_state_ptr(context, builder):
-    return _get_state_ptr(context, builder, 'np')
-
-def get_state_ptr(context, builder, name):
-    return {
-        "py": get_py_state_ptr,
-        "np": get_np_state_ptr,
-        }[name](context, builder)
 
 
 def _fill_defaults(context, builder, sig, args, defaults):
@@ -1002,7 +1017,7 @@ def poisson_impl(context, builder, sig, args):
         big_lam = builder.fcmp_ordered('>=', lam, ir.Constant(double, 10.0))
         with builder.if_then(big_lam):
             # For lambda >= 10.0, we switch to a more accurate
-            # algorithm (see _helperlib.c).
+            # algorithm (see _random.c).
             fnty = ir.FunctionType(int64_t, (rnd_state_ptr_t, double))
             fn = builder.function.module.get_or_insert_function(fnty,
                                                                 "numba_poisson_ptrs")

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -78,6 +78,8 @@ def get_state_ptr(context, builder, name):
     func_name = "numba_get_%s_random_state" % name
     fnty = ir.FunctionType(rnd_state_ptr_t, ())
     fn = builder.module.get_or_insert_function(fnty, func_name)
+    # These two attributes allow LLVM to hoist the function call
+    # outside of loops.
     fn.attributes.add('readnone')
     fn.attributes.add('nounwind')
     return builder.call(fn, ())

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -32,26 +32,6 @@ N = 624
 N_const = ir.Constant(int32_t, N)
 
 
-_pid = None
-
-def random_init():
-    """
-    Routine ensuring the PRNG is properly initialized.
-    """
-    global _pid
-    if _pid != os.getpid():
-        _helperlib.rnd_global_init()
-        # Note this only marks the states unitialized.
-        # Actual initialization with system entropy, if needed,
-        # is done lazily (see rnd_implicit_init() in _random.c).
-        for state_ptr in [_helperlib.rnd_get_py_state_ptr(),
-                          _helperlib.rnd_get_np_state_ptr()]:
-            _helperlib.rnd_reset(state_ptr)
-        _pid = os.getpid()
-
-random_init()
-
-
 # This is the same struct as rnd_state_t in _random.c.
 rnd_state_t = ir.LiteralStructType([
     # index

--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -15,7 +15,6 @@ import numpy as np
 import numba.unittest_support as unittest
 from numba import jit, _helperlib, types
 from numba.compiler import compile_isolated
-from numba.targets.randomimpl import random_init
 from .support import TestCase, compile_function, tag
 
 
@@ -236,10 +235,6 @@ class TestRandom(BaseTest):
     # C code and SSE-using LLVM code), which is especially brutal for some
     # iterative algorithms with sensitive exit conditions.
     # Therefore we stick to hardcoded integers for seed values.
-
-    def setUp(self):
-        # Make sure the PRNG is initialized before we set the seed
-        random_init()
 
     def _check_random_seed(self, seedfunc, randomfunc):
         """
@@ -909,10 +904,6 @@ class TestRandomArrays(BaseTest):
     Test array-producing variants of np.random.* functions.
     """
 
-    def setUp(self):
-        # Make sure the PRNG is initialized before we set the seed
-        random_init()
-
     def _compile_array_dist(self, funcname, nargs):
         qualname = "np.random.%s" % (funcname,)
         argstring = ', '.join('abcd'[:nargs])
@@ -1042,10 +1033,6 @@ class TestRandomChoice(BaseTest):
     """
     Test np.random.choice.
     """
-
-    def setUp(self):
-        # Make sure the PRNG is initialized before we set the seed
-        random_init()
 
     def _check_results(self, pop, res, replace=True):
         """
@@ -1210,10 +1197,6 @@ class TestRandomMultinomial(BaseTest):
     # A biased dice
     pvals = np.array([1, 1, 1, 2, 3, 1], dtype=np.float64)
     pvals /= pvals.sum()
-
-    def setUp(self):
-        # Make sure the PRNG is initialized before we set the seed
-        random_init()
 
     def _check_sample(self, n, pvals, sample):
         """


### PR DESCRIPTION
This uses the C compiler's (and runtime linker's) support for thread-local variables in order to implement thread-local PRNG state. The state is lazily initialized with system entropy. Also, it is reinitialized after fork().