### PR TITLE
Use more challenging values in slice tests.

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -256,7 +256,7 @@ class CudaArraySetting(SerialMixin, unittest.TestCase):
             member=str(e.exception),
             container=[
                 "Can't assign 3-D array to 1-D self",  # device
-                "could not broadcast input array from shape (2,3) into shape (25)",  # simulator
+                "could not broadcast input array from shape (2,3) into shape (35)",  # simulator
             ])
 
     def test_incompatible_shape(self):

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -16,7 +16,7 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
             self.assertEqual(arr[i], darr[i])
 
     def test_index_2d(self):
-        arr = np.arange(9).reshape(3, 3)
+        arr = np.arange(3 * 4).reshape(3, 4)
         darr = cuda.to_device(arr)
 
         for i in range(arr.shape[0]):
@@ -24,7 +24,7 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
                 self.assertEqual(arr[i, j], darr[i, j])
 
     def test_index_3d(self):
-        arr = np.arange(3 ** 3).reshape(3, 3, 3)
+        arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
         darr = cuda.to_device(arr)
 
         for i in range(arr.shape[0]):
@@ -42,7 +42,7 @@ class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):
             np.testing.assert_equal(arr[i::2], darr[i::2].copy_to_host())
 
     def test_strided_index_2d(self):
-        arr = np.arange(6 ** 2).reshape(6, 6)
+        arr = np.arange(6 * 7).reshape(6, 7)
         darr = cuda.to_device(arr)
 
         for i in range(arr.shape[0]):
@@ -51,7 +51,7 @@ class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):
                                         darr[i::2, j::2].copy_to_host())
 
     def test_strided_index_3d(self):
-        arr = np.arange(6 ** 3).reshape(6, 6, 6)
+        arr = np.arange(6 * 7 * 8).reshape(6, 7, 8)
         darr = cuda.to_device(arr)
 
         for i in range(arr.shape[0]):
@@ -83,7 +83,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                 self.assertTrue(np.all(expect == got))
 
     def test_select_3d_first_two_dim(self):
-        arr = np.arange(3 ** 3).reshape(3, 3, 3)
+        arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
         darr = cuda.to_device(arr)
         # Select first dimension
         for i in range(arr.shape[0]):
@@ -104,7 +104,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                 self.assertTrue(np.all(expect == got))
 
     def test_select_f(self):
-        a = np.arange(5 * 5 * 5).reshape(5, 5, 5, order='F')
+        a = np.arange(5 * 6 * 7).reshape(5, 6, 7, order='F')
         da = cuda.to_device(a)
 
         for i in range(a.shape[0]):
@@ -117,7 +117,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                 self.assertTrue(np.all(da[:, i, j].copy_to_host() == a[:, i, j]))
 
     def test_select_c(self):
-        a = np.arange(5 * 5 * 5).reshape(5, 5, 5, order='C')
+        a = np.arange(5 * 6 * 7).reshape(5, 6, 7, order='C')
         da = cuda.to_device(a)
 
         for i in range(a.shape[0]):
@@ -130,7 +130,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                 self.assertTrue(np.all(da[:, i, j].copy_to_host() == a[:, i, j]))
 
     def test_prefix_select(self):
-        arr = np.arange(5 ** 2).reshape(5, 5, order='F')
+        arr = np.arange(5 * 7).reshape(5, 7, order='F')
 
         darr = cuda.to_device(arr)
         self.assertTrue(np.all(darr[:1, 1].copy_to_host() == arr[:1, 1]))
@@ -143,7 +143,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                                           darr[i:j].copy_to_host())
 
     def test_negative_slicing_2d(self):
-        arr = np.arange(9).reshape(3, 3)
+        arr = np.arange(12).reshape(3, 4)
         darr = cuda.to_device(arr)
         for x, y, w, s in product(range(-4, 4), repeat=4):
             np.testing.assert_array_equal(arr[x:y, w:s],
@@ -161,7 +161,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
         np.testing.assert_array_equal(darr[:0][-1:].copy_to_host(), arr[:0][-1:])
 
     def test_empty_slice_2d(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
         np.testing.assert_array_equal(darr[:0].copy_to_host(), arr[:0])
         np.testing.assert_array_equal(darr[3, :0].copy_to_host(), arr[3, :0])
@@ -179,36 +179,36 @@ class CudaArraySetting(SerialMixin, unittest.TestCase):
     """
 
     def test_scalar(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
         arr[2, 2] = 500
         darr[2, 2] = 500
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_rank(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
         arr[2] = 500
         darr[2] = 500
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_broadcast(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
         arr[:, 2] = 500
         darr[:, 2] = 500
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_array_assign_column(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
-        _400 = np.full(shape=5, fill_value=400)
+        _400 = np.full(shape=7, fill_value=400)
         arr[2] = _400
         darr[2] = _400
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_array_assign_row(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
         _400 = np.full(shape=5, fill_value=400)
         arr[:, 2] = _400
@@ -216,25 +216,25 @@ class CudaArraySetting(SerialMixin, unittest.TestCase):
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_array_assign_subarray(self):
-        arr = np.arange(5 * 5 * 5).reshape(5, 5, 5)
+        arr = np.arange(5 * 6 * 7).reshape(5, 6, 7)
         darr = cuda.to_device(arr)
-        _400 = np.full(shape=(5, 5), fill_value=400)
+        _400 = np.full(shape=(6, 7), fill_value=400)
         arr[2] = _400
         darr[2] = _400
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_array_assign_deep_subarray(self):
-        arr = np.arange(5 * 5 * 5 * 5).reshape(5, 5, 5, 5)
+        arr = np.arange(5 * 6 * 7 * 8).reshape(5, 6, 7, 8)
         darr = cuda.to_device(arr)
-        _400 = np.full(shape=5, fill_value=400)
+        _400 = np.full(shape=(5, 6, 8), fill_value=400)
         arr[:, :, 2] = _400
         darr[:, :, 2] = _400
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_array_assign_all(self):
-        arr = np.arange(5 * 5).reshape(5, 5)
+        arr = np.arange(5 * 7).reshape(5, 7)
         darr = cuda.to_device(arr)
-        _400 = np.full(shape=5, fill_value=400)
+        _400 = np.full(shape=(5, 7), fill_value=400)
         arr[:] = _400
         darr[:] = _400
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
@@ -247,7 +247,7 @@ class CudaArraySetting(SerialMixin, unittest.TestCase):
         np.testing.assert_array_equal(darr.copy_to_host(), arr)
 
     def test_incompatible_highdim(self):
-        darr = cuda.to_device(np.arange(5 * 5))
+        darr = cuda.to_device(np.arange(5 * 7))
 
         with self.assertRaises(ValueError) as e:
             darr[:] = np.ones(shape=(1, 2, 3))


### PR DESCRIPTION
This patch trivially alters the values in the CUDA slice tests
with view of ensuring that code is working correctly in arrays
with shapes that are different in each dimension.