### PR TITLE
Test runner feature: failed-first and last-failed

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -159,11 +159,24 @@ Examples:
 * to run all tests in parallel, using multiple sub-processes::
 
     $ python -m numba.runtests -m
-    
+
 * For a detailed list of all options::
 
     $ python -m numba.runtests -h
 
+The numba test suite can take a long time to complete.  When you want to avoid
+the long wait,  it is useful to focus on the failing tests first with the
+following test runner options:
+
+* The ``--failed-first`` option is added to capture the list of failed tests
+  and to re-execute them first::
+
+    $ python -m numba.runtests --failed-first -mvb
+
+* The ``--last-failed`` option is used with ``--failed-first`` to execute
+  the previously failed tests only::
+
+    $ python -m numba.runtests --last-failed -mvb
 
 Development rules
 -----------------

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -9,7 +9,11 @@ from numba import config, unittest_support as unittest
 from numba.tests.support import captured_stdout
 
 
-class CUDATestCase(unittest.TestCase):
+class SerialMixin(object):
+    _numba_parallel_test_ = False
+
+
+class CUDATestCase(SerialMixin, unittest.TestCase):
     def tearDown(self):
         from numba.cuda.cudadrv.devices import reset
 

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -6,11 +6,7 @@ import os
 import sys
 
 from numba import config, unittest_support as unittest
-from numba.tests.support import captured_stdout
-
-
-class SerialMixin(object):
-    _numba_parallel_test_ = False
+from numba.tests.support import captured_stdout, SerialMixin
 
 
 class CUDATestCase(SerialMixin, unittest.TestCase):

--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -1,4 +1,4 @@
-from numba.testing import SerialSuite
+from numba.testing import unittest
 from numba.testing import load_testsuite
 from numba import cuda
 from os.path import dirname, join
@@ -6,7 +6,7 @@ from os.path import dirname, join
 
 def load_tests(loader, tests, pattern):
 
-    suite = SerialSuite()
+    suite = unittest.TestSuite()
     this_dir = dirname(__file__)
     suite.addTests(load_testsuite(loader, join(this_dir, 'nocuda')))
     if cuda.is_available():

--- a/numba/cuda/tests/cudadrv/__init__.py
+++ b/numba/cuda/tests/cudadrv/__init__.py
@@ -1,6 +1,0 @@
-from numba.testing import SerialSuite
-from numba.testing import load_testsuite
-import os
-
-def load_tests(loader, tests, pattern):
-    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestArrayAttr(unittest.TestCase):
+class TestArrayAttr(SerialMixin, unittest.TestCase):
     def test_contigous_2d(self):
         ary = np.arange(10)
         cary = ary.reshape(2, 5)

--- a/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestContextStack(unittest.TestCase):
+class TestContextStack(SerialMixin, unittest.TestCase):
     def setUp(self):
         # Reset before testing
         cuda.close()

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -5,10 +5,10 @@ from itertools import product
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class CudaArrayIndexing(unittest.TestCase):
+class CudaArrayIndexing(SerialMixin, unittest.TestCase):
     def test_index_1d(self):
         arr = np.arange(10)
         darr = cuda.to_device(arr)
@@ -33,7 +33,7 @@ class CudaArrayIndexing(unittest.TestCase):
                     self.assertEqual(arr[i, j, k], darr[i, j, k])
 
 
-class CudaArrayStridedSlice(unittest.TestCase):
+class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):
 
     def test_strided_index_1d(self):
         arr = np.arange(10)
@@ -61,7 +61,7 @@ class CudaArrayStridedSlice(unittest.TestCase):
                                             darr[i::2, j::2, k::2].copy_to_host())
 
 
-class CudaArraySlicing(unittest.TestCase):
+class CudaArraySlicing(SerialMixin, unittest.TestCase):
     def test_prefix_1d(self):
         arr = np.arange(5)
         darr = cuda.to_device(arr)

