### PR TITLE
add contextual information to runtime errors

### DIFF
--- a/numba/errors.py
+++ b/numba/errors.py
@@ -225,6 +225,11 @@ def _format_msg(fmt, args, kwargs):
     return fmt.format(*args, **kwargs)
 
 
+import os.path
+_numba_path = os.path.dirname(__file__)
+loc_info = {}
+
+
 @contextlib.contextmanager
 def new_error_context(fmt_, *args, **kwargs):
     """
@@ -239,6 +244,11 @@ def new_error_context(fmt_, *args, **kwargs):
     ``fmt_.format(*args, **kwargs)`` to produce the final message string.
     """
     errcls = kwargs.pop('errcls_', InternalError)
+
+    loc = kwargs.get('loc', None)
+    if loc is not None and not loc.filename.startswith(_numba_path):
+        loc_info.update(kwargs)
+
     try:
         yield
     except NumbaError as e:

--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -20,6 +20,8 @@ from ..config import PYVERSION
 from ..numpy_support import ufunc_find_matching_loop, select_array_wrapper
 from ..typing import npydecl
 
+from .. import errors
+
 registry = Registry()
 lower = registry.lower
 
@@ -252,6 +254,11 @@ def _build_array(context, builder, array_ty, input_types, inputs):
                                  builder.icmp(lc.ICMP_SLT, arg_result, ONE)):
             msg = "unable to broadcast argument %d to output array" % (
                 arg_number,)
+
+            loc = errors.loc_info.get('loc', None)
+            if loc is not None:
+                msg += '\nFile "%s", line %d, ' % (loc.filename, loc.line)
+
             context.call_conv.return_user_exc(builder, ValueError, (msg,))
 
     real_array_ty = array_ty.as_array


### PR DESCRIPTION
This PR is intended as an issue report rather than merge seeking. I don't think changes here satisfies quality level of numba, but it could serve simplified PoC purpose.

I just identified and fixed a subtle bug in my lengthy (a njitted function with several hundreds of lines) code aided by changes here, which otherwise made no progress for days. Here's the demonstration of hardness without source file/line information in runtime errors.

Most bugs can be easily identified by just disabling jit and see what numpy says,  but as in this (corner?) case, numpy broadcasts a zero-length array with another lengthy array in == comparison, while numba does report an error. Though numba did a better job in hinting the bug, but lacking of source location info in the runtime error, had made it clueless annoying, since my code is rather lengthy & complex.

I'd hope source file/line to be included officially in numba runtime errors as possible, sooner than later.

Numba is, after all, an amazing master piece!

```python
import sys
import traceback

import numba as nb
import numpy as np


def bug_free(a, b):
    for ii in np.where(b < 0.5)[0]:
        yield a[
            (a['ti'] == ii)
            & (a['tv'] < 6)
            ]


def bug_prone(a, b):
    # the following line misses `[0]` to simulate a bug in lengthy code
    for ii in np.where(b < 0.5):
        yield a[
            (a['ti'] == ii)
            & (a['tv'] < 6)
            ]


b = np.random.random(5)
a = np.random.randint(7, size=10).view(np.dtype([
    ('ti', np.intp),
    ('tv', np.intp),
]))
print('a=', a, 'b=', b)

try:
    print('bug free np=', list(bug_free(a, b)))
    print('bug prone np=', list(bug_prone(a, b)))
except ValueError:
    traceback.print_exc(file=sys.stdout)
    print(' ^^ above is numpy error trace')

try:
    print('bug free nb=', list(nb.njit()(bug_free)(a, b)))
    print('bug prone nb=', list(nb.njit()(bug_prone)(a, b)))
except ValueError:
    traceback.print_exc(file=sys.stdout)
    print(' ^^ above is numba error trace')
```
will output:
```pycon
a= [(3, 3) (1, 6) (3, 3) (1, 5) (0, 4)] b= [ 0.81706988  0.42658492  0.09646511  0.07678733  0.24299798]
bug free np= [array([(1, 5)], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([(3, 3), (3, 3)], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([], 
      dtype=[('ti', '<i8'), ('tv', '<i8')])]
bug prone np= [array([], 
      dtype=[('ti', '<i8'), ('tv', '<i8')])]
bug free nb= [array([(1, 5)], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([(3, 3), (3, 3)], 
      dtype=[('ti', '<i8'), ('tv', '<i8')]), array([], 
      dtype=[('ti', '<i8'), ('tv', '<i8')])]
Traceback (most recent call last):
  File "/poc/numba_brdcst.py", line 41, in <module>
    print('bug prone nb=', list(nb.njit()(bug_prone)(a, b)))
ValueError: unable to broadcast argument 2 to output array
File "/poc/numba_brdcst.py", line 21, 
 ^^ above is numba error trace
```

The 2nd last line is not there by default, this changeset adds it.