### PR TITLE
[WIP] Cfunc x86 abi

### DIFF
--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -6,15 +6,22 @@ from __future__ import print_function, division, absolute_import
 
 import ctypes
 
+from copy import deepcopy
+
 from llvmlite import ir
 
-from . import utils, compiler
+import numba.types as types
+
+from . import config, sigutils, utils, compiler
 from .caching import NullCache, FunctionCache
 from .dispatcher import _FunctionCompiler
 from .targets import registry
 from .typing import signature
 from .typing.ctypes_utils import to_ctypes
 
+
+MINIMAL_ABI_TUPLE_SIZE = 16  # bytes
+MAX_ABI_COERCION_SIZE = 8  # bytes
 
 class _CFuncCompiler(_FunctionCompiler):
 
@@ -34,6 +41,24 @@ class _CFuncCompiler(_FunctionCompiler):
 class CFunc(object):
     """
     A compiled C callback, as created by the @cfunc decorator.
+
+    Produced LLVM IR function signature adheres amd64 ABI and corresponds to
+    a LLVM IR which would be produced by clang compiler for given C signature
+
+    amd64 ABI:
+    1) return values larger than MINIMAL_ABI_TUPLE_SIZE
+    must be written into memory location supplied by the caller
+    in ret_ptr*
+    2) Structure arguments larger than MINIMAL_TYPE_SIZE must be passed by
+    pointer
+    3.1) Structure arguments smaller than MINIMAL_TYPE_SIZE and which can be
+    aligned by the largrest field without padding, must be passed flat
+    3.2) Structure arguments smaller than MINIMAL_TYPE_SIZE which cannot be aligned
+    without padding, must be passed by pointer
+    4) Small integers are coerced and merged into larger integers
+    5) Two floats are merged in a vector.
+    5) Struct fields are aligned to the largest field size
+    6) Boolean fields are always at least 1 byte inside a struct
     """
     _targetdescr = registry.cpu_target
 
@@ -56,6 +81,78 @@ class CFunc(object):
         self._wrapper_address = None
         self._cache = NullCache()
         self._cache_hits = 0
+
+        self.return_by_ptr = False
+
+        self._sig.args = tuple(map(_replace_boolean, self._sig.args))
+        self._sig.return_type = _replace_boolean(self._sig.return_type)
+
+        self.wrapper_sig = deepcopy(self._sig)
+        # compute wrapper signature
+        self._compute_wrapper_signature()
+
+    def _compute_wrapper_signature(self):
+        self._compute_arguments()
+        self._compute_return_type()
+        self._adjust_signature()
+
+    def _compute_arguments(self):
+        new_args = []
+        args = self._sig.args
+        for arg in args:
+            if isinstance(arg, types.Tuple):
+                if _get_llvm_type_size(arg) > MINIMAL_ABI_TUPLE_SIZE:
+                    # Replace big structs by pointers
+                    new_arg = types.CPointer(arg)
+                    new_args.append(new_arg)
+                else:
+                    # Unnest small structs
+                    args_ = _flatten(arg)
+                    new_args2 = _merge_tuple_args(args_)
+                    if len(new_args2) > 2:
+                        # should not unnest into more than 2 args
+                        new_arg = types.CPointer(arg)
+                        new_args.append(new_arg)
+                    else:
+                        new_args += new_args2
+            else:
+                new_args.append(arg)
+        self.wrapper_sig.args = new_args
+
+    def _compute_return_type(self):
+        retty = self.wrapper_sig.return_type
+        new_retty = retty
+        if isinstance(retty, types.Tuple):
+            if _get_llvm_type_size(retty) > MINIMAL_ABI_TUPLE_SIZE:
+                # Replace big struct by pointer
+                new_retty = types.CPointer(retty)
+                self.return_by_ptr = True
+            else:
+                # Unnest small structs
+                args_ = _flatten(retty)
+                new_args2 = _merge_tuple_args(args_)
+                # return one argument flat
+                if len(new_args2) == 1:
+                    new_retty = new_args2[0]
+                # if the coercion was successful, make a new tuple  with
+                # coerced fields and pass by value
+                elif list(args_) != list(new_args2) or len(args_) == 2:
+                    new_retty = make_tuple(new_args2)
+                else:
+                    # pass the original tuple by ptr
+                    new_retty = types.CPointer(retty)
+                    self.return_by_ptr = True
+
+        self.wrapper_sig.return_type = new_retty
+
+    def _adjust_signature(self):
+        if self.return_by_ptr:
+            # add retty as one of the arguments
+            # return void
+            retty = self.wrapper_sig.return_type
+            assert isinstance(retty, types.CPointer)
+            self.wrapper_sig.args.insert(0, retty)
+            self.wrapper_sig.return_type = types.CVoid()
 
     def enable_caching(self):
         self._cache = FunctionCache(self._pyfunc)
