### PR TITLE
Skip alignment tests on armv7l.

### DIFF
--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division, absolute_import
 import errno
 import multiprocessing
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -38,6 +39,7 @@ from .test_linalg import needs_lapack
 
 import llvmlite.binding as ll
 
+_is_armv7l = platform.machine() == 'armv7l'
 
 def dummy(x):
     return x
@@ -391,6 +393,7 @@ class TestDispatcher(BaseTest):
         self.assertIs(ref(), None)
 
     @needs_lapack
+    @unittest.skipIf(_is_armv7l, "Unaligned loads unsupported")
     def test_misaligned_array_dispatch(self):
         # for context see issue #2937
         def foo(a):
@@ -429,6 +432,7 @@ class TestDispatcher(BaseTest):
         check("C_contig_misaligned", C_contig_misaligned)
         check("F_contig_misaligned", F_contig_misaligned)
 
+    @unittest.skipIf(_is_armv7l, "Unaligned loads unsupported")
     def test_immutability_in_array_dispatch(self):
 
         # RO operation in function
@@ -470,6 +474,7 @@ class TestDispatcher(BaseTest):
               disable_write_bit=True)
 
     @needs_lapack
+    @unittest.skipIf(_is_armv7l, "Unaligned loads unsupported")
     def test_misaligned_high_dimension_array_dispatch(self):
 
         def foo(a):


### PR DESCRIPTION
Tests requiring unusual alignments fail on armv7l as typically a
mis-aligned load causes SIGBUS. This patch makes these tests
skipped on armv7l.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
