### PR TITLE
Remove hacky code added in 2482 and feature enhancement

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -165,7 +165,13 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.ravel` (no order argument; 'C' order only)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
 * :meth:`~numpy.ndarray.sort` (without arguments)
-* :meth:`~numpy.ndarray.sum` (without arguments or with a constant, non-keyword axis argument in the range 0 to 3)
+* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument)
+
+  * If the ``axis`` argument is a compile-time constant, all valid values are supported.
+    An out-of-range value will result in a ``LoweringError`` at compile-time.
+  * If the ``axis`` argument is not a compile-time constant, only values from 0 to 3 are supported.
+    An out-of-range value will result in a runtime exception.
+
 * :meth:`~numpy.ndarray.transpose` (without arguments, and without copying)
 * :meth:`~numpy.ndarray.view` (only the 1-argument form)
 
@@ -197,7 +203,7 @@ floating-point and complex numbers:
   change is supported e.g. real input -> real
   output, complex input -> complex output).
 * :func:`numpy.linalg.eigh` (only the first argument).
-* :func:`numpy.linalg.eigvals` (only running with data that does not cause a 
+* :func:`numpy.linalg.eigvals` (only running with data that does not cause a
   domain change is supported e.g. real input -> real output,
   complex input -> complex output).
 * :func:`numpy.linalg.eigvalsh` (only the first argument).

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -327,7 +327,7 @@ def intrinsic(*args, **kwargs):
         def example(typingctx, ...):
             ...
 
-    Support keyword arguments are:
+    Supported keyword arguments are:
 
     - support_literals : bool
         Indicates to the type inferencer that the typing logic accepts and can specialize to

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -22,7 +22,7 @@ from numba.typing import signature
 from .arrayobj import make_array, load_item, store_item, _empty_nd_impl
 
 from numba.extending import intrinsic
-from numba.errors import RequireConstValue
+from numba.errors import RequireConstValue, TypingError
 
 
 @intrinsic
@@ -176,6 +176,12 @@ def array_sum_axis(context, builder, sig, args):
     if isinstance(ty_axis, types.Const):
         # this special-cases for constant axis
         const_axis_val = ty_axis.value
+        # fix negative axis
+        if const_axis_val < 0:
+            const_axis_val = ty_array.ndim + const_axis_val
+        if const_axis_val < 0 or const_axis_val > ty_array.ndim:
+            raise TypingError("'axis' entry is out of bounds")
+
         ty_axis = context.typing_context.resolve_value_type(const_axis_val)
         axis_val = context.get_constant(ty_axis, const_axis_val)
         # rewrite arguments

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -180,7 +180,7 @@ def array_sum_axis(context, builder, sig, args):
         if const_axis_val < 0:
             const_axis_val = ty_array.ndim + const_axis_val
         if const_axis_val < 0 or const_axis_val > ty_array.ndim:
-            raise TypingError("'axis' entry is out of bounds")
+            raise ValueError("'axis' entry is out of bounds")
 
         ty_axis = context.typing_context.resolve_value_type(const_axis_val)
         axis_val = context.get_constant(ty_axis, const_axis_val)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -29,12 +29,12 @@ from numba.errors import RequireConstValue
 def _create_tuple_result_shape(tyctx, shape_list, shape_tuple):
     """
     This routine converts shape list where the axis dimension has already
-    been popped to a tuple for indexing of the same size.  The original shape 
-    tuple is also required because it contains a length field at compile time 
+    been popped to a tuple for indexing of the same size.  The original shape
+    tuple is also required because it contains a length field at compile time
     whereas the shape list does not.
     """
 
-    # The new tuple's size is one less than the original tuple since axis 
+    # The new tuple's size is one less than the original tuple since axis
     # dimension removed.
     nd = len(shape_tuple) - 1
     # The return type of this intrinsic is an int tuple of length nd.
@@ -65,7 +65,7 @@ def _create_tuple_result_shape(tyctx, shape_list, shape_tuple):
 
     return function_sig, codegen
 
-@intrinsic
+@intrinsic(support_literals=True)
 def _gen_index_tuple(tyctx, shape_tuple, value, axis):
     """
     Generates a tuple that can be used to index a specific slice from an
@@ -74,10 +74,6 @@ def _gen_index_tuple(tyctx, shape_tuple, value, axis):
     in the axis dimension and 'axis' is that dimension.  For this to work,
     axis has to be a const.
     """
-
-    if not isinstance(axis, types.Const):
-        raise RequireConstValue('axis must be a const')
-
     # Get the value of the axis constant.
     axis_value = axis.value
     # The length of the indexing tuple to be output.
@@ -98,7 +94,7 @@ def _gen_index_tuple(tyctx, shape_tuple, value, axis):
     types_list = ([types.slice2_type] * before) +  \
                   [types.intp] +                   \
                  ([types.slice2_type] * after)
-    
+
     # Creates the output type of the function.
     tupty = types.Tuple(types_list)
     # Defines the signature of the intrinsic.
@@ -140,6 +136,7 @@ def _gen_index_tuple(tyctx, shape_tuple, value, axis):
 
     return function_sig, codegen
 
+
 #----------------------------------------------------------------------------
 # Basic stats and aggregates
 
@@ -164,12 +161,12 @@ def array_sum_axis(context, builder, sig, args):
     """
     The third parameter to gen_index_tuple that generates the indexing
     tuples has to be a const so we can't just pass "axis" through since
-    that isn't const.  We can check for specific values and have 
+    that isn't const.  We can check for specific values and have
     different instances that do take consts.  Supporting axis summation
     only up to the fourth dimension for now.
     """
 
-    # typing/arraydecl.py:sum_expand defines the return type for sum with axis. 
+    # typing/arraydecl.py:sum_expand defines the return type for sum with axis.
     # It is one dimension less than the input array.
     zero = sig.return_type.dtype(0)
     # Again, the result array is one less than the input array dimensions.

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -704,7 +704,9 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         self.assertIn(errmsg, str(raises.exception))
         with self.assertRaises(ValueError) as raises:
             foo.py_func(a)
-        self.assertEqual(str(raises.exception), errmsg)
+        # Numpy 1.13 has a different error message than prior numpy
+        # Just check for the "out of bounds" phrase in it.
+        self.assertIn("out of bounds", str(raises.exception))
 
     def test_cumsum(self):
         pyfunc = array_cumsum

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -698,12 +698,13 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         self.assertPreciseEqual(foo(a), foo.py_func(a))
         # ndim == 2, axis == -3, BAD
         a = np.ones((1, 2))
-        with self.assertRaises(TypingError) as raises:
+        with self.assertRaises(LoweringError) as raises:
             foo(a)
-        self.assertIn("'axis' entry is out of bounds", str(raises.exception), )
+        errmsg = "'axis' entry is out of bounds"
+        self.assertIn(errmsg, str(raises.exception))
         with self.assertRaises(ValueError) as raises:
             foo.py_func(a)
-        self.assertEqual(str(raises.exception), "'axis' entry is out of bounds")
+        self.assertEqual(str(raises.exception), errmsg)
 
     def test_cumsum(self):
         pyfunc = array_cumsum

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1129,7 +1129,10 @@ class TypeInferer(object):
             typ = typ.copy(readonly=True)
 
         self.sentry_modified_builtin(inst, gvar)
-        self.lock_type(target.name, typ, loc=inst.loc)
+        # Setting literal_value for globals because they are handled
+        # like const value in numba
+        self.lock_type(target.name, typ, loc=inst.loc,
+                       literal_value=gvar.value)
         self.assumed_immutables.add(inst)
 
     def typeof_expr(self, inst, target, expr):

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -364,12 +364,24 @@ def fold_arg_vars(typevars, args, vararg, kws, get_literals=False):
 
     pos_args = args[:n_pos_args]
     if vararg is not None:
-        if not isinstance(args[-1], types.BaseTuple):
+        errmsg = "*args in function call should be a tuple, got %s"
+        # Handle constant literal used for `*args`
+        if isinstance(args[-1], types.Const):
+            const_val = args[-1].value
+            # Is the constant value a tuple?
+            if not isinstance(const_val, tuple):
+                raise TypeError(errmsg % (args[-1],))
+            # Append the elements in the const tuple to the positional args
+            pos_args += args[-1].value
+        # Handle non-constant
+        elif not isinstance(args[-1], types.BaseTuple):
             # Unsuitable for *args
             # (Python is more lenient and accepts all iterables)
-            raise TypeError("*args in function call should be a tuple, got %s"
-                            % (args[-1],))
-        pos_args += args[-1].types
+            raise TypeError(errmsg % (args[-1],))
+        else:
+            # Append the elements in the tuple to the positional args
+            pos_args += args[-1].types
+        # Drop the last arg
         args = args[:-1]
     kw_args = dict(zip(kwds, args[n_pos_args:]))
     return pos_args, kw_args
@@ -424,7 +436,7 @@ class CallConstraint(object):
                     return
 
         literals = fold_arg_vars(typevars, self.args, self.vararg, self.kws,
-                                  get_literals=True)
+                                 get_literals=True)
         # Resolve call type
         sig = typeinfer.resolve_call(fnty, pos_args, kw_args, literals=literals)
         if sig is None:

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -259,6 +259,12 @@ class Callable(Type):
         Returns a tuple of (list of signatures, parameterized)
         """
 
+    def get_call_type_with_literals(self, context, args, kws, literals):
+        """Simliar to .get_call_type() but with extra argument for literals.
+        Default implementation ignores literals and forwards to .get_call_type().
+        """
+        return self.get_call_type(context, args, kws)
+
 
 class DTypeSpec(Type):
     """

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -117,6 +117,12 @@ class BoundFunction(Callable, Opaque):
     def get_call_type(self, context, args, kws):
         return self.template(context).apply(args, kws)
 
+    def get_call_type_with_literals(self, context, args, kws, literals):
+        if literals is not None and self.template.support_literals:
+            return self.template(context).apply(*literals)
+        else:
+            return self.get_call_type(context, args, kws)
+
     def get_call_signatures(self):
         sigs = getattr(self.template, 'cases', [])
         is_param = hasattr(self.template, 'generic')

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -50,6 +50,17 @@ class BaseFunction(Callable):
                 self._impl_keys[sig.args] = temp.get_impl_key(sig)
                 return sig
 
+    def get_call_type_with_literals(self, context, args, kws, literals):
+        for temp_cls in self.templates:
+            temp = temp_cls(context)
+            if literals is not None and temp.support_literals:
+                sig = temp.apply(*literals)
+            else:
+                sig = temp.apply(args, kws)
+            if sig is not None:
+                self._impl_keys[sig.args] = temp.get_impl_key(sig)
+                return sig
+
     def get_call_signatures(self):
         sigs = []
         is_param = False

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -559,7 +559,7 @@ def sum_expand(self, args, kws):
     args_len = len(args)
     assert args_len <= 1
     if args_len == 0:
-        # No axis parameter so the return type of the summation is a scalar 
+        # No axis parameter so the return type of the summation is a scalar
         # of the type of the array.
         return signature(_expand_integer(self.this.dtype), *args, recvr=self.this)
     else:
@@ -589,10 +589,11 @@ def generic_index(self, args, kws):
     assert not kws
     return signature(types.intp, recvr=self.this)
 
-def install_array_method(name, generic):
+def install_array_method(name, generic, support_literals=False):
     my_attr = {"key": "array." + name, "generic": generic}
     temp_class = type("Array_" + name, (AbstractTemplate,), my_attr)
-
+    if support_literals:
+        temp_class.support_literals = support_literals
     def array_attribute_attachment(self, ary):
         return types.BoundFunction(temp_class, ary)
 
@@ -604,7 +605,7 @@ for fname in ["min", "max"]:
 
 # Functions that return a machine-width type, to avoid overflows
 install_array_method("prod", generic_expand)
-install_array_method("sum", sum_expand)
+install_array_method("sum", sum_expand, support_literals=True)
 
 # Functions that return a machine-width type, to avoid overflows
 for fname in ["cumsum", "cumprod"]:

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -199,12 +199,7 @@ class BaseContext(object):
 
         if isinstance(func, types.Callable):
             # XXX fold this into the __call__ attribute logic?
-            try:
-                return func.get_call_type(self, args, kws)
-            except errors.RequireConstValue:
-                if literals is None:
-                    raise
-                return func.get_call_type(self, *literals)
+            return func.get_call_type_with_literals(self, args, kws, literals)
 
     def _get_attribute_templates(self, typ):
         """

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -365,6 +365,9 @@ def _numpy_redirect(fname):
     cls = type("Numpy_redirect_{0}".format(fname), (Numpy_method_redirection,),
                dict(key=numpy_function, method_name=fname))
     infer_global(numpy_function, types.Function(cls))
+    # special case literal support for 'sum'
+    if fname == 'sum':
+        cls.support_literals = True
 
 for func in ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
              'cumsum', 'cumprod', 'argmin', 'argmax', 'argsort',

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -167,6 +167,9 @@ class FunctionTemplate(object):
     # subclass overide-able
     unsafe_casting = True
 
+    # Whether the typing support literals
+    support_literals = False
+
     def __init__(self, context):
         self.context = context
 


### PR DESCRIPTION
(base on #2482)

* add runtime check to ensure the compiler didn't incorrectly assumed constantness
    * ~~~TODO: check if llvm will remove the check~~~ (Yes, it does)
* refactor the way an impl indicates it can accept `types.Const` to not use exception as a signal.
* make np.sum specialize to constant literals for axis without limit.
    * dynamic axis value is still limited to 0, 1, 2, 3
* support axis as kwargs e.g. `np.sum(axis=1)`

