### PR TITLE
Remove dead array equal @infer code

### DIFF
--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -695,14 +695,3 @@ for fName in ["var", "std"]:
 # Functions that return an index (intp)
 install_array_method("argmin", generic_index)
 install_array_method("argmax", generic_index)
-
-
-@infer
-class CmpOpEqArray(AbstractTemplate):
-    key = '=='
-
-    def generic(self, args, kws):
-        assert not kws
-        [va, vb] = args
-        if isinstance(va, types.Array) and va == vb:
-            return signature(va.copy(dtype=types.boolean), va, vb)


### PR DESCRIPTION
Looks like the `@infer` code for array `==` is dead, and Codecov agrees ([link](https://codecov.io/gh/numba/numba/src/master/numba/typing/arraydecl.py)). There is  an `@infer_global` definition in npydecl.py that takes precedence.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
