### PR TITLE
[WIP] Emit LLVM optimization remarks

### DIFF
--- a/numba/config.py
+++ b/numba/config.py
@@ -182,6 +182,8 @@ class _EnvReloader(object):
         # Force dump of type annotation
         ANNOTATE = _readenv("NUMBA_DUMP_ANNOTATION", int, 0)
 
+        OPT_REMARKS = _readenv("NUMBA_OPT_REMARKS", int, 0)
+
         # Dump IR in such as way as to aid in "diff"ing.
         DIFF_IR = _readenv("NUMBA_DIFF_IR", int, 0)
 

--- a/numba/debuginfo.py
+++ b/numba/debuginfo.py
@@ -132,8 +132,6 @@ class DIBuilder(AbstractDIBuilder):
         di_subp = self._add_subprogram(name=name, linkagename=function.name,
                                        line=loc.line)
         function.set_metadata("dbg", di_subp)
-        # disable inlining for this function for easier debugging
-        function.attributes.add('noinline')
 
     def finalize(self):
         dbgcu = self.module.get_or_insert_named_metadata(self.DBG_CU_NAME)


### PR DESCRIPTION
Exposes the LLVM optimization remarks feature added in https://github.com/numba/llvmlite/pull/337.

The remarks files will be stored under `numba_opt_remarks` directory.  Each compiled function (each overload) will be stored in a separate file under the directory.

To enable the opt-remarks, set `NUMBA_OPT_REMARKS=1`  and `NUMBA_DEBUGINFO=1`.  The debug info is required for source location.

To view the opt-remarks as a pretty annotated html, use the opt-viewer from LLVM.  For instance,

```
python <LLVM_INSTALL_PREFIX>/share/opt-viewer/opt-viewer.py numba_opt_remarks/*
```

For conda user, install llvmdev from `conda install -c numba llvmdev`.  Opt-viewer will be at `$CONDA_PREFIX/share/opt-viewer/opt-viewer.py `

Related read: https://llvm.org/devmtg/2016-11/Slides/Nemet-Compiler-assistedPerformanceAnalysis.pdf

**Update**

User feedback:
* make the remarks part of the the dispatcher object.