### PR TITLE
Fix dubious pthread_cond_signal not in lock

### DIFF
--- a/numba/npyufunc/workqueue.c
+++ b/numba/npyufunc/workqueue.c
@@ -212,8 +212,8 @@ queue_state_wait(Queue *queue, int old, int repl)
         queue_condition_wait(cond);
     }
     queue->state = repl;
-    queue_condition_unlock(cond);
     queue_condition_signal(cond);
+    queue_condition_unlock(cond);
 }
 
 static void


### PR DESCRIPTION
Based on #2615.

This is an error reported by valgrind's helgrind.