### PR TITLE
Rebranding fix

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -13,7 +13,7 @@ Communication
 Mailing-list
 ''''''''''''
 
-We have a public mailing-list that you can e-mail at numba-users@continuum.io.
+We have a public mailing-list that you can e-mail at numba-users@anaconda.com.
 If you have any questions about contributing to Numba, it is ok to ask them
 on this mailing-list.  You can subscribe and read the archives on
 `Google Groups <https://groups.google.com/a/continuum.io/forum/#!forum/numba-users>`_,


### PR DESCRIPTION
Continuum to Anaconda.com