### PR TITLE
Sets list dtor linkage to `linkonce_odr` to fix visibility in AOT.

### DIFF
--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -279,7 +279,7 @@ class ListInstance(_ListPayloadMixin):
         if not fn.is_declaration:
             # End early if the dtor is already defined
             return fn
-        fn.linkage = 'internal'
+        fn.linkage = 'linkonce_odr'
         # Populate the dtor
         builder = ir.IRBuilder(fn.append_basic_block())
         base_ptr = fn.args[0]  # void*

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -90,6 +90,10 @@ if has_blas:
 def zeros(n):
     return np.zeros(n)
 
+# requires list dtor, #issue3535
+@cc_nrt.export('np_argsort', 'intp[:](float64[:])')
+def np_argsort(arr):
+    return np.argsort(arr)
 
 #
 # Legacy API

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -278,8 +278,15 @@ class TestCC(BasePYCCTest):
             if has_blas:
                 res = lib.vector_dot(4)
                 self.assertPreciseEqual(res, 30.0)
+            # test argsort
+            val = np.float64([2., 5., 1., 3., 4.])
+            res = lib.np_argsort(val)
+            expected = np.argsort(val)
+            self.assertPreciseEqual(res, expected)
 
             code = """if 1:
+                from numpy.testing import assert_equal
+                from numpy import float64, argsort
                 res = lib.zero_scalar(1)
                 assert res == 0.0
                 res = lib.zeros(3)
@@ -287,6 +294,10 @@ class TestCC(BasePYCCTest):
                 if %(has_blas)s:
                     res = lib.vector_dot(4)
                     assert res == 30.0
+                val = float64([2., 5., 1., 3., 4.])
+                res = lib.np_argsort(val)
+                expected = argsort(val)
+                assert_equal(res, expected)
                 """ % dict(has_blas=has_blas)
             self.check_cc_compiled_in_subprocess(lib, code)
 


### PR DESCRIPTION
As title, includes test. Without this patch LLVM SIGABRTs as the
list dtor function has local linkage specified but the visibility
is not set to default.

fixes #3535, fixes #2594

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
