### PR TITLE
Fix NRT test failure due to increased overhead when running in coverage

### DIFF
--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -222,7 +222,8 @@ class TestTracemalloc(unittest.TestCase):
         stat = diff[0]
         # There is a slight overhead, so the allocated size won't exactly be N
         self.assertGreaterEqual(stat.size, N)
-        self.assertLess(stat.size, N * 1.01)
+
+        self.assertLess(stat.size, N * 1.015)
         frame = stat.traceback[0]
         self.assertEqual(os.path.basename(frame.filename), "test_nrt.py")
         self.assertEqual(frame.lineno, alloc_lineno)

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -222,8 +222,10 @@ class TestTracemalloc(unittest.TestCase):
         stat = diff[0]
         # There is a slight overhead, so the allocated size won't exactly be N
         self.assertGreaterEqual(stat.size, N)
-
-        self.assertLess(stat.size, N * 1.015)
+        self.assertLess(stat.size, N * 1.015,
+                        msg=("Unexpected allocation overhead encountered. "
+                             "May be due to difference in CPython "
+                             "builds or running under coverage"))
         frame = stat.traceback[0]
         self.assertEqual(os.path.basename(frame.filename), "test_nrt.py")
         self.assertEqual(frame.lineno, alloc_lineno)


### PR DESCRIPTION
The modified test has been failing recently in TravisCI.  The test is sensitive to changes in CPython builds and running mode (in coverage) that affects the memory allocation overhead.  The changes increases the accepted threshold so it doesn't fail in TravisCI when running in coverage.