### PR TITLE
More CUDA intrinsics

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -51,6 +51,15 @@ Thread Indexing
     The shape of the grid of blocks, accressed through the attributes ``x``,
     ``y``, and ``z``.
 
+.. attribute:: numba.cuda.laneid
+
+    The thread index in the current warp, as an integer spanning the range
+    from 0 inclusive to the :attr:`numba.cuda.warpsize` exclusive.
+
+.. attribute:: numba.cuda.warpsize
+
+    The size in threads of a warp on the gpu. Currently this is always 32.
+
 .. function:: numba.cuda.grid(ndim)
 
    Return the absolute position of the current thread in the entire
@@ -141,8 +150,23 @@ Synchronization and Atomic Operations
     function waits until all threads in the block call it, at which point it
     returns control to all its callers.
 
-    .. warning:: Must be called by every thread in the thread-block. Falling to
-                 do so may result in undefined behavior.
+.. function:: numba.cuda.syncthreads_count(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where the return value is a count
+    of the threads where ``predicate`` is true.
+
+.. function:: numba.cuda.syncthreads_and(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where 1 is returned if ``predicate`` is
+    true for all threads or 0 otherwise.
+
+.. function:: numba.cuda.syncthreads_or(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where 1 is returned if ``predicate`` is
+    true for any thread or 0 otherwise.
+
+    .. warning:: Syncthreads functions must be called by every thread in the
+                 thread-block. Falling to do so may result in undefined behavior.
 
 Memory Fences
 ~~~~~~~~~~~~~
@@ -169,6 +193,72 @@ are guaranteed to not move across the memory fences by optimization passes.
 
 
    A memory fence at system level (across GPUs).
+
+Warp Intrinsics
+~~~~~~~~~~~~~~~~~~
+
+All warp level operations require at least CUDA 9. If the gpu compute capability
+is below 7.x, then all calls to the warp intrinsics must be warp convergent.
+
+.. function:: numba.cuda.syncwarp(membermask)
+
+   Synchronize a masked subset of the threads in a warp.
+
+.. function:: numba.cuda.all_sync(membermask, predicate)
+
+    If for all threads in the masked warp the ``predicate`` is true, then
+    a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.any_sync(membermask, predicate)
+
+    If for any thread in the masked warp the ``predicate`` is true, then
+    a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.eq_sync(membermask, predicate)
+
+    If for all threads in the masked warp the boolean ``predicate`` is the same,
+    then a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.ballot_sync(membermask, predicate)
+
+    Returns a mask of all threads in the warp whose ``predicate`` is true,
+    and are within the given mask.
+
+.. function:: numba.cuda.shfl_sync(membermask, value, src_lane)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``src_lane``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_up_sync(membermask, value, delta)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid - delta``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_down_sync(membermask, value, delta)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid + delta``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_xor_sync(membermask, value, lane_mask)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid ^ lane_mask``.
+
+.. function:: numba.cuda.match_any_sync(membermask, value, lane_mask)
+
+    Returns a mask of threads that have same ``value`` as the given ``value``
+    from within the masked warp.
+
+.. function:: numba.cuda.match_all_sync(membermask, value, lane_mask)
+
+    Returns a tuple of (mask, pred), where mask is a mask of threads that have
+    same ``value`` as the given ``value`` from within the masked warp, if they
+    all have the same value, otherwise it is 0. And pred is a boolean of whether
+    or not all threads in the mask warp have the same warp.
+
 
 Integer Intrinsics
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -58,7 +58,7 @@ Thread Indexing
 
 .. attribute:: numba.cuda.warpsize
 
-    The size in threads of a warp on the gpu. Currently this is always 32.
+    The size in threads of a warp on the GPU. Currently this is always 32.
 
 .. function:: numba.cuda.grid(ndim)
 
@@ -165,7 +165,7 @@ Synchronization and Atomic Operations
     An extension to :attr:`numba.cuda.syncthreads` where 1 is returned if ``predicate`` is
     true for any thread or 0 otherwise.
 
-    .. warning:: Syncthreads functions must be called by every thread in the
+    .. warning:: All syncthreads functions must be called by every thread in the
                  thread-block. Falling to do so may result in undefined behavior.
 
 Memory Fences
@@ -197,8 +197,10 @@ are guaranteed to not move across the memory fences by optimization passes.
 Warp Intrinsics
 ~~~~~~~~~~~~~~~~~~
 
-All warp level operations require at least CUDA 9. If the gpu compute capability
-is below 7.x, then all calls to the warp intrinsics must be warp convergent.
+All warp level operations require at least CUDA 9. The argument ``membermask`` is
+a 32 bit integer mask with each bit corresponding to a thread in the warp, with 1
+meaning the thread is in the subset of threads within the function call. The
+``membermask`` must be all 1 if the GPU compute capability is below 7.x.
 
 .. function:: numba.cuda.syncwarp(membermask)
 
@@ -206,17 +208,17 @@ is below 7.x, then all calls to the warp intrinsics must be warp convergent.
 
 .. function:: numba.cuda.all_sync(membermask, predicate)
 
-    If for all threads in the masked warp the ``predicate`` is true, then
+    If the ``predicate`` is true for all threads in the masked warp, then
     a non-zero value is returned, otherwise 0 is returned.
 
 .. function:: numba.cuda.any_sync(membermask, predicate)
 
-    If for any thread in the masked warp the ``predicate`` is true, then
+    If the ``predicate`` is true for any thread in the masked warp, then
     a non-zero value is returned, otherwise 0 is returned.
 
 .. function:: numba.cuda.eq_sync(membermask, predicate)
 
-    If for all threads in the masked warp the boolean ``predicate`` is the same,
+    If the boolean ``predicate`` is the same for all threads in the masked warp,
     then a non-zero value is returned, otherwise 0 is returned.
 
 .. function:: numba.cuda.ballot_sync(membermask, predicate)

--- a/docs/source/cuda/simulator.rst
+++ b/docs/source/cuda/simulator.rst
@@ -78,6 +78,7 @@ Some limitations of the simulator include:
   unexpected behaviour.
 * Most of the driver API is unimplemented.
 * It is not possible to link PTX code with CUDA Python functions.
+* Warps and warp-level operations are not yet implemented.
 
 Obviously, the speed of the simulator is also much lower than that of a real
 device. It may be necessary to reduce the size of input data and the size of the

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -71,6 +71,14 @@ class Cuda_gridDim_z(MacroTemplate):
     key = cuda.gridDim.z
 
 
+class Cuda_warpsize(MacroTemplate):
+    key = cuda.warpsize
+
+
+class Cuda_laneid(MacroTemplate):
+    key = cuda.laneid
+
+
 class Cuda_shared_array(MacroTemplate):
     key = cuda.shared.array
 
@@ -90,19 +98,84 @@ class Cuda_syncthreads(ConcreteTemplate):
 
 
 @intrinsic
+class Cuda_syncthreads_count(ConcreteTemplate):
+    key = cuda.syncthreads_count
+    cases = [signature(types.i4, types.i4)]
+
+
+@intrinsic
+class Cuda_syncthreads_and(ConcreteTemplate):
+    key = cuda.syncthreads_and
+    cases = [signature(types.i4, types.i4)]
+
+
+@intrinsic
+class Cuda_syncthreads_or(ConcreteTemplate):
+    key = cuda.syncthreads_or
+    cases = [signature(types.i4, types.i4)]
+
+
+@intrinsic
 class Cuda_threadfence_device(ConcreteTemplate):
     key = cuda.threadfence
     cases = [signature(types.none)]
+
 
 @intrinsic
 class Cuda_threadfence_block(ConcreteTemplate):
     key = cuda.threadfence_block
     cases = [signature(types.none)]
 
+
 @intrinsic
 class Cuda_threadfence_system(ConcreteTemplate):
     key = cuda.threadfence_system
     cases = [signature(types.none)]
+
+
+@intrinsic
+class Cuda_syncwarp(ConcreteTemplate):
+    key = cuda.syncwarp
+    cases = [signature(types.none, types.i4)]
+
+
+@intrinsic
+class Cuda_shfl_sync_intrinsic(ConcreteTemplate):
+    key = cuda.shfl_sync_intrinsic
+    cases = [
+        signature(types.Tuple((types.i4, types.b1)), types.i4, types.i4, types.i4, types.i4, types.i4),
+        signature(types.Tuple((types.i8, types.b1)), types.i4, types.i4, types.i8, types.i4, types.i4),
+        signature(types.Tuple((types.f4, types.b1)), types.i4, types.i4, types.f4, types.i4, types.i4),
+        signature(types.Tuple((types.f8, types.b1)), types.i4, types.i4, types.f8, types.i4, types.i4),
+    ]
+
+
+@intrinsic
+class Cuda_vote_sync_intrinsic(ConcreteTemplate):
+    key = cuda.vote_sync_intrinsic
+    cases = [signature(types.Tuple((types.i4, types.b1)), types.i4, types.i4, types.b1)]
+
+
+@intrinsic
+class Cuda_match_any_sync(ConcreteTemplate):
+    key = cuda.match_any_sync
+    cases = [
+        signature(types.i4, types.i4, types.i4),
+        signature(types.i4, types.i4, types.i8),
+        signature(types.i4, types.i4, types.f4),
+        signature(types.i4, types.i4, types.f8),
+    ]
+
+
+@intrinsic
+class Cuda_match_all_sync(ConcreteTemplate):
+    key = cuda.match_all_sync
+    cases = [
+        signature(types.Tuple((types.i4, types.b1)), types.i4, types.i4),
+        signature(types.Tuple((types.i4, types.b1)), types.i4, types.i8),
+        signature(types.Tuple((types.i4, types.b1)), types.i4, types.f4),
+        signature(types.Tuple((types.i4, types.b1)), types.i4, types.f8),
+    ]
 
 
 @intrinsic
@@ -368,6 +441,12 @@ class CudaModuleTemplate(AttributeTemplate):
     def resolve_gridDim(self, mod):
         return types.Module(cuda.gridDim)
 
+    def resolve_warpsize(self, mod):
+        return types.Macro(Cuda_warpsize)
+
+    def resolve_laneid(self, mod):
+        return types.Macro(Cuda_laneid)
+
     def resolve_shared(self, mod):
         return types.Module(cuda.shared)
 
@@ -386,6 +465,15 @@ class CudaModuleTemplate(AttributeTemplate):
     def resolve_syncthreads(self, mod):
         return types.Function(Cuda_syncthreads)
 
+    def resolve_syncthreads_count(self, mod):
+        return types.Function(Cuda_syncthreads_count)
+
+    def resolve_syncthreads_and(self, mod):
+        return types.Function(Cuda_syncthreads_and)
+
+    def resolve_syncthreads_or(self, mod):
+        return types.Function(Cuda_syncthreads_or)
+
     def resolve_threadfence(self, mod):
         return types.Function(Cuda_threadfence_device)
 
@@ -394,6 +482,21 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_threadfence_system(self, mod):
         return types.Function(Cuda_threadfence_system)
+
+    def resolve_syncwarp(self, mod):
+        return types.Function(Cuda_syncwarp)
+
+    def resolve_shfl_sync_intrinsic(self, mod):
+        return types.Function(Cuda_shfl_sync_intrinsic)
+
+    def resolve_vote_sync_intrinsic(self, mod):
+        return types.Function(Cuda_vote_sync_intrinsic)
+
+    def resolve_match_any_sync(self, mod):
+        return types.Function(Cuda_match_any_sync)
+
+    def resolve_match_all_sync(self, mod):
+        return types.Function(Cuda_match_all_sync)
 
     def resolve_selp(self, mod):
         return types.Function(Cuda_selp)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -211,6 +211,33 @@ def ptx_syncthreads(context, builder, sig, args):
     return context.get_dummy_value()
 
 
+@lower(stubs.syncthreads_count, types.i4)
+def ptx_syncthreads_count(context, builder, sig, args):
+    fname = 'llvm.nvvm.barrier0.popc'
+    lmod = builder.module
+    fnty = Type.function(Type.int(32), (Type.int(32),))
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(sync, args)
+
+
+@lower(stubs.syncthreads_and, types.i4)
+def ptx_syncthreads_and(context, builder, sig, args):
+    fname = 'llvm.nvvm.barrier0.and'
+    lmod = builder.module
+    fnty = Type.function(Type.int(32), (Type.int(32),))
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(sync, args)
+
+
+@lower(stubs.syncthreads_or, types.i4)
+def ptx_syncthreads_or(context, builder, sig, args):
+    fname = 'llvm.nvvm.barrier0.or'
+    lmod = builder.module
+    fnty = Type.function(Type.int(32), (Type.int(32),))
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(sync, args)
+
+
 @lower(stubs.threadfence_block)
 def ptx_threadfence_block(context, builder, sig, args):
     assert not args
@@ -242,6 +269,101 @@ def ptx_threadfence_device(context, builder, sig, args):
     sync = lmod.get_or_insert_function(fnty, name=fname)
     builder.call(sync, ())
     return context.get_dummy_value()
+
+
+@lower(stubs.syncwarp, types.i4)
+def ptx_warp_sync(context, builder, sig, args):
+    fname = 'llvm.nvvm.bar.warp.sync'
+    lmod = builder.module
+    fnty = Type.function(Type.void(), (Type.int(32),))
+    sync = lmod.get_or_insert_function(fnty, name=fname)
+    builder.call(sync, args)
+    return context.get_dummy_value()
+
+
+@lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.i4, types.i4, types.i4)
+@lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.i8, types.i4, types.i4)
+@lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.f4, types.i4, types.i4)
+@lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.f8, types.i4, types.i4)
+def ptx_shfl_sync_i32(context, builder, sig, args):
+    mask, mode, value, index, clamp = args
+    value_type = sig.args[2]
+    if value_type in types.real_domain:
+        value = builder.bitcast(value, Type.int(value_type.bitwidth))
+    fname = 'llvm.nvvm.shfl.sync.i32'
+    lmod = builder.module
+    fnty = Type.function(
+        Type.struct((Type.int(32), Type.int(1))),
+        (Type.int(32), Type.int(32), Type.int(32), Type.int(32), Type.int(32))
+    )
+    func = lmod.get_or_insert_function(fnty, name=fname)
+    if value_type.bitwidth == 32:
+        ret = builder.call(func, (mask, mode, value, index, clamp))
+        if value_type == types.float32:
+            rv = builder.extract_value(ret, 0)
+            pred = builder.extract_value(ret, 1)
+            fv = builder.bitcast(rv, Type.float())
+            ret = cgutils.make_anonymous_struct(builder, (fv, pred))
+    else:
+        value1 = builder.trunc(value, Type.int(32))
+        value_lshr = builder.lshr(value, context.get_constant(types.i8, 32))
+        value2 = builder.trunc(value_lshr, Type.int(32))
+        ret1 = builder.call(func, (mask, mode, value1, index, clamp))
+        ret2 = builder.call(func, (mask, mode, value2, index, clamp))
+        rv1 = builder.extract_value(ret1, 0)
+        rv2 = builder.extract_value(ret2, 0)
+        pred = builder.extract_value(ret1, 1)
+        rv1_64 = builder.zext(rv1, Type.int(64))
+        rv2_64 = builder.zext(rv2, Type.int(64))
+        rv_shl = builder.shl(rv2_64, context.get_constant(types.i8, 32))
+        rv = builder.or_(rv_shl, rv1_64)
+        if value_type == types.float64:
+            rv = builder.bitcast(rv, Type.double())
+        ret = cgutils.make_anonymous_struct(builder, (rv, pred))
+    return ret
+
+
+@lower(stubs.vote_sync_intrinsic, types.i4, types.i4, types.boolean)
+def ptx_vote_sync(context, builder, sig, args):
+    fname = 'llvm.nvvm.vote.sync'
+    lmod = builder.module
+    fnty = Type.function(Type.struct((Type.int(32), Type.int(1))),
+                         (Type.int(32), Type.int(32), Type.int(1)))
+    func = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(func, args)
+
+
+@lower(stubs.match_any_sync, types.i4, types.i4)
+@lower(stubs.match_any_sync, types.i4, types.i8)
+@lower(stubs.match_any_sync, types.i4, types.f4)
+@lower(stubs.match_any_sync, types.i4, types.f8)
+def ptx_match_any_sync(context, builder, sig, args):
+    mask, value = args
+    width = sig.args[1].bitwidth
+    if sig.args[1] in types.real_domain:
+        value = builder.bitcast(value, Type.int(width))
+    fname = 'llvm.nvvm.match.any.sync.i{}'.format(width)
+    lmod = builder.module
+    fnty = Type.function(Type.int(32), (Type.int(32), Type.int(width)))
+    func = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(func, (mask, value))
+
+
+@lower(stubs.match_all_sync, types.i4, types.i4)
+@lower(stubs.match_all_sync, types.i4, types.i8)
+@lower(stubs.match_all_sync, types.i4, types.f4)
+@lower(stubs.match_all_sync, types.i4, types.f8)
+def ptx_match_all_sync(context, builder, sig, args):
+    mask, value = args
+    width = sig.args[1].bitwidth
+    if sig.args[1] in types.real_domain:
+        value = builder.bitcast(value, Type.int(width))
+    fname = 'llvm.nvvm.match.all.sync.i{}'.format(width)
+    lmod = builder.module
+    fnty = Type.function(Type.struct((Type.int(32), Type.int(1))),
+                         (Type.int(32), Type.int(width)))
+    func = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(func, (mask, value))
 
 
 @lower(stubs.popc, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -286,6 +286,12 @@ def ptx_warp_sync(context, builder, sig, args):
 @lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.f4, types.i4, types.i4)
 @lower(stubs.shfl_sync_intrinsic, types.i4, types.i4, types.f8, types.i4, types.i4)
 def ptx_shfl_sync_i32(context, builder, sig, args):
