### PR TITLE
Add reference to the data buffer in array.ctypes object

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1151,7 +1151,8 @@ class GeneratorModel(CompositeModel):
 class ArrayCTypesModel(StructModel):
     def __init__(self, dmm, fe_type):
         # ndim = fe_type.ndim
-        members = [('data', types.CPointer(fe_type.dtype))]
+        members = [('data', types.CPointer(fe_type.dtype)),
+                   ('meminfo', types.MemInfoPointer(fe_type.dtype))]
         super(ArrayCTypesModel, self).__init__(dmm, fe_type, members)
 
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1924,10 +1924,12 @@ def array_ctypes(context, builder, typ, value):
     arrayty = make_array(typ)
     array = arrayty(context, builder, value)
     # Create new ArrayCType structure
-    ctinfo = context.make_helper(builder, types.ArrayCTypes(typ))
+    act = types.ArrayCTypes(typ)
+    ctinfo = context.make_helper(builder, act)
     ctinfo.data = array.data
+    ctinfo.meminfo = array.meminfo
     res = ctinfo._getvalue()
-    return impl_ret_untracked(context, builder, typ, res)
+    return impl_ret_borrowed(context, builder, act, res)
 
 @lower_getattr(types.ArrayCTypes, "data")
 def array_ctypes_data(context, builder, typ, value):


### PR DESCRIPTION
Fix #2887.

#2887 is an issue due to array.ctypes not retaining a reference to the underlying data.