### PR TITLE
Fix #2812: gufunc scalar output bug.

### DIFF
--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -12,7 +12,7 @@ from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestGUFuncScalr(SerialMixin, TestCase):
+class TestGUFuncScalar(SerialMixin, TestCase):
     def test_gufunc_scalar_output(self):
         #    function type:
         #        - has no void return type

--- a/numba/npyufunc/deviceufunc.py
+++ b/numba/npyufunc/deviceufunc.py
@@ -498,7 +498,7 @@ def expand_gufunc_template(template, indims, outdims, funcname, argtypes):
               for aref, adims, atype in zip(argnames, indims, argtypes)]
     outputs = [_gen_src_for_indexing(aref, adims, atype)
                for aref, adims, atype in zip(argnames[len(indims):], outdims,
-                                             argtypes)]
+                                             argtypes[len(indims):])]
     argitems = inputs + outputs
     src = template.format(name=funcname, args=', '.join(argnames),
                           checkedarg=checkedarg,


### PR DESCRIPTION
Closes #2812 

Bug reason: incorrectly using all argument types as output types.

Actual fix is a one liner.