### PR TITLE
Add random number generator support for CUDA device code

### DIFF
--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -10,6 +10,7 @@ Numba for CUDA GPUs
    device-functions.rst
    cudapysupported.rst
    intrinsics.rst
+   random.rst
    device-management.rst
    examples.rst
    simulator.rst

--- a/docs/source/cuda/random.rst
+++ b/docs/source/cuda/random.rst
@@ -17,8 +17,15 @@ sequences.  The  numba.cuda.random module provides a host function to do this,
 as well as CUDA device functions to obtain uniformly or normally distributed
 random numbers.
 
+.. note:: Numba (like cuRAND) uses the
+    `Box-Muller transform <https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform>`
+    to generate normally distributed random numbers from a uniform generator.
+    However, Box-Muller generates pairs of random numbers, and the current
+    implementation only returns one of them.  As a result, generating normally
+    distributed values is half the speed of uniformly distributed values.
+
 .. automodule:: numba.cuda.random
-    :members: create_xoroshiro128p_states, init_xoroshiro128p_states, xoroshiro128p_uniform_float32, xoroshiro128p_uniform_float64, xoroshiro128p_normal_float32, xoroshiro128p_normal_float64, 
+    :members: create_xoroshiro128p_states, init_xoroshiro128p_states, xoroshiro128p_uniform_float32, xoroshiro128p_uniform_float64, xoroshiro128p_normal_float32, xoroshiro128p_normal_float64 
     :noindex:
 
 Example

--- a/docs/source/cuda/random.rst
+++ b/docs/source/cuda/random.rst
@@ -1,0 +1,57 @@
+
+Random Number Generation
+========================
+
+Numba provides a random number generation algorithm that can be executed on
+the GPU.  Due to technical issues with how NVIDIA implemented cuRAND, however,
+Numba's GPU random number generator is not based on cuRAND.  Instead, Numba's
+GPU RNG is an implementation of the `xoroshiro128+ algorithm
+<http://xoroshiro.di.unimi.it/>`_. The xoroshiro128+ algorithm has a period of
+``2**128 - 1``, which is shorter than the period of the XORWOW algorithm
+used by default in cuRAND, but xoroshiro128+ still passes the BigCrush tests
+of random number generator quality.
+
+When using any RNG on the GPU, it is important to make sure that each thread
+has its own RNG state, and they have been initialized to produce non-overlapping
+sequences.  The  numba.cuda.random module provides a host function to do this,
+as well as CUDA device functions to obtain uniformly or normally distributed
+random numbers.
+
+.. automodule:: numba.cuda.random
+    :members: create_xoroshiro128p_states, init_xoroshiro128p_states, xoroshiro128p_uniform_float32, xoroshiro128p_uniform_float64, xoroshiro128p_normal_float32, xoroshiro128p_normal_float64, 
+    :noindex:
+
+Example
+'''''''
+
+Here is a sample program that uses the random number generator::
+
+    from __future__ import print_function, absolute_import
+
+    from numba import cuda
+    from numba.cuda.random import create_xoroshiro128p_states, xoroshiro128p_uniform_float32
+    import numpy as np
+
+    @cuda.jit
+    def compute_pi(rng_states, iterations, out):
+        """Find the maximum value in values and store in result[0]"""
+        thread_id = cuda.grid(1)
+
+        # Compute pi by drawing random (x, y) points and finding what
+        # fraction lie inside a unit circle
+        inside = 0
+        for i in range(iterations):
+            x = xoroshiro128p_uniform_float32(rng_states, thread_id)
+            y = xoroshiro128p_uniform_float32(rng_states, thread_id)
+            if x**2 + y**2 <= 1.0:
+                inside += 1
+
+        out[thread_id] = 4.0 * inside / iterations
+
+    threads_per_block = 64
+    blocks = 24
+    rng_states = create_xoroshiro128p_states(threads_per_block * blocks, seed=1)
+    out = np.zeros(threads_per_block * blocks, dtype=np.float32)
+
+    compute_pi[blocks, threads_per_block](rng_states, 10000, out)
+    print('pi:', out.mean())

