### PR TITLE
Enable caching for ufunc

### DIFF
--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -168,7 +168,7 @@ Dispatcher objects
 Vectorized functions (ufuncs and DUFuncs)
 -----------------------------------------
 
-.. decorator:: numba.vectorize(*, signatures=[], identity=None, nopython=True, target='cpu', forceobj=False, locals={})
+.. decorator:: numba.vectorize(*, signatures=[], identity=None, nopython=True, target='cpu', forceobj=False, cache=False, locals={})
 
    Compile the decorated function and wrap it either as a `Numpy
    ufunc`_ or a Numba :class:`~numba.DUFunc`.  The optional
@@ -217,8 +217,12 @@ Vectorized functions (ufuncs and DUFuncs)
       @vectorize(["float64(float64)", "float32(float32)"], target='cuda')
       def f(x): ...
 
+   The compiled function can be cached to reduce future compilation time.
+   It is enabled by setting *cache* to True. Only the "cpu" and "parallel"
+   targets support caching.
 
-.. decorator:: numba.guvectorize(signatures, layout, *, identity=None, nopython=True, target='cpu', forceobj=False, locals={})
+
+.. decorator:: numba.guvectorize(signatures, layout, *, identity=None, nopython=True, target='cpu', forceobj=False, cache=False, locals={})
 
    Generalized version of :func:`numba.vectorize`.  While
    :func:`numba.vectorize` will produce a simple ufunc whose core
@@ -257,6 +261,9 @@ Vectorized functions (ufuncs and DUFuncs)
       as supported by Numpy.  Note that Numpy uses the term "signature",
       which we unfortunately use for something else.
 
+   The compiled function can be cached to reduce future compilation time.
+   It is enabled by setting *cache* to True. Only the "cpu" and "parallel"
+   targets support caching.
 
 .. _Numpy ufunc: http://docs.scipy.org/doc/numpy/reference/ufuncs.html
 

--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -15,6 +15,10 @@ class _BaseVectorize(object):
         return kwargs.pop('identity', None)
 
     @classmethod
+    def get_cache(cls, kwargs):
+        return kwargs.pop('cache', False)
+
+    @classmethod
     def get_target_implementation(cls, kwargs):
         target = kwargs.pop('target', 'cpu')
         try:
@@ -29,8 +33,9 @@ class Vectorize(_BaseVectorize):
 
     def __new__(cls, func, **kws):
         identity = cls.get_identity(kws)
+        cache = cls.get_cache(kws)
         imp = cls.get_target_implementation(kws)
-        return imp(func, identity, kws)
+        return imp(func, identity=identity, cache=cache, targetoptions=kws)
 
 
 class GUVectorize(_BaseVectorize):
@@ -39,8 +44,10 @@ class GUVectorize(_BaseVectorize):
 
     def __new__(cls, func, signature, **kws):
         identity = cls.get_identity(kws)
+        cache = cls.get_cache(kws)
         imp = cls.get_target_implementation(kws)
-        return imp(func, signature, identity, kws)
+        return imp(func, signature, identity=identity, cache=cache,
+                   targetoptions=kws)
 
 
 def vectorize(ftylist_or_function=(), **kws):
@@ -73,6 +80,10 @@ def vectorize(ftylist_or_function=(), **kws):
         The identity (or unit) value for the element-wise function
         being implemented.  Allowed values are None (the default), 0, 1,
         and "reorderable".
+
+    cache: bool
+        Turns on caching.
+
 
     Returns
     --------
@@ -135,6 +146,9 @@ def guvectorize(ftylist, signature, **kws):
         The identity (or unit) value for the element-wise function
         being implemented.  Allowed values are None (the default), 0, 1,
         and "reorderable".
+
+    cache: bool
+        Turns on caching.
 
     target: str
             A string for code generation target.  Defaults to "cpu".

--- a/numba/npyufunc/deviceufunc.py
+++ b/numba/npyufunc/deviceufunc.py
@@ -357,7 +357,9 @@ def to_dtype(ty):
 
 
 class DeviceVectorize(_BaseUFuncBuilder):
-    def __init__(self, func, identity=None, targetoptions={}):
+    def __init__(self, func, identity=None, cache=False, targetoptions={}):
+        if cache:
+            raise TypeError("caching is not supported")
         assert not targetoptions
         self.py_func = func
         self.identity = parse_identity(identity)
