### PR TITLE
add uintp as a valid type to the tuple operator.getitem

### DIFF
--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -202,7 +202,9 @@ def iternext_unituple(context, builder, sig, args, result):
 
 
 @lower_builtin(operator.getitem, types.UniTuple, types.intp)
+@lower_builtin(operator.getitem, types.UniTuple, types.uintp)
 @lower_builtin(operator.getitem, types.NamedUniTuple, types.intp)
+@lower_builtin(operator.getitem, types.NamedUniTuple, types.uintp)
 def getitem_unituple(context, builder, sig, args):
     tupty, _ = sig.args
     tup, idx = args

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -205,6 +205,12 @@ class TestOperations(TestCase):
             cr.entry_point((), 0)
         self.assertEqual("tuple index out of range", str(raises.exception))
 
+        # test uintp indexing (because, e.g., parfors generates unsigned prange)
+        cr = compile_isolated(pyfunc,
+                              [types.UniTuple(types.int64, 3), types.uintp])
+        for i in range(len(tup)):
+            self.assertPreciseEqual(cr.entry_point(tup, types.uintp(i)), tup[i])
+
         # With a compile-time static index (the code generation path is different)
         pyfunc = tuple_index_static
         for typ in (types.UniTuple(types.int64, 4),
@@ -216,7 +222,6 @@ class TestOperations(TestCase):
         typ = types.UniTuple(types.int64, 1)
         with self.assertTypingError():
             cr = compile_isolated(pyfunc, (typ,))
-
 
     def test_in(self):
         pyfunc = in_usecase

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -205,7 +205,7 @@ class TestOperations(TestCase):
             cr.entry_point((), 0)
         self.assertEqual("tuple index out of range", str(raises.exception))
 
-        # test uintp indexing (because, e.g., parfors generates unsigned prange)
+        # test uintp indexing (because, e.g., parfor generates unsigned prange)
         cr = compile_isolated(pyfunc,
                               [types.UniTuple(types.int64, 3), types.uintp])
         for i in range(len(tup)):
@@ -359,6 +359,10 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
         p = Point(4, 5, 6)
         for i in range(len(p)):
             self.assertPreciseEqual(cfunc(p, i), pyfunc(p, i))
+
+        # test uintp indexing (because, e.g., parfor generates unsigned prange)
+        for i in range(len(p)):
+            self.assertPreciseEqual(cfunc(p, types.uintp(i)), pyfunc(p, i))
 
     def test_bool(self):
         def check(p):


### PR DESCRIPTION
In the lowering function for  operator.getitem on tuples, I have added uintp as a valid type

closes #3733 

Unit tests not added yet, pending positive review. No fails or errors on existing tests.

The test function in the original issue now runs

```
import numba as nb
def test1b():
    x = (1, 2, 3, 4, 5,)
    for i in nb.prange(len(x)):
        print(x[nb.types.uintp(i)])
```


