### PR TITLE
fix value returned in disable_jit warning

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -94,7 +94,7 @@ class _EnvReloader(object):
                 return ctor(value)
             except Exception:
                 warnings.warn("environ %s defined but failed to parse '%s'" %
-                              (name, res), RuntimeWarning)
+                              (name, value), RuntimeWarning)
                 return default
 
         # Print warnings to screen about function compilation


### PR DESCRIPTION
Fixing a small bug I ran into this afternoon when setting `NUMBA_DISABLE_JIT=True`

leading to

```
/home/gil/miniconda3/envs/pygbe/lib/python3.5/site-packages/numba/config.py in process_environ(self, environ)
    190 
    191         # Disable jit for debugging
--> 192         DISABLE_JIT = _readenv("NUMBA_DISABLE_JIT", int, 0)
    193 
    194         # CUDA Configs

/home/gil/miniconda3/envs/pygbe/lib/python3.5/site-packages/numba/config.py in _readenv(name, ctor, default)
     95             except Exception:
     96                 warnings.warn("environ %s defined but failed to parse '%s'" %
---> 97                               (name, res), RuntimeWarning)
     98                 return default
     99 

NameError: name 'res' is not defined
```

The value of the envvar `NUMBA_DISABLE_JIT` is stored in `value`, not `res`