### PR TITLE
Solve DeprecationWarning on Python 3.7.

### DIFF
--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -1,7 +1,10 @@
 """
 Python wrapper that connects CPython interpreter to the numba dictobject.
 """
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 from numba.types import DictType, TypeRef
 from numba import njit, dictobject, types, cgutils


### PR DESCRIPTION
This still preserves backwards compatibility with Python 2.

`collections.AbstractBaseClasses` was deprecated in favor of `collections.abc.AbstractBaseClasses` in Python 3.7, and the second form is allowed in all Python 3 versions AFAICT. I've added a fallback to `collections.AbstractBaseClasses` in case of an issue.
