### PR TITLE
Unicode type iteration

### DIFF
--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -30,7 +30,7 @@ from numba.types import (
     Type,
 )
 from numba.typeconv import Conversion
-from numba.targets.imputils import impl_ret_borrowed
+from numba.targets.imputils import impl_ret_borrowed, RefType
 from numba.errors import TypingError
 from numba import typing
 
@@ -1126,7 +1126,7 @@ def impl_dict_getiter(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.DictIteratorType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def impl_iterator_iternext(context, builder, sig, args, result):
     iter_type = sig.args[0]
     it = context.make_helper(builder, iter_type, args[0])

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -1126,7 +1126,7 @@ def impl_dict_getiter(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.DictIteratorType)
-@iternext_impl
+@iternext_impl()
 def impl_iterator_iternext(context, builder, sig, args, result):
     iter_type = sig.args[0]
     it = context.make_helper(builder, iter_type, args[0])

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -200,7 +200,7 @@ size_t NRT_MemInfo_refcount(NRT_MemInfo *mi) {
 
 static
 void nrt_internal_dtor_safe(void *ptr, size_t size, void *info) {
-    NRT_Debug(nrt_debug_print("NRT_internal_dtor_safe %p, %p\n", ptr, info));
+    NRT_Debug(nrt_debug_print("nrt_internal_dtor_safe %p, %p\n", ptr, info));
     /* See NRT_MemInfo_alloc_safe() */
     memset(ptr, 0xDE, MIN(size, 256));
 }
@@ -218,7 +218,7 @@ void *nrt_allocate_meminfo_and_data(size_t size, NRT_MemInfo **mi_out) {
 static
 void nrt_internal_custom_dtor_safe(void *ptr, size_t size, void *info) {
     NRT_dtor_function dtor = info;
-    NRT_Debug(nrt_debug_print("NRT_internal_custom_dtor_safe %p, %p\n",
+    NRT_Debug(nrt_debug_print("nrt_internal_custom_dtor_safe %p, %p\n",
                               ptr, info));
     if (dtor) {
         dtor(ptr, size, NULL);
@@ -339,7 +339,7 @@ void NRT_MemInfo_dump(NRT_MemInfo *mi, FILE *out) {
 
 static void
 nrt_varsize_dtor(void *ptr, size_t size, void *info) {
-    NRT_Debug(nrt_debug_print("NRT_varsize_dtor %p\n", ptr));
+    NRT_Debug(nrt_debug_print("nrt_varsize_dtor %p\n", ptr));
     if (info) {
         /* call element dtor */
         typedef void dtor_fn_t(void *ptr);

--- a/numba/runtime/nrt.c
+++ b/numba/runtime/nrt.c
@@ -200,7 +200,7 @@ size_t NRT_MemInfo_refcount(NRT_MemInfo *mi) {
 
 static
 void nrt_internal_dtor_safe(void *ptr, size_t size, void *info) {
-    NRT_Debug(nrt_debug_print("nrt_internal_dtor_safe %p, %p\n", ptr, info));
+    NRT_Debug(nrt_debug_print("NRT_internal_dtor_safe %p, %p\n", ptr, info));
     /* See NRT_MemInfo_alloc_safe() */
     memset(ptr, 0xDE, MIN(size, 256));
 }
@@ -218,7 +218,7 @@ void *nrt_allocate_meminfo_and_data(size_t size, NRT_MemInfo **mi_out) {
 static
 void nrt_internal_custom_dtor_safe(void *ptr, size_t size, void *info) {
     NRT_dtor_function dtor = info;
-    NRT_Debug(nrt_debug_print("nrt_internal_custom_dtor_safe %p, %p\n",
+    NRT_Debug(nrt_debug_print("NRT_internal_custom_dtor_safe %p, %p\n",
                               ptr, info));
     if (dtor) {
         dtor(ptr, size, NULL);
@@ -295,14 +295,14 @@ void NRT_MemInfo_destroy(NRT_MemInfo *mi) {
 }
 
 void NRT_MemInfo_acquire(NRT_MemInfo *mi) {
-    NRT_Debug(nrt_debug_print("NRT_acquire %p refct=%zu\n", mi,
+    NRT_Debug(nrt_debug_print("NRT_MemInfo_acquire %p refct=%zu\n", mi,
                                                             mi->refct));
     assert(mi->refct > 0 && "RefCt cannot be zero");
     TheMSys.atomic_inc(&mi->refct);
 }
 
 void NRT_MemInfo_call_dtor(NRT_MemInfo *mi) {
-    NRT_Debug(nrt_debug_print("nrt_meminfo_call_dtor %p\n", mi));
+    NRT_Debug(nrt_debug_print("NRT_MemInfo_call_dtor %p\n", mi));
     if (mi->dtor && !TheMSys.shutting)
         /* We have a destructor and the system is not shutting down */
         mi->dtor(mi->data, mi->size, mi->dtor_info);
@@ -311,7 +311,7 @@ void NRT_MemInfo_call_dtor(NRT_MemInfo *mi) {
 }
 
 void NRT_MemInfo_release(NRT_MemInfo *mi) {
-    NRT_Debug(nrt_debug_print("NRT_release %p refct=%zu\n", mi,
+    NRT_Debug(nrt_debug_print("NRT_MemInfo_release %p refct=%zu\n", mi,
                                                             mi->refct));
     assert (mi->refct > 0 && "RefCt cannot be 0");
     /* RefCt drop to zero */
@@ -339,7 +339,7 @@ void NRT_MemInfo_dump(NRT_MemInfo *mi, FILE *out) {
 
 static void
 nrt_varsize_dtor(void *ptr, size_t size, void *info) {
-    NRT_Debug(nrt_debug_print("nrt_buffer_dtor %p\n", ptr));
+    NRT_Debug(nrt_debug_print("NRT_varsize_dtor %p\n", ptr));
     if (info) {
         /* call element dtor */
         typedef void dtor_fn_t(void *ptr);

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -24,7 +24,8 @@ from numba.targets.imputils import (lower_builtin, lower_getattr,
                                     lower_setattr_generic,
                                     lower_cast, lower_constant,
                                     iternext_impl, impl_ret_borrowed,
-                                    impl_ret_new_ref, impl_ret_untracked)
+                                    impl_ret_new_ref, impl_ret_untracked,
+                                    RefType)
 from numba.typing import signature
 from numba.extending import register_jitable, overload, overload_method
 from . import quicksort, mergesort, slicing
@@ -277,7 +278,7 @@ def _getitem_array1d(context, builder, arrayty, array, idx, wraparound):
     return load_item(context, builder, arrayty, ptr)
 
 @lower_builtin('iternext', types.ArrayIterator)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_array(context, builder, sig, args, result):
     [iterty] = sig.args
     [iter] = args
@@ -2976,7 +2977,7 @@ def make_array_flatiter(context, builder, arrty, arr):
 
 
 @lower_builtin('iternext', types.NumpyFlatType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_numpy_flatiter(context, builder, sig, args, result):
     [flatiterty] = sig.args
     [flatiter] = args
@@ -3054,7 +3055,7 @@ def make_array_ndenumerate(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.NumpyNdEnumerateType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_numpy_nditer(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args
@@ -3106,7 +3107,7 @@ def make_array_ndindex(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.NumpyNdIndexType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_numpy_ndindex(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args
@@ -3137,7 +3138,7 @@ def make_array_nditer(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, nditerty, res)
 
 @lower_builtin('iternext', types.NumpyNdIterType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_numpy_ndindex(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -277,7 +277,7 @@ def _getitem_array1d(context, builder, arrayty, array, idx, wraparound):
     return load_item(context, builder, arrayty, ptr)
 
 @lower_builtin('iternext', types.ArrayIterator)
-@iternext_impl
+@iternext_impl()
 def iternext_array(context, builder, sig, args, result):
     [iterty] = sig.args
     [iter] = args
@@ -2976,7 +2976,7 @@ def make_array_flatiter(context, builder, arrty, arr):
 
 
 @lower_builtin('iternext', types.NumpyFlatType)
-@iternext_impl
+@iternext_impl()
 def iternext_numpy_flatiter(context, builder, sig, args, result):
     [flatiterty] = sig.args
     [flatiter] = args
@@ -3054,7 +3054,7 @@ def make_array_ndenumerate(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.NumpyNdEnumerateType)
-@iternext_impl
+@iternext_impl()
 def iternext_numpy_nditer(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args
@@ -3106,7 +3106,7 @@ def make_array_ndindex(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.NumpyNdIndexType)
-@iternext_impl
+@iternext_impl()
 def iternext_numpy_ndindex(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args
@@ -3137,7 +3137,7 @@ def make_array_nditer(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, nditerty, res)
 
 @lower_builtin('iternext', types.NumpyNdIterType)
-@iternext_impl
+@iternext_impl()
 def iternext_numpy_ndindex(context, builder, sig, args, result):
     [nditerty] = sig.args
     [nditer] = args

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -8,6 +8,7 @@ import collections
 import contextlib
 import inspect
 import functools
+from enum import Enum
 
 from .. import typing, cgutils, types, utils
 from .. typing.templates import BaseRegistryLoader
@@ -234,7 +235,7 @@ def iterator_impl(iterable_type, iterator_type):
         # These are unbound methods
         iternext = cls.iternext
 
-        @iternext_impl()
+        @iternext_impl(RefType.BORROWED)
         def iternext_wrapper(context, builder, sig, args, result):
             (value,) = args
             iterobj = cls(context, builder, value)
@@ -293,8 +294,24 @@ class _IternextResult(object):
         """
         return self._pairobj.first
 
+class RefType(Enum):
+    """
+    Enumerate the reference type
+    """
+    """
+    A new reference
+    """
+    NEW = 1
+    """
+    A borrowed reference
+    """
+    BORROWED = 2
+    """
+    An untracked reference
+    """
+    UNTRACKED = 3
 
-def iternext_impl(new_ref=False):
+def iternext_impl(ref_type=None):
     """
     Wrap the given iternext() implementation so that it gets passed
     an _IternextResult() object easing the returning of the iternext()
@@ -305,16 +322,23 @@ def iternext_impl(new_ref=False):
     The wrapped function will be called with the following signature:
         (context, builder, sig, args, iternext_result)
     """
+    if ref_type is None:
+        raise ValueError("ref_type must be an enum member of imputils.RefType")
+
     def outer(func):
         def wrapper(context, builder, sig, args):
             pair_type = sig.return_type
             pairobj = context.make_helper(builder, pair_type)
             func(context, builder, sig, args,
                 _IternextResult(context, builder, pairobj))
-            if new_ref:
+            if ref_type == RefType.NEW:
                 impl_ret = impl_ret_new_ref
-            else:
+            elif ref_type == RefType.BORROWED:
                 impl_ret = impl_ret_borrowed
+            elif ref_type == RefType.UNTRACKED:
+                impl_ret = impl_ret_untracked
+            else:
+                raise ValueError("Unknown ref_type encountered")
             return impl_ret(context, builder,
                                     pair_type, pairobj._getvalue())
         return wrapper

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -5,7 +5,7 @@ Implementation of various iterable and iterator types.
 from numba import types, cgutils
 from numba.targets.imputils import (
     lower_builtin, iternext_impl, call_iternext, call_getiter,
-    impl_ret_borrowed, impl_ret_new_ref)
+    impl_ret_borrowed, impl_ret_new_ref, RefType)
 
 
 
@@ -44,7 +44,7 @@ def make_enumerate_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.EnumerateType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_enumerate(context, builder, sig, args, result):
     [enumty] = sig.args
     [enum] = args
@@ -87,7 +87,7 @@ def make_zip_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.ZipType)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_zip(context, builder, sig, args, result):
     [zip_type] = sig.args
     [zipobj] = args
@@ -125,7 +125,7 @@ def iternext_zip(context, builder, sig, args, result):
 # generator implementation
 
 @lower_builtin('iternext', types.Generator)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_zip(context, builder, sig, args, result):
     genty, = sig.args
     gen, = args

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -44,7 +44,7 @@ def make_enumerate_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.EnumerateType)
-@iternext_impl
+@iternext_impl()
 def iternext_enumerate(context, builder, sig, args, result):
     [enumty] = sig.args
     [enum] = args
@@ -87,7 +87,7 @@ def make_zip_object(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin('iternext', types.ZipType)
-@iternext_impl
+@iternext_impl()
 def iternext_zip(context, builder, sig, args, result):
     [zip_type] = sig.args
     [zipobj] = args
@@ -125,7 +125,7 @@ def iternext_zip(context, builder, sig, args, result):
 # generator implementation
 
 @lower_builtin('iternext', types.Generator)
-@iternext_impl
+@iternext_impl()
 def iternext_zip(context, builder, sig, args, result):
     genty, = sig.args
     gen, = args

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -11,7 +11,8 @@ from llvmlite import ir
 from numba import types, cgutils, typing
 from numba.targets.imputils import (lower_builtin, lower_cast,
                                     iternext_impl, impl_ret_borrowed,
-                                    impl_ret_new_ref, impl_ret_untracked)
+                                    impl_ret_new_ref, impl_ret_untracked,
+                                    RefType)
 from numba.utils import cached_property
 from . import quicksort, slicing
 
@@ -487,7 +488,7 @@ def getiter_list(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, inst.value)
 
 @lower_builtin('iternext', types.ListIter)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_listiter(context, builder, sig, args, result):
     inst = ListIterInstance(context, builder, sig.args[0], args[0])
 

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -487,7 +487,7 @@ def getiter_list(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, inst.value)
 
 @lower_builtin('iternext', types.ListIter)
-@iternext_impl
+@iternext_impl()
 def iternext_listiter(context, builder, sig, args, result):
     inst = ListIterInstance(context, builder, sig.args[0], args[0])
 

--- a/numba/targets/setobj.py
+++ b/numba/targets/setobj.py
@@ -14,7 +14,7 @@ from numba import types, cgutils, typing
 from numba.targets.imputils import (lower_builtin, lower_cast,
                                     iternext_impl, impl_ret_borrowed,
                                     impl_ret_new_ref, impl_ret_untracked,
-                                    for_iter, call_len)
+                                    for_iter, call_len, RefType)
 from numba.utils import cached_property
 from . import quicksort, slicing
 
@@ -1215,7 +1215,7 @@ def getiter_set(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, inst.value)
 
 @lower_builtin('iternext', types.SetIter)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_listiter(context, builder, sig, args, result):
     inst = SetIterInstance(context, builder, sig.args[0], args[0])
     inst.iternext(result)

--- a/numba/targets/setobj.py
+++ b/numba/targets/setobj.py
@@ -1215,7 +1215,7 @@ def getiter_set(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, inst.value)
 
 @lower_builtin('iternext', types.SetIter)
-@iternext_impl
+@iternext_impl()
 def iternext_listiter(context, builder, sig, args, result):
     inst = SetIterInstance(context, builder, sig.args[0], args[0])
     inst.iternext(result)

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -8,7 +8,8 @@ import operator
 
 from .imputils import (lower_builtin, lower_getattr_generic, lower_cast,
                        lower_constant,
-                       iternext_impl, impl_ret_borrowed, impl_ret_untracked)
+                       iternext_impl, impl_ret_borrowed, impl_ret_untracked,
+                       RefType)
 from .. import typing, types, cgutils
 from ..extending import overload_method
 
@@ -148,7 +149,7 @@ def getiter_unituple(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.UniTupleIter)
-@iternext_impl()
+@iternext_impl(RefType.BORROWED)
 def iternext_unituple(context, builder, sig, args, result):
     [tupiterty] = sig.args
     [tupiter] = args

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -148,7 +148,7 @@ def getiter_unituple(context, builder, sig, args):
 
 
 @lower_builtin('iternext', types.UniTupleIter)
-@iternext_impl
+@iternext_impl()
 def iternext_unituple(context, builder, sig, args, result):
     [tupiterty] = sig.args
     [tupiter] = args

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -474,11 +474,21 @@ class ContextManager(Callable, Phantom):
         return typing.signature(self, *posargs)
 
 
-class UnicodeType(SimpleIterableType):
+class UnicodeType(IterableType):
 
     def __init__(self, name):
-        super(SimpleIterableType, self).__init__(name)
-        self._iterator_type = UnicodeIteratorType(self)
+        # this is updated on first call to `.iterator_type`.
+        self._iterator_type = None
+        super(UnicodeType, self).__init__(name)
+
+    @property
+    def iterator_type(self):
+        # lazily grab the iterator_type, self needs to init before the
+        # iterator_type is instantiated else variety of pickle failures
+        if self._iterator_type is None:
+            self._iterator_type = UnicodeIteratorType(self)
+        return self._iterator_type
+
 
 class UnicodeIteratorType(SimpleIteratorType):
 

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -474,7 +474,15 @@ class ContextManager(Callable, Phantom):
         return typing.signature(self, *posargs)
 
 
-class UnicodeType(Type):
-    def __init__(self, name):
-        super(UnicodeType, self).__init__(name)
+class UnicodeType(SimpleIterableType):
 
+    def __init__(self, name):
+        super(SimpleIterableType, self).__init__(name)
+        self._iterator_type = UnicodeIteratorType(self)
+
+class UnicodeIteratorType(SimpleIteratorType):
+
+    def __init__(self, dtype):
+        name = "iter_unicode"
+        self.data = dtype
+        super(UnicodeIteratorType, self).__init__(name, dtype)

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -15,7 +15,7 @@ from numba.extending import (
     intrinsic,
 )
 from numba.targets.imputils import (lower_constant, lower_cast, lower_builtin,
-                                    iternext_impl, impl_ret_new_ref)
+                                    iternext_impl, impl_ret_new_ref, RefType)
 from numba.datamodel import register_default, StructModel
 from numba import cgutils
 from numba import types
@@ -771,7 +771,7 @@ def getiter_unicode(context, builder, sig, args):
 
 @lower_builtin('iternext', types.UnicodeIteratorType)
 # a new ref counted object is put into result._yield so set the new_ref to True!
-@iternext_impl(new_ref=True)
+@iternext_impl(RefType.NEW)
 def iternext_unicode(context, builder, sig, args, result):
     [iterty] = sig.args
     [iter] = args

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -14,7 +14,9 @@ from numba.extending import (
     overload_method,
     intrinsic,
 )
-from numba.targets.imputils import lower_constant, lower_cast
+from numba.targets.imputils import (lower_constant, lower_cast, lower_builtin,
+                                    iternext_impl, impl_ret_new_ref)
+from numba.datamodel import register_default, StructModel
 from numba import cgutils
 from numba import types
 from numba import njit
@@ -29,7 +31,7 @@ from numba._helperlib import c_helpers
 from numba.targets.hashing import _Py_hash_t
 from numba.unsafe.bytes import memcpy_region
 
-### DATA MODEL
+# DATA MODEL
 
 
 @register_model(types.UnicodeType)
@@ -53,7 +55,14 @@ make_attribute_wrapper(types.UnicodeType, 'kind', '_kind')
 make_attribute_wrapper(types.UnicodeType, 'hash', '_hash')
 
 
-### CAST
+@register_default(types.UnicodeIteratorType)
+class UnicodeIteratorModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [('index', types.EphemeralPointer(types.uintp)),
+                   ('data', fe_type.data)]
+        super(UnicodeIteratorModel, self).__init__(dmm, fe_type, members)
+
+# CAST
 
 
 def compile_time_get_string_data(obj):
@@ -106,14 +115,14 @@ def cast_from_literal(context, builder, fromty, toty, val):
     )
 
 
-### CONSTANT
+# CONSTANT
 
 @lower_constant(types.unicode_type)
 def constant_unicode(context, builder, typ, pyval):
     return make_string_from_constant(context, builder, typ, pyval)
 
 
-### BOXING
+# BOXING
 
 
 @unbox(types.UnicodeType)
@@ -143,7 +152,8 @@ def box_unicode_str(typ, val, c):
     Convert a native unicode structure to a unicode string
     """
     uni_str = cgutils.create_struct_proxy(typ)(c.context, c.builder, value=val)
-    res = c.pyapi.string_from_kind_and_data(uni_str.kind, uni_str.data, uni_str.length)
+    res = c.pyapi.string_from_kind_and_data(
+        uni_str.kind, uni_str.data, uni_str.length)
     # hash isn't needed now, just compute it so it ends up in the unicodeobject
     # hash cache, cpython doesn't always do this, depends how a string was
     # created it's safe, just burns the cycles required to hash on @box
@@ -152,7 +162,7 @@ def box_unicode_str(typ, val, c):
     return res
 
 
-#### HELPER FUNCTIONS
+# HELPER FUNCTIONS
 
 
 def make_deref_codegen(bitsize):
@@ -270,7 +280,7 @@ def set_uint32(typingctx, data, idx, ch):
 
 @njit(_nrt=False)
 def _set_code_point(a, i, ch):
-    ### WARNING: This method is very dangerous:
+    # WARNING: This method is very dangerous:
     #   * Assumes that data contents can be changed (only allowed for new
     #     strings)
     #   * Assumes that the kind of unicode string is sufficiently wide to
@@ -283,7 +293,8 @@ def _set_code_point(a, i, ch):
     elif a._kind == PY_UNICODE_4BYTE_KIND:
         set_uint32(a._data, i, ch)
     else:
-        raise AssertionError("Unexpected unicode representation in _set_code_point")
+        raise AssertionError(
+            "Unexpected unicode representation in _set_code_point")
 
 
 @njit
@@ -381,7 +392,7 @@ def _is_whitespace(code_point):
         or code_point == 0x3000
 
 
-#### PUBLIC API
+# PUBLIC API
 
 @overload(len)
 def unicode_len(s):
@@ -539,11 +550,11 @@ def unicode_split(a, sep=None, maxsplit=-1):
                     if is_whitespace:
                         pass  # keep consuming space
                     else:
-                        last = idx # this is the start of the next string
+                        last = idx  # this is the start of the next string
                         in_whitespace_block = False
                 else:
                     if not is_whitespace:
-                        pass # keep searching for whitespace transition
+                        pass  # keep searching for whitespace transition
                     else:
                         parts.append(a[last:idx])
                         in_whitespace_block = True
@@ -596,7 +607,7 @@ def unicode_join(sep, parts):
                 return join_list(sep, parts)
             return join_list_impl
         else:
-            pass # lists of any other type not supported
+            pass  # lists of any other type not supported
     elif isinstance(parts, types.IterableType):
         def join_iter_impl(sep, parts):
             parts_list = [p for p in parts]
@@ -610,7 +621,7 @@ def unicode_join(sep, parts):
         return join_str_impl
 
 
-### String creation
+# String creation
 
 @njit
 def normalize_str_idx(idx, length, is_start=True):
@@ -683,10 +694,12 @@ def _strncpy(dst, dst_offset, src, src_offset, n):
         src_byte_offset = byte_width * src_offset
         dst_byte_offset = byte_width * dst_offset
         nbytes = n * byte_width
-        memcpy_region(dst._data, dst_byte_offset, src._data, src_byte_offset, nbytes, align=1)
+        memcpy_region(dst._data, dst_byte_offset, src._data,
+                      src_byte_offset, nbytes, align=1)
     else:
         for i in range(n):
-            _set_code_point(dst, dst_offset + i, _get_code_point(src, src_offset + i))
+            _set_code_point(dst, dst_offset + i,
+                            _get_code_point(src, src_offset + i))
 
 
 @overload(operator.getitem)
@@ -730,3 +743,70 @@ def unicode_concat(a, b):
                 _set_code_point(result, len(a) + j, _get_code_point(b, j))
             return result
         return concat_impl
+
+
+@lower_builtin('getiter', types.UnicodeType)
+def getiter_unicode(context, builder, sig, args):
+    [ty] = sig.args
+    [data] = args
+
+    iterobj = context.make_helper(builder, sig.return_type)
+
+    # set the index to zero
+    zero = context.get_constant(types.uintp, 0)
+    indexptr = cgutils.alloca_once_value(builder, zero)
+
+    iterobj.index = indexptr
+
+    # wire in the unicode type data
+    iterobj.data = data
+
+    # incref as needed
+    if context.enable_nrt:
+        context.nrt.incref(builder, ty, data)
+
+    res = iterobj._getvalue()
+    return impl_ret_new_ref(context, builder, sig.return_type, res)
+
+
+@lower_builtin('iternext', types.UnicodeIteratorType)
+# a new ref counted object is put into result._yield so set the new_ref to True!
+@iternext_impl(new_ref=True)
+def iternext_unicode(context, builder, sig, args, result):
+    [iterty] = sig.args
+    [iter] = args
+
+    tyctx = context.typing_context
+
+    # get ref to unicode.__getitem__
+    fnty = tyctx.resolve_value_type(operator.getitem)
+    getitem_sig = fnty.get_call_type(tyctx, (types.unicode_type, types.uintp),
+                                     {})
+    getitem_impl = context.get_function(fnty, getitem_sig)
+
+    # get ref to unicode.__len__
+    fnty = tyctx.resolve_value_type(len)
+    len_sig = fnty.get_call_type(tyctx, (types.unicode_type,), {})
+    len_impl = context.get_function(fnty, len_sig)
+
+    # grab unicode iterator struct
+    iterobj = context.make_helper(builder, iterty, value=iter)
+
+    # find the length of the string
+    strlen = len_impl(builder, (iterobj.data,))
+
+    # find the current index
+    index = builder.load(iterobj.index)
+
+    # see if the index is in range
+    is_valid = builder.icmp_unsigned('<', index, strlen)
+    result.set_valid(is_valid)
+
+    with builder.if_then(is_valid):
+        # return value at index
+        gotitem = getitem_impl(builder, (iterobj.data, index,))
+        result.yield_(gotitem)
+
+        # bump index for next cycle
+        nindex = cgutils.increment_index(builder, index)
+        builder.store(nindex, iterobj.index)


### PR DESCRIPTION
This makes the unicode type iterable and also fixes up a selection
of other things that were causing minor issues on the way. Not
limited to:

 * Contractual clarity over reference ownership in `iternext_impl`
 * Matching debug print with function names in C code
 * PEP8

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
