### PR TITLE
Attempt to fix #2473

### DIFF
--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1007,7 +1007,7 @@ class TestCache(BaseCacheUsecasesTest):
             cmd = ['chattr', '+i', self.tempdir]
             # redirect stderr to stdout and use check_output as a noise sink
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
+        except Exception:
             pass
         else:
             cmd = ['chattr', '-i', self.tempdir]
@@ -1030,7 +1030,7 @@ class TestCache(BaseCacheUsecasesTest):
             cmd = ['chattr', '+i', pycache]
             # redirect stderr to stdout and use check_output as a noise sink
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError:
+        except Exception:
             pass
         else:
             cmd = ['chattr', '-i', pycache]

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1002,6 +1002,17 @@ class TestCache(BaseCacheUsecasesTest):
         os.chmod(self.tempdir, 0o500)
         self.addCleanup(os.chmod, self.tempdir, old_perms)
 
+        # if run as root dir perms have no effect, so call chattr +i
+        try: # will fail if not root
+            cmd = ['chattr', '+i', self.tempdir]
+            # redirect stderr to stdout and use check_output as a noise sink
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            cmd = ['chattr', '-i', self.tempdir]
+            self.addCleanup(subprocess.check_output, cmd, stderr=subprocess.STDOUT)
+
         self._test_pycache_fallback()
 
     @unittest.skipIf(os.name == "nt",
@@ -1013,6 +1024,17 @@ class TestCache(BaseCacheUsecasesTest):
         old_perms = os.stat(pycache).st_mode
         os.chmod(pycache, 0o500)
         self.addCleanup(os.chmod, pycache, old_perms)
+
+        # if run as root dir perms have no effect, so call chattr +i
+        try: # will fail if not root
+            cmd = ['chattr', '+i', pycache]
+            # redirect stderr to stdout and use check_output as a noise sink
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            cmd = ['chattr', '-i', pycache]
+            self.addCleanup(subprocess.check_output, cmd, stderr=subprocess.STDOUT)
 
         self._test_pycache_fallback()
 


### PR DESCRIPTION
This attempts to fix #2473 by using chattr to cause immutability
in cache locations which is needed if building/testing as the
root user on *nix systems.

Fixes #2473