### PR TITLE
Fix #2132

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -124,8 +124,8 @@ returns a view of the imaginary part of the complex array and it returns a zero
 array with the same shape and dtype for other numeric dtypes.  For non-numeric
 dtypes, including all structured/record dtypes, using these attributes will
 result in a compile-time (`TypingError`) error.  This behavior differs from
-Numpy's but it is chosen to avoid the confusion with potential field names that
-overlaps with these attributes.
+Numpy's but it is chosen to avoid the potential confusion with field names that
+overlap these attributes.
 
 Calculation
 -----------

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -96,6 +96,8 @@ The following attributes of Numpy arrays are supported:
 * :attr:`~numpy.ndarray.size`
 * :attr:`~numpy.ndarray.strides`
 * :attr:`~numpy.ndarray.T`
+* :attr:`~numpy.ndarray.real`
+* :attr:`~numpy.ndarray.imag`
 
 The ``flags`` object
 ''''''''''''''''''''
@@ -109,6 +111,21 @@ The ``flat`` object
 The object returned by the :attr:`~numpy.ndarray.flat` attribute supports
 iteration and indexing, but be careful: indexing is very slow on
 non-C-contiguous arrays.
+
+The ``real`` and ``imag`` attributes
+''''''''''''''''''''''''''''''''''''
+
+Numpy supports these attributes regardless of the dtype but Numba chooses to
+limit their support to avoid potential user error.  For numeric dtypes,
+Numba follows Numpy's behavior.  The :attr:`~numpy.ndarray.real` attribute
+returns a view of the real part of the complex array and it behaves as an identity
+function for other numeric dtypes.  The :attr:`~numpy.ndarray.imag` attribute
+returns a view of the imaginary part of the complex array and it returns a zero
+array with the same shape and dtype for other numeric dtypes.  For non-numeric
+dtypes, including all structured/record dtypes, using these attributes will
+result in a compile-time (`TypingError`) error.  This behavior differs from
+Numpy's but it is chosen to avoid the confusion with potential field names that
+overlaps with these attributes.
 
 Calculation
 -----------

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1912,6 +1912,33 @@ def array_imag_part(context, builder, typ, value):
 
 
 def array_complex_attr(context, builder, typ, value, attr):
+    """
+    Given a complex array, it's memory layout is:
+
+        R C R C R C
+        ^   ^   ^
+
+    (`R` indicates a float for the real part;
+     `C` indicates a float for the imaginery part;
+     the `^` indicates the start of each element)
+
+    To get the real part, we can simply change the dtype and itemsize to that
+    of the underlying float type.  The new layout is:
+
+        R x R x R x
+        ^   ^   ^
+
+    (`x` indicates unused)
+
+    A load operation will use the dtype to determine the number of bytes to
+    load.
+
+    To get the imaginary part, we shift the pointer by 1 float offset and
+    change the dtype and itemsize.  The new layout is:
+
+        x C x C x C
+          ^   ^   ^
+    """
     if attr not in ['real', 'imag'] or typ.dtype not in types.complex_domain:
         raise NotImplementedError("cannot get attribute `{}`".format(attr))
 

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -237,15 +237,23 @@ class TestComplexArray(MemoryLeakMixin, unittest.TestCase):
     def test_real_attr(self):
         pyfunc = array_real
         cfunc = njit(pyfunc)
+        # test 1D
         size = 10
         arr = np.arange(size) + np.arange(size) * 10j
+        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        # test 2D
+        arr = arr.reshape(2, 5)
         self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
 
     def test_imag_attr(self):
         pyfunc = array_imag
         cfunc = njit(pyfunc)
+        # test 1D
         size = 10
         arr = np.arange(size) + np.arange(size) * 10j
+        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        # test 2D
+        arr = arr.reshape(2, 5)
         self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
 
 

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -232,28 +232,22 @@ class TestArrayCTypes(MemoryLeakMixin, unittest.TestCase):
         self.assertEqual(pyfunc(arr), cfunc(arr))
 
 
-class TestRealImagAttr(MemoryLeakMixin, unittest.TestCase):
-    def test_complex_real(self):
-        pyfunc = array_real
+class TestRealImagAttr(MemoryLeakMixin, TestCase):
+    def check_complex(self, pyfunc):
         cfunc = njit(pyfunc)
         # test 1D
         size = 10
         arr = np.arange(size) + np.arange(size) * 10j
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
         # test 2D
         arr = arr.reshape(2, 5)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+
+    def test_complex_real(self):
+        self.check_complex(array_real)
 
     def test_complex_imag(self):
-        pyfunc = array_imag
-        cfunc = njit(pyfunc)
-        # test 1D
-        size = 10
-        arr = np.arange(size) + np.arange(size) * 10j
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
-        # test 2D
-        arr = arr.reshape(2, 5)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.check_complex(array_imag)
 
     def check_number_real(self, dtype):
         pyfunc = array_real
@@ -261,10 +255,10 @@ class TestRealImagAttr(MemoryLeakMixin, unittest.TestCase):
         # test 1D
         size = 10
         arr = np.arange(size, dtype=dtype)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
         # test 2D
         arr = arr.reshape(2, 5)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
         # test identity
         self.assertEqual(arr.data, pyfunc(arr).data)
         self.assertEqual(arr.data, cfunc(arr).data)