+    """
+    The NVVM intrinsic for shfl only supports i32, but the cuda intrinsic function supports
+    both 32 and 64 bit ints and floats, so for feature parity, i64, f32, and f64 are implemented.
+    Floats by way of bitcasting the float to an int, then shuffling, then bitcasting back.
+    And 64-bit values by packing them into 2 32bit values, shuffling thoose, and then packing back together.
+    """
     mask, mode, value, index, clamp = args
     value_type = sig.args[2]
     if value_type in types.real_domain:

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -1,8 +1,11 @@
 from __future__ import print_function, absolute_import, division
 
 # Re export
-from .stubs import (threadIdx, blockIdx, blockDim, gridDim, syncthreads,
-                    shared, local, const, grid, gridsize, atomic,
+from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
+                    warpsize, syncthreads, syncthreads_count, syncwarp,
+                    syncthreads_and, syncthreads_or, shared, local,
+                    const, grid, gridsize, atomic, shfl_sync_intrinsic,
+                    vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
                     threadfence, selp, popc, brev, clz, ffs)
 from .cudadrv.error import CudaSupportError
@@ -16,6 +19,10 @@ from .api import _auto_device
 
 from .kernels import reduction
 reduce = Reduce = reduction.Reduce
+
+from .intrinsic_wrapper import (all_sync, any_sync, eq_sync, ballot_sync,
+                                shfl_sync, shfl_up_sync, shfl_down_sync,
+                                shfl_xor_sync)
 
 
 def is_available():

