### PR TITLE
Set exit on error in incremental scripts

### DIFF
--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -6,3 +6,5 @@ python setup.py build_ext -q --inplace
 
 @rem Install numba locally for use in `numba -s` sys info tool at test time
 python -m pip install -e .
+
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/install_miniconda.sh
+++ b/buildscripts/incremental/install_miniconda.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -v -e
+
 # Install Miniconda
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -26,3 +26,5 @@ if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx pygments)
 if "%BUILD_DOC%" == "yes" (%PIP_INSTALL% sphinx_bootstrap_theme)
 @rem Install dependencies for code coverage (codecov.io)
 if "%RUN_COVERAGE%" == "yes" (%PIP_INSTALL% codecov)
+
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -v
+set -v -e
 
 CONDA_INSTALL="conda install -q -y"
 PIP_INSTALL="pip install -q"

--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -28,3 +28,5 @@ if "%RUN_COVERAGE%" == "yes" (
     set NUMBA_ENABLE_CUDASIM=1
     python -m numba.runtests -b -m -- numba.tests
 )
+
+if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
Conda is tolerant to failure and without `set -e`, bad combinations
of packages to conda install simply don't install and the build then
continues with missing packages. This make it an error.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
