### PR TITLE
Overloadable operator.setitem 

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -411,13 +411,10 @@ class Lower(BaseLower):
         valuety = self.typeof(value_var.name)
         indexty = self.typeof(index_var.name)
 
-        try:
-            impl = self.context.get_function('setitem', signature)
-        except NotImplementedError:
-            op = operator.setitem
-            fnop = self.context.typing_context.resolve_value_type(op)
-            fnop.get_call_type(self.context.typing_context, signature.args, {})
-            impl = self.context.get_function(fnop, signature)
+        op = operator.setitem
+        fnop = self.context.typing_context.resolve_value_type(op)
+        fnop.get_call_type(self.context.typing_context, signature.args, {})
+        impl = self.context.get_function(fnop, signature)
 
         # Convert argument to match
         if isinstance(targetty, types.Optional):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -411,7 +411,13 @@ class Lower(BaseLower):
         valuety = self.typeof(value_var.name)
         indexty = self.typeof(index_var.name)
 
-        impl = self.context.get_function('setitem', signature)
+        try:
+            impl = self.context.get_function('setitem', signature)
+        except NotImplementedError:
+            op = operator.setitem
+            fnop = self.context.typing_context.resolve_value_type(op)
+            fnop.get_call_type(self.context.typing_context, signature.args, {})
+            impl = self.context.get_function(fnop, signature)
 
         # Convert argument to match
         if isinstance(targetty, types.Optional):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -444,7 +444,7 @@ def getitem_array_tuple(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-@lower_builtin('setitem', types.Buffer, types.Any, types.Any)
+@lower_builtin(operator.setitem, types.Buffer, types.Any, types.Any)
 def setitem_array(context, builder, sig, args):
     """
     array[a] = scalar_or_array
@@ -3007,7 +3007,7 @@ def iternext_numpy_getitem(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-@lower_builtin('setitem', types.NumpyFlatType, types.Integer,
+@lower_builtin(operator.setitem, types.NumpyFlatType, types.Integer,
            types.Any)
 def iternext_numpy_getitem(context, builder, sig, args):
     flatiterty = sig.args[0]

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -111,7 +111,7 @@ def getitem_cpointer(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-@lower_builtin('setitem', types.CPointer, types.Integer, types.Any)
+@lower_builtin(operator.setitem, types.CPointer, types.Integer, types.Any)
 def setitem_cpointer(context, builder, sig, args):
     base_ptr, idx, val = args
     elem_ptr = builder.gep(base_ptr, [idx])

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -512,7 +512,7 @@ def getitem_list(context, builder, sig, args):
 
     return impl_ret_borrowed(context, builder, sig.return_type, result)
 
-@lower_builtin('setitem', types.List, types.Integer, types.Any)
+@lower_builtin(operator.setitem, types.List, types.Integer, types.Any)
 def setitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     index = args[1]
@@ -547,7 +547,7 @@ def getslice_list(context, builder, sig, args):
 
     return impl_ret_new_ref(context, builder, sig.return_type, result.value)
 
-@lower_builtin('setitem', types.List, types.SliceType, types.Any)
+@lower_builtin(operator.setitem, types.List, types.SliceType, types.Any)
 def setitem_list(context, builder, sig, args):
     dest = ListInstance(context, builder, sig.args[0], args[0])
     src = ListInstance(context, builder, sig.args[2], args[2])

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -4,6 +4,7 @@ import numba.unittest_support as unittest
 from .support import TestCase
 
 import sys
+import operator
 
 # deliberately imported twice for different use cases
 import numpy as np
@@ -371,7 +372,10 @@ class TestArrayComprehension(unittest.TestCase):
         # test is expected to fail
         with self.assertRaises(TypingError) as raises:
             self.check(comp_nest_with_dependency, 5)
-        self.assertIn('Cannot resolve setitem', str(raises.exception))
+        self.assertIn(
+            'Invalid use of Function({})'.format(operator.setitem),
+            str(raises.exception),
+        )
 
     @tag('important')
     def test_no_array_comp(self):
@@ -458,8 +462,14 @@ class TestArrayComprehension(unittest.TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc = jit(nopython=True)(array_comp)
             cfunc(10, 2.3j)
-        self.assertIn("setitem: array({}, 1d, C)[0] = complex128".format(types.intp),
-                      str(raises.exception))
+        self.assertIn(
+            "Invalid use of Function({})".format(operator.setitem),
+            str(raises.exception),
+        )
+        self.assertIn(
+            "(array({}, 1d, C), Literal[int](0), complex128)".format(types.intp),
+            str(raises.exception),
+        )
 
     def test_array_comp_shuffle_sideeffect(self):
         nelem = 100

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import math
 import re
 import textwrap
+import operator
 
 import numpy as np
 
@@ -152,7 +153,14 @@ class TestTypingError(unittest.TestCase):
             compile_isolated(array_setitem_invalid_cast, ())
 
         errmsg = str(raises.exception)
-        self.assertIn("setitem: array(float64, 1d, C)[0] = complex128", errmsg)
+        self.assertIn(
+            "Invalid use of Function({})".format(operator.setitem),
+            errmsg,
+        )
+        self.assertIn(
+            "(array(float64, 1d, C), Literal[int](0), complex128)",
+            errmsg,
+        )
 
     def test_template_rejection_error_message_cascade(self):
         from numba import njit

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -168,10 +168,8 @@ class GetItemBuffer(AbstractTemplate):
         if out is not None:
             return signature(out.result, ary, out.index)
 
-@infer
+@infer_global(operator.setitem)
 class SetItemBuffer(AbstractTemplate):
-    key = "setitem"
-
     def generic(self, args, kws):
         assert not kws
         ary, idx, val = args

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -549,10 +549,8 @@ class GetItemCPointer(AbstractTemplate):
             return signature(ptr.dtype, ptr, normalize_1d_index(idx))
 
 
-@infer
+@infer_global(operator.setitem)
 class SetItemCPointer(AbstractTemplate):
-    key = "setitem"
-
     def generic(self, args, kws):
         assert not kws
         ptr, idx, val = args

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -53,10 +53,8 @@ class GetItemSequence(AbstractTemplate):
             elif isinstance(idx, types.Integer):
                 return signature(seq.dtype, seq, idx)
 
-@infer
+@infer_global(operator.setitem)
 class SetItemSequence(AbstractTemplate):
-    key = "setitem"
-
     def generic(self, args, kws):
         seq, idx, value = args
         if isinstance(seq, types.MutableSequence):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -309,10 +309,8 @@ class BaseContext(object):
         assert isinstance(index, types.Type), index
         args = target, index, value
         kws = {}
-        sig = self.resolve_function_type("setitem", args, kws)
-        if sig is None:
-            fnty = self.resolve_value_type(operator.setitem)
-            sig = fnty.get_call_type(self, (target, index, value), {})
+        fnty = self.resolve_value_type(operator.setitem)
+        sig = fnty.get_call_type(self, (target, index, value), {})
         return sig
 
     def resolve_delitem(self, target, index):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -5,6 +5,7 @@ import types as pytypes
 import weakref
 import threading
 import contextlib
+import operator
 
 import numba
 from numba import types, errors
@@ -308,7 +309,11 @@ class BaseContext(object):
         assert isinstance(index, types.Type), index
         args = target, index, value
         kws = {}
-        return self.resolve_function_type("setitem", args, kws)
+        sig = self.resolve_function_type("setitem", args, kws)
+        if sig is None:
+            fnty = self.resolve_value_type(operator.setitem)
+            sig = fnty.get_call_type(self, (target, index, value), {})
+        return sig
 
     def resolve_delitem(self, target, index):
         args = target, index


### PR DESCRIPTION
Make setitem overloadable and update builtin setitem implementations to use `operator.setitem`.