### PR TITLE
Core changes in PR #2318

### DIFF
--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -223,7 +223,7 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
         _init()
 
         # Build wrapper for ufunc entry point
-        ptr, env = build_gufunc_wrapper(self.py_func, cres, self.sin, self.sout,
+        ptr, env, wrapper_name = build_gufunc_wrapper(self.py_func, cres, self.sin, self.sout,
                                         cache=self.cache)
 
         # Get dtypes
@@ -242,15 +242,15 @@ def build_gufunc_wrapper(py_func, cres, sin, sout, cache):
     library = cres.library
     ctx = cres.target_context
     signature = cres.signature
-    innerfunc, env = ufuncbuilder.build_gufunc_wrapper(py_func, cres, sin, sout,
+    innerfunc, env, wrapper_name = ufuncbuilder.build_gufunc_wrapper(py_func, cres, sin, sout,
                                                        cache=cache)
     sym_in = set(sym for term in sin for sym in term)
     sym_out = set(sym for term in sout for sym in term)
     inner_ndim = len(sym_in | sym_out)
 
-    ptr = build_gufunc_kernel(library, ctx, innerfunc, signature, inner_ndim)
+    ptr, name = build_gufunc_kernel(library, ctx, innerfunc, signature, inner_ndim)
 
-    return ptr, env
+    return ptr, env, name
 
 
 def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
@@ -383,7 +383,7 @@ def build_gufunc_kernel(library, ctx, innerfunc, sig, inner_ndim):
 
     wrapperlib.add_ir_module(mod)
     wrapperlib.add_linking_library(library)
-    return wrapperlib.get_pointer_to_function(lfunc.name)
+    return wrapperlib.get_pointer_to_function(lfunc.name), lfunc.name
 
 
 # ---------------------------------------------------------------------------

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -311,7 +311,7 @@ class GUFuncBuilder(_BaseUFuncBuilder):
         """
         # Buider wrapper for ufunc entry point
         signature = cres.signature
-        ptr, env = build_gufunc_wrapper(self.py_func, cres, self.sin, self.sout,
+        ptr, env, wrapper_name = build_gufunc_wrapper(self.py_func, cres, self.sin, self.sout,
                                         cache=self.cache)
 
         # Get dtypes

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -405,7 +405,7 @@ class _GufuncWrapper(object):
                 self.cache.save_overload(self.cres.signature, wrapperlib)
             # Finalize and get function pointer
             ptr = wrapperlib.get_pointer_to_function(wrapper_name)
-            return ptr, self.env
+            return ptr, self.env, wrapper_name
 
     def gen_loop_body(self, builder, pyapi, func, args):
         status, retval = self.call_conv.call_function(builder, func,


### PR DESCRIPTION
This are the core changes in #2318 to our existing files and excluding some of the very trivial changes that depends on the rest of PR #2318.  This should merge back into #2318 with no changes (the merge commit should be empty).

In "numba/targets/linalg.py", the addition of `_dummy_liveness_func` is not included because of its usage requires allocating a list object.  We should offer a better utility.