### PR TITLE
Prevent mutation of objmode fallback IR.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -328,7 +328,6 @@ exclude =
     numba/tests/test_hashing.py
     numba/tests/test_itanium_mangler.py
     numba/tests/test_sys_stdin_assignment.py
-    numba/tests/test_closure.py
     numba/tests/test_dispatcher.py
     numba/tests/test_ufuncs.py
     numba/tests/pdlike_usecase.py

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -402,9 +402,6 @@ class BasePipeline(object):
     def stage_process_ir(self):
         ir_processing_stage(self.func_ir)
 
-    def stage_preserve_ir(self):
-        self.func_ir_original = copy.deepcopy(self.func_ir)
-
     def frontend_looplift(self):
         """
         Loop lifting analysis and transformation
@@ -457,7 +454,6 @@ class BasePipeline(object):
         """
         Front-end: Analyze bytecode, generate Numba IR, infer types
         """
-        self.func_ir = self.func_ir_original or self.func_ir
         if self.flags.enable_looplift:
             assert not self.lifted
             cres = self.frontend_looplift()
@@ -780,9 +776,6 @@ class BasePipeline(object):
         The current stages contain type-agnostic rewrite passes.
         """
         if not self.flags.no_rewrites:
-            if self.status.can_fallback:
-                pm.add_stage(self.stage_preserve_ir,
-                             "preserve IR for fallback")
             pm.add_stage(self.stage_generic_rewrites, "nopython rewrites")
             pm.add_stage(self.stage_dead_branch_prune, "dead branch pruning")
         pm.add_stage(self.stage_inline_pass,

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -981,7 +981,7 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
         # original flags, IR might get broken but we've got a CompileResult
         # that's usable from above.
         rw_cres = None
-        if flags.no_rewrites is False:
+        if not flags.no_rewrites:
             try:
                 rw_cres = compile_local(func_ir.copy(), flags)
             except Exception:

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -965,8 +965,7 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
         # 4. If 3 was successful, use the result, else use 2.
 
         # create flags with no rewrites
-        from copy import deepcopy
-        norw_flags = deepcopy(flags)
+        norw_flags = copy.deepcopy(flags)
         norw_flags.no_rewrites = True
 
         def compile_local(the_ir, the_flags):

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -941,18 +941,66 @@ def compile_extra(typingctx, targetctx, func, args, return_type, flags,
 
 
 def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
-               locals, lifted=(), lifted_from=None, library=None,
-               pipeline_class=Pipeline):
+               locals, lifted=(), lifted_from=None, is_lifted_loop=False,
+               library=None, pipeline_class=Pipeline):
     """
     Compile a function with the given IR.
 
     For internal use only.
     """
 
