### PR TITLE
Second pass at error rewrites (interpreter errors).

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -301,6 +301,20 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         for the given *args* and *kws*, and return the resulting callable.
         """
         assert not kws
+
+        def error_rewrite(e, issue_type):
+            """
+            Rewrite and raise Exception `e` with help supplied based on the
+            specified issue_type.
+            """
+            if config.SHOW_HELP:
+                help_msg = errors.error_extras[issue_type]
+                e.patch_message(''.join(e.args) + help_msg)
+            if config.FULL_TRACEBACKS:
+                raise e
+            else:
+                reraise(type(e), e, None)
+
         argtypes = []
         for a in args:
             if isinstance(a, OmittedArg):
@@ -332,25 +346,19 @@ class _DispatcherBase(_dispatcher.Dispatcher):
                                 for i, err in failed_args))
                 e.patch_message(msg)
 
-            # add in help info
-            if config.SHOW_HELP:
-                help_msg = errors.error_extras['typing']
-                e.patch_message(''.join(e.args) + help_msg)
-
-            # raise
-            if config.FULL_TRACEBACKS:
-                raise e
-            else:
-                reraise(type(e), e, None)
+            error_rewrite(e, 'typing')
         except errors.UnsupportedError as e:
             # Something unsupported is present in the user code, add help info
-            if config.SHOW_HELP:
-                help_msg = errors.error_extras['unsupported_error']
-                e.patch_message(''.join(e.args) + help_msg)
-            if config.FULL_TRACEBACKS:
-                raise e
-            else:
-                reraise(type(e), e, None)
+            error_rewrite(e, 'unsupported_error')
+        except (errors.NotDefinedError, errors.RedefinedError,
+                errors.VerificationError) as e:
+            # These errors are probably from an issue with either the code supplied
+            # being syntactically or otherwise invalid
+            error_rewrite(e, 'interpreter')
+        except errors.ConstantInferenceError as e:
+            # this is from trying to infer something as constant when it isn't
+            # or isn't supported as a constant
+            error_rewrite(e, 'constant_inference')
         except Exception as e:
             if config.SHOW_HELP:
                 if hasattr(e, 'patch_message'):

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -241,6 +241,35 @@ If this functionality is important to you please file a feature request at:
 https://github.com/numba/numba/issues/new
 """
 
