### PR TITLE
Adopt itanium C++-style mangling for CPU and CUDA targets

### DIFF
--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -311,13 +311,13 @@ In the terminal:
   (gdb) run chk_debug.py
   Starting program: /home/user/miniconda/bin/python chk_debug.py
   ...
-  Breakpoint 1, __main__.foo$1.int64 () at chk_debug.py:5
+  Breakpoint 1, __main__::foo$241(long long) () at chk_debug.py:5
   5	    b = a + 1
   (gdb) n
   6	    c = a * 2.34
   (gdb) bt
-  #0  __main__.foo$1.int64 () at chk_debug.py:6
-  #1  0x00007ffff7fec47c in cpython..main..foo$1.int64 ()
+  #0  __main__::foo$241(long long) () at chk_debug.py:6
+  #1  0x00007ffff7fec47c in cpython::__main__::foo$241(long long) ()
   #2  0x00007fffeb7976e2 in call_cfunc (locals=0x0, kws=0x0, args=0x7fffeb486198,
   ...
   (gdb) info locals
@@ -389,13 +389,13 @@ We can use ``cuda-memcheck`` to find the memory error:
   $ cuda-memcheck python chk_cuda_debug.py
   ========= CUDA-MEMCHECK
   ========= Invalid __global__ write of size 8
-  =========     at 0x00000148 in /home/user/chk_cuda_debug.py:6:cudaPy__5F__5F_main_5F__5F__2E_foo_24_1_2E_array_28_int64_2C__20_1d_2C__20_C_29_
+  =========     at 0x00000148 in /home/user/chk_cuda_debug.py:6:cudapy::__main__::foo$241(Array<__int64, int=1, C, mutable, aligned>)
   =========     by thread (31,0,0) in block (0,0,0)
   =========     Address 0x500a600f8 is out of bounds
   ...
   =========
   ========= Invalid __global__ write of size 8
-  =========     at 0x00000148 in /home/user/chk_cuda_debug.py:6:cudaPy__5F__5F_main_5F__5F__2E_foo_24_1_2E_array_28_int64_2C__20_1d_2C__20_C_29_
+  =========     at 0x00000148 in /home/user/chk_cuda_debug.py:6:cudapy::__main__::foo$241(Array<__int64, int=1, C, mutable, aligned>)
   =========     by thread (30,0,0) in block (0,0,0)
   =========     Address 0x500a600f0 is out of bounds
   ...

--- a/numba/funcdesc.py
+++ b/numba/funcdesc.py
@@ -7,20 +7,7 @@ from collections import defaultdict
 import sys
 
 from . import types, itanium_mangler
-from .utils import PY3, _dynamic_modname, _dynamic_module
-
-
-def transform_arg_name(arg):
-    # XXX deadcode?
-    if isinstance(arg, types.Record):
-        return "Record_%s" % arg._code
-    elif (isinstance(arg, types.Array) and
-          isinstance(arg.dtype, types.Record)):
-        type_name = "array" if arg.mutable else "readonly array"
-        return ("%s(Record_%s, %sd, %s)"
-                % (type_name, arg.dtype._code, arg.ndim, arg.layout))
-    else:
-        return str(arg)
+from .utils import _dynamic_modname, _dynamic_module
 
 
 def default_mangler(name, argtypes):

--- a/numba/itanium_mangler.py
+++ b/numba/itanium_mangler.py
@@ -33,6 +33,7 @@ from __future__ import print_function, absolute_import
 import re
 
 from numba import types
+from numba import types, utils
 
 
 # According the scheme, valid characters for mangled names are [a-zA-Z0-9_$].
