### PR TITLE
Fix ParallelAccelerator arrayexpr repr

### DIFF
--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -2921,6 +2921,12 @@ def repr_arrayexpr(arrayexpr):
     """
     if isinstance(arrayexpr, tuple):
         opr = arrayexpr[0]
+        # sometimes opr is not string like '+', but is a ufunc object
+        if not isinstance(opr, str):
+            if hasattr(opr, '__name__'):
+                opr = opr.__name__
+            else:
+                opr = '_'  # can return dummy since repr is not critical
         args = arrayexpr[1]
         if len(args) == 1:
             return '({}{})'.format(opr, repr_arrayexpr(args[0]))

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1131,6 +1131,17 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countArrayAllocs(test_impl, (types.intp, types.intp)), 4)
         self.assertEqual(countParfors(test_impl, (types.intp, types.intp)), 4)
 
+    @skip_unsupported
+    def test_ufunc_expr(self):
+        # issue #2885
+        def test_impl(A, B):
+            return np.bitwise_and(A, B)
+
+        A = np.ones(3, np.uint8)
+        B = np.ones(3, np.uint8)
+        B[1] = 0
+        self.check(test_impl, A, B)
+
 
 class TestPrangeBase(TestParforsBase):
 


### PR DESCRIPTION
Fixes #2885. Removes assumption that arrayexpr operator is just string.