### PR TITLE
Update for LLVM 5

### DIFF
--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -544,14 +544,21 @@ def _proxy(old):
 
 
 class JitEngine(object):
-    """Wraps a ExecutionEngine to provide custom symbol tracking.
+    """Wraps an ExecutionEngine to provide custom symbol tracking.
     Since the symbol tracking is incomplete  (doesn't consider
     loaded code object), we are not putting it in llvmlite.
     """
     def __init__(self, ee):
         self._ee = ee
         # Track symbol defined via codegen'd Module
-        # but not any cached object
+        # but not any cached object.
+        # NOTE: `llvm::ExecutionEngine` will catch duplicated symbols and
+        # we are not going to protect against that.  A proper duplicated
+        # symbol detection will need a more logic to check for the linkage
+        # (e.g. like `weak` linkage symbol can override).   This
+        # `_defined_symbols` set will be just enough to tell if a symbol
+        # exists and will not cause the `EE` symbol lookup to `exit(1)`
+        # when symbol-not-found.
         self._defined_symbols = set()
 
     def is_symbol_defined(self, name):


### PR DESCRIPTION
Addressing changes for https://github.com/numba/llvmlite/pull/307

Use custom symbol tracking to avoid llvm>5 ExecutionEngine crashes when asking of non-existing symbol address.
A proxy class to ExecutionEngine is added to override certain methods to scan to defined symbols.
The symbol scanning will only works for the usecase in numba and it is not general enough to be included in llvmlite.  For instance, there are other ways to add symbols to the execution engine but our symbols scanning will not see them.  A proper solution is to somehow expose the `JITSymbolResolver` from `ExceutionEngine` but it is currently a private attribute and the *EE* subclasses are hidden.