### PR TITLE
Avoid ignored exception due to missing globals at interpreter teardown

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -46,7 +46,7 @@ class Environment(_dynfunc.Environment):
             )
 
     def __del__(self):
-        if utils.IS_PY3:
+        if utils is None or utils.IS_PY3:
             return
         if _keepalive is None:
             return


### PR DESCRIPTION
as titled