### PR TITLE
Fix nested multi-dimensional parfor type inference issue

### DIFF
--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -2138,8 +2138,8 @@ def parfor_typeinfer(parfor, typeinferer):
     save_blocks = typeinferer.blocks
     blocks = wrap_parfor_blocks(parfor)
     index_vars = [l.index_variable for l in parfor.loop_nests]
-    if len(parfor.loop_nests) > 1:
-        index_vars.append(parfor.index_var)
+    # no need to handle parfor.index_var (tuple of variables), since it will be
+    # assigned to a tuple from individual indices
     first_block = min(blocks.keys())
     loc = blocks[first_block].loc
     index_assigns = [ir.Assign(ir.Const(1, loc), v, loc) for v in index_vars]

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -890,6 +890,19 @@ class TestPrange(TestParforsBase):
         self.prange_tester(test_impl, np.random.ranf(4))
 
     @skip_unsupported
+    def test_prange15(self):
+        # from issue 2587
+        # test parfor type inference when there is multi-dimensional indexing
+        def test_impl(N):
+            acc = 0
+            for i in range(N):
+                x = np.ones((1, 1))
+                acc += x[0, 0]
+            return acc
+
+        self.prange_tester(test_impl, 1024)
+
+    @skip_unsupported
     def test_kde_example(self):
         def test_impl(X):
             # KDE example


### PR DESCRIPTION
The tuple index variable of multi-dimensional parfors was being assigned a dummy integer constant which is fixed. Resolves #2587.