### PR TITLE
Implement np.linalg.{eigvals(), eigh(), eigvalsh()}.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -175,6 +175,11 @@ floating-point and complex numbers:
 * :func:`numpy.linalg.eig` (only running with data that does not cause a domain
   change is supported e.g. real input -> real
   output, complex input -> complex output).
+* :func:`numpy.linalg.eigh` (only the first argument).
+* :func:`numpy.linalg.eigvals` (only running with data that does not cause a 
+  domain change is supported e.g. real input -> real output,
+  complex input -> complex output).
+* :func:`numpy.linalg.eigvalsh` (only the first argument).
 * :func:`numpy.linalg.inv`
 * :func:`numpy.linalg.lstsq`
 * :func:`numpy.linalg.matrix_rank`

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -94,6 +94,7 @@ build_c_helpers_dict(void)
     declmethod(xxpotrf);
     declmethod(ez_rgeev);
     declmethod(ez_cgeev);
+    declmethod(ez_xxxevd);
     declmethod(ez_gesdd);
     declmethod(ez_geqrf);
     declmethod(ez_xxgqr);

--- a/numba/_lapack.c
+++ b/numba/_lapack.c
@@ -657,7 +657,7 @@ static size_t kind_size(char kind)
  *     c -> s
  *     z -> d
  * ---------------
- * 
+ *
  */
 static char underlying_float_kind(char kind)
 {
@@ -1044,17 +1044,6 @@ numba_ez_cgeev(char kind, char jobvl, char jobvr,  Py_ssize_t n, void *a,
 
     return (int)info;
 }
-
-
-typedef void (*xsyevd_t)(char *jobz, char *uplo, F_INT *n, void *a, F_INT *lda,
-                         void *w, void *work, F_INT *lwork, F_INT *iwork,
-                         F_INT *liwork, F_INT *info);
-
-typedef void (*xheevd_t)(char *jobz, char *uplo, F_INT *n, void *a, F_INT *lda,
-                         void *w, void *work, F_INT *lwork, void *rwork,
-                         F_INT *lrwork, F_INT *iwork, F_INT *liwork,
-                         F_INT *info);
-
 
 /* real space symmetric eigen systems info from ssyevd/dsyevd */
 static int

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -317,6 +317,18 @@ def eig_matrix(a):
     return np.linalg.eig(a)
 
 
+def eigvals_matrix(a):
+    return np.linalg.eigvals(a)
+
+
+def eigh_matrix(a):
+    return np.linalg.eigh(a)
+
+
+def eigvalsh_matrix(a):
+    return np.linalg.eigvalsh(a)
+
+
 def svd_matrix(a, full_matrices=1):
     return np.linalg.svd(a, full_matrices)
 
@@ -789,9 +801,9 @@ class TestLinalgCholesky(TestLinalgBase):
                            (np.ones(4, dtype=np.float64).reshape(2, 2),))
 
 
-class TestLinalgEig(TestLinalgBase):
+class TestLinalgEigenSystems(TestLinalgBase):
     """
-    Tests for np.linalg.eig.
+    Tests for np.linalg.eig/eigvals.
     """
 
     def sample_matrix(self, m, dtype, order):
@@ -805,25 +817,31 @@ class TestLinalgEig(TestLinalgBase):
         Q = np.array(Q, dtype=dtype, order=order)
         return Q
 
-    def assert_no_domain_change(self, cfunc, args):
-        msg = "eig() argument must not cause a domain change."
+    def assert_no_domain_change(self, name, cfunc, args):
+        msg = name + "() argument must not cause a domain change."
         self.assert_error(cfunc, args, msg)
 
-    @needs_lapack
-    def test_linalg_eig(self):
+    def checker_for_linalg_eig(
+            self, name, func, expected_res_len, check_for_domain_change=None):
         """
         Test np.linalg.eig
         """
         n = 10
-        cfunc = jit(nopython=True)(eig_matrix)
+        cfunc = jit(nopython=True)(func)
 
         def check(a):
-            expected = eig_matrix(a)
+            expected = func(a)
             got = cfunc(a)
             # check that the returned tuple is same length
             self.assertEqual(len(expected), len(got))
