### PR TITLE
Fix non-module object used as the module of a function.

### DIFF
--- a/numba/_dynfunc.c
+++ b/numba/_dynfunc.c
@@ -294,6 +294,9 @@ pycfunction_new(PyObject *module, PyObject *name, PyObject *doc,
     if (modname == NULL) goto FAIL;
 
     funcobj = PyCFunction_NewEx(&closure->def, (PyObject *) closure, modname);
+    Py_DECREF(closure);
+    Py_DECREF(modname);
+
     return funcobj;
 
 FAIL:

--- a/numba/_dynfunc.c
+++ b/numba/_dynfunc.c
@@ -284,18 +284,22 @@ pycfunction_new(PyObject *module, PyObject *name, PyObject *doc,
                 PyCFunction fnaddr, EnvironmentObject *env, PyObject *keepalive)
 {
     PyObject *funcobj;
-    PyObject *modname;
-    ClosureObject *closure;
+    PyObject *modname = NULL;
+    ClosureObject *closure = NULL;
 
     closure = closure_new(module, name, doc, fnaddr, env, keepalive);
-    if (closure == NULL)
-        return NULL;
+    if (closure == NULL) goto FAIL;
 
-    modname = PyString_FromString(PyModule_GetName(module));
+    modname = PyObject_GetAttrString(module, "__name__");
+    if (modname == NULL) goto FAIL;
+
     funcobj = PyCFunction_NewEx(&closure->def, (PyObject *) closure, modname);
-    Py_DECREF(closure);
-    Py_DECREF(modname);
     return funcobj;
+
+FAIL:
+    Py_XDECREF(closure);
+    Py_XDECREF(modname);
+    return NULL;
 }
 
 /*


### PR DESCRIPTION
This can happen in IPython cells; i.e. IPython uses [`DummyMod`](https://github.com/ipython/ipython/blob/19b47faf7468e01eed4bef7f4b287a0c20b2337b/IPython/core/interactiveshell.py#L277-L281) uses as the module.

This seems to be related to: https://github.com/ipython/ipyparallel/issues/347

