### PR TITLE
Add support for np.delete

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -281,6 +281,7 @@ The following top-level functions are supported:
   SciPy >= 0.16; extreme value handling per NumPy 1.11+)
 * :func:`numpy.correlate` (only the 2 first arguments)
 * :func:`numpy.cov` (only the 5 first arguments, requires NumPy >= 1.10 and SciPy >= 0.16)
+* :func:`numpy.delete` (only the 2 first arguments)
 * :func:`numpy.diag`
 * :func:`numpy.digitize`
 * :func:`numpy.dstack`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2350,7 +2350,7 @@ def np_delete(arr, obj):
     # https://github.com/numpy/numpy/blob/af66e487a57bfd4850f4306e3b85d1dac3c70412/numpy/lib/function_base.py#L4065-L4267
 
     if not isinstance(arr, (types.Array, types.Sequence)):
-        raise TypingError("delete(): arr must be either an Array or a Sequence")
+        raise TypingError("arr must be either an Array or a Sequence")
 
     def np_delete_impl(arr, obj):
         arr = np.ravel(np.asarray(arr))
@@ -2369,7 +2369,7 @@ def np_delete(arr, obj):
         pos = obj
 
         if (pos < -N or pos >= N):
-            raise IndexError('delete(): pos must be less than the len(arr)')
+            raise IndexError('pos must be less than the len(arr)')
             # NumPy raises IndexError: index 'i' is out of
             # bounds for axis 'x' with size 'n'
 
@@ -2382,7 +2382,7 @@ def np_delete(arr, obj):
         return np_delete_impl
     else: # scalar value
         if not isinstance(obj, types.Integer):
-            raise TypingError('delete(): obj should be of type Integer')
+            raise TypingError('obj should be of type Integer')
 
         return np_delete_scalar_impl
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2793,43 +2793,44 @@ def np_delete(arr, obj):
     if not isinstance(arr, (types.Array, types.Sequence)):
         raise TypingError("arr must be either an Array or a Sequence")
 
-    def np_delete_impl(arr, obj):
-        arr = np.ravel(np.asarray(arr))
-        N = arr.size
-
-        keep = np.ones(N, dtype=np.bool_)
-        obj = handler(obj)
-        keep[obj] = False
-        return arr[keep]
-
-    def np_delete_scalar_impl(arr, obj):
-        arr = np.ravel(np.asarray(arr))
-        N = arr.size
-        pos = obj
-
-        if (pos < -N or pos >= N):
-            raise IndexError('obj must be less than the len(arr)')
-            # NumPy raises IndexError: index 'i' is out of
-            # bounds for axis 'x' with size 'n'
-
-        if (pos < 0):
-            pos += N
-
-        return np.concatenate((arr[:pos], arr[pos+1:]))
-
     if isinstance(obj, (types.Array, types.Sequence, types.SliceType)):
         if isinstance(obj, (types.SliceType)):
             handler = np_delete_handler_isslice 
         else:
             if not isinstance(obj.dtype, types.Integer):
                 raise TypingError('obj should be of Integer dtype')
-            handler = np_delete_handler_isarray 
+            handler = np_delete_handler_isarray
 
+        def np_delete_impl(arr, obj):
+            arr = np.ravel(np.asarray(arr))
+            N = arr.size
+
+            keep = np.ones(N, dtype=np.bool_)
+            obj = handler(obj)
+            keep[obj] = False
+            return arr[keep]
         return np_delete_impl
+
     else: # scalar value
         if not isinstance(obj, types.Integer):
             raise TypingError('obj should be of Integer dtype')
+
+        def np_delete_scalar_impl(arr, obj):
+            arr = np.ravel(np.asarray(arr))
+            N = arr.size
+            pos = obj
+
+            if (pos < -N or pos >= N):
+                raise IndexError('obj must be less than the len(arr)')
+                # NumPy raises IndexError: index 'i' is out of
+                # bounds for axis 'x' with size 'n'
+
+            if (pos < 0):
+                pos += N
+
+            return np.concatenate((arr[:pos], arr[pos+1:]))
         return np_delete_scalar_impl
+
 
 @overload(np.diff)
 def np_diff_impl(a, n=1):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2344,6 +2344,47 @@ def np_imag(a):
 #----------------------------------------------------------------------------
 # Misc functions
 
+@overload(np.delete)
+def np_delete(a, obj, axis=None):
+    # Implementation based on numpy
+    # https://github.com/numpy/numpy/blob/v1.15.1/numpy/lib/function_base.py#L4065-L4267 
+
+    if not isinstance(a, types.Array):
+        raise ValueError("'arr' must be an array")
+
+    if isinstance(obj, (types.Array, types.Sequence)):
+        def np_delete_impl(a, obj, axis=None):
+            if (axis is None):
+                arr = np.ravel(a)
+
+            N = arr.size
+
+            keep = np.ones(N, dtype=np.bool_)
+            obj = np.array(obj)
+            keep[obj] = False
+            return arr[keep]
+
+    else: # scalar value
+        def np_delete_impl(a, obj, axis=None):
+            if (axis is None):
+                arr = np.ravel(a)
+
+            N = arr.size
+            pos = obj.item()
+
+            if (pos < -N or pos >= N):
+                msg = 'Index is out of bounds'
+                raise ValueError(msg)
+                # NumPy raises IndexError: index 'i' is out of
+                # bounds for axis 'x' with size 'n'
+
+            if (pos < 0):
+                pos += N
+
+            return np.concatenate((arr[:pos], arr[pos+1:]))
+
+    return np_delete_impl
+
 @overload(np.diff)
 def np_diff_impl(a, n=1):
     if not isinstance(a, types.Array) or a.ndim == 0:

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2782,6 +2782,9 @@ def np_imag(a):
 #----------------------------------------------------------------------------
 # Misc functions
 
