### PR TITLE
Allow matching non-array objects in find_callname()

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1443,7 +1443,7 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
             attrs.append(callee_def.attr)
             if typemap and obj.name in typemap:
                 typ = typemap[obj.name]
-                if isinstance(typ, types.npytypes.Array):
+                if not isinstance(typ, types.Module):
                     return attrs[0], obj
             callee_def = definition_finder(func_ir, obj)
         else:

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1388,11 +1388,12 @@ def build_definitions(blocks, definitions=None):
 build_defs_extensions = {}
 
 def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition):
-    """Check if a call expression is calling a numpy function, and
-    return the callee's function name and module name (both are strings),
-    or raise GuardException. For array attribute calls such as 'a.f(x)'
-    when 'a' is a numpy array, the array variable 'a' is returned
-    in place of the module name.
+    """Try to find a call expression's function and module names and return
+    them as strings for unbounded calls. If the call is a bounded call, return
+    the self object instead of module name. Raise GuardException if failed.
+
+    Providing typemap can make the call matching more accurate in corner cases
+    such as bounded call on an object which is inside another object.
     """
     require(isinstance(expr, ir.Expr) and expr.op == 'call')
     callee = expr.func

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -1,11 +1,11 @@
 import numba
 from numba import unittest_support as unittest
 from .support import TestCase
-from numba import compiler, typing, jitclass
+from numba import compiler, jitclass
 from numba.targets.registry import cpu_target
 
 
-@jitclass([('val', numba.types.List(numba.intp)),])
+@jitclass([('val', numba.types.List(numba.intp))])
 class Dummy(object):
     def __init__(self, val):
         self.val = val
@@ -23,7 +23,7 @@ class TestIrUtils(TestCase):
         def test_func():
             d = Dummy([1])
             d.val.append(2)
-        
+
         test_ir = compiler.run_frontend(test_func)
         typingctx = cpu_target.typing_context
         typemap, _, _ = compiler.type_inference_stage(
@@ -31,7 +31,8 @@ class TestIrUtils(TestCase):
         matched_call = numba.ir_utils.find_callname(
             test_ir, test_ir.blocks[0].body[14].value, typemap)
         self.assertTrue(isinstance(matched_call, tuple)
-            and len(matched_call) == 2 and matched_call[0] == 'append')
+                        and len(matched_call) == 2
+                        and matched_call[0] == 'append')
 
 
 if __name__ == "__main__":

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -1,0 +1,38 @@
+import numba
+from numba import unittest_support as unittest
+from .support import TestCase
+from numba import compiler, typing, jitclass
+from numba.targets.registry import cpu_target
+
+
+@jitclass([('val', numba.types.List(numba.intp)),])
+class Dummy(object):
+    def __init__(self, val):
+        self.val = val
+
+
+class TestIrUtils(TestCase):
+    """
+    Tests ir handling utility functions like find_callname.
+    """
+
+    def test_obj_func_match(self):
+        """Test matching of an object method (other than Array see #3449)
+        """
+
+        def test_func():
+            d = Dummy([1])
+            d.val.append(2)
+        
+        test_ir = compiler.run_frontend(test_func)
+        typingctx = cpu_target.typing_context
+        typemap, _, _ = compiler.type_inference_stage(
+            typingctx, test_ir, (), None)
+        matched_call = numba.ir_utils.find_callname(
+            test_ir, test_ir.blocks[0].body[14].value, typemap)
+        self.assertTrue(isinstance(matched_call, tuple)
+            and len(matched_call) == 2 and matched_call[0] == 'append')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`find_callname` can match bound methods for arrays (e.g. `array.func`) but not for other objects. This PR enables this feature for all objects.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
