### PR TITLE
Add FMA intrinsic support

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -265,7 +265,7 @@ meaning the thread is in the subset of threads within the function call. The
 Integer Intrinsics
 ~~~~~~~~~~~~~~~~~~
 
-A subset of the CUDA Math API's integer intrisics are available. For further
+A subset of the CUDA Math API's integer intrinsics are available. For further
 documentation, including semantics, please refer to the `CUDA Toolkit
 documentation
 <docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__INT.html>`_.
@@ -287,6 +287,24 @@ documentation
 .. function:: numba.cuda.ffs
 
    Find the position of the least significant bit set to 1 in an integer.
+
+
+Floating Point Intrinsics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A subset of the CUDA Math API's floating point intrinsics are available. For further
+documentation, including semantics, please refer to the `single
+<https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html>`_ and
+`double <https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html>`_
+precision parts of the CUDA Toolkit documentation.
+
+
+.. function:: numba.cuda.fma
+
+   Perform the fused multiply-add operation. Named after the ``fma`` and ``fmaf`` in
+   the C api, but maps to the ``fma.rn.f32`` and ``fma.rn.f64`` (round-to-nearest-even)
+   PTX instructions.
+
 
 Control Flow Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -196,6 +196,18 @@ class Cuda_popc(ConcreteTemplate):
         signature(types.uint64, types.uint64),
     ]
 
+@intrinsic
+class Cuda_fma(ConcreteTemplate):
+    """
+    Supported types from `llvm.fma`
+    [here](https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#standard-c-library-intrinics)
+    """
+    key = cuda.fma
+    cases = [
+        signature(types.float32, types.float32, types.float32, types.float32),
+        signature(types.float64, types.float64, types.float64, types.float64),
+    ]
+
 
 @intrinsic
 class Cuda_brev(ConcreteTemplate):
@@ -461,6 +473,9 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_ffs(self, mod):
         return types.Function(Cuda_ffs)
+
+    def resolve_fma(self, mod):
+        return types.Function(Cuda_fma)
 
     def resolve_syncthreads(self, mod):
         return types.Function(Cuda_syncthreads)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -377,6 +377,11 @@ def ptx_popc(context, builder, sig, args):
     return builder.ctpop(args[0])
 
 
+@lower(stubs.fma, types.Any, types.Any, types.Any)
+def ptx_fma(context, builder, sig, args):
+    return builder.fma(*args)
+
+
 @lower(stubs.brev, types.u4)
 def ptx_brev_u4(context, builder, sig, args):
     # FIXME the llvm.bitreverse.i32 intrinsic isn't supported by nvcc

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -7,7 +7,7 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     const, grid, gridsize, atomic, shfl_sync_intrinsic,
                     vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
-                    threadfence, selp, popc, brev, clz, ffs)
+                    threadfence, selp, popc, brev, clz, ffs, fma)
 from .cudadrv.error import CudaSupportError
 from .cudadrv import nvvm
 from . import initialize

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -216,6 +216,9 @@ class FakeCUDAModule(object):
     def popc(self, val):
         return bin(val).count("1")
 
+    def fma(self, a, b, c):
+        return a * b + c
+
     def brev(self, val):
         return int('{:032b}'.format(val)[::-1], 2)
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -174,7 +174,7 @@ class syncthreads_count(Stub):
     '''
     syncthreads_count(predictate)
 
-    An extension to numba.cuda.syncthreads where the return value is a count 
+    An extension to numba.cuda.syncthreads where the return value is a count
     of the threads where predicate is true.
     '''
     _description_ = '<syncthreads_count()>'
@@ -417,6 +417,16 @@ class selp(Stub):
     selp(a, b, c)
 
     Select between source operands, based on the value of the predicate source operand.
+    """
+
+#-------------------------------------------------------------------------------
+# single / double precision arithmetic
+
+class fma(Stub):
+    """
+    fma(a, b, c)
+
+    Perform the fused multiply-add operation.
     """
 
 #-------------------------------------------------------------------------------

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -64,6 +64,10 @@ def simple_popc(ary, c):
     ary[0] = cuda.popc(c)
 
 
+def simple_fma(ary, a, b, c):
+    ary[0] = cuda.fma(a, b, c)
+
+
 def simple_brev(ary, c):
     ary[0] = cuda.brev(c)
 
@@ -263,6 +267,18 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
         ary = np.zeros(1, dtype=np.int32)
         compiled(ary, 0xF00000000000)
         self.assertEquals(ary[0], 4)
+
+    def test_fma_f4(self):
+        compiled = cuda.jit("void(f4[:], f4, f4, f4)")(simple_fma)
+        ary = np.zeros(1, dtype=np.float32)
+        compiled(ary, 2., 3., 4.)
+        np.testing.assert_allclose(ary[0], 2 * 3 + 4)
+
+    def test_fma_f8(self):
+        compiled = cuda.jit("void(f8[:], f8, f8, f8)")(simple_fma)
+        ary = np.zeros(1, dtype=np.float64)
+        compiled(ary, 2., 3., 4.)
+        np.testing.assert_allclose(ary[0], 2 * 3 + 4)
 
     def test_brev_u4(self):
         compiled = cuda.jit("void(uint32[:], uint32)")(simple_brev)


### PR DESCRIPTION
[This function](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html#group__CUDA__MATH__DOUBLE_1gff2117f6f3c4ff8a2aa4ce48a0ff2070) in the C API. nb: this PR is dependent on https://github.com/numba/llvmlite/pull/380 .