### PR TITLE
Use automatic numbering syntax in list.

### DIFF
--- a/docs/source/user/parallel.rst
+++ b/docs/source/user/parallel.rst
@@ -31,7 +31,7 @@ Supported Operations
 In this section, we give a list of all the array operations that have
 parallel semantics and for which we attempt to parallelize.
 
-1. All numba array operations that are supported by :ref:`case-study-array-expressions`,
+#. All numba array operations that are supported by :ref:`case-study-array-expressions`,
    which include common arithmetic functions between Numpy arrays, and between
    arrays and scalars, as well as Numpy ufuncs. They are often called
    `element-wise` or `point-wise` array operations:
@@ -42,29 +42,29 @@ parallel semantics and for which we attempt to parallelize.
     * :ref:`Numpy ufuncs <supported_ufuncs>` that are supported in :term:`nopython mode`.
     * User defined :class:`~numba.DUFunc` through :func:`~numba.vectorize`.
 
-2. Numpy reduction functions ``sum``, ``prod``, ``min``, ``max``, ``argmin``,
+#. Numpy reduction functions ``sum``, ``prod``, ``min``, ``max``, ``argmin``,
    and ``argmax``. Also, array math functions ``mean``, ``var``, and ``std``.
 
-3. Numpy array creation functions ``zeros``, ``ones``, ``arange``, ``linspace``,
+#. Numpy array creation functions ``zeros``, ``ones``, ``arange``, ``linspace``,
    and several random functions (rand, randn, ranf, random_sample, sample,
    random, standard_normal, chisquare, weibull, power, geometric, exponential,
    poisson, rayleigh, normal, uniform, beta, binomial, f, gamma, lognormal,
    laplace, randint, triangular).
 
-4. Numpy ``dot`` function between a matrix and a vector, or two vectors.
+#. Numpy ``dot`` function between a matrix and a vector, or two vectors.
    In all other cases, Numba's default implementation is used.
 
-5. Multi-dimensional arrays are also supported for the above operations
+#. Multi-dimensional arrays are also supported for the above operations
    when operands have matching dimension and size. The full semantics of
    Numpy broadcast between arrays with mixed dimensionality or size is
    not supported, nor is the reduction across a selected dimension.
 
-6. Array assignment in which the target is an array selection using a slice
+#. Array assignment in which the target is an array selection using a slice
    or a boolean array, and the value being assigned is either a scalar or
    another selection where the slice range or bitarray are inferred to be
    compatible.
 
-6. The ``reduce`` operator of ``functools`` is supported for specifying parallel
+#. The ``reduce`` operator of ``functools`` is supported for specifying parallel
    reductions on 1D Numpy arrays but the initial value argument is mandatory.
 
 .. _numba-prange:


### PR DESCRIPTION
Fixes there being two '6.' in the list!