### PR TITLE
Add flags to pass through to conda build for buildbot

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -17,6 +17,11 @@ build:
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.numba_entry:main
+  # needed so cross compilation flags are picked up from bb env
+  script_env:
+    - CFLAGS
+    - CXXFLAGS
+    - PY_VCRUNTIME_REDIST
 
 requirements:
   # build and run dependencies are duplicated to avoid setuptools issues


### PR DESCRIPTION
This adds in some environment variables that hold flags that conda
build needs access to to do cross compilation for x86.