### PR TITLE
CUDA DeviceNDArray: Support numpy tranpose API

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -128,7 +128,7 @@ Examples:
 
 * to run those tests::
 
-    $ python -m numba.runtests -l numba.tests.test_usecases
+    $ python -m numba.runtests numba.tests.test_usecases
 
 * to run all tests in parallel, using multiple sub-processes::
 

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -115,6 +115,21 @@ class DeviceNDArrayBase(object):
         clone.stream = stream
         return clone
 
+    @property
+    def T(self):
+        return self.transpose()
+
+    def transpose(self, axes=None):
+        if axes and tuple(axes) == tuple(range(self.ndim)):
+            return self
+        elif self.ndim != 2:
+            raise NotImplementedError("transposing a non-2D DeviceNDArray isn't supported")
+        elif axes is not None and set(axes) != set(range(self.ndim)):
+            raise ValueError("invalid axes list %r" % (axes,))
+        else:
+            from numba.cuda.kernels.transpose import transpose
+            return transpose(self)
+
     def _default_stream(self, stream):
         return self.stream if not stream else stream
 

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -58,6 +58,48 @@ class TestCudaNDArray(unittest.TestCase):
         gpumem.copy_to_host(array)
         self.assertTrue((array == original * 2).all())
 
+    def test_devicearray_transpose_wrongdim(self):
+        gpumem = cuda.to_device(np.array(np.arange(12)).reshape(3, 4, 1))
+
+        with self.assertRaises(NotImplementedError) as e:
+            np.transpose(gpumem)
+
+        self.assertEqual(
+            "transposing a non-2D DeviceNDArray isn't supported",
+            str(e.exception))
+
+    def test_devicearray_transpose_identity(self):
+        # any-shape identities should work
+        original = np.array(np.arange(24)).reshape(3, 4, 2)
+        array = np.transpose(cuda.to_device(original), axes=(0, 1, 2)).copy_to_host()
+        self.assertTrue(np.all(array == original))
+
+    def test_devicearray_transpose_duplicatedaxis(self):
+        gpumem = cuda.to_device(np.array(np.arange(12)).reshape(3, 4))
+
+        with self.assertRaises(ValueError) as e:
+            np.transpose(gpumem, axes=(0, 0))
+
+        self.assertEqual('invalid axes list (0, 0)', str(e.exception))
+
+    def test_devicearray_transpose_wrongaxis(self):
+        gpumem = cuda.to_device(np.array(np.arange(12)).reshape(3, 4))
+
+        with self.assertRaises(ValueError) as e:
+            np.transpose(gpumem, axes=(0, 2))
+
+        self.assertEqual('invalid axes list (0, 2)', str(e.exception))
+
+    def test_devicearray_transpose_ok(self):
+        original = np.array(np.arange(12)).reshape(3, 4)
+        array = np.transpose(cuda.to_device(original)).copy_to_host()
+        self.assertTrue(np.all(array == original.T))
+
+    def test_devicearray_transpose_T(self):
+        original = np.array(np.arange(12)).reshape(3, 4)
+        array = cuda.to_device(original).T.copy_to_host()
+        self.assertTrue(np.all(array == original.T))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add the `transpose` member and `T` property to `DeviceNDArray` so it works with `np.transpose`. Only support 2D arrays for now, using the existing kernel in `numba.cuda.kernels.transpose`.