### PR TITLE
Guard code to prevent the use of 'parallel' on win32 + py27

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -4,6 +4,7 @@ Define @jit and related decorators.
 
 from __future__ import print_function, division, absolute_import
 
+import sys
 import warnings
 
 from . import config, sigutils
@@ -132,6 +133,12 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **opti
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
+
+    if options.get('parallel'):
+        if sys.platform.startswith('win32') and sys.version_info[:2] == (2, 7):
+            msg = ("The 'parallel' target is not currently supported on "
+                "Windows operating systems when using Python 2.7.")
+            raise RuntimeError(msg)
 
     # Handle signature
     if signature_or_function is None:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
+import sys
+
 import numpy as np
 
 import numba
@@ -182,6 +184,28 @@ class TestParfors(unittest.TestCase):
             #print(tp.func_ir.dump())
             #print(countParfors(tp.func_ir) == 1)
             self.assertTrue(countParfors(test_ir) == 1)
+
+    @unittest.skipIf(not (sys.platform.startswith('win32')
+                          and sys.version_info[:2] == (2, 7)),
+                    "Only impacts Windows with Python 2.7")
+    def test_windows_py27_combination_raises(self):
+        """
+        This test is in place until issues with the 'parallel'
+        target on Windows with Python 2.7 are fixed.
+        """
+        
+        @njit(parallel=True)
+        def ddot(a, v):
+            return np.dot(a, v)
+
+        A = np.linspace(0, 1, 20).reshape(2, 10)
+        v = np.linspace(2, 1, 10)
+        with self.assertRaises(RuntimeError) as raised:
+            ddot(A, v)
+        msg = ("The 'parallel' target is not currently supported on "
+            "Windows operating systems when using Python 2.7.")
+        self.assertIn(msg, str(raised.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This patch adds a guard to the jit (and derivative) decorators
to prevent the use of the 'parallel' on Windows with Python 2.7.

A test is added to test_parfors.py.

This patch can be reverted once the few 'parallel' issues are fixed.