### PR TITLE
Use `ir.unknown_loc` for unknown `Loc`, as #3390 with tests

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -147,6 +147,10 @@ class Loc(object):
         return type(self)(self.filename, line, col)
 
 
+# Used for annotating errors when source location is unknown.
+unknown_loc = Loc("unknown location", 0, 0)
+
+
 class VarMap(object):
     def __init__(self):
         self._con = {}

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -954,7 +954,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
             if not tv.defined:
                 offender = find_offender(name)
                 val = getattr(offender, 'value', 'unknown operation')
-                loc = getattr(offender, 'loc', 'unknown location')
+                loc = getattr(offender, 'loc', ir.unknown_loc)
                 msg = "Undefined variable '%s', operation: %s, location: %s"
                 raise TypingError(msg % (var, val, loc), loc)
             tp = tv.getone()
@@ -1039,7 +1039,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                                     break
 
                     for name, offender in returns.items():
-                        loc = getattr(offender, 'loc', 'unknown location')
+                        loc = getattr(offender, 'loc', ir.unknown_loc)
                         msg = ("Return of: IR name '%s', type '%s', "
                                "location: %s")
                         interped = msg % (name, atype, loc.strformat())

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -963,7 +963,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                 msg = ("Cannot infer the type of variable '%s'%s, "
                       "have imprecise type: %s. %s")
                 istmp = " (temporary variable)" if var.startswith('$') else ""
-                loc = getattr(offender, 'loc', 'unknown location')
+                loc = getattr(offender, 'loc', ir.unknown_loc)
                 # is this an untyped list? try and provide help
                 extra_msg = diagnose_imprecision(offender)
                 raise TypingError(msg % (var, istmp, tp, extra_msg), loc)


### PR DESCRIPTION
This supersedes #3390 (thanks for the original patch @Quasilyte) and includes testing (thanks @ehsantn for the reproducer).

Closes https://github.com/numba/numba/issues/3390
Fixes https://github.com/numba/numba/issues/3389