### PR TITLE
Fix the default unboxing logic

### DIFF
--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -1025,7 +1025,7 @@ def unbox_dispatcher(typ, obj, c):
 def unbox_unsupported(typ, obj, c):
     c.pyapi.err_set_string("PyExc_TypeError",
                            "can't unbox {!r} type".format(typ))
-    res = c.pyapi.get_null_object()
+    res = c.context.get_constant_null(typ)
     return NativeValue(res, is_error=cgutils.true_bit)
 
 

--- a/numba/tests/test_extending_types.py
+++ b/numba/tests/test_extending_types.py
@@ -96,8 +96,8 @@ class TestExtTypDummy(unittest.TestCase):
         self.assertIn("TypeError: cannot type float(complex128)",
                       str(raises.exception))
 
-    def test_unbox(self):
-        """A test for the unbox logic on unknown type
+    def test_unboxing(self):
+        """A test for the unboxing logic on unknown type
         """
         Dummy = self.Dummy
 
@@ -109,9 +109,23 @@ class TestExtTypDummy(unittest.TestCase):
         # make sure a cpython wrapper is created
         @njit(no_cpython_wrapper=False)
         def bar(dummy_obj):
-            pass   #return dummy_obj
+            pass
 
         foo(123)
         with self.assertRaises(TypeError) as raises:
             bar(Dummy(123))
         self.assertIn("can't unbox Dummy type", str(raises.exception))
+
+    def test_boxing(self):
+        """A test for the boxing logic on unknown type
+        """
+        Dummy = self.Dummy
+
+        @njit
+        def foo(x):
+            return Dummy(x)
+
+        with self.assertRaises(TypeError) as raises:
+            foo(123)
+        self.assertIn("cannot convert native Dummy to Python object",
+                      str(raises.exception))


### PR DESCRIPTION
One line fix in `boxing.py` so the default unboxing logic compiles properly.  Tests are added to exercise the code path of the default (un)boxer.  