### PR TITLE
Fix generator return (#1808)

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1111,10 +1111,10 @@ class GeneratorModel(CompositeModel):
         return value
 
     def as_return(self, builder, value):
-        return value
+        return self.as_data(builder, value)
 
     def from_return(self, builder, value):
-        return value
+        return self.from_data(builder, value)
 
     def as_data(self, builder, value):
         return builder.load(value)

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -452,10 +452,7 @@ class CPUCallConv(BaseCallConv):
         code = builder.call(callee, realargs)
         status = self._get_return_status(builder, code,
                                          builder.load(excinfoptr))
-        if is_generator_function:
-            retval = retvaltmp
-        else:
-            retval = builder.load(retvaltmp)
+        retval = builder.load(retvaltmp)
         out = self.context.get_returned_value(builder, resty, retval)
         return status, out
 

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -8,6 +8,8 @@ from numba.compiler import compile_isolated, Flags
 from numba import jit, njit, types
 from .support import TestCase, MemoryLeakMixin, tag
 from numba import testing
+from numba.datamodel.testing import test_factory
+
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
@@ -611,6 +613,13 @@ class TestGeneratorWithNRT(MemoryLeakMixin, TestCase):
             return out
 
         self.assertEqual(main(), magic)
+
+
+class TestGeneratorModel(test_factory()):
+    fe_type = types.Generator(gen_func=None, yield_type=types.int32,
+                              arg_types=[types.int64, types.float32],
+                              state_types=[types.intp, types.intp[::1]],
+                              has_finalizer=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The bug was caused by a mismatch in the datamodel conversion function for return type.