### PR TITLE
Fix for #2178 annotation fails to handle lifted loops

### DIFF
--- a/numba/annotations/type_annotations.py
+++ b/numba/annotations/type_annotations.py
@@ -154,7 +154,7 @@ class TypeAnnotation(object):
         python_source = SourceLines(self.func_id.func)
         ir_lines = self.prepare_annotations()
         line_nums = [num for num in python_source]
-        lifted_lines = [l.bytecode.firstlineno for l in self.lifted]
+        lifted_lines = [l.get_source_location for l in self.lifted]
 
         def add_ir_line(func_data, line):
             line_str = line.strip()

--- a/numba/tests/test_annotations.py
+++ b/numba/tests/test_annotations.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division
 
 from numba import unittest_support as unittest
-from numba.compiler import compile_isolated
-from numba import types
+from numba.compiler import compile_isolated, compile_extra, Flags
+from numba import types, typing
 from numba.io_support import StringIO
+from numba.targets.registry import cpu_target
+from numba.targets import cpu
 
 try:
     import jinja2
@@ -35,6 +37,49 @@ class TestAnnotation(unittest.TestCase):
         buf.close()
         self.assertIn("foo", output)
 
+    def test_exercise_code_path_with_lifted_loop(self):
+        """
+        Ensures that lifted loops are handled correctly in obj mode
+        """
+
+        # the functions to jit
+        def bar(x):
+            return x
+
+        def foo(x):
+            h = 0.
+            for k in range(x):
+                h = h + k
+            if x:
+                h = h - bar(x)
+            return h
+
+        # compile into an isolated context
+        typingctx = typing.Context()
+        targetctx = cpu.CPUContext(typingctx)
+        with cpu_target.nested_context(typingctx, targetctx):
+            FLAGS = Flags()
+            FLAGS.set('force_pyobject')
+
+            def compilethis(func, args):
+                return compile_extra(typingctx, targetctx,
+                                     func, args, None, FLAGS, {})
+
+            args = [types.int32]
+            # need bar to compile foo
+            compilethis(bar, args)
+            # store result of compiling foo
+            cres = compilethis(foo, args)
+
+        ta = cres.type_annotation
+        self.assertIs(ta.html_output, None)
+
+        buf = StringIO()
+        ta.html_annotate(buf)
+        output = buf.getvalue()
+        buf.close()
+        self.assertIn("bar", output)
+        self.assertIn("foo", output)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Simple fix for numba annotations not handling lifted loops
correctly as in #2178.