### PR TITLE
Fix cuda tests and error reporting in test discovery

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 
+import os
 from functools import reduce, wraps
 import operator
 import sys
@@ -583,8 +584,17 @@ class CUDAKernel(CUDAKernelBase):
                 ctaid = [load_symbol("ctaid" + i) for i in 'zyx']
                 code = excval.value
                 exccls, exc_args, loc = self.call_helper.get_exception(code)
+                # Prefix the exception message with the source location
+                if loc is None:
+                    locinfo = ''
+                else:
+                    sym, filepath, lineno = loc
+                    filepath = os.path.relpath(filepath)
+                    locinfo = 'In function %r, file %s, line %s, ' % (
+                        sym, filepath, lineno,
+                        )
                 # Prefix the exception message with the thread position
-                prefix = "tid=%s ctaid=%s" % (tid, ctaid)
+                prefix = "%stid=%s ctaid=%s" % (locinfo, tid, ctaid)
                 if exc_args:
                     exc_args = ("%s: %s" % (prefix, exc_args[0]),) + exc_args[1:]
                 else:

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -582,7 +582,7 @@ class CUDAKernel(CUDAKernelBase):
                 tid = [load_symbol("tid" + i) for i in 'zyx']
                 ctaid = [load_symbol("ctaid" + i) for i in 'zyx']
                 code = excval.value
-                exccls, exc_args = self.call_helper.get_exception(code)
+                exccls, exc_args, loc = self.call_helper.get_exception(code)
                 # Prefix the exception message with the thread position
                 prefix = "tid=%s ctaid=%s" % (tid, ctaid)
                 if exc_args:

--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -5,7 +5,6 @@ from os.path import dirname, join
 
 
 def load_tests(loader, tests, pattern):
-
     suite = unittest.TestSuite()
     this_dir = dirname(__file__)
     suite.addTests(load_testsuite(loader, join(this_dir, 'nocuda')))

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -9,7 +9,7 @@ class MyError(Exception):
 
 
 regex_pattern = (
-    r'In function [\'"]test_exc[\'"], file ([\.\/\\a-zA-Z_0-9]+), line \d+'
+    r'In function [\'"]test_exc[\'"], file [\.\/\\\-a-zA-Z_0-9]+, line \d+'
 )
 
 

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -8,6 +8,10 @@ class MyError(Exception):
     pass
 
 
+regex_pattern = (
+    r'In function [\'"]test_exc[\'"], file ([\.\/\\a-zA-Z_0-9]+), line \d+'
+)
+
 class TestUserExc(SerialMixin, unittest.TestCase):
     def test_user_exception(self):
         @cuda.jit("void(int32)", debug=True)
@@ -20,10 +24,12 @@ class TestUserExc(SerialMixin, unittest.TestCase):
         test_exc(0)    # no raise
         with self.assertRaises(MyError) as cm:
             test_exc(1)
-        self.assertEqual("tid=[0, 0, 0] ctaid=[0, 0, 0]", str(cm.exception))
+        self.assertRegexpMatches(str(cm.exception), regex_pattern)
+        self.assertIn("tid=[0, 0, 0] ctaid=[0, 0, 0]", str(cm.exception))
         with self.assertRaises(MyError) as cm:
             test_exc(2)
