### PR TITLE
Accidentally left Anton off contributor list for 0.40

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -129,6 +129,7 @@ Documentation Updates:
 
 Contributors:
 
+* Anton Malakhov
 * Alex Ford
 * Anthony Bisulco
 * Ehsan Totoni (core dev)


### PR DESCRIPTION
Given the amount Anton contributed to the threading work, we should list him in the 0.40 release notes.