### PR TITLE
Typeof dtype values

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -302,7 +302,6 @@ class EnumModel(ProxyModel):
 @register_default(types.NumberClass)
 @register_default(types.NamedTupleClass)
 @register_default(types.DType)
-@register_default(types.ValueDType)
 @register_default(types.RecursiveCall)
 class OpaqueModel(PrimitiveModel):
     """

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -302,6 +302,7 @@ class EnumModel(ProxyModel):
 @register_default(types.NumberClass)
 @register_default(types.NamedTupleClass)
 @register_default(types.DType)
+@register_default(types.ValueDType)
 @register_default(types.RecursiveCall)
 class OpaqueModel(PrimitiveModel):
     """

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -95,18 +95,15 @@ def from_dtype(dtype):
     try:
         return FROM_DTYPE[dtype]
     except KeyError:
-        try:
-            char = getattr(dtype, 'char')
-        except AttributeError:
-            pass
-        else:
-            if char in 'SU':
-                return _from_str_dtype(dtype)
-            if char in 'mM':
-                return _from_datetime_dtype(dtype)
-            if char in 'V':
-                subtype = from_dtype(dtype.subdtype[0])
-                return types.NestedArray(subtype, dtype.shape)
+        char = dtype.char
+
+        if char in 'SU':
+            return _from_str_dtype(dtype)
+        if char in 'mM':
+            return _from_datetime_dtype(dtype)
+        if char in 'V':
+            subtype = from_dtype(dtype.subdtype[0])
+            return types.NestedArray(subtype, dtype.shape)
 
     raise NotImplementedError(dtype)
 

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -34,23 +34,6 @@ FROM_DTYPE = {
 
     np.dtype('complex64'): types.complex64,
     np.dtype('complex128'): types.complex128,
-
-    np.bool: types.boolean,
-    np.int8: types.int8,
-    np.int16: types.int16,
-    np.int32: types.int32,
-    np.int64: types.int64,
-
-    np.uint8: types.uint8,
-    np.uint16: types.uint16,
-    np.uint32: types.uint32,
-    np.uint64: types.uint64,
-
-    np.float32: types.float32,
-    np.float64: types.float64,
-
-    np.complex64: types.complex64,
-    np.complex128: types.complex128,
 }
 
 re_typestr = re.compile(r'[<>=\|]([a-z])(\d+)?$', re.I)
@@ -104,7 +87,9 @@ def from_dtype(dtype):
     Return a Numba Type instance corresponding to the given Numpy *dtype*.
     NotImplementedError is raised on unsupported Numpy dtypes.
     """
-    if getattr(dtype, "fields", None) is not None:
+    if type(dtype) == type and issubclass(dtype, np.generic):
+        dtype = np.dtype(dtype)
+    elif getattr(dtype, "fields", None) is not None:
         return from_struct_dtype(dtype)
 
     try:
@@ -133,6 +118,7 @@ _as_dtype_letters = {
     types.UnicodeCharSeq: 'U',
 }
 
+
 def as_dtype(nbtype):
     """
     Return a numpy dtype instance corresponding to the given Numba type.
@@ -158,7 +144,7 @@ def as_dtype(nbtype):
         return as_dtype(nbtype.dtype)
     if isinstance(nbtype, types.npytypes.DType):
         return as_dtype(nbtype.dtype)
-    if isinstance(nbtype, types.npytypes.ValueDType):
+    if isinstance(nbtype, types.NumberClass):
         return as_dtype(nbtype.dtype)
     raise NotImplementedError("%r cannot be represented as a Numpy dtype"
                               % (nbtype,))

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -133,6 +133,8 @@ def as_dtype(nbtype):
         return nbtype.dtype
     if isinstance(nbtype, types.EnumMember):
         return as_dtype(nbtype.dtype)
+    if isinstance(nbtype, types.npytypes.DType):
+        return as_dtype(nbtype.dtype)
     raise NotImplementedError("%r cannot be represented as a Numpy dtype"
                               % (nbtype,))
 

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -980,7 +980,7 @@ def box_number_class(typ, val, c):
     return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
 
 @unbox(types.NumberClass)
-def unbox_dtype(typ, val, c):
+def unbox_number_class(typ, val, c):
     return NativeValue(c.context.get_dummy_value())
 
 

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -971,7 +971,7 @@ def box_dtype(typ, val, c):
 
 @unbox(types.DType)
 def unbox_dtype(typ, obj, c):
