### PR TITLE
Allow environ overriding of cpu target and cpu features.

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -137,6 +137,27 @@ Compilation options
    calls the original Python function instead of a compiled version.  This
    can be useful if you want to run the Python debugger over your code.
 
+.. envvar:: NUMBA_CPU_NAME and NUMBA_CPU_FEATURES
+
+    Override CPU and CPU features detection.
+    By setting ``NUMBA_CPU_NAME=generic``, A generic CPU model is picked
+    for the CPU architecture and the features (NUMBA_CPU_FEATURES) is
+    defaulted to empty.  CPU features must be listed with the format
+    ``+feature1,-feature2`` where ``+`` indicates enable and ``-`` indicates
+    disable. For example, ``+sse,+sse2,-avx,-avx2`` enables SSE and SSE2, and
+    disables AVX and AVX2.
+
+    These settings are passed to LLVM for configuring the compilation target.
+    To get a list of available option, use the ``llc`` commandline tool
+    from LLVM, like::
+
+        llc -march=x86 -mattr=help
+
+
+    .. tip:: To force all caching functions (``@jit(cache=True)``) to emit
+        portable code (portable within the same architecture and OS),
+        simply set ``NUMBA_CPU_NAME=generic``.
+
 
 GPU support
 -----------
@@ -160,7 +181,7 @@ Threading Control
 
 .. envvar:: NUMBA_NUM_THREADS
 
-   If set, the number of threads in the thread pool for the parallel CPU target 
+   If set, the number of threads in the thread pool for the parallel CPU target
    will take this value. Must be greater than zero. This value is independent
    of ``OMP_NUM_THREADS`` and ``MKL_NUM_THREADS``.
 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -140,16 +140,16 @@ Compilation options
 .. envvar:: NUMBA_CPU_NAME and NUMBA_CPU_FEATURES
 
     Override CPU and CPU features detection.
-    By setting ``NUMBA_CPU_NAME=generic``, A generic CPU model is picked
-    for the CPU architecture and the features (NUMBA_CPU_FEATURES) is
-    defaulted to empty.  CPU features must be listed with the format
+    By setting ``NUMBA_CPU_NAME=generic``, a generic CPU model is picked
+    for the CPU architecture and the feature list (``NUMBA_CPU_FEATURES``)
+    defaults to empty.  CPU features must be listed with the format
     ``+feature1,-feature2`` where ``+`` indicates enable and ``-`` indicates
     disable. For example, ``+sse,+sse2,-avx,-avx2`` enables SSE and SSE2, and
     disables AVX and AVX2.
 
     These settings are passed to LLVM for configuring the compilation target.
-    To get a list of available option, use the ``llc`` commandline tool
-    from LLVM, like::
+    To get a list of available options, use the ``llc`` commandline tool
+    from LLVM, for example::
 
         llc -march=x86 -mattr=help
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -97,6 +97,9 @@ class _EnvReloader(object):
                               (name, value), RuntimeWarning)
                 return default
 
+        def optional_str(x):
+            return str(x) if x is not None else None
+
         # Print warnings to screen about function compilation
         #   0 = Numba warnings suppressed (default)
         #   1 = All Numba warnings shown
@@ -126,6 +129,13 @@ class _EnvReloader(object):
         # Enable debugging of type inference
         DEBUG_TYPEINFER = _readenv("NUMBA_DEBUG_TYPEINFER", int, 0)
 
+        # Configure compilation target to use the specified CPU name
+        # and CPU feature as the host information.
+        # Note: this override "host" option for AOT compilation.
+        CPU_NAME = _readenv("NUMBA_CPU_NAME", optional_str, None)
+        CPU_FEATURES = _readenv("NUMBA_CPU_FEATURES", optional_str,
+                                ("" if str(CPU_NAME).lower() == 'generic'
+                                 else None))
         # Optimization level
         OPT = _readenv("NUMBA_OPT", int, 3)
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -131,7 +131,7 @@ class _EnvReloader(object):
 
         # Configure compilation target to use the specified CPU name
         # and CPU feature as the host information.
