### PR TITLE
Allow pipeline manipulation by user

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -10,6 +10,7 @@ from . import config, errors, runtests, types
 
 # Re-export typeof
 from .special import typeof, prange
+from .special import set_user_pipeline_func
 
 # Re-export error classes
 from .errors import *
@@ -45,6 +46,7 @@ __all__ = """
     njit
     typeof
     prange
+    set_user_pipeline_func
     vectorize
     """.split() + types.__all__ + errors.__all__
 

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -10,7 +10,6 @@ from . import config, errors, runtests, types
 
 # Re-export typeof
 from .special import typeof, prange
-from .special import set_user_pipeline_func
 
 # Re-export error classes
 from .errors import *
@@ -46,7 +45,6 @@ __all__ = """
     njit
     typeof
     prange
-    set_user_pipeline_func
     vectorize
     """.split() + types.__all__ + errors.__all__
 

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -23,6 +23,10 @@ from numba.inline_closurecall import InlineClosureCallPass
 # Lock for the preventing multiple compiler execution
 lock_compiler = threading.RLock()
 
+user_pipeline_func = None
+def set_user_pipeline_func(func):
+    global user_pipeline_func
+    user_pipeline_func = func
 
 class Flags(utils.ConfigOptions):
     # These options are all false by default, but the defaults are
@@ -681,6 +685,9 @@ class Pipeline(object):
             pm.create_pipeline("interp")
             pm.add_stage(self.stage_compile_interp_mode, "compiling with interpreter mode")
             pm.add_stage(self.stage_cleanup, "cleanup intermediate results")
+
+        if user_pipeline_func:
+            user_pipeline_func(pm, self)
 
         pm.finalize()
         res = pm.run(self.status)

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -39,11 +39,13 @@ class OmittedArg(object):
 
 class _FunctionCompiler(object):
 
-    def __init__(self, py_func, targetdescr, targetoptions, locals):
+    def __init__(self, py_func, targetdescr, targetoptions, locals,
+                                                        user_pipeline_funcs):
         self.py_func = py_func
         self.targetdescr = targetdescr
         self.targetoptions = targetoptions
         self.locals = locals
+        self.user_pipeline_funcs = user_pipeline_funcs
         self.pysig = utils.pysignature(self.py_func)
 
     def fold_argument_types(self, args, kws):
@@ -77,7 +79,8 @@ class _FunctionCompiler(object):
                                       self.targetdescr.target_context,
                                       impl,
                                       args=args, return_type=return_type,
-                                      flags=flags, locals=self.locals)
+                                      flags=flags, locals=self.locals,
+                                      user_pipeline_funcs=self.user_pipeline_funcs)
         # Check typing error if object mode is used
         if cres.typing_error is not None and not flags.enable_pyobject:
             raise cres.typing_error
@@ -452,7 +455,8 @@ class Dispatcher(_DispatcherBase):
     __uuid = None
     __numba__ = 'py_func'
 
