### PR TITLE
compiler threadsafety lockdown

### DIFF
--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -60,20 +60,19 @@ class CFunc(object):
     def enable_caching(self):
         self._cache = FunctionCache(self._pyfunc)
 
+    @compiler.global_compiler_lock
     def compile(self):
-        # Use cache and compiler in a critical section
-        with compiler.lock_compiler:
-            # Try to load from cache
-            cres = self._cache.load_overload(self._sig, self._targetdescr.target_context)
-            if cres is None:
-                cres = self._compile_uncached()
-                self._cache.save_overload(self._sig, cres)
-            else:
-                self._cache_hits += 1
+        # Try to load from cache
+        cres = self._cache.load_overload(self._sig, self._targetdescr.target_context)
+        if cres is None:
+            cres = self._compile_uncached()
+            self._cache.save_overload(self._sig, cres)
+        else:
+            self._cache_hits += 1
 
-            self._library = cres.library
-            self._wrapper_name = cres.fndesc.llvm_cfunc_wrapper_name
-            self._wrapper_address = self._library.get_pointer_to_function(self._wrapper_name)
+        self._library = cres.library
+        self._wrapper_name = cres.fndesc.llvm_cfunc_wrapper_name
+        self._wrapper_address = self._library.get_pointer_to_function(self._wrapper_name)
 
     def _compile_uncached(self):
         sig = self._sig

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -5,8 +5,6 @@ from collections import namedtuple, defaultdict
 import sys
 import warnings
 import traceback
