### PR TITLE
[WIP] Implement jitclass default constructor arguments. 

### DIFF
--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -619,6 +619,59 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.a, x * y)
         self.assertEqual(tc.b, z)
 
+    def test_default_args(self):
+        spec = [('x', int32),
+                ('y', int32),
+                ('z', int32)]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self, x, y, z=1):
+                self.x = x
+                self.y = y
+                self.z = z
+
+        tc = TestClass(1, 2, 3)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 3)
+
+        tc = TestClass(1, 2)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 1)
+
+        tc = TestClass(y=2, z=5, x=1)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 5)
+
+    @unittest.skipIf(sys.version_info < (3,), "Python 3-specific test")
+    def test_default_args_keyonly(self):
+        spec = [('x', int32),
+                ('y', int32),
+                ('z', int32),
+                ('a', int32)]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self, x, y, z=1, *, a=5):
+                self.x = x
+                self.y = y
+                self.z = z
+                self.a = a
+        
+        tc = TestClass(2, 3)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 3)
+        self.assertEqual(tc.z, 1)
+        self.assertEqual(tc.a, 5)
+
+        tc = TestClass(y=4, x=2, a=42, z=100)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 4)
+        self.assertEqual(tc.z, 100)
+        self.assertEqual(tc.a, 42)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2661.

Hi. This is my first contribution here, and it's not yet fully finished. The two remaining things are:

- [ ] Consider whether the bind logic should only be invoked if a constructor has at least one default value parameter, otherwise it might be too costly. (Is it ok to have that constructor logic in raw/unoptimized Python in the first place?)
- [ ] Support Python 3 keyword only arguments. Currently a failing test `test_default_args_keyonly (numba.tests.test_jitclasses.TestJitClass)` is included which illustrates the issue.
- [ ] Support position only arguments.