@@ -89,8 +186,9 @@ class CFunc(object):
         library = cres.library
         module = library.create_ir_module(fndesc.unique_name)
         context = cres.target_context
-        ll_argtypes = [context.get_value_type(ty) for ty in sig.args]
-        ll_return_type = context.get_value_type(sig.return_type)
+        wrap_sig = self.wrapper_sig
+        ll_argtypes = [context.get_argument_type(ty) for ty in wrap_sig.args]
+        ll_return_type = context.get_value_type(wrap_sig.return_type)
 
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)
         wrapfn = module.add_function(wrapty, fndesc.llvm_cfunc_wrapper_name)
@@ -106,13 +204,21 @@ class CFunc(object):
     def _build_c_wrapper(self, context, builder, cres, c_args):
         sig = self._sig
         pyapi = context.get_python_api(builder)
+        if self.return_by_ptr:
+            # omit the first argument which is the res ptr
+            retptr = c_args[0]
+            retptr.add_attribute("noalias")
+            retptr.add_attribute("sret")
+            c_args = c_args[1:]
+        else:
+            retptr = None
+        context.get_python_api(builder)
 
         fnty = context.call_conv.get_function_type(sig.return_type, sig.args)
-        fn = builder.module.add_function(fnty, cres.fndesc.llvm_func_name)
+        function_ir = builder.module.add_function(
+            fnty, cres.fndesc.llvm_func_name)
 
-        # XXX no obvious way to freeze an environment
-        status, out = context.call_conv.call_function(
-            builder, fn, sig.return_type, sig.args, c_args)
+        status, out = self._generate_func_call(context, builder, function_ir, c_args)
 
         with builder.if_then(status.is_error, likely=False):
             # If (and only if) an error occurred, acquire the GIL
@@ -125,7 +231,87 @@ class CFunc(object):
             pyapi.decref(strobj)
             pyapi.gil_release(gil_state)
 
