### PR TITLE
Raise unsupported for kwargs given to `print()`

### DIFF
--- a/numba/tests/test_print.py
+++ b/numba/tests/test_print.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import numba.unittest_support as unittest
 from numba.compiler import compile_isolated, Flags
-from numba import jit, types
+from numba import jit, types, errors
 from .support import captured_stdout, tag, TestCase
 
 
@@ -37,7 +37,6 @@ def print_vararg(a, b, c):
 
 def print_string_vararg(a, b, c):
     print(a, "hop!", b, *c)
-
 
 def make_print_closure(x):
     def print_closure():
@@ -179,6 +178,16 @@ class TestPrint(TestCase):
             bar(x)
             self.assertEqual(sys.stdout.getvalue(), '[0 1 2 3 4]\nhello\n')
 
+    def test_print_w_kwarg_raises(self):
+        @jit(nopython=True)
+        def print_kwarg():
+            print('x', flush=True)
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            print_kwarg()
+        expected = ("Numba's print() function implementation does not support "
+                    "keyword arguments.")
+        self.assertIn(raises.exception.msg, expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This amends the rewriting of `print()` globals to check for kwargs
being present and raising if that is the case as they are not
supported.

Fixes #3474

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