--- a/numba/cuda/tests/cudadrv/test_cuda_auto_context.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_auto_context.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaAutoContext(unittest.TestCase):
+class TestCudaAutoContext(SerialMixin, unittest.TestCase):
     def test_auto_context(self):
         """A problem was revealed by a customer that the use cuda.to_device
         does not create a CUDA context.

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -3,12 +3,12 @@ import ctypes
 from numba.cuda.cudadrv.devicearray import (DeviceRecord, from_record_like,
                                             auto_device)
 from numba import cuda, numpy_support
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 import numpy as np
 
 @skip_on_cudasim('Device Record API unsupported in the simulator')
-class TestCudaDeviceRecord(unittest.TestCase):
+class TestCudaDeviceRecord(SerialMixin, unittest.TestCase):
     """
     Tests the DeviceRecord class with np.void host types.
     """

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import
 from ctypes import c_int, sizeof
 from numba.cuda.cudadrv.driver import host_to_device, device_to_host
 from numba.cuda.cudadrv import devices
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 
 ptx1 = '''
@@ -60,7 +60,7 @@ ptx2 = '''
 
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
-class TestCudaDriver(unittest.TestCase):
+class TestCudaDriver(SerialMixin, unittest.TestCase):
     def setUp(self):
         self.assertTrue(len(devices.gpus) > 0)
         self.context = devices.get_context()

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -15,6 +15,7 @@ class TestCudaMemory(CUDATestCase):
 
     def tearDown(self):
         del self.context
+        super(TestCudaMemory, self).tearDown()
 
     def _template(self, obj):
         self.assertTrue(driver.is_device_memory(obj))
@@ -74,6 +75,7 @@ class TestCudaMemoryFunctions(CUDATestCase):
 
     def tearDown(self):
         del self.context
+        super(TestCudaMemoryFunctions, self).tearDown()
 
     def test_memcpy(self):
         hstary = np.arange(100, dtype=np.uint32)

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -1,12 +1,12 @@
 import numpy as np
 from numba.cuda.cudadrv import devicearray
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('Device Array API unsupported in the simulator')
-class TestCudaNDArray(unittest.TestCase):
+class TestCudaNDArray(SerialMixin, unittest.TestCase):
     def test_device_array_interface(self):
         dary = cuda.device_array(shape=100)
         devicearray.verify_cuda_ndarray_interface(dary)

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -5,12 +5,12 @@ from contextlib import contextmanager
 import numpy as np
 
 from numba import cuda, config
-from numba.cuda.testing import unittest, skip_on_cudasim
+from numba.cuda.testing import unittest, skip_on_cudasim, SerialMixin
 from numba.tests.support import captured_stderr
 
 
 @skip_on_cudasim('not supported on CUDASIM')
-class TestDeallocation(unittest.TestCase):
+class TestDeallocation(SerialMixin, unittest.TestCase):
     def test_max_pending_count(self):
         # get deallocation manager and flush it
         deallocs = cuda.current_context().deallocations
@@ -57,7 +57,7 @@ class TestDeallocation(unittest.TestCase):
 
 
 @skip_on_cudasim("defer_cleanup has no effect in CUDASIM")
-class TestDeferCleanup(unittest.TestCase):
+class TestDeferCleanup(SerialMixin, unittest.TestCase):
     def test_basic(self):
         harr = np.arange(5)
         darr1 = cuda.to_device(harr)
@@ -123,7 +123,7 @@ class TestDeferCleanup(unittest.TestCase):
         self.assertEqual(len(deallocs), 0)
 
 
-class TestDeferCleanupAvail(unittest.TestCase):
+class TestDeferCleanupAvail(SerialMixin, unittest.TestCase):
     def test_context_manager(self):
         # just make sure the API is available
         with cuda.defer_cleanup():
@@ -131,7 +131,7 @@ class TestDeferCleanupAvail(unittest.TestCase):
 
 
 @skip_on_cudasim('not supported on CUDASIM')
-class TestDel(unittest.TestCase):
+class TestDel(SerialMixin, unittest.TestCase):
     """
     Ensure resources are deleted properly without ignored exception.
     """

--- a/numba/cuda/tests/cudadrv/test_detect.py
+++ b/numba/cuda/tests/cudadrv/test_detect.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, print_function
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.tests.support import captured_stdout
 
-class TestCudaDetect(unittest.TestCase):
+class TestCudaDetect(SerialMixin, unittest.TestCase):
     def test_cuda_detect(self):
         # exercise the code path
         with captured_stdout() as out:

--- a/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba/cuda/tests/cudadrv/test_events.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, print_function
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaEvent(unittest.TestCase):
+class TestCudaEvent(SerialMixin, unittest.TestCase):
     def test_event_elapsed(self):
         N = 32
         dary = cuda.device_array(N, dtype=np.double)

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -3,12 +3,13 @@ import os.path
 import numpy as np
 from numba.cuda.testing import unittest
 from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import SerialMixin
 from numba.cuda.cudadrv.driver import Linker
 from numba.cuda import require_context
 from numba import cuda
 
 @skip_on_cudasim('Linking unsupported in the simulator')
-class TestLinker(unittest.TestCase):
+class TestLinker(SerialMixin, unittest.TestCase):
 
     @require_context
     def test_linker_basic(self):
@@ -35,6 +36,7 @@ class TestLinker(unittest.TestCase):
         foo(A, B)
 
         self.assertTrue(A[0] == 123 + 2 * 321)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/__init__.py
+++ b/numba/cuda/tests/cudapy/__init__.py
@@ -1,6 +1,0 @@
-from numba.testing import SerialSuite
-from numba.testing import load_testsuite
-import os
-
-def load_tests(loader, tests, pattern):
-    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/cuda/tests/cudapy/test_alignment.py
+++ b/numba/cuda/tests/cudapy/test_alignment.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import from_dtype, cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
-class TestAlignment(unittest.TestCase):
+class TestAlignment(SerialMixin, unittest.TestCase):
     def test_record_alignment(self):
         rec_dtype = np.dtype([('a', 'int32'), ('b', 'float64')], align=True)
         rec = from_dtype(rec_dtype)

--- a/numba/cuda/tests/cudapy/test_array.py
+++ b/numba/cuda/tests/cudapy/test_array.py
@@ -2,11 +2,11 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda
 
 
-class TestCudaArray(unittest.TestCase):
+class TestCudaArray(SerialMixin, unittest.TestCase):
     def test_gpu_array_zero_length(self):
         x = np.arange(0)
         dx = cuda.to_device(x)

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -3,10 +3,10 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaArrayArg(unittest.TestCase):
+class TestCudaArrayArg(SerialMixin, unittest.TestCase):
     def test_array_ary(self):
 
         @cuda.jit('double(double[:],int64)', device=True, inline=True)

--- a/numba/cuda/tests/cudapy/test_array_methods.py
+++ b/numba/cuda/tests/cudapy/test_array_methods.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 from numba import unittest_support as unittest
 import numpy as np
 from numba import cuda
+from numba.cuda.testing import SerialMixin
 
 
 def reinterpret_array_type(byte_arr, start, stop, output):
@@ -11,7 +12,7 @@ def reinterpret_array_type(byte_arr, start, stop, output):
     output[0] = val
 
 
-class TestCudaArrayMethods(unittest.TestCase):
+class TestCudaArrayMethods(SerialMixin, unittest.TestCase):
     def test_reinterpret_array_type(self):
         """
         Reinterpret byte array as int32 in the GPU.

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from numba import config
 from numba import cuda, uint32, uint64, float32, float64
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def cc_X_or_above(major, minor):
@@ -183,7 +183,7 @@ def atomic_compare_and_swap(res, old, ary):
         old[gid] = out
 
 
