### PR TITLE
Fix #2872: update rng doc about thread/fork-safety

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -462,13 +462,8 @@ startup with entropy drawn from the operating system.
    code) will seed the Python random generator, not the Numba random generator.
 
 .. note::
-   The generator is not thread-safe when :ref:`releasing the GIL <jit-nogil>`.
-
-   Also, under Unix, if creating a child process using :func:`os.fork` or the
-   :mod:`multiprocessing` module, the child's random generator will inherit
-   the parent's state and will therefore produce the same sequence of
-   numbers (except when using the "forkserver" start method under Python 3.4
-   and later).
+   Since version 0.28.0, the generator is thread-safe and fork-safe.  Each
+   thread and each process will produce independent streams of random numbers.
 
 .. seealso::
    Numba also supports most additional distributions from the :ref:`Numpy


### PR DESCRIPTION
as titled.