-        builder.ret(out)
+        self._generate_return(builder, out, retptr, context)
+
+    def _generate_func_call(self, context, builder, function_ir, c_args):
+        sig = self._sig
+
+        def _replace_with_pointer(c_arg):
+            c_arg.add_attribute("byval")
+            return builder.load(c_arg)
+
+        new_cargs = []
+        c_arg_ind = 0
+        for arg_type in sig.args:
+            if isinstance(arg_type, types.Tuple):
+                if _get_llvm_type_size(arg_type) > MINIMAL_ABI_TUPLE_SIZE:
+                    c_arg = c_args[c_arg_ind]
+                    new_cargs.append(_replace_with_pointer(c_arg))
+                    c_arg_ind += 1
+                else:
+                    args_ = _flatten(arg_type)
+                    new_args2 = _merge_tuple_args(args_)
+                    # should not unnest into more than 2 args
+                    if len(new_args2) > 2:
+                        c_arg = c_args[c_arg_ind]
+                        new_cargs.append(_replace_with_pointer(c_arg))
+                        c_arg_ind += 1
+                    else:
+                        # tuple has been unnested
+                        # allocate a new tuple
+                        # copy the arguments
+                        allocated_tuple_ptr = builder.alloca(
+                            context.get_value_type(arg_type))
+
+                        shift_by = 0
+                        for i in range(len(new_args2)):
+                            c_arg = c_args[c_arg_ind]
+                            shifted_ptr = builder.gep(allocated_tuple_ptr,
+                                                      [ir.Constant(
+                                                          ir.IntType(32),
+                                                          shift_by)])
+                            cast_ptr = builder.bitcast(shifted_ptr,
+                                                       ir.PointerType(
+                                                           c_arg.type))
+                            builder.store(c_arg, cast_ptr)
+                            size_sum = 0
+                            target_field_size = _get_llvm_type_size(
+                                new_args2[i])
+                            for arg in args_[shift_by:]:
+                                size_sum += _get_llvm_type_size(arg)
+                                shift_by += 1
+                                if size_sum >= target_field_size:
+                                    break
+
+                        c_arg_ind += 1
+                        allocated_tuple = builder.load(allocated_tuple_ptr)
+                        new_cargs.append(allocated_tuple)
+            else:
+                c_arg = c_args[c_arg_ind]
+                new_cargs.append(c_arg)
+                c_arg_ind += 1
+
+        return context.call_conv.call_function(builder, function_ir,
+                                               sig.return_type, sig.args,
+                                               new_cargs)
+
+    def _generate_return(self, builder, out_val, retptr, context):
+        if retptr:
+            builder.store(out_val, retptr)
+            builder.ret_void()
+        else:
+            # cast out val to the function return type
+            numba_retty = context.get_value_type(self._sig.return_type)
+            c_retty = context.get_value_type(
+                self.wrapper_sig.return_type)
+            allocated_ret_ptr = builder.alloca(numba_retty)
+            builder.store(out_val, allocated_ret_ptr)
+            res_ptr = builder.bitcast(allocated_ret_ptr,
+                                      ir.PointerType(c_retty))
+            ret = builder.load(res_ptr)
+            builder.ret(ret)
+
+
 
     @property
     def native_name(self):
@@ -176,3 +362,134 @@ class CFunc(object):
 
     def __repr__(self):
         return "<Numba C callback %r>" % (self.__qualname__,)
