### PR TITLE
Add system reporting tool.

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -51,6 +51,8 @@ test:
     # Check Numba executables are there
     - pycc -h
     - numba -h
+    # run system info tool
+    - numba -s
     # Check test discovery works
     - python -m numba.tests.test_runtests
     # Run the CUDA test suite

--- a/buildscripts/condarecipe.hsa/meta.yaml
+++ b/buildscripts/condarecipe.hsa/meta.yaml
@@ -42,5 +42,7 @@ test:
     # Check Numba executables are there
     - pycc -h
     - numba -h
+    # run system info tool
+    - numba -s
     # Check test discovery works
     - python -m numba.tests.test_runtests

--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -41,6 +41,8 @@ test:
     # Check Numba executables are there
     - pycc -h
     - numba -h
+    # run system info tool
+    - numba -s
     # Check test discovery works
     - python -m numba.tests.test_runtests
     # Run the whole test suite

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -43,6 +43,8 @@ test:
     # Check Numba executables are there
     - pycc -h
     - numba -h
+    # run system info tool
+    - numba -s
     # Check test discovery works
     - python -m numba.tests.test_runtests
     # Run the whole test suite

--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -3,3 +3,6 @@ call activate %CONDA_ENV%
 
 @rem Build numba extensions without silencing compile errors
 python setup.py build_ext -q --inplace
+
+@rem Install numba locally for use in `numba -s` sys info tool at test time
+python -m pip install -e .

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -9,3 +9,6 @@ set -v -e
 python setup.py build_ext -q --inplace
 # (note we don't install to avoid problems with extra long Windows paths
 #  during distutils-dependent tests -- e.g. test_pycc)
+
+# Install numba locally for use in `numba -s` sys info tool at test time
+python -m pip install -e .

--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -3,6 +3,10 @@ call activate %CONDA_ENV%
 
 @rem Ensure that the documentation builds without warnings
 if "%BUILD_DOC%" == "yes" python setup.py build_doc
+@rem Run system info tool
+pushd bin
+numba -s
+popd
 @rem First check that the test discovery works
 python -m numba.tests.test_runtests
 @rem Now run the Numba test suite

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -9,6 +9,10 @@ set -v -e
 pushd docs
 if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi
 popd
+# Run system info tool
+pushd bin
+numba -s
+popd
 # First check that the test discovery works
 python -m numba.tests.test_runtests
 # Now run the Numba test suite

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -44,14 +44,17 @@ def open_cudalib(lib, ccc=False):
     return _dllopener(path)
 
 
-def test(_platform=None):
+def test(_platform=None, print_paths=True):
     failed = False
     libs = 'cublas cusparse cufft curand nvvm'.split()
     for lib in libs:
         path = get_cudalib(lib, _platform)
         print('Finding', lib)
         if path:
-            print('\tlocated at', path)
+            if print_paths:
+                print('\tlocated at', path)
+            else:
+                print('\tnamed ', os.path.basename(path))
         else:
             print('\tERROR: can\'t locate lib')
             failed = True

--- a/numba/numba_entry.py
+++ b/numba/numba_entry.py
@@ -89,21 +89,23 @@ def get_sys_info():
         # Look for GPUs
         try:
             cu.list_devices()[0]  # will a device initialise?
-        except Exception as e:
+        except BaseException as e:
             msg_not_found = "CUDA driver library cannot be found"
             msg_disabled_by_user = "CUDA disabled by user"
-            if msg_not_found in e.msg:
-                print(
-                    msg_not_found +
-                    " or no CUDA enabled devices are present.")
-            elif msg_disabled_by_user in e.msg:
-                print(
-                    msg_disabled_by_user +
-                    " or no CUDA enabled devices are present.")
+            msg_end = " or no CUDA enabled devices are present."
+            msg_generic_problem = "Error: CUDA device intialisation problem."
+            msg = getattr(e, 'msg', None)
+            if msg is not None:
+                if msg_not_found in msg:
+                    err_msg = msg_not_found + msg_end
+                elif msg_disabled_by_user in msg:
+                    err_msg = msg_disabled_by_user + msg_end
+                else:
+                    err_msg = msg_generic_problem + " Message:" + msg
             else:
-                print(
-                    "Error: unknown CUDA device intialisation problem. Message:" +
-                    e.msg)
+                err_msg = msg_generic_problem + " " + str(e)
+            # Best effort error report
+            print("%s\nError class: %s" % (err_msg, str(type(e))))
         else:
             try:
                 cu.detect()