+np_delete_handler_isslice = register_jitable(lambda x : x)
+np_delete_handler_isarray = register_jitable(lambda x : np.asarray(x))
+
 @overload(np.delete)
 def np_delete(arr, obj):
     # Implementation based on numpy
@@ -2816,11 +2819,11 @@ def np_delete(arr, obj):
 
     if isinstance(obj, (types.Array, types.Sequence, types.SliceType)):
         if isinstance(obj, (types.SliceType)):
-            handler = register_jitable(lambda x : x)
+            handler = np_delete_handler_isslice 
         else:
             if not isinstance(obj.dtype, types.Integer):
                 raise TypingError('obj should be of Integer dtype')
-            handler = register_jitable(lambda x : np.asarray(x))
+            handler = np_delete_handler_isarray 
 
         return np_delete_impl
     else: # scalar value

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2344,9 +2344,6 @@ def np_imag(a):
 #----------------------------------------------------------------------------
 # Misc functions
 
-np_delete_handler_isslice = register_jitable(lambda x : x)
-np_delete_handler_isarray = register_jitable(lambda x : np.asarray(x))
-
 @overload(np.delete)
 def np_delete(arr, obj):
     # Implementation based on numpy
@@ -2381,16 +2378,16 @@ def np_delete(arr, obj):
 
     if isinstance(obj, (types.Array, types.Sequence, types.SliceType)):
         if isinstance(obj, (types.SliceType)):
-            handler = np_delete_handler_isslice
+            handler = register_jitable(lambda x : x)
         else:
             if not isinstance(obj.dtype, types.Integer):
                 raise TypingError('obj should be of Integer dtype')
-            handler = np_delete_handler_isarray
+            handler = register_jitable(lambda x : np.asarray(x))
 
         return np_delete_impl
     else: # scalar value
         if not isinstance(obj, types.Integer):
-            raise TypingError('obj should be of type Integer')
+            raise TypingError('obj should be of Integer dtype')
         return np_delete_scalar_impl
 
 @overload(np.diff)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2384,7 +2384,7 @@ def np_delete(arr, obj):
             handler = np_delete_handler_isslice
         else:
             if not isinstance(obj.dtype, types.Integer):
-                raise TypingError('obj should be of type Integer')
+                raise TypingError('obj should be of Integer dtype')
             handler = np_delete_handler_isarray
 
         return np_delete_impl

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2354,7 +2354,6 @@ def np_delete(arr, obj):
 
     def np_delete_impl(arr, obj):
         arr = np.ravel(np.asarray(arr))
-
         N = arr.size
 
         keep = np.ones(N, dtype=np.bool_)
@@ -2364,7 +2363,6 @@ def np_delete(arr, obj):
 
     def np_delete_scalar_impl(arr, obj):
         arr = np.ravel(np.asarray(arr))
-
         N = arr.size
         pos = obj
 
@@ -2378,15 +2376,22 @@ def np_delete(arr, obj):
 
         return np.concatenate((arr[:pos], arr[pos+1:]))
 
-    if isinstance(obj, (types.Array, types.Sequence)):
+    def np_delete_slice_impl(arr, obj):
+        arr = np.ravel(np.asarray(arr))
+        N = arr.size
+
+        keep = np.ones(N, dtype=np.bool_)
+        keep[obj] = False
+        return arr[keep]
+
+    if isinstance(obj, (types.SliceType)):
+        return np_delete_slice_impl
+    elif isinstance(obj, (types.Array, types.Sequence)):
         return np_delete_impl
     else: # scalar value
         if not isinstance(obj, types.Integer):
             raise TypingError('obj should be of type Integer')
-
         return np_delete_scalar_impl
-
-    return np_delete_impl
 
 @overload(np.diff)
 def np_diff_impl(a, n=1):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -29,6 +29,9 @@ def angle1(x):
 def angle2(x, deg):
     return np.angle(x, deg)
 
+def delete(a, obj, axis=None):
+    return np.delete(a, obj, axis)
+
 def diff1(a):
     return np.diff(a)
 
@@ -295,6 +298,34 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x_values = np.array(x_values)
         x_types = [types.complex64, types.complex128]
         check(x_types, x_values)
