### PR TITLE
Make the dependency on compilers for AOT optional.

### DIFF
--- a/buildscripts/condarecipe.buildbot/meta.yaml
+++ b/buildscripts/condarecipe.buildbot/meta.yaml
@@ -41,9 +41,6 @@ requirements:
     - llvmlite 0.21.*
     - funcsigs                 # [py27]
     - singledispatch           # [py27]
-    # Need these for AOT. Do not init msvc as it may not be present
-    - {{ compiler('c') }}      # [not win]
-    - {{ compiler('cxx') }}    # [not win]
 test:
   requires:
     - jinja2
@@ -53,6 +50,9 @@ test:
     - ipython
     - cudatoolkit {{ environ.get('CUDATOOLKIT_VERSION', '7.5') }} # default to 7.5
     - setuptools
+    # Need these for AOT. Do not init msvc as it may not be present
+    - {{ compiler('c') }}      # [not win]
+    - {{ compiler('cxx') }}    # [not win]
   files:
     - mandel.py
   commands:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -34,9 +34,6 @@ requirements:
     - llvmlite 0.21.*
     - funcsigs                 # [py27]
     - singledispatch           # [py27]
-    # Need these for AOT. Do not init msvc as it may not be present
-    - {{ compiler('c') }}      # [not win]
-    - {{ compiler('cxx') }}    # [not win]
 test:
   requires:
     - jinja2
@@ -45,6 +42,9 @@ test:
     - scipy
     - ipython
     - setuptools
+    # Need these for AOT. Do not init msvc as it may not be present
+    - {{ compiler('c') }}      # [not win]
+    - {{ compiler('cxx') }}    # [not win]
   files:
     - mandel.py
   commands:

--- a/docs/source/user/pycc.rst
+++ b/docs/source/user/pycc.rst
@@ -102,7 +102,9 @@ in your ``setup.py`` script, using distutils or setuptools::
 The ``source_module`` above is the module defining the ``cc`` object.
 Extensions compiled like this will be automatically included in the
 build files for your Python project, so you can distribute them inside
-binary packages such as wheels or Conda packages.
+binary packages such as wheels or Conda packages. Note that in the case of
+using conda, the compilers used for AOT need to be those that are available
+in the Anaconda distribution.
 
 
 Signature syntax

--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -11,7 +11,7 @@ import functools
 import os
 import subprocess
 import sys
-
+from tempfile import NamedTemporaryFile
 
 _configs = {
     # DLL suffix, Python C extension suffix
@@ -28,6 +28,28 @@ find_shared_ending = functools.partial(get_configs, 0)
 find_pyext_ending = functools.partial(get_configs, 1)
 
 
+def _check_external_compiler():
+    # see if the external compiler bound in numpy.distutil is present
+    # and working
+    compiler = new_compiler()
+    customize_compiler(compiler)
+    for suffix in ['.c', '.cxx']:
+        with NamedTemporaryFile('wt', suffix=suffix) as ntf:
+            simple_c = "int main(void) { return 0; }"
+            ntf.write(simple_c)
+            ntf.flush()
+            try:
+                compiler.compile([ntf.name])
+            except Exception: # likely CompileError
+                return False
+    return True
+
+
+# boolean on whether the externally provided compiler is present and
+# functioning correctly
+_external_compiler_ok = _check_external_compiler()
+
+
 class _DummyExtension(object):
     libraries = []
 
@@ -35,6 +57,9 @@ class _DummyExtension(object):
 class Toolchain(object):
 
     def __init__(self):
+        if not _external_compiler_ok:
+            self._raise_external_compiler_error()
+
         # Need to import it here since setuptools may monkeypatch it
         from distutils.dist import Distribution
         self._verbose = False
@@ -56,6 +81,27 @@ class Toolchain(object):
         # DEBUG will let Numpy spew many messages, so stick to INFO
         # to print commands executed by distutils
         log.set_threshold(log.INFO if value else log.WARN)
+
+    def _raise_external_compiler_error(self):
+        basemsg = ("Attempted to compile AOT function without the "
+                   "compiler used by `numpy.distutils` present.")
+        conda_msg = "If using conda try:\n\n#> conda install %s"
+        plt = sys.platform
+        if plt.startswith('linux'):
+            if sys.maxsize <= 2 ** 32:
+                compilers = ['gcc_linux-32', 'gxx_linux-32']
+            else:
+                compilers = ['gcc_linux-64', 'gxx_linux-64']
+            msg = "%s %s" % (basemsg, conda_msg % ' '.join(compilers))
+        elif plt.startswith('darwin'):
+            compilers = ['clang_osx-64', 'clangxx_osx-64']
+            msg = "%s %s" % (basemsg, conda_msg % ' '.join(compilers))
+        elif plt.startswith('win32'):
+            winmsg = "Cannot find suitable msvc."
+            msg = "%s %s" % (basemsg, winmsg)
+        else:
+            msg = "Unknown platform %s" % plt
+        raise RuntimeError(msg)
 
     def compile_objects(self, sources, output_dir,
                         include_dirs=(), depends=(), macros=(),
@@ -137,15 +183,16 @@ def _patch_exec_command():
     orig_exec_command = mod._exec_command
     mod._exec_command = _exec_command
 
-def _exec_command(command, use_shell=None, use_tee = None, **env):
+
+def _exec_command(command, use_shell=None, use_tee=None, **env):
     """
     Internal workhorse for exec_command().
     Code from https://github.com/numpy/numpy/pull/7862
     """
     if use_shell is None:
-        use_shell = os.name=='posix'
+        use_shell = os.name == 'posix'
     if use_tee is None:
-        use_tee = os.name=='posix'
+        use_tee = os.name == 'posix'
 
     executable = None
 

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from unittest import skip
 from ctypes import *
 
 import numpy as np
@@ -21,6 +22,13 @@ from numba import unittest_support as unittest
 from numba.pycc import main
 from numba.pycc.decorators import clear_export_registry
 from numba.pycc.platform import find_shared_ending, find_pyext_ending
+from numba.pycc.platform import _external_compiler_ok
+
+# if suitable compilers are not present then skip.
+_skip_reason = 'AOT compatible compilers missing'
+_skip_missing_compilers = unittest.skipIf(not _external_compiler_ok,
+                                          _skip_reason)
+
 from .matmul_usecase import has_blas
 from .support import TestCase, tag, import_dynamic, temp_directory
 
@@ -64,6 +72,7 @@ class BasePYCCTest(TestCase):
             sys.modules.pop(name, None)
 
 
+@_skip_missing_compilers
 class TestLegacyAPI(BasePYCCTest):
 
     def test_pycc_ctypes_lib(self):
@@ -136,6 +145,7 @@ class TestLegacyAPI(BasePYCCTest):
         self.assertTrue(bc.startswith((bitcode_magic, bitcode_wrapper_magic)), bc)
 
 
+@_skip_missing_compilers
 class TestCC(BasePYCCTest):
 
     def setUp(self):
@@ -265,6 +275,7 @@ class TestCC(BasePYCCTest):
             self.check_cc_compiled_in_subprocess(lib, code)
 
 
+@_skip_missing_compilers
 class TestDistutilsSupport(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This patch removes the dependency on the presence of the Anaconda
compiler toolchain at runtime which is needed for AOT compilation.

If AOT is attempted without the compilers present a RuntimeError is
raised with a message about obtaining the right toolchain. Tests
are updated to skip AOT testing if the right compilers are not
present, conda recipes now have compilers purely as a test
dependency, docs are updated.