### PR TITLE
typeinfer: use unknown_loc object instead of string literal

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -113,6 +113,10 @@ class Loc(object):
         return type(self)(self.filename, line, col)
 
 
+# Used for annotating errors when source location is unknown.
+unknown_loc = Loc("unknown location", 0, 0)
+
+
 class VarMap(object):
     def __init__(self):
         self._con = {}

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -905,7 +905,7 @@ class TypeInferer(object):
                     if offender is not None:
                         break
                 val = getattr(offender, 'value', 'unknown operation')
-                loc = getattr(offender, 'loc', 'unknown location')
+                loc = getattr(offender, 'loc', ir.unknown_loc)
                 msg = "Undefined variable '%s', operation: %s, location: %s"
                 raise TypingError(msg % (var, val, loc), loc)
             tp = tv.getone()
@@ -983,7 +983,7 @@ class TypeInferer(object):
                                     break
 
                     for name, offender in returns.items():
-                        loc = getattr(offender, 'loc', 'unknown location')
+                        loc = getattr(offender, 'loc', ir.unknown_loc)
                         msg = ("Return of: IR name '%s', type '%s', "
                                "location: %s")
                         interped = msg % (name, atype, loc.strformat())


### PR DESCRIPTION
typeinfer: use unknown_loc object instead of string literal 

Fixes #3389

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

