### PR TITLE
Add max_registers Option to cuda.jit

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -411,15 +411,15 @@ class CachedCUFunction(object):
             msg = ('cannot pickle CUDA kernel function with additional '
                    'libraries to link against')
             raise RuntimeError(msg)
-        args = (self.__class__, self.entry_name, self.ptx, self.linking)
+        args = (self.__class__, self.entry_name, self.ptx, self.linking, self.max_registers)
         return (serialize._rebuild_reduction, args)
 
     @classmethod
-    def _rebuild(cls, entry_name, ptx, linking):
+    def _rebuild(cls, entry_name, ptx, linking, max_registers):
         """
         Rebuild an instance.
         """
-        return cls(entry_name, ptx, linking)
+        return cls(entry_name, ptx, linking, max_registers)
 
 
 class CUDAKernel(CUDAKernelBase):

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1540,7 +1540,7 @@ FILE_EXTENSION_MAP = {
 
 
 class Linker(object):
-    def __init__(self):
+    def __init__(self, max_registers=0):
         logsz = int(os.environ.get('NUMBAPRO_CUDA_LOG_SIZE', 1024))
         linkerinfo = (c_char * logsz)()
         linkererrors = (c_char * logsz)()
@@ -1552,6 +1552,8 @@ class Linker(object):
             enums.CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES: c_void_p(logsz),
             enums.CU_JIT_LOG_VERBOSE: c_void_p(1),
         }
+        if max_registers:
+            options[enums.CU_JIT_MAX_REGISTERS] = c_void_p(max_registers)
 
         raw_keys = list(options.keys()) + [enums.CU_JIT_TARGET_FROM_CUCONTEXT]
         raw_values = list(options.values())

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -44,6 +44,8 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
        disables precise division and square root. This parameter has no effect
        on device function, whose fastmath setting depends on the kernel function
        from which they are called.
+    :param max_registers: Limit the kernel to using at most this number of
+       registers per thread. Useful for increasing occupancy.
     """
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
 

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -8,6 +8,55 @@ from numba.cuda.cudadrv.driver import Linker
 from numba.cuda import require_context
 from numba import cuda
 
+
+def function_with_lots_of_registers(x, a, b, c, d, e, f):
+    a1 = 1.0
+    a2 = 1.0
+    a3 = 1.0
+    a4 = 1.0
+    a5 = 1.0
+    b1 = 1.0
+    b2 = 1.0
+    b3 = 1.0
+    b4 = 1.0
+    b5 = 1.0
+    c1 = 1.0
+    c2 = 1.0
+    c3 = 1.0
+    c4 = 1.0
+    c5 = 1.0
+    d1 = 10
+    d2 = 10
+    d3 = 10
+    d4 = 10
+    d5 = 10
+    for i in range(a):
+        a1 += b
+        a2 += c
+        a3 += d
+        a4 += e
+        a5 += f
+        b1 *= b
+        b2 *= c
+        b3 *= d
+        b4 *= e
+        b5 *= f
+        c1 /= b
+        c2 /= c
+        c3 /= d
+        c4 /= e
+        c5 /= f
+        d1 <<= b
+        d2 <<= c
+        d3 <<= d
+        d4 <<= e
+        d5 <<= f
+    x[cuda.grid(1)] = a1 + a2 + a3 + a4 + a5
+    x[cuda.grid(1)] += b1 + b2 + b3 + b4 + b5
+    x[cuda.grid(1)] += c1 + c2 + c3 + c4 + c5
+    x[cuda.grid(1)] += d1 + d2 + d3 + d4 + d5
+
+
 @skip_on_cudasim('Linking unsupported in the simulator')
 class TestLinker(SerialMixin, unittest.TestCase):
 
@@ -36,6 +85,19 @@ class TestLinker(SerialMixin, unittest.TestCase):
         foo(A, B)
 
         self.assertTrue(A[0] == 123 + 2 * 321)
+
+    @require_context
+    def test_set_registers_57(self):
+        compiled = cuda.jit(max_registers=57)(function_with_lots_of_registers)
+        compiled = compiled.specialize(np.empty(32), *range(6))
+        self.assertEquals(57, compiled._func.get().attrs.regs)
+
+    @require_context
+    def test_set_registers_38(self):
+        compiled = cuda.jit(max_registers=38)(function_with_lots_of_registers)
+        compiled = compiled.specialize(np.empty(32), *range(6))
+        self.assertEquals(38, compiled._func.get().attrs.regs)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Limiting registers is useful for improving occupancy, at the expense of spilling to local memory. Use the `CU_JIT_MAX_REGISTERS` argument when linking!