### PR TITLE
Enable overload(operator.getitem)

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -571,7 +571,13 @@ class Lower(BaseLower):
     def lower_getitem(self, resty, expr, value, index, signature):
         baseval = self.loadvar(value.name)
         indexval = self.loadvar(index.name)
-        impl = self.context.get_function(operator.getitem, signature)
+        op = operator.getitem
+        try:
+            impl = self.context.get_function(op, signature)
+        except NotImplementedError:
+            fnop = self.context.typing_context.resolve_value_type(op)
+            fnop.get_call_type(self.context.typing_context, signature.args, {})
+            impl = self.context.get_function(fnop, signature)
         argvals = (baseval, indexval)
         argtyps = (self.typeof(value.name),
                    self.typeof(index.name))

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -571,13 +571,12 @@ class Lower(BaseLower):
     def lower_getitem(self, resty, expr, value, index, signature):
         baseval = self.loadvar(value.name)
         indexval = self.loadvar(index.name)
+        # Get implementation of getitem
         op = operator.getitem
-        try:
-            impl = self.context.get_function(op, signature)
-        except NotImplementedError:
-            fnop = self.context.typing_context.resolve_value_type(op)
-            fnop.get_call_type(self.context.typing_context, signature.args, {})
-            impl = self.context.get_function(fnop, signature)
+        fnop = self.context.typing_context.resolve_value_type(op)
+        fnop.get_call_type(self.context.typing_context, signature.args, {})
+        impl = self.context.get_function(fnop, signature)
+
         argvals = (baseval, indexval)
         argtyps = (self.typeof(value.name),
                    self.typeof(index.name))

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 import weakref
 import time
 from collections import namedtuple, deque
+import operator
 from functools import partial
 
 from llvmlite.llvmpy.core import Constant, Type, Builder
