### PR TITLE
Add logging to CUDA driver

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -199,6 +199,8 @@ class _EnvReloader(object):
         # CUDA logging level
         # Any level name from the *logging* module.  Case insensitive.
         # Defaults to CRITICAL if not set or invalid.
+        # Note: This setting only applies when logging is not configured.
+        #       Any existing logging configuration is preserved.
         CUDA_LOG_LEVEL = _readenv("NUMBA_CUDA_LOG_LEVEL", str, '')
 
         # Maximum number of pending CUDA deallocations (default: 10)

--- a/numba/config.py
+++ b/numba/config.py
@@ -196,6 +196,11 @@ class _EnvReloader(object):
         # Enable CUDA simulator
         ENABLE_CUDASIM = _readenv("NUMBA_ENABLE_CUDASIM", int, 0)
 
+        # CUDA logging level
+        # Any level name from the *logging* module.  Case insensitive.
+        # Defaults to CRITICAL if not set or invalid.
+        CUDA_LOG_LEVEL = _readenv("NUMBA_CUDA_LOG_LEVEL", str, '')
+
         # Maximum number of pending CUDA deallocations (default: 10)
         CUDA_DEALLOCS_COUNT = _readenv("NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT",
                                        int, 10)

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -52,9 +52,6 @@ def _make_logger():
     return logger
 
 
-_logger = _make_logger()
-
-
 class DeadMemoryError(RuntimeError):
     pass
 
@@ -203,6 +200,10 @@ class Driver(object):
             self.initialization_error = e
 
     def initialize(self):
+        # lazily initialize logger
+        global _logger
+        _logger = _make_logger()
+
         self.is_initialized = True
         try:
             _logger.info('init')

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -40,15 +40,25 @@ MIN_REQUIRED_CC = (2, 0)
 
 def _make_logger():
     logger = logging.getLogger(__name__)
-    lvl = str(config.CUDA_LOG_LEVEL).upper()
-    lvl = getattr(logging, lvl, None)
-    if not isinstance(lvl, int):
-        lvl = logging.CRITICAL
-    logger.setLevel(lvl)
-    handler = logging.StreamHandler(sys.stderr)
-    fmt = '== CUDA [%(relativeCreated)d] %(levelname)5s -- %(message)s'
-    handler.setFormatter(logging.Formatter(fmt=fmt))
-    logger.addHandler(handler)
+    # is logging configured?
+    if not logger.hasHandlers():
+        # read user config
+        lvl = str(config.CUDA_LOG_LEVEL).upper()
+        lvl = getattr(logging, lvl, None)
+        if not isinstance(lvl, int):
+            # default to critical level
+            lvl = logging.CRITICAL
+        logger.setLevel(lvl)
+        # did user specify a level?
+        if config.CUDA_LOG_LEVEL:
+            # create a simple handler that prints to stderr
+            handler = logging.StreamHandler(sys.stderr)
+            fmt = '== CUDA [%(relativeCreated)d] %(levelname)5s -- %(message)s'
+            handler.setFormatter(logging.Formatter(fmt=fmt))
+            logger.addHandler(handler)
+        else:
+            # otherwise, put a null handler
+            logger.addHandler(logging.NullHandler())
     return logger
 
 


### PR DESCRIPTION
Add logging to CUDA driver to facilitate debugging.

Set "NUMBA_CUDA_LOG_LEVEL=INFO" to include all resource management info.
Set "NUMBA_CUDA_LOG_LEVEL=DEBUG" to include API call logging.
