### PR TITLE
Refactor call lowering

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -281,7 +281,7 @@ class EnumModel(ProxyModel):
 @register_default(types.Dummy)
 @register_default(types.ExceptionInstance)
 @register_default(types.ExternalFunction)
-@register_default(types.NumbaFunction)
+@register_default(types.InternalFunction)
 @register_default(types.Macro)
 @register_default(types.EnumClass)
 @register_default(types.IntEnumClass)

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -66,11 +66,11 @@ def ctor({args}):
 
 def _getargs(fn):
     """
-    Returns list of positional and keyword argument names in order. 
+    Returns list of positional and keyword argument names in order.
     """
     sig = utils.pysignature(fn)
     params = sig.parameters
-    args = [k for k, v in params.items() 
+    args = [k for k, v in params.items()
             if (v.kind & v.POSITIONAL_OR_KEYWORD) == v.POSITIONAL_OR_KEYWORD]
     return args
 
@@ -294,7 +294,7 @@ class ClassBuilder(object):
             instance_type = sig.args[0]
             method = instance_type.jitmethods[attr]
             disp_type = types.Dispatcher(method)
-            call = context.get_function(disp_type, sig)
+            call = context.get_definition(disp_type, sig)
             out = call(builder, args)
             return imputils.impl_ret_new_ref(context, builder,
                                              sig.return_type, out)
@@ -353,7 +353,7 @@ def attr_impl(context, builder, typ, value, attr):
         sig = templates.signature(None, typ)
         dispatcher = types.Dispatcher(getter)
         sig = dispatcher.get_call_type(context.typing_context, [typ], {})
-        call = context.get_function(dispatcher, sig)
+        call = context.get_definition(dispatcher, sig)
         out = call(builder, [value])
         return imputils.impl_ret_new_ref(context, builder, sig.return_type, out)
 
@@ -392,7 +392,7 @@ def attr_impl(context, builder, sig, args, attr):
         disp_type = types.Dispatcher(setter)
         sig = disp_type.get_call_type(context.typing_context,
                                       (typ, valty), {})
-        call = context.get_function(disp_type, sig)
+        call = context.get_definition(disp_type, sig)
         call(builder, (target, val))
 
     else:
@@ -458,7 +458,7 @@ def ctor_impl(context, builder, sig, args):
 
     init = inst_typ.jitmethods['__init__']
     disp_type = types.Dispatcher(init)
-    call = context.get_function(disp_type, types.void(*init_sig))
+    call = context.get_definition(disp_type, types.void(*init_sig))
     realargs = [inst_struct._getvalue()] + list(args)
     call(builder, realargs)
 

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -291,7 +291,7 @@ class Lower(BaseLower):
             signature = self.fndesc.calltypes[inst]
             assert signature is not None
             try:
-                impl = self.context.get_function('static_setitem', signature)
+                impl = self.context.get_definition('static_setitem', signature)
             except NotImplementedError:
                 return self.lower_setitem(inst.target, inst.index_var, inst.value, signature)
             else:
@@ -319,7 +319,7 @@ class Lower(BaseLower):
 
             signature = self.fndesc.calltypes[inst]
             assert signature is not None
-            impl = self.context.get_function('delitem', signature)
+            impl = self.context.get_definition('delitem', signature)
 
             assert targetty == signature.args[0]
             index = self.context.cast(self.builder, index, indexty,
@@ -362,7 +362,7 @@ class Lower(BaseLower):
         valuety = self.typeof(value_var.name)
         indexty = self.typeof(index_var.name)
 
-        impl = self.context.get_function('setitem', signature)
+        impl = self.context.get_definition('setitem', signature)
 
         # Convert argument to match
         if isinstance(targetty, types.Optional):
@@ -470,7 +470,7 @@ class Lower(BaseLower):
                 return None
             static_sig = typing.signature(signature.return_type, *tys)
             try:
-                static_impl = self.context.get_function(op, static_sig)
+                static_impl = self.context.get_definition(op, static_sig)
                 return static_impl(self.builder, args)
             except NotImplementedError:
                 return None
@@ -491,14 +491,14 @@ class Lower(BaseLower):
             return cast_result(res)
 
         # Normal implementation for generic arguments
-        impl = self.context.get_function(op, signature)
+        impl = self.context.get_definition(op, signature)
         res = impl(self.builder, (lhs, rhs))
         return cast_result(res)
 
     def lower_getitem(self, resty, expr, value, index, signature):
         baseval = self.loadvar(value.name)
         indexval = self.loadvar(index.name)
-        impl = self.context.get_function("getitem", signature)
+        impl = self.context.get_definition("getitem", signature)
         argvals = (baseval, indexval)
         argtyps = (self.typeof(value.name),
                    self.typeof(index.name))
@@ -589,7 +589,7 @@ class Lower(BaseLower):
         fixed_sig.pysig = sig.pysig
 
         argvals = self.fold_call_args(fnty, sig, pos_args, inst.vararg, {})
-        impl = self.context.get_function(print, fixed_sig)
+        impl = self.context.get_definition(print, fixed_sig)
         impl(self.builder, argvals)
 
     def lower_call_external_function(self, fnty, argvals):
@@ -715,7 +715,7 @@ class Lower(BaseLower):
             typ = self.typeof(expr.value.name)
             # Get function
             signature = self.fndesc.calltypes[expr]
-            impl = self.context.get_function(expr.fn, signature)
+            impl = self.context.get_definition(expr.fn, signature)
             # Convert argument to match
             val = self.context.cast(self.builder, val, typ, signature.args[0])
             res = impl(self.builder, [val])
@@ -745,7 +745,7 @@ class Lower(BaseLower):
             val = self.loadvar(expr.value.name)
             ty = self.typeof(expr.value.name)
             signature = self.fndesc.calltypes[expr]
-            impl = self.context.get_function(expr.op, signature)
+            impl = self.context.get_definition(expr.op, signature)
             [fty] = signature.args
             castval = self.context.cast(self.builder, val, ty, fty)
             res = impl(self.builder, (castval,))
@@ -772,10 +772,10 @@ class Lower(BaseLower):
             tup = self.context.get_constant_undef(resty)
             pairty = types.Pair(itemty, types.boolean)
             getiter_sig = typing.signature(ty.iterator_type, ty)
-            getiter_impl = self.context.get_function('getiter',
+            getiter_impl = self.context.get_definition('getiter',
                                                      getiter_sig)
             iternext_sig = typing.signature(pairty, ty.iterator_type)
-            iternext_impl = self.context.get_function('iternext',
+            iternext_impl = self.context.get_definition('iternext',
                                                       iternext_sig)
             iterobj = getiter_impl(self.builder, (val,))
             # We call iternext() as many times as desired (`expr.count`).
@@ -834,7 +834,7 @@ class Lower(BaseLower):
             try:
                 # Both get_function() and the returned implementation can
                 # raise NotImplementedError if the types aren't supported
-                impl = self.context.get_function("static_getitem", signature)
+                impl = self.context.get_definition("static_getitem", signature)
                 return impl(self.builder, (self.loadvar(expr.value.name), expr.index))
             except NotImplementedError:
                 if expr.index_var is None:

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -658,7 +658,7 @@ class Lower(BaseLower):
     def lower_call_normal(self, fnty, signature, argvals):
         # Normal function resolution
         self.debug_print("# calling normal function: {0}".format(fnty))
-        return self.context.call_function(self.builder, fnty, signature, argvals)
+        return self.context.apply_definition(self.builder, fnty, signature, argvals)
 
     def lower_call(self, resty, expr):
         signature = self.fndesc.calltypes[expr]

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -603,13 +603,6 @@ class Lower(BaseLower):
             self.builder, func, fndesc.argtypes, argvals)
         return res
 
-    def lower_call_numba_function(self, fnty, argvals):
-        # Handle a compiled Numba function
-        self.debug_print("# calling numba function")
-        res = self.context.call_internal(self.builder, fnty.fndesc, fnty.sig,
-                                         argvals)
-        return res
-
     def lower_call_external_function_pointer(self, fnty, pointer, signature,
                                              argvals):
         self.debug_print("# calling external function pointer")
@@ -665,12 +658,7 @@ class Lower(BaseLower):
     def lower_call_normal(self, fnty, signature, argvals):
         # Normal function resolution
         self.debug_print("# calling normal function: {0}".format(fnty))
-        impl = self.context.get_function(fnty, signature)
-        res = impl(self.builder, argvals)
-        libs = getattr(impl, "libs", ())
-        for lib in libs:
-            self.library.add_linking_library(lib)
-        return res
+        return self.context.call_function(self.builder, fnty, signature, argvals)
 
     def lower_call(self, resty, expr):
         signature = self.fndesc.calltypes[expr]

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -396,7 +396,7 @@ def _lower_array_expr(lowerer, expr):
             cast_args = [self.cast(val, inty, outty)
                          for val, inty, outty in arg_zip]
             result = self.context.call_internal(
-                builder, cres.fndesc, inner_sig, cast_args)
+                builder, cres.fndesc, inner_sig, cast_args, libs=[cres.library])
             return self.cast(result, inner_sig.return_type,
                              self.outer_sig.return_type)
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -64,7 +64,7 @@ def make_array(array_type):
         def _make_refs(self, ref):
             sig = signature(real_array_type, array_type)
             try:
-                array_impl = self._context.get_function('__array__', sig)
+                array_impl = self._context.get_definition('__array__', sig)
             except NotImplementedError:
                 return super(ArrayStruct, self)._make_refs(ref)
 
@@ -1324,7 +1324,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         # Check shape is equal to sequence length
         index_shape = indexer.get_shape()
         assert len(index_shape) == 1
-        len_impl = context.get_function(len, signature(types.intp, srcty))
+        len_impl = context.get_definition(len, signature(types.intp, srcty))
         seq_len = len_impl(builder, (src,))
 
         shape_error = builder.icmp_signed('!=', index_shape[0], seq_len)
@@ -1335,7 +1335,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         def src_getitem(source_indices):
             idx, = source_indices
-            getitem_impl = context.get_function('getitem',
+            getitem_impl = context.get_definition('getitem',
                                                 signature(src_dtype, srcty, types.intp))
             return getitem_impl(builder, (src, idx))
 
@@ -3643,7 +3643,7 @@ def _get_seq_size(context, builder, seqty, seq):
     if isinstance(seqty, types.BaseTuple):
         return context.get_constant(types.intp, len(seqty))
     elif isinstance(seqty, types.Sequence):
-        len_impl = context.get_function(len, signature(types.intp, seqty,))
+        len_impl = context.get_definition(len, signature(types.intp, seqty,))
         return len_impl(builder, (seq,))
     else:
         assert 0
@@ -3653,7 +3653,7 @@ def _get_borrowing_getitem(context, seqty):
     Return a getitem() implementation that doesn't incref its result.
     """
     retty = seqty.dtype
-    getitem_impl = context.get_function('getitem',
+    getitem_impl = context.get_definition('getitem',
                                         signature(retty, seqty, types.intp))
     def wrap(builder, args):
         ret = getitem_impl(builder, args)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -779,7 +779,7 @@ class BaseContext(object):
         if ty is None:
             cres = self.compile_subroutine_no_cache(builder, impl, sig,
                                                     locals=locals)
-            ty = types.NumbaFunction(cres.fndesc, sig)
+            ty = types.InternalFunction(cres.fndesc, sig)
             self.cached_internal_func[cache_key] = ty
         return ty
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -466,6 +466,26 @@ class BaseContext(object):
         lty = self.get_value_type(ty)
         return Constant.null(lty)
 
+    def call_function(self, builder, fn, sig, args):
+        """
+        Resolve function using `get_function` and call it.
+        *fn* and *sig* are the same as in `get_function`.
+        *builder* is the llvm IR builder.
+        *args* is a sequence of llvm IR values for the arguments.
+
+        Note: this doesn't actually "call" any function.  The "function"
+        definition is emitted directly into the "caller".
+        """
+        # Resolve
+        impl = self.get_function(fn, sig)
+        # Call
+        result = impl(builder, args)
+        # Link in dependencies
+        cg = self.codegen()
+        for lib in getattr(impl, "libs", ()):
+            cg.add_linking_library(lib)
+        return result
+
     def get_function(self, fn, sig, _firstcall=True):
         """
         Return the implementation of function *fn* for signature *sig*.

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -800,7 +800,7 @@ class BaseContext(object):
         if ty is None:
             cres = self.compile_subroutine_no_cache(builder, impl, sig,
                                                     locals=locals)
-            ty = types.InternalFunction(cres.fndesc, sig, libs=[cres.library])
+            ty = types.InternalFunction(cres=cres)
             self.cached_internal_func[cache_key] = ty
         return ty
 
@@ -810,12 +810,15 @@ class BaseContext(object):
         *args*.
         """
         ty = self.compile_subroutine(builder, impl, sig, locals)
-        return self.call_internal(builder, ty.fndesc, sig, args, libs=ty.libs)
+        return self.call_internal(builder, ty.cres.fndesc, sig, args,
+                                  libs=[ty.cres.library])
 
     def call_internal(self, builder, fndesc, sig, args, libs=()):
         """
         Given the function descriptor of an internally compiled function,
         emit a call to that function with the given arguments.
+        Optionally, linking libraries are provided by *libs* as a sequence
+        of `CodeLibrary` objects.
         """
         # Add call to the generated function
         llvm_mod = builder.module

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -477,7 +477,7 @@ class BaseContext(object):
         definition is emitted directly into the "caller".
         """
         # Resolve
-        impl = self.get_function(fn, sig)
+        impl = self.get_definition(fn, sig)
         # Call
         result = impl(builder, args)
         # Link in dependencies
@@ -490,9 +490,9 @@ class BaseContext(object):
         module.add_named_metadata('.numba.linker.libs',
                                   [llvmir.IntType(64)(uid), str(library)])
 
-    def get_function(self, fn, sig, _firstcall=True):
+    def get_definition(self, fn, sig, _firstcall=True):
         """
-        Return the implementation of function *fn* for signature *sig*.
+        Return the definition of function *fn* for signature *sig*.
         The return value is a callable with the signature (builder, args).
         """
         sig = sig.as_function()
@@ -511,7 +511,7 @@ class BaseContext(object):
         if isinstance(fn, types.Type):
             # It's a type instance => try to find a definition for the type class
             try:
-                return self.get_function(type(fn), sig)
+                return self.get_definition(type(fn), sig)
             except NotImplementedError:
                 # Raise exception for the type instance, for a better error message
                 pass
@@ -520,7 +520,7 @@ class BaseContext(object):
         # calling the first time.
         if _firstcall:
             self.refresh()
-            return self.get_function(fn, sig, _firstcall=False)
+            return self.get_definition(fn, sig, _firstcall=False)
 
         raise NotImplementedError("No definition for lowering %s%s" % (key, sig))
 
@@ -677,7 +677,7 @@ class BaseContext(object):
         cav = self.cast(builder, av, at, ty)
         cbv = self.cast(builder, bv, bt, ty)
         cmpsig = typing.signature(types.boolean, ty, ty)
-        cmpfunc = self.get_function(key, cmpsig)
+        cmpfunc = self.get_definition(key, cmpsig)
         return cmpfunc(builder, (cav, cbv))
 
     def make_optional_none(self, builder, valtype):
@@ -695,7 +695,7 @@ class BaseContext(object):
         """
         Return the truth value of a value of the given Numba type.
         """
-        impl = self.get_function(bool, typing.signature(types.boolean, typ))
+        impl = self.get_definition(bool, typing.signature(types.boolean, typ))
         return impl(builder, (val,))
 
     def get_c_value(self, builder, typ, name, dllimport=False):

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -466,19 +466,17 @@ class BaseContext(object):
         lty = self.get_value_type(ty)
         return Constant.null(lty)
 
-    def call_function(self, builder, fn, sig, args):
-        """
-        Resolve function using `get_function` and call it.
-        *fn* and *sig* are the same as in `get_function`.
+    def apply_definition(self, builder, fn, sig, args):
+        """Apply function definition into current location of the IR builder.
+
+        Resolve function using `get_definition` and apply it.
+        *fn* and *sig* are the same as in `get_definition`.
         *builder* is the llvm IR builder.
         *args* is a sequence of llvm IR values for the arguments.
-
-        Note: this doesn't actually "call" any function.  The "function"
-        definition is emitted directly into the "caller".
         """
         # Resolve
         impl = self.get_definition(fn, sig)
-        # Call
+        # Apply
         result = impl(builder, args)
         # Link in dependencies
         for lib in getattr(impl, "libs", ()):

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -21,7 +21,7 @@ def generic_is_not(context, builder, sig, args):
     """
     Implement `x is not y` as `not (x is y)`.
     """
-    is_impl = context.get_function('is', sig)
+    is_impl = context.get_definition('is', sig)
     return builder.not_(is_impl(builder, args))
 
 
@@ -40,7 +40,7 @@ def generic_is(context, builder, sig, args):
             else:
                 # fallbacks to `==`
                 try:
-                    eq_impl = context.get_function('==', sig)
+                    eq_impl = context.get_definition('==', sig)
                 except NotImplementedError:
                     # no `==` implemented for this type
                     return cgutils.false_bit
@@ -111,7 +111,7 @@ def do_minmax(context, builder, argtys, args, cmpop):
         acc = context.cast(builder, acc, accty, ty)
         v = context.cast(builder, v, vty, ty)
         cmpsig = typing.signature(types.boolean, ty, ty)
-        ge = context.get_function(cmpop, cmpsig)
+        ge = context.get_definition(cmpop, cmpsig)
         pred = ge(builder, (v, acc))
         res = builder.select(pred, v, acc)
         return ty, res
@@ -244,7 +244,7 @@ def number_constructor(context, builder, sig, args):
     """
     if isinstance(sig.return_type, types.Array):
         # Array constructor
-        impl = context.get_function(np.array, sig)
+        impl = context.get_definition(np.array, sig)
         return impl(builder, args)
     else:
         # Scalar constructor

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -315,7 +315,7 @@ def call_getiter(context, builder, iterable_type, val):
     of value *val*, and return the corresponding LLVM inst.
     """
     getiter_sig = typing.signature(iterable_type.iterator_type, iterable_type)
-    getiter_impl = context.get_function('getiter', getiter_sig)
+    getiter_impl = context.get_definition('getiter', getiter_sig)
     return getiter_impl(builder, (val,))
 
 
@@ -328,7 +328,7 @@ def call_iternext(context, builder, iterator_type, val):
     itemty = iterator_type.yield_type
     pair_type = types.Pair(itemty, types.boolean)
     iternext_sig = typing.signature(pair_type, iterator_type)
-    iternext_impl = context.get_function('iternext', iternext_sig)
+    iternext_impl = context.get_definition('iternext', iternext_sig)
     val = iternext_impl(builder, (val,))
     pairobj = context.make_helper(builder, pair_type, val)
     return _IternextResult(context, builder, pairobj)
@@ -340,7 +340,7 @@ def call_len(context, builder, ty, val):
     this type.
     """
     try:
-        len_impl = context.get_function(len, typing.signature(types.intp, ty,))
+        len_impl = context.get_definition(len, typing.signature(types.intp, ty,))
     except NotImplementedError:
         return None
     else:

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -400,5 +400,5 @@ unary_math_int_impl(math.degrees, degrees_float_impl)
 @lower(math.pow, types.Float, types.Float)
 @lower(math.pow, types.Float, types.Integer)
 def pow_impl(context, builder, sig, args):
-    impl = context.get_function("**", sig)
+    impl = context.get_definition("**", sig)
     return impl(builder, args)

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -266,7 +266,7 @@ def _build_array(context, builder, array_ty, input_types, inputs):
     array_wrapper_ty = input_types[array_wrapper_index]
     try:
         # __array_wrap__(source wrapped array, out array) -> out wrapped array
-        array_wrap = context.get_function('__array_wrap__',
+        array_wrap = context.get_definition('__array_wrap__',
                                           array_ty(array_wrapper_ty, real_array_ty))
     except NotImplementedError:
         # If it's the same priority as a regular array, assume we

--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -677,7 +677,7 @@ def real_divmod_func_body(context, builder, vx, wx):
         realtypemap = {'float': types.float32,
                        'double': types.float64}
         realtype = realtypemap[str(wx.type)]
-        floorfn = context.get_function(math.floor,
+        floorfn = context.get_definition(math.floor,
                                        typing.signature(realtype, realtype))
         floordiv = floorfn(builder, [div])
         floordivdiff = builder.fsub(div, floordiv)
@@ -764,7 +764,7 @@ def real_power_impl(context, builder, sig, args):
     x, y = args
     module = builder.module
     if context.implement_powi_as_math_call:
-        imp = context.get_function(math.pow, sig)
+        imp = context.get_definition(math.pow, sig)
         res = imp(builder, args)
     else:
         fn = lc.Function.intrinsic(module, lc.INTR_POW, [y.type])
@@ -805,7 +805,7 @@ def real_ne_impl(context, builder, sig, args):
 def real_abs_impl(context, builder, sig, args):
     [ty] = sig.args
     sig = typing.signature(ty, ty)
-    impl = context.get_function(math.fabs, sig)
+    impl = context.get_definition(math.fabs, sig)
     return impl(builder, args)
 
 

--- a/numba/targets/operatorimpl.py
+++ b/numba/targets/operatorimpl.py
@@ -25,7 +25,7 @@ def map_operator(name, inplace_name, op):
         if reverse_args:
             args = args[::-1]
             sig = typing.signature(sig.return_type, *sig.args[::-1])
-        impl = context.get_function(op, sig)
+        impl = context.get_definition(op, sig)
         return impl(builder, args)
 
     if inplace_name:
@@ -35,9 +35,9 @@ def map_operator(name, inplace_name, op):
         def binop_inplace_impl(context, builder, sig, args):
             first = sig.args[0]
             if first.mutable:
-                impl = context.get_function(op + '=', sig)
+                impl = context.get_definition(op + '=', sig)
             else:
-                impl = context.get_function(op, sig)
+                impl = context.get_definition(op, sig)
             return impl(builder, args)
 
 

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -72,7 +72,7 @@ def print_varargs_impl(context, builder, sig, args):
 
     for i, (argtype, argval) in enumerate(zip(sig.args, args)):
         signature = typing.signature(types.none, argtype)
-        imp = context.get_function("print_item", signature)
+        imp = context.get_definition("print_item", signature)
         imp(builder, [argval])
         if i < len(args) - 1:
             pyapi.print_string(' ')

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -1219,7 +1219,7 @@ for typing_key, arity in [
         arr = arrayobj._empty_nd_impl(context, builder, arrty, shapes)
 
         # ... and populate it in natural order
-        scalar_impl = context.get_function(typing_key, scalar_sig)
+        scalar_impl = context.get_definition(typing_key, scalar_sig)
         with cgutils.for_range(builder, arr.nitems) as loop:
             val = scalar_impl(builder, scalar_args)
             ptr = cgutils.gep(builder, arr.data, loop.index)

--- a/numba/targets/setobj.py
+++ b/numba/targets/setobj.py
@@ -58,7 +58,7 @@ def get_hash_value(context, builder, typ, value):
     Compute the hash of the given value.
     """
     sig = typing.signature(types.intp, typ)
-    fn = context.get_function(hash, sig)
+    fn = context.get_definition(hash, sig)
     h = fn(builder, (value,))
     # Fixup reserved values
     is_ok = is_hash_used(context, builder, h)
@@ -184,7 +184,7 @@ class _SetPayload(object):
 
         mask = self.mask
         dtype = self._ty.dtype
-        eqfn = context.get_function('==',
+        eqfn = context.get_definition('==',
                                     typing.signature(types.boolean, dtype, dtype))
 
         one = ir.Constant(intp_t, 1)

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -100,7 +100,7 @@ def hash_tuple(context, builder, sig, args):
         # h = h * mult
         h = builder.mul(h, mult)
         val = builder.extract_value(tup, i)
-        hash_impl = context.get_function(hash,
+        hash_impl = context.get_definition(hash,
                                          typing.signature(sig.return_type, ty))
         h_val = hash_impl(builder, (val,))
         # h = h ^ hash(val)

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -244,7 +244,7 @@ class ExternalFunction(Function):
         return self.symbol, self.sig
 
 
-class NumbaFunction(Function):
+class InternalFunction(Function):
     """
     A named native function with the Numba calling convention
     (resolvable by LLVM).
@@ -257,7 +257,7 @@ class NumbaFunction(Function):
         self.sig = sig
         template = typing.make_concrete_template(fndesc.qualname,
                                                  fndesc.qualname, [sig])
-        super(NumbaFunction, self).__init__(template)
+        super(InternalFunction, self).__init__(template)
 
     @property
     def key(self):

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -251,10 +251,11 @@ class InternalFunction(Function):
     For internal use only.
     """
 
-    def __init__(self, fndesc, sig):
+    def __init__(self, fndesc, sig, libs):
         from .. import typing
         self.fndesc = fndesc
         self.sig = sig
+        self.libs = libs
         template = typing.make_concrete_template(fndesc.qualname,
                                                  fndesc.qualname, [sig])
         super(InternalFunction, self).__init__(template)

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -251,18 +251,17 @@ class InternalFunction(Function):
     For internal use only.
     """
 
-    def __init__(self, fndesc, sig, libs):
+    def __init__(self, cres):
         from .. import typing
-        self.fndesc = fndesc
-        self.sig = sig
-        self.libs = libs
-        template = typing.make_concrete_template(fndesc.qualname,
-                                                 fndesc.qualname, [sig])
+        self.cres = cres
+        template = typing.make_concrete_template(cres.fndesc.qualname,
+                                                 cres.fndesc.qualname,
+                                                 [cres.signature])
         super(InternalFunction, self).__init__(template)
 
     @property
     def key(self):
-        return self.fndesc.unique_name, self.sig
+        return self.cres.fndesc.unique_name, self.cres.signature
 
 
 class NamedTupleClass(Callable, Opaque):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -302,7 +302,7 @@ class BaseContext(object):
         else:
             return ty
 
-        if isinstance(val, (types.ExternalFunction, types.NumbaFunction)):
+        if isinstance(val, (types.ExternalFunction,)):
             return val
 
         # Try to look up target specific typing information

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -503,12 +503,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             disp = cls._get_dispatcher(typing_context, typ, attr, sig.args, {})
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig.args, {})
-            call = context.get_function(disp_type, sig)
-            # Link dependent library
-            cg = context.codegen()
-            for lib in getattr(call, 'libs', ()):
-                cg.add_linking_library(lib)
-            return call(builder, args)
+            return context.call_function(builder, disp_type, sig, args)
 
     def _resolve(self, typ, attr):
         if self._attr != attr:

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -438,7 +438,7 @@ class _OverloadAttributeTemplate(AttributeTemplate):
             disp = cls._get_dispatcher(typing_context, typ, attr, sig_args, sig_kws)
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig_args, sig_kws)
-            call = context.get_function(disp_type, sig)
+            call = context.get_definition(disp_type, sig)
             return call(builder, (value,))
 
     @classmethod

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -503,7 +503,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             disp = cls._get_dispatcher(typing_context, typ, attr, sig.args, {})
             disp_type = types.Dispatcher(disp)
             sig = disp_type.get_call_type(typing_context, sig.args, {})
-            return context.call_function(builder, disp_type, sig, args)
+            return context.apply_definition(builder, disp_type, sig, args)
 
     def _resolve(self, typ, attr):
         if self._attr != attr:


### PR DESCRIPTION
(Based on #2286)

An attempt to cut down code duplication and clarify the code around call lowering.

The `.lower_call` is too long.  This patch breaks it up and cut out some dead logic; e.g. handling of `NumbaFunction` which never occurs in user-compiled code thus never handled by the `Lower` class.

Inside the target context, a "function" means many things.  This patch renamed the "functions" in the `._defns` into "definitions" to imply that they are not really functions in the emitted code.  They are feature definitions that are expanded into the IR-Builder as if it is inlined. 


**Update 1**

In the process of the refactor, I have found a bug that puts some CodeLibrary objects into Codegen for all subsequent compilation to link to.  This bloats memory use, causes unnecessary LLVM IR linking, and codegen of unused code.  To fix this, 86ef373 changes the design of linking.  Since not all code path has access to the CodeLibrary object, the linkage info is inserted into the IR-module as metadata.  The info is parsed during `CodeLibrary.add_ir_module`.  