-            # and that length is 2
-            self.assertEqual(len(got), 2)
+            # and that dimension is correct
+            res_is_tuple = False
+            if isinstance(got, tuple):
+                res_is_tuple = True
+                self.assertEqual(len(got), expected_res_len)
+            else:  # its an array
+                self.assertEqual(got.ndim, expected_res_len)
+
             # and that the computed results are contig and in the same way
             self.assert_contig_sanity(got, "F")
 
@@ -837,76 +855,134 @@ class TestLinalgEig(TestLinalgBase):
                     # plain match failed, test by reconstruction
                     use_reconstruction = True
 
-            # if plain match fails then reconstruction is used.
-            # this checks that A*V ~== V*W
+            # If plain match fails then reconstruction is used.
+            # this checks that A*V ~== V*diag(W)
             # i.e. eigensystem ties out
             # this is required as numpy uses only double precision lapack
             # routines and computation of eigenvectors is numerically
-            # sensitive, numba using the type specific routines therefore
+            # sensitive, numba uses the type specific routines therefore
             # sometimes comes out with a different (but entirely
             # valid) answer (eigenvectors are not unique etc.).
+            # This is only applicable if eigenvectors are computed
+            # along with eigenvalues i.e. result is a tuple.
+            resolution = 5 * np.finfo(a.dtype).resolution
             if use_reconstruction:
-                w, v = got
-                lhs = np.dot(a, v)
-                rhs = np.dot(v, np.diag(w))
-                resolution = 5 * np.finfo(a.dtype).resolution
-                np.testing.assert_allclose(
-                    lhs,
-                    rhs,
-                    rtol=resolution,
-                    atol=resolution
-                )
+                if res_is_tuple:
+                    w, v = got
+                    # modify 'a' if hermitian eigensystem functionality is
+                    # being tested. 'L' for use lower part is default and
+                    # the only thing used at present so we conjugate transpose
+                    # the lower part into the upper for use in the 
+                    # reconstruction. By construction the sample matrix is 
+                    # tridiag so this is just a question of copying the lower
+                    # diagonal into the upper and conjugating on the way.
+                    if name[-1] == 'h':
+                        idxl = np.nonzero(np.eye(a.shape[0], a.shape[1], -1))
+                        idxu = np.nonzero(np.eye(a.shape[0], a.shape[1], 1))
+                        cfunc(a)
+                        # upper idx must match lower for default uplo="L"
+                        # if complex, conjugate
+                        a[idxu] = np.conj(a[idxl])
+                        # also, only the real part of the diagonals is
+                        # considered in the calculation so the imag is zeroed
+                        # out for the purposes of use in reconstruction.
+                        a[np.diag_indices(a.shape[0])] = np.real(np.diag(a))
+
+                    lhs = np.dot(a, v)
+                    rhs = np.dot(v, np.diag(w))
+
+                    np.testing.assert_allclose(
+                        lhs.real,
+                        rhs.real,
+                        rtol=resolution,
+                        atol=resolution
+                    )
+                    if np.iscomplexobj(v):
+                        np.testing.assert_allclose(
+                            lhs.imag,
+                            rhs.imag,
+                            rtol=resolution,
+                            atol=resolution
+                        )
+                else:
+                    # This isn't technically reconstruction but is here to
+                    # deal with that the order of the returned eigenvalues
+                    # may differ in the case of routines just returning
+                    # eigenvalues and there's no true reconstruction
+                    # available with which to perform a check.
+                    np.testing.assert_allclose(
+                        np.sort(expected),
+                        np.sort(got),
+                        rtol=resolution,
+                        atol=resolution
+                    )
 
             # Ensure proper resource management
             with self.assertNoNRTLeak():
                 cfunc(a)
-
+        
+        # The main test loop
         for dtype, order in product(self.dtypes, 'FC'):
             a = self.sample_matrix(n, dtype, order)
             check(a)
 
-        rn = "eig"
-
-        # test both a real and complex type as the impls are different
+        # Test both a real and complex type as the impls are different
         for ty in [np.float32, np.complex64]:
             # Non square matrices
             self.assert_non_square(cfunc, (np.ones((2, 3), dtype=ty),))
 
             # Wrong dtype
