### PR TITLE
Update installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,26 +6,20 @@ Numba
    :target: https://gitter.im/numba/numba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
    :alt: Gitter
 
-A compiler for Python array and numerical functions
-###################################################
+A Just-In-Time Compiler for Numerical Functions in Python
+#########################################################
 
-Numba is an Open Source NumPy-aware optimizing compiler for Python
-sponsored by Anaconda, Inc.  It uses the
-remarkable LLVM compiler infrastructure to compile Python syntax to
-machine code.
+Numba is an open source, NumPy-aware optimizing compiler for Python sponsored
+by Anaconda, Inc.  It uses the LLVM compiler project to generate machine code
+from Python syntax.
 
-It is aware of NumPy arrays as typed memory regions and so can speed-up
-code using NumPy arrays.  Other, less well-typed code will be translated
-to Python C-API calls effectively removing the "interpreter" but not removing
-the dynamic indirection.
+Numba can compile a large subset of numerically-focused Python, including many
+NumPy functions.  Additionally, Numba has support for automatic
+parallelization of loops, generation of GPU-accelerated code, and creation of
+ufuncs and C callbacks.
 
-Numba is also not a tracing JIT.  It *compiles* your code before it gets
-run either using run-time type information or type information you provide
-in the decorator.
-
-Numba is a mechanism for producing machine code from Python syntax and typed
-data structures such as those that exist in NumPy.
-
+For more information about Numba, see the Numba homepage: 
+http://numba.pydata.org
 
 Dependencies
 ============
@@ -45,76 +39,12 @@ Distribution: https://www.anaconda.com/download
 
    $ conda install numba
 
-If you wanted to compile Numba from source,
-it is recommended to use conda environment to maintain multiple isolated
-development environments.  To create a new environment for Numba development::
-
-   $ conda create -p ~/dev/mynumba python numpy llvmlite
-
-To select the installed version, append "=VERSION" to the package name,
-where, "VERSION" is the version number.  For example::
-
-   $ conda create -p ~/dev/mynumba python=2.7 numpy=1.11 llvmlite
-
-to use Python 2.7 and Numpy 1.11.
-
-If you need CUDA support, you should also install the CUDA toolkit::
-
-   $ conda install cudatoolkit
-
-This installs the CUDA Toolkit version 8.0, which requires driver version 375.x
-or later to be installed.
-
-Custom Python Environments
---------------------------
-
-If you're not using conda, you will need to build llvmlite yourself:
-
-Building and installing llvmlite
-''''''''''''''''''''''''''''''''
-
-See https://github.com/numba/llvmlite for the most up-to-date instructions.
-You will need a build of LLVM 6.0.x.
-
-::
-
-   $ git clone https://github.com/numba/llvmlite
-   $ cd llvmlite
-   $ python setup.py install
-
-Installing Numba
-''''''''''''''''
-
-::
-
-   $ git clone https://github.com/numba/numba.git
-   $ cd numba
-   $ pip install -r requirements.txt
-   $ python setup.py build_ext --inplace
-   $ python setup.py install
-
-or simply
-
-::
-
-   $ pip install numba
-
-If you want to enable CUDA support, you will need to install CUDA Toolkit 8.0.
-After installing the toolkit, you might have to specify environment variables
-in order to override the standard search paths:
-
-NUMBAPRO_CUDA_DRIVER
-  Path to the CUDA driver shared library
-NUMBAPRO_NVVM
-  Path to the CUDA libNVVM shared library file
-NUMBAPRO_LIBDEVICE
-  Path to the CUDA libNVVM libdevice directory which contains .bc files
-
+For more options, see the Installation Guide: http://numba.pydata.org/numba-doc/latest/user/installing.html
 
 Documentation
 =============
 
-http://numba.pydata.org/numba-doc/dev/index.html
+http://numba.pydata.org/numba-doc/latest/index.html
 
 
 Mailing Lists
@@ -128,13 +58,6 @@ http://news.gmane.org/gmane.comp.python.numba.user
 
 Some old archives are at: http://librelist.com/browser/numba/
 
-
-Website
-=======
-
-See if our sponsor can help you (which can help this project): https://www.anaconda.com
-
-http://numba.pydata.org
 
 
 Continuous Integration

--- a/README.rst
+++ b/README.rst
@@ -25,14 +25,14 @@ Dependencies
 ============
 
 * llvmlite
-* numpy (version 1.9 or higher)
+* NumPy (version 1.9 or higher)
 * funcsigs (for Python 2)
 
 
 Installing
 ==========
 
-The easiest way to install numba and get updates is by using the Anaconda
+The easiest way to install Numba and get updates is by using the Anaconda
 Distribution: https://www.anaconda.com/download
 
 ::
@@ -50,17 +50,19 @@ http://numba.pydata.org/numba-doc/latest/index.html
 Mailing Lists
 =============
 
-Join the numba mailing list numba-users@continuum.io:
+Join the Numba mailing list numba-users@continuum.io:
 https://groups.google.com/a/continuum.io/d/forum/numba-users
 
-or access it through the Gmane mirror:
-http://news.gmane.org/gmane.comp.python.numba.user
-
 Some old archives are at: http://librelist.com/browser/numba/
-
 
 
 Continuous Integration
 ======================
 
-https://travis-ci.org/numba/numba
+.. image:: https://travis-ci.org/numba/numba.svg?branch=master
+    :target: https://travis-ci.org/numba/numba
+    :alt: Travis CI
+
+.. image:: https://ci.appveyor.com/api/projects/status/klm0dk21innm33mi?svg=true)
+    :target: https://ci.appveyor.com/project/seibert/numba-j46mi
+    :alt: AppVeyor

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -72,7 +72,7 @@ request from the Github interface.
 
 If you want, you can submit a pull request even when you haven't finished
 working.  This can be useful to gather feedback, or to stress your changes
-against the :ref:`continuous integration <travis_ci>` platorm.  In this
+against the :ref:`continuous integration <travis_ci>` platform.  In this
 case, please prepend ``[WIP]`` to your pull request's title.
 
 .. _buildenv:
@@ -80,7 +80,7 @@ case, please prepend ``[WIP]`` to your pull request's title.
 Build environment
 '''''''''''''''''
 
