### PR TITLE
Improve handling of big array globals

### DIFF
--- a/docs/source/reference/pysemantics.rst
+++ b/docs/source/reference/pysemantics.rst
@@ -41,7 +41,10 @@ Numba: a Numba-compiled function sees the value of those variables at the
 time the function was compiled.  Also, it is not possible to change their
 values from the function.
 
-To modify a global variable within a function, you can pass it as an argument
-and modify it in place without the need to explicitly return it.
+Numba **may or may not** copy global variables referenced inside a compiled
+function.  Small global arrays are copied for potential compiler optimization
+with immutability assumption.  However, large global arrays are not copied to
+conserve memory.  The definition of "small" and "large" may change.
+
 
 .. todo:: This document needs completing.

--- a/numba/caching.py
+++ b/numba/caching.py
@@ -402,7 +402,8 @@ class FunctionCache(_Cache):
         elif cres.lifted:
             cannot_cache = "as it uses lifted loops"
         elif cres.has_dynamic_globals:
-            cannot_cache = "as it uses dynamic globals (such as ctypes pointers)"
+            cannot_cache = ("as it uses dynamic globals "
+                            "(such as ctypes pointers and large global arrays)")
         if cannot_cache:
             msg = ('Cannot cache compiled function "%s" %s'
                    % (self._funcname, cannot_cache))

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -41,10 +41,6 @@ class BaseLower(object):
     """
     Lower IR to LLVM
     """
-
-    # If true, then can't cache LLVM module accross process calls
-    has_dynamic_globals = False
-
     def __init__(self, context, library, fndesc, func_ir):
         self.context = context
         self.library = library
@@ -227,6 +223,13 @@ class BaseLower(object):
         if config.DEBUG_JIT:
             self.context.debug_print(self.builder, "DEBUGJIT: {0}".format(msg))
 
+    @property
+    def has_dynamic_globals(self):
+        """
+        If true, then can't cache LLVM module accross process calls.
+        """
+        return self.library.has_dynamic_globals
+
 
 class Lower(BaseLower):
     GeneratorLower = generators.GeneratorLower
@@ -371,9 +374,6 @@ class Lower(BaseLower):
         value = inst.value
         # In nopython mode, closure vars are frozen like globals
         if isinstance(value, (ir.Const, ir.Global, ir.FreeVar)):
-            if isinstance(ty, types.ExternalFunctionPointer):
-                self.has_dynamic_globals = True
-
             res = self.context.get_constant_generic(self.builder, ty,
                                                     value.value)
             self.incref(ty, res)

--- a/numba/runtime/_nrt_python.c
+++ b/numba/runtime/_nrt_python.c
@@ -313,7 +313,8 @@ NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
         PyObject *obj = try_to_return_parent(arystruct, ndim, descr);
         if (obj) {
             /* Release NRT reference to the numpy array */
-            NRT_MemInfo_release(arystruct->meminfo);
+            if (arystruct->meminfo)
+                NRT_MemInfo_release(arystruct->meminfo);
             return obj;
         }
     }

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -969,7 +969,7 @@ class BaseContext(object):
         """
         Returns dynamic address as a void pointer `i8*`.
 
-        Internally, a named metadata is added to inform the lowerer about
+        Internally, a global variable is added to inform the lowerer about
         the usage of dynamic addresses.  Caching will be disabled.
         """
         assert self.allow_dynamic_globals, "dyn globals disabled in this target"

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -973,7 +973,7 @@ class BaseContext(object):
         the usage of dynamic addresses.  Caching will be disabled.
         """
         assert self.allow_dynamic_globals, "dyn globals disabled in this target"
-        assert isinstance(intaddr, int), 'dyn addr not of int type'
+        assert isinstance(intaddr, utils.INT_TYPES), 'dyn addr not of int type'
         mod = builder.module
         llvoidptr = self.get_value_type(types.voidptr)
         addr = self.get_constant(types.uintp, intaddr).inttoptr(llvoidptr)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -921,7 +921,7 @@ class BaseContext(object):
         size_limit = 10**6
 
         if (self.allow_dynamic_globals and
-                typ.layout not in 'FC' or ary.nbytes > size_limit):
+                (typ.layout not in 'FC' or ary.nbytes > size_limit)):
             # get pointer from the ary
             dataptr = ary.ctypes.data
             data = self.add_dynamic_addr(builder, dataptr, info=str(type(dataptr)))

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -264,9 +264,9 @@ def constant_dummy(context, builder, ty, pyval):
 @lower_constant(types.ExternalFunctionPointer)
 def constant_function_pointer(context, builder, ty, pyval):
     ptrty = context.get_function_pointer_type(ty)
-    ptrval = context.get_constant_generic(builder, types.intp,
-                                          ty.get_pointer(pyval))
-    return builder.inttoptr(ptrval, ptrty)
+    ptrval = context.add_dynamic_addr(builder, ty.get_pointer(pyval),
+                                      info=str(pyval))
+    return builder.bitcast(ptrval, ptrty)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -31,6 +31,8 @@ class CPUContext(BaseContext):
     """
     Changes BaseContext calling convention
     """
+    allow_dynamic_globals = True
+
     # Overrides
     def create_module(self, name):
         return self._internal_codegen._create_empty_module(name)

--- a/numba/tests/cache_usecases.py
+++ b/numba/tests/cache_usecases.py
@@ -102,6 +102,13 @@ closure1 = make_closure(3)
 closure2 = make_closure(5)
 
 
+biggie = np.arange(10**6)
+
+@jit(cache=True, nopython=True)
+def use_big_array():
+    return biggie
+
+
 Z = 1
 
 # Exercise returning a record instance.  This used to hardcode the dtype

--- a/numba/tests/test_array_constants.py
+++ b/numba/tests/test_array_constants.py
@@ -5,7 +5,7 @@ import numpy as np
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba.errors import TypingError
-from numba import jit, types
+from numba import jit, types, typeof
 
 
 a0 = np.array(42)
@@ -140,25 +140,38 @@ class TestConstantArray(unittest.TestCase):
         a constant array into the code thats prohibitively long and consume
         too much RAM.
         """
