### PR TITLE
np.unique return_counts support

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -287,7 +287,7 @@ The following top-level functions are supported:
 * :func:`numpy.stack`
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.transpose`
-* :func:`numpy.unique` (only the first argument)
+* :func:`numpy.unique` (only the first argument and return_counts argument)
 * :func:`numpy.vstack`
 * :func:`numpy.where`
 * :func:`numpy.zeros` (only the 2 first arguments)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1826,13 +1826,29 @@ def _change_dtype(context, builder, oldty, newty, ary):
 
 
 @overload(np.unique)
-def np_unique(a):
+def np_unique(a, return_counts=False):
     def np_unique_impl(a):
         b = np.sort(a.ravel())
         head = list(b[:1])
         tail = [x for i, x in enumerate(b[1:]) if b[i] != x]
         return np.array(head + tail)
-    return np_unique_impl
+
+    def np_unique_wcounts_impl(a):
+        b = np.sort(a.ravel())
+        unique = list(b[:1])
+        counts = [1 for _ in unique]
+        for x in b[1:]:
+            if x != unique[-1]:
+                unique.append(x)
+                counts.append(1)
+            else:
+                counts[-1] += 1
+        return unique, counts
+
+    if not return_counts:
+        return np_unique_impl
+    else:
+        return np_unique_wcounts_impl
 
 
 @lower_builtin('array.view', types.Array, types.DTypeSpec)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -179,8 +179,8 @@ def array_imag(a):
     return np.imag(a)
 
 
-def np_unique(a):
-    return np.unique(a)
+def np_unique(a, return_counts=False):
+    return np.unique(a, return_counts=return_counts)
 
 
 def array_dot(a, b):
@@ -875,10 +875,15 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         def check(a):
             np.testing.assert_equal(pyfunc(a), cfunc(a))
 
-        check(np.array([[1, 1, 3], [3, 4, 5]]))
-        check(np.array(np.zeros(5)))
-        check(np.array([[3.1, 3.1], [1.7, 2.29], [3.3, 1.7]]))
-        check(np.array([]))
+        def check_w_counts(a):
+            np.testing.assert_equal(
+                pyfunc(a, return_counts=True), cfunc(a, return_counts=True))
+
+        for check_ in [check, check_w_counts]:
+            check_(np.array([[1, 1, 3], [3, 4, 5]]))
+            check_(np.array(np.zeros(5)))
+            check_(np.array([[3.1, 3.1], [1.7, 2.29], [3.3, 1.7]]))
+            check_(np.array([]))
 
     def test_array_dot(self):
         # just ensure that the dot impl dispatches correctly, do


### PR DESCRIPTION
This adds np.unique return_counts from https://github.com/numba/numba/issues/2884#issuecomment-382278786

While the overload works when called manually, the test fails with

``` shell
E           numba.errors.TypingError: Failed at nopython (nopython frontend)
E           Invalid usage of Function(<function unique at 0x10ba1e378>) with parameters (array(int64, 2d, C), return_counts=bool)
E            * parameterized
E           In definition 0:
E               TypeError: got an unexpected keyword argument 'return_counts'
E
```

If you know how to properly test this or if the overload approach is 'wrong' please let me know and I will change the PR accordingly.
Thanks!