### PR TITLE
Update communication channels

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -20,6 +20,32 @@ on this mailing-list.  You can subscribe and read the archives on
 and there is also a `Gmane mirror <http://news.gmane.org/gmane.comp.python.numba.user>`_
 allowing NNTP access.
 
+Real-time Chat
+''''''''''''''
+
+Numba uses Gitter for public real-time chat.  To help improve the
+signal-to-noise ratio, we have two channels:
+
+* `numba/numba <https://gitter.im/numba/numba>`_: General Numba discussion,
+  questions, and debugging help.
+* `numba/numba-dev <https://gitter.im/numba/numba-dev>`_: Discussion of PRs,
+  planning, release coordination, etc.
+
+Both channels are public, but we may ask that discussions on numba-dev move to
+the numba channel.  This is simply to ensure that numba-dev is easy for core
+developers to keep up with.
+
+Note that the Github issue tracker is the best place to report bugs.  Bug
+reports in chat are difficult to track and likely to be lost.
+
+Weekly Meetings
+'''''''''''''''
+
+The core Numba developers have a weekly video conference to discuss roadmap,
+feature planning, and outstanding issues.  These meetings are invite only, but
+minutes will be taken and will be posted to the
+`Numba wiki <https://github.com/numba/numba/wiki/Meeting-Minutes>`_.
+
 .. _report-numba-bugs:
 
 Bug tracker


### PR DESCRIPTION
Document our 2018 shift to using Gitter and posting meeting minutes to the Numba wiki.