### PR TITLE
Fix mutable flag transmission in .astype

### DIFF
--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -419,6 +419,11 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         arr = np.arange(16, dtype=np.int32)[::2]
         check(arr, np.uint64)
 
+        # check read only attr does not get copied
+        arr = np.arange(16, dtype=np.int32)
+        arr.flags.writeable = False
+        check(arr, np.int32)
+
         # Invalid conversion
         dt = np.dtype([('x', np.int8)])
         with self.assertTypingError() as raises:

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -449,7 +449,9 @@ class ArrayAttribute(AttributeTemplate):
                             "cannot convert from %s to %s"
                             % (dtype, ary, ary.dtype, dtype))
         layout = ary.layout if ary.layout in 'CF' else 'C'
-        retty = ary.copy(dtype=dtype, layout=layout)
+        # reset the write bit irrespective of whether the cast type is the same
+        # as the current dtype, this replicates numpy
+        retty = ary.copy(dtype=dtype, layout=layout, readonly=False)
         return signature(retty, *args)
 
     @bound_function("array.ravel")


### PR DESCRIPTION
As title. `np.ndarray.astype` always returns a mutable array.

Fixes #3844

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
