### PR TITLE
Isolate mutation on func_ir._definitions 

### DIFF
--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -400,7 +400,7 @@ def dead_branch_prune(func_ir, called_args):
     # (if desired). It is required that the const is assigned a value that
     # indicates the branch taken as its mutated value would be read in the case
     # of object mode fall back in place of the condition itself. For
-    # completeness the func_ir._definitions and ._consts are also updated to
+    # completeness the ._consts are also updated to
     # make the IR state self consistent.
 
     deadcond = [x[0] for x in nullified_conditions]

--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -411,10 +411,6 @@ def dead_branch_prune(func_ir, called_args):
                     # rewrite the condition as a true/false bit
                     branch_bit = nullified_conditions[deadcond.index(cond)][1]
                     x.value = ir.Const(branch_bit, loc=x.loc)
-                    # update the specific definition to the new const
-                    defns = func_ir._definitions[x.target.name]
-                    repl_idx = defns.index(cond)
-                    defns[repl_idx] = x.value
 
     # Remove dead blocks, this is safe as it relies on the CFG only.
     cfg = compute_cfg_from_blocks(func_ir.blocks)

--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -933,7 +933,7 @@ class ArrayAnalysis(object):
 
     def _define(self, equiv_set, var, typ, value):
         self.typemap[var.name] = typ
-        self.func_ir._definitions[var.name] = [value]
+        self.func_ir.temp_definitions[var.name] = [value]
         equiv_set.define(var, self.func_ir, typ)
 
     def _analyze_inst(self, label, scope, equiv_set, inst):

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -450,6 +450,7 @@ def _add_definitions(func_ir, block):
     assigns = block.find_insts(ir.Assign)
     for stmt in assigns:
         definitions[stmt.target.name].append(stmt.value)
+        # XXX: DEAD CODE?
 
 def _find_arraycall(func_ir, block):
     """Look for statement like "x = numpy.array(y)" or "x[..] = y"

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -1108,6 +1108,10 @@ class FunctionIR(object):
         from numba.ir_utils import build_definitions
         return ReadOnlyMapping(build_definitions(self.blocks))
 
+    @property
+    def combined_definitions(self):
+        return ChainMap(self.temp_definitions, self._definitions)
+
     def _reset_analysis_variables(self):
         from . import consts
 
@@ -1179,7 +1183,7 @@ class FunctionIR(object):
         """
 
         if use_temp:
-            defmap = ChainMap(self.temp_definitions, self._definitions)
+            defmap = self.combined_definitions
         else:
             defmap = self._definitions
 

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -651,9 +651,6 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
     if arg_aliases is None:
         arg_aliases = set(a for a in args if not is_immutable_type(a, typemap))
 
-    # update definitions since they are not guaranteed to be up-to-date
-    # FIXME keep definitions up-to-date to avoid the need for rebuilding
-    func_ir._definitions = build_definitions(func_ir.blocks)
     np_alias_funcs = ['ravel', 'transpose', 'reshape']
 
     for bl in blocks.values():
@@ -1020,7 +1017,7 @@ def get_call_table(blocks, call_table=None, reverse_call_table=None, topological
         order = find_topo_order(blocks)
     else:
         order = list(blocks.keys())
-    
+
     for label in reversed(order):
         for inst in reversed(blocks[label].body):
             if isinstance(inst, ir.Assign):
@@ -1186,7 +1183,7 @@ def canonicalize_array_math(func_ir, typemap, calltypes, typingctx):
                     g_np_assign = ir.Assign(g_np, g_np_var, loc)
                     rhs.value = g_np_var
                     new_body.append(g_np_assign)
-                    func_ir._definitions[g_np_var.name] = [g_np]
+                    func_ir.temp_definitions[g_np_var.name] = [g_np]
                     # update func var type
                     func = getattr(numpy, rhs.attr)
                     func_typ = get_np_ufunc_typ(func)

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1459,7 +1459,6 @@ class ParforPass(object):
         simplify(self.func_ir, self.typemap, self.calltypes)
 
         if self.options.fusion:
-            self.func_ir._definitions = build_definitions(self.func_ir.blocks)
             self.array_analysis.equiv_sets = dict()
             self.array_analysis.run(self.func_ir.blocks)
             # reorder statements to maximize fusion

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -488,7 +488,6 @@ class StencilPass(object):
                     # indices can be inferred as constant in simple expressions
                     # like -c where c is constant
                     # handled here since this is a common stencil index pattern
-                    stencil_ir._definitions = ir_utils.build_definitions(stencil_blocks)
                     index_list = [_get_const_index_expr(
                         stencil_ir, self.func_ir, v) for v in index_list]
                     if index_offsets:

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -142,9 +142,7 @@ class TestInlining(TestCase):
                 if (isinstance(stmt, ir.Assign) and isinstance(stmt.value, ir.Var)
                         and guard(find_const, func_ir, stmt.value) == 2):
                     # replace expr with a dummy call
-                    func_ir._definitions[stmt.target.name].remove(stmt.value)
                     stmt.value = ir.Expr.call(ir.Var(block.scope, "myvar", loc=stmt.loc), (), (), stmt.loc)
-                    func_ir._definitions[stmt.target.name].append(stmt.value)
                     #func = g.py_func#
                     inline_closure_call(func_ir, {}, block, i, lambda: 2)
                     break

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -340,7 +340,6 @@ def get_optimized_numba_ir(test_func, args, **kws):
             tp.func_ir, tp.typemap, tp.calltypes, tp.return_type,
             tp.typingctx, options, flags, diagnostics=diagnostics)
         parfor_pass.run()
-        test_ir._definitions = build_definitions(test_ir.blocks)
 
     return test_ir, tp
 


### PR DESCRIPTION
 WIP.  DO NOT MERGE

This is a refactor on the `func_ir._definitions` attribute usage.

• `._definitions` is now immutable and autogenerated from the IR so it is never out-of-sync.
• a new `.temp_definitions` is added to find places that does temporary mutation on it (like in array_analysis.py and inline_closurecall.py).  These temporary mutations are not yet visible in the IR, yet.  (TODO: refactor these mutations so we get remove `.temp_definitions`. 