### PR TITLE
Add assert to ir.py to help enforce correct structuring

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1183,7 +1183,7 @@ class ArrayAnalysis(object):
             if (isinstance(size_rel, int) or (isinstance(size_rel, tuple) and
                 equiv_set.is_equiv(size_rel[0], dsize.name))):
                 rel = size_rel if isinstance(size_rel, int) else size_rel[1]
-                size_val = ir.Const(rel, size_typ)
+                size_val = ir.Const(rel, loc=loc)
                 size_var = ir.Var(scope, mk_unique_var("slice_size"), loc)
                 self._define(equiv_set, size_var, size_typ, size_val)
 

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -532,10 +532,10 @@ class DelAttr(Stmt):
 
 class StoreMap(Stmt):
     def __init__(self, dct, key, value, loc):
-        assert instance(dct, Var)
-        assert instance(key, Var)
-        assert instance(value, Var)
-        assert instance(loc, Loc)
+        assert isinstance(dct, Var)
+        assert isinstance(key, Var)
+        assert isinstance(value, Var)
+        assert isinstance(loc, Loc)
         self.dct = dct
         self.key = key
         self.value = value

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -186,7 +186,7 @@ class VarMap(object):
 
 class AbstractRHS(object):
     """Abstract base class for anything that can be the RHS of an assignment.
-    This class **do not** define any methods.
+    This class **does not** define any methods.
     """
 
 

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -10,7 +10,7 @@ import re
 import sys
 import warnings
 import operator
-from types import FunctionType
+from types import FunctionType, BuiltinFunctionType
 
 from numba import config, errors
 from .utils import BINOPS_TO_OPERATORS, INPLACE_BINOPS_TO_OPERATORS, UNARY_BUITINS_TO_OPERATORS, OPERATORS_TO_BUILTINS
@@ -280,7 +280,7 @@ class Expr(Inst):
 
     @classmethod
     def binop(cls, fn, lhs, rhs, loc):
-        assert not isinstance(fn, str)
+        assert isinstance(fn, BuiltinFunctionType)
         assert isinstance(lhs, Var)
         assert isinstance(rhs, Var)
         assert isinstance(loc, Loc)
@@ -290,8 +290,8 @@ class Expr(Inst):
 
     @classmethod
     def inplace_binop(cls, fn, immutable_fn, lhs, rhs, loc):