@@ -421,7 +423,9 @@ class DeviceVectorize(_BaseUFuncBuilder):
 
 
 class DeviceGUFuncVectorize(_BaseUFuncBuilder):
-    def __init__(self, func, sig, identity=None, targetoptions={}):
+    def __init__(self, func, sig, identity=None, cache=False, targetoptions={}):
+        if cache:
+            raise TypeError("caching is not supported")
         # Allow nopython flag to be set.
         if not targetoptions.pop('nopython', True):
             raise TypeError("nopython flag must be True")

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -73,15 +73,14 @@ class DUFunc(_internal._DUFunc):
     # _internal.c:dufunc_init()
     __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
-    def __init__(self, py_func, identity=None, targetoptions={}):
+    def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
         if isinstance(py_func, Dispatcher):
             py_func = py_func.py_func
-        do_cache = targetoptions.pop("cache", False)
         self.targetoptions = targetoptions.copy()
         kws = {}
         kws['identity'] = ufuncbuilder.parse_identity(identity)
 
-        dispatcher = jit(target='npyufunc', cache=do_cache)(py_func)
+        dispatcher = jit(target='npyufunc', cache=cache)(py_func)
         super(DUFunc, self).__init__(dispatcher, **kws)
         # Loop over a copy of the keys instead of the keys themselves,
         # since we're changing the dictionary while looping.

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -76,10 +76,12 @@ class DUFunc(_internal._DUFunc):
     def __init__(self, py_func, identity=None, targetoptions={}):
         if isinstance(py_func, Dispatcher):
             py_func = py_func.py_func
+        do_cache = targetoptions.pop("cache", False)
         self.targetoptions = targetoptions.copy()
         kws = {}
         kws['identity'] = ufuncbuilder.parse_identity(identity)
-        dispatcher = jit(target='npyufunc')(py_func)
+
+        dispatcher = jit(target='npyufunc', cache=do_cache)(py_func)
         super(DUFunc, self).__init__(dispatcher, **kws)
         # Loop over a copy of the keys instead of the keys themselves,
         # since we're changing the dictionary while looping.

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -205,12 +205,14 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
 # ---------------------------------------------------------------------------
 
 class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
-    def __init__(self, py_func, signature, identity=None, targetoptions={}):
+    def __init__(self, py_func, signature, identity=None, cache=False,
+                 targetoptions={}):
         # Force nopython mode
         targetoptions.update(dict(nopython=True))
         super(ParallelGUFuncBuilder, self).__init__(py_func=py_func,
                                                     signature=signature,
                                                     identity=identity,
+                                                    cache=cache,
                                                     targetoptions=targetoptions)
 
     def build(self, cres):

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -44,9 +44,8 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
         ctx = cres.target_context
         signature = cres.signature
         library = cres.library
-        llvm_func = library.get_function(cres.fndesc.llvm_func_name)
-        wrapper = build_ufunc_wrapper(library, ctx, llvm_func, signature)
-        ptr = library.get_pointer_to_function(wrapper.name)
+        fname = cres.fndesc.llvm_func_name
+        ptr = build_ufunc_wrapper(library, ctx, fname, signature)
         # Get dtypes
         dtypenums = [np.dtype(a.name).num for a in signature.args]
         dtypenums.append(np.dtype(signature.return_type.name).num)
@@ -54,13 +53,11 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
         return dtypenums, ptr, keepalive
 
 
-def build_ufunc_wrapper(library, ctx, lfunc, signature):
-    innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, lfunc, signature,
+def build_ufunc_wrapper(library, ctx, fname, signature):
+    innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, fname, signature,
                                                  objmode=False, env=None,
                                                  envptr=None)
-    lfunc = build_ufunc_kernel(library, ctx, innerfunc, signature)
-    library.add_ir_module(lfunc.module)
-    return lfunc
+    return build_ufunc_kernel(library, ctx, innerfunc, signature)
 
 
 def build_ufunc_kernel(library, ctx, innerfunc, sig):
@@ -100,10 +97,9 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
                                              lc.Type.pointer(intp_t),
                                              lc.Type.pointer(intp_t),
                                              byte_ptr_t])
-
-    mod = library.create_ir_module('parallel.ufunc.wrapper')
+    wrapperlib = ctx.codegen().create_library('parallelufuncwrapper')
+    mod = wrapperlib.create_ir_module('parallel.ufunc.wrapper')
     lfunc = mod.add_function(fnty, name=".kernel")
