### PR TITLE
Fix invalid ParallelAccelerator hoisting issue.

### DIFF
--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1125,7 +1125,7 @@ class TestParfors(TestParforsBase):
                 out[0] = 2 * out[0] 
             return out[0]
 
-        out = np.arange(1, dtype=np.double) + 1.0
+        out = np.ones(1)
         self.check(test_impl, out)
         
     @skip_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1118,6 +1118,17 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
 
     @skip_unsupported
+    def test_parfor_hoist_setitem(self):
+        # Make sure that read of out is not hoisted.
+        def test_impl(out):
+            for i in prange(10):
+                out[0] = 2 * out[0] 
+            return out[0]
+
+        out = np.arange(1, dtype=np.double) + 1.0
+        self.check(test_impl, out)
+        
+    @skip_unsupported
     @needs_blas
     def test_parfor_generate_fuse(self):
         # issue #2857


### PR DESCRIPTION
If a prange has a setitem of an array that also has a getitem of the same array in the same loop, in the previous code the getitem could be hoisted incorrectly.  This PR stops the getitem from being hoisted if there's a corresponding setitem in the same loop.