### PR TITLE
Fix cuda pointer ownership problem with user/externally allocated pointer

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -697,8 +697,8 @@ class Context(object):
         self._attempt_allocation(allocator)
 
         _memory_finalizer = _make_mem_finalizer(driver.cuMemFree, bytesize)
-        mem = RCPointer(weakref.proxy(self), ptr, bytesize,
-                        _memory_finalizer(self, ptr))
+        mem = AutoFreePointer(weakref.proxy(self), ptr, bytesize,
+                              _memory_finalizer(self, ptr))
         self.allocations[ptr.value] = mem
         return mem.own()
 
@@ -1217,14 +1217,14 @@ class MemoryPointer(object):
         return self.device_pointer
 
 
-class RCPointer(MemoryPointer):
+class AutoFreePointer(MemoryPointer):
     """Modifies the ownership semantic of the MemoryPointer so that the
     instance lifetime is directly tied to the number of references.
 
     When `.refct` reaches zero, the finalizer is invoked.
     """
     def __init__(self, *args, **kwargs):
-        super(RCPointer, self).__init__(*args, **kwargs)
+        super(AutoFreePointer, self).__init__(*args, **kwargs)
         # Releease the self reference to the buffer, so that the finalizer
         # is invoked if all the derived pointers are gone.
         self.refct -= 1


### PR DESCRIPTION
When user wraps externally allocated cuda memory with `MemoryPointer`, the expected usage is that the `MemoryPointer` instance owns the allocated memory.  However, due to initial assumption for internal use, the `MemoryPointer` instance was not acquiring a reference to the buffer (refct=0 initially).  This leads to pre-mature freeing of the buffer when derived pointer is freed even though the parent `MemoryPointer` is still alive.  This patch fixes this issue.  

As for internal use, a new `RCPointer` is created that preserve the old behavior, where derive pointers are controlling the lifetime of the allocation.