-        self.assertEqual("tid=[0, 0, 0] ctaid=[0, 0, 0]: foo", str(cm.exception))
+        self.assertRegexpMatches(str(cm.exception), regex_pattern)
+        self.assertIn("tid=[0, 0, 0] ctaid=[0, 0, 0]: foo", str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
-from numba.cuda.testing import unittest, SerialMixin
-from numba import cuda
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba import cuda, config
 
 
 class MyError(Exception):
@@ -12,7 +12,9 @@ regex_pattern = (
     r'In function [\'"]test_exc[\'"], file ([\.\/\\a-zA-Z_0-9]+), line \d+'
 )
 
+
 class TestUserExc(SerialMixin, unittest.TestCase):
+
     def test_user_exception(self):
         @cuda.jit("void(int32)", debug=True)
         def test_exc(x):
@@ -24,11 +26,14 @@ class TestUserExc(SerialMixin, unittest.TestCase):
         test_exc(0)    # no raise
         with self.assertRaises(MyError) as cm:
             test_exc(1)
-        self.assertRegexpMatches(str(cm.exception), regex_pattern)
+        if not config.ENABLE_CUDASIM:
+            self.assertRegexpMatches(str(cm.exception), regex_pattern)
         self.assertIn("tid=[0, 0, 0] ctaid=[0, 0, 0]", str(cm.exception))
         with self.assertRaises(MyError) as cm:
             test_exc(2)
-        self.assertRegexpMatches(str(cm.exception), regex_pattern)
+        if not config.ENABLE_CUDASIM:
+            self.assertRegexpMatches(str(cm.exception), regex_pattern)
+            self.assertRegexpMatches(str(cm.exception), regex_pattern)
         self.assertIn("tid=[0, 0, 0] ctaid=[0, 0, 0]: foo", str(cm.exception))
 
 

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -194,7 +194,6 @@ class MinimalCallConv(BaseCallConv):
             raise TypeError("exc_args should be None or tuple, got %r"
                             % (exc_args,))
 
-        pyapi = self.context.get_python_api(builder)
         # Build excinfo struct
         if loc is not None:
             f1 = loc._raw_function_name()
@@ -203,11 +202,9 @@ class MinimalCallConv(BaseCallConv):
                 locinfo = None
         else:
             locinfo = None
-        if exc_args is not None:
-            exc = (exc, exc_args, locinfo)
 
         call_helper = self._get_call_helper(builder)
-        exc_id = call_helper._add_exception(exc, exc_args)
+        exc_id = call_helper._add_exception(exc, exc_args, locinfo)
         self._return_errcode_raw(builder, _const_int(exc_id))
 
     def return_status_propagate(self, builder, status):
@@ -296,9 +293,19 @@ class _MinimalCallHelper(object):
     def __init__(self):
         self.exceptions = {}
 
-    def _add_exception(self, exc, exc_args):
+    def _add_exception(self, exc, exc_args, locinfo):
+        """
+        Parameters
+        ----------
+        exc :
+            exception type
+        exc_args : None or tuple
+            exception args
+        locinfo : tuple
+            location information
+        """
         exc_id = len(self.exceptions) + FIRST_USEREXC
-        self.exceptions[exc_id] = exc, exc_args
+        self.exceptions[exc_id] = exc, exc_args, locinfo
         return exc_id
 
     def get_exception(self, exc_id):

--- a/numba/testing/__init__.py
+++ b/numba/testing/__init__.py
@@ -1,34 +1,39 @@
 from __future__ import print_function, division, absolute_import
 
-import numba.unittest_support as unittest
-
-import sys
 import os
-from os.path import join, isfile, relpath, normpath, splitext
-from fnmatch import fnmatch
+import sys
 import functools
+import traceback
+from fnmatch import fnmatch
+from os.path import join, isfile, relpath, normpath, splitext
 
 from .main import NumbaTestProgram, SerialSuite, make_tag_decorator
 from numba import config
+import numba.unittest_support as unittest
 
 
 def load_testsuite(loader, dir):
     """Find tests in 'dir'."""
-    suite = unittest.TestSuite()
-    files = []
-    for f in os.listdir(dir):
-        path = join(dir, f)
-        if isfile(path) and fnmatch(f, 'test_*.py'):
-            files.append(f)
-        elif isfile(join(path, '__init__.py')):
-            suite.addTests(loader.discover(path))
-    for f in files:
-        # turn 'f' into a filename relative to the toplevel dir...
-        f = relpath(join(dir, f), loader._top_level_dir)
-        # ...and translate it to a module name.
-        f = splitext(normpath(f.replace(os.path.sep, '.')))[0]
-        suite.addTests(loader.loadTestsFromName(f))
-    return suite
+    try:
+        suite = unittest.TestSuite()
+        files = []
+        for f in os.listdir(dir):
+            path = join(dir, f)
+            if isfile(path) and fnmatch(f, 'test_*.py'):
+                files.append(f)
+            elif isfile(join(path, '__init__.py')):
+                suite.addTests(loader.discover(path))
+        for f in files:
+            # turn 'f' into a filename relative to the toplevel dir...
+            f = relpath(join(dir, f), loader._top_level_dir)
+            # ...and translate it to a module name.
+            f = splitext(normpath(f.replace(os.path.sep, '.')))[0]
+            suite.addTests(loader.loadTestsFromName(f))
+        return suite
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(-1)
+
 
 def allow_interpreter_mode(fn):
     """Temporarily re-enable intepreter mode

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -24,10 +24,9 @@ class TestCase(unittest.TestCase):
             errmsg = '{!r} not startswith {!r}'.format(ln, prefix)
             self.assertTrue(ln.startswith(prefix), msg=errmsg)
 
-    def check_testsuite_size(self, args, minsize, maxsize):
+    def check_testsuite_size(self, args, minsize):
         """
-        Check that the reported numbers of tests are in the
-        (minsize, maxsize) range, or are equal to minsize if maxsize is None.
+        Check that the reported numbers of tests are at least *minsize*.
         """
         lines = self.get_testsuite_listing(args)
         last_line = lines[-1]
@@ -37,11 +36,10 @@ class TestCase(unittest.TestCase):
         # so do an approximate check.
         self.assertIn(len(lines), range(number + 1, number + 10))
         self.assertGreaterEqual(number, minsize)
-        self.assertLessEqual(number, maxsize)
         return lines
 
     def check_all(self, ids):
-        lines = self.check_testsuite_size(ids, 5000, 8000)
+        lines = self.check_testsuite_size(ids, 5000)
         # CUDA should be included by default
         self.assertTrue(any('numba.cuda.tests.' in line for line in lines))
         # As well as subpackage
@@ -59,7 +57,7 @@ class TestCase(unittest.TestCase):
         # Even without CUDA enabled, there is at least one test
         # (in numba.cuda.tests.nocuda)
         minsize = 100 if cuda.is_available() else 1
-        self.check_testsuite_size(['numba.cuda.tests'], minsize, 1000)
+        self.check_testsuite_size(['numba.cuda.tests'], minsize)
 
     @unittest.skipIf(not cuda.is_available(), "NO CUDA")
     def test_cuda_submodules(self):
@@ -69,26 +67,26 @@ class TestCase(unittest.TestCase):
         self.check_listing_prefix('numba.cuda.tests.cudasim')
 
     def test_module(self):
-        self.check_testsuite_size(['numba.tests.test_utils'], 3, 15)
-        self.check_testsuite_size(['numba.tests.test_nested_calls'], 5, 15)
+        self.check_testsuite_size(['numba.tests.test_utils'], 3)
+        self.check_testsuite_size(['numba.tests.test_nested_calls'], 5)
         # Several modules
         self.check_testsuite_size(['numba.tests.test_nested_calls',
-                                   'numba.tests.test_utils'], 13, 30)
+                                   'numba.tests.test_utils'], 13)
 
     def test_subpackage(self):
-        self.check_testsuite_size(['numba.tests.npyufunc'], 50, 200)
+        self.check_testsuite_size(['numba.tests.npyufunc'], 50)
 
     @unittest.skipIf(sys.version_info < (3, 4),
                      "'--random' only supported on Python 3.4 or higher")
     def test_random(self):
-        self.check_testsuite_size(['--random', '0.1', 'numba.tests.npyufunc'],
-                                  5, 20)
+        self.check_testsuite_size(
+            ['--random', '0.1', 'numba.tests.npyufunc'], 5)
 
     @unittest.skipIf(sys.version_info < (3, 4),
                      "'--tags' only supported on Python 3.4 or higher")
     def test_tags(self):
         self.check_testsuite_size(
-            ['--tags', 'important', 'numba.tests.npyufunc'], 20, 50,
+            ['--tags', 'important', 'numba.tests.npyufunc'], 20,
             )
 
 

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -35,27 +35,12 @@ class TestCase(unittest.TestCase):
         number = int(last_line.split(' ')[0])
         # There may be some "skipped" messages at the beginning,
         # so do an approximate check.
-        try:
-            self.assertIn(len(lines), range(number + 1, number + 10))
-            if maxsize is None:
-                self.assertEqual(number, minsize)
-            else:
-                self.assertGreaterEqual(number, minsize)
-                self.assertLessEqual(number, maxsize)
-        except AssertionError:
-            # catch any error in the above, chances are test discovery
-            # has failed due to a syntax error or import problem.
-            # run the actual test suite to try and find the cause to
-            # inject into the error message for the user
-            try:
-                cmd = ['python', '-m', 'numba.runtests'] + list(args)
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-            except Exception as e:
-                msg = ("Test discovery has failed, the reported cause of the "
-                       " failure is:\n\n:")
-                indented  = '\n'.join(['\t' + x for x in
-                                       e.output.decode('UTF-8').splitlines()])
-                raise RuntimeError(msg + indented)
+        self.assertIn(len(lines), range(number + 1, number + 10))
+        if maxsize is None:
+            self.assertEqual(number, minsize)
+        else:
+            self.assertGreaterEqual(number, minsize)
+            self.assertLessEqual(number, maxsize)
         return lines
 
     def check_all(self, ids):


### PR DESCRIPTION
* Fix error reporting in test discovery.  Any error will trigger an `sys.exit(-1)` with the exception printed in stderr.
* Remove upper limit to test count in `test_runtests.py`.
* Fix cuda exception raising tests.
* Add source location reporting in cuda exception raising.  (#3325)