### PR TITLE
Fix memory management of __cuda_array_interface__ views.

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -36,11 +36,11 @@ def from_cuda_array_interface(desc, owner=None):
 
     shape, strides, dtype = _prepare_shape_strides_dtype(
         shape, strides, dtype, order='C')
+    size = driver.memory_size_from_info(shape, strides, dtype.itemsize)
 
     devptr = driver.get_devptr_for_active_ctx(desc['data'][0])
     data = driver.MemoryPointer(
-        current_context(), devptr, size=np.prod(shape) * dtype.itemsize,
-        owner=owner)
+        current_context(), devptr, size=size, owner=owner)
     da = devicearray.DeviceNDArray(shape=shape, strides=strides,
                                    dtype=dtype, gpu_data=data)
     return da

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1211,7 +1211,13 @@ class MemoryPointer(object):
                 raise RuntimeError('size cannot be negative')
             pointer = drvapi.cu_device_ptr(base)
             view = MemoryPointer(self.context, pointer, size, owner=self.owner)
-        return OwnedPointer(weakref.proxy(self.owner), view)
+
+        if isinstance(self.owner, (MemoryPointer, OwnedPointer)):
+            # Owned by a numba-managed memory segment, take an owned reference
+            return OwnedPointer(weakref.proxy(self.owner), view)
+        else:
+            # Owned by external alloc, return view with same external owner
+            return view
 
     @property
     def device_ctypes_pointer(self):

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -107,13 +107,16 @@ class TestCudaArrayInterface(CUDATestCase):
                          out._arr.device_ctypes_pointer.value)
 
     def test_array_views(self):
-        """views created via array interface should provide:
-            - standard indexing operations
+        """Views created via array interface support:
+            - Strided slices
+            - Strided slices
         """
         h_arr = np.random.random(10)
         c_arr = cuda.to_device(h_arr)
 
         arr = cuda.as_cuda_array(c_arr)
+
+        # __getitem__ interface accesses expected data
 
         # Direct views
         np.testing.assert_array_equal(arr.copy_to_host(), h_arr)
@@ -127,12 +130,46 @@ class TestCudaArrayInterface(CUDATestCase):
 
         # View of strided array
         arr_strided = cuda.as_cuda_array(c_arr[::2])
+        np.testing.assert_array_equal(arr_strided.copy_to_host(), h_arr[::2])
 
+        # A strided-view-of-array and view-of-strided-array have the same
+        # shape, strides, itemsize, and alloc_size
         self.assertEqual(arr[::2].shape, arr_strided.shape)
         self.assertEqual(arr[::2].strides, arr_strided.strides)
         self.assertEqual(arr[::2].dtype.itemsize, arr_strided.dtype.itemsize)
         self.assertEqual(arr[::2].alloc_size, arr_strided.alloc_size)
-        np.testing.assert_array_equal(arr_strided.copy_to_host(), h_arr[::2])
+
+        # __setitem__ interface propogates into external array
+
+        # Writes to a slice
+        arr[:5] = np.pi
+        np.testing.assert_array_equal(
+            c_arr.copy_to_host(),
+            np.concatenate((np.full(5, np.pi), h_arr[5:]))
+        )
+
+        # Writes to a slice from a view
+        arr[:5] = arr[5:]
+        np.testing.assert_array_equal(
+            c_arr.copy_to_host(),
+            np.concatenate((h_arr[5:], h_arr[5:]))
+        )
+
+        # Writes through a view
+        arr[:] = cuda.to_device(h_arr)
+        np.testing.assert_array_equal(c_arr.copy_to_host(), h_arr)
+
+        # Writes to a strided slice
+        arr[::2] = np.pi
+        np.testing.assert_array_equal(
+            c_arr.copy_to_host()[::2],
+            np.full(5, np.pi),
+        )
+        np.testing.assert_array_equal(
+            c_arr.copy_to_host()[1::2],
+            h_arr[1::2]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -106,6 +106,24 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(returned.device_ctypes_pointer.value,
                          out._arr.device_ctypes_pointer.value)
 
+    def test_view_indexing(self):
+        """views created via array interface should provide:
+            - standard indexing operations
+        """
+        h_arr = np.random.random(10)
+        m_arr = MyArray(cuda.to_device(h_arr))
+
+        arr = cuda.as_cuda_array(m_arr)
+
+        # Direct views
+        np.testing.assert_array_equal(arr.copy_to_host(), h_arr)
+        np.testing.assert_array_equal(arr[:].copy_to_host(), h_arr)
+
+        # Slicing
+        np.testing.assert_array_equal(arr[:5].copy_to_host(), h_arr[:5])
+
+        # Striding
+        np.testing.assert_array_equal(arr[::2].copy_to_host(), h_arr[::2])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
_fixes #3333 fixes #3334_

* Fix view size calculation for strided cuda arrays.

  Fix calculation of allocation size for views of strided memory segments
  exposed via __cuda_array_interface__. `from_cuda_array_interface` must
  consider array strides when determining size of referenced segment.

  Add test covering __cuda_array_interface__ views of strided memory.

* Fix view creation for external cuda arrays.

  Fix pointer creation for views of externally-managed cuda arrays. Return
  MemoryPointer referencing the same external owner when creating a view,
  rather than creating an OwnedPointer reference.

  Test cuda array view __getitem__ interface.