### PR TITLE
A few cleanups for rewrites

### DIFF
--- a/docs/source/developer/rewrites.rst
+++ b/docs/source/developer/rewrites.rst
@@ -76,8 +76,11 @@ The :class:`Rewrite` Base Class
 
    .. method:: match(self, block, typemap, callmap)
 
-      The :func:`~Rewrite.match` method takes three arguments other
+      The :func:`~Rewrite.match` method takes four arguments other
       than *self*:
+
+      * *func_ir*: This is an instance of :class:`numba.ir.FunctionIR` for the
+        function being rewritten.
 
       * *block*: This is an instance of :class:`numba.ir.Block`.  The
         matching method should iterate over the instructions contained

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -30,7 +30,7 @@ class RewriteArrayExprs(rewrites.Rewrite):
         if 'arrayexpr' not in special_ops:
             special_ops['arrayexpr'] = _lower_array_expr
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         """
         Using typing and a basic block, search the basic block for array
         expressions.

--- a/numba/rewrites/ir_print.py
+++ b/numba/rewrites/ir_print.py
@@ -10,7 +10,7 @@ class RewritePrintCalls(Rewrite):
     Rewrite calls to the print() global function to dedicated IR print() nodes.
     """
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.prints = prints = {}
         self.block = block
         # Find all assignments with a right-hand print() call
@@ -21,7 +21,7 @@ class RewritePrintCalls(Rewrite):
                     # Only positional args are supported
                     continue
                 try:
-                    callee = interp.infer_constant(expr.func)
+                    callee = func_ir.infer_constant(expr.func)
                 except errors.ConstantInferenceError:
                     continue
                 if callee is print:
@@ -56,7 +56,7 @@ class DetectConstPrintArguments(Rewrite):
     Detect and store constant arguments to print() nodes.
     """
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.consts = consts = {}
         self.block = block
         for inst in block.find_insts(ir.Print):
@@ -65,7 +65,7 @@ class DetectConstPrintArguments(Rewrite):
                 continue
             for idx, var in enumerate(inst.args):
                 try:
-                    const = interp.infer_constant(var)
+                    const = func_ir.infer_constant(var)
                 except errors.ConstantInferenceError:
                     continue
                 consts.setdefault(inst, {})[idx] = const

--- a/numba/rewrites/static_binop.py
+++ b/numba/rewrites/static_binop.py
@@ -11,7 +11,7 @@ class DetectStaticBinops(Rewrite):
     # Those operators can benefit from a constant-inferred argument
     rhs_operators = {'**'}
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.static_lhs = {}
         self.static_rhs = {}
         self.block = block
@@ -20,7 +20,7 @@ class DetectStaticBinops(Rewrite):
             try:
                 if (expr.fn in self.rhs_operators
                     and expr.static_rhs is ir.UNDEFINED):
-                    self.static_rhs[expr] = interp.infer_constant(expr.rhs)
+                    self.static_rhs[expr] = func_ir.infer_constant(expr.rhs)
             except errors.ConstantInferenceError:
                 continue
 

--- a/numba/rewrites/static_getitem.py
+++ b/numba/rewrites/static_getitem.py
@@ -10,7 +10,7 @@ class RewriteConstGetitems(Rewrite):
     `static_getitem(value=arr, index=<constant value>)`.
     """
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.getitems = getitems = {}
         self.block = block
         # Detect all getitem expressions and find which ones can be
@@ -18,7 +18,7 @@ class RewriteConstGetitems(Rewrite):
         for expr in block.find_exprs(op='getitem'):
             if expr.op == 'getitem':
                 try:
-                    const = interp.infer_constant(expr.index)
+                    const = func_ir.infer_constant(expr.index)
                 except errors.ConstantInferenceError:
                     continue
                 getitems[expr] = const
@@ -54,14 +54,14 @@ class RewriteConstSetitems(Rewrite):
     `static_setitem(target=arr, index=<constant value>, ...)`.
     """
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.setitems = setitems = {}
         self.block = block
         # Detect all setitem statements and find which ones can be
         # rewritten
         for inst in block.find_insts(ir.SetItem):
             try:
-                const = interp.infer_constant(inst.index)
+                const = func_ir.infer_constant(inst.index)
             except errors.ConstantInferenceError:
                 continue
             setitems[inst] = const

--- a/numba/rewrites/static_raise.py
+++ b/numba/rewrites/static_raise.py
@@ -17,7 +17,7 @@ class RewriteConstRaises(Rewrite):
     def _is_exception_type(self, const):
         return isinstance(const, type) and issubclass(const, Exception)
 
-    def _break_constant(self, interp, const):
+    def _break_constant(self, const):
         """
         Break down constant exception.
         """
@@ -29,7 +29,7 @@ class RewriteConstRaises(Rewrite):
             raise NotImplementedError("unsupported exception constant %r"
                                       % (const,))
 
-    def match(self, interp, block, typemap, calltypes):
+    def match(self, func_ir, block, typemap, calltypes):
         self.raises = raises = {}
         self.block = block
         # Detect all raise statements and find which ones can be
@@ -40,8 +40,8 @@ class RewriteConstRaises(Rewrite):
                 exc_type, exc_args = None, None
             else:
                 # raise <something> => find the definition site for <something>
-                const = interp.infer_constant(inst.exception)
-                exc_type, exc_args = self._break_constant(interp, const)
+                const = func_ir.infer_constant(inst.exception)
+                exc_type, exc_args = self._break_constant(const)
             raises[inst] = exc_type, exc_args
 
         return len(raises) > 0


### PR DESCRIPTION
- Add missing argument for `Rewrite.match` to documentation
- Rename `interp` argument to `func_ir` to better match type of argument
- A few minor code cleanups