### PR TITLE
Fix #2356 fragile test that depends on how the script is executed.

### DIFF
--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -522,7 +522,9 @@ class TestDispatcherMethods(TestCase):
             # simple stringify test
             if wrapper:
                 wrapper = "{}{}".format(len(wrapper), wrapper)
-            prefix = r'^digraph "CFG for \'_ZN{}5numba'.format(wrapper)
+            module_name = __name__.split('.', 1)[0]
+            module_len = len(module_name)
+            prefix = r'^digraph "CFG for \'_ZN{}{}{}'.format(wrapper, module_len, module_name)
             self.assertRegexpMatches(str(cfg), prefix)
             # .display() requires an optional dependency on `graphviz`.
             # just test for the attribute without running it.


### PR DESCRIPTION
The fix is to grab the module name from `__name__`.