### PR TITLE
Emit selp Instructions to Avoid Branching

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -168,3 +168,19 @@ are guaranteed to not move across the memory fences by optimization passes.
 .. function:: numba.cuda.threadfence_system
 
    A memory fence at system level (across GPUs)
+
+Control Flow Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A subset of the CUDA's control flow instructions are directly available as
+intrinsics. Avoiding branches is a key way to improve CUDA performance, and
+using these intrinsics mean you don't have to rely on the ``nvcc`` optimizer
+identifying and removing branches. For further documentation, including
+semantics, please refer to the `relevant CUDA Toolkit documentation
+<docs.nvidia.com/cuda/parallel-thread-execution/index.html#comparison-and-selection-instructions>`_.
+
+
+.. function:: numba.cuda.selp
+
+    Select between two expressions, depending on the value of the first
+    argument. Similar to LLVM's ``select`` instruction.

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -106,6 +106,28 @@ class Cuda_threadfence_system(ConcreteTemplate):
 
 
 @intrinsic
+class Cuda_selp(AbstractTemplate):
+    key = cuda.selp
+
+    def generic(self, args, kws):
+        assert not kws
+        test, a, b = args
+
+
+        # per docs
+        # http://docs.nvidia.com/cuda/parallel-thread-execution/index.html#comparison-and-selection-instructions-selp
+        supported_types = (types.float64, types.float32,
+                           types.int16, types.uint16,
+                           types.int32, types.uint32,
+                           types.int64, types.uint64)
+
+        if a != b or a not in supported_types:
+            return
+
+        return signature(a, test, a, a)
+
+
+@intrinsic
 class Cuda_atomic_add(AbstractTemplate):
     key = cuda.atomic.add
 
@@ -294,6 +316,9 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_threadfence_system(self, mod):
         return types.Function(Cuda_threadfence_system)
+
+    def resolve_selp(self, mod):
+        return types.Function(Cuda_selp)
 
     def resolve_atomic(self, mod):
         return types.Module(cuda.atomic)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -244,6 +244,12 @@ def ptx_threadfence_device(context, builder, sig, args):
     return context.get_dummy_value()
 
 
+@lower(stubs.selp, types.Any, types.Any, types.Any)
+def ptx_selp(context, builder, sig, args):
+    test, a, b = args
+    return builder.select(test, a, b)
+
+
 def _normalize_indices(context, builder, indty, inds):
     """
     Convert integer indices into tuple of intp

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -4,7 +4,7 @@ from __future__ import print_function, absolute_import, division
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
                     shared, local, const, grid, gridsize, atomic,
                     threadfence_block, threadfence_system,
-                    threadfence)
+                    threadfence, selp)
 from .cudadrv.error import CudaSupportError
 from .cudadrv import nvvm
 from . import initialize

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -196,6 +196,9 @@ class FakeCUDAModule(object):
         # No-op
         pass
 
+    def selp(self, a, b, c):
+        return b if a else c
+
     def grid(self, n):
         bdim = self.blockDim
         bid = self.blockIdx

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -286,6 +286,16 @@ class const(Stub):
     '''
 
 #-------------------------------------------------------------------------------
+# comparison and selection instructions
+
+class selp(Stub):
+    """
+    selp(a, b, c)
+
+    Select between source operands, based on the value of the predicate source operand.
+    """
+
+#-------------------------------------------------------------------------------
 # atomic
 
 class atomic(Stub):

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -1,8 +1,9 @@
 from __future__ import print_function, absolute_import, division
 
 import numpy as np
+import re
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
 
 
 def simple_threadidx(ary):
@@ -57,6 +58,27 @@ def intrinsic_forloop_step(c):
     for x in range(startX, width, gridX):
         for y in range(startY, height, gridY):
             c[y, x] = x + y
+
+
+@cuda.jit
+def branching_with_ifs(a, b, c):
+    i = cuda.grid(1)
+
+    if a[i] > 4:
+        if b % 2 == 0:
+            a[i] = c[i]
+        else:
+            a[i] = 13
+    else:
+        a[i] = 3
+
+
+@cuda.jit
+def branching_with_selps(a, b, c):
+    i = cuda.grid(1)
+
+    inner = cuda.selp(b % 2 == 0, c[i], 13)
+    a[i] = cuda.selp(a[i] > 4, inner, 3)
 
 
 class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
@@ -122,6 +144,27 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
         ary = np.zeros(1, dtype=np.int32)
         compiled[nctaid, ntid](ary)
         self.assertEqual(ary[0], nctaid * ntid)
+
+    @skip_on_cudasim('Tests PTX emission')
+    def test_selp(self):
+        n = 32
+        b = 6
+        c = np.full(shape=32, fill_value=17)
+
+        expected = c.copy()
+        expected[:5] = 3
+
+        a = np.arange(n)
+        branching_with_ifs[n, 1](a, b, c)
+        ptx = list(branching_with_ifs.inspect_asm().values())[0]
+        self.assertEqual(2, len(re.findall(r'\s+bra\s+', ptx)))
+        np.testing.assert_array_equal(a, expected, err_msg='branching')
+
+        a = np.arange(n)
+        branching_with_selps[n, 1](a, b, c)
+        ptx = list(branching_with_selps.inspect_asm().values())[0]
+        self.assertEqual(0, len(re.findall(r'\s+bra\s+', ptx)))
+        np.testing.assert_array_equal(a, expected, err_msg='selp')
 
     def test_simple_gridsize2d(self):
         compiled = cuda.jit("void(int32[::1])")(simple_gridsize2d)


### PR DESCRIPTION
Branching is particularly bad in GPU code, so allow users to specify [selp](http://docs.nvidia.com/cuda/parallel-thread-execution/index.html#comparison-and-selection-instructions-selp) instructions (identical semantics to LLVM's `select` IR to avoid branches.