-        # Note: this override "host" option for AOT compilation.
+        # Note: this overrides "host" option for AOT compilation.
         CPU_NAME = _readenv("NUMBA_CPU_NAME", optional_str, None)
         CPU_FEATURES = _readenv("NUMBA_CPU_FEATURES", optional_str,
                                 ("" if str(CPU_NAME).lower() == 'generic'

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -648,7 +648,7 @@ class BaseCPUCodegen(object):
         """
         Return a tuple unambiguously describing the codegen behaviour.
         """
-        return (self._llvm_module.triple, ll.get_host_cpu_name(),
+        return (self._llvm_module.triple, self._get_host_cpu_name(),
                 self._tm_features)
 
     def _scan_and_fix_unresolved_refs(self, module):
@@ -668,6 +668,27 @@ class BaseCPUCodegen(object):
             fnptr.linkage = 'external'
         return builder.bitcast(builder.load(fnptr), fnty.as_pointer())
 
+    def _get_host_cpu_name(self):
+        return (ll.get_host_cpu_name()
+                if config.CPU_NAME is None
+                else config.CPU_NAME)
+
+    def _get_host_cpu_features(self):
+        if config.CPU_FEATURES is not None:
+            return config.CPU_FEATURES
+        try:
+            features = ll.get_host_cpu_features()
+        except RuntimeError:
+            return ''
+        else:
+            if not config.ENABLE_AVX:
+                # Disable all features with name starting with 'avx'
+                for k in features:
+                    if k.startswith('avx'):
+                        features[k] = False
+
+            # Set feature attributes
+            return features.flatten()
 
 class AOTCPUCodegen(BaseCPUCodegen):
     """
@@ -685,7 +706,7 @@ class AOTCPUCodegen(BaseCPUCodegen):
     def _customize_tm_options(self, options):
         cpu_name = self._cpu_name
         if cpu_name == 'host':
-            cpu_name = ll.get_host_cpu_name()
+            cpu_name = self._get_host_cpu_name()
         options['cpu'] = cpu_name
         options['reloc'] = 'pic'
         options['codemodel'] = 'default'
@@ -710,8 +731,7 @@ class JITCPUCodegen(BaseCPUCodegen):
     def _customize_tm_options(self, options):
         # As long as we don't want to ship the code to another machine,
         # we can specialize for this CPU.
-        options['cpu'] = ll.get_host_cpu_name()
-
+        options['cpu'] = self._get_host_cpu_name()
         options['reloc'] = 'default'
         options['codemodel'] = 'jitdefault'
 
@@ -724,19 +744,7 @@ class JITCPUCodegen(BaseCPUCodegen):
 
     def _customize_tm_features(self):
         # For JIT target, we will use LLVM to get the feature map
-        try:
-            features = ll.get_host_cpu_features()
-        except RuntimeError:
-            return ''
-        else:
-            if not config.ENABLE_AVX:
-                # Disable all features with name starting with 'avx'
-                for k in features:
-                    if k.startswith('avx'):
-                        features[k] = False
-
-            # Set feature attributes
-            return features.flatten()
+        return self._get_host_cpu_features()
 
     def _add_module(self, module):
         self._engine.add_module(module)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1029,6 +1029,15 @@ class TestCacheWithCpuSetting(BaseCacheUsecasesTest):
     # Disable parallel testing due to envvars modification
     _numba_parallel_test_ = False
 
+    def check_later_mtimes(self, mtimes_old):
+        match_count = 0
+        for k, v in self.get_cache_mtimes().items():
+            if k in mtimes_old:
+                self.assertGreaterEqual(v, mtimes_old[k])
+                match_count += 1
+        self.assertGreater(match_count, 0,
+                           msg='nothing to compare')
+
     def test_user_set_cpu_name(self):
         self.check_pycache(0)
         mod = self.import_module()
@@ -1042,8 +1051,8 @@ class TestCacheWithCpuSetting(BaseCacheUsecasesTest):
             self.run_in_separate_process()
         finally:
             del os.environ['NUMBA_CPU_NAME']
-        self.assertNotEqual(self.get_cache_mtimes(), mtimes)
-        self.assertNotEqual(len(self.cache_contents()), cache_size)
+        self.check_later_mtimes(mtimes)
+        self.assertGreater(len(self.cache_contents()), cache_size)
         # Check cache index
         cache = mod.add_usecase._cache
         cache_file = cache._cache_file
@@ -1077,8 +1086,8 @@ class TestCacheWithCpuSetting(BaseCacheUsecasesTest):
             self.run_in_separate_process()
         finally:
             del os.environ['NUMBA_CPU_FEATURES']
-        self.assertNotEqual(self.get_cache_mtimes(), mtimes)
-        self.assertNotEqual(len(self.cache_contents()), cache_size)
+        self.check_later_mtimes(mtimes)
+        self.assertGreater(len(self.cache_contents()), cache_size)
         # Check cache index
         cache = mod.add_usecase._cache
         cache_file = cache._cache_file

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -648,8 +648,7 @@ class BaseCacheTest(TestCase):
         pass
 
 
-class TestCache(BaseCacheTest):
-
+class BaseCacheUsecasesTest(BaseCacheTest):
     here = os.path.dirname(__file__)
     usecases_file = os.path.join(here, "cache_usecases.py")
     modname = "dispatcher_caching_test_fodder"
@@ -695,6 +694,9 @@ class TestCache(BaseCacheTest):
         if misses is not None:
             self.assertEqual(sum(st.cache_misses.values()), misses,
                              st.cache_misses)
+
+
+class TestCache(BaseCacheUsecasesTest):
 
     @tag('important')
     def test_caching(self):
@@ -1021,6 +1023,11 @@ class TestCache(BaseCacheTest):
         # Run a second time and check caching
         err = execute_with_input()
         self.assertEqual(err.strip(), "cache hits = 1")
+
+
+class TestCacheWithCpuSetting(BaseCacheUsecasesTest):
+    # Disable parallel testing due to envvars modification
+    _numba_parallel_test_ = False
 
     def test_user_set_cpu_name(self):
         self.check_pycache(0)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -18,6 +18,7 @@ from numba import _dispatcher
 from numba.errors import NumbaWarning
 from .support import TestCase, tag, temp_directory, import_dynamic
 
+import llvmlite.binding as ll
 
 def dummy(x):
     return x
@@ -1020,6 +1021,73 @@ class TestCache(BaseCacheTest):
         # Run a second time and check caching
         err = execute_with_input()
         self.assertEqual(err.strip(), "cache hits = 1")
+
+    def test_user_set_cpu_name(self):
+        self.check_pycache(0)
+        mod = self.import_module()
+        mod.self_test()
+        cache_size = len(self.cache_contents())
+
+        mtimes = self.get_cache_mtimes()
+        # Change CPU name to generic
+        try:
+            os.environ['NUMBA_CPU_NAME'] = 'generic'
+            self.run_in_separate_process()
+        finally:
+            del os.environ['NUMBA_CPU_NAME']
+        self.assertNotEqual(self.get_cache_mtimes(), mtimes)
+        self.assertNotEqual(len(self.cache_contents()), cache_size)
+        # Check cache index
+        cache = mod.add_usecase._cache
+        cache_file = cache._cache_file
+        cache_index = cache_file._load_index()
+        self.assertEqual(len(cache_index), 2)
+        [key_a, key_b] = cache_index.keys()
+        if key_a[1][1] == ll.get_host_cpu_name():
+            key_host, key_generic = key_a, key_b
+        else:
+            key_host, key_generic = key_b, key_a
+        self.assertEqual(key_host[1][1], ll.get_host_cpu_name())
+        self.assertEqual(key_host[1][2], ll.get_host_cpu_features().flatten())
+        self.assertEqual(key_generic[1][1], 'generic')
+        self.assertEqual(key_generic[1][2], '')
+
+    def test_user_set_cpu_features(self):
+        self.check_pycache(0)
+        mod = self.import_module()
+        mod.self_test()
+        cache_size = len(self.cache_contents())
+
+        mtimes = self.get_cache_mtimes()
+        # Change CPU feature
+        my_cpu_features = '-sse;-avx'
+
+        system_features = ll.get_host_cpu_features().flatten()
+
+        self.assertNotEqual(system_features, my_cpu_features)
+        try:
+            os.environ['NUMBA_CPU_FEATURES'] = my_cpu_features
+            self.run_in_separate_process()
+        finally:
+            del os.environ['NUMBA_CPU_FEATURES']
+        self.assertNotEqual(self.get_cache_mtimes(), mtimes)
+        self.assertNotEqual(len(self.cache_contents()), cache_size)
+        # Check cache index
+        cache = mod.add_usecase._cache
+        cache_file = cache._cache_file
+        cache_index = cache_file._load_index()
+        self.assertEqual(len(cache_index), 2)
+        [key_a, key_b] = cache_index.keys()
+
+        if key_a[1][2] == system_features:
+            key_host, key_generic = key_a, key_b
+        else:
+            key_host, key_generic = key_b, key_a
+
+        self.assertEqual(key_host[1][1], ll.get_host_cpu_name())
+        self.assertEqual(key_host[1][2], system_features)
+        self.assertEqual(key_generic[1][1], ll.get_host_cpu_name())
+        self.assertEqual(key_generic[1][2], my_cpu_features)
 
 
 class TestMultiprocessCache(BaseCacheTest):


### PR DESCRIPTION
Closes https://github.com/numba/numba/issues/2499

Useful for sharing cache among multiple machines of the same OS and CPU arch.