### PR TITLE
Convert return of None from intrinsic implementation to dummy value

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -698,6 +698,18 @@ class Lower(BaseLower):
         else:
             res = self._lower_call_normal(fnty, expr, signature)
 
+        # If lowering the call returned None, interpret that as returning dummy
+        # value if the return type of the function is void, otherwise there is
+        # a problem
+        if res is None:
+            if signature.return_type == types.void:
+                res = self.context.get_dummy_value()
+            else:
+                raise LoweringError(
+                    msg="non-void function returns None from implementation",
+                    loc=self.loc
+                )
+
         return self.context.cast(self.builder, res, signature.return_type,
                                  resty)
 


### PR DESCRIPTION
Small quality of life improvement that allows the implementation of an intrinsic, like this:
``` python
    def codegen(context, builder, signature, args):
        data, idx, ch = args
        if bitsize < 32:
            ch = builder.trunc(ch, IntType(bitsize))
        ptr = builder.bitcast(data, IntType(bitsize).as_pointer())
        builder.store(ch, builder.gep(ptr, [idx]))
        return context.get_dummy_value()
```
to drop the final `return context.get_dummy_value()` if the signature of the function has a `void` return type.  Otherwise, a lowering error is raised to tell you that you are returning None from the implementation non-void function, which is more useful than the exception that happens now.