### PR TITLE
In build script activate env before installing.

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -28,14 +28,16 @@ conda remove --all -q -y -n $CONDA_ENV
 
 conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON numpy=$NUMPY pip
 
+# Activate first
+set +v
+source activate $CONDA_ENV
+set -v
+
+# Install optional packages into activated env
 if [ "${VANILLA_INSTALL}" != "yes" ]; then
     # Scipy, CFFI, jinja2, IPython and pygments are optional dependencies, but exercised in the test suite
     $CONDA_INSTALL ${EXTRA_CHANNELS} cffi scipy jinja2 ipython pygments
 fi
-
-set +v
-source activate $CONDA_ENV
-set -v
 
 # Install the compiler toolchain
 if [[ $(uname) == Linux ]]; then


### PR DESCRIPTION
In making the changes for VANILLA_INSTALL this logic bug crept in:
Essentially, the optional packages are erroneously being installed
in the root env and not in the newly created env as it wasn't
activated at install time. This fixes it!

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