+
+
+def _get_llvm_type_size(type_):
+    # compute size of a type inside a tuple
+    try:
+        return int(type_.bitwidth / 8)
+    except AttributeError:
+        pass
+    if isinstance(type_, types.Boolean):
+        return 1
+    if isinstance(type_, types.Tuple):
+        return _get_llvm_type_size(type_.types)
+    elif isinstance(type_, types.UniTuple):
+        return _get_llvm_type_size(type_.dtype) * type_.count
+    elif isinstance(type_, types.Record):
+        return type_.size
+    elif isinstance(type_, types.CPointer):
+        return 8
+    elif isinstance(type_, types.NoneType):
+        return 0
+    try:
+        return sum([_get_llvm_type_size(ty) for ty in type_])
+    except TypeError:
+        pass
+    assert False, "Cannot compute size of " + type_.name
+
+
+
+def _merge_tuple_args(args_):
+    new_args = []
+    to_merge = []
+    # Merge small scalar arguments
+    for arg_ in args_:
+        arg_size = _get_llvm_type_size(arg_)
+        if arg_size < MAX_ABI_COERCION_SIZE:
+            if _get_llvm_type_size(to_merge) + \
+                    arg_size <= MAX_ABI_COERCION_SIZE:
+                to_merge.append(arg_)
+            else:
+                _append_not_none(new_args, _coerce_types(to_merge, True))
+                to_merge = [arg_]
+        else:
+            _append_not_none(new_args, _coerce_types(to_merge, True))
+            to_merge = []
+            new_args.append(arg_)
+
+    align_64 = False
+    if any(map(lambda a: _get_llvm_type_size(a) >= MAX_ABI_COERCION_SIZE,
+               args_)):
+        align_64 = True
+    if to_merge:
+        _append_not_none(new_args, _coerce_types(to_merge, align_64))
+    return new_args
+
+
+def _coerce_types(to_merge, align=False):
+    size = _get_llvm_type_size(to_merge)
+    if size == 0:
+        return
+    if len(to_merge) == 1:
+        return to_merge[0]
+    if len(to_merge) == 2:
+        if all(map(lambda ty: isinstance(ty, types.Float), to_merge)):
+            # merge float32, float32 to <2 x float>
+            return types.Vector(types.float32, 2)
+    if align:
+        # align by the biggest primitive byte size
+        return types.int64
+
+    # int32 forces 32 bit alignment
+    if types.int32 in to_merge:
+        return types.int64
+    # int16 forces 16 bit alignment
+    if types.int16 in to_merge:
+        # here we know that all types are <= 16 bits
+        size = len(to_merge) * 2
+    type_str = "int" + str(size * 8)
+
+    return types.Integer(type_str)
+
+
+def _append_not_none(list_, el):
+    if el is not None:
+        list_.append(el)
+
+
+def _replace_boolean(typ):
+    # structs should be 8 bit aligned
+    # replace i1 with i8
+    def _rec(typ_):
+        assert isinstance(typ_, types.Type)
+        if isinstance(typ_, types.Tuple):
+            child_types = [_rec(t) for t in typ_.types]
+            return make_tuple(child_types)
+        if isinstance(typ_, types.Boolean):
+            return types.int8
+        return typ_
+
+    if not isinstance(typ, types.Tuple):
+        return typ
+    return _rec(typ)
+
+
+def _flatten(iterable_):
+    """
+    Flatten nested iterable of (tuple, list).
+    """
+
+    def rec(iterable__):
+        for i in iterable__:
+            if isinstance(i, (tuple, list)):
+                for j in rec(i):
+                    yield j
+            elif isinstance(i, (types.UniTuple, types.Tuple)):
+                for j in rec(i.types):
+                    yield j
+            else:
+                yield i
+
+    if not isinstance(iterable_,
+                      (tuple, list, types.UniTuple, types.Tuple)):
+        return iterable_,
+    return tuple(rec(iterable_))
+
+
+def make_tuple(child_types):
+    out = types.Tuple([])
+    out.types = tuple(child_types)
+    out.name = "(%s)" % ', '.join(str(i) for i in child_types)
+    out.count = len(child_types)
+    return out

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -377,6 +377,46 @@ class CVoidModel(PrimitiveModel):
         super(CVoidModel, self).__init__(dmm, fe_type, be_type)
 
 
+@register_default(types.Vector)
+class VectorModel(PrimitiveModel):
+
+    def __init__(self, dmm, fe_type):
+        dtype_model = dmm.lookup(fe_type.dtype)
+        count = fe_type.count
+        be_type = VectorType(count, dtype_model.get_value_type())
+        super(VectorModel, self).__init__(dmm, fe_type, be_type)
+
+
+#  XXX: this should be part of llvmlite
+class VectorType(ir.Type):
+
+    def __init__(self, count, typ):
+        assert isinstance(count, int) and count >= 0
+        assert isinstance(typ, ir.Type)
+        super(VectorType, self).__init__()
+        self.count = count
+        self.type = typ
+
+    def __copy__(self):
+        return self
+
+    def _to_string(self):
+        return '<%u' % self.count + ' x ' + str(self.type) + '>'
+
+    def __eq__(self, other):
+        if isinstance(other, VectorType):
+            return self.count == other.count and self.type == other.type
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(VectorType)
+
+    @property
+    def intrinsic_name(self):
+        return str(self)
+
+
 @register_default(types.EphemeralArray)
 class EphemeralArrayModel(PointerModel):
 

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -370,6 +370,13 @@ class EphemeralPointerModel(PointerModel):
         return builder.bitcast(ptr, self.get_value_type())
 
 
+@register_default(types.CVoid)
+class CVoidModel(PrimitiveModel):
+    def __init__(self, dmm, fe_type):
+        be_type = ir.VoidType()
+        super(CVoidModel, self).__init__(dmm, fe_type, be_type)
+
+
 @register_default(types.EphemeralArray)
 class EphemeralArrayModel(PointerModel):
 