-class TestCudaAtomics(unittest.TestCase):
+class TestCudaAtomics(SerialMixin, unittest.TestCase):
     def test_atomic_add(self):
         ary = np.random.randint(0, 32, size=32).astype(np.uint32)
         orig = ary.copy()

--- a/numba/cuda/tests/cudapy/test_autojit.py
+++ b/numba/cuda/tests/cudapy/test_autojit.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, absolute_import, division
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('Simulator does not have definitions attribute')
-class TestCudaAutoJit(unittest.TestCase):
+class TestCudaAutoJit(SerialMixin, unittest.TestCase):
     def test_autojit(self):
         @cuda.autojit
         def what(a, b, c):

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -4,7 +4,7 @@ import numpy as np
 import math
 import time
 from numba import cuda, double
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 RISKFREE = 0.02
@@ -47,7 +47,7 @@ def randfloat(rand_var, low, high):
     return (1.0 - rand_var) * low + rand_var * high
 
 
-class TestBlackScholes(unittest.TestCase):
+class TestBlackScholes(SerialMixin, unittest.TestCase):
     def test_blackscholes(self):
         OPT_N = 400
         iterations = 2

--- a/numba/cuda/tests/cudapy/test_boolean.py
+++ b/numba/cuda/tests/cudapy/test_boolean.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, absolute_import
 import numpy as np
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda
 
 
@@ -11,7 +11,7 @@ def boolean_func(A, vertial):
         A[0] = 321
 
 
-class TestCudaBoolean(unittest.TestCase):
+class TestCudaBoolean(SerialMixin, unittest.TestCase):
     def test_boolean(self):
         func = cuda.jit('void(float64[:], bool_)')(boolean_func)
         A = np.array([0], dtype='float64')

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -2,6 +2,7 @@ from numba import unittest_support as unittest
 import numpy as np
 from numba import cuda, types
 import struct
+from numba.cuda.testing import SerialMixin
 
 
 def float_to_int(x):
@@ -20,7 +21,7 @@ def float_to_complex(x):
     return np.complex128(x)
 
 
-class TestCasting(unittest.TestCase):
+class TestCasting(SerialMixin, unittest.TestCase):
     def _create_wrapped(self, pyfunc, intype, outtype):
         wrapped_func = cuda.jit(device=True)(pyfunc)
 

--- a/numba/cuda/tests/cudapy/test_complex.py
+++ b/numba/cuda/tests/cudapy/test_complex.py
@@ -9,7 +9,7 @@ import textwrap
 
 import numpy as np
 
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda, types, utils, numpy_support
 from numba.tests.support import TestCase, compile_function
 from numba.tests.complex_usecases import *
@@ -53,7 +53,7 @@ def compile_scalar_func(pyfunc, argtypes, restype):
     return kernel_wrapper
 
 
