### PR TITLE
Fix empty_like from readonly arrays.

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -4438,7 +4438,7 @@ def array_argsort(context, builder, sig, args):
 @lower_cast(types.Array, types.Array)
 def array_to_array(context, builder, fromty, toty, val):
     # Type inference should have prevented illegal array casting.
-    assert toty.layout == 'A'
+    assert fromty.mutable != toty.mutable or toty.layout == 'A'
     return val
 
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -702,6 +702,12 @@ class ConstructorLikeBaseTest(object):
             # Non-contiguous array
             if arr.ndim > 0:
                 check_arr(arr[::2])
+            # Check new array doesn't inherit readonly flag
+            arr.flags['WRITEABLE'] = False
+            # verify read-only
+            with self.assertRaises(ValueError):
+                arr[0] = 1
+            check_arr(arr)
 
         # Scalar argument => should produce a 0-d array
         check_arr(orig[0])

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -521,7 +521,7 @@ class NdConstructorLike(CallableTemplate):
             if nb_dtype is not None:
                 if isinstance(arg, types.Array):
                     layout = arg.layout if arg.layout != 'A' else 'C'
-                    return arg.copy(dtype=nb_dtype, layout=layout)
+                    return arg.copy(dtype=nb_dtype, layout=layout, readonly=False)
                 else:
                     return types.Array(nb_dtype, 0, 'C')
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -565,7 +565,7 @@ if numpy_version >= (1, 8):
                     nb_dtype = arg
                 if nb_dtype is not None:
                     if isinstance(arg, types.Array):
-                        return arg.copy(dtype=nb_dtype)
+                        return arg.copy(dtype=nb_dtype, readonly=False)
                     else:
                         return types.Array(dtype=nb_dtype, ndim=0, layout='C')
 


### PR DESCRIPTION
Arrays created with empty_like should always be writable.