### PR TITLE
Fix handling of empty gpu slices.

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -97,7 +97,9 @@ class DeviceNDArrayBase(object):
             else:
                 self.alloc_size = _driver.device_memory_size(gpu_data)
         else:
-            gpu_data = None
+            # Make NULL pointer for empty allocation
+            gpu_data = _driver.MemoryPointer(context=devices.get_context(),
+                                             pointer=c_void_p(0), size=0)
             self.alloc_size = 0
 
         self.gpu_data = gpu_data

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1027,7 +1027,8 @@ class MemoryPointer(object):
             size = self.size - start
         else:
             size = stop - start
-        assert size > 0, "zero or negative memory size"
+        if size < 0:
+            raise RuntimeError('size cannot be negative')
         pointer = drvapi.cu_device_ptr(base)
         view = MemoryPointer(self.context, pointer, size, owner=self.owner)
         return OwnedPointer(weakref.proxy(self.owner), view)

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1022,15 +1022,23 @@ class MemoryPointer(object):
             driver.cuMemsetD8(self.device_pointer, byte, count)
 
     def view(self, start, stop=None):
-        base = self.device_pointer.value + start
         if stop is None:
             size = self.size - start
         else:
             size = stop - start
-        if size < 0:
-            raise RuntimeError('size cannot be negative')
-        pointer = drvapi.cu_device_ptr(base)
-        view = MemoryPointer(self.context, pointer, size, owner=self.owner)
+
+        # Handle NULL/empty memory buffer
+        if self.device_pointer.value is None:
+            if size != 0:
+                raise RuntimeError("non-empty slice into empty slice")
+            view = self      # new view is just a reference to self
+        # Handle normal case
+        else:
+            base = self.device_pointer.value + start
+            if size < 0:
+                raise RuntimeError('size cannot be negative')
+            pointer = drvapi.cu_device_ptr(base)
+            view = MemoryPointer(self.context, pointer, size, owner=self.owner)
         return OwnedPointer(weakref.proxy(self.owner), view)
 
     @property

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -97,6 +97,18 @@ class CudaArraySlicing(unittest.TestCase):
         darr = cuda.to_device(arr)
         self.assertTrue(np.all(darr[:1, 1].copy_to_host() == arr[:1, 1]))
 
