### PR TITLE
np.where with broadcasting

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1918,7 +1918,7 @@ def _where_inner_y_scalar(cond, x, y, res):
         res[idx] = x[idx] if c else y
     return res
 
-def foo(context, builder, sig, args, where_inner):
+def _where_inner(context, builder, sig, args, where_inner):
     cond, x, y = sig.args
 
     x_dt = determine_dtype(x)
@@ -1941,22 +1941,22 @@ def array_scalar_scalar_where(context, builder, sig, args):
     """
     np.where(array, scalar, scalar)
     """
-    where_inner = _where_inner_x_y_scalar
-    return foo(context, builder, sig, args, where_inner)
+    impl = _where_inner_x_y_scalar
+    return _where_inner(context, builder, sig, args, impl)
 
 def array_array_scalar_where(context, builder, sig, args):
     """
     np.where(array, array, scalar)
     """
-    where_inner = _where_inner_y_scalar
-    return foo(context, builder, sig, args, where_inner)
+    impl = _where_inner_y_scalar
+    return _where_inner(context, builder, sig, args, impl)
 
 def array_scalar_array_where(context, builder, sig, args):
     """
     np.where(array, scalar, array)
     """
-    where_inner = _where_inner_x_scalar
-    return foo(context, builder, sig, args, where_inner)
+    impl = _where_inner_x_scalar
+    return _where_inner(context, builder, sig, args, impl)
 
 @lower_builtin(np.where, types.Any, types.Any, types.Any)
 def any_where(context, builder, sig, args):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1903,21 +1903,21 @@ def array_where(context, builder, sig, args):
 
 
 @register_jitable
-def _where_inner_x_y_scalar(cond, x, y, res):
+def _where_x_y_scalar(cond, x, y, res):
     for idx, c in np.ndenumerate(cond):
         res[idx] = x if c else y
     return res
 
 
 @register_jitable
-def _where_inner_x_scalar(cond, x, y, res):
+def _where_x_scalar(cond, x, y, res):
     for idx, c in np.ndenumerate(cond):
         res[idx] = x if c else y[idx]
     return res
 
 
 @register_jitable
-def _where_inner_y_scalar(cond, x, y, res):
+def _where_y_scalar(cond, x, y, res):
     for idx, c in np.ndenumerate(cond):
         res[idx] = x[idx] if c else y
     return res
@@ -1943,9 +1943,9 @@ def _where_inner(context, builder, sig, args, impl):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-array_scalar_scalar_where = partial(_where_inner, impl=_where_inner_x_y_scalar)
-array_array_scalar_where = partial(_where_inner, impl=_where_inner_y_scalar)
-array_scalar_array_where = partial(_where_inner, impl=_where_inner_x_scalar)
+array_scalar_scalar_where = partial(_where_inner, impl=_where_x_y_scalar)
+array_array_scalar_where = partial(_where_inner, impl=_where_y_scalar)
+array_scalar_array_where = partial(_where_inner, impl=_where_x_scalar)
 
 
 @lower_builtin(np.where, types.Any, types.Any, types.Any)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1965,14 +1965,16 @@ def any_where(context, builder, sig, args):
     if isinstance(cond, types.Array):
         if isinstance(x, types.Array):
             if isinstance(y, types.Array):
-                return array_where(context, builder, sig, args)
+                impl = array_where
             elif isinstance(y, (types.Number, types.Boolean)):
-                return array_array_scalar_where(context, builder, sig, args)
+                impl = array_array_scalar_where
         elif isinstance(x, (types.Number, types.Boolean)):
             if isinstance(y, types.Array):
-                return array_scalar_array_where(context, builder, sig, args)
+                impl = array_scalar_array_where
             elif isinstance(y, (types.Number, types.Boolean)):
-                return array_scalar_scalar_where(context, builder, sig, args)
+                impl = array_scalar_scalar_where
+
+        return impl(context, builder, sig, args)
 
     def scalar_where_impl(cond, x, y):
         """

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -682,13 +682,27 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             got = cfunc(condition, y, x)
             self.assertPreciseEqual(got, expected)
 
-        x = np.array([[1, 2, 3],
-                      [4, 5, 6],
-                      [7, 8, 9]])
-        y = 0
-        condition = np.logical_or(x > 8, x < 2)
-        params = (condition, x, y)
-        check_ok(params)
+        def array_permutations():
+            x = np.arange(9).reshape(3, 3)
+            yield x
+            yield x * 1.1
+            yield np.asfortranarray(x)
+            yield x[::-1]
+            yield np.linspace(-10, 10, 60).reshape(3, 4, 5) * 1j
+
+        def scalar_permutations():
+            yield 0
+            yield 4.3
+            yield np.nan
+            yield True
+            yield 8 + 4j
+
+        for x in array_permutations():
+            for y in scalar_permutations():
+                x_mean = np.mean(x)
+                condition = x > x_mean
+                params = (condition, x, y)
+                check_ok(params)
 
     def test_item(self):
         pyfunc = array_item

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -639,7 +639,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         for x in (0, 1, True, False, 2.5, 0j):
             check_scal(x)
 
-    def test_np_where_3_broadcast(self):
+    def test_np_where_3_broadcast_x_y_scalar(self):
         pyfunc = np_where_3
         cfunc = jit(nopython=True)(pyfunc)
 
@@ -665,6 +665,30 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
             params = (a > 1, True, False)
             check_ok(params)
+
+    def test_np_where_3_broadcast_x_or_y_scalar(self):
+        pyfunc = np_where_3
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check_ok(args):
+            condition, x, y = args
+
+            expected = pyfunc(condition, x, y)
+            got = cfunc(condition, x, y)
+            self.assertPreciseEqual(got, expected)
+
+            # swap x and y
+            expected = pyfunc(condition, y, x)
+            got = cfunc(condition, y, x)
+            self.assertPreciseEqual(got, expected)
+
+        x = np.array([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 9]])
+        y = 0
+        condition = np.logical_or(x > 8, x < 2)
+        params = (condition, x, y)
+        check_ok(params)
 
     def test_item(self):
         pyfunc = array_item

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1146,11 +1146,16 @@ class Where(AbstractTemplate):
                         as_dtype(getattr(args[2], 'dtype', args[2]))))
             if isinstance(cond, types.Array):
                 # array where()
-                if (cond.ndim == x.ndim == y.ndim):
-                    if x.layout == y.layout == cond.layout:
-                        retty = types.Array(retdty, x.ndim, x.layout)
-                    else:
-                        retty = types.Array(retdty, x.ndim, 'C')
+                if isinstance(x, types.Array) and isinstance(y, types.Array):
+                    if (cond.ndim == x.ndim == y.ndim):
+                        if x.layout == y.layout == cond.layout:
+                            retty = types.Array(retdty, x.ndim, x.layout)
+                        else:
+                            retty = types.Array(retdty, x.ndim, 'C')
+                        return signature(retty, *args)
+                else:
+                    # x and y both scalar
+                    retty = types.Array(retdty, cond.ndim, cond.layout)
                     return signature(retty, *args)
             else:
                 # scalar where()


### PR DESCRIPTION
Small extension to `np.where` to support use cases like:

```python
a = np.linspace(-2, 5, 20).reshape(4, 5)
cond = a > 0
mask = np.where(cond, 1, 0)
```

Initial commit for CI.