### PR TITLE
Support inferring stencil index as constant in simple unary expressions

### DIFF
--- a/docs/source/user/stencil.rst
+++ b/docs/source/user/stencil.rst
@@ -127,8 +127,10 @@ simple expressions if possible. For example::
 
     @njit(parallel=True)
     def stencil_test(A):
-       c = 2
-       return stencil(lambda a, c, d2: 0.3 * (a[-c+1] + a[0] + a[c-1]))(A, c)
+        c = 2
+        B = stencil(
+            lambda a, c: 0.3 * (a[-c+1] + a[0] + a[c-1]))(A, c)
+        return B
 
 
 Stencil decorator options

--- a/docs/source/user/stencil.rst
+++ b/docs/source/user/stencil.rst
@@ -7,7 +7,7 @@
 Using the ``@stencil`` decorator
 ================================
 
-Stencils are a common computational pattern in which array elements 
+Stencils are a common computational pattern in which array elements
 are updated according to some fixed pattern called the stencil kernel.
 Numba provides the ``@stencil`` decorator so that users may
 easily specify a stencil kernel and Numba then generates the looping
@@ -21,7 +21,7 @@ Basic usage
 ===========
 
 An example use of the ``@stencil`` decorator::
- 
+
    from numba import stencil
 
    @stencil
@@ -38,8 +38,8 @@ Conceptually, the stencil kernel is run once for each element in the
 output array.  The return value from the stencil kernel is the value
 written into the output array for that particular element.
 
-The parameter ``a`` represents the input array over which the 
-kernel is applied.  
+The parameter ``a`` represents the input array over which the
+kernel is applied.
 Indexing into this array takes place with respect to the current element
 of the output array being processed.  For example, if element ``(x, y)``
 is being processed then ``a[0, 0]`` in the stencil kernel corresponds to
@@ -48,9 +48,9 @@ kernel corresponds to ``a[x - 1, y + 1]`` in the input array.
 
 Depending on the specified kernel, the kernel may not be applicable to the
 borders of the output array as this may cause the input array to be
-accessed out-of-bounds.  The way in which the stencil decorator handles 
-this situation is dependent upon which :ref:`stencil-mode` is selected.  
-The default mode is for the stencil decorator to set the border elements 
+accessed out-of-bounds.  The way in which the stencil decorator handles
+this situation is dependent upon which :ref:`stencil-mode` is selected.
+The default mode is for the stencil decorator to set the border elements
 of the output array to zero.
 
 To invoke a stencil on an input array, call the stencil as if it were
@@ -105,13 +105,13 @@ all such input array arguments.
 Kernel shape inference and border handling
 ==========================================
 
-In the above example and in most cases, the array indexing in the 
+In the above example and in most cases, the array indexing in the
 stencil kernel will exclusively use ``Integer`` literals.
 In such cases, the stencil decorator is able to analyze the stencil
 kernel to determine its size.  In the above example, the stencil
 decorator determines that the kernel is ``3 x 3`` in shape since indices
 ``-1`` to ``1`` are used for both the first and second dimensions.  Note that
-the stencil decorator also correctly handles non-symmetric and 
+the stencil decorator also correctly handles non-symmetric and
 non-square stencil kernels.
 
 Based on the size of the stencil kernel, the stencil decorator is
@@ -122,11 +122,19 @@ of the output array.  In the above example, points ``-1`` and ``+1`` are
 accessed in each dimension and thus the output array has a border
 of size one in all dimensions.
 
+The parallel mode is able to infer kernel indices as constants from
+simple expressions if possible. For example::
+
+    @njit(parallel=True)
+    def stencil_test(A):
+       c = 2
+       return stencil(lambda a, c, d2: 0.3 * (a[-c+1] + a[0] + a[c-1]))(A, c)
+
 
 Stencil decorator options
 =========================
 
-While the stencil decorator may be augmented in the future to 
+While the stencil decorator may be augmented in the future to
 provide additional mechanisms for border handling, at the moment
 the stencil decorator currently supports only one option.
 
@@ -138,7 +146,7 @@ the stencil decorator currently supports only one option.
 Sometimes it may be inconvenient to write the stencil kernel
 exclusively with ``Integer`` literals.  For example, let us say we
 would like to compute the trailing 30-day moving average of a
-time series of data.  One could write 
+time series of data.  One could write
 ``(a[-29] + a[-28] + ... + a[-1] + a[0]) / 30`` but the stencil
 decorator offers a more concise form using the ``neighborhood``
 option::
@@ -176,7 +184,7 @@ to a constant value, as specified by the ``cval`` parameter.
 
 The optional cval parameter defaults to zero but can be set to any
 desired value, which is then used for the border of the output array
-if the mode parameter is set to ``constant``.  The cval parameter is 
+if the mode parameter is set to ``constant``.  The cval parameter is
 ignored in all other modes.  The type of the cval parameter must match
 the return type of the stencil kernel.  If the user wishes the output
 array to be constructed from a particular type then they should ensure