-    innerfunc = mod.add_function(fnty, name=innerfunc.name)
 
     bb_entry = lfunc.append_basic_block('')
 
@@ -180,11 +176,12 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
     # Add tasks for queue; one per thread
     as_void_ptr = lambda arg: builder.bitcast(arg, byte_ptr_t)
 
+    fnptr = ctx.get_constant(types.uintp, innerfunc).inttoptr(byte_ptr_t)
     for each_args, each_dims in zip(args_list, count_list):
         innerargs = [as_void_ptr(x) for x
-                     in [innerfunc, each_args, each_dims, steps, data]]
+                     in [each_args, each_dims, steps, data]]
 
-        builder.call(add_task, innerargs)
+        builder.call(add_task, [fnptr] + innerargs)
 
     # Signal worker that we are ready
     builder.call(ready, ())
@@ -198,7 +195,9 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
 
     builder.ret_void()
 
-    return lfunc
+    wrapperlib.add_ir_module(mod)
+    wrapperlib.add_linking_library(library)
+    return wrapperlib.get_pointer_to_function(lfunc.name)
 
 
 # ---------------------------------------------------------------------------
@@ -224,12 +223,10 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
         library = cres.library
         signature = cres.signature
         llvm_func = library.get_function(cres.fndesc.llvm_func_name)
-        wrapper, env = build_gufunc_wrapper(library, ctx, llvm_func,
+        ptr, env = build_gufunc_wrapper(library, ctx, llvm_func,
                                             signature, self.sin, self.sout,
                                             fndesc=cres.fndesc,
                                             env=cres.environment)
-
-        ptr = library.get_pointer_to_function(wrapper.name)
 
         # Get dtypes
         dtypenums = []
@@ -245,16 +242,16 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
 
 def build_gufunc_wrapper(library, ctx, llvm_func, signature, sin, sout, fndesc,
                          env):
-    innerfunc, env = ufuncbuilder.build_gufunc_wrapper(library, ctx, llvm_func,
+    innerfunc, env = ufuncbuilder.build_gufunc_wrapper(library, ctx,
                                                        signature, sin, sout,
                                                        fndesc=fndesc, env=env)
     sym_in = set(sym for term in sin for sym in term)
     sym_out = set(sym for term in sout for sym in term)
     inner_ndim = len(sym_in | sym_out)
 
-    lfunc = build_gufunc_kernel(library, ctx, innerfunc, signature, inner_ndim)
-    library.add_ir_module(lfunc.module)
-    return lfunc, env
+    ptr = build_gufunc_kernel(library, ctx, innerfunc, signature, inner_ndim)
+
+    return ptr, env
 
 
 def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
@@ -297,10 +294,9 @@ def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
                                              lc.Type.pointer(intp_t),
                                              lc.Type.pointer(intp_t),
                                              byte_ptr_t])
-
-    mod = library.create_ir_module('parallel.gufunc.wrapper')
+    wrapperlib = ctx.codegen().create_library('parallelufuncwrapper')
+    mod = wrapperlib.create_ir_module('parallel.gufunc.wrapper')
     lfunc = mod.add_function(fnty, name=".kernel")
-    innerfunc = mod.add_function(fnty, name=innerfunc.name)
 
     bb_entry = lfunc.append_basic_block('')
 
@@ -372,10 +368,11 @@ def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
     # Add tasks for queue; one per thread
     as_void_ptr = lambda arg: builder.bitcast(arg, byte_ptr_t)
 
+    fnptr = ctx.get_constant(types.uintp, innerfunc).inttoptr(byte_ptr_t)
     for each_args, each_dims in zip(args_list, count_list):
         innerargs = [as_void_ptr(x) for x
-                     in [innerfunc, each_args, each_dims, steps, data]]
-        builder.call(add_task, innerargs)
+                     in [each_args, each_dims, steps, data]]
+        builder.call(add_task, [fnptr] + innerargs)
 
     # Signal worker that we are ready
     builder.call(ready, ())
@@ -384,7 +381,9 @@ def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
 
     builder.ret_void()
 
-    return lfunc
+    wrapperlib.add_ir_module(mod)
+    wrapperlib.add_linking_library(library)
+    return wrapperlib.get_pointer_to_function(lfunc.name)
 
 
 # ---------------------------------------------------------------------------

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -226,11 +226,9 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
         ctx = cres.target_context
         library = cres.library
         signature = cres.signature
