### PR TITLE
Fix #2663: incorrect offset when indexing cuda array.

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -82,6 +82,27 @@ class CudaArraySlicing(unittest.TestCase):
                 got = sliced.copy_to_host()
                 self.assertTrue(np.all(expect == got))
 
+    def test_select_3d_first_two_dim(self):
+        arr = np.arange(3 ** 3).reshape(3, 3, 3)
+        darr = cuda.to_device(arr)
+        # Select first dimension
+        for i in range(arr.shape[0]):
+            expect = arr[i]
+            sliced = darr[i]
+            self.assertEqual(expect.shape, sliced.shape)
+            self.assertEqual(expect.strides, sliced.strides)
+            got = sliced.copy_to_host()
+            self.assertTrue(np.all(expect == got))
+        # Select second dimension
+        for i in range(arr.shape[0]):
+            for j in range(arr.shape[1]):
+                expect = arr[i, j]
+                sliced = darr[i, j]
+                self.assertEqual(expect.shape, sliced.shape)
+                self.assertEqual(expect.strides, sliced.strides)
+                got = sliced.copy_to_host()
+                self.assertTrue(np.all(expect == got))
+
     def test_select_f(self):
         a = np.arange(5 * 5 * 5).reshape(5, 5, 5, order='F')
         da = cuda.to_device(a)

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -163,6 +163,7 @@ class Array(object):
             dim = Dim(offset, offset + ashape * astride, ashape, astride,
                       single=False)
             dims.append(dim)
+            offset = 0  # offset only applies to first dimension
         return cls(dims, itemsize)
 
     def __init__(self, dims, itemsize):


### PR DESCRIPTION
Closes #2663.

The bug:
When offsetting into a cuda array memory, the leading offset is incorrectly applied to the inner dimensions.  The error seen in the issue #2663 is due to loading an invalid address.

The Fix: 
A one line fix to reset the offset for subsequent dimension.