### PR TITLE
Added docstring coding convention and specified line terminator to developer docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
 numba/_version.py export-subst

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -204,6 +204,11 @@ well-defined coding style (would it be nice to follow :pep:`7`?).
 Code and documentation should generally fit within 80 columns, for
 maximum readability with all existing tools (such as code review UIs).
 
+In addition:
+
+* Docstrings should adhere to the [NumPy docstring convention](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
+* Lines are terminated with \r\n (Windows style).
+
 Stability
 '''''''''
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -207,7 +207,6 @@ maximum readability with all existing tools (such as code review UIs).
 In addition:
 
 * Docstrings should adhere to the [NumPy docstring convention](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
-* Lines are terminated with \r\n (Windows style).
 
 Stability
 '''''''''


### PR DESCRIPTION
I have created this to queue a conversation about expanding on coding conventions for this project.
I fully expect this to change before being pulled.