### PR TITLE
Try to fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ install:
 build: false
 
 test_script:
+  - numba -s
   # Run a subset of the test suite, as AppVeyor is quite slow.
   # %CMD_IN_ENV% is needed for distutils/setuptools-based tests
   # on certain build configurations.

--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -1,8 +1,5 @@
 
 call activate %CONDA_ENV%
 
-@rem Build numba extensions without silencing compile errors
-python setup.py build_ext -q --inplace
-
 @rem Install numba locally for use in `numba -s` sys info tool at test time
 python -m pip install -e .

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -5,10 +5,5 @@ source activate $CONDA_ENV
 # Make sure any error below is reported as such
 set -v -e
 
-# Build numba extensions without silencing compile errors
-python setup.py build_ext -q --inplace
-# (note we don't install to avoid problems with extra long Windows paths
-#  during distutils-dependent tests -- e.g. test_pycc)
-
 # Install numba locally for use in `numba -s` sys info tool at test time
 python -m pip install -e .


### PR DESCRIPTION
If we `pip install`, no need to build extensions as a separate step.