### PR TITLE
Fix test failure due to overly strict test on floating point values.

### DIFF
--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -38,14 +38,18 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
         try:
             # change to a smaller ratio
             config.CUDA_DEALLOCS_RATIO = max_pending / mi.total
-            self.assertEqual(deallocs._max_pending_bytes, max_pending)
+            # due to round off error (floor is used in calculating _max_pending_bytes)
+            # it can be off by 1.
+            self.assertAlmostEqual(deallocs._max_pending_bytes, max_pending, delta=1)
 
             # deallocate half the max size
+            # this will not trigger deallocation
             cuda.to_device(np.ones(max_pending // 2, dtype=np.int8))
             self.assertEqual(len(deallocs), 1)
 
             # deallocate another remaining
-            cuda.to_device(np.ones(max_pending - deallocs._size, dtype=np.int8))
+            # this will not trigger deallocation
+            cuda.to_device(np.ones(deallocs._max_pending_bytes - deallocs._size, dtype=np.int8))
             self.assertEqual(len(deallocs), 2)
 
             # another byte to trigger .clear()

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -42,12 +42,12 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
             # it can be off by 1.
             self.assertAlmostEqual(deallocs._max_pending_bytes, max_pending, delta=1)
 
-            # deallocate half the max size
+            # allocate half the max size
             # this will not trigger deallocation
             cuda.to_device(np.ones(max_pending // 2, dtype=np.int8))
             self.assertEqual(len(deallocs), 1)
 
-            # deallocate another remaining
+            # allocate another remaining
             # this will not trigger deallocation
             cuda.to_device(np.ones(deallocs._max_pending_bytes - deallocs._size, dtype=np.int8))
             self.assertEqual(len(deallocs), 2)


### PR DESCRIPTION
Failure was due to (x / y * y) != x.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
