### PR TITLE
Bump llvmlite requirement to 0.16 and add install_name_tool_fixer to mviewbuf for OS X

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - numpy x.x
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/buildscripts/condarecipe.hsa/meta.yaml
+++ b/buildscripts/condarecipe.hsa/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - python
     - numpy x.x
     # On channel https://binstar.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://binstar.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
     - libhlc

--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -19,14 +19,14 @@ requirements:
     - numpy x.x
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.15.*
+    - llvmlite 0.16.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ def get_ext_modules():
             depends=['numba/npyufunc/workqueue.h'])
 
     ext_mviewbuf = Extension(name='numba.mviewbuf',
+                             extra_link_args=install_name_tool_fixer,
                              sources=['numba/mviewbuf.c'])
 
     ext_nrt_python = Extension(name='numba.runtime._nrt_python',


### PR DESCRIPTION
Should fix buildbot failures