### PR TITLE
Abort simulator threads on exception in thread block.

### DIFF
--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -136,7 +136,7 @@ class BlockThread(threading.Thread):
     Manages the execution of a function for a single CUDA thread.
     '''
     def __init__(self, f, manager, blockIdx, threadIdx):
-        super(BlockThread, self).__init__(target=f)
+        super(BlockThread, self).__init__(target=f, daemon=True)
         self.syncthreads_event = threading.Event()
         self.syncthreads_blocked = False
         self._manager = manager

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -136,13 +136,14 @@ class BlockThread(threading.Thread):
     Manages the execution of a function for a single CUDA thread.
     '''
     def __init__(self, f, manager, blockIdx, threadIdx):
-        super(BlockThread, self).__init__(target=f, daemon=True)
+        super(BlockThread, self).__init__(target=f)
         self.syncthreads_event = threading.Event()
         self.syncthreads_blocked = False
         self._manager = manager
         self.blockIdx = Dim3(*blockIdx)
         self.threadIdx = Dim3(*threadIdx)
         self.exception = None
+        self.daemon = True
         self.abort = False
         blockDim = Dim3(*self._manager._block_dim)
         self.thread_id = self.threadIdx.x + blockDim.x * (self.threadIdx.y + blockDim.y * self.threadIdx.z)

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -143,6 +143,7 @@ class BlockThread(threading.Thread):
         self.blockIdx = Dim3(*blockIdx)
         self.threadIdx = Dim3(*threadIdx)
         self.exception = None
+        self.abort = False
         blockDim = Dim3(*self._manager._block_dim)
         self.thread_id = self.threadIdx.x + blockDim.x * (self.threadIdx.y + blockDim.y * self.threadIdx.z)
 
@@ -160,9 +161,16 @@ class BlockThread(threading.Thread):
             self.exception = (type(e), type(e)(msg), tb)
 
     def syncthreads(self):
+
+        if self.abort:
+            raise RuntimeError("abort flag set on syncthreads call")
+
         self.syncthreads_blocked = True
         self.syncthreads_event.wait()
         self.syncthreads_event.clear()
+
+        if self.abort:
+            raise RuntimeError("abort flag set on syncthreads clear")
 
     def syncthreads_count(self, value):
         self._manager.block_state[self.threadIdx.x, self.threadIdx.y, self.threadIdx.z] = value
@@ -234,6 +242,14 @@ class BlockManager(object):
                 if t.syncthreads_blocked:
                     blockedthreads.add(t)
                 elif t.exception:
+
+                    # Abort all other simulator threads on exception,
+                    # do *not* join immediately to facilitate debugging.
+                    for t_other in threads:
+                        t_other.abort = True
+                        t_other.syncthreads_blocked = False
+                        t_other.syncthreads_event.set()
+
                     reraise(*(t.exception))
             if livethreads == blockedthreads:
                 for t in blockedthreads:

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import, print_function, division
 
+import threading
+
 import numpy as np
 
 from numba import unittest_support as unittest
 from numba import cuda
 from numba.cuda.testing import SerialMixin
+import numba.cuda.simulator as simulator
 
 
 class TestCudaSimIssues(SerialMixin, unittest.TestCase):
@@ -27,6 +30,33 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
         outer[1, 11](arr)
         expected = np.arange(arr.size, dtype=np.int32)
         np.testing.assert_equal(expected, arr)
+
+    def test_deadlock_on_exception(self):
+        def assert_no_blockthreads():
+            blockthreads = [
+                t for t in threading.enumerate()
+                if isinstance(t, simulator.kernel.BlockThread)
+            ]
+
+            self.assertListEqual(blockthreads, [])
+
+        @simulator.jit
+        def assign_with_sync(x, y):
+            i = cuda.grid(1)
+            y[i] = x[i]
+
+            cuda.syncthreads()
+
+        x = np.arange(20)
+        y = np.empty(20)
+        assign_with_sync[1, 20](x, y)
+        np.testing.assert_array_equal(x, y)
+        assert_no_blockthreads()
+
+
+        with self.assertRaises(IndexError):
+            assign_with_sync[1, 30](x, y)
+        assert_no_blockthreads()
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -40,10 +40,9 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
 
                 # join blockthreads with a short timeout to allow aborted threads
                 # to exit
-                if t.abort:
-                    t.join(1)
+                t.join(1)
                 if t.is_alive():
-                    blockthreads.append(t)
+                    self.fail("Blocked kernel thread: %s" % t)
 
             self.assertListEqual(blockthreads, [])
 
@@ -53,16 +52,17 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
             y[i] = x[i]
 
             cuda.syncthreads()
+            cuda.syncthreads()
 
-        x = np.arange(20)
-        y = np.empty(20)
-        assign_with_sync[1, 20](x, y)
+        x = np.arange(3)
+        y = np.empty(3)
+        assign_with_sync[1, 3](x, y)
         np.testing.assert_array_equal(x, y)
         assert_no_blockthreads()
 
 
         with self.assertRaises(IndexError):
-            assign_with_sync[1, 30](x, y)
+            assign_with_sync[1, 6](x, y)
         assert_no_blockthreads()
 
 


### PR DESCRIPTION
_Resolves #3063 by implementing both possible solutions._

* Adds a repro test case for #3063 to the cuda simulator test suite.

* Adds an `abort` flag to cuda simulator `BlockThread`s and flags all threads for abort if a mid-block exception occurs. Checks abort flag on syncthreads calls, ending thread with `RuntimeError` if thread has been aborted.

* Launches kernel threads as daemon threads, allowing process exit in case of living/blocked simulator threads.