### PR TITLE
Add guard for test needing SciPy/BLAS

### DIFF
--- a/numba/tests/test_debug.py
+++ b/numba/tests/test_debug.py
@@ -16,6 +16,7 @@ from numba.targets.cpu import ParallelOptions
 from numba.errors import NumbaWarning
 from numba import compiler, prange
 from .test_parfors import skip_unsupported
+from .matmul_usecase import needs_blas
 
 def simple_nopython(somearg):
     retval = somearg + 1
@@ -236,6 +237,7 @@ class TestParforsDebug(TestCase):
                 break
         self.assertTrue(warning_found, "Warning message should be found.")
 
+    @needs_blas
     @skip_unsupported
     def test_warns(self):
         """


### PR DESCRIPTION
This patch adds a guard around a test that needs SciPy (BLAS)
support to prevent it running if SciPy isn't present.