### PR TITLE
Add rtsys init guard and test.

### DIFF
--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -47,6 +47,11 @@ class _Runtime(object):
 
             self._init = True
 
+    def _init_guard(self):
+        if not self._init:
+            msg = "Runtime must be initialized before use."
+            raise RuntimeError(msg)
+
     @staticmethod
     def shutdown():
         """
@@ -60,6 +65,7 @@ class _Runtime(object):
         """
         Return the Library object containing the various NRT functions.
         """
+        self._init_guard()
         return self._library
 
     def meminfo_new(self, data, pyobj):
@@ -68,6 +74,7 @@ class _Runtime(object):
         MemInfo will acquire a reference on `pyobj`.
         The release of MemInfo will release a reference on `pyobj`.
         """
+        self._init_guard()
         mi = _nrt.meminfo_new(data, pyobj)
         return MemInfo(mi)
 
@@ -81,6 +88,7 @@ class _Runtime(object):
         This is used for debugging and testing purposes.
         See `NRT_MemInfo_alloc_safe()` in "nrt.h" for details.
         """
+        self._init_guard()
         if safe:
             mi = _nrt.meminfo_alloc_safe(size)
         else:
@@ -92,6 +100,7 @@ class _Runtime(object):
         Returns a namedtuple of (alloc, free, mi_alloc, mi_free) for count of
         each memory operations.
         """
+        # No init guard needed to access stats members
         return _nrt_mstats(alloc=_nrt.memsys_get_stats_alloc(),
                            free=_nrt.memsys_get_stats_free(),
                            mi_alloc=_nrt.memsys_get_stats_mi_alloc(),


### PR DESCRIPTION
This adds a guard to the methods on the rtsys instance to ensure that
the rtsys is initialized prior to use (lack of init leads to null ptr
access... segfault).

The failing-in-isolation tests reported in #2848 now have an indirect
call to `rtsys.initialize()` made by virtue of invoking
`numba.targets.cpu.CPUContext` in the test class `setUp`, this
initializing the rtsys correctly.

Fixes #2848