### PR TITLE
Fix race condition due to concurrent compilation and cache loading

### DIFF
--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -59,8 +59,9 @@ class CFunc(object):
         self._cache = FunctionCache(self._pyfunc)
 
     def compile(self):
-        # Try to load from cache
+        # Use cache and compiler in a critical section
         with compiler.lock_compiler:
+            # Try to load from cache
             cres = self._cache.load_overload(self._sig, self._targetdescr.target_context)
             if cres is None:
                 cres = self._compile_uncached()

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -8,6 +8,7 @@ from pprint import pprint
 import sys
 import warnings
 import traceback
+import threading
 from .tracing import trace, event
 
 from numba import (bytecode, interpreter, funcdesc, postproc,
@@ -15,6 +16,10 @@ from numba import (bytecode, interpreter, funcdesc, postproc,
                    errors, types, ir, types, rewrites, transforms)
 from numba.targets import cpu, callconv
 from numba.annotations import type_annotations
+
+
+# Lock for the preventing multiple compiler execution
+lock_compiler = threading.RLock()
 
 
 class Flags(utils.ConfigOptions):

--- a/numba/llvmthreadsafe.py
+++ b/numba/llvmthreadsafe.py
@@ -1,0 +1,43 @@
+"""
+Utils for managing LLVM for threadsafe usage.
+"""
+import types
+import threading
+import functools
+import contextlib
+import llvmlite.binding as llvm
+
+
+class LockLLVM(object):
+    """
+    For locking LLVM.
+    Usable as contextmanager and decorator.
+    """
+
+    def __init__(self):
+        self._llvm_lock = threading.RLock()
+
+    def __enter__(self):
+        self._llvm_lock.acquire()
+
+    def __exit__(self, *args, **kwargs):
+        self._llvm_lock.release()
+
+    def __call__(self, fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            with self:
+                return fn(*args, **kwargs)
+        return wrapped
+
+
+# Make singleton
+lock_llvm = LockLLVM()
+del LockLLVM
+
+# Bind llvm API with the lock
+parse_assembly = lock_llvm(llvm.parse_assembly)
+parse_bitcode = lock_llvm(llvm.parse_bitcode)
+create_mcjit_compiler = lock_llvm(llvm.create_mcjit_compiler)
+create_module_pass_manager = lock_llvm(llvm.create_module_pass_manager)
+create_function_pass_manager = lock_llvm(llvm.create_function_pass_manager)

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -85,17 +85,18 @@ class UFuncDispatcher(object):
         """
         typingctx = self.targetdescr.typing_context
         targetctx = self.targetdescr.target_context
-        cres = self.cache.load_overload(sig, targetctx)
-        if cres is not None:
-            # Use cached version
+        with compiler.lock_compiler:
+            cres = self.cache.load_overload(sig, targetctx)
+            if cres is not None:
+                # Use cached version
+                return cres
+            # Compile
+            args, return_type = sigutils.normalize_signature(sig)
+            cres = compiler.compile_extra(typingctx, targetctx, self.py_func,
+                                        args=args, return_type=return_type,
+                                        flags=flags, locals=locals)
+            self.cache.save_overload(sig, cres)
             return cres
-        # Compile
-        args, return_type = sigutils.normalize_signature(sig)
-        cres = compiler.compile_extra(typingctx, targetctx, self.py_func,
-                                      args=args, return_type=return_type,
-                                      flags=flags, locals=locals)
-        self.cache.save_overload(sig, cres)
-        return cres
 
 
 dispatcher_registry['npyufunc'] = UFuncDispatcher

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -85,6 +85,7 @@ class UFuncDispatcher(object):
         """
         typingctx = self.targetdescr.typing_context
         targetctx = self.targetdescr.target_context
+        # Use cache and compiler in a critical section
         with compiler.lock_compiler:
             cres = self.cache.load_overload(sig, targetctx)
             if cres is not None:

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -390,6 +390,7 @@ class _GufuncWrapper(object):
         library.add_linking_library(self.library)
 
     def build(self):
+        # Use cache and compiler in a critical section
         with compiler.lock_compiler:
             wrapperlib = self.cache.load_overload(self.cres.signature, self.cres.target_context)
             wrapper_name = "__gufunc__." + self.fndesc.mangled_name

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from llvmlite.llvmpy.core import Type, Builder, ICMP_EQ, Constant
 
-from numba import types, cgutils
+from numba import types, cgutils, compiler
 from ..caching import make_library_cache, NullCache
 
 
@@ -390,20 +390,21 @@ class _GufuncWrapper(object):
         library.add_linking_library(self.library)
 
     def build(self):
-        wrapperlib = self.cache.load_overload(self.cres.signature, self.cres.target_context)
-        wrapper_name = "__gufunc__." + self.fndesc.mangled_name
+        with compiler.lock_compiler:
+            wrapperlib = self.cache.load_overload(self.cres.signature, self.cres.target_context)
+            wrapper_name = "__gufunc__." + self.fndesc.mangled_name
 
-        if wrapperlib is None:
-            # Create library and enable caching
-            wrapperlib = self.context.codegen().create_library(str(self))
-            wrapperlib.enable_object_caching()
-            # Build wrapper
-            self._build_wrapper(wrapperlib, wrapper_name)
-            # Cache
-            self.cache.save_overload(self.cres.signature, wrapperlib)
-        # Finalize and get function pointer
-        ptr = wrapperlib.get_pointer_to_function(wrapper_name)
-        return ptr, self.env
+            if wrapperlib is None:
+                # Create library and enable caching
+                wrapperlib = self.context.codegen().create_library(str(self))
+                wrapperlib.enable_object_caching()
+                # Build wrapper
+                self._build_wrapper(wrapperlib, wrapper_name)
+                # Cache
+                self.cache.save_overload(self.cres.signature, wrapperlib)
+            # Finalize and get function pointer
+            ptr = wrapperlib.get_pointer_to_function(wrapper_name)
+            return ptr, self.env
 
     def gen_loop_body(self, builder, pyapi, func, args):
         status, retval = self.call_conv.call_function(builder, func,

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -7,7 +7,6 @@ import sys
 
 from llvmlite import ir
 import llvmlite.llvmpy.core as lc
-import llvmlite.binding as ll
 
 from numba import cgutils
 from numba.utils import IS_PY3

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -5,7 +5,6 @@ import contextlib
 import pickle
 
 from llvmlite import ir
-import llvmlite.binding as ll
 from llvmlite.llvmpy.core import Type, Constant, LLVMException
 import llvmlite.llvmpy.core as lc
 

--- a/numba/runtime/nrtopt.py
+++ b/numba/runtime/nrtopt.py
@@ -4,7 +4,7 @@ NRT specific optimizations
 import re
 from collections import defaultdict, deque
 
-from llvmlite import binding as llvm
+import numba.llvmthreadsafe as llvmts
 
 
 _regex_incref = re.compile(r'\s*call void @NRT_incref\((.*)\)')
@@ -153,4 +153,4 @@ def remove_redundant_nrt_refct(ll_module):
         processed += lines
 
     newll = '\n'.join(processed)
-    return llvm.parse_assembly(newll)
+    return llvmts.parse_assembly(newll)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -3,7 +3,6 @@ from __future__ import print_function, absolute_import
 import sys
 
 import llvmlite.llvmpy.core as lc
-import llvmlite.binding as ll
 
 from numba import _dynfunc, config
 from numba.callwrapper import PyCallWrapper

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -8,6 +8,7 @@ import ctypes
 from llvmlite import ir
 import llvmlite.binding as ll
 
+from numba import llvmthreadsafe as llvmts
 from numba import utils, config
 from numba import _helperlib
 from . import intrinsics
@@ -195,7 +196,7 @@ define void @fnclex() {
 }
     """
     ll.initialize_native_asmparser()
-    library.add_llvm_module(ll.parse_assembly(ir_mod))
+    library.add_llvm_module(llvmts.parse_assembly(ir_mod))
     library.finalize()
     return library
 

--- a/numba/tests/test_cgutils.py
+++ b/numba/tests/test_cgutils.py
@@ -6,7 +6,6 @@ import struct
 import sys
 
 import llvmlite.llvmpy.core as lc
-import llvmlite.binding as ll
 import numpy as np
 
 import numba.unittest_support as unittest

--- a/numba/tests/test_threadsafety.py
+++ b/numba/tests/test_threadsafety.py
@@ -1,0 +1,90 @@
+"""
+Test threadsafety for compiler.
+These tests will cause segfault if fail.
+"""
+import threading
+import random
+
+import numpy as np
+
+from numba import config
+from numba import unittest_support as unittest
+from numba import jit, vectorize, guvectorize
+
+from .support import temp_directory, override_config
+
+
+class TestThreadSafety(unittest.TestCase):
+
+    def run_jit(self, **options):
+        def runner():
+            @jit(**options)
+            def foo(n, v):
+                return np.ones(n)
+            return foo(4, 10)
+        return runner
+
+    def run_compile(self, fnlist):
+        self._cache_dir = temp_directory(self.__class__.__name__)
+        with override_config('CACHE_DIR', self._cache_dir):
+            def chooser():
+                for _ in range(10):
+                    fn = random.choice(fnlist)
+                    fn()
+
+            ths = [threading.Thread(target=chooser)
+                   for i in range(4)]
+            for th in ths:
+                th.start()
+            for th in ths:
+                th.join()
+
+    def test_concurrent_jit(self):
+        self.run_compile([self.run_jit(nopython=True)])
+
+    def test_concurrent_jit_cache(self):
+        self.run_compile([self.run_jit(nopython=True, cache=True)])
+
+    def run_vectorize(self, **options):
+        def runner():
+            @vectorize(['(f4, f4)'], **options)
+            def foo(a, b):
+                return a + b
+
+            a = b = np.random.random(10).astype(np.float32)
+            return foo(a, b)
+        return runner
+
+    def test_concurrent_vectorize(self):
+        self.run_compile([self.run_vectorize(nopython=True)])
+
+    def test_concurrent_vectorize_cache(self):
+        self.run_compile([self.run_vectorize(nopython=True, cache=True)])
+
+    def run_guvectorize(self, **options):
+        def runner():
+            @guvectorize(['(f4, f4, f4[:])'], '(),()->()', **options)
+            def foo(a, b, out):
+                out[0] = a + b
+
+            a = b = np.random.random(10).astype(np.float32)
+            return foo(a, b)
+        return runner
+
+    def test_concurrent_guvectorize(self):
+        self.run_compile([self.run_guvectorize(nopython=True)])
+
+    def test_concurrent_guvectorize_cache(self):
+        self.run_compile([self.run_guvectorize(nopython=True, cache=True)])
+
+    def test_concurrent_mix_use(self):
+        self.run_compile([self.run_jit(nopython=True, cache=True),
+                          self.run_jit(nopython=True),
+                          self.run_vectorize(nopython=True, cache=True),
+                          self.run_vectorize(nopython=True),
+                          self.run_guvectorize(nopython=True, cache=True),
+                          self.run_guvectorize(nopython=True)])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Base on #2286 

Fix #2213.  The real problem is race condition inside LLVM code.  

This patch adds new locks to protect any LLVM API.