### PR TITLE
Handle unpacking in building tuple (BUILD_TUPLE_UNPACK opcode)

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -494,7 +494,7 @@ class ShapeEquivSet(EquivSet):
         for i in inds:
             require(i in self.ind_to_var)
             vs = self.ind_to_var[i]
-            assert(vs != [])
+            require(vs != [])
             shape.append(vs[0])
         return tuple(shape)
 

--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -358,13 +358,20 @@ class DataFlowAnalysis(object):
             info.append(inst, func=func, vararg=vararg, res=res)
             info.push(res)
 
-    def op_BUILD_TUPLE_UNPACK_WITH_CALL(self, info, inst):
+    def _build_tuple_unpack(self, info, inst):
         # Builds tuple from other tuples on the stack
         tuples = list(reversed([info.pop() for _ in range(inst.arg)]))
         temps = [info.make_temp() for _ in range(len(tuples) - 1)]
         info.append(inst, tuples=tuples, temps=temps)
         # The result is in the last temp var
         info.push(temps[-1])
+
+    def op_BUILD_TUPLE_UNPACK_WITH_CALL(self, info, inst):
+        # just unpack the input tuple, call inst will be handled afterwards
+        self._build_tuple_unpack(info, inst)
+
+    def op_BUILD_TUPLE_UNPACK(self, info, inst):
+        self._build_tuple_unpack(info, inst)
 
     def op_BUILD_CONST_KEY_MAP(self, info, inst):
         keys = info.pop()

--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -711,7 +711,7 @@ class DataFlowAnalysis(object):
             if MAKE_CLOSURE:
                 closure = info.pop()
             if num_annotations > 0:
-                annotations = info.pop() 
+                annotations = info.pop()
             if num_kwdefaults > 0:
                 kwdefaults = []
                 for i in range(num_kwdefaults):
@@ -734,7 +734,7 @@ class DataFlowAnalysis(object):
             if inst.arg & 0x1:
                 defaults = info.pop()
         res = info.make_temp()
