### PR TITLE
Add cross compile flags to local recipe

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -10,6 +10,11 @@ build:
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.numba_entry:main
+  # needed so cross compilation flags are picked up from bb env
+  script_env:
+    - CFLAGS
+    - CXXFLAGS
+    - PY_VCRUNTIME_REDIST
 
 requirements:
   # build and run dependencies are duplicated to avoid setuptools issues


### PR DESCRIPTION
As per previous patch, adds the same flags to the local build
recipe.