### PR TITLE
Fix array inliner for multiple array definition.

### DIFF
--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -794,7 +794,7 @@ def _fix_nested_array(func_ir):
             arr = numba.unsafe.ndarray.empty_inferred(...).
         If it is arr = b[...], find array definition of b recursively.
         """
-        arr_def = func_ir.get_definition(arr)
+        arr_def = get_definition(func_ir, arr)
         _make_debug_print("find_array_def")(arr, arr_def)
         if isinstance(arr_def, ir.Expr):
             if guard(_find_unsafe_empty_inferred, func_ir, arr_def):

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -503,5 +503,22 @@ class TestArrayComprehension(unittest.TestCase):
             return a
         self.check(f, 5, assert_allocate_list=True)
 
+    def test_reuse_of_array_var(self):
+        """ Test issue 3742 """
+        # redefinition of z breaks array comp as there's multiple defn
+        def foo(n):
+            # doesn't matter where this is in the code, it's just to ensure a
+            # `make_function` opcode exists
+            [i for i in range(1)]
+            z = np.empty(n)
+            for i in range(n):
+                z = np.zeros(n)
+                z[i] = i # write is required to trip the bug
+
+            return z
+
+        self.check(foo, 10, assert_allocate_list=True)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title. Uses safe `ir_utils.get_definition()` to ensure array
inliner bails appropriately if there's a situation it can't handle
e.g. redefinition of array var.

Fixes #3742

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
