### PR TITLE
Add intrinsic to help debug refcount

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -64,7 +64,6 @@ exclude =
     numba/dataflow.py
     numba/special.py
     numba/controlflow.py
-    numba/cgutils.py
     numba/macro.py
     numba/runtests.py
     numba/pythonapi.py

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1088,6 +1088,17 @@ numba_gdb_breakpoint(void) {
   /* does nothing */
 }
 
+
+/*
+ * Helper to deal with stdout, stderr
+ */
+NUMBA_EXPORT_FUNC(void)
+numba_flush_stdout(void) {
+  fflush(stdout);
+}
+
+
+
 /*
  * Define bridge for all math functions
  */

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1088,7 +1088,6 @@ numba_gdb_breakpoint(void) {
   /* does nothing */
 }
 
-
 /*
  * Define bridge for all math functions
  */

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -1090,16 +1090,6 @@ numba_gdb_breakpoint(void) {
 
 
 /*
- * Helper to deal with stdout, stderr
- */
-NUMBA_EXPORT_FUNC(void)
-numba_flush_stdout(void) {
-  fflush(stdout);
-}
-
-
-
-/*
  * Define bridge for all math functions
  */
 

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -123,6 +123,9 @@ build_c_helpers_dict(void)
     /* for gdb breakpoint */
     declmethod(gdb_breakpoint);
 
+    /* util for stdout, stderr */
+    declmethod(flush_stdout);
+
 #define MATH_UNARY(F, R, A) declmethod(F);
 #define MATH_BINARY(F, R, A, B) declmethod(F);
     #include "mathnames.h"

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -123,9 +123,6 @@ build_c_helpers_dict(void)
     /* for gdb breakpoint */
     declmethod(gdb_breakpoint);
 
-    /* util for stdout, stderr */
-    declmethod(flush_stdout);
-
 #define MATH_UNARY(F, R, A) declmethod(F);
 #define MATH_BINARY(F, R, A, B) declmethod(F);
     #include "mathnames.h"
@@ -169,6 +166,16 @@ build_npymath_exports_dict(void)
     }
     return dct;
 }
