### PR TITLE
Fix environment propagation

### DIFF
--- a/docs/source/developer/environment.rst
+++ b/docs/source/developer/environment.rst
@@ -11,7 +11,7 @@ In nopython-mode, the Env is used for:
 
 * Storing pyobjects for reconstruction from native values,
   such as:
-  * for printing native values of numpy arrays;
+  * for printing native values of NumPy arrays;
   * for returning or yielding native values back to the interpreter.
 
 In object-mode, the Env is used for:
@@ -50,9 +50,9 @@ global variable is computed from the name of the function
 (see ``FunctionDescriptor.env_name`` and ``.get_env_name()`` of the target
 context).
 
-The Env initialized when the compiled-function is loaded. The JIT engine finds
-the address of the associated global variable for the Env and stores the
+The Env is initialized when the compiled-function is loaded. The JIT engine
+finds the address of the associated global variable for the Env and stores the
 address of the Env into it.  For cached functions, the same process applies.
-For ahead-of-time compiled function, the module initializer in the generated
+For ahead-of-time compiled functions, the module initializer in the generated
 library is responsible for initializing the global variables of all the Envs
 in the module.

--- a/docs/source/developer/environment.rst
+++ b/docs/source/developer/environment.rst
@@ -1,0 +1,58 @@
+
+==================
+Environment Object
+==================
+
+The Environment object (Env) is used to maintain references to python objects
+that are needed to support compiled functions for both object-mode and
+nopython-mode.
+
+In nopython-mode, the Env is used for:
+
+* Storing pyobjects for reconstruction from native values,
+  such as:
+  * for printing native values of numpy arrays;
+  * for returning or yielding native values back to the interpreter.
+
+In object-mode, the Env is used for:
+
+* storing constant values referenced in the code.
+* storing a reference to the function's global dictionary to load global
+  values.
+
+
+The Implementation
+==================
+
+The Env is implemented in two parts.  In ``_dynfunc.c``, the Env is defined
+as ``EnvironmentObject`` as a Python C-extension type.  In ``lowering.py``,
+the `EnvironmentObject`` (exported as ``_dynfunc.Environment``) is extended
+to support necessary operations needed at lowering.
+
+
+Serialization
+-------------
+
+The Env supports being pickled.  Compilation cache files and ahead-of-time
+compiled modules serialize all the used Envs for recreation at the runtime.
+
+Usage
+-----
+
+At the start of the lowering for a function or a generator, an Env is created.
+Throughout the compilation, the Env is mutated to attach additional
+information.  The compiled code references an Env via a global variable in
+the emitted LLVM IR.  The global variable is zero-initialized with "common"
+linkage, which is the default linkage for C global values.  The use of this
+linkage allows multiple definitions of the global variable to be merged into
+a single definition when the modules are linked together.  The name of the
+global variable is computed from the name of the function
+(see ``FunctionDescriptor.env_name`` and ``.get_env_name()`` of the target
+context).
+
+The Env initialized when the compiled-function is loaded. The JIT engine finds
+the address of the associated global variable for the Env and stores the
+address of the Env into it.  For cached functions, the same process applies.
+For ahead-of-time compiled function, the module initializer in the generated
+library is responsible for initializing the global variables of all the Envs
+in the module.

--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -17,3 +17,4 @@ Developer Manual
    listings.rst
    stencil.rst
    custom_pipeline.rst
+   environment.rst

--- a/numba/bytecode.py
+++ b/numba/bytecode.py
@@ -323,3 +323,8 @@ class FunctionIdentity(object):
         self.unique_name = '{}${}'.format(self.func_qualname, uid)
 
         return self
+
+    def derive(self):
+        """Copy the object and increment the unique counter.
+        """
+        return self.from_function(self.func)

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -182,7 +182,7 @@ class PyCallWrapper(object):
 
     def get_env(self, api, builder):
         """Get the Environment object which is declared as a global
-        is the module of the wrapped function.
+        in the module of the wrapped function.
         """
         envname = self.context.get_env_name(self.fndesc)
         gvptr = self.context.declare_env_global(builder.module, envname)

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -140,7 +140,7 @@ class PyCallWrapper(object):
             builder.ret(api.get_null_object())
 
         # Extract the Environment object from the Closure
-        envptr, env_manager = self.get_env(api, builder, closure)
+        env_manager = self.get_env(api, builder, closure)
 
         cleanup_manager = _ArgManager(self.context, builder, api,
                                       env_manager, endblk, nargs)
@@ -185,7 +185,7 @@ class PyCallWrapper(object):
         env_body = self.context.get_env_body(builder, envptr)
         api.emit_environment_sentry(envptr, return_pyobject=True)
         env_manager = api.get_env_manager(self.env, env_body, envptr)
-        return envptr, env_manager
+        return env_manager
 
     def _simplified_return_type(self):
         """

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -139,8 +139,8 @@ class PyCallWrapper(object):
         with builder.goto_block(endblk):
             builder.ret(api.get_null_object())
 
-        # Extract the Environment object from the Closure
-        env_manager = self.get_env(api, builder, closure)
+        # Get the Environment object
+        env_manager = self.get_env(api, builder)
 
         cleanup_manager = _ArgManager(self.context, builder, api,
                                       env_manager, endblk, nargs)
@@ -180,7 +180,10 @@ class PyCallWrapper(object):
         self.context.call_conv.raise_error(builder, api, status)
         builder.ret(api.get_null_object())
 
-    def get_env(self, api, builder, closure):
+    def get_env(self, api, builder):
+        """Get the Environment object which is declared as a global
+        is the module of the wrapped function.
+        """
         envname = self.context.get_env_name(self.fndesc)
         gvptr = self.context.declare_env_global(builder.module, envname)
         envptr = builder.load(gvptr)

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -181,9 +181,12 @@ class PyCallWrapper(object):
         builder.ret(api.get_null_object())
 
     def get_env(self, api, builder, closure):
-        # We extract the Environment object from the closure,
-        # because we are in a different module than the compilation unit.
-        envptr = self.context.get_env_from_closure(builder, closure)
+        # envptr = self.context.get_env_from_closure(builder, closure)
+
+        envname = self.context.get_env_name(self.fndesc)
+        envptr = builder.load(self.context.declare_env_global(builder.module,
+                                                              envname))
+
         env_body = self.context.get_env_body(builder, envptr)
         api.emit_environment_sentry(envptr, return_pyobject=True)
         env_manager = api.get_env_manager(self.env, env_body, envptr)

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -181,6 +181,8 @@ class PyCallWrapper(object):
         builder.ret(api.get_null_object())
 
     def get_env(self, api, builder, closure):
+        # We extract the Environment object from the closure,
+        # because we are in a different module than the compilation unit.
         envptr = self.context.get_env_from_closure(builder, closure)
         env_body = self.context.get_env_body(builder, envptr)
         api.emit_environment_sentry(envptr, return_pyobject=True)

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -160,7 +160,7 @@ class PyCallWrapper(object):
 
         status, retval = self.context.call_conv.call_function(
             builder, self.func, self.fndesc.restype, self.fndesc.argtypes,
-            innerargs, env=envptr)
+            innerargs)
         # Do clean up
         self.debug_print(builder, "# callwrapper: emit_cleanup")
         cleanup_manager.emit_cleanup()

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -141,7 +141,6 @@ class PyCallWrapper(object):
 
         # Get the Environment object
         env_manager = self.get_env(api, builder)
-        api.incref(env_manager.env_ptr)
 
         cleanup_manager = _ArgManager(self.context, builder, api,
                                       env_manager, endblk, nargs)
@@ -171,12 +170,10 @@ class PyCallWrapper(object):
         with builder.if_then(status.is_ok, likely=True):
             # Ok => return boxed Python value
             with builder.if_then(status.is_none):
-                api.decref(env_manager.env_ptr)
                 api.return_none()
 
             retty = self._simplified_return_type()
             obj = api.from_native_return(retty, retval, env_manager)
-            api.decref(env_manager.env_ptr)
             builder.ret(obj)
 
         # Error out

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -181,13 +181,12 @@ class PyCallWrapper(object):
         builder.ret(api.get_null_object())
 
     def get_env(self, api, builder, closure):
-        # envptr = self.context.get_env_from_closure(builder, closure)
-
         envname = self.context.get_env_name(self.fndesc)
-        envptr = builder.load(self.context.declare_env_global(builder.module,
-                                                              envname))
+        gvptr = self.context.declare_env_global(builder.module, envname)
+        envptr = builder.load(gvptr)
 
         env_body = self.context.get_env_body(builder, envptr)
+
         api.emit_environment_sentry(envptr, return_pyobject=True)
         env_manager = api.get_env_manager(self.env, env_body, envptr)
         return env_manager

--- a/numba/callwrapper.py
+++ b/numba/callwrapper.py
@@ -141,6 +141,7 @@ class PyCallWrapper(object):
 
         # Get the Environment object
         env_manager = self.get_env(api, builder)
+        api.incref(env_manager.env_ptr)
 
         cleanup_manager = _ArgManager(self.context, builder, api,
                                       env_manager, endblk, nargs)
@@ -170,10 +171,12 @@ class PyCallWrapper(object):
         with builder.if_then(status.is_ok, likely=True):
             # Ok => return boxed Python value
             with builder.if_then(status.is_none):
+                api.decref(env_manager.env_ptr)
                 api.return_none()
 
             retty = self._simplified_return_type()
             obj = api.from_native_return(retty, retval, env_manager)
+            api.decref(env_manager.env_ptr)
             builder.ret(obj)
 
         # Error out

--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -112,7 +112,7 @@ class CFunc(object):
 
         # XXX no obvious way to freeze an environment
         status, out = context.call_conv.call_function(
-            builder, fn, sig.return_type, sig.args, c_args, env=None)
+            builder, fn, sig.return_type, sig.args, c_args)
 
         with builder.if_then(status.is_error, likely=False):
             # If (and only if) an error occurred, acquire the GIL

--- a/numba/funcdesc.py
+++ b/numba/funcdesc.py
@@ -33,11 +33,12 @@ class FunctionDescriptor(object):
     """
     __slots__ = ('native', 'modname', 'qualname', 'doc', 'typemap',
                  'calltypes', 'args', 'kws', 'restype', 'argtypes',
-                 'mangled_name', 'unique_name', 'inline', 'noalias')
+                 'mangled_name', 'unique_name', 'env_name',
+                 'inline', 'noalias')
 
     def __init__(self, native, modname, qualname, unique_name, doc,
                  typemap, restype, calltypes, args, kws, mangler=None,
-                 argtypes=None, inline=False, noalias=False):
+                 argtypes=None, inline=False, noalias=False, env_name=None):
         self.native = native
         self.modname = modname
         self.qualname = qualname
@@ -63,6 +64,10 @@ class FunctionDescriptor(object):
         # be chosen at link time.
         qualprefix = qualifying_prefix(self.modname, self.unique_name)
         self.mangled_name = mangler(qualprefix, self.argtypes)
+        if env_name is None:
+            env_name = mangler(".NumbaEnv.{}".format(qualprefix),
+                               self.argtypes)
+        self.env_name = env_name
         self.inline = inline
         self.noalias = noalias
 

--- a/numba/generators.py
+++ b/numba/generators.py
@@ -80,6 +80,7 @@ class BaseGeneratorLower(object):
         the passed-by-reference generator structure).
         """
         lower.setup_function(self.fndesc)
+
         builder = lower.builder
 
         # Insert the generator into the target context in order to allow

--- a/numba/generators.py
+++ b/numba/generators.py
@@ -20,6 +20,9 @@ class GeneratorDescriptor(FunctionDescriptor):
         """
         Build a GeneratorDescriptor for the generator returned by the
         function described by *fndesc*, with type *gentype*.
+
+        The generator inherits the env_name from the *fndesc*.
+        All emitted functions for the generator shares the same Env.
         """
         assert isinstance(gentype, types.Generator)
         restype = gentype.yield_type

--- a/numba/generators.py
+++ b/numba/generators.py
@@ -30,7 +30,7 @@ class GeneratorDescriptor(FunctionDescriptor):
         self = cls(fndesc.native, fndesc.modname, qualname, unique_name,
                    fndesc.doc, fndesc.typemap, restype, fndesc.calltypes,
                    args, fndesc.kws, argtypes=argtypes, mangler=mangler,
-                   inline=True)
+                   inline=True, env_name=fndesc.env_name)
         return self
 
     @property

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -932,7 +932,8 @@ class FunctionIR(object):
         if arg_names is not None:
             new_ir.arg_names = arg_names
         new_ir._reset_analysis_variables()
-
+        # Make fresh func_id
+        new_ir.func_id = new_ir.func_id.derive()
         return new_ir
 
     def copy(self):

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -920,7 +920,6 @@ class FunctionIR(object):
         Post-processing will have to be run again on the new IR.
         """
         firstblock = blocks[min(blocks)]
-        is_generator = self.is_generator and not force_non_generator
 
         new_ir = copy.copy(self)
         new_ir.blocks = blocks

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -29,15 +29,6 @@ class Environment(_dynfunc.Environment):
     def __reduce__(self):
         return _rebuild_env, (self.globals['__name__'], self.consts)
 
-    def as_pointer(self, targetctx, ptrty=types.pyobject):
-        """
-        Return a constant pointer for the environment object.
-        """
-        ll_addr = targetctx.get_value_type(types.intp)
-        ll_ptr = targetctx.get_value_type(ptrty)
-        envptr = ll_addr(id(self)).inttoptr(ll_ptr)
-        return envptr
-
 
 def _rebuild_env(modname, consts):
     from . import serialize
@@ -138,10 +129,7 @@ class BaseLower(object):
     def emit_environment_object(self):
         # Define global for the environment and initialize it to NULL
         envname = self.context.get_env_name(self.fndesc)
-        gvenv = llvmir.GlobalVariable(self.module, cgutils.voidptr_t,
-                                      name=envname)
-        gvenv.linkage = 'weak_odr'  # Ensure single definition
-        gvenv.initializer = cgutils.get_null_value(gvenv.type.pointee)
+        gvenv = self.context.declare_env_global(self.module, envname)
 
         # Make Getter function
         fnty = llvmir.FunctionType(cgutils.voidptr_t, ())

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -16,7 +16,7 @@ from . import debuginfo
 
 
 class Environment(_dynfunc.Environment):
-    """Stores globals and constants pyobjects for runtime.
+    """Stores globals and constant pyobjects for runtime.
 
     It is often needed to convert b/w nopython objects and pyobjects.
     """

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -15,6 +15,10 @@ from . import debuginfo
 
 
 class Environment(_dynfunc.Environment):
+    """Stores globals and constants pyobjects for runtime.
+
+    It is often needed to convert b/w nopython objects and pyobjects.
+    """
     __slots__ = ()
 
     @classmethod

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -41,11 +41,8 @@ def make_dufunc_kernel(_dufunc):
                 func_type, name=self.cres.fndesc.llvm_func_name)
             entry_point.attributes.add("alwaysinline")
 
-            envptr = self.cres.environment.as_pointer(self.cres.target_context)
-
             _, res = self.context.call_conv.call_function(
-                self.builder, entry_point, isig.return_type, isig.args, cast_args,
-                env=envptr)
+                self.builder, entry_point, isig.return_type, isig.args, cast_args)
             return self.cast(res, isig.return_type, osig.return_type)
 
     DUFuncKernel.__name__ += _dufunc.ufunc.__name__

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -42,7 +42,8 @@ def make_dufunc_kernel(_dufunc):
             entry_point.attributes.add("alwaysinline")
 
             _, res = self.context.call_conv.call_function(
-                self.builder, entry_point, isig.return_type, isig.args, cast_args)
+                self.builder, entry_point, isig.return_type, isig.args,
+                cast_args)
             return self.cast(res, isig.return_type, osig.return_type)
 
     DUFuncKernel.__name__ += _dufunc.ufunc.__name__

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -55,8 +55,9 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
 
 
 def build_ufunc_wrapper(library, ctx, fname, signature, cres):
-    innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, fname, signature,
-                                                 objmode=False, cres=cres)
+    innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, fname,
+                                                 signature, objmode=False,
+                                                 cres=cres)
     return build_ufunc_kernel(library, ctx, innerfunc, signature)
 
 

--- a/numba/npyufunc/parallel.py
+++ b/numba/npyufunc/parallel.py
@@ -46,11 +46,7 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
         library = cres.library
         fname = cres.fndesc.llvm_func_name
 
-        env = cres.environment
-        envptr = env.as_pointer(ctx)
-
-        ptr = build_ufunc_wrapper(library, ctx, fname, signature, env=env,
-                                  envptr=envptr)
+        ptr = build_ufunc_wrapper(library, ctx, fname, signature, cres)
         # Get dtypes
         dtypenums = [np.dtype(a.name).num for a in signature.args]
         dtypenums.append(np.dtype(signature.return_type.name).num)
@@ -58,10 +54,9 @@ class ParallelUFuncBuilder(ufuncbuilder.UFuncBuilder):
         return dtypenums, ptr, keepalive
 
 
-def build_ufunc_wrapper(library, ctx, fname, signature, env, envptr):
+def build_ufunc_wrapper(library, ctx, fname, signature, cres):
     innerfunc = ufuncbuilder.build_ufunc_wrapper(library, ctx, fname, signature,
-                                                 objmode=False, env=env,
-                                                 envptr=envptr)
+                                                 objmode=False, cres=cres)
     return build_ufunc_kernel(library, ctx, innerfunc, signature)
 
 

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -153,17 +153,14 @@ def _build_element_wise_ufunc_wrapper(cres, signature):
     library = cres.library
     fname = cres.fndesc.llvm_func_name
 
-    env = cres.environment
-    envptr = env.as_pointer(ctx)
-
     with compiler.lock_compiler:
         ptr = build_ufunc_wrapper(library, ctx, fname, signature,
-                                cres.objectmode, envptr, env)
+                                  cres.objectmode, cres)
 
     # Get dtypes
     dtypenums = [as_dtype(a).num for a in signature.args]
     dtypenums.append(as_dtype(signature.return_type).num)
-    return dtypenums, ptr, env
+    return dtypenums, ptr, cres.environment
 
 
 _identities = {

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -46,7 +46,8 @@ def _build_ufunc_loop_body_objmode(load, store, context, func, builder,
     # the ufunc's execution.  We restore it unless the ufunc raised
     # a new error.
     with pyapi.err_push(keep_new=True):
-        status, retval = context.call_conv.call_function(builder, func, types.pyobject,
+        status, retval = context.call_conv.call_function(builder, func,
+                                                         types.pyobject,
                                                          _objargs, elems)
         # Release owned reference to arguments
         for elem in elems:
@@ -144,7 +145,6 @@ def build_ufunc_wrapper(library, context, fname, signature, objmode, cres):
 
     wrapperlib = context.codegen().create_library('ufunc_wrapper')
     wrapper_module = wrapperlib.create_ir_module('')
-
     if objmode:
         func_type = context.call_conv.get_function_type(
             types.pyobject, [types.pyobject] * len(signature.args))
@@ -418,9 +418,9 @@ class _GufuncWrapper(object):
             return ptr, self.env, wrapper_name
 
     def gen_loop_body(self, builder, pyapi, func, args):
-        status, retval = self.call_conv.call_function(builder, func,
-                                                      self.signature.return_type,
-                                                      self.signature.args, args)
+        status, retval = self.call_conv.call_function(
+            builder, func, self.signature.return_type, self.signature.args,
+            args)
 
         with builder.if_then(status.is_error, likely=False):
             gil = pyapi.gil_ensure()

--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -14,8 +14,7 @@ def _build_ufunc_loop_body(load, store, context, func, builder, arrays, out,
     # Compute
     status, retval = context.call_conv.call_function(builder, func,
                                                      signature.return_type,
-                                                     signature.args, elems,
-                                                     env=env)
+                                                     signature.args, elems)
 
     # Store
     with builder.if_else(status.is_ok, likely=True) as (if_ok, if_error):
@@ -48,7 +47,7 @@ def _build_ufunc_loop_body_objmode(load, store, context, func, builder,
     # a new error.
     with pyapi.err_push(keep_new=True):
         status, retval = context.call_conv.call_function(builder, func, types.pyobject,
-                                                         _objargs, elems, env=env)
+                                                         _objargs, elems)
         # Release owned reference to arguments
         for elem in elems:
             pyapi.decref(elem)
@@ -418,8 +417,7 @@ class _GufuncWrapper(object):
     def gen_loop_body(self, builder, pyapi, func, args):
         status, retval = self.call_conv.call_function(builder, func,
                                                       self.signature.return_type,
-                                                      self.signature.args, args,
-                                                      env=self.envptr)
+                                                      self.signature.args, args)
 
         with builder.if_then(status.is_error, likely=False):
             gil = pyapi.gil_ensure()
@@ -536,7 +534,7 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
 
     status, retval = context.call_conv.call_function(
         builder, func, types.pyobject, object_sig,
-        object_args, env=env)
+        object_args)
     builder.store(status.is_error, error_pointer)
 
     # Release returned object

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -130,6 +130,7 @@ class _ModuleCompiler(object):
         """
         self.exported_function_types = {}
         self.function_environments = {}
+        self.environment_gvs = {}
 
         codegen = self.context.codegen()
         library = codegen.create_library(self.module_name)
@@ -165,6 +166,8 @@ class _ModuleCompiler(object):
                     cres.fndesc.restype, cres.fndesc.argtypes)
                 self.exported_function_types[entry] = fnty
                 self.function_environments[entry] = cres.environment
+
+                self.environment_gvs[entry] = cres.fndesc.env_name
             else:
                 llvm_func.name = entry.symbol
                 self.dll_exports.append(entry.symbol)
@@ -261,17 +264,31 @@ class _ModuleCompiler(object):
                                               env_defs_init)
         return gv.gep([ZERO, ZERO])
 
+    def _emit_envgvs_array(self, llvm_module, builder, pyapi):
+        env_setters = []
+        for entry in self.export_entries:
+            envgv_name = self.environment_gvs[entry]
+            gv = self.context.declare_env_global(llvm_module, envgv_name)
+            envgv = gv.bitcast(lt._void_star)
+            env_setters.append(envgv)
+
+        env_setters_init = lc.Constant.array(lt._void_star, env_setters)
+        gv = self.context.insert_unique_const(llvm_module,
+                                              '.module_envgvs',
+                                              env_setters_init)
+        return gv.gep([ZERO, ZERO])
+
     def _emit_module_init_code(self, llvm_module, builder, modobj,
-                               method_array, env_array):
+                               method_array, env_array, envgv_array):
         """
         Emit call to "external" init function, if any.
         """
         if self.external_init_function:
             fnty = ir.FunctionType(lt._int32,
                                    [modobj.type, self.method_def_ptr,
-                                    self.env_def_ptr])
+                                    self.env_def_ptr, envgv_array.type])
             fn = llvm_module.add_function(fnty, self.external_init_function)
-            return builder.call(fn, [modobj, method_array, env_array])
+            return builder.call(fn, [modobj, method_array, env_array, envgv_array])
         else:
             return None
 
@@ -330,6 +347,7 @@ class ModuleCompilerPy2(_ModuleCompiler):
                             lc.Constant.int(lt._int32, sys.api_version)))
 
         env_array = self._emit_environment_array(llvm_module, builder, pyapi)
+
         self._emit_module_init_code(llvm_module, builder, mod,
                                     method_array, env_array)
         # XXX No way to notify failure to caller...
@@ -484,8 +502,9 @@ class ModuleCompilerPy3(_ModuleCompiler):
             builder.ret(NULL.bitcast(mod_init_fn.type.pointee.return_type))
 
         env_array = self._emit_environment_array(llvm_module, builder, pyapi)
+        envgv_array = self._emit_envgvs_array(llvm_module, builder, pyapi)
         ret = self._emit_module_init_code(llvm_module, builder, mod,
-                                          method_array, env_array)
+                                          method_array, env_array, envgv_array)
         if ret is not None:
             with builder.if_then(cgutils.is_not_null(builder, ret)):
                 # Init function errored out

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -166,7 +166,6 @@ class _ModuleCompiler(object):
                     cres.fndesc.restype, cres.fndesc.argtypes)
                 self.exported_function_types[entry] = fnty
                 self.function_environments[entry] = cres.environment
-
                 self.environment_gvs[entry] = cres.fndesc.env_name
             else:
                 llvm_func.name = entry.symbol
@@ -288,7 +287,8 @@ class _ModuleCompiler(object):
                                    [modobj.type, self.method_def_ptr,
                                     self.env_def_ptr, envgv_array.type])
             fn = llvm_module.add_function(fnty, self.external_init_function)
-            return builder.call(fn, [modobj, method_array, env_array, envgv_array])
+            return builder.call(fn, [modobj, method_array, env_array,
+                                     envgv_array])
         else:
             return None
 

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -347,9 +347,10 @@ class ModuleCompilerPy2(_ModuleCompiler):
                             lc.Constant.int(lt._int32, sys.api_version)))
 
         env_array = self._emit_environment_array(llvm_module, builder, pyapi)
+        envgv_array = self._emit_envgvs_array(llvm_module, builder, pyapi)
 
         self._emit_module_init_code(llvm_module, builder, mod,
-                                    method_array, env_array)
+                                    method_array, env_array, envgv_array)
         # XXX No way to notify failure to caller...
 
         builder.ret_void()

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -264,6 +264,10 @@ class _ModuleCompiler(object):
         return gv.gep([ZERO, ZERO])
 
     def _emit_envgvs_array(self, llvm_module, builder, pyapi):
+        """
+        Emit an array of Environment pointers that needs to be filled at
+        initialization.
+        """
         env_setters = []
         for entry in self.export_entries:
             envgv_name = self.environment_gvs[entry]

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -73,6 +73,9 @@ typedef struct {
     int len;
 } env_def_t;
 
+/* Environment GlobalVariable address type */
+typedef void **env_gv_t;
+
 /*
  * Recreate an environment object from a env_def_t structure.
  */
@@ -115,7 +118,8 @@ recreate_environment(PyObject *module, env_def_t env)
 
 int
 PYCC(pycc_init_) (PyObject *module, PyMethodDef *defs,
-                                    env_def_t *envs)
+                                    env_def_t *envs,
+                                    env_gv_t *envgvs)
 {
     PyMethodDef *fdef;
     PyObject *modname = NULL;
@@ -168,6 +172,9 @@ PYCC(pycc_init_) (PyObject *module, PyMethodDef *defs,
             Py_DECREF(envobj);
             goto error;
         }
+        // Store the environment pointer into the global
+        *envgvs[i] = envobj;
+
         func = pycfunction_new(module, nameobj, docobj,
                                fdef->ml_meth, envobj, NULL);
         Py_DECREF(envobj);

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -111,6 +111,8 @@ class EnvironmentManager(object):
         """
         Add a constant to the environment, return its index.
         """
+        # print(self.pyapi.builder.function.name)
+        # print('WRITE', self.env, 'const', const)
         # All constants are frozen inside the environment
         if isinstance(const, str):
             const = utils.intern(const)
@@ -128,6 +130,8 @@ class EnvironmentManager(object):
         A borrowed reference is returned.
         """
         assert index < len(self.env.consts)
+        # print('READ', self.env, self.env.consts[index])
+        # cgutils.printf(self.pyapi.builder, "READ from {} but got %p\n".format(hex(id(self.env))), self.env_ptr)
         return self.pyapi.list_getitem(self.env_body.consts, index)
 
 

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -111,8 +111,6 @@ class EnvironmentManager(object):
         """
         Add a constant to the environment, return its index.
         """
-        # print(self.pyapi.builder.function.name)
-        # print('WRITE', self.env, 'const', const)
         # All constants are frozen inside the environment
         if isinstance(const, str):
             const = utils.intern(const)
@@ -130,8 +128,6 @@ class EnvironmentManager(object):
         A borrowed reference is returned.
         """
         assert index < len(self.env.consts)
-        # print('READ', self.env, self.env.consts[index])
-        # cgutils.printf(self.pyapi.builder, "READ from {} but got %p\n".format(hex(id(self.env))), self.env_ptr)
         return self.pyapi.list_getitem(self.env_body.consts, index)
 
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -279,7 +279,10 @@ class BaseContext(object):
         return funcdesc.default_mangler(name, types)
 
     def get_env_name(self, fndesc):
-        """Get the environment name given a FunctionDescriptior
+        """Get the environment name given a FunctionDescriptior.
+
+        Use this instead of the ``fndesc.env_name`` so that the target-context
+        can provide necessary mangling of the symbol to meet ABI requirements.
         """
         return fndesc.env_name
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -283,6 +283,23 @@ class BaseContext(object):
         """
         return 'NumbaEnv.' + fndesc.mangled_name.lstrip('_Z')
 
+    def declare_env_global(self, module, envname):
+        """Declare the Environment pointer as a global of the module.
+
+        Parameters
+        ----------
+        module :
+            The LLVM Module
+        envname : str
+            The name of the global variable.
+        """
+        if envname not in module.globals:
+            gv = llvmir.GlobalVariable(module, cgutils.voidptr_t, name=envname)
+            gv.linkage = 'common'
+            gv.initializer = cgutils.get_null_value(gv.type.pointee)
+
+        return module.globals[envname]
+
     def get_arg_packer(self, fe_args):
         return datamodel.ArgPacker(self.data_model_manager, fe_args)
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -278,6 +278,11 @@ class BaseContext(object):
         """
         return funcdesc.default_mangler(name, types)
 
+    def get_env_name(self, fndesc):
+        """Get the environment name given a FunctionDescriptior
+        """
+        return 'NumbaEnv.' + fndesc.mangled_name.lstrip('_Z')
+
     def get_arg_packer(self, fe_args):
         return datamodel.ArgPacker(self.data_model_manager, fe_args)
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -218,6 +218,9 @@ class BaseContext(object):
     # python exceution environment
     environment = None
 
+    # the function descriptor
+    fndesc = None
+
     def __init__(self, typing_context):
         _load_global_helpers()
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -292,6 +292,10 @@ class BaseContext(object):
     def declare_env_global(self, module, envname):
         """Declare the Environment pointer as a global of the module.
 
+        The pointer is initialized to NULL.  It must be filled by the runtime
+        with the actual address of the Env before the associated function
+        can be executed.
+
         Parameters
         ----------
         module :

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -281,7 +281,7 @@ class BaseContext(object):
     def get_env_name(self, fndesc):
         """Get the environment name given a FunctionDescriptior
         """
-        return 'NumbaEnv.' + fndesc.mangled_name.lstrip('_Z')
+        return fndesc.env_name
 
     def declare_env_global(self, module, envname):
         """Declare the Environment pointer as a global of the module.

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -405,10 +405,6 @@ class CPUCallConv(BaseCallConv):
         excarg.name = "excinfo"
         excarg.add_attribute("nocapture")
         excarg.add_attribute("noalias")
-        envarg = self.get_env_argument(fn)
-        envarg.name = "env"
-        envarg.add_attribute("nocapture")
-        envarg.add_attribute("noalias")
 
         if noalias:
             args = self.get_arguments(fn)
@@ -423,12 +419,6 @@ class CPUCallConv(BaseCallConv):
         Get the Python-level arguments of LLVM *func*.
         """
         return func.args[3:]
-
-    def get_env_argument(self, func):
-        """
-        Get the environment argument of LLVM *func*.
-        """
-        return func.args[2]
 
     def _get_return_argument(self, func):
         return func.args[0]

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -254,11 +254,10 @@ class MinimalCallConv(BaseCallConv):
         """
         return func.args[1:]
 
-    def call_function(self, builder, callee, resty, argtys, args, env=None):
+    def call_function(self, builder, callee, resty, argtys, args):
         """
         Call the Numba-compiled *callee*.
         """
-        assert env is None
         retty = callee.args[0].type.pointee
         retvaltmp = cgutils.alloca_once(builder, retty)
         # initialize return value
@@ -437,15 +436,12 @@ class CPUCallConv(BaseCallConv):
     def _get_excinfo_argument(self, func):
         return func.args[1]
 
-    def call_function(self, builder, callee, resty, argtys, args, env=None):
+    def call_function(self, builder, callee, resty, argtys, args):
         """
         Call the Numba-compiled *callee*.
         """
-        if env is None:
-            # This only works with functions that don't use the environment
-            # (nopython functions).
-            env = cgutils.get_null_value(PYOBJECT)
-        is_generator_function = isinstance(resty, types.Generator)
+        # XXX remove this
+        env = cgutils.get_null_value(PYOBJECT)
 
         # XXX better fix for callees that are not function values
         #     (pointers to function; thus have no `.args` attribute)

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -599,6 +599,7 @@ class BaseCPUCodegen(object):
         self._llvm_module.name = "global_codegen_module"
         self._rtlinker = RuntimeLinker()
         self._init(self._llvm_module)
+        self._live_envs = {}
 
     def _init(self, llvm_module):
         assert list(llvm_module.global_variables) == [], "Module isn't empty"
@@ -814,6 +815,8 @@ class JITCPUCodegen(BaseCPUCodegen):
         gvaddr = self._engine.get_global_value_address(env_name)
         envptr = (ctypes.c_void_p * 1).from_address(gvaddr)
         envptr[0] = ctypes.c_void_p(id(env))
+        # Keep env alive for the lifetime of the codegen object.
+        self._live_envs[env_name] = env
 
 
 def initialize_llvm():

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -599,7 +599,6 @@ class BaseCPUCodegen(object):
         self._llvm_module.name = "global_codegen_module"
         self._rtlinker = RuntimeLinker()
         self._init(self._llvm_module)
-        self._live_envs = {}
 
     def _init(self, llvm_module):
         assert list(llvm_module.global_variables) == [], "Module isn't empty"
@@ -815,8 +814,6 @@ class JITCPUCodegen(BaseCPUCodegen):
         gvaddr = self._engine.get_global_value_address(env_name)
         envptr = (ctypes.c_void_p * 1).from_address(gvaddr)
         envptr[0] = ctypes.c_void_p(id(env))
-        # Keep env alive for the lifetime of the codegen object.
-        self._live_envs[env_name] = env
 
 
 def initialize_llvm():

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -583,7 +583,9 @@ class JitEngine(object):
     set_object_cache = _proxy(ll.ExecutionEngine.set_object_cache)
     finalize_object = _proxy(ll.ExecutionEngine.finalize_object)
     get_function_address = _proxy(ll.ExecutionEngine.get_function_address)
-
+    get_global_value_address = _proxy(
+        ll.ExecutionEngine.get_global_value_address
+        )
 
 class BaseCPUCodegen(object):
 
@@ -803,6 +805,15 @@ class JITCPUCodegen(BaseCPUCodegen):
         #      violation with certain test combinations.
         # # Early bind the engine method to avoid keeping a reference to self.
         # return functools.partial(self._engine.remove_module, module)
+
+    def set_env(self, env_name, env):
+        """Set the environment address.
+
+        Update the GlobalVariable named *env_name* to the address of *env*.
+        """
+        gvaddr = self._engine.get_global_value_address(env_name)
+        envptr = (ctypes.c_void_p * 1).from_address(gvaddr)
+        envptr[0] = ctypes.c_void_p(id(env))
 
 
 def initialize_llvm():

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -100,8 +100,7 @@ class CPUContext(BaseContext):
             builder, envptr, _dynfunc._impl_info['offsetof_env_body'])
         return EnvBody(self, builder, ref=body_ptr, cast_ref=True)
 
-    def get_env_manager(self, builder, envarg=None):
-        envarg = envarg or self.call_conv.get_env_argument(builder.function)
+    def get_env_manager(self, builder):
         env_getter = builder.module.globals['get_numba_env']
         envarg = builder.call(env_getter, [])
         pyapi = self.get_python_api(builder)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -156,7 +156,6 @@ class CPUContext(BaseContext):
         # Code generation
         baseptr = library.get_pointer_to_function(fndesc.llvm_func_name)
         fnptr = library.get_pointer_to_function(fndesc.llvm_cpython_wrapper_name)
-        envsetter = library.get_pointer_to_function(self.get_env_name(fndesc) + '.setter')
 
         # Note: we avoid reusing the original docstring to avoid encoding
         # issues on Python 2, see issue #1908
@@ -180,7 +179,6 @@ class CPUContext(BaseContext):
         '''
         aryty = types.Array(types.int32, ndim, 'A')
         return self.get_abi_sizeof(self.get_value_type(aryty))
-
 
 class ParallelOptions(object):
     """

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -173,6 +173,7 @@ class CPUContext(BaseContext):
         # Code generation
         baseptr = library.get_pointer_to_function(fndesc.llvm_func_name)
         fnptr = library.get_pointer_to_function(fndesc.llvm_cpython_wrapper_name)
+        envsetter = library.get_pointer_to_function(self.get_env_name(fndesc) + '.setter')
 
         # Note: we avoid reusing the original docstring to avoid encoding
         # issues on Python 2, see issue #1908
@@ -183,7 +184,7 @@ class CPUContext(BaseContext):
                                        # objects to keepalive with the function
                                        (library,)
                                        )
-
+        # TODO: make this part of codegen/engine
         ee = library.codegen._engine._ee
         gvaddr = ee.get_global_value_address(self.get_env_name(fndesc))
         envptr = (ctypes.c_void_p * 1).from_address(gvaddr)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -4,6 +4,7 @@ import sys
 import ctypes
 
 import llvmlite.llvmpy.core as lc
+from llvmlite import ir as llvmir
 
 from numba import _dynfunc, config
 from numba.callwrapper import PyCallWrapper

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -78,23 +78,6 @@ class CPUContext(BaseContext):
     def call_conv(self):
         return callconv.CPUCallConv(self)
 
-    def get_env_from_closure(self, builder, clo):
-        """
-        From the pointer *clo* to a _dynfunc.Closure, get a pointer
-        to the enclosed _dynfunc.Environment.
-
-        WARNING: The Environment is also stored as a global per compiliation-unit.
-        Use .get_env_manager() to receive it.
-        """
-        with cgutils.if_unlikely(builder, cgutils.is_null(builder, clo)):
-            self.debug_print(builder, "Fatal error: missing _dynfunc.Closure")
-            builder.unreachable()
-
-        clo_body_ptr = cgutils.pointer_add(
-            builder, clo, _dynfunc._impl_info['offsetof_closure_body'])
-        clo_body = ClosureBody(self, builder, ref=clo_body_ptr, cast_ref=True)
-        return clo_body.env
-
     def get_env_body(self, builder, envptr):
         """
         From the given *envptr* (a pointer to a _dynfunc.Environment object),

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -81,6 +81,9 @@ class CPUContext(BaseContext):
         """
         From the pointer *clo* to a _dynfunc.Closure, get a pointer
         to the enclosed _dynfunc.Environment.
+
+        WARNING: The Environment is also stored as a global per compiliation-unit.
+        Use .get_env_manager() to receive it.
         """
         with cgutils.if_unlikely(builder, cgutils.is_null(builder, clo)):
             self.debug_print(builder, "Fatal error: missing _dynfunc.Closure")
@@ -101,6 +104,8 @@ class CPUContext(BaseContext):
         return EnvBody(self, builder, ref=body_ptr, cast_ref=True)
 
     def get_env_manager(self, builder):
+        # Each compilation unit must have a "get_numba_env()" defined
+        # to receive the Environment object.
         env_getter = builder.module.globals['get_numba_env']
         envarg = builder.call(env_getter, [])
         pyapi = self.get_python_api(builder)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -86,10 +86,9 @@ class CPUContext(BaseContext):
         return EnvBody(self, builder, ref=body_ptr, cast_ref=True)
 
     def get_env_manager(self, builder):
-        # Each compilation unit must have a "get_numba_env()" defined
-        # to receive the Environment object.
-        env_getter = builder.module.globals['get_numba_env']
-        envarg = builder.call(env_getter, [])
+        envgv = self.declare_env_global(builder.module,
+                                        self.get_env_name(self.fndesc))
+        envarg = builder.load(envgv)
         pyapi = self.get_python_api(builder)
         pyapi.emit_environment_sentry(envarg)
         env_body = self.get_env_body(builder, envarg)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -1,10 +1,8 @@
 from __future__ import print_function, absolute_import
 
 import sys
-import ctypes
 
 import llvmlite.llvmpy.core as lc
-from llvmlite import ir as llvmir
 
 from numba import _dynfunc, config
 from numba.callwrapper import PyCallWrapper
@@ -166,11 +164,7 @@ class CPUContext(BaseContext):
                                        # objects to keepalive with the function
                                        (library,)
                                        )
-        # TODO: make this part of codegen/engine
-        ee = library.codegen._engine._ee
-        gvaddr = ee.get_global_value_address(self.get_env_name(fndesc))
-        envptr = (ctypes.c_void_p * 1).from_address(gvaddr)
-        envptr[0] = ctypes.c_void_p(id(env))
+        library.codegen.set_env(self.get_env_name(fndesc), env)
         return cfunc
 
     def calc_array_sizeof(self, ndim):

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -175,7 +175,7 @@ def user_function(fndesc, libs):
         func = context.declare_function(builder.module, fndesc)
         # env=None assumes this is a nopython function
         status, retval = context.call_conv.call_function(
-            builder, func, fndesc.restype, fndesc.argtypes, args, env=None)
+            builder, func, fndesc.restype, fndesc.argtypes, args)
         with cgutils.if_unlikely(builder, status.is_error):
             context.call_conv.return_status_propagate(builder, status)
         assert sig.return_type == fndesc.restype
@@ -211,7 +211,7 @@ def user_generator(gendesc, libs):
         func = context.declare_function(builder.module, gendesc)
         # env=None assumes this is a nopython function
         status, retval = context.call_conv.call_function(
-            builder, func, gendesc.restype, gendesc.argtypes, args, env=None)
+            builder, func, gendesc.restype, gendesc.argtypes, args)
         # Return raw status for caller to process StopIteration
         return status, retval
 

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -619,6 +619,26 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.a, x * y)
         self.assertEqual(tc.b, z)
 
+    def test_generator_method(self):
+        spec = []
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                pass
+
+            def gen(self, niter):
+                for i in range(niter):
+                    yield np.arange(i)
+
+        def expected_gen(niter):
+            for i in range(niter):
+                yield np.arange(i)
+
+        for niter in range(10):
+            for expect, got in zip(expected_gen(niter), TestClass().gen(niter)):
+                self.assertPreciseEqual(expect, got)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1671,9 +1671,10 @@ class TestPrange(TestPrangeBase):
             for line in v.splitlines():
                 # get the fn definition line
                 if 'define' in line and k in line:
-                    # there should only be 3x noalias, one on each of the first
-                    # 3 args (retptr, excinfo, env).
-                    self.assertEqual(line.count('noalias'), 3)
+                    # there should only be 2x noalias, one on each of the first
+                    # 2 args (retptr, excinfo).
+                    # Note: used to be 3x no noalias, but env arg is dropped.
+                    self.assertEqual(line.count('noalias'), 2)
                     break
 
     @skip_unsupported

--- a/numba/tests/test_print.py
+++ b/numba/tests/test_print.py
@@ -172,9 +172,12 @@ class TestPrint(TestCase):
             foo(x)
             foo('hello')
 
+        # Printing an array requires the Env.
+        # We need to make sure the inner function can obtain the Env.
+        x = np.arange(5)
         with captured_stdout():
-            bar(94872)
-            self.assertEqual(sys.stdout.getvalue(), '94872\nhello\n')
+            bar(x)
+            self.assertEqual(sys.stdout.getvalue(), '[0 1 2 3 4]\nhello\n')
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_print.py
+++ b/numba/tests/test_print.py
@@ -162,6 +162,20 @@ class TestPrint(TestCase):
             cfunc(1, (2, 3), (4, 5j))
             self.assertEqual(sys.stdout.getvalue(), '1 hop! (2, 3) 4 5j\n')
 
+    def test_inner_fn_print(self):
+        @jit(nopython=True)
+        def foo(x):
+            print(x)
+
+        @jit(nopython=True)
+        def bar(x):
+            foo(x)
+            foo('hello')
+
+        with captured_stdout():
+            bar(94872)
+            self.assertEqual(sys.stdout.getvalue(), '94872\nhello\n')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #2411 
Closes #3000 

Reason for the fix:

* Printing array requires converting the array back to pyobject.  The process requires the Environment object (Env).
* The Env is passed to the top-level jitted function by the python-to-nopython bridge.  But, it is not available to function called from within a nopython function.  As a result, array printing only works if the function is top-level.


New behavior:

* Make the Env a global per compiled-user-function for both nopython-mode and objectmode.  
* The calling-convention is changed.  The Env used to be passed as the 3rd argument.  The Env argument is now dropped.  The first actual argument starts at the 3rd argument.
* The Env is emitted as a zero-initialized `i8*` global variable.
* When the JIT loads a compiled function into memory, it updates the Env global pointer.  The same process works for cached function as well.
* When the AOT module is loaded, the module initializer updates all the Env global pointers in the module.
* In the body of the emitted function, the Env can be obtained by loading the corresponding global-variable.
* To obtain the Env for a particular function, one only needs to know the `FunctionDescriptor`, from which the name of the symbol that points to the Env can be obtained.
* All Env global-variables are defined to have [common linkage](https://llvm.org/docs/LangRef.html#linkage-types).  They exist and merge like C `int my_global;` in global scope. 