@@ -13,7 +14,7 @@ from . import (_dynfunc, cgutils, config, funcdesc, generators, ir, types,
 from .errors import LoweringError, new_error_context, TypingError
 from .targets import removerefctpass
 from .funcdesc import default_mangler
-from . import debuginfo, utils
+from . import debuginfo
 
 
 class Environment(_dynfunc.Environment):
@@ -570,7 +571,7 @@ class Lower(BaseLower):
     def lower_getitem(self, resty, expr, value, index, signature):
         baseval = self.loadvar(value.name)
         indexval = self.loadvar(index.name)
-        impl = self.context.get_function("getitem", signature)
+        impl = self.context.get_function(operator.getitem, signature)
         argvals = (baseval, indexval)
         argtyps = (self.typeof(value.name),
                    self.typeof(index.name))

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1337,8 +1337,10 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         def src_getitem(source_indices):
             idx, = source_indices
-            getitem_impl = context.get_function(operator.getitem,
-                                                signature(src_dtype, srcty, types.intp))
+            getitem_impl = context.get_function(
+                operator.getitem,
+                signature(src_dtype, srcty, types.intp),
+                )
             return getitem_impl(builder, (src, idx))
 
         def src_cleanup():

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -402,8 +402,8 @@ def _getitem_array_generic(context, builder, return_type, aryty, ary,
         return load_item(context, builder, aryty, dataptr)
 
 
-@lower_builtin('getitem', types.Buffer, types.Integer)
-@lower_builtin('getitem', types.Buffer, types.SliceType)
+@lower_builtin(operator.getitem, types.Buffer, types.Integer)
+@lower_builtin(operator.getitem, types.Buffer, types.SliceType)
 def getitem_arraynd_intp(context, builder, sig, args):
     """
     Basic indexing with an integer or a slice.
@@ -419,7 +419,7 @@ def getitem_arraynd_intp(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-@lower_builtin('getitem', types.Buffer, types.BaseTuple)
+@lower_builtin(operator.getitem, types.Buffer, types.BaseTuple)
 def getitem_array_tuple(context, builder, sig, args):
     """
     Basic or advanced indexing with a tuple.
@@ -1028,7 +1028,7 @@ def fancy_getitem(context, builder, sig, args,
     return impl_ret_new_ref(context, builder, out_ty, out._getvalue())
 
 
-@lower_builtin('getitem', types.Buffer, types.Array)
+@lower_builtin(operator.getitem, types.Buffer, types.Array)
 def fancy_getitem_array(context, builder, sig, args):
     """
     Advanced or basic indexing with an array.
@@ -1337,7 +1337,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
 
         def src_getitem(source_indices):
             idx, = source_indices
-            getitem_impl = context.get_function('getitem',
+            getitem_impl = context.get_function(operator.getitem,
                                                 signature(src_dtype, srcty, types.intp))
             return getitem_impl(builder, (src, idx))
 
@@ -2983,7 +2983,7 @@ def iternext_numpy_flatiter(context, builder, sig, args, result):
     flatiter.iternext_specific(context, builder, arrty, arr, result)
 
 
-@lower_builtin('getitem', types.NumpyFlatType, types.Integer)
+@lower_builtin(operator.getitem, types.NumpyFlatType, types.Integer)
 def iternext_numpy_getitem(context, builder, sig, args):
     flatiterty = sig.args[0]
     flatiter, index = args
@@ -3919,7 +3919,7 @@ def _get_borrowing_getitem(context, seqty):
     Return a getitem() implementation that doesn't incref its result.
     """
     retty = seqty.dtype
-    getitem_impl = context.get_function('getitem',
+    getitem_impl = context.get_function(operator.getitem,
                                         signature(retty, seqty, types.intp))
     def wrap(builder, args):
         ret = getitem_impl(builder, args)

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -81,7 +81,7 @@ def deferred_to_any(context, builder, fromty, toty, val):
 
 #------------------------------------------------------------------------------
 
-@lower_builtin('getitem', types.CPointer, types.Integer)
+@lower_builtin(operator.getitem, types.CPointer, types.Integer)
 def getitem_cpointer(context, builder, sig, args):
     base_ptr, idx = args
     elem_ptr = builder.gep(base_ptr, [idx])

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -33,6 +33,9 @@ class Registry(object):
         The decorated implementation has the signature
         (context, builder, sig, args).
         """
+        #
+        assert func != 'getitem', 'switch to `operator.getitem`'
+
         def decorate(impl):
             self.functions.append((impl, func, argtys))
             return impl

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -33,9 +33,6 @@ class Registry(object):
         The decorated implementation has the signature
         (context, builder, sig, args).
         """
-        #
-        assert func != 'getitem', 'switch to `operator.getitem`'
-
         def decorate(impl):
             self.functions.append((impl, func, argtys))
             return impl

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -501,7 +501,7 @@ def iternext_listiter(context, builder, sig, args, result):
         inst.index = builder.add(index, context.get_constant(types.intp, 1))
 
 
-@lower_builtin('getitem', types.List, types.Integer)
+@lower_builtin(operator.getitem, types.List, types.Integer)
 def getitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     index = args[1]
@@ -524,7 +524,7 @@ def setitem_list(context, builder, sig, args):
     return context.get_dummy_value()
 
 
-@lower_builtin('getitem', types.List, types.SliceType)
+@lower_builtin(operator.getitem, types.List, types.SliceType)
 def getslice_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     slice = context.make_helper(builder, sig.args[1], args[1])

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -193,8 +193,8 @@ def iternext_unituple(context, builder, sig, args, result):
         builder.store(nidx, iterval.index)
 
 
-@lower_builtin('getitem', types.UniTuple, types.intp)
-@lower_builtin('getitem', types.NamedUniTuple, types.intp)
+@lower_builtin(operator.getitem, types.UniTuple, types.intp)
+@lower_builtin(operator.getitem, types.NamedUniTuple, types.intp)
 def getitem_unituple(context, builder, sig, args):
     tupty, _ = sig.args
     tup, idx = args

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -258,6 +258,14 @@ def overload_add_dummy(arg1, arg2):
         return dummy_add_impl
 
 
+@overload(operator.getitem)
+def overload_dummy_getitem(obj, idx):
+    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+        def dummy_getitem_impl(obj, idx):
+            return idx + 123
+        return dummy_getitem_impl
+
+
 def call_add_operator(arg1, arg2):
     return operator.add(arg1, arg2)
 
@@ -283,6 +291,10 @@ def call_iadd_binop(arg1, arg2):
     arg1 += arg2
 
     return arg1
+
+
+def call_getitem(obj, idx):
+    return obj[idx]
 
 
 @overload_method(MyDummyType, 'length')
@@ -581,6 +593,10 @@ class TestHighLevelExtending(TestCase):
         # this will call add(Number, Number) as MyDummy implicitly casts to Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
 
+    def test_getitem(self):
+        pyfunc = call_getitem
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(MyDummy(), 321), 321 + 123)
 
     def test_no_cpython_wrapper(self):
         """

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -14,6 +14,7 @@ Constraints push types forward following the dataflow.
 
 from __future__ import print_function, division, absolute_import
 
+import operator
 import contextlib
 import itertools
 from pprint import pprint
@@ -326,7 +327,7 @@ class StaticGetItemConstraint(object):
         self.value = value
         self.index = index
         if index_var is not None:
-            self.fallback = IntrinsicCallConstraint(target, 'getitem',
+            self.fallback = IntrinsicCallConstraint(target, operator.getitem,
                                                     (value, index_var), {},
                                                     None, loc)
         else:
@@ -437,7 +438,7 @@ class CallConstraint(object):
             if not a.is_precise():
                 # Getitem on non-precise array is allowed to
                 # support array-comprehension
-                if fnty == 'getitem' and isinstance(pos_args[0], types.Array):
+                if fnty == operator.getitem and isinstance(pos_args[0], types.Array):
                     pass
                 # Otherwise, don't compute type yet
                 else:
@@ -494,7 +495,7 @@ class CallConstraint(object):
 
     def refine(self, typeinfer, updated_type):
         # Is getitem?
-        if self.func == 'getitem':
+        if self.func == operator.getitem:
             aryty = typeinfer.typevars[self.args[0].name].getone()
             # is array not precise?
             if _is_array_not_precise(aryty):
@@ -1250,8 +1251,9 @@ class TypeInferer(object):
             self.constraints.append(constraint)
             self.calls.append((inst.value, constraint))
         elif expr.op == 'getitem':
-            self.typeof_intrinsic_call(inst, target, 'getitem', expr.value,
-                                       expr.index)
+            self.typeof_intrinsic_call(
+                inst, target, operator.getitem, expr.value, expr.index,
+                )
         elif expr.op == 'getattr':
             constraint = GetAttrConstraint(target.name, attr=expr.attr,
                                            value=expr.value, loc=inst.loc,

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -159,9 +159,9 @@ def get_array_index_type(ary, idx):
     return Indexing(idx, res, advanced)
 
 
-@infer
+@infer_global(operator.getitem)
 class GetItemBuffer(AbstractTemplate):
-    key = "getitem"
+    key = operator.getitem
 
     def generic(self, args, kws):
         assert not kws

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -161,8 +161,6 @@ def get_array_index_type(ary, idx):
 
 @infer_global(operator.getitem)
 class GetItemBuffer(AbstractTemplate):
-    key = operator.getitem
-
     def generic(self, args, kws):
         assert not kws
         [ary, idx] = args

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -550,9 +550,9 @@ def normalize_1d_index(index):
         return types.intp if index.signed else types.uintp
 
 
-@infer
+@infer_global(operator.getitem)
 class GetItemCPointer(AbstractTemplate):
-    key = "getitem"
+    key = operator.getitem
 
     def generic(self, args, kws):
         assert not kws

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -17,7 +17,6 @@ from numba.typing.templates import (AttributeTemplate, ConcreteTemplate,
 
 @infer_global(print)
 class Print(AbstractTemplate):
-
     def generic(self, args, kws):
         for a in args:
             sig = self.context.resolve_function_type("print_item", (a,), {})
@@ -46,7 +45,6 @@ class Abs(ConcreteTemplate):
 
 @infer_global(slice)
 class Slice(ConcreteTemplate):
-    key = slice
     cases = [
         signature(types.slice2_type),
         signature(types.slice2_type, types.none, types.none),
@@ -168,64 +166,58 @@ class BinOp(ConcreteTemplate):
 
 @infer_global(operator.add)
 class BinOpAdd(BinOp):
-    key = operator.add
+    pass
 
 
 @infer_global(operator.iadd)
 class BinOpAdd(BinOp):
-    key = operator.iadd
+    pass
 
 
 @infer_global(operator.sub)
 class BinOpSub(BinOp):
-    key = operator.sub
+    pass
 
 
 @infer_global(operator.isub)
 class BinOpSub(BinOp):
-    key = operator.isub
+    pass
 
 
 @infer_global(operator.mul)
 class BinOpMul(BinOp):
-    key = operator.mul
+    pass
 
 
 @infer_global(operator.imul)
 class BinOpMul(BinOp):
-    key = operator.imul
+    pass
 
 if not IS_PY3:
     @infer_global(operator.div)
     class BinOpDiv(BinOp):
-        key = operator.div
+        pass
 
 
     @infer_global(operator.idiv)
     class BinOpDiv(BinOp):
-        key = operator.idiv
+        pass
 
 
 @infer_global(operator.mod)
 class BinOpMod(ConcreteTemplate):
-    key = operator.mod
-
     cases = list(integer_binop_cases)
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
 
 
 @infer_global(operator.imod)
 class BinOpMod(ConcreteTemplate):
-    key = operator.imod
-
     cases = list(integer_binop_cases)
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
 
 
 @infer_global(operator.truediv)
 class BinOpTrueDiv(ConcreteTemplate):
-    key = operator.truediv
-
     cases = [signature(types.float64, op1, op2)
              for op1, op2 in itertools.product(machine_ints, machine_ints)]
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
@@ -234,8 +226,6 @@ class BinOpTrueDiv(ConcreteTemplate):
 
 @infer_global(operator.itruediv)
 class BinOpTrueDiv(ConcreteTemplate):
-    key = operator.itruediv
-
     cases = [signature(types.float64, op1, op2)
              for op1, op2 in itertools.product(machine_ints, machine_ints)]
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
@@ -244,16 +234,12 @@ class BinOpTrueDiv(ConcreteTemplate):
 
 @infer_global(operator.floordiv)
 class BinOpFloorDiv(ConcreteTemplate):
-    key = operator.floordiv
-
     cases = list(integer_binop_cases)
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
 
 
 @infer_global(operator.ifloordiv)
 class BinOpFloorDiv(ConcreteTemplate):
-    key = operator.ifloordiv
-
     cases = list(integer_binop_cases)
     cases += [signature(op, op, op) for op in sorted(types.real_domain)]
 
@@ -266,8 +252,6 @@ class DivMod(ConcreteTemplate):
 
 @infer_global(operator.pow)
 class BinOpPower(ConcreteTemplate):
-    key = operator.pow
-
     cases = list(integer_binop_cases)
     # Ensure that float32 ** int doesn't go through DP computations
     cases += [signature(types.float32, types.float32, op)
@@ -282,8 +266,6 @@ class BinOpPower(ConcreteTemplate):
 
 @infer_global(operator.ipow)
 class BinOpPower(ConcreteTemplate):
-    key = operator.ipow
-
     cases = list(integer_binop_cases)
     # Ensure that float32 ** int doesn't go through DP computations
     cases += [signature(types.float32, types.float32, op)
@@ -298,8 +280,8 @@ class BinOpPower(ConcreteTemplate):
 
 @infer_global(pow)
 class PowerBuiltin(BinOpPower):
-    key = pow
     # TODO add 3 operand version
+    pass
 
 
 class BitwiseShiftOperation(ConcreteTemplate):
@@ -323,22 +305,21 @@ class BitwiseShiftOperation(ConcreteTemplate):
 
 @infer_global(operator.lshift)
 class BitwiseLeftShift(BitwiseShiftOperation):
-    key = operator.lshift
-
+    pass
 
 @infer_global(operator.ilshift)
 class BitwiseLeftShift(BitwiseShiftOperation):
-    key = operator.ilshift
+    pass
 
 
 @infer_global(operator.rshift)
 class BitwiseRightShift(BitwiseShiftOperation):
-    key = operator.rshift
+    pass
 
 
 @infer_global(operator.irshift)
 class BitwiseRightShift(BitwiseShiftOperation):
-    key = operator.ilshift
+    pass
 
 
 class BitwiseLogicOperation(BinOp):
@@ -349,32 +330,32 @@ class BitwiseLogicOperation(BinOp):
 
 @infer_global(operator.and_)
 class BitwiseAnd(BitwiseLogicOperation):
-    key = operator.and_
+    pass
 
 
 @infer_global(operator.iand)
 class BitwiseAnd(BitwiseLogicOperation):
-    key = operator.iand
+    pass
 
 
 @infer_global(operator.or_)
 class BitwiseOr(BitwiseLogicOperation):
-    key = operator.or_
+    pass
 
 
 @infer_global(operator.ior)
 class BitwiseOr(BitwiseLogicOperation):
-    key = operator.ior
+    pass
 
 
 @infer_global(operator.xor)
 class BitwiseXor(BitwiseLogicOperation):
-    key = operator.xor
+    pass
 
 
 @infer_global(operator.ixor)
 class BitwiseXor(BitwiseLogicOperation):
-    key = operator.ixor
+    pass
 
 
 # Bitwise invert and negate are special: we must not upcast the operand
@@ -383,8 +364,6 @@ class BitwiseXor(BitwiseLogicOperation):
 
 @infer_global(operator.invert)
 class BitwiseInvert(ConcreteTemplate):
-    key = operator.invert
-
     # Note Numba follows the Numpy semantics of returning a bool,
     # while Python returns an int.  This makes it consistent with
     # np.invert() and makes array expressions correct.
@@ -393,6 +372,7 @@ class BitwiseInvert(ConcreteTemplate):
     cases += [signature(choose_result_int(op), op) for op in sorted(types.signed_domain)]
 
     unsafe_casting = False
+
 
 class UnaryOp(ConcreteTemplate):
     cases = [signature(choose_result_int(op), op) for op in sorted(types.unsigned_domain)]
@@ -404,17 +384,16 @@ class UnaryOp(ConcreteTemplate):
 
 @infer_global(operator.neg)
 class UnaryNegate(UnaryOp):
-    key = operator.neg
+    pass
 
 
 @infer_global(operator.pos)
 class UnaryPositive(UnaryOp):
-   key = operator.pos
+   pass
 
 
 @infer_global(operator.not_)
 class UnaryNot(ConcreteTemplate):
-    key = operator.not_
     cases = [signature(types.boolean, types.boolean)]
     cases += [signature(types.boolean, op) for op in sorted(types.signed_domain)]
     cases += [signature(types.boolean, op) for op in sorted(types.unsigned_domain)]
@@ -436,40 +415,46 @@ class UnorderedCmpOp(ConcreteTemplate):
 
 @infer_global(operator.lt)
 class CmpOpLt(OrderedCmpOp):
-    key = operator.lt
+    pass
+
 
 @infer_global(operator.le)
 class CmpOpLe(OrderedCmpOp):
-    key = operator.le
+    pass
+
 
 @infer_global(operator.gt)
 class CmpOpGt(OrderedCmpOp):
-    key = operator.gt
+    pass
+
 
 @infer_global(operator.ge)
 class CmpOpGe(OrderedCmpOp):
-    key = operator.ge
+    pass
+
 
 @infer_global(operator.eq)
 class CmpOpEq(UnorderedCmpOp):
-    key = operator.eq
+    pass
+
 
 @infer_global(operator.eq)
 class ConstOpEq(AbstractTemplate):
-    key = operator.eq
     def generic(self, args, kws):
         assert not kws
         (arg1, arg2) = args
         if isinstance(arg1, types.Const) and isinstance(arg2, types.Const):
             return signature(types.boolean, arg1, arg2)
 
+
 @infer_global(operator.ne)
 class ConstOpNotEq(ConstOpEq):
-    key = operator.ne
+    pass
+
 
 @infer_global(operator.ne)
 class CmpOpNe(UnorderedCmpOp):
-    key = operator.ne
+    pass
 
 
 class TupleCompare(AbstractTemplate):
@@ -484,34 +469,39 @@ class TupleCompare(AbstractTemplate):
             else:
                 return signature(types.boolean, lhs, rhs)
 
+
 @infer_global(operator.eq)
 class TupleEq(TupleCompare):
-    key = operator.eq
+    pass
+
 
 @infer_global(operator.ne)
 class TupleNe(TupleCompare):
-    key = operator.ne
+    pass
+
 
 @infer_global(operator.ge)
 class TupleGe(TupleCompare):
-    key = operator.ge
+    pass
+
 
 @infer_global(operator.gt)
 class TupleGt(TupleCompare):
-    key = operator.gt
+    pass
+
 
 @infer_global(operator.le)
 class TupleLe(TupleCompare):
-    key = operator.le
+    pass
+
 
 @infer_global(operator.lt)
 class TupleLt(TupleCompare):
-    key = operator.lt
+    pass
+
 
 @infer_global(operator.add)
 class TupleAdd(AbstractTemplate):
-    key = operator.add
-
     def generic(self, args, kws):
         if len(args) == 2:
             a, b = args
@@ -530,12 +520,12 @@ class CmpOpIdentity(AbstractTemplate):
 
 @infer_global(operator.is_)
 class CmpOpIs(CmpOpIdentity):
-    key = operator.is_
+    pass
 
 
 @infer_global(operator.is_not)
 class CmpOpIsNot(CmpOpIdentity):
-    key = operator.is_not
+    pass
 
 
 def normalize_1d_index(index):
@@ -552,8 +542,6 @@ def normalize_1d_index(index):
 
 @infer_global(operator.getitem)
 class GetItemCPointer(AbstractTemplate):
-    key = operator.getitem
-
     def generic(self, args, kws):
         assert not kws
         ptr, idx = args
@@ -574,8 +562,6 @@ class SetItemCPointer(AbstractTemplate):
 
 @infer_global(len)
 class Len(AbstractTemplate):
-    key = len
-
     def generic(self, args, kws):
         assert not kws
         (val,) = args
@@ -586,8 +572,6 @@ class Len(AbstractTemplate):
 
 @infer_global(tuple)
 class TupleConstructor(AbstractTemplate):
-    key = tuple
-
     def generic(self, args, kws):
         assert not kws
         # empty tuple case
@@ -601,8 +585,6 @@ class TupleConstructor(AbstractTemplate):
 
 @infer_global(operator.contains)
 class Contains(AbstractTemplate):
-    key = operator.contains
-
     def generic(self, args, kws):
         assert not kws
         (seq, val) = args
@@ -612,8 +594,6 @@ class Contains(AbstractTemplate):
 
 @infer_global(operator.truth)
 class TupleBool(AbstractTemplate):
-    key = operator.truth
-
     def generic(self, args, kws):
         assert not kws
         (val,) = args
@@ -1025,10 +1005,13 @@ class MinValInfer(AbstractTemplate):
         assert isinstance(args[0], (types.DType, types.NumberClass))
         return signature(args[0].dtype, *args)
 
+
 #------------------------------------------------------------------------------
 
-from numba.extending import (typeof_impl, type_callable, models, register_model,
-                                make_attribute_wrapper)
+from numba.extending import (
+    typeof_impl, type_callable, models, register_model, make_attribute_wrapper,
+    )
+
 
 class IndexValue(object):
     """
@@ -1041,16 +1024,19 @@ class IndexValue(object):
     def __repr__(self):
         return 'IndexValue(%f, %f)' % (self.index, self.value)
 
+
 class IndexValueType(types.Type):
     def __init__(self, val_typ):
         self.val_typ = val_typ
         super(IndexValueType, self).__init__(
                                     name='IndexValueType({})'.format(val_typ))
 
+
 @typeof_impl.register(IndexValue)
 def typeof_index(val, c):
     val_typ = typeof_impl(val.value, c)
     return IndexValueType(val_typ)
+
 
 @type_callable(IndexValue)
 def type_index_value(context):
@@ -1058,6 +1044,7 @@ def type_index_value(context):
         if ind == types.intp or ind == types.uintp:
             return IndexValueType(mval)
     return typer
+
 
 @register_model(IndexValueType)
 class IndexValueModel(models.StructModel):
@@ -1067,6 +1054,7 @@ class IndexValueModel(models.StructModel):
             ('value', fe_type.val_typ),
             ]
         models.StructModel.__init__(self, dmm, fe_type, members)
+
 
 make_attribute_wrapper(IndexValueType, 'index', 'index')
 make_attribute_wrapper(IndexValueType, 'value', 'value')

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -37,9 +37,10 @@ class SequenceBool(AbstractTemplate):
         if isinstance(val, (types.Sequence)):
             return signature(types.boolean, val)
 
-@infer
+
+@infer_global(operator.getitem)
 class GetItemSequence(AbstractTemplate):
-    key = "getitem"
+    key = operator.getitem
 
     def generic(self, args, kws):
         seq, idx = args

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -4,7 +4,6 @@ Define typing templates
 from __future__ import print_function, division, absolute_import
 
 import functools
-from functools import reduce
 import operator
 import sys
 from types import MethodType
@@ -341,6 +340,9 @@ def make_overload_template(func, overload_func, jit_options):
     func_name = getattr(func, '__name__', str(func))
     name = "OverloadTemplate_%s" % (func_name,)
     base = _OverloadFunctionTemplate
+    # XXX: temporary
+    if func is operator.getitem:
+        func = 'getitem'
     dct = dict(key=func, _overload_func=staticmethod(overload_func),
                _impl_cache={}, _compiled_overloads={}, _jit_options=jit_options)
     return type(base)(name, (base,), dct)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -340,9 +340,6 @@ def make_overload_template(func, overload_func, jit_options):
     func_name = getattr(func, '__name__', str(func))
     name = "OverloadTemplate_%s" % (func_name,)
     base = _OverloadFunctionTemplate
-    # XXX: temporary
-    if func is operator.getitem:
-        func = 'getitem'
     dct = dict(key=func, _overload_func=staticmethod(overload_func),
                _impl_cache={}, _compiled_overloads={}, _jit_options=jit_options)
     return type(base)(name, (base,), dct)


### PR DESCRIPTION
- [x] modify lowering to use `operator.getitem` as the key instead of `"getitem"`
- [x] modify typing to do the same as above
- [x] remove hack in lowering
- [x] add test