### PR TITLE
Allow float() overload for user types

### DIFF
--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -785,9 +785,6 @@ class Float(AbstractTemplate):
 
         [arg] = args
 
-        if arg not in types.number_domain:
-            raise TypeError("float() only support for numbers")
-
         if arg in types.complex_domain:
             raise TypeError("float() does not support complex")
 


### PR DESCRIPTION
Removes the assertion in type inference of `float()` that prevents overload by non-number types.