### PR TITLE
Handler for known LoweringErrors.

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -16,6 +16,7 @@ from numba.annotations import type_annotations
 from numba.parfor import PreParforPass, ParforPass, Parfor
 from numba.inline_closurecall import InlineClosureCallPass
 from numba.errors import CompilerError
+from numba.ir_utils import raise_on_unsupported_feature
 
 # terminal color markup
 _termcolor = errors.termcolor()
@@ -694,6 +695,9 @@ class BasePipeline(object):
                                  lifted=(),
                                  fndesc=None,)
 
+    def stage_catch_errors_before_lowering(self):
+        raise_on_unsupported_feature(self.func_ir)
+
     def stage_cleanup(self):
         """
         Cleanup intermediate results to release resources.
@@ -759,6 +763,8 @@ class BasePipeline(object):
         self.add_pre_typing_stage(pm)
         self.add_typing_stage(pm)
         self.add_optimization_stage(pm)
+        pm.add_stage(self.stage_catch_errors_before_lowering,
+                     "handle known issues before lowering")
         self.add_lowering_stage(pm)
         self.add_cleanup_stage(pm)
 
@@ -770,6 +776,8 @@ class BasePipeline(object):
         pm.add_stage(self.stage_objectmode_frontend,
                      "object mode frontend")
         pm.add_stage(self.stage_annotate_type, "annotate type")
+        pm.add_stage(self.stage_catch_errors_before_lowering,
+                     "handle known issues before lowering")
         pm.add_stage(self.stage_objectmode_backend, "object mode backend")
         self.add_cleanup_stage(pm)
 

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -695,7 +695,7 @@ class BasePipeline(object):
                                  lifted=(),
                                  fndesc=None,)
 
-    def stage_catch_errors_before_lowering(self):
+    def stage_ir_legalization(self):
         raise_on_unsupported_feature(self.func_ir)
 
     def stage_cleanup(self):
@@ -763,8 +763,8 @@ class BasePipeline(object):
         self.add_pre_typing_stage(pm)
         self.add_typing_stage(pm)
         self.add_optimization_stage(pm)
-        pm.add_stage(self.stage_catch_errors_before_lowering,
-                     "handle known issues before lowering")
+        pm.add_stage(self.stage_ir_legalization,
+                     "ensure IR is legal prior to lowering")
         self.add_lowering_stage(pm)
         self.add_cleanup_stage(pm)
 
@@ -776,8 +776,8 @@ class BasePipeline(object):
         pm.add_stage(self.stage_objectmode_frontend,
                      "object mode frontend")
         pm.add_stage(self.stage_annotate_type, "annotate type")
-        pm.add_stage(self.stage_catch_errors_before_lowering,
-                     "handle known issues before lowering")
+        pm.add_stage(self.stage_ir_legalization,
+                     "ensure IR is legal prior to lowering")
         pm.add_stage(self.stage_objectmode_backend, "object mode backend")
         self.add_cleanup_stage(pm)
 

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1692,34 +1692,33 @@ def raise_on_unsupported_feature(func_ir):
     unsupported features.
     """
     for blk in func_ir.blocks.values():
-        for stmt in blk.body:
+        for stmt in blk.find_insts(ir.Assign):
             # This raises on finding `make_function`
-            if isinstance(stmt, ir.Assign):
-                if isinstance(stmt.value, ir.Expr):
-                    if stmt.value.op == 'make_function':
-                        val = stmt.value
+            if isinstance(stmt.value, ir.Expr):
+                if stmt.value.op == 'make_function':
+                    val = stmt.value
 
-                        # See if the construct name can be refined
-                        code = getattr(val, 'code', None)
-                        if code is not None:
-                            # check if this is a closure, the co_name will
-                            # be the captured function name which is not
-                            # useful so be explicit
-                            if getattr(val, 'closure', None) is not None:
-                                use = '<creating a function from a closure>'
-                                expr = ''
-                            else:
-                                use = code.co_name
-                                expr = '(%s) ' % use
-                        else:
-                            use = '<could not ascertain use case>'
+                    # See if the construct name can be refined
+                    code = getattr(val, 'code', None)
+                    if code is not None:
+                        # check if this is a closure, the co_name will
+                        # be the captured function name which is not
+                        # useful so be explicit
+                        if getattr(val, 'closure', None) is not None:
+                            use = '<creating a function from a closure>'
                             expr = ''
