### PR TITLE
Fix ds_permute types and add tests

### DIFF
--- a/numba/roc/hsadecl.py
+++ b/numba/roc/hsadecl.py
@@ -86,15 +86,25 @@ class Hsa_activelanepermute_wavewidth(ConcreteTemplate):
     cases = [signature(ty, ty, types.uint32, ty, types.bool_)
              for ty in (types.integer_domain|types.real_domain)]
 
-@intrinsic
-class Hsa_ds_permute(ConcreteTemplate):
-    key = roc.ds_permute
-    cases = [signature(types.int32, types.int32, types.int32)]
+
+class _Hsa_ds_permuting(ConcreteTemplate):
+    # parameter: index, source
+    cases = [signature(types.int32, types.int32, types.int32),
+             signature(types.int32, types.int64, types.int32),
+             signature(types.float32, types.int32, types.float32),
+             signature(types.float32, types.int64, types.float32)]
+    unsafe_casting = False
+
 
 @intrinsic
-class Hsa_ds_bpermute(ConcreteTemplate):
+class Hsa_ds_permute(_Hsa_ds_permuting):
+    key = roc.ds_permute
+
+
+@intrinsic
+class Hsa_ds_bpermute(_Hsa_ds_permuting):
     key = roc.ds_bpermute
-    cases = [signature(types.int32, types.int32, types.int32)]
+
 
 # hsa.shared submodule -------------------------------------------------------
 

--- a/numba/roc/tests/hsapy/test_intrinsics.py
+++ b/numba/roc/tests/hsapy/test_intrinsics.py
@@ -1,0 +1,110 @@
+from __future__ import print_function, absolute_import, division
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba import roc
+from numba.errors import TypingError
+import operator as oper
+
+_WAVESIZE = roc.get_context().agent.wavefront_size
+
+@roc.jit(device=True)
+def shuffle_up(val, width):
+    tid = roc.get_local_id(0)
+    roc.wavebarrier()
+    idx = (tid + width) % _WAVESIZE
+    res = roc.ds_permute(idx, val)
+    return res
+
+@roc.jit(device=True)
+def shuffle_down(val, width):
+    tid = roc.get_local_id(0)
+    roc.wavebarrier()
+    idx = (tid - width) % _WAVESIZE
+    res = roc.ds_permute(idx, val)
+    return res
+
+@roc.jit(device=True)
+def broadcast(val, from_lane):
+    tid = roc.get_local_id(0)
+    roc.wavebarrier()
+    res = roc.ds_bpermute(from_lane, val)
+    return res
+
+def gen_kernel(shuffunc):
+    @roc.jit
+    def kernel(inp, outp, amount):
+        tid = roc.get_local_id(0)
+        val = inp[tid]
+        outp[tid] = shuffunc(val, amount)
+    return kernel
+
+
+class TestDsPermute(unittest.TestCase):
+
+    def test_ds_permute(self):
+
+        inp = np.arange(_WAVESIZE).astype(np.int32)
+        outp = np.zeros_like(inp)
+
+        for shuffler, op in [(shuffle_down, oper.neg), (shuffle_up, oper.pos)]:
+            kernel = gen_kernel(shuffler)
+            for shuf in range(-_WAVESIZE, _WAVESIZE):
+                kernel[1, _WAVESIZE](inp, outp, shuf)
+                np.testing.assert_allclose(outp, np.roll(inp, op(shuf)))
+
+    def test_ds_permute_random_floats(self):
+
+        inp = np.linspace(0, 1, _WAVESIZE).astype(np.float32)
+        outp = np.zeros_like(inp)
+
+        for shuffler, op in [(shuffle_down, oper.neg), (shuffle_up, oper.pos)]:
+            kernel = gen_kernel(shuffler)
+            for shuf in range(-_WAVESIZE, _WAVESIZE):
+                kernel[1, _WAVESIZE](inp, outp, shuf)
+                np.testing.assert_allclose(outp, np.roll(inp, op(shuf)))
+
+    def test_ds_permute_type_safety(self):
+        """ Checks that float64's are not being downcast to float32"""
+        kernel = gen_kernel(shuffle_down)
+        inp = np.linspace(0, 1, _WAVESIZE).astype(np.float64)
+        outp = np.zeros_like(inp)
+        with self.assertRaises(TypingError) as e:
+            kernel[1, _WAVESIZE](inp, outp, 1)
+        errmsg = e.exception.msg
+        self.assertIn('Invalid use of Function', errmsg)
+        self.assertIn('with argument(s) of type(s): (float64, int64)', errmsg)
+
+    def test_ds_bpermute(self):
+
+        @roc.jit
+        def kernel(inp, outp, lane):
+            tid = roc.get_local_id(0)
+            val = inp[tid]
+            outp[tid] = broadcast(val, lane)
+
+        inp = np.arange(_WAVESIZE).astype(np.int32)
+        outp = np.zeros_like(inp)
+        for lane in range(0, _WAVESIZE):
+            kernel[1, _WAVESIZE](inp, outp, lane)
+            np.testing.assert_allclose(outp, lane)
+
+    def test_ds_bpermute_random_floats(self):
+
+        @roc.jit
+        def kernel(inp, outp, lane):
+            tid = roc.get_local_id(0)
+            val = inp[tid]
+            outp[tid] = broadcast(val, lane)
+
+        inp = np.linspace(0, 1, _WAVESIZE).astype(np.float32)
+        outp = np.zeros_like(inp)
+
+        for lane in range(0, _WAVESIZE):
+            kernel[1, _WAVESIZE](inp, outp, lane)
+            np.testing.assert_allclose(outp, inp[lane])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes the `ds_{,b}permute` intrinsic typing so that only
32bit types can be used in the source, whereas the index lane
can be int32 or int64. Tests are added.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