-    pipeline = pipeline_class(typingctx, targetctx, library,
-                              args, return_type, flags, locals)
-    return pipeline.compile_ir(func_ir=func_ir, lifted=lifted,
-                               lifted_from=lifted_from)
+    # This is a special branch that should only run on IR from a lifted loop
+    if is_lifted_loop:
+        # This code is pessimistic and costly, but it is a not often trodden
+        # path and it will go away once IR is made immutable. The problem is
+        # that the rewrite passes can mutate the IR into a state that makes
+        # it possible for invalid tokens to be transmitted to lowering which
+        # then trickle through into LLVM IR and causes RuntimeErrors as LLVM
+        # cannot compile it. As a result the following approach is taken:
+        # 1. Create some new flags that copy the original ones but switch
+        #    off rewrites.
+        # 2. Compile with 1. to get a compile result
+        # 3. Try and compile another compile result but this time with the
+        #    original flags (and IR being rewritten).
+        # 4. If 3 was successful, use the result, else use 2.
+
+        # create flags with no rewrites
+        from copy import deepcopy
+        norw_flags = deepcopy(flags)
+        norw_flags.no_rewrites = True
+
+        def compile_local(the_ir, the_flags):
+            pipeline = pipeline_class(typingctx, targetctx, library,
+                                      args, return_type, the_flags, locals)
+            return pipeline.compile_ir(func_ir=the_ir, lifted=lifted,
+                                       lifted_from=lifted_from)
+
+        # compile with rewrites off, IR shouldn't be mutated irreparably
+        norw_cres = compile_local(func_ir.copy(), norw_flags)
+
+        # try and compile with rewrites on if no_rewrites was not set in the
+        # original flags, IR might get broken but we've got a CompileResult
+        # that's usable from above.
+        rw_cres = None
+        if flags.no_rewrites is False:
+            try:
+                rw_cres = compile_local(func_ir.copy(), flags)
+            except Exception:
+                pass
+
+        # if the rewrite variant of compilation worked, use it, else use
+        # the norewrites backup
+        if rw_cres is not None:
+            cres = rw_cres
+        else:
+            cres = norw_cres
+        return cres
+
+    else:
+        pipeline = pipeline_class(typingctx, targetctx, library,
+                                  args, return_type, flags, locals)
+        return pipeline.compile_ir(func_ir=func_ir, lifted=lifted,
+                                lifted_from=lifted_from)
 
 
 def compile_internal(typingctx, targetctx, library,

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -237,11 +237,11 @@ class _PipelineManager(object):
     def run(self, status):
         assert self._finalized, "PM must be finalized before run()"
         for pipeline_name in self.pipeline_order:
-            event(pipeline_name)
+            event("Pipeline: %s" % pipeline_name)
             is_final_pipeline = pipeline_name == self.pipeline_order[-1]
             for stage, stage_name in self.pipeline_stages[pipeline_name]:
                 try:
-                    event(stage_name)
+                    event("-- %s" % stage_name)
                     stage()
                 except _EarlyPipelineCompletion as e:
                     return e.result
@@ -286,7 +286,6 @@ class BasePipeline(object):
         self.bc = None
         self.func_id = None
         self.func_ir = None
-        self.func_ir_original = None  # used for fallback
         self.lifted = None
         self.lifted_from = None
         self.typemap = None

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -763,50 +763,16 @@ class LiftedCode(_DispatcherBase):
 
             self._pre_compile(args, return_type, flags)
 
-            # This code is pessimistic and costly, but it is a not often trodden
-            # path and it will go away once IR is made immutable. The problem is
-            # that the rewrite passes can mutate the IR into a state that makes
-            # it possible for invalid tokens to be transmitted to lowering which
-            # then trickle through into LLVM IR and causes RuntimeErrors as LLVM
-            # cannot compile it. As a result the following approach is taken:
-            # 1. Create some new flags that copy the original ones but switch
-            #    off rewrites.
-            # 2. Compile with 1. to get a compile result
-            # 3. Try and compile another compile result but this time with the
-            #    original flags (and IR being rewritten).
-            # 4. If 3 was successful, use the result, else use 2.
-            # create flags with no rewrites
-            norw_flags = deepcopy(flags)
-            norw_flags.no_rewrites = True
-
-            def compile_local(the_ir, the_flags):
-                return compiler.compile_ir(typingctx=self.typingctx,
-                                        targetctx=self.targetctx,
-                                        func_ir=the_ir,
-                                        args=args, return_type=return_type,
-                                        flags=the_flags, locals=self.locals,
-                                        lifted=(),
-                                        lifted_from=self.lifted_from)
-
-            # compile with rewrites off, IR shouldn't be mutated irreparably
-            norw_cres = compile_local(self.func_ir.copy(), norw_flags)
-
-            # try and compile with rewrites on if no_rewrites was not set in the
-            # original flags, IR might get broken but we've got a CompileResult
-            # that's usable from above.
-            rw_cres = None
-            if flags.no_rewrites is False:
-                try:
-                    rw_cres = compile_local(self.func_ir.copy(), flags)
-                except Exception:
-                    pass
-
-            # if the rewrite variant of compilation worked, use it, else use
-            # the norewrites backup
-            if rw_cres is not None:
-                cres = rw_cres
-            else:
-                cres = norw_cres
+            # Clone IR to avoid (some of the) mutation in the rewrite pass
+            cloned_func_ir = self.func_ir.copy()
+            cres = compiler.compile_ir(typingctx=self.typingctx,
+                                       targetctx=self.targetctx,
+                                       func_ir=cloned_func_ir,
+                                       args=args, return_type=return_type,
+                                       flags=flags, locals=self.locals,
+                                       lifted=(),
+                                       lifted_from=self.lifted_from,
+                                       is_lifted_loop=True,)
 
             # Check typing error if object mode is used
             if cres.typing_error is not None and not flags.enable_pyobject:

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -45,11 +45,12 @@ class InlineClosureCallPass(object):
     closures, and inlines the body of the closure function to the call site.
     """
 
-    def __init__(self, func_ir, parallel_options, swapped={}):
+    def __init__(self, func_ir, parallel_options, swapped={}, typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
         self.swapped = swapped
         self._processed_stencils = []
+        self.typed = typed
 
     def run(self):
         """Run inline closure call pass.
@@ -97,7 +98,8 @@ class InlineClosureCallPass(object):
             for k, s in sorted(sized_loops, key=lambda tup: tup[1], reverse=True):
                 visited.append(k)
                 if guard(_inline_arraycall, self.func_ir, cfg, visited, loops[k],
-                         self.swapped, self.parallel_options.comprehension):
+                         self.swapped, self.parallel_options.comprehension,
+                         self.typed):
                     modified = True
             if modified:
                 _fix_nested_array(self.func_ir)
