### PR TITLE
Fix issue 2179 where looplifting used the wrong variable version

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -644,10 +644,17 @@ class Scope(object):
 
     def get(self, name):
         """
-        Refer to a variable
+        Refer to a variable.  Returns the latest version.
         """
         if name in self.redefined:
             name = "%s.%d" % (name, self.redefined[name])
+        return self.get_exact(name)
+
+    def get_exact(self, name):
+        """
+        Refer to a variable.  The returned variable has the exact
+        name (exact variable version).
+        """
         try:
             return self.localvars.get(name)
         except NotDefinedError:

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -406,6 +406,27 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
             cfunc = jit(forceobj=True)(pyfunc)
             self.assertEqual(pyfunc(True), cfunc(True))
 
+    def test_variable_scope_bug(self):
+        """
+        https://github.com/numba/numba/issues/2179
+
+        Looplifting transformation is using the wrong verion of variable `h`.
+        """
+        from numba import jit
+
+        def bar(x):
+            return x
+
+        def foo(x):
+            h = 0.
+            for k in range(x):
+                h = h + k
+            h = h - bar(x)
+            return h
+
+        cfoo = jit(foo)
+        self.assertEqual(foo(10), cfoo(10))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/transforms.py
+++ b/numba/transforms.py
@@ -71,20 +71,19 @@ def _loop_lift_modify_call_block(liftedloop, block, inputs, outputs, returnto):
     scope = block.scope
     loc = block.loc
     blk = ir.Block(scope=scope, loc=loc)
-
     # load loop
     fn = ir.Const(value=liftedloop, loc=loc)
     fnvar = scope.make_temp(loc=loc)
     blk.append(ir.Assign(target=fnvar, value=fn, loc=loc))
     # call loop
-    args = [scope.get(name) for name in inputs]
+    args = [scope.get_exact(name) for name in inputs]
     callexpr = ir.Expr.call(func=fnvar, args=args, kws=(), loc=loc)
     # temp variable for the return value
     callres = scope.make_temp(loc=loc)
     blk.append(ir.Assign(target=callres, value=callexpr, loc=loc))
     # unpack return value
     for i, out in enumerate(outputs):
-        target = scope.get(out)
+        target = scope.get_exact(out)
         getitem = ir.Expr.static_getitem(value=callres, index=i,
                                          index_var=None, loc=loc)
         blk.append(ir.Assign(target=target, value=getitem, loc=loc))
@@ -128,7 +127,7 @@ def _loop_lift_prepare_loop_func(loopinfo, blocks):
 
         block = ir.Block(scope=scope, loc=loc)
         # prepare tuples to return
-        vals = [scope.get(name=name) for name in loopinfo.outputs]
+        vals = [scope.get_exact(name=name) for name in loopinfo.outputs]
         tupexpr = ir.Expr.build_tuple(items=vals, loc=loc)
         tup = scope.make_temp(loc=loc)
         block.append(ir.Assign(target=tup, value=tupexpr, loc=loc))


### PR DESCRIPTION
Fix looplifting transformation which was getting the wrong variable version.  It was getting the latest version if the variable is redefined later.