### PR TITLE
Fix slow objectmode fallback by avoiding calling repr on values

### DIFF
--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -149,7 +149,7 @@ class TestArgumentTypingError(unittest.TestCase):
             cfunc(1, foo, 1)
         expected = textwrap.dedent("""\
             This error may have been caused by the following argument(s):
-            - argument 1: cannot determine Numba type of value <Foo instance>"""
+            - argument 1: cannot determine Numba type of <class 'numba.tests.test_typingerror.Foo'>"""
             )
         self.assertIn(expected, str(raises.exception))
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -27,7 +27,7 @@ def typeof(val, purpose=Purpose.argument):
     c = _TypeofContext(purpose)
     ty = typeof_impl(val, c)
     if ty is None:
-        msg = "cannot determine Numba type of value %r" % (val,)
+        msg = "cannot determine Numba type of %r" % (type(val),)
         raise ValueError(msg)
     return ty
 


### PR DESCRIPTION
..., which can be large and stringifying can be slow; hence, causing
objectmode fallback to be very slow.