### PR TITLE
Switch alloca for static and threadprivate.

### DIFF
--- a/numba/npyufunc/omppool.cpp
+++ b/numba/npyufunc/omppool.cpp
@@ -101,11 +101,18 @@ parallel_for(void *fn, char **args, size_t *dimensions, size_t *steps, void *dat
         printf("\n");
     }
 
+    // C99 has 127 stipulated as the minimum number of arguments that must
+    // be supported in a function call
+    #define _C99_FN_ARG_COUNT 127
+    // These are threadprivate, one copy per thread, this is in preference to
+    // using alloca and the stack which can overflow for large size inputs
+    static size_t count_space[_C99_FN_ARG_COUNT];
+    static char * array_arg_space[_C99_FN_ARG_COUNT];
+
+    #pragma omp threadprivate(count_space, array_arg_space)
     #pragma omp parallel for
     for(ptrdiff_t r = 0; r < size; r++)
     {
-        size_t * count_space = (size_t *)alloca(sizeof(size_t) * arg_len);
-        char ** array_arg_space = (char**)alloca(sizeof(char*) * array_count);
         memcpy(count_space, dimensions, arg_len * sizeof(size_t));
         count_space[0] = 1;
 

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -500,6 +500,28 @@ class TestThreadingLayerSelection(ThreadLayerTestHelper):
 TestThreadingLayerSelection.generate()
 
 
+class TestMiscBackendIssues(ThreadLayerTestHelper):
+
+    _DEBUG = False
+
+    @skip_no_omp
+    def test_omp_stack_overflow_fix(self):
+        """
+        Tests that the stack does not overflow in OMP implementation
+        """
+        body = """if 1:
+            func = threading_backend_usecases.simple_vec
+            N = 2**20
+            x = np.ones(N, np.float32)
+            y = np.ones(N, np.float32)
+            func(x, y)
+        """
+        runme = self.template % body
+        cmdline = [sys.executable, '-c', runme]
+        out, err = self.run_cmd(cmdline)
+        if self._DEBUG:
+            print(out, err)
+
 # 32bit or windows py27 (not that this runs on windows)
 @parfors_skip_unsupported
 @skip_unless_gnu_omp

--- a/numba/tests/threading_backend_usecases.py
+++ b/numba/tests/threading_backend_usecases.py
@@ -1,6 +1,6 @@
 import signal
 import sys
-from numba import njit
+from numba import njit, vectorize
 import numpy as np
 
 def sigterm_handler(signum, frame):
@@ -24,3 +24,7 @@ def busy_func(a, b, q=None):
     except BaseException as e:
         if q is not None:
             q.put(e)
+
+@vectorize(['float32(float32, float32)'], target='parallel')
+def simple_vec(x, y):
+    return x + y


### PR DESCRIPTION
This switches alloca for OMP threadprivate static array use to
prevent potential stack overflow in cases where the driving parallel
loop has a high bound.

Fixes #3406

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
