### PR TITLE
Fix #2053: Avoid polling in parallel CPU target

### DIFF
--- a/numba/npyufunc/workqueue.h
+++ b/numba/npyufunc/workqueue.h
@@ -12,39 +12,9 @@ enum QUEUE_STATE {
     IDLE = 0, READY, RUNNING, DONE
 };
 
-/*
-sleep for a short time
-*/
-static
-void take_a_nap(int usec);
-
-
-/*
-CAS: compare and swap function
-
-It is generated from parallel.py by LLVM to get a portable CAS function.
-*/
-typedef int cas_function_t(volatile int *ptr, int old, int val);
-
-/*
-Do CAS until successful.
-Spin until the value in `ptr` changes from `old` to `repl`.
-Takes a 1us nap in after each CAS failure.
-*/
-static
-void cas_wait(volatile int *ptr, const int old, const int repl);
-
 /* Launch new thread */
 static
 thread_pointer numba_new_thread(void *worker, void *arg);
-
-/* Set CAS function.
-Note: During interpreter teardown, LLVM will release all function memory.
-      To protect against the fault due to calling non-executable memory,
-      Call set_cas(NULL) to disable the workqueue.
-*/
-static
-void set_cas(void *ptr);
 
 /* Launch `count` number of threads and create the associated thread queue.
 Must invoke once before each add_task() is used.


### PR DESCRIPTION
This should fix sleeping issues on Windows, and avoid waking the CPU periodically to check for pending parallel tasks.

Some notes about the implementation:
- this only changes the lower-level routines for synchronizing between a worker and the master thread; the higher-level design is unchanged
- by using system routines, the baseline (minimum) cost of a state change is increased; however, the removal of the polling mechanism ensures that performance doesn't generate because of spurious wakeups (or, on the contrary, spurious delays)
- I still think the overall queueing mechanism needs some rewrite using a specialized facility (e.g. `libdispatch`)

Note this needs Windows Vista or higher.