--- a/numba/cuda/intrinsic_wrapper.py
+++ b/numba/cuda/intrinsic_wrapper.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from .decorators import jit
+import numba
+
+
+@jit(device=True)
+def all_sync(mask, predicate):
+    """
+    If for all threads in the masked warp the predicate is true, then
+    a non-zero value is returned, otherwise 0 is returned.
+    """
+    return numba.cuda.vote_sync_intrinsic(mask, 0, predicate)[1]
+
+
+@jit(device=True)
+def any_sync(mask, predicate):
+    """
+    If for any thread in the masked warp the predicate is true, then
+    a non-zero value is returned, otherwise 0 is returned.
+    """
+    return numba.cuda.vote_sync_intrinsic(mask, 1, predicate)[1]
+
+
+@jit(device=True)
+def eq_sync(mask, predicate):
+    """
+    If for all threads in the masked warp the boolean predicate is the same,
+    then a non-zero value is returned, otherwise 0 is returned.
+    """
+    return numba.cuda.vote_sync_intrinsic(mask, 2, predicate)[1]
+
+
+@jit(device=True)
+def ballot_sync(mask, predicate):
+    """
+    Returns a mask of all threads in the warp whoose predicate is true,
+    and are within the given mask.
+    """
+    return numba.cuda.vote_sync_intrinsic(mask, 3, predicate)[0]
+
+
+@jit(device=True)
+def shfl_sync(mask, value, src_lane):
+    """
+    Shuffles value across the masked warp and returns the value
+    from src_lane. If this is outside the warp, then the
+    given value is returned.
+    """
+    return numba.cuda.shfl_sync_intrinsic(mask, 0, value, src_lane, 0x1f)[0]
+
+
+@jit(device=True)
+def shfl_up_sync(mask, value, delta):
+    """
+    Shuffles value across the masked warp and returns the value
+    from (laneid - delta). If this is outside the warp, then the
+    given value is returned.
+    """
+    return numba.cuda.shfl_sync_intrinsic(mask, 1, value, delta, 0)[0]
+
+
+@jit(device=True)
+def shfl_down_sync(mask, value, delta):
+    """
+    Shuffles value across the masked warp and returns the value
+    from (laneid + delta). If this is outside the warp, then the
+    given value is returned.
+    """
+    return numba.cuda.shfl_sync_intrinsic(mask, 2, value, delta, 0x1f)[0]
+
+
+@jit(device=True)
+def shfl_xor_sync(mask, value, lane_mask):
+    """
+    Shuffles value across the masked warp and returns the value
+    from (laneid ^ lane_mask).
+    """
+    return numba.cuda.shfl_sync_intrinsic(mask, 3, value, lane_mask, 0x1f)[0]

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -113,6 +113,9 @@ SREG_MAPPING = {
     'nctaid.x': 'llvm.nvvm.read.ptx.sreg.nctaid.x',
     'nctaid.y': 'llvm.nvvm.read.ptx.sreg.nctaid.y',
     'nctaid.z': 'llvm.nvvm.read.ptx.sreg.nctaid.z',
+
+    'warpsize': 'llvm.nvvm.read.ptx.sreg.warpsize',
+    'laneid': 'llvm.nvvm.read.ptx.sreg.laneid',
 }
 
 

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -130,6 +130,8 @@ class BlockThread(threading.Thread):
         self.blockIdx = Dim3(*blockIdx)
         self.threadIdx = Dim3(*threadIdx)
         self.exception = None
