### PR TITLE
Allow fine-grained control of fastmath flags to partially address #2923

### DIFF
--- a/docs/source/user/performance-tips.rst
+++ b/docs/source/user/performance-tips.rst
@@ -100,6 +100,19 @@ Numba is through the use of the ``fastmath`` keyword argument::
 | ``do_sum_fast`` |      17.8 ms    |
 +-----------------+-----------------+
 
+In some cases you may wish to opt-in to only a subset of possible fast-math
+optimizations. This can be done by supplying a set of `LLVM fast-math flags
+<https://llvm.org/docs/LangRef.html#fast-math-flags>`_ to ``fastmath``.::
+
+    def add_assoc(x, y):
+        return (x - y) + y
+
+    print(njit(fastmath=False)(add_assoc)(0, np.inf)) # nan
+    print(njit(fastmath=True) (add_assoc)(0, np.inf)) # 0.0
+    print(njit(fastmath={'reassoc', 'nsz'})(add_assoc)(0, np.inf)) # 0.0
+    print(njit(fastmath={'reassoc'})       (add_assoc)(0, np.inf)) # nan
+    print(njit(fastmath={'nsz'})           (add_assoc)(0, np.inf)) # nan
+
 
 Parallel=True
 -------------
@@ -171,19 +184,6 @@ Execution times are as follows, ``fastmath`` again improves performance.
 +-------------------------+-----------------+
 | ``do_sum_parallel_fast``|      5.37 ms    |
 +-------------------------+-----------------+
-
-In some cases you may wish to opt-in to only a subset of possible fast-math
-optimizations. This can be done by supplying a set of `LLVM fast-math flags
-<https://llvm.org/docs/LangRef.html#fast-math-flags>`_ to ``fastmath``.::
-
-    def add_assoc(x, y):
-        return (x - y) + y
-
-    print(nb.njit(fastmath=False)(add_assoc)(0, np.inf)) # nan
-    print(nb.njit(fastmath=True) (add_assoc)(0, np.inf)) # 0.0
-    print(nb.njit(fastmath={'reassoc', 'nsz'})(add_assoc)(0, np.inf)) # 0.0
-    print(nb.njit(fastmath={'reassoc'})       (add_assoc)(0, np.inf)) # nan
-    print(nb.njit(fastmath={'nsz'})           (add_assoc)(0, np.inf)) # nan
 
 .. _intel-svml:
 

--- a/docs/source/user/performance-tips.rst
+++ b/docs/source/user/performance-tips.rst
@@ -172,6 +172,19 @@ Execution times are as follows, ``fastmath`` again improves performance.
 | ``do_sum_parallel_fast``|      5.37 ms    |
 +-------------------------+-----------------+
 
+In some cases you may wish to opt-in to only a subset of possible fast-math
+optimizations. This can be done by supplying a set of `LLVM fast-math flags
+<https://llvm.org/docs/LangRef.html#fast-math-flags>`_ to ``fastmath``.::
+
+    def add_assoc(x, y):
+        return (x - y) + y
+
+    print(nb.njit(fastmath=False)(add_assoc)(0, np.inf)) # nan
+    print(nb.njit(fastmath=True) (add_assoc)(0, np.inf)) # 0.0
+    print(nb.njit(fastmath={'reassoc', 'nsz'})(add_assoc)(0, np.inf)) # 0.0
+    print(nb.njit(fastmath={'reassoc'})       (add_assoc)(0, np.inf)) # nan
+    print(nb.njit(fastmath={'nsz'})           (add_assoc)(0, np.inf)) # nan
+
 .. _intel-svml:
 
 Intel SVML

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -50,7 +50,7 @@ class Flags(utils.ConfigOptions):
         'nrt': False,
         'no_rewrites': False,
         'error_model': 'python',
-        'fastmath': False,
+        'fastmath': cpu.FastMathOptions(False),
         'noalias': False,
     }
 
