### PR TITLE
Fix DeprecationWarning about imp module

### DIFF
--- a/numba/serialize.py
+++ b/numba/serialize.py
@@ -4,7 +4,15 @@ Serialization support for compiled functions.
 
 from __future__ import print_function, division, absolute_import
 
-import importlib
+from .utils import PYVERSION
+
+# `imp` deprecated since Py3.4, use `importlib` as replacement since Py3.1
+if PYVERSION < (3, 1):
+    from imp import get_magic as _get_magic
+    bc_magic = _get_magic()
+else:
+    from importlib.util import MAGIC_NUMBER as bc_magic
+
 import marshal
 import sys
 from types import FunctionType, ModuleType
@@ -72,7 +80,7 @@ def _reduce_code(code):
     """
     Reduce a code object to picklable components.
     """
-    return marshal.version, importlib.util.MAGIC_NUMBER, marshal.dumps(code)
+    return marshal.version, bc_magic, marshal.dumps(code)
 
 def _dummy_closure(x):
     """
@@ -106,7 +114,7 @@ def _rebuild_code(marshal_version, bytecode_magic, marshalled):
         raise RuntimeError("incompatible marshal version: "
                            "interpreter has %r, marshalled code has %r"
                            % (marshal.version, marshal_version))
-    if imp.get_magic() != bytecode_magic:
+    if bc_magic != bytecode_magic:
         raise RuntimeError("incompatible bytecode version")
     return marshal.loads(marshalled)
 

--- a/numba/serialize.py
+++ b/numba/serialize.py
@@ -4,7 +4,7 @@ Serialization support for compiled functions.
 
 from __future__ import print_function, division, absolute_import
 
-import imp
+import importlib
 import marshal
 import sys
 from types import FunctionType, ModuleType
@@ -72,7 +72,7 @@ def _reduce_code(code):
     """
     Reduce a code object to picklable components.
     """
-    return marshal.version, imp.get_magic(), marshal.dumps(code)
+    return marshal.version, importlib.util.MAGIC_NUMBER, marshal.dumps(code)
 
 def _dummy_closure(x):
     """

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -172,6 +172,26 @@ class TestDispatcherPickling(TestCase):
         g.disable_compile()
         self.assertEqual(g(2, 4), 13)
 
+    def test_imp_deprecation(self):
+        """
+        The imp module was deprecated in v3.4 in favour of importlib
+        """
+        code = """if 1:
+            import pickle
+            import warnings
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always', DeprecationWarning)
+                from numba import njit
+                @njit
+                def foo(x):
+                    return x + 1
+                foo(1)
+                serialized_foo = pickle.dumps(foo)
+            for x in w:
+                if 'serialize.py' in x.filename:
+                    assert "the imp module is deprecated" not in x.msg
+        """
+        subprocess.check_call([sys.executable, "-c", code])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In 2013, Python Issue #18192 introduced importlib.util.MAGIC_NUMBER and documented deprecated imp.get_magic() as deprecated

With Python 3.7, DeprecationWarnings are shown again by default.
