### PR TITLE
Add support for returning enums in vectorize

### DIFF
--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -130,6 +130,8 @@ def as_dtype(nbtype):
         return np.dtype('%s%d' % (letter, nbtype.count))
     if isinstance(nbtype, types.Record):
         return nbtype.dtype
+    if isinstance(nbtype, types.EnumMember):
+        return as_dtype(nbtype.dtype)
     raise NotImplementedError("%r cannot be represented as a Numpy dtype"
                               % (nbtype,))
 

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -53,8 +53,9 @@ def int_coerce_usecase(x):
 
 def vectorize_usecase(x):
     if x != RequestError.not_found:
-        return RequestError.internal_error
-    return x
+        return RequestError['internal_error']
+    else:
+        return RequestError.dummy
 
 
 class BaseEnumTest(object):


### PR DESCRIPTION
This adds support for inferring numpy dtype from enums, allowing them to
be the return type of vectorized/guvectorized functions.

Fixes #2416.