### PR TITLE
Enhance error message for undefined variables.

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -754,6 +754,16 @@ class Block(object):
             if isinstance(inst, cls):
                 yield inst
 
+    def find_variable_assignment(self, name):
+        """
+        Returns the assignment inst associated with variable "name", None if
+        it cannot be found.
+        """
+        for x in self.find_insts(cls=Assign):
+            if x.target.name == name:
+                return x
+        return None
+
     def prepend(self, inst):
         assert isinstance(inst, Stmt)
         self.body.insert(0, inst)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -882,17 +882,11 @@ class TypeInferer(object):
         def check_var(name):
             tv = self.typevars[name]
             if not tv.defined:
-                def find_offender(name):
-                    """
-                    finds the offending variable definition to allow its
-                    inclusion in an error message
-                    """
-                    for block in self.func_ir.blocks.values():
-                        for x in block.find_insts(ir.Assign):
-                            if x.target.name == name:
-                                return x
-                    return None
-                offender = find_offender(var)
+                offender = None
+                for block in self.func_ir.blocks.values():
+                    offender = block.find_variable_assignment(name)
+                    if offender is not None:
+                        break
                 val = getattr(offender, 'value', 'unknown operation')
                 loc = getattr(offender, 'loc', 'unknown location')
                 msg = "Undefined variable '%s', operation: %s, location: %s"


### PR DESCRIPTION
This patch traces back a temporary to its definition if type
inference fails to resolve a type for the temporary. This allows
a more informative error message to be emitted.

Fixes #2237