@@ -532,7 +534,8 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     else:
         raise GuardException
 
-def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False):
+def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
+                      typed=False):
     """Look for array(list) call in the exit block of a given loop, and turn list operations into
     array operations in the loop if the following conditions are met:
       1. The exit block contains an array call on the list;
@@ -677,10 +680,16 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False)
             range_func_def.value = internal_prange
 
     else:
-        len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
-        stmts.append(_new_definition(func_ir, len_func_var,
-                     ir.Global('range_iter_len', range_iter_len, loc=loc), loc))
-        size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
+        # this doesn't work in objmode as it's effectively untyped
+        if typed:
+            len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
+            stmts.append(_new_definition(func_ir, len_func_var,
+                        ir.Global('range_iter_len', range_iter_len, loc=loc),
+                        loc))
+            size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
+        else:
+            raise GuardException
+
 
     stmts.append(_new_definition(func_ir, size_var, size_val, loc))
 
@@ -702,11 +711,16 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False)
                          ir.Global('empty', np.empty, loc=loc), loc))
         array_kws = [('dtype', dtype_var)]
     else:
-        # otherwise we'll call unsafe_empty_inferred
-        stmts.append(_new_definition(func_ir, empty_func,
-                         ir.Global('unsafe_empty_inferred',
-                             unsafe_empty_inferred, loc=loc), loc))
-        array_kws = []
+        # this doesn't work in objmode as it's effectively untyped
+        if typed:
+            # otherwise we'll call unsafe_empty_inferred
+            stmts.append(_new_definition(func_ir, empty_func,
+                            ir.Global('unsafe_empty_inferred',
+                                unsafe_empty_inferred, loc=loc), loc))
+            array_kws = []
+        else:
+            raise GuardException
+
     # array_var = empty_func(size_tuple_var)
     stmts.append(_new_definition(func_ir, array_var,
                  ir.Expr.call(empty_func, (size_tuple_var,), list(array_kws), loc=loc), loc))

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -491,7 +491,11 @@ class TestObjmodeFallback(TestCase):
             return intercept, coefs
 
         for d in self.decorators:
-            d(fit)(np.arange(10).reshape(1, 10), np.arange(10).reshape(1, 10))
+            res = d(fit)(np.arange(10).reshape(1, 10),
+                         np.arange(10).reshape(1, 10))
+            exp = fit(np.arange(10).reshape(1, 10),
+                      np.arange(10).reshape(1, 10))
+            np.testing.assert_equal(res, exp)
 
     def test_issue3289(self):
         b = [(5, 124), (52, 5)]
@@ -516,7 +520,8 @@ class TestObjmodeFallback(TestCase):
 
         data = {'x': np.arange(5), 'y': [[1], [2, 3]]}
         for d in self.decorators:
-            d(foo)(data)
+            res = d(foo)(data)
+            np.testing.assert_allclose(res, foo(data))
 
     def test_issue3659(self):
 
@@ -524,7 +529,8 @@ class TestObjmodeFallback(TestCase):
             a = np.array(((1, 2), (3, 4)))
             return np.array([x for x in a])
         for d in self.decorators:
-            d(main)()
+            res = d(main)()
+            np.testing.assert_allclose(res, main())
 
     def test_issue3803(self):
 
@@ -535,7 +541,8 @@ class TestObjmodeFallback(TestCase):
 
         X = np.zeros((10,))
         for d in self.decorators:
-            d(center)(X)
+            res = d(center)(X)
+            np.testing.assert_allclose(res, center(X))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -532,6 +532,30 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         # Ensure that is really a new overload for the lifted loop
         self.assertEqual(len(lifted.signatures), 2)
 
+    def test_lift_listcomp_block0(self):
+
+        def foo(X):
+            [y for y in (1,)]
+            for x in (1,):
+                pass
+            return X
+
+        # this is not nice, if you have 2+? liftable loops with one of them
+        # being list comp and in block 0 and force objmode compilation is set,
+        # in py27 this leads to a BUILD_LIST that is a lifting candidate with an
+        # entry of block 0, this is a problem as the loop lift prelude would be
+        # written to block -1 and havoc ensues. Therefore block 0 loop lifts
+        # are banned under this set of circumstances.
+
+        # check all compile and execute
+        from numba import jit
+        f = jit()(foo)
+        f(1)
+        self.assertEqual(f.overloads[f.signatures[0]].lifted, ())
+
+        f = jit(forceobj=True)(foo)
+        f(1)
+        self.assertEqual(len(f.overloads[f.signatures[0]].lifted), 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -306,7 +306,9 @@ def get_optimized_numba_ir(test_func, args, **kws):
         typingctx.refresh()
         targetctx.refresh()
 
-        inline_pass = inline_closurecall.InlineClosureCallPass(tp.func_ir, options)
+        inline_pass = inline_closurecall.InlineClosureCallPass(tp.func_ir,
+                                                               options,
+                                                               typed=True)
         inline_pass.run()
 
         numba.rewrites.rewrite_registry.apply(

--- a/numba/transforms.py
+++ b/numba/transforms.py
@@ -49,7 +49,7 @@ def _extract_loop_lifting_candidates(cfg, blocks):
     candidates = []
     for loop in find_top_level_loops(cfg):
         if (same_exit_point(loop) and one_entry(loop) and cannot_yield(loop) and
-            cfg.entry_point not in loop.entries):
+            cfg.entry_point() not in loop.entries):
             candidates.append(loop)
     return candidates
 

--- a/numba/transforms.py
+++ b/numba/transforms.py
@@ -86,6 +86,11 @@ def _loop_lift_get_candidate_infos(cfg, blocks, livemap):
     loops = _extract_loop_lifting_candidates(cfg, blocks)
     loopinfos = []
     for loop in loops:
+        # this is to prevent a bad rewrite where a prelude for a lifted
+        # loop would get written into block -1 if a loop entry were in block 0
+        if 0 in loop.entries:
+            continue
+
         [callfrom] = loop.entries   # requirement checked earlier
         an_exit = next(iter(loop.exits))  # anyone of the exit block
         [(returnto, _)] = cfg.successors(an_exit)  # requirement checked earlier


### PR DESCRIPTION
As title. This prevents the mutation of the IR used in the objmode
fall back compilation pipeline by simply regenerating it from the
original function source. It also removes an invalid array inlining
behaviour that was occurring in object mode. The new tests hit
the branches in array inlining where no type information is
present, the existing tests hit the branches where type
information is present.

Fixes #2955
Fixes #3239
Fixes #3289
Fixes #3413
Fixes #3659
Fixes #3803

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
