### PR TITLE
Add fastmath flags

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -40,6 +40,7 @@ class Flags(utils.ConfigOptions):
         'nrt': False,
         'no_rewrites': False,
         'error_model': 'python',
+        'fastmath': False,
     }
 
 
@@ -677,6 +678,8 @@ def _make_subtarget(targetctx, flags):
         subtargetoptions['enable_boundcheck'] = True
     if flags.nrt:
         subtargetoptions['enable_nrt'] = True
+    if flags.fastmath:
+        subtargetoptions['enable_fastmath'] = True
     error_model = callconv.create_error_model(flags.error_model, targetctx)
     subtargetoptions['error_model'] = error_model
 

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -24,6 +24,7 @@ class UFuncTargetOptions(TargetOptions):
     OPTIONS = {
         "nopython" : bool,
         "forceobj" : bool,
+        "fastmath" : bool,
     }
 
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -210,6 +210,9 @@ class BaseContext(object):
     # Whether dynamic globals (CPU runtime addresses) is allowed
     allow_dynamic_globals = False
 
+    # Fast math flags
+    enable_fastmath = False
+
     def __init__(self, typing_context):
         _load_global_helpers()
 

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -13,6 +13,7 @@ from numba.utils import cached_property
 from numba.targets import callconv, codegen, externals, intrinsics, listobj, setobj
 from .options import TargetOptions
 from numba.runtime import rtsys
+from . import fastmathpass
 
 # Keep those structures in sync with _dynfunc.c.
 
@@ -121,6 +122,9 @@ class CPUContext(BaseContext):
         return setobj.build_set(self, builder, set_type, items)
 
     def post_lowering(self, mod, library):
+        if self.enable_fastmath:
+            fastmathpass.rewrite_module(mod)
+
         if self.is32bit:
             # 32-bit machine needs to replace all 64-bit div/rem to avoid
             # calls to compiler-rt
@@ -190,6 +194,7 @@ class CPUTargetOptions(TargetOptions):
         "_nrt": bool,
         "no_rewrites": bool,
         "no_cpython_wrapper": bool,
+        "fastmath": bool,
     }
 
 

--- a/numba/targets/fastmathpass.py
+++ b/numba/targets/fastmathpass.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, print_function
+
+from llvmlite import ir
+from llvmlite.ir.transforms import Visitor, CallVisitor
+
+
+class FastFloatBinOpVisitor(Visitor):
+    """
+    A pass to add fastmath flag to float-binop instruction if they don't have
+    any flags.
+    """
+    float_binops = frozenset(['fadd', 'fsub', 'fmul', 'fdiv', 'frem', 'fcmp'])
+
+    def visit_Instruction(self, instr):
+        if instr.opname in self.float_binops:
+            if not instr.flags:
+                instr.flags.append('fast')
+
+
+class FastFloatCallVisitor(CallVisitor):
+    """
+    A pass to change all float function calls to use fastmath.
+    """
+    def visit_Call(self, instr):
+        # Add to any call that has float/double return type
+        if instr.type in (ir.FloatType(), ir.DoubleType()):
+            instr.fastmath.add('fast')
+
+
+def rewrite_module(mod):
+    """
+    Rewrite the given LLVM module to use fastmath everywhere.
+    """
+    FastFloatBinOpVisitor().visit(mod)
+    FastFloatCallVisitor().visit(mod)
+

--- a/numba/targets/options.py
+++ b/numba/targets/options.py
@@ -17,8 +17,8 @@ class TargetOptions(object):
             try:
                 ctor = self.OPTIONS[k]
             except KeyError:
-                fmt = "Does not support option: '%s'"
-                raise KeyError(fmt % k)
+                fmt = "%r does not support option: '%s'"
+                raise KeyError(fmt % (self.__class__, k))
             else:
                 self.values[k] = ctor(v)
 
@@ -63,6 +63,9 @@ class TargetOptions(object):
 
         if kws.pop('no_cpython_wrapper', False):
             flags.set('no_cpython_wrapper')
+
+        if kws.pop('fastmath', False):
+            flags.set('fastmath')
 
         flags.set("enable_pyobject_looplift")
 

--- a/numba/tests/test_fastmath.py
+++ b/numba/tests/test_fastmath.py
@@ -1,0 +1,69 @@
+from __future__ import print_function, absolute_import
+
+import math
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba.tests.support import captured_stdout, override_config
+from numba import njit, vectorize, guvectorize
+
+
+class TestFastMath(unittest.TestCase):
+    def test_jit(self):
+        def foo(x):
+            return x + math.sin(x)
+        fastfoo = njit(fastmath=True)(foo)
+        slowfoo = njit(foo)
+        self.assertEqual(fastfoo(0.5), slowfoo(0.5))
+        fastllvm = fastfoo.inspect_llvm(fastfoo.signatures[0])
+        slowllvm = slowfoo.inspect_llvm(slowfoo.signatures[0])
+        # Ensure fast attribute in fast version only
+        self.assertIn('fadd fast', fastllvm)
+        self.assertIn('call fast', fastllvm)
+        self.assertNotIn('fadd fast', slowllvm)
+        self.assertNotIn('call fast', slowllvm)
+
+    def test_vectorize(self):
+        def foo(x):
+            return x + math.sin(x)
+        fastfoo = vectorize(fastmath=True)(foo)
+        slowfoo = vectorize(foo)
+        x = np.random.random(8).astype(np.float32)
+        # capture the optimized llvm to check for fast flag
+        with override_config('DUMP_OPTIMIZED', True):
+            with captured_stdout() as slow_cap:
+                expect = slowfoo(x)
+            slowllvm = slow_cap.getvalue()
+            with captured_stdout() as fast_cap:
+                got = fastfoo(x)
+            fastllvm = fast_cap.getvalue()
+        np.testing.assert_almost_equal(expect, got)
+        self.assertIn('fadd fast', fastllvm)
+        self.assertIn('call fast', fastllvm)
+        self.assertNotIn('fadd fast', slowllvm)
+        self.assertNotIn('call fast', slowllvm)
+
+    def test_guvectorize(self):
+        def foo(x, out):
+            out[0] = x + math.sin(x)
+        x = np.random.random(8).astype(np.float32)
+        with override_config('DUMP_OPTIMIZED', True):
+            types = ['(float32, float32[:])']
+            sig = '()->()'
+            with captured_stdout() as fast_cap:
+                fastfoo = guvectorize(types, sig, fastmath=True)(foo)
+            fastllvm = fast_cap.getvalue()
+            with captured_stdout() as slow_cap:
+                slowfoo = guvectorize(types, sig)(foo)
+            slowllvm = slow_cap.getvalue()
+        expect = slowfoo(x)
+        got = fastfoo(x)
+        np.testing.assert_almost_equal(expect, got)
+        self.assertIn('fadd fast', fastllvm)
+        self.assertIn('call fast', fastllvm)
+        self.assertNotIn('fadd fast', slowllvm)
+        self.assertNotIn('call fast', slowllvm)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a fastmath flag to decorators to enable fastmath function-wide.

The fastmath flag is added as a post-lowering pass that modifies the `llvmlite.ir.Module`.  All relevant float-type binops and float-returning calls will get a `fast` flag.

This enables more aggressive auto-vectorization even on transcendental functions.

Depends on https://github.com/numba/llvmlite/pull/239