### PR TITLE
Adds in warning message when using 'parallel' if cache=True

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -142,6 +142,13 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **opti
                    "Windows operating systems when using Python 2.7, or "
                    "on 32 bit hardware.")
             raise RuntimeError(msg)
+        if cache:
+            msg = ("Caching is not available when the 'parallel' target is in "
+                   "use. Caching is now being disabled to allow execution to "
+                   "continue.")
+            warnings.warn(msg, RuntimeWarning)
+            cache = False
+
 
     # Handle signature
     if signature_or_function is None:


### PR DESCRIPTION
This adds in a warning message if 'parallel' is used in combination
with caching, the message warns the user that this is not supported
and then sets caching to false. A test is added to verify behaviour.

This patch is prompted by https://github.com/numba/numba/issues/2439

Fixes https://github.com/numba/numba/issues/2441