@@ -95,8 +96,13 @@ def _escape_string(text):
     hex format.
     """
     def repl(m):
-        return ''.join(('$%02x' % ch) for ch in m.group(0).encode('utf8'))
-    return re.sub(_re_invalid_char, repl, text)
+        return ''.join(('$%02x' % utils.asbyteint(ch))
+                       for ch in m.group(0).encode('utf8'))
+    ret = re.sub(_re_invalid_char, repl, text)
+    # Return str if we got a unicode (for py2)
+    if not isinstance(ret, str):
+        return ret.encode('ascii')
+    return ret
 
 
 def _fix_lead_digit(text):

--- a/numba/itanium_mangler.py
+++ b/numba/itanium_mangler.py
@@ -3,7 +3,7 @@ Itanium CXX ABI Mangler
 
 Reference: http://mentorembedded.github.io/cxx-abi/abi.html
 
-The basic of the mangling scheme.
+The basics of the mangling scheme.
 
 We are hijacking the CXX mangling scheme for our use.  We map Python modules
 into CXX namespace.  A `module1.submodule2.foo` is mapped to
@@ -13,10 +13,10 @@ templated types; for example, `array(int64, 1d, C)` becomes an
 
 All mangled names are prefixed with "_Z".  It is followed by the name of the
 entity.  A name contains one or more identifiers.  Each identifier is encoded
-in as "<num of char><name>".   If the name is namespaced and, therefore,
-multiple identifiers, the entire name is encoded as "N<name>E".
+as "<num of char><name>".   If the name is namespaced and, therefore,
+has multiple identifiers, the entire name is encoded as "N<name>E".
 
-For functions, arguments types follow.  There are condensed encoding for basic
+For functions, arguments types follow.  There are condensed encodings for basic
 built-in types; e.g. "i" for int, "f" for float.  For other types, the
 previously mentioned name encoding should be used.
 
@@ -32,7 +32,6 @@ from __future__ import print_function, absolute_import
 
 import re
 
-from numba import types
 from numba import types, utils
 
 

--- a/numba/itanium_mangler.py
+++ b/numba/itanium_mangler.py
@@ -2,6 +2,30 @@
 Itanium CXX ABI Mangler
 
 Reference: http://mentorembedded.github.io/cxx-abi/abi.html
+
+The basic of the mangling scheme.
+
+We are hijacking the CXX mangling scheme for our use.  We map Python modules
+into CXX namespace.  A `module1.submodule2.foo` is mapped to
+`module1::submodule2::foo`.   For parameterized numba types, we treat them as
+templated types; for example, `array(int64, 1d, C)` becomes an
+`array<int64, 1, C>`.
+
+All mangled names are prefixed with "_Z".  It is followed by the name of the
+entity.  A name contains one or more identifiers.  Each identifier is encoded
+in as "<num of char><name>".   If the name is namespaced and, therefore,
+multiple identifiers, the entire name is encoded as "N<name>E".
+
+For functions, arguments types follow.  There are condensed encoding for basic
+built-in types; e.g. "i" for int, "f" for float.  For other types, the
+previously mentioned name encoding should be used.
+
+For templated types, the template parameters are encoded immediately after the
+name.  If it is namespaced, it should be within the 'N' 'E' marker.  Template
+parameters are encoded in "I<params>E", where each parameter is encoded using
+the mentioned name encoding scheme.  Template parameters can contain literal
+values like the '1' in the array type shown earlier.  There is special encoding
+scheme for them to avoid leading digits.
 """
 
 from __future__ import print_function, absolute_import

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -520,8 +520,10 @@ class TestDispatcherMethods(TestCase):
 
         def check_display(cfg, wrapper=''):
             # simple stringify test
-            prefix = 'digraph "CFG for \'{}numba.'.format(wrapper)
-            self.assertTrue(str(cfg).startswith(prefix))
+            if wrapper:
+                wrapper = "{}{}".format(len(wrapper), wrapper)
+            prefix = r'^digraph "CFG for \'_ZN{}5numba'.format(wrapper)
+            self.assertRegexpMatches(str(cfg), prefix)
             # .display() requires an optional dependency on `graphviz`.
             # just test for the attribute without running it.
             self.assertTrue(callable(cfg.display))
@@ -537,7 +539,7 @@ class TestDispatcherMethods(TestCase):
         # Call inspect_cfg(signature, show_wrapper="python")
         cfg = foo.inspect_cfg(signature=foo.signatures[0],
                               show_wrapper="python")
-        check_display(cfg, wrapper='cpython.')
+        check_display(cfg, wrapper='cpython')
 
     def test_inspect_types(self):
         @jit

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -39,11 +39,11 @@ class TestInlining(TestCase):
 
     def assert_has_pattern(self, fullname, text):
         pat = self.make_pattern(fullname)
-        self.assertIsNotNone(re.search(pat, text), msg=text)
+        self.assertRegexpMatches(text, pat, msg=text)
 
     def assert_not_has_pattern(self, fullname, text):
         pat = self.make_pattern(fullname)
