### PR TITLE
Add np.nanprod implementation

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -223,6 +223,7 @@ The following reduction functions are supported:
 * :func:`numpy.nanmean` (only the first argument)
 * :func:`numpy.nanmedian` (only the first argument)
 * :func:`numpy.nanmin` (only the first argument)
+* :func:`numpy.nanprod` (only the first argument)
 * :func:`numpy.nanstd` (only the first argument)
 * :func:`numpy.nansum` (only the first argument)
 * :func:`numpy.nanvar` (only the first argument)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -421,6 +421,27 @@ def np_nansum(a):
 
     return nansum_impl
 
+if numpy_version >= (1, 10):
+    @overload(np.nanprod)
+    def np_nanprod(a):
+        if not isinstance(a, types.Array):
+            return
+        if isinstance(a.dtype, types.Integer):
+            retty = types.intp
+        else:
+            retty = a.dtype
+        one = retty(1)
+        isnan = get_isnan(a.dtype)
+
+        def nanprod_impl(arr):
+            c = one
+            for view in np.nditer(arr):
+                v = view.item()
+                if not isnan(v):
+                    c *= v
+            return c
+
+        return nanprod_impl
 
 #----------------------------------------------------------------------------
 # Median and partitioning

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -536,10 +536,11 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
                            array_nanmax,
                            array_nanmin,
                            array_nansum,
-                           array_nanprod,
                            ]
         if np_version >= (1, 8):
             reduction_funcs += [array_nanmean, array_nanstd, array_nanvar]
+        if np_version >= (1, 10):
+            reduction_funcs += [array_nanprod]
 
         dtypes_to_test = [np.int32, np.float32, np.bool_]
 

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -104,6 +104,9 @@ def array_nanmean(arr):
 def array_nansum(arr):
     return np.nansum(arr)
 
+def array_nanprod(arr):
+    return np.nanprod(arr)
+
 def array_nanstd(arr):
     return np.nanstd(arr)
 
@@ -270,6 +273,11 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # it returns Nan while later Numpy returns 0.
         self.check_reduction_basic(array_nansum,
                                    all_nans=np_version >= (1, 9))
+
+    @tag('important')
+    @unittest.skipUnless(np_version >= (1, 10), "nanprod needs Numpy 1.10+")
+    def test_nanprod_basic(self):
+        self.check_reduction_basic(array_nanprod)
 
     @tag('important')
     @unittest.skipUnless(np_version >= (1, 8), "nanstd needs Numpy 1.8+")
@@ -528,6 +536,7 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
                            array_nanmax,
                            array_nanmin,
                            array_nansum,
+                           array_nanprod,
                            ]
         if np_version >= (1, 8):
             reduction_funcs += [array_nanmean, array_nanstd, array_nanvar]


### PR DESCRIPTION
`np.nanprod` was added in numpy 1.10. This patch adds a numba implementation for it and extends the test suite.