--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -305,7 +305,7 @@ class FunctionIdentity(object):
             func_qualname = func.__name__
 
         self = cls()
-        self.func = pyfunc
+        self.func = func
         self.func_qualname = func_qualname
         self.func_name = func_qualname.split('.')[-1]
         self.code = code

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 import math
 
-from numba import cuda, float32, float64, int64, uint64, void, from_dtype
+from numba import cuda, float32, float64, uint32, int64, uint64, from_dtype, jit
 
 import numpy as np
 
@@ -20,20 +20,26 @@ import numpy as np
 # Splitmix64 is used to generate the initial state of the xoroshiro128+ generator
 # to ensure that small seeds don't result in predictable output.
 
+# **WARNING**: There is a lot of verbose casting in this file to ensure that NumPy
+# casting conventions (which cast uint64 [op] int32 to float64) don't turn integers
+# into floats when using these functions in the CUDA simulator.
+#
+# There are also no function type signatures to ensure that compilation is
+# deferred so that import is quick, and Sphinx autodoc works.  We are also
+# using the CPU @jit decorator everywhere to create functions that work as both
+# CPU and CUDA device functions.
 
 xoroshiro128p_dtype = np.dtype([('s0', np.uint64), ('s1', np.uint64)])
 xoroshiro128p_type = from_dtype(xoroshiro128p_dtype)
 
 
-@cuda.jit(void(xoroshiro128p_type[:], int64, uint64), device=True)
+@jit
 def init_xoroshiro128p_state(states, index, seed):
     '''Use SplitMix64 to generate an xoroshiro128p state from 64-bit seed.
 
     This ensures that manually set small seeds don't result in a predictable
     initial sequence from the random number generator 
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: uint64
@@ -41,40 +47,48 @@ def init_xoroshiro128p_state(states, index, seed):
     :type seed: int64
     :param seed: seed value to use when initializing state
     '''
-    z = seed + uint64(0x9E3779B97F4A7C15);
-    z = (z ^ (z >> 30)) * uint64(0xBF58476D1CE4E5B9)
-    z = (z ^ (z >> 27)) * uint64(0x94D049BB133111EB)
-    z = z ^ (z >> 31)
+    index = int64(index)
+    seed = uint64(seed)
+
+    z = seed + uint64(0x9E3779B97F4A7C15)
+    z = (z ^ (z >> uint32(30))) * uint64(0xBF58476D1CE4E5B9)
+    z = (z ^ (z >> uint32(27))) * uint64(0x94D049BB133111EB)
+    z = z ^ (z >> uint32(31))
 
     states[index]['s0'] = z
     states[index]['s1'] = z
 
 
-@cuda.jit('uint64(uint64, int32)', device=True)
+@jit
 def rotl(x, k):
     '''Left rotate x by k bits.'''
