### PR TITLE
Size Numba logo in docs in em units.  Fixes #3313

### DIFF
--- a/docs/_static/numba-docs.css
+++ b/docs/_static/numba-docs.css
@@ -20,7 +20,7 @@ body {
 }
 
 .navbar-brand img {
-    height: 135%;
+    height: 32px;
 }
 
 .nav li a {

--- a/docs/_static/numba-docs.css
+++ b/docs/_static/numba-docs.css
@@ -20,7 +20,7 @@ body {
 }
 
 .navbar-brand img {
-    height: 32px;
+    height: 1.1em;
 }
 
 .nav li a {


### PR DESCRIPTION
Now Safari looks the same as Chrome:
<img width="1060" alt="numba_documentation_ _numba_0_40_0rc1_0_g088548a_dirty_documentation" src="https://user-images.githubusercontent.com/425352/48373436-6ee0cd80-e687-11e8-9f11-1eff7ceed0a6.png">

(Before Numba logo extended below the horizontal rule because Safari computed the size to be 70% bigger than Chrome.)