### PR TITLE
Tweak typography with CSS

### DIFF
--- a/docs/_static/numba-docs.css
+++ b/docs/_static/numba-docs.css
@@ -1,0 +1,36 @@
+h1, .h1 {
+    font-size: 42px;
+}
+
+h2, .h2 {
+    font-size: 34px;
+}
+
+h3, .h3 {
+    font-size: 26px;
+}
+
+
+body {
+    font-size: 14px;
+}
+
+.navbar-brand {
+    font-size: 30px;
+}
+
+.navbar-brand img {
+    height: 135%;
+}
+
+@media (min-width: 768px) {
+    .container {
+        width: 700px;
+    }
+}
+
+@media (min-width: 992px) {
+    .container {
+        width: 930px;
+    }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -298,3 +298,6 @@ def _autogenerate():
 
 
 _autogenerate()
+
+def setup(app):
+    app.add_stylesheet("numba-docs.css")


### PR DESCRIPTION
Headings are smaller, body text bigger, increased the size of the side margins (to make reading text easier), and adjusted the Numba logo to be a little larger.

Before:
![image](https://user-images.githubusercontent.com/425352/44686520-287abb80-aa14-11e8-861f-58734060ef1a.png)

After:
![image](https://user-images.githubusercontent.com/425352/44686529-2f093300-aa14-11e8-8092-d8968d56b797.png)