@@ -905,7 +905,7 @@ def _make_subtarget(targetctx, flags):
     if flags.auto_parallel:
         subtargetoptions['auto_parallel'] = flags.auto_parallel
     if flags.fastmath:
-        subtargetoptions['enable_fastmath'] = True
+        subtargetoptions['fastmath'] = flags.fastmath
     error_model = callconv.create_error_model(flags.error_model, targetctx)
     subtargetoptions['error_model'] = error_model
 

--- a/numba/npyufunc/ufuncbuilder.py
+++ b/numba/npyufunc/ufuncbuilder.py
@@ -11,6 +11,7 @@ from numba.decorators import jit
 from numba.targets.descriptors import TargetDescriptor
 from numba.targets.options import TargetOptions
 from numba.targets.registry import dispatcher_registry, cpu_target
+from numba.targets.cpu import FastMathOptions
 from numba import utils, compiler, types, sigutils
 from numba.numpy_support import as_dtype
 from . import _internal
@@ -24,7 +25,7 @@ class UFuncTargetOptions(TargetOptions):
     OPTIONS = {
         "nopython" : bool,
         "forceobj" : bool,
-        "fastmath" : bool,
+        "fastmath" : FastMathOptions,
     }
 
 

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -215,7 +215,7 @@ class BaseContext(object):
     allow_dynamic_globals = False
 
     # Fast math flags
-    enable_fastmath = False
+    fastmath = False
 
     # python exceution environment
     environment = None

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -128,8 +128,8 @@ class CPUContext(BaseContext):
         return setobj.build_set(self, builder, set_type, items)
 
     def post_lowering(self, mod, library):
-        if self.enable_fastmath:
-            fastmathpass.rewrite_module(mod)
+        if self.fastmath:
+            fastmathpass.rewrite_module(mod, self.fastmath)
 
         if self.is32bit:
             # 32-bit machine needs to replace all 64-bit div/rem to avoid
@@ -186,6 +186,41 @@ class CPUContext(BaseContext):
         return self.get_abi_sizeof(self.get_value_type(aryty))
 
 
