### PR TITLE
Fix rewrite pass affecting objmode lowering during fallback

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -267,6 +267,7 @@ class Pipeline(object):
         self.bc = None
         self.func_id = None
         self.func_ir = None
+        self.func_ir_original = None  # used for fallback
         self.lifted = None
         self.lifted_from = None
         self.typemap = None
@@ -377,6 +378,9 @@ class Pipeline(object):
     def stage_process_ir(self):
         ir_processing_stage(self.func_ir)
 
+    def stage_preserve_ir(self):
+        self.func_ir_original = self.func_ir.copy()
+
     def frontend_looplift(self):
         """
         Loop lifting analysis and transformation
@@ -410,6 +414,7 @@ class Pipeline(object):
         """
         Front-end: Analyze bytecode, generate Numba IR, infer types
         """
+        self.func_ir = self.func_ir_original or self.func_ir
         if self.flags.enable_looplift:
             assert not self.lifted
             cres = self.frontend_looplift()
@@ -609,6 +614,8 @@ class Pipeline(object):
                 pm.add_stage(self.stage_analyze_bytecode, "analyzing bytecode")
             pm.add_stage(self.stage_process_ir, "processing IR")
             if not self.flags.no_rewrites:
+                if self.status.can_fallback:
+                    pm.add_stage(self.stage_preserve_ir, "preserve IR for fallback")
                 pm.add_stage(self.stage_generic_rewrites, "nopython rewrites")
             pm.add_stage(self.stage_nopython_frontend, "nopython frontend")
             pm.add_stage(self.stage_annotate_type, "annotate type")

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -845,6 +845,11 @@ class FunctionIR(object):
 
         return new_ir
 
+    def copy(self):
+        new_ir = copy.copy(self)
+        new_ir.blocks = self.blocks.copy()
+        return new_ir
+
     def get_block_entry_vars(self, block):
         """
         Return a set of variable names possibly alive at the beginning of

--- a/numba/tests/test_object_mode.py
+++ b/numba/tests/test_object_mode.py
@@ -108,5 +108,56 @@ class TestObjectMode(TestCase):
             cfunc(42)
 
 
+class TestObjectModeInvalidRewrite(TestCase):
+    """
+    Tests to ensure that rewrite passes didn't affect objmode lowering.
+    """
+
+    def _ensure_objmode(self, disp):
+        self.assertTrue(disp.signatures)
+        self.assertFalse(disp.nopython_signatures)
+        return disp
+
+    def test_static_raise_in_objmode_fallback(self):
+        """
+        Test code based on user submitted issue at
+        https://github.com/numba/numba/issues/2159
+        """
+        def test0(n):
+            return n
+
+        def test1(n):
+            if n == 0:
+                # static raise will fail in objmode if the IR is modified by
+                # rewrite pass
+                raise ValueError()
+            return test0(n)  # trigger objmode fallback
+
+        compiled = jit(test1)
+        self.assertEqual(test1(10), compiled(10))
+        self._ensure_objmode(compiled)
+
+    def test_static_setitem_in_objmode_fallback(self):
+        """
+        Test code based on user submitted issue at
+        https://github.com/numba/numba/issues/2169
+        """
+
+        def test0(n):
+            return n
+
+        def test(a1, a2):
+            a1 = np.asarray(a1)
+            # static setitem here will fail in objmode if the IR is modified by
+            # rewrite pass
+            a2[0] = 1
+            return test0(a1.sum() + a2.sum())   # trigger objmode fallback
+
+        compiled = jit(test)
+        args = np.array([3]), np.array([4])
+        self.assertEqual(test(*args), compiled(*args))
+        self._ensure_objmode(compiled)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Rewrite passes mutates the IR in-place but the inserted opcode is not understood by the objmode lowering.  When a function fails typing and fallbacks to the objmode, the IR is already mutated.  This patch fixes it by preserving the original IR and restoring the IR upon entry to the objmode pipeline.

Closes #2159  and #2169 