### PR TITLE
Make the runtime initialiser threadsafe

### DIFF
--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from . import nrtdynmod
 from llvmlite import binding as ll
 
+from ..llvmthreadsafe import lock_llvm
 from numba.utils import finalize as _finalize
 from . import _nrt_python as _nrt
 
@@ -15,6 +16,7 @@ class _Runtime(object):
     def __init__(self):
         self._init = False
 
+    @lock_llvm # prevent race to install compiled library functions
     def initialize(self, ctx):
         """Initializes the NRT
 


### PR DESCRIPTION
This tiny patch puts a lock around the runtime initialisation
code to prevent races that were occuring. These races took the
form of:

 * Compilation on the primary thread taking a while, this delaying
   the init guard from being set and then secondary threads would
   enter and race to install their copies of atomic operations to
   the runtime.
 * As a side effect of the above, whilst most of the time harmless,
   on occasion the inc, dec and cas could come from different
   written instances of the library, this creating bizarre states
   and some invalid function pointers especially if shutdown
   happened.
 * If invalid function pointers were then accessed, it manifested
   as an access violation, therefore segfault!

Hopefully this fixes it (thanks to @sklam for discussion over IRC).