### PR TITLE
Support overloading operator.delitem

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -364,7 +364,11 @@ class Lower(BaseLower):
 
             signature = self.fndesc.calltypes[inst]
             assert signature is not None
-            impl = self.context.get_function('delitem', signature)
+
+            op = operator.delitem
+            fnop = self.context.typing_context.resolve_value_type(op)
+            fnop.get_call_type(self.context.typing_context, signature.args, {})
+            impl = self.context.get_function(fnop, signature)
 
             assert targetty == signature.args[0]
             index = self.context.cast(self.builder, index, indexty,

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -608,7 +608,7 @@ def setitem_list(context, builder, sig, args):
 
 
 
-@lower_builtin('delitem', types.List, types.Integer)
+@lower_builtin(operator.delitem, types.List, types.Integer)
 def delitem_list_index(context, builder, sig, args):
 
     def list_delitem_impl(lst, i):
@@ -617,7 +617,7 @@ def delitem_list_index(context, builder, sig, args):
     return context.compile_internal(builder, list_delitem_impl, sig, args)
 
 
-@lower_builtin('delitem', types.List, types.SliceType)
+@lower_builtin(operator.delitem, types.List, types.SliceType)
 def delitem_list(context, builder, sig, args):
     inst = ListInstance(context, builder, sig.args[0], args[0])
     slice = context.make_helper(builder, sig.args[1], args[1])

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -262,6 +262,14 @@ def overload_add_dummy(arg1, arg2):
         return dummy_add_impl
 
 
+@overload(operator.delitem)
+def overload_dummy_delitem(obj, idx):
+    if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+        def dummy_delitem_impl(obj, idx):
+            print('del', obj, idx)
+        return dummy_delitem_impl
+
+
 @overload(operator.getitem)
 def overload_dummy_getitem(obj, idx):
     if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
@@ -295,6 +303,10 @@ def call_iadd_binop(arg1, arg2):
     arg1 += arg2
 
     return arg1
+
+
+def call_delitem(obj, idx):
+    del obj[idx]
 
 
 def call_getitem(obj, idx):
@@ -622,6 +634,22 @@ class TestHighLevelExtending(TestCase):
 
         # this will call add(Number, Number) as MyDummy implicitly casts to Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
+
+    def test_delitem(self):
+        pyfunc = call_delitem
+        cfunc = jit(nopython=True)(pyfunc)
+        obj = MyDummy()
+        e = None
+
+        with captured_stdout() as out:
+            try:
+                cfunc(obj, 321)
+            except Exception as exc:
+                e = exc
+
+        if e is not None:
+            raise e
+        self.assertEqual(out.getvalue(), 'del hello! 321\n')
 
     def test_getitem(self):
         pyfunc = call_getitem
@@ -972,7 +1000,7 @@ class TestIntrinsic(TestCase):
         def void_func(typingctx, a):
             sig = types.void(types.int32)
             def codegen(context, builder, signature, args):
-                pass  # do nothing, return None, should be turned into 
+                pass  # do nothing, return None, should be turned into
                       # dummy value
 
             return sig, codegen

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -70,10 +70,8 @@ class SetItemSequence(AbstractTemplate):
                 return signature(types.none, seq, idx, seq.dtype)
 
 
-@infer
+@infer_global(operator.delitem)
 class DelItemSequence(AbstractTemplate):
-    key = "delitem"
-
     def generic(self, args, kws):
         seq, idx = args
         if isinstance(seq, types.MutableSequence):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -5,6 +5,7 @@ import types as pytypes
 import weakref
 import threading
 import contextlib
+import operator
 
 import numba
 from numba import types, errors
@@ -313,7 +314,9 @@ class BaseContext(object):
     def resolve_delitem(self, target, index):
         args = target, index
         kws = {}
-        return self.resolve_function_type("delitem", args, kws)
+        fnty = self.resolve_value_type(operator.delitem)
+        sig = fnty.get_call_type(self, args, kws)
+        return sig
 
     def resolve_module_constants(self, typ, attr):
         """


### PR DESCRIPTION
As titled.

Needed for `del dict[key]`