### PR TITLE
Enable CUDA toolkit version testing

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -22,6 +22,7 @@ build:
     - CFLAGS
     - CXXFLAGS
     - PY_VCRUNTIME_REDIST
+    - LD_LIBRARY_PATH # for CUDA on Linux
 
 requirements:
   # build and run dependencies are duplicated to avoid setuptools issues
@@ -48,7 +49,7 @@ test:
     - cffi
     - scipy
     - ipython
-    - cudatoolkit
+    - cudatoolkit {{ environ.get('CUDATOOLKIT_VERSION', '7.5') }} # default to 7.5
     - setuptools
   files:
     - mandel.py


### PR DESCRIPTION
This adds:
* `LD_LIBRARY_PATH` to allow CUDA to work in docker container
   builds
* Support for setting a CUDA toolkit version number at testing
  time.