### PR TITLE
Augment SVML detection with llvmlite SVML patch detection.

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -4,8 +4,9 @@ Version 0.38.1
 This is a critical bug fix release addressing:
 https://github.com/numba/numba/issues/3006
 
-The bug does not impact users who install Numba using conda or pip (using
-wheels from PyPI).
+The bug does not impact users using conda packages from Anaconda or Intel Python
+Distribution (but it does impact conda-forge). It does not impact users of pip
+using wheels from PyPI.
 
 This only impacts a small number of users where:
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,33 @@
+Version 0.38.1
+--------------
+
+This is a critical bug fix release addressing:
+https://github.com/numba/numba/issues/3006
+
+The bug does not impact users who install Numba using conda or pip (using
+wheels from PyPI).
+
+This only impacts a small number of users where:
+
+ * The ICC runtime (specifically libsvml) is present in the user's environment.
+ * The user is using an llvmlite statically linked against a version of LLVM
+   that has not been patched with SVML support.
+ * The platform is 64-bit.
+
+The release fixes a code generation path that could lead to the production of
+incorrect results under the above situation.
+
+Fixes:
+
+* PR #3007: Augment SVML detection with llvmlite SVML patch detection.
+
+Contributors:
+
+The following people contributed to this release.
+
+* Stuart Archibald (core dev)
+
+
 Version 0.38.0
 --------------
 


### PR DESCRIPTION
This adds defensive behaviour to SVML detection following changes
to llvmlite that added a function to declare whether SVML was enabled,
via patching LLVM, at compile time. This is a critical patch that
corrects erroneous behaviour, for context see #3006.

Closes #3006
Fixes #2998

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