-            self.assert_wrong_dtype(rn, cfunc,
+            self.assert_wrong_dtype(name, cfunc,
                                     (np.ones((2, 2), dtype=np.int32),))
 
             # Dimension issue
-            self.assert_wrong_dimensions(rn, cfunc, (np.ones(10, dtype=ty),))
+            self.assert_wrong_dimensions(name, cfunc, (np.ones(10, dtype=ty),))
 
             # no nans or infs
             self.assert_no_nan_or_inf(cfunc,
                                       (np.array([[1., 2., ], [np.inf, np.nan]],
                                                 dtype=ty),))
 
-        # By design numba does not support dynamic return types, numpy does
-        # and uses this in the case of returning eigenvalues/vectors of
-        # a real matrix. The return type of np.linalg.eig(), when
-        # operating on a matrix in real space depends on the values present
-        # in the matrix itself (recalling that eigenvalues are the roots of the
-        # characteristic polynomial of the system matrix, which will by
-        # construction depend on the values present in the system matrix).
-        # This test asserts that if a domain change is required on the return
-        # type, i.e. complex eigenvalues from a real input, an error is raised.
-        # For complex types, regardless of the value of the imaginary part of
-        # the returned eigenvalues, a complex type will be returned, this
-        # follows numpy and fits in with numba.
+        if check_for_domain_change:
+            # By design numba does not support dynamic return types, numpy does
+            # and uses this in the case of returning eigenvalues/vectors of
+            # a real matrix. The return type of np.linalg.eig(), when
+            # operating on a matrix in real space depends on the values present
+            # in the matrix itself (recalling that eigenvalues are the roots of the
+            # characteristic polynomial of the system matrix, which will by
+            # construction depend on the values present in the system matrix).
+            # This test asserts that if a domain change is required on the return
+            # type, i.e. complex eigenvalues from a real input, an error is raised.
+            # For complex types, regardless of the value of the imaginary part of
+            # the returned eigenvalues, a complex type will be returned, this
+            # follows numpy and fits in with numba.
 
-        # First check that the computation is valid (i.e. in complex space)
-        A = np.array([[1, -2], [2, 1]])
-        check(A.astype(np.complex128))
-        # and that the imaginary part is nonzero
-        l, _ = eig_matrix(A)
-        self.assertTrue(np.any(l.imag))
+            # First check that the computation is valid (i.e. in complex space)
+            A = np.array([[1, -2], [2, 1]])
+            check(A.astype(np.complex128))
+            # and that the imaginary part is nonzero
+            l, _ = func(A)
+            self.assertTrue(np.any(l.imag))
 
-        # Now check that the computation fails in real space
-        for ty in [np.float32, np.float64]:
-            self.assert_no_domain_change(cfunc, (A.astype(ty),))
+            # Now check that the computation fails in real space
+            for ty in [np.float32, np.float64]:
+                self.assert_no_domain_change(name, cfunc, (A.astype(ty),))
+
+    @needs_lapack
+    def test_linalg_eig(self):
+        self.checker_for_linalg_eig("eig", eig_matrix, 2, True)
+
+    @needs_lapack
+    def test_linalg_eigvals(self):
+        self.checker_for_linalg_eig("eigvals", eigvals_matrix, 1, True)
+
+    @needs_lapack
+    def test_linalg_eigh(self):
+        self.checker_for_linalg_eig("eigh", eigh_matrix, 2, False)
+
+    @needs_lapack
+    def test_linalg_eigvalsh(self):
+        self.checker_for_linalg_eig("eigvalsh", eigvalsh_matrix, 1, False)
 
 
 class TestLinalgSvd(TestLinalgBase):


### PR DESCRIPTION
This PR implements:
 * numpy.linalg.eigvals()
 * numpy.linalg.eigh()
 * numpy.linalg.eigvalsh()

and augments the tests and input data for numpy.linalg.eig()
for reuse with the above. Further, it exposes an easy to use
wrapper of the Hermitian eigen-value/vector routines available
from LAPACK.