+        blockDim = Dim3(*self._manager._block_dim)
+        self.thread_id = self.threadIdx.x + blockDim.x * (self.threadIdx.y + blockDim.y * self.threadIdx.z)
 
     def run(self):
         try:
@@ -148,6 +150,27 @@ class BlockThread(threading.Thread):
         self.syncthreads_blocked = True
         self.syncthreads_event.wait()
         self.syncthreads_event.clear()
+
+    def syncthreads_count(self, value):
+        self._manager.block_state[self.threadIdx.x, self.threadIdx.y, self.threadIdx.z] = value
+        self.syncthreads()
+        count = np.count_nonzero(self._manager.block_state)
+        self.syncthreads()
+        return count
+
+    def syncthreads_and(self, value):
+        self._manager.block_state[self.threadIdx.x, self.threadIdx.y, self.threadIdx.z] = value
+        self.syncthreads()
+        test = np.all(self._manager.block_state)
+        self.syncthreads()
+        return 1 if test else 0
+
+    def syncthreads_or(self, value):
+        self._manager.block_state[self.threadIdx.x, self.threadIdx.y, self.threadIdx.z] = value
+        self.syncthreads()
+        test = np.any(self._manager.block_state)
+        self.syncthreads()
+        return 1 if test else 0
 
     def __str__(self):
         return 'Thread <<<%s, %s>>>' % (self.blockIdx, self.threadIdx)
