### PR TITLE
Avoid leaking memory when iterating over uniform tuple

### DIFF
--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -188,6 +188,8 @@ def iternext_unituple(context, builder, sig, args, result):
                                        types.intp)
         getitem_out = getitem_unituple(context, builder, getitem_sig,
                                        [tup, idx])
+        if context.enable_nrt:
+            context.nrt.decref(builder, tupiterty.container.dtype, getitem_out)
         result.yield_(getitem_out)
         nidx = builder.add(idx, context.get_constant(types.intp, 1))
         builder.store(nidx, iterval.index)


### PR DESCRIPTION
We added an extra reference count to every element as it was pulled out of the
tuple. For a tuple of arrays this could end up leaking quite a lot of memory!

Related to #3473, but I seem to have discovered a previously unreported issue that is merely similar to the one reported in that ticket.