### PR TITLE
Keep a queue of references to last N deserialized functions.  Fixes #3026

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -246,7 +246,7 @@ Compilation options
     implementation of this is not a true LRU, but the large size of the cache
     should be sufficient for most situations.
 
-    *Default value:* 100
+    *Default value:* 128
 
 
 GPU support

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -237,14 +237,15 @@ Compilation options
 
 .. envvar:: NUMBA_FUNCTION_CACHE_SIZE
 
-    Override size of function cache for retaining recently deserialized
-    functions in memory.  In systems like Dask, it is common for functions to
-    be deserialized multiple times.  Numba will cache functions as long as
-    there is a reference somewhere in the interpreter.  This cache size
-    variable controls how many functions that are no longer referenced will
-    also be retained, just in case they show up in the future.  The
-    implementation of this is not a true LRU, but the large size of the cache
-    should be sufficient for most situations.
+    Override the size of the function cache for retaining recently
+    deserialized functions in memory.  In systems like
+    `Dask <http://dask.pydata.org>`_, it is common for functions to be deserialized
+    multiple times.  Numba will cache functions as long as there is a
+    reference somewhere in the interpreter.  This cache size variable controls
+    how many functions that are no longer referenced will also be retained,
+    just in case they show up in the future.  The implementation of this is
+    not a true LRU, but the large size of the cache should be sufficient for
+    most situations.
 
     *Default value:* 128
 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -246,7 +246,7 @@ Compilation options
     implementation of this is not a true LRU, but the large size of the cache
     should be sufficient for most situations.
 
-    *Default value:* 1000
+    *Default value:* 100
 
 
 GPU support

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -235,6 +235,19 @@ Compilation options
         portable code (portable within the same architecture and OS),
         simply set ``NUMBA_CPU_NAME=generic``.
 
+.. envvar:: NUMBA_FUNCTION_CACHE_SIZE
+
+    Override size of function cache for retaining recently deserialized
+    functions in memory.  In systems like Dask, it is common for functions to
+    be deserialized multiple times.  Numba will cache functions as long as
+    there is a reference somewhere in the interpreter.  This cache size
+    variable controls how many functions that are no longer referenced will
+    also be retained, just in case they show up in the future.  The
+    implementation of this is not a true LRU, but the large size of the cache
+    should be sufficient for most situations.
+
+    *Default value:* 1000
+
 
 GPU support
 -----------

--- a/numba/config.py
+++ b/numba/config.py
@@ -154,7 +154,7 @@ class _EnvReloader(object):
 
         # How many recently deserialized functions to retain regardless
         # of external references
-        FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 100)
+        FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 128)
 
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)

--- a/numba/config.py
+++ b/numba/config.py
@@ -152,6 +152,10 @@ class _EnvReloader(object):
         # Enable debugging of front-end operation (up to and including IR generation)
         DEBUG_FRONTEND = _readenv("NUMBA_DEBUG_FRONTEND", int, 0)
 
+        # How many recently deserialized functions to retain regardless
+        # of external references
+        FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 1000)
+
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -154,7 +154,7 @@ class _EnvReloader(object):
 
         # How many recently deserialized functions to retain regardless
         # of external references
-        FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 1000)
+        FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 100)
 
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -514,6 +514,9 @@ class Dispatcher(_DispatcherBase):
         }
     # A {uuid -> instance} mapping, for deserialization
     _memo = weakref.WeakValueDictionary()
+    # hold refs to last N functions deserialized, retaining them in _memo
+    # regardless of whether there is another reference
+    _recent = collections.deque(maxlen=config.FUNCTION_CACHE_SIZE)
     __uuid = None
     __numba__ = 'py_func'
 
@@ -624,6 +627,7 @@ class Dispatcher(_DispatcherBase):
         assert self.__uuid is None
         self.__uuid = u
         self._memo[u] = self
+        self._recent.append(self)
 
     def compile(self, sig):
         if not self._can_compile:

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -676,7 +676,13 @@ class TestIntrinsic(TestCase):
         memo_size += 1
         self.assertEqual(memo_size, len(memo))
         del original  # remove original before unpickling
-        # by deleting, the memo entry is removed
+
+        # by deleting, the memo entry is NOT removed due to recent
+        # function queue
+        self.assertEqual(memo_size, len(memo))
+
+        # Manually force clear of _recent queue
+        _Intrinsic._recent.clear()
         memo_size -= 1
         self.assertEqual(memo_size, len(memo))
 


### PR DESCRIPTION
Simplest solution to #3026 is to keep a deque of last N Dispatcher (and Intrinsic) UUIDs that have been created so that those functions stay in the cache, regardless of whether there are references anywhere else in the interpreter.  The size of this queue is controlled with an environment variable.

Questions:
* Is this queue approach too simple?  There no LRU dict object in the standard library, and `functools.lru_cache` is written in such a way that makes it hard to use as a dictionary.
* The are tests of the memoization behavior for `_Intrinsic`, but not for `Dispatcher`.  Votes on where that test should be added?
* Is 1000 a reasonable number for the default?  Given how small functions generally are in memory, this seems fine to me.