### PR TITLE
Fix random permutation test.

### DIFF
--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -956,11 +956,15 @@ class TestRandom(BaseTest):
             # Sanity check
             arrs = [np.arange(20), np.arange(20).reshape(5, 2, 2)]
             for a in arrs:
-                for i in range(3):
+                checked = 0
+                while checked < 3:
                     b = func(a)
-                    self.assertFalse(np.array_equal(a, b))
-                    self.assertTrue(np.array_equal(np.sort(a, axis=0),
-                                                   np.sort(b, axis=0)))
+                    # check that permuted arrays are equal when sorted
+                    # account for the possibility of the identity permutation
+                    if not np.array_equal(a, b):
+                        self.assertTrue(np.array_equal(np.sort(a, axis=0),
+                                                       np.sort(b, axis=0)))
+                        checked += 1
 
 
 class TestRandomArrays(BaseTest):


### PR DESCRIPTION
This fixes the random permutation test. It was sporadically failing
on Python 2.7 as occasionally a permutation was picked that was the
identity permutation and the test was asserting that:

```
input != permutation(input)
```

most of the time as input was large and linear this wasn't a problem
but occasionally for permutations in the first axis on arrays with a
small first dimension the identity permutation would appear and cause
the test to fail.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
