### PR TITLE
Fix casting in namedtuple ctor.

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1401,7 +1401,7 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
                 if hasattr(callee_def.value, key):
                     value = getattr(callee_def.value, key)
                     break
-            if not isinstance(value, str):
+            if not value or not isinstance(value, str):
                 raise GuardException
             attrs.append(value)
             def_val = callee_def.value

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1401,7 +1401,7 @@ def find_callname(func_ir, expr, typemap=None, definition_finder=get_definition)
                 if hasattr(callee_def.value, key):
                     value = getattr(callee_def.value, key)
                     break
-            if not value:
+            if not isinstance(value, str):
                 raise GuardException
             attrs.append(value)
             def_val = callee_def.value

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -17,7 +17,14 @@ from ..extending import overload_method
 @lower_builtin(types.NamedTupleClass, types.VarArg(types.Any))
 def namedtuple_constructor(context, builder, sig, args):
     # A namedtuple has the same representation as a regular tuple
-    res = context.make_tuple(builder, sig.return_type, args)
+    # the arguments need casting (lower_cast) from the types in the ctor args
+    # to those in the ctor return type, this is to handle cases such as a
+    # literal present in the args, but a type present in the return type.
+    newargs = []
+    for i, arg in enumerate(args):
+        casted = context.cast(builder, arg, sig.args[i], sig.return_type[i])
+        newargs.append(casted)
+    res = context.make_tuple(builder, sig.return_type, tuple(newargs))
     # The tuple's contents are borrowed
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -474,6 +474,17 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
         r = call(123, 0)
         self.assertEqual(r, Rect(width=123, height=-321))
 
+    @unittest.skipIf(utils.PYVERSION < (3, 0), "needs Python 3")
+    def test_string_literal_in_ctor(self):
+        # Test for issue #3813
+
+        @jit(nopython=True)
+        def foo():
+            return Rect(10, 'somestring')
+
+        r = foo()
+        self.assertEqual(r, Rect(width=10, height='somestring'))
+
 
 class TestTupleNRT(TestCase, MemoryLeakMixin):
     def test_tuple_add(self):


### PR DESCRIPTION
As title, sorts out literals in ctor args but types
in the ctor return type. Also fixes a bug in closure
inlining which incorrectly assumes a value is a string.

Fixes #3813

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
