### PR TITLE
Fix issue #2561, handle missing successor on loop exit

### DIFF
--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -70,6 +70,10 @@ def lift_gen1(x):
         a[i] = x
     yield np.sum(a)
 
+def lift_issue2561(x):
+    for i in range(10):
+        for j in range(10):
+            return
 
 def reject1(x):
     a = np.arange(4)
@@ -200,6 +204,9 @@ class TestLoopLifting(MemoryLeakMixin, TestCase):
 
     def test_lift5(self):
         self.check_lift_ok(lift5, (types.intp,), (123,))
+
+    def test_lift_issue2561(self):
+        self.check_lift_ok(lift_issue2561, (types.List,), ([],))
 
     @tag('important')
     def test_lift_gen1(self):

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -70,10 +70,12 @@ def lift_gen1(x):
         a[i] = x
     yield np.sum(a)
 
-def lift_issue2561(x):
+def lift_issue2561():
+    np.empty(1)   # This forces objectmode because no nrt
     for i in range(10):
         for j in range(10):
-            return
+            return 1
+    return 2
 
 def reject1(x):
     a = np.arange(4)
@@ -206,7 +208,7 @@ class TestLoopLifting(MemoryLeakMixin, TestCase):
         self.check_lift_ok(lift5, (types.intp,), (123,))
 
     def test_lift_issue2561(self):
-        self.check_lift_ok(lift_issue2561, (types.List,), ([],))
+        self.check_no_lift(lift_issue2561, (), ())
 
     @tag('important')
     def test_lift_gen1(self):


### PR DESCRIPTION
This attempts to fix #2561, there are cases where there is no
successor present for a loop exit node (quite possibly due to
bytecode optimisations). This patch guards against this case by
trying to find alternative successors and dropping the looplift
candidate if none are found.

Fixes #2561.