### PR TITLE
Fixed nogil example that threw a TypeError when executed.

### DIFF
--- a/examples/nogil.py
+++ b/examples/nogil.py
@@ -9,7 +9,7 @@ import numpy as np
 from numba import jit
 
 nthreads = 4
-size = 1e6
+size = 10**6
 
 def func_np(a, b):
     """


### PR DESCRIPTION
The example threw a

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-ae572e7c31ab> in <module>()
     78 func_nb_mt = make_multithread(inner_func_nb, nthreads)
     79 
---> 80 a = np.random.rand(size)
     81 b = np.random.rand(size)
     82 

mtrand.pyx in mtrand.RandomState.rand (numpy\random\mtrand\mtrand.c:19701)()

mtrand.pyx in mtrand.RandomState.random_sample (numpy\random\mtrand\mtrand.c:15527)()

mtrand.pyx in mtrand.cont0_array (numpy\random\mtrand\mtrand.c:6127)()

TypeError: 'float' object cannot be interpreted as an integer
```

because the `size = 1e6` is a float. 