### PR TITLE
Numba created worker threads will convert exception to warnings.

### DIFF
--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -80,6 +80,7 @@ build_c_helpers_dict(void)
     declmethod(py_type);
     declmethod(unpack_slice);
     declmethod(do_raise);
+    declmethod(convert_exception_to_warning);
     declmethod(unpickle);
     declmethod(attempt_nocopy_reshape);
     declmethod(get_list_private_data);

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -56,7 +56,8 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
 def build_ufunc_wrapper(library, ctx, fname, signature):
     innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, fname, signature,
                                                  objmode=False, env=None,
-                                                 envptr=None)
+                                                 envptr=None,
+                                                 warn_exception=True)
     return build_ufunc_kernel(library, ctx, innerfunc, signature)
 
 

--- a/numba/npyufunc/workqueue.h
+++ b/numba/npyufunc/workqueue.h
@@ -27,7 +27,7 @@ void launch_threads(int count);
 Automatically assigned to queues of different thread in a round robin fashion.
 */
 static
-void add_task(void *fn, void *args, void *dims, void *steps, void *data);
+void add_task(void *fn, void *args, void *dims, void *steps, void *data, int *ret);
 
 /* Wait until all tasks are done */
 static

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -287,6 +287,11 @@ class PythonAPI(object):
             exc = self.make_none()
         return self.builder.call(fn, (exc,))
 
+    def convert_exception_to_warning(self):
+        fnty = Type.function(Type.void(), ())
+        fn = self._get_function(fnty, name="numba_convert_exception_to_warning")
+        return self.builder.call(fn, ())
+
     def err_set_object(self, exctype, excval):
         fnty = Type.function(Type.void(), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyErr_SetObject")


### PR DESCRIPTION
Fix for issue #2299.  

Currently, exceptions raised in numba created threads (e.g. like in parallel ufunc) will be lost.  Internally, numba set an exception to the PyThreadState but the thread is not managed by the interpreter.  When these threads exits, the interpreter is not notified.  As a result, the exception is lost.

The fix is to convert exceptions in numba created threads into warnings.  There are no easy way to propagate exception back to the calling thread.  This is not handled by python created thread.  Exception raised in python created threads will just get printed out when the threads terminate.

**Update**

I modified the parallel ufunc kernel to return the number of exception occurred.  The thread launcher can use that info to raise a `RuntimeError` at the caller thread to indicate that exceptions occurred during the ufunc execution.