### PR TITLE
[WIP] Compile on PyPy on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - env: PYTHON=3.6 NUMPY=1.12 BUILD_DOC=yes CONDA_ENV=travisci
         - env: PYTHON=3.4 NUMPY=1.10 CONDA_ENV=travisci
         - env: PYTHON=2.7 NUMPY=1.9 CONDA_ENV=travisci
+        - env: PYTHON=pypy NUMPY=1.12 CONDA_ENV=travisci
 
 branches:
     only:

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -10,5 +10,10 @@ python setup.py build_ext -q --inplace
 # (note we don't install to avoid problems with extra long Windows paths
 #  during distutils-dependent tests -- e.g. test_pycc)
 
+if [ "$PYTHON" == "pypy" ]; then
+  # Since we can't run the system info tool, just exit.
+  exit 0
+fi
+
 # Install numba locally for use in `numba -s` sys info tool at test time
 python -m pip install -e .

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -13,20 +13,33 @@ conda list
 # (note workaround for https://github.com/conda/conda/issues/2679:
 #  `conda env remove` issue)
 conda remove --all -q -y -n $CONDA_ENV
-# Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
-conda create -n $CONDA_ENV -q -y python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2 ipython
+
+if [ "$PYTHON" == "pypy" ]; then
+  # Create a basic environment for PyPy - no Scipy, jinja2, or ipython (CFFI is part of PyPy)
+  conda create -c gmarkall -n $CONDA_ENV -q -y pypy
+else
+  # Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
+  conda create -n $CONDA_ENV -q -y python=$PYTHON numpy=$NUMPY cffi pip scipy jinja2 ipython
+fi
 
 set +v
 source activate $CONDA_ENV
 set -v
 
 # Install latest llvmlite build
-$CONDA_INSTALL -c numba llvmlite
+if [ "$PYTHON" == "pypy" ]; then
+  $CONDA_INSTALL -c numba llvmlite
+else
+  python -m ensurepip
+  $CONDA_INSTALL -c gmarkall pypy-llvmlite
+  # There are no conda packages for PyPy for singledispatch and funcsigs. enum34
+  # is presently rolled into the pypy-llvmlite package
+  $PIP_INSTALL singledispatch funcsigs
+fi
+
 # Install enum34 and singledispatch for Python < 3.4
 if [ $PYTHON \< "3.4" ]; then $CONDA_INSTALL enum34; fi
 if [ $PYTHON \< "3.4" ]; then $PIP_INSTALL singledispatch; fi
-# Install funcsigs for Python < 3.3
-if [ $PYTHON \< "3.3" ]; then $CONDA_INSTALL -c numba funcsigs; fi
 # Install dependencies for building the documentation
 if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx pygments; fi
 if [ "$BUILD_DOC" == "yes" ]; then $PIP_INSTALL sphinxjp.themecore sphinxjp.themes.basicstrap; fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -9,10 +9,20 @@ set -v -e
 pushd docs
 if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi
 popd
+
+# We only build on PyPy at present, not test.
+if [ "$PYTHON" == "pypy" ]; then
+  # Since we can't run the system info tool, just state the Python version.
+  python --version
+  exit 0
+fi
+
 # Run system info tool
 pushd bin
 numba -s
 popd
+
+
 # First check that the test discovery works
 python -m numba.tests.test_runtests
 # Now run the Numba test suite

--- a/numba/_dynfunc.c
+++ b/numba/_dynfunc.c
@@ -51,7 +51,7 @@ env_clear(EnvironmentObject *env)
 static void
 env_dealloc(EnvironmentObject *env)
 {
-    _PyObject_GC_UNTRACK((PyObject *) env);
+    PyObject_GC_UnTrack((PyObject *) env);
     env_clear(env);
     Py_TYPE(env)->tp_free((PyObject *) env);
 }
@@ -174,7 +174,7 @@ closure_traverse(ClosureObject *clo, visitproc visit, void *arg)
 static void
 closure_dealloc(ClosureObject *clo)
 {
-    _PyObject_GC_UNTRACK((PyObject *) clo);
+    PyObject_GC_UnTrack((PyObject *) clo);
     if (clo->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *) clo);
     PyObject_Free((void *) clo->def.ml_name);
