### PR TITLE
Fix with-objmode warning

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -784,6 +784,8 @@ class ObjModeLiftedWith(LiftedWith):
     def __init__(self, *args, **kwargs):
         self.output_types = kwargs.pop('output_types', None)
         super(LiftedWith, self).__init__(*args, **kwargs)
+        if not self.flags.force_pyobject:
+            raise ValueError("expecting `flags.enable_pyobject`")
         if not self.flags.enable_pyobject:
             raise ValueError("expecting `flags.enable_pyobject`")
         if self.output_types is None:

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -785,9 +785,7 @@ class ObjModeLiftedWith(LiftedWith):
         self.output_types = kwargs.pop('output_types', None)
         super(LiftedWith, self).__init__(*args, **kwargs)
         if not self.flags.force_pyobject:
-            raise ValueError("expecting `flags.enable_pyobject`")
-        if not self.flags.enable_pyobject:
-            raise ValueError("expecting `flags.enable_pyobject`")
+            raise ValueError("expecting `flags.force_pyobject`")
         if self.output_types is None:
             raise TypeError('`output_types` must be provided')
 

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -522,7 +522,10 @@ class TestLiftObj(MemoryLeak, TestCase):
 
         with self.assertRaises(errors.TypingError) as raises:
             njit(foo)(123)
-        self.assertIn("Failed in object mode pipeline", str(raises.exception))
+        # Check that an error occurred in with-lifting in objmode
+        pat = ("During: resolving callee type: "
+               "type\(ObjModeLiftedWith\(<.*>\)\)")
+        self.assertRegexpMatches(str(raises.exception), pat)
 
     def test_case07_mystery_key_error(self):
         # this raises a key error

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -290,6 +290,12 @@ def expected_failure_for_function_arg(fn):
 
 class TestLiftObj(MemoryLeak, TestCase):
 
+    def setUp(self):
+        warnings.simplefilter("error", errors.NumbaWarning)
+
+    def tearDown(self):
+        warnings.resetwarnings()
+
     def assert_equal_return_and_stdout(self, pyfunc, *args):
         py_args = copy.deepcopy(args)
         c_args = copy.deepcopy(args)

--- a/numba/transforms.py
+++ b/numba/transforms.py
@@ -299,6 +299,7 @@ def with_lifting(func_ir, typingctx, targetctx, flags, locals):
             myflags.enable_looplift = False
             # Lifted with-block uses object mode
             myflags.enable_pyobject = True
+            myflags.force_pyobject = True
             cls = ObjModeLiftedWith
         else:
             cls = LiftedWith

--- a/numba/withcontexts.py
+++ b/numba/withcontexts.py
@@ -156,6 +156,9 @@ class _ObjModeContextType(WithContext):
         - with-block cannot use incoming function object.
         - with-block cannot ``yield``, ``break``, ``return`` or ``raise`` \
           such that the execution will leave the with-block immediately.
+        - with-block cannot contain `with` statements.
+        - random number generator states do not synchronize; i.e. \
+          nopython-mode and object-mode uses different RNG states.
 
     .. note:: When used outside of no-python mode, the context-manager has no
         effect.


### PR DESCRIPTION
As reported in https://github.com/numba/numba/issues/3355#issuecomment-426841943

This adds the force_pyobject flag to the compiling of the lifted objmode function.  This ensures the lifted function is compiled in objectmode all the time.  Without this flag, as in the case before this patch, the lifted function may not be in objectmode.  The change has revealed unsupported features that were previously thought to be supported.  The commit https://github.com/numba/numba/commit/3cbe645cd5b796e4ba33e43a4061ec3420b3818d updates the tests to reflect the lack of support for RNG and nested with-context.