--- a/numba/numba_entry.py
+++ b/numba/numba_entry.py
@@ -72,7 +72,10 @@ def get_sys_info():
             ("Python Implementation",
              platform.python_implementation()))
         print(fmt % ("Python Version", platform.python_version()))
-        print(fmt % ("Python Locale ", ' '.join(locale.getdefaultlocale())))
+        print(
+            fmt %
+            ("Python Locale ", ' '.join(
+                [x for x in locale.getdefaultlocale() if x is not None])))
 
         print("")
         print("__LLVM information__")

--- a/numba/numba_entry.py
+++ b/numba/numba_entry.py
@@ -90,9 +90,16 @@ def get_sys_info():
         try:
             cu.list_devices()[0]  # will a device initialise?
         except Exception as e:
-            msg = "CUDA driver library cannot be found"
-            if msg in e.msg:
-                print(msg + " or no CUDA enabled devices are present.")
+            msg_not_found = "CUDA driver library cannot be found"
+            msg_disabled_by_user = "CUDA disabled by user"
+            if msg_not_found in e.msg:
+                print(
+                    msg_not_found +
+                    " or no CUDA enabled devices are present.")
+            elif msg_disabled_by_user in e.msg:
+                print(
+                    msg_disabled_by_user +
+                    " or no CUDA enabled devices are present.")
             else:
                 print(
                     "Error: unknown CUDA device intialisation problem. Message:" +

--- a/numba/numba_entry.py
+++ b/numba/numba_entry.py
@@ -6,6 +6,163 @@ import os
 import subprocess
 
 
+def get_sys_info():
+    # delay these imports until now as they are only needed in this
+    # function which then exits.
+    import platform
+    import json
+    from numba import cuda as cu
+    from numba.cuda import cudadrv
+    from numba.cuda.cudadrv.driver import driver as cudriver
+    import textwrap as tw
+    import ctypes as ct
+    import llvmlite.binding as llvmbind
+    import locale
+    from datetime import datetime
+    from itertools import chain
+    from subprocess import check_output, CalledProcessError
+
+    try:
+        fmt = "%-21s : %-s"
+        print("-" * 80)
+        print("__Time Stamp__")
+        print(datetime.utcnow())
+        print("")
+
+        print("__Hardware Information__")
+        print(fmt % ("Machine", platform.machine()))
+        print(fmt % ("CPU Name", llvmbind.get_host_cpu_name()))
+        features = sorted(
+            [key for key, value in llvmbind.get_host_cpu_features().items() if value])
+        cpu_feat = tw.fill(' '.join(features), 80)
+        print(fmt % ("CPU Features", ""))
+        print(cpu_feat)
+        print("")
+
+        print("__OS Information__")
+        print(fmt % ("Platform", platform.platform(aliased=True)))
+        print(fmt % ("Release", platform.release()))
+        system_name = platform.system()
+        print(fmt % ("System Name", system_name))
+        print(fmt % ("Version", platform.version()))
+        try:
+            if system_name == 'Linux':
+                info = platform.linux_distribution()
+            elif system_name == 'Windows':
+                info = platform.win32_ver()
+            elif system_name == 'Darwin':
+                info = platform.mac_ver()
+            else:
+                raise RuntimeError("Unknown system.")
+            buf = ''.join([x
+                           if x != '' else ' '
+                           for x in list(chain.from_iterable(info))])
+            print(fmt % ("OS specific info", buf))
+
+            if system_name == 'Linux':
+                print(fmt % ("glibc info", ' '.join(platform.libc_ver())))
+        except:
+            print("Error: System name incorrectly identified or unknown.")
+        print("")
+
+        print("__Python Information__")
+        print(fmt % ("Python Compiler", platform.python_compiler()))
+        print(
+            fmt %
+            ("Python Implementation",
+             platform.python_implementation()))
+        print(fmt % ("Python Version", platform.python_version()))
+        print(fmt % ("Python Locale ", ' '.join(locale.getdefaultlocale())))
+
+        print("")
+        print("__LLVM information__")
+        print(
+            fmt %
+            ("LLVM version", '.'.join(
+                [str(k) for k in llvmbind.llvm_version_info])))
+
+        print("")
+        print("__CUDA Information__")
+        # Look for GPUs
+        try:
+            cu.list_devices()[0]  # will a device initialise?
+        except Exception as e:
+            msg = "CUDA driver library cannot be found"
+            if msg in e.msg:
+                print(msg + " or no CUDA enabled devices are present.")
+            else:
+                print(
+                    "Error: unknown CUDA device intialisation problem. Message:" +
+                    e.msg)
+        else:
+            try:
+                cu.detect()
+                dv = ct.c_int(0)
+                cudriver.cuDriverGetVersion(ct.byref(dv))
+                print(fmt % ("CUDA driver version", dv.value))
+                print("CUDA libraries:")
+                cudadrv.libs.test(sys.platform, print_paths=False)
+            except:
+                print(
+                    "Error: Probing CUDA failed (device and driver present, runtime problem?)\n")
+
+        # Look for conda and conda information
+        print("")
+        print("__Conda Information__")
+        cmd = ["conda", "info", "--json"]
+        try:
+            conda_out = check_output(cmd)
+        except Exception as e:
+            print(
+                "Conda not present/not working.\nError was %s\n" % e)
+        else:
+            data = ''.join(conda_out.decode("utf-8").splitlines())
+            jsond = json.loads(data)
+            keys = ['conda_build_version',
+                    'conda_env_version',
+                    'platform',
+                    'python_version',
+                    'root_writable']
+            for k in keys:
+                try:
+                    print(fmt % (k, jsond[k]))
+                except KeyError:
+                    pass
+
+            # get info about current environment
+            cmd = ["conda", "list"]
+            try:
+                conda_out = check_output(cmd)
+            except CalledProcessError as e:
+                print("Error: Conda command failed. Error was %s\n" % e.output)
+            else:
+                print("")
+                print("__Current Conda Env__")
+                data = conda_out.decode("utf-8").splitlines()
+                for k in data:
+                    if k[0] != '#':  # don't show where the env is, personal data
+                        print(k)
+
+        print("-" * 80)
+
+    except Exception as e:
+        print("Error: The system reporting tool has failed unexpectedly.")
+        print("Exception was:")
+        print(e)
+
+    finally:
+        print(
+            "%s" %
+            "If requested, please copy and paste the information between\n"
+            "the dashed (----) lines, or from a given specific section as\n"
+            "appropriate.\n\n"
+            "=============================================================\n"
+            "IMPORTANT: Please ensure that you are happy with sharing the\n"
+            "contents of the information present, any information that you\n"
+            "wish to keep private you should remove before sharing.\n"
+            "=============================================================\n")
+
+
 def make_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--annotate', help='Annotate source',
@@ -22,7 +179,9 @@ def make_parser():
                         help='[Deprecated] Dump the AST')
     parser.add_argument('--annotate-html', nargs=1,
                         help='Output source annotation as html')
