### PR TITLE
Fix setitem/getitem resolvers

### DIFF
--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -254,18 +254,18 @@ class BaseContext(object):
     def resolve_static_setitem(self, target, index, value):
         assert not isinstance(index, types.Type), index
         args = target, index, value
-        kws = ()
+        kws = {}
         return self.resolve_function_type("static_setitem", args, kws)
 
     def resolve_setitem(self, target, index, value):
         assert isinstance(index, types.Type), index
         args = target, index, value
-        kws = ()
+        kws = {}
         return self.resolve_function_type("setitem", args, kws)
 
     def resolve_delitem(self, target, index):
         args = target, index
-        kws = ()
+        kws = {}
         return self.resolve_function_type("delitem", args, kws)
 
     def resolve_module_constants(self, typ, attr):


### PR DESCRIPTION
To add an overload for a setitem (https://github.com/Quansight/numba-xnd/blob/48b4256bb1cd9bf5e33c0ee889cdee784a8a8591/numba_xnd/libxnd.py#L152-L159), I needed to update these `kws` to be dictionaries instead of tuples. Otherwise, numba would complain with:

```
Traceback (most recent call last):
  File "/Users/saul/p/numba-xnd/numba/numba/errors.py", line 595, in new_error_context
    yield
  File "/Users/saul/p/numba-xnd/numba/numba/typeinfer.py", line 606, in __call__
    sig = typeinfer.context.resolve_setitem(targetty, idxty, valty)
  File "/Users/saul/p/numba-xnd/numba/numba/typing/context.py", line 264, in resolve_setitem
    return self.resolve_function_type("setitem", args, kws)
  File "/Users/saul/p/numba-xnd/numba/numba/typing/context.py", line 192, in resolve_function_type
    res = defn.apply(args, kws)
  File "/Users/saul/p/numba-xnd/numba/numba/typing/templates.py", line 238, in apply
    sig = typer(*args, **kws)
TypeError: typer() argument after ** must be a mapping, not tuple
```
