### PR TITLE
Permit dtype argument as sole kwarg in np.eye

### DIFF
--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -873,6 +873,13 @@ class TestNdEye(BaseTest):
             return np.eye(n)
         self.check_outputs(func, [(1,), (3,)])
 
+    def test_eye_n_dtype(self):
+        # check None option, dtype class, instance of dtype class
+        for dt in (None, np.complex128, np.complex64(1)):
+            def func(n, dtype=dt):
+                return np.eye(n, dtype=dtype)
+            self.check_outputs(func, [(1,), (3,)])
+
     def test_eye_n_m(self):
         def func(n, m):
             return np.eye(n, m)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -623,21 +623,6 @@ def _infer_dtype_from_inputs(inputs):
     return dtype
 
 
-@infer_global(np.eye)
-class NdEye(CallableTemplate):
-
-    def generic(self):
-        def typer(N, M=None, k=None, dtype=None):
-            if dtype is None:
-                nb_dtype = types.float64
-            else:
-                nb_dtype = _parse_dtype(dtype)
-            if nb_dtype is not None:
-                return types.Array(ndim=2, dtype=nb_dtype, layout='C')
-
-        return typer
-
-
 @infer_global(np.arange)
 class NdArange(AbstractTemplate):
 


### PR DESCRIPTION
As title, also reimplements `np.eye` using high level API.

Fixes #3159

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
