### PR TITLE
Continuation of PR #2894

### DIFF
--- a/LICENSES.third-party
+++ b/LICENSES.third-party
@@ -76,3 +76,26 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+funcsigs
+--------
+The following:
+https://github.com/numba/numba/blob/8476b8b4eb396d78460407d10e421048b9346c4e/numba/utils.py#L90-L115
+is from a pull request https://github.com/aliles/funcsigs/pull/30/files on the
+repository https://github.com/aliles/funcsigs which has the following license:
+
+
+Copyright 2013 Aaron Iles
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/buildscripts/remove_unwanted_files.py
+++ b/buildscripts/remove_unwanted_files.py
@@ -14,6 +14,7 @@ py2_only_files = []
 py3_only_files = [
     'numba/tests/annotation_usecases.py',
     'numba/tests/overload_usecases.py',
+    'numba/tests/jitclass_usecases.py',
     ]
 
 

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -73,13 +73,12 @@ def ctor({args}):
 """
 
 
-def _getargs(fn):
+def _getargs(fn_sig):
     """
     Returns list of positional and keyword argument names in order.
     """
-    sig = utils.pysignature(fn)
-    params = sig.parameters
-    args = [k for k, v in params.items()
+    params = fn_sig.parameters
+    args = [k for k, v in params.items() 
             if (v.kind & v.POSITIONAL_OR_KEYWORD) == v.POSITIONAL_OR_KEYWORD]
     return args
 
@@ -105,9 +104,11 @@ class JitClassType(type):
         Note the wrapper will only accept positional arguments.
         """
         init = cls.class_type.instance_type.methods['__init__']
+        init_sig = utils.pysignature(init)
         # get postitional and keyword arguments
         # offset by one to exclude the `self` arg
-        args = _getargs(init)[1:]
+        args = _getargs(init_sig)[1:]
+        cls._ctor_sig = init_sig
         ctor_source = _ctor_template.format(args=', '.join(args))
         glbls = {"__numba_cls_": cls}
         exec_(ctor_source, glbls)
@@ -120,7 +121,11 @@ class JitClassType(type):
         return False
 
     def __call__(cls, *args, **kwargs):
-        return cls._ctor(*args, **kwargs)
+        # The first argument of _ctor_sig is `cls`, which here
+        # is bound to None and then skipped when invoking the constructor.
+        bind = cls._ctor_sig.bind(None, *args, **kwargs)
+        bind.apply_defaults()
+        return cls._ctor(*bind.args[1:], **bind.kwargs)
 
 
 ##############################################################################

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -78,7 +78,7 @@ def _getargs(fn_sig):
     Returns list of positional and keyword argument names in order.
     """
     params = fn_sig.parameters
-    args = [k for k, v in params.items() 
+    args = [k for k, v in params.items()
             if (v.kind & v.POSITIONAL_OR_KEYWORD) == v.POSITIONAL_OR_KEYWORD]
     return args
 

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -12,7 +12,7 @@ from numba import njit
 from numba.typing import templates
 from numba.datamodel import default_manager, models
 from numba.targets import imputils
-from numba import cgutils, utils
+from numba import cgutils, utils, errors
 from numba.config import PYVERSION
 from numba.six import exec_
 
@@ -78,8 +78,13 @@ def _getargs(fn_sig):
     Returns list of positional and keyword argument names in order.
     """
     params = fn_sig.parameters
-    args = [k for k, v in params.items()
-            if (v.kind & v.POSITIONAL_OR_KEYWORD) == v.POSITIONAL_OR_KEYWORD]
+    args = []
+    for k, v in params.items():
+        if (v.kind & v.POSITIONAL_OR_KEYWORD) == v.POSITIONAL_OR_KEYWORD:
+            args.append(k)
+        else:
+            msg = "%s argument type unsupported in jitclass" % v.kind
+            raise errors.UnsupportedError(msg)
     return args
 
 

