### PR TITLE
Alternative to #2620.  Remove dead code ByteCodeInst.get.

### DIFF
--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -12,7 +12,6 @@ import itertools
 from types import CodeType, ModuleType
 
 from numba import errors, utils
-from numba.config import PYVERSION
 
 
 opcode_info = namedtuple('opcode_info', ['argsize'])
@@ -74,10 +73,6 @@ class ByteCodeInst(object):
         self.opname = dis.opname[opcode]
         self.arg = arg
         self.lineno = -1  # unknown line number
-
-    @classmethod
-    def get(cls, offset, opname, arg):
-        return cls(offset, dis.opmap[opname], arg)
 
     @property
     def is_jump(self):


### PR DESCRIPTION
Closes #2620.

The fix in #2620 is changing code that is never used.  This patch removes the dead code.