### PR TITLE
Implement +/-(types.boolean) Fix #2624

### DIFF
--- a/numba/targets/numbers.py
+++ b/numba/targets/numbers.py
@@ -487,12 +487,30 @@ def int_sign_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
+def bool_negate_impl(context, builder, sig, args):
+    [typ] = sig.args
+    [val] = args
+    res = context.cast(builder, val, typ, sig.return_type)
+    res = builder.neg(res)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+def bool_unary_positive_impl(context, builder, sig, args):
+    [typ] = sig.args
+    [val] = args
+    res = context.cast(builder, val, typ, sig.return_type)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
 lower_builtin('==', types.boolean, types.boolean)(int_eq_impl)
 lower_builtin('!=', types.boolean, types.boolean)(int_ne_impl)
 lower_builtin('<', types.boolean, types.boolean)(int_ult_impl)
 lower_builtin('<=', types.boolean, types.boolean)(int_ule_impl)
 lower_builtin('>', types.boolean, types.boolean)(int_ugt_impl)
 lower_builtin('>=', types.boolean, types.boolean)(int_uge_impl)
+lower_builtin('-', types.boolean)(bool_negate_impl)
+lower_builtin('+', types.boolean)(bool_unary_positive_impl)
+
 
 @lower_builtin('==', types.Const, types.Const)
 def const_eq_impl(context, builder, sig, args):

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -1110,7 +1110,7 @@ class TestOperators(TestCase):
             cfunc = cres.entry_point
             self.assertEqual(pyfunc(val), cfunc(val))
 
-    # XXX test_negate should check for negative and positive zeros and infinites
+    # XXX test_negate should check for negative and positive zeros and infinities
 
     @tag('important')
     def test_negate_npm(self):
@@ -1123,6 +1123,8 @@ class TestOperators(TestCase):
             types.float32,
             types.float64,
             types.complex128,
+            types.boolean,
+            types.boolean,
         ]
         values = [
             1,
@@ -1131,11 +1133,14 @@ class TestOperators(TestCase):
             1.2,
             2.4,
             3.4j,
+            True,
+            False,
         ]
         for ty, val in zip(argtys, values):
             cres = compile_isolated(pyfunc, [ty])
             cfunc = cres.entry_point
             self.assertAlmostEqual(pyfunc(val), cfunc(val))
+
 
     def test_negate(self):
         pyfunc = self.op.negate_usecase
@@ -1145,6 +1150,8 @@ class TestOperators(TestCase):
             3,
             1.2,
             3.4j,
+            True,
+            False,
         ]
         cres = compile_isolated(pyfunc, (), flags=force_pyobj_flags)
         cfunc = cres.entry_point
@@ -1161,6 +1168,8 @@ class TestOperators(TestCase):
             types.float32,
             types.float64,
             types.complex128,
+            types.boolean,
+            types.boolean,
         ]
         values = [
             1,
@@ -1169,6 +1178,8 @@ class TestOperators(TestCase):
             1.2,
             2.4,
             3.4j,
+            True,
+            False
         ]
         for ty, val in zip(argtys, values):
             cres = compile_isolated(pyfunc, [ty])
@@ -1183,6 +1194,8 @@ class TestOperators(TestCase):
             3,
             1.2,
             3.4j,
+            True,
+            False,
         ]
         cres = compile_isolated(pyfunc, (), flags=force_pyobj_flags)
         cfunc = cres.entry_point

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -297,16 +297,17 @@ class BitwiseInvert(ConcreteTemplate):
     # while Python returns an int.  This makes it consistent with
     # np.invert() and makes array expressions correct.
     cases = [signature(types.boolean, types.boolean)]
-    cases += [signature(choose_result_int(op), op) for op in types.unsigned_domain]
-    cases += [signature(choose_result_int(op), op) for op in types.signed_domain]
+    cases += [signature(choose_result_int(op), op) for op in sorted(types.unsigned_domain)]
+    cases += [signature(choose_result_int(op), op) for op in sorted(types.signed_domain)]
 
     unsafe_casting = False
 
 class UnaryOp(ConcreteTemplate):
-    cases = [signature(choose_result_int(op), op) for op in types.unsigned_domain]
-    cases += [signature(choose_result_int(op), op) for op in types.signed_domain]
+    cases = [signature(choose_result_int(op), op) for op in sorted(types.unsigned_domain)]
+    cases += [signature(choose_result_int(op), op) for op in sorted(types.signed_domain)]
     cases += [signature(op, op) for op in sorted(types.real_domain)]
     cases += [signature(op, op) for op in sorted(types.complex_domain)]
+    cases += [signature(types.intp, types.boolean)]
 
 
 @infer


### PR DESCRIPTION
This fixes #2624 by adding support for +/- applied to a boolean
type. It also forces consistent ordering of type resolution
sequence in UnaryOp.

Fixes #2624

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
