### PR TITLE
Fix tuple indexing codegeneration for empty tuple

### DIFF
--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -183,6 +183,13 @@ class TestOperations(TestCase):
         for i in range(len(tup)):
             self.assertPreciseEqual(cr.entry_point(tup, i), tup[i])
 
+        # Test empty tuple
+        cr = compile_isolated(pyfunc,
+                              [types.UniTuple(types.int64, 0), types.int64])
+        with self.assertRaises(IndexError) as raises:
+            cr.entry_point((), 0)
+        self.assertEqual("tuple index out of range", str(raises.exception))
+
         # With a compile-time static index (the code generation path is different)
         pyfunc = tuple_index_static
         for typ in (types.UniTuple(types.int64, 4),
@@ -194,6 +201,7 @@ class TestOperations(TestCase):
         typ = types.UniTuple(types.int64, 1)
         with self.assertTypingError():
             cr = compile_isolated(pyfunc, (typ,))
+
 
     def test_in(self):
         pyfunc = in_usecase


### PR DESCRIPTION
Indexing into empty tuple type will result in an empty LLVM switch block.

This fixes it by special-casing the empty tuple to bypass the switch block generation.