-        info.append(inst, name=name, code=code, closure=closure, annotations=annotations, 
+        info.append(inst, name=name, code=code, closure=closure, annotations=annotations,
                     kwdefaults=kwdefaults, defaults=defaults, res=res)
         info.push(res)
 

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -217,7 +217,7 @@ class Interpreter(object):
 
     @property
     def code_cellvars(self):
-        return self.bytecode.co_cellvars 
+        return self.bytecode.co_cellvars
 
     @property
     def code_freevars(self):
@@ -272,7 +272,7 @@ class Interpreter(object):
         # See Parameter class in inspect.py (from Python source)
         if name[0] == '.' and name[1:].isdigit():
             name = 'implicit{}'.format(name[1:])
- 
+
         # Try to simplify the variable lookup by returning an earlier
         # variable assigned to *name*.
         var = self.assigner.get_assignment_source(name)
@@ -976,7 +976,7 @@ class Interpreter(object):
 
     def op_MAKE_CLOSURE(self, inst, name, code, closure, annotations, kwdefaults, defaults, res):
         self.op_MAKE_FUNCTION(inst, name, code, closure, annotations, kwdefaults, defaults, res)
-    
+
     def op_LOAD_CLOSURE(self, inst, res):
         n_cellvars = len(self.code_cellvars)
         if inst.arg < n_cellvars:

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -671,12 +671,19 @@ class Interpreter(object):
             expr = ir.Expr.call(func, [], [], loc=self.loc, vararg=vararg)
             self.store(expr, res)
 
-    def op_BUILD_TUPLE_UNPACK_WITH_CALL(self, inst, tuples, temps):
+    def _build_tuple_unpack(self, inst, tuples, temps):
         first = self.get(tuples[0])
         for other, tmp in zip(map(self.get, tuples[1:]), temps):
             out = ir.Expr.binop(fn='+', lhs=first, rhs=other, loc=self.loc)
             self.store(out, tmp)
             first = tmp
+
+    def op_BUILD_TUPLE_UNPACK_WITH_CALL(self, inst, tuples, temps):
+        # just unpack the input tuple, call inst will be handled afterwards
+        self._build_tuple_unpack(inst, tuples, temps)
+
+    def op_BUILD_TUPLE_UNPACK(self, inst, tuples, temps):
+        self._build_tuple_unpack(inst, tuples, temps)
 
     def op_BUILD_CONST_KEY_MAP(self, inst, keys, keytmps, values, res):
         # Unpack the constant key-tuple and reused build_map which takes

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -676,7 +676,7 @@ class Interpreter(object):
         for other, tmp in zip(map(self.get, tuples[1:]), temps):
             out = ir.Expr.binop(fn='+', lhs=first, rhs=other, loc=self.loc)
             self.store(out, tmp)
-            first = tmp
+            first = self.get(tmp)
 
     def op_BUILD_TUPLE_UNPACK_WITH_CALL(self, inst, tuples, temps):
         # just unpack the input tuple, call inst will be handled afterwards

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -329,6 +329,17 @@ def sized_bool(context, builder, sig, args):
     else:
         return cgutils.false_bit
 
+@lower_builtin(tuple)
+def lower_empty_tuple(context, builder, sig, args):
+    retty = sig.return_type
+    res = context.get_constant_undef(retty)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
+
+@lower_builtin(tuple, types.BaseTuple)
+def lower_tuple(context, builder, sig, args):
+    val, = args
+    return impl_ret_untracked(context, builder, sig.return_type, val)
+
 # -----------------------------------------------------------------------------
 
 def get_type_max_value(typ):

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -342,6 +342,14 @@ class TestArrayAnalysis(TestCase):
         self._compile_and_test(test_namedtuple, (types.intp,),
                                 equivs=[self.with_equiv('r', ('n', 'n'))],)
 
+        # np.where is tricky since it returns tuple of arrays
+        def test_np_where_tup_return(A):
+            c = np.where(A)
+            return len(c[0])
+
+        self._compile_and_test(test_np_where_tup_return,
+            (types.Array(types.intp, 1, 'C'),), asserts=None)
+
         def test_shape(A):
             (m, n) = A.shape
             B = np.ones((m, n))

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -327,6 +327,14 @@ class TestArrayAnalysis(TestCase):
                                asserts=[self.with_assert('A', 'B'),
                                         self.without_assert('C', 'D')])
 
+        def test_tup_arg(T):
+            T2 = T
+            return T2[0]
+
+        int_arr_typ = types.Array(types.intp, 1, 'C')
+        self._compile_and_test(test_tup_arg,
+            (types.Tuple((int_arr_typ, int_arr_typ)),), asserts=None)
+
         T = namedtuple("T", ['a','b'])
         def test_namedtuple(n):
             r = T(n, n)

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
-from numba import jit, types, errors
+from numba import jit, types, errors, utils
 from .support import TestCase, MemoryLeakMixin, tag
 
 
@@ -94,9 +94,6 @@ def identity(tup):
 
 def index_method_usecase(tup, value):
     return tup.index(value)
-
-def build_tuple_unpack(tup):
-    return (1, *tup)
 
 
 class TestTupleReturn(TestCase):
@@ -505,9 +502,11 @@ class TestMethods(TestCase):
 
 class TestTupleBuildUnpack(TestCase):
 
+    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
     def test_build_unpack(self):
         def check(p):
-            pyfunc = build_tuple_unpack
+            # using eval here since Python 2 doesn't even support the syntax
+            pyfunc = eval("lambda a: (1, *a)")
             cfunc = jit(nopython=True)(pyfunc)
             self.assertPreciseEqual(cfunc(p), pyfunc(p))
 

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -515,6 +515,53 @@ class TestTupleBuild(TestCase):
         # Heterogeneous
         check((4, 5.5))
 
