### PR TITLE
Fix deadlock in parallel gufunc when kernel acquires the GIL.

### DIFF
--- a/numba/tests/npyufunc/test_parallel_ufunc_issues.py
+++ b/numba/tests/npyufunc/test_parallel_ufunc_issues.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba.tests.support import captured_stdout
-from numba import vectorize
+from numba import vectorize, guvectorize
 
 
 class TestParUfuncIssues(unittest.TestCase):
@@ -50,6 +50,52 @@ class TestParUfuncIssues(unittest.TestCase):
             print(x % 10)  # this reacquires the GIL
             cbar(x % 10)   # this reacquires the GIL
             return x * 2
+
+        # Numpy ufunc has a heuristic to determine whether to release the GIL
+        # during execution.  Small input size (10) seems to not release the GIL.
+        # Large input size (1000) seems to release the GIL.
+        for nelem in [1, 10, 100, 1000]:
+            # inputs
+            a = np.arange(nelem, dtype=np.int32)
+            acopy = a.copy()
+            # run and capture stdout
+            with captured_stdout() as buf:
+                got = foo(a)
+            stdout = buf.getvalue()
+            buf.close()
+            # process outputs from print
+            got_output = sorted(map(lambda x: x.strip(), stdout.splitlines()))
+            # build expected output
+            expected_output = [str(x % 10) for x in range(nelem)]
+            expected_output += [characters[x % 10] for x in range(nelem)]
+            expected_output = sorted(expected_output)
+            # verify
+            self.assertEqual(got_output, expected_output)
+            np.testing.assert_equal(got, 2 * acopy)
+
+
+
+class TestParGUfuncIssues(unittest.TestCase):
+    def test_gil_reacquire_deadlock(self):
+        """
+        Testing similar issue to #1998 due to GIL reacquiring for Gufunc
+        """
+        # make a ctypes callback that requires the GIL
+        proto = ctypes.CFUNCTYPE(None, ctypes.c_int32)
+        characters = 'abcdefghij'
+
+        def bar(x):
+            print(characters[x])
+
+        cbar = proto(bar)
+
+        # our unit under test
+        @guvectorize(['(int32, int32[:])'], "()->()",
+                     target='parallel', nopython=True)
+        def foo(x, out):
+            print(x % 10)  # this reacquires the GIL
+            cbar(x % 10)   # this reacquires the GIL
+            out[0] = x * 2
 
         # Numpy ufunc has a heuristic to determine whether to release the GIL
         # during execution.  Small input size (10) seems to not release the GIL.


### PR DESCRIPTION
Incldes a test for demonstrating the issue and verifying the fix.

Note: the GIL ensure/release and save/restore thread API use is copied directly from the parallel ufunc version in these lines:
* https://github.com/sklam/numba/blob/85f162610f71bdad8e382e46b1d59edb6a7c510a/numba/npyufunc/parallel.py#L114-L116
* https://github.com/sklam/numba/blob/85f162610f71bdad8e382e46b1d59edb6a7c510a/numba/npyufunc/parallel.py#L193-L195