### PR TITLE
This adds @needs_blas to tests that use BLAS

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -12,6 +12,7 @@ from numba.errors import TypingError, LoweringError
 from numba.numpy_support import (as_dtype, strict_ufunc_typing,
                                  version as numpy_version)
 from .support import TestCase, CompilationCache, MemoryLeak, MemoryLeakMixin, tag
+from .matmul_usecase import needs_blas
 
 
 def np_around_array(arr, decimals, out):
@@ -880,6 +881,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(np.array([[3.1, 3.1], [1.7, 2.29], [3.3, 1.7]]))
         check(np.array([]))
 
+    @needs_blas
     def test_array_dot(self):
         # just ensure that the dot impl dispatches correctly, do
         # not test dot itself, this is done in test_linalg.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1064,6 +1064,7 @@ class TestParfors(TestParforsBase):
         self.assertIn("Overwrite of parallel loop index", str(raises.exception))
 
     @skip_unsupported
+    @needs_blas
     def test_parfor_array_access4(self):
         # in this test, one index of a multi-dim access should be replaced
         # np.dot parallel implementation produces this case
@@ -1117,6 +1118,7 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
 
     @skip_unsupported
+    @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857
         def test_impl(N, D):


### PR DESCRIPTION
These tests need BLAS, they fail if run without SciPy (the BLAS
provider) being present. Add a decorator to skip if no BLAS is
available.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
