### PR TITLE
Fixes an issue with caching when function needs NRT and refcount pruning

### DIFF
--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -75,8 +75,6 @@ class CodeLibrary(object):
         self._final_module = llvmts.parse_assembly(
             str(self._codegen._create_empty_module(self._name)))
         self._final_module.name = cgutils.normalize_ir_text(self._name)
-        # Remember this on the module, for the object cache hooks
-        self._final_module.__library = weakref.proxy(self)
         self._shared_module = None
         # Track names of the dynamic globals
         self._dynamic_globals = []
@@ -240,6 +238,9 @@ class CodeLibrary(object):
         """
         Make the underlying LLVM module ready to use.
         """
+        # Remember this on the module, for the object cache hooks
+        self._final_module.__library = weakref.proxy(self)
+
         # It seems add_module() must be done only here and not before
         # linking in other modules, otherwise get_pointer_to_function()
         # could fail.

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -726,6 +726,20 @@ class TestCache(BaseCacheTest):
         # Check the code runs ok from another process
         self.run_in_separate_process()
 
+    @tag('important')
+    def test_caching_nrt_pruned(self):
+        self.check_pycache(0)
+        mod = self.import_module()
+        self.check_pycache(0)
+
+        f = mod.add_usecase
+        self.assertPreciseEqual(f(2, 3), 6)
+        self.check_pycache(2)  # 1 index, 1 data
+        # NRT pruning may affect cache
+        self.assertPreciseEqual(f(2, np.arange(3)), 2 + np.arange(3) + 1)
+        self.check_pycache(3)  # 1 index, 2 data
+        self.check_hits(f, 0, 2)
+
     def test_inner_then_outer(self):
         # Caching inner then outer function is ok
         mod = self.import_module()


### PR DESCRIPTION
The fix is to move object cache hook to finalization.
The `_final_module` at may have been changed to an different object by nrt refcount pruning.