-    return (x << k) | (x >> (64 - k))
+    x = uint64(x)
+    k = uint32(k)
+
+    #print(type(x << k))
+    #print(type((x >> uint32(64 - k))))
+
+    return (x << k) | (x >> uint32(64 - k))
 
 
-@cuda.jit(uint64(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_next(states, index):
     '''Return the next random uint64 and advance the RNG in states[index].
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
-
+    :rtype: uint64
     '''
+    index = int64(index)
     s0 = states[index]['s0']
     s1 = states[index]['s1']
     result = s0 + s1
     
     s1 ^= s0
-    states[index]['s0'] = rotl(s0, 55) ^ s1 ^ (s1 << 14)
-    states[index]['s1'] = rotl(s1, 36)
+    states[index]['s0'] = uint64(rotl(s0, uint32(55))) ^ s1 ^ (s1 << uint32(14))
+    states[index]['s1'] = uint64(rotl(s1, uint32(36)))
     
     return result
 
@@ -82,24 +96,23 @@ def xoroshiro128p_next(states, index):
 XOROSHIRO128P_JUMP = (uint64(0xbeac0467eba5facb), uint64(0xd86b048b86aa9922))
 
 
-@cuda.jit(void(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_jump(states, index):
-    '''Advance the RNG in states[index] by 2**64 steps.
+    '''Advance the RNG in ``states[index]`` by 2**64 steps.
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
-
     '''
+    index = int64(index)
+
     s0 = uint64(0)
     s1 = uint64(0)
     
     for i in range(2):
         for b in range(64):
-            if XOROSHIRO128P_JUMP[i] & uint64(1) << b:
+            if XOROSHIRO128P_JUMP[i] & (uint64(1) << uint32(b)):
                 s0 ^= states[index]['s0']
                 s1 ^= states[index]['s1']
             xoroshiro128p_next(states, index)
@@ -108,66 +121,66 @@ def xoroshiro128p_jump(states, index):
     states[index]['s1'] = s1
 
 
-@cuda.jit('float64(uint64)', device=True)
+@jit
 def uint64_to_unit_float64(x):
     '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
-    return (x >> 11) * (float64(1) / (uint64(1) << 53))
+    x = uint64(x)
+    return (x >> uint32(11)) * (float64(1) / (uint64(1) << uint32(53)))
 
 
-@cuda.jit('float32(uint64)', device=True)
+@jit
 def uint64_to_unit_float32(x):
     '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
+    x = uint64(x)
     return float32(uint64_to_unit_float64(x))
 
 
-@cuda.jit(float32(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_uniform_float32(states, index):
-    '''Return a float32 in range [0.0, 1.0) and advance states[index].
+    '''Return a float32 in range [0.0, 1.0) and advance ``states[index]``.
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
-
+    :rtype: float32
     '''
+    index = int64(index)
     return uint64_to_unit_float32(xoroshiro128p_next(states, index))
 
 
-@cuda.jit(float64(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_uniform_float64(states, index):
-    '''Return a float64 in range [0.0, 1.0) and advance states[index].
+    '''Return a float64 in range [0.0, 1.0) and advance ``states[index]``.
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
-
+    :rtype: float64
     '''
+    index = int64(index)    
     return uint64_to_unit_float64(xoroshiro128p_next(states, index))
 
 
 TWO_PI_FLOAT32 = np.float32(2 * math.pi)
 TWO_PI_FLOAT64 = np.float64(2 * math.pi)
 
-@cuda.jit(float32(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_normal_float32(states, index):
-    '''Return a normally distributed float32 and advance states[index].
+    '''Return a normally distributed float32 and advance ``states[index]``.
 
     The return value is drawn from a Gaussian of mean=0 and sigma=1 using the
     Box-Muller transform.  This advances the RNG sequence by two steps.
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
-
+    :rtype: float32
     '''
+    index = int64(index)
+
     u1 = xoroshiro128p_uniform_float32(states, index)
     u2 = xoroshiro128p_uniform_float32(states, index)
 
@@ -177,20 +190,21 @@ def xoroshiro128p_normal_float32(states, index):
     return z0
 
 
-@cuda.jit(float64(xoroshiro128p_type[:], int64), device=True)
+@jit
 def xoroshiro128p_normal_float64(states, index):
-    '''Return a normally distributed float32 and advance states[index].
+    '''Return a normally distributed float32 and advance ``states[index]``.
 
     The return value is drawn from a Gaussian of mean=0 and sigma=1 using the
     Box-Muller transform.  This advances the RNG sequence by two steps.
 
-    Parameters
-    ----------
     :type states: 1D array, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type index: int64
     :param index: offset in states to update
+    :rtype: float64
     '''
+    index = int64(index)
+
     u1 = xoroshiro128p_uniform_float32(states, index)
     u2 = xoroshiro128p_uniform_float32(states, index)
 
@@ -200,8 +214,11 @@ def xoroshiro128p_normal_float64(states, index):
     return z0
 
 
-@cuda.jit((xoroshiro128p_type[:], uint64, uint64))
+@cuda.jit
 def init_xoroshiro128p_states_kernel(states, seed, subsequence_start):
+    seed = uint64(seed)
+    subsequence_start = uint64(subsequence_start)
+
     # Only run this with a single thread and block
     n = states.shape[0]
 
@@ -232,16 +249,10 @@ def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
     The subsequence_start parameter can be used to advance the first RNG state
     by a multiple of 2**64 steps.
 
-    Parameters
-    ----------
     :type states: 1D DeviceNDArray, dtype=xoroshiro128p_dtype
     :param states: array of RNG states
     :type seed: uint64
     :param seed: starting seed for list of generators
-
-    Returns
-    -------
-    float32 random number in range [0.0, 1.0)
     '''
     init_xoroshiro128p_states_kernel[1, 1, stream](states, seed, subsequence_start)
 
@@ -258,8 +269,6 @@ def create_xoroshiro128p_states(n, seed, subsequence_start=0, stream=0):
     The subsequence_start parameter can be used to advance the first RNG state
     by a multiple of 2**64 steps.
 
-    Parameters
-    ----------
     :type n: int
     :param n: number of RNG states to create
     :type seed: uint64
@@ -268,10 +277,6 @@ def create_xoroshiro128p_states(n, seed, subsequence_start=0, stream=0):
     :param subsequence_start: 
     :type stream: CUDA stream 
     :param stream: stream to run initialization kernel on
-
-    Returns
-    -------
-    float32 random number in range [0.0, 1.0)
     '''
     states = cuda.device_array(n, dtype=xoroshiro128p_dtype, stream=stream)
     init_xoroshiro128p_states(states, seed, subsequence_start, stream)

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -1,0 +1,266 @@
+from __future__ import print_function, absolute_import
+import math
+
+from numba import cuda, float32, float64, int64, uint64, void, from_dtype
+
+import numpy as np
+
+# This implementation is based upon the xoroshiro128+ and splitmix64 algorithms
+# described at:
+#
+#     http://xoroshiro.di.unimi.it/
+#
+# and originally implemented by David Blackman and Sebastiano Vigna.
+#
+# The implementations below are based on the C source code:
+#
+#  * http://xoroshiro.di.unimi.it/xoroshiro128plus.c
+#  * http://xoroshiro.di.unimi.it/splitmix64.c
+#
+# Splitmix64 is used to generate the initial state of the xoroshiro128+ generator
+# to ensure that small seeds don't result in predictable output.
+
+
+xoroshiro128p_dtype = np.dtype([('s0', np.uint64), ('s1', np.uint64)])
+xoroshiro128p_type = from_dtype(xoroshiro128p_dtype)
+
+
+@cuda.jit(void(xoroshiro128p_type[:], int64, uint64), device=True)
+def init_xoroshiro128p_state(states, index, seed):
+    '''Use SplitMix64 to generate an xoroshiro128p state from 64-bit seed.
+
+    This ensures that manually set small seeds don't result in a predictable
+    initial sequence from the random number generator 
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: uint64
+    :param index: offset in states to update
+    :type seed: int64
+    :param seed: seed value to use when initializing state
+    '''
+    z = seed + uint64(0x9E3779B97F4A7C15);
+    z = (z ^ (z >> 30)) * uint64(0xBF58476D1CE4E5B9)
+    z = (z ^ (z >> 27)) * uint64(0x94D049BB133111EB)
+    z = z ^ (z >> 31)
+
+    states[index]['s0'] = z
+    states[index]['s1'] = z
+
+
+@cuda.jit('uint64(uint64, int32)', device=True)
+def rotl(x, k):
+    '''Left rotate x by k bits.'''
+    return (x << k) | (x >> (64 - k))
+
+
+@cuda.jit(uint64(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_next(states, index):
+    '''Return the next random uint64 and advance the RNG in states[index].
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+
+    '''
+    s0 = states[index]['s0']
+    s1 = states[index]['s1']
+    result = s0 + s1
+    
+    s1 ^= s0
+    states[index]['s0'] = rotl(s0, 55) ^ s1 ^ (s1 << 14)
+    states[index]['s1'] = rotl(s1, 36)
+    
+    return result
+
+
+XOROSHIRO128P_JUMP = (uint64(0xbeac0467eba5facb), uint64(0xd86b048b86aa9922))
+
+
+@cuda.jit(void(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_jump(states, index):
+    '''Advance the RNG in states[index] by 2**64 steps.
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+
+    '''
+    s0 = uint64(0)
+    s1 = uint64(0)
+    
+    for i in range(2):
+        for b in range(64):
+            if XOROSHIRO128P_JUMP[i] & uint64(1) << b:
+                s0 ^= states[index]['s0']
+                s1 ^= states[index]['s1']
+            xoroshiro128p_next(states, index)
+    
+    states[index]['s0'] = s0
+    states[index]['s1'] = s1
+
+
+@cuda.jit('float64(uint64)', device=True)
+def uint64_to_unit_float64(x):
+    '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
+    return (x >> 11) * (float64(1) / (uint64(1) << 53))
+
+
+@cuda.jit('float32(uint64)', device=True)
+def uint64_to_unit_float32(x):
+    '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
+    return float32(uint64_to_unit_float64(x))
+
+
+@cuda.jit(float32(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_uniform_float32(states, index):
+    '''Return a float32 in range [0.0, 1.0) and advance states[index].
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+
+    '''
+    return uint64_to_unit_float32(xoroshiro128p_next(states, index))
+
+
+@cuda.jit(float64(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_uniform_float64(states, index):
+    '''Return a float64 in range [0.0, 1.0) and advance states[index].
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+
+    '''
+    return uint64_to_unit_float64(xoroshiro128p_next(states, index))
+
+
+TWO_PI_FLOAT32 = np.float32(2 * math.pi)
+TWO_PI_FLOAT64 = np.float64(2 * math.pi)
+
+@cuda.jit(float32(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_normal_float32(states, index):
+    '''Return a normally distributed float32 and advance states[index].
+
+    The return value is drawn from a Gaussian of mean=0 and sigma=1 using the
+    Box-Muller transform.  This advances the RNG sequence by two steps.
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+
+    '''
+    u1 = xoroshiro128p_uniform_float32(states, index)
+    u2 = xoroshiro128p_uniform_float32(states, index)
+
+    z0 = math.sqrt(-float32(2.0) * math.log(u1)) * math.cos(TWO_PI_FLOAT32 * u2)
+    # discarding second normal value
+    # z1 = math.sqrt(-float32(2.0) * math.log(u1)) * math.sin(TWO_PI_FLOAT32 * u2)
+    return z0
+
+
+@cuda.jit(float64(xoroshiro128p_type[:], int64), device=True)
+def xoroshiro128p_normal_float64(states, index):
+    '''Return a normally distributed float32 and advance states[index].
+
+    The return value is drawn from a Gaussian of mean=0 and sigma=1 using the
+    Box-Muller transform.  This advances the RNG sequence by two steps.
+
+    Parameters
+    ----------
+    :type states: 1D array, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type index: int64
+    :param index: offset in states to update
+    '''
+    u1 = xoroshiro128p_uniform_float32(states, index)
+    u2 = xoroshiro128p_uniform_float32(states, index)
+
+    z0 = math.sqrt(-float64(2.0) * math.log(u1)) * math.cos(TWO_PI_FLOAT64 * u2)
+    # discarding second normal value
+    # z1 = math.sqrt(-float64(2.0) * math.log(u1)) * math.sin(TWO_PI_FLOAT64 * u2)
+    return z0
+
+
+@cuda.jit((xoroshiro128p_type[:], uint64, uint64))
+def init_xoroshiro128p_states_kernel(states, seed, subsequence_start):
+    # Only run this with a single thread and block
+    n = states.shape[0]
+
+    if n < 1:
+        return  # assuming at least 1 state going forward
+
+    init_xoroshiro128p_state(states, 0, seed)
+
+    # advance to starting subsequence number
+    for _ in range(subsequence_start):
+        xoroshiro128p_jump(states, 0)
+
+    # populate the rest of the array
+    for i in range(1, n):
+        states[i] = states[i - 1]  # take state of previous generator
+        xoroshiro128p_jump(states, i) # and jump forward 2**64 steps
+
+
+def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
+    '''Initialize RNG states on the GPU for parallel generators.
+    
+    This intializes the RNG states 
+
+    Parameters
+    ----------
+    :type states: 1D DeviceNDArray, dtype=xoroshiro128p_dtype
+    :param states: array of RNG states
+    :type seed: uint64
+    :param seed: starting seed for list of generators
+
+    Returns
+    -------
+    float32 random number in range [0.0, 1.0)
+    '''
+    init_xoroshiro128p_states_kernel[1, 1, stream](states, seed, subsequence_start)
+
+
+def create_xoroshiro128p_states(n, seed, subsequence_start=0, stream=0):
+    '''Returns a new device array initialized for n random number generators.
+    
+    This intializes the RNG states 
+
+    Parameters
+    ----------
+    :type n: int
+    :param n: number of RNG states to create
+    :type seed: uint64
+    :param seed: starting seed for list of generators
+    :type subsequence_start: uint64
+    :param subsequence_start: 
+    :type stream: CUDA stream 
+    :param stream: stream to run initialization kernel on
+
+    Returns
+    -------
+    float32 random number in range [0.0, 1.0)
+    '''
+    states = cuda.device_array(n, dtype=xoroshiro128p_dtype, stream=stream)
+    init_xoroshiro128p_states(states, seed, subsequence_start, stream)
+    return states
+
+

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -223,7 +223,14 @@ def init_xoroshiro128p_states_kernel(states, seed, subsequence_start):
 def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
     '''Initialize RNG states on the GPU for parallel generators.
     
-    This intializes the RNG states 
+    This intializes the RNG states so that each state in the array corresponds
+    subsequences in the separated by 2**64 steps from each other in the main
+    sequence.  Therefore, as long no CUDA thread requests more than 2**64 random
+    numbers, all of the RNG states produced by this function are guaranteed to
+    be independent.
+
+    The subsequence_start parameter can be used to advance the first RNG state
+    by a multiple of 2**64 steps.
 
     Parameters
     ----------
@@ -242,7 +249,14 @@ def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
 def create_xoroshiro128p_states(n, seed, subsequence_start=0, stream=0):
     '''Returns a new device array initialized for n random number generators.
     
-    This intializes the RNG states 
+    This intializes the RNG states so that each state in the array corresponds
+    subsequences in the separated by 2**64 steps from each other in the main
+    sequence.  Therefore, as long no CUDA thread requests more than 2**64 random
+    numbers, all of the RNG states produced by this function are guaranteed to
+    be independent.
+
+    The subsequence_start parameter can be used to advance the first RNG state
+    by a multiple of 2**64 steps.
 
     Parameters
     ----------

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -30,7 +30,7 @@ import numpy as np
 # using the CPU @jit decorator everywhere to create functions that work as
 # both CPU and CUDA device functions.
 
-xoroshiro128p_dtype = np.dtype([('s0', np.uint64), ('s1', np.uint64)])
+xoroshiro128p_dtype = np.dtype([('s0', np.uint64), ('s1', np.uint64)], align=True)
 xoroshiro128p_type = from_dtype(xoroshiro128p_dtype)
 
 

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -1,0 +1,94 @@
+from __future__ import print_function, division, absolute_import
+
+import math
+
+import numpy as np
+
+from numba import cuda, config, float32
+from numba.cuda.testing import unittest
+import numba.cuda.random
+
+# Distributions
+UNIFORM = 1
+NORMAL = 2
+
+
+@cuda.jit
+def rng_kernel_float32(states, out, count, distribution):
+    thread_id = cuda.grid(1)
+
+    for i in range(count):
+        if distribution == UNIFORM:
+            out[thread_id * count + i] = cuda.random.xoroshiro128p_uniform_float32(states, thread_id)
+        elif distribution == NORMAL:
+            out[thread_id * count + i] = cuda.random.xoroshiro128p_normal_float32(states, thread_id)
+
+
+@cuda.jit
+def rng_kernel_float64(states, out, count, distribution):
+    thread_id = cuda.grid(1)
+    nthreads = cuda.gridsize(1)
+
+    for i in range(count):
+        if distribution == UNIFORM:
+            out[thread_id * count + i] = cuda.random.xoroshiro128p_uniform_float64(states, thread_id)
+        elif distribution == NORMAL:
+            out[thread_id * count + i] = cuda.random.xoroshiro128p_normal_float64(states, thread_id)
+
+
+class TestCudaRandomXoroshiro128p(unittest.TestCase):
+    def test_create(self):
+        states = cuda.random.create_xoroshiro128p_states(10, seed=1)
+        s = states.copy_to_host()
+        self.assertEqual(len(np.unique(s)), 10)
+
+    def test_create_subsequence_start(self):
+        states = cuda.random.create_xoroshiro128p_states(10, seed=1)
+        s1 = states.copy_to_host()
+
+        states = cuda.random.create_xoroshiro128p_states(10, seed=1,
+            subsequence_start=3)
+        s2 = states.copy_to_host()
+
+        # Starting seeds should match up with offset of 3
+        np.testing.assert_array_equal(s1[3:], s2[:-3])
+
+    def test_create_stream(self):
+        stream = cuda.stream()
+        states = cuda.random.create_xoroshiro128p_states(10, seed=1, stream=stream)
+        s = states.copy_to_host()
+        self.assertEqual(len(np.unique(s)), 10)
+
+    def check_uniform(self, kernel_func, dtype):
+        states = cuda.random.create_xoroshiro128p_states(64*10, seed=1)
+        out = np.zeros(10 * 64 * 128, dtype=np.float32)
+
+        kernel_func[10, 64](states, out, 128, UNIFORM)
+        self.assertAlmostEqual(out.min(), 0.0, places=4)
+        self.assertAlmostEqual(out.max(), 1.0, places=4)
+        self.assertAlmostEqual(out.mean(), 0.5, places=3)
+        self.assertAlmostEqual(out.std(), 1.0/(2*math.sqrt(3)), places=3)
+
+    def test_uniform_float32(self):
+        self.check_uniform(rng_kernel_float32, np.float32)
+
+    def test_uniform_float64(self):
+        self.check_uniform(rng_kernel_float64, np.float64)
+
+    def check_normal(self, kernel_func, dtype):
+        states = cuda.random.create_xoroshiro128p_states(64 * 10, seed=1)
+        out = np.zeros(10 * 64 * 128, dtype=dtype)
+
+        kernel_func[10, 64](states, out, 128, NORMAL)
+
+        self.assertAlmostEqual(out.mean(), 0.0, places=2)
+        self.assertAlmostEqual(out.std(), 1.0, places=2)
+
+    def test_normal_float32(self):
+        self.check_normal(rng_kernel_float32, np.float32)
+
+    def test_normal_float32(self):
+        self.check_normal(rng_kernel_float64, np.float64)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -7,6 +7,12 @@ import numpy as np
 from numba import cuda, config, float32
 from numba.cuda.testing import unittest
 import numba.cuda.random
+from numba.cuda.testing import skip_on_cudasim
+
+from numba.cuda.random import \
+    xoroshiro128p_uniform_float32, xoroshiro128p_normal_float32, \
+    xoroshiro128p_uniform_float64, xoroshiro128p_normal_float64
+
 
 # Distributions
 UNIFORM = 1
@@ -19,21 +25,20 @@ def rng_kernel_float32(states, out, count, distribution):
 
     for i in range(count):
         if distribution == UNIFORM:
-            out[thread_id * count + i] = cuda.random.xoroshiro128p_uniform_float32(states, thread_id)
+            out[thread_id * count + i] = xoroshiro128p_uniform_float32(states, thread_id)
         elif distribution == NORMAL:
-            out[thread_id * count + i] = cuda.random.xoroshiro128p_normal_float32(states, thread_id)
+            out[thread_id * count + i] = xoroshiro128p_normal_float32(states, thread_id)
 
 
 @cuda.jit
 def rng_kernel_float64(states, out, count, distribution):
     thread_id = cuda.grid(1)
-    nthreads = cuda.gridsize(1)
 
     for i in range(count):
         if distribution == UNIFORM:
-            out[thread_id * count + i] = cuda.random.xoroshiro128p_uniform_float64(states, thread_id)
+            out[thread_id * count + i] = xoroshiro128p_uniform_float64(states, thread_id)
         elif distribution == NORMAL:
-            out[thread_id * count + i] = cuda.random.xoroshiro128p_normal_float64(states, thread_id)
+            out[thread_id * count + i] = xoroshiro128p_normal_float64(states, thread_id)
 
 
 class TestCudaRandomXoroshiro128p(unittest.TestCase):
@@ -60,34 +65,36 @@ class TestCudaRandomXoroshiro128p(unittest.TestCase):
         self.assertEqual(len(np.unique(s)), 10)
 
     def check_uniform(self, kernel_func, dtype):
-        states = cuda.random.create_xoroshiro128p_states(64*10, seed=1)
-        out = np.zeros(10 * 64 * 128, dtype=np.float32)
+        states = cuda.random.create_xoroshiro128p_states(32 * 2, seed=1)
+        out = np.zeros(2 * 32 * 32, dtype=np.float32)
 
-        kernel_func[10, 64](states, out, 128, UNIFORM)
-        self.assertAlmostEqual(out.min(), 0.0, places=4)
-        self.assertAlmostEqual(out.max(), 1.0, places=4)
-        self.assertAlmostEqual(out.mean(), 0.5, places=3)
-        self.assertAlmostEqual(out.std(), 1.0/(2*math.sqrt(3)), places=3)
+        kernel_func[2, 32](states, out, 32, UNIFORM)
+        self.assertAlmostEqual(out.min(), 0.0, delta=1e-3)
+        self.assertAlmostEqual(out.max(), 1.0, delta=1e-3)
+        self.assertAlmostEqual(out.mean(), 0.5, delta=1.5e-2)
+        self.assertAlmostEqual(out.std(), 1.0/(2*math.sqrt(3)), delta=6e-3)
 
     def test_uniform_float32(self):
         self.check_uniform(rng_kernel_float32, np.float32)
 
+    @skip_on_cudasim('skip test for speed under cudasim')
     def test_uniform_float64(self):
         self.check_uniform(rng_kernel_float64, np.float64)
 
     def check_normal(self, kernel_func, dtype):
-        states = cuda.random.create_xoroshiro128p_states(64 * 10, seed=1)
-        out = np.zeros(10 * 64 * 128, dtype=dtype)
+        states = cuda.random.create_xoroshiro128p_states(32 * 2, seed=1)
+        out = np.zeros(2 * 32 * 32, dtype=dtype)
 
-        kernel_func[10, 64](states, out, 128, NORMAL)
+        kernel_func[2, 32](states, out, 32, NORMAL)
 
-        self.assertAlmostEqual(out.mean(), 0.0, places=2)
-        self.assertAlmostEqual(out.std(), 1.0, places=2)
+        self.assertAlmostEqual(out.mean(), 0.0, delta=4e-3)
+        self.assertAlmostEqual(out.std(), 1.0, delta=2e-3)
 
     def test_normal_float32(self):
         self.check_normal(rng_kernel_float32, np.float32)
 
-    def test_normal_float32(self):
+    @skip_on_cudasim('skip test for speed under cudasim')
+    def test_normal_float64(self):
         self.check_normal(rng_kernel_float64, np.float64)
 
 if __name__ == '__main__':

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -450,6 +450,7 @@ class Dispatcher(_DispatcherBase):
     # A {uuid -> instance} mapping, for deserialization
     _memo = weakref.WeakValueDictionary()
     __uuid = None
+    __numba__ = 'py_func'
 
     def __init__(self, py_func, locals={}, targetoptions={}, impl_kind='direct'):
         """


### PR DESCRIPTION
Adds a new `numba.cuda.random` module which implements the xoroshiro128+ RNG.  This seems to be the simplest high quality RNG available, and only requires a 128 bit state vector.

Edit: autodoc issues fixed