+class FastMathOptions(object):
+    """
+    Options for controlling fast math optimization.
+    """
+    def __init__(self, value):
+        # https://releases.llvm.org/7.0.0/docs/LangRef.html#fast-math-flags
+        valid_flags = {
+            'fast',
+            'nnan', 'ninf', 'nsz', 'arcp',
+            'contract', 'afn', 'reassoc',
+        }
+
+        if value is True:
+            self.flags = {'fast'}
+        elif value is False:
+            self.flags = set()
+        elif isinstance(value, set):
+            invalid = value - valid_flags
+            if invalid:
+                raise ValueError("Unrecognized fastmath flags: %s" % invalid)
+            self.flags = value
+        elif isinstance(value, dict):
+            invalid = set(value.keys()) - valid_flags
+            if invalid:
+                raise ValueError("Unrecognized fastmath flags: %s" % invalid)
+            self.flags = {v for v, enable in value.items() if enable}
+        else:
+            raise ValueError("Expect fastmath option to be either a bool, dict or set")
+
+    def __bool__(self):
+        return bool(self.flags)
+
+    __nonzero__ = __bool__
+
+
 class ParallelOptions(object):
     """
     Options for controlling auto parallelization.
@@ -229,7 +264,7 @@ class CPUTargetOptions(TargetOptions):
         "_nrt": bool,
         "no_rewrites": bool,
         "no_cpython_wrapper": bool,
-        "fastmath": bool,
+        "fastmath": FastMathOptions,
         "error_model": str,
         "parallel": ParallelOptions,
     }

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -213,7 +213,7 @@ class FastMathOptions(object):
                 raise ValueError("Unrecognized fastmath flags: %s" % invalid)
             self.flags = {v for v, enable in value.items() if enable}
         else:
-            raise ValueError("Expect fastmath option to be either a bool, dict or set")
+            raise ValueError("Expected fastmath option(s) to be either a bool, dict or set")
 
     def __bool__(self):
         return bool(self.flags)

--- a/numba/targets/options.py
+++ b/numba/targets/options.py
@@ -66,8 +66,8 @@ class TargetOptions(object):
         if 'parallel' in kws:
             flags.set('auto_parallel', kws.pop('parallel'))
 
-        if kws.pop('fastmath', False):
-            flags.set('fastmath')
+        if 'fastmath' in kws:
+            flags.set('fastmath', kws.pop('fastmath'))
 
         if 'error_model' in kws:
             flags.set('error_model', kws.pop('error_model'))

--- a/numba/tests/test_fastmath.py
+++ b/numba/tests/test_fastmath.py
@@ -23,6 +23,40 @@ class TestFastMath(unittest.TestCase):
         self.assertNotIn('fadd fast', slowllvm)
         self.assertNotIn('call fast', slowllvm)
 
+    def test_jit_subset_behaviour(self):
+        def foo(x, y):
+            return (x - y) + y
+        fastfoo = njit(fastmath={'reassoc', 'nsz'})(foo)
+        slowfoo = njit(fastmath={'reassoc'})(foo)
+        self.assertEqual(fastfoo(0.5, np.inf), 0.5)
+        self.assertTrue(np.isnan(slowfoo(0.5, np.inf)))
+
+    def test_jit_subset_code(self):
+        def foo(x):
+            return x + math.sin(x)
+        fastfoo = njit(fastmath={'reassoc', 'nsz'})(foo)
+        slowfoo = njit()(foo)
+        self.assertEqual(fastfoo(0.5), slowfoo(0.5))
+        fastllvm = fastfoo.inspect_llvm(fastfoo.signatures[0])
+        slowllvm = slowfoo.inspect_llvm(slowfoo.signatures[0])
+        # Ensure fast attributes in fast version only
+        self.assertNotIn('fadd fast', slowllvm)
+        self.assertNotIn('call fast', slowllvm)
+        self.assertNotIn('fadd reassoc nsz', slowllvm)
+        self.assertNotIn('call reassoc nsz', slowllvm)
+        self.assertNotIn('fadd nsz reassoc', slowllvm)
+        self.assertNotIn('call nsz reassoc', slowllvm)
+        self.assertTrue(
+            ('fadd nsz reassoc' in fastllvm) or
+            ('fadd reassoc nsz' in fastllvm),
+            fastllvm
+        )
+        self.assertTrue(
+            ('call nsz reassoc' in fastllvm) or
+            ('call reassoc nsz' in fastllvm),
+            fastllvm
+        )
+
     def test_vectorize(self):
         def foo(x):
             return x + math.sin(x)

--- a/numba/tests/test_fastmath.py
+++ b/numba/tests/test_fastmath.py
@@ -57,6 +57,28 @@ class TestFastMath(unittest.TestCase):
             fastllvm
         )
 
+    def test_jit_subset_errors(self):
+        with self.assertRaises(ValueError) as raises:
+            njit(fastmath={'spqr'})(lambda x: x + 1)(1)
+        self.assertIn(
+            "Unrecognized fastmath flags:",
+            str(raises.exception),
+        )
+
+        with self.assertRaises(ValueError) as raises:
+            njit(fastmath={'spqr': False})(lambda x: x + 1)(1)
+        self.assertIn(
+            'Unrecognized fastmath flags:',
+            str(raises.exception),
+        )
+
+        with self.assertRaises(ValueError) as raises:
+            njit(fastmath=1337)(lambda x: x + 1)(1)
+        self.assertIn(
+            'Expected fastmath option(s) to be',
+            str(raises.exception),
+        )
+
     def test_vectorize(self):
         def foo(x):
             return x + math.sin(x)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -74,7 +74,7 @@ class TestParforsBase(TestCase):
         self.fast_pflags = Flags()
         self.fast_pflags.set('auto_parallel', cpu.ParallelOptions(True))
         self.fast_pflags.set('nrt')
-        self.fast_pflags.set('fastmath')
+        self.fast_pflags.set('fastmath', cpu.FastMathOptions(True))
         super(TestParforsBase, self).__init__(*args)
 
     def _compile_this(self, func, sig, flags):

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -56,7 +56,7 @@ class TestRemoveDead(unittest.TestCase):
         fast_pflags = Flags()
         fast_pflags.set('auto_parallel', cpu.ParallelOptions(True))
         fast_pflags.set('nrt')
-        fast_pflags.set('fastmath')
+        fast_pflags.set('fastmath', cpu.FastMathOptions(True))
         return compile_isolated(func, arg_types, flags=fast_pflags).entry_point
 
     def test1(self):

--- a/numba/tests/test_svml.py
+++ b/numba/tests/test_svml.py
@@ -11,6 +11,7 @@ from itertools import chain, combinations
 
 import numba
 from numba import prange, unittest_support as unittest
+from numba.targets import cpu
 from numba.compiler import compile_isolated, Flags
 from numba.six import exec_
 from .support import TestCase, tag, override_env_config
@@ -225,7 +226,9 @@ class TestSVMLGeneration(TestCase):
             flags.set('error_model', 'numpy')
             flags.__name__ = '_'.join(ft+('usecase',))
             for f in ft:
-                flags.set(f)
+                flags.set(f, {
+                    'fastmath': cpu.FastMathOptions(True)
+                }.get(f, True))
             flag_list.append(flags)
         # main loop covering all the modes and use-cases
         for dtype in ('complex64', 'float64', 'float32', 'int32', ):
@@ -268,7 +271,7 @@ class TestSVML(TestCase):
         # flags for njit(fastmath=True)
         self.fastflags = Flags()
         self.fastflags.set('nrt')
-        self.fastflags.set('fastmath')
+        self.fastflags.set('fastmath', cpu.FastMathOptions(True))
         super(TestSVML, self).__init__(*args)
 
     def compile(self, func, *args, **kwargs):
@@ -366,6 +369,7 @@ class TestSVML(TestCase):
                     # then to override using `numba.config`
                     import numba
                     from numba import config
+                    from numba.targets import cpu
                     from numba.tests.support import override_env_config
                     from numba.compiler import compile_isolated, Flags
 
@@ -376,7 +380,7 @@ class TestSVML(TestCase):
                         f = Flags()
                         f.set('nrt')
                         std = compile_isolated(math_sin_loop, sig, flags=f)
-                        f.set('fastmath')
+                        f.set('fastmath', cpu.FastMathOptions(True))
                         fast = compile_isolated(math_sin_loop, sig, flags=f)
                         fns = std, fast
 


### PR DESCRIPTION
#2923 observes that it would be useful to have some ability to restrict to just a subset of the `fastmath` optimizations. This PR implements that part without addressing some of the other points raised by that issue.

As an aside: in practice I didn't find this feature to be very useful - I was hoping it would let me exploit lots of LLVM optimisations while still doing the Right Thing for NaNs (which are frequently used to flag missing data in quant finance applications). Unfortunately, in practice it seems that many LLVM transformations require the full set of fast-math flags, even if they are not strictly necessary. So even with an example like this from the numba docs:

````
    @njit(fastmath=True)
    def do_sum_fast(A):
        acc = 0.
        # with fastmath, the reduction can be vectorized as floating point
        # reassociation is permitted.
        for x in A:
            acc += np.sqrt(x)
        return acc
````

You see that (with LLVM 7) this gets optimised to a tight loop with `fastmath={'nnan', 'ninf', 'nsz', 'arcp', 'contract', 'afn', 'reassoc'}` but **not** with `fastmath={'nnan', 'ninf', 'nsz',  'contract', 'afn', 'reassoc'}`, even though the function doesn't do any division!