### PR TITLE
Fix potential cache file collision

### DIFF
--- a/numba/caching.py
+++ b/numba/caching.py
@@ -329,9 +329,10 @@ class _CacheImpl(object):
             raise RuntimeError("cannot cache function %r: no locator available "
                                "for file %r" % (qualname, source_path))
         self._locator = locator
-        # Keep the last dotted component, since the package name is already
-        # encoded in the directory.
-        modname = py_func.__module__.split('.')[-1]
+        # Use filename base name as module name to avoid conflict between
+        # foo/__init__.py and foo/foo.py
+        filename = inspect.getfile(py_func)
+        modname = os.path.splitext(os.path.basename(filename))[0]
         fullname = "%s.%s" % (modname, qualname)
         abiflags = getattr(sys, 'abiflags', '')
         self._filename_base = self.get_filename_base(fullname, abiflags)

--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -3,7 +3,6 @@ from __future__ import print_function, absolute_import, division
 import sys
 import os.path
 import re
-from contextlib import contextmanager
 import subprocess
 
 import numpy as np
@@ -11,7 +10,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import config
 
-from ..support import captured_stdout, override_config
+from ..support import capture_cache_log
 from ..test_dispatcher import BaseCacheTest
 
 
@@ -29,12 +28,6 @@ class UfuncCacheTest(BaseCacheTest):
 
     regex_data_loaded = re.compile(r'\[cache\] data loaded from')
     regex_index_loaded = re.compile(r'\[cache\] index loaded from')
-
-    @contextmanager
-    def capture_cache_log(self):
-        with captured_stdout() as out:
-            with override_config('DEBUG_CACHE', True):
-                yield out
 
     def check_cache_saved(self, cachelog, count):
         """
@@ -62,13 +55,13 @@ class UfuncCacheTest(BaseCacheTest):
         mod = self.import_module()
         usecase = getattr(mod, usecase_name)
         # New cache entry saved
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             new_ufunc = usecase(**kwargs)
         cachelog = out.getvalue()
         self.check_cache_saved(cachelog, count=n_overloads)
 
         # Use cached version
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             cached_ufunc = usecase(**kwargs)
         cachelog = out.getvalue()
         self.check_cache_loaded(cachelog, count=n_overloads)
@@ -113,16 +106,16 @@ class TestDUfuncCacheTest(UfuncCacheTest):
         mod = self.import_module()
         usecase = getattr(mod, usecase_name)
         # Create dufunc
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             ufunc = usecase()
         self.check_cache_saved(out.getvalue(), count=0)
         # Compile & cache
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             ufunc(np.arange(10))
         self.check_cache_saved(out.getvalue(), count=1)
         self.check_cache_loaded(out.getvalue(), count=0)
         # Use cached
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             ufunc = usecase()
             ufunc(np.arange(10))
         self.check_cache_loaded(out.getvalue(), count=1)
@@ -146,7 +139,7 @@ class TestGUfuncCacheTest(UfuncCacheTest):
     def test_filename_prefix(self):
         mod = self.import_module()
         usecase = getattr(mod, "direct_gufunc_cache_usecase")
-        with self.capture_cache_log() as out:
+        with capture_cache_log() as out:
             usecase()
         cachelog = out.getvalue()
         # find number filename with "guf-" prefix

--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -11,7 +11,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import config
 
-from ..support import captured_stdout
+from ..support import captured_stdout, override_config
 from ..test_dispatcher import BaseCacheTest
 
 
@@ -33,9 +33,8 @@ class UfuncCacheTest(BaseCacheTest):
     @contextmanager
     def capture_cache_log(self):
         with captured_stdout() as out:
-            old, config.DEBUG_CACHE = config.DEBUG_CACHE, True
-            yield out
-            config.DEBUG_CACHE = old
+            with override_config('DEBUG_CACHE', True):
+                yield out
 
     def check_cache_saved(self, cachelog, count):
         """

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -424,6 +424,29 @@ def override_config(name, value):
         setattr(config, name, old_value)
 
 
+@contextlib.contextmanager
+def override_env_config(name, value):
+    """
+    Return a context manager that temporarily sets an Numba config environment
+    *name* to *value*.
+    """
+    old = os.environ.get(name)
+    os.environ[name] = value
+    config.reload_config()
+
+    try:
+        yield
+    finally:
+        if old is None:
+            # If it wasn't set originally, delete the environ var
+            del os.environ[name]
+        else:
+            # Otherwise, restore to the old value
+            os.environ[name] = old
+        # Always reload config
+        config.reload_config()
+
+
 def compile_function(name, code, globs):
     """
     Given a *code* string, compile it with globals *globs* and return

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -583,6 +583,13 @@ def captured_stderr():
     return captured_output("stderr")
 
 
+@contextlib.contextmanager
+def capture_cache_log():
+    with captured_stdout() as out:
+        with override_config('DEBUG_CACHE', True):
+            yield out
+
+
 class MemoryLeak(object):
 
     __enable_leak_check = True

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import threading
 import warnings
-from contextlib import contextmanager
 
 import numpy as np
 
@@ -18,10 +17,11 @@ from numba import config
 from numba import _dispatcher
 from numba.errors import NumbaWarning
 from .support import (TestCase, tag, temp_directory, import_dynamic,
-                      captured_stdout, override_env_config)
+                      override_env_config, capture_cache_log)
 from numba.targets import codegen
 
 import llvmlite.binding as ll
+
 
 def dummy(x):
     return x
@@ -1251,13 +1251,6 @@ def bar():
             r2 = bar2()
         q.put(buf.getvalue())
         q.put(r2)
-
-
-@contextmanager
-def capture_cache_log():
-    with captured_stdout() as out:
-        with override_env_config('NUMBA_DEBUG_CACHE', '1'):
-            yield out
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #2602 

Cache filename is now prefixed with the filename of the source file.

Also, the tests for the cache file naming revealed problems in other tests that patches the `numba.config` either through direct modification of `config` or through `os.environ`.  The problem is that the config reloading in the start of compilation is conditional to whether any environment variables were changed (see https://github.com/numba/numba/blob/dedfe7c514965b17b8a6be4b553c5ee563d4eb92/numba/config.py#L79-L83).  Residual changes (likely from teardown of other tests) can have sideeffect on later test.  To address this issue, the override_config APIs are enhanced so that the sideeffect will not leak to other tests and all tests that patches config will use the override_config API.

**Additional comments on the effect of new cache file naming scheme**

* Given that the cache file is pinned to numba version, there will not be conflict with existing cache file.  
* Only cache file originated from function defined in `__init__.py` is affected.