### PR TITLE
Add np.MachAr, np.finfo, np.iinfo

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -302,7 +302,8 @@ construct a scalar) or a sequence (to construct an array):
 * :class:`numpy.uintc`
 * :class:`numpy.uintp`
 
-The following machine parameter classes are supported:
+The following machine parameter classes are supported, with all purely numerical
+attributes:
 
 * :class:`numpy.iinfo`
 * :class:`numpy.finfo` (``machar`` attribute not supported)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -302,6 +302,13 @@ construct a scalar) or a sequence (to construct an array):
 * :class:`numpy.uintc`
 * :class:`numpy.uintp`
 
+The following machine parameter classes are supported:
+
+* :class:`numpy.iinfo`
+* :class:`numpy.finfo` (``machar`` attribute not supported)
+* :class:`numpy.MachAr` (with no arguments to the constructor)
+
+
 Literal arrays
 --------------
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1385,13 +1385,19 @@ MachAr = namedtuple('MachAr', _mach_ar_supported)
 
 # Do not support MachAr field
 # finfo
-_finfo_supported = ('bits', 'eps', 'epsneg', 'iexp', 'machep', 'max',
-                    'maxexp', 'min', 'minexp', 'negep', 'nexp', 'nmant',
-                    'precision', 'resolution', 'tiny',)
+_finfo_supported = ('eps', 'epsneg', 'iexp', 'machep', 'max', 'maxexp', 'min',
+                    'minexp', 'negep', 'nexp', 'nmant', 'precision',
+                    'resolution', 'tiny',)
+if numpy_version >= (1, 12):
+    _finfo_supported = ('bits',) + _finfo_supported
+
 finfo = namedtuple('finfo', _finfo_supported)
 
 # iinfo
-_iinfo_supported = ('min', 'max', 'bits',)
+_iinfo_supported = ('min', 'max')
+if numpy_version >= (1, 12):
+    _iinfo_supported = _iinfo_supported + ('bits',)
+
 iinfo = namedtuple('iinfo', _iinfo_supported)
 
 @overload(np.MachAr)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1386,8 +1386,8 @@ MachAr = namedtuple('MachAr', _mach_ar_supported)
 # Do not support MachAr field
 # finfo
 _finfo_supported = ('bits', 'eps', 'epsneg', 'iexp', 'machep', 'max',
-                    'maxexp', 'negep', 'nexp', 'nmant', 'precision',
-                    'resolution', 'tiny',)
+                    'maxexp', 'min', 'minexp', 'negep', 'nexp', 'nmant',
+                    'precision', 'resolution', 'tiny',)
 finfo = namedtuple('finfo', _finfo_supported)
 
 # iinfo

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -5,6 +5,7 @@ Implementation of math operations on Array objects.
 from __future__ import print_function, absolute_import, division
 
 import math
+from collections import namedtuple
 
 import numpy as np
 
@@ -1372,3 +1373,44 @@ def np_histogram(a, bins=10, range=None):
             return hist, bins
 
     return histogram_impl
+
+
+# Create np.finfo, np.iinfo and np.MachAr
+# machar
+_mach_ar_supported = ('ibeta', 'it', 'machep', 'eps', 'negep', 'epsneg',
+                      'iexp', 'minexp', 'xmin', 'maxexp', 'xmax', 'irnd',
+                      'ngrd', 'epsilon', 'tiny', 'huge', 'precision',
+                      'resolution',)
+MachAr = namedtuple('MachAr', _mach_ar_supported)
+
+# Do not support MachAr field
+# finfo
+_finfo_supported = ('bits', 'eps', 'epsneg', 'iexp', 'machep', 'max',
+                    'maxexp', 'negep', 'nexp', 'nmant', 'precision',
+                    'resolution', 'tiny',)
+finfo = namedtuple('finfo', _finfo_supported)
+
+# iinfo
+_iinfo_supported = ('min', 'max', 'bits',)
+iinfo = namedtuple('iinfo', _iinfo_supported)
+
+@overload(np.MachAr)
+def MachAr_impl():
+    f = np.MachAr()
+    _mach_ar_data = tuple([getattr(f, x) for x in _mach_ar_supported])
+    def impl():
+        return MachAr(*_mach_ar_data)
+    return impl
+
+def generate_xinfo(np_func, container, attr):
+    @overload(np_func)
+    def xinfo_impl(arg):
+        nbty = getattr(arg, 'dtype', arg)
+        f = np_func(as_dtype(nbty))
+        data = tuple([getattr(f, x) for x in attr])
+        def impl(arg):
+            return container(*data)
+        return impl
+
+generate_xinfo(np.finfo, finfo, _finfo_supported)
+generate_xinfo(np.iinfo, iinfo, _iinfo_supported)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -433,6 +433,8 @@ def foo():
     return np.%s(ty)
 '''
 
+    bits = ('bits',) if np_version >= (1, 12)  else ()
+
     def check(self, func, attrs, *args):
         pyfunc = func
         cfunc = jit(nopython=True)(pyfunc)
@@ -462,9 +464,9 @@ def foo():
 
     def test_finfo(self):
         types = [np.float32, np.float64, np.complex64, np.complex128]
-        attrs = ('bits', 'eps', 'epsneg', 'iexp', 'machep', 'max',
-                 'maxexp', 'negep', 'nexp', 'nmant', 'precision',
-                 'resolution', 'tiny',)
+        attrs = self.bits + ('eps', 'epsneg', 'iexp', 'machep', 'max',
+                'maxexp', 'negep', 'nexp', 'nmant', 'precision',
+                'resolution', 'tiny',)
         for ty in types:
             self.check(finfo, attrs, ty(1))
             hc_func = self.create_harcoded_variant(np.finfo, ty)
@@ -486,7 +488,7 @@ def foo():
         # check types and instances of types
         types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16,
                  np.uint32, np.uint64]
-        attrs = ('min', 'max', 'bits')
+        attrs = ('min', 'max') + self.bits
         for ty in types:
             self.check(iinfo, attrs, ty(1))
             hc_func = self.create_harcoded_variant(np.iinfo, ty)


### PR DESCRIPTION
This adds and tests the classes:
* `np.MachAr`
* `np.finfo`
* `np.iinfo`

the implementation is via named tuple opposed to jitclass for
efficiency and to maintain serialization capability.

Updates the documentation and notes limitations.

Closes #2507.