### PR TITLE
More locks...

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -34,6 +34,7 @@ from .jitclass import jitclass
 # Keep this for backward compatibility.
 test = runtests.main
 
+from numba import llvmthreadsafe as llvmts
 
 __all__ = """
     autojit
@@ -52,6 +53,7 @@ __all__ = """
 _min_llvmlite_version = (0, 19, 0)
 _min_llvm_version = (4, 0, 0)
 
+@llvmts.lock_llvm
 def _ensure_llvm():
     """
     Make sure llvmlite is operational.

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -11,6 +11,7 @@ from numba.targets.base import BaseContext
 from numba.targets.callconv import MinimalCallConv
 from numba.targets import cmathimpl, operatorimpl
 from numba.typing import cmathdecl, operatordecl
+import numba.llvmthreadsafe as llvmts
 
 from numba import itanium_mangler
 from .cudadrv import nvvm
@@ -65,6 +66,7 @@ class CUDATargetContext(BaseContext):
     def create_module(self, name):
         return self._internal_codegen._create_empty_module(name)
 
+    @llvmts.lock_llvm
     def init(self):
         self._internal_codegen = codegen.JITCUDACodegen("numba.cuda.jit")
         self._target_data = ll.create_target_data(nvvm.default_data_layout)

--- a/numba/llvmthreadsafe.py
+++ b/numba/llvmthreadsafe.py
@@ -1,12 +1,8 @@
 """
 Utils for managing LLVM for threadsafe usage.
 """
-import types
 import threading
 import functools
-import contextlib
-import llvmlite.binding as llvm
-
 
 class LockLLVM(object):
     """
@@ -35,34 +31,3 @@ class LockLLVM(object):
 lock_llvm = LockLLVM()
 del LockLLVM
 
-
-def _patch_dispose(llvmobj):
-    """
-    Patch the _dispose method of the llvm object to use the llvm lock.
-    """
-    dtor = llvmobj._dispose
-
-    def _ts_dispose():
-        with lock_llvm:
-            dtor()
-
-    llvmobj._dispose = _ts_dispose
-    return llvmobj
-
-
-def _patch_retval_dispose(fn):
-    """
-    Patch the _dispose method of the return value of the wrapped function.
-    """
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        return _patch_dispose(fn(*args, **kwargs))
-    return wrapper
-
-
-# Bind llvm API with the lock
-parse_assembly = lock_llvm(_patch_retval_dispose(llvm.parse_assembly))
-parse_bitcode = lock_llvm(_patch_retval_dispose(llvm.parse_bitcode))
-create_mcjit_compiler = lock_llvm(llvm.create_mcjit_compiler)
-create_module_pass_manager = lock_llvm(llvm.create_module_pass_manager)
-create_function_pass_manager = lock_llvm(llvm.create_function_pass_manager)

--- a/numba/llvmthreadsafeapi.py
+++ b/numba/llvmthreadsafeapi.py
@@ -1,0 +1,33 @@
+import llvmlite.binding as llvm
+import functools
+from numba import llvmthreadsafe as llvmts
+
+def _patch_dispose(llvmobj):
+    """
+    Patch the _dispose method of the llvm object to use the llvm lock.
+    """
+    dtor = llvmobj._dispose
+
+    def _ts_dispose():
+        dtor()
+
+    llvmobj._dispose = _ts_dispose
+    return llvmobj
+
+
+def _patch_retval_dispose(fn):
+    """
+    Patch the _dispose method of the return value of the wrapped function.
+    """
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return _patch_dispose(fn(*args, **kwargs))
+    return wrapper
+
+
+# Bind llvm API with the lock
+parse_assembly = llvmts.lock_llvm(_patch_retval_dispose(llvm.parse_assembly))
+parse_bitcode = llvmts.lock_llvm(_patch_retval_dispose(llvm.parse_bitcode))
+create_mcjit_compiler = llvmts.lock_llvm(llvm.create_mcjit_compiler)
+create_module_pass_manager = llvmts.lock_llvm(llvm.create_module_pass_manager)
+create_function_pass_manager = llvmts.lock_llvm(llvm.create_function_pass_manager)

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -19,6 +19,7 @@ import numpy as np
 import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
 
+import numba.llvmthreadsafe as llvmts
 from numba.npyufunc import ufuncbuilder
 from numba.numpy_support import as_dtype
 from numba import types, utils, cgutils, config
@@ -417,6 +418,7 @@ def _launch_threads():
 
 _is_initialized = False
 
+@llvmts.lock_llvm
 def _init():
     from . import workqueue as lib
     from ctypes import CFUNCTYPE, c_void_p

--- a/numba/runtime/nrtopt.py
+++ b/numba/runtime/nrtopt.py
@@ -4,7 +4,7 @@ NRT specific optimizations
 import re
 from collections import defaultdict, deque
 
-import numba.llvmthreadsafe as llvmts
+import numba.llvmthreadsafeapi as llvmtsapi
 
 
 _regex_incref = re.compile(r'\s*(?:tail)?\s*call void @NRT_incref\((.*)\)')
@@ -164,4 +164,4 @@ def remove_redundant_nrt_refct(ll_module):
         return ll_module
 
     newll = _remove_redundant_nrt_refct(str(ll_module))