-        llvm_func = library.get_function(cres.fndesc.llvm_func_name)
-        ptr, env = build_gufunc_wrapper(library, ctx, llvm_func,
-                                            signature, self.sin, self.sout,
-                                            fndesc=cres.fndesc,
-                                            env=cres.environment)
+        ptr, env = build_gufunc_wrapper(library, ctx, signature, self.sin,
+                                        self.sout, fndesc=cres.fndesc,
+                                        env=cres.environment)
 
         # Get dtypes
         dtypenums = []
@@ -244,8 +242,7 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
         return dtypenums, ptr, env
 
 
-def build_gufunc_wrapper(library, ctx, llvm_func, signature, sin, sout, fndesc,
-                         env):
+def build_gufunc_wrapper(library, ctx, signature, sin, sout, fndesc, env):
     innerfunc, env = ufuncbuilder.build_gufunc_wrapper(library, ctx,
                                                        signature, sin, sout,
                                                        fndesc=fndesc, env=env)

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -176,6 +176,7 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
     # Add tasks for queue; one per thread
     as_void_ptr = lambda arg: builder.bitcast(arg, byte_ptr_t)
 
+    # Note: the runtime address is taken and used as a constant in the function.
     fnptr = ctx.get_constant(types.uintp, innerfunc).inttoptr(byte_ptr_t)
     for each_args, each_dims in zip(args_list, count_list):
         innerargs = [as_void_ptr(x) for x
@@ -195,6 +196,7 @@ def build_ufunc_kernel(library, ctx, innerfunc, sig):
 
     builder.ret_void()
 
+    # Link and compile
     wrapperlib.add_ir_module(mod)
     wrapperlib.add_linking_library(library)
     return wrapperlib.get_pointer_to_function(lfunc.name)
@@ -368,6 +370,7 @@ def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
     # Add tasks for queue; one per thread
     as_void_ptr = lambda arg: builder.bitcast(arg, byte_ptr_t)
 
+    # Note: the runtime address is taken and used as a constant in the function.
     fnptr = ctx.get_constant(types.uintp, innerfunc).inttoptr(byte_ptr_t)
     for each_args, each_dims in zip(args_list, count_list):
         innerargs = [as_void_ptr(x) for x

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -196,10 +196,10 @@ class _BaseUFuncBuilder(object):
 
 class UFuncBuilder(_BaseUFuncBuilder):
 
-    def __init__(self, py_func, identity=None, targetoptions={}):
+    def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(target='npyufunc', **targetoptions)(py_func)
+        self.nb_func = jit(target='npyufunc', cache=cache, **targetoptions)(py_func)
         self._sigs = []
         self._cres = {}
 
@@ -255,11 +255,11 @@ class UFuncBuilder(_BaseUFuncBuilder):
 class GUFuncBuilder(_BaseUFuncBuilder):
 
     # TODO handle scalar
-    def __init__(self, py_func, signature, identity=None, targetoptions={}):
+    def __init__(self, py_func, signature, identity=None, cache=False,
+                 targetoptions={}):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        do_cache = targetoptions.pop('cache', False)
-        self.nb_func = jit(target='npyufunc', cache=do_cache)(py_func)
+        self.nb_func = jit(target='npyufunc', cache=cache)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
         self.targetoptions = targetoptions

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -219,7 +219,7 @@ def build_ufunc_wrapper(library, context, fname, signature, objmode, envptr, env
         builder.ret_void()
     del builder
 
-    # Run optimizer
+    # Link and finalize
     wrapperlib.add_ir_module(wrapper_module)
     wrapperlib.add_linking_library(library)
     return wrapperlib.get_pointer_to_function(wrapper.name)
@@ -357,9 +357,9 @@ class _GufuncWrapper(object):
 
         builder.ret_void()
 
+        # Link and finalize
         self.wrapperlib.add_ir_module(wrapper_module)
         self.wrapperlib.add_linking_library(self.library)
-        wrapper = self.wrapperlib.get_function(wrapper.name)
         ptr = self.wrapperlib.get_pointer_to_function(wrapper.name)
         return ptr, self.env
 

--- a/numba/tests/npyufunc/cache_usecases.py
+++ b/numba/tests/npyufunc/cache_usecases.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+import numba as nb
+
+#
+# UFunc
+#
+
+def direct_ufunc_cache_usecase(**kwargs):
+    @nb.vectorize(["intp(intp)", "float64(float64)"], cache=True, **kwargs)
+    def ufunc(inp):
+        return inp * 2
+
+    return ufunc
+
+
+def indirect_ufunc_cache_usecase():
+    @nb.njit(cache=True)
+    def indirect_ufunc_core(inp):
+        return inp * 3
+
+    @nb.vectorize(["intp(intp)", "float64(float64)", "complex64(complex64)"])
+    def ufunc(inp):
+        return indirect_ufunc_core(inp)
+
+    return ufunc
+
+
+#
+# DUFunc
+#
+
+def direct_dufunc_cache_usecase(**kwargs):
+    @nb.vectorize(cache=True, **kwargs)
+    def ufunc(inp):
+        return inp * 2
+
+    return ufunc
+
+
+def indirect_dufunc_cache_usecase():
+    @nb.njit(cache=True)
+    def indirect_ufunc_core(inp):
+        return inp * 3
+
+    @nb.vectorize
+    def ufunc(inp):
+        return indirect_ufunc_core(inp)
+
+    return ufunc
+
+
+#
+# GUFunc
+#
+
+def direct_gufunc_cache_usecase(**kwargs):
+    @nb.guvectorize(["(intp, intp[:])", "(float64, float64[:])"],
+                    "()->()", cache=True, **kwargs)
+    def gufunc(inp, out):
+        out[0] = inp * 2
+
+    return gufunc
+
+
+def indirect_gufunc_cache_usecase():
+    @nb.njit(cache=True)
+    def core(x):
+        return x * 3
+
+    @nb.guvectorize(["(intp, intp[:])", "(float64, float64[:])",
+                     "(complex64, complex64[:])"], "()->()",)
+    def gufunc(inp, out):
+        out[0] = core(inp)
+
+    return gufunc

--- a/numba/tests/npyufunc/cache_usecases.py
+++ b/numba/tests/npyufunc/cache_usecases.py
@@ -1,6 +1,5 @@
-import numpy as np
-
 import numba as nb
+
 
 #
 # UFunc
@@ -14,12 +13,13 @@ def direct_ufunc_cache_usecase(**kwargs):
     return ufunc
 
 
-def indirect_ufunc_cache_usecase():
+def indirect_ufunc_cache_usecase(**kwargs):
     @nb.njit(cache=True)
     def indirect_ufunc_core(inp):
         return inp * 3
 
-    @nb.vectorize(["intp(intp)", "float64(float64)", "complex64(complex64)"])
+    @nb.vectorize(["intp(intp)", "float64(float64)", "complex64(complex64)"],
+                  **kwargs)
     def ufunc(inp):
         return indirect_ufunc_core(inp)
 
@@ -38,12 +38,12 @@ def direct_dufunc_cache_usecase(**kwargs):
     return ufunc
 
 
-def indirect_dufunc_cache_usecase():
+def indirect_dufunc_cache_usecase(**kwargs):
     @nb.njit(cache=True)
     def indirect_ufunc_core(inp):
         return inp * 3
 
-    @nb.vectorize
+    @nb.vectorize(**kwargs)
     def ufunc(inp):
         return indirect_ufunc_core(inp)
 
@@ -63,13 +63,13 @@ def direct_gufunc_cache_usecase(**kwargs):
     return gufunc
 
 
-def indirect_gufunc_cache_usecase():
+def indirect_gufunc_cache_usecase(**kwargs):
     @nb.njit(cache=True)
     def core(x):
         return x * 3
 
     @nb.guvectorize(["(intp, intp[:])", "(float64, float64[:])",
-                     "(complex64, complex64[:])"], "()->()",)
+                     "(complex64, complex64[:])"], "()->()", **kwargs)
     def gufunc(inp, out):
         out[0] = core(inp)
 

--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -1,0 +1,155 @@
+from __future__ import print_function, absolute_import, division
+
+import os.path
+import re
+from contextlib import contextmanager
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba import config
+
+from ..support import MemoryLeakMixin, captured_stdout
+from ..test_dispatcher import BaseCacheTest
+
+
+class UfuncCacheTest(BaseCacheTest):
+    """
+    Since the cache stats is not exposed by ufunc, we test by looking at the
+    cache debug log.
+    """
+    here = os.path.dirname(__file__)
+    usecases_file = os.path.join(here, "cache_usecases.py")
+    modname = "ufunc_caching_test_fodder"
+
+    regex_data_saved = re.compile(r'\[cache\] data saved to')
+    regex_index_saved = re.compile(r'\[cache\] index saved to')
+
+    regex_data_loaded = re.compile(r'\[cache\] data loaded from')
+    regex_index_loaded = re.compile(r'\[cache\] index loaded from')
+
+    @contextmanager
+    def capture_cache_log(self):
+        with captured_stdout() as out:
+            old, config.DEBUG_CACHE = config.DEBUG_CACHE, True
+            yield out
+            config.DEBUG_CACHE = old
+
+    def check_cache_saved(self, cachelog, count):
+        """
+        Check number of cache-save were issued
+        """
+        data_saved = self.regex_data_saved.findall(cachelog)
+        index_saved = self.regex_index_saved.findall(cachelog)
+        self.assertEqual(len(data_saved), count)
+        self.assertEqual(len(index_saved), count)
+
+    def check_cache_loaded(self, cachelog, count):
+        """
+        Check number of cache-load were issued
+        """
+        data_loaded = self.regex_data_loaded.findall(cachelog)
+        index_loaded = self.regex_index_loaded.findall(cachelog)
+        self.assertEqual(len(data_loaded), count)
+        self.assertEqual(len(index_loaded), count)
+
+    def check_ufunc_cache(self, usecase_name, n_overloads, **kwargs):
+        """
+        Check number of cache load/save.
+        There should be one per overloaded version.
+        """
+        mod = self.import_module()
+        usecase = getattr(mod, usecase_name)
+        # New cache entry saved
+        with self.capture_cache_log() as out:
+            new_ufunc = usecase(**kwargs)
+        cachelog = out.getvalue()
+        self.check_cache_saved(cachelog, count=n_overloads)
+
+        # Use cached version
+        with self.capture_cache_log() as out:
+            cached_ufunc = usecase(**kwargs)
+        cachelog = out.getvalue()
+        self.check_cache_loaded(cachelog, count=n_overloads)
+
+        return new_ufunc, cached_ufunc
+
+
+class TestUfuncCacheTest(UfuncCacheTest):
+
+    def test_direct_ufunc_cache(self, **kwargs):
+        new_ufunc, cached_ufunc = self.check_ufunc_cache(
+            "direct_ufunc_cache_usecase", n_overloads=2, **kwargs)
+        # Test the cached and original versions
+        inp = np.random.random(10).astype(np.float64)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+        inp = np.arange(10, dtype=np.intp)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+
+    def test_direct_ufunc_cache_objmode(self):
+        self.test_direct_ufunc_cache(forceobj=True)
+
+    def test_indirect_ufunc_cache(self):
+        new_ufunc, cached_ufunc = self.check_ufunc_cache(
+            "indirect_ufunc_cache_usecase", n_overloads=3)
+        # Test the cached and original versions
+        inp = np.random.random(10).astype(np.float64)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+        inp = np.arange(10, dtype=np.intp)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+
+
+class TestDUfuncCacheTest(UfuncCacheTest):
+    def check_dufunc_usecase(self, usecase_name):
+
+        mod = self.import_module()
+        usecase = getattr(mod, usecase_name)
+        # Create dufunc
+        with self.capture_cache_log() as out:
+            ufunc = usecase()
+        self.check_cache_saved(out.getvalue(), count=0)
+        # Compile & cache
+        with self.capture_cache_log() as out:
+            ufunc(np.arange(10))
+        self.check_cache_saved(out.getvalue(), count=1)
+        self.check_cache_loaded(out.getvalue(), count=0)
+        # Use cached
+        with self.capture_cache_log() as out:
+            ufunc = usecase()
+            ufunc(np.arange(10))
+        self.check_cache_loaded(out.getvalue(), count=1)
+
+    def test_direct_dufunc_cache(self):
+        # We don't test for objmode because DUfunc don't support it.
+        self.check_dufunc_usecase('direct_dufunc_cache_usecase')
+
+    def test_indirect_dufunc_cache(self):
+        self.check_dufunc_usecase('indirect_dufunc_cache_usecase')
+
+
+class TestGUFuncCacheTest(UfuncCacheTest):
+
+    def test_direct_gufunc_cache(self, **kwargs):
+        new_ufunc, cached_ufunc = self.check_ufunc_cache(
+            "direct_gufunc_cache_usecase", n_overloads=2, **kwargs)
+        # Test the cached and original versions
+        inp = np.random.random(10).astype(np.float64)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+        inp = np.arange(10, dtype=np.intp)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+
+    def test_direct_gufunc_cache_objmode(self):
+        self.test_direct_gufunc_cache(forceobj=True)
+
+    def test_indirect_gufunc_cache(self):
+        new_ufunc, cached_ufunc = self.check_ufunc_cache(
+            "indirect_gufunc_cache_usecase", n_overloads=3)
+        # Test the cached and original versions
+        inp = np.random.random(10).astype(np.float64)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+        inp = np.arange(10, dtype=np.intp)
+        np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -89,19 +89,26 @@ class TestUfuncCacheTest(UfuncCacheTest):
     def test_direct_ufunc_cache_objmode(self):
         self.test_direct_ufunc_cache(forceobj=True)
 
-    def test_indirect_ufunc_cache(self):
+    def test_direct_ufunc_cache_parallel(self):
+        self.test_direct_ufunc_cache(target='parallel')
+
+    def test_indirect_ufunc_cache(self, **kwargs):
         new_ufunc, cached_ufunc = self.check_ufunc_cache(
-            "indirect_ufunc_cache_usecase", n_overloads=3)
+            "indirect_ufunc_cache_usecase", n_overloads=3, **kwargs)
         # Test the cached and original versions
         inp = np.random.random(10).astype(np.float64)
         np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
         inp = np.arange(10, dtype=np.intp)
         np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
 
