### PR TITLE
Fixes #2458, poor performance in np.median

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -459,18 +459,25 @@ def _partition(A, low, high):
         A[low], A[mid] = A[mid], A[low]
     if A[high] < A[mid]:
         A[high], A[mid] = A[mid], A[high]
-        if A[mid] < A[low]:
-            A[low], A[mid] = A[mid], A[low]
+    if A[mid] < A[low]:
+        A[low], A[mid] = A[mid], A[low]
     pivot = A[mid]
 
     A[high], A[mid] = A[mid], A[high]
-
     i = low
-    for j in range(low, high):
-        if A[j] <= pivot:
-            A[i], A[j] = A[j], A[i]
+    j = high - 1
+    while True:
+        while i < high and A[i] < pivot:
             i += 1
-
+        while j >= low and pivot < A[j]:
+            j -= 1
+        if i >= j:
+            break
+        A[i], A[j] = A[j], A[i]
+        i += 1
+        j -= 1
+    # Put the pivot back in its final place (all items before `i`
+    # are smaller than the pivot, all items at/after `i` are larger)
     A[i], A[high] = A[high], A[i]
     return i
 


### PR DESCRIPTION
This fixes the reported poor performance in `np.median`, it
copies in the rest of the algorithm for partitioning from the
Numba quicksort implementation.

Fixes #2458