### PR TITLE
Expose environment object to target-context inside lowerer

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -217,6 +217,9 @@ class BaseContext(object):
     # Fast math flags
     enable_fastmath = False
 
+    # python exceution environment
+    environment = None
+
     def __init__(self, typing_context):
         _load_global_helpers()
 

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -99,6 +99,13 @@ class CPUContext(BaseContext):
             builder, envptr, _dynfunc._impl_info['offsetof_env_body'])
         return EnvBody(self, builder, ref=body_ptr, cast_ref=True)
 
+    def get_env_manager(self, builder, envarg=None):
+        envarg = envarg or self.call_conv.get_env_argument(builder.function)
+        pyapi = self.get_python_api(builder)
+        pyapi.emit_environment_sentry(envarg)
+        env_body = self.get_env_body(builder, envarg)
+        return pyapi.get_env_manager(self.environment, env_body, envarg)
+
     def get_generator_state(self, builder, genptr, return_type):
         """
         From the given *genptr* (a pointer to a _dynfunc.Generator object),


### PR DESCRIPTION
via the subtarget info.

This is to avoid the hack needed in https://github.com/numba/numba/pull/2405/files#diff-067c6329c9ddf60932fd3f3111969487R858

This also remove the duplicated "Sanity check" in the original source in lowering.py.  `. emit_environment_sentry` already does that.