@@ -275,6 +269,9 @@ class TestRealImagAttr(MemoryLeakMixin, unittest.TestCase):
         self.assertEqual(arr[0, 0], 5)
 
     def test_number_real(self):
+        """
+        Testing .real of non-complex dtypes
+        """
         for dtype in [np.uint8, np.int32, np.float32, np.float64]:
             self.check_number_real(dtype)
 
@@ -284,10 +281,10 @@ class TestRealImagAttr(MemoryLeakMixin, unittest.TestCase):
         # test 1D
         size = 10
         arr = np.arange(size, dtype=dtype)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
         # test 2D
         arr = arr.reshape(2, 5)
-        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+        self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
         # test are zeros
         self.assertEqual(cfunc(arr).tolist(), np.zeros_like(arr).tolist())
         # test readonly
@@ -298,6 +295,9 @@ class TestRealImagAttr(MemoryLeakMixin, unittest.TestCase):
                          str(raises.exception))
 
     def test_number_imag(self):
+        """
+        Testing .imag of non-complex dtypes
+        """
         for dtype in [np.uint8, np.int32, np.float32, np.float64]:
             self.check_number_imag(dtype)
 

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -79,6 +79,14 @@ def array_ctypes_data(arr):
     return arr.ctypes.data
 
 
+def array_real(arr):
+    return arr.real
+
+
+def array_imag(arr):
+    return arr.imag
+
+
 class TestArrayAttr(MemoryLeakMixin, TestCase):
 
     def setUp(self):
@@ -223,6 +231,22 @@ class TestArrayCTypes(MemoryLeakMixin, unittest.TestCase):
         cfunc = njit(pyfunc)
         arr = np.arange(3)
         self.assertEqual(pyfunc(arr), cfunc(arr))
+
+
+class TestComplexArray(MemoryLeakMixin, unittest.TestCase):
+    def test_real_attr(self):
+        pyfunc = array_real
+        cfunc = njit(pyfunc)
+        size = 10
+        arr = np.arange(size) + np.arange(size) * 10j
+        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
+
+    def test_imag_attr(self):
+        pyfunc = array_imag
+        cfunc = njit(pyfunc)
+        size = 10
+        arr = np.arange(size) + np.arange(size) * 10j
+        self.assertEqual(pyfunc(arr).tolist(), cfunc(arr).tolist())
 
 
 if __name__ == '__main__':

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -404,6 +404,8 @@ class ArrayAttribute(AttributeTemplate):
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:
                 return ary.copy(dtype=ary.dtype.typeof(attr), layout='A')
+        elif ary.dtype in types.complex_domain and attr in ['real', 'imag']:
+            return ary.copy(dtype=ary.dtype.underlying_float, layout='A')
 
 
 @infer

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -261,6 +261,24 @@ class ArrayAttribute(AttributeTemplate):
             retty = ary.copy(layout=layout)
         return retty
 
+    def resolve_real(self, ary):
+        return self._resolve_real_imag(ary, attr='real')
+
+    def resolve_imag(self, ary):
+        return self._resolve_real_imag(ary, attr='imag')
+
+    def _resolve_real_imag(self, ary, attr):
+        if ary.dtype in types.complex_domain:
+            return ary.copy(dtype=ary.dtype.underlying_float, layout='A')
+        elif ary.dtype in types.number_domain:
+            res = ary.copy(dtype=ary.dtype)
+            if attr == 'imag':
+                res = res.copy(readonly=True)
+            return res
+        else:
+            msg = "cannot access .{} of array of {}"
+            raise TypeError(msg.format(attr, ary.dtype))
+
     @bound_function("array.transpose")
     def resolve_transpose(self, ary, args, kws):
         assert not args
@@ -404,8 +422,6 @@ class ArrayAttribute(AttributeTemplate):
         if isinstance(ary.dtype, types.Record):
             if attr in ary.dtype.fields:
                 return ary.copy(dtype=ary.dtype.typeof(attr), layout='A')
-        elif ary.dtype in types.complex_domain and attr in ['real', 'imag']:
-            return ary.copy(dtype=ary.dtype.underlying_float, layout='A')
 
 
 @infer

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -9,6 +9,7 @@ from numba.typing.templates import (AttributeTemplate, AbstractTemplate,
 # import time side effect: array operations requires typing support of sequence
 # defined in collections: e.g. array.shape[i]
 from numba.typing import collections
+from numba.errors import TypingError
 
 Indexing = namedtuple("Indexing", ("index", "result", "advanced"))
 
@@ -277,7 +278,7 @@ class ArrayAttribute(AttributeTemplate):
             return res
         else:
             msg = "cannot access .{} of array of {}"
-            raise TypeError(msg.format(attr, ary.dtype))
+            raise TypingError(msg.format(attr, ary.dtype))
 
     @bound_function("array.transpose")
     def resolve_transpose(self, ary, args, kws):


### PR DESCRIPTION
Implements getattr to .real and .imag for numeric arrays.
These attributes are disallowed for record/structure arrays because numpy's behavior is not useful (.real is an identity and .imag returns a readonly `zeros_like(self)` array) and it shadows a potential user error.  Numba will raise a TypingError instead.