### PR TITLE
gdb test guard needs to ack ptrace permissions

### DIFF
--- a/numba/tests/test_gdb.py
+++ b/numba/tests/test_gdb.py
@@ -8,9 +8,10 @@ import sys
 import threading
 from itertools import permutations
 
-from numba import njit, gdb, gdb_init, gdb_breakpoint, prange, config, errors
+from numba import njit, gdb, gdb_init, gdb_breakpoint, prange, errors
 from numba import jit
 from numba import unittest_support as unittest
+from numba.targets.gdb_hook import _confirm_gdb
 
 from .support import (TestCase, captured_stdout, tag)
 from .test_parfors import skip_unsupported as parfors_skip_unsupported
@@ -26,9 +27,16 @@ not_unix = unittest.skipIf(_unix_like, "non unix-like OS is required")
 
 _gdb_cond = os.environ.get('GDB_TEST', None) == '1'
 needs_gdb_harness = unittest.skipUnless(_gdb_cond, "needs gdb harness")
-_gdbloc = config.GDB_BINARY
-_has_gdb = (os.path.exists(_gdbloc) and os.path.isfile(_gdbloc))
-needs_gdb = unittest.skipUnless(_has_gdb, "gdb binary is required")
+
+# check if gdb is present and working
+try:
+    _confirm_gdb()
+    _HAVE_GDB = True
+except Exception:
+    _HAVE_GDB = False
+
+_msg = "functioning gdb with correct ptrace permissions is required"
+needs_gdb = unittest.skipUnless(_HAVE_GDB, _msg)
 long_running = tag('long_running')
 
 _dbg_njit = njit(debug=True)


### PR DESCRIPTION
This fixes the test guard for gdb to require:
a) the binary
b) ptrace_scope permissions set appropriately

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
