### PR TITLE
Fix #2143 and add `numba.extending.register_jitable`

### DIFF
--- a/numba/extending.py
+++ b/numba/extending.py
@@ -86,6 +86,36 @@ def overload(func, jit_options={}):
     return decorate
 
 
+def register_jitable(*args, **kwargs):
+    """
+    Register a regular python function that can be executed by the python
+    interpreter and can be compiled into a nopython function when referenced
+    by other jit'ed functions.  Can be used as::
+
+        @register_jitable
+        def foo(x, y):
+            return x + y
+
+    Or, with compiler options::
+
+        @register_jitable(_nrt=False) # disable runtime allocation
+        def foo(x, y):
+            return x + y
+
+    """
+    def wrap(fn):
+        # It is just a wrapper for @overload
+        @overload(fn, jit_options=kwargs)
+        def ov_wrap(*args, **kwargs):
+            return fn
+        return fn
+
+    if kwargs:
+        return wrap
+    else:
+        return wrap(*args)
+
+
 def overload_attribute(typ, attr):
     """
     A decorator marking the decorated function as typing and implementing

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -24,6 +24,7 @@ from numba.targets.imputils import (lower_builtin, lower_getattr,
                                     iternext_impl, impl_ret_borrowed,
                                     impl_ret_new_ref, impl_ret_untracked)
 from numba.typing import signature
+from numba.extending import register_jitable
 from . import quicksort, slicing
 
 
@@ -4339,14 +4340,12 @@ def impl_shape_unchecked(context, builder, sig, args):
 
 @extending.overload(np.lib.stride_tricks.as_strided)
 def as_strided(x, shape=None, strides=None):
-    from numba import jit
-
     if shape in (None, types.none):
-        @jit(nopython=True)
+        @register_jitable
         def get_shape(x, shape):
             return x.shape
     else:
-        @jit(nopython=True)
+        @register_jitable
         def get_shape(x, shape):
             return shape
 
@@ -4357,7 +4356,7 @@ def as_strided(x, shape=None, strides=None):
         # use cases of as_strided() pass explicit *strides*.
         raise NotImplementedError("as_strided() strides argument is mandatory")
     else:
-        @jit(nopython=True)
+        @register_jitable
         def get_strides(x, strides):
             return strides
 

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -56,6 +56,7 @@ class CPUContext(BaseContext):
         self.install_registry(operatorimpl.registry)
         self.install_registry(printimpl.registry)
         self.install_registry(randomimpl.registry)
+        self.install_registry(randomimpl.registry)
 
     @property
     def target_data(self):

--- a/numba/targets/quicksort.py
+++ b/numba/targets/quicksort.py
@@ -237,6 +237,6 @@ def make_py_quicksort(*args, **kwargs):
     return make_quicksort_impl((lambda f: f), *args, **kwargs)
 
 def make_jit_quicksort(*args, **kwargs):
-    from numba import jit
-    return make_quicksort_impl((lambda f: jit(nopython=True)(f)),
+    from numba.extending import register_jitable
+    return make_quicksort_impl((lambda f: register_jitable(f)),
                                *args, **kwargs)

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -12,11 +12,11 @@ import numpy as np
 
 from llvmlite import ir
 
-from numba.extending import overload
+from numba.extending import overload, register_jitable
 from numba.targets.imputils import (Registry, impl_ret_untracked,
                                     impl_ret_new_ref)
 from numba.typing import signature
-from numba import _helperlib, cgutils, types, jit
+from numba import _helperlib, cgutils, types
 
 
 registry = Registry()
@@ -1271,15 +1271,15 @@ def choice(a, size=None, replace=True):
         assert a.ndim == 1
         dtype = a.dtype
 
-        @jit(nopython=True)
+        @register_jitable
         def get_source_size(a):
             return len(a)
 
-        @jit(nopython=True)
+        @register_jitable
         def copy_source(a):
             return a.copy()
 
-        @jit(nopython=True)
+        @register_jitable
         def getitem(a, a_i):
             return a[a_i]
 
@@ -1287,15 +1287,15 @@ def choice(a, size=None, replace=True):
         # choice() over an implied arange() population
         dtype = np.intp
 
-        @jit(nopython=True)
+        @register_jitable
         def get_source_size(a):
             return a
 
-        @jit(nopython=True)
+        @register_jitable
         def copy_source(a):
             return np.arange(a)
 
-        @jit(nopython=True)
+        @register_jitable
         def getitem(a, a_i):
             return a_i
 
@@ -1354,7 +1354,7 @@ def multinomial(n, pvals, size=None):
 
     dtype = np.intp
 
-    @jit(nopython=True)
+    @register_jitable
     def multinomial_inner(n, pvals, out):
         # Numpy's algorithm for multinomial()
         fl = out.flat


### PR DESCRIPTION
`@jit` register functions to the current typing context once but our tests may create temporary, isolated typing context.  The problem in #2143 is due to the import of `numba.targets.linalg` happening when it is in a temporary typing context, causing internal `@jit`'ed functions to be missing when later used by a different typing context.  

This patch replaces all internal `@jit` with `@register_jitable` (need better name?).  The new decorator uses `@overload`, which will properly repopulate into new typing contexts that reference it.

The `@register_jitable` behaves like `@overload` but with a single definition.  The decorator returns the given function object but, internally, register the object to a global value registry.  When the decorated function is called by regular python code, it is interpreted.  When called by numba jitted code, it is jit'ed.