### PR TITLE
Fixes constant string lowering inside tuples

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -626,6 +626,17 @@ def pack_array(builder, values, ty=None):
     return ary
 
 
+def pack_struct(builder, values):
+    """
+    Pack a sequence of values in a LLVM struct.
+    """
+    structty = ir.LiteralStructType([v.type for v in values])
+    st = structty(ir.Undefined)
+    for i, v in enumerate(values):
+        st = builder.insert_value(st, v, i)
+    return st
+
+
 def unpack_tuple(builder, tup, count=None):
     """
     Unpack an array or structure of values, return a Python tuple.

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -628,7 +628,7 @@ def pack_array(builder, values, ty=None):
 
 def pack_struct(builder, values):
     """
-    Pack a sequence of values in a LLVM struct.
+    Pack a sequence of values into a LLVM struct.
     """
     structty = ir.LiteralStructType([v.type for v in values])
     st = structty(ir.Undefined)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3725,7 +3725,9 @@ def _as_layout_array(context, builder, sig, args, output_layout):
         ary = make_array(aryty)(context, builder, value=args[0])
         ret = make_array(retty)(context, builder)
 
-        shape = context.get_constant(types.UniTuple(types.intp, 1), (1,))
+        shape = context.get_constant_generic(
+            builder, types.UniTuple(types.intp, 1), (1,),
+        )
         strides = context.make_tuple(builder,
                                      types.UniTuple(types.intp, 1),
                                      (ary.itemsize,))

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -704,8 +704,10 @@ class BaseContext(object):
         assert ty is not None
         cav = self.cast(builder, av, at, ty)
         cbv = self.cast(builder, bv, bt, ty)
-        cmpsig = typing.signature(types.boolean, ty, ty)
-        cmpfunc = self.get_function(key, cmpsig)
+        fnty = self.typing_context.resolve_value_type(key)
+        cmpsig = fnty.get_call_type(self.typing_context, argtypes, {})
+        cmpfunc = self.get_function(fnty, cmpsig)
+        self.add_linking_libs(getattr(cmpfunc, 'libs', ()))
         return cmpfunc(builder, (cav, cbv))
 
     def make_optional_none(self, builder, valtype):

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -131,7 +131,9 @@ def unituple_constant(context, builder, ty, pyval):
     """
     consts = [context.get_constant_generic(builder, ty.dtype, v)
               for v in pyval]
-    return ir.ArrayType(consts[0].type, len(consts))(consts)
+    return impl_ret_borrowed(
+        context, builder, ty, cgutils.pack_array(builder, consts),
+    )
 
 @lower_constant(types.Tuple)
 @lower_constant(types.NamedTuple)
@@ -141,7 +143,9 @@ def unituple_constant(context, builder, ty, pyval):
     """
     consts = [context.get_constant_generic(builder, ty.types[i], v)
               for i, v in enumerate(pyval)]
-    return ir.Constant.literal_struct(consts)
+    return impl_ret_borrowed(
+        context, builder, ty, cgutils.pack_struct(builder, consts),
+    )
 
 
 #------------------------------------------------------------------------------

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -435,5 +435,37 @@ class TestUnicode(BaseTest):
                              msg='failed on {}'.format(args))
 
 
+@unittest.skipUnless(_py34_or_later,
+                     'unicode support requires Python 3.4 or later')
+class TestUnicodeInTuple(BaseTest):
+
+    def test_const_unicode_in_tuple(self):
+        # Issue 3673
+        @njit
+        def f():
+            return ('aa',) < ('bb',)
+
+        self.assertEqual(f.py_func(), f())
+
+        @njit
+        def f():
+            return ('cc',) < ('bb',)
+
+        self.assertEqual(f.py_func(), f())
+
+    def test_const_unicode_in_hetero_tuple(self):
+        @njit
+        def f():
+            return ('aa', 1) < ('bb', 1)
+
+        self.assertEqual(f.py_func(), f())
+
+        @njit
+        def f():
+            return ('aa', 1) < ('aa', 2)
+
+        self.assertEqual(f.py_func(), f())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -102,7 +102,6 @@ def cast_from_literal(context, builder, fromty, toty, val):
 
 @lower_constant(types.unicode_type)
 def constant_unicode(context, builder, typ, pyval):
-    literal_string = pyval
     return make_string_from_constant(context, builder, typ, pyval)
 
 

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -77,6 +77,10 @@ def compile_time_get_string_data(obj):
 
 
 def make_string_from_constant(context, builder, typ, literal_string):
+    """
+    Get string data by `compile_time_get_string_data()` and return a
+    unicode_type LLVM value
+    """
     databytes, length, kind = compile_time_get_string_data(literal_string)
     mod = builder.module
     gv = context.insert_const_bytes(mod, databytes)


### PR DESCRIPTION
- fix incomplete implementation for constant string lowering.
- fix packing of constant strings into a constant tuple.
    - Details: the constant string lowering does not always produce a llvm `ir.Constant`.
- `generic_compare` should use `.resolve_value_type` to get function type.