-import threading
-import functools
 from .tracing import event
 
 from numba import (bytecode, interpreter, funcdesc, postproc,

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -29,7 +29,6 @@ class _CompilerLock(object):
         @functools.wraps(func)
         def _acquire_compile_lock(*args, **kwargs):
             with self:
-                require_global_compiler_lock()
                 return func(*args, **kwargs)
         return _acquire_compile_lock
 

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -6,11 +6,14 @@ import functools
 class _CompilerLock(object):
     def __init__(self):
         self._lock = threading.RLock()
+        self._locked = False
 
     def acquire(self):
         self._lock.acquire()
+        self._locked = True
 
     def release(self):
+        self._locked = False
         self._lock.release()
 
     def __enter__(self):
@@ -20,7 +23,7 @@ class _CompilerLock(object):
         self.release()
 
     def is_locked(self):
-        return self._lock._is_owned()
+        return self._locked
 
     def __call__(self, func):
         @functools.wraps(func)

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -6,14 +6,14 @@ import functools
 class _CompilerLock(object):
     def __init__(self):
         self._lock = threading.RLock()
-        self._locked = False
+        self._locked = 0
 
     def acquire(self):
         self._lock.acquire()
-        self._locked = True
+        self._locked += 1
 
     def release(self):
-        self._locked = False
+        self._locked -= 1
         self._lock.release()
 
     def __enter__(self):
@@ -23,7 +23,7 @@ class _CompilerLock(object):
         self.release()
 
     def is_locked(self):
-        return self._locked
+        return self._locked > 0
 
     def __call__(self, func):
         @functools.wraps(func)

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -6,14 +6,11 @@ import functools
 class _CompilerLock(object):
     def __init__(self):
         self._lock = threading.RLock()
-        self._locked = 0
 
     def acquire(self):
         self._lock.acquire()
-        self._locked += 1
 
     def release(self):
-        self._locked -= 1
         self._lock.release()
 
     def __enter__(self):
@@ -23,14 +20,28 @@ class _CompilerLock(object):
         self.release()
 
     def is_locked(self):
-        return self._locked > 0
+        is_owned = getattr(self._lock, '_is_owned')
+        if not callable(is_owned):
+            is_owned = self._is_owned
+        return is_owned()
 
     def __call__(self, func):
         @functools.wraps(func)
-        def wrapped(*args, **kwargs):
+        def _acquire_compile_lock(*args, **kwargs):
             with self:
+                require_global_compiler_lock()
                 return func(*args, **kwargs)
-        return wrapped
+        return _acquire_compile_lock
+
+    def _is_owned(self):
+        # This method is borrowed from threading.Condition.
+        # Return True if lock is owned by current_thread.
+        # This method is called only if _lock doesn't have _is_owned().
+        if self._lock.acquire(0):
+            self._lock.release()
+            return False
+        else:
+            return True
 
 
 global_compiler_lock = _CompilerLock()

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -49,5 +49,5 @@ global_compiler_lock = _CompilerLock()
 def require_global_compiler_lock():
     """Sentry that checks the global_compiler_lock is acquired.
     """
-    # Use assert to allow turning off this checks
+    # Use assert to allow turning off this check
     assert global_compiler_lock.is_locked()

--- a/numba/compiler_lock.py
+++ b/numba/compiler_lock.py
@@ -1,0 +1,40 @@
+import threading
+import functools
+
+
+# Lock for the preventing multiple compiler execution
+class _CompilerLock(object):
+    def __init__(self):
+        self._lock = threading.RLock()
+
+    def acquire(self):
+        self._lock.acquire()
+
+    def release(self):
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+
+    def __exit__(self, exc_val, exc_type, traceback):
+        self.release()
+
+    def is_locked(self):
+        return self._lock._is_owned()
+
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return wrapped
+
+
+global_compiler_lock = _CompilerLock()
+
+
+def require_global_compiler_lock():
+    """Sentry that checks the global_compiler_lock is acquired.
+    """
+    # Use assert to allow turning off this checks
+    assert global_compiler_lock.is_locked()

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -13,6 +13,7 @@ from numba import ctypes_support as ctypes
 from numba import config, compiler, types, sigutils
 from numba.typing.templates import AbstractTemplate, ConcreteTemplate
 from numba import funcdesc, typing, utils, serialize
+from numba.compiler_lock import global_compiler_lock
 
 from .cudadrv.autotune import AutoTuner
 from .cudadrv.devices import get_context
@@ -22,25 +23,7 @@ from .api import get_current_device
 from .args import wrap_arg
 
 
-_cuda_compiler_lock = compiler.lock_compiler
-
-
-def nonthreadsafe(fn):
-    """
-    Wraps a function to prevent multiple threads from executing it in parallel
-    due to LLVM is not threadsafe.
-    This is preferred over contextmanager due to llvm.Module.__del__ being
-    non-threadsafe and it is cumbersome to manually keep track of when it is
-    triggered.
-    """
-    @wraps(fn)
-    def core(*args, **kwargs):
-        with _cuda_compiler_lock:
-            return fn(*args, **kwargs)
-    return core
-
-
-@nonthreadsafe
+@global_compiler_lock
 def compile_cuda(pyfunc, return_type, args, debug, inline):
     # First compilation will trigger the initialization of the CUDA backend.
     from .descriptor import CUDATargetDesc
@@ -72,7 +55,7 @@ def compile_cuda(pyfunc, return_type, args, debug, inline):
     return cres
 
 
-@nonthreadsafe
+@global_compiler_lock
 def compile_kernel(pyfunc, args, link, debug=False, inline=False,
                    fastmath=False, extensions=[]):
     cres = compile_cuda(pyfunc, types.void, args, debug=debug, inline=inline)

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -22,7 +22,7 @@ from .api import get_current_device
 from .args import wrap_arg
 
 
-_cuda_compiler_lock = threading.RLock()
+_cuda_compiler_lock = compiler.lock_compiler
 
 
 def nonthreadsafe(fn):

--- a/numba/pycc/cc.py
+++ b/numba/pycc/cc.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 
 from numba import sigutils, typing
-from numba.compiler import lock_compiler
+from numba.compiler_lock import global_compiler_lock
 from .compiler import ModuleCompiler, ExportEntry
 from .platform import Toolchain
 
@@ -188,43 +188,43 @@ class CC(object):
                                                   extra_cflags=extra_cflags)
         return objects
 
