### PR TITLE
Fix the NvvmSupportError message when CC too low

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -299,7 +299,7 @@ def _find_arch(mycc):
             if i == 0:
                 # CC lower than supported
                 raise NvvmSupportError("GPU compute capability %d.%d is "
-                                       "not supported (requires >=2.0)" % mycc)
+                                       "not supported (requires >=%d.%d)" % (*mycc, *cc))
             else:
                 # return the previous CC
                 return SUPPORTED_CC[i - 1]


### PR DESCRIPTION
Commit 298ca3c accommodated the code to NVIDIA's drop of support for
compute capability 2.x (Fermi) by introducing a check of CUDA_VERSION
(originally) or NVVM_VERSION (since 2bb5c98) and conditional assignment
of different lists to the SUPPORTED_CC variable. However, this branching
was made with disregard of the error message passed when the GPU Compute
Capability is lower than supported, where the minimal version
value of 2.0 had been hard-coded before. This caused a discrepancy and
has been resulting in confusing messages, e.g.:
"GPU compute capability 2.1 is not supported (requires >=2.0)".

This commit makes the error message dependent on the first supported CC
(as inferred from NVVM_VERSION), which is to be displayed as the
minimal requirement.

<!--
I was not able to build Numba (with `python setup.py build_ext --inplace`) in my environment: IIUC, because of elfutils-0.175 causing some objdump errors and I had removed cached older versions prematurely.
However, it is a small change on the basic Python level.
-->