### PR TITLE
Handle matching directly supported functions

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1359,7 +1359,7 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
     callee_def = definition_finder(func_ir, callee)
     attrs = []
     while True:
-        if isinstance(callee_def, ir.Global):
+        if isinstance(callee_def, (ir.Global, ir.FreeVar)):
             # require(callee_def.value == numpy)
             # these checks support modules like numpy, numpy.random as well as
             # calls like len() and intrinsitcs like assertEquiv

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1376,6 +1376,10 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
                 mod_name = callee_def.value.__module__
                 if mod_name is not None:
                     attrs.append(mod_name)
+                else:
+                    # it might be a np.random function imported directly
+                    if hasattr(numpy.random, value):
+                        attrs += ['random', 'numpy']
             else:
                 class_name = callee_def.value.__class__.__name__
                 if class_name == 'builtin_function_or_method':

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1374,7 +1374,8 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
             attrs.append(value)
             if hasattr(callee_def.value, '__module__'):
                 mod_name = callee_def.value.__module__
-                attrs.append(mod_name)
+                if mod_name is not None:
+                    attrs.append(mod_name)
             else:
                 class_name = callee_def.value.__class__.__name__
                 if class_name == 'builtin_function_or_method':

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1374,12 +1374,16 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
             attrs.append(value)
             if hasattr(callee_def.value, '__module__'):
                 mod_name = callee_def.value.__module__
-                if mod_name is not None:
+                # it might be a numpy function imported directly
+                if (hasattr(numpy, value)
+                        and callee_def.value == getattr(numpy, value)):
+                    attrs += ['numpy']
+                # it might be a np.random function imported directly
+                elif (hasattr(numpy.random, value)
+                        and callee_def.value == getattr(numpy.random, value)):
+                    attrs += ['random', 'numpy']
+                elif mod_name is not None:
                     attrs.append(mod_name)
-                else:
-                    # it might be a np.random function imported directly
-                    if hasattr(numpy.random, value):
-                        attrs += ['random', 'numpy']
             else:
                 class_name = callee_def.value.__class__.__name__
                 if class_name == 'builtin_function_or_method':

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -12,6 +12,7 @@ import types as pytypes
 import warnings
 from functools import reduce
 import numpy as np
+from numpy.random import randn
 
 import numba
 from numba import unittest_support as unittest
@@ -477,6 +478,22 @@ class TestParfors(TestParforsBase):
             y = 2 * v1
             return 4 * np.sum(x**2 + y**2 < 1) / 10
         self.check(test_impl, *self.simple_args)
+
+    @skip_unsupported
+    def test_np_func_direct_import(self):
+        from numpy import ones  # import here becomes FreeVar
+        def test_impl(n):
+            A = ones(n)
+            return A[0]
+        n = 111
+        self.check(test_impl, n)
+
+    @skip_unsupported
+    def test_np_random_func_direct_import(self):
+        def test_impl(n):
+            A = randn(n)
+            return A[0]
+        self.assertTrue(countParfors(test_impl, (types.int64, )) == 1)
 
     @skip_unsupported
     def test_arange(self):


### PR DESCRIPTION
fixes #2711 

Numpy functions that are directly supported look different in `find_callname`. This PR handles this case by trying to find the function from the Numpy module.