### PR TITLE
Fix Windows 64 bit CUDA tests.

### DIFF
--- a/numba/cuda/tests/cudapy/test_complex.py
+++ b/numba/cuda/tests/cudapy/test_complex.py
@@ -70,7 +70,7 @@ class BaseComplexTest(object):
                  float('inf'), float('-inf')]
         return [complex(x, y) for x, y in itertools.product(reals, reals)]
 
-    def run_func(self, pyfunc, sigs, values, ulps=1):
+    def run_func(self, pyfunc, sigs, values, ulps=1, ignore_sign_on_zero=False):
         for sig in sigs:
             if isinstance(sig, types.Type):
                 sig = sig,
@@ -96,7 +96,9 @@ class BaseComplexTest(object):
             for got, expected, args in zip(got_list, expected_list, ok_values):
                 msg = 'for input %r with prec %r' % (args, prec)
                 self.assertPreciseEqual(got, expected, prec=prec,
-                                        ulps=ulps, msg=msg)
+                                        ulps=ulps,
+                                        ignore_sign_on_zero=ignore_sign_on_zero,
+                                        msg=msg)
 
     run_unary = run_func
     run_binary = run_func
@@ -136,7 +138,7 @@ class TestCMath(BaseComplexTest, TestCase):
                        self.basic_values())
 
     def check_unary_func(self, pyfunc, ulps=1, values=None,
-                         returns_float=False):
+                         returns_float=False, ignore_sign_on_zero=False):
         if returns_float:
             def sig(tp):
                 return tp.underlying_float(tp)
@@ -144,10 +146,12 @@ class TestCMath(BaseComplexTest, TestCase):
             def sig(tp):
                 return tp(tp)
         self.run_unary(pyfunc, [sig(types.complex128)],
-                       values or self.more_values(), ulps=ulps)
+                       values or self.more_values(), ulps=ulps,
+                       ignore_sign_on_zero=ignore_sign_on_zero)
         # Avoid discontinuities around pi when in single precision.
         self.run_unary(pyfunc, [sig(types.complex64)],
-                       values or self.basic_values(), ulps=ulps)
+                       values or self.basic_values(), ulps=ulps,
+                       ignore_sign_on_zero=ignore_sign_on_zero)
 
     # Conversions
 
@@ -218,10 +222,11 @@ class TestCMath(BaseComplexTest, TestCase):
 
     def test_sin(self):
         # See test_sinh.
-        self.check_unary_func(sin_usecase)
+        self.check_unary_func(sin_usecase, ulps=2)
 
     def test_tan(self):
-        self.check_unary_func(tan_usecase, ulps=2)
+        self.check_unary_func(tan_usecase, ulps=2,
+                              ignore_sign_on_zero=True)
 
     # Hyperbolic functions
 
@@ -232,16 +237,18 @@ class TestCMath(BaseComplexTest, TestCase):
         self.check_unary_func(asinh_usecase, ulps=2)
 
     def test_atanh(self):
-        self.check_unary_func(atanh_usecase, ulps=2)
+        self.check_unary_func(atanh_usecase, ulps=2,
+                              ignore_sign_on_zero=True)
 
     def test_cosh(self):
         self.check_unary_func(cosh_usecase, ulps=2)
 
     def test_sinh(self):
-        self.check_unary_func(sinh_usecase)
+        self.check_unary_func(sinh_usecase, ulps=2)
 
     def test_tanh(self):
-        self.check_unary_func(tanh_usecase, ulps=2)
+        self.check_unary_func(tanh_usecase, ulps=2,
+                              ignore_sign_on_zero=True)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_serialize.py
+++ b/numba/cuda/tests/cudapy/test_serialize.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import pickle
 import numpy as np
-from numba import cuda, vectorize
+from numba import cuda, vectorize, numpy_support, types
 from numba import unittest_support as unittest
 from numba.cuda.testing import skip_on_cudasim
 
@@ -63,8 +63,10 @@ class TestPickle(unittest.TestCase):
         def cuda_vect(x):
             return x * 2
 
+        # accommodate int representations in np.arange
+        npty = numpy_support.as_dtype(types.intp)
         # get expected result
-        ary = np.arange(10)
+        ary = np.arange(10, dtype=npty)
         expected = cuda_vect(ary)
         # first pickle
         foo1 = pickle.loads(pickle.dumps(cuda_vect))


### PR DESCRIPTION
This fixes issues with signed zeros and floating point errors at
near machine precision for some libm functions.

It also fixes `np.arange(x)` instantiating with a dtype of
`int32` when used in a `@vectorize` function compiled for
`types.intp` (`int64`).

Fixes #2510