### PR TITLE
Fix Array Analysis for Global Namedtuples

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -535,7 +535,6 @@ class ShapeEquivSet(EquivSet):
             for x in self.ind_to_var[j]:
                 if x.name in names:
                     varlist.append(x)
-            assert(len(varlist) > 0)
             ind_to_var[i] = varlist
         newset.ind_to_var = ind_to_var
         return newset

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -873,5 +873,19 @@ class TestArrayAnalysisParallelRequired(TestCase):
         except IndexError:
             self.fail("test_bug2537 raised IndexError!")
 
+    @skip_unsupported
+    def test_global_namedtuple(self):
+        Row = namedtuple('Row', ['A'])
+        row = Row(3)
+
+        def test_impl():
+            rr = row
+            res = rr.A
+            if res == 2:
+                res = 3
+            return res
+
+        self.assertEqual(njit(test_impl, parallel=True)(), test_impl())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This removes an assertion in array analysis that requires variables being available for equivalent objects (during intersection of block equivalences). However, global namedtuple instances do not necessarily have variables in the target function.