### PR TITLE
Refactor np.interp

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -287,9 +287,7 @@ The following top-level functions are supported:
 * :func:`numpy.histogram` (only the 3 first arguments)
 * :func:`numpy.hstack`
 * :func:`numpy.identity`
-* :func:`numpy.interp` (only the 3 first arguments; requires NumPy >= 1.10;
-  complex dtype handling per NumPy 1.12+; ``xp`` must be monotonically
-  increasing)
+* :func:`numpy.interp` (only the 3 first arguments; requires NumPy >= 1.10)
 * :func:`numpy.linspace` (only the 3-argument form)
 * :class:`numpy.ndenumerate`
 * :class:`numpy.ndindex`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1604,21 +1604,6 @@ def binary_search_with_guess(key, arr, length, guess):
 
     return imin - 1
 
-# Note to reader
-# --------------
-# You might be offended by the apparent duplication in the following
-# four functions; I can relate, if so.
-#
-# The implementations attempt to replicate numpy as faithfully as
-# possible across versions, bugs and all.
-#
-# It would be possible to refactor and take out some
-# of the duplication, but at the cost of making the translation back
-# to numpy source more opaque.  Having spent many hours tracking down
-# subtle bugs in reproducing numpy behaviour, please refactor with
-# caution, if you feel compelled to do so (and keep an eye on
-# performance if you branch within implementation(s)).
-
 @register_jitable
 def np_interp_impl_complex_fp_inner(x, xp, fp, dtype):
     # this is a facsimile of arr_interp_complex prior to 1.16:
@@ -1689,7 +1674,6 @@ def np_interp_impl_complex_fp_inner(x, xp, fp, dtype):
                 dres.flat[i] = rval
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
-
             else:
                 if slopes.size:
                     slope = slopes[j]
@@ -1782,11 +1766,9 @@ def np_interp_impl_complex_fp_inner_116(x, xp, fp, dtype):
                 dres.flat[i] = rval
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
-
             elif dx[j] == x_val:
                 # Avoid potential non-finite interpolation
                 dres.flat[i] = dy[j]
-
             else:
                 if slopes.size:
                     slope = slopes[j]
@@ -1870,7 +1852,6 @@ def np_interp_impl_inner(x, xp, fp, dtype):
                 dres.flat[i] = rval
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
-
             else:
                 if slopes.size:
                     slope = slopes[j]
@@ -1952,11 +1933,9 @@ def np_interp_impl_inner_116(x, xp, fp, dtype):
                 dres.flat[i] = rval
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
-
             elif dx[j] == x_val:
                 # Avoid potential non-finite interpolation
                 dres.flat[i] = dy[j]
-
             else:
                 if slopes.size:
                     slope = slopes[j]

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1576,7 +1576,7 @@ def binary_search_with_guess(key, arr, length, guess):
                     key >= arr[guess - LIKELY_IN_CACHE_SIZE]:
                 imin = guess - LIKELY_IN_CACHE_SIZE
         else:
-            # key >= arr[guess - 1
+            # key >= arr[guess - 1]
             return guess - 1
     else:
         # key >= arr[guess]
@@ -1590,7 +1590,7 @@ def binary_search_with_guess(key, arr, length, guess):
                 # key >= arr[guess + 2]
                 imin = guess + 2
                 # last attempt to restrict search to items in cache
-                if (guess < length - LIKELY_IN_CACHE_SIZE - 1) and \
+                if (guess < (length - LIKELY_IN_CACHE_SIZE - 1)) and \
                         (key < arr[guess + LIKELY_IN_CACHE_SIZE]):
                     imax = guess + LIKELY_IN_CACHE_SIZE
 
@@ -1606,9 +1606,9 @@ def binary_search_with_guess(key, arr, length, guess):
 
 @register_jitable
 def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
-    dz = np.asarray(x)
-    dx = np.asarray(xp)
-    dy = np.asarray(fp)
+    dz = np.asarray(x).astype(np.float64)
+    dx = np.asarray(xp).astype(np.float64)
+    dy = np.asarray(fp).astype(np.complex128)
 
     if len(dx) == 0:
         raise ValueError('array of sample points is empty')
