### PR TITLE
Fix invalid cuda context in memory transfer calls in another thread

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -136,6 +136,7 @@ class DeviceNDArrayBase(object):
         else:
             return self.gpu_data.device_ctypes_pointer
 
+    @devices.require_context
     def copy_to_device(self, ary, stream=0):
         """Copy `ary` to `self`.
 
@@ -153,6 +154,7 @@ class DeviceNDArrayBase(object):
             sz = min(_driver.host_memory_size(ary), self.alloc_size)
             _driver.host_to_device(self, ary, sz, stream=stream)
 
+    @devices.require_context
     def copy_to_host(self, ary=None, stream=0):
         """Copy ``self`` to ``ary`` or create a new Numpy ndarray
         if ``ary`` is ``None``.

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -332,6 +332,7 @@ class DeviceNDArray(DeviceNDArrayBase):
         else:
             raise NotImplementedError("operation requires copying")
 
+    @devices.require_context
     def __getitem__(self, item):
         return self._do_getitem(item)
 


### PR DESCRIPTION
Closes #2522 

Add context autoinit to `copy_to_device` and `copy_to_host`.
