### PR TITLE
Fixing the boolean copy from data

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -172,7 +172,7 @@ class BooleanModel(DataModel):
         return self._bit_type
 
     def get_data_type(self):
-        return self._byte_type
+        return self._bit_type
 
     def get_return_type(self):
         return self.get_data_type()


### PR DESCRIPTION
closes #2921 

Hello,
I am very pleased with contributing to numba project.
This PR is first job for me. 
Please reviewing my PR.

I fixed the bug for taking a numpy boolean array to memory.
In my opion, there is no problem for copying from disk by using 1bit size.

I have also tested in llvmlite using `ir`.
There is no problem when boolean copy to 1 bit size.

```python
import numpy as np
from llvmlite import ir

a = np.bool(True)
print(a)

int8 = ir.IntType(8)
int1 = ir.IntType(1)

bit_bool = int1(a)
byte_bool = int8(a)
print(bit_bool)
print(byte_bool)
```

``` bash
True
i1 true
i8 true
```

If there any problems in my PR, I welcome valuable comments.
