### PR TITLE
Explicitly state default value of error_model in docstring

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -75,7 +75,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False, **opti
                 The error-model affects divide-by-zero behavior.
                 Valid values are 'python' and 'numpy'. The 'python' model
                 raises exception.  The 'numpy' model sets the result to
-                *+/-inf* or *nan*.
+                *+/-inf* or *nan*. Default value is 'python'.
 
     Returns
     --------


### PR DESCRIPTION
The default values for the options to the `jit` decorator are all stated explicitly in the docstring, except for `error_model`. Adding this will save the user from digging around to look it up elsewhere.