+                        else:
+                            use = code.co_name
+                            expr = '(%s) ' % use
+                    else:
+                        use = '<could not ascertain use case>'
+                        expr = ''
 
-                        msg = ("Numba encountered the use of a language "
-                               "feature it does not support in this context: "
-                               "%s (op code: make_function not supported). If "
-                               "the feature is explicitly supported it is "
-                               "likely that the result of the expression %s"
-                               "is being used in an unsupported manner.") % \
-                                (use, expr)
-                        raise UnsupportedError(msg, stmt.value.loc)
+                    msg = ("Numba encountered the use of a language "
+                            "feature it does not support in this context: "
+                            "%s (op code: make_function not supported). If "
+                            "the feature is explicitly supported it is "
+                            "likely that the result of the expression %s"
+                            "is being used in an unsupported manner.") % \
+                            (use, expr)
+                    raise UnsupportedError(msg, stmt.value.loc)

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -16,7 +16,7 @@ from numba.typing.templates import signature, infer_global, AbstractTemplate
 from numba.targets.imputils import impl_ret_untracked
 from numba.analysis import (compute_live_map, compute_use_defs,
                             compute_cfg_from_blocks)
-from numba.errors import TypingError
+from numba.errors import TypingError, UnsupportedError
 import copy
 
 _unique_var_count = 0
@@ -1682,3 +1682,44 @@ def is_namedtuple_class(c):
     if not isinstance(fields, tuple):
         return False
     return all(isinstance(f, str) for f in fields)
+
+def raise_on_unsupported_feature(func_ir):
+    """
+    Helper function to walk IR and raise if it finds op codes
+    that are unsupported. Could be extended to cover IR sequences
+    as well as op codes. Intended use is to call it as a pipeline
+    stage just prior to lowering to prevent LoweringErrors for known
+    unsupported features.
+    """
+    for blk in func_ir.blocks.values():
+        for stmt in blk.body:
+            # This raises on finding `make_function`
+            if isinstance(stmt, ir.Assign):
+                if isinstance(stmt.value, ir.Expr):
+                    if stmt.value.op == 'make_function':
+                        val = stmt.value
+
+                        # See if the construct name can be refined
+                        code = getattr(val, 'code', None)
+                        if code is not None:
+                            # check if this is a closure, the co_name will
+                            # be the captured function name which is not
+                            # useful so be explicit
+                            if getattr(val, 'closure', None) is not None:
+                                use = '<creating a function from a closure>'
+                                expr = ''
+                            else:
+                                use = code.co_name
+                                expr = '(%s) ' % use
+                        else:
+                            use = '<could not ascertain use case>'
+                            expr = ''
+
+                        msg = ("Numba encountered the use of a language "
+                               "feature it does not support in this context: "
+                               "%s (op code: make_function not supported). If "
+                               "the feature is explicitly supported it is "
+                               "likely that the result of the expression %s"
+                               "is being used in an unsupported manner.") % \
+                                (use, expr)
+                        raise UnsupportedError(msg, stmt.value.loc)

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -8,7 +8,8 @@ import numpy
 
 import numba.unittest_support as unittest
 from numba import njit, jit, testing, utils
-from numba.errors import NotDefinedError, TypingError, LoweringError
+from numba.errors import (NotDefinedError, TypingError, LoweringError,
+                          UnsupportedError)
 from .support import TestCase, tag
 from numba.six import exec_
 
@@ -425,7 +426,7 @@ class TestInlinedClosure(TestCase):
         msg = "Unsupported use of op_LOAD_CLOSURE encountered"
         self.assertIn(msg, str(raises.exception))
 
-        with self.assertRaises(LoweringError) as raises:
+        with self.assertRaises(UnsupportedError) as raises:
             cfunc = jit(nopython=True)(outer11)
             cfunc(var)
         msg = "make_function"

