### PR TITLE
Upgrade to llvmlite 0.19.*

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -26,14 +26,14 @@ requirements:
     - numpy x.x
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/buildscripts/condarecipe.hsa/meta.yaml
+++ b/buildscripts/condarecipe.hsa/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - python
     - numpy x.x
     # On channel https://binstar.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://binstar.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
     - libhlc

--- a/buildscripts/condarecipe.jenkins/meta.yaml
+++ b/buildscripts/condarecipe.jenkins/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -19,14 +19,14 @@ requirements:
     - numpy x.x
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
   run:
     - python
     - numpy x.x
     # On channel https://anaconda.org/numba/
-    - llvmlite 0.18.*
+    - llvmlite 0.19.*
     - funcsigs       [py27]
     - singledispatch [py27]
 test:

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -989,8 +989,9 @@ def printf(builder, format, *args):
     global_fmt = global_constant(mod, "printf_format", fmt_bytes)
     fnty = ir.FunctionType(int32_t, [cstring], var_arg=True)
     # Insert printf()
-    fn = mod.get_global('printf')
-    if fn is None:
+    try:
+        fn = mod.get_global('printf')
+    except KeyError:
         fn = ir.Function(mod, fnty, name="printf")
     # Call
     ptr_fmt = builder.bitcast(global_fmt, cstring)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -401,11 +401,12 @@ class BaseContext(object):
         Insert a unique internal constant named *name*, with LLVM value
         *val*, into module *mod*.
         """
-        gv = mod.get_global(name)
-        if gv is not None:
-            return gv
-        else:
+        try:
+            gv = mod.get_global(name)
+        except KeyError:
             return cgutils.global_constant(mod, name, val)
+        else:
+            return gv
 
     def get_argument_type(self, ty):
         return self.data_model_manager[ty].get_argument_type()

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -659,9 +659,10 @@ class BaseCPUCodegen(object):
         voidptr = llvmir.IntType(8).as_pointer()
         ptrname = self._rtlinker.PREFIX + name
         llvm_mod = builder.module
-        fnptr = llvm_mod.get_global(ptrname)
-        # Not defined?
-        if fnptr is None:
+        try:
+            fnptr = llvm_mod.get_global(ptrname)
+        except KeyError:
+            # Not defined?
             fnptr = llvmir.GlobalVariable(llvm_mod, voidptr, name=ptrname)
             fnptr.linkage = 'external'
         return builder.bitcast(builder.load(fnptr), fnty.as_pointer())


### PR DESCRIPTION
Upgrade to llvmlite 0.19.*
This patch make llvmlite 0.18 incompatible  due to numba/llvmlite#273