### PR TITLE
Fix #2340, generator error yielding bool

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -450,8 +450,16 @@ class Lower(BaseLower):
         # Yield to caller
         val = self.loadvar(inst.value.name)
         typ = self.typeof(inst.value.name)
-        val = self.context.cast(self.builder, val, typ, self.gentype.yield_type)
-        self.call_conv.return_value(self.builder, val)
+
+        # cast the local val to the type yielded
+        yret = self.context.cast(self.builder, val, typ,
+                                    self.gentype.yield_type)
+
+        # get the return repr of yielded value
+        retval = self.context.get_return_value(self.builder, typ, yret)
+        
+        # return
+        self.call_conv.return_value(self.builder, retval)
 
         # Resumption point
         y.lower_yield_resume()

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -113,6 +113,9 @@ def gen_ndenumerate(arr):
         yield tup
 
 
+def gen_bool():
+    yield True
+
 class TestGenerators(MemoryLeakMixin, TestCase):
     def check_generator(self, pygen, cgen):
         self.assertEqual(next(cgen), next(pygen))
@@ -244,6 +247,20 @@ class TestGenerators(MemoryLeakMixin, TestCase):
 
     def test_gen8_objmode(self):
         self.check_gen8(forceobj=True)
+
+    def check_gen9(self, flags=no_pyobj_flags):
+        pyfunc = gen_bool
+        cr = compile_isolated(pyfunc, (), flags=flags)
+        pygen = pyfunc()
+        cgen = cr.entry_point()
+        self.check_generator(pygen, cgen)
+
+    @tag('important')
+    def test_gen9(self):
+        self.check_gen9(flags=no_pyobj_flags)
+
+    def test_gen9_objmode(self):
+        self.check_gen9(flags=forceobj_flags)
 
     def check_consume_generator(self, gen_func):
         cgen = jit(nopython=True)(gen_func)


### PR DESCRIPTION
This fixes #2340. The lowering of yield needs to return the return
type representation of that which is yielded and not a return type
from the type of the yield itself.

Fixes #2340.