### PR TITLE
Add support for multidimensional CFFI arrays

### DIFF
--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -146,17 +146,29 @@ class TestCFFI(TestCase):
 
     def test_from_buffer_numpy_multi_array(self):
         c1 = np.array([1, 2], order='C', dtype=np.float32)
+        c1_zeros = np.zeros_like(c1)
         c2 = np.array([[1, 2], [3, 4]], order='C', dtype=np.float32)
+        c2_zeros = np.zeros_like(c2)
         f1 = np.array([1, 2], order='F', dtype=np.float32)
+        f1_zeros = np.zeros_like(f1)
         f2 = np.array([[1, 2], [3, 4]], order='F', dtype=np.float32)
+        f2_zeros = np.zeros_like(f2)
+        f2_copy = f2.copy('K')
         pyfunc = mod.vector_sin_float32
         cfunc = jit(nopython=True)(pyfunc)
-        cfunc(c1, c1)   # No exception because of C layout and single dimension
-        cfunc(c2, c2)   # No exception because of C layout
-        cfunc(f1, f1)   # No exception because of single dimension
+        # No exception because of C layout and single dimension
+        self.check_vector_sin(cfunc, c1, c1_zeros)
+        # No exception because of C layout
+        cfunc(c2, c2_zeros)
+        sin_c2 = np.sin(c2)
+        sin_c2[1] = [0, 0]  # Reset to zero, since cfunc only processes one row
+        np.testing.assert_allclose(c2_zeros, sin_c2)
+        # No exception because of single dimension
+        self.check_vector_sin(cfunc, f1, f1_zeros)
         # Exception because multi-dimensional with F layout
         with self.assertRaises(errors.TypingError) as raises:
-            cfunc(f2, f2)
+            cfunc(f2, f2_zeros)
+        np.testing.assert_allclose(f2, f2_copy)
         self.assertIn("from_buffer() only supports multidimensional arrays with C layout",
                       str(raises.exception))
 

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -111,6 +111,8 @@ def map_type(cffi_type):
             return types.voidptr
         else:
             return types.CPointer(map_type(pointee))
+    elif kind == 'array':
+        return map_type(cffi_type.item)
     else:
         result = _type_map().get(cffi_type)
         if result is None:
@@ -144,6 +146,9 @@ class FFI_from_buffer(templates.AbstractTemplate):
                               % (ary,))
         if ary.layout not in ('C', 'F'):
             raise TypingError("from_buffer() unsupported on non-contiguous buffers (got %s)"
+                              % (ary,))
+        if ary.layout != 'C' and ary.ndim > 1:
+            raise TypingError("from_buffer() only supports multidimensional arrays with C layout (got %s)"
                               % (ary,))
         ptr = types.CPointer(ary.dtype)
         return templates.signature(ptr, ary)


### PR DESCRIPTION
Currently, when using the CFFI `from_buffer` interface in no Python mode, multidimensional arrays fail with a `TypeError` along the lines of `<ctype 'double[3]'>`. This pull request adds type mapping for multidimensional arrays that should fix this.