### PR TITLE
Forbid unsafe casting in bitwise operation

### DIFF
--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -1022,6 +1022,32 @@ class TestOperators(TestCase):
     def test_bitwise_not_npm(self):
         self.test_bitwise_not(flags=Noflags)
 
+    def test_bitwise_float(self):
+        """
+        Make sure that bitwise float operations are not allowed
+        """
+        def assert_reject_compile(pyfunc, argtypes):
+            msg = 'expecting TypingError with compiling {}'.format(pyfunc)
+            with self.assertRaises(errors.TypingError, msg=msg):
+                compile_isolated(pyfunc, argtypes)
+
+        methods = [
+            'bitshift_left_usecase',
+            'bitshift_ileft_usecase',
+            'bitshift_right_usecase',
+            'bitshift_iright_usecase',
+            'bitwise_and_usecase',
+            'bitwise_iand_usecase',
+            'bitwise_or_usecase',
+            'bitwise_ior_usecase',
+            'bitwise_xor_usecase',
+            'bitwise_ixor_usecase',
+            'bitwise_not_usecase_binary',
+        ]
+        for name in methods:
+            pyfunc = getattr(self.op, name)
+            assert_reject_compile(pyfunc, (types.float32, types.float32))
+
     def test_not(self):
         pyfunc = self.op.not_usecase
 

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -378,6 +378,20 @@ class TestOperators(TestCase):
 
     op = LiteralOperatorImpl
 
+    _bitwise_opnames = {
+        'bitshift_left_usecase': '<<',
+        'bitshift_ileft_usecase': '<<',
+        'bitshift_right_usecase': '>>',
+        'bitshift_iright_usecase': '>>',
+        'bitwise_and_usecase': '&',
+        'bitwise_iand_usecase': '&',
+        'bitwise_or_usecase': '|',
+        'bitwise_ior_usecase': '|',
+        'bitwise_xor_usecase': '^',
+        'bitwise_ixor_usecase': '^',
+        'bitwise_not_usecase_binary': '~',
+    }
+
     def run_test_ints(self, pyfunc, x_operands, y_operands, types_list,
                       flags=force_pyobj_flags):
         if pyfunc is NotImplemented:
@@ -1026,10 +1040,16 @@ class TestOperators(TestCase):
         """
         Make sure that bitwise float operations are not allowed
         """
-        def assert_reject_compile(pyfunc, argtypes):
-            msg = 'expecting TypingError with compiling {}'.format(pyfunc)
-            with self.assertRaises(errors.TypingError, msg=msg):
+        def assert_reject_compile(pyfunc, argtypes, opname):
+            msg = 'expecting TypingError when compiling {}'.format(pyfunc)
+            with self.assertRaises(errors.TypingError, msg=msg) as raises:
                 compile_isolated(pyfunc, argtypes)
+            # check error message
+            fmt = 'Invalid usage of {}'
+            expecting = fmt.format(opname
+                                   if isinstance(opname, str)
+                                   else 'Function({})'.format(opname))
+            self.assertIn(expecting, str(raises.exception))
 
         methods = [
             'bitshift_left_usecase',
@@ -1044,9 +1064,11 @@ class TestOperators(TestCase):
             'bitwise_ixor_usecase',
             'bitwise_not_usecase_binary',
         ]
+
         for name in methods:
             pyfunc = getattr(self.op, name)
-            assert_reject_compile(pyfunc, (types.float32, types.float32))
+            assert_reject_compile(pyfunc, (types.float32, types.float32),
+                                  opname=self._bitwise_opnames[name])
 
     def test_not(self):
         pyfunc = self.op.not_usecase
@@ -1192,6 +1214,20 @@ class TestOperators(TestCase):
 class TestOperatorModule(TestOperators):
 
     op = FunctionalOperatorImpl
