### PR TITLE
Adapt library search to accommodate multiple locations

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_libraries.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_libraries.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from numba.cuda.testing import unittest
-from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError
 from numba.cuda.testing import skip_on_cudasim
 from numba.findlib import find_lib
 

--- a/numba/cuda/tests/cudadrv/test_cuda_libraries.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_libraries.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+
+from numba.cuda.testing import unittest
+from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError
+from numba.cuda.testing import skip_on_cudasim
+from numba.findlib import find_lib
+
+
+@skip_on_cudasim('Library detection unsupported in the simulator')
+class TestLibraryDetection(unittest.TestCase):
+
+    def test_detect(self):
+        """
+        This test is solely present to ensure that shipped cudatoolkits have
+        additional core libraries in locations that Numba scans by default.
+        PyCulib (and potentially others) rely on Numba's library finding
+        capacity to find and subsequently load these libraries.
+        """
+        core_libs = ['nvvm', 'cublas', 'cusparse', 'cufft', 'curand']
+        for l in core_libs:
+            self.assertNotEqual(find_lib(l), [])

--- a/numba/findlib.py
+++ b/numba/findlib.py
@@ -4,13 +4,18 @@ import os
 import re
 
 
-def get_lib_dir():
+def get_lib_dirs():
     """
     Anaconda specific
     """
-    dirname = 'DLLs' if sys.platform == 'win32' else 'lib'
-    libdir = os.path.join(sys.prefix, dirname)
-    return libdir
+    if sys.platform == 'win32':
+        # on windows, historically `DLLs` has been used for CUDA libraries,
+        # since approximately CUDA 9.2, `Library\bin` has been used.
+        dirnames = ['DLLs', os.path.join('Library', 'bin')]
+    else:
+        dirnames = ['lib', ]
+    libdirs = [os.path.join(sys.prefix, x) for x in dirnames]
+    return libdirs
 
 
 DLLNAMEMAP = {
@@ -31,8 +36,14 @@ def find_lib(libname, libdir=None, platform=None):
 
 
 def find_file(pat, libdir=None):
-    libdir = libdir or get_lib_dir()
-    entries = os.listdir(libdir)
-    candidates = [os.path.join(libdir, ent)
-                  for ent in entries if pat.match(ent)]
-    return [c for c in candidates if os.path.isfile(c)]
+    if libdir is None:
+        libdirs = get_lib_dirs()
+    else:
+        libdirs = list(libdir)
+    files = []
+    for ldir in libdirs:
+        entries = os.listdir(ldir)
+        candidates = [os.path.join(ldir, ent)
+                      for ent in entries if pat.match(ent)]
+        files.extend([c for c in candidates if os.path.isfile(c)])
+    return files


### PR DESCRIPTION
Windows has legacy DLLs dir and newer Library\bin dir as places
to search for libraries in conda packages.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
