### PR TITLE
Fix types and layout for `np.where`.

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -609,10 +609,10 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             got = cres.entry_point(scal, x, y)
             self.assertPreciseEqual(got, expected)
 
-            arr = np.int16([1, 0, -1, 0])
-            check_arr(arr)
-            arr = np.bool_([1, 0, 1])
-            check_arr(arr)
+        arr = np.int16([1, 0, -1, 0])
+        check_arr(arr)
+        arr = np.bool_([1, 0, 1])
+        check_arr(arr)
 
         arr = fac(24)
         check_arr(arr)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1133,18 +1133,22 @@ class Where(AbstractTemplate):
             return signature(retty, ary)
 
         elif len(args) == 3:
-            # NOTE: contrary to Numpy, we only support homogeneous arguments
             cond, x, y = args
+            retdty = from_dtype(np.promote_types(
+                        as_dtype(getattr(args[1], 'dtype', args[1])),
+                        as_dtype(getattr(args[2], 'dtype', args[2]))))
             if isinstance(cond, types.Array):
                 # array where()
-                if (cond.ndim == x.ndim == y.ndim and
-                    x.dtype == y.dtype):
-                    retty = types.Array(x.dtype, x.ndim, x.layout)
+                if (cond.ndim == x.ndim == y.ndim):
+                    if x.layout == y.layout == cond.layout:
+                        retty = types.Array(retdty, x.ndim, x.layout)
+                    else:
+                        retty = types.Array(retdty, x.ndim, 'C')
                     return signature(retty, *args)
             else:
                 # scalar where()
-                if not isinstance(x, types.Array) and x == y:
-                    retty = types.Array(x, 0, 'C')
+                if not isinstance(x, types.Array):
+                    retty = types.Array(retdty, 0, 'C')
                     return signature(retty, *args)
 
 


### PR DESCRIPTION
This fixes `np.where` to match the returned layouts from NumPy, it
also removes the limitation applied over homogeneous dtypes.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
