### PR TITLE
Fix #3705: slicing error with negative strides

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -220,6 +220,10 @@ class DeviceNDArrayBase(object):
 
             result_array = d_arr.copy_to_host()
         """
+        if any(s < 0 for s in self.strides):
+            msg = 'D->H copy not implemented for negative strides: {}'
+            raise NotImplementedError(msg.format(self.strides))
+        assert self.alloc_size >= 0, "Negative memory size"
         stream = self._default_stream(stream)
         if ary is None:
             hostary = np.empty(shape=self.alloc_size, dtype=np.byte)
@@ -227,7 +231,6 @@ class DeviceNDArrayBase(object):
             check_array_compatibility(self, ary)
             hostary = ary
 
-        assert self.alloc_size >= 0, "Negative memory size"
         if self.alloc_size != 0:
             _driver.device_to_host(hostary, self, self.alloc_size, stream=stream)
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1715,7 +1715,7 @@ def device_memory_size(devmem):
         s, e = device_extents(devmem)
         sz = e - s
         devmem._cuda_memsize_ = sz
-    assert sz > 0, "zero length array"
+    assert sz >= 0, "{} length array".format(sz)
     return sz
 
 

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -170,6 +170,39 @@ class TestCudaArrayInterface(CUDATestCase):
             h_arr[1::2]
         )
 
+    def test_negative_strided_issue(self):
+        # issue #3705
+        h_arr = np.random.random(10)
+        c_arr = cuda.to_device(h_arr)
+
+        def base_offset(orig, sliced):
+            return sliced['data'][0] - orig['data'][0]
+
+        h_ai = h_arr.__array_interface__
+        c_ai = c_arr.__cuda_array_interface__
+
+        h_ai_sliced = h_arr[::-1].__array_interface__
+        c_ai_sliced = c_arr[::-1].__cuda_array_interface__
+
+        # Check data offset is correct
+        self.assertEqual(
+            base_offset(h_ai, h_ai_sliced),
+            base_offset(c_ai, c_ai_sliced),
+        )
+        # Check shape and strides are correct
+        self.assertEqual(h_ai_sliced['shape'], c_ai_sliced['shape'])
+        self.assertEqual(h_ai_sliced['strides'], c_ai_sliced['strides'])
+
+    def test_negative_strided_copy_to_host(self):
+        # issue #3705
+        h_arr = np.random.random(10)
+        c_arr = cuda.to_device(h_arr)
+        sliced = c_arr[::-1]
+        with self.assertRaises(NotImplementedError) as raises:
+            sliced.copy_to_host()
+        expected_msg = 'D->H copy not implemented for negative strides'
+        self.assertIn(expected_msg, str(raises.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -59,9 +59,7 @@ class Dim(object):
             if stride == 0:
                 size = 1
             else:
-                size = (stop - start + (stride - 1)) // stride
-            if size < 0:
-                size = 0
+                size = _compute_size(start, stop, stride)
             ret = Dim(
                 start=start,
                 stop=stop,
@@ -405,3 +403,17 @@ def is_element_indexing(item, ndim):
 
     return False
 
+
+def _compute_size(start, stop, step):
+    """Algorithm adapted from cpython rangeobject.c
+    """
+    if step > 0:
+        lo = start
+        hi = stop
+    else:
+        lo = stop
+        hi = start
+        step = -step
+    if lo >= hi:
+        return 0
+    return (hi - lo - 1) // step + 1

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -117,6 +117,44 @@ class TestSlicing(unittest.TestCase):
             self.assertEqual(got.shape, expect.shape)
             self.assertEqual(got.strides, expect.strides)
 
+    #### Strided
+
+    def test_strided_1d(self):
+        nparr = np.empty(4)
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        xx = -2, -1, 1, 2
+        for x in xx:
+            expect = nparr[::x]
+            got = arr[::x]
+            self.assertSameContig(got, expect)
+            self.assertEqual(got.shape, expect.shape)
+            self.assertEqual(got.strides, expect.strides)
+
+    def test_strided_2d(self):
+        nparr = np.empty((4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        xx = -2, -1, 1, 2
+        for a, b in itertools.product(xx, xx):
+            expect = nparr[::a, ::b]
+            got = arr[::a, ::b]
+            self.assertSameContig(got, expect)
+            self.assertEqual(got.shape, expect.shape)
+            self.assertEqual(got.strides, expect.strides)
+
+    def test_strided_3d(self):
+        nparr = np.empty((4, 5, 6))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        xx = -2, -1, 1, 2
+        for a, b, c in itertools.product(xx, xx, xx):
+            expect = nparr[::a, ::b, ::c]
+            got = arr[::a, ::b, ::c]
+            self.assertSameContig(got, expect)
+            self.assertEqual(got.shape, expect.shape)
+            self.assertEqual(got.strides, expect.strides)
+
 
 class TestReshape(unittest.TestCase):
     def test_reshape_2d2d(self):
@@ -190,7 +228,7 @@ class TestSqueeze(unittest.TestCase):
             arr.squeeze(axis=1)
         with self.assertRaises(ValueError):
             arr.squeeze(axis=(2, 3))
-        
+
 
 class TestExtent(unittest.TestCase):
     def test_extent_1d(self):


### PR DESCRIPTION
* Simplified and improved slice indexing in `Dim`.  it now matches `range()[sliceobj]`
* Disable `.copy_to_host()` on negative strided array.