### PR TITLE
Switch to new Gitter notification webhook URL and encrypt it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ notifications:
         secure: SGgsT4DevPiF/u4y3HBorUYCVWan7EjSnEBmuGPnGkepv8JxfOnbbeM3ca2TSWa601J4OP2K2JhehUGZSn6YkTx5XKOzqF2pddZQX8j0B4htDgV2qvcY/aIUFz8UW2uQAuguP6OlHPmAj5KgF5raJ34rkmTd8UgObL6jAan2Kzg=
     webhooks:
         urls:
-            - https://webhooks.gitter.im/e/bd67cc227432d99bf1f1
+            - secure: "IpSOubapaCybPfQc/XRaFTB7nry+wSN0dGkU/m4aBclLiEx8Op+mAH8rm9N58U6TG5jhcNBmv7RCjs6k3Pi0Ra3Bt0x6fjB/46Xj93k0tftcfIn+0jLjujbmJym0efTxhj4ip+b0awh8f/LKY/U46PfEBSJmxUppY84YhRU23kI="
         on_success: change
         on_failure: always
         on_start: false


### PR DESCRIPTION
The URL has changed (for obvious reasons), and is now encrypted.