### PR TITLE
Potential fix for "cannot compute fingerprint of empty X" #2152

### DIFF
--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -521,8 +521,10 @@ class TestFingerprint(TestCase):
         distinct.add(compute_fingerprint([4.5, 6.7]))
         distinct.add(compute_fingerprint([(1,)]))
 
-        with self.assertRaises(ValueError):
-            compute_fingerprint([])
+        # empty lists are equal
+        s = compute_fingerprint([])
+        self.assertEqual(compute_fingerprint([]), s)
+        distinct.add(s)
 
     def test_sets(self):
         distinct = DistinctChecker()
@@ -535,9 +537,12 @@ class TestFingerprint(TestCase):
         distinct.add(compute_fingerprint(set([1j])))
         distinct.add(compute_fingerprint(set([4.5, 6.7])))
         distinct.add(compute_fingerprint(set([(1,)])))
+        
+        # empty sets are equal
+        s = compute_fingerprint(set())
+        self.assertEqual(compute_fingerprint(set()), s)
+        distinct.add(s)
 
-        with self.assertRaises(ValueError):
-            compute_fingerprint(set())
         with self.assertRaises(NotImplementedError):
             compute_fingerprint(frozenset([2, 3]))
 


### PR DESCRIPTION
This patch is one way of seemingly fixing the inability to compute
the fingerprint of an empty list (or set!), as reported in #2152.

It seems like empty containers can take part in fast lookup but
only if more op codes are added. Whether this is a valid approach,
given possible nuances, and the general "adding more opcodes"
going against the principle of fast lookup, is to be determined.

It should be noted that using '[' for an empty list seemingly
works too.