### PR TITLE
Disable remove_module on MCJIT due to memory leak inside LLVM

### DIFF
--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -712,8 +712,11 @@ class JITCPUCodegen(BaseCPUCodegen):
 
     def _add_module(self, module):
         self._engine.add_module(module)
-        # Early bind the engine method to avoid keeping a reference to self.
-        return functools.partial(self._engine.remove_module, module)
+        # XXX: disabling remove module due to MCJIT engine leakage in
+        #      removeModule.  The removeModule causes consistent access
+        #      violation with certain test combinations.
+        # # Early bind the engine method to avoid keeping a reference to self.
+        # return functools.partial(self._engine.remove_module, module)
 
 
 _llvm_initialized = False

--- a/numba/tests/test_codegen.py
+++ b/numba/tests/test_codegen.py
@@ -148,6 +148,7 @@ class JITCPUCodegenTestCase(TestCase):
 
     # Lifetime tests
 
+    @unittest.expectedFailure  # MCJIT removeModule leaks and it is disabled
     def test_library_lifetime(self):
         library = self.compile_module(asm_sum_outer, asm_sum_inner)
         # Exercise code generation


### PR DESCRIPTION
(Based on  #2291)
