### PR TITLE
Fix refct pruning not removing refct op with tail call.

### DIFF
--- a/numba/runtime/nrtopt.py
+++ b/numba/runtime/nrtopt.py
@@ -7,22 +7,12 @@ from collections import defaultdict, deque
 import numba.llvmthreadsafe as llvmts
 
 
-_regex_incref = re.compile(r'\s*call void @NRT_incref\((.*)\)')
-_regex_decref = re.compile(r'\s*call void @NRT_decref\((.*)\)')
+_regex_incref = re.compile(r'\s*(?:tail)?\s*call void @NRT_incref\((.*)\)')
+_regex_decref = re.compile(r'\s*(?:tail)?\s*call void @NRT_decref\((.*)\)')
 _regex_bb = re.compile(r'([\'"]?[-a-zA-Z$._][-a-zA-Z$._0-9]*[\'"]?:)|^define')
 
 
-def remove_redundant_nrt_refct(ll_module):
-    """
-    Remove redundant reference count operations from the
-    `llvmlite.binding.ModuleRef`. This parses the ll_module as a string and
-    line by line to remove the unnecessary nrt refct pairs within each block.
-    Decref calls are moved after the last incref call in the block to avoid
-    temporarily decref'ing to zero (which can happen due to hidden decref from
-    alias).
-
-    Note: non-threadsafe due to usage of global LLVMcontext
-    """
+def _remove_redundant_nrt_refct(llvmir):
     # Note: As soon as we have better utility in analyzing materialized LLVM
     #       module in llvmlite, we can redo this without so much string
     #       processing.
@@ -144,19 +134,34 @@ def remove_redundant_nrt_refct(ll_module):
         # insert decrefs at last_pos
         return head + decrefs + bb_lines[last_pos:]
 
+    # Driver
+    processed = []
+
+    for is_func, lines in _extract_functions(llvmir):
+        if is_func:
+            lines = _process_function(lines)
+
+        processed += lines
+
+    return '\n'.join(processed)
+
+
+def remove_redundant_nrt_refct(ll_module):
+    """
+    Remove redundant reference count operations from the
+    `llvmlite.binding.ModuleRef`. This parses the ll_module as a string and
+    line by line to remove the unnecessary nrt refct pairs within each block.
+    Decref calls are moved after the last incref call in the block to avoid
+    temporarily decref'ing to zero (which can happen due to hidden decref from
+    alias).
+
+    Note: non-threadsafe due to usage of global LLVMcontext
+    """
     # Early escape if NRT_incref is not used
     try:
         ll_module.get_function('NRT_incref')
     except NameError:
         return ll_module
 
-    processed = []
-
-    for is_func, lines in _extract_functions(ll_module):
-        if is_func:
-            lines = _process_function(lines)
-
-        processed += lines
-
-    newll = '\n'.join(processed)
+    newll = _remove_redundant_nrt_refct(str(ll_module))
     return llvmts.parse_assembly(newll)


### PR DESCRIPTION
Also, add test to check refct pruning behavior.

(Followup to #2346)

More notes:
I slightly refactored the `remove_redundant_nrt_refct` so that it is easier to test with a string input.