### PR TITLE
Fix nvvm ir patch in mishandling "load"

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -572,10 +572,9 @@ def llvm39_to_34_ir(ir):
             # Rewrite "load ty, ty* ptr"
             # to "load ty *ptr"
             m = re_load.search(line)
-            if m is None:
-                raise RuntimeError("failed parsing load: %s" % (line,))
-            pos = m.end()
-            line = line[:pos] + parse_out_leading_type(line[pos:])
+            if m:
+                pos = m.end()
+                line = line[:pos] + parse_out_leading_type(line[pos:])
         if 'call ' in line:
             # Rewrite "call ty (...) @foo"
             # to "call ty (...)* @foo"

--- a/numba/cuda/tests/cudadrv/test_ir_patch.py
+++ b/numba/cuda/tests/cudadrv/test_ir_patch.py
@@ -2,19 +2,24 @@ from __future__ import print_function, absolute_import, division
 
 from numba.cuda.testing import unittest
 from numba.cuda.testing import skip_on_cudasim
-from numba.cuda.cudadrv.nvvm import llvm39_to_34_ir
 
 
 @skip_on_cudasim('Linking unsupported in the simulator')
 class TestIRPatch(unittest.TestCase):
+    def patch(self, ir):
+        # Import here to avoid error in CUDASIM
+        from numba.cuda.cudadrv.nvvm import llvm39_to_34_ir
+
+        return llvm39_to_34_ir(ir)
+
     def test_load_rewrite(self):
         text = "%myload = not really"
-        out = llvm39_to_34_ir(text)
+        out = self.patch(text)
         # No rewrite
         self.assertEqual(text, out)
 
         text = "%myload = load i32, i32* val"
-        out = llvm39_to_34_ir(text)
+        out = self.patch(text)
         # Rewritten
         self.assertEqual("%myload = load i32* val", out)
 

--- a/numba/cuda/tests/cudadrv/test_ir_patch.py
+++ b/numba/cuda/tests/cudadrv/test_ir_patch.py
@@ -1,0 +1,23 @@
+from __future__ import print_function, absolute_import, division
+
+from numba.cuda.testing import unittest
+from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.cudadrv.nvvm import llvm39_to_34_ir
+
+
+@skip_on_cudasim('Linking unsupported in the simulator')
+class TestIRPatch(unittest.TestCase):
+    def test_load_rewrite(self):
+        text = "%myload = not really"
+        out = llvm39_to_34_ir(text)
+        # No rewrite
+        self.assertEqual(text, out)
+
+        text = "%myload = load i32, i32* val"
+        out = llvm39_to_34_ir(text)
+        # Rewritten
+        self.assertEqual("%myload = load i32* val", out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The error was introduced in https://github.com/numba/numba/pull/2272 . 