### PR TITLE
Remove the pointer-stuffing hack for storing meminfos in lists

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,7 +18,7 @@ Francesc Alted                           <francesc@continuum.io>
 Frederic                                 <nouiz@nouiz.org>
 Gaëtan de Menten                         <gdementen@gmail.com>
 GFKjunior                                <xacadena@gmail.com>
-Graham Markall                           <graham.markall@continuum.io>
+Graham Markall                           <graham.markall@embecosm.com>
 Hernan Grecco                            <hernan.grecco@gmail.com>
 Ilan Schnell                             <ilanschnell@gmail.com>
 James Bergstra                           <james.bergstra@gmail.com>

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -82,9 +82,6 @@ build_c_helpers_dict(void)
     declmethod(do_raise);
     declmethod(unpickle);
     declmethod(attempt_nocopy_reshape);
-    declmethod(get_list_private_data);
-    declmethod(set_list_private_data);
-    declmethod(reset_list_private_data);
     declmethod(get_pyobject_private_data);
     declmethod(set_pyobject_private_data);
     declmethod(reset_pyobject_private_data);

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -745,21 +745,6 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name="PyList_SetSlice")
         return self.builder.call(fn, (lst, start, stop, obj))
 
-    def list_get_private_data(self, lst):
-        fnty = Type.function(self.voidptr, [self.pyobj])
-        fn = self._get_function(fnty, name="numba_get_list_private_data")
-        return self.builder.call(fn, (lst,))
-
-    def list_set_private_data(self, lst, ptr):
-        fnty = Type.function(Type.void(), [self.pyobj, self.voidptr])
-        fn = self._get_function(fnty, name="numba_set_list_private_data")
-        return self.builder.call(fn, (lst, ptr))
-
-    def list_reset_private_data(self, lst):
-        fnty = Type.function(Type.void(), [self.pyobj])
-        fn = self._get_function(fnty, name="numba_reset_list_private_data")
-        return self.builder.call(fn, (lst,))
-
 
     #
     # Concrete tuple API

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -580,7 +580,9 @@ def _python_list_to_native(typ, obj, c, size, listptr, errorptr):
                 list.parent = obj
             # Stuff meminfo pointer into the Python object for
             # later reuse.
-            c.pyapi.list_set_private_data(obj, list.meminfo)
+            with c.builder.if_then(c.builder.not_(c.builder.load(errorptr)),
+                                                  likely=False):
+                c.pyapi.object_set_private_data(obj, list.meminfo)
             list.set_dirty(False)
             c.builder.store(list.value, listptr)
 
@@ -605,9 +607,8 @@ def unbox_list(typ, obj, c):
     errorptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
     listptr = cgutils.alloca_once(c.builder, c.context.get_value_type(typ))
 
-    # Use pointer-stuffing hack to see if the list was previously unboxed,
-    # if so, re-use the meminfo.
-    ptr = c.pyapi.list_get_private_data(obj)
+    # See if the list was previously unboxed, if so, re-use the meminfo.
+    ptr = c.pyapi.object_get_private_data(obj)
 
     with c.builder.if_else(cgutils.is_not_null(c.builder, ptr)) \
         as (has_meminfo, otherwise):
@@ -624,8 +625,8 @@ def unbox_list(typ, obj, c):
             _python_list_to_native(typ, obj, c, size, listptr, errorptr)
 
     def cleanup():
-        # Clean up the stuffed pointer, as the meminfo is now invalid.
-        c.pyapi.list_reset_private_data(obj)
+        # Clean up the associated pointer, as the meminfo is now invalid.
+        c.pyapi.object_reset_private_data(obj)
 
     return NativeValue(c.builder.load(listptr),
                        is_error=c.builder.load(errorptr),


### PR DESCRIPTION
This is the first of several PRs that will contribute support for running Numba on PyPy. The pointer-stuffing hack is not compatible with PyPy, because cpyext doesn't emulate CPython struct fields, only public APIs.

This PR associates meminfo structs with lists using the same mechanism as is used for sets and tuples, and removes the code implementing the pointer-stuffing hack. It appears as though the pointer-stuffing hack is a left-over from when list support was first implemented, before the generic mechanism for tracking meminfo structs associated with objects was added. I thought that the most appropriate thing to do to resolve the issue with PyPy would be to just not use pointer-stuffing anymore. If there are reasons that I'm unaware of that it's there, I could rework this to use pointer-stuffing on CPython and the common mechanism on PyPy.

I thought about trying to tidy up a little more - for example, the (un)boxing of tuples is now very similar to that of lists. However, I concluded that that might make things less clear, rather than more. That said, I'd be happy to rework this PR to tidy things up with some guidance about what would be cleanest.