### PR TITLE
New GPU reduction algorithm

### DIFF
--- a/numba/cuda/kernels/reduction.py
+++ b/numba/cuda/kernels/reduction.py
@@ -3,7 +3,6 @@ A library written in CUDA Python for generating reduction kernels
 """
 from __future__ import division
 
-from numba import cuda
 from numba.numpy_support import from_dtype
 
 
@@ -12,6 +11,8 @@ _NUMWARPS = 4
 
 
 def _gpu_reduce_factory(fn, nbtype):
+    from numba import cuda
+
     reduce_op = cuda.jit(device=True)(fn)
     inner_sm_size = _WARPSIZE + 1   # plus one to avoid SM collision
     max_blocksize = _NUMWARPS * _WARPSIZE
@@ -206,6 +207,8 @@ class Reduce(object):
         :return: If ``res`` is specified, ``None`` is returned. Otherwise, the
                 result of the reduction is returned.
         """
+        from numba import cuda
+
         # ensure 1d array
         if arr.ndim != 1:
             raise TypeError("only support 1D array")

--- a/numba/cuda/kernels/reduction.py
+++ b/numba/cuda/kernels/reduction.py
@@ -1,287 +1,165 @@
 """
 A library written in CUDA Python for generating reduction kernels
 """
-from __future__ import print_function, division, absolute_import
-from functools import reduce
-import math
+from __future__ import division
+
+from numba import cuda
 from numba.numpy_support import from_dtype
-from numba.types import uint32, intp
 
-# This implementations is based on patterns described in "Optimizing Parallel
-# Reduction In CUDA" by Mark Harris:
-# http://developer.download.nvidia.com/compute/cuda/1.1-Beta/x86_website/projects/reduction/doc/reduction.pdf
-# - sections of this document are referred to throughout this code.
-#
-# In this implementation, a tree-based approach to performing the reduction in
-# parallel is taken, with threads in one block co-operating to reduce a
-# sub-vector into a single value. Each block's partial reduction result is
-# written out to produce a vector of partially-reduced results. Reduction
-# kernels are invoked repeatedly until the remaining vector of partially-reduced
-# results contains 16 or fewer elements, at which point the vector of partial
-# results is transferred to the CPU for a final reduction to a single value.
-#
-# NOTE: This transfer of to the CPU for the final reduction is not an optimal
-# strategy, as it required a roundtrip transferring data between the CPU and GPU
-# when the reduction forms part of a set of operations on data on the GPU.
-# Remedying this by performing the final reduction on the GPU is a TODO item -
-# see https://github.com/numba/numba/issues/1407
 
-def reduction_template(binop, typ, blocksize):
-    """
-    Returns a kernel that performs a partial reduction. This implementation is
-    similar to that shown in the section "Reduction #6" of "Optimizing Parallel
-    Reduction in CUDA" by Mark Harris.
+_WARPSIZE = 32
+_NUMWARPS = 4
 
-    Args
-    ----
-    binop : function object
-        A binary function as the reduction operation
-    typ : numba type
-        The numba type to the reduction operation
-    blocksize : int
-        The CUDA block size (thread per block)
-    """
-    from numba import cuda
 
-    # Ensure that there is enough shared memory for smaller block sizes
-    sdatasize = max(blocksize, 64)
+def _gpu_reduce_factory(fn, nbtype):
+    reduce_op = cuda.jit(device=True)(fn)
+    inner_sm_size = _WARPSIZE + 1   # plus one to avoid SM collision
+    max_blocksize = _NUMWARPS * _WARPSIZE
 
-    if blocksize > 512:
-        # The reducer implementation is limited to 512 threads per block. This
-        # is not an issue in practice, since the reduction function does not
-        # instantiate this template with a blocksize greater than 512.
-        raise ValueError("blocksize too big")
-
-    # Compile binary operation as device function
-    binop = cuda.jit((typ, typ), device=True)(binop)
-
-    # Compile reducer
-    @cuda.jit((typ[:], typ[:], intp, intp))
-    def reducer(inp, out, nelem, ostride):
+    @cuda.jit(device=True)
+    def inner_warp_reduction(sm_partials, init):
         tid = cuda.threadIdx.x
