### PR TITLE
Add debug guard to debug only C function.

### DIFF
--- a/numba/_dictobject.c
+++ b/numba/_dictobject.c
@@ -292,11 +292,14 @@ aligned_size(Py_ssize_t sz) {
     return sz + (alignment - sz % alignment) % alignment;
 }
 
+#ifndef NDEBUG
+/* NOTE: This function is only used in assert()s */
 /* Align pointer *ptr* to pointer size */
 static void*
 aligned_pointer(void *ptr) {
     return (void*)aligned_size((size_t)ptr);
 }
+#endif
 
 /* lookup indices.  returns DKIX_EMPTY, DKIX_DUMMY, or ix >=0 */
 static Py_ssize_t


### PR DESCRIPTION
As title. Stops the compilers rightly complaining about this
function being unused when compiling at release levels.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