@@ -1644,9 +1644,9 @@ def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
 
         # only pre-calculate slopes if there are relatively few of them.
         if lenxp <= lenx:
-            slopes = np.empty((lenxp - 1), dtype=np.complex128)
+            slopes = np.empty((lenxp - 1), dtype=dtype)
         else:
-            slopes = np.empty(0, dtype=np.complex128)
+            slopes = np.empty(0, dtype=dtype)
 
         if slopes.size:
             for i in range(lenxp - 1):
@@ -1700,9 +1700,9 @@ def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
 
 @register_jitable
 def np_interp_impl_inner(x, xp, fp, dtype, nan_handling_per_116):
-    dz = np.asarray(x)
-    dx = np.asarray(xp)
-    dy = np.asarray(fp)
+    dz = np.asarray(x).astype(np.float64)
+    dx = np.asarray(xp).astype(np.float64)
+    dy = np.asarray(fp).astype(np.float64)
 
     if len(dx) == 0:
         raise ValueError('array of sample points is empty')
@@ -1738,12 +1738,9 @@ def np_interp_impl_inner(x, xp, fp, dtype, nan_handling_per_116):
 
         # only pre-calculate slopes if there are relatively few of them.
         if lenxp <= lenx:
-            slopes = np.empty((lenxp - 1), dtype=np.float64)
-        else:
-            slopes = np.empty(0, dtype=np.float64)
-
-        if slopes.size:
             slopes = (dy[1:] - dy[:-1]) / (dx[1:] - dx[:-1])
+        else:
+            slopes = np.empty(0, dtype=dtype)
 
         for i in range(lenx):
             x_val = dz.flat[i]

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1555,9 +1555,10 @@ def binary_search_with_guess(key, arr, length, guess):
     # If len <= 4 use linear search.
     # From above we know key >= arr[0] when we start.
     if length <= 4:
-        for i in range(1, length):
-            if key < arr[i]:
-                return i - 1
+        i = 1
+        while i < length and key >= arr[i]:
+            i += 1
+        return i - 1
 
     if guess > length - 3:
         guess = length - 3

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1606,9 +1606,9 @@ def binary_search_with_guess(key, arr, length, guess):
 
 @register_jitable
 def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
-    dz = np.asarray(x).astype(np.float64)
-    dx = np.asarray(xp).astype(np.float64)
-    dy = np.asarray(fp).astype(np.complex128)
+    dz = np.asarray(x)
+    dx = np.asarray(xp)
+    dy = np.asarray(fp)
 
     if len(dx) == 0:
         raise ValueError('array of sample points is empty')
@@ -1673,10 +1673,9 @@ def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
 
-            elif dx[j] == x_val:
-                if nan_handling_per_116:
-                    # Avoid potential non-finite interpolation
-                    dres.flat[i] = dy[j]
+            elif dx[j] == x_val and nan_handling_per_116:
+                # Avoid potential non-finite interpolation
+                dres.flat[i] = dy[j]
 
             else:
                 if slopes.size:
@@ -1694,15 +1693,15 @@ def np_interp_impl_complex_fp_inner(x, xp, fp, dtype, nan_handling_per_116):
                 # NOTE: I think this is not in any 1.16.x yet...
                 #
                 # If we get nan in one direction, try the other
-                # ... (not implemented)
+                # ... (not implemented yet)
 
     return dres
 
 @register_jitable
 def np_interp_impl_inner(x, xp, fp, dtype, nan_handling_per_116):
-    dz = np.asarray(x).astype(np.float64)
-    dx = np.asarray(xp).astype(np.float64)
-    dy = np.asarray(fp).astype(np.float64)
+    dz = np.asarray(x)
+    dx = np.asarray(xp)
+    dy = np.asarray(fp)
 
     if len(dx) == 0:
         raise ValueError('array of sample points is empty')
