### PR TITLE
Fix #1259: liveness problem with generator that has multiple backedges

### DIFF
--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -225,6 +225,10 @@ class Interpreter(object):
         """
         Post-processing and analysis on generated IR
         """
+        from . import transforms
+
+        self.blocks = transforms.canonicalize_cfg(self.blocks)
+
         # emit del nodes
         self._insert_var_dels()
 


### PR DESCRIPTION
Fixes #1259

A new post-processing transformation pass is added before liveness info is computed, so that loops that have multiple backedges are canonicalized .  The canonicalization gatheres all backedges into a new tail block inside the loop.  This ensures a place to delete variables that are only alive within the loop.

