### PR TITLE
Note pyobject and voidptr are types in docs

### DIFF
--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -100,6 +100,15 @@ the beginning or the end of the index specification::
    >>> numba.float32[::1, :, :]
    array(float32, 3d, F)
 
+Miscellaneous Types
+-------------------
+
+===================   =================================================
+Type name(s)          Comments
+===================   =================================================
+pyobject              generic Python object
+voidptr               raw pointer, no operations can be performed on it
+===================   =================================================
 
 Advanced types
 ==============


### PR DESCRIPTION
Fixes #3219.