### PR TITLE
Fix #2285 `@overload_method` not linking dependent libs

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -116,6 +116,10 @@ class _EnvReloader(object):
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)
 
+        # Redirect cache directory
+        # Contains path to the directory
+        CACHE_DIR = _readenv("NUMBA_CACHE_DIR", str, "")
+
         # Enable tracing support
         TRACE = _readenv("NUMBA_TRACE", int, 0)
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -491,7 +491,7 @@ class TestOverloadMethodCaching(TestCase):
         except AttributeError:
             ctx = multiprocessing
         q = ctx.Queue()
-        p = ctx.Process(target=self.run_caching_overload_method, args=(q,))
+        p = ctx.Process(target=run_caching_overload_method, args=(q,))
         p.start()
         q.put(MyDummy())
         p.join()
@@ -500,12 +500,15 @@ class TestOverloadMethodCaching(TestCase):
         res = q.get(timeout=1)
         self.assertEqual(res, 13)
 
-    @staticmethod
-    def run_caching_overload_method(q):
-        arg = q.get()
-        cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
-        res = cfunc(arg)
-        q.put(res)
+
+def run_caching_overload_method(q):
+    """
+    Used by TestOverloadMethodCaching.test_caching_overload_method
+    """
+    arg = q.get()
+    cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
+    res = cfunc(arg)
+    q.put(res)
 
 
 class TestIntrinsic(TestCase):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -471,6 +471,12 @@ class TestHighLevelExtending(TestCase):
         expectmsg = "cannot convert native Module"
         self.assertIn(expectmsg, errmsg)
 
+
+class TestOverloadMethodCaching(TestCase):
+    # Nested multiprocessing.Pool raises AssertionError:
+    # "daemonic processes are not allowed to have children"
+    _numba_parallel_test_ = False
+
     def test_caching_overload_method(self):
         cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
         self.assertPreciseEqual(cfunc(MyDummy()), 13)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -504,6 +504,10 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig.args, {})
             call = context.get_function(disp_type, sig)
+            # Link dependent library
+            cg = context.codegen()
+            for lib in getattr(call, 'libs', ()):
+                cg.add_linking_library(lib)
             return call(builder, args)
 
     def _resolve(self, typ, attr):


### PR DESCRIPTION
* Fix to #2285.  The actual fix is quite small inside templates.py
* Most of the changes is for testing and adding a configurable temporary cache directory for testing.