### PR TITLE
Fix gdb support on RPi

### DIFF
--- a/numba/tests/test_gdb.py
+++ b/numba/tests/test_gdb.py
@@ -18,9 +18,9 @@ from .test_parfors import skip_unsupported as parfors_skip_unsupported
 
 _platform = sys.platform
 
-_unix_like = (_platform.startswith('linux') or
-              _platform.startswith('darwin') or
-              ('bsd' in _platform))
+_unix_like = (_platform.startswith('linux')
+              or _platform.startswith('darwin')
+              or ('bsd' in _platform))
 
 unix_only = unittest.skipUnless(_unix_like, "unix-like OS is required")
 not_unix = unittest.skipIf(_unix_like, "non unix-like OS is required")
@@ -158,7 +158,7 @@ class TestGdbBinding(TestCase):
             popen.stdout.flush()
             popen.stderr.flush()
             popen.kill()
-        timeout = threading.Timer(20., kill)
+        timeout = threading.Timer(120., kill)
         try:
             timeout.start()
             out, err = popen.communicate()
@@ -196,10 +196,17 @@ class TestGdbBinding(TestCase):
             self.assertIn('OK', e)
             self.assertTrue('FAIL' not in e)
             self.assertTrue('ERROR' not in e)
+
+        decs = []
         if 'quick' in name:
-            setattr(cls, methname, test_template)
-        else:
-            setattr(cls, methname, long_running(test_template))
+            decs.append(long_running)
+        if 'parallel' in name:
+            decs.append(parfors_skip_unsupported)
+
+        for dec in decs:
+            test_template = dec(test_template)
+
+        setattr(cls, methname, test_template)
 
     @classmethod
     def generate(cls):


### PR DESCRIPTION
This adjusts the timers for RPi so that gdb has time to
launch, it also prevents parfors tests running as they
are not supported.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