-        assert not isinstance(fn, str)
-        assert not isinstance(immutable_fn, str)
+        assert isinstance(fn, BuiltinFunctionType)
+        assert isinstance(immutable_fn, BuiltinFunctionType)
         assert isinstance(lhs, Var)
         assert isinstance(rhs, Var)
         assert isinstance(loc, Loc)

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -820,12 +820,8 @@ class Var(AbstractRHS):
     """
 
     def __init__(self, scope, name, loc):
-        if scope is None:
-            # XXX: THIS SHOULD GO AWAY
-            import warnings
-            # warnings.warn("Var(scope=None, ...)")
-        else:
-            assert isinstance(scope, Scope)
+        # NOTE: Use of scope=None should be removed.
+        assert scope is None or isinstance(scope, Scope)
         assert isinstance(name, str)
         assert isinstance(loc, Loc)
         self.scope = scope

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -282,6 +282,7 @@ class Expr(Inst):
         assert not isinstance(fn, str)
         assert isinstance(lhs, Var)
         assert isinstance(rhs, Var)
+        assert isinstance(loc, Loc)
         op = 'binop'
         return cls(op=op, loc=loc, fn=fn, lhs=lhs, rhs=rhs,
                    static_lhs=UNDEFINED, static_rhs=UNDEFINED)
@@ -292,6 +293,7 @@ class Expr(Inst):
         assert not isinstance(immutable_fn, str)
         assert isinstance(lhs, Var)
         assert isinstance(rhs, Var)
+        assert isinstance(loc, Loc)
         op = 'inplace_binop'
         return cls(op=op, loc=loc, fn=fn, immutable_fn=immutable_fn,
                    lhs=lhs, rhs=rhs,
@@ -299,36 +301,41 @@ class Expr(Inst):
 
     @classmethod
     def unary(cls, fn, value, loc):
-        assert isinstance(fn, Var)
-        assert isinstance(value, Var)
+        assert isinstance(value, (str, Var)) or callable(fn)
+        assert isinstance(loc, Loc)
         op = 'unary'
         fn = UNARY_BUITINS_TO_OPERATORS.get(fn, fn)
         return cls(op=op, loc=loc, fn=fn, value=value)
 
     @classmethod
     def call(cls, func, args, kws, loc, vararg=None):
-        assert isinstance(func, Var)
+        assert isinstance(func, (Var, Intrinsic))
+        assert isinstance(loc, Loc)
         op = 'call'
         return cls(op=op, loc=loc, func=func, args=args, kws=kws,
                    vararg=vararg)
 
     @classmethod
     def build_tuple(cls, items, loc):
+        assert isinstance(loc, Loc)
         op = 'build_tuple'
         return cls(op=op, loc=loc, items=items)
 
     @classmethod
     def build_list(cls, items, loc):
+        assert isinstance(loc, Loc)
         op = 'build_list'
         return cls(op=op, loc=loc, items=items)
 
     @classmethod
     def build_set(cls, items, loc):
+        assert isinstance(loc, Loc)
         op = 'build_set'
         return cls(op=op, loc=loc, items=items)
 
     @classmethod
     def build_map(cls, items, size, loc):
+        assert isinstance(loc, Loc)
         op = 'build_map'
         return cls(op=op, loc=loc, items=items, size=size)
 
@@ -341,18 +348,21 @@ class Expr(Inst):
     @classmethod
     def pair_second(cls, value, loc):
         assert isinstance(value, Var)
+        assert isinstance(loc, Loc)
         op = 'pair_second'
         return cls(op=op, loc=loc, value=value)
 
     @classmethod
     def getiter(cls, value, loc):
         assert isinstance(value, Var)
+        assert isinstance(loc, Loc)
         op = 'getiter'
         return cls(op=op, loc=loc, value=value)
 
     @classmethod
     def iternext(cls, value, loc):
         assert isinstance(value, Var)
+        assert isinstance(loc, Loc)
         op = 'iternext'
         return cls(op=op, loc=loc, value=value)
 
@@ -360,6 +370,7 @@ class Expr(Inst):
     def exhaust_iter(cls, value, count, loc):
         assert isinstance(value, Var)
         assert isinstance(count, int)
+        assert isinstance(loc, Loc)
         op = 'exhaust_iter'
         return cls(op=op, loc=loc, value=value, count=count)
 
@@ -367,6 +378,7 @@ class Expr(Inst):
     def getattr(cls, value, attr, loc):
         assert isinstance(value, Var)
         assert isinstance(attr, str)
+        assert isinstance(loc, Loc)
         op = 'getattr'
         return cls(op=op, loc=loc, value=value, attr=attr)
 
@@ -374,6 +386,7 @@ class Expr(Inst):
     def getitem(cls, value, index, loc):
         assert isinstance(value, Var)
         assert isinstance(index, Var)
+        assert isinstance(loc, Loc)
         op = 'getitem'
         return cls(op=op, loc=loc, value=value, index=index)
 
@@ -381,6 +394,7 @@ class Expr(Inst):
     def static_getitem(cls, value, index, index_var, loc):
         assert isinstance(value, Var)
         assert index_var is None or isinstance(index_var, Var)
+        assert isinstance(loc, Loc)
         op = 'static_getitem'
         return cls(op=op, loc=loc, value=value, index=index,
                    index_var=index_var)
@@ -391,6 +405,7 @@ class Expr(Inst):
         A node for implicit casting at the return statement
         """
         assert isinstance(value, Var)
+        assert isinstance(loc, Loc)
         op = 'cast'
         return cls(op=op, value=value, loc=loc)
 
@@ -399,6 +414,7 @@ class Expr(Inst):
         """
         A node for making a function object.
         """
+        assert isinstance(loc, Loc)
         op = 'make_function'
         return cls(op=op, name=name, code=code, closure=closure, defaults=defaults, loc=loc)
 
@@ -543,7 +559,7 @@ class Raise(Terminator):
     is_exit = True
 
     def __init__(self, exception, loc):
-        assert isinstance(exception, Var)
+        assert exception is None or isinstance(exception, Var)
         assert isinstance(loc, Loc)
         self.exception = exception
         self.loc = loc

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -9,9 +9,10 @@ import pprint
 import re
 import sys
 import warnings
-from numba import config, errors
 import operator
+from types import FunctionType
 
+from numba import config, errors
 from .utils import BINOPS_TO_OPERATORS, INPLACE_BINOPS_TO_OPERATORS, UNARY_BUITINS_TO_OPERATORS, OPERATORS_TO_BUILTINS
 from .errors import (NotDefinedError, RedefinedError, VerificationError,
                      ConstantInferenceError)
@@ -301,7 +302,7 @@ class Expr(Inst):
 
     @classmethod
     def unary(cls, fn, value, loc):