@@ -175,6 +198,7 @@ class BlockManager(object):
         self._grid_dim = grid_dim
         self._block_dim = block_dim
         self._f = f
+        self.block_state = np.zeros(block_dim, dtype=np.bool)
 
     def run(self, grid_point, *args):
         # Create all threads

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -181,6 +181,14 @@ class FakeCUDAModule(object):
     def blockIdx(self):
         return threading.current_thread().blockIdx
 
+    @property
+    def warpsize(self):
+        return 32
+
+    @property
+    def laneid(self):
+        return threading.current_thread().thread_id % 32
+
     def syncthreads(self):
         threading.current_thread().syncthreads()
 
@@ -195,6 +203,15 @@ class FakeCUDAModule(object):
     def threadfence_system(self):
         # No-op
         pass
+
+    def syncthreads_count(self, val):
+        return threading.current_thread().syncthreads_count(val)
+
+    def syncthreads_and(self, val):
+        return threading.current_thread().syncthreads_and(val)
+
+    def syncthreads_or(self, val):
+        return threading.current_thread().syncthreads_or(val)
 
     def popc(self, val):
         return bin(val).count("1")

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -77,6 +77,10 @@ class gridDim(Stub):
     y = macro.Macro('nctaid.y', SREG_SIGNATURE)
     z = macro.Macro('nctaid.z', SREG_SIGNATURE)
 
+
+warpsize = macro.Macro('warpsize', SREG_SIGNATURE)
+laneid = macro.Macro('laneid', SREG_SIGNATURE)
+
 #-------------------------------------------------------------------------------
 # Grid Macro
 
@@ -154,7 +158,7 @@ def gridsize_expand(ndim):
 gridsize = macro.Macro('ptx.gridsize', gridsize_expand, callable=True)
 
 #-------------------------------------------------------------------------------
-# synthreads
+# syncthreads
 
 class syncthreads(Stub):
     '''
@@ -163,7 +167,90 @@ class syncthreads(Stub):
     function waits until all threads in the block call it, at which point it
     returns control to all its callers.
     '''