-Numba has a number of dependencies (mostly `numpy <http://www.numpy.org/>`_
+Numba has a number of dependencies (mostly `NumPy <http://www.numpy.org/>`_
 and `llvmlite <https://github.com/numba/llvmlite>`_) with non-trivial build
 instructions.  Unless you want to build those dependencies yourself, we
 recommend you use `conda <http://conda.pydata.org/miniconda.html>`_ to
@@ -94,11 +94,13 @@ of the llvmlite library::
 
 Then create an environment with the right dependencies::
 
-   $ conda create -n numbaenv python=3.6 llvmlite numpy scipy
+   $ conda create -n numbaenv python=3.6 llvmlite numpy scipy jinja2 cffi
 
 .. note::
    This installs an environment based on Python 3.6, but you can of course
-   choose another version supported by Numba.
+   choose another version supported by Numba.  To test additional features,
+   you may also need to install ``tbb`` and/or ``llvm-openmp`` and 
+   ``intel-openmp``.
 
 To activate the environment for the current shell session::
 
@@ -221,11 +223,12 @@ Platform support
 ''''''''''''''''
 
 Every commit to the master branch is automatically tested on all of the
-platform Numba supports.  This includes ARMv7, ARMv8, POWER8, as well as both
+platforms Numba supports.  This includes ARMv7, ARMv8, POWER8, as well as both
 AMD and NVIDIA GPUs.  The build system however is internal to Anaconda, so we
-also use `Travis CI <https://travis-ci.org/numba/numba>`_ to provide public
-continuous integration information for as many combinations as can be
-supported by the service.  Travis automatically tests all pull requests on OS
+also use `Travis CI <https://travis-ci.org/numba/numba>`_ and 
+`AppVeyor <https://ci.appveyor.com/project/seibert/numba-j46mi>`_ to provide 
+public continuous integration information for as many combinations as can be
+supported by the service.  Travis CI automatically tests all pull requests on OS
 X and Linux, as well as a sampling of different Python and NumPy versions.  If
 you see problems on platforms you are unfamiliar with, feel free to ask for
 help in your pull request.  The Numba core developers can help diagnose

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -80,44 +80,45 @@ case, please prepend ``[WIP]`` to your pull request's title.
 Build environment
 '''''''''''''''''
 
-Numba has a number of dependencies (mostly `Numpy <http://www.numpy.org/>`_
+Numba has a number of dependencies (mostly `numpy <http://www.numpy.org/>`_
 and `llvmlite <https://github.com/numba/llvmlite>`_) with non-trivial build
 instructions.  Unless you want to build those dependencies yourself, we
-recommend you use `Conda <http://conda.pydata.org/miniconda.html>`_ to
+recommend you use `conda <http://conda.pydata.org/miniconda.html>`_ to
 create a dedicated development environment and install precompiled versions
 of those dependencies there.
 
-First add the Binstar ``numba`` channel so as to get development builds of
-the llvmlite library::
+First add the Anaconda Cloud ``numba`` channel so as to get development builds
+of the llvmlite library::
 
    $ conda config --add channels numba
 
 Then create an environment with the right dependencies::
 
-   $ <path_to_miniconda>/conda create -n numbaenv python=3.5 llvmlite numpy
+   $ conda create -n numbaenv python=3.6 llvmlite numpy scipy
 
 .. note::
-   This installs an environment based on Python 3.5, but you can of course
+   This installs an environment based on Python 3.6, but you can of course
    choose another version supported by Numba.
 
 To activate the environment for the current shell session::
 
-   $ source <path_to_miniconda>/activate numbaenv
+   $ conda activate numbaenv
 
 .. note::
-   Those instructions are for a standard Linux shell.  You may need to
+   These instructions are for a standard Linux shell.  You may need to
    adapt them for other platforms.
 
 Once the environment is activated, you have a dedicated Python with the
 required dependencies::
 
-   $ python
-   Python 3.4.2 |Continuum Analytics, Inc.| (default, Oct 21 2014, 17:16:37)
-   [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux
-   Type "help", "copyright", "credits" or "license" for more information.
-   >>> import llvmlite
-   >>> llvmlite.__version__
-   '0.2.0-3-g9f60cd1'
+    $ python
+    Python 3.6.6 |Anaconda, Inc.| (default, Jun 28 2018, 11:07:29)
+    [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import llvmlite
+    >>> llvmlite.__version__
+    '0.24.0'
+
 
 Building Numba
 ''''''''''''''
@@ -125,6 +126,8 @@ Building Numba
 For a convenient development workflow, we recommend you build Numba inside
 its source checkout::
 
+   $ git clone git://github.com/numba/numba.git
+   $ cd numba
    $ python setup.py build_ext --inplace
 
 This assumes you have a working C compiler and runtime on your development
@@ -217,27 +220,22 @@ also needs to pass the test suite before it is merged in.
 Platform support
 ''''''''''''''''
 
-Numba is to be kept compatible with Python 2.7, 3.4 and 3.5 under
-at least Linux, OS X and Windows.  Also, Numpy versions 1.7 and upwards
-are supported.
-
-We don't expect invidual contributors to test those combinations
-themselves! Instead, we have a continuous integration platform.  Part of
-the platform is hosted at `Travis-CI <https://travis-ci.org/numba/numba>`_.
-Each time you submit a pull request, a corresponding build will be started
-at Travis-CI and check that Numba builds and tests without any errors.
-You can expect this to take less than 20 minutes.
-
-Some platforms (such as Windows) cannot be hosted by Travis-CI, and the
-Numba team has therefore access to a separate platform provided by
-`Anaconda, Inc. <https://anaconda.com>`_, our sponsor. We hope parts of that
-infrastructure can be made public in the future.
+Every commit to the master branch is automatically tested on all of the
+platform Numba supports.  This includes ARMv7, ARMv8, POWER8, as well as both
+AMD and NVIDIA GPUs.  The build system however is internal to Anaconda, so we
+also use `Travis CI <https://travis-ci.org/numba/numba>`_ to provide public
+continuous integration information for as many combinations as can be
+supported by the service.  Travis automatically tests all pull requests on OS
+X and Linux, as well as a sampling of different Python and NumPy versions.  If
+you see problems on platforms you are unfamiliar with, feel free to ask for
+help in your pull request.  The Numba core developers can help diagnose
+cross-platform compatibiliy issues.
 
 
 Documentation
 -------------
 
-The numba documentation is split over two repositories:
+The Numba documentation is split over two repositories:
 
 * This documentation is in the ``docs`` directory inside the
   `Numba repository <https://github.com/numba/numba>`_.

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -42,8 +42,8 @@ Note that Numba, like Anaconda, only supports PPC in 64-bit little-endian mode.
 
 To enable CUDA GPU support for Numba, install the latest `graphics drivers from
 NVIDIA <https://www.nvidia.com/Download/index.aspx>`_ for your platform.
-(Note that the open source Nouveau drivers shipped by default with Ubuntu do
-not support CUDA.).  Then install the ``cudatoolkit`` package::
+(Note that the open source Nouveau drivers shipped by default with many Linux
+distributions do not support CUDA.)  Then install the ``cudatoolkit`` package::
 
     $ conda install cudatoolkit
 
@@ -59,7 +59,7 @@ Binary wheels for Windows, Mac, and Linux are also available from `PyPI
     $ pip install numba
 
 This will download all of the needed dependencies as well.  You do not need to
-have *LLVM* installed to use Numba (in fact, Numba will ignore all LLVM
+have LLVM installed to use Numba (in fact, Numba will ignore all LLVM
 versions installed on the system) as the required components are bundled into
 the llvmlite wheel.
 
@@ -68,9 +68,9 @@ To use CUDA with Numba installed by `pip`, you need to install the `CUDA SDK
 set the following environment variables so Numba can locate the required
 libraries:
 
-  * ``NUMBAPRO_CUDA_DRIVER`` - Path to the CUDA driver shared library file
-  * ``NUMBAPRO_NVVM`` - Path to the CUDA libNVVM shared library file
-  * ``NUMBAPRO_LIBDEVICE`` - Path to the CUDA libNVVM libdevice *directory* which contains .bc files
+* ``NUMBAPRO_CUDA_DRIVER`` - Path to the CUDA driver shared library file
+* ``NUMBAPRO_NVVM`` - Path to the CUDA libNVVM shared library file
+* ``NUMBAPRO_LIBDEVICE`` - Path to the CUDA libNVVM libdevice *directory* which contains .bc files
 
 
 Enabling AMD ROCm GPU Support
@@ -97,7 +97,7 @@ sample notebooks.
     conda-based Python distribution for the Raspberry Pi.  We are now uploading
     packages to the ``numba`` channel on Anaconda Cloud for ARMv7-based boards,
     which currently incudes the the Raspberry Pi 2 and 3, but not the Pi 1 or
-    Zero.  These can be installed using conda from the `numba` channel::
+    Zero.  These can be installed using conda from the ``numba`` channel::
 
         $ conda install -c numba numba
 
@@ -115,7 +115,7 @@ sample notebooks.
     called `Jetconda <https://github.com/seibert/jetconda/releases>`_.  Jetconda
     is built on Ubuntu 16.04 running on the Jetson TX2, although the packages may
     work on other ARMv8 systems running Ubuntu 16.04.  Once Jetconda is installed,
-    Numba can be installed from the ``numba`` channel
+    Numba can be installed from the ``numba`` channel::
 
         $ conda install -c numba numba
 
@@ -145,8 +145,11 @@ Once that is completed, you can download the latest Numba source code from
 Source archives of the latest release can also be found on
 `PyPI <https://pypi.org/project/numba/>`_.  In addition to ``llvmlite``, you will also need:
 
-  * A C compiler compatible with your Python installation
-  * `Numpy <http://www.numpy.org/>`_
+* A C compiler compatible with your Python installation.  If you are using
+  Anaconda, you can install the Linux compiler conda packages ``gcc_linux-64`` 
+  and ``gxx_linux-64``, or macOS packages ``clang_osx-64`` and
+  ``clangxx_osx-64``.
+* `NumPy <http://www.numpy.org/>`_
 
 Then you can build and install Numba from the top level of the source tree::
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -89,38 +89,38 @@ Then:
 See the `roc-examples <https://github.com/numba/roc-examples>`_ repository for
 sample notebooks.
 
+.. Hide this until we have the conda packages available
+    Installing on Linux ARMv7 Platforms
+    -----------------------------------
 
-Installing on Linux ARMv7 Platforms
------------------------------------
+    `Berryconda <https://https://github.com/jjhelmus/berryconda>`_ is a
+    conda-based Python distribution for the Raspberry Pi.  We are now uploading
+    packages to the ``numba`` channel on Anaconda Cloud for ARMv7-based boards,
+    which currently incudes the the Raspberry Pi 2 and 3, but not the Pi 1 or
+    Zero.  These can be installed using conda from the `numba` channel::
 
-`Berryconda <https://https://github.com/jjhelmus/berryconda>`_ is a
-conda-based Python distribution for the Raspberry Pi.  We are now uploading
-packages to the ``numba`` channel on Anaconda Cloud for ARMv7-based boards,
-which currently incudes the the Raspberry Pi 2 and 3, but not the Pi 1 or
-Zero.  These can be installed using conda from the `numba` channel::
+        $ conda install -c numba numba
 
-    $ conda install -c numba numba
-
-Berryconda and Numba may work on other Linux-based ARMv7 systems, but this has
-not been tested.
+    Berryconda and Numba may work on other Linux-based ARMv7 systems, but this has
+    not been tested.
 
 
-Installing on Linux ARMv8 (AArch64) Platforms
----------------------------------------------
+    Installing on Linux ARMv8 (AArch64) Platforms
+    ---------------------------------------------
 
-Although many ARMv8 platforms are likely to require building Numba from
-source, we do build and test conda packages on the `NVIDIA Jetson TX2
-<https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_.
-These packages rely on an infrequently updated port of Berryconda to ARMv8
-called `Jetconda <https://github.com/seibert/jetconda/releases>`_.  Jetconda
-is built on Ubuntu 16.04 running on the Jetson TX2, although the packages may
-work on other ARMv8 systems running Ubuntu 16.04.  Once Jetconda is installed,
-Numba can be installed from the ``numba`` channel
+    Although many ARMv8 platforms are likely to require building Numba from
+    source, we do build and test conda packages on the `NVIDIA Jetson TX2
+    <https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_.
+    These packages rely on an infrequently updated port of Berryconda to ARMv8
+    called `Jetconda <https://github.com/seibert/jetconda/releases>`_.  Jetconda
+    is built on Ubuntu 16.04 running on the Jetson TX2, although the packages may
+    work on other ARMv8 systems running Ubuntu 16.04.  Once Jetconda is installed,
+    Numba can be installed from the ``numba`` channel
 
-    $ conda install -c numba numba
+        $ conda install -c numba numba
 
-To enable CUDA support on the TX2, set the ``NUMBAPRO`` environment variables
-as described above.
+    To enable CUDA support on the TX2, set the ``NUMBAPRO`` environment variables
+    as described above.
 
 
 .. _numba-source-install-instructions:

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -1,6 +1,6 @@
 
-Getting started
-===============
+Installation
+============
 
 Compatibility
 -------------
@@ -17,60 +17,192 @@ Our supported platforms are:
 * NVIDIA GPUs of compute capability 2.0 and later
 * AMD ROC dGPUs (linux only and not for AMD Carrizo or Kaveri APU)
 
+:ref:`numba-parallel` is only available on 64-bit platforms,
+and is not supported in Python 2.7 on Windows.
 
-Installing using Conda
-----------------------
+Installing using conda on x86/x86_64/POWER Platforms
+----------------------------------------------------
 
-The easiest way to install numba and get updates is by using Conda,
+The easiest way to install Numba and get updates is by using ``conda``,
 a cross-platform package manager and software distribution maintained
 by Anaconda, Inc.  You can either use `Anaconda
 <https://www.anaconda.com/download>`_ to get the full stack in one download,
 or `Miniconda <https://conda.io/miniconda.html>`_ which will install
-the minimum packages needed to get started.
+the minimum packages required for a conda environment.
 
 Once you have conda installed, just type::
 
-   $ conda install numba
+    $ conda install numba
 
 or::
 
-   $ conda update numba
+    $ conda update numba
+
+Note that Numba, like Anaconda, only supports PPC in 64-bit little-endian mode.
+
+To enable CUDA GPU support for Numba, install the latest `graphics drivers from
+NVIDIA <https://www.nvidia.com/Download/index.aspx>`_ for your platform.
+(Note that the open source Nouveau drivers shipped by default with Ubuntu do
+not support CUDA.).  Then install the ``cudatoolkit`` package::
+
+    $ conda install cudatoolkit
+
+You do not need to install the CUDA SDK from NVIDIA.
+
+
+Installing using pip on x86/x86_64 Platforms
+--------------------------------------------
+
+Binary wheels for Windows, Mac, and Linux are also available from `PyPI
+<https://pypi.org/project/numba/>`_.  You can install Numba using ``pip``::
+
+    $ pip install numba
+
+This will download all of the needed dependencies as well.  You do not need to
+have *LLVM* installed to use Numba (in fact, Numba will ignore all LLVM
+versions installed on the system) as the required components are bundled into
+the llvmlite wheel.
+
+To use CUDA with Numba installed by `pip`, you need to install the `CUDA SDK
+<https://developer.nvidia.com/cuda-downloads>`_ from NVIDIA.  Then you may need to
+set the following environment variables so Numba can locate the required
+libraries:
+
+  * ``NUMBAPRO_CUDA_DRIVER`` - Path to the CUDA driver shared library file
+  * ``NUMBAPRO_NVVM`` - Path to the CUDA libNVVM shared library file
+  * ``NUMBAPRO_LIBDEVICE`` - Path to the CUDA libNVVM libdevice *directory* which contains .bc files
+
+
+Enabling AMD ROCm GPU Support
+-----------------------------
+
+The `ROCm Platform <https://rocm.github.io/>`_ allows GPU computing with AMD
+GPUs on Linux.  To enable ROCm support in Numba,  conda is required, so begin
+with an Anaconda or Miniconda installation with Numba 0.40 or later installed.
+Then:
+
+1. Follow the `ROCm installation instructions <https://rocm.github.io/install.html>`_.
+2. Install ``roctools`` conda package from the ``numba`` channel::
+
+    $ conda install -c numba roctools
+
+See the `roc-examples <https://github.com/numba/roc-examples>`_ repository for
+sample notebooks.
+
+
+Installing on Linux ARMv7 Platforms
+-----------------------------------
+
+`Berryconda <https://https://github.com/jjhelmus/berryconda>`_ is a
+conda-based Python distribution for the Raspberry Pi.  We are now uploading
+packages to the ``numba`` channel on Anaconda Cloud for ARMv7-based boards,
+which currently incudes the the Raspberry Pi 2 and 3, but not the Pi 1 or
+Zero.  These can be installed using conda from the `numba` channel::
+
+    $ conda install -c numba numba
+
+Berryconda and Numba may work on other Linux-based ARMv7 systems, but this has
+not been tested.
+
+
+Installing on Linux ARMv8 (AArch64) Platforms
+---------------------------------------------
+
+Although many ARMv8 platforms are likely to require building Numba from
+source, we do build and test conda packages on the `NVIDIA Jetson TX2
+<https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_.
+These packages rely on an infrequently updated port of Berryconda to ARMv8
+called `Jetconda <https://github.com/seibert/jetconda/releases>`_.  Jetconda
+is built on Ubuntu 16.04 running on the Jetson TX2, although the packages may
+work on other ARMv8 systems running Ubuntu 16.04.  Once Jetconda is installed,
+Numba can be installed from the ``numba`` channel
+
+    $ conda install -c numba numba
+
+To enable CUDA support on the TX2, set the ``NUMBAPRO`` environment variables
+as described above.
+
 
 .. _numba-source-install-instructions:
 
 Installing from source
 ----------------------
 
-We won't cover requirements in detail here, but you can get the bleeding-edge
-source code from `Github <https://github.com/numba/numba>`_::
+Installing Numba from source is fairly straightforward (similar to other
+Python packages), but installing `llvmlite
+<https://github.com/numba/llvmlite>`_ can be quite challenging due to the need
+for a special LLVM build.  If you are building from source for the purposes of
+Numba development, see :ref:`buildenv` for details on how to create a Numba
+development environment with conda.
 
-   $ git clone git://github.com/numba/numba.git
+If you are building Numba from source for other reasons, first follow the
+`llvmlite installation guide <https://llvmlite.readthedocs.io/en/latest/admin-guide/install.html>`_.
+Once that is completed, you can download the latest Numba source code from 
+`Github <https://github.com/numba/numba>`_::
 
-Source archives of the latest release can be found on
-`PyPI <https://pypi.python.org/pypi/numba/>`_.
+    $ git clone git://github.com/numba/numba.git
 
-You will need a C compiler corresponding to your Python installation, as
-well as the `Numpy <http://www.numpy.org/>`_ and
-`llvmlite <https://github.com/numba/llvmlite>`_ packages.  See :ref:`buildenv`
-for more information.
+Source archives of the latest release can also be found on
+`PyPI <https://pypi.org/project/numba/>`_.  In addition to ``llvmlite``, you will also need:
+
+  * A C compiler compatible with your Python installation
+  * `Numpy <http://www.numpy.org/>`_
+
+Then you can build and install Numba from the top level of the source tree::
+
+    $ python setup.py install
+
 
 Checking your installation
 --------------------------
 
 You should be able to import Numba from the Python prompt::
 
-   $ python
-   Python 3.4.2 |Continuum Analytics, Inc.| (default, Oct 21 2014, 17:16:37)
-   [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux
-   Type "help", "copyright", "credits" or "license" for more information.
-   >>> import numba
-   >>> numba.__version__
-   '0.16.0-82-g350c9d2'
+    $ python
+    Python 2.7.15 |Anaconda custom (x86_64)| (default, May  1 2018, 18:37:05)
+    [GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import numba
+    >>> numba.__version__
+    '0.39.0+0.g4e49566.dirty'
 
-You can also try executing the :ref:`pycc <pycc>` utility::
+You can also try executing the `numba -s` command to report information about
+your system capabilities::
 
-   $ pycc --help
-   usage: pycc [-h] [-o OUTPUT] [-c | --llvm] [--linker LINKER]
-               [--linker-args LINKER_ARGS] [--header] [--python] [-d]
-               inputs [inputs ...]
+    $ numba -s
+    System info:
+    --------------------------------------------------------------------------------
+    __Time Stamp__
+    2018-08-28 15:46:24.631054
+    
+    __Hardware Information__
+    Machine                             : x86_64
+    CPU Name                            : haswell
+    CPU Features                        :
+    aes avx avx2 bmi bmi2 cmov cx16 f16c fma fsgsbase lzcnt mmx movbe pclmul popcnt
+    rdrnd sse sse2 sse3 sse4.1 sse4.2 ssse3 xsave xsaveopt
+    
+    __OS Information__
+    Platform                            : Darwin-17.6.0-x86_64-i386-64bit
+    Release                             : 17.6.0
+    System Name                         : Darwin
+    Version                             : Darwin Kernel Version 17.6.0: Tue May  8 15:22:16 PDT 2018; root:xnu-4570.61.1~1/RELEASE_X86_64
+    OS specific info                    : 10.13.5   x86_64
+    
+    __Python Information__
+    Python Compiler                     : GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)
+    Python Implementation               : CPython
+    Python Version                      : 2.7.15
+    Python Locale                       : en_US UTF-8
+    
+    __LLVM information__
+    LLVM version                        : 6.0.0
+    
+    __CUDA Information__
+    Found 1 CUDA devices
+    id 0         GeForce GT 750M                              [SUPPORTED]
+                          compute capability: 3.0
+                               pci device id: 0
+                                  pci bus id: 1
 
+(output truncated due to length)


### PR DESCRIPTION
This cleans up the installation instructions, and gives information for all of the other platforms Numba now supports.

Marked as [WIP] until there are armv7 packages in the Numba channel and we get the Jetconda installer sorted out.

Fixes #3107.