### PR TITLE
Implement np.take and ndarray.take

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -146,6 +146,7 @@ The following methods of Numpy arrays are supported in their basic form
 * :meth:`~numpy.ndarray.prod`
 * :meth:`~numpy.ndarray.std`
 * :meth:`~numpy.ndarray.sum`
+* :meth:`~numpy.ndarray.take`
 * :meth:`~numpy.ndarray.var`
 
 The corresponding top-level Numpy functions (such as :func:`numpy.sum`)
@@ -274,6 +275,7 @@ The following top-level functions are supported:
 * :func:`numpy.sinc`
 * :func:`numpy.sort` (no optional arguments)
 * :func:`numpy.stack`
+* :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.vstack`
 * :func:`numpy.where`
 * :func:`numpy.zeros` (only the 2 first arguments)

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -426,6 +426,18 @@ class ArrayAttribute(AttributeTemplate):
         assert not args
         return signature(ary.copy(ndim=1, layout='C'))
 
+    @bound_function("array.take")
+    def resolve_take(self, ary, args, kws):
+        assert not kws
+        argty, = args
+        if isinstance(argty, types.Integer):
+            sig = signature(ary.dtype, *args)
+        elif isinstance(argty, types.Array):
+            sig = signature(argty.copy(layout='C', dtype=ary.dtype), *args)
+        elif isinstance(argty, types.List):
+            sig = signature(types.Array(ary.dtype, 1, 'C'), *args)
+        return sig
+
     def generic_resolve(self, ary, attr):
         # Resolution of other attributes, for record arrays
         if isinstance(ary.dtype, types.Record):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1173,6 +1173,22 @@ class DiagCtor(CallableTemplate):
         return typer
 
 
+@infer_global(np.take)
+class Take(AbstractTemplate):
+
+    def generic(self, args, kws):
+        assert not kws
+        assert len(args) == 2
+        arr, ind = args
+        if isinstance(ind, types.Number):
+            retty = arr.dtype
+        elif isinstance(ind, types.Array):
+            retty = types.Array(ndim=ind.ndim, dtype=arr.dtype, layout='C')
+        elif isinstance(ind, types.List):
+            retty = types.Array(ndim=1, dtype=arr.dtype, layout='C')
+
+        return signature(retty, *args)
+
 # -----------------------------------------------------------------------------
 # Numba helpers
 


### PR DESCRIPTION
This implements np.take and ndarray.take for basic integer based
indexing using ndarrays as the index, it also supports scalar and
single indexed lists as indexes.

There is a slight inefficiency in having to copy the index array
if it is F ordered to ensure C ordering for walking with nditer,
this is due to nditer not supporting flags at present.

Closes #2466.