### PR TITLE
Workaround for #3098

### DIFF
--- a/numba/tests/test_optional.py
+++ b/numba/tests/test_optional.py
@@ -73,6 +73,8 @@ def a_is_not_b(a, b):
 
 class TestOptional(TestCase):
 
+    _numba_parallel_test_ = False
+
     def test_return_double_or_none(self):
         pyfunc = return_double_or_none
         cres = compile_isolated(pyfunc, [types.boolean])


### PR DESCRIPTION
I've been messing about on this branch a bit trying to debug #3098 with not much luck. 

I think it is more important to have a representative source of truth for public CI than to have PRs stalled whilst this problem is debugged. As a result, this patch forces the `Optional` tests to run in serial (and by design, last in the test sequence), for whatever reason this makes the build pass. 

I'm of the view that this should be merged and everything else with failing CI rebuilt. We can trivially get back to a broken state to investigate #3098 by simply commenting the line added in this patch.