### PR TITLE
Unregister temporarily pinned host arrays at once

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -248,7 +248,6 @@ def pinned(*arylist):
                                       mapped=False)
         pmlist.append(pm)
     yield
-    del pmlist
 
 
 @require_context
@@ -269,10 +268,14 @@ def mapped(*arylist, **kws):
     for ary, pm in zip(arylist, pmlist):
         devary = devicearray.from_array_like(ary, gpu_data=pm, stream=stream)
         devarylist.append(devary)
-    if len(devarylist) == 1:
-        yield devarylist[0]
-    else:
-        yield devarylist
+    try:
+        if len(devarylist) == 1:
+            yield devarylist[0]
+        else:
+            yield devarylist
+    finally:
+        for ary in pmlist:
+            ary.free()
 
 
 def event(timing=True):

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -256,16 +256,14 @@ def mapped(*arylist, **kws):
     """A context manager for temporarily mapping a sequence of host ndarrays.
     """
     assert not kws or 'stream' in kws, "Only accept 'stream' as keyword."
-    pmlist = []
     stream = kws.get('stream', 0)
+    pmlist = []
+    devarylist = []
     for ary in arylist:
         pm = current_context().mempin(ary, driver.host_pointer(ary),
                                     driver.host_memory_size(ary),
                                     mapped=True)
         pmlist.append(pm)
-
-    devarylist = []
-    for ary, pm in zip(arylist, pmlist):
         devary = devicearray.from_array_like(ary, gpu_data=pm, stream=stream)
         devarylist.append(devary)
     try:
@@ -277,8 +275,8 @@ def mapped(*arylist, **kws):
         # When exiting from `with cuda.mapped(*arrs) as mapped_arrs:`, the name
         # `mapped_arrs` stays in scope, blocking automatic unmapping based on
         # reference count. We therefore invoke the finalizer manually.
-        for ary in pmlist:
-            ary.free()
+        for pm in pmlist:
+            pm.free()
 
 
 def event(timing=True):

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -274,6 +274,9 @@ def mapped(*arylist, **kws):
         else:
             yield devarylist
     finally:
+        # When exiting from `with cuda.mapped(*arrs) as mapped_arrs:`, the name
+        # `mapped_arrs` stays in scope, blocking automatic unmapping based on
+        # reference count. We therefore invoke the finalizer manually.
         for ary in pmlist:
             ary.free()
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -696,9 +696,8 @@ class Context(object):
 
         self._attempt_allocation(allocator)
 
-        _memory_finalizer = _make_mem_finalizer(driver.cuMemFree, bytesize)
-        mem = AutoFreePointer(weakref.proxy(self), ptr, bytesize,
-                              _memory_finalizer(self, ptr))
+        finalizer = _alloc_finalizer(self, ptr, bytesize)
+        mem = AutoFreePointer(weakref.proxy(self), ptr, bytesize, finalizer)
         self.allocations[ptr.value] = mem
         return mem.own()
 
@@ -722,17 +721,14 @@ class Context(object):
 
         owner = None
 
-        if mapped:
-            _hostalloc_finalizer = _make_mem_finalizer(driver.cuMemFreeHost,
-                                                       bytesize)
-            finalizer = _hostalloc_finalizer(self, pointer)
-            mem = MappedMemory(weakref.proxy(self), owner, pointer,
-                               bytesize, finalizer=finalizer)
+        finalizer = _hostalloc_finalizer(self, pointer, bytesize, mapped)
 
+        if mapped:
+            mem = MappedMemory(weakref.proxy(self), owner, pointer, bytesize,
+                               finalizer=finalizer)
             self.allocations[mem.handle.value] = mem
             return mem.own()
         else:
-            finalizer = _pinnedalloc_finalizer(self.deallocations, pointer)
             mem = PinnedMemory(weakref.proxy(self), owner, pointer, bytesize,
                                finalizer=finalizer)
             return mem
@@ -760,18 +756,16 @@ class Context(object):
         else:
             allocator()
 
+        finalizer = _pin_finalizer(self, pointer, mapped)
+
         if mapped:
-            _mapped_finalizer = _make_mem_finalizer(driver.cuMemHostUnregister,
-                                                    size)
-            finalizer = _mapped_finalizer(self, pointer)
             mem = MappedMemory(weakref.proxy(self), owner, pointer, size,
                                finalizer=finalizer)
             self.allocations[mem.handle.value] = mem
             return mem.own()
         else:
             mem = PinnedMemory(weakref.proxy(self), owner, pointer, size,
-                               finalizer=_pinned_finalizer(self.deallocations,
-                                                           pointer))
+                               finalizer=finalizer)
             return mem
 
     def memunpin(self, pointer):
