### PR TITLE
Fixes 2210

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -27,14 +27,6 @@ def autojit(*args, **kws):
     return jit(*args, **kws)
 
 
-class _DisableJitWrapper(object):
-    def __init__(self, py_func):
-        self.py_func = py_func
-
-    def __call__(self, *args, **kwargs):
-        return self.py_func(*args, **kwargs)
-
-
 _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
@@ -185,7 +177,7 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
             from . import cuda
             return cuda.jit(func)
         if config.DISABLE_JIT and not target == 'npyufunc':
-            return _DisableJitWrapper(func)
+            return func
         disp = dispatcher(py_func=func, locals=locals,
                           targetoptions=targetoptions,
                           **dispatcher_args)

--- a/numba/tests/test_jitmethod.py
+++ b/numba/tests/test_jitmethod.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from numba import config, jit, types
 from numba.compiler import compile_isolated
-from numba.decorators import _DisableJitWrapper
 from numba.tests.support import override_config
 
 
@@ -50,38 +49,23 @@ class TestJITMethod(unittest.TestCase):
 class TestDisabledJIT(unittest.TestCase):
     def test_decorated_function(self):
         with override_config('DISABLE_JIT', True):
-            @jit
             def method(x):
-                return x
+                return x          
+            jitted = jit(method)
 
-        self.assertIsInstance(method, _DisableJitWrapper)
-        self.assertIsNotNone(method.py_func)
+        self.assertEqual(jitted, method)
         self.assertEqual(10, method(10))
+        self.assertEqual(10, jitted(10))
 
     def test_decorated_function_with_kwargs(self):
-        with override_config('DISABLE_JIT', True):
-            @jit(nopython=True)
-            def method(x):
-                return x
-
-        self.assertIsInstance(method, _DisableJitWrapper)
-        self.assertIsNotNone(method.py_func)
-        self.assertEqual(10, method(10))
-
-    def test_py_func(self):
-        with override_config('DISABLE_JIT', True):
-            def method(x):
-                return x
-            jitted = jit(method)
-        self.assertEqual(jitted.py_func, method)
-
-    def test_py_func_with_kwargs(self):
         with override_config('DISABLE_JIT', True):
             def method(x):
                 return x
             jitted = jit(nopython=True)(method)
-        self.assertEqual(jitted.py_func, method)
 
+        self.assertEqual(jitted, method)
+        self.assertEqual(10, method(10))
+        self.assertEqual(10, jitted(10))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #2210 by simply removing the `_DisableJitWrapper`
indirection and returning the Python function instead.

Fixes #2210.