-    raise NotImplementedError("dtype unboxing unsupported")
+    raise NotImplementedError("dtype unboxing unsupported ")
 
 
 @box(types.PyObject)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -969,6 +969,10 @@ def box_dtype(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
     return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
 
+@unbox(types.DType)
+def unbox_dtype(typ, obj, c):
+    raise NotImplementedError("dtype unboxing unsupported")
+
 
 @box(types.PyObject)
 @box(types.Object)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -969,6 +969,9 @@ def box_dtype(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
     return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
 
+@unbox(types.DType)
+def unbox_dtype(typ, val, c):
+    return NativeValue(c.context.get_dummy_value())
 
 @box(types.ValueDType)
 def box_value_dtype(typ, val, c):
@@ -977,9 +980,7 @@ def box_value_dtype(typ, val, c):
 
 @unbox(types.ValueDType)
 def unbox_value_dtype(typ, obj, c):
-    np_type = numpy_support.as_dtype(typ.dtype)
-    print("NUMPY TYPE", np_type, np_type.type)
-    return NativeValue(np_type)
+    return NativeValue(c.context.get_dummy_value())
 
 
 @box(types.PyObject)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -969,9 +969,17 @@ def box_dtype(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
     return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
 
-@unbox(types.DType)
-def unbox_dtype(typ, obj, c):
-    raise NotImplementedError("dtype unboxing unsupported ")
+
+@box(types.ValueDType)
+def box_value_dtype(typ, val, c):
+    np_dtype = numpy_support.as_dtype(typ.dtype)
+    return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
+
+@unbox(types.ValueDType)
+def unbox_value_dtype(typ, obj, c):
+    np_type = numpy_support.as_dtype(typ.dtype)
+    print("NUMPY TYPE", np_type, np_type.type)
+    return NativeValue(np_type)
 
 
 @box(types.PyObject)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -973,13 +973,14 @@ def box_dtype(typ, val, c):
 def unbox_dtype(typ, val, c):
     return NativeValue(c.context.get_dummy_value())
 
-@box(types.ValueDType)
-def box_value_dtype(typ, val, c):
+
+@box(types.NumberClass)
+def box_number_class(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
     return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
 
-@unbox(types.ValueDType)
-def unbox_value_dtype(typ, obj, c):
+@unbox(types.NumberClass)
+def unbox_dtype(typ, val, c):
     return NativeValue(c.context.get_dummy_value())
 
 

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -193,6 +193,9 @@ def array_dot(a, b):
 def array_dot_chain(a, b):
     return a.dot(b).dot(b)
 
+def array_ctor(n, dtype):
+    return np.ones(n, dtype=dtype)
+
 
 class TestArrayMethods(MemoryLeakMixin, TestCase):
     """
@@ -932,6 +935,20 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         cfunc = jit(nopython=True)(pyfunc)
         a = np.arange(16.).reshape(4, 4)
         np.testing.assert_equal(pyfunc(a, a), cfunc(a, a))
+
+    def test_array_ctor_with_dtype_arg(self):
+        # Test using np.dtype and np.generic (i.e. np.dtype.type) has args
+        pyfunc = array_ctor
+        cfunc = jit(nopython=True)(pyfunc)
+        n = 2
+        args = n, np.int32
+        np.testing.assert_array_equal(pyfunc(*args), cfunc(*args))
+        args = n, np.dtype('int32')
+        np.testing.assert_array_equal(pyfunc(*args), cfunc(*args))
+        args = n, np.float32
+        np.testing.assert_array_equal(pyfunc(*args), cfunc(*args))
+        args = n, np.dtype('f4')
+        np.testing.assert_array_equal(pyfunc(*args), cfunc(*args))
 
 
 class TestArrayComparisons(TestCase):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -69,6 +69,7 @@ def generated_usecase(x, y=5):
             return x - y
     return impl
 
+
 def bad_generated_usecase(x, y=5):
     if isinstance(x, types.Complex):
         def impl(x):
@@ -80,13 +81,10 @@ def bad_generated_usecase(x, y=5):
 
 
 def dtype_generated_usecase(a, b, dtype=None):
-    NoneTypes = (types.misc.NoneType, types.misc.Omitted)
-
-    if isinstance(dtype, NoneTypes):
+    if isinstance(dtype, (types.misc.NoneType, types.misc.Omitted)):
         out_dtype = np.result_type(*(np.dtype(ary.dtype.name)
-                                   for ary in (a, b)
-                                   if not isinstance(ary, NoneTypes)))
-    elif isinstance(dtype, (types.DType, types.ValueDType)):
+                                   for ary in (a, b)))
+    elif isinstance(dtype, (types.DType, types.NumberClass)):
         out_dtype = as_dtype(dtype)
     else:
         raise TypeError("Unhandled Type %s" % type(dtype))
@@ -648,8 +646,9 @@ class TestGeneratedDispatcher(TestCase):
         f = generated_jit(nopython=True)(dtype_generated_usecase)
         a = np.ones((10,), dtype=np.float32)
         b = np.ones((10,), dtype=np.float64)
-        f(a, b)
-        f(a, b, dtype=np.int32)
+        self.assertEqual(f(a, b).dtype, np.float64)
+        self.assertEqual(f(a, b, dtype=np.dtype('int32')).dtype, np.int32)
+        self.assertEqual(f(a, b, dtype=np.int32).dtype, np.int32)
 
     def test_signature_errors(self):
         """

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -270,6 +270,13 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         self.assertEqual(typeof(dtype), types.DType(rec_ty))
 
     @tag('important')
+    def test_dtype_values(self):
+        self.assertEqual(typeof(np.int64), types.DType(types.int64))
+        self.assertEqual(typeof(np.float64), types.DType(types.float64))
+        self.assertEqual(typeof(np.int32), types.DType(types.int32))
+        self.assertEqual(typeof(np.int8), types.DType(types.int8))
+
+    @tag('important')
     def test_ctypes(self):
         ty_cos = typeof(c_cos)
         ty_sin = typeof(c_sin)

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -271,10 +271,10 @@ class TestTypeof(ValueTypingTestBase, TestCase):
 
     @tag('important')
     def test_dtype_values(self):
-        self.assertEqual(typeof(np.int64), types.DType(types.int64))
-        self.assertEqual(typeof(np.float64), types.DType(types.float64))
-        self.assertEqual(typeof(np.int32), types.DType(types.int32))
-        self.assertEqual(typeof(np.int8), types.DType(types.int8))
+        self.assertEqual(typeof(np.int64), types.ValueDType(types.int64))
+        self.assertEqual(typeof(np.float64), types.ValueDType(types.float64))
+        self.assertEqual(typeof(np.int32), types.ValueDType(types.int32))
+        self.assertEqual(typeof(np.int8), types.ValueDType(types.int8))
 
     @tag('important')
     def test_ctypes(self):

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -271,10 +271,10 @@ class TestTypeof(ValueTypingTestBase, TestCase):
 
     @tag('important')
     def test_dtype_values(self):
-        self.assertEqual(typeof(np.int64), types.ValueDType(types.int64))
-        self.assertEqual(typeof(np.float64), types.ValueDType(types.float64))
-        self.assertEqual(typeof(np.int32), types.ValueDType(types.int32))
-        self.assertEqual(typeof(np.int8), types.ValueDType(types.int8))
+        self.assertEqual(typeof(np.int64), types.NumberClass(types.int64))
+        self.assertEqual(typeof(np.float64), types.NumberClass(types.float64))
+        self.assertEqual(typeof(np.int32), types.NumberClass(types.int32))
+        self.assertEqual(typeof(np.int8), types.NumberClass(types.int8))
 
     @tag('important')
     def test_ctypes(self):

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -87,7 +87,11 @@ class Record(Type):
 
 class DType(DTypeSpec, Opaque):
     """
-    Type class for Numpy dtypes.
+    Type class associated with the `np.dtype`.
+
+    i.e. :code:`assert type(np.dtype('int32')) == np.dtype`
+
+    np.dtype('int32')
     """
 
     def __init__(self, dtype):
@@ -106,6 +110,33 @@ class DType(DTypeSpec, Opaque):
 
     def __getitem__(self, arg):
         res = super(DType, self).__getitem__(arg)
+        return res.copy(dtype=self.dtype)
+
+
+class ValueDType(DTypeSpec, Opaque):
+    """
+    Type class associated with the type attribute of an `np.dtype`
+
+
+    i.e. :code:`assert type(np.int32) == type`
+
+    """
+    def __init__(self, dtype):
+        assert isinstance(dtype, Type)
+        self._dtype = dtype
+        name = "value-dtype(%s)" % (dtype,)
+        super(DTypeSpec, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.dtype
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __getitem__(self, arg):
+        res = super(ValueDType, self).__getitem__(arg)
         return res.copy(dtype=self.dtype)
 
 

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -113,33 +113,6 @@ class DType(DTypeSpec, Opaque):
         return res.copy(dtype=self.dtype)
 
 
-class ValueDType(DTypeSpec, Opaque):
-    """
-    Type class associated with the type attribute of an `np.dtype`
-
-
-    i.e. :code:`assert type(np.int32) == type`
-
-    """
-    def __init__(self, dtype):
-        assert isinstance(dtype, Type)
-        self._dtype = dtype
-        name = "value-dtype(%s)" % (dtype,)
-        super(DTypeSpec, self).__init__(name)
-
-    @property
-    def key(self):
-        return self.dtype
-
-    @property
-    def dtype(self):
-        return self._dtype
-
-    def __getitem__(self, arg):
-        res = super(ValueDType, self).__getitem__(arg)
-        return res.copy(dtype=self.dtype)
-
-
 class NumpyFlatType(SimpleIteratorType, MutableSequence):
     """
     Type class for `ndarray.flat()` objects.

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -90,13 +90,8 @@ def typeof_type(val, c):
     if issubclass(val, tuple) and hasattr(val, "_asdict"):
         return types.NamedTupleClass(val)
 
-    try:
-        tp = numpy_support.from_dtype(val)
-    except NotImplementedError:
-        pass
-    else:
-        return types.ValueDType(tp)
-
+    if issubclass(val, np.generic):
+        return types.NumberClass(numpy_support.from_dtype(val))
 
 
 @typeof_impl.register(bool)


### PR DESCRIPTION
This PR implements a solution for https://github.com/numba/numba/issues/3503  by adding support for dtype values. for e.g.. `np.int64`, which is a `type`, compared to np.dtype('int64') which is a `np.dtype`

