### PR TITLE
Continuation of PR #3730

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -80,7 +80,6 @@ exclude =
     numba/types/common.py
     numba/types/iterators.py
     numba/types/scalars.py
-    numba/jitclass/base.py
     numba/targets/fastmathpass.py
     numba/targets/setobj.py
     numba/targets/options.py
@@ -244,7 +243,6 @@ exclude =
     numba/tests/matmul_usecase.py
     numba/tests/complex_usecases.py
     numba/tests/test_array_exprs.py
-    numba/tests/test_jitclasses.py
     numba/tests/test_polynomial.py
     numba/tests/test_wrapper.py
     numba/tests/test_obj_lifetime.py

--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -99,7 +99,9 @@ def _specialize_box(typ):
         dct[field] = property(getter, setter, doc=doc)
     # Inject methods as class members
     for name, func in typ.methods.items():
-        if not (name.startswith('__') and name.endswith('__')):
+        if (name == "__getitem__" or name == "__setitem__") or \
+                (not (name.startswith('__') and name.endswith('__'))):
+
             dct[name] = _generate_method(name, func)
     # Create subclass
     subcls = type(typ.classname, (_box.Box,), dct)

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -226,7 +226,6 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                     cur = cur.next
                 cur.next = other
 
-
         node_type.define(LinkedNode.class_type.instance_type)
 
         first = LinkedNode(123, None)
@@ -293,7 +292,6 @@ class TestJitClass(TestCase, MemoryLeakMixin):
     def test_is(self):
         Vector = self._make_Vector2()
         vec_a = Vector(1, 2)
-        vec_b = Vector(1, 2)
 
         @njit
         def do_is(a, b):
@@ -529,7 +527,6 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             def check_private_method(self, factor):
                 return self.__private_method(factor)
 
-
         value = 123
         inst = MyClass(value)
         # test attributes
@@ -717,6 +714,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         @njit
         def get_key(t, real, imag):
             return t[complex(real, imag)]
+
         @njit
         def set_key(t, real, imag, data):
             t[complex(real, imag)] = data

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -639,6 +639,158 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             for expect, got in zip(expected_gen(niter), TestClass().gen(niter)):
                 self.assertPreciseEqual(expect, got)
 
+    def test_getitem(self):
+        spec = [('data', int32[:])]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                self.data = np.zeros(10, dtype=np.int32)
+
+            def __setitem__(self, key, data):
+                self.data[key] = data
+
+            def __getitem__(self, key):
+                return self.data[key]
+
+        @njit
+        def create_and_set_indices():
+            t = TestClass()
+            t[1] = 1
+            t[2] = 2
+            t[3] = 3
+            return t
+
+        @njit
+        def get_index(t, n):
+            return t[n]
+
+        t = create_and_set_indices()
+        assert get_index(t, 1) == 1
+        assert get_index(t, 2) == 2
+        assert get_index(t, 3) == 3
+
+    def test_getitem_unbox(self):
+        spec = [('data', int32[:])]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                self.data = np.zeros(10, dtype=np.int32)
+
+            def __setitem__(self, key, data):
+                self.data[key] = data
+
+            def __getitem__(self, key):
+                return self.data[key]
+
+        t = TestClass()
+        t[1] = 10
+
+        @njit
+        def set2return1(t):
+            t[2] = 20
+            return t[1]
+
+        t_1 = set2return1(t)
+        assert t_1 == 10
+        assert t[2] == 20
+
+    def test_getitem_complex_key(self):
+        spec = [('data', int32[:, :])]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                self.data = np.zeros((10, 10), dtype=np.int32)
+
+            def __setitem__(self, key, data):
+                self.data[int(key.real), int(key.imag)] = data
+
+            def __getitem__(self, key):
+                return self.data[int(key.real), int(key.imag)]
+
+        t = TestClass()
+        # save value 4 at position 3
+        t[complex(1, 1)] = 3
+
+        @njit
+        def get_key(t, real, imag):
+            return t[complex(real, imag)]
+        @njit
+        def set_key(t, real, imag, data):
+            t[complex(real, imag)] = data
+
+        assert get_key(t, 1, 1) == 3
+        set_key(t, 2, 2, 4)
+        assert t[complex(2, 2)] == 4
+
+    def test_getitem_tuple_key(self):
+        spec = [('data', int32[:, :])]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                self.data = np.zeros((10, 10), dtype=np.int32)
+
+            def __setitem__(self, key, data):
+                self.data[key[0], key[1]] = data
+
+            def __getitem__(self, key):
+                return self.data[key[0], key[1]]
+
+        t = TestClass()
+        t[1, 1] = 11
+
+        @njit
+        def get11(t):
+            return t[1, 1]
+
+        @njit
+        def set22(t, data):
+            t[2, 2] = data
+
+        assert get11(t) == 11
+        set22(t, 22)
+        assert t[2, 2] == 22
+
+    def test_getitem_slice_key(self):
+        spec = [('data', int32[:])]
+
+        @jitclass(spec)
+        class TestClass(object):
+            def __init__(self):
+                self.data = np.zeros(10, dtype=np.int32)
+
+            def __setitem__(self, slc, data):
+                self.data[slc.start] = data
+                self.data[slc.stop] = data + slc.step
+
+            def __getitem__(self, slc):
+                return self.data[slc.start]
+
+        t = TestClass()
+        # set t.data[1] = 1 and t.data[5] = 2
+        t[1:5:1] = 1
+
+        assert t[1:1:1] == 1
+        assert t[5:5:5] == 2
+
+        @njit
+        def get5(t):
+            return t[5:6:1]
+
+        assert get5(t) == 2
+
+        # sets t.data[2] = data, and t.data[6] = data + 1
+        @njit
+        def set26(t, data):
+            t[2:6:1] = data
+
+        set26(t, 2)
+        assert t[2:2:1] == 2
+        assert t[6:6:1] == 3
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -666,9 +666,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             return t[n]
 
         t = create_and_set_indices()
