### PR TITLE
Skip cudasim only tests

### DIFF
--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -20,6 +20,10 @@ def skip_on_cudasim(reason):
     return unittest.skipIf(config.ENABLE_CUDASIM, reason)
 
 
+def skip_unless_cudasim(reason):
+    return unittest.skipUnless(config.ENABLE_CUDASIM, reason)
+
+
 @contextlib.contextmanager
 def redirect_fd(fd):
     """

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import cuda
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import SerialMixin, skip_unless_cudasim
 import numba.cuda.simulator as simulator
 
 
@@ -31,6 +31,7 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
         expected = np.arange(arr.size, dtype=np.int32)
         np.testing.assert_equal(expected, arr)
 
+    @skip_unless_cudasim('Only works on CUDASIM')
     def test_deadlock_on_exception(self):
         def assert_no_blockthreads():
             blockthreads = []


### PR DESCRIPTION
The affected test is failing and leading to segfault in other cuda tests.
This fixes the problem by skipping the test, which is intended for running in the simulator,  on real hw.