### PR TITLE
Getitem should not return optional type

### DIFF
--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -866,7 +866,7 @@ def impl_getitem(d, key):
         elif ix < DKIX.EMPTY:
             raise AssertionError("internal dict error during lookup")
         else:
-            return val
+            return _nonoptional(val)
 
     return impl
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1261,4 +1261,3 @@ class TestDictForbiddenTypes(TestCase):
     def test_disallow_set(self):
         self.assert_disallow_key(types.Set(types.intp))
         self.assert_disallow_value(types.Set(types.intp))
-

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1210,6 +1210,18 @@ class TestDictRefctTypes(MemoryLeakMixin, TestCase):
         self.assertEqual(len(d), 0)
         self.assertFalse(d)
 
+    def test_getitem_return_type(self):
+        # Dict.__getitem__ must return non-optional type.
+        d = Dict.empty(types.int64, types.int64[:])
+        d[1] = np.arange(10)
+
+        @njit
+        def foo(d):
+            d[1] += 100
+
+        foo(d)
+        self.assertPreciseEqual(d[1], np.arange(10) + 100)
+
 
 class TestDictForbiddenTypes(TestCase):
     def assert_disallow(self, expect, callable):
@@ -1243,3 +1255,4 @@ class TestDictForbiddenTypes(TestCase):
     def test_disallow_set(self):
         self.assert_disallow_key(types.Set(types.intp))
         self.assert_disallow_value(types.Set(types.intp))
+

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1213,7 +1213,7 @@ class TestDictRefctTypes(MemoryLeakMixin, TestCase):
     def test_getitem_return_type(self):
         # Dict.__getitem__ must return non-optional type.
         d = Dict.empty(types.int64, types.int64[:])
-        d[1] = np.arange(10)
+        d[1] = np.arange(10, dtype=np.int64)
 
         @njit
         def foo(d):

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1226,7 +1226,7 @@ class TestDictRefctTypes(MemoryLeakMixin, TestCase):
         self.assertIsInstance(retty, types.Array)
         self.assertNotIsInstance(retty, types.Optional)
         # Value is correctly updated
-        self.assertPreciseEqual(d[1], np.arange(10) + 100)
+        self.assertPreciseEqual(d[1], np.arange(10, dtype=np.int64) + 100)
 
 
 class TestDictForbiddenTypes(TestCase):

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1218,8 +1218,14 @@ class TestDictRefctTypes(MemoryLeakMixin, TestCase):
         @njit
         def foo(d):
             d[1] += 100
+            return d[1]
 
         foo(d)
+        # Return type is an array, not optional
+        retty = foo.nopython_signatures[0].return_type
+        self.assertIsInstance(retty, types.Array)
+        self.assertNotIsInstance(retty, types.Optional)
+        # Value is correctly updated
         self.assertPreciseEqual(d[1], np.arange(10) + 100)
 
 


### PR DESCRIPTION
Forces `dict.__getitem__` to return non-optional value.  The added tests ensures that inplace array operations work on the return type of `dict.__getitem__`.   It is an separate issue that inplace-operator does not type correctly for optional types.