### PR TITLE
Fix install_requires to allow pip getting pre-release version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ packages = find_packages("numba", "numba")
 
 build_requires = ['numpy']
 
-install_requires = ['llvmlite', 'numpy']
+install_requires = ['llvmlite>=0.22.0.dev0', 'numpy']
 if sys.version_info < (3, 4):
     install_requires.extend(['enum34', 'singledispatch'])
 if sys.version_info < (3, 3):


### PR DESCRIPTION
This is needed for pip to recognize the llvmlite 0.22.0rc1.

See https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions