### PR TITLE
Add `long_running` test flag and feature to exclude tests.

### DIFF
--- a/buildscripts/incremental/test.cmd
+++ b/buildscripts/incremental/test.cmd
@@ -23,10 +23,10 @@ python -m numba.tests.test_runtests
 if "%RUN_COVERAGE%" == "yes" (
     set PYTHONPATH=.
     coverage erase
-    coverage run runtests.py -b -m -- numba.tests
+    coverage run runtests.py -b --exclude-tags='long_running' -m -- numba.tests
 ) else (
     set NUMBA_ENABLE_CUDASIM=1
-    python -m numba.runtests -b -m -- numba.tests
+    python -m numba.runtests -b --exclude-tags='long_running' -m -- numba.tests
 )
 
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -65,7 +65,7 @@ python -m numba.tests.test_runtests
 if [ "$RUN_COVERAGE" == "yes" ]; then
     export PYTHONPATH=.
     coverage erase
-    $SEGVCATCH coverage run runtests.py -b -m $TEST_NPROCS -- numba.tests
+    $SEGVCATCH coverage run runtests.py -b --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 else
-    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -m $TEST_NPROCS -- numba.tests
+    NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 fi

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -36,7 +36,7 @@ nrt_flags = Flags()
 nrt_flags.set("nrt")
 
 
-tag = testing.make_tag_decorator(['important'])
+tag = testing.make_tag_decorator(['important', 'long_running'])
 
 
 class CompilationCache(object):

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -379,9 +379,9 @@ class TestSpecificBackend(TestParallelBackendBase):
             self.assertTrue('FAIL' not in e)
             self.assertTrue('ERROR' not in e)
         injected_test = "test_%s_%s_%s" % (p, name, backend)
-        # Mark as important for appveyor
+        # Mark as long_running
         setattr(cls, injected_test,
-                tag("important")(backend_guard(test_template)))
+                tag('long_running')(backend_guard(test_template)))
 
     @classmethod
     def generate(cls):

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -82,12 +82,27 @@ class TestCase(unittest.TestCase):
         self.check_testsuite_size(
             ['--random', '0.1', 'numba.tests.npyufunc'], 5)
 
-    @unittest.skipIf(sys.version_info < (3, 4),
-                     "'--tags' only supported on Python 3.4 or higher")
-    def test_tags(self):
-        self.check_testsuite_size(
-            ['--tags', 'important', 'numba.tests.npyufunc'], 20,
-            )
+    def test_include_exclude_tags(self):
+        def get_count(arg_list):
+            lines = self.get_testsuite_listing(arg_list)
+            self.assertIn('tests found', lines[-1])
+            count = int(lines[-1].split()[0])
+            self.assertTrue(count > 0)
+            return count
+
+        tags = ['long_running', 'long_running, important']
+
+        for tag in tags:
+            total = get_count(['numba.tests'])
+            included = get_count(['--tags', tag, 'numba.tests'])
+            excluded = get_count(['--exclude-tags', tag, 'numba.tests'])
+            self.assertEqual(total, included + excluded)
+
+            # check syntax with `=` sign in
+            total = get_count(['numba.tests'])
+            included = get_count(['--tags=%s' % tag, 'numba.tests'])
+            excluded = get_count(['--exclude-tags=%s' % tag, 'numba.tests'])
+            self.assertEqual(total, included + excluded)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are certain tests which necessarily take a very long time
as they tax CPU resources. It is not appropriate for these tests
to run on public CI as it they contribute significantly to testing
times and sometimes cause timeouts on CI infrastructure. This
patch adds the test tag `@tag('long_test')` and the option
`--exclude-tags` to the test suite runner. Using these in
combination along with marking known long tests should speed up
test times in CI.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