-    _description_ = '<syncthread()>'
+    _description_ = '<syncthreads()>'
+
+
+class syncthreads_count(Stub):
+    '''
+    syncthreads_count(predictate)
+
+    An extension to numba.cuda.syncthreads where the return value is a count 
+    of the threads where predicate is true.
+    '''
+    _description_ = '<syncthreads_count()>'
+
+
+class syncthreads_and(Stub):
+    '''
+    syncthreads_and(predictate)
+
+    An extension to numba.cuda.syncthreads where 1 is returned if predicate is
+    true for all threads or 0 otherwise.
+    '''
+    _description_ = '<syncthreads_and()>'
+
+
+class syncthreads_or(Stub):
+    '''
+    syncthreads_or(predictate)
+
+    An extension to numba.cuda.syncthreads where 1 is returned if predicate is
+    true for any thread or 0 otherwise.
+    '''
+    _description_ = '<syncthreads_or()>'
+
+
+# -------------------------------------------------------------------------------
+# warp level operations
+
+class syncwarp(Stub):
+    '''
+    syncwarp(mask)
+
+    Synchronizes a masked subset of threads in a warp.
+    '''
+    _description_ = '<warp_sync()>'
+
+
+class shfl_sync_intrinsic(Stub):
+    '''
+    shfl_sync_intrinsic(mask, mode, value, mode_offset, clamp)
+
+    Nvvm intrinsic for shuffling data across a warp
+    docs.nvidia.com/cuda/nvvm-ir-spec/index.html#nvvm-intrin-warp-level-datamove
+    '''
+    _description_ = '<shfl_sync()>'
+
+
+class vote_sync_intrinsic(Stub):
+    '''
+    vote_sync_intrinsic(mask, mode, predictate)
+
+    Nvvm intrinsic for broadcasting across a warp
+    docs.nvidia.com/cuda/nvvm-ir-spec/index.html#nvvm-intrin-warp-level-vote
+    '''
+    _description_ = '<vote_sync()>'
+
+
+class match_any_sync(Stub):
+    '''
+    match_any_sync(mask, value)
+
+    Returns a mask of threads that have same value as the given value from within the masked warp.
+    '''
+    _description_ = '<match_any_sync()>'
+
+
+class match_all_sync(Stub):
+    '''
+    match_all_sync(mask, value)
+
+    Returns a tuple of (mask, pred), where mask is a mask of threads that have
+    same value as the given value from within the masked warp, if they
+    all have the same value, otherwise it is 0. And pred is a boolean of whether
+    or not all threads in the mask warp have the same warp.
+    '''
+    _description_ = '<match_all_sync()>'
 
 
 # -------------------------------------------------------------------------------

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -226,7 +226,7 @@ class vote_sync_intrinsic(Stub):
     '''
     vote_sync_intrinsic(mask, mode, predictate)
 
-    Nvvm intrinsic for broadcasting across a warp
+    Nvvm intrinsic for performing a reduce and broadcast across a warp
     docs.nvidia.com/cuda/nvvm-ir-spec/index.html#nvvm-intrin-warp-level-vote
     '''
     _description_ = '<vote_sync()>'
@@ -236,6 +236,7 @@ class match_any_sync(Stub):
     '''
     match_any_sync(mask, value)
 
+    Nvvm intrinsic for performing a compare and broadcast across a warp.
     Returns a mask of threads that have same value as the given value from within the masked warp.
     '''
     _description_ = '<match_any_sync()>'
@@ -245,9 +246,10 @@ class match_all_sync(Stub):
     '''
     match_all_sync(mask, value)
 
+    Nvvm intrinsic for performing a compare and broadcast across a warp.
     Returns a tuple of (mask, pred), where mask is a mask of threads that have
     same value as the given value from within the masked warp, if they
-    all have the same value, otherwise it is 0. And pred is a boolean of whether
+    all have the same value, otherwise it is 0. Pred is a boolean of whether
     or not all threads in the mask warp have the same warp.
     '''
     _description_ = '<match_all_sync()>'

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -137,7 +137,7 @@ class TestCudaSync(SerialMixin, unittest.TestCase):
         compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_count)
         ary_in = np.ones(72, dtype=np.int32)
         ary_out = np.zeros(72, dtype=np.int32)
-        ary_in[7] = 0
+        ary_in[31] = 0
         ary_in[42] = 0
         compiled[1, 72](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 70))
@@ -149,7 +149,7 @@ class TestCudaSync(SerialMixin, unittest.TestCase):
         ary_out = np.zeros(nelem, dtype=np.int32)
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 1))
-        ary_in[7] = 0
+        ary_in[31] = 0
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 0))
 
@@ -160,7 +160,7 @@ class TestCudaSync(SerialMixin, unittest.TestCase):
         ary_out = np.zeros(nelem, dtype=np.int32)
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 0))
-        ary_in[7] = 1
+        ary_in[31] = 1
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 1))
 

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -56,6 +56,22 @@ def use_threadfence_system(ary):
     ary[0] += 321
 
 
+def use_syncthreads_count(ary_in, ary_out):
+    i = cuda.grid(1)
+    ary_out[i] = cuda.syncthreads_count(ary_in[i])
+
+
+def use_syncthreads_and(ary_in, ary_out):
+    i = cuda.grid(1)
+    ary_out[i] = cuda.syncthreads_and(ary_in[i])
+
+
+def use_syncthreads_or(ary_in, ary_out):
+    i = cuda.grid(1)
+    ary_out[i] = cuda.syncthreads_or(ary_in[i])
+
+
+
 class TestCudaSync(SerialMixin, unittest.TestCase):
     def test_useless_sync(self):
         compiled = cuda.jit("void(int32[::1])")(useless_sync)
@@ -116,6 +132,37 @@ class TestCudaSync(SerialMixin, unittest.TestCase):
         self.assertEqual(123 + 321, ary[0])
         if not ENABLE_CUDASIM:
             self.assertIn("membar.sys;", compiled.ptx)
