### PR TITLE
Adding NUMBA_ENABLE_PROFILING envvar, enabling jit event

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -97,6 +97,14 @@ These variables influence what is printed out during compilation of
    of the compiler frontend, up to and including generation of the Numba
    Intermediate Representation.
 
+.. envvar:: NUMBA_DEBUGINFO
+
+   if sets to non-zero, enable debug for the full application by setting
+   the default value of the ``debug`` option in ``jit``. Beware that
+   enabling debug info significantly increases the memory consumption
+   for each compiled function.
+   Default value equals to the value of `NUMBA_ENABLE_PROFILING`.
+
 .. envvar:: NUMBA_DEBUG_TYPEINFER
 
    If set to non-zero, print out debugging information about type inference.
@@ -105,6 +113,11 @@ These variables influence what is printed out during compilation of
 
    If set to non-zero, print out information about operation of the
    :ref:`JIT compilation cache <jit-cache>`.
+
+.. envvar:: NUMBA_ENABLE_PROFILING
+
+   Enables JIT events of LLVM in order to support profiling of jitted functions.
+   This option is automatically enabled under certain profilers.
 
 .. envvar:: NUMBA_TRACE
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -302,10 +302,18 @@ class _EnvReloader(object):
         NUMBA_NUM_THREADS = _readenv("NUMBA_NUM_THREADS", int,
                                      NUMBA_DEFAULT_NUM_THREADS)
 
+        # Profiling support
+
+        # Indicates if a profiler detected. Only VTune can be detected for now
+        RUNNING_UNDER_PROFILER = 'VS_PROFILER' in os.environ
+
+        # Enables jit events in LLVM in order to support profiling of dynamic code
+        ENABLE_PROFILING = _readenv("NUMBA_ENABLE_PROFILING", int, int(RUNNING_UNDER_PROFILER))
+
         # Debug Info
 
         # The default value for the `debug` flag
-        DEBUGINFO_DEFAULT = _readenv("NUMBA_DEBUGINFO", int, 0)
+        DEBUGINFO_DEFAULT = _readenv("NUMBA_DEBUGINFO", int, ENABLE_PROFILING)
         CUDA_DEBUGINFO_DEFAULT = _readenv("NUMBA_CUDA_DEBUGINFO", int, 0)
 
         # Inject the configuration values into the module globals

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -612,6 +612,9 @@ class BaseCPUCodegen(object):
         tm = target.create_target_machine(**tm_options)
         engine = ll.create_mcjit_compiler(llvm_module, tm)
 
+        if config.ENABLE_PROFILING:
+            engine.enable_jit_events()
+
         self._tm = tm
         self._engine = JitEngine(engine)
         self._target_data = engine.target_data


### PR DESCRIPTION
Default value depends on whether profiling was detected
It also serves as a default value for NUMBA_DEBUGINFO

@sklam @seibert 

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
