### PR TITLE
Fix np.random.shuffle sideeffect 

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -586,7 +586,7 @@ remove_call_handlers = []
 
 def remove_dead_random_call(rhs, lives, call_list):
     if len(call_list) == 3 and call_list[1:] == ['random', numpy]:
-        return call_list[0] != 'seed'
+        return call_list[0] not in {'seed', 'shuffle'}
     return False
 
 remove_call_handlers.append(remove_dead_random_call)

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -481,7 +481,7 @@ class TestArrayComprehension(unittest.TestCase):
         # For a large enough array, the chances of shuffle to not move any
         # element is tiny enough.
         self.assertNotEqual(got, expect)
-        self.assertRegexpMatches(got, r'\[\d+(\s+\d+)+\]')
+        self.assertRegexpMatches(got, r'\[(\s*\d+)+\]')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #3477.  The issue is due to `np.random.shuffle()` is a inplace operation and sideeffect and be "exported" by print.

A proper fix will require changing the analysis to understand sideeffect being "exported" via `print()`.  e.g. does the sideeffect of a function be observable via channels beside return values and output arguments?