### PR TITLE
Fix silently ignoring of unsupported args in .sum like and .cumsum like array methods

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -135,8 +135,14 @@ def array_itemset(a, v):
 def array_sum(a, *args):
     return a.sum(*args)
 
+def array_sum_kws(a, axis):
+    return a.sum(axis=axis)
+
 def array_cumsum(a, *args):
     return a.cumsum(*args)
+
+def array_cumsum_kws(a, axis):
+    return a.cumsum(axis=axis)
 
 
 class TestArrayMethods(MemoryLeakMixin, TestCase):
@@ -618,6 +624,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # BAD: with axis
         with self.assertRaises(TypingError):
             cfunc(a, 1)
+        # BAD: with kw axis
+        pyfunc = array_sum_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        with self.assertRaises(TypingError):
+            cfunc(a, axis=1)
 
     def test_cumsum(self):
         pyfunc = array_cumsum
@@ -628,6 +639,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # BAD: with axis
         with self.assertRaises(TypingError):
             cfunc(a, 1)
+        # BAD: with kw axis
+        pyfunc = array_cumsum_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        with self.assertRaises(TypingError):
+            cfunc(a, axis=1)
 
 
 class TestArrayComparisons(TestCase):

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -528,9 +528,13 @@ def generic_homog(self, args, kws):
     return signature(self.this.dtype, recvr=self.this)
 
 def generic_expand(self, args, kws):
+    assert not args
+    assert not kws
     return signature(_expand_integer(self.this.dtype), recvr=self.this)
 
 def generic_expand_cumulative(self, args, kws):
+    assert not args
+    assert not kws
     assert isinstance(self.this, types.Array)
     return_type = types.Array(dtype=_expand_integer(self.this.dtype),
                               ndim=1, layout='C')


### PR DESCRIPTION
Fixes #2446

Follow the same pattern on the array methods to use assertion to guard unused arguments.