+
+    def test_delete(self):
+
+        def arrays():
+            # array, obj, axis
+            # 
+            # 1d array, scalar, None
+            yield np.arange(10), 3, None
+            yield np.arange(10), -3, None # Negative obj
+            # 1d array, list, None
+            yield np.arange(10), [3, 5, 6], None
+            yield np.arange(10), [2, 3, 4, 5], None
+            # 3d array, scalar, None
+            yield np.arange(3 * 4 * 5).reshape(3, 4, 5), 2, None
+            # 3d array, list, None
+            yield np.arange(3 * 4 * 5).reshape(3, 4, 5), [5, 30, 27, 8], None
+            #
+            # yield np.arange(5 * 2).reshape(5, 2), 2, 0
+
+        pyfunc = delete
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for a, obj, axis in arrays():
+            expected = pyfunc(a, obj, axis)
+            got = cfunc(a, obj, axis)
+            # print(expected)
+            # print(got)
+            self.assertPreciseEqual(expected, got)
 
     def diff_arrays(self):
         """

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -328,24 +328,29 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(arr, obj)
             self.assertPreciseEqual(expected, got)
 
+    def test_delete_exceptions(self):
+        pyfunc = delete
+        cfunc = jit(nopython=True)(pyfunc)
+        self.disable_leak_check()
+
         with self.assertRaises(TypingError) as raises:
             cfunc([1, 2], 3.14)
         self.assertIn(
-            'delete(): obj should be of type Integer',
+            'obj should be of type Integer',
             str(raises.exception)
         )
 
         with self.assertRaises(TypingError) as raises:
             cfunc(2, 3)
         self.assertIn(
-            'delete(): arr must be either an Array or a Sequence',
+            'arr must be either an Array or a Sequence',
             str(raises.exception)
         )
 
         with self.assertRaises(IndexError) as raises:
             cfunc([1, 2], 3)
         self.assertIn(
-            'delete(): pos must be less than the len(arr)',
+            'pos must be less than the len(arr)',
             str(raises.exception),
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -344,7 +344,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(10), [3.5, 5.6, 6.2])
         self.assertIn(
-            'obj should be of type Integer',
+            'obj should be of Integer dtype',
             str(raises.exception)
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -337,7 +337,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc([1, 2], 3.14)
         self.assertIn(
-            'obj should be of type Integer',
+            'obj should be of Integer dtype',
             str(raises.exception)
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -29,8 +29,8 @@ def angle1(x):
 def angle2(x, deg):
     return np.angle(x, deg)
 
-def delete(a, obj):
-    return np.delete(a, obj)
+def delete(arr, obj):
+    return np.delete(arr, obj)
 
 def diff1(a):
     return np.diff(a)
@@ -318,7 +318,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             # 3d array, list
             yield np.arange(3 * 4 * 5).reshape(3, 4, 5), [5, 30, 27, 8]
             # slices
-            # yield [1, 2, 3, 4], slice(1, 3, 1)
+            yield [1, 2, 3, 4], slice(1, 3, 1)
+            yield np.arange(10), slice(10)
 
         pyfunc = delete
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -323,8 +323,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         for a, obj, axis in arrays():
             expected = pyfunc(a, obj, axis)
             got = cfunc(a, obj, axis)
-            # print(expected)
-            # print(got)
             self.assertPreciseEqual(expected, got)
 
     def diff_arrays(self):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -342,6 +342,13 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         )
 
         with self.assertRaises(TypingError) as raises:
+            cfunc(np.arange(10), [3.5, 5.6, 6.2])
+        self.assertIn(
+            'obj should be of type Integer',
+            str(raises.exception)
+        )
+
+        with self.assertRaises(TypingError) as raises:
             cfunc(2, 3)
         self.assertIn(
             'arr must be either an Array or a Sequence',
@@ -351,7 +358,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(IndexError) as raises:
             cfunc([1, 2], 3)
         self.assertIn(
-            'pos must be less than the len(arr)',
+            'obj must be less than the len(arr)',
             str(raises.exception),
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -342,12 +342,12 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
-        # with self.assertRaises(IndexError) as raises:
-        #     cfunc([1, 2], 3)
-        # self.assertIn(
-        #     'delete():',
-        #     str(raises.exception),
-        # )
+        with self.assertRaises(IndexError) as raises:
+            cfunc([1, 2], 3)
+        self.assertIn(
+            'delete(): pos must be less than the len(arr)',
+            str(raises.exception),
+        )
 
     def diff_arrays(self):
         """

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -31,8 +31,10 @@ def angle1(x):
 def angle2(x, deg):
     return np.angle(x, deg)
 
+
 def delete(arr, obj):
     return np.delete(arr, obj)
+
 
 def diff1(a):
     return np.diff(a)
@@ -348,7 +350,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         def arrays():
             # array, obj
-            # 
+            #
             # an array-like type
             yield [1, 2, 3, 4, 5], 3
             yield [1, 2, 3, 4, 5], [2, 3]


### PR DESCRIPTION
WIP: adding `np.delete` support to Numba. Fixes #3854 

Currently, the implementation only works with the first two parameters: `np.delete(array, obj)`. I will work soon to add support for the `axis` parameter.