+    @global_compiler_lock
     def _compile_object_files(self, build_dir):
-        with lock_compiler:
-            compiler = ModuleCompiler(self._export_entries, self._basename,
-                                    self._use_nrt, cpu_name=self._target_cpu)
-            compiler.external_init_function = self._init_function
-            temp_obj = os.path.join(build_dir,
-                                    os.path.splitext(self._output_file)[0] + '.o')
-            log.info("generating LLVM code for '%s' into %s",
-                    self._basename, temp_obj)
-            compiler.write_native_object(temp_obj, wrap=True)
-            return [temp_obj], compiler.dll_exports
+        compiler = ModuleCompiler(self._export_entries, self._basename,
+                                self._use_nrt, cpu_name=self._target_cpu)
+        compiler.external_init_function = self._init_function
+        temp_obj = os.path.join(build_dir,
+                                os.path.splitext(self._output_file)[0] + '.o')
+        log.info("generating LLVM code for '%s' into %s",
+                self._basename, temp_obj)
+        compiler.write_native_object(temp_obj, wrap=True)
+        return [temp_obj], compiler.dll_exports
 
+    @global_compiler_lock
     def compile(self):
         """
         Compile the extension module.
         """
-        with lock_compiler:
-            self._toolchain.verbose = self.verbose
-            build_dir = tempfile.mkdtemp(prefix='pycc-build-%s-' % self._basename)
+        self._toolchain.verbose = self.verbose
+        build_dir = tempfile.mkdtemp(prefix='pycc-build-%s-' % self._basename)
 
-            # Compile object file
-            objects, dll_exports = self._compile_object_files(build_dir)
+        # Compile object file
+        objects, dll_exports = self._compile_object_files(build_dir)
 
-            # Compile mixins
-            objects += self._compile_mixins(build_dir)
+        # Compile mixins
+        objects += self._compile_mixins(build_dir)
 
-            # Then create shared library
-            extra_ldflags = self._get_extra_ldflags()
-            output_dll = os.path.join(self._output_dir, self._output_file)
-            libraries = self._toolchain.get_python_libraries()
-            library_dirs = self._toolchain.get_python_library_dirs()
-            self._toolchain.link_shared(output_dll, objects,
-                                        libraries, library_dirs,
-                                        export_symbols=dll_exports,
-                                        extra_ldflags=extra_ldflags)
+        # Then create shared library
+        extra_ldflags = self._get_extra_ldflags()
+        output_dll = os.path.join(self._output_dir, self._output_file)
+        libraries = self._toolchain.get_python_libraries()
+        library_dirs = self._toolchain.get_python_library_dirs()
+        self._toolchain.link_shared(output_dll, objects,
+                                    libraries, library_dirs,
+                                    export_symbols=dll_exports,
+                                    extra_ldflags=extra_ldflags)
 
-            shutil.rmtree(build_dir)
+        shutil.rmtree(build_dir)
 
     def distutils_extension(self, **kwargs):
         """

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -11,7 +11,9 @@ import llvmlite.llvmpy.core as lc
 from numba import cgutils
 from numba.utils import IS_PY3
 from . import llvm_types as lt
-from numba.compiler import compile_extra, Flags, lock_compiler
+from numba.compiler import compile_extra, Flags
+from numba.compiler_lock import (require_global_compiler_lock,
+                                 global_compiler_lock)
 from numba.targets.registry import cpu_target
 from numba.runtime import nrtdynmod
 
@@ -124,66 +126,66 @@ class _ModuleCompiler(object):
         """
         raise NotImplementedError
 
+    @global_compiler_lock
     def _cull_exports(self):
         """Read all the exported functions/modules in the translator
         environment, and join them into a single LLVM module.
         """
-        with lock_compiler:
-            self.exported_function_types = {}
-            self.function_environments = {}
-            self.environment_gvs = {}
+        self.exported_function_types = {}
+        self.function_environments = {}
+        self.environment_gvs = {}
 