@@ -1758,10 +1757,9 @@ def np_interp_impl_inner(x, xp, fp, dtype, nan_handling_per_116):
             elif j == lenxp - 1:
                 dres.flat[i] = dy[j]
 
-            elif dx[j] == x_val:
-                if nan_handling_per_116:
-                    # Avoid potential non-finite interpolation
-                    dres.flat[i] = dy[j]
+            elif dx[j] == x_val and nan_handling_per_116:
+                # Avoid potential non-finite interpolation
+                dres.flat[i] = dy[j]
 
             else:
                 if slopes.size:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2220,22 +2220,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(x, xp, fp)
             np.testing.assert_allclose(expected, got, equal_nan=True)
 
-    @unittest.skipUnless(np_version >= (1, 12), "complex handling per Numpy 1.12+")
-    def test_interp_complex_edge_case(self):
-        pyfunc = interp
-        cfunc = jit(nopython=True)(pyfunc)
-        _check = partial(self._check_output, pyfunc, cfunc, abs_tol=1e-12)
-
-        for x in range(-2, 4):
-            xp = np.arange(3) + 0.01
-            fp = np.arange(3) + 1j
-            _check(params={'x': x, 'xp': xp, 'fp': fp})
-
-        # note: in versions of NumPy prior to 1.12, this test causes
-        # Numpy to raise: TypeError: Cannot cast array data from
-        # dtype('complex128')  to dtype('float64') according to the
-        # rule 'safe'
-
     @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
     def test_interp_exceptions(self):
         pyfunc = interp

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1938,6 +1938,25 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
             self.assertIn('y cannot be a scalar', str(e.exception))
 
+
+    def test_interp_DELETE_ME(self):
+        pyfunc = interp
+        cfunc = jit(nopython=True)(pyfunc)
+
+        x = np.array([1.4, np.nan, np.inf, -np.inf, 0.0, -9.1])
+        x = x.reshape(3, 2, order='F')
+        xp = np.linspace(-4, 4, 10)
+        fp = np.arange(-5, 5)
+        params = {'x': x, 'xp': xp, 'fp': fp}
+
+        expected = pyfunc(**params)
+        got = cfunc(**params)
+
+        print(expected)
+        print(got)
+
+
+
     @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
     def test_interp_basic(self):
         pyfunc = interp

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2327,66 +2327,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         _check(params)
 
     @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
-    def test_interp_supplemental_tests_single_1(self):
-        # debug 1
-        pyfunc = interp
-        cfunc = jit(nopython=True)(pyfunc)
-        _check = partial(self._check_output, pyfunc, cfunc)
-
-        for size in [1]:
-            xp = np.arange(size, dtype=np.double)
-            yp = np.ones(size, dtype=np.double)
-            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
-            decpts = incpts[::-1]
-
-            incres = cfunc(incpts, xp, yp)
-            decres = cfunc(decpts, xp, yp)
-            inctgt = np.array([1, 1, 1, 1], dtype=float)
-            dectgt = inctgt[::-1]
-            np.testing.assert_almost_equal(incres, inctgt)
-            np.testing.assert_almost_equal(decres, dectgt)
-
-    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
-    def test_interp_supplemental_tests_single_2(self):
-        # debug 2
-        pyfunc = interp
-        cfunc = jit(nopython=True)(pyfunc)
-        _check = partial(self._check_output, pyfunc, cfunc)
-
-        for size in [2]:
-            xp = np.arange(size, dtype=np.double)
-            yp = np.ones(size, dtype=np.double)
-            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
-            decpts = incpts[::-1]
-
-            incres = cfunc(incpts, xp, yp)
-            decres = cfunc(decpts, xp, yp)
-            inctgt = np.array([1, 1, 1, 1], dtype=float)
-            dectgt = inctgt[::-1]
-            np.testing.assert_almost_equal(incres, inctgt)
-            np.testing.assert_almost_equal(decres, dectgt)
-
-    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
-    def test_interp_supplemental_tests_single_3(self):
-        # debug 3
-        pyfunc = interp
-        cfunc = jit(nopython=True)(pyfunc)
-        _check = partial(self._check_output, pyfunc, cfunc)
-
-        for size in [3]:
-            xp = np.arange(size, dtype=np.double)
-            yp = np.ones(size, dtype=np.double)
-            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
-            decpts = incpts[::-1]
-
-            incres = cfunc(incpts, xp, yp)
-            decres = cfunc(decpts, xp, yp)
-            inctgt = np.array([1, 1, 1, 1], dtype=float)
-            dectgt = inctgt[::-1]
-            np.testing.assert_almost_equal(incres, inctgt)
-            np.testing.assert_almost_equal(decres, dectgt)
-
-    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
     def test_interp_supplemental_tests(self):
         # inspired by class TestInterp
         # https://github.com/numpy/numpy/blob/f5b6850f231/numpy/lib/tests/test_function_base.py

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2327,6 +2327,66 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         _check(params)
 
     @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