+
+    _bitwise_opnames = {
+        'bitshift_left_usecase': operator.lshift,
+        'bitshift_ileft_usecase': operator.ilshift,
+        'bitshift_right_usecase': operator.rshift,
+        'bitshift_iright_usecase': operator.irshift,
+        'bitwise_and_usecase': operator.and_,
+        'bitwise_iand_usecase': operator.iand,
+        'bitwise_or_usecase': operator.or_,
+        'bitwise_ior_usecase': operator.ior,
+        'bitwise_xor_usecase': operator.xor,
+        'bitwise_ixor_usecase': operator.ixor,
+        'bitwise_not_usecase_binary': operator.invert,
+    }
 
 
 class TestMixedInts(TestCase):

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -250,6 +250,8 @@ class BitwiseShiftOperation(ConcreteTemplate):
              for op in sorted(types.signed_domain)]
     cases += [signature(max(op, types.uintp), op, types.intp)
               for op in sorted(types.unsigned_domain)]
+    no_unsafe_casting = True
+
 
 @infer
 class BitwiseLeftShift(BitwiseShiftOperation):
@@ -264,6 +266,7 @@ class BitwiseRightShift(BitwiseShiftOperation):
 class BitwiseLogicOperation(BinOp):
     cases = [signature(types.boolean, types.boolean, types.boolean)]
     cases += list(integer_binop_cases)
+    no_unsafe_casting = True
 
 
 @infer
@@ -296,6 +299,7 @@ class BitwiseInvert(ConcreteTemplate):
     cases += [signature(choose_result_int(op), op) for op in types.unsigned_domain]
     cases += [signature(choose_result_int(op), op) for op in types.signed_domain]
 
+    no_unsafe_casting = True
 
 class UnaryOp(ConcreteTemplate):
     cases = [signature(choose_result_int(op), op) for op in types.unsigned_domain]

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -252,7 +252,7 @@ class BitwiseShiftOperation(ConcreteTemplate):
     cases += [signature(max(op, types.uintp), op, op2)
               for op in sorted(types.unsigned_domain)
               for op2 in [types.uintp, types.intp]]
-    no_unsafe_casting = True
+    unsafe_casting = False
 
 
 @infer
@@ -268,7 +268,7 @@ class BitwiseRightShift(BitwiseShiftOperation):
 class BitwiseLogicOperation(BinOp):
     cases = [signature(types.boolean, types.boolean, types.boolean)]
     cases += list(integer_binop_cases)
-    no_unsafe_casting = True
+    unsafe_casting = False
 
 
 @infer
@@ -301,7 +301,7 @@ class BitwiseInvert(ConcreteTemplate):
     cases += [signature(choose_result_int(op), op) for op in types.unsigned_domain]
     cases += [signature(choose_result_int(op), op) for op in types.signed_domain]
 
-    no_unsafe_casting = True
+    unsafe_casting = False
 
 class UnaryOp(ConcreteTemplate):
     cases = [signature(choose_result_int(op), op) for op in types.unsigned_domain]

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -246,10 +246,12 @@ class BitwiseShiftOperation(ConcreteTemplate):
     # should always be positive but will generally be considered
     # signed anyway, since it's often a constant integer).
     # (also, see issue #1995 for right-shifts)
-    cases = [signature(max(op, types.intp), op, types.intp)
-             for op in sorted(types.signed_domain)]
-    cases += [signature(max(op, types.uintp), op, types.intp)
-              for op in sorted(types.unsigned_domain)]
+    cases = [signature(max(op, types.intp), op, op2)
+             for op in sorted(types.signed_domain)
+             for op2 in [types.uintp, types.intp]]
+    cases += [signature(max(op, types.uintp), op, op2)
+              for op in sorted(types.unsigned_domain)
+              for op2 in [types.uintp, types.intp]]
     no_unsafe_casting = True
 
 

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -444,7 +444,7 @@ class BaseContext(object):
             else:
                 return min(forward, backward)
 
-    def _rate_arguments(self, actualargs, formalargs):
+    def _rate_arguments(self, actualargs, formalargs, no_unsafe_casting=False):
         """
         Rate the actual arguments for compatibility against the formal
         arguments.  A Rating instance is returned, or None if incompatible.
@@ -455,6 +455,8 @@ class BaseContext(object):
         for actual, formal in zip(actualargs, formalargs):
             conv = self.can_convert(actual, formal)
             if conv is None:
+                return None
+            elif no_unsafe_casting and conv >= Conversion.unsafe:
                 return None
 
             if conv == Conversion.promote:
@@ -490,20 +492,24 @@ class BaseContext(object):
         return True
 
     def resolve_overload(self, key, cases, args, kws,
-                         allow_ambiguous=True):
+                         allow_ambiguous=True, no_unsafe_casting=False):
         """
         Given actual *args* and *kws*, find the best matching
         signature in *cases*, or None if none matches.
         *key* is used for error reporting purposes.
         If *allow_ambiguous* is False, a tie in the best matches
         will raise an error.