--- a/numba/tests/test_cfunc.py
+++ b/numba/tests/test_cfunc.py
@@ -12,8 +12,11 @@ import sys
 import numpy as np
 
 from numba import unittest_support as unittest
+from numba.types import int8, float32, int32, int16, int64, Vector, float64, \
+    char, double, CVoid
 from numba import cfunc, carray, farray, types, typing, utils
 from numba import cffi_support
+from numba.ccallback import CFunc, make_tuple
 from .support import TestCase, tag, captured_stderr
 from .test_dispatcher import BaseCacheTest
 
@@ -364,6 +367,496 @@ class TestCArray(TestCase):
         Test Numba-compiled farray() against pure Python farray()
         """
         self.check_numba_carray_farray(farray_usecase, farray_dtype_usecase)
+
+# amd64 ABI tests
+
+class TestPass(unittest.TestCase):
+
+    def test_1_float(self):
+        retty = int8
+        args = [float32]
+        res = CFunc(lambda a: 42, (args, retty), {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_1_int(self):
+        retty = int8
+        args = [int32]
+        res = CFunc(lambda a: 42, (args, retty), {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_2_floats(self):
+        retty = int8
+        args = [float32, float32]
+        res = CFunc(lambda a, b: 42, (args, retty), {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_2_ints(self):
+        retty = int8
+        args = [int32, int32]
+        res = CFunc(lambda a, b: 42, (args, retty), {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_6_ints_char(self):
+        retty = int8
+        args = [int32, int32, int32, int32, int32, int32, int8]
+        res = CFunc(lambda a1, a2, a3, a4, a5, a6, a7: 42, (args, retty),
+                        {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_6_ints_ptr(self):
+        retty = int8
+        args = [int32, int32, int32, int32, int32, int32, types.CPointer(int8)]
+        res = CFunc(lambda a1, a2, a3, a4, a5, a6, a7: 42, (args, retty),
+                        {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_9_floats(self):
+        retty = int8
+        args = [float32, float32, float32, float32, float32, float32, float32,
+                float32, float32]
+        res = CFunc(lambda a1, a2, a3, a4, a5, a6, a7, a8, a9: 42,
+                        (args, retty),
+                        {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_char_short_int_long_ptr(self):
+        retty = int8
+        args = [int8, int16, int32, int64, types.CPointer(int8)]
+        res = CFunc(lambda a1, a2, a3, a4, a5: 42,
+                        (args, retty),
+                        {}, {})
+
+        expected_args = args
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_int_struct_int(self):
+        retty = int8
+        args = [int32, make_tuple([int32])]
+        res = CFunc(lambda a1, a2: 42, (args, retty), {}, {})
+
+        expected_args = [int32, int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_int_struct_short_int_int(self):
+        retty = int8
+        args = [int32, make_tuple([int16, int32, int32])]
+        res = CFunc(lambda a1, a2: 42, (args, retty), {}, {})
+
+        expected_args = [int32, int64, int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_1_float(self):
+        retty = int8
+        args = [make_tuple([float32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [float32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_1_int(self):
+        retty = int8
+        args = [make_tuple([int32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_2_floats(self):
+        retty = int8
+        args = [make_tuple([float32, float32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [Vector(float32, 2)]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_4_floats(self):
+        retty = int8
+        args = [make_tuple([float32, float32, float32, float32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [Vector(float32, 2), Vector(float32, 2)]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_2_ints(self):
+        retty = int8
+        args = [make_tuple([int32, int32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int64]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_3_ints(self):
+        retty = int8
+        args = [make_tuple([int32, int32, int32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int64, int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_double_int(self):
+        retty = int8
+        args = [make_tuple([float64, int32])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [float64, int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_long_ptr(self):
+        retty = int8
+        args = [make_tuple([int64, types.CPointer(int8)])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int64, types.CPointer(int8)]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_struct_2_int_2_int(self):
+        retty = int8
+        args = [make_tuple([make_tuple([int32, int32]), int8, int16])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int64, int32]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_array_8_char_3chars(self):
+        retty = int8
+        args = [make_tuple([types.UniTuple(int8, 8), int8, int8, int8])]
+        res = CFunc(lambda a1: 42, (args, retty), {}, {})
+
+        expected_args = [int64, types.Integer("int24")]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_float_struct_pointer_array_1_long(self):
+        retty = int8
+        args = [float32, make_tuple(
+            [types.CPointer(int8), types.UniTuple(int64, 1)])]
+        res = CFunc(lambda a1, a2: 42, (args, retty), {}, {})
+
+        expected_args = [float32, types.CPointer(int8), types.int64]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_float_struct_pointer_array_2_long(self):
+        retty = int8
+        args = [float32, make_tuple(
+            [types.CPointer(int8), types.UniTuple(int64, 2)])]
+        res = CFunc(lambda a1, a2: 42, (args, retty), {}, {})
+
+        expected_args = [float32, types.CPointer(args[1])]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+
+class TestPassReturn(unittest.TestCase):
+
+    def test_struct_long_ptr_r_ptr(self):
+        retty = types.CPointer(int8)
+        args = [make_tuple([int64, types.CPointer(int8)])]
+        res = CFunc(lambda a1: a1[1], (args, retty), {}, {})
+
+        expected_args = [int64, types.CPointer(int8)]
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+
+class TestReturn(unittest.TestCase):
+
+    def test_char(self):
+        retty = char
+        args = []
+        res = CFunc(lambda: 42, (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_double(self):
+        retty = double
+        args = []
+        res = CFunc(lambda: 42, (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_float(self):
+        retty = float32
+        args = []
+        res = CFunc(lambda: 42, (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_int(self):
+        retty = int32
+        args = []
+        res = CFunc(lambda: 42, (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_1_short(self):
+        retty = int16
+        args = []
+        res = CFunc(lambda: 42, (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_1_float(self):
+        retty = make_tuple([float32])
+        args = []
+        res = CFunc(lambda: (42,), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = float32
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_1_int(self):
+        retty = make_tuple([int32])
+        args = []
+        res = CFunc(lambda: (42,), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = int32
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_2_floats(self):
+        retty = make_tuple([float32, float32])
+        args = []
+        res = CFunc(lambda: (21, 21), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = Vector(float32, 2)
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_2_ints(self):
+        retty = make_tuple([int32, int32])
+        args = []
+        res = CFunc(lambda: (21, 21), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = int64
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_3_ints(self):
+        retty = make_tuple([int32, int32, int32])
+        args = []
+        res = CFunc(lambda: (14, 14, 14), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = make_tuple([int64, int32])
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_4_ints(self):
+        retty = make_tuple([int32, int32, int32, int32])
+        args = []
+        res = CFunc(lambda: (14, 14, 14, 14), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = make_tuple([int64, int64])
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_5_ints(self):
+        retty = make_tuple([int32, int32, int32, int32, int32])
+        args = []
+        res = CFunc(lambda: (14, 14, 14, 14, 14), (args, retty), {}, {})
+
+        expected_args = [types.CPointer(retty)]
+        expected_return = CVoid()
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+    def test_struct_long_int(self):
+        retty = make_tuple([int64, int32])
+        args = []
+        res = CFunc(lambda: (21, 21), (args, retty), {}, {})
+
+        expected_args = []
+        expected_return = retty
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+
+
+class TestBoolean(unittest.TestCase):
+
+    def test_single(self):
+        tuple_type = make_tuple(
+            [types.boolean])
+        sig = ([tuple_type], tuple_type)
+        res = CFunc(lambda t1: t1, sig, {}, {})
+
+        expected_args = [types.int8, ]
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+
+    def test_tuple(self):
+        sig = ([make_tuple(
+            [types.boolean, types.boolean, types.boolean, types.boolean])],
+               types.int32)
+        res = CFunc(lambda t1: 42, sig, {}, {})
+
+        expected_args = [types.int32]
+        res.compile()
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+
+    def test_big_struct_arg(self):
+        retty = types.int32
+        tuple_type = make_tuple(
+            [types.boolean, types.int64, types.boolean])
+        sig = ([tuple_type], retty)
+        res = CFunc(lambda t: 2, sig, {}, {})
+
+        expected_return = retty
+        expected_args = [types.CPointer(make_tuple(
+            [types.int8, types.int64, types.int8]))]
+        res.compile()
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+
+    def test_big_struct_return(self):
+        tuple_type = make_tuple(
+            [types.boolean, types.int64, types.boolean])
+        sig = ([], tuple_type)
+        res = CFunc(lambda: (False, 3, True), sig, {}, {})
+
+        expected_return = CVoid()
+        expected_args = [types.CPointer(make_tuple(
+            [types.int8, types.int64, types.int8])), ]
+        res.compile()
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+        self.assertEqual(expected_args, res.wrapper_sig.args)
+
+    def test_bool1(self):
+        retty = types.int32
+        sig = ([types.boolean], retty)
+
+        res = CFunc(lambda x: 42, sig, {}, {})
+
+        expected_return = retty
+        expected_arg = [types.boolean]
+        res.compile()
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+        self.assertEqual(expected_arg, res.wrapper_sig.args)
+
+    def test_bool2(self):
+        retty = types.int32
+        sig = ([types.boolean, types.boolean], retty)
+
+        res = CFunc(lambda b1, b2: 42, sig, {}, {})
+
+        expected_return = retty
+        expected_arg = [types.boolean, types.boolean]
+        res.compile()
+        self.assertEqual(expected_return, res.wrapper_sig.return_type)
+        self.assertEqual(expected_arg, res.wrapper_sig.args)
+
 
 
 if __name__ == "__main__":

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -218,6 +218,14 @@ class Dummy(Type):
     """
 
 
