### PR TITLE
Ensure consistent iteration order of blocks for type inference.

### DIFF
--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -248,7 +248,7 @@ class TestListComprehension(unittest.TestCase):
             with self.assertRaises(TypingError) as raises:
                 cfunc = jit(nopython=True)(list22)
                 cfunc(var)
-            msg = "Invalid usage of == with parameters"
+            msg = "cannot unify reflected list(int64) and int64"
             self.assertIn(msg, str(raises.exception))
 
 

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -18,6 +18,7 @@ import contextlib
 import itertools
 from pprint import pprint
 import traceback
+from collections import OrderedDict
 
 from numba import ir, types, utils, config, six, typing
 from .errors import TypingError, UntypedAttributeError, new_error_context
@@ -649,7 +650,10 @@ class TypeInferer(object):
 
     def __init__(self, context, func_ir, warnings):
         self.context = context
-        self.blocks = func_ir.blocks
+        # sort based on label, ensure iteration order!
+        self.blocks = OrderedDict()
+        for k in sorted(func_ir.blocks.keys()):
+            self.blocks[k] = func_ir.blocks[k]
         self.generator_info = func_ir.generator_info
         self.func_id = func_ir.func_id
         self.func_ir = func_ir


### PR DESCRIPTION
When undertaking type inference the order in which the blocks were
walked was based on the iteration of a dictionary, this meant that
constraint network ordering was subject to the dictionary iteration
order. As a result, the same function IR could result in different
inferred types across Python versions at the whim of dictionary
ordering. This patch fixes this by storing the IR blocks in an
OrderedDict ordered ascending by the IR label.