### PR TITLE
Fix #2007 (part 1). Empty array handling in np.linalg.

### DIFF
--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -766,7 +766,7 @@ def _inv_err_handler(r):
 
 @register_jitable
 def _dummy_liveness_func(a):
-    """pass a list of variables to be preseved through dead code elimination"""
+    """pass a list of variables to be preserved through dead code elimination"""
     return a[0]
 
 
@@ -797,6 +797,9 @@ def inv_impl(a):
         else:
             acpy = np.asfortranarray(a)
 
+        if n == 0:
+            return acpy
+
         ipiv = np.empty(n, dtype=F_INT_nptype)
 
         r = numba_xxgetrf(kind, n, n, acpy.ctypes, n, ipiv.ctypes)
@@ -806,8 +809,6 @@ def inv_impl(a):
         _inv_err_handler(r)
 
         # help liveness analysis
-        #acpy.size
-        #ipiv.size
         _dummy_liveness_func([acpy.size, ipiv.size])
         return acpy
 
@@ -863,6 +864,10 @@ if numpy_version >= (1, 8):
 
             # The output is allocated in C order
             out = a.copy()
+
+            if n == 0:
+                return out
+
             # Pass UP since xxpotrf() operates in F order
             # The semantics ensure this works fine
             # (out is really its Hermitian in F order, but UP instructs
@@ -922,6 +927,9 @@ if numpy_version >= (1, 8):
             vl = np.empty((n, ldvl), dtype=a.dtype)
             vr = np.empty((n, ldvr), dtype=a.dtype)
 