@@ -343,7 +343,7 @@ generator_clear(GeneratorObject *gen)
 static void
 generator_dealloc(GeneratorObject *gen)
 {
-    _PyObject_GC_UNTRACK((PyObject *) gen);
+    PyObject_GC_UnTrack((PyObject *) gen);
     if (gen->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *) gen);
     /* XXX The finalizer may be called after the LLVM module has been

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -109,12 +109,58 @@ numba_ldexpf(float x, int exp)
     return x;
 }
 
+/*
+ * _Py_C_pow is copied from Objects/complexobject.c in CPython 2.7.12 to
+ * provide complex power in PyPy.
+ *
+ * FIXME: This may not result in ZeroDivisionError being thrown by PyPy
+ * where it would be in CPython (when CPOW_ERRNO == EDOM), but this won't
+ * easily be checked until tests are working on PyPy.
+ */
+
+#ifdef PYPY_VERSION
+static int _cpow_errno;
+#define CPOW_ERRNO _cpow_errno
+
+Py_complex
+_Py_c_pow(Py_complex a, Py_complex b)
+{
+    Py_complex r;
+    double vabs,len,at,phase;
+    if (b.real == 0. && b.imag == 0.) {
+        r.real = 1.;
+        r.imag = 0.;
+    }
+    else if (a.real == 0. && a.imag == 0.) {
+        if (b.imag != 0. || b.real < 0.)
+            CPOW_ERRNO = EDOM;
+        r.real = 0.;
+        r.imag = 0.;
+    }
+    else {
+        vabs = hypot(a.real,a.imag);
+        len = pow(vabs,b.real);
+        at = atan2(a.imag, a.real);
+        phase = at*b.real;
+        if (b.imag != 0.0) {
+            len /= exp(at*b.imag);
+            phase += b.imag*log(vabs);
+        }
+        r.real = len*cos(phase);
+        r.imag = len*sin(phase);
+    }
+    return r;
+}
+#else
+#define CPOW_ERRNO errno
+#endif // PYPY_VERSION
+
 /* provide complex power */
 NUMBA_EXPORT_FUNC(void)
 numba_cpow(Py_complex *a, Py_complex *b, Py_complex *out) {
-    errno = 0;
+    CPOW_ERRNO = 0;
     *out = _Py_c_pow(*a, *b);
-    if (errno == EDOM) {
+    if (CPOW_ERRNO == EDOM) {
         /* _Py_c_pow() doesn't bother returning the right value
            in this case, as Python raises ZeroDivisionError */
         out->real = out->imag = Py_NAN;

--- a/numba/_math_c99.h
+++ b/numba/_math_c99.h
@@ -87,4 +87,18 @@ VISIBILITY_HIDDEN float m_atan2f(float y, float x);
 
 #define atan2_fixed(x, y) m_atan2(x, y)
 
+#ifdef PYPY_VERSION
+
+/* Various macros that are not defined on PyPy. These probably should be
+   available in PyPy and fixed upstream, but presently they are required to
+   build Numba. */
+
+#define Py_MATH_PI 3.14159265358979323846
+
+#define Py_IS_NAN(X) isnan(X)
+#define Py_IS_FINITE(X) isfinite(X)
+#define Py_IS_INFINITY(X) isinf(X)
+
+#endif /* PYPY_VERSION */
+
 #endif /* NUMBA_MATH_C99_H_ */

--- a/numba/_typeof.c
+++ b/numba/_typeof.c
@@ -325,7 +325,7 @@ compute_fingerprint(string_writer_t *w, PyObject *val)
         PyObject *item;
         Py_ssize_t pos = 0;
         /* Only one item is considered, as in typeof.py */
-        if (!_PySet_NextEntry(val, &pos, &item, &h)) {
+        if (PySet_GET_SIZE(val) == 0) {
             /* Empty set */
             PyErr_SetString(PyExc_ValueError,
                             "cannot compute fingerprint of empty set");


### PR DESCRIPTION
This is something of a placeholder at the moment - the code is pretty much as I plan for it to be (and is based on #2253), but I'm still thinking about a good way to produce llvmlite packages for pypy that can be used to test Numba with. Some thoughts/comments:

- All this enables is compiling the C extension part of Numba on PyPy - it won't even import at the moment. Import working correctly, and more straightforward use-cases working, will be part of the following PR - this is just to try and keep the work into as small and manageable chunks as possible.
- IIRC llvmlite packages were produced on a Jenkins server internal to Continuum, and then uploaded to anaconda.org - is that still the case? If so, will it be OK to add an extra configuration to build llvmlite packages in the long term?
- The llvmlite package that's used here at the moment is created from this recipe: https://github.com/gmarkall/llvmlite/tree/pypycondarecipehack/conda-recipes/llvmlite - this recipe rolls in pip and enum34, which is not ideal. I think that I should build the pypy package again but this time make sure it includes pip and setuptools, and make a pypy-enum34 conda package. I didn't do either of these things yet because it will be a little time-consuming, and wanted to get a bit of feedback first before going ahead with trying to do that.
- libllvmlite.so for PyPy is 491MB, which seems a little excessive. Maybe I need to see why that's so big quite soon too.

All feedback / thoughts appreciated! In the meantime, I'll be trying to improve the packaging setup and fixing anything that this appears to have broken.