-        self.assertIsNone(re.search(pat, text), msg=text)
+        self.assertNotRegexpMatches(text, pat, msg=text)
 
     def test_inner_function(self):
         with override_config('DUMP_ASSEMBLY', True):

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -1,9 +1,10 @@
 from __future__ import print_function, absolute_import
 
+import re
+
 from .support import TestCase, override_config, captured_stdout
 from numba import unittest_support as unittest
 from numba import jit, types
-from numba.compiler import compile_isolated
 
 
 @jit((types.int32,), nopython=True)
@@ -29,6 +30,21 @@ class TestInlining(TestCase):
     We just trust LLVM's inlining heuristics.
     """
 
+    def make_pattern(self, fullname):
+        """
+        Make regexpr to match mangled name
+        """
+        parts = fullname.split('.')
+        return r'_ZN?' + r''.join([r'\d+{}'.format(p) for p in parts])
+
+    def assert_has_pattern(self, fullname, text):
+        pat = self.make_pattern(fullname)
+        self.assertIsNotNone(re.search(pat, text), msg=text)
+
+    def assert_not_has_pattern(self, fullname, text):
+        pat = self.make_pattern(fullname)
+        self.assertIsNone(re.search(pat, text), msg=text)
+
     def test_inner_function(self):
         with override_config('DUMP_ASSEMBLY', True):
             with captured_stdout() as out:
@@ -38,8 +54,8 @@ class TestInlining(TestCase):
         # guarantees it was inlined into the outer function).
         asm = out.getvalue()
         prefix = __name__
-        self.assertIn('%s.outer_simple' % prefix, asm)
-        self.assertNotIn('%s.inner' % prefix, asm)
+        self.assert_has_pattern('%s.outer_simple' % prefix, asm)
+        self.assert_not_has_pattern('%s.inner' % prefix, asm)
 
     def test_multiple_inner_functions(self):
         # Same with multiple inner functions, and multiple calls to
@@ -51,9 +67,9 @@ class TestInlining(TestCase):
         self.assertPreciseEqual(cfunc(1), 6)
         asm = out.getvalue()
         prefix = __name__
-        self.assertIn('%s.outer_multiple' % prefix, asm)
-        self.assertNotIn('%s.more' % prefix, asm)
-        self.assertNotIn('%s.inner' % prefix, asm)
+        self.assert_has_pattern('%s.outer_multiple' % prefix, asm)
+        self.assert_not_has_pattern('%s.more' % prefix, asm)
+        self.assert_not_has_pattern('%s.inner' % prefix, asm)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -39,11 +39,13 @@ class TestInlining(TestCase):
 
     def assert_has_pattern(self, fullname, text):
         pat = self.make_pattern(fullname)
-        self.assertRegexpMatches(text, pat, msg=text)
+        self.assertIsNotNone(re.search(pat, text),
+                             msg='expected {}'.format(pat))
 
     def assert_not_has_pattern(self, fullname, text):
         pat = self.make_pattern(fullname)
-        self.assertNotRegexpMatches(text, pat, msg=text)
+        self.assertIsNone(re.search(pat, text),
+                          msg='unexpected {}'.format(pat))
 
     def test_inner_function(self):
         with override_config('DUMP_ASSEMBLY', True):

--- a/numba/tests/test_itanium_mangler.py
+++ b/numba/tests/test_itanium_mangler.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 from __future__ import print_function, absolute_import
 
 import re

--- a/numba/tests/test_itanium_mangler.py
+++ b/numba/tests/test_itanium_mangler.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, absolute_import
 
+import re
+
 from numba import unittest_support as unittest
 from numba import itanium_mangler
 from numba import int32, int64, uint32, uint64, float32, float64
@@ -61,6 +63,20 @@ class TestItaniumManager(unittest.TestCase):
         name = str(range_iter32_type)
         expect = "{n}{name}".format(n=len(name), name=name)
         self.assertEqual(expect, got)
+
+    def test_mangle_literal(self):
+        # check int
+        got = itanium_mangler.mangle_value(123)
+        expect = "Li123E"
+        self.assertEqual(expect, got)
+        # check float (not handled using standard)
+        got = itanium_mangler.mangle_value(12.3)
+        self.assertRegexpMatches(got, r'^\d+_12\$[0-9a-z][0-9a-z]3$')
+
+    def test_mangle_unicode(self):
+        name = u'f∂ƒ©z'
+        got = itanium_mangler.mangle_identifier(name)
+        self.assertRegexpMatches(got, r'^\d+f(\$[a-z0-9][a-z0-9])+z$')
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_itanium_mangler.py
+++ b/numba/tests/test_itanium_mangler.py
@@ -59,7 +59,7 @@ class TestItaniumManager(unittest.TestCase):
     def test_custom_type(self):
         got = itanium_mangler.mangle_type(range_iter32_type)
         name = str(range_iter32_type)
-        expect = "u{n}{name}".format(n=len(name), name=name)
+        expect = "{n}{name}".format(n=len(name), name=name)
         self.assertEqual(expect, got)
 
 

--- a/numba/tests/test_mangling.py
+++ b/numba/tests/test_mangling.py
@@ -4,9 +4,7 @@ Test function name mangling.
 The mangling affects the ABI of numba compiled binaries.
 """
 
