### PR TITLE
Fix for #2862

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3277,7 +3277,7 @@ if numpy_version >= (1, 8):
     def numpy_full_nd(context, builder, sig, args):
 
         def full(shape, value):
-            arr = np.empty(shape)
+            arr = np.empty(shape, type(value))
             for idx in np.ndindex(arr.shape):
                 arr[idx] = value
             return arr

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3285,12 +3285,20 @@ def numpy_zeros_like_nd(context, builder, sig, args):
 if numpy_version >= (1, 8):
     @lower_builtin(np.full, types.Any, types.Any)
     def numpy_full_nd(context, builder, sig, args):
-
-        def full(shape, value):
-            arr = np.empty(shape, type(value))
-            for idx in np.ndindex(arr.shape):
-                arr[idx] = value
-            return arr
+        if numpy_version < (1, 12):
+            # np < 1.12 returns float64 full regardless of value type
+            def full(shape, value):
+                arr = np.empty(shape)
+                val = np.float64(value.real)
+                for idx in np.ndindex(arr.shape):
+                    arr[idx] = val
+                return arr
+        else:
+            def full(shape, value):
+                arr = np.empty(shape, type(value))
+                for idx in np.ndindex(arr.shape):
+                    arr[idx] = value
+                return arr
 
         res = context.compile_internal(builder, full, sig, args)
         return impl_ret_new_ref(context, builder, sig.return_type, res)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -873,6 +873,13 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(np.array([]))
 
 
+    def test_2862(self):
+        def pyfunc(shape, value):
+            return np.full(shape, value)
+        cfunc = jit(nopython=True)(pyfunc)
+        np.testing.assert_equal(pyfunc((1, 10), 1), cfunc((1, 10), 1))
+
+
 class TestArrayComparisons(TestCase):
 
     def test_identity(self):

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -873,13 +873,6 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(np.array([]))
 
 
-    def test_2862(self):
-        def pyfunc(shape, value):
-            return np.full(shape, value)
-        cfunc = jit(nopython=True)(pyfunc)
-        np.testing.assert_equal(pyfunc((1, 10), 1), cfunc((1, 10), 1))
-
-
 class TestArrayComparisons(TestCase):
 
     def test_identity(self):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -672,6 +672,17 @@ class TestNdFull(ConstructorBaseTest, TestCase):
             return np.full((m, n), np.int32(1))
         self.check_2d(func)
 
+        # tests meta issues from #2862, that np < 1.12 always
+        # returns float64. Complex uses `.real`, imaginary part dropped
+        def func(m, n):
+            return np.full((m, n), np.complex128(1))
+        self.check_2d(func)
+
+        # and that if a dtype is specified, this influences the return type
+        def func(m, n):
+            return np.full((m, n), 1, dtype=np.int8)
+        self.check_2d(func)
+
 
 class ConstructorLikeBaseTest(object):
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -666,6 +666,12 @@ class TestNdFull(ConstructorBaseTest, TestCase):
             return np.full((m, n), 1 + 4.5j, dtype=np.complex64)
         self.check_2d(func)
 
+    def test_2d_dtype_from_type(self):
+        # tests issue #2862
+        def func(m, n):
+            return np.full((m, n), np.int32(1))
+        self.check_2d(func)
+
 
 class ConstructorLikeBaseTest(object):
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -543,7 +543,10 @@ if numpy_version >= (1, 8):
         def generic(self):
             def typer(shape, fill_value, dtype=None):
                 if dtype is None:
-                    nb_dtype = fill_value
+                    if numpy_version < (1, 12):
+                        nb_dtype = types.float64
+                    else:
+                        nb_dtype = fill_value
                 else:
                     nb_dtype = _parse_dtype(dtype)
 


### PR DESCRIPTION
Added `type(value)` argument to call to `np.empty` in the implementation for `np.full`, works with integers now.