### PR TITLE
 Passing jitted functions as args

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -35,16 +35,11 @@ The ``raise`` statement is supported in several forms:
 Similarly, the ``assert`` statement is supported with or without an error
 message.
 
-Inner function and closure
---------------------------
-
-Numba now supports inner functions as long as they are non-recursive
-and only called locally, but not passed as argument or returned as
-result. The use of closure variables (variables defined in outer scopes)
-within an inner function is also supported.
+Functions
+---------
 
 Function calls
---------------
+''''''''''''''
 
 Numba supports function calls using positional and named arguments, as well
 as arguments with default values and ``*args`` (note the argument for
@@ -53,6 +48,46 @@ not supported.
 
 Function calls to locally defined inner functions are supported as long as
 they can be fully inlined.
+
+Functions as arguments
+''''''''''''''''''''''
+
+Functions can be passed as argument into another function.  But, they cannot
+be returned. For example:
+
+.. code-block:: python
+
+  from numba import jit
+
+  @jit
+  def add1(x):
+      return x + 1
+
+  @jit
+  def bar(fn, x):
+      return fn(x)
+
+  @jit
+  def foo(x):
+      return bar(add1, x)
+
+  # Passing add1 within numba compiled code.
+  print(foo(1))
+  # Passing add1 into bar from interpreted code
+  print(bar(add1, 1))
+
+.. note:: Numba does not handle function objects as real objects.  Once a
+          function is assigned to a variable, the variable cannot be
+          re-assigned to a different function.
+
+
+Inner function and closure
+'''''''''''''''''''''''''''
+
+Numba now supports inner functions as long as they are non-recursive
+and only called locally, but not passed as argument or returned as
+result. The use of closure variables (variables defined in outer scopes)
+within an inner function is also supported.
 
 Recursive calls
 '''''''''''''''

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -486,6 +486,10 @@ class Dispatcher(_DispatcherBase):
         self._type = types.Dispatcher(self)
         self.typingctx.insert_global(self, self._type)
 
+    @property
+    def _numba_type_(self):
+        return types.Dispatcher(self)
+
     def enable_caching(self):
         self._cache = FunctionCache(self.py_func)
 

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -1330,9 +1330,9 @@ class PythonAPI(object):
         pointer is returned (NULL if an error occurred).
         This method steals any native (NRT) reference embedded in *val*.
         """
-        impl = _boxers.lookup(typ.__class__)
-        if impl is None:
-            raise NotImplementedError("cannot convert native %s to Python object" % (typ,))
+        from numba.targets.boxing import box_unsupported
+
+        impl = _boxers.lookup(typ.__class__, box_unsupported)
 
         c = _BoxContext(self.context, self.builder, self, env_manager)
         return impl(typ, val, c)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -5,12 +5,12 @@ import contextlib
 import pickle
 
 from llvmlite import ir
-from llvmlite.llvmpy.core import Type, Constant, LLVMException
+from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
 from numba.config import PYVERSION
 import numba.ctypes_support as ctypes
-from numba import numpy_support, config
+from numba import config
 from numba import types, utils, cgutils, lowering, _helperlib
 
 
@@ -28,13 +28,13 @@ class _Registry(object):
             return func
         return decorator
 
-    def lookup(self, typeclass):
+    def lookup(self, typeclass, default=None):
         assert issubclass(typeclass, types.Type)
         for cls in typeclass.__mro__:
             func = self.functions.get(cls)
             if func is not None:
                 return func
-        return None
+        return default
 
 # Registries of boxing / unboxing implementations
 _boxers = _Registry()
@@ -1311,10 +1311,9 @@ class PythonAPI(object):
         Unbox the Python object as the given Numba type.
         A NativeValue instance is returned.
         """
-        impl = _unboxers.lookup(typ.__class__)
-        if impl is None:
-            raise NotImplementedError("cannot convert %s to native value" % (typ,))
+        from numba.targets.boxing import unbox_unsupported
 
+        impl = _unboxers.lookup(typ.__class__, unbox_unsupported)
         c = _UnboxContext(self.context, self.builder, self)
         return impl(typ, obj, c)
 

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -912,8 +912,15 @@ def box_deferred(typ, val, c):
 
 @unbox(types.DeferredType)
 def unbox_deferred(typ, obj, c):
-    native_value= c.pyapi.to_native_value(typ.get(), obj)
+    native_value = c.pyapi.to_native_value(typ.get(), obj)
     model = c.context.data_model_manager[typ]
     res = model.set(c.builder, model.make_uninitialized(), native_value.value)
     return NativeValue(res, is_error=native_value.is_error,
                        cleanup=native_value.cleanup)
+
+
+def unbox_unsupported(typ, obj, c):
+    c.pyapi.err_set_string("PyExc_TypeError",
+                           "can't unbox {!r} type".format(typ))
+    res = c.pyapi.get_null_object()
+    return NativeValue(res, is_error=cgutils.true_bit)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -931,3 +931,11 @@ def unbox_unsupported(typ, obj, c):
                            "can't unbox {!r} type".format(typ))
     res = c.pyapi.get_null_object()
     return NativeValue(res, is_error=cgutils.true_bit)
+
+
+def box_unsupported(typ, val, c):
+    msg = "cannot convert native %s to Python object" % (typ,)
+    c.pyapi.err_set_string("PyExc_TypeError", msg)
+    res = c.pyapi.get_null_object()
+    return res
+

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -919,6 +919,13 @@ def unbox_deferred(typ, obj, c):
                        cleanup=native_value.cleanup)
 
 
+@unbox(types.Dispatcher)
+def unbox_dispatcher(typ, obj, c):
+    # A dispatcher object has no meaningful value in native code
+    res = c.context.get_constant_undef(typ)
+    return NativeValue(res)
+
+
 def unbox_unsupported(typ, obj, c):
     c.pyapi.err_set_string("PyExc_TypeError",
                            "can't unbox {!r} type".format(typ))

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1351,6 +1351,18 @@ class TestDispatcherFunctionBoundaries(TestCase):
                       cmpfn=jit(lambda x, y: x[1] - y[1]))
         self.assertEqual(got, (0, 4))
 
+    def test_dispatcher_cannot_return_to_python(self):
+        @jit(nopython=True)
+        def foo(fn):
+            return fn
+
+        fn = jit(lambda x: x)
+
+        with self.assertRaises(TypeError) as raises:
+            foo(fn)
+        self.assertRegexpMatches(str(raises.exception),
+                                 "cannot convert native .* to Python object")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1364,6 +1364,28 @@ class TestDispatcherFunctionBoundaries(TestCase):
         self.assertRegexpMatches(str(raises.exception),
                                  "cannot convert native .* to Python object")
 
+    def test_dispatcher_in_sequence_arg(self):
+        @jit(nopython=True)
+        def one(x):
+            return x + 1
+
+        @jit(nopython=True)
+        def two(x):
+            return one(one(x))
+
+        @jit(nopython=True)
+        def three(x):
+            return one(one(one(x)))
+
+        @jit(nopython=True)
+        def choose(fns, x):
+            return fns[0](x), fns[1](x), fns[2](x)
+
+        # Tuple case
+        self.assertEqual(choose((one, two, three), 1), (2, 3, 4))
+        # List case
+        self.assertEqual(choose([one, one, one], 1), (2, 2, 2))
+
 
 class TestBoxingDefaultError(unittest.TestCase):
     # Testing default error at boxing/unboxing

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1332,6 +1332,25 @@ class TestDispatcherFunctionBoundaries(TestCase):
         for arg, expect in zip(inputs, expected_results):
             self.assertPreciseEqual(bar(add1, arg), expect)
 
+    def test_dispatcher_as_arg_usecase(self):
+        @jit(nopython=True)
+        def maximum(seq, cmpfn):
+            tmp = seq[0]
+            for each in seq[1:]:
+                cmpval = cmpfn(tmp, each)
+                if cmpval < 0:
+                    tmp = each
+            return tmp
+
+        got = maximum([1, 2, 3, 4], cmpfn=jit(lambda x, y: x - y))
+        self.assertEqual(got, 4)
+        got = maximum(list(zip(range(5), range(5)[::-1])),
+                      cmpfn=jit(lambda x, y: x[0] - y[0]))
+        self.assertEqual(got, (4, 0))
+        got = maximum(list(zip(range(5), range(5)[::-1])),
+                      cmpfn=jit(lambda x, y: x[1] - y[1]))
+        self.assertEqual(got, (0, 4))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1306,5 +1306,28 @@ def cache_file_collision_tester(q, tempdir, modname_bar1, modname_bar2):
     q.put(r2)
 
 
+class TestDispatcherFunctionBoundaries(TestCase):
+    def test_pass_dispatcher_as_arg_inside(self):
+        # Test that a Dispatcher object can be pass as argument
+        # inside a nopython function.
+        @jit(nopython=True)
+        def add1(x):
+            return x + 1
+
+        @jit(nopython=True)
+        def bar(fn, x):
+            return fn(x)
+
+        @jit(nopython=True)
+        def foo(x):
+            return bar(add1, x)
+
+        self.assertEqual(foo(1), 1 + 1)
+        self.assertEqual(foo(11.1), 11.1 + 1)
+        self.assertPreciseEqual(foo(np.arange(10)), np.arange(10) + 1)
+
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1307,9 +1307,8 @@ def cache_file_collision_tester(q, tempdir, modname_bar1, modname_bar2):
 
 
 class TestDispatcherFunctionBoundaries(TestCase):
-    def test_pass_dispatcher_as_arg_inside(self):
+    def test_pass_dispatcher_as_arg(self):
         # Test that a Dispatcher object can be pass as argument
-        # inside a nopython function.
         @jit(nopython=True)
         def add1(x):
             return x + 1
@@ -1322,11 +1321,16 @@ class TestDispatcherFunctionBoundaries(TestCase):
         def foo(x):
             return bar(add1, x)
 
-        self.assertEqual(foo(1), 1 + 1)
-        self.assertEqual(foo(11.1), 11.1 + 1)
-        self.assertPreciseEqual(foo(np.arange(10)), np.arange(10) + 1)
+        # Check dispatcher as argument inside NPM
+        inputs = [1, 11.1, np.arange(10)]
+        expected_results = [x + 1 for x in inputs]
 
+        for arg, expect in zip(inputs, expected_results):
+            self.assertPreciseEqual(foo(arg), expect)
 
+        # Check dispatcher as argument from python
+        for arg, expect in zip(inputs, expected_results):
+            self.assertPreciseEqual(bar(add1, arg), expect)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -466,7 +466,7 @@ class TestHighLevelExtending(TestCase):
         np.testing.assert_equal(expect, got)
         # Verify that the Module type cannot be returned to CPython
         bad_cfunc = jit(nopython=True)(non_boxable_bad_usecase)
-        with self.assertRaises(NotImplementedError) as raises:
+        with self.assertRaises(TypeError) as raises:
             bad_cfunc()
         errmsg = str(raises.exception)
         expectmsg = "cannot convert native Module"


### PR DESCRIPTION
This patch enables Dispatcher object to be used as function arguments.  They still can't be returned. Also, this patch makes boxing and unboxing error at nopython/python boundary a runtime exception instead of a compile time exception by providing a default boxing/unboxing implementation that raises.