### PR TITLE
Support user pipeline class in with lifting

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -915,7 +915,7 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
     """
 
     pipeline = pipeline_class(typingctx, targetctx, library,
-                        args, return_type, flags, locals)
+                              args, return_type, flags, locals)
     return pipeline.compile_ir(func_ir=func_ir, lifted=lifted,
                                lifted_from=lifted_from)
 

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -443,7 +443,8 @@ class BasePipeline(object):
             cres = compile_ir(self.typingctx, self.targetctx, main,
                               self.args, self.return_type,
                               self.flags, self.locals,
-                              lifted=tuple(withs), lifted_from=None)
+                              lifted=tuple(withs), lifted_from=None,
+                              pipeline_class=type(self))
             raise _EarlyPipelineCompletion(cres)
 
     def stage_objectmode_frontend(self):
@@ -905,14 +906,15 @@ def compile_extra(typingctx, targetctx, func, args, return_type, flags,
 
 
 def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
-               locals, lifted=(), lifted_from=None, library=None):
+               locals, lifted=(), lifted_from=None, library=None,
+               pipeline_class=Pipeline):
     """
     Compile a function with the given IR.
 
     For internal use only.
     """
 
-    pipeline = Pipeline(typingctx, targetctx, library,
+    pipeline = pipeline_class(typingctx, targetctx, library,
                         args, return_type, flags, locals)
     return pipeline.compile_ir(func_ir=func_ir, lifted=lifted,
                                lifted_from=lifted_from)


### PR DESCRIPTION
Currently, the `with` lifting stage calls the compiler again with the default pipeline class. This PR fixes it to use the current pipeline class, which can be user-defined.

Closes #3347.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