@@ -206,7 +214,7 @@ The stencil decorator returns a callable object of type ``StencilFunc``.
 ``StencilFunc`` objects contains a number of attributes but the only one of
 potential interest to users is the ``neighborhood`` attribute.
 If the ``neighborhood`` option was passed to the stencil decorator then
-the provided neighborhood is stored in this attribute.  Else, upon 
+the provided neighborhood is stored in this attribute.  Else, upon
 first execution or compilation, the system calculates the neighborhood
 as described above and then stores the computed neighborhood into this
 attribute.  A user may then inspect the attribute if they wish to verify
@@ -226,8 +234,8 @@ also include the following optional parameter.
 -------
 
 The optional ``out`` parameter is added to every stencil function
-generated by Numba.  If specified, the ``out`` parameter tells 
-Numba that the user is providing their own pre-allocated array 
+generated by Numba.  If specified, the ``out`` parameter tells
+Numba that the user is providing their own pre-allocated array
 to be used for the output of the stencil.  In this case, the
 stencil function will not allocate its own output array.
 Users should assure that the return type of the stencil kernel can

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -11,8 +11,7 @@ from llvmlite import ir as lir
 
 import numba
 from numba.six import exec_
-from numba import (ir, types, typing, config, analysis, utils, cgutils,
-    rewrites, postproc)
+from numba import ir, types, typing, config, analysis, utils, cgutils, rewrites
 from numba.typing.templates import signature, infer_global, AbstractTemplate
 from numba.targets.imputils import impl_ret_untracked
 from numba.analysis import (compute_live_map, compute_use_defs,
@@ -1574,6 +1573,7 @@ def get_ir_of_code(glbls, fcode):
     inline_pass = numba.inline_closurecall.InlineClosureCallPass(
         ir, numba.targets.cpu.ParallelOptions(False))
     inline_pass.run()
+    from numba import postproc
     post_proc = postproc.PostProcessor(ir)
     post_proc.run()
     return ir

--- a/numba/stencil.py
+++ b/numba/stencil.py
@@ -182,8 +182,8 @@ class StencilFunc(object):
                         elif stmt_index_var.name in const_dict:
                             kernel_consts += [const_dict[stmt_index_var.name]]
                         else:
-                            raise ValueError("Non-constant specified for "
-                                             "stencil kernel index.")
+                            raise ValueError("stencil kernel index is not "
+                                "constant, 'neighborhood' option required")
 
                     if ndim == 1:
                         # Single dimension always has index variable 'index0'.
@@ -261,7 +261,8 @@ class StencilFunc(object):
                             neighborhood[i][1] = max(neighborhood[i][1], te)
                         else:
                             raise ValueError(
-                                "Non-constant used as stencil index.")
+                                "stencil kernel index is not constant,"
+                                "'neighborhood' option required")
                     index_len = len(index)
                 elif isinstance(index, int):
                     neighborhood[0][0] = min(neighborhood[0][0], index)

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -689,6 +689,10 @@ def _get_const_index_expr(kernel_defs, func_ir, index_var):
     """
     try:
         require(isinstance(index_var, ir.Var))
+        # case where the index is a const itself in outer function
+        var_const =  guard(ir_utils.find_const, func_ir, index_var)
+        if var_const is not None:
+            return var_const
         # match definition inner_var = unary(index_var)
         var_def_list = kernel_defs[index_var.name]
         require(len(var_def_list) == 1)

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -688,6 +688,7 @@ def _get_const_index_expr(kernel_defs, func_ir, index_var):
     in the outer function. index_var is assumed to be inside stencil kernel
     """
     try:
+        require(isinstance(index_var, ir.Var))
         # match definition inner_var = unary(index_var)
         var_def_list = kernel_defs[index_var.name]
         require(len(var_def_list) == 1)

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -450,6 +450,14 @@ class TestStencil(TestStencilBase):
                                                                    A, c, out=B)
             return B
 
+        def test_impl3(n):
+            A = np.arange(n)
+            B = np.zeros(n)
+            c = 2
+            numba.stencil(lambda a,c : 0.3 * (a[-c+1] + a[0] + a[c-1]))(
+                                                                   A, c, out=B)
+            return B
+
         def test_impl_seq(n):
             A = np.arange(n)
             B = np.zeros(n)
@@ -462,12 +470,15 @@ class TestStencil(TestStencilBase):
         # constant inference is only possible in parallel path
         cpfunc1 = self.compile_parallel(test_impl1, (types.intp,))
         cpfunc2 = self.compile_parallel(test_impl2, (types.intp,))
+        cpfunc3 = self.compile_parallel(test_impl3, (types.intp,))
         expected = test_impl_seq(n)
         # parfor result
         parfor_output1 = cpfunc1.entry_point(n)
         parfor_output2 = cpfunc2.entry_point(n)