+    def test_empty_slice_1d(self):
+        arr = np.arange(5)
+        darr = cuda.to_device(arr)
+        for i in range(darr.shape[0]):
+            np.testing.assert_array_equal(darr[i:i].copy_to_host(), arr[i:i])
+
+    def test_empty_slice_2d(self):
+        arr = np.arange(5 * 5).reshape(5, 5)
+        darr = cuda.to_device(arr)
+        np.testing.assert_array_equal(darr[:0].copy_to_host(), arr[:0])
+        np.testing.assert_array_equal(darr[3, :0].copy_to_host(), arr[3, :0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -102,13 +102,16 @@ class CudaArraySlicing(unittest.TestCase):
         darr = cuda.to_device(arr)
         for i in range(darr.shape[0]):
             np.testing.assert_array_equal(darr[i:i].copy_to_host(), arr[i:i])
+        # empty slice of empty slice
+        self.assertFalse(darr[:0][:0].copy_to_host())
 
     def test_empty_slice_2d(self):
         arr = np.arange(5 * 5).reshape(5, 5)
         darr = cuda.to_device(arr)
         np.testing.assert_array_equal(darr[:0].copy_to_host(), arr[:0])
         np.testing.assert_array_equal(darr[3, :0].copy_to_host(), arr[3, :0])
-
+        # empty slice of empty slice
+        self.assertFalse(darr[:0][:0].copy_to_host())
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
+
+from itertools import product
+
 import numpy as np
+
 from numba import cuda
 from numba.cuda.testing import unittest
 
@@ -97,6 +101,22 @@ class CudaArraySlicing(unittest.TestCase):
         darr = cuda.to_device(arr)
         self.assertTrue(np.all(darr[:1, 1].copy_to_host() == arr[:1, 1]))
 
+    def test_negative_slicing_1d(self):
+        arr = np.arange(10)
+        darr = cuda.to_device(arr)
+        for i, j in product(range(-10, 10), repeat=2):
+            print("arr[{}:{}]".format(i, j))
+            np.testing.assert_array_equal(arr[i:j],
+                                          darr[i:j].copy_to_host())
+
+    def test_negative_slicing_2d(self):
+        arr = np.arange(9).reshape(3, 3)
+        darr = cuda.to_device(arr)
+        for x, y, w, s in product(range(-4, 4), repeat=4):
+            print("arr[{}:{}, {}:{}]".format(x, y, w, s))
+            np.testing.assert_array_equal(arr[x:y, w:s],
+                                          darr[x:y, w:s].copy_to_host())
+
     def test_empty_slice_1d(self):
         arr = np.arange(5)
         darr = cuda.to_device(arr)
@@ -104,6 +124,9 @@ class CudaArraySlicing(unittest.TestCase):
             np.testing.assert_array_equal(darr[i:i].copy_to_host(), arr[i:i])
         # empty slice of empty slice
         self.assertFalse(darr[:0][:0].copy_to_host())
+        # out-of-bound slice just produces empty slices
+        np.testing.assert_array_equal(darr[:0][:1].copy_to_host(), arr[:0][:1])
+        np.testing.assert_array_equal(darr[:0][-1:].copy_to_host(), arr[:0][-1:])
 
     def test_empty_slice_2d(self):
         arr = np.arange(5 * 5).reshape(5, 5)
@@ -112,6 +135,10 @@ class CudaArraySlicing(unittest.TestCase):
         np.testing.assert_array_equal(darr[3, :0].copy_to_host(), arr[3, :0])
         # empty slice of empty slice
         self.assertFalse(darr[:0][:0].copy_to_host())
+        # out-of-bound slice just produces empty slices
+        np.testing.assert_array_equal(darr[:0][:1].copy_to_host(), arr[:0][:1])
+        np.testing.assert_array_equal(darr[:0][-1:].copy_to_host(), arr[:0][-1:])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -105,7 +105,6 @@ class CudaArraySlicing(unittest.TestCase):
         arr = np.arange(10)
         darr = cuda.to_device(arr)
         for i, j in product(range(-10, 10), repeat=2):
-            print("arr[{}:{}]".format(i, j))
             np.testing.assert_array_equal(arr[i:j],
                                           darr[i:j].copy_to_host())
 
@@ -113,7 +112,6 @@ class CudaArraySlicing(unittest.TestCase):
         arr = np.arange(9).reshape(3, 3)
         darr = cuda.to_device(arr)
         for x, y, w, s in product(range(-4, 4), repeat=4):
-            print("arr[{}:{}, {}:{}]".format(x, y, w, s))
             np.testing.assert_array_equal(arr[x:y, w:s],
                                           darr[x:y, w:s].copy_to_host())
 

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -47,32 +47,38 @@ class Dim(object):
             stop = start + 1
             step = None
 
+        # Default values
+        #   Start value is default to zero
         if start is None:
             start = 0
+        #   Stop value is default to self.size
         if stop is None:
             stop = self.size
+        #   Step is default to 1
         if step is None:
             step = 1
 
         stride = step * self.stride
 
+        # Compute start in bytes
         if start >= 0:
             start = self.start + start * self.stride
         else:
             start = self.stop + start * self.stride
+        start = max(start, self.start)
 
+        # Compute stop in bytes
         if stop >= 0:
             stop = self.start + stop * self.stride
         else:
             stop = self.stop + stop * self.stride
+        stop = min(stop, self.stop)
+
+        # Clip stop
+        if (stop - start) > self.size * self.stride:
+            stop = start + self.size * stride
 
         size = (stop - start + (stride - 1)) // stride
-
-        if self.start >= start > self.stop:
-            raise IndexError("start index out-of-bound")
-
-        if self.start > stop >= self.stop:
-            raise IndexError("stop index out-of-bound")
 
         if stop < start:
             start = stop
@@ -196,6 +202,7 @@ class Array(object):
         lastidx = [s - 1 for s in self.shape]
         start = compute_index(firstidx, self.dims)
         stop = compute_index(lastidx, self.dims) + self.itemsize
+        stop = max(stop, start)   # ensure postive extent
         return Extent(start, stop)
 
     def __repr__(self):

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -68,10 +68,10 @@ class Dim(object):
 
         size = (stop - start + (stride - 1)) // stride
 
-        if self.start >= start >= self.stop:
+        if self.start >= start > self.stop:
             raise IndexError("start index out-of-bound")
 
-        if self.start >= stop >= self.stop:
+        if self.start > stop >= self.stop:
             raise IndexError("stop index out-of-bound")
 
         if stop < start:


### PR DESCRIPTION
* Remove overly strict assertion on zero size view.
* Match slicing behavior to numpy's on out-of-bound slices (i.e. bounds are clip to valid values)