--- a/numba/tests/jitclass_usecases.py
+++ b/numba/tests/jitclass_usecases.py
@@ -1,0 +1,21 @@
+"""
+Usecases with Python 3 syntax in the signatures. This is a separate module
+in order to avoid syntax errors with Python 2.
+"""
+
+
+class TestClass1(object):
+    def __init__(self, x, y, z=1, *, a=5):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.a = a
+
+
+class TestClass2(object):
+    def __init__(self, x, y, z=1, *args, a=5):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.args = args
+        self.a = a

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -16,6 +16,9 @@ from numba.jitclass import _box
 from numba.runtime.nrt import MemInfo
 from numba.errors import LoweringError
 
+# there are some python 3 specific syntax tests
+if sys.version_info >= (3,):
+    from .jitclass_usecases import TestClass1, TestClass2
 
 def _get_meminfo(box):
     ptr = _box.box_get_meminfoptr(box)
@@ -653,13 +656,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 ('z', int32),
                 ('a', int32)]
 
-        @jitclass(spec)
-        class TestClass(object):
-            def __init__(self, x, y, z=1, *, a=5):
-                self.x = x
-                self.y = y
-                self.z = z
-                self.a = a
+        TestClass = jitclass(spec)(TestClass1)
 
         tc = TestClass(2, 3)
         self.assertEqual(tc.x, 2)
@@ -694,14 +691,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 ('a', int32)]
 
         with self.assertRaises(errors.UnsupportedError) as raises:
-            @jitclass(spec)
-            class TestClass(object):
-                def __init__(self, x, y, z=1, *args, a=5):
-                    self.x = x
-                    self.y = y
-                    self.z = z
-                    self.args = args
-                    self.a = a
+            jitclass(spec)(TestClass2)
 
         msg = "VAR_POSITIONAL argument type unsupported"
         self.assertIn(msg, str(raises.exception))

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -619,26 +619,6 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.a, x * y)
         self.assertEqual(tc.b, z)
 
-    def test_generator_method(self):
-        spec = []
-
-        @jitclass(spec)
-        class TestClass(object):
-            def __init__(self):
-                pass
-
-            def gen(self, niter):
-                for i in range(niter):
-                    yield np.arange(i)
-
-        def expected_gen(niter):
-            for i in range(niter):
-                yield np.arange(i)
-
-        for niter in range(10):
-            for expect, got in zip(expected_gen(niter), TestClass().gen(niter)):
-                self.assertPreciseEqual(expect, got)
-
     def test_default_args(self):
         spec = [('x', int32),
                 ('y', int32),
@@ -692,6 +672,40 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.y, 4)
         self.assertEqual(tc.z, 100)
         self.assertEqual(tc.a, 42)
+
+        tc = TestClass(y=4, x=2, a=42)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 4)
+        self.assertEqual(tc.z, 1)
+        self.assertEqual(tc.a, 42)
+
+        tc = TestClass(y=4, x=2)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 4)
+        self.assertEqual(tc.z, 1)
+        self.assertEqual(tc.a, 5)
+
+
+    def test_generator_method(self):
+        spec = []
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                pass
+
+            def gen(self, niter):
+                for i in range(niter):
+                    yield np.arange(i)
+
+        def expected_gen(niter):
+            for i in range(niter):
+                yield np.arange(i)
+
+        for niter in range(10):
+            for expect, got in zip(expected_gen(niter), TestClass().gen(niter)):
+                self.assertPreciseEqual(expect, got)
+
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -639,6 +639,60 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             for expect, got in zip(expected_gen(niter), TestClass().gen(niter)):
                 self.assertPreciseEqual(expect, got)
 
