### PR TITLE
Move ROC vectorize init to npyufunc

### DIFF
--- a/numba/npyufunc/__init__.py
+++ b/numba/npyufunc/__init__.py
@@ -11,16 +11,27 @@ del _internal, array_exprs
 
 def _init():
 
-    def init_vectorize():
+    def init_cuda_vectorize():
         from numba.cuda.vectorizers import CUDAVectorize
         return CUDAVectorize
 
-    def init_guvectorize():
+    def init_cuda_guvectorize():
         from numba.cuda.vectorizers import CUDAGUFuncVectorize
         return CUDAGUFuncVectorize
 
-    Vectorize.target_registry.ondemand['cuda'] = init_vectorize
-    GUVectorize.target_registry.ondemand['cuda'] = init_guvectorize
+    Vectorize.target_registry.ondemand['cuda'] = init_cuda_vectorize
+    GUVectorize.target_registry.ondemand['cuda'] = init_cuda_guvectorize
+
+    def init_roc_vectorize():
+        from numba.roc.vectorizers import HsaVectorize
+        return HsaVectorize
+
+    def init_roc_guvectorize():
+        from numba.roc.vectorizers import HsaGUFuncVectorize
+        return HsaGUFuncVectorize
+
+    Vectorize.target_registry.ondemand['roc'] = init_roc_vectorize
+    GUVectorize.target_registry.ondemand['roc'] = init_roc_guvectorize
 
 _init()
 del _init

--- a/numba/roc/__init__.py
+++ b/numba/roc/__init__.py
@@ -6,7 +6,6 @@ import os
 import numba.testing
 from .api import *
 from .stubs import atomic
-from . import initialize
 
 
 def is_available():


### PR DESCRIPTION
This moves the registration and initialisation of ROC ufunc mech
to the npyufunc init so that e.g.

`@vectorize(target='roc')`

works without having to `import numba.roc` before hand to ensure
the ROC ufunc machinery is registered.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
