### PR TITLE
relative doc links

### DIFF
--- a/docs/source/extending/index.rst
+++ b/docs/source/extending/index.rst
@@ -17,8 +17,8 @@ of APIs to this end:
   and experience with Numba internals.
 
 It may be helpful for readers of this chapter to also read some of the
-documents in the :doc:`developer manual </developer/index>`, especially
-the :doc:`architecture document </developer/architecture>`.
+documents in the :doc:`developer manual <../developer/index>`, especially
+the :doc:`architecture document <../developer/architecture>`.
 
 
 .. toctree::

--- a/docs/source/user/overview.rst
+++ b/docs/source/user/overview.rst
@@ -17,7 +17,7 @@ Numba's main features are:
 * :ref:`on-the-fly code generation <jit>` (at import time or runtime, at the
   user's preference)
 * native code generation for the CPU (default) and
-  :doc:`GPU hardware </cuda/index>`
+  :doc:`GPU hardware <../cuda/index>`
 * integration with the Python scientific software stack (thanks to Numpy)
 
 Here is how a Numba-optimized function, taking a Numpy array as argument,


### PR DESCRIPTION
relative doc links. This makes it easier to copy the Numba docs to docs.anaconda.com.