-        i = cuda.blockIdx.x * (blocksize * 2) + tid
-        gridSize = blocksize * 2 * cuda.gridDim.x
+        warpid = tid // _WARPSIZE
+        laneid = tid % _WARPSIZE
 
-        # Blocks perform most of the reduction within shared memory, in the
-        # sdata array
-        sdata = cuda.shared.array(sdatasize, dtype=typ)
+        sm_this = sm_partials[warpid, :]
+        sm_this[laneid] = init
+        # XXX expect warp synchronization
+        width = _WARPSIZE // 2
+        while width:
+            if laneid < width:
+                old = sm_this[laneid]
+                sm_this[laneid] = reduce_op(old, sm_this[laneid + width])
+            width //= 2
+            # XXX expect warp synchronization
 
-        # The first reduction operation is performed during the process of
-        # loading the data from global memory, in order to reduce the number of
-        # idle threads (See "Reduction #4: First Add During Load")
-        while i < nelem:
-            sdata[tid] = binop(inp[i], inp[i + blocksize])
-            i += gridSize
+    @cuda.jit(device=True)
+    def device_reduce_full_block(arr, partials, sm_partials):
+        """
+        A device function that computes reduction in the current block.
+        """
+        tid = cuda.threadIdx.x
+        blkid = cuda.blockIdx.x
+        blksz = cuda.blockDim.x
+        gridsz = cuda.gridDim.x
 
-        # The following reduction steps rely on all values being loaded into
-        # sdata; we need to synchronize in order to meet this condition
+        # block strided loop to compute the reduction
+        start = tid + blksz * blkid
+        stop = arr.size
+        step = blksz * gridsz
+
+        # load first value
+        tmp = arr[start]
+        for i in range(start + step, stop, step):
+            tmp = reduce_op(tmp, arr[i])
+
+        cuda.syncthreads()
+        # inner-warp reduction
+        inner_warp_reduction(sm_partials, tmp)
+
+        cuda.syncthreads()
+        # at this point, only the first slot for each warp in tsm_partials
+        # is valid.
+
+        # finish up block reduction
+        # warning: this is assuming 4 warps.
+        # assert numwarps == 4
+        if tid < 2:
+            sm_partials[tid, 0] = reduce_op(sm_partials[tid, 0],
+                                            sm_partials[tid + 2, 0])
+        if tid == 0:
+            partials[blkid] = reduce_op(sm_partials[0, 0], sm_partials[1, 0])
+
+    @cuda.jit(device=True)
+    def device_reduce_partial_block(arr, partials, sm_partials):
+        # MUST only have 1 block and all threads global-load exactly once
+        tid = cuda.threadIdx.x
+        blkid = cuda.blockIdx.x
+        blksz = cuda.blockDim.x
+        warpid = tid // _WARPSIZE
+        laneid = tid % _WARPSIZE
+
+        size = arr.size
+        # load first value
+        tid = cuda.threadIdx.x
+        value = arr[tid]
+        sm_partials[warpid, laneid] = value
+
         cuda.syncthreads()
 
-        # The following lines implement an unrolled loop that repeatedly reduces
-        # the number of values by two (by performing the reduction operation)
-        # until only a single value is left. This is done to reduce instruction
-        # overhead (See the section "Instruction Bottleneck")
-        if blocksize >= 512:
-            if tid < 256:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 256])
-                cuda.syncthreads()
+        if (warpid + 1) * _WARPSIZE < size:
+            # fully populated warps
+            inner_warp_reduction(sm_partials, value)
+        else:
+            # partially populated warps
+            # NOTE: this uses a very inefficient sequential algorithm
+            if laneid == 0:
+                sm_this = sm_partials[warpid, :]
+                base = warpid * _WARPSIZE
+                for i in range(1, size - base):
+                    sm_this[0] = reduce_op(sm_this[0], sm_this[i])
 
