### PR TITLE
Fix regression: cuda test submodules not loading properly in runtests

### DIFF
--- a/numba/cuda/tests/cudadrv/__init__.py
+++ b/numba/cuda/tests/cudadrv/__init__.py
@@ -1,0 +1,6 @@
+from numba.testing import load_testsuite
+import os
+
+
+def load_tests(loader, tests, pattern):
+    return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/cudapy/__init__.py
+++ b/numba/cuda/tests/cudapy/__init__.py
@@ -1,0 +1,6 @@
+from numba.testing import load_testsuite
+import os
+
+
+def load_tests(loader, tests, pattern):
+    return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/cudasim/__init__.py
+++ b/numba/cuda/tests/cudasim/__init__.py
@@ -1,0 +1,6 @@
+from numba.testing import load_testsuite
+import os
+
+
+def load_tests(loader, tests, pattern):
+    return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/nocuda/__init__.py
+++ b/numba/cuda/tests/nocuda/__init__.py
@@ -1,0 +1,6 @@
+from numba.testing import load_testsuite
+import os
+
+
+def load_tests(loader, tests, pattern):
+    return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -1,9 +1,10 @@
 from __future__ import division, print_function
 
-from numba import unittest_support as unittest
-
 import sys
 import subprocess
+
+from numba import unittest_support as unittest
+from numba import cuda
 
 
 class TestCase(unittest.TestCase):
@@ -60,6 +61,7 @@ class TestCase(unittest.TestCase):
         # (in numba.cuda.tests.nocuda)
         self.check_testsuite_size(['numba.cuda.tests'], 1, 400)
 
+    @unittest.skipIf(not cuda.is_available(), "NO CUDA")
     def test_cuda_submodules(self):
         self.check_listing_prefix('numba.cuda.tests.cudadrv')
         self.check_listing_prefix('numba.cuda.tests.cudapy')

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -11,14 +11,24 @@ class TestCase(unittest.TestCase):
     Therefore, the logic used here shouldn't use numba.testing, but only the upstream
     unittest, and run the numba test suite only in a subprocess."""
 
+    def get_testsuite_listing(self, args):
+        cmd = ['python', '-m', 'numba.runtests', '-l'] + list(args)
+        lines = subprocess.check_output(cmd).decode().splitlines()
+        lines = [line for line in lines if line.strip()]
+        return lines
+
+    def check_listing_prefix(self, prefix):
+        listing = self.get_testsuite_listing([prefix])
+        for ln in listing[:-1]:
+            errmsg = '{!r} not startswith {!r}'.format(ln, prefix)
+            self.assertTrue(ln.startswith(prefix), msg=errmsg)
+
     def check_testsuite_size(self, args, minsize, maxsize=None):
         """
         Check that the reported numbers of tests are in the
         (minsize, maxsize) range, or are equal to minsize if maxsize is None.
         """
-        cmd = ['python', '-m', 'numba.runtests', '-l'] + list(args)
-        lines = subprocess.check_output(cmd).decode().splitlines()
-        lines = [line for line in lines if line.strip()]
+        lines = self.get_testsuite_listing(args)
         last_line = lines[-1]
         self.assertTrue(last_line.endswith('tests found'))
         number = int(last_line.split(' ')[0])
@@ -49,6 +59,12 @@ class TestCase(unittest.TestCase):
         # Even without CUDA enabled, there is at least one test
         # (in numba.cuda.tests.nocuda)
         self.check_testsuite_size(['numba.cuda.tests'], 1, 400)
+
+    def test_cuda_submodules(self):
+        self.check_listing_prefix('numba.cuda.tests.cudadrv')
+        self.check_listing_prefix('numba.cuda.tests.cudapy')
+        self.check_listing_prefix('numba.cuda.tests.nocuda')
+        self.check_listing_prefix('numba.cuda.tests.cudasim')
 
     def test_module(self):
         self.check_testsuite_size(['numba.tests.test_utils'], 3, 15)


### PR DESCRIPTION
Revert changes in #2703 that causes cuda test submodules to not load properly in runtests.

This also adds tests to prevent future regression.