### PR TITLE
Implement getitem and setitem for jitclasses

### DIFF
--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -345,7 +345,7 @@ class ClassBuilder(object):
             class SetItem(templates.AbstractTemplate):
                 key = "setitem"
                 def generic(self, args, kws):
-                    instance, *rest = args
+                    instance  = args[0]
                     if isinstance(instance, types.ClassInstanceType) and \
                             '__setitem__' in instance.jitmethods:
                         meth = instance.jitmethods['__setitem__']

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 from collections import OrderedDict
 import types as pytypes
 import inspect
+import operator
 
 from llvmlite import ir as llvmir
 
@@ -297,6 +298,7 @@ class ClassBuilder(object):
         Register method implementations for the given instance type.
         """
         for meth in instance_type.jitmethods:
+
             # There's no way to retrive the particular method name
             # inside the implementation function, so we have to register a
             # specific closure for each different name
@@ -305,18 +307,56 @@ class ClassBuilder(object):
                 self.implemented_methods.add(meth)
 
     def _implement_method(self, registry, attr):
-        @registry.lower((types.ClassInstanceType, attr),
-                        types.ClassInstanceType, types.VarArg(types.Any))
-        def imp(context, builder, sig, args):
-            instance_type = sig.args[0]
-            method = instance_type.jitmethods[attr]
-            disp_type = types.Dispatcher(method)
-            call = context.get_function(disp_type, sig)
-            out = call(builder, args)
-            _add_linking_libs(context, call)
-            return imputils.impl_ret_new_ref(context, builder,
-                                             sig.return_type, out)
+        def get_imp():
+            def imp(context, builder, sig, args):
+                instance_type = sig.args[0]
+                method = instance_type.jitmethods[attr]
+                disp_type = types.Dispatcher(method)
+                call = context.get_function(disp_type, sig)
+                out = call(builder, args)
+                _add_linking_libs(context, call)
+                return imputils.impl_ret_new_ref(context, builder,
+                                                sig.return_type, out)
+            return imp
 
+        if attr == "__getitem__":
+            parent = self
+
+            @templates.infer_global(operator.getitem)
+            class GetItem(templates.AbstractTemplate):
+                def generic(self, args, kws):
+                    instance, value = args
+                    if isinstance(instance, types.ClassInstanceType) and \
+                            instance.class_type == parent.class_type:
+                        meth = instance.jitmethods['__getitem__']
+                        disp_type = types.Dispatcher(meth)
+                        sig = disp_type.get_call_type(self.context, args, kws)
+
+                        return sig
+
+            imputils.lower_builtin(operator.getitem,
+                types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
+        elif attr == "__setitem__":
+            parent = self
+
+            @templates.infer
+            class SetItem(templates.AbstractTemplate):
+                key = "setitem"
+                def generic(self, args, kws):
+                    instance, *rest = args
+                    if isinstance(instance, types.ClassInstanceType) and \
+                            instance.class_type == parent.class_type:
+                        meth = instance.jitmethods['__setitem__']
+                        disp_type = types.Dispatcher(meth)
+                        sig = disp_type.get_call_type(self.context, args, kws)
+
+                        return sig
+
+            imputils.lower_builtin(
+                'setitem', types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
+        else:
+            registry.lower((types.ClassInstanceType, attr),
+                            types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
 
 
 @templates.infer_getattr

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -334,6 +334,10 @@ class ClassBuilder(object):
 
                         return sig
 
+            # lower both getitem and __getitem__ to catch the calls
+            # from python and numba
+            imputils.lower_builtin((types.ClassInstanceType, "__getitem__"),
+                types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
             imputils.lower_builtin(operator.getitem,
                 types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
         elif attr == "__setitem__":
@@ -352,6 +356,10 @@ class ClassBuilder(object):
 
                         return sig
 
+            # lower both setitem and __setitem__ to catch the calls
+            # from python and numba
+            imputils.lower_builtin((types.ClassInstanceType, "__setitem__"),
+                types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
             imputils.lower_builtin(
                 'setitem', types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
         else:

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -307,6 +307,8 @@ class ClassBuilder(object):
                 self.implemented_methods.add(meth)
 
     def _implement_method(self, registry, attr):
+        print("implementing ", attr)
+        # create a separate instance of imp method to avoid closure clashing
         def get_imp():
             def imp(context, builder, sig, args):
                 instance_type = sig.args[0]
@@ -320,19 +322,21 @@ class ClassBuilder(object):
             return imp
 
         if attr == "__getitem__":
-            parent = self
+            # create new class to bind closure
+            def make_getitem(parent):
+                class GetItem(templates.AbstractTemplate):
+                    def generic(self, args, kws):
+                        instance, value = args
+                        if isinstance(instance, types.ClassInstanceType) and \
+                                instance.class_type == parent.class_type:
+                            meth = instance.jitmethods['__getitem__']
+                            disp_type = types.Dispatcher(meth)
+                            sig = disp_type.get_call_type(self.context, args, kws)
 
-            @templates.infer_global(operator.getitem)
-            class GetItem(templates.AbstractTemplate):
-                def generic(self, args, kws):
-                    instance, value = args
-                    if isinstance(instance, types.ClassInstanceType) and \
-                            instance.class_type == parent.class_type:
-                        meth = instance.jitmethods['__getitem__']
-                        disp_type = types.Dispatcher(meth)
-                        sig = disp_type.get_call_type(self.context, args, kws)
+                            return sig
+                return GetItem
 
-                        return sig
+            templates.infer_global(operator.getitem)(make_getitem(self))
 
             # lower both getitem and __getitem__ to catch the calls
             # from python and numba
@@ -341,20 +345,25 @@ class ClassBuilder(object):
             imputils.lower_builtin(operator.getitem,
                 types.ClassInstanceType, types.VarArg(types.Any))(get_imp())
         elif attr == "__setitem__":
-            parent = self
+            # create new class to bind closure
+            def make_setitem(parent):
+                # infer_global doesn't work here
+                class SetItem(templates.AbstractTemplate):
+                    key = "setitem"
+                    def generic(self, args, kws):
+                        print(parent.class_type)
+                        instance, *rest = args
+                        if isinstance(instance, types.ClassInstanceType) and \
+                                instance.class_type == parent.class_type:
+                            print("Found setitem")
+                            meth = instance.jitmethods['__setitem__']
+                            disp_type = types.Dispatcher(meth)
+                            sig = disp_type.get_call_type(self.context, args, kws)
 
-            @templates.infer
-            class SetItem(templates.AbstractTemplate):
-                key = "setitem"
-                def generic(self, args, kws):
-                    instance, *rest = args
-                    if isinstance(instance, types.ClassInstanceType) and \
-                            instance.class_type == parent.class_type:
-                        meth = instance.jitmethods['__setitem__']
-                        disp_type = types.Dispatcher(meth)
-                        sig = disp_type.get_call_type(self.context, args, kws)
-
-                        return sig
+                            return sig
+                return SetItem
+            print("binding setitem with ", self.class_type)
+            templates.infer(make_setitem(self))
 
             # lower both setitem and __setitem__ to catch the calls
             # from python and numba

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -99,7 +99,9 @@ def _specialize_box(typ):
         dct[field] = property(getter, setter, doc=doc)
     # Inject methods as class members
     for name, func in typ.methods.items():
-        if not (name.startswith('__') and name.endswith('__')):
+        if (name == "__getitem__" or name == "__setitem__") or \
+            (not (name.startswith('__') and name.endswith('__'))):
+
             dct[name] = _generate_method(name, func)
     # Create subclass
     subcls = type(typ.classname, (_box.Box,), dct)

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -100,7 +100,7 @@ def _specialize_box(typ):
     # Inject methods as class members
     for name, func in typ.methods.items():
         if (name == "__getitem__" or name == "__setitem__") or \
-            (not (name.startswith('__') and name.endswith('__'))):
+                (not (name.startswith('__') and name.endswith('__'))):
 
             dct[name] = _generate_method(name, func)
     # Create subclass

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -643,7 +643,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [('data', int32[:])]
 
         @jitclass(spec)
-        class TestClass:
+        class TestClass(object):
             def __init__(self):
                 self.data = np.zeros(10, dtype=np.int32)
 
@@ -674,7 +674,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [('data', int32[:])]
 
         @jitclass(spec)
-        class TestClass:
+        class TestClass(object):
             def __init__(self):
                 self.data = np.zeros(10, dtype=np.int32)
 
@@ -701,7 +701,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
         # save value of len(data) to the position indicated as len(key)
         @jitclass(spec)
-        class TestClass:
+        class TestClass(object):
             def __init__(self):
                 self.data = np.zeros(10, dtype=np.int32)
 
@@ -728,7 +728,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [('data', int32[:, :])]
 
         @jitclass(spec)
-        class TestClass:
+        class TestClass(object):
             def __init__(self):
                 self.data = np.zeros((10, 10), dtype=np.int32)
 
@@ -757,7 +757,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [('data', int32[:])]
 
         @jitclass(spec)
-        class TestClass:
+        class TestClass(object):
             def __init__(self):
                 self.data = np.zeros(10, dtype=np.int32)
 


### PR DESCRIPTION
This PR adds support for `__getitem__` and `__setitem__` in `jitclass` definition, i.e. syntax like `jitclass_instance[10] = 20` become possible in numba as well as python.

Since calls to `__getitem__` are converted to `operator.getitem` we have to override a global. Also, the unboxing needed a minor adjustment. Everything should be covered by the tests.

Partyly solves https://github.com/numba/numba/issues/1606