+
+    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
+    def test_build_unpack_more(self):
+        def check(p):
+            # using eval here since Python 2 doesn't even support the syntax
+            pyfunc = eval("lambda a: (1, *a, (1, 2), *a)")
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(p), pyfunc(p))
+
+        # Homogeneous
+        check((4, 5))
+        # Heterogeneous
+        check((4, 5.5))
+
+
+    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
+    def test_build_unpack_call(self):
+        def check(p):
+            # using eval here since Python 2 doesn't even support the syntax
+            @jit
+            def inner(*args):
+                return args
+            pyfunc = eval("lambda a: inner(1, *a)", locals())
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(p), pyfunc(p))
+
+        # Homogeneous
+        check((4, 5))
+        # Heterogeneous
+        check((4, 5.5))
+
+    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
+    def test_build_unpack_call_more(self):
+        def check(p):
+            # using eval here since Python 2 doesn't even support the syntax
+            @jit
+            def inner(*args):
+                return args
+            pyfunc = eval("lambda a: inner(1, *a, *(1, 2), *a)", locals())
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(p), pyfunc(p))
+
+        # Homogeneous
+        check((4, 5))
+        # Heterogeneous
+        check((4, 5.5))
+
     def test_tuple_constructor(self):
         def check(pyfunc, arg):
             cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -500,7 +500,7 @@ class TestMethods(TestCase):
         self.assertEqual(msg, str(raises.exception))
 
 
-class TestTupleBuildUnpack(TestCase):
+class TestTupleBuild(TestCase):
 
     @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
     def test_build_unpack(self):
@@ -514,6 +514,18 @@ class TestTupleBuildUnpack(TestCase):
         check((4, 5))
         # Heterogeneous
         check((4, 5.5))
+
+    def test_tuple_constructor(self):
+        def check(pyfunc, arg):
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(arg), pyfunc(arg))
+
+        # empty
+        check(lambda _: tuple(), ())
+        # Homogeneous
+        check(lambda a: tuple(a), (4, 5))
+        # Heterogeneous
+        check(lambda a: tuple(a), (4, 5.5))
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -546,7 +546,7 @@ class TestTupleBuild(TestCase):
         # Heterogeneous
         check((4, 5.5))
 
-    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
+    @unittest.skipIf(utils.PYVERSION < (3, 6), "needs Python 3.6+")
     def test_build_unpack_call_more(self):
         def check(p):
             # using eval here since Python 2 doesn't even support the syntax

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -95,6 +95,9 @@ def identity(tup):
 def index_method_usecase(tup, value):
     return tup.index(value)
 
+def build_tuple_unpack(tup):
+    return (1, *tup)
+
 
 class TestTupleReturn(TestCase):
 
@@ -499,6 +502,19 @@ class TestMethods(TestCase):
         msg = 'tuple.index(x): x not in tuple'
         self.assertEqual(msg, str(raises.exception))
 
+
+class TestTupleBuildUnpack(TestCase):
+
+    def test_build_unpack(self):
+        def check(p):
+            pyfunc = build_tuple_unpack
+            cfunc = jit(nopython=True)(pyfunc)
+            self.assertPreciseEqual(cfunc(p), pyfunc(p))
+
+        # Homogeneous
+        check((4, 5))
+        # Heterogeneous
+        check((4, 5.5))
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -510,6 +510,20 @@ class Len(AbstractTemplate):
         elif isinstance(val, (types.RangeType)):
             return signature(val.dtype, val)
 
+@infer_global(tuple)
+class TupleConstructor(AbstractTemplate):
+    key = tuple
+
+    def generic(self, args, kws):
+        assert not kws
+        # empty tuple case
+        if len(args) == 0:
+            return signature(types.Tuple(()))
+        (val,) = args
+        # tuple as input
+        if isinstance(val, types.BaseTuple):
+            return signature(val, val)
+
 
 @infer
 class TupleBool(AbstractTemplate):


### PR DESCRIPTION
Handles `BUILD_TUPLE_UNPACK` the same as `BUILD_TUPLE_UNPACK_WITH_CALL`. This enables creating tuples like `(*a, *b)` where `a` and `b` are tuples. 

Bonus: added support for `tuple` constructor with empty or another tuple as input.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