+        If *no_unsafe_casting* is True, unsafe casting is forbidden.
         """
         assert not kws, "Keyword arguments are not supported, yet"
+        options = {
+            'no_unsafe_casting': no_unsafe_casting,
+        }
         # Rate each case
         candidates = []
         for case in cases:
             if len(args) == len(case.args):
-                rating = self._rate_arguments(args, case.args)
+                rating = self._rate_arguments(args, case.args, **options)
                 if rating is not None:
                     candidates.append((rating.astuple(), case))
 

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -444,7 +444,7 @@ class BaseContext(object):
             else:
                 return min(forward, backward)
 
-    def _rate_arguments(self, actualargs, formalargs, no_unsafe_casting=False):
+    def _rate_arguments(self, actualargs, formalargs, unsafe_casting=True):
         """
         Rate the actual arguments for compatibility against the formal
         arguments.  A Rating instance is returned, or None if incompatible.
@@ -456,7 +456,7 @@ class BaseContext(object):
             conv = self.can_convert(actual, formal)
             if conv is None:
                 return None
-            elif no_unsafe_casting and conv >= Conversion.unsafe:
+            elif not unsafe_casting and conv >= Conversion.unsafe:
                 return None
 
             if conv == Conversion.promote:
@@ -492,18 +492,18 @@ class BaseContext(object):
         return True
 
     def resolve_overload(self, key, cases, args, kws,
-                         allow_ambiguous=True, no_unsafe_casting=False):
+                         allow_ambiguous=True, unsafe_casting=True):
         """
         Given actual *args* and *kws*, find the best matching
         signature in *cases*, or None if none matches.
         *key* is used for error reporting purposes.
         If *allow_ambiguous* is False, a tie in the best matches
         will raise an error.
-        If *no_unsafe_casting* is True, unsafe casting is forbidden.
+        If *unsafe_casting* is False, unsafe casting is forbidden.
         """
         assert not kws, "Keyword arguments are not supported, yet"
         options = {
-            'no_unsafe_casting': no_unsafe_casting,
+            'unsafe_casting': unsafe_casting,
         }
         # Rate each case
         candidates = []

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -152,12 +152,16 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
 
 
 class FunctionTemplate(object):
+    # Set to true to disable unsafe cast.
+    # subclass overide-able
+    no_unsafe_casting = False
+
     def __init__(self, context):
         self.context = context
 
     def _select(self, cases, args, kws):
         options = {
-            'no_unsafe_casting': getattr(self, 'no_unsafe_casting', False),
+            'no_unsafe_casting': self.no_unsafe_casting,
         }
         selected = self.context.resolve_overload(self.key, cases, args, kws,
                                                  **options)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -154,14 +154,14 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
 class FunctionTemplate(object):
     # Set to true to disable unsafe cast.
     # subclass overide-able
-    no_unsafe_casting = False
+    unsafe_casting = True
 
     def __init__(self, context):
         self.context = context
 
     def _select(self, cases, args, kws):
         options = {
-            'no_unsafe_casting': self.no_unsafe_casting,
+            'unsafe_casting': self.unsafe_casting,
         }
         selected = self.context.resolve_overload(self.key, cases, args, kws,
                                                  **options)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -156,7 +156,11 @@ class FunctionTemplate(object):
         self.context = context
 
     def _select(self, cases, args, kws):
-        selected = self.context.resolve_overload(self.key, cases, args, kws)
+        options = {
+            'no_unsafe_casting': getattr(self, 'no_unsafe_casting', False),
+        }
+        selected = self.context.resolve_overload(self.key, cases, args, kws,
+                                                 **options)
         return selected
 
     def get_impl_key(self, sig):


### PR DESCRIPTION
This patch adds a `no_unsafe_casting` flag the `FunctionTemplate` and resolution methods to forbid the selection of signatures that require unsafe casting (e.g. float -> int).  

Bitwise function templates are updated to use this flag.