### PR TITLE
Fix optional type returning in recursive call

### DIFF
--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -810,6 +810,8 @@ class BaseContext(object):
 
         with cgutils.if_unlikely(builder, status.is_error):
             self.call_conv.return_status_propagate(builder, status)
+
+        res = imputils.fix_returning_optional(self, builder, sig, status, res)
         return res
 
     def call_unresolved(self, builder, name, sig, args):
@@ -852,6 +854,8 @@ class BaseContext(object):
                                                    sig.args, args)
         with cgutils.if_unlikely(builder, status.is_error):
             self.call_conv.return_status_propagate(builder, status)
+
+        res = imputils.fix_returning_optional(self, builder, sig, status, res)
         return res
 
     def get_executable(self, func, fndesc):

--- a/numba/tests/recursion_usecases.py
+++ b/numba/tests/recursion_usecases.py
@@ -194,3 +194,24 @@ def make_raise_mutual(jit=lambda x: x):
             return 1
 
     return outer
+
+
+def make_optional_return_case(jit=lambda x: x):
+    @jit
+    def foo(x):
+        if x > 5:
+            return x - 1
+        else:
+            return
+
+    @jit
+    def bar(x):
+        out = foo(x)
+        if out is None:
+            return out
+        elif out < 8:
+            return out
+        else:
+            return x * bar(out)
+
+    return bar

--- a/numba/tests/test_recursion.py
+++ b/numba/tests/test_recursion.py
@@ -49,6 +49,12 @@ class TestSelfRecursion(TestCase):
 
         self.assertEqual(str(raises.exception), "raise_self")
 
+    def test_optional_return(self):
+        pfunc = self.mod.make_optional_return_case()
+        cfunc = self.mod.make_optional_return_case(jit(nopython=True))
+        for arg in (0, 5, 10, 15):
+            self.assertEqual(pfunc(arg), cfunc(arg))
+
 
 class TestMutualRecursion(TestCase):
 


### PR DESCRIPTION
For one of the issue in https://github.com/numba/numba/issues/2971.

This fixes the issue that Optional return type is not properly handled in recursive call.