### PR TITLE
Fix #1995: right shift should be logical when first operand is unsigned

### DIFF
--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -1370,9 +1370,16 @@ class TestMixedInts(TestCase):
                            % (x, y, (xt, yt)))
                     self.assertPreciseEqual(got, expected, msg=msg)
 
-        for xt, yt in self.signed_pairs:
+        # For bitshifts, only the first operand's signedness matters
+        # to choose the operation's signedness.
+        signed_pairs = [(u, v) for u, v in self.type_pairs
+                        if u.signed]
+        unsigned_pairs = [(u, v) for u, v in self.type_pairs
+                          if not u.signed]
+
+        for xt, yt in signed_pairs:
             check(xt, yt, control_signed)
-        for xt, yt in self.unsigned_pairs:
+        for xt, yt in unsigned_pairs:
             check(xt, yt, control_unsigned)
 
     def test_lshift(self):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -241,8 +241,15 @@ class PowerBuiltin(BinOpPower):
 
 
 class BitwiseShiftOperation(ConcreteTemplate):
-    cases = list(integer_binop_cases)
-
+    # For bitshifts, only the first operand's signedness matters
+    # to choose the operation's signedness (the second operand
+    # should always be positive but will generally be considered
+    # signed anyway, since it's often a constant integer).
+    # (also, see issue #1995 for right-shifts)
+    cases = [signature(max(op, types.intp), op, types.intp)
+             for op in sorted(types.signed_domain)]
+    cases += [signature(max(op, types.uintp), op, types.intp)
+              for op in sorted(types.unsigned_domain)]
 
 @infer
 class BitwiseLeftShift(BitwiseShiftOperation):


### PR DESCRIPTION
This changes the rules for bitshift operations: only the first operand matters for signedness, so that e.g. `unsigned >> 2` will be considered unsigned and not signed. 

Note that Numpy is much more annoying:
```
>>> np.uint64(18446744073709551615) >> 2
Traceback (most recent call last):
  File "<ipython-input-10-988f6401a88f>", line 1, in <module>
    np.uint64(18446744073709551615) >> 2
TypeError: ufunc 'right_shift' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```