### PR TITLE
Fix 2263: error when linking two modules with dynamic globals

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -978,7 +978,12 @@ class BaseContext(object):
         mod = builder.module
         llvoidptr = self.get_value_type(types.voidptr)
         addr = self.get_constant(types.uintp, intaddr).inttoptr(llvoidptr)
-        gv = mod.add_global_variable(llvoidptr, name='numba.dynamic.globals')
+        # Use a unique name by embedding the address value
+        symname = 'numba.dynamic.globals.{:x}'.format(intaddr)
+        gv = mod.add_global_variable(llvoidptr, name=symname)
+        # Use linkonce linkage to allow merging with other GV of the same name.
+        # And, avoid optimization from assuming its value.
+        gv.linkage = 'linkonce'
         gv.initializer = addr
         return builder.load(gv)
 

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -155,6 +155,7 @@ class TestCFFI(TestCase):
         def foo(x):
             return inner(x) + my_sin(x + 1)
 
+        # Error occurs when foo is being compiled
         x = 1.123
         self.assertEqual(foo(x), my_sin(x) + my_sin(x + 1))
 


### PR DESCRIPTION
The fix is to use `linkonce` linkage and embed value of the dynamic address into the name of the global-tracking symbol.  The `linkonce` linkage will ensure other equally-named symbol will be merged.