### PR TITLE
Fixes for stencil tests and cmath sin()

### DIFF
--- a/numba/tests/test_complex.py
+++ b/numba/tests/test_complex.py
@@ -38,7 +38,7 @@ class BaseComplexTest(object):
                  float('inf'), float('-inf')]
         return [complex(x, y) for x, y in itertools.product(reals, reals)]
 
-    def run_unary(self, pyfunc, x_types, x_values, ulps=1,
+    def run_unary(self, pyfunc, x_types, x_values, ulps=1, abs_tol=None,
                   flags=enable_pyobj_flags):
         for tx in x_types:
             cr = compile_isolated(pyfunc, [tx], flags=flags)
@@ -53,7 +53,7 @@ class BaseComplexTest(object):
                 got = cfunc(vx)
                 msg = 'for input %r with prec %r' % (vx, prec)
                 self.assertPreciseEqual(got, expected, prec=prec,
-                                        ulps=ulps, msg=msg)
+                                        ulps=ulps, abs_tol=abs_tol, msg=msg)
 
     def run_binary(self, pyfunc, value_types, values, ulps=1,
                    flags=enable_pyobj_flags):
@@ -136,12 +136,15 @@ class TestCMath(BaseComplexTest, TestCase):
         self.run_unary(pyfunc, [types.complex128, types.complex64],
                        self.basic_values(), flags=flags)
 
-    def check_unary_func(self, pyfunc, flags, ulps=1, values=None):
+    def check_unary_func(self, pyfunc, flags, ulps=1, abs_tol=None,
+                         values=None):
         self.run_unary(pyfunc, [types.complex128],
-                       values or self.more_values(), flags=flags, ulps=ulps)
+                       values or self.more_values(), flags=flags, ulps=ulps,
+                       abs_tol=abs_tol)
         # Avoid discontinuities around pi when in single precision.
         self.run_unary(pyfunc, [types.complex64],
-                       values or self.basic_values(), flags=flags, ulps=ulps)
+                       values or self.basic_values(), flags=flags, ulps=ulps,
+                       abs_tol=abs_tol)
 
     # Conversions
 
@@ -260,10 +263,10 @@ class TestCMath(BaseComplexTest, TestCase):
 
     def test_sin(self):
         # See test_sinh.
-        self.check_unary_func(sin_usecase, enable_pyobj_flags)
+        self.check_unary_func(sin_usecase, enable_pyobj_flags, abs_tol='eps')
 
     def test_sin_npm(self):
-        self.check_unary_func(sin_usecase, no_pyobj_flags)
+        self.check_unary_func(sin_usecase, no_pyobj_flags, abs_tol='eps')
 
     def test_tan(self):
         self.check_unary_func(tan_usecase, enable_pyobj_flags, ulps=2)
@@ -298,10 +301,10 @@ class TestCMath(BaseComplexTest, TestCase):
         self.check_unary_func(cosh_usecase, no_pyobj_flags, ulps=2)
 
     def test_sinh(self):
-        self.check_unary_func(sinh_usecase, enable_pyobj_flags)
+        self.check_unary_func(sinh_usecase, enable_pyobj_flags, abs_tol='eps')
 
     def test_sinh_npm(self):
-        self.check_unary_func(sinh_usecase, no_pyobj_flags)
+        self.check_unary_func(sinh_usecase, no_pyobj_flags, abs_tol='eps')
 
     def test_tanh(self):
         self.check_unary_func(tanh_usecase, enable_pyobj_flags, ulps=2)

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -28,7 +28,8 @@ _py27 = sys.version_info[:2] == (2, 7)
 _windows_py27 = (sys.platform.startswith('win32') and _py27)
 _32bit = sys.maxsize <= 2 ** 32
 _reason = 'parfors not supported'
-skip_unsupported = unittest.skipIf(_32bit or _windows_py27, _reason)
+_unsupported = _32bit or _windows_py27
+skip_unsupported = unittest.skipIf(_unsupported, _reason)
 
 
 @stencil
@@ -76,10 +77,12 @@ def stencil_with_standard_indexing_2d(a, b):
 def addone_njit(a):
     return a + 1
 
-
-@njit(parallel=True)
-def addone_pjit(a):
-    return a + 1
+# guard against the decorator being run on unsupported platforms
+# as it will raise and stop test discovery from working
+if not _unsupported:
+    @njit(parallel=True)
+    def addone_pjit(a):
+        return a + 1
 
 
 class TestStencilBase(unittest.TestCase):


### PR DESCRIPTION
test_stencil has a declaration at the module level which causes
test discovery to fail on unsupported platforms and as a result
breaks incremental conda build recipes, included is a fix.

cmath sin{,h}() is sometimes generated via `sincos` intrinsic in
LLVM 5.x which has a slightly different value near `pi`, it is
near zero and near machine precision, this adds an absolute
tolerance to the tests to accommodate.