@@ -899,32 +893,39 @@ def load_module_image(context, image):
                   _module_finalizer(context, handle))
 
 
-def _make_mem_finalizer(dtor, bytesize):
-    def mem_finalize(context, handle):
-        allocations = context.allocations
-        deallocations = context.deallocations
+def _alloc_finalizer(context, handle, size):
+    allocations = context.allocations
+    deallocations = context.deallocations
 
-        def core():
-            if allocations:
-                del allocations[handle.value]
-
-            deallocations.add_item(dtor, handle, size=bytesize)
-
-        return core
-
-    return mem_finalize
-
-
-def _pinnedalloc_finalizer(deallocs, handle):
     def core():
-        deallocs.add_item(driver.cuMemFreeHost, handle)
+        if allocations:
+            del allocations[handle.value]
+        deallocations.add_item(driver.cuMemFree, handle, size)
 
     return core
 
 
-def _pinned_finalizer(deallocs, handle):
+def _hostalloc_finalizer(context, handle, size, mapped):
+    allocations = context.allocations
+    deallocations = context.deallocations
+    if not mapped:
+        size = _SizeNotSet
+
     def core():
-        deallocs.add_item(driver.cuMemHostUnregister, handle)
+        if mapped and allocations:
+            del allocations[handle.value]
+        deallocations.add_item(driver.cuMemFreeHost, handle, size)
+
+    return core
+
+
+def _pin_finalizer(context, handle, mapped):
+    allocations = context.allocations
+
+    def core():
+        if mapped and allocations:
+            del allocations[handle.value]
+        driver.cuMemHostUnregister(handle)
 
     return core
 
@@ -1237,7 +1238,7 @@ class AutoFreePointer(MemoryPointer):
         self.refct -= 1
 
 
-class MappedMemory(MemoryPointer):
+class MappedMemory(AutoFreePointer):
     __cuda_memory__ = True
 
     def __init__(self, context, owner, hostpointer, size,

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -172,6 +172,61 @@ class TestDel(SerialMixin, unittest.TestCase):
         with self.check_ignored_exception(ctx):
             del mem
 
+    def test_pinned_contextmanager(self):
+        # Check that temporarily pinned memory is unregistered immediately,
+        # such that it can be re-pinned at any time
+        class PinnedException(Exception):
+            pass
+
+        arr = np.zeros(1)
+        ctx = cuda.current_context()
+        ctx.deallocations.clear()
+        with self.check_ignored_exception(ctx):
+            with cuda.pinned(arr):
+                pass
+            with cuda.pinned(arr):
+                pass
+            # Should also work inside a `defer_cleanup` block
+            with cuda.defer_cleanup():
+                with cuda.pinned(arr):
+                    pass
+                with cuda.pinned(arr):
+                    pass
+            # Should also work when breaking out of the block due to an exception
+            try:
+                with cuda.pinned(arr):
+                    raise PinnedException
+            except PinnedException:
+                with cuda.pinned(arr):
+                    pass
+
+    def test_mapped_contextmanager(self):
+        # Check that temporarily mapped memory is unregistered immediately,
+        # such that it can be re-mapped at any time
+        class MappedException(Exception):
+            pass
+
+        arr = np.zeros(1)
+        ctx = cuda.current_context()
+        ctx.deallocations.clear()
+        with self.check_ignored_exception(ctx):
+            with cuda.mapped(arr) as marr:
+                pass
+            with cuda.mapped(arr) as marr:
+                pass
+            # Should also work inside a `defer_cleanup` block
+            with cuda.defer_cleanup():
+                with cuda.mapped(arr) as marr:
+                    pass
+                with cuda.mapped(arr) as marr:
+                    pass
+            # Should also work when breaking out of the block due to an exception
+            try:
+                with cuda.mapped(arr) as marr:
+                    raise MappedException
+            except MappedException:
+                with cuda.mapped(arr) as marr:
+                    pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #3508 

This changes the behavior of the context managers `cuda.{pinned,mapped}` such that page-locked memory is unregistered immediately when the context manager exits, even if a device array reference to the mapped memory lingers from using the form `with cuda.mapped(arr) as marr:`. This is necessary to obtain the expected behavior of a context manager, as discussed in #3508.

Host memory allocated through `cuda.{pinned,mapped}_array` still has delayed deallocation, using the same queue as device memory. This does not lead to any serious inconsistencies, but one can imagine cases where a program consumes and page-locks more memory than needed for extended periods of time due to a dearth of device deallocations. Let me know if you think these deallocations should be instant too.