### PR TITLE
[CUDA8] use NVVM IR ver 1.3

### DIFF
--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -136,7 +136,7 @@ declare i32 @llvm.nvvm.read.ptx.sreg.ntid.x() nounwind readnone
 declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() nounwind readnone
 
 !nvvm.annotations = !{!1}
-!1 = metadata !{void (i32*)* @simple, metadata !"kernel", i32 1}
+!1 = !{void (i32*)* @simple, !"kernel", i32 1}
 '''
 
 gpu32 = '''
@@ -171,7 +171,7 @@ declare i32 @llvm.nvvm.read.ptx.sreg.ntid.x() nounwind readnone
 declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() nounwind readnone
 
 !nvvm.annotations = !{!1}
-!1 = metadata !{void (i32*)* @simple, metadata !"kernel", i32 1}
+!1 = !{void (i32*)* @simple, !"kernel", i32 1}
 
 '''
 


### PR DESCRIPTION
~~**This patch makes CUDA 8 a strict requirement for CUDA support.**~~ (update: as discussed privately, we will make CUDA 8 optional by falling back to old IR version if necessary)
- NVVM now use the same LLVM IR format (ver 3.8)
- NVVM is now stricter in symbol names.  No dot (".") in symbols.
- Update atomic helpers.
