### PR TITLE
Add support for CUDA 9

### DIFF
--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -17,8 +17,15 @@ else:
 def get_libdevice(arch):
     libdir = (os.environ.get('NUMBAPRO_LIBDEVICE') or
               os.environ.get('NUMBAPRO_CUDALIB'))
+
     pat = r'libdevice\.%s(\.\d+)*\.bc$' % arch
     candidates = find_file(re.compile(pat), libdir)
+
+    if not candidates:
+        # CUDA 9 switches to fat library, with no arch in name
+        pat = r'libdevice(\.\d+)*\.bc$'
+        candidates = find_file(re.compile(pat), libdir)
+
     return max(candidates) if candidates else None
 
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -13,7 +13,15 @@ from llvmlite import ir
 from numba import config
 from .error import NvvmError, NvvmSupportError
 from .libs import get_libdevice, open_libdevice, open_cudalib
+from .driver import driver as cudriver
 
+
+def get_cuda_version_int():
+    dv = c_int(0)
+    cudriver.cuDriverGetVersion(byref(dv))
+    return dv.value
+
+CUDA_VERSION = get_cuda_version_int()
 
 logger = logging.getLogger(__name__)
 
@@ -275,7 +283,12 @@ default_data_layout = data_layout[tuple.__itemsize__ * 8]
 
 
 # List of supported compute capability in sorted order
-SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2)
+if CUDA_VERSION < 8000:
+    SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2)
+elif CUDA_VERSION < 9000:
+    SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2)
+else:
+    SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0)
 
 
 def _find_arch(mycc):

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -13,15 +13,7 @@ from llvmlite import ir
 from numba import config
 from .error import NvvmError, NvvmSupportError
 from .libs import get_libdevice, open_libdevice, open_cudalib
-from .driver import driver as cudriver
 
-
-def get_cuda_version_int():
-    dv = c_int(0)
-    cudriver.cuDriverGetVersion(byref(dv))
-    return dv.value
-
-CUDA_VERSION = get_cuda_version_int()
 
 logger = logging.getLogger(__name__)
 
@@ -282,12 +274,21 @@ data_layout = {
 default_data_layout = data_layout[tuple.__itemsize__ * 8]
 
 
+try:
+    NVVM_VERSION = NVVM().get_version()
+except:
+    # the CUDA driver may not be present
+    NVVM_VERSION = (0, 0)
+
 # List of supported compute capability in sorted order
-if CUDA_VERSION < 8000:
+if NVVM_VERSION < (1, 3):
+    # CUDA 7.5 and earlier
     SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2)
-elif CUDA_VERSION < 9000:
+elif NVVM_VERSION < (1, 4):
+    # CUDA 8.0
     SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2)
 else:
+    # CUDA 9.0 and later
     SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0)
 
 

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -77,15 +77,8 @@ class TestNvvmDriver(unittest.TestCase):
 @skip_on_cudasim('NVVM Driver unsupported in the simulator')
 class TestArchOption(unittest.TestCase):
     def test_get_arch_option(self):
-        self.assertEqual(get_arch_option(2, 0), 'compute_20')
-        self.assertEqual(get_arch_option(2, 1), 'compute_21')
-        self.assertEqual(get_arch_option(3, 0), 'compute_30')
-        self.assertEqual(get_arch_option(3, 3), 'compute_30')
-        self.assertEqual(get_arch_option(3, 4), 'compute_30')
-        self.assertEqual(get_arch_option(3, 5), 'compute_35')
-        self.assertEqual(get_arch_option(3, 6), 'compute_35')
-        self.assertEqual(get_arch_option(5, 0), 'compute_50')
-        self.assertEqual(get_arch_option(5, 1), 'compute_50')
+        for arch in SUPPORTED_CC:
+            self.assertEqual(get_arch_option(*arch), 'compute_%d%d' % arch)
         self.assertEqual(get_arch_option(1000, 0),
                          'compute_%d%d' % SUPPORTED_CC[-1])
 

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -77,6 +77,11 @@ class TestNvvmDriver(unittest.TestCase):
 @skip_on_cudasim('NVVM Driver unsupported in the simulator')
 class TestArchOption(unittest.TestCase):
     def test_get_arch_option(self):
+        # Test returning the nearest lowest arch.
+        self.assertEqual(get_arch_option(3, 0), 'compute_30')
+        self.assertEqual(get_arch_option(3, 3), 'compute_30')
+        self.assertEqual(get_arch_option(3, 4), 'compute_30')
+        # Test known arch.
         for arch in SUPPORTED_CC:
             self.assertEqual(get_arch_option(*arch), 'compute_%d%d' % arch)
         self.assertEqual(get_arch_option(1000, 0),


### PR DESCRIPTION
* Adds additional heuristic to find libdevice in CUDA 9.
* Changes the list of supported compute capabilities based on the detected CUDA.  CUDA 9 drops CC 2.x.  Also added in some missing compute capabilities.