-        assert get_index(t, 1) == 1
-        assert get_index(t, 2) == 2
-        assert get_index(t, 3) == 3
+        self.assertEqual(get_index(t, 1), 1)
+        self.assertEqual(get_index(t, 2), 2)
+        self.assertEqual(get_index(t, 3), 3)
 
     def test_getitem_unbox(self):
         spec = [('data', int32[:])]
@@ -693,8 +693,8 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             return t[1]
 
         t_1 = set2return1(t)
-        assert t_1 == 10
-        assert t[2] == 20
+        self.assertEqual(t_1, 10)
+        self.assertEqual(t[2], 20)
 
     def test_getitem_complex_key(self):
         spec = [('data', int32[:, :])]
@@ -711,7 +711,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 return self.data[int(key.real), int(key.imag)]
 
         t = TestClass()
-        # save value 4 at position 3
+
         t[complex(1, 1)] = 3
 
         @njit
@@ -721,9 +721,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         def set_key(t, real, imag, data):
             t[complex(real, imag)] = data
 
-        assert get_key(t, 1, 1) == 3
+        self.assertEqual(get_key(t, 1, 1), 3)
         set_key(t, 2, 2, 4)
-        assert t[complex(2, 2)] == 4
+        self.assertEqual(t[complex(2, 2)], 4)
 
     def test_getitem_tuple_key(self):
         spec = [('data', int32[:, :])]
@@ -750,9 +750,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         def set22(t, data):
             t[2, 2] = data
 
-        assert get11(t) == 11
+        self.assertEqual(get11(t), 11)
         set22(t, 22)
-        assert t[2, 2] == 22
+        self.assertEqual(t[2, 2], 22)
 
     def test_getitem_slice_key(self):
         spec = [('data', int32[:])]
@@ -773,14 +773,14 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         # set t.data[1] = 1 and t.data[5] = 2
         t[1:5:1] = 1
 
-        assert t[1:1:1] == 1
-        assert t[5:5:5] == 2
+        self.assertEqual(t[1:1:1], 1)
+        self.assertEqual(t[5:5:5], 2)
 
         @njit
         def get5(t):
             return t[5:6:1]
 
-        assert get5(t) == 2
+        self.assertEqual(get5(t), 2)
 
         # sets t.data[2] = data, and t.data[6] = data + 1
         @njit
@@ -788,8 +788,8 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             t[2:6:1] = data
 
         set26(t, 2)
-        assert t[2:2:1] == 2
-        assert t[6:6:1] == 3
+        self.assertEqual(t[2:2:1], 2)
+        self.assertEqual(t[6:6:1], 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This rebase-fixups PR #3730 on master as of ~0.43.0, so as to get the original PR as a single patch. The code is then fixed up against current master to use the now overloadable `operator.setitem` and refactored to remove duplication. Flake 8 fixes are applied.