+
+
+/*
+ * Helper to deal with flushing stdout
+ */
+PyAPI_FUNC(void)
+_numba_flush_stdout(void) {
+  fflush(stdout);
+}
+
 
 static PyMethodDef ext_methods[] = {
     { "rnd_get_state", (PyCFunction) _numba_rnd_get_state, METH_O, NULL },

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -171,7 +171,9 @@ build_npymath_exports_dict(void)
 /*
  * Helper to deal with flushing stdout
  */
-PyAPI_FUNC(void)
+PyAPI_FUNC(void) _numba_flush_stdout(void) ;
+
+void
 _numba_flush_stdout(void) {
   fflush(stdout);
 }

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -10,7 +10,7 @@ import functools
 
 from llvmlite import ir
 
-from . import utils
+from . import utils, config
 
 
 bool_t = ir.IntType(1)
@@ -1025,11 +1025,15 @@ def snprintf(builder, buffer, bufsz, format, *args):
     fnty = ir.FunctionType(
         int32_t, [cstring, intp_t, cstring], var_arg=True,
     )
+    # Actual symbol name of snprintf is different on win32.
+    symbol = 'snprintf'
+    if config.IS_WIN32:
+        symbol = '_' + symbol
     # Insert snprintf()
     try:
-        fn = mod.get_global('snprintf')
+        fn = mod.get_global(symbol)
     except KeyError:
-        fn = ir.Function(mod, fnty, name="snprintf")
+        fn = ir.Function(mod, fnty, name=symbol)
     # Call
     ptr_fmt = builder.bitcast(global_fmt, cstring)
     return builder.call(fn, [buffer, bufsz, ptr_fmt] + list(args))

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -52,6 +52,7 @@ def make_bytearray(buf):
 
 _struct_proxy_cache = {}
 
+
 def create_struct_proxy(fe_type, kind='value'):
     """
     Returns a specialized StructProxy subclass for the given fe_type.
@@ -177,7 +178,7 @@ class _StructProxy(object):
         value = self._cast_member_from_value(index, value)
         if value.type != ptr.type.pointee:
             if (is_pointer(value.type) and is_pointer(ptr.type.pointee)
-                and value.type.pointee == ptr.type.pointee.pointee):
+                    and value.type.pointee == ptr.type.pointee.pointee):
                 # Differ by address-space only
                 # Auto coerce it
                 value = self._context.addrspacecast(self._builder,
@@ -440,6 +441,7 @@ def increment_index(builder, val):
 
 
 Loop = collections.namedtuple('Loop', ('index', 'do_break'))
+
 
 @contextmanager
 def for_range(builder, count, start=None, intp=None):
@@ -744,6 +746,7 @@ def is_scalar_zero_or_nan(builder, value):
     return _scalar_pred_against_zero(
         builder, value, functools.partial(builder.fcmp_unordered, '=='), '==')
 
+
 is_true = is_not_scalar_zero
 is_false = is_scalar_zero
 
@@ -766,6 +769,7 @@ def guard_null(context, builder, value, exc_tuple):
         exc_args = exc_tuple[1:] or None
         context.call_conv.return_user_exc(builder, exc, exc_args)
 
+
 def guard_memory_error(context, builder, pointer, msg=None):
     """
     Guard against *pointer* being NULL (and raise a MemoryError).
@@ -774,6 +778,7 @@ def guard_memory_error(context, builder, pointer, msg=None):
     exc_args = (msg,) if msg else ()
     with builder.if_then(is_null(builder, pointer), likely=False):
         context.call_conv.return_user_exc(builder, MemoryError, exc_args)
+
 
 @contextmanager
 def if_zero(builder, value, likely=False):
@@ -849,8 +854,6 @@ def memset(builder, ptr, size, value):
     """
     Fill *size* bytes starting from *ptr* with *value*.
     """
-    sizety = size.type
-    memset = "llvm.memset.p0i8.i%d" % (sizety.width)
     fn = builder.module.declare_intrinsic('llvm.memset', (voidptr_t, size.type))
     ptr = builder.bitcast(ptr, voidptr_t)
     if isinstance(value, int):
@@ -961,6 +964,7 @@ def raw_memcpy(builder, dst, src, count, itemsize, align=1):
     """
     return _raw_memcpy(builder, 'llvm.memcpy', dst, src, count, itemsize, align)
 
+
 def raw_memmove(builder, dst, src, count, itemsize, align=1):
     """
     Emit a raw memmove() call for `count` items of size `itemsize`
@@ -1030,8 +1034,9 @@ def snprintf(builder, buffer, bufsz, format, *args):
     ptr_fmt = builder.bitcast(global_fmt, cstring)
     return builder.call(fn, [buffer, bufsz, ptr_fmt] + list(args))
 
+
 def snprintf_stackbuffer(builder, bufsz, format, *args):
-    """Similar to `sprint()` but the buffer is stack allocated to size *bufsz*.
+    """Similar to `snprintf()` but the buffer is stack allocated to size *bufsz*.
 
     Returns the buffer pointer as i8*.
     """

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -1008,14 +1008,6 @@ def printf(builder, format, *args):
     ptr_fmt = builder.bitcast(global_fmt, cstring)
     return builder.call(fn, [ptr_fmt] + list(args))
 
-def flush_stdout(builder):
-    """Calls numba_flush_stdout
-    """
-    mod = builder.module
-    fnty = ir.FunctionType(ir.VoidType(), [])
-    fn = mod.get_or_insert_function(fnty, name='numba_flush_stdout')
-    return builder.call(fn, ())
-
 
 if utils.PY3:
     def normalize_ir_text(text):

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -1008,6 +1008,14 @@ def printf(builder, format, *args):
     ptr_fmt = builder.bitcast(global_fmt, cstring)
     return builder.call(fn, [ptr_fmt] + list(args))
 
+def flush_stdout(builder):
+    """Calls numba_flush_stdout
+    """
+    mod = builder.module
+    fnty = ir.FunctionType(ir.VoidType(), [])
+    fn = mod.get_or_insert_function(fnty, name='numba_flush_stdout')
+    return builder.call(fn, ())
+
 
 if utils.PY3:
     def normalize_ir_text(text):

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -1,9 +1,6 @@
 from __future__ import print_function
 
-import sys
 import random
-import multiprocessing
-
 import numpy as np
 
 from .support import TestCase, redirect_c_stdout
@@ -12,7 +9,6 @@ from numba.unsafe.tuple import tuple_setitem
 from numba.unsafe.ndarray import to_fixed_tuple, empty_inferred
 from numba.unsafe.refcount import dump_refcount
 from numba.errors import TypingError
-
 
 
 class TestTupleIntrinsic(TestCase):
@@ -134,4 +130,3 @@ class TestRefCount(TestCase):
         tupty = types.Tuple.from_types([aryty] * 2)
         self.assertIn(pat.format(aryty), output)
         self.assertIn(pat.format(tupty), output)
-

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import random
 import numpy as np
 
-from .support import TestCase, redirect_c_stdout
+from .support import TestCase, captured_stdout
 from numba import njit, types
 from numba.unsafe.tuple import tuple_setitem
 from numba.unsafe.ndarray import to_fixed_tuple, empty_inferred
@@ -120,10 +120,11 @@ class TestRefCount(TestCase):
             dump_refcount(a)
             dump_refcount(b)
 
-        with redirect_c_stdout() as stream:
+        # Capture output to sys.stdout
+        with captured_stdout() as stream:
             use_dump_refcount()
 
-        output = stream.read()
+        output = stream.getvalue()
         # Check that it printed
         pat = "dump refct of {}"
         aryty = types.float64[::1]

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -1,14 +1,18 @@
 from __future__ import print_function
 
+import sys
 import random
+import multiprocessing
 
 import numpy as np
 
-from .support import TestCase
-from numba import njit
+from .support import TestCase, redirect_c_stdout
+from numba import njit, types
 from numba.unsafe.tuple import tuple_setitem
 from numba.unsafe.ndarray import to_fixed_tuple, empty_inferred
+from numba.unsafe.refcount import dump_refcount
 from numba.errors import TypingError
+
 
 
 class TestTupleIntrinsic(TestCase):
@@ -109,3 +113,25 @@ class TestNdarrayIntrinsic(TestCase):
         got = func()
         expect = np.asarray([3.1] * 10)
         np.testing.assert_array_equal(got, expect)
+
+
+class TestRefCount(TestCase):
+    def test_dump_refcount(self):
+        @njit
+        def use_dump_refcount():
+            a = np.ones(10)
+            b = (a, a)
+            dump_refcount(a)
+            dump_refcount(b)
+
+        with redirect_c_stdout() as stream:
+            use_dump_refcount()
+
+        output = stream.read()
+        # Check that it printed
+        pat = "dump refct of {}"
+        aryty = types.float64[::1]
+        tupty = types.Tuple.from_types([aryty] * 2)
+        self.assertIn(pat.format(aryty), output)
+        self.assertIn(pat.format(tupty), output)
+

--- a/numba/unsafe/refcount.py
+++ b/numba/unsafe/refcount.py
@@ -30,7 +30,9 @@ def dump_refcount(typingctx, obj):
                 miptr = builder.bitcast(mi, _meminfo_struct_type.as_pointer())
                 refctptr = cgutils.gep_inbounds(builder, miptr, 0, 0)
                 refct = builder.load(refctptr)
-                cgutils.printf(builder, "| {} -> %zd".format(ty), refct)
+                cgutils.sprintf_stackbuffer(
+                    builder, 20, "| {} -> %zd".format(ty), refct,
+                )
             cgutils.printf(builder, ";\n")
             return cgutils.true_bit
         else:

--- a/numba/unsafe/refcount.py
+++ b/numba/unsafe/refcount.py
@@ -1,0 +1,42 @@
+"""
+Helpers to see the refcount information of an object
+"""
+
+from numba import types
+from numba import cgutils
+from numba.extending import intrinsic
+
+from numba.runtime.nrtdynmod import _meminfo_struct_type
+
+
+@intrinsic
+def dump_refcount(typingctx, obj):
+    """Dump the refcount of an object to stdout.
+
+    Returns True if and only if object is reference-counted and NRT is enabled.
+    """
+    def codegen(context, builder, signature, args):
+        [obj] = args
+        [ty] = signature.args
+        # A sequence of (type, meminfo)
+        meminfos = []
+        if context.enable_nrt:
+            tmp_mis = context.nrt.get_meminfos(builder, ty, obj)
+            meminfos.extend(tmp_mis)
+
+        if meminfos:
+            cgutils.printf(builder, "dump refct of {}".format(ty))
+            for ty, mi in meminfos:
+                miptr = builder.bitcast(mi, _meminfo_struct_type.as_pointer())
+                refctptr = cgutils.gep_inbounds(builder, miptr, 0, 0)
+                refct = builder.load(refctptr)
+                cgutils.printf(builder, "| {} -> %zd".format(ty), refct)
+            cgutils.printf(builder, ";\n")
+            # Flush immediately
+            cgutils.flush_stdout(builder)
+            return cgutils.true_bit
+        else:
+            return cgutils.false_bit
+
+    sig = types.bool_(obj)
+    return sig, codegen

--- a/numba/unsafe/refcount.py
+++ b/numba/unsafe/refcount.py
@@ -32,8 +32,6 @@ def dump_refcount(typingctx, obj):
                 refct = builder.load(refctptr)
                 cgutils.printf(builder, "| {} -> %zd".format(ty), refct)
             cgutils.printf(builder, ";\n")
-            # Flush immediately
-            cgutils.flush_stdout(builder)
             return cgutils.true_bit
         else:
             return cgutils.false_bit


### PR DESCRIPTION
* Adds `numba.unsafe.refcount.dump_refcout(obj)` to print the refcount info to ~C stdout via printf.~ to `sys.stdout` and use libc `snprintf` for formatting. (msvcrt's printf has weird behavior preventing testing.)
* Refactor how meminfos are retrieved.
* Move `redirect_fd()` to base testing support.