### PR TITLE
Add tuple support to np.take.

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3387,6 +3387,8 @@ def numpy_take_2(context, builder, sig, args):
 
 @lower_builtin('array.take', types.Array, types.List)
 @lower_builtin(np.take, types.Array, types.List)
+@lower_builtin('array.take', types.Array, types.BaseTuple)
+@lower_builtin(np.take, types.Array, types.BaseTuple)
 def numpy_take_3(context, builder, sig, args):
 
     def take_impl(a, indices):

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -740,6 +740,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # 2. 1d array index
         # 3. nd array index, >2d and F order
         # 4. reflected list
+        # 5. tuples
 
         test_indices = []
         test_indices.append(1)
@@ -751,6 +752,9 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         test_indices.append(np.array([[[1, 5, 1], [11, 3, 0]]]))
         test_indices.append(np.array([[[[1, 5]], [[11, 0]],[[1, 2]]]]))
         test_indices.append([1, 5, 1, 11, 3])
+        test_indices.append((1, 5, 1))
+        test_indices.append(((1, 5, 1), (11, 3, 2)))
+        test_indices.append((((1,), (5,), (1,)), ((11,), (3,), (2,))))
 
         layouts = cycle(['C', 'F', 'A'])
 

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -186,12 +186,15 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
         # 2. 1d array index
         # 3. nd array index
         # 4. reflected list
+        # 5. tuples
         
         test_indices = []
         test_indices.append(1)
         test_indices.append(np.array([1, 5, 1, 11, 3]))
         test_indices.append(np.array([[[1], [5]], [[1], [11]]]))
         test_indices.append([1, 5, 1, 11, 3])
+        test_indices.append((1, 5, 1))
+        test_indices.append(((1, 5, 1), (11, 3, 2)))
     
         for dt in [np.int64, np.complex128]:
             A = np.arange(12, dtype=dt).reshape((4, 3))

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
+import numpy as np
+
 from collections import namedtuple
 
 from numba import types, utils
@@ -434,8 +436,12 @@ class ArrayAttribute(AttributeTemplate):
             sig = signature(ary.dtype, *args)
         elif isinstance(argty, types.Array):
             sig = signature(argty.copy(layout='C', dtype=ary.dtype), *args)
-        elif isinstance(argty, types.List):
+        elif isinstance(argty, types.List): # 1d lists only
             sig = signature(types.Array(ary.dtype, 1, 'C'), *args)
+        elif isinstance(argty, types.BaseTuple):
+            sig = signature(types.Array(ary.dtype, np.ndim(argty), 'C'), *args)
+        else:
+            raise TypeError("take(%s) not supported for %s" % argty)
         return sig
 
     def generic_resolve(self, ary, attr):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1198,6 +1198,10 @@ class Take(AbstractTemplate):
             retty = types.Array(ndim=ind.ndim, dtype=arr.dtype, layout='C')
         elif isinstance(ind, types.List):
             retty = types.Array(ndim=1, dtype=arr.dtype, layout='C')
+        elif isinstance(ind, types.BaseTuple):
+            retty = types.Array(ndim=np.ndim(ind), dtype=arr.dtype, layout='C')
+        else:
+            return None
 
         return signature(retty, *args)
 


### PR DESCRIPTION
Adds missing tuple support to `np.take`. Any tuple which would
be accepted by the ndarray ctor is accepted.

Fixes #2533