-    def __init__(self, py_func, locals={}, targetoptions={}, impl_kind='direct'):
+    def __init__(self, py_func, locals={}, user_pipeline_funcs=[],
+                                        targetoptions={}, impl_kind='direct'):
         """
         Parameters
         ----------
@@ -475,11 +479,13 @@ class Dispatcher(_DispatcherBase):
 
         self.targetoptions = targetoptions
         self.locals = locals
+        self.user_pipeline_funcs = user_pipeline_funcs
         self._cache = NullCache()
         compiler_class = self._impl_kinds[impl_kind]
         self._impl_kind = impl_kind
         self._compiler = compiler_class(py_func, self.targetdescr,
-                                        targetoptions, locals)
+                                        targetoptions, locals,
+                                        user_pipeline_funcs)
         self._cache_hits = collections.Counter()
         self._cache_misses = collections.Counter()
 

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -517,12 +517,12 @@ class Dispatcher(_DispatcherBase):
         return (serialize._rebuild_reduction,
                 (self.__class__, str(self._uuid),
                  serialize._reduce_function(self.py_func, globs),
-                 self.locals, self.targetoptions, self._impl_kind,
-                 self._can_compile, sigs))
+                 self.locals, self.user_pipeline_funcs, self.targetoptions,
+                 self._impl_kind, self._can_compile, sigs))
 
     @classmethod
-    def _rebuild(cls, uuid, func_reduced, locals, targetoptions, impl_kind,
-                 can_compile, sigs):
+    def _rebuild(cls, uuid, func_reduced, locals, user_pipeline_funcs,
+                 targetoptions, impl_kind, can_compile, sigs):
         """
         Rebuild an Dispatcher instance after it was __reduce__'d.
         """
@@ -531,7 +531,7 @@ class Dispatcher(_DispatcherBase):
         except KeyError:
             pass
         py_func = serialize._rebuild_function(*func_reduced)
-        self = cls(py_func, locals, targetoptions, impl_kind)
+        self = cls(py_func, locals, user_pipeline_funcs, targetoptions, impl_kind)
         # Make sure this deserialization will be merged with subsequent ones
         self._set_uuid(uuid)
         for sig in sigs:

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -40,7 +40,7 @@ class OmittedArg(object):
 class _FunctionCompiler(object):
 
     def __init__(self, py_func, targetdescr, targetoptions, locals,
-                                                        user_pipeline_funcs):
+                                                        user_pipeline_funcs=[]):
         self.py_func = py_func
         self.targetdescr = targetdescr
         self.targetoptions = targetoptions
@@ -98,9 +98,10 @@ class _FunctionCompiler(object):
 
 class _GeneratedFunctionCompiler(_FunctionCompiler):
 
-    def __init__(self, py_func, targetdescr, targetoptions, locals):
+    def __init__(self, py_func, targetdescr, targetoptions, locals,
+                                                        user_pipeline_funcs=[]):
         super(_GeneratedFunctionCompiler, self).__init__(
-            py_func, targetdescr, targetoptions, locals)
+            py_func, targetdescr, targetoptions, locals, user_pipeline_funcs)
         self.impls = set()
 
     def get_globals_for_reduction(self):

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -49,11 +49,12 @@ class UFuncDispatcher(object):
     """
     targetdescr = ufunc_target
 
-    def __init__(self, py_func, locals={}, targetoptions={}):
+    def __init__(self, py_func, locals={}, user_pipeline_funcs=[], targetoptions={}):
         self.py_func = py_func
         self.overloads = utils.UniqueDict()
         self.targetoptions = targetoptions
         self.locals = locals
+        self.user_pipeline_funcs = user_pipeline_funcs
         self.cache = NullCache()
 
     def enable_caching(self):

--- a/numba/special.py
+++ b/numba/special.py
@@ -3,5 +3,8 @@ from __future__ import print_function, division, absolute_import
 from .typing.typeof import typeof
 from .parfor import prange
 
+def set_user_pipeline_func(func):
+    from .compiler import set_user_pipeline_func
+    set_user_pipeline_func(func)
 
-__all__ = ['typeof','prange']
+__all__ = ['typeof','prange','set_user_pipeline_func']

--- a/numba/special.py
+++ b/numba/special.py
@@ -3,8 +3,4 @@ from __future__ import print_function, division, absolute_import
 from .typing.typeof import typeof
 from .parfor import prange
 
-def set_user_pipeline_func(func):
-    from .compiler import set_user_pipeline_func
-    set_user_pipeline_func(func)
-
-__all__ = ['typeof','prange','set_user_pipeline_func']
+__all__ = ['typeof','prange']


### PR DESCRIPTION
This patch allows advanced users to manipulate the compiler pipeline with minimal changes to the core. All pipeline data structures can be accessed as well. Here is an example for adding a print stage before the backend stage:

```python
def print_ir(func_ir):
    func_ir.dump()

def add_print_stage(pipeline_manager, pipeline):
    pp = pipeline_manager.pipeline_stages['nopython']
    new_pp = []
    for (func,desc) in pp:
        if desc=='nopython mode backend':
            new_pp.append((lambda:print_ir(pipeline.func_ir), "print IR"))
        new_pp.append((func,desc))
    pipeline_manager.pipeline_stages['nopython'] = new_pp

numba.set_user_pipeline_func(add_print_stage)
```