### PR TITLE
Workaround mysterious race condition with apt

### DIFF
--- a/buildscripts/azure/azure-linux.yml
+++ b/buildscripts/azure/azure-linux.yml
@@ -77,7 +77,8 @@ jobs:
 
   steps:
     - script: |
-        if [ "$(uname)" == "Linux" ]; then sudo apt-get install -y libc6-dev-i386; fi
+        # Sleep 10 seconds because of race condition with background apt process
+        if [ "$(uname)" == "Linux" ]; then sleep 10; sudo apt-get install -y libc6-dev-i386; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH


### PR DESCRIPTION
Something is temporarily holding the dpkg lock on the Azure VMs when they first start up.  This prevents the linux 32 config from apt-get installing something, but only some of the time.  Adding a delay to hopefully avoid the conflict.
