### PR TITLE
Implement compiler support for dictionary

### DIFF
--- a/numba/_dictobject.c
+++ b/numba/_dictobject.c
@@ -672,7 +672,7 @@ numba_dict_insert(
         hashpos = find_empty_slot(dk, hash);
         ep = get_entry(dk, dk->nentries);
         set_index(dk, hashpos, dk->nentries);
-        copy_val(dk, entry_get_key(dk, ep), key_bytes);
+        copy_key(dk, entry_get_key(dk, ep), key_bytes);
         assert ( hash != -1 );
         ep->hash = hash;
         copy_val(dk, entry_get_val(dk, ep), val_bytes);

--- a/numba/_dictobject.c
+++ b/numba/_dictobject.c
@@ -866,7 +866,7 @@ numba_dict_popitem(NB_Dict *d, char *key_bytes, char *val_bytes)
 }
 
 void
-numba_dict_dump_keys(NB_Dict *d) {
+numba_dict_dump(NB_Dict *d) {
     long long i, j, k;
     long long size, n;
     char *cp;
@@ -876,7 +876,7 @@ numba_dict_dump_keys(NB_Dict *d) {
     n = d->used;
     size = dk->nentries;
 
-    printf("Key dump\n");
+    printf("Dict dump\n");
     printf("   key_size = %lld\n", (long long)d->keys->key_size);
     printf("   val_size = %lld\n", (long long)d->keys->val_size);
 
@@ -1052,7 +1052,7 @@ numba_test_dict(void) {
     CHECK (d->keys->usable == USABLE_FRACTION(d->keys->size) - d->used);
 
     // Dump
-    numba_dict_dump_keys(d);
+    numba_dict_dump(d);
 
     // Make sure everything are still in there
     ix = numba_dict_lookup(d, "bef", 0xbeef, got_value);

--- a/numba/_dictobject.c
+++ b/numba/_dictobject.c
@@ -865,11 +865,11 @@ numba_dict_popitem(NB_Dict *d, char *key_bytes, char *val_bytes)
     return OK;
 }
 
-
 void
 numba_dict_dump_keys(NB_Dict *d) {
-    long long i, j;
+    long long i, j, k;
     long long size, n;
+    char *cp;
     NB_DictEntry *ep;
     NB_DictKeys *dk = d->keys;
 
@@ -877,12 +877,22 @@ numba_dict_dump_keys(NB_Dict *d) {
     size = dk->nentries;
 
     printf("Key dump\n");
+    printf("   key_size = %lld\n", (long long)d->keys->key_size);
+    printf("   val_size = %lld\n", (long long)d->keys->val_size);
 
     for (i = 0, j = 0; i < size; i++) {
         ep = get_entry(dk, i);
         if (ep->hash != -1) {
             long long hash = ep->hash;
-            printf("  key=%s hash=%llu value=%s\n", entry_get_key(dk, ep), hash, entry_get_val(dk, ep));
+            printf("  key=");
+            for (cp=entry_get_key(dk, ep), k=0; k < d->keys->key_size; ++k, ++cp){
+                printf("%02x ", ((int)*cp) & 0xff);
+            }
+            printf(" hash=%llu value=", hash);
+            for (cp=entry_get_val(dk, ep), k=0; k < d->keys->val_size; ++k, ++cp){
+                printf("%02x ", ((int)*cp) & 0xff);
+            }
+            printf("\n");
             j++;
         }
     }

--- a/numba/_dictobject.h
+++ b/numba/_dictobject.h
@@ -191,4 +191,8 @@ NUMBA_EXPORT_FUNC(int)
 numba_dict_iter_next(NB_DictIter *it, const char **key_ptr, const char **val_ptr);
 
 
+NUMBA_EXPORT_FUNC(void)
+numba_dict_dump_keys(NB_Dict *);
+
+
 #endif

--- a/numba/_dictobject.h
+++ b/numba/_dictobject.h
@@ -192,7 +192,7 @@ numba_dict_iter_next(NB_DictIter *it, const char **key_ptr, const char **val_ptr
 
 
 NUMBA_EXPORT_FUNC(void)
-numba_dict_dump_keys(NB_Dict *);
+numba_dict_dump(NB_Dict *);
 
 
 #endif

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -136,7 +136,7 @@ build_c_helpers_dict(void)
     declmethod(dict_iter_sizeof);
     declmethod(dict_iter);
     declmethod(dict_iter_next);
-    declmethod(dict_dump_keys);
+    declmethod(dict_dump);
 
 #define MATH_UNARY(F, R, A) declmethod(F);
 #define MATH_BINARY(F, R, A, B) declmethod(F);

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -136,6 +136,7 @@ build_c_helpers_dict(void)
     declmethod(dict_iter_sizeof);
     declmethod(dict_iter);
     declmethod(dict_iter_next);
+    declmethod(dict_dump_keys);
 
 #define MATH_UNARY(F, R, A) declmethod(F);
 #define MATH_BINARY(F, R, A, B) declmethod(F);

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -299,6 +299,7 @@ class EnumModel(ProxyModel):
 @register_default(types.EnumClass)
 @register_default(types.IntEnumClass)
 @register_default(types.NumberClass)
+@register_default(types.TypeRef)
 @register_default(types.NamedTupleClass)
 @register_default(types.DType)
 @register_default(types.RecursiveCall)

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -26,8 +26,7 @@ from numba.types import (
     DictIteratorType,
     Type,
 )
-from numba.targets.imputils import impl_ret_borrowed, impl_ret_new_ref
-from numba.errors import TypingError
+from numba.targets.imputils import impl_ret_borrowed
 
 
 ll_dict_type = cgutils.voidptr_t
@@ -88,7 +87,6 @@ make_attribute_wrapper(types.DictType, 'data', '_data')
 def _raise_user_error(context, builder, status, msg):
     with builder.if_then(builder.icmp_signed('!=', status, status.type(0))):
         context.call_conv.return_user_exc(builder, RuntimeError, (msg,))
-
 
 
 def _call_dict_free(context, builder, ptr):
@@ -736,7 +734,7 @@ def impl_values(d):
 
 
 @overload(operator.eq)
-def impl_equality(da, db):
+def impl_equal(da, db):
     if not isinstance(da, types.DictType):
         return
     if not isinstance(db, types.DictType):
@@ -766,7 +764,7 @@ def impl_equality(da, db):
 
 
 @overload(operator.ne)
-def impl_equality(da, db):
+def impl_not_equal(da, db):
     if not isinstance(da, types.DictType):
         return
 

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -585,6 +585,20 @@ def impl_delitem(d, k):
     return impl
 
 
+@overload(operator.contains)
+def impl_contains(d, k):
+    if not isinstance(d, types.DictType):
+        return
+
+    keyty = d.key_type
+
+    def impl(d, k):
+        k = _cast(k, keyty)
+        ix, val = _dict_lookup(d, k, hash(k))
+        return ix > DKIX_EMPTY
+    return impl
+
+
 @overload_method(types.DictType, 'clear')
 def impl_clear(d):
     if not isinstance(d, types.DictType):

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -605,9 +605,9 @@ def impl_values(d):
 @lower_builtin('getiter', types.DictItemsIterableType)
 @lower_builtin('getiter', types.DictKeysIterableType)
 @lower_builtin('getiter', types.DictValuesIterableType)
-def impl_items_getiter(context, builder, sig, args):
-    itemiterablety = sig.args[0]
-    it = context.make_helper(builder, itemiterablety.iterator_type, args[0])
+def impl_iterable_getiter(context, builder, sig, args):
+    iterablety = sig.args[0]
+    it = context.make_helper(builder, iterablety.iterator_type, args[0])
 
     fnty = ir.FunctionType(
         ir.VoidType(),
@@ -623,14 +623,38 @@ def impl_items_getiter(context, builder, sig, args):
     pstate = cgutils.alloca_once(builder, state_type, zfill=True)
     it.state = _as_bytes(builder, pstate)
 
-    dp = _dict_get_data(context, builder, itemiterablety.parent, it.parent)
+    dp = _dict_get_data(context, builder, iterablety.parent, it.parent)
+    builder.call(fn, [it.state, dp])
+    return it._getvalue()
+
+
+@lower_builtin('getiter', types.DictType)
+def impl_dict_getiter(context, builder, sig, args):
+    iterablety = types.DictKeysIterableType(sig.args[0])
+    it = context.make_helper(builder, iterablety.iterator_type)
+
+    fnty = ir.FunctionType(
+        ir.VoidType(),
+        [ll_dictiter_type, ll_dict_type],
+    )
+
+    fn = ir.Function(builder.module, fnty, name='numba_dict_iter')
+
+    proto = ctypes.CFUNCTYPE(ctypes.c_size_t)
+    dictiter_sizeof = proto(_helperlib.c_helpers['dict_iter_sizeof'])
+    state_type = ir.ArrayType(ir.IntType(8), dictiter_sizeof())
+
+    pstate = cgutils.alloca_once(builder, state_type, zfill=True)
+    it.state = _as_bytes(builder, pstate)
+
+    dp = _dict_get_data(context, builder, iterablety.parent, args[0])
     builder.call(fn, [it.state, dp])
     return it._getvalue()
 
 
 @lower_builtin('iternext', types.DictIteratorType)
 @iternext_impl
-def impl_items_iternext(context, builder, sig, args, result):
+def impl_iterator_iternext(context, builder, sig, args, result):
     iter_type = sig.args[0]
     it = context.make_helper(builder, iter_type, args[0])
 

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -145,7 +145,7 @@ def _make_dict(typingctx, keyty, valty, ptr):
     ptr : llvm pointer value
         Points to the dictionary object.
     """
-    dict_ty = types.DictType(keyty.dtype, valty.dtype)
+    dict_ty = types.DictType(keyty.instance_type, valty.instance_type)
 
     def codegen(context, builder, signature, args):
         [_, _, ptr] = args
@@ -207,7 +207,7 @@ def _cast(typingctx, val, typ):
     def codegen(context, builder, signature, args):
         [val, typ] = args
         return val
-    casted = typ.dtype
+    casted = typ.instance_type
     sig = casted(casted, typ)
     return sig, codegen
 

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -1,0 +1,165 @@
+
+import ctypes
+import operator
+from pprint import pprint
+
+from llvmlite import ir
+
+from numba import cgutils
+from numba.extending import (
+    overload,
+    intrinsic,
+    register_model,
+    models,
+    make_attribute_wrapper,
+)
+from numba import types
+from numba.types import DictType, Type
+
+
+ll_dict_type = cgutils.voidptr_t
+ll_status = cgutils.int32_t
+ll_ssize_t = cgutils.intp_t
+
+
+
+@register_model(DictType)
+class DictModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('data', types.voidptr),
+        ]
+        super(DictModel, self).__init__(dmm, fe_type, members)
+
+
+make_attribute_wrapper(types.DictType, 'data', '_data')
+
+
+def new_dict(key_type, value_type):
+    raise NotImplementedError
+
+
+@intrinsic
+def _dict_new_minsize(typingctx, keyty, valty):
+    """Wrap numba_dict_new_minsize.
+
+    Allocate a new dictionary object at the minimum capacity.
+
+    Parameters
+    ----------
+    keyty, valty: Type
+        Type of the key and value, respectively.
+
+    """
+    resty = types.voidptr
+    sig = resty(keyty, valty)
+
+    def codegen(context, builder, sig, args):
+        fnty = ir.FunctionType(
+            ll_status,
+            [ll_dict_type.as_pointer(), ll_ssize_t, ll_ssize_t],
+        )
+        fn = ir.Function(builder.module, fnty, name='numba_dict_new_minsize')
+        ll_key = context.get_data_type(keyty)
+        ll_val = context.get_data_type(valty)
+        sz_key = context.get_abi_sizeof(ll_key)
+        sz_val = context.get_abi_sizeof(ll_val)
+        refdp = cgutils.alloca_once(builder, ll_dict_type, zfill=True)
+        status = builder.call(fn, [refdp, ll_ssize_t(sz_key), ll_ssize_t(sz_val)])
+        dp = builder.load(refdp)
+        return dp
+
+    return sig, codegen
+
+
+@intrinsic
+def _dict_length(typingctx, d):
+    """Wrap numba_dict_length
+
+    Returns the length of the dictionary.
+    """
+    resty = types.intp
+    sig = resty(d)
+
+    def codegen(context, builder, sig, args):
+        fnty = ir.FunctionType(
+            ll_ssize_t,
+            [ll_dict_type],
+        )
+        fn = ir.Function(builder.module, fnty, name='numba_dict_length')
+        n = builder.call(fn, args)
+        return n
+
+    return sig, codegen
+
+
+@intrinsic
+def _make_dict(typingctx, keyty, valty, ptr):
+    """Make a dictionary struct with the given *ptr*
+
+    Parameters
+    ----------
+    keyty, valty: Type
+        Type of the key and value, respectively.
+    ptr : llvm pointer value
+        Points to the dictionary object.
+    """
+    dict_ty = types.DictType(keyty.dtype, valty.dtype)
+
+    def codegen(context, builder, signature, args):
+        [_, _, ptr] = args
+        ctor = cgutils.create_struct_proxy(dict_ty)
+        dstruct = ctor(context, builder)
+        dstruct.data = ptr
+        return dstruct._getvalue()
+
+    sig = dict_ty(keyty, valty, ptr)
+    return sig, codegen
+
+
+@overload(new_dict)
+def impl_new_dict(key, value):
+    """Creates a new dictionary with *key* and *value* as the type
+    of the dictionary key and value, respectively.
+    """
+    if any([
+        not isinstance(key, Type),
+        not isinstance(value, Type),
+    ]):
+        raise TypeError
+
+    keyty, valty = key, value
+
+    def imp(key, value):
+        dp = _dict_new_minsize(keyty, valty)
+        d = _make_dict(keyty, valty, dp)
+        return d
+
+    return imp
+
+
+@overload(len)
+def impl_len(d):
+    """len(dict)
+    """
+    if not isinstance(d, types.DictType):
+        return
+
+    def impl(d):
+        return _dict_length(d._data)
+
+    return impl
+
+
+@overload(operator.setitem)
+def impl_setitem(d, key, value):
+    print('>>>', d, key, value)
+    if not isinstance(d, types.DictType):
+        return
+
+    def impl(d, key, value):
+        hashval = hash(key)
+        print(hashval)
+        # return _dict_insert(d, key, hashval, value)
+
+    return impl

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -309,16 +309,17 @@ def impl_setitem(d, key, value):
 
 
 @overload_method(types.DictType, 'get')
-def impl_get(d, key):
-    if not isinstance(d, types.DictType):
+def impl_get(dct, k, d=None):
+    if not isinstance(dct, types.DictType):
         return
-    keyty = d.key_type
+    keyty = dct.key_type
 
-    def impl(d, key):
-        key = _cast(key, keyty)
-        ix, val = _dict_lookup(d, key, hash(key))
+    def impl(dct, k, d=None):
+        k = _cast(k, keyty)
+        ix, val = _dict_lookup(dct, k, hash(k))
         if ix > DKIX_EMPTY:
             return val
+        return d
 
     return impl
 

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -627,6 +627,18 @@ def impl_copy(d):
     return impl
 
 
+@overload_method(types.DictType, 'setdefault')
+def impl_setdefault(dct, k, d=None):
+    if not isinstance(dct, types.DictType):
+        return
+
+    def impl(dct, k, d=None):
+        if k not in dct:
+            dct[k] = d
+
+    return impl
+
+
 @overload_method(types.DictType, 'items')
 def impl_items(d):
     if not isinstance(d, types.DictType):

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -575,11 +575,14 @@ def impl_pop(dct, k, d=None):
     return impl
 
 
-# @overload(operator.delitem)
-# def impl_delitem(d, key):
-#     if not isinstance(d, types.DictType):
-#         return
-#     print(">>>>>>>")
+@overload(operator.delitem)
+def impl_delitem(d, k):
+    if not isinstance(d, types.DictType):
+        return
+
+    def impl(d, k):
+        d.pop(k)
+    return impl
 
 
 @overload_method(types.DictType, 'clear')

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -611,6 +611,22 @@ def impl_clear(d):
     return impl
 
 
+@overload_method(types.DictType, 'copy')
+def impl_copy(d):
+    if not isinstance(d, types.DictType):
+        return
+
+    key_type, val_type = d.key_type, d.value_type
+
+    def impl(d):
+        newd = new_dict(key_type, val_type)
+        for k, v in d.items():
+            newd[k] = v
+        return newd
+
+    return impl
+
+
 @overload_method(types.DictType, 'items')
 def impl_items(d):
     if not isinstance(d, types.DictType):

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -111,7 +111,7 @@ def _call_dict_free(context, builder, ptr):
         ir.VoidType(),
         [ll_dict_type],
     )
-    free = ir.Function(builder.module, fnty, name='numba_dict_free')
+    free = builder.module.get_or_insert_function(fnty, name='numba_dict_free')
     builder.call(free, [ptr])
 
 
@@ -218,7 +218,7 @@ def _dict_new_minsize(typingctx, keyty, valty):
             ll_status,
             [ll_dict_type.as_pointer(), ll_ssize_t, ll_ssize_t],
         )
-        fn = ir.Function(builder.module, fnty, name='numba_dict_new_minsize')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_new_minsize')
         # Determine sizeof key and value types
         ll_key = context.get_data_type(keyty.instance_type)
         ll_val = context.get_data_type(valty.instance_type)
@@ -253,7 +253,7 @@ def _dict_insert(typingctx, d, key, hashval, val):
         )
         [d, key, hashval, val] = args
         [td, tkey, thashval, tval] = sig.args
-        fn = ir.Function(builder.module, fnty, name='numba_dict_insert')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_insert')
 
         dm_key = context.data_model_manager[tkey]
         dm_val = context.data_model_manager[tval]
@@ -296,7 +296,7 @@ def _dict_length(typingctx, d):
             ll_ssize_t,
             [ll_dict_type],
         )
-        fn = ir.Function(builder.module, fnty, name='numba_dict_length')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_length')
         [d] = args
         [td] = sig.args
         dp = _dict_get_data(context, builder, td, d)
@@ -322,7 +322,7 @@ def _dict_dump(typingctx, d):
         [td] = sig.args
         [d] = args
         dp = _dict_get_data(context, builder, td, d)
-        fn = ir.Function(builder.module, fnty, name='numba_dict_dump')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_dump')
 
         builder.call(fn, [dp])
 
@@ -345,7 +345,7 @@ def _dict_lookup(typingctx, d, key, hashval):
         )
         [td, tkey, thashval] = sig.args
         [d, key, hashval] = args
-        fn = ir.Function(builder.module, fnty, name='numba_dict_lookup')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_lookup')
 
         dm_key = context.data_model_manager[tkey]
         dm_val = context.data_model_manager[td.value_type]
@@ -399,7 +399,7 @@ def _dict_popitem(typingctx, d):
         )
         [d] = args
         [td] = sig.args
-        fn = ir.Function(builder.module, fnty, name='numba_dict_popitem')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_popitem')
 
         dm_key = context.data_model_manager[td.key_type]
         dm_val = context.data_model_manager[td.value_type]
@@ -448,7 +448,7 @@ def _dict_delitem(typingctx, d, hk, ix):
         [d, hk, ix] = args
         [td, thk, tix] = sig.args
 
-        fn = ir.Function(builder.module, fnty, name='numba_dict_delitem')
+        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_delitem')
 
         dp = _dict_get_data(context, builder, td, d)
         status = builder.call(fn, [dp, hk, ix])
@@ -845,7 +845,7 @@ def impl_iterable_getiter(context, builder, sig, args):
         [ll_dictiter_type, ll_dict_type],
     )
 
-    fn = ir.Function(builder.module, fnty, name='numba_dict_iter')
+    fn = builder.module.get_or_insert_function(fnty, name='numba_dict_iter')
 
     proto = ctypes.CFUNCTYPE(ctypes.c_size_t)
     dictiter_sizeof = proto(_helperlib.c_helpers['dict_iter_sizeof'])
@@ -878,7 +878,7 @@ def impl_dict_getiter(context, builder, sig, args):
         [ll_dictiter_type, ll_dict_type],
     )
 
-    fn = ir.Function(builder.module, fnty, name='numba_dict_iter')
+    fn = builder.module.get_or_insert_function(fnty, name='numba_dict_iter')
 
     proto = ctypes.CFUNCTYPE(ctypes.c_size_t)
     dictiter_sizeof = proto(_helperlib.c_helpers['dict_iter_sizeof'])
@@ -910,8 +910,7 @@ def impl_iterator_iternext(context, builder, sig, args, result):
         ll_status,
         [ll_bytes, p2p_bytes, p2p_bytes]
     )
-    iternext = ir.Function(
-        builder.module,
+    iternext = builder.module.get_or_insert_function(
         iternext_fnty,
         name='numba_dict_iter_next',
     )

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -472,3 +472,23 @@ def impl_pop(dct, k, d=None):
             return val
 
     return impl
+
+
+# @overload(operator.delitem)
+# def impl_delitem(d, key):
+#     if not isinstance(d, types.DictType):
+#         return
+#     print(">>>>>>>")
+
+
+
+@overload_method(types.DictType, 'clear')
+def impl_clear(d):
+    if not isinstance(d, types.DictType):
+        return
+
+    def impl(d):
+        while len(d):
+            d.popitem()
+
+    return impl

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -127,7 +127,7 @@ def _imp_dtor(context, module):
 def _dict_new_minsize(typingctx, keyty, valty):
     """Wrap numba_dict_new_minsize.
 
-    Allocate a new dictionary object at the minimum capacity.
+    Allocate a new dictionary object with the minimum capacity.
 
     Parameters
     ----------
@@ -233,7 +233,7 @@ def _dict_length(typingctx, d):
 
 @intrinsic
 def _dict_dump_keys(typingctx, d):
-    """Dump the dictionary key and values.
+    """Dump the dictionary keys and values.
     Wraps numba_dict_dump_keys for debugging.
     """
     resty = types.void
@@ -258,7 +258,7 @@ def _dict_dump_keys(typingctx, d):
 def _dict_lookup(typingctx, d, key, hashval):
     """Wrap numba_dict_lookup
 
-    Returns 2-tuple of (intp, value_type?)
+    Returns 2-tuple of (intp, ?value_type)
     """
     resty = types.Tuple([types.intp, types.Optional(d.value_type)])
     sig = resty(d, key, hashval)
@@ -291,7 +291,7 @@ def _dict_lookup(typingctx, d, key, hashval):
                 _as_bytes(builder, ptr_val),
             ],
         )
-        # Load value is output is available
+        # Load value if output is available
         found = builder.icmp_signed('>=', ix, ix.type(DKIX_EMPTY))
 
         out = context.make_optional_none(builder, td.value_type)
@@ -383,9 +383,9 @@ def _dict_delitem(typingctx, d, hk, ix):
 
 
 def _iterator_codegen(resty):
-    """The common codegen for iterator intrinsic.
+    """The common codegen for iterator intrinsics.
 
-    Populates the iterator struct and incref.
+    Populates the iterator struct and increfs.
     """
 
     def codegen(context, builder, sig, args):
@@ -881,7 +881,7 @@ def impl_iterator_iternext(context, builder, sig, args, result):
 
     status = builder.call(iternext, (it.state, key_raw_ptr, val_raw_ptr))
     # TODO: no handling of error state i.e. mutated dictionary
-    #       any error are treated as exhausted iterator
+    #       all errors are treated as exhausted iterator
     is_valid = builder.icmp_unsigned('==', status, status.type(0))
     result.set_valid(is_valid)
 
@@ -904,8 +904,8 @@ def impl_iterator_iternext(context, builder, sig, args, result):
         key = dm_key.load_from_data_pointer(builder, key_ptr)
         val = dm_val.load_from_data_pointer(builder, val_ptr)
 
-        # All dict iterator uses this common implementation.
-        # There differences are resolved here.
+        # All dict iterators use this common implementation.
+        # Their differences are resolved here.
         if isinstance(iter_type.iterable, DictItemsIterableType):
             # .items()
             tup = context.make_tuple(builder, yield_type, [key, val])

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -321,3 +321,25 @@ def impl_get(d, key):
             return val
 
     return impl
+
+
+@overload(operator.getitem)
+def impl_getitem(d, key):
+    if not isinstance(d, types.DictType):
+        return
+
+    keyty = d.key_type
+
+    def impl(d, key):
+        key = _cast(key, keyty)
+        ix, val = _dict_lookup(d, key, hash(key))
+        if ix == DKIX_EMPTY:
+            raise KeyError()
+        elif ix < DKIX_EMPTY:
+            raise AssertionError("internal dict error during lookup")
+        else:
+            return val
+
+    return impl
+
+

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -13,7 +13,6 @@ from numba.extending import (
     intrinsic,
     register_model,
     models,
-    make_attribute_wrapper,
     lower_builtin,
 )
 from numba.targets.imputils import iternext_impl

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -253,6 +253,17 @@ def unbox_charseq(typ, obj, c):
     return NativeValue(ret, is_error=c.builder.not_(ok))
 
 
+
+@box(types.Optional)
+def box_optional(typ, val, c):
+    optval = c.context.make_helper(c.builder, typ, val)
+    ret = cgutils.alloca_once_value(c.builder, c.pyapi.borrow_none())
+    with c.builder.if_then(optval.valid):
+        validres = c.box(typ.type, optval.data)
+        c.builder.store(validres, ret)
+    return c.builder.load(ret)
+
+
 @unbox(types.Optional)
 def unbox_optional(typ, obj, c):
     """

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -261,6 +261,7 @@ def complex_impl(context, builder, sig, args):
 
 
 @lower_builtin(types.NumberClass, types.Any)
+@lower_builtin(types.TypeRef, types.Any)
 def number_constructor(context, builder, sig, args):
     """
     Call a number class, e.g. np.int32(...)

--- a/numba/tests/test_dictimpl.py
+++ b/numba/tests/test_dictimpl.py
@@ -222,7 +222,7 @@ class TestDictImpl(TestCase):
         # numba_dict_length(NB_Dict *d)
         self.numba_dict_length = wrap(
             'dict_length',
-            ctypes.c_int,
+            ctypes.c_ssize_t,
             [dict_t],
         )
         # numba_dict_insert_ez(

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -65,7 +65,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             for i in range(n):
                 d[i] = i
             # retrieval loop
-            return d.get(target, d=default)
+            return d.get(target, default)
 
         self.assertEqual(foo(5, 3, -1), 3)
         self.assertEqual(foo(5, 5, -1), -1)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -213,3 +213,35 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             foo(keys, vals, pops),
             core.py_func(dict(zip(keys, vals)), pops),
         )
+
+    # def test_dict_delitem(self):
+    #     @njit
+    #     def foo(keys, vals):
+    #         d = dictobject.new_dict(int32, float64)
+    #         # insertion
+    #         for k, v in zip(keys, vals):
+    #             d[k] = v
+    #         del d[k]
+
+    #     keys = [1, 2, 3]
+    #     vals = [0.1, 0.2, 0.3]
+    #     foo(keys, vals)
+
+    def test_dict_clear(self):
+        """
+        Exercise dict.clear
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            b4 = len(d)
+            # clear
+            d.clear()
+            return b4, len(d)
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+        self.assertEqual(foo(keys, vals), (3, 0))

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -395,3 +395,20 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         out = foo(keys, vals)
         self.assertEqual(out, list(zip(keys, vals)))
 
+    def test_dict_setdefault(self):
+        """
+        Exercise dict.setdefault
+        """
+        @njit
+        def foo():
+            d = dictobject.new_dict(int32, float64)
+            d.setdefault(1, 1.2) # used because key is not in
+            a = d.get(1)
+            d[1] = 2.3
+            b = d.get(1)
+            d[2] = 3.4
+            d.setdefault(2, 4.5)  # not used because key is in
+            c = d.get(2)
+            return a, b, c
+
+        self.assertEqual(foo(), (1.2, 2.3, 3.4))

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -353,3 +353,26 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             foo(keys, vals),
             [1, 2, 3]
         )
+
+    def test_dict_contains(self):
+        """
+        Exercise operator.contains
+        """
+        @njit
+        def foo(keys, vals, checklist):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            out = []
+            for k in checklist:
+                out.append(k in d)
+            return out
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+
+        self.assertEqual(
+            foo(keys, vals, [2, 3, 4, 1, 0]),
+            [True, True, False, True, False],
+        )

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -89,7 +89,10 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(keys, vals, 1), 0.1)
         self.assertEqual(foo(keys, vals, 2), 0.2)
         self.assertEqual(foo(keys, vals, 3), 0.3)
-
+        # check no leak so far
+        self.assert_no_memory_leak()
+        # disable leak check for exception test
+        self.disable_leak_check()
         with self.assertRaises(KeyError):
             foo(keys, vals, 0)
         with self.assertRaises(KeyError):
@@ -150,6 +153,11 @@ class TestDictObject(MemoryLeakMixin, TestCase):
                 core.py_func(dict(zip(keys, vals)), npop=3),
             )
 
+        # check no leak so far
+        self.assert_no_memory_leak()
+        # disable leak check for exception test
+        self.disable_leak_check()
+
         with self.assertRaises(KeyError):
             foo(keys, vals, npop=4)
 
@@ -174,6 +182,11 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(keys, vals, 2), (0.2, 2))
         self.assertEqual(foo(keys, vals, 3), (0.3, 2))
         self.assertEqual(foo(keys, vals, 0), (None, 3))
+
+        # check no leak so far
+        self.assert_no_memory_leak()
+        # disable leak check for exception test
+        self.disable_leak_check()
 
         @njit
         def foo():
@@ -230,6 +243,10 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(keys, vals, 1), (2, None))
         self.assertEqual(foo(keys, vals, 2), (2, None))
         self.assertEqual(foo(keys, vals, 3), (2, None))
+        # check no leak so far
+        self.assert_no_memory_leak()
+        # disable leak check for exception test
+        self.disable_leak_check()
         with self.assertRaises(KeyError):
             foo(keys, vals, 0)
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -13,8 +13,18 @@ from .support import TestCase, MemoryLeakMixin
 class TestDictObject(MemoryLeakMixin, TestCase):
     def test_dict_create(self):
         @njit
-        def foo():
+        def foo(n):
             d = dictobject.new_dict(int32, float32)
+            for i in range(n):
+                d[i] = i + 1
             return len(d)
 
-        self.assertEqual(foo(), 0)
+        # Insert nothing
+        self.assertEqual(foo(n=0), 0)
+        # Insert 1 entry
+        self.assertEqual(foo(n=1), 1)
+        # Insert 2 entries
+        self.assertEqual(foo(n=2), 2)
+        # Insert 100 entries
+        self.assertEqual(foo(n=100), 100)
+

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -214,18 +214,23 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             core.py_func(dict(zip(keys, vals)), pops),
         )
 
-    # def test_dict_delitem(self):
-    #     @njit
-    #     def foo(keys, vals):
-    #         d = dictobject.new_dict(int32, float64)
-    #         # insertion
-    #         for k, v in zip(keys, vals):
-    #             d[k] = v
-    #         del d[k]
+    def test_dict_delitem(self):
+        @njit
+        def foo(keys, vals, target):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            del d[target]
+            return len(d), d.get(target)
 
-    #     keys = [1, 2, 3]
-    #     vals = [0.1, 0.2, 0.3]
-    #     foo(keys, vals)
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+        self.assertEqual(foo(keys, vals, 1), (2, None))
+        self.assertEqual(foo(keys, vals, 2), (2, None))
+        self.assertEqual(foo(keys, vals, 3), (2, None))
+        with self.assertRaises(KeyError):
+            foo(keys, vals, 0)
 
     def test_dict_clear(self):
         """

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1,0 +1,20 @@
+"""
+Testing C implementation of the numba dictionary
+"""
+from __future__ import print_function, absolute_import, division
+
+
+from numba import njit
+from numba import int32, float32
+from numba import dictobject
+from .support import TestCase, MemoryLeakMixin
+
+
+class TestDictObject(MemoryLeakMixin, TestCase):
+    def test_dict_create(self):
+        @njit
+        def foo():
+            d = dictobject.new_dict(int32, float32)
+            return len(d)
+
+        self.assertEqual(foo(), 0)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -245,3 +245,83 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         keys = [1, 2, 3]
         vals = [0.1, 0.2, 0.3]
         self.assertEqual(foo(keys, vals), (3, 0))
+
+    def test_dict_items(self):
+        """
+        Exercise dict.items
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            out = []
+            for kv in d.items():
+                out.append(kv)
+            return out
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+
+        self.assertEqual(
+            foo(keys, vals),
+            list(zip(keys, vals)),
+        )
+
+        # Test .items() on empty dict
+        @njit
+        def foo():
+            d = dictobject.new_dict(int32, float64)
+            out = []
+            for kv in d.items():
+                out.append(kv)
+            return out
+
+        self.assertEqual(foo(), [])
+
+    def test_dict_keys(self):
+        """
+        Exercise dict.keys
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            out = []
+            for k in d.keys():
+                out.append(k)
+            return out
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+
+        self.assertEqual(
+            foo(keys, vals),
+            keys,
+        )
+
+    def test_dict_values(self):
+        """
+        Exercise dict.values
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            out = []
+            for k in d.values():
+                out.append(k)
+            return out
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+
+        self.assertEqual(
+            foo(keys, vals),
+            vals,
+        )

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1,10 +1,11 @@
 """
-Testing numba implementation of the numba dictionary
+Testing numba implementation of the numba dictionary.
+
+The tests here only checks that the numba typing and codegen are working
+correctly.  Detail testing of the underlying dictionary operations is done
+in test_dictimpl.py.
 """
 from __future__ import print_function, absolute_import, division
-
-import random
-
 
 from numba import njit
 from numba import int32, float32, float64
@@ -376,3 +377,21 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             foo(keys, vals, [2, 3, 4, 1, 0]),
             [True, True, False, True, False],
         )
+
+    def test_dict_copy(self):
+        """
+        Exercise dict.copy
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            return list(d.copy().items())
+
+        keys = list(range(20))
+        vals = [x + i / 100 for i, x in enumerate(keys)]
+        out = foo(keys, vals)
+        self.assertEqual(out, list(zip(keys, vals)))
+

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -53,6 +53,22 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(10, [0, 1, 9]), [0, 1, 9])
         self.assertEqual(foo(10, [-1, 9, 1]), [None, 9, 1])
 
+    def test_dict_get_with_default(self):
+        """
+        Exercise dict.get(k, d) where d is set
+        """
+        @njit
+        def foo(n, target, default):
+            d = dictobject.new_dict(int32, float64)
+            # insertion loop
+            for i in range(n):
+                d[i] = i
+            # retrieval loop
+            return d.get(target, d=default)
+
+        self.assertEqual(foo(5, 3, -1), 3)
+        self.assertEqual(foo(5, 5, -1), -1)
+
     def test_dict_getitem(self):
         """
         Exercise dictionary __getitem__

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -5,13 +5,16 @@ from __future__ import print_function, absolute_import, division
 
 
 from numba import njit
-from numba import int32, float32
+from numba import int32, float32, float64
 from numba import dictobject
 from .support import TestCase, MemoryLeakMixin
 
 
 class TestDictObject(MemoryLeakMixin, TestCase):
     def test_dict_create(self):
+        """
+        Exercise dictionary creation, insertion and len
+        """
         @njit
         def foo(n):
             d = dictobject.new_dict(int32, float32)
@@ -27,4 +30,23 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(n=2), 2)
         # Insert 100 entries
         self.assertEqual(foo(n=100), 100)
+
+    def test_dict_get(self):
+        """
+        Exercise dictionary creation, insertion and get
+        """
+        @njit
+        def foo(n, targets):
+            d = dictobject.new_dict(int32, float64)
+            # insertion loop
+            for i in range(n):
+                d[i] = i
+            # retrieval loop
+            output = []
+            for t in targets:
+                output.append(d.get(t))
+            return output
+
+        self.assertEqual(foo(5, [0, 1, 9]), [0, 1, None])
+        self.assertEqual(foo(10, [0, 1, 9]), [0, 1, 9])
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -314,8 +314,8 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             for k, v in zip(keys, vals):
                 d[k] = v
             out = []
-            for k in d.values():
-                out.append(k)
+            for v in d.values():
+                out.append(v)
             return out
 
         keys = [1, 2, 3]
@@ -324,4 +324,27 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(
             foo(keys, vals),
             vals,
+        )
+
+    def test_dict_iter(self):
+        """
+        Exercise iter(dict)
+        """
+        @njit
+        def foo(keys, vals):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+            out = []
+            for k in d:
+                out.append(k)
+            return out
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+
+        self.assertEqual(
+            foo(keys, vals),
+            [1, 2, 3]
         )

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1,7 +1,9 @@
 """
-Testing C implementation of the numba dictionary
+Testing numba implementation of the numba dictionary
 """
 from __future__ import print_function, absolute_import, division
+
+import random
 
 
 from numba import njit
@@ -49,4 +51,30 @@ class TestDictObject(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(5, [0, 1, 9]), [0, 1, None])
         self.assertEqual(foo(10, [0, 1, 9]), [0, 1, 9])
+        self.assertEqual(foo(10, [-1, 9, 1]), [None, 9, 1])
+
+    def test_dict_getitem(self):
+        """
+        Exercise dictionary __getitem__
+        """
+        @njit
+        def foo(keys, vals, target):
+            d = dictobject.new_dict(int32, float64)
+            # insertion
+            for k, v in zip(keys, vals):
+                d[k] = v
+
+            # lookup
+            return d[target]
+
+        keys = [1, 2, 3]
+        vals = [0.1, 0.2, 0.3]
+        self.assertEqual(foo(keys, vals, 1), 0.1)
+        self.assertEqual(foo(keys, vals, 2), 0.2)
+        self.assertEqual(foo(keys, vals, 3), 0.3)
+
+        with self.assertRaises(KeyError):
+            foo(keys, vals, 0)
+        with self.assertRaises(KeyError):
+            foo(keys, vals, 4)
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -7,8 +7,9 @@ in test_dictimpl.py.
 """
 from __future__ import print_function, absolute_import, division
 
+import sys
 import numpy as np
-from numba import njit
+from numba import njit, utils
 from numba import int32, int64, float32, float64, types
 from numba import dictobject
 from numba.errors import TypingError
@@ -608,6 +609,8 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
+    @unittest.skipUnless(utils.IS_PY3 and sys.maxsize > 2 ** 32,
+                         "Python 3, 64 bit test only")
     def test_007_collision_checks(self):
         # this checks collisions in real life for 64bit systems
         @njit
@@ -849,6 +852,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         @njit
         def foo():
             d = dictobject.new_dict(int32, float64)
+
             def bar():
                 d[1] = 12.
                 d[2] = 14.

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1,8 +1,8 @@
 """
 Testing numba implementation of the numba dictionary.
 
-The tests here only checks that the numba typing and codegen are working
-correctly.  Detail testing of the underlying dictionary operations is done
+The tests here only check that the numba typing and codegen are working
+correctly.  Detailed testing of the underlying dictionary operations is done
 in test_dictimpl.py.
 """
 from __future__ import print_function, absolute_import, division

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -725,7 +725,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         m = 10
         self.assertEqual(foo(m), (m, 0))
 
-    def test_016(self):
+    def test_016_cannot_downcast_key(self):
         @njit
         def foo():
             d = dictobject.new_dict(int32, float64)
@@ -739,7 +739,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
-    def test_017(self):
+    def test_017_cannot_downcast_default(self):
         @njit
         def foo():
             d = dictobject.new_dict(int32, float64)
@@ -753,7 +753,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
-    def test_018(self):
+    def test_018_keys_iter_are_views(self):
         # this is broken somewhere in llvmlite, intent of test is to check if
         # keys behaves like a view or not
         @njit
@@ -767,7 +767,9 @@ class TestDictObject(MemoryLeakMixin, TestCase):
             rk2 = [x for x in k2]
             return rk1, rk2
 
-        print(foo())
+        a, b = foo()
+        self.assertEqual(a, b)
+        self.assertEqual(a, [11, 22])
 
     def test_019(self):
         # should keys/vals be set-like?

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -423,3 +423,14 @@ class Literal(Type):
 
         return self._literal_type_cache
 
+
+
+class TypeRef(Dummy):
+    """Reference to a type.
+
+    Used when a type is passed as a value
+    """
+    def __init__(self, instance_type):
+        self.instance_type = instance_type
+        super(TypeRef, self).__init__('typeref[{}]'.format(self.instance_type))
+

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -428,7 +428,7 @@ class Literal(Type):
 class TypeRef(Dummy):
     """Reference to a type.
 
-    Used when a type is passed as a value
+    Used when a type is passed as a value.
     """
     def __init__(self, instance_type):
         self.instance_type = instance_type

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -439,3 +439,17 @@ class SetEntry(Type):
     @property
     def key(self):
         return self.set_type
+
+
+class DictType(Type):
+    """Dictionary type
+    """
+    def __init__(self, keyty, valty):
+        self.key_type = keyty
+        self.value_type = valty
+        name = '{}[{},{}]'.format(
+            self.__class__.__name__,
+            keyty,
+            valty,
+        )
+        super(DictType, self).__init__(name)

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -445,11 +445,59 @@ class DictType(Type):
     """Dictionary type
     """
     def __init__(self, keyty, valty):
+        assert not isinstance(keyty, TypeRef)
+        assert not isinstance(valty, TypeRef)
         self.key_type = keyty
         self.value_type = valty
+        self.keyvalue_type = Tuple([keyty, valty])
         name = '{}[{},{}]'.format(
             self.__class__.__name__,
             keyty,
             valty,
         )
         super(DictType, self).__init__(name)
+
+
+class DictItemsIterableType(SimpleIterableType):
+    """Dictionary iteratable type for .items()
+    """
+    def __init__(self, parent):
+        assert isinstance(parent, DictType)
+        self.parent = parent
+        self.yield_type = self.parent.keyvalue_type
+        name = "items[{}]".format(self.parent.name)
+        iterator_type = DictIteratorType(self)
+        super(DictItemsIterableType, self).__init__(name, iterator_type)
+
+
+class DictKeysIterableType(SimpleIterableType):
+    """Dictionary iteratable type for .items()
+    """
+    def __init__(self, parent):
+        assert isinstance(parent, DictType)
+        self.parent = parent
+        self.yield_type = self.parent.key_type
+        name = "keys[{}]".format(self.parent.name)
+        iterator_type = DictIteratorType(self)
+        super(DictKeysIterableType, self).__init__(name, iterator_type)
+
+
+class DictValuesIterableType(SimpleIterableType):
+    """Dictionary iteratable type for .items()
+    """
+    def __init__(self, parent):
+        assert isinstance(parent, DictType)
+        self.parent = parent
+        self.yield_type = self.parent.value_type
+        name = "values[{}]".format(self.parent.name)
+        iterator_type = DictIteratorType(self)
+        super(DictValuesIterableType, self).__init__(name, iterator_type)
+
+
+class DictIteratorType(SimpleIteratorType):
+    def __init__(self, iterable):
+        self.parent = iterable.parent
+        self.iterable = iterable
+        yield_type = iterable.yield_type
+        name = "iter[{}->{}]".format(iterable.parent, yield_type)
+        super(DictIteratorType, self).__init__(name, yield_type)

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -441,7 +441,7 @@ class SetEntry(Type):
         return self.set_type
 
 
-class DictType(Type):
+class DictType(IterableType):
     """Dictionary type
     """
     def __init__(self, keyty, valty):
@@ -456,6 +456,10 @@ class DictType(Type):
             valty,
         )
         super(DictType, self).__init__(name)
+
+    @property
+    def iterator_type(self):
+        return DictKeysIterableType(self).iterator_type
 
 
 class DictItemsIterableType(SimpleIterableType):

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -129,6 +129,8 @@ class BaseFunction(Callable):
                         sig = temp.apply(nolitargs, nolitkws)
                 except Exception as e:
                     sig = None
+                    import traceback
+                    traceback.print_exc()
                     failures.add_error(temp_cls, e)
                 else:
                     if sig is not None:

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -129,8 +129,6 @@ class BaseFunction(Callable):
                         sig = temp.apply(nolitargs, nolitkws)
                 except Exception as e:
                     sig = None
-                    import traceback
-                    traceback.print_exc()
                     failures.add_error(temp_cls, e)
                 else:
                     if sig is not None:

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -5,7 +5,7 @@ import itertools
 import numpy as np
 import operator
 
-from numba import types, prange
+from numba import types, prange, errors
 from numba.parfor import internal_prange
 
 from numba.utils import PYVERSION, RANGE_ITER_OBJECTS, IS_PY3
@@ -755,7 +755,7 @@ class TypeRefAttribute(AttributeTemplate):
         ty = classty.instance_type
 
         if not isinstance(ty, types.Number):
-            raise TypingError("invalid use of non-number types")
+            raise errors.TypingError("invalid use of non-number types")
 
         def typer(val):
             # Scalar constructor, e.g. int32(42)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -744,16 +744,24 @@ class NumberClassAttribute(AttributeTemplate):
         return types.Function(make_callable_template(key=ty, typer=typer))
 
 
-def register_number_classes(register_global):
-    nb_types = set(types.number_domain)
-    nb_types.add(types.bool_)
+@infer_getattr
+class TypeRefAttribute(AttributeTemplate):
+    key = types.TypeRef
 
-    for ty in nb_types:
-        register_global(ty, types.NumberClass(ty))
+    def resolve___call__(self, classty):
+        """
+        Resolve a number class's constructor (e.g. calling int(...))
+        """
+        ty = classty.instance_type
 
+        if not isinstance(ty, types.Number):
+            raise TypingError("invalid use of non-number types")
 
-register_number_classes(infer_global)
+        def typer(val):
+            # Scalar constructor, e.g. int32(42)
+            return ty
 
+        return types.Function(make_callable_template(key=ty, typer=typer))
 
 #------------------------------------------------------------------------------
 

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -232,4 +232,9 @@ def typeof_typeref(val, c):
 
 @typeof_impl.register(types.Type)
 def typeof_typeref(val, c):
-    return types.TypeRef(val)
+    if isinstance(val, types.BaseFunction):
+        return val
+    elif isinstance(val, (types.Number, types.Boolean)):
+        return types.NumberClass(val)
+    else:
+        return types.TypeRef(val)

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -219,3 +219,7 @@ def typeof_array(val, c):
     arrty = typeof_impl(val.get('host'), c)
     return types.SmartArrayType(arrty.dtype, arrty.ndim, arrty.layout, type(val))
 
+
+@typeof_impl.register(types.NumberClass)
+def typeof_number_class(val, c):
+    return val

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -223,3 +223,13 @@ def typeof_array(val, c):
 @typeof_impl.register(types.NumberClass)
 def typeof_number_class(val, c):
     return val
+
+
+@typeof_impl.register(types.TypeRef)
+def typeof_typeref(val, c):
+    return val
+
+
+@typeof_impl.register(types.Type)
+def typeof_typeref(val, c):
+    return types.TypeRef(val)


### PR DESCRIPTION
(Based on #3775, #3760, #3715) 

Implement most dictionary operations.

Still missing:

- ~~comparisons (equality)~~
- boxing and unboxing
- cpython side interface
- refct types are not supported; only works on POD types.
- typeinference backtracking magic
- (am I missing anything?)

Actual changes starts at https://github.com/numba/numba/pull/3777/commits/c56c5ac5795166dfdc3835dccf4019c127ca10ed.

The major changes are in:
- numba/dictobject.py  for the compiler support of the dictionary
- numba/types/containers.py for the dictionary typing
- numba/tests/test_dictobject.py for the tests

Note: `TypeRef` is added to allow referencing any numba-type as global-value or arguments as used in the constructor of dictionary.  It is different from `NumberClass`, which is for i.e. `np.float32`.  