### PR TITLE
Support printing Numpy arrays

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -855,14 +855,12 @@ def native_lowering_stage(targetctx, library, interp, typemap, restype,
         inline=flags.forceinline)
 
     lower = lowering.Lower(targetctx, library, fndesc, interp)
-    targetctx.lowerer = lower
     lower.lower()
     if not flags.no_cpython_wrapper:
         lower.create_cpython_wrapper(flags.release_gil)
     env = lower.env
     call_helper = lower.call_helper
     has_dynamic_globals = lower.has_dynamic_globals
-    del targetctx.lowerer
     del lower
 
     if flags.no_compile:

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -855,12 +855,14 @@ def native_lowering_stage(targetctx, library, interp, typemap, restype,
         inline=flags.forceinline)
 
     lower = lowering.Lower(targetctx, library, fndesc, interp)
+    targetctx.lowerer = lower
     lower.lower()
     if not flags.no_cpython_wrapper:
         lower.create_cpython_wrapper(flags.release_gil)
     env = lower.env
     call_helper = lower.call_helper
     has_dynamic_globals = lower.has_dynamic_globals
+    del targetctx.lowerer
     del lower
 
     if flags.no_compile:

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -41,12 +41,13 @@ def print_item_impl(context, builder, sig, args):
     ty, = sig.args
     val, = args
 
-    pyapi = context.get_python_api(builder)
+    context.lowerer.init_pyapi()
+    pyapi = context.lowerer.pyapi
 
     if context.enable_nrt:
         context.nrt.incref(builder, ty, val)
-    # XXX unfortunately, we don't have access to the env manager from here
-    obj = pyapi.from_native_value(ty, val)
+
+    obj = pyapi.from_native_value(ty, val, context.lowerer.env_manager)
     with builder.if_else(cgutils.is_not_null(builder, obj), likely=True) as (if_ok, if_error):
         with if_ok:
             pyapi.print_object(obj)

--- a/numba/targets/printimpl.py
+++ b/numba/targets/printimpl.py
@@ -41,13 +41,13 @@ def print_item_impl(context, builder, sig, args):
     ty, = sig.args
     val, = args
 
-    context.lowerer.init_pyapi()
-    pyapi = context.lowerer.pyapi
+    pyapi = context.get_python_api(builder)
+    env_manager = context.get_env_manager(builder)
 
     if context.enable_nrt:
         context.nrt.incref(builder, ty, val)
 
-    obj = pyapi.from_native_value(ty, val, context.lowerer.env_manager)
+    obj = pyapi.from_native_value(ty, val, env_manager)
     with builder.if_else(cgutils.is_not_null(builder, obj), likely=True) as (if_ok, if_error):
         with if_ok:
             pyapi.print_object(obj)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -28,17 +28,9 @@ class Print(AbstractTemplate):
 class PrintItem(AbstractTemplate):
     key = "print_item"
 
-    def is_accepted_type(self, ty):
-        if isinstance(ty, (types.Array, types.Record)):
-            # These types require an environment to serialize back to a
-            # Python object.
-            return False
-        return True
-
     def generic(self, args, kws):
         arg, = args
-        if self.is_accepted_type(arg):
-            return signature(types.none, *args)
+        return signature(types.none, *args)
 
 
 @infer_global(abs)


### PR DESCRIPTION
This is done by making the lowerer object available in lowering functions as an attribute in context. I suspect having the lowerer available is generally useful. For example, `array_exprs` and parfors use it.

Maybe the lowerer should be passed to lowering routines instead of context in general?