### PR TITLE
CUDA_ERROR_MISALIGNED_ADDRESS Using Multiple Const Arrays

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -116,6 +116,11 @@ def ptx_cmem_arylike(context, builder, sig, args):
     gv.global_constant = True
     gv.initializer = constary
 
+    # Preserve the underlying alignment
+    lldtype = context.get_data_type(aryty.dtype)
+    align = context.get_abi_sizeof(lldtype)
+    gv.align = 2 ** (align - 1).bit_length()
+
     # Convert to generic address-space
     conv = nvvmutils.insert_addrspace_conv(lmod, Type.int(8), addrspace)
     addrspaceptr = gv.bitcast(Type.pointer(Type.int(8), addrspace))


### PR DESCRIPTION
Multiple const arrays are densly packed, so if an array has a non-aligned footprint (e.g. the 3-byte array in this PR's test case) the next const array will start at a 3-byte alignment, and (e.g.) 4-byte loads will fail. This is because the arrays are all declared as `i8 align 1` byte arrays, when they should be declared as `i8 align XX` arrays, where XX is the actual alignment requirement of the data. [Shared-memory arrays already do this](https://github.com/numba/numba/blob/master/numba/cuda/cudaimpl.py#L539-L540).