### PR TITLE
Handle when get_host_cpu_features() raises RuntimeError

### DIFF
--- a/numba/numba_entry.py
+++ b/numba/numba_entry.py
@@ -32,11 +32,16 @@ def get_sys_info():
         print("__Hardware Information__")
         print(fmt % ("Machine", platform.machine()))
         print(fmt % ("CPU Name", llvmbind.get_host_cpu_name()))
-        features = sorted(
-            [key for key, value in llvmbind.get_host_cpu_features().items() if value])
-        cpu_feat = tw.fill(' '.join(features), 80)
-        print(fmt % ("CPU Features", ""))
-        print(cpu_feat)
+        try:
+            featuremap = llvmbind.get_host_cpu_features()
+        except RuntimeError:
+            print(fmt % ("CPU Features", "NA"))
+        else:
+            features = sorted([key for key, value in featuremap.items()
+                               if value])
+            cpu_feat = tw.fill(' '.join(features), 80)
+            print(fmt % ("CPU Features", ""))
+            print(cpu_feat)
         print("")
 
         print("__OS Information__")

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -721,16 +721,19 @@ class JITCPUCodegen(BaseCPUCodegen):
 
     def _customize_tm_features(self):
         # For JIT target, we will use LLVM to get the feature map
-        features = ll.get_host_cpu_features()
+        try:
+            features = ll.get_host_cpu_features()
+        except RuntimeError:
+            return ''
+        else:
+            if not config.ENABLE_AVX:
+                # Disable all features with name starting with 'avx'
+                for k in features:
+                    if k.startswith('avx'):
+                        features[k] = False
 
-        if not config.ENABLE_AVX:
-            # Disable all features with name starting with 'avx'
-            for k in features:
-                if k.startswith('avx'):
-                    features[k] = False
-
-        # Set feature attributes
-        return features.flatten()
+            # Set feature attributes
+            return features.flatten()
 
     def _add_module(self, module):
         self._engine.add_module(module)


### PR DESCRIPTION
due to LLVM unable to retrieve cpu features.