### PR TITLE
Allow non-global reference to objmode() context-manager

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1774,6 +1774,25 @@ def fill_callee_epilogue(block, outputs):
     return block
 
 
+def find_global_value(func_ir, var):
+    """Check if a variable is a global value, and return the value,
+    or raise GuardException otherwise.
+    """
+    dfn = func_ir.get_definition(var)
+    if isinstance(dfn, ir.Global):
+        return dfn.value
+
+    if isinstance(dfn, ir.Expr) and dfn.op == 'getattr':
+        prev_val = find_global_value(func_ir, dfn.value)
+        try:
+            val = getattr(prev_val, dfn.attr)
+            return val
+        except KeyError:
+            raise GuardException
+
+    raise GuardException
+
+
 def raise_on_unsupported_feature(func_ir):
     """
     Helper function to walk IR and raise if it finds op codes

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -4,6 +4,7 @@ import copy
 import warnings
 import numpy as np
 
+import numba
 from numba import unittest_support as unittest
 from numba.transforms import find_setupwiths, with_lifting
 from numba.withcontexts import bypass_context, call_context, objmode_context
@@ -317,7 +318,14 @@ class TestLiftObj(MemoryLeak, TestCase):
                 bar(ival)
             return ival + 1
 
+        def foo_nonglobal(ival):
+            ival += 1
+            with numba.objmode:
+                bar(ival)
+            return ival + 1
+
         self.assert_equal_return_and_stdout(foo, 123)
+        self.assert_equal_return_and_stdout(foo_nonglobal, 123)
 
     def test_lift_objmode_array_in(self):
         def bar(arr):
@@ -359,8 +367,14 @@ class TestLiftObj(MemoryLeak, TestCase):
                 y = inverse(x)
             return x, y
 
+        def foo_nonglobal(x):
+            with numba.objmode(y="float64"):
+                y = inverse(x)
+            return x, y
+
         arg = 123
         self.assert_equal_return_and_stdout(foo, arg)
+        self.assert_equal_return_and_stdout(foo_nonglobal, arg)
 
     def test_lift_objmode_return_array(self):
         def inverse(x):

--- a/numba/withcontexts.py
+++ b/numba/withcontexts.py
@@ -156,8 +156,6 @@ class _ObjModeContextType(WithContext):
         - with-block cannot use incoming function object.
         - with-block cannot ``yield``, ``break``, ``return`` or ``raise`` \
           such that the execution will leave the with-block immediately.
-        - the ``objmode()`` function must be directly referenced as a global. \
-          i.e. ``with numba.objmode():`` doesn't work.
 
     .. note:: When used outside of no-python mode, the context-manager has no
         effect.


### PR DESCRIPTION
As title. Allowing only global reference to `objmode()` seems confusing.