-        assert isinstance(value, (str, Var)) or callable(fn)
+        assert isinstance(value, (str, Var, FunctionType))
         assert isinstance(loc, Loc)
         op = 'unary'
         fn = UNARY_BUITINS_TO_OPERATORS.get(fn, fn)
@@ -519,7 +520,7 @@ class SetAttr(Stmt):
 class DelAttr(Stmt):
     def __init__(self, target, attr, loc):
         assert isinstance(target, Var)
-        assert isinstance(attr, Var)
+        assert isinstance(attr, str)
         assert isinstance(loc, Loc)
         self.target = target
         self.attr = attr

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -3562,7 +3562,12 @@ def remove_dead_parfor_recursive(parfor, lives, arg_aliases, alias_map,
     return_label, tuple_var = _add_liveness_return_block(blocks, lives, typemap)
 
     # branch back to first body label to simulate loop
-    branch = ir.Branch(0, first_body_block, return_label, ir.Loc("parfors_dummy", -1))
+    scope = blocks[last_label].scope
+
+    branchcond = ir.Var(scope, mk_unique_var("$branchcond"), ir.Loc("parfors_dummy", -1))
+    typemap[branchcond.name] = types.boolean
+
+    branch = ir.Branch(branchcond, first_body_block, return_label, ir.Loc("parfors_dummy", -1))
     blocks[last_label].body.append(branch)
 
     # add dummy jump in init_block for CFG to work
@@ -3614,7 +3619,11 @@ def simplify_parfor_body_CFG(blocks):
                 # add dummy return to enable CFG creation
                 # can't use dummy_return_in_loop_body since body changes
                 last_block = parfor.loop_body[max(parfor.loop_body.keys())]
-                last_block.body.append(ir.Return(0, ir.Loc("parfors_dummy", -1)))
+                scope = last_block.scope
+                loc = ir.Loc("parfors_dummy", -1)
+                const = ir.Var(scope, mk_unique_var("$const"), loc)
+                last_block.body.append(ir.Assign(ir.Const(0, loc), const, loc))
+                last_block.body.append(ir.Return(const, loc))
                 parfor.loop_body = simplify_CFG(parfor.loop_body)
                 last_block = parfor.loop_body[max(parfor.loop_body.keys())]
                 last_block.body.pop()
@@ -3926,8 +3935,10 @@ def dummy_return_in_loop_body(loop_body):
     """
     # max is last block since we add it manually for prange
     last_label = max(loop_body.keys())
+    scope = loop_body[last_label].scope
+    const = ir.Var(scope, mk_unique_var("$const"), ir.Loc("parfors_dummy", -1))
     loop_body[last_label].body.append(
-        ir.Return(0, ir.Loc("parfors_dummy", -1)))
+        ir.Return(const, ir.Loc("parfors_dummy", -1)))
     yield
     # remove dummy return
     loop_body[last_label].body.pop()

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -338,8 +338,14 @@ class StencilPass(object):
 
         # simplify CFG of parfor body (exit block could be simplified often)
         # add dummy return to enable CFG
-        stencil_blocks[parfor_body_exit_label].body.append(ir.Return(0,
-                                            ir.Loc("stencilparfor_dummy", -1)))
+        dummy_loc = ir.Loc("stencilparfor_dummy", -1)
+        ret_const_var = ir.Var(scope, mk_unique_var("$cval_const"), dummy_loc)
+        cval_const_assign = ir.Assign(ir.Const(0, loc=dummy_loc), ret_const_var, dummy_loc)
+        stencil_blocks[parfor_body_exit_label].body.append(cval_const_assign)
+
+        stencil_blocks[parfor_body_exit_label].body.append(
+            ir.Return(ret_const_var, dummy_loc),
+        )
         stencil_blocks = ir_utils.simplify_CFG(stencil_blocks)
         stencil_blocks[max(stencil_blocks.keys())].body.pop()
 

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -143,7 +143,7 @@ class TestInlining(TestCase):
                         and guard(find_const, func_ir, stmt.value) == 2):
                     # replace expr with a dummy call
                     func_ir._definitions[stmt.target.name].remove(stmt.value)
-                    stmt.value = ir.Expr.call(None, (), (), stmt.loc)
+                    stmt.value = ir.Expr.call(ir.Var(block.scope, "myvar", loc=stmt.loc), (), (), stmt.loc)
                     func_ir._definitions[stmt.target.name].append(stmt.value)
                     #func = g.py_func#
                     inline_closure_call(func_ir, {}, block, i, lambda: 2)


### PR DESCRIPTION
* Add assert checks for IR structure to prevent errors.
* Fixed several errors
* Letting `ir.Var(scope=None, ...)` slide in this PR.  Fixing it is a lot more involved.