+    def test_interp_supplemental_tests_single_1(self):
+        # debug 1
+        pyfunc = interp
+        cfunc = jit(nopython=True)(pyfunc)
+        _check = partial(self._check_output, pyfunc, cfunc)
+
+        for size in [1]:
+            xp = np.arange(size, dtype=np.double)
+            yp = np.ones(size, dtype=np.double)
+            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
+            decpts = incpts[::-1]
+
+            incres = cfunc(incpts, xp, yp)
+            decres = cfunc(decpts, xp, yp)
+            inctgt = np.array([1, 1, 1, 1], dtype=float)
+            dectgt = inctgt[::-1]
+            np.testing.assert_almost_equal(incres, inctgt)
+            np.testing.assert_almost_equal(decres, dectgt)
+
+    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
+    def test_interp_supplemental_tests_single_2(self):
+        # debug 2
+        pyfunc = interp
+        cfunc = jit(nopython=True)(pyfunc)
+        _check = partial(self._check_output, pyfunc, cfunc)
+
+        for size in [2]:
+            xp = np.arange(size, dtype=np.double)
+            yp = np.ones(size, dtype=np.double)
+            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
+            decpts = incpts[::-1]
+
+            incres = cfunc(incpts, xp, yp)
+            decres = cfunc(decpts, xp, yp)
+            inctgt = np.array([1, 1, 1, 1], dtype=float)
+            dectgt = inctgt[::-1]
+            np.testing.assert_almost_equal(incres, inctgt)
+            np.testing.assert_almost_equal(decres, dectgt)
+
+    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
+    def test_interp_supplemental_tests_single_3(self):
+        # debug 3
+        pyfunc = interp
+        cfunc = jit(nopython=True)(pyfunc)
+        _check = partial(self._check_output, pyfunc, cfunc)
+
+        for size in [3]:
+            xp = np.arange(size, dtype=np.double)
+            yp = np.ones(size, dtype=np.double)
+            incpts = np.array([-1, 0, size - 1, size], dtype=np.double)
+            decpts = incpts[::-1]
+
+            incres = cfunc(incpts, xp, yp)
+            decres = cfunc(decpts, xp, yp)
+            inctgt = np.array([1, 1, 1, 1], dtype=float)
+            dectgt = inctgt[::-1]
+            np.testing.assert_almost_equal(incres, inctgt)
+            np.testing.assert_almost_equal(decres, dectgt)
+
+    @unittest.skipUnless(np_version >= (1, 10), "interp needs Numpy 1.10+")
     def test_interp_supplemental_tests(self):
         # inspired by class TestInterp
         # https://github.com/numpy/numpy/blob/f5b6850f231/numpy/lib/tests/test_function_base.py


### PR DESCRIPTION
Initial commit; a long way to go.

Ambition is to replicate `np.interp` exactly for all versions 1.10+ by straight porting the underlying numpy implementation and its changes through time / versions.

Will update this PR as it progresses towards that goal and invite a review when it looks to be in good shape.