-            codegen = self.context.codegen()
-            library = codegen.create_library(self.module_name)
+        codegen = self.context.codegen()
+        library = codegen.create_library(self.module_name)
 
-            # Generate IR for all exported functions
-            flags = Flags()
-            flags.set("no_compile")
-            if not self.export_python_wrap:
-                flags.set("no_cpython_wrapper")
-            if self.use_nrt:
-                flags.set("nrt")
-                # Compile NRT helpers
-                nrt_module, _ = nrtdynmod.create_nrt_module(self.context)
-                library.add_ir_module(nrt_module)
+        # Generate IR for all exported functions
+        flags = Flags()
+        flags.set("no_compile")
+        if not self.export_python_wrap:
+            flags.set("no_cpython_wrapper")
+        if self.use_nrt:
+            flags.set("nrt")
+            # Compile NRT helpers
+            nrt_module, _ = nrtdynmod.create_nrt_module(self.context)
+            library.add_ir_module(nrt_module)
 
-            for entry in self.export_entries:
-                cres = compile_extra(self.typing_context, self.context,
-                                    entry.function,
-                                    entry.signature.args,
-                                    entry.signature.return_type, flags,
-                                    locals={}, library=library)
+        for entry in self.export_entries:
+            cres = compile_extra(self.typing_context, self.context,
+                                entry.function,
+                                entry.signature.args,
+                                entry.signature.return_type, flags,
+                                locals={}, library=library)
 
-                func_name = cres.fndesc.llvm_func_name
-                llvm_func = cres.library.get_function(func_name)
-
-                if self.export_python_wrap:
-                    llvm_func.linkage = lc.LINKAGE_INTERNAL
-                    wrappername = cres.fndesc.llvm_cpython_wrapper_name
-                    wrapper = cres.library.get_function(wrappername)
-                    wrapper.name = self._mangle_method_symbol(entry.symbol)
-                    wrapper.linkage = lc.LINKAGE_EXTERNAL
-                    fnty = cres.target_context.call_conv.get_function_type(
-                        cres.fndesc.restype, cres.fndesc.argtypes)
-                    self.exported_function_types[entry] = fnty
-                    self.function_environments[entry] = cres.environment
-                    self.environment_gvs[entry] = cres.fndesc.env_name
-                else:
-                    llvm_func.name = entry.symbol
-                    self.dll_exports.append(entry.symbol)
+            func_name = cres.fndesc.llvm_func_name
+            llvm_func = cres.library.get_function(func_name)
 
             if self.export_python_wrap:
-                wrapper_module = library.create_ir_module("wrapper")
-                self._emit_python_wrapper(wrapper_module)
-                library.add_ir_module(wrapper_module)
+                llvm_func.linkage = lc.LINKAGE_INTERNAL
+                wrappername = cres.fndesc.llvm_cpython_wrapper_name
+                wrapper = cres.library.get_function(wrappername)
+                wrapper.name = self._mangle_method_symbol(entry.symbol)
+                wrapper.linkage = lc.LINKAGE_EXTERNAL
+                fnty = cres.target_context.call_conv.get_function_type(
+                    cres.fndesc.restype, cres.fndesc.argtypes)
+                self.exported_function_types[entry] = fnty
+                self.function_environments[entry] = cres.environment
+                self.environment_gvs[entry] = cres.fndesc.env_name
+            else:
+                llvm_func.name = entry.symbol
+                self.dll_exports.append(entry.symbol)
 
-            # Hide all functions in the DLL except those explicitly exported
-            library.finalize()
-            for fn in library.get_defined_functions():
-                if fn.name not in self.dll_exports:
-                    fn.visibility = "hidden"
+        if self.export_python_wrap:
+            wrapper_module = library.create_ir_module("wrapper")
+            self._emit_python_wrapper(wrapper_module)
+            library.add_ir_module(wrapper_module)
 
