### PR TITLE
Adds optional number of processes for `-m` in testing

### DIFF
--- a/buildscripts/condarecipe.buildbot/run_test.bat
+++ b/buildscripts/condarecipe.buildbot/run_test.bat
@@ -13,6 +13,6 @@ numba -s
 python -m numba.tests.test_runtests
 
 @rem Run the CUDA test suite
-python -m numba.runtests -v -m -b numba.cuda.tests
+python -m numba.runtests -v -b -m -- numba.cuda.tests
 
 if errorlevel 1 exit 1

--- a/buildscripts/condarecipe.buildbot/run_test.sh
+++ b/buildscripts/condarecipe.buildbot/run_test.sh
@@ -15,6 +15,13 @@ else
   echo Error
 fi
 
+# limit CPUs in use on PPC64LE, fork() issues
+# occur on high core count systems
+archstr=`uname -m`
+if [[ "$archstr" == 'ppc64le' ]]; then
+    TEST_NPROCS=16
+fi
+
 # Check Numba executables are there
 pycc -h
 numba -h
@@ -26,4 +33,4 @@ numba -s
 python -m numba.tests.test_runtests
 
 # Run the CUDA test suite
-$SEGVCATCH python -m numba.runtests -v -m -b numba.cuda.tests
+$SEGVCATCH python -m numba.runtests -v -b -m $TEST_NPROCS -- numba.cuda.tests

--- a/buildscripts/condarecipe.local/run_test.bat
+++ b/buildscripts/condarecipe.local/run_test.bat
@@ -13,6 +13,6 @@ numba -s
 python -m numba.tests.test_runtests
 
 @rem Run the whole test suite
-python -m numba.runtests -m -b
+python -m numba.runtests -b -m
 
 if errorlevel 1 exit 1

--- a/buildscripts/condarecipe.local/run_test.sh
+++ b/buildscripts/condarecipe.local/run_test.sh
@@ -15,6 +15,13 @@ else
   echo Error
 fi
 
+# limit CPUs in use on PPC64LE, fork() issues
+# occur on high core count systems
+archstr=`uname -m`
+if [[ "$archstr" == 'ppc64le' ]]; then
+    TEST_NPROCS=16
+fi
+
 # Check Numba executables are there
 pycc -h
 numba -h
@@ -26,4 +33,4 @@ numba -s
 python -m numba.tests.test_runtests
 
 # Run the whole test suite
-$SEGVCATCH python -m numba.runtests -m -b
+$SEGVCATCH python -m numba.runtests -b -m $TEST_NPROCS

--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -23,8 +23,8 @@ python -m numba.tests.test_runtests
 if "%RUN_COVERAGE%" == "yes" (
     set PYTHONPATH=.
     coverage erase
-    coverage run runtests.py -b -m numba.tests
+    coverage run runtests.py -b -m -- numba.tests
 ) else (
     set NUMBA_ENABLE_CUDASIM=1
-    python -m numba.runtests -b -m numba.tests
+    python -m numba.runtests -b -m -- numba.tests
 )

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -30,6 +30,13 @@ else
   echo Error
 fi
 
+# limit CPUs in use on PPC64LE, fork() issues
+# occur on high core count systems
+archstr=`uname -m`
+if [[ "$archstr" == 'ppc64le' ]]; then
+    TEST_NPROCS=16
+fi
+
 # First check that the test discovery works
 python -m numba.tests.test_runtests
 # Now run the Numba test suite
@@ -38,7 +45,7 @@ python -m numba.tests.test_runtests
 if [ "$RUN_COVERAGE" == "yes" ]; then
     export PYTHONPATH=.
     coverage erase
-    $SEGVCATCH coverage run runtests.py -b -m numba.tests
+    $SEGVCATCH coverage run runtests.py -b -m $TEST_NPROCS -- numba.tests
 else
-    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -m numba.tests
+    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -m $TEST_NPROCS -- numba.tests
 fi


### PR DESCRIPTION
This adds the ability to specify the number of processes to use
when using the parallel test suite runner with view of being able
to limit the resources the test suite uses on more constrained
systems.

Fixes #2940

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
