### PR TITLE
Add extra refcount pruning after inlining

### DIFF
--- a/numba/runtime/nrtdynmod.py
+++ b/numba/runtime/nrtdynmod.py
@@ -47,6 +47,8 @@ def _define_nrt_incref(module, atomic_incr):
     """
     fn_incref = module.get_or_insert_function(incref_decref_ty,
                                               name="NRT_incref")
+    # Cannot inline this for refcount pruning to work
+    fn_incref.attributes.add('noinline')
     builder = ir.IRBuilder(fn_incref.append_basic_block())
     [ptr] = fn_incref.args
     is_null = builder.icmp_unsigned("==", ptr, cgutils.get_null_value(ptr.type))
@@ -66,6 +68,8 @@ def _define_nrt_decref(module, atomic_decr):
     """
     fn_decref = module.get_or_insert_function(incref_decref_ty,
                                               name="NRT_decref")
+    # Cannot inline this for refcount pruning to work
+    fn_decref.attributes.add('noinline')
     calldtor = module.add_function(ir.FunctionType(ir.VoidType(), [_pointer_type]),
                                    name="NRT_MemInfo_call_dtor")
 

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -121,6 +121,7 @@ class CodeLibrary(object):
         Internal: optimize this library's final module.
         """
         self._codegen._mpm.run(self._final_module)
+        self._final_module = remove_redundant_nrt_refct(self._final_module)
 
     def _get_module_for_linking(self):
         """


### PR DESCRIPTION
* Fixes #2345
* Also fixes some issue with identifying basicblock and null ptr handling inside the refcount pruning pass.
* NRT_incref/NRT_decref are no longer inlined for the 2nd pruning pass to recognize them.   Noinline has little performance effect but more pruning equals big perf win.

Future works:

* The pruning pass is very inefficient as it requires string parsing.  We want to do it directly in the LLVM bitcode with reconstructing the LLVM module.

