### PR TITLE
Remove skip for win32 cosine test

### DIFF
--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -235,8 +235,6 @@ class TestMathLib(TestCase):
         self.run_unary(pyfunc, x_types, x_values, flags)
 
     @tag('important')
-    @unittest.skipIf(sys.platform == 'win32',
-                     "not exactly equal on win32 (issue #597)")
     def test_cos_npm(self):
         self.test_cos(flags=no_pyobj_flags)
 


### PR DESCRIPTION
Closes #597

I have tested it on our buildfarm that on win32 C's cos(-1) no longer diverge from python's