-            return library
+        # Hide all functions in the DLL except those explicitly exported
+        library.finalize()
+        for fn in library.get_defined_functions():
+            if fn.name not in self.dll_exports:
+                fn.visibility = "hidden"
+
+        return library
 
     def write_llvm_bitcode(self, output, wrap=False, **kws):
         self.export_python_wrap = wrap

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -12,8 +12,7 @@ from numba import cgutils
 from numba.utils import IS_PY3
 from . import llvm_types as lt
 from numba.compiler import compile_extra, Flags
-from numba.compiler_lock import (require_global_compiler_lock,
-                                 global_compiler_lock)
+from numba.compiler_lock import global_compiler_lock
 from numba.targets.registry import cpu_target
 from numba.runtime import nrtdynmod
 

--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -6,6 +6,7 @@ from . import nrtdynmod
 from llvmlite import binding as ll
 
 from numba.utils import finalize as _finalize
+from numba.compiler_lock import global_compiler_lock
 from . import _nrt_python as _nrt
 
 _nrt_mstats = namedtuple("nrt_mstats", ["alloc", "free", "mi_alloc", "mi_free"])
@@ -15,37 +16,35 @@ class _Runtime(object):
     def __init__(self):
         self._init = False
 
+    @global_compiler_lock
     def initialize(self, ctx):
         """Initializes the NRT
 
         Must be called before any actual call to the NRT API.
         Safe to be called multiple times.
         """
-        from numba.compiler import lock_compiler
+        if self._init:
+            # Already initialized
+            return
 
-        with lock_compiler:
-            if self._init:
-                # Already initialized
-                return
+        # Register globals into the system
+        for py_name in _nrt.c_helpers:
+            c_name = "NRT_" + py_name
+            c_address = _nrt.c_helpers[py_name]
+            ll.add_symbol(c_name, c_address)
 
-            # Register globals into the system
-            for py_name in _nrt.c_helpers:
-                c_name = "NRT_" + py_name
-                c_address = _nrt.c_helpers[py_name]
-                ll.add_symbol(c_name, c_address)
+        # Compile atomic operations
+        self._library = nrtdynmod.compile_nrt_functions(ctx)
 
-            # Compile atomic operations
-            self._library = nrtdynmod.compile_nrt_functions(ctx)
+        self._ptr_inc = self._library.get_pointer_to_function("nrt_atomic_add")
+        self._ptr_dec = self._library.get_pointer_to_function("nrt_atomic_sub")
+        self._ptr_cas = self._library.get_pointer_to_function("nrt_atomic_cas")
 
-            self._ptr_inc = self._library.get_pointer_to_function("nrt_atomic_add")
-            self._ptr_dec = self._library.get_pointer_to_function("nrt_atomic_sub")
-            self._ptr_cas = self._library.get_pointer_to_function("nrt_atomic_cas")
+        # Install atomic ops to NRT
+        _nrt.memsys_set_atomic_inc_dec(self._ptr_inc, self._ptr_dec)
+        _nrt.memsys_set_atomic_cas(self._ptr_cas)
 
-            # Install atomic ops to NRT
-            _nrt.memsys_set_atomic_inc_dec(self._ptr_inc, self._ptr_dec)
-            _nrt.memsys_set_atomic_cas(self._ptr_cas)
-
-            self._init = True
+        self._init = True
 
     def _init_guard(self):
         if not self._init:

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -15,6 +15,7 @@ import llvmlite.binding as ll
 
 from numba import types, utils, cgutils, typing, funcdesc, debuginfo
 from numba import _dynfunc, _helperlib
