### PR TITLE
Workaround Windows floordiv heisenbug

### DIFF
--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -10,8 +10,8 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import jit, types, typeinfer, utils, errors
-from numba.config import PYVERSION
+from numba import jit, numpy_support, types, typeinfer, utils, errors
+from numba.config import PYVERSION, MACHINE_BITS
 from .support import TestCase, tag
 from .true_div_usecase import truediv_usecase, itruediv_usecase
 from .matmul_usecase import (matmul_usecase, imatmul_usecase, DumbMatrix,
@@ -27,6 +27,22 @@ def make_static_power(exp):
     def pow_usecase(x):
         return x ** exp
     return pow_usecase
+
+
+# On 64-bit Windows, MSVC 2008 (Python 2.7) and Numpy 1.9, there's a
+# heisenbug that seems to manifest as wrong values returned by the CRT's
+# fmodf() function (which is called by LLVM's lowering of the `frem`
+# instruction).
+# Perhaps Numpy messing with some internal FP state that confuses the CRT?
+# Regardless, the only sane thing to do seems to be to skip the tests...
+
+_windows_floordiv_heisenbug = (
+    sys.platform == 'win32' and numpy_support.version[:2] == (1, 9)
+    and MACHINE_BITS == 64)
+
+_avoid_windows_floordiv_heisenbug = unittest.skipIf(
+    _windows_floordiv_heisenbug,
+    "avoid Windows + Numpy floordiv heisenbug - see PR #2057")
 
 
 class LiteralOperatorImpl(object):
@@ -547,6 +563,10 @@ class TestOperators(TestCase):
         self.run_test_floats(pyfunc, x_operands, y_operands, types_list,
                              flags=flags)
 
+    @_avoid_windows_floordiv_heisenbug
+    def run_binop_floats_floordiv(self, pyfunc, flags=force_pyobj_flags):
+        self.run_binop_floats(pyfunc, flags=flags)
+
     def run_binop_complex(self, pyfunc, flags=force_pyobj_flags):
         x_operands = [-1.1 + 0.3j, 0.0 + 0.0j, 1.1j]
         y_operands = [-1.5 - 0.7j, 0.8j, 2.1 - 2.0j]
@@ -606,7 +626,7 @@ class TestOperators(TestCase):
     generate_binop_tests(locals(),
                          ('floordiv', 'ifloordiv', 'mod', 'imod'),
                          {'ints': 'run_binop_ints',
-                          'floats': 'run_binop_floats',
+                          'floats': 'run_binop_floats_floordiv',
                           })
 
     def check_div_errors(self, usecase_name, msg, flags=force_pyobj_flags,

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -16,6 +16,7 @@ from numba import vectorize
 from numba.config import PYVERSION
 from numba.errors import LoweringError, TypingError
 from .support import TestCase, CompilationCache, MemoryLeakMixin, tag
+from .test_operators import _avoid_windows_floordiv_heisenbug
 
 from numba.typing.npydecl import supported_ufuncs, all_ufuncs
 
@@ -335,8 +336,9 @@ class TestUFuncs(BaseUFuncTest, TestCase):
         self.binary_ufunc_test(np.true_divide, flags=flags, int_output_type=types.float64)
 
     @tag('important')
-    def test_floor_divide_ufunc(self):
-        self.binary_ufunc_test(np.floor_divide)
+    @_avoid_windows_floordiv_heisenbug
+    def test_floor_divide_ufunc(self, flags=no_pyobj_flags):
+        self.binary_ufunc_test(np.floor_divide, flags=flags)
 
     @tag('important')
     def test_negative_ufunc(self, flags=no_pyobj_flags):
@@ -351,6 +353,7 @@ class TestUFuncs(BaseUFuncTest, TestCase):
         self.binary_ufunc_test(np.power, flags=flags)
 
     @tag('important')
+    @_avoid_windows_floordiv_heisenbug
     def test_remainder_ufunc(self, flags=no_pyobj_flags):
         self.binary_ufunc_test(np.remainder, flags=flags)
 
@@ -1084,6 +1087,7 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
     def test_inplace_div(self):
         self.inplace_float_op_test('/=', [-1, 1.5, 3], [-5, 0, 2.5])
 
+    @_avoid_windows_floordiv_heisenbug
     def test_inplace_remainder(self):
         self.inplace_float_op_test('%=', [-1, 1.5, 3], [-5, 2, 2.5])
 
@@ -1152,6 +1156,7 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
         self.binary_op_test('/', int_output_type=int_out_type)
 
     @tag('important')
+    @_avoid_windows_floordiv_heisenbug
     def test_floor_divide_array_op(self):
         # Avoid floating-point zeros as x // 0.0 can have varying results
         # depending on the algorithm (which changed accross Numpy versions)
@@ -1179,6 +1184,7 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
         self.binary_op_test('//')
 
     @tag('important')
+    @_avoid_windows_floordiv_heisenbug
     def test_remainder_array_op(self):
         self.binary_op_test('%')
 


### PR DESCRIPTION
On 64-bit Windows, MSVC 2008 (Python 2.7) and Numpy 1.9, there's a heisenbug that seems to manifest as wrong values returned by the CRT's fmodf() function (which is called by LLVM's lowering of the `frem` instruction).