### PR TITLE
WIP: use pairwise summation in `sum`

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -196,8 +196,9 @@ def array_sum(context, builder, sig, args):
         else:
             n2 = n // 2
             n2 -= n2 % 8
-            return (pairwise_sum(arr, n2, 0, n2)
-                    + pairwise_sum(arr, n - n2, n2, n))
+            middle = start + n2
+            return (pairwise_sum(arr, n2, start, middle)
+                    + pairwise_sum(arr, n - n2, middle, stop))
 
     def array_sum_impl(arr):
         n = arr.size

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -4,6 +4,7 @@ from itertools import product, cycle, permutations
 import sys
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 from numba import unittest_support as unittest
 from numba import jit, typeof, types
@@ -737,6 +738,12 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # Numpy 1.13 has a different error message than prior numpy
         # Just check for the "out of bounds" phrase in it.
         self.assertIn("out of bounds", str(raises.exception))
+
+    def test_gh2855(self):
+        pyfunc = array_sum
+        cfunc = jit(nopython=True)(pyfunc)
+        A = np.ones(10**6, dtype=np.float32) / np.float32(255.0)
+        assert_allclose(cfunc(A), pyfunc(A), rtol=1e-7)
 
     def test_cumsum(self):
         pyfunc = array_cumsum


### PR DESCRIPTION
Working towards fixing gh-2855. The immediate problem is that this currently a little over 2x slower. The NumPy implementation unrolls loops manually, maybe that would help.

**Edit**: manually unrolling the loops doesn't help.

Timings:

```
In [1]: import numpy as np

In [2]: from numba import njit

In [3]: @njit
   ...: def f(A):
   ...:     return np.sum(A)
   ...:

In [4]: A = np.ones(10**6) / np.float32(255.0)

In [5]: f(A)
Out[5]: 3921.568627447501

In [6]: %timeit f(A)
```

On master:

```
779 µs ± 11.8 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

On this branch:

```
1.62 ms ± 13.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

Just doing it with NumPy directly:

```
In [1]: import numpy as np

In [2]: A = np.ones(10**6, dtype=np.float32) / np.float32(255.0)

In [3]: %timeit np.sum(A)
313 µs ± 14.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```