+        def test(biggie):
+            expect = np.copy(biggie)
+            self.assertEqual(typeof(biggie), typeof(expect))
+
+            def pyfunc():
+                return biggie
+
+            cres = compile_isolated(pyfunc, ())
+            # Check that the array is not frozen into the LLVM IR.
+            # LLVM size must be less than the array size.
+            self.assertLess(len(cres.library.get_llvm_str()), biggie.nbytes)
+            # Run and test result
+            out = cres.entry_point()
+            self.assertIs(biggie, out)
+            # Remove all local references to biggie
+            del out
+            biggie = None  #  del biggie is syntax error in py2
+            # Run again and verify result
+            out = cres.entry_point()
+            np.testing.assert_equal(expect, out)
+            self.assertEqual(typeof(expect), typeof(out))
+
         nelem = 10**7   # 10 million items
-        biggie = np.arange(nelem)
 
-        def pyfunc():
-            return biggie
-
-        cres = compile_isolated(pyfunc, ())
-        # Check that the array is not frozen into the LLVM IR.
-        # LLVM size must be less than the array size.
-        self.assertLess(len(cres.library.get_llvm_str()), biggie.nbytes)
-        # Run and test result
-        out = cres.entry_point()
-        self.assertIs(biggie, out)
-        # Remove all local references to biggie
-        del out
-        biggie = None  #  del biggie is syntax error in py2
-        # Run again and verify result
-        out = cres.entry_point()
-        np.testing.assert_equal(np.arange(nelem), out)
+        c_array = np.arange(nelem).reshape(nelem)
+        f_array = np.asfortranarray(np.random.random((2, nelem // 2)))
+        self.assertEqual(typeof(c_array).layout, 'C')
+        self.assertEqual(typeof(f_array).layout, 'F')
+        # Test C contig
+        test(c_array)
+        # Test F contig
+        test(f_array)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_array_constants.py
+++ b/numba/tests/test_array_constants.py
@@ -154,7 +154,8 @@ class TestConstantArray(unittest.TestCase):
         out = cres.entry_point()
         self.assertIs(biggie, out)
         # Remove all local references to biggie
-        del biggie, out
+        del out
+        biggie = None  #  del biggie is syntax error in py2
         # Run again and verify result
         out = cres.entry_point()
         np.testing.assert_equal(np.arange(nelem), out)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -689,6 +689,20 @@ class TestCache(BaseCacheTest):
                          'Cannot cache compiled function "looplifted" '
                          'as it uses lifted loops')
 
+    def test_big_array(self):
+        # Code references big array globals cannot be cached
+        mod = self.import_module()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaWarning)
+
+            f = mod.use_big_array
+            np.testing.assert_equal(f(), mod.biggie)
+            self.check_pycache(0)
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('Cannot cache compiled function "use_big_array" '
+                      'as it uses dynamic globals', str(w[0].message))
+
     def test_ctypes(self):
         # Functions using a ctypes pointer can't be cached and raise
         # a warning.

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1046,8 +1046,7 @@ class TypeInferer(object):
 
         if isinstance(typ, types.Array):
             # Global array in nopython mode is constant
-            # XXX why layout='C'?
-            typ = typ.copy(layout='C', readonly=True)
+            typ = typ.copy(readonly=True)
 
         self.sentry_modified_builtin(inst, gvar)
         self.lock_type(target.name, typ, loc=inst.loc)


### PR DESCRIPTION
Closes #2188 

Numba freezes global array as constant into the jitted code.  With large global arrays, the compilation process can take excessively long and RAM consuming.   This patch disable the freezing of large arrays (> 1MB for now) and instead uses the runtime reference access the global array.

In addition, the handling of dynamic globals is refactored.  Dynamic globals are inserted in the LLVM IR as global variables with the name prefix "numba.dynamic.globals".  They are preserved in the LLVM IR after optimization and linking.  The `CodeLibrary` is responsible to track their existence.  Originally, it is a flag in the `BaseLower`.

We should refactor all usage of dynamic runtime addresses to rely on `BaseContext.add_dynamic_addr` instead.  Searching for all `IRBuilder.inttoptr` usage will help locate all dynamic addresses.