-import re
-
-from numba import types
+from numba import types, utils
 from numba.funcdesc import default_mangler
 from .support import unittest, TestCase
 
@@ -31,7 +29,8 @@ class TestMangling(TestCase):
         self.assertIsInstance(name, str)
         # manually encode it
         unichar = fname[2]
-        enc = ''.join('${:02x}'.format(c) for c in unichar.encode('utf8'))
+        enc = ''.join('${:02x}'.format(utils.asbyteint(c))
+                      for c in unichar.encode('utf8'))
         text = 'fo' + enc
         expect = '_Z{}{}if'.format(len(text), text)
         self.assertEqual(name, expect)

--- a/numba/tests/test_mangling.py
+++ b/numba/tests/test_mangling.py
@@ -36,7 +36,7 @@ class TestMangling(TestCase):
         expect = '_Z{}{}if'.format(len(text), text)
         self.assertEqual(name, expect)
         # ensure result chars are in the right charset
-        self.assertIsNotNone(re.match(r'^_Z[a-zA-Z0-9_\$]+$', name))
+        self.assertRegexpMatches(name, r'^_Z[a-zA-Z0-9_\$]+$')
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_mangling.py
+++ b/numba/tests/test_mangling.py
@@ -4,6 +4,8 @@ Test function name mangling.
 The mangling affects the ABI of numba compiled binaries.
 """
 
+import re
+
 from numba import types
 from numba.funcdesc import default_mangler
 from .support import unittest, TestCase
@@ -14,22 +16,27 @@ class TestMangling(TestCase):
         fname = 'foo'
         argtypes = types.int32,
         name = default_mangler(fname, argtypes)
-        self.assertEqual(name, 'foo.int32')
+        self.assertEqual(name, '_Z3fooi')
 
     def test_two_args(self):
         fname = 'foo'
         argtypes = types.int32, types.float32
         name = default_mangler(fname, argtypes)
-        self.assertEqual(name, 'foo.int32.float32')
+        self.assertEqual(name, '_Z3fooif')
 
     def test_unicode_fname(self):
         fname = u'foಠ'
         argtypes = types.int32, types.float32
         name = default_mangler(fname, argtypes)
         self.assertIsInstance(name, str)
-        expect = 'fo\\u{0:04x}.int32.float32'.format(ord(u'ಠ'))
+        # manually encode it
+        unichar = fname[2]
+        enc = ''.join('${:02x}'.format(c) for c in unichar.encode('utf8'))
+        text = 'fo' + enc
+        expect = '_Z{}{}if'.format(len(text), text)
         self.assertEqual(name, expect)
-
+        # ensure result chars are in the right charset
+        self.assertIsNotNone(re.match(r'^_Z[a-zA-Z0-9_\$]+$', name))
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -630,18 +630,17 @@ class TestRecordDtype(unittest.TestCase):
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
         # len(transformed) is generally 10, but could be longer if a large
-        # number of typecodes are in use. Checking <16 should provide enough
+        # number of typecodes are in use. Checking <20 should provide enough
         # tolerance.
-        self.assertLess(len(transformed), 16)
+        self.assertLess(len(transformed), 20)
 
         struct_arr = types.Array(rec, 1, 'C')
         transformed = mangle_type(struct_arr)
         self.assertIn('Array', transformed)
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
-        # Length is usually 34 - 5 chars tolerance as above.
-        self.assertLess(len(transformed), 40)
-
+        # Length is usually 50 - 5 chars tolerance as above.
+        self.assertLess(len(transformed), 50)
 
     def test_record_two_arrays(self):
         """

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -6,7 +6,7 @@ import numpy as np
 from numba import jit, numpy_support, types
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
-from numba.funcdesc import transform_arg_name
+from numba.itanium_mangler import mangle_type
 from numba.utils import IS_PY3
 from .support import tag
 