+            if n == 0:
+                return (wr, vr.T)
+
             r = numba_ez_rgeev(kind,
                                JOBVL,
                                JOBVR,
@@ -952,11 +960,6 @@ if numpy_version >= (1, 8):
 
             # put these in to help with liveness analysis,
             # `.ctypes` doesn't keep the vars alive
-            #acpy.size
-            #vl.size
-            #vr.size
-            #wr.size
-            #wi.size
             _dummy_liveness_func([acpy.size, vl.size, vr.size, wr.size, wi.size])
             return (wr, vr.T)
 
@@ -982,6 +985,9 @@ if numpy_version >= (1, 8):
             vl = np.empty((n, ldvl), dtype=a.dtype)
             vr = np.empty((n, ldvr), dtype=a.dtype)
 
+            if n == 0:
+                return (w, vr.T)
+
             r = numba_ez_cgeev(kind,
                                JOBVL,
                                JOBVR,
@@ -997,10 +1003,6 @@ if numpy_version >= (1, 8):
 
             # put these in to help with liveness analysis,
             # `.ctypes` doesn't keep the vars alive
-            #acpy.size
-            #vl.size
-            #vr.size
-            #w.size
             _dummy_liveness_func([acpy.size, vl.size, vr.size, w.size])
             return (w, vr.T)
 
@@ -1044,6 +1046,10 @@ if numpy_version >= (1, 8):
             ldvl = 1
             ldvr = 1
             wr = np.empty(n, dtype=a.dtype)
+
+            if n == 0:
+                return wr
+
             wi = np.empty(n, dtype=a.dtype)
 
             # not referenced but need setting for MKL null check
@@ -1080,11 +1086,6 @@ if numpy_version >= (1, 8):
 
             # put these in to help with liveness analysis,
             # `.ctypes` doesn't keep the vars alive
-            #acpy.size
-            #vl.size
-            #vr.size
-            #wr.size
-            #wi.size
             _dummy_liveness_func([acpy.size, vl.size, vr.size, wr.size, wi.size])
             return wr
 
@@ -1107,6 +1108,10 @@ if numpy_version >= (1, 8):
             ldvl = 1
             ldvr = 1
             w = np.empty(n, dtype=a.dtype)
+
+            if n == 0:
+                return w
+
             vl = np.empty((1), dtype=a.dtype)
             vr = np.empty((1), dtype=a.dtype)
 
@@ -1125,10 +1130,6 @@ if numpy_version >= (1, 8):
 
             # put these in to help with liveness analysis,
             # `.ctypes` doesn't keep the vars alive
-            #acpy.size
-            #vl.size
-            #vr.size
-            #w.size
             _dummy_liveness_func([acpy.size, vl.size, vr.size, w.size])
             return w
 
@@ -1172,6 +1173,9 @@ if numpy_version >= (1, 8):
 
             w = np.empty(n, dtype=w_dtype)
 
+            if n == 0:
+                return (w, acpy)
+
             r = numba_ez_xxxevd(kind,  # kind
                                 JOBZ,  # jobz
                                 UPLO,  # uplo
@@ -1183,8 +1187,6 @@ if numpy_version >= (1, 8):
             _handle_err_maybe_convergence_problem(r)
 
             # help liveness analysis
-            #acpy.size
-            #w.size
             _dummy_liveness_func([acpy.size, w.size])
             return (w, acpy)
 
@@ -1225,6 +1227,9 @@ if numpy_version >= (1, 8):
 
             w = np.empty(n, dtype=w_dtype)
 
+            if n == 0:
+                return w
+
             r = numba_ez_xxxevd(kind,  # kind
                                 JOBZ,  # jobz
                                 UPLO,  # uplo
@@ -1236,8 +1241,6 @@ if numpy_version >= (1, 8):
             _handle_err_maybe_convergence_problem(r)
 
             # help liveness analysis
-            #acpy.size
-            #w.size
             _dummy_liveness_func([acpy.size, w.size])
             return w
 
@@ -1265,6 +1268,9 @@ if numpy_version >= (1, 8):
         def svd_impl(a, full_matrices=1):
             n = a.shape[-1]
             m = a.shape[-2]
+
+            if n == 0 or m == 0:
+                raise np.linalg.LinAlgError("Arrays cannot be empty")
 
             _check_finite_matrix(a)
 
@@ -1305,10 +1311,6 @@ if numpy_version >= (1, 8):
             _handle_err_maybe_convergence_problem(r)
 
             # help liveness analysis
-            #acpy.size
-            #vt.size
-            #u.size
-            #s.size
             _dummy_liveness_func([acpy.size, vt.size, u.size, s.size])
             return (u.T, s, vt.T)
 
@@ -1337,6 +1339,9 @@ def qr_impl(a):
     def qr_impl(a):
         n = a.shape[-1]
         m = a.shape[-2]
+
+        if n == 0 or m == 0:
+            raise np.linalg.LinAlgError("Arrays cannot be empty")
 
         _check_finite_matrix(a)
 
@@ -1388,8 +1393,6 @@ def qr_impl(a):
         _handle_err_maybe_convergence_problem(ret)
 
         # help liveness analysis
-        #tau.size
-        #q.size
         _dummy_liveness_func([tau.size, q.size])
         return (q[:, :minmn], r)
 
@@ -1463,6 +1466,35 @@ def _system_check_dimensionally_valid_impl(a, b):
             if am != bm:
                 raise np.linalg.LinAlgError(
                     "Incompatible array sizes, system is not dimensionally valid.")
+        return twoD_impl
+
+
+def _system_check_non_empty(a, b):
+    """
+    Check that AX=B style system input is not empty.
+    """
+    raise NotImplementedError
+
+
+@overload(_system_check_non_empty)
+def _system_check_non_empty_impl(a, b):
+    ndim = b.ndim
+    if ndim == 1:
+        def oneD_impl(a, b):
+            am = a.shape[-2]
+            an = a.shape[-1]
+            bm = b.shape[-1]
+            if am == 0 or bm == 0 or an == 0:
+                raise np.linalg.LinAlgError('Arrays cannot be empty')
+        return oneD_impl
+    else:
+        def twoD_impl(a, b):
+            am = a.shape[-2]
+            an = a.shape[-1]
+            bm = b.shape[-2]
+            bn = b.shape[-1]
+            if am == 0 or bm == 0 or an == 0 or bn == 0:
+                raise np.linalg.LinAlgError('Arrays cannot be empty')
         return twoD_impl
 
 
@@ -1571,7 +1603,10 @@ def lstsq_impl(a, b, rcond=-1.0):
         _check_finite_matrix(a)
         _check_finite_matrix(b)
 
-        # check the systems is dimensionally valid
+        # check the system is not empty
+        _system_check_non_empty(a, b)
+
+        # check the systems are dimensionally valid
         _system_check_dimensionally_valid(a, b)
 
         minmn = min(m, n)
@@ -1622,10 +1657,6 @@ def lstsq_impl(a, b, rcond=-1.0):
         x = _lstsq_solution(b, bcpy, n)
 
         # help liveness analysis
-        #acpy.size
-        #bcpy.size
-        #s.size
-        #rank_ptr.size
         _dummy_liveness_func([acpy.size, bcpy.size, s.size, rank_ptr.size])
         return (x, res, rank, s[:minmn])
 
@@ -1691,6 +1722,9 @@ def solve_impl(a, b):
 
         # b is overwritten on exit with the solution, copy allocate
         bcpy = np.empty((nrhs, n), dtype=np_dt).T
+        if n == 0:
+            return _solve_compute_return(b, bcpy)
+
         # specialised copy in due to b being 1 or 2D
         _system_copy_in_b(bcpy, b, nrhs)
 
@@ -1710,9 +1744,6 @@ def solve_impl(a, b):
         _inv_err_handler(r)
 
         # help liveness analysis
-        #acpy.size
-        #bcpy.size
-        #ipiv.size
         _dummy_liveness_func([acpy.size, bcpy.size, ipiv.size])
         return _solve_compute_return(b, bcpy)
 
@@ -1795,6 +1826,9 @@ def pinv_impl(a, rcond=1.e-15):
             acpy = np.copy(a)
         else:
             acpy = np.asfortranarray(a)
+
+        if m == 0 or n == 0:
+            return acpy.T.ravel().reshape(a.shape).T
 
         minmn = min(m, n)
 
@@ -1935,11 +1969,17 @@ def slogdet_impl(a):
 
     diag_walker = _get_slogdet_diag_walker(a)
 
+    ONE = a.dtype(1)
+    ZERO = getattr(a.dtype, "underlying_float", a.dtype)(0)
+
     def slogdet_impl(a):
         n = a.shape[-1]
         if a.shape[-2] != n:
             msg = "Last 2 dimensions of the array must be square."
             raise np.linalg.LinAlgError(msg)
+
+        if n == 0:
+            return (ONE, ZERO)
 
         _check_finite_matrix(a)
 
@@ -1973,7 +2013,6 @@ def slogdet_impl(a):
             sgn = -1
 
         # help liveness analysis
-        #ipiv.size
         _dummy_liveness_func([ipiv.size])
         return diag_walker(n, acpy, sgn)
 
@@ -2017,7 +2056,7 @@ def _compute_singular_values_impl(a):
     np_ret_type = np_support.as_dtype(nb_ret_type)
     np_dtype = np_support.as_dtype(a.dtype)
 
-    # This are not referenced in the computation but must be set
+    # These are not referenced in the computation but must be set
     # for MKL.
     u = np.empty((1, 1), dtype=np_dtype)
     vt = np.empty((1, 1), dtype=np_dtype)
@@ -2032,17 +2071,18 @@ def _compute_singular_values_impl(a):
         # call LAPACK to shortcut doing the "reconstruct
         # singular vectors from reflectors" step and just
         # get back the singular values.
-        _check_finite_matrix(a)
         n = a.shape[-1]
         m = a.shape[-2]
+        if m == 0 or n == 0:
+            raise np.linalg.LinAlgError('Arrays cannot be empty')
+        _check_finite_matrix(a)
+
         ldu = m
         minmn = min(m, n)
 
         # need to be >=1 but aren't referenced
         ucol = 1
         ldvt = 1
-
-        _check_finite_matrix(a)
 
         if F_layout:
             acpy = np.copy(a)
@@ -2070,10 +2110,6 @@ def _compute_singular_values_impl(a):
         _handle_err_maybe_convergence_problem(r)
 
         # help liveness analysis
-        #acpy.size
-        #vt.size
-        #u.size
-        #s.size
         _dummy_liveness_func([acpy.size, vt.size, u.size, s.size])
         return s
 
@@ -2482,6 +2518,14 @@ def matrix_power_impl(a, n):
             for k in range(a.shape[0]):
                 A[k, k] = 1.
             return A
+
+        am, an = a.shape[-1], a.shape[-2]
+        if am != an:
+            raise ValueError('input must be a square array')
+
+        # empty, return a copy
+        if am == 0:
+            return a.copy()
 
         # note: to be consistent over contiguousness, C order is
         # returned as that is what dot() produces and the most common


### PR DESCRIPTION
This largely fixes and tests the handling of empty arrays in the
Numba np.linalg implementation. Without this patch PyFatals were
rightfully being raised from the LAPACK wrappers as arguments that
should be in Z^+ were being entered as 0.