### PR TITLE
Add len(..) Support to DeviceNDArray

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -352,6 +352,9 @@ class DeviceNDArray(DeviceNDArrayBase):
         """
         return self.copy_to_host().__array__(dtype)
 
+    def __len__(self):
+        return self.shape[0]
+
     def reshape(self, *newshape, **kws):
         """
         Reshape the array without changing its contents, similarly to

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -43,6 +43,20 @@ class TestCudaNDArray(SerialMixin, unittest.TestCase):
             self.assertEqual(arr.bind(stream).stream, stream)
             self.assertEqual(arr.stream, stream)
 
+    def test_len_1d(self):
+        ary = np.empty((3,))
+        dary = cuda.device_array(3)
+        self.assertEqual(len(ary), len(dary))
+
+    def test_len_2d(self):
+        ary = np.empty((3, 5))
+        dary = cuda.device_array((3, 5))
+        self.assertEqual(len(ary), len(dary))
+
+    def test_len_3d(self):
+        ary = np.empty((3, 5, 7))
+        dary = cuda.device_array((3, 5, 7))
+        self.assertEqual(len(ary), len(dary))
 
     def test_devicearray_partition(self):
         N = 100


### PR DESCRIPTION
You can't make 0-D device-nd-arrays, `numba.cuda.cudadrv.devicearray.DeviceNDArrayBase((), (), np.float64)` throws