### PR TITLE
fix a few typos

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -232,7 +232,7 @@ supported by the service.  Travis CI automatically tests all pull requests on OS
 X and Linux, as well as a sampling of different Python and NumPy versions.  If
 you see problems on platforms you are unfamiliar with, feel free to ask for
 help in your pull request.  The Numba core developers can help diagnose
-cross-platform compatibiliy issues.
+cross-platform compatibility issues.
 
 
 Documentation

--- a/docs/source/developer/generators.rst
+++ b/docs/source/developer/generators.rst
@@ -156,8 +156,8 @@ Let's describe those fields in order.
   at which resumption point execution must resume.  By convention, it can
   have two special values: 0 means execution must start at the beginning of
   the generator (i.e. the first time :py:func:`next` is called); -1 means
-  the generator is exhauted and resumption must immediately raise StopIteration.
-  Other values indicate the yield point's index starting from 1
+  the generator is exhausted and resumption must immediately raise
+  StopIteration.  Other values indicate the yield point's index starting from 1
   (corresponding to the indices shown in the generator info above).
 
 * The second member, the *arguments structure* is read-only after it is first

--- a/docs/source/developer/live_variable_analysis.rst
+++ b/docs/source/developer/live_variable_analysis.rst
@@ -4,7 +4,7 @@
 Live Variable Analysis
 ======================
 
-(Releated issue https://github.com/numba/numba/pull/1611)
+(Related issue https://github.com/numba/numba/pull/1611)
 
 Numba uses reference-counting for garbage collection, a technique that
 requires cooperation by the compiler.  The Numba IR encodes the location


### PR DESCRIPTION
Just a few typos in the documentation.