### PR TITLE
Return variable renaming dict from inline_closurecall

### DIFF
--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -240,6 +240,9 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     make_function node. `typingctx`, `typemap` and `calltypes` are typing
     data structures of the caller, available if we are in a typed pass.
     `arg_typs` includes the types of the arguments at the callsite.
+
+    Returns IR blocks of the callee and the variable renaming dictionary used
+    for them to facilitate further processing of new blocks.
     """
     scope = block.scope
     instr = block.body[i]

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -371,7 +371,7 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     if work_list != None:
         for block in new_blocks:
             work_list.append(block)
-    return callee_blocks
+    return callee_blocks, var_dict
 
 def _make_debug_print(prefix):
     def debug_print(*args):

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1322,7 +1322,7 @@ class PreParforPass(object):
                             if check is not None:
                                 g[check.name] = check.func
                             # inline the parallel implementation
-                            new_blocks = inline_closure_call(self.func_ir, g,
+                            new_blocks, _ = inline_closure_call(self.func_ir, g,
                                             block, i, new_func, self.typingctx, typs,
                                             self.typemap, self.calltypes, work_list)
                             call_table = get_call_table(new_blocks, topological_ordering=False)

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -158,7 +158,7 @@ class TestInlining(TestCase):
         # and it contains the original variable name used in locals
         @numba.njit(locals={'b': numba.float64})
         def g(a):
-            b = a+1
+            b = a + 1
             return b
 
         def test_impl():

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -164,7 +164,6 @@ class TestInlining(TestCase):
         def test_impl():
             return g(1)
 
-        inline_out = None
         func_ir = compiler.run_frontend(test_impl)
         blocks = list(func_ir.blocks.values())
         for block in blocks:
@@ -176,12 +175,11 @@ class TestInlining(TestCase):
                     if (isinstance(func_def, (ir.Global, ir.FreeVar))
                             and isinstance(func_def.value, CPUDispatcher)):
                         py_func = func_def.value.py_func
-                        inline_out = inline_closure_call(
+                        _, var_map = inline_closure_call(
                             func_ir, py_func.__globals__, block, i, py_func)
                         break
 
-        self.assertTrue(isinstance(inline_out, tuple)
-            and isinstance(inline_out[1], dict) and 'b' in inline_out[1])
+        self.assertTrue('b' in var_map)
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -7,7 +7,8 @@ from .support import TestCase, override_config, captured_stdout
 import numba
 from numba import unittest_support as unittest
 from numba import jit, njit, types, ir, compiler
-from numba.ir_utils import guard, find_callname, find_const
+from numba.ir_utils import guard, find_callname, find_const, get_definition
+from numba.targets.registry import CPUDispatcher
 from numba.inline_closurecall import inline_closure_call
 from .test_parfors import skip_unsupported
 
@@ -151,6 +152,36 @@ class TestInlining(TestCase):
 
         self.assertEqual(len(func_ir._definitions['b']), 2)
 
+    @skip_unsupported
+    def test_inline_var_dict_ret(self):
+        # make sure inline_closure_call returns the variable replacement dict
+        # and it contains the original variable name used in locals
+        @numba.njit(locals={'b': numba.float64})
+        def g(a):
+            b = a+1
+            return b
+
+        def test_impl():
+            return g(1)
+
+        inline_out = None
+        func_ir = compiler.run_frontend(test_impl)
+        blocks = list(func_ir.blocks.values())
+        for block in blocks:
+            for i, stmt in enumerate(block.body):
+                if (isinstance(stmt, ir.Assign)
+                        and isinstance(stmt.value, ir.Expr)
+                        and stmt.value.op == 'call'):
+                    func_def = guard(get_definition, func_ir, stmt.value.func)
+                    if (isinstance(func_def, (ir.Global, ir.FreeVar))
+                            and isinstance(func_def.value, CPUDispatcher)):
+                        py_func = func_def.value.py_func
+                        inline_out = inline_closure_call(
+                            func_ir, py_func.__globals__, block, i, py_func)
+                        break
+
+        self.assertTrue(isinstance(inline_out, tuple)
+            and isinstance(inline_out[1], dict) and 'b' in inline_out[1])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title. This enables update of `locals` (and potentially other data structures that include variable names) when inlining functions.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