+from numba.compiler_lock import global_compiler_lock
 from numba.pythonapi import PythonAPI
 from . import arrayobj, builtins, imputils
 from .imputils import (user_function, user_generator,
@@ -785,7 +786,8 @@ class BaseContext(object):
         """
         # Compile
         from numba import compiler
-        with compiler.lock_compiler:
+
+        with global_compiler_lock:
             codegen = self.codegen()
             library = codegen.create_library(impl.__name__)
             if flags is None:

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -207,6 +207,8 @@ class CodeLibrary(object):
         Finalization involves various stages of code optimization and
         linking.
         """
+        from numba.compiler import lock_compiler
+        assert lock_compiler._is_owned()
         # Report any LLVM-related problems to the user
         self._codegen._check_llvm_bugs()
 

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -4,7 +4,6 @@ import warnings
 import functools
 import locale
 import weakref
-from collections import defaultdict
 import ctypes
 
 import llvmlite.llvmpy.core as lc
@@ -15,6 +14,7 @@ import llvmlite.ir as llvmir
 from numba import config, utils, cgutils
 from numba.runtime.nrtopt import remove_redundant_nrt_refct
 from numba.runtime import rtsys
+from numba.compiler_lock import require_global_compiler_lock
 
 _x86arch = frozenset(['x86', 'i386', 'i486', 'i586', 'i686', 'i786',
                       'i886', 'i986'])
@@ -207,8 +207,8 @@ class CodeLibrary(object):
         Finalization involves various stages of code optimization and
         linking.
         """
-        from numba.compiler import lock_compiler
-        assert lock_compiler._is_owned()
+        require_global_compiler_lock()
+
         # Report any LLVM-related problems to the user
         self._codegen._check_llvm_bugs()
 

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -12,6 +12,7 @@ from numba.utils import cached_property
 from numba.targets import callconv, codegen, externals, intrinsics, listobj, setobj
 from .options import TargetOptions
 from numba.runtime import rtsys
+from numba.compiler_lock import global_compiler_lock
 from . import fastmathpass
 
 # Keep those structures in sync with _dynfunc.c.
@@ -37,6 +38,7 @@ class CPUContext(BaseContext):
     def create_module(self, name):
         return self._internal_codegen._create_empty_module(name)
 
+    @global_compiler_lock
     def init(self):
         self.is32bit = (utils.MACHINE_BITS == 32)
         self._internal_codegen = codegen.JITCPUCodegen("numba.exec")

--- a/numba/tests/test_cgutils.py
+++ b/numba/tests/test_cgutils.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba import cgutils, types, typing
+from numba.compiler import lock_compiler
 from numba.targets import cpu
 from .support import TestCase
 
@@ -28,13 +29,14 @@ class StructureTestCase(TestCase):
 
     @contextlib.contextmanager
     def compile_function(self, nargs):
+
         llvm_fnty = lc.Type.function(machine_int, [machine_int] * nargs)
         ctypes_fnty = ctypes.CFUNCTYPE(ctypes.c_size_t,
-                                       * (ctypes.c_size_t,) * nargs)
+                                    * (ctypes.c_size_t,) * nargs)
         module = self.context.create_module("")
 
         function = module.get_or_insert_function(llvm_fnty,
-                                                 name=self.id())
+                                                name=self.id())
         assert function.is_declaration
         entry_block = function.append_basic_block('entry')
         builder = lc.Builder(entry_block)
@@ -42,12 +44,13 @@ class StructureTestCase(TestCase):
         first = [True]
 
         def call_func(*args):
-            codegen = self.context.codegen()
-            library = codegen.create_library("test_module.%s" % self.id())
-            library.add_ir_module(module)
-            cptr = library.get_pointer_to_function(function.name)
-            cfunc = ctypes_fnty(cptr)
-            return cfunc(*args)
+            with lock_compiler:
+                codegen = self.context.codegen()
+                library = codegen.create_library("test_module.%s" % self.id())
+                library.add_ir_module(module)
+                cptr = library.get_pointer_to_function(function.name)
+                cfunc = ctypes_fnty(cptr)
+                return cfunc(*args)
 
         yield self.context, builder, function.args, call_func
 

--- a/numba/tests/test_cgutils.py
+++ b/numba/tests/test_cgutils.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba import cgutils, types, typing
-from numba.compiler import lock_compiler
+from numba.compiler_lock import global_compiler_lock
 from numba.targets import cpu
 from .support import TestCase
 
@@ -29,7 +29,6 @@ class StructureTestCase(TestCase):
 
     @contextlib.contextmanager
     def compile_function(self, nargs):
-
         llvm_fnty = lc.Type.function(machine_int, [machine_int] * nargs)
         ctypes_fnty = ctypes.CFUNCTYPE(ctypes.c_size_t,
                                     * (ctypes.c_size_t,) * nargs)
@@ -43,14 +42,14 @@ class StructureTestCase(TestCase):
 
         first = [True]
 
+        @global_compiler_lock
         def call_func(*args):
-            with lock_compiler:
-                codegen = self.context.codegen()
-                library = codegen.create_library("test_module.%s" % self.id())
-                library.add_ir_module(module)
-                cptr = library.get_pointer_to_function(function.name)
-                cfunc = ctypes_fnty(cptr)
-                return cfunc(*args)
+            codegen = self.context.codegen()
+            library = codegen.create_library("test_module.%s" % self.id())
+            library.add_ir_module(module)
+            cptr = library.get_pointer_to_function(function.name)
+            cfunc = ctypes_fnty(cptr)
+            return cfunc(*args)
 
         yield self.context, builder, function.args, call_func
 

--- a/numba/tests/test_codegen.py
+++ b/numba/tests/test_codegen.py
@@ -17,7 +17,7 @@ import llvmlite.binding as ll
 import numba.unittest_support as unittest
 from numba import utils
 from numba.targets.codegen import JITCPUCodegen
-from numba.compiler import lock_compiler
+from numba.compiler_lock import global_compiler_lock
 from .support import TestCase
 
 
@@ -56,12 +56,12 @@ class JITCPUCodegenTestCase(TestCase):
     """
 
     def setUp(self):
-        lock_compiler.acquire()
+        global_compiler_lock.acquire()
         self.codegen = JITCPUCodegen('test_codegen')
 
     def tearDown(self):
         del self.codegen
-        lock_compiler.release()
+        global_compiler_lock.release()
 
     def compile_module(self, asm, linking_asm=None):
         library = self.codegen.create_library('compiled_module')

--- a/numba/tests/test_codegen.py
+++ b/numba/tests/test_codegen.py
@@ -17,6 +17,7 @@ import llvmlite.binding as ll
 import numba.unittest_support as unittest
 from numba import utils
 from numba.targets.codegen import JITCPUCodegen
+from numba.compiler import lock_compiler
 from .support import TestCase
 
 
@@ -55,10 +56,12 @@ class JITCPUCodegenTestCase(TestCase):
     """
 
     def setUp(self):
+        lock_compiler.acquire()
         self.codegen = JITCPUCodegen('test_codegen')
 
     def tearDown(self):
         del self.codegen
+        lock_compiler.release()
 
     def compile_module(self, asm, linking_asm=None):
         library = self.codegen.create_library('compiled_module')

--- a/numba/tests/test_compiler_lock.py
+++ b/numba/tests/test_compiler_lock.py
@@ -1,0 +1,23 @@
+import unittest
+from numba.compiler_lock import (
+    global_compiler_lock,
+    require_global_compiler_lock,
+)
+from .support import TestCase
+
+
+class TestCompilerLock(TestCase):
+    def test_gcl_as_context_manager(self):
+        with global_compiler_lock:
+            require_global_compiler_lock()
+
+    def test_gcl_as_decorator(self):
+        @global_compiler_lock
+        def func():
+            require_global_compiler_lock()
+
+        func()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* rename `lock_compiler` -> `global_compiler_lock`
* add `numba/compiler_lock.py` and move global_compiler_lock in there
* `global_compiler_lock` is a contextmanager and a decorator
* add `require_global_compiler_lock()` to detect if the `global_compiler_lock` is acquired by the current thread.