+    def test_indirect_ufunc_cache_parallel(self):
+        self.test_indirect_ufunc_cache(target='parallel')
+
 
 class TestDUfuncCacheTest(UfuncCacheTest):
-    def check_dufunc_usecase(self, usecase_name):
+    # Note: DUFunc doesn't support parallel target yet
 
+    def check_dufunc_usecase(self, usecase_name):
         mod = self.import_module()
         usecase = getattr(mod, usecase_name)
         # Create dufunc
@@ -127,7 +134,7 @@ class TestDUfuncCacheTest(UfuncCacheTest):
         self.check_dufunc_usecase('indirect_dufunc_cache_usecase')
 
 
-class TestGUFuncCacheTest(UfuncCacheTest):
+class TestGUfuncCacheTest(UfuncCacheTest):
 
     def test_direct_gufunc_cache(self, **kwargs):
         new_ufunc, cached_ufunc = self.check_ufunc_cache(
@@ -141,14 +148,20 @@ class TestGUFuncCacheTest(UfuncCacheTest):
     def test_direct_gufunc_cache_objmode(self):
         self.test_direct_gufunc_cache(forceobj=True)
 
-    def test_indirect_gufunc_cache(self):
+    def test_direct_gufunc_cache_parallel(self):
+        self.test_direct_gufunc_cache(target='parallel')
+
+    def test_indirect_gufunc_cache(self, **kwargs):
         new_ufunc, cached_ufunc = self.check_ufunc_cache(
-            "indirect_gufunc_cache_usecase", n_overloads=3)
+            "indirect_gufunc_cache_usecase", n_overloads=3, **kwargs)
         # Test the cached and original versions
         inp = np.random.random(10).astype(np.float64)
         np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
         inp = np.arange(10, dtype=np.intp)
         np.testing.assert_equal(new_ufunc(inp), cached_ufunc(inp))
+
+    def test_indirect_gufunc_cache_parallel(self, **kwargs):
+        self.test_indirect_gufunc_cache(target='parallel')
 
 
 if __name__ == '__main__':

--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -9,7 +9,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import config
 
-from ..support import MemoryLeakMixin, captured_stdout
+from ..support import captured_stdout
 from ..test_dispatcher import BaseCacheTest
 
 


### PR DESCRIPTION
TODO:
* [x] add tests
* [x] clean up

**Update 1:**

* New cache keyword is added to the vectorize and guvectorize.
* Caching is supported on cpu and parallel targets by caching the ufunc kernel function via the same machinery for normal jit functions.
* Caching support is added by changing how the ufunc wrapper is linked to the kernel function.  Instead of inserting the wrapper into the same code library of the kernel, it is inserted into a separate codelibrary and the libraries are linked together.
