### PR TITLE
Use float64 add Atomics, Where Available

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -688,7 +688,8 @@ class AutoJitCUDAKernel(CUDAKernelBase):
     '''
     CUDA Kernel object. When called, the kernel object will specialize itself
     for the given arguments (if no suitable specialized version already exists)
-    and launch on the device associated with the current context.
+    & compute capability, and launch on the device associated with the current
+    context.
 
     Kernel objects are not to be constructed by the user, but instead are
     created using the :func:`numba.cuda.jit` decorator.
@@ -697,7 +698,10 @@ class AutoJitCUDAKernel(CUDAKernelBase):
         super(AutoJitCUDAKernel, self).__init__()
         self.py_func = func
         self.bind = bind
+
+        # keyed by a `(compute capability, args)` tuple
         self.definitions = {}
+
         self.targetoptions = targetoptions
 
         # defensive copy
@@ -754,35 +758,39 @@ class AutoJitCUDAKernel(CUDAKernelBase):
         '''
         argtypes, return_type = sigutils.normalize_signature(sig)
         assert return_type is None
-        kernel = self.definitions.get(argtypes)
+        cc = get_current_device().compute_capability
+        kernel = self.definitions.get((cc, argtypes))
         if kernel is None:
             if 'link' not in self.targetoptions:
                 self.targetoptions['link'] = ()
             kernel = compile_kernel(self.py_func, argtypes,
                                     **self.targetoptions)
-            self.definitions[argtypes] = kernel
+            self.definitions[(cc, argtypes)] = kernel
             if self.bind:
                 kernel.bind()
         return kernel
 
-    def inspect_llvm(self, signature=None):
+    def inspect_llvm(self, compute_capability=None, signature=None):
         '''
         Return the LLVM IR for all signatures encountered thus far, or the LLVM
-        IR for a specific signature if given.
+        IR for a specific signature and compute_capability if given.
         '''
+        cc = compute_capability or get_current_device().compute_capability
         if signature is not None:
-            return self.definitions[signature].inspect_llvm()
+            return self.definitions[(cc, signature)].inspect_llvm()
         else:
             return dict((sig, defn.inspect_llvm())
                         for sig, defn in self.definitions.items())
 
-    def inspect_asm(self, signature=None):
+    def inspect_asm(self, compute_capability=None, signature=None):
         '''
         Return the generated assembly code for all signatures encountered thus
-        far, or the LLVM IR for a specific signature if given.
+        far, or the LLVM IR for a specific signature and compute_capability
+        if given.
         '''
+        cc = compute_capability or get_current_device().compute_capability
         if signature is not None:
-            return self.definitions[signature].inspect_asm()
+            return self.definitions[(cc, signature)].inspect_asm()
         else:
             return dict((sig, defn.inspect_asm())
                         for sig, defn in self.definitions.items())
@@ -796,7 +804,7 @@ class AutoJitCUDAKernel(CUDAKernelBase):
         if file is None:
             file = sys.stdout
 
-        for ver, defn in utils.iteritems(self.definitions):
+        for _, defn in utils.iteritems(self.definitions):
             defn.inspect_types(file=file)
 
     @classmethod
@@ -812,7 +820,7 @@ class AutoJitCUDAKernel(CUDAKernelBase):
     def __reduce__(self):
         """
         Reduce the instance for serialization.
-        Compiled definitions are serialized in PTX form.
+        Compiled definitions are discarded.
         """
         glbls = serialize._get_function_globals_for_reduction(self.py_func)
         func_reduced = serialize._reduce_function(self.py_func, glbls)

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -770,7 +770,7 @@ class AutoJitCUDAKernel(CUDAKernelBase):
                 kernel.bind()
         return kernel
 
