### PR TITLE
Fix #3214.  Mishandling of POP_BLOCK in while True loop.

### DIFF
--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -143,6 +143,12 @@ class Interpreter(object):
         # Get DFA block info
         self.dfainfo = self.dfa.infos[self.current_block_offset]
         self.assigner = Assigner()
+        # Check out-of-scope syntactic-block
+        while self.syntax_blocks:
+            if inst.offset >= self.syntax_blocks[-1].exit:
+                self.syntax_blocks.pop()
+            else:
+                break
 
     def _end_current_block(self):
         self._remove_unused_temporaries()

--- a/numba/tests/test_flow_control.py
+++ b/numba/tests/test_flow_control.py
@@ -174,9 +174,25 @@ def ifelse_usecase4(x, y):
     if x == y:
         return 1
 
+
 def ternary_ifelse_usecase1(x, y):
     return True if x > y else False
 
+
+def double_infinite_loop(x, y):
+    L = x
+    i = y
+
+    while True:
+        while True:
+            if i == L - 1:
+                break
+            i += 1
+        i += 1
+        if i >= L:
+            break
+
+    return i, L
 
 class TestFlowControl(TestCase):
 
@@ -346,6 +362,13 @@ class TestFlowControl(TestCase):
     @tag('important')
     def test_ternary_ifelse1_npm(self):
         self.test_ternary_ifelse1(flags=no_pyobj_flags)
+
+    def test_double_infinite_loop(self, flags=enable_pyobj_flags):
+        self.run_test(double_infinite_loop, [10], [0],
+                      flags=flags)
+
+    def test_double_infinite_loop_npm(self):
+        self.test_double_infinite_loop(flags=no_pyobj_flags)
 
 
 class TestCFGraph(TestCase):


### PR DESCRIPTION
Closes #3214.

The fix is to clear "expired" syntax-block at the start of processing a new basicblock.
