### PR TITLE
Fix `np.nanmedian` for all NaN case.

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -770,6 +770,11 @@ if numpy_version >= (1, 9):
                 if not isnan(v):
                     temp_arry[n] = v
                     n += 1
+
+            # all NaNs
+            if n == 0:
+                return np.nan
+
             return _median_inner(temp_arry, n)
 
         return nanmedian_impl

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -345,6 +345,8 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             yield a
             a[a % 4 >= 2] = float('nan')
             yield a
+            a[:] = float('nan')
+            yield a
 
         self.check_median_basic(pyfunc, variations)
 


### PR DESCRIPTION
The case of an array containing all NaN was incorrectly handled
in the Numba impl of `np.nanmedian`, this patch handles such a
scenario and returns `np.nan` to match Numpy behaviour.

Fixes #2617