@@ -626,7 +626,7 @@ class TestRecordDtype(unittest.TestCase):
         transformed name being excessively long.
         """
         rec = numpy_support.from_dtype(recordtype3)
-        transformed = transform_arg_name(rec)
+        transformed = mangle_type(rec)
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
         # len(transformed) is generally 10, but could be longer if a large
@@ -635,8 +635,8 @@ class TestRecordDtype(unittest.TestCase):
         self.assertLess(len(transformed), 16)
 
         struct_arr = types.Array(rec, 1, 'C')
-        transformed = transform_arg_name(struct_arr)
-        self.assertIn('array', transformed)
+        transformed = mangle_type(struct_arr)
+        self.assertIn('Array', transformed)
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
         # Length is usually 34 - 5 chars tolerance as above.

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -93,6 +93,17 @@ class Type(object):
         """
         return self.name
 
+    @property
+    def mangling_args(self):
+        """
+        Returns `(basename, args)` where `basename` is the name of the type
+        and `args` is a sequence of parameters of the type.
+
+        Subclass should override to specialize the behavior.
+        By default, this returns `(self.name, ())`.
+        """
+        return self.name, ()
+
     def __repr__(self):
         return self.name
 

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -196,6 +196,10 @@ class UniTuple(BaseAnonymousTuple, _HomogenousTuple, Sequence):
         super(UniTuple, self).__init__(name)
 
     @property
+    def mangling_args(self):
+        return self.__class__.__name__, (self.dtype, self.count)
+
+    @property
     def key(self):
         return self.dtype, self.count
 
@@ -245,6 +249,10 @@ class Tuple(BaseAnonymousTuple, _HeterogenousTuple):
         self.count = len(self.types)
         name = "(%s)" % ', '.join(str(i) for i in self.types)
         super(Tuple, self).__init__(name)
+
+    @property
+    def mangling_args(self):
+        return self.__class__.__name__, tuple(t for t in self.types)
 
     @property
     def key(self):

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -67,6 +67,10 @@ class Record(Type):
         # (https://github.com/numpy/numpy/issues/5715)
         return (self.descr, self.size, self.aligned)
 
+    @property
+    def mangling_args(self):
+        return self.__class__.__name__, (self._code,)
+
     def __len__(self):
         return len(self.fields)
 

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -283,6 +283,13 @@ class Array(Buffer):
             name = "%s(%s, %sd, %s)" % (type_name, dtype, ndim, layout)
         super(Array, self).__init__(dtype, ndim, layout, name=name)
 
+    @property
+    def mangling_args(self):
+        args = [self.dtype, self.ndim, self.layout,
+                'mutable' if self.mutable else 'readonly',
+                'aligned' if self.aligned else 'unaligned']
+        return self.__class__.__name__, args
+
     def copy(self, dtype=None, ndim=None, layout=None, readonly=None):
         if dtype is None:
             dtype = self.dtype

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -33,6 +33,7 @@ if IS_PY3:
     get_ident = threading.get_ident
     intern = sys.intern
     file_replace = os.replace
+    asbyteint = int
 
     def erase_traceback(exc_value):
         """
@@ -49,6 +50,10 @@ else:
     longint = long
     get_ident = thread.get_ident
     intern = intern
+    def asbyteint(x):
+        # convert 1-char str into int
+        return ord(x)
+
     if sys.platform == 'win32':
         def file_replace(src, dest):
             # Best-effort emulation of os.replace()


### PR DESCRIPTION
* Update and fixes to the existing itanium mangler
* Change CPU and CUDA target to use the mangler
* Add `.mangling_args()` method for types to specialize their name
    * e.g. Array will now show like a C++ template class

The use of itanium mangling scheme will shorten most symbol name and allow debuggers/profilers to show a more human-readable name.  