### PR TITLE
Change getiter and iternext to not be pure.  Resolves #3425

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -637,19 +637,22 @@ def is_pure(rhs, lives, call_table):
         returns the same result.  This is not the case for things
         like calls to numpy.random.
     """
-    if isinstance(rhs, ir.Expr) and rhs.op == 'call':
-        func_name = rhs.func.name
-        if func_name not in call_table or call_table[func_name] == []:
+    if isinstance(rhs, ir.Expr)
+        if rhs.op == 'call':
+			func_name = rhs.func.name
+			if func_name not in call_table or call_table[func_name] == []:
+				return False
+			call_list = call_table[func_name]
+			if (call_list == [slice] or
+				call_list == ['log', numpy] or
+				call_list == ['empty', numpy]):
+				return True
+			for f in is_pure_extensions:
+				if f(rhs, lives, call_list):
+					return True
+			return False
+        elif rhs.op == 'getiter' or rhs.op == 'iternext':
             return False
-        call_list = call_table[func_name]
-        if (call_list == [slice] or
-            call_list == ['log', numpy] or
-            call_list == ['empty', numpy]):
-            return True
-        for f in is_pure_extensions:
-            if f(rhs, lives, call_list):
-                return True
-        return False
     if isinstance(rhs, ir.Yield):
         return False
     return True

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -637,7 +637,7 @@ def is_pure(rhs, lives, call_table):
         returns the same result.  This is not the case for things
         like calls to numpy.random.
     """
-    if isinstance(rhs, ir.Expr)
+    if isinstance(rhs, ir.Expr):
         if rhs.op == 'call':
             func_name = rhs.func.name
             if func_name not in call_table or call_table[func_name] == []:

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -639,18 +639,18 @@ def is_pure(rhs, lives, call_table):
     """
     if isinstance(rhs, ir.Expr)
         if rhs.op == 'call':
-			func_name = rhs.func.name
-			if func_name not in call_table or call_table[func_name] == []:
-				return False
-			call_list = call_table[func_name]
-			if (call_list == [slice] or
-				call_list == ['log', numpy] or
-				call_list == ['empty', numpy]):
-				return True
-			for f in is_pure_extensions:
-				if f(rhs, lives, call_list):
-					return True
-			return False
+            func_name = rhs.func.name
+            if func_name not in call_table or call_table[func_name] == []:
+                return False
+            call_list = call_table[func_name]
+            if (call_list == [slice] or
+                call_list == ['log', numpy] or
+                call_list == ['empty', numpy]):
+                return True
+            for f in is_pure_extensions:
+                if f(rhs, lives, call_list):
+                    return True
+            return False
         elif rhs.op == 'getiter' or rhs.op == 'iternext':
             return False
     if isinstance(rhs, ir.Yield):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1358,6 +1358,22 @@ class TestParfors(TestParforsBase):
         A = np.arange(n)
         self.check(test_impl, A)
 
+    @skip_unsupported
+    def test_no_hoisting_with_member_function_call(self):
+        def test_impl(X):
+            n = X.shape[0]
+            acc = 0
+            for i in prange(n):
+                R = {1, 2, 3}
+                R.add(i)
+                tmp = 0
+                for x in R:
+                    tmp += x
+                acc += tmp
+            return acc
+
+        self.check(test_impl, np.random.ranf(128))
+
 
 class TestPrangeBase(TestParforsBase):
 


### PR DESCRIPTION
Resolves #3425.

is_pure in ir_utils.py is kind of scary.  It seems to be an opt-out of purity rather than an opt-in.  In #3425, a getiter and iternext were being hoisted and then with subsequent LLVM optimizations some block was reduced to a jmp to itself, ergo infinite loop and hang.  I did a scan of ir.py searching for other IR nodes that aren't pure but there's some I'm not sure about so @stuartarchibald could do a better job here.