+        parfor_output3 = cpfunc3.entry_point(n)
         np.testing.assert_almost_equal(parfor_output1, expected, decimal=3)
         np.testing.assert_almost_equal(parfor_output2, expected, decimal=3)
+        np.testing.assert_almost_equal(parfor_output3, expected, decimal=3)
 
     @skip_unsupported
     @tag('important')

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -450,12 +450,23 @@ class TestStencil(TestStencilBase):
                                                                    A, c, out=B)
             return B
 
+        # recursive expr case
         def test_impl3(n):
             A = np.arange(n)
             B = np.zeros(n)
             c = 2
             numba.stencil(lambda a,c : 0.3 * (a[-c+1] + a[0] + a[c-1]))(
                                                                    A, c, out=B)
+            return B
+
+        # multi-constant case
+        def test_impl4(n):
+            A = np.arange(n)
+            B = np.zeros(n)
+            d = 1
+            c = 2
+            numba.stencil(lambda a,c,d : 0.3 * (a[-c+d] + a[0] + a[c-d]))(
+                                                                A, c, d, out=B)
             return B
 
         def test_impl_seq(n):
@@ -471,14 +482,17 @@ class TestStencil(TestStencilBase):
         cpfunc1 = self.compile_parallel(test_impl1, (types.intp,))
         cpfunc2 = self.compile_parallel(test_impl2, (types.intp,))
         cpfunc3 = self.compile_parallel(test_impl3, (types.intp,))
+        cpfunc4 = self.compile_parallel(test_impl4, (types.intp,))
         expected = test_impl_seq(n)
         # parfor result
         parfor_output1 = cpfunc1.entry_point(n)
         parfor_output2 = cpfunc2.entry_point(n)
         parfor_output3 = cpfunc3.entry_point(n)
+        parfor_output4 = cpfunc4.entry_point(n)
         np.testing.assert_almost_equal(parfor_output1, expected, decimal=3)
         np.testing.assert_almost_equal(parfor_output2, expected, decimal=3)
         np.testing.assert_almost_equal(parfor_output3, expected, decimal=3)
+        np.testing.assert_almost_equal(parfor_output4, expected, decimal=3)
 
     @skip_unsupported
     @tag('important')

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -494,6 +494,20 @@ class TestStencil(TestStencilBase):
         np.testing.assert_almost_equal(parfor_output3, expected, decimal=3)
         np.testing.assert_almost_equal(parfor_output4, expected, decimal=3)
 
+        # check error in regular Python path
+        with self.assertRaises(ValueError) as e:
+            test_impl4(4)
+
+        self.assertIn("stencil kernel index is not constant, "
+                      "'neighborhood' option required", str(e.exception))
+        # check error in njit path
+        # TODO: ValueError should be thrown instead of LoweringError
+        with self.assertRaises(LoweringError) as e:
+            njit(test_impl4)(4)
+
+        self.assertIn("stencil kernel index is not constant, "
+                      "'neighborhood' option required", str(e.exception))
+
     @skip_unsupported
     @tag('important')
     def test_stencil_parallel_off(self):

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -434,11 +434,19 @@ class TestStencil(TestStencilBase):
         constant from a unary expr. Otherwise, this would raise an error since
         neighborhood length is not specified.
         """
-        def test_impl(n):
+        def test_impl1(n):
             A = np.arange(n)
             B = np.zeros(n)
             c = 1
             numba.stencil(lambda a,c : 0.3 * (a[-c] + a[0] + a[c]))(
+                                                                   A, c, out=B)
+            return B
+
+        def test_impl2(n):
+            A = np.arange(n)
+            B = np.zeros(n)
+            c = 2
+            numba.stencil(lambda a,c : 0.3 * (a[1-c] + a[0] + a[c-1]))(
                                                                    A, c, out=B)
             return B
 
@@ -452,11 +460,14 @@ class TestStencil(TestStencilBase):
 
         n = 100
         # constant inference is only possible in parallel path
-        cpfunc = self.compile_parallel(test_impl, (types.intp,))
+        cpfunc1 = self.compile_parallel(test_impl1, (types.intp,))
+        cpfunc2 = self.compile_parallel(test_impl2, (types.intp,))
         expected = test_impl_seq(n)
         # parfor result
-        parfor_output = cpfunc.entry_point(n)
-        np.testing.assert_almost_equal(parfor_output, expected, decimal=3)
+        parfor_output1 = cpfunc1.entry_point(n)
+        parfor_output2 = cpfunc2.entry_point(n)
+        np.testing.assert_almost_equal(parfor_output1, expected, decimal=3)
+        np.testing.assert_almost_equal(parfor_output2, expected, decimal=3)
 
     @skip_unsupported
     @tag('important')


### PR DESCRIPTION
A common pattern in stencil indices is using `A[-c]` where `c` is a constant. This PR infers `-c` as constant as well, allowing more optimization and inference of neighborhood. This only works in `parallel=True` mode.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
