### PR TITLE
Fix return type difference for 32bit ctypes.c_void_p

### DIFF
--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -245,11 +245,11 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
             return ptr
 
         # Compile it
-        cres = compile_isolated(pyfunc, [types.intp[::1]])
+        cres = compile_isolated(pyfunc, [types.int64[::1]])
         cfunc = cres.entry_point
 
         # Setup inputs
-        arr_got = np.zeros(1, dtype=np.intp)
+        arr_got = np.zeros(1, dtype=np.int64)
         arr_expect = arr_got.copy()
 
         # Run functions

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -245,11 +245,11 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
             return ptr
 
         # Compile it
-        cres = compile_isolated(pyfunc, [types.int64[::1]])
+        cres = compile_isolated(pyfunc, [types.uintp[::1]])
         cfunc = cres.entry_point
 
         # Setup inputs
-        arr_got = np.zeros(1, dtype=np.int64)
+        arr_got = np.zeros(1, dtype=np.uintp)
         arr_expect = arr_got.copy()
 
         # Run functions

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -113,9 +113,10 @@ def make_function_type(cfnptr):
     cargs = [from_ctypes(a)
              for a in cfnptr.argtypes]
     cret = from_ctypes(cfnptr.restype)
-    # void* return type is implicitly converted to intp to match python
+    # void* return type is a int/long on 32 bit platforms and an int on 64 bit
+    # platforms, explicit conversion to a int64 should match.
     if cret == types.voidptr:
-        cret = types.intp
+        cret = types.int64
     if sys.platform == 'win32' and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL:
         # 'stdcall' calling convention under Windows
         cconv = 'x86_stdcallcc'

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -116,7 +116,7 @@ def make_function_type(cfnptr):
     # void* return type is a int/long on 32 bit platforms and an int on 64 bit
     # platforms, explicit conversion to a int64 should match.
     if cret == types.voidptr:
-        cret = types.intp
+        cret = types.uintp
     if sys.platform == 'win32' and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL:
         # 'stdcall' calling convention under Windows
         cconv = 'x86_stdcallcc'

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -116,7 +116,7 @@ def make_function_type(cfnptr):
     # void* return type is a int/long on 32 bit platforms and an int on 64 bit
     # platforms, explicit conversion to a int64 should match.
     if cret == types.voidptr:
-        cret = types.int64
+        cret = types.intp
     if sys.platform == 'win32' and not cfnptr._flags_ & ctypes._FUNCFLAG_CDECL:
         # 'stdcall' calling convention under Windows
         cconv = 'x86_stdcallcc'


### PR DESCRIPTION
On 32bit platforms a ctypes CFUNCTYPE returning a
`ctypes.c_void_p` will return a `long`, on 64bit platforms the
same will return an `int`. This change accommodates.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