--- a/numba/tests/test_dataflow.py
+++ b/numba/tests/test_dataflow.py
@@ -197,7 +197,7 @@ class TestDataFlow(TestCase):
 
     def test_unsupported_op_code(self, flags=force_pyobj_flags):
         pyfunc = unsupported_op_code
-        with self.assertRaises(errors.LoweringError) as raises:
+        with self.assertRaises(errors.UnsupportedError) as raises:
             cr = compile_isolated(pyfunc, (), flags=flags)
         msg="make_function"
         self.assertIn(msg, str(raises.exception))

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 from numba import jit, njit
 from numba import unittest_support as unittest
-from numba import errors
+from numba import errors, utils
 
 
 class TestErrorHandlingBeforeLowering(unittest.TestCase):
@@ -25,16 +25,19 @@ class TestErrorHandlingBeforeLowering(unittest.TestCase):
             self.assertIn(expected, str(raises.exception))
 
     def test_unsupported_make_function_listcomp(self):
-        @jit
-        def func(x):
-            a = [i for i in x]
-            return undefined_global  # force error
+        try:
+            @jit
+            def func(x):
+                a = [i for i in x]
+                return undefined_global  # force error
 
-        with self.assertRaises(errors.UnsupportedError) as raises:
-            func([1])
+            with self.assertRaises(errors.UnsupportedError) as raises:
+                func([1])
 
-        expected = self.expected_msg % "<listcomp>"
-        self.assertIn(expected, str(raises.exception))
+            expected = self.expected_msg % "<listcomp>"
+            self.assertIn(expected, str(raises.exception))
+        except NameError: #py27 cannot handle the undefined global
+            self.assertTrue(utils.PY2)
 
     def test_unsupported_make_function_return_inner_func(self):
         def func(x):

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -1,0 +1,58 @@
+"""
+Unspecified error handling tests
+"""
+from __future__ import division
+
+from numba import jit, njit
+from numba import unittest_support as unittest
+from numba import errors
+
+
+class TestErrorHandlingBeforeLowering(unittest.TestCase):
+
+    expected_msg = ("Numba encountered the use of a language feature it does "
+                    "not support in this context: %s")
+
+    def test_unsupported_make_function_lambda(self):
+        def func(x):
+            f = lambda x: x  # requires `make_function`
+
+        for pipeline in jit, njit:
+            with self.assertRaises(errors.UnsupportedError) as raises:
+                pipeline(func)(1)
+
+            expected = self.expected_msg % "<lambda>"
+            self.assertIn(expected, str(raises.exception))
+
+    def test_unsupported_make_function_listcomp(self):
+        @jit
+        def func(x):
+            a = [i for i in x]
+            return undefined_global  # force error
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            func([1])
+
+        expected = self.expected_msg % "<listcomp>"
+        self.assertIn(expected, str(raises.exception))
+
+    def test_unsupported_make_function_return_inner_func(self):
+        def func(x):
+            """ return the closure """
+            z = x + 1
+
+            def inner(x):
+                return x + z
+            return inner
+
+        for pipeline in jit, njit:
+            with self.assertRaises(errors.UnsupportedError) as raises:
+                pipeline(func)(1)
+
+            expected = self.expected_msg % \
+                "<creating a function from a closure>"
+            self.assertIn(expected, str(raises.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -39,6 +39,17 @@ class TestErrorHandlingBeforeLowering(unittest.TestCase):
         except NameError: #py27 cannot handle the undefined global
             self.assertTrue(utils.PY2)
 
+    def test_unsupported_make_function_dictcomp(self):
+        @jit
+        def func():
+            return {i:0 for i in range(1)}
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            func()
+
+        expected = self.expected_msg % "<dictcomp>"
+        self.assertIn(expected, str(raises.exception))
+
     def test_unsupported_make_function_return_inner_func(self):
         def func(x):
             """ return the closure """


### PR DESCRIPTION
Quite a few `LoweringError`s are from the use of known and detectable
unsupported language features. This adds a stage to the compiler
pipeline just ahead of the lowering pass that will try and identify
such cases and raise a more helpful error message.

Fixes #2993

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