-    return llvmts.parse_assembly(newll)
+    return llvmtsapi.parse_assembly(newll)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -149,6 +149,7 @@ class OverloadSelector(object):
 
 
 @utils.runonce
+@llvmts.lock_llvm
 def _load_global_helpers():
     """
     Execute once to install special symbols into the LLVM symbol table.
@@ -1005,6 +1006,7 @@ class BaseContext(object):
         assert isinstance(ty, llvmir.Type), "Expected LLVM type"
         return ty.get_abi_size(self.target_data)
 
+    @llvmts.lock_llvm
     def get_abi_alignment(self, ty):
         """
         Get the ABI alignment of LLVM type *ty*.
@@ -1023,6 +1025,7 @@ class BaseContext(object):
         """Run target specific post-lowering transformation here.
         """
 
+    @llvmts.lock_llvm
     def create_module(self, name):
         """Create a LLVM module
         """

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -9,6 +9,7 @@ from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba import llvmthreadsafe as llvmts
+from numba import llvmthreadsafeapi as llvmtsapi
 from numba import utils, config
 from numba import _helperlib
 from . import intrinsics
@@ -113,6 +114,7 @@ class _Installer(object):
 
     _installed = False
 
+    @llvmts.lock_llvm
     def install(self, context):
         """
         Install the functions into LLVM.  This only needs to be done once,
@@ -196,7 +198,7 @@ define void @fnclex() {
 }
     """
     ll.initialize_native_asmparser()
-    library.add_llvm_module(llvmts.parse_assembly(ir_mod))
+    library.add_llvm_module(llvmtsapi.parse_assembly(ir_mod))
     library.finalize()
     return library
 

--- a/numba/tests/npyufunc/test_parallel_ufunc_issues.py
+++ b/numba/tests/npyufunc/test_parallel_ufunc_issues.py
@@ -11,6 +11,9 @@ from numba import vectorize, guvectorize
 
 
 class TestParUfuncIssues(unittest.TestCase):
+    
+    _numba_parallel_test_ = False
+    
     def test_thread_response(self):
         """
         Related to #89.
@@ -76,6 +79,9 @@ class TestParUfuncIssues(unittest.TestCase):
 
 
 class TestParGUfuncIssues(unittest.TestCase):
+    
+    _numba_parallel_test_ = False
+    
     def test_gil_reacquire_deadlock(self):
         """
         Testing similar issue to #1998 due to GIL reacquiring for Gufunc

--- a/numba/tests/test_debug.py
+++ b/numba/tests/test_debug.py
@@ -14,6 +14,7 @@ from numba.compiler import compile_isolated, Flags
 from numba.errors import NumbaWarning
 from numba import compiler
 from .test_parfors import skip_unsupported
+from .matmul_usecase import needs_blas
 
 def simple_nopython(somearg):
     retval = somearg + 1
@@ -232,6 +233,7 @@ class TestParforWarnings(TestCase):
                 break
         self.assertTrue(warning_found, "Warning message should be found.")
 
+    @needs_blas
     @skip_unsupported
     def test_warns(self):
         try:

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -654,6 +654,8 @@ class BaseCacheUsecasesTest(BaseCacheTest):
     usecases_file = os.path.join(here, "cache_usecases.py")
     modname = "dispatcher_caching_test_fodder"
 
+    _numba_parallel_test_ = False
+
     def run_in_separate_process(self):
         # Cached functions can be run from a distinct process.
         # Also stresses issue #1603: uncached function calling cached function


### PR DESCRIPTION
A number of tests are still intermittently failing due to concurrent
access made to the LLVM context and LLVM in general. The three most
common offenders have already been patched, this attempts to fix most
of the remaining!

To work out where to put locks, llvmlite was instrumented with a
special decorator applied to all functions that make FFI calls to LLVM.
This decorator was context managed such that it would walk the stack
prior to yield and check that there was a llvmthreadsafe.py lock
present and raise if not. Running the test suite with this enabled
highlighted where locks needed to go. Since the llvmthreadsafe locks are
reentrant there's no harm in them being nested which reduced complexity
in applying them.

To help with tracing the stacks, this patch moves the functions that
had locks and called the LLVM API via llvmlite in
numba/llvmthreadsafe.py to numba/llvmthreadsafeapi.py so that the
presentation of a lock is consistent for all stacks (i.e. it's a
tracable import with consistent location not a local).

Once the locks were in place a couple of other issues materialised, due
to the difference in test run times caused by all the stack walking,
some tests relying on on disk cache failed when run in parallel mode due
to multiple threads writing/reading with a much longer interval between
the operations, as such reliance on e.g. testing properties of a single
cache location failed.

Limitations: The safety of LLVM calls at interpreter shutdown and during
more involved GC events is not necessarily covered as walking the
stack becomes more of a struggle during these times. Further, garbage
collection/deletion of the module level LLVM calls in
llvmthreadsafeapi.py trigger calls to an explicit `__del__` on the
execution engine wrapper which hits the LLVM FFI layer, these calls do
not have a lock guarding them at present as no simple hooks exist in
Numba for performing a guarded delete during e.g. interpreter shutdown.

This patch may or may not be applied. Given the limitations noted it may
make more sense to defer these fixes and patch llvmlite instead and
concentrate on fixing Python side synchronisation issues inside Numba.