### PR TITLE
Fix issue #2564.

### DIFF
--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -209,7 +209,7 @@ class TestListComprehension(unittest.TestCase):
                     raise
 
         # test functions that are expected to fail
-        with self.assertRaises(LoweringError) as raises:
+        with self.assertRaises(TypingError) as raises:
             cfunc = jit(nopython=True)(list5)
             cfunc(var)
         # TODO: we can't really assert the error message for the above
@@ -365,7 +365,7 @@ class TestArrayComprehension(unittest.TestCase):
             l = np.array([[i * j for j in range(i+1)] for i in range(n)])
             return l
         # test is expected to fail
-        with self.assertRaises(LoweringError) as raises:
+        with self.assertRaises(TypingError) as raises:
             self.check(comp_nest_with_dependency, 5)
         self.assertIn('Failed', str(raises.exception))
 
@@ -384,6 +384,14 @@ class TestArrayComprehension(unittest.TestCase):
             return l
 
         self.check(nested_array, 10)
+
+    @tag('important')
+    def test_nested_array_with_const(self):
+        def nested_array(n):
+            l = np.array([ np.array([x for x in range(3)]) for y in range(4)])
+            return l
+
+        self.check(nested_array, 0)
 
     @tag('important')
     def test_array_comp_with_iter(self):


### PR DESCRIPTION
The problem arises when constants used in comprehension is defined only after array creation.
The fix is to detect this situation and define the constant before array creation.