-        if blocksize >= 256:
-            if tid < 128:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 128])
-                cuda.syncthreads()
-
-        if blocksize >= 128:
-            if tid < 64:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 64])
-                cuda.syncthreads()
-
-        # At this point only the first warp has any work to do - we perform a
-        # check on the thread ID here so that we can avoid calling syncthreads
-        # (operations are synchronous within a warp) and also to avoid checking
-        # the thread ID at each iteration (See the section "Unrolling the Last
-        # Warp)
-        if tid < 32:
-            if blocksize >= 64:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 32])
-            if blocksize >= 32:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 16])
-            if blocksize >= 16:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 8])
-            if blocksize >= 8:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 4])
-            if blocksize >= 4:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 2])
-            if blocksize >= 2:
-                sdata[tid] = binop(sdata[tid], sdata[tid + 1])
-
-        # Write this block's partially reduced value into the vector of all
-        # partially-reduced values.
+        cuda.syncthreads()
+        # finish up
         if tid == 0:
-            out[cuda.blockIdx.x * ostride] = sdata[0]
+            num_active_warps = (blksz + _WARPSIZE - 1) // _WARPSIZE
 
-    # Return reducer
-    return reducer
+            result = sm_partials[0, 0]
+            for i in range(1, num_active_warps):
+                result = reduce_op(result, sm_partials[i, 0])
 
+            partials[blkid] = result
 
-_get_copy_strides_kernel_cache = None
+    def gpu_reduce_block_strided(arr, partials, init, use_init):
+        """
+        Perform reductions on *arr* and writing out partial reduction result
+        into *partials*.  The length of *partials* is determined by the
+        number of threadblocks. The initial value is set with *init*.
 
+        Launch config:
 
-def _get_copy_strides_kernel():
-    # Partial reduction kernels write their output strided - this kernel is
-    # used to copy the strided output to a compacted array which can be used
-    # as input to the next kernel.
-    from numba import cuda
+        Blocksize must be mutiple of warpsize and it is limited to 4 warps.
+        """
+        tid = cuda.threadIdx.x
 
-    global _get_copy_strides_kernel_cache
+        sm_partials = cuda.shared.array((_NUMWARPS, inner_sm_size),
+                                        dtype=nbtype)
+        if cuda.blockDim.x == max_blocksize:
+            device_reduce_full_block(arr, partials, sm_partials)
+        else:
+            device_reduce_partial_block(arr, partials, sm_partials)
+        # deal with the initializer
+        if use_init and tid == 0 and cuda.blockIdx.x == 0:
+            partials[0] = reduce_op(partials[0], init)
 
-    if _get_copy_strides_kernel_cache is None:
-        @cuda.jit
-        def copy_strides(arr, n, stride, tpb):
-            sm = cuda.shared.array(1, dtype=uint32)
-            i = cuda.threadIdx.x
-            base = 0
-            if i == 0:
-                sm[0] = 0
-
-            val = arr[0]
-            while base < n:
-                idx = base + i
-                if idx < n:
-                    val = arr[idx * stride]
-
-                cuda.syncthreads()
-
-                if base + i < n:
-                    arr[sm[0] + i] = val
-
-                if i == 0:
-                    sm[0] += tpb
-
-                base += tpb
-
-        _get_copy_strides_kernel_cache = copy_strides
-
-    return _get_copy_strides_kernel_cache
+    return cuda.jit(gpu_reduce_block_strided)
 
 
 class Reduce(object):
-    # The reduction kernels are precompiled for all block sizes at the time when
-    # the reduction operation is first called. A single reduction can use
-    # multiple kernels specialized for different sizes. These compiled kernels
-    # are cached inside the ``Reduce`` instance that created them.
-    #
-    # Keeping the instance alive can avoid re-compiling.
+    _cache = {}
 
-    def __init__(self, binop):
+    def __init__(self, functor):
         """Create a reduction object that reduces values using a given binary
         function. The binary function is compiled once and cached inside this
         object. Keeping this object alive will prevent re-compilation.
 
         :param binop: A function to be compiled as a CUDA device function that
-                      will be used as the binary operation for reduction on a
-                      CUDA device. Internally, it is compiled using
-                      ``cuda.jit(signature, device=True)``.
+                    will be used as the binary operation for reduction on a
+                    CUDA device. Internally, it is compiled using
+                    ``cuda.jit(signature, device=True)``.
         """
