### PR TITLE
Do not need to call parallel optimizations "experimental" anymore

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -161,8 +161,8 @@ Does Numba automatically parallelize code?
 It can, in some cases:
 
 * Ufuncs and gufuncs with the ``target="parallel"`` option will run on multiple threads.
-* The experimental ``parallel=True`` option to ``@jit`` will attempt to optimize
-  array operations and run them in parallel.  It also adds support for ``prange()`` to
+* The ``parallel=True`` option to ``@jit`` will attempt to optimize array
+  operations and run them in parallel.  It also adds support for ``prange()`` to
   explicitly parallelize a loop.
 
 You can also manually run computations on multiple threads yourself and use

--- a/docs/source/user/jit.rst
+++ b/docs/source/user/jit.rst
@@ -186,11 +186,11 @@ a file-based cache.  This is done by passing ``cache=True``::
 ``parallel``
 ------------
 
-Enables an experimental feature that automatically parallelizes (and
-performs other optimizations for) those operations in the function known to
-have parallel semantics.  For a list of supported operations, see
-:ref:`numba-parallel`.  This feature is enabled by passing ``parallel=True`` and
-must be used in conjunction with ``nopython=True``::
+Enables automatic parallelization (and related optimizations) for those
+operations in the function known to have parallel semantics.  For a list of
+supported operations, see :ref:`numba-parallel`.  This feature is enabled by
+passing ``parallel=True`` and must be used in conjunction with
+``nopython=True``::
 
    @jit(nopython=True, parallel=True)
    def f(x, y):

--- a/docs/source/user/parallel.rst
+++ b/docs/source/user/parallel.rst
@@ -8,7 +8,7 @@ Automatic parallelization with ``@jit``
 =======================================
 
 Setting the :ref:`parallel_jit_option` option for :func:`~numba.jit` enables
-an experimental Numba feature that attempts to automatically parallelize and
+a Numba transformation pass that attempts to automatically parallelize and
 perform other optimizations on (part of) a function. At the moment, this
 feature only works on CPUs.
 
@@ -73,10 +73,11 @@ parallel semantics and for which we attempt to parallelize.
 Explicit Parallel Loops
 ========================
 
-Another experimental feature of this module is support for explicit parallel
-loops. One can use Numba's ``prange`` instead of ``range`` to specify that a
-loop can be parallelized. The user is required to make sure that the loop does
-not have cross iteration dependencies except for supported reductions.
+Another feature of this code transformation pass is support for explicit
+parallel loops. One can use Numba's ``prange`` instead of ``range`` to specify
+that a loop can be parallelized. The user is required to make sure that the
+loop does not have cross iteration dependencies except for supported
+reductions.
 
 A reduction is inferred automatically if a variable is updated by a binary
 function/operator using its previous value in the loop body. The initial value


### PR DESCRIPTION
Update docs to reflect that parallel accelerator has been around for a while now.