### PR TITLE
Avoid forking iterator states due to resumption in generator

### DIFF
--- a/numba/generators.py
+++ b/numba/generators.py
@@ -347,8 +347,6 @@ class LowerYield(object):
         for vs in aliases.values():
             vs &= set(self.live_vars)
 
-        from pprint import pprint
-        pprint(aliases)
         return aliases
 
     def _get_alias_set(self, name):

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -639,7 +639,20 @@ class TestIteratorInGenerator(MemoryLeakMixin, TestCase):
 
         got = list(foo())
         expect = list(foo.py_func())
+        self.assertEqual(got, expect)
 
+    def test_nested_loop(self):
+        @njit
+        def foo():
+            i = iter(range(6))
+            for j in range(3):
+                for x in i:
+                    yield (j, x)
+                # `i` is exhausted at this point and in future iteration
+                yield (j, 99)
+
+        got = list(foo())
+        expect = list(foo.py_func())
         self.assertEqual(got, expect)
 
 

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -622,5 +622,26 @@ class TestGeneratorModel(test_factory()):
                               has_finalizer=False)
 
 
+class TestIteratorInGenerator(MemoryLeakMixin, TestCase):
+    """
+    Test iterators in generators.
+    Related issues: https://github.com/numba/numba/pull/2165
+    """
+    def test_basic(self):
+        @njit
+        def foo():
+            a = iter(range(6))
+            for i in a:
+                yield i
+            yield 99
+            for i in a:
+                yield i
+
+        got = list(foo())
+        expect = list(foo.py_func())
+
+        self.assertEqual(got, expect)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2165

The problem in #2165: 
At resumption point, aliasing iterator variables are being recreated into different iterator object.

The fix:
Using a very simple alias analysis on IteratorType and that `getiter(IteratorType)` is an identity function to find aliasing iterator variables and use the alias info to avoid invalid duplication of iterator objects.