### PR TITLE
Rename cfg before parfor translation (#2477)

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -990,7 +990,8 @@ def simplify_CFG(blocks):
                 blocks[node].body.extend(blocks[next_node].body)
                 blocks.pop(next_node)
                 label_map[next_node] = node
-    return
+
+    return rename_labels(blocks)
 
 
 arr_math = ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -192,7 +192,7 @@ class ParforPass(object):
     def run(self):
         """run parfor conversion pass: replace Numpy calls
         with Parfors when possible and optimize the IR."""
-        simplify_CFG(self.func_ir.blocks)
+        self.func_ir.blocks = simplify_CFG(self.func_ir.blocks)
         # remove Del statements for easier optimization
         remove_dels(self.func_ir.blocks)
         # e.g. convert A.sum() to np.sum(A) for easier match and optimization

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1928,16 +1928,3 @@ def parfor_typeinfer(parfor, typeinferer):
 
 
 typeinfer.typeinfer_extensions[Parfor] = parfor_typeinfer
-
-# add lowering functions for prange same as range
-# enables prange to work in nopython mode without parallel flag
-def lower_prange_seq():
-    import numba.targets.rangeobj  # import to install range lowerers
-    from numba.targets.imputils import builtin_registry
-    prange_lowerers = []
-    for imp, func, args in builtin_registry.functions:
-        if func == range:
-            prange_lowerers.append((imp, prange, args))
-    builtin_registry.functions.extend(prange_lowerers)
-
-lower_prange_seq()

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1928,3 +1928,16 @@ def parfor_typeinfer(parfor, typeinferer):
 
 
 typeinfer.typeinfer_extensions[Parfor] = parfor_typeinfer
+
+# add lowering functions for prange same as range
+# enables prange to work in nopython mode without parallel flag
+def lower_prange_seq():
+    import numba.targets.rangeobj  # import to install range lowerers
+    from numba.targets.imputils import builtin_registry
+    prange_lowerers = []
+    for imp, func, args in builtin_registry.functions:
+        if func == range:
+            prange_lowerers.append((imp, prange, args))
+    builtin_registry.functions.extend(prange_lowerers)
+
+lower_prange_seq()

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -4,7 +4,7 @@ Implementation of the range object for fixed-size integers.
 
 import llvmlite.llvmpy.core as lc
 
-from numba import types, cgutils
+from numba import types, cgutils, prange
 from .listobj import ListIterInstance
 from .arrayobj import make_array
 from .imputils import (lower_builtin, lower_cast,
@@ -25,6 +25,7 @@ def make_range_impl(int_type, range_state_type, range_iter_type):
     RangeState = cgutils.create_struct_proxy(range_state_type)
 
     @lower_builtin(range, int_type)
+    @lower_builtin(prange, int_type)
     def range1_impl(context, builder, sig, args):
         """
         range(stop: int) -> range object
@@ -40,6 +41,7 @@ def make_range_impl(int_type, range_state_type, range_iter_type):
                                   state._getvalue())
 
     @lower_builtin(range, int_type, int_type)
+    @lower_builtin(prange, int_type, int_type)
     def range2_impl(context, builder, sig, args):
         """
         range(start: int, stop: int) -> range object
@@ -55,6 +57,7 @@ def make_range_impl(int_type, range_state_type, range_iter_type):
                                   state._getvalue())
 
     @lower_builtin(range, int_type, int_type, int_type)
+    @lower_builtin(prange, int_type, int_type, int_type)
     def range3_impl(context, builder, sig, args):
         """
         range(start: int, stop: int, step: int) -> range object

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -466,6 +466,24 @@ class TestParfors(TestParforsBase):
         np.testing.assert_allclose(parfor_output, py_output, rtol=0.05)
         self.assertIn('@do_scheduling', cpfunc.library.get_llvm_str())
 
+    @skip_unsupported
+    def test_cfg(self):
+        # from issue #2477
+        def test_impl(x, is_positive, N):
+            for i in numba.prange(2):
+                for j in range( i*N//2, (i+1)*N//2 ):
+                    is_positive[j] = 0
+                    if x[j] > 0:
+                        is_positive[j] = 1
+
+            return is_positive
+
+        N = 100
+        x = np.random.rand(N)
+        is_positive = np.zeros(N)
+        self.check(test_impl, x, is_positive, N)
+
+
 class TestPrange(TestParforsBase):
 
     def prange_tester(self, pyfunc, *args, **kwargs):


### PR DESCRIPTION
The issue in #2477  was that parfor analysis passes assume topological ordering of labels which wasn't the case by default. This commit renames labels according to topological order before translation.