-    def inspect_llvm(self, compute_capability=None, signature=None):
+    def inspect_llvm(self, signature=None, compute_capability=None):
         '''
         Return the LLVM IR for all signatures encountered thus far, or the LLVM
         IR for a specific signature and compute_capability if given.
@@ -782,7 +782,7 @@ class AutoJitCUDAKernel(CUDAKernelBase):
             return dict((sig, defn.inspect_llvm())
                         for sig, defn in self.definitions.items())
 
-    def inspect_asm(self, compute_capability=None, signature=None):
+    def inspect_asm(self, signature=None, compute_capability=None):
         '''
         Return the generated assembly code for all signatures encountered thus
         far, or the LLVM IR for a specific signature and compute_capability

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division
 import itertools
 import llvmlite.llvmpy.core as lc
 from .cudadrv import nvvm
+from .api import current_context
 from numba import cgutils
 
 
@@ -20,7 +21,10 @@ def declare_atomic_add_float32(lmod):
 
 
 def declare_atomic_add_float64(lmod):
-    fname = '___numba_atomic_double_add'
+    if current_context().device.compute_capability >= (6, 0):
+        fname = 'llvm.nvvm.atomic.load.add.f64.p0f64'
+    else:
+        fname = '___numba_atomic_double_add'
     fnty = lc.Type.function(lc.Type.double(),
         (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
     return lmod.get_or_insert_function(fnty, fname)

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -250,9 +250,9 @@ class TestCudaAtomics(SerialMixin, unittest.TestCase):
                 self.assertIn('atom.add.f64', asm)
         else:
             if shared:
-                self.assertIn('atom.shared.cas.f64', asm)
+                self.assertIn('atom.shared.cas.b64', asm)
             else:
-                self.assertIn('atom.cas.f64', asm)
+                self.assertIn('atom.cas.b64', asm)
 
     @skip_unless_cc_50
     def test_atomic_add_double(self):

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -7,6 +7,10 @@ from numba.utils import StringIO
 
 @skip_on_cudasim('Simulator does not generate code to be inspected')
 class TestInspect(SerialMixin, unittest.TestCase):
+    @property
+    def cc(self):
+        return cuda.current_context().device.compute_capability
+
     def test_monotyped(self):
         @cuda.jit("(float32, int32)")
         def foo(x, y):
@@ -49,23 +53,23 @@ class TestInspect(SerialMixin, unittest.TestCase):
         # Signature in LLVM dict
         llvmirs = foo.inspect_llvm()
         self.assertEqual(2, len(llvmirs), )
-        self.assertIn((intp, intp), llvmirs)
-        self.assertIn((float64, float64), llvmirs)
+        self.assertIn((self.cc, (intp, intp)), llvmirs)
+        self.assertIn((self.cc, (float64, float64)), llvmirs)
 
         # Function name in LLVM
-        self.assertIn("foo", llvmirs[intp, intp])
-        self.assertIn("foo", llvmirs[float64, float64])
+        self.assertIn("foo", llvmirs[self.cc, (intp, intp)])
+        self.assertIn("foo", llvmirs[self.cc, (float64, float64)])
 
         asmdict = foo.inspect_asm()
 
         # Signature in LLVM dict
         self.assertEqual(2, len(asmdict), )
-        self.assertIn((intp, intp), asmdict)
-        self.assertIn((float64, float64), asmdict)
+        self.assertIn((self.cc, (intp, intp)), asmdict)
+        self.assertIn((self.cc, (float64, float64)), asmdict)
 
         # NNVM inserted in PTX
-        self.assertIn("foo", asmdict[intp, intp])
-        self.assertIn("foo", asmdict[float64, float64])
+        self.assertIn("foo", asmdict[self.cc, (intp, intp)])
+        self.assertIn("foo", asmdict[self.cc, (float64, float64)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Compute Capability cards >= 6.0 support atomic double addition. Use this (instead of numba's CAS-spinning) if available).

@seibert you were right about numba caching LLVM IR globally in an `AutoJitCUDAKernel` - this needs to be per-compute capability as numba poly-fills functionality where not available.   