### PR TITLE
Fix issue with test discovery and broken CUDA drivers.

### DIFF
--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -23,8 +23,18 @@ def is_available():
 
     This will initialize the driver if it hasn't been initialized.
     """
-    return driver.driver.is_available and nvvm.is_available()
+    # whilst `driver.is_available` will init the driver itself,
+    # the driver initialization may raise and as a result break
+    # test discovery/orchestration as `cuda.is_available` is often
+    # used as a guard for whether to run a CUDA test, the try/except
+    # below is to handle this case.
+    driver_is_available = False
+    try:
+        driver_is_available = driver.driver.is_available
+    except CudaSupportError:
+        pass
 
+    return driver_is_available and nvvm.is_available()
 
 def cuda_error():
     """Returns None or an exception if the CUDA driver fails to initialize.


### PR DESCRIPTION
This patch allows the test discovery mechanism to work even in the
case of a broken/misconfigured CUDA driver.

Fixes #2841