### PR TITLE
Use cuda driver api to get best blocksize for best occupancy

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -683,7 +683,7 @@ class CUDAKernel(CUDAKernelBase):
     @property
     def autotune(self):
         """Return the autotuner object associated with this kernel."""
-        warnings.warn(_deprec_warn_msg, DeprecationWarning)
+        warnings.warn(_deprec_warn_msg.format('autotune'), DeprecationWarning)
         has_autotune = hasattr(self, '_autotune')
         if has_autotune and self._autotune.dynsmem == self.sharedmem:
             return self._autotune
@@ -700,11 +700,12 @@ class CUDAKernel(CUDAKernelBase):
         number of warps that can be active on the multiprocessor at once.
         Calculate the theoretical occupancy of the kernel given the
         current configuration."""
+        warnings.warn(_deprec_warn_msg.format('occupancy'), DeprecationWarning)
         thread_per_block = reduce(operator.mul, self.blockdim, 1)
         return self.autotune.closest(thread_per_block)
 
 
-_deprec_warn_msg = ("The *autotune* feature is is deprecated and will be "
+_deprec_warn_msg = ("The .{} attribute is is deprecated and will be "
                     "removed in a future release")
 
 

--- a/numba/cuda/tests/cudapy/test_deprecation.py
+++ b/numba/cuda/tests/cudapy/test_deprecation.py
@@ -1,0 +1,44 @@
+from __future__ import print_function, absolute_import
+
+import warnings
+from contextlib import contextmanager
+
+from numba.tests.support import override_config, TestCase
+from numba.cuda.testing import skip_on_cudasim
+from numba import unittest_support as unittest
+from numba import cuda, types
+from numba.cuda.testing import SerialMixin
+
+
+@skip_on_cudasim("Skipped on simulator")
+class TestCudaDebugInfo(SerialMixin, TestCase):
+    """Tests features that will be deprecated
+    """
+    @contextmanager
+    def assert_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            yield w
+
+    def test_autotune(self):
+        @cuda.jit("(int32[:],)")
+        def foo(xs):
+            xs[0] = 1
+
+        with self.assert_deprecation_warning() as w:
+            foo.autotune
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
+            assert ".autotune" in str(w[-1].message)
+
+        with self.assert_deprecation_warning() as w:
+            foo.occupancy
+            assert len(w) == 2
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert ".occupancy" in str(w[0].message)
+            assert issubclass(w[1].category, DeprecationWarning)
+            assert ".autotune" in str(w[1].message)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes https://github.com/numba/numba/issues/2808

- [x] Use cuda driver api to get best blocksize for best occupancy.
- [x] Deprecate the autotune API.