-class BaseComplexTest(object):
+class BaseComplexTest(SerialMixin):
 
     def basic_values(self):
         reals = [-0.0, +0.0, 1, -1, +1.5, -3.5,

--- a/numba/cuda/tests/cudapy/test_complex_kernel.py
+++ b/numba/cuda/tests/cudapy/test_complex_kernel.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaComplex(unittest.TestCase):
+class TestCudaComplex(SerialMixin, unittest.TestCase):
     def test_cuda_complex_arg(self):
         @cuda.jit('void(complex128[:], complex128)')
         def foo(a, b):

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 CONST1D = np.arange(10, dtype=np.float64) / 2.
@@ -33,7 +33,7 @@ def cuconst3d(A):
     A[i, j, k] = C[i, j, k]
 
 
-class TestCudaConstantMemory(unittest.TestCase):
+class TestCudaConstantMemory(SerialMixin, unittest.TestCase):
     def test_const_array(self):
         jcuconst = cuda.jit('void(float64[:])')(cuconst)
         self.assertTrue('.const' in jcuconst.ptx)

--- a/numba/cuda/tests/cudapy/test_cuda_autojit.py
+++ b/numba/cuda/tests/cudapy/test_cuda_autojit.py
@@ -2,9 +2,10 @@ from __future__ import print_function
 from numba import unittest_support as unittest
 from numba import cuda
 import numpy as np
+from numba.cuda.testing import SerialMixin
 
 
-class TestCudaAutojit(unittest.TestCase):
+class TestCudaAutojit(SerialMixin, unittest.TestCase):
     def test_device_array(self):
         @cuda.autojit
         def foo(x, y):

--- a/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba/cuda/tests/cudapy/test_debug.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import
 
 import numpy as np
 
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 from numba.tests.support import override_config, captured_stderr, captured_stdout
 from numba import unittest_support as unittest
 from numba import cuda, float64
@@ -14,7 +14,7 @@ def simple_cuda(A, B):
 
 
 @skip_on_cudasim('Simulator does not produce debug dumps')
-class TestDebugOutput(unittest.TestCase):
+class TestDebugOutput(SerialMixin, unittest.TestCase):
 
     def compile_simple_cuda(self):
         with captured_stderr() as err:

--- a/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -4,10 +4,11 @@ from numba.tests.support import override_config, TestCase
 from numba.cuda.testing import skip_on_cudasim
 from numba import unittest_support as unittest
 from numba import cuda, types
+from numba.cuda.testing import SerialMixin
 
 
 @skip_on_cudasim('Simulator does not produce debug dumps')
-class TestCudaDebugInfo(TestCase):
+class TestCudaDebugInfo(SerialMixin, TestCase):
     """
     These tests only checks the compiled PTX for debuginfo section
     """

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -5,12 +5,12 @@ import types
 
 import numpy as np
 
-from numba.cuda.testing import unittest, skip_on_cudasim
+from numba.cuda.testing import unittest, skip_on_cudasim, SerialMixin
 from numba import cuda, jit
 from numba.errors import TypingError
 
 
-class TestDeviceFunc(unittest.TestCase):
+class TestDeviceFunc(SerialMixin, unittest.TestCase):
 
     def test_use_add2f(self):
 

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import
 import numpy as np
 
 from numba import config, cuda, jit
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def foo(ary):
@@ -15,7 +15,7 @@ def foo(ary):
         ary.shape[-x]
 
 
-class TestException(unittest.TestCase):
+class TestException(SerialMixin, unittest.TestCase):
     def test_exception(self):
         unsafe_foo = cuda.jit(foo)
         safe_foo = cuda.jit(debug=True)(foo)

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -4,9 +4,10 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import cuda, float32
+from numba.cuda.testing import SerialMixin
 
 
-class TestFastMathOption(unittest.TestCase):
+class TestFastMathOption(SerialMixin, unittest.TestCase):
     def test_kernel(self):
 
         def foo(arr, val):

--- a/numba/cuda/tests/cudapy/test_forall.py
+++ b/numba/cuda/tests/cudapy/test_forall.py
@@ -4,10 +4,10 @@ import numpy as np
 
 from numba import cuda
 import numba.unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 @skip_on_cudasim('forall API unsupported in the simulator')
-class TestForAll(unittest.TestCase):
+class TestForAll(SerialMixin, unittest.TestCase):
     def test_forall_1(self):
 
         @cuda.jit

--- a/numba/cuda/tests/cudapy/test_freevar.py
+++ b/numba/cuda/tests/cudapy/test_freevar.py
@@ -3,10 +3,10 @@ from __future__ import print_function, absolute_import
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestFreeVar(unittest.TestCase):
+class TestFreeVar(SerialMixin, unittest.TestCase):
     def test_freevar(self):
         """Make sure we can compile the following kernel with freevar reference
         in macros

--- a/numba/cuda/tests/cudapy/test_globals.py
+++ b/numba/cuda/tests/cudapy/test_globals.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, division
 import numpy as np
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 N = 100
 
@@ -28,7 +28,7 @@ def coop_smem2d(ary):
     ary[i, j] = sm[i, j]
 
 
-class TestCudaTestGlobal(unittest.TestCase):
+class TestCudaTestGlobal(SerialMixin, unittest.TestCase):
     def test_global_int_const(self):
         """Test simple_smem
         """

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -7,11 +7,11 @@ from numba import void, float32, float64
 from numba import guvectorize
 from numba import cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAGufunc(unittest.TestCase):
+class TestCUDAGufunc(SerialMixin, unittest.TestCase):
 
     def test_gufunc_small(self):
 

--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -7,19 +7,19 @@ from __future__ import absolute_import, print_function, division
 import numpy as np
 from numba import guvectorize, cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestGUFuncScalr(unittest.TestCase):
+class TestGUFuncScalr(SerialMixin, unittest.TestCase):
     def test_gufunc_scalar_output(self):
-    #    function type:
-    #        - has no void return type
-    #        - array argument is one dimenion fewer than the source array
-    #        - scalar output is passed as a 1-element array.
-    #
-    #    signature: (n)->()
-    #        - the function takes an array of n-element and output a scalar.
+        #    function type:
+        #        - has no void return type
+        #        - array argument is one dimenion fewer than the source array
+        #        - scalar output is passed as a 1-element array.
+        #
+        #    signature: (n)->()
+        #        - the function takes an array of n-element and output a scalar.
 
         @guvectorize(['void(int32[:], int32[:])'], '(n)->()', target='cuda')
         def sum_row(inp, out):

--- a/numba/cuda/tests/cudapy/test_idiv.py
+++ b/numba/cuda/tests/cudapy/test_idiv.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 from numba import cuda, float32, float64, int32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaIDiv(unittest.TestCase):
+class TestCudaIDiv(SerialMixin, unittest.TestCase):
     def test_inplace_div(self):
 
         @cuda.jit(argtypes=[float32[:, :], int32, int32])

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, division, absolute_import
 from numba import cuda, float64, intp
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 from numba.utils import StringIO
 
 
 @skip_on_cudasim('Simulator does not generate code to be inspected')
-class TestInspect(unittest.TestCase):
+class TestInspect(SerialMixin, unittest.TestCase):
     def test_monotyped(self):
         @cuda.jit("(float32, int32)")
         def foo(x, y):

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import numpy as np
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def simple_threadidx(ary):
@@ -59,7 +59,7 @@ def intrinsic_forloop_step(c):
             c[y, x] = x + y
 
 
-class TestCudaIntrinsic(unittest.TestCase):
+class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
     def test_simple_threadidx(self):
         compiled = cuda.jit("void(int32[:])")(simple_threadidx)
         ary = np.ones(1, dtype=np.int32)

--- a/numba/cuda/tests/cudapy/test_lang.py
+++ b/numba/cuda/tests/cudapy/test_lang.py
@@ -6,10 +6,10 @@ from __future__ import print_function, absolute_import, division
 
 import numpy as np
 from numba import cuda, float64
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestLang(unittest.TestCase):
+class TestLang(SerialMixin, unittest.TestCase):
     def test_enumerate(self):
         tup = (1., 2.5, 3.)
 

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 import time
 from numba import cuda, config, float64, void
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 # NOTE: CUDA kernel does not return any value
 
@@ -12,7 +12,7 @@ else:
     tpb = 16
 SM_SIZE = tpb, tpb
 
-class TestCudaLaplace(unittest.TestCase):
+class TestCudaLaplace(SerialMixin, unittest.TestCase):
     def test_laplace_small(self):
 
         @cuda.jit(float64(float64, float64), device=True, inline=True)
@@ -64,7 +64,7 @@ class TestCudaLaplace(unittest.TestCase):
                 error[by, bx] = err_sm[0, 0]
 
 
-        
+
         if config.ENABLE_CUDASIM:
             NN, NM = 4, 4
             iter_max = 20

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 
 from numba import cuda, int32, complex128
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def culocal(A, B):
@@ -30,7 +30,7 @@ def culocal1tuple(A, B):
         B[i] = C[i]
 
 
-class TestCudaLocalMem(unittest.TestCase):
+class TestCudaLocalMem(SerialMixin, unittest.TestCase):
     def test_local_array(self):
         jculocal = cuda.jit('void(int32[:], int32[:])')(culocal)
         self.assertTrue('.local' in jculocal.ptx)

--- a/numba/cuda/tests/cudapy/test_macro.py
+++ b/numba/cuda/tests/cudapy/test_macro.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 from numba import cuda, float32
-from numba.cuda.testing import unittest
 from numba.errors import MacroError
+from numba.cuda.testing import unittest, SerialMixin
 from numba.cuda.testing import skip_on_cudasim
 
 GLOBAL_CONSTANT = 5
@@ -48,7 +48,7 @@ def udt_invalid_2(A):
     A[i, j] = sa[i, j]
 
 
-class TestMacro(unittest.TestCase):
+class TestMacro(SerialMixin, unittest.TestCase):
     def getarg(self):
         return np.array(100, dtype=np.float32, ndmin=1)
 

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 import sys
 import numpy as np
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda, float32, float64, int32
 import math
 
@@ -174,7 +174,7 @@ def math_mod_binop(A, B, C):
     C[i] = A[i] % B[i]
 
 
-class TestCudaMath(unittest.TestCase):
+class TestCudaMath(SerialMixin, unittest.TestCase):
     def unary_template_float32(self, func, npfunc, start=0, stop=1):
         self.unary_template(func, npfunc, np.float32, float32, start, stop)
 

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 
 from numba import cuda, config, float32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 # Ensure the test takes a reasonable amount of time in the simulator
 if config.ENABLE_CUDASIM:
@@ -15,7 +15,7 @@ n = bpg * tpb
 SM_SIZE = (tpb, tpb)
 
 
-class TestCudaMatMul(unittest.TestCase):
+class TestCudaMatMul(SerialMixin, unittest.TestCase):
 
     def test_func(self):
 

--- a/numba/cuda/tests/cudapy/test_montecarlo.py
+++ b/numba/cuda/tests/cudapy/test_montecarlo.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, absolute_import
 import math
 from numba import cuda
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaMonteCarlo(unittest.TestCase):
+class TestCudaMonteCarlo(SerialMixin, unittest.TestCase):
     def test_montecarlo(self):
         """Just make sure we can compile this
         """

--- a/numba/cuda/tests/cudapy/test_multigpu.py
+++ b/numba/cuda/tests/cudapy/test_multigpu.py
@@ -1,11 +1,11 @@
 from numba import cuda
 import numpy as np
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 import threading
 
 
-class TestMultiGPUContext(unittest.TestCase):
+class TestMultiGPUContext(SerialMixin, unittest.TestCase):
     @unittest.skipIf(len(cuda.gpus) < 2, "need more than 1 gpus")
     def test_multigpu_context(self):
         @cuda.jit("void(float64[:], float64[:])")

--- a/numba/cuda/tests/cudapy/test_multiprocessing.py
+++ b/numba/cuda/tests/cudapy/test_multiprocessing.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from numba import cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 has_mp_get_context = hasattr(mp, 'get_context')
 is_unix = os.name == 'posix'
@@ -22,7 +22,7 @@ def fork_test(q):
 
 
 @skip_on_cudasim('disabled for cudasim')
-class TestMultiprocessing(unittest.TestCase):
+class TestMultiprocessing(SerialMixin, unittest.TestCase):
     @unittest.skipUnless(has_mp_get_context, 'requires mp.get_context')
     @unittest.skipUnless(is_unix, 'requires Unix')
     def test_fork(self):

--- a/numba/cuda/tests/cudapy/test_multithreads.py
+++ b/numba/cuda/tests/cudapy/test_multithreads.py
@@ -4,7 +4,7 @@ import multiprocessing
 import numpy as np
 from numba import cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 try:
     from concurrent.futures import ThreadPoolExecutor
@@ -45,7 +45,7 @@ def spawn_process_entry(q):
 
 
 @skip_on_cudasim('disabled for cudasim')
-class TestMultiThreadCompiling(unittest.TestCase):
+class TestMultiThreadCompiling(SerialMixin, unittest.TestCase):
 
     @unittest.skipIf(not has_concurrent_futures, "no concurrent.futures")
     def test_concurrent_compiling(self):

--- a/numba/cuda/tests/cudapy/test_nondet.py
+++ b/numba/cuda/tests/cudapy/test_nondet.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda, float32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def generate_input(n):
@@ -10,7 +10,7 @@ def generate_input(n):
     return A, B
 
 
-class TestCudaNonDet(unittest.TestCase):
+class TestCudaNonDet(SerialMixin, unittest.TestCase):
     def test_for_pre(self):
         """Test issue with loop not running due to bad sign-extension at the for loop
         precondition.

--- a/numba/cuda/tests/cudapy/test_operator.py
+++ b/numba/cuda/tests/cudapy/test_operator.py
@@ -1,12 +1,12 @@
 from __future__ import print_function, absolute_import, division
 
 import numpy as np
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda
 import operator
 
 
-class TestOperatorModule(unittest.TestCase):
+class TestOperatorModule(SerialMixin, unittest.TestCase):
     """
     Test if operator module is supported by the CUDA target.
     """

--- a/numba/cuda/tests/cudapy/test_powi.py
+++ b/numba/cuda/tests/cudapy/test_powi.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import
 import math
 import numpy as np
 from numba import cuda, float64, int8, int32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def cu_mat_power(A, power, power_A):
@@ -25,7 +25,7 @@ def cu_mat_power_binop(A, power, power_A):
     power_A[y, x] = A[y, x] ** power
 
 
-class TestCudaPowi(unittest.TestCase):
+class TestCudaPowi(SerialMixin, unittest.TestCase):
     def test_powi(self):
         dec = cuda.jit(argtypes=[float64[:, :], int8, float64[:, :]])
         kernel = dec(cu_mat_power)

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from numba import cuda
 from numba import unittest_support as unittest
-from numba.cuda.testing import captured_cuda_stdout
+from numba.cuda.testing import captured_cuda_stdout, SerialMixin
 
 
 def cuhello():
@@ -27,7 +27,7 @@ def printempty():
     print()
 
 
-class TestPrint(unittest.TestCase):
+class TestPrint(SerialMixin, unittest.TestCase):
 
     def test_cuhello(self):
         jcuhello = cuda.jit('void()', debug=False)(cuhello)

--- a/numba/cuda/tests/cudapy/test_py2_div_issue.py
+++ b/numba/cuda/tests/cudapy/test_py2_div_issue.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda, float32, int32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
-class TestCudaPy2Div(unittest.TestCase):
+class TestCudaPy2Div(SerialMixin, unittest.TestCase):
     def test_py2_div_issue(self):
         @cuda.jit(argtypes=[float32[:], float32[:], float32[:], int32])
         def preCalc(y, yA, yB, numDataPoints):

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -7,7 +7,7 @@ import numpy as np
 from numba import cuda, config, float32
 from numba.cuda.testing import unittest
 import numba.cuda.random
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 from numba.cuda.random import \
     xoroshiro128p_uniform_float32, xoroshiro128p_normal_float32, \
@@ -41,7 +41,7 @@ def rng_kernel_float64(states, out, count, distribution):
             out[thread_id * count + i] = xoroshiro128p_normal_float64(states, thread_id)
 
 
-class TestCudaRandomXoroshiro128p(unittest.TestCase):
+class TestCudaRandomXoroshiro128p(SerialMixin, unittest.TestCase):
     def test_create(self):
         states = cuda.random.create_xoroshiro128p_states(10, seed=1)
         s = states.copy_to_host()

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 from numba import cuda, numpy_support, types
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 def set_a(ary, i, v):
@@ -100,7 +100,7 @@ recordwith2darray = np.dtype([('i', np.int32),
                               ('j', np.float32, (3, 2))])
 
 
-class TestRecordDtype(unittest.TestCase):
+class TestRecordDtype(SerialMixin, unittest.TestCase):
 
     def _createSampleArrays(self):
         self.sample1d = np.recarray(3, dtype=recordtype)

--- a/numba/cuda/tests/cudapy/test_reduction.py
+++ b/numba/cuda/tests/cudapy/test_reduction.py
@@ -3,13 +3,13 @@ import numpy as np
 from numba import cuda
 from numba import unittest_support as unittest
 from numba.config import ENABLE_CUDASIM
-
+from numba.cuda.testing import SerialMixin
 
 # Avoid recompilation of the sum_reduce function by keeping it at global scope
 sum_reduce = cuda.Reduce(lambda a, b: a + b)
 
 
-class TestReduction(unittest.TestCase):
+class TestReduction(SerialMixin, unittest.TestCase):
     def _sum_reduce(self, n):
         A = (np.arange(n, dtype=np.float64) + 1)
         expect = A.sum()

--- a/numba/cuda/tests/cudapy/test_serialize.py
+++ b/numba/cuda/tests/cudapy/test_serialize.py
@@ -3,11 +3,11 @@ import pickle
 import numpy as np
 from numba import cuda, vectorize, numpy_support, types
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('pickling not supported in CUDASIM')
-class TestPickle(unittest.TestCase):
+class TestPickle(SerialMixin, unittest.TestCase):
 
     def check_call(self, callee):
         arr = np.array([100])

--- a/numba/cuda/tests/cudapy/test_slicing.py
+++ b/numba/cuda/tests/cudapy/test_slicing.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda, float32, int32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 
 def foo(inp, out):
@@ -14,7 +14,7 @@ def copy(inp, out):
     cufoo(inp[i, :], out[i, :])
 
 
-class TestCudaSlicing(unittest.TestCase):
+class TestCudaSlicing(SerialMixin, unittest.TestCase):
     def test_slice_as_arg(self):
         global cufoo
         cufoo = cuda.jit("void(int32[:], int32[:])", device=True)(foo)

--- a/numba/cuda/tests/cudapy/test_sm.py
+++ b/numba/cuda/tests/cudapy/test_sm.py
@@ -1,11 +1,11 @@
 from numba import cuda, int32, float64
 
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 
 import numpy as np
 
 
-class TestSharedMemoryIssue(unittest.TestCase):
+class TestSharedMemoryIssue(SerialMixin, unittest.TestCase):
     def test_issue_953_sm_linkage_conflict(self):
         @cuda.jit(device=True)
         def inner():

--- a/numba/cuda/tests/cudapy/test_smart_array.py
+++ b/numba/cuda/tests/cudapy/test_smart_array.py
@@ -10,14 +10,14 @@ from numba.extending import typeof_impl
 from numba.cuda.kernels.transpose import transpose
 from numba.tracing import event
 from numba import SmartArray
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 @skip_on_cudasim('Simulator does not support Device arrays')
-class TestJIT(unittest.TestCase):
+class TestJIT(SerialMixin, unittest.TestCase):
     """Test handling of numba.SmartArray"""
 
     def test_transpose(self):
-        
+
         # To verify non-redundant data movement run this test with NUMBA_TRACE=1
         a = SmartArray(np.arange(16, dtype=float).reshape(4,4))
         b = SmartArray(where='gpu', shape=(4,4), dtype=float)

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 import numpy as np
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba.config import ENABLE_CUDASIM
 
 
@@ -56,7 +56,7 @@ def use_threadfence_system(ary):
     ary[0] += 321
 
 
-class TestCudaSync(unittest.TestCase):
+class TestCudaSync(SerialMixin, unittest.TestCase):
     def test_useless_sync(self):
         compiled = cuda.jit("void(int32[::1])")(useless_sync)
         nelem = 10

--- a/numba/cuda/tests/cudapy/test_transpose.py
+++ b/numba/cuda/tests/cudapy/test_transpose.py
@@ -3,12 +3,13 @@ from numba import cuda
 from numba.cuda.kernels.transpose import transpose
 from numba.cuda.testing import unittest
 from numba.testing.ddt import ddt, data, unpack
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
+
 
 @skip_on_cudasim('Device Array API unsupported in the simulator')
 @ddt
-class Test(unittest.TestCase):
-        
+class Test(SerialMixin, unittest.TestCase):
+
     @data((5, 6, np.float64),
           (128, 128, np.complex128),
           (1025, 512, np.float64))

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, absolute_import, division
 
-from numba.cuda.testing import unittest
+from numba.cuda.testing import unittest, SerialMixin
 from numba import cuda
 
 
@@ -8,7 +8,7 @@ class MyError(Exception):
     pass
 
 
-class TestUserExc(unittest.TestCase):
+class TestUserExc(SerialMixin, unittest.TestCase):
     def test_user_exception(self):
         @cuda.jit("void(int32)", debug=True)
         def test_exc(x):

--- a/numba/cuda/tests/cudapy/test_vectorize_complex.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_complex.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import, print_function, division
 import numpy as np
 from numba import vectorize
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeComplex(unittest.TestCase):
+class TestVectorizeComplex(SerialMixin, unittest.TestCase):
     def test_vectorize_complex(self):
         @vectorize(['complex128(complex128)'], target='cuda')
         def vcomp(a):

--- a/numba/cuda/tests/cudapy/test_vectorize_decor.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_decor.py
@@ -5,11 +5,11 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import vectorize, cuda
 from numba.tests.npyufunc import test_vectorize_decor
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeDecor(test_vectorize_decor.BaseVectorizeDecor):
+class TestVectorizeDecor(SerialMixin, test_vectorize_decor.BaseVectorizeDecor):
     def test_gpu_1(self):
         self._test_template_1('cuda')
 
@@ -21,7 +21,7 @@ class TestVectorizeDecor(test_vectorize_decor.BaseVectorizeDecor):
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestGPUVectorizeBroadcast(unittest.TestCase):
+class TestGPUVectorizeBroadcast(SerialMixin, unittest.TestCase):
     def test_broadcast_bug_90(self):
         """
         https://github.com/ContinuumIO/numbapro/issues/90

--- a/numba/cuda/tests/cudapy/test_vectorize_device.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_device.py
@@ -3,11 +3,11 @@ from numba import vectorize
 from numba import cuda, float32
 import numpy as np
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCudaVectorizeDeviceCall(unittest.TestCase):
+class TestCudaVectorizeDeviceCall(SerialMixin, unittest.TestCase):
     def test_cuda_vectorize_device_call(self):
 
         @cuda.jit(float32(float32, float32, float32), device=True)

--- a/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import vectorize
 from numba import cuda, float64
 from numba import unittest_support as unittest
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 from numba import config
 
 sig = [float64(float64, float64)]
@@ -15,7 +15,7 @@ if config.ENABLE_CUDASIM:
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAVectorizeScalarArg(unittest.TestCase):
+class TestCUDAVectorizeScalarArg(SerialMixin, unittest.TestCase):
 
     def test_vectorize_scalar_arg(self):
         @vectorize(sig, target=target)

--- a/numba/cuda/tests/cudasim/__init__.py
+++ b/numba/cuda/tests/cudasim/__init__.py
@@ -1,8 +1,0 @@
-from numba.testing import SerialSuite
-from numba.testing import load_testsuite
-import os
-from numba import config
-
-
-def load_tests(loader, tests, pattern):
-    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -4,9 +4,10 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import cuda
+from numba.cuda.testing import SerialMixin
 
 
-class TestCudaSimIssues(unittest.TestCase):
+class TestCudaSimIssues(SerialMixin, unittest.TestCase):
 
     def test_cuda_module_in_device_function(self):
         """

--- a/numba/cuda/tests/nocuda/__init__.py
+++ b/numba/cuda/tests/nocuda/__init__.py
@@ -1,6 +1,0 @@
-from numba.testing import SerialSuite
-from numba.testing import load_testsuite
-import os
-
-def load_tests(loader, tests, pattern):
-    return SerialSuite(load_testsuite(loader, os.path.dirname(__file__)))

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from numba.cuda.compiler import compile_kernel
 from numba.cuda.cudadrv import nvvm
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, SerialMixin
 from numba import unittest_support as unittest
 from numba import types, utils
 
@@ -10,7 +10,7 @@ from numba import types, utils
 @skip_on_cudasim('libNVVM not supported in simulator')
 @unittest.skipIf(utils.MACHINE_BITS == 32, "CUDA not support for 32-bit")
 @unittest.skipIf(not nvvm.is_available(), "No libNVVM")
-class TestNvvmWithoutCuda(unittest.TestCase):
+class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
     def test_nvvm_llvm_to_ptx(self):
         """
         A simple test to exercise nvvm.llvm_to_ptx()

--- a/numba/runtests.py
+++ b/numba/runtests.py
@@ -1,3 +1,8 @@
+from __future__ import print_function
+
+import json
+import re
+
 
 def _main(argv, **kwds):
     from numba.testing import run_tests
@@ -5,13 +10,86 @@ def _main(argv, **kwds):
     # is the name of the calling program.
     # The 'main' API function is invoked in-process, and thus
     # will synthesize that name.
-    return run_tests(argv, defaultTest='numba.tests', **kwds).wasSuccessful()
+
+    if '--ff' in argv:
+        # Fail first
+        argv.remove('--ff')
+        _FailFirstRunner().main(argv, kwds)
+    else:
+        return run_tests(argv, defaultTest='numba.tests',
+                         **kwds).wasSuccessful()
+
 
 def main(*argv, **kwds):
     """keyword arguments are accepted for backward compatiblity only.
     See `numba.testing.run_tests()` documentation for details."""
-
     return _main(['<main>'] + list(argv), **kwds)
+
+
+class _FailFirstRunner(object):
+    """
+    Test Runner to handle the failfirst (--ff) option.
+    """
+    cache_filename = '.runtests_lastfailed'
+
+    def main(self, argv, kwds):
+        from numba.testing import run_tests
+        prog = argv[0]
+        argv = argv[1:]
+        flags = [a for a in argv if a.startswith('-')]
+
+        all_tests, failed_tests = self.find_last_failed(argv)
+        # Prepare tests to run
+        if failed_tests:
+            ft = "There were {} previously failed tests"
+            print(ft.format(len(failed_tests)))
+            remaing_tests = [t for t in all_tests
+                             if t not in failed_tests]
+            tests = failed_tests + remaing_tests
+        else:
+            tests = list(all_tests)
+        # Run the testsuite
+        print("Running {} tests".format(len(tests)))
+        print('Flags', flags)
+        result = run_tests([prog] + flags + tests, **kwds)
+        # Save failed
+        self.save_failed_tests(result, all_tests)
+
+    def save_failed_tests(self, result, all_tests):
+        cache = []
+        # Find failed tests
+        failed = set()
+        for case in result.errors + result.failures:
+            failed.add(case[0].id())
+        # Build cache
+        for t in all_tests:
+            if t in failed:
+                cache.append(t)
+        # Write cache
+        with open(self.cache_filename, 'w') as fout:
+            json.dump(cache, fout)
+
+    def find_last_failed(self, argv):
+        from numba.tests.support import captured_output
+
+        # Find all tests
+        listargv = ['-l'] + [a for a in argv if not a.startswith('-')]
+        with captured_output("stdout") as stream:
+            main(*listargv)
+
+            pat = re.compile(r"^(\w+\.)+\w+$")
+            lines = stream.getvalue().splitlines()
+        all_tests = [x for x in lines if pat.match(x) is not None]
+
+        try:
+            fobj = open(self.cache_filename)
+        except IOError:
+            failed_tests = []
+        else:
+            with fobj as fin:
+                failed_tests = json.load(fin)
+        return all_tests, failed_tests
+
 
 if __name__ == '__main__':
     import sys

--- a/numba/runtests.py
+++ b/numba/runtests.py
@@ -11,10 +11,10 @@ def _main(argv, **kwds):
     # The 'main' API function is invoked in-process, and thus
     # will synthesize that name.
 
-    if '--ff' in argv:
-        # Fail first
-        argv.remove('--ff')
-        _FailFirstRunner().main(argv, kwds)
+    if '--failed-first' in argv:
+        # Failed first
+        argv.remove('--failed-first')
+        _FailedFirstRunner().main(argv, kwds)
     else:
         return run_tests(argv, defaultTest='numba.tests',
                          **kwds).wasSuccessful()
@@ -26,9 +26,9 @@ def main(*argv, **kwds):
     return _main(['<main>'] + list(argv), **kwds)
 
 
-class _FailFirstRunner(object):
+class _FailedFirstRunner(object):
     """
-    Test Runner to handle the failfirst (--ff) option.
+    Test Runner to handle the failed-first (--failed-first) option.
     """
     cache_filename = '.runtests_lastfailed'
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -407,6 +407,13 @@ class TestCase(unittest.TestCase):
         self.assertPreciseEqual(got, expected)
         return got, expected
 
+
+class SerialMixin(object):
+    """Mixin to mark test for serial execution.
+    """
+    _numba_parallel_test_ = False
+
+
 # Various helpers
 
 @contextlib.contextmanager


### PR DESCRIPTION
(related to #2623)

Adds two features in the test runner to run previously failed tests first (`--failed-first`) and run failed tests only (`--last-failed`).  The new options can mix with `-m`, `-v`, `-b`, `-f`.

In addition, the cuda test suite is slightly refactored to avoid relying on the custom test loader to make the tests run in serial.  The new `SerialMixin` class is added to all cuda tests.  This means that `python -m numba.runtests -m numba.cuda.tests.cudapy.<special_test_module>` will not failed due to the bypassing the testloader and failing to recognize that the test must run in serial.