-    parser.add_argument('filename', help='Python source filename')
+    parser.add_argument('-s', '--sysinfo', action="store_true",
+                        help='Output system information for bug reporting')
+    parser.add_argument('filename', nargs='?', help='Python source filename')
     return parser
 
 
@@ -37,6 +196,11 @@ def main():
         print("AST dump is removed.  Numba no longer depends on AST.")
         sys.exit(1)
 
+    if args.sysinfo:
+        print("System info:")
+        get_sys_info()
+        sys.exit(0)
+
     os.environ['NUMBA_DUMP_ANNOTATION'] = str(int(args.annotate))
     if args.annotate_html is not None:
         try:
@@ -48,7 +212,9 @@ def main():
     os.environ['NUMBA_DUMP_OPTIMIZED'] = str(int(args.dump_optimized))
     os.environ['NUMBA_DUMP_ASSEMBLY'] = str(int(args.dump_assembly))
 
-    cmd = [sys.executable, args.filename]
-    subprocess.call(cmd)
-
-
+    if args.filename:
+        cmd = [sys.executable, args.filename]
+        subprocess.call(cmd)
+    else:
+        print("numba: error: the following arguments are required: filename")
+        sys.exit(1)


### PR DESCRIPTION
This augments the `numba` program with the `-s/--sysinfo` flag
which will dump out pertinent system information such that users
can report what their system looks like in a standard way. This
will hopefully be useful for replication and debugging by core
devs, especially when the suspected cause is OS specific or
GPU drivers/runtime.

Effort has been made to try and ensure only hardware/software
related information is reported to offer a degree of anonymity.