### PR TITLE
Better handling of missing op codes

### DIFF
--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -77,8 +77,13 @@ class DataFlowAnalysis(object):
 
     def dispatch(self, info, inst):
         fname = "op_%s" % inst.opname.replace('+', '_')
-        fn = getattr(self, fname)
+        fn = getattr(self, fname, self.handle_unknown_opcode)
         fn(info, inst)
+
+    def handle_unknown_opcode(self, info, inst):
+        msg = "Use of unknown opcode {} at line {} of {}"
+        raise NotImplementedError(msg.format(inst.opname, inst.lineno,
+                                             self.bytecode.func_id.filename))
 
     def dup_topx(self, info, inst, count):
         orig = [info.pop() for _ in range(count)]

--- a/numba/tests/test_dataflow.py
+++ b/numba/tests/test_dataflow.py
@@ -81,6 +81,11 @@ def var_swapping(a, b, c, d, e):
     a, b, c, d = b, c, d, a
     return a + b + c + d +e
 
+def unsupported_op_code():
+    # needs unsupported "MAKE_FUNCTION" opcode
+    def f():
+        pass
+    return f
 
 class TestDataFlow(TestCase):
 
@@ -190,7 +195,13 @@ class TestDataFlow(TestCase):
     def test_for_break_npm(self):
         self.test_for_break(no_pyobj_flags)
 
-
+    def test_unsupported_op_code(self, flags=force_pyobj_flags):
+        pyfunc = unsupported_op_code
+        with self.assertRaises(RuntimeError) as raises:
+            cr = compile_isolated(pyfunc, (), flags=flags)
+        msg="Use of unknown opcode MAKE_FUNCTION"
+        self.assertIn(msg, str(raises.exception))
+        
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
This adds a test for the patch from @sklam (also added) that enabled the better error handling in the case of an opcode unknown to Numba being encountered. Messages now read similar to:
```
NotImplementedError: Failed at nopython (analyzing bytecode)
Use of unknown opcode THE_MISSING_OPCODE at line X of somefile.py
```
