### PR TITLE
Fix segfault in Appveyor build with Python 3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
   matrix:
     # Since appveyor is quite slow, we only use a single configuration
     # and a subset of the test suite (see test_script below)
-    - PYTHON: "3.5"
+    - PYTHON: "3.4"
       ARCH: "64"
       NUMPY: "1.11"
       CONDA_ENV: testenv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,12 @@ install:
 
 build: false
 
+before_test:
+  # Run system info tool
+  - ps: pushd bin
+  - ps: python numba -s
+  - ps: popd
+
 test_script:
   # Run a subset of the test suite, as AppVeyor is quite slow.
   # %CMD_IN_ENV% is needed for distutils/setuptools-based tests


### PR DESCRIPTION
The appveyor build kept segfaulting during the build.cmd script
in the command:
```
python -m pip install -e .
```
Doing the same with a debugger available showed the segfault was
inconsistent but in `os_spawnve` when it occurred.

In testing, it was found Python < 3.5 does not have this problem.
@sklam noted https://github.com/numpy/numpy/issues/7607
and experienced the same issue (many thanks).

As a fix to get Appveyor working again, this patch moves the
test Python version to 3.4.