### PR TITLE
Silence DeprecationWarning

### DIFF
--- a/numba/annotations/type_annotations.py
+++ b/numba/annotations/type_annotations.py
@@ -12,13 +12,7 @@ import textwrap
 from numba.io_support import StringIO
 from numba import ir
 import numba.dispatcher
-from numba.config import PYVERSION
-
-
-if PYVERSION >= (3, 3):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
+from numba.six import Mapping
 
 
 class SourceLines(Mapping):

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -14,15 +14,9 @@ from numba.typing import templates
 from numba.datamodel import default_manager, models
 from numba.targets import imputils
 from numba import cgutils, utils, errors
-from numba.config import PYVERSION
-from numba.six import exec_
+from numba.six import exec_, Sequence
 from . import _box
 
-
-if PYVERSION >= (3, 3):
-    from collections.abc import Sequence
-else:
-    from collections import Sequence
 
 ##############################################################################
 # Data model

--- a/numba/roc/hsadrv/driver.py
+++ b/numba/roc/hsadrv/driver.py
@@ -22,13 +22,8 @@ from numba import config
 from .error import HsaSupportError, HsaDriverError, HsaApiError
 from . import enums, enums_ext, drvapi
 from numba.utils import longint as long
+from numba.six import Sequence
 import numpy as np
-
-
-if config.PYVERSION >= (3, 3):
-    from collections.abc import Sequence
-else:
-    from collections import Sequence
 
 
 _logger = logging.getLogger(__name__)

--- a/numba/six.py
+++ b/numba/six.py
@@ -768,6 +768,13 @@ if sys.version_info[0:2] < (3, 4):
 else:
     wraps = functools.wraps
 
+
+if sys.version_info[:2] < (3, 3):
+    from collections import Mapping, MutableMapping, Sequence
+else:
+    from collections.abc import Mapping, MutableMapping, Sequence
+
+
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
     # This requires a bit of explanation: the basic idea is to make a dummy

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -1,8 +1,7 @@
 """
 Python wrapper that connects CPython interpreter to the numba dictobject.
 """
-from collections import MutableMapping
-
+from numba.six import MutableMapping
 from numba.types import DictType, TypeRef
 from numba.targets.imputils import numba_typeref_ctor
 from numba import njit, dictobject, types, cgutils, errors, typeof

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -14,12 +14,7 @@ from . import templates
 from .typeof import typeof, Purpose
 
 from numba import utils
-from numba.config import PYVERSION
-
-if PYVERSION >= (3, 3):
-    from collections.abc import Sequence
-else:
-    from collections import Sequence
+from numba.six import Sequence
 
 
 class Rating(object):

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -23,11 +23,6 @@ except ImportError:
     from io import StringIO
 from numba.config import PYVERSION, MACHINE_BITS
 
-if PYVERSION >= (3, 3):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
-
 
 IS_PY3 = PYVERSION >= (3, 0)
 


### PR DESCRIPTION
This should silence warnings like below:
```
C:\Users\dhirschfeld\envs\dev\lib\site-packages\numba\typed\typeddict.py:4
  C:\Users\dhirschfeld\envs\dev\lib\site-packages\numba\typed\typeddict.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```