### PR TITLE
Add auto_synchronize support to ROC stream

### DIFF
--- a/numba/roc/hsadrv/driver.py
+++ b/numba/roc/hsadrv/driver.py
@@ -1378,6 +1378,15 @@ class Stream(object):
             del self._callbacks[sig]
             ct += 1
 
+    @contextmanager
+    def auto_synchronize(self):
+        '''
+        A context manager that waits for all commands in this stream to execute
+        and commits any pending memory transfers upon exiting the context.
+        '''
+        yield self
+        self.synchronize()
+
 
 def _make_mem_finalizer(dtor):
     """

--- a/numba/roc/tests/hsapy/test_async_kernel.py
+++ b/numba/roc/tests/hsapy/test_async_kernel.py
@@ -15,7 +15,8 @@ logger = logging.getLogger()
 
 @unittest.skipUnless(dgpu_present, 'test only on dGPU system')
 class TestAsyncKernel(unittest.TestCase):
-    def test_1(self):
+
+    def test_manual_stream(self):
         logger.info('context info: %s', roc.get_context().agent)
 
         @roc.jit("int32[:], int32[:]")
@@ -58,6 +59,53 @@ class TestAsyncKernel(unittest.TestCase):
 
         logger.info("synchronize")
         stream.synchronize()
+
+        logger.info("compare result")
+        np.testing.assert_equal(coarse_res_arr, coarse_arr + ntimes)
+
+    def test_ctx_managed_stream(self):
+        logger.info('context info: %s', roc.get_context().agent)
+
+        @roc.jit("int32[:], int32[:]")
+        def add1_kernel(dst, src):
+            i = roc.get_global_id(0)
+            if i < dst.size:
+                dst[i] = src[i] + 1
+
+        blksz = 256
+        gridsz = 10**5
+        nitems = blksz * gridsz
+        ntimes = 500
+
+        arr = np.arange(nitems, dtype=np.int32)
+
+        logger.info('make coarse_arr')
+        coarse_arr = roc.coarsegrain_array(shape=arr.shape, dtype=arr.dtype)
+        coarse_arr[:] = arr
+
+        logger.info('make coarse_res_arr')
+        coarse_res_arr = roc.coarsegrain_array(shape=arr.shape, dtype=arr.dtype)
+        coarse_res_arr[:] = 0
+
+        logger.info("make stream")
+        stream = roc.stream()
+
+        with stream.auto_synchronize():
+            logger.info('make gpu_res_arr')
+            gpu_res_arr = roc.device_array_like(coarse_arr)
+
+            logger.info('make gpu_arr')
+            gpu_arr = roc.to_device(coarse_arr, stream=stream)
+
+            for i in range(ntimes):
+                logger.info('launch kernel: %d', i)
+                add1_kernel[gridsz, blksz, stream](gpu_res_arr, gpu_arr)
+                gpu_arr.copy_to_device(gpu_res_arr, stream=stream)
+
+            logger.info('get kernel result')
+            gpu_res_arr.copy_to_host(coarse_res_arr, stream=stream)
+
+        logger.info("synchronize on ctx __exit__")
 
         logger.info("compare result")
         np.testing.assert_equal(coarse_res_arr, coarse_arr + ntimes)


### PR DESCRIPTION
This adds the auto_synchronize ctx manager to ROC streams cf. the
CUDA backend. Adds test of same.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
