### PR TITLE
Skip CFG test on 64bit windows

### DIFF
--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -293,6 +293,7 @@ class CodeLibrary(object):
         self._sentry_cache_disable_inspection()
         return str(self._codegen._tm.emit_assembly(self._final_module))
 
+    @llvmts.lock_llvm
     def get_function_cfg(self, name):
         """
         Get control-flow graph of the LLVM function

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import utils, jit, generated_jit, types, typeof
+from numba import config
 from numba import _dispatcher
 from numba.errors import NumbaWarning
 from .support import TestCase, tag, temp_directory, import_dynamic
@@ -492,6 +493,7 @@ class TestDispatcherMethods(TestCase):
             # Look for the function name
             self.assertTrue("foo" in asm)
 
+    @unittest.skipIf(config.IS_WIN32 and not config.IS_32BITS, "access violation on 64-bit windows")
     def test_inspect_cfg(self):
         # Exercise the .inspect_cfg().  These are minimal tests and does not
         # fully checks the correctness of the function.


### PR DESCRIPTION
This patch locks the function CFG generator and skips the test on windows 64bit due to access violations.