### PR TITLE
Display a warning if parallel=True is set but not possible.

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -74,6 +74,13 @@ variables.  On a 32-bit machine, you may sometimes need the magnitude of
 ``np.int64`` (for example ``np.int64(0)`` instead of ``0``).  It will
 propagate to all computations involving those variables.
 
+How can I tell if ``parallel=True`` worked?
+-------------------------------------------
+
+Set the :ref:`environment variable <numba-envvars>` ``NUMBA_WARNINGS`` to
+non-zero and if the ``parallel=True`` transformations failed for a function
+decorated as such, a warning will be displayed.
+
 
 Performance
 ===========

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -74,6 +74,8 @@ variables.  On a 32-bit machine, you may sometimes need the magnitude of
 ``np.int64`` (for example ``np.int64(0)`` instead of ``0``).  It will
 propagate to all computations involving those variables.
 
+.. _parallel_faqs:
+
 How can I tell if ``parallel=True`` worked?
 -------------------------------------------
 

--- a/docs/source/user/parallel.rst
+++ b/docs/source/user/parallel.rst
@@ -120,4 +120,4 @@ it would require a pervasive change that rewrites the code to extract kernel
 computation that can be parallelized, which was both tedious and challenging.
 
 
-.. seealso:: :ref:`parallel_jit_option`
+.. seealso:: :ref:`parallel_jit_option`, :ref:`Parallel FAQs <parallel_FAQs>`


### PR DESCRIPTION
This patch makes it such that if a user:
* decorates a function with `parallel=True` but the function
  does not contain parallel semantics
* has the environment variable `NUMBA_WARNINGS` set to non-zero

then a warning is displayed referring to the decorated function
informing the user that the parallel tranforms have failed.

Closes #2461.