### PR TITLE
Fix target definition update in inlining

### DIFF
--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -351,9 +351,12 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     # 6. replace Return with assignment to LHS
     topo_order = find_topo_order(callee_blocks)
     _replace_returns(callee_blocks, instr.target, new_label)
-    #    remove the old definition of instr.target too
-    if (instr.target.name in func_ir._definitions):
-        func_ir._definitions[instr.target.name] = []
+
+    # remove the old definition of instr.target too
+    if (instr.target.name in func_ir._definitions
+            and call_expr in func_ir._definitions[instr.target.name]):
+        # NOTE: target can have multiple definitions due to control flow
+        func_ir._definitions[instr.target.name].remove(call_expr)
 
     # 7. insert all new blocks, and add back definitions
     for label in topo_order:

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -6,8 +6,8 @@ import numpy as np
 from .support import TestCase, override_config, captured_stdout
 import numba
 from numba import unittest_support as unittest
-from numba import jit, njit, types
-from numba.ir_utils import guard, find_callname
+from numba import jit, njit, types, ir, compiler
+from numba.ir_utils import guard, find_callname, find_const
 from numba.inline_closurecall import inline_closure_call
 from .test_parfors import skip_unsupported
 
@@ -123,6 +123,34 @@ class TestInlining(TestCase):
                                                                     test_impl)
         A = np.arange(10)
         self.assertEqual(test_impl(A), j_func(A))
+
+    @skip_unsupported
+    def test_inline_update_target_def(self):
+
+        def test_impl(a):
+            if a == 1:
+                b = 2
+            else:
+                b = 3
+            return b
+
+        func_ir = compiler.run_frontend(test_impl)
+        blocks = list(func_ir.blocks.values())
+        for block in blocks:
+            for i, stmt in enumerate(block.body):
+                # match b = 2 and replace with lambda: 2
+                if (isinstance(stmt, ir.Assign) and isinstance(stmt.value, ir.Var)
+                        and guard(find_const, func_ir, stmt.value) == 2):
+                    # replace expr with a dummy call
+                    func_ir._definitions[stmt.target.name].remove(stmt.value)
+                    stmt.value = ir.Expr.call(None, (), (), stmt.loc)
+                    func_ir._definitions[stmt.target.name].append(stmt.value)
+                    #func = g.py_func#
+                    inline_closure_call(func_ir, {}, block, i, lambda: 2)
+                    break
+
+        self.assertEqual(len(func_ir._definitions['b']), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Inlining was replacing all the definition of the target variable, even if it had multiple. This patch fixes it.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
