### PR TITLE
Fix random integer generation to match results from NumPy.

### DIFF
--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -394,11 +394,12 @@ class TestRandom(BaseTest):
             else:
                 rr = self._follow_cpython(ptr).randrange
             widths = [w for w in [1, 5, 8, 5000, 2**40, 2**62 + 2**61] if w < max_width]
+            pydtype = tp if is_numpy and np.__version__ >= '1.11.0' else None
             for width in widths:
                 self._check_dist(func1, rr, [(width,)], niters=10,
-                                 pydtype=(tp if is_numpy else None))
+                                 pydtype=pydtype)
                 self._check_dist(func2, rr, [(-2, 2 +width)], niters=10,
-                                 pydtype=(tp if is_numpy else None))
+                                 pydtype=pydtype)
                 if func3 is not None:
                     self.assertPreciseEqual(func3(-2, 2 + width, 6),
                                             rr(-2, 2 + width, 6))


### PR DESCRIPTION
This pull request modifies Numba's PRNG to match NumPy when using `np.random` (while not modifying the behavior of `random`), implementing much of what is described in #2782.

It adds support for 64-bit integers, which was missing in the patch in the aforementioned issue, and fixes a problem with power of two ranges (extending the unit tests to check for this). Support for CPython's PRNG initialization was not added.