+    def test_default_args(self):
+        spec = [('x', int32),
+                ('y', int32),
+                ('z', int32)]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self, x, y, z=1):
+                self.x = x
+                self.y = y
+                self.z = z
+
+        tc = TestClass(1, 2, 3)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 3)
+
+        tc = TestClass(1, 2)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 1)
+
+        tc = TestClass(y=2, z=5, x=1)
+        self.assertEqual(tc.x, 1)
+        self.assertEqual(tc.y, 2)
+        self.assertEqual(tc.z, 5)
+
+    @unittest.skipIf(sys.version_info < (3,), "Python 3-specific test")
+    def test_default_args_keyonly(self):
+        spec = [('x', int32),
+                ('y', int32),
+                ('z', int32),
+                ('a', int32)]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self, x, y, z=1, *, a=5):
+                self.x = x
+                self.y = y
+                self.z = z
+                self.a = a
+
+        tc = TestClass(2, 3)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 3)
+        self.assertEqual(tc.z, 1)
+        self.assertEqual(tc.a, 5)
+
+        tc = TestClass(y=4, x=2, a=42, z=100)
+        self.assertEqual(tc.x, 2)
+        self.assertEqual(tc.y, 4)
+        self.assertEqual(tc.z, 100)
+        self.assertEqual(tc.a, 42)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -141,7 +141,25 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
     - default_handler(index, param, default) is called for omitted arguments
     - stararg_handler(index, param, values) is called for a "*args" argument
     """
-    ba = pysig.bind(*args, **kws)
+
+    # deal with kwonly args
+    params = pysig.parameters
+    kwonly = []
+    for name, p in params.items():
+        if p.kind == p.KEYWORD_ONLY:
+            kwonly.append(name)
+
+    if kwonly:
+        bind_args = args[:-len(kwonly)]
+    else:
+        bind_args = args
+    bind_kws = kws.copy()
+    if kwonly:
+        for idx, n in enumerate(kwonly):
+            bind_kws[n] = args[len(kwonly) + idx]
+
+    # now bind
+    ba = pysig.bind(*bind_args, **bind_kws)
     for i, param in enumerate(pysig.parameters.values()):
         name = param.name
         default = param.default

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -85,6 +85,34 @@ except ImportError:
         from funcsigs import signature as pysignature
         from funcsigs import Signature as pySignature
         from funcsigs import Parameter as pyParameter
+        from funcsigs import BoundArguments
+
+        # monkey patch `apply_defaults` onto `BoundArguments` cf inspect in py3
+        # This patch is from https://github.com/aliles/funcsigs/pull/30/files
+        # with minor modifications, and thanks!
+        def apply_defaults(self):
+            arguments = self.arguments
+
+            # Creating a new one and not modifying in-place for thread safety.
+            new_arguments = []
+
+            for name, param in self._signature.parameters.items():
+                try:
+                    new_arguments.append((name, arguments[name]))
+                except KeyError:
+                    if param.default is not param.empty:
+                        val = param.default
+                    elif param.kind is _VAR_POSITIONAL:
+                        val = ()
+                    elif param.kind is _VAR_KEYWORD:
+                        val = {}
+                    else:
+                        # BoundArguments was likely created by bind_partial
+                        continue
+                    new_arguments.append((name, val))
+
+            self.arguments = collections.OrderedDict(new_arguments)
+        BoundArguments.apply_defaults = apply_defaults
     except ImportError:
         raise ImportError("please install the 'funcsigs' package "
                           "('pip install funcsigs')")

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -90,6 +90,7 @@ except ImportError:
         # monkey patch `apply_defaults` onto `BoundArguments` cf inspect in py3
         # This patch is from https://github.com/aliles/funcsigs/pull/30/files
         # with minor modifications, and thanks!
+        # See LICENSES.third-party.
         def apply_defaults(self):
             arguments = self.arguments
 


### PR DESCRIPTION
This is a continuation of PR #2894 that attempts to solve the difficulties into which it ran. The purpose of this code is to permit default constructor arguments in `jitclass`, it also now handles keyword only arguments too. Positional only arguments are not considered (see https://www.python.org/dev/peps/pep-0570/).

NOTE: The patch https://github.com/numba/numba/commit/8476b8b4eb396d78460407d10e421048b9346c4e contains a modified copy of the PR open against `funcsigs` here https://github.com/aliles/funcsigs/pull/30/files.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