+interpreter_error_info = """
+Unsupported Python functionality was found in the code Numba was trying to
+compile. This error could be due to invalid code, does the code work
+without Numba? (A quick way to check is to temporarily disable Numba JIT by
+setting the `NUMBA_DISABLE_JIT` environment variable to non-zero and then
+rerunning the code).
+
+If the code is valid and the unsupported functionality is important to you
+please file a feature request at: https://github.com/numba/numba/issues/new
+
+To see Python/NumPy features supported by the latest release of Numba visit:
+http://numba.pydata.org/numba-doc/dev/reference/pysupported.html
+and
+http://numba.pydata.org/numba-doc/dev/reference/numpysupported.html
+"""
+
+constant_inference_info = """
+Numba could not make a constant out of something that it decided should be
+a constant. This could well be a current limitation in Numba's internals,
+please either raise a bug report along with a minimal reproducer at:
+https://github.com/numba/numba/issues/new
+
+(if you need help writing a minimal reproducer please see)
+http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+
+Or, alternatively please feel free to speak to the Numba core developers
+directly at: https://gitter.im/numba/numba
+"""
+
 typing_error_info = """
 This is not usually a problem with Numba itself but instead often caused by
 the use of unsupported features or an issue in resolving types.
@@ -278,6 +307,8 @@ error_extras = dict()
 error_extras['unsupported_error'] = unsupported_error_info
 error_extras['typing'] = typing_error_info
 error_extras['reportable'] = reportable_issue_info
+error_extras['interpreter'] = interpreter_error_info
+error_extras['constant_inference'] = constant_inference_info
 
 
 def deprecated(arg):
@@ -399,30 +430,37 @@ class UnsupportedError(NumbaError):
     """
     Numba does not have an implementation for this functionality.
     """
+    pass
 
 
 class IRError(NumbaError):
     """
     An error occurred during Numba IR generation.
     """
+    pass
 
 
 class RedefinedError(IRError):
+    """
+    An error occurred during interpretation of IR due to variable redefinition.
+    """
     pass
 
 
 class NotDefinedError(IRError):
+    """
+    An undefined variable is encountered during interpretation of IR.
+    """
     def __init__(self, name, loc=None):
         self.name = name
-        self.loc = loc
-
-    def __str__(self):
-        loc = "?" if self.loc is None else self.loc
-        return "{name!r} is not defined in {loc}".format(name=self.name,
-                                                         loc=self.loc)
+        msg = "Variable '%s' is not defined." % name
+        super(NotDefinedError, self).__init__(msg, loc=loc)
 
 
 class VerificationError(IRError):
+    """
+    An error occurred during IR verification.
+    """
     pass
 
 
@@ -430,9 +468,13 @@ class MacroError(NumbaError):
     """
     An error occurred during macro expansion.
     """
+    pass
 
 
 class DeprecationError(NumbaError):
+    """
+    Functionality is deprecated.
+    """
     pass
 
 
@@ -440,7 +482,6 @@ class LoweringError(NumbaError):
     """
     An error occurred during lowering.
     """
-
     def __init__(self, msg, loc):
         self.msg = msg
         self.loc = loc
@@ -451,12 +492,14 @@ class ForbiddenConstruct(LoweringError):
     """
     A forbidden Python construct was encountered (e.g. use of locals()).
     """
+    pass
 
 
 class TypingError(NumbaError):
     """
     A type inference failure.
     """
+    pass
 
 
 class UntypedAttributeError(TypingError):
@@ -470,18 +513,25 @@ class ByteCodeSupportError(NumbaError):
     """
     Failure to extract the bytecode of the user's function.
     """
+    def __init__(self, msg, loc=None):
+        super(ByteCodeSupportError, self).__init__(msg, loc=loc)
 
 
 class CompilerError(NumbaError):
     """
     Some high-level error in the compiler.
     """
+    pass
 
 
 class ConstantInferenceError(NumbaError):
     """
     Failure during constant inference.
     """
+    def __init__(self, value, loc=None):
+        self.value = value
+        msg = "Cannot make a constant from: %s" % value
+        super(ConstantInferenceError, self).__init__(msg, loc=loc)
 
 
 class InternalError(NumbaError):
@@ -498,6 +548,7 @@ class RequireConstValue(TypingError):
     """For signaling a function typing require constant value for some of
     its arguments.
     """
+    pass
 
 
 def _format_msg(fmt, args, kwargs):

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -5,7 +5,7 @@ import dis
 import sys
 from copy import copy
 
-from . import config, ir, controlflow, dataflow, utils, errors
+from . import config, ir, controlflow, dataflow, utils, errors, six
 from .utils import builtins, PYVERSION
 from .errors import NotDefinedError
 
@@ -235,8 +235,15 @@ class Interpreter(object):
                 return fn(inst, **kws)
             except errors.NotDefinedError as e:
                 if e.loc is None:
-                    e.loc = self.loc
-                raise e
+                    loc = self.loc
+                else:
+                    loc = e.loc
+
+                err = errors.NotDefinedError(e.name, loc=loc)
+                if not config.FULL_TRACEBACKS:
+                    six.raise_from(err, None)
+                else:
+                    raise err
 
 
     # --- Scope operations ---

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -343,7 +343,7 @@ class Expr(Inst):
         return self._rec_list_vars(self._kws)
 
     def infer_constant(self):
-        raise ConstantInferenceError("cannot make a constant of %s" % (self,))
+        raise ConstantInferenceError('%s' % self, loc=self.loc)
 
 
 class SetItem(Stmt):
@@ -574,7 +574,7 @@ class Arg(object):
         return 'arg(%d, name=%s)' % (self.index, self.name)
 
     def infer_constant(self):
-        raise ConstantInferenceError("cannot make a constant of %s" % (self,))
+        raise ConstantInferenceError('%s' % self, loc=self.loc)
 
 
 class Const(object):


### PR DESCRIPTION
This is a second pass at improving error handling, the first pass
focussed on Typing and related errors, this pass focusses on
errors arising during bytecode interpretation and analysis.

Fixes #3001.
