### PR TITLE
Fix #3135

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -63,7 +63,12 @@ class Loc(object):
                     spaces += 1
                 return spaces
 
-            selected = lines[self.line - nlines_up:self.line]
+            # A few places in the code still use no `loc` or default to line 1
+            # this is often in places where exceptions are used for the purposes
+            # of flow control. As a result max is in use to prevent slice from
+            # `[negative: positive]`
+            selected = lines[max(0, self.line - nlines_up):self.line]
+
             # see if selected contains a definition
             def_found = False
             for x in selected:
@@ -83,12 +88,13 @@ class Loc(object):
                     spaces = count_spaces(x)
                     ret.append(' '*(4 + spaces) + '<source elided>\n')
 
-            ret.extend(selected[:-1])
-            ret.append(_termcolor.highlight(selected[-1]))
+            if selected:
+                ret.extend(selected[:-1])
+                ret.append(_termcolor.highlight(selected[-1]))
 
-            # point at the problem with a caret
-            spaces = count_spaces(selected[-1])
-            ret.append(' '*(spaces) + _termcolor.indicate("^"))
+                # point at the problem with a caret
+                spaces = count_spaces(selected[-1])
+                ret.append(' '*(spaces) + _termcolor.indicate("^"))
 
         # if in the REPL source may not be available
         if not ret:

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -83,5 +83,21 @@ class TestUnsupportedReporting(unittest.TestCase):
         expected = "Use of unsupported NumPy function 'numpy.asarray'"
         self.assertIn(expected, str(raises.exception))
 
+
+class TestMiscErrorHandling(unittest.TestCase):
+
+    def test_use_of_exception_for_flow_control(self):
+        # constant inference uses exceptions with no Loc specified to determine
+        # flow control, this asserts that the construction of the lowering
+        # error context handler works in the case of an exception with no Loc
+        # specified. See issue #3135.
+        @njit
+        def fn(x):
+            return 10**x
+
+        a = np.array([1.0],dtype=np.float64)
+        fn(a) # should not raise
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #3135 by adding guards to make sure that only line
numbers in Z^+ are accessed and if no lines are found then they
are not addressed. Test case from bug report is added.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