+
+    def test_syncthreads_count(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_count)
+        ary_in = np.ones(72, dtype=np.int32)
+        ary_out = np.zeros(72, dtype=np.int32)
+        ary_in[7] = 0
+        ary_in[42] = 0
+        compiled[1, 72](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 70))
+
+    def test_syncthreads_and(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_and)
+        nelem = 100
+        ary_in = np.ones(nelem, dtype=np.int32)
+        ary_out = np.zeros(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
+        ary_in[7] = 0
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+
+    def test_syncthreads_or(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_or)
+        nelem = 100
+        ary_in = np.zeros(nelem, dtype=np.int32)
+        ary_out = np.zeros(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+        ary_in[7] = 1
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_warp_ops.py
+++ b/numba/cuda/tests/cudapy/test_warp_ops.py
@@ -201,11 +201,11 @@ class TestCudaWarpOperations(SerialMixin, unittest.TestCase):
         self.assertTrue(np.all(ary_out == 1))
 
     def test_vote_sync_ballot(self):
-        compiled = cuda.jit("void(int32[:])")(use_vote_sync_ballot)
+        compiled = cuda.jit("void(uint32[:])")(use_vote_sync_ballot)
         nelem = 32
-        ary = np.empty(nelem, dtype=np.int32)
+        ary = np.empty(nelem, dtype=np.uint32)
         compiled[1, nelem](ary)
-        self.assertTrue(np.all(ary == np.int32(0xffffffff)))
+        self.assertTrue(np.all(ary == np.uint32(0xffffffff)))
 
     @unittest.skipUnless(_safe_cc_check((7, 0)),
                          "Matching requires at least Volta Architecture")

--- a/numba/cuda/tests/cudapy/test_warp_ops.py
+++ b/numba/cuda/tests/cudapy/test_warp_ops.py
@@ -1,0 +1,253 @@
+from __future__ import print_function, absolute_import
+import numpy as np
+from numba import cuda, config
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+
+
+def useless_syncwarp(ary):
+    i = cuda.grid(1)
+    cuda.syncwarp(0xffffffff)
+    ary[i] = i
+
+
+def use_shfl_sync_idx(ary, idx):
+    i = cuda.grid(1)
+    val = cuda.shfl_sync(0xffffffff, i, idx)
+    ary[i] = val
+
+
+def use_shfl_sync_up(ary, delta):
+    i = cuda.grid(1)
+    val = cuda.shfl_up_sync(0xffffffff, i, delta)
+    ary[i] = val
+
+
+def use_shfl_sync_down(ary, delta):
+    i = cuda.grid(1)
+    val = cuda.shfl_down_sync(0xffffffff, i, delta)
+    ary[i] = val
+
+
+def use_shfl_sync_xor(ary, xor):
+    i = cuda.grid(1)
+    val = cuda.shfl_xor_sync(0xffffffff, i, xor)
+    ary[i] = val
+
+
+def use_shfl_sync_with_val(ary, into):
+    i = cuda.grid(1)
+    val = cuda.shfl_sync(0xffffffff, into, 0)
+    ary[i] = val
+
+
+def use_vote_sync_all(ary_in, ary_out):
+    i = cuda.grid(1)
+    pred = cuda.all_sync(0xffffffff, ary_in[i])
+    ary_out[i] = pred
+
+
+def use_vote_sync_any(ary_in, ary_out):
+    i = cuda.grid(1)
+    pred = cuda.any_sync(0xffffffff, ary_in[i])
+    ary_out[i] = pred
+
+
+def use_vote_sync_eq(ary_in, ary_out):
+    i = cuda.grid(1)
+    pred = cuda.eq_sync(0xffffffff, ary_in[i])
+    ary_out[i] = pred
+
+
+def use_vote_sync_ballot(ary):
+    i = cuda.threadIdx.x
+    ballot = cuda.ballot_sync(0xffffffff, True)
+    ary[i] = ballot
+
+
+def use_match_any_sync(ary_in, ary_out):
+    i = cuda.grid(1)
+    ballot = cuda.match_any_sync(0xffffffff, ary_in[i])
+    ary_out[i] = ballot
+
+
+def use_match_all_sync(ary_in, ary_out):
+    i = cuda.grid(1)
+    ballot, pred = cuda.match_all_sync(0xffffffff, ary_in[i])
+    ary_out[i] = ballot if pred else 0
+
+
+def use_independent_scheduling(arr):
+    i = cuda.threadIdx.x
+    if i % 4 == 0:
+        ballot = cuda.ballot_sync(0x11111111, True)
+    elif i % 4 == 1:
+        ballot = cuda.ballot_sync(0x22222222, True)
+    elif i % 4 == 2:
+        ballot = cuda.ballot_sync(0x44444444, True)
+    elif i % 4 == 3:
+        ballot = cuda.ballot_sync(0x88888888, True)
+    arr[i] = ballot
+
+
+def _safe_skip():
+    if config.ENABLE_CUDASIM:
+        return False
+    else:
+        return cuda.cudadrv.nvvm.NVVM_VERSION >= (1, 4)
+
+
+def _safe_cc_check(cc):
+    if config.ENABLE_CUDASIM:
+        return True
+    else:
+        return cuda.get_current_device().compute_capability >= cc
+
+
+@unittest.skipUnless(_safe_skip(), "Warp Operations require at least CUDA 9 and are not yet implemented for the CudaSim")
+class TestCudaWarpOperations(SerialMixin, unittest.TestCase):
+    def test_useless_syncwarp(self):
+        compiled = cuda.jit("void(int32[:])")(useless_syncwarp)
+        nelem = 32
+        ary = np.empty(nelem, dtype=np.int32)
+        exp = np.arange(nelem, dtype=np.int32)
+        compiled[1, nelem](ary)
+        self.assertTrue(np.all(ary == exp))
+
+    def test_shfl_sync_idx(self):
+        compiled = cuda.jit("void(int32[:], int32)")(use_shfl_sync_idx)
+        nelem = 32
+        idx = 4
+        ary = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary, idx)
+        self.assertTrue(np.all(ary == idx))
+
+    def test_shfl_sync_up(self):
+        compiled = cuda.jit("void(int32[:], int32)")(use_shfl_sync_up)
+        nelem = 32
+        delta = 4
+        ary = np.empty(nelem, dtype=np.int32)
+        exp = np.arange(nelem, dtype=np.int32)
+        exp[delta:] -= delta
+        compiled[1, nelem](ary, delta)
+        self.assertTrue(np.all(ary == exp))
+
+    def test_shfl_sync_down(self):
+        compiled = cuda.jit("void(int32[:], int32)")(use_shfl_sync_down)
+        nelem = 32
+        delta = 4
+        ary = np.empty(nelem, dtype=np.int32)
+        exp = np.arange(nelem, dtype=np.int32)
+        exp[:-delta] += delta
+        compiled[1, nelem](ary, delta)
+        self.assertTrue(np.all(ary == exp))
+
+    def test_shfl_sync_xor(self):
+        compiled = cuda.jit("void(int32[:], int32)")(use_shfl_sync_xor)
+        nelem = 32
+        xor = 16
+        ary = np.empty(nelem, dtype=np.int32)
+        exp = np.arange(nelem, dtype=np.int32) ^ xor
+        compiled[1, nelem](ary, xor)
+        self.assertTrue(np.all(ary == exp))
+
+    def test_shfl_sync_i64(self):
+        compiled = cuda.jit("void(int64[:], int64)")(use_shfl_sync_with_val)
+        nelem = 32
+        val = np.int64(1 << 42)
+        ary = np.empty(nelem, dtype=np.int64)
+        compiled[1, nelem](ary, val)
+        self.assertTrue(np.all(ary == val))
+
+    def test_shfl_sync_f32(self):
+        compiled = cuda.jit("void(float32[:], float32)")(use_shfl_sync_with_val)
+        nelem = 32
+        val = np.float32(np.pi)
+        ary = np.empty(nelem, dtype=np.float32)
+        compiled[1, nelem](ary, val)
+        self.assertTrue(np.all(ary == val))
+
+    def test_shfl_sync_f64(self):
+        compiled = cuda.jit("void(float64[:], float64)")(use_shfl_sync_with_val)
+        nelem = 32
+        val = np.float64(np.pi)
+        ary = np.empty(nelem, dtype=np.float64)
+        compiled[1, nelem](ary, val)
+        self.assertTrue(np.all(ary == val))
+
+    def test_vote_sync_all(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_vote_sync_all)
+        nelem = 32
+        ary_in = np.ones(nelem, dtype=np.int32)
+        ary_out = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
+        ary_in[-1] = 0
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+
+    def test_vote_sync_any(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_vote_sync_any)
+        nelem = 32
+        ary_in = np.zeros(nelem, dtype=np.int32)
+        ary_out = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+        ary_in[2] = 1
+        ary_in[5] = 1
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
+
+    def test_vote_sync_eq(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_vote_sync_eq)
+        nelem = 32
+        ary_in = np.zeros(nelem, dtype=np.int32)
+        ary_out = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
+        ary_in[1] = 1
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+        ary_in[:] = 1
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 1))
+
+    def test_vote_sync_ballot(self):
+        compiled = cuda.jit("void(int32[:])")(use_vote_sync_ballot)
+        nelem = 32
+        ary = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary)
+        self.assertTrue(np.all(ary == np.int32(0xffffffff)))
+
+    @unittest.skipUnless(_safe_cc_check((7, 0)), "Matching requires at least Volta Architecture")
+    def test_match_any_sync(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_match_any_sync)
+        nelem = 10
+        ary_in = np.arange(nelem, dtype=np.int32) % 2
+        ary_out = np.empty(nelem, dtype=np.int32)
+        exp = np.tile((0b1010101010, 0b0101010101), 5)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == exp))
+
+    @unittest.skipUnless(_safe_cc_check((7, 0)), "Matching requires at least Volta Architecture")
+    def test_match_all_sync(self):
+        compiled = cuda.jit("void(int32[:], int32[:])")(use_match_all_sync)
+        nelem = 10
+        ary_in = np.zeros(nelem, dtype=np.int32)
+        ary_out = np.empty(nelem, dtype=np.int32)
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0b1111111111))
+        ary_in[1] = 4
+        compiled[1, nelem](ary_in, ary_out)
+        self.assertTrue(np.all(ary_out == 0))
+
+    @unittest.skipUnless(_safe_cc_check((7, 0)), "Independent scheduling requires at least Volta Architecture")
+    def test_independent_scheduling(self):
+        compiled = cuda.jit("void(int32[:])")(use_independent_scheduling)
+        arr = np.empty(32, dtype=np.int32)
+        exp = np.tile((0x11111111, 0x22222222, 0x44444444, 0x88888888), 8)
+        compiled[1, 32](arr)
+        self.assertTrue(np.all(ary_out == exp))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added support for the warp intrinsics, two more special registers, and the other sync-threads functions. I tested everything on a 1080Ti at work, but I don't have accesses to a Volta GPU to test its new features (matching and independent scheduling).

TODO:
- [x] Add documentation
- [x] Add wrappers around the shfl_sync and vote_sync intrinsics to make them look more like the normally used functions
- [x] Add more thorough tests
- [ ] Support for warps in the CUDA simulator. Unsure how to do this correctly.
