### PR TITLE
Fixes for overload_method

### DIFF
--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -148,13 +148,6 @@ class BaseCallConv(object):
         arginfo = self._get_arg_packer(argtypes)
         return arginfo.from_arguments(builder, raw_args)
 
-    def _fix_argtypes(self, argtypes):
-        """
-        Fix argument types, removing any omitted arguments.
-        """
-        return tuple(ty for ty in argtypes
-                     if not isinstance(ty, types.Omitted))
-
     def _get_arg_packer(self, argtypes):
         """
         Get an argument packer for the given argument types.

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -882,23 +882,25 @@ class TestHighLevelExtending(TestCase):
 
         self.assertEqual(bar(Z), (10, 20, 30))
 
-    @unittest.skipUnless(_IS_PY3, "unicode not supported in py2")
     def test_overload_method_literal_unpack(self):
         # Issue #3683
         @overload_method(types.Array, 'litfoo')
         def litfoo(arr, val):
-            if val == types.unicode_type:
-                def impl(arr, val):
-                    return val
-                return impl
+            # Must be an integer
+            if isinstance(val, types.Integer):
+                # Must not be literal
+                if not isinstance(val, types.Literal):
+                    def impl(arr, val):
+                        return val
+                    return impl
 
         @njit
         def bar(A):
-            return A.litfoo("LiTeRaL")
+            return A.litfoo(0xcafe)
 
         A = np.zeros(1)
         bar(A)
-        self.assertEqual(bar(A), 'LiTeRaL')
+        self.assertEqual(bar(A), 0xcafe)
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -12,7 +12,7 @@ import re
 import numpy as np
 
 from numba import unittest_support as unittest
-from numba import jit, types, errors, typing, compiler
+from numba import njit, jit, types, errors, typing, compiler
 from numba.targets.registry import cpu_target
 from numba.compiler import compile_isolated
 from .support import (TestCase, captured_stdout, tag, temp_directory,
@@ -865,6 +865,22 @@ class TestHighLevelExtending(TestCase):
         msg = str(e.exception)
         self.assertIn("use of VAR_KEYWORD (e.g. **kwargs) is unsupported", msg)
         self.assertIn("offending argument name is '**kws'", msg)
+
+    def test_overload_method_kwargs(self):
+        @overload_method(types.Array, 'foo')
+        def fooimpl(arr, a_kwarg=10):
+            def impl(arr, a_kwarg=10):
+                return a_kwarg
+            return impl
+
+        @njit
+        def bar(A):
+            print(A.foo())
+
+        Z = np.arange(5)
+
+        bar(Z)
+
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):
     hit = cfunc._cache_hits[cfunc.signatures[0]]

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -867,6 +867,7 @@ class TestHighLevelExtending(TestCase):
         self.assertIn("offending argument name is '**kws'", msg)
 
     def test_overload_method_kwargs(self):
+        # Issue #3489
         @overload_method(types.Array, 'foo')
         def fooimpl(arr, a_kwarg=10):
             def impl(arr, a_kwarg=10):
@@ -881,6 +882,22 @@ class TestHighLevelExtending(TestCase):
 
         self.assertEqual(bar(Z), (10, 20, 30))
 
+    def test_overload_method_literal_unpack(self):
+        # Issue #3683
+        @overload_method(types.Array, 'litfoo')
+        def litfoo(arr, val):
+            if val == types.unicode_type:
+                def impl(arr, val):
+                    return val
+                return impl
+
+        @njit
+        def bar(A):
+            return A.litfoo("LiTeRaL")
+
+        A = np.zeros(1)
+        bar(A)
+        self.assertEqual(bar(A), 'LiTeRaL')
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -875,11 +875,11 @@ class TestHighLevelExtending(TestCase):
 
         @njit
         def bar(A):
-            print(A.foo())
+            return A.foo()
 
         Z = np.arange(5)
 
-        bar(Z)
+        self.assertEqual(bar(Z), 10)
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -882,6 +882,7 @@ class TestHighLevelExtending(TestCase):
 
         self.assertEqual(bar(Z), (10, 20, 30))
 
+    @unittest.skipUnless(_IS_PY3, "unicode not supported in py2")
     def test_overload_method_literal_unpack(self):
         # Issue #3683
         @overload_method(types.Array, 'litfoo')

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -875,11 +875,12 @@ class TestHighLevelExtending(TestCase):
 
         @njit
         def bar(A):
-            return A.foo()
+            return A.foo(), A.foo(20), A.foo(a_kwarg=30)
 
         Z = np.arange(5)
 
-        self.assertEqual(bar(Z), 10)
+        self.assertEqual(bar(Z), (10, 20, 30))
+
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -575,7 +575,7 @@ class _OverloadAttributeTemplate(AttributeTemplate):
         Get the compiled dispatcher implementing the attribute for
         the given formal signature.
         """