+class CVoid(Type):
+    """
+     This type should be mapped to void in LLVM IR
+    """
+    def __init__(self):
+        super(CVoid, self).__init__("cvoid")
+
+
 class Hashable(Type):
     """
     Base class for hashable types.

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -271,6 +271,35 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
                 return Tuple(unified)
 
 
+class Vector(BaseAnonymousTuple, _HomogenousTuple, Sequence):
+    """
+    This type should be mapped to a vector in LLVM IR
+    """
+
+    def __init__(self, dtype, count):
+        self.dtype = dtype
+        self.count = count
+        name = "<%d x %s>" % (count, dtype)
+        super(Vector, self).__init__(name)
+
+    @property
+    def mangling_args(self):
+        return self.__class__.__name__, (self.dtype, self.count)
+
+    @property
+    def key(self):
+        return self.dtype, self.count
+
+    def unify(self, typingctx, other):
+        """
+        Unify Vector with their dtype
+        """
+        if isinstance(other, Vector) and len(self) == len(other):
+            dtype = typingctx.unify_pairs(self.dtype, other.dtype)
+            if dtype is not None:
+                return Vector(dtype=dtype, count=self.count)
+
+
 class BaseNamedTuple(BaseTuple):
     pass
 

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -271,7 +271,7 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
                 return Tuple(unified)
 
 
-class Vector(BaseAnonymousTuple, _HomogenousTuple, Sequence):
+class Vector(BaseAnonymousTuple, _HomogeneousTuple, Sequence):
     """
     This type should be mapped to a vector in LLVM IR
     """


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This PR makes CFunc produce LLVM IR function wrapper compliant with amd64 ABI specification and 
have the same function signature as expected by a clang compiler for a given C type. Most importantly it covers the struct handling. Most of the test cases were taken from https://github.com/scrossuk/llvm-abi.
Additionally, two new types are added, CVoid and Vector. CVoid is needed for the correct void return type. Vector type is expected by clang when two floats occur inside a struct. The VectorType class should eventually be added to llvmlite, but for the sake of making it pass the CI is included directly here.


