### PR TITLE
Adds `.nbytes` property to CUDA device array objects.

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -333,10 +333,10 @@ class DeviceNDArrayBase(object):
 
     @property
     def nbytes(self):
-        if hasattr(self, 'alloc_size'):
-            return self.alloc_size
-        else:
-            return 0
+        # Note: not using `alloc_size`.  `alloc_size` reports memory
+        # consumption of the allocation, not the size of the array
+        # https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.nbytes.html
+        return self.dtype.itemsize * self.size
 
 
 class DeviceRecord(DeviceNDArrayBase):

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -331,6 +331,13 @@ class DeviceNDArrayBase(object):
             gpu_data=self.gpu_data,
             )
 
+    @property
+    def nbytes(self):
+        if hasattr(self, 'alloc_size'):
+            return self.alloc_size
+        else:
+            return 0
+
 
 class DeviceRecord(DeviceNDArrayBase):
     '''

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -52,6 +52,11 @@ class FakeCUDAArray(object):
     def alloc_size(self):
         return self._ary.nbytes
 
+    @property
+    def nbytes(self):
+        # return nbytes -- FakeCUDAArray is a wrapper around NumPy
+        return self._ary.nbytes
+
     def __getattr__(self, attrname):
         try:
             attr = getattr(self._ary, attrname)

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -138,8 +138,8 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(arr[::2].strides, arr_strided.strides)
         self.assertEqual(arr[::2].dtype.itemsize, arr_strided.dtype.itemsize)
         self.assertEqual(arr[::2].alloc_size, arr_strided.alloc_size)
-        self.assertEqual(arr[::2].nbytes, arr_strided.size *
-                arr_strided.dtype.itemsize)
+        self.assertEqual(arr[::2].nbytes,
+                         arr_strided.size * arr_strided.dtype.itemsize)
 
         # __setitem__ interface propogates into external array
 

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -138,6 +138,7 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(arr[::2].strides, arr_strided.strides)
         self.assertEqual(arr[::2].dtype.itemsize, arr_strided.dtype.itemsize)
         self.assertEqual(arr[::2].alloc_size, arr_strided.alloc_size)
+        self.assertEqual(arr[::2].nbytes, arr_strided.alloc_size)
 
         # __setitem__ interface propogates into external array
 

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -138,7 +138,8 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(arr[::2].strides, arr_strided.strides)
         self.assertEqual(arr[::2].dtype.itemsize, arr_strided.dtype.itemsize)
         self.assertEqual(arr[::2].alloc_size, arr_strided.alloc_size)
-        self.assertEqual(arr[::2].nbytes, arr_strided.alloc_size)
+        self.assertEqual(arr[::2].nbytes, arr_strided.size *
+                arr_strided.dtype.itemsize)
 
         # __setitem__ interface propogates into external array
 


### PR DESCRIPTION
Adding a property to device objects to return the size (in bytes) of the array

closes https://github.com/numba/numba/issues/3810