-        cache_key = context, typ, attr
+        cache_key = context, typ, attr, tuple(sig_args), tuple(sig_kws.items())
         try:
             disp = cls._impl_cache[cache_key]
         except KeyError:

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -604,6 +604,17 @@ class _OverloadAttributeTemplate(AttributeTemplate):
         return sig.return_type
 
 
+def _adjust_omitted_args(argtypes, argvals):
+    """Add dummy arguments for each missing types.Omitted in *argtypes*.
+    """
+    if len(argtypes) > len(argvals):
+        argvals = list(argvals)
+        for t in reversed(argtypes):
+            if isinstance(t, types.Omitted):
+                argvals.append(None)
+    return argvals
+
+
 class _OverloadMethodTemplate(_OverloadAttributeTemplate):
     """
     A base class of templates for @overload_method functions.
@@ -627,7 +638,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             call = context.get_function(disp_type, sig)
             # Link dependent library
             context.add_linking_libs(getattr(call, 'libs', ()))
-            return call(builder, args)
+            return call(builder, _adjust_omitted_args(sig.args, args))
 
     def _resolve(self, typ, attr):
         if self._attr != attr:

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -86,6 +86,13 @@ class Signature(object):
             return self
         sig = signature(self.return_type, *self.args[1:],
                         recvr=self.args[0])
+
+        # Adjust the python signature
+        params = list(self.pysig.parameters.values())[1:]
+        sig.pysig = utils.pySignature(
+            parameters=params,
+            return_annotation=self.pysig.return_annotation,
+        )
         return sig
 
     def as_function(self):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -611,17 +611,6 @@ class _OverloadAttributeTemplate(AttributeTemplate):
         return sig.return_type
 
 
-def _adjust_omitted_args(argtypes, argvals):
-    """Add dummy arguments for each missing types.Omitted in *argtypes*.
-    """
-    if len(argtypes) > len(argvals):
-        argvals = list(argvals)
-        for t in reversed(argtypes):
-            if isinstance(t, types.Omitted):
-                argvals.append(None)
-    return argvals
-
-
 class _OverloadMethodTemplate(_OverloadAttributeTemplate):
     """
     A base class of templates for @overload_method functions.
@@ -645,7 +634,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             call = context.get_function(disp_type, sig)
             # Link dependent library
             context.add_linking_libs(getattr(call, 'libs', ()))
-            return call(builder, _adjust_omitted_args(sig.args, args))
+            return call(builder, args)
 
     def _resolve(self, typ, attr):
         if self._attr != attr:

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -78,10 +78,12 @@ else:
 
 try:
     from inspect import signature as pysignature
+    from inspect import Signature as pySignature
     from inspect import Parameter as pyParameter
 except ImportError:
     try:
         from funcsigs import signature as pysignature
+        from funcsigs import Signature as pySignature
         from funcsigs import Parameter as pyParameter
     except ImportError:
         raise ImportError("please install the 'funcsigs' package "


### PR DESCRIPTION
Fix #3489.  `overload_method` now supports keyword arguments.
Fix #3683.  attribute dispatcher cache will consider the argument types.