-        self._kernels = {}
-        self._cached_types = set()
-        self._binop = binop
+        self._functor = functor
 
-    def _get_kernel(self, size, nbtype):
-        blocksize = min(size // 2, 512)
-        key = nbtype, blocksize
-        return self._kernels[key], blocksize * 2
+    def _compile(self, dtype):
+        key = self._functor, dtype
+        if key in self._cache:
+            kernel = self._cache[key]
+        else:
+            kernel = _gpu_reduce_factory(self._functor, from_dtype(dtype))
+            self._cache[key] = kernel
+        return kernel
 
-    def _type_and_size(self, dary, size):
-        nbtype = from_dtype(dary.dtype)
-
-        if size is None:
-            # Use the array size if the `size` is not defined
-            size = dary.size
-
-        if size > dary.size:
-            raise ValueError("size > array.size")
-
-        return nbtype, size
-
-    def _execute_reduction(self, dary, size, stream, init=0):
-
-        from numba import cuda
-
-        nbtype, size = self._type_and_size(dary, size)
-        copy_strides = _get_copy_strides_kernel()
-
-        # The reduction is split into multiple steps, because each block writes
-        # a partial result out, which cannot be used as input to other blocks
-        # within the same kernel launch because this would require a global
-        # synchronization. The global synchronization takes place between kernel
-        # launches. See the section "Problem: Global Synchronization".
-        while size >= 2:
-            # Find the closest size that is power of two, and the remainder
-            p2size = 2 ** int(math.log(size, 2))
-            diffsize = size - p2size
-
-            # Generate a kernel to reduce the first p2size elements
-            kernel, blocksize = self._get_kernel(p2size, nbtype)
-            size = p2size
-            gridsize = size // blocksize
-            assert gridsize <= p2size
-            if gridsize > 0:
-                worksize = blocksize * gridsize
-                blocksize = blocksize // 2
-                assert size - worksize == 0
-                # The reduction kernel stores its result in the first element of
-                # its assigned sub-vector
-                kernel[gridsize, blocksize, stream](dary, dary, worksize,
-                                                    blocksize)
-                # Make the partial results contiguous by copying them to the
-                # beginning of the vector
-                copy_strides[1, 512, stream](dary, gridsize, blocksize, 512)
-                # New size is gridsize, because there are exactly as many
-                # elements remaining as there were thread blocks.
-                size = gridsize
-
-            # Compact any leftover elements beyond the p2size-th element of the
-            # input vector by appending them to the contiguous vector of partial
-            # results from the reduction kernel.
-            if diffsize > 0:
-                itemsize = dary.dtype.itemsize
-                dst = dary.gpu_data.view(size * itemsize)
-                src = dary.gpu_data.view(p2size * itemsize)
-                cuda.driver.device_to_device(dst, src, diffsize * itemsize,
-                                             stream=stream)
-                size += diffsize
-
-        # Finalise reduction with initial value if necessary
-        if init != 0:
-            kernel, _ = self._get_kernel(0, nbtype)
-            kernel(dary, init)
-
-    def _precompile_kernels(self, nbtype):
-        from numba import cuda
-
-        # Compile the reduction template for all required block sizes. See the
-        # section "Invoking Template Kernels"
-        if nbtype not in self._cached_types:
-            for blocksize in (1, 2, 4, 8, 16, 32, 64, 128, 256, 512):
-                key = nbtype, blocksize
-                self._kernels[key] = reduction_template(self._binop, nbtype,
-                                                        blocksize)
-
-            # Precompile the kernel for reducing with the initial value. We use
-            # a block size of 0 as a placeholder for the reduction with the
-            # initial value.
-            binop = cuda.jit((nbtype, nbtype), device=True)(self._binop)
-
-            @cuda.jit((nbtype[:], nbtype))
-            def reduction_finish(arr, init):
-                arr[0] = binop(arr[0], init)
-
-            self._kernels[nbtype, 0] = reduction_finish
-
-            self._cached_types.add(nbtype)
-
-    def __call__(self, arr, res=None, size=None, init=0, stream=0):
+    def __call__(self, arr, size=None, res=None, init=0, stream=0):
         """Performs a full reduction.
 
         :param arr: A host or device array. If a device array is given, the
@@ -289,42 +167,70 @@ class Reduce(object):
                     are overwritten. If a host array is given, it is copied to
                     the device automatically.
         :param size: Optional integer specifying the number of elements in
-                     ``arr`` to reduce. If this parameter is not specified, the
-                     entire array is reduced.
+                    ``arr`` to reduce. If this parameter is not specified, the
+                    entire array is reduced.
         :param res: Optional device array into which to write the reduction
                     result to. The result is written into the first element of
                     this array. If this parameter is specified, then no
                     communication of the reduction output takes place from the
                     device to the host.
         :param init: Optional initial value for the reduction, the type of which
-                     must match ``arr.dtype``.
+                    must match ``arr.dtype``.
         :param stream: Optional CUDA stream in which to perform the reduction.
-                       If no stream is specified, the default stream of 0 is
-                       used.
+                    If no stream is specified, the default stream of 0 is
+                    used.
         :return: If ``res`` is specified, ``None`` is returned. Otherwise, the
-                 result of the reduction is returned.
+                result of the reduction is returned.
         """
-        from numba import cuda
-
+        # ensure 1d array
         if arr.ndim != 1:
             raise TypeError("only support 1D array")
 
-        # Avoid computation for zero-length input
-        if (size is not None and size == 0) or (arr.size == 0):
-            if res is None:
-                return init
-            else:
-                res[0] = init
-                return None
+        # adjust array size
+        if size is not None:
+            arr = arr[:size]
 
-        darr, _ = cuda.devicearray.auto_device(arr, stream=stream)
-        nbtype = from_dtype(arr.dtype)
-        self._precompile_kernels(nbtype)
-        self._execute_reduction(darr, size, stream, init=init)
+        init = arr.dtype.type(init)  # ensure the right type
 
-        if res is None:
-            return darr[0]
+        # return `init` if `arr` is empty
+        if arr.size < 1:
+            return init
+
+        kernel = self._compile(arr.dtype)
+
+        # Perform the reduction on the GPU
+        blocksize = _NUMWARPS * _WARPSIZE
+        size_full = (arr.size // blocksize) * blocksize
+        size_partial = arr.size - size_full
+        full_blockct = min(size_full // blocksize, _WARPSIZE * 2)
+
+        # allocate size of partials array
+        partials_size = full_blockct
+        if size_partial:
+            partials_size += 1
+        partials = cuda.device_array(shape=partials_size, dtype=arr.dtype)
+
+        if size_full:
+            # kernel for the fully populated threadblocks
+            kernel[full_blockct, blocksize, stream](arr[:size_full],
+                                                    partials[:full_blockct],
+                                                    init,
+                                                    True)
+
+        if size_partial:
+            # kernel for partially populated threadblocks
+            kernel[1, size_partial, stream](arr[size_full:],
+                                            partials[full_blockct:],
+                                            init,
+                                            not full_blockct)
+
+        if partials.size > 1:
+            # finish up
+            kernel[1, partials_size, stream](partials, partials, init, False)
+
+        # handle return value
+        if res is not None:
+            res[:1].copy_to_device(partials[:1], stream=stream)
+            return
         else:
-            view = darr.bind(stream=stream)[:1]
-            res.copy_to_device(view, stream=stream)
-            return None
+            return partials[0]


### PR DESCRIPTION
The new gpu reduction impl is originally written for https://github.com/gpuopenanalytics/pygdf/blob/master/pygdf/reduction.py since pygdf needs more interactive use and the compilation time of the current gpu reduction in numba is long.   In turns out the new reduction code is also faster.  See benchmark below.

<img width="484" alt="screen shot 2017-05-17 at 4 47 09 pm" src="https://cloud.githubusercontent.com/assets/1929845/26180554/ccf6741a-3b2f-11e7-8c92-80954d179660.png">


The new impl keeps all the public interface the same.   The unittest at https://github.com/numba/numba/blob/master/numba/cuda/tests/cudapy/test_reduction.py works as is.
