### PR TITLE
np.tri, np.tril, np.triu - default optional args

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1084,7 +1084,7 @@ def _tri_impl(N, M, k):
 def np_tri(N, M=None, k=0):
 
     # we require k to be integer, unlike numpy
-    if not isinstance(k, types.Integer):
+    if not isinstance(k, (int, types.Integer)):
         raise TypeError('k must be an integer')
 
     def tri_impl(N, M=None, k=0):
@@ -1119,7 +1119,7 @@ def np_tril_impl_2d(m, k=0):
 def my_tril(m, k=0):
 
     # we require k to be integer, unlike numpy
-    if not isinstance(k, types.Integer):
+    if not isinstance(k, (int, types.Integer)):
         raise TypeError('k must be an integer')
 
     def np_tril_impl_1d(m, k=0):
@@ -1151,7 +1151,7 @@ def np_triu_impl_2d(m, k=0):
 def my_triu(m, k=0):
 
     # we require k to be integer, unlike numpy
-    if not isinstance(k, types.Integer):
+    if not isinstance(k, (int, types.Integer)):
         raise TypeError('k must be an integer')
 
     def np_triu_impl_1d(m, k=0):


### PR DESCRIPTION
`np.tri`, `np.tril` and `np.triu` implementations complain unless optional arguments are explicitly provided - for example:

```python
import numpy as np
from numba import njit


@njit
def fast(A):
    return np.tril(A)


if __name__ == '__main__':
    A = np.arange(25).reshape(5, 5)
    out = fast(A)
    print(out)
```

...fails with:
```
Invalid use of Function(<function tril at 0x00000266657BC400>) with argument(s) of type(s): (array(int32, 2d, C))
 * parameterized
In definition 0:
    TypeError: k must be an integer
```

This PR should take care of that.  

Submitting for CI...
