### PR TITLE
Avoid implementation error being hidden by the try-except

### DIFF
--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -56,6 +56,7 @@ class DUFuncLowerer(object):
     def __init__(self, dufunc):
         self.kernel = make_dufunc_kernel(dufunc)
         self.libs = []
+        self.__name__ = '.'.join([self.__class__.__name__, str(dufunc)])
 
     def __call__(self, context, builder, sig, args):
         from ..targets import npyimpl

--- a/numba/npyufunc/dufunc.py
+++ b/numba/npyufunc/dufunc.py
@@ -56,7 +56,6 @@ class DUFuncLowerer(object):
     def __init__(self, dufunc):
         self.kernel = make_dufunc_kernel(dufunc)
         self.libs = []
-        self.__name__ = '.'.join([self.__class__.__name__, str(dufunc)])
 
     def __call__(self, context, builder, sig, args):
         from ..targets import npyimpl

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -4,7 +4,6 @@ from collections import namedtuple, defaultdict
 import copy
 import os
 import sys
-import functools
 from itertools import permutations, takewhile
 from contextlib import contextmanager
 
@@ -1143,7 +1142,6 @@ def _wrap_missing_loc(fn):
     Otherwise, return the original *fn*.
     """
     if not _has_loc(fn):
-        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             kwargs.pop('loc')     # drop unused loc
             return fn(*args, **kwargs)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from collections import namedtuple, defaultdict
 import copy
-import functools
 import os
 import sys
 from itertools import permutations, takewhile
@@ -1143,10 +1142,22 @@ def _wrap_missing_loc(fn):
     Otherwise, return the original *fn*.
     """
     if not _has_loc(fn):
-        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             kwargs.pop('loc')     # drop unused loc
             return fn(*args, **kwargs)
+
+        # Copy the following attributes from the wrapped.
+        # Following similar implementation as functools.wraps but
+        # ignore attributes if not available (i.e fix py2.7)
+        attrs = '__name__', 'libs'
+        for attr in attrs:
+            try:
+                val = getattr(fn, attr)
+            except AttributeError:
+                pass
+            else:
+                setattr(wrapper, attr, val)
+
         return wrapper
     else:
         return fn

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 from collections import namedtuple, defaultdict
 import copy
+import functools
 import os
 import sys
 from itertools import permutations, takewhile
@@ -1142,6 +1143,7 @@ def _wrap_missing_loc(fn):
     Otherwise, return the original *fn*.
     """
     if not _has_loc(fn):
+        @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             kwargs.pop('loc')     # drop unused loc
             return fn(*args, **kwargs)


### PR DESCRIPTION
which is checking for `TypeError` from missing the loc keyword.
Changes to check for the loc param explicitly and wrap if it is missing.

Without this match, other `TypeError` occurred in the implementation may be incorrectly reported as `numpy_arange_1() got an unexpected keyword argument 'loc'`.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
