### PR TITLE
Workaround for kb982107

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -24,20 +24,22 @@
 /*
  * Other helpers.
  */
- 
 
+
+/* Fix fmod() and fmodf() for windows x64 VC 9.0 (VS 2008)
+https://support.microsoft.com/en-us/kb/982107
+*/
 static  void (*fnclex)(void) = NULL;
 
-
 NUMBA_EXPORT_FUNC(double)
-numba_fmod(double x, double y){
-    fnclex();
+numba_fixed_fmod(double x, double y){
+    fnclex();  /* no inline asm in x64 =( */
     return fmod(x, y);
 }
 
 NUMBA_EXPORT_FUNC(float)
-numba_fmodf(float x, float y) {
-    fnclex();
+numba_fixed_fmodf(float x, float y) {
+    fnclex();  /* no inline asm in x64 =( */
     return fmodf(x, y);
 }
 

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -24,6 +24,27 @@
 /*
  * Other helpers.
  */
+ 
+
+static  void (*fnclex)(void) = NULL;
+
+
+NUMBA_EXPORT_FUNC(double)
+numba_fmod(double x, double y){
+    fnclex();
+    return fmod(x, y);
+}
+
+NUMBA_EXPORT_FUNC(float)
+numba_fmodf(float x, float y) {
+    fnclex();
+    return fmodf(x, y);
+}
+
+NUMBA_EXPORT_FUNC(void)
+numba_set_fnclex(void *fn){
+    fnclex = fn;
+}
 
 /* provide 64-bit division function to 32-bit platforms */
 NUMBA_EXPORT_FUNC(int64_t)

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -36,6 +36,10 @@ build_c_helpers_dict(void)
 
 #define declpointer(ptr) _declpointer(#ptr, &numba_##ptr)
 
+declmethod(fmod);
+declmethod(fmodf);
+declmethod(set_fnclex);
+
     declmethod(sdiv);
     declmethod(srem);
     declmethod(udiv);

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -36,9 +36,9 @@ build_c_helpers_dict(void)
 
 #define declpointer(ptr) _declpointer(#ptr, &numba_##ptr)
 
-declmethod(fmod);
-declmethod(fmodf);
-declmethod(set_fnclex);
+    declmethod(fixed_fmod);
+    declmethod(fixed_fmodf);
+    declmethod(set_fnclex);
 
     declmethod(sdiv);
     declmethod(srem);

--- a/numba/mathnames.h
+++ b/numba/mathnames.h
@@ -70,8 +70,8 @@ MATH_UNARY(truncf, float, float)
 MATH_BINARY(pow, double, double, double)
 MATH_BINARY(powf, float, float, float)
 
-//MATH_BINARY(fmod, double, double, double)
-//MATH_BINARY(fmodf, float, float, float)
+MATH_BINARY(fmod, double, double, double)
+MATH_BINARY(fmodf, float, float, float)
 
 MATH_BINARY(atan2_fixed, double, double, double)
 MATH_BINARY(atan2, double, double, double)

--- a/numba/mathnames.h
+++ b/numba/mathnames.h
@@ -70,8 +70,8 @@ MATH_UNARY(truncf, float, float)
 MATH_BINARY(pow, double, double, double)
 MATH_BINARY(powf, float, float, float)
 
-MATH_BINARY(fmod, double, double, double)
-MATH_BINARY(fmodf, float, float, float)
+//MATH_BINARY(fmod, double, double, double)
+//MATH_BINARY(fmodf, float, float, float)
 
 MATH_BINARY(atan2_fixed, double, double, double)
 MATH_BINARY(atan2, double, double, double)

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -191,8 +191,7 @@ define void @fnclex() {
   ret void
 }
     """
-    # XXX llvmlite does not expose this initializer as a python function, yet.
-    ll.ffi.lib.LLVMPY_InitializeNativeAsmParser()
+    ll.initialize_native_asmparser()
     library.add_llvm_module(ll.parse_assembly(ir_mod))
     library.finalize()
     return library

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -162,7 +162,8 @@ class _ExternalMathFunctions(_Installer):
                 ll.add_symbol(fname, c_helpers[fname])
 
         if need_kb982107:
-            set_fnclex(context, c_helpers)
+            # Make the library immortal
+            self._kb982107_lib = set_fnclex(context, c_helpers)
 
 
 def set_fnclex(context, c_helpers):
@@ -176,6 +177,8 @@ def set_fnclex(context, c_helpers):
     library = compile_fnclex(context)
     fnclex_ptr = library.get_pointer_to_function('fnclex')
     fn(fnclex_ptr)
+
+    return library
 
 
 def compile_fnclex(context):

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -3,13 +3,19 @@ Register external C functions necessary for Numba code generation.
 """
 
 import sys
+import ctypes
 
 from llvmlite import ir
 import llvmlite.binding as ll
 
-from numba import utils
+from numba import utils, config
 from numba import _helperlib
 from . import intrinsics
+
+# Require workaround for https://support.microsoft.com/en-us/kb/982107 ?
+need_kb982107 = (config.PYVERSION == (2, 7) and
+                 config.IS_WIN32 and
+                 not config.IS_32BITS)
 
 
 def _add_missing_symbol(symbol, addr):
@@ -150,35 +156,46 @@ class _ExternalMathFunctions(_Installer):
             # (under Windows, different versions of the C runtime can
             #  be loaded at the same time, for example msvcrt100 by
             #  CPython and msvcrt120 by LLVM)
-            ll.add_symbol(fname, c_helpers[fname])
-            
-        import ctypes
-        ptr_set_fnclex = c_helpers['set_fnclex']
-        fn = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(ptr_set_fnclex)
-        
-        library = compile_fnclex(context)
-        fnclex_ptr=library.get_pointer_to_function('fnclex')
-        fn(fnclex_ptr)
+            if need_kb982107 and fname.startswith('fmod'):
+                ll.add_symbol(fname, c_helpers['fixed_' + fname])
+            else:
+                ll.add_symbol(fname, c_helpers[fname])
 
- 
+        if need_kb982107:
+            set_fnclex(context, c_helpers)
+
+
+def set_fnclex(context, c_helpers):
+    """
+    Install fnclex before fmod calls.
+    Workaround for https://support.microsoft.com/en-us/kb/982107
+    """
+    ptr_set_fnclex = c_helpers['set_fnclex']
+    fn = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(ptr_set_fnclex)
+
+    library = compile_fnclex(context)
+    fnclex_ptr = library.get_pointer_to_function('fnclex')
+    fn(fnclex_ptr)
+
+
 def compile_fnclex(context):
     """
-    Compile the multi3() helper function used by LLVM
-    for 128-bit multiplication on 32-bit platforms.
+    Compile a function that calls fnclex to workround
+    https://support.microsoft.com/en-us/kb/982107
     """
     codegen = context.codegen()
-    library = codegen.create_library("multi3")
+    library = codegen.create_library("kb982107")
     ir_mod = """
 define void @fnclex() {
   call void asm sideeffect "fnclex", ""()
   ret void
 }
     """
+    # XXX llvmlite does not expose this initializer as a python function, yet.
     ll.ffi.lib.LLVMPY_InitializeNativeAsmParser()
     library.add_llvm_module(ll.parse_assembly(ir_mod))
     library.finalize()
-
     return library
 
-        
+
 c_math_functions = _ExternalMathFunctions()

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -10,8 +10,8 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import jit, numpy_support, types, typeinfer, utils, errors
-from numba.config import PYVERSION, MACHINE_BITS
+from numba import jit, types, typeinfer, utils, errors
+from numba.config import PYVERSION
 from .support import TestCase, tag
 from .true_div_usecase import truediv_usecase, itruediv_usecase
 from .matmul_usecase import (matmul_usecase, imatmul_usecase, DumbMatrix,
@@ -27,22 +27,6 @@ def make_static_power(exp):
     def pow_usecase(x):
         return x ** exp
     return pow_usecase
-
-
-# On 64-bit Windows, MSVC 2008 (Python 2.7) and Numpy 1.9, there's a
-# heisenbug that seems to manifest as wrong values returned by the CRT's
-# fmodf() function (which is called by LLVM's lowering of the `frem`
-# instruction).
-# Perhaps Numpy messing with some internal FP state that confuses the CRT?
-# Regardless, the only sane thing to do seems to be to skip the tests...
-
-_windows_floordiv_heisenbug = (
-    sys.platform == 'win32' and numpy_support.version[:2] == (1, 9)
-    and MACHINE_BITS == 64)
-
-_avoid_windows_floordiv_heisenbug = unittest.skipIf(
-    _windows_floordiv_heisenbug,
-    "avoid Windows + Numpy floordiv heisenbug - see PR #2057")
 
 
 class LiteralOperatorImpl(object):
@@ -563,7 +547,6 @@ class TestOperators(TestCase):
         self.run_test_floats(pyfunc, x_operands, y_operands, types_list,
                              flags=flags)
 
-    @_avoid_windows_floordiv_heisenbug
     def run_binop_floats_floordiv(self, pyfunc, flags=force_pyobj_flags):
         self.run_binop_floats(pyfunc, flags=flags)
 

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -16,7 +16,6 @@ from numba import jit, vectorize
 from numba.config import PYVERSION
 from numba.errors import LoweringError, TypingError
 from .support import TestCase, CompilationCache, MemoryLeakMixin, tag
-from .test_operators import _avoid_windows_floordiv_heisenbug
 
 from numba.typing.npydecl import supported_ufuncs, all_ufuncs
 
@@ -336,9 +335,8 @@ class TestUFuncs(BaseUFuncTest, TestCase):
         self.binary_ufunc_test(np.true_divide, flags=flags, int_output_type=types.float64)
 
     @tag('important')
-    @_avoid_windows_floordiv_heisenbug
-    def test_floor_divide_ufunc(self, flags=no_pyobj_flags):
-        self.binary_ufunc_test(np.floor_divide, flags=flags)
+    def test_floor_divide_ufunc(self):
+        self.binary_ufunc_test(np.floor_divide)
 
     @tag('important')
     def test_negative_ufunc(self, flags=no_pyobj_flags):
@@ -353,7 +351,6 @@ class TestUFuncs(BaseUFuncTest, TestCase):
         self.binary_ufunc_test(np.power, flags=flags)
 
     @tag('important')
-    @_avoid_windows_floordiv_heisenbug
     def test_remainder_ufunc(self, flags=no_pyobj_flags):
         self.binary_ufunc_test(np.remainder, flags=flags)
 
@@ -1087,7 +1084,6 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
     def test_inplace_div(self):
         self.inplace_float_op_test('/=', [-1, 1.5, 3], [-5, 0, 2.5])
 
-    @_avoid_windows_floordiv_heisenbug
     def test_inplace_remainder(self):
         self.inplace_float_op_test('%=', [-1, 1.5, 3], [-5, 2, 2.5])
 
@@ -1156,7 +1152,6 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
         self.binary_op_test('/', int_output_type=int_out_type)
 
     @tag('important')
-    @_avoid_windows_floordiv_heisenbug
     def test_floor_divide_array_op(self):
         # Avoid floating-point zeros as x // 0.0 can have varying results
         # depending on the algorithm (which changed accross Numpy versions)
@@ -1184,7 +1179,6 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
         self.binary_op_test('//')
 
     @tag('important')
-    @_avoid_windows_floordiv_heisenbug
     def test_remainder_array_op(self):
         self.binary_op_test('%')
 


### PR DESCRIPTION
workaround for #2057
supersedes #2140 

Fix adopted from https://support.microsoft.com/en-us/kb/982107

kb982107 describes a problem with fmod (and fmodf) that an application that triggers a x87 exception from an external module and then calling fmod from MSVCRT will cause it to return an indeterminate value.  In our case, some linalg testcases that uses MKL is triggering floating-point exceptions; thus, from a external module compiled by Intel C++.  Subsequent fmod (and fmodf) calls may misbehave.  

This affects python2.7 (VC9.0/VS2008) on x64 windows platform.  

The workaround is to call the `fnclex` instruction before calling fmod (and fmodf).  This patch uses LLVM to dynamically assemble the required instructions because the lack of inline asm support in x64 MSVC.
