### PR TITLE
Fix array.sum(axis) 1d input return type.

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -165,6 +165,11 @@ def array_sum_const_multi(arr, axis):
     e = np.sum(arr, axis=-1)
     return a, b, c, d, e
 
+def array_sum_const_axis_neg_one(a, axis):
+    # use .sum with -1 axis, this is for use with 1D arrays where the above
+    # "const_multi" variant would raise errors
+    return a.sum(axis=-1)
+
 def array_cumsum(a, *args):
     return a.cumsum(*args)
 
@@ -777,6 +782,17 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         self.assertPreciseEqual(pyfunc(a, axis=1), cfunc(a, axis=1))
         # OK
         self.assertPreciseEqual(pyfunc(a, axis=2), cfunc(a, axis=2))
+
+    def test_sum_1d_kws(self):
+        # check 1d reduces to scalar
+        pyfunc = array_sum_kws
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(10.)
+        self.assertPreciseEqual(pyfunc(a, axis=0), cfunc(a, axis=0))
+        pyfunc = array_sum_const_axis_neg_one
+        cfunc = jit(nopython=True)(pyfunc)
+        a = np.arange(10.)
+        self.assertPreciseEqual(pyfunc(a, axis=-1), cfunc(a, axis=-1))
 
     def test_sum_const(self):
         pyfunc = array_sum_const_multi

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -625,10 +625,15 @@ def sum_expand(self, args, kws):
         out = signature(_expand_integer(self.this.dtype), *args,
                         recvr=self.this)
     else:
-        # There is an axis paramter so the return type of this summation is
-        # an array of dimension one less than the input array.
-        return_type = types.Array(dtype=_expand_integer(self.this.dtype),
-                                  ndim=self.this.ndim-1, layout='C')
+        # There is an axis parameter
+        if self.this.ndim == 1:
+            # 1d reduces to a scalar
+            return_type = self.this.dtype
+        else:
+            # the return type of this summation is  an array of dimension one
+            # less than the input array.
+            return_type = types.Array(dtype=_expand_integer(self.this.dtype),
+                                    ndim=self.this.ndim-1, layout='C')
         out = signature(return_type, *args, recvr=self.this)
     return out.replace(pysig=pysig)
 


### PR DESCRIPTION
Makes it such that if a summation with an axis is called on
a 1d array the return type is scalar.

Fixes #3815

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
