### PR TITLE
Fix #2321 docs referring to non-existing function.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -373,7 +373,7 @@ Distributions
 * :func:`numpy.random.logistic`
 * :func:`numpy.random.lognormal`
 * :func:`numpy.random.logseries`
-* :func:`numpy.random.multibinomial`
+* :func:`numpy.random.multinomial`
 * :func:`numpy.random.negative_binomial`
 * :func:`numpy.random.normal`
 * :func:`numpy.random.pareto`


### PR DESCRIPTION
Fixes #2321, docs refer to `np.random.multibinomial` when they
should refer to `np.random.multinomial`.