### PR TITLE
__mul__ for strings, initial implementation and tests

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -166,6 +166,7 @@ The following functions, attributes and methods are currently supported:
 
 * ``len()``
 * ``+`` (concatenation of strings)
+* ``*`` (repetition of strings)
 * ``in``, ``.contains()``
 * ``==``, ``<``, ``<=``, ``>``, ``>=`` (comparison)
 * ``.startswith()``

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -367,12 +367,18 @@ class TestUnicode(BaseTest):
     def test_repeat(self, flags=no_pyobj_flags):
         pyfunc = repeat_usecase
         cfunc = njit(pyfunc)
-        for a in UNICODE_EXAMPLES:
-            for b in (1, 2, 3):
+        for a in UNICODE_EXAMPLES + ['']:
+            for b in (-1, 0, 1, 2, 3, 4, 5, 7, 8, 15, 70):
                 self.assertEqual(pyfunc(a, b),
                                  cfunc(a, b))
                 self.assertEqual(pyfunc(b, a),
                                  cfunc(b, a))
+
+    def test_repeat_exception_float(self):
+        self.disable_leak_check()
+        cfunc = njit(repeat_usecase)
+        with self.assertRaises(TypingError) as raises:
+            cfunc('hi', 2.5)
 
     def test_split_exception_empty_sep(self):
         self.disable_leak_check()

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -39,6 +39,8 @@ def getitem_usecase(x, i):
 def concat_usecase(x, y):
     return x + y
 
+def repeat_usecase(x, y):
+    return x * y
 
 def inplace_concat_usecase(x, y):
     x += y
@@ -361,6 +363,16 @@ class TestUnicode(BaseTest):
                 self.assertEqual(pyfunc(a, b),
                                  cfunc(a, b),
                                  "'%s' + '%s'?" % (a, b))
+
+    def test_repeat(self, flags=no_pyobj_flags):
+        pyfunc = repeat_usecase
+        cfunc = njit(pyfunc)
+        for a in UNICODE_EXAMPLES:
+            for b in (1, 2, 3):
+                self.assertEqual(pyfunc(a, b),
+                                 cfunc(a, b))
+                self.assertEqual(pyfunc(b, a),
+                                 cfunc(b, a))
 
     def test_split_exception_empty_sep(self):
         self.disable_leak_check()

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -39,8 +39,10 @@ def getitem_usecase(x, i):
 def concat_usecase(x, y):
     return x + y
 
+
 def repeat_usecase(x, y):
     return x * y
+
 
 def inplace_concat_usecase(x, y):
     x += y

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -379,6 +379,7 @@ class TestUnicode(BaseTest):
         cfunc = njit(repeat_usecase)
         with self.assertRaises(TypingError) as raises:
             cfunc('hi', 2.5)
+        self.assertIn('Invalid use of Function(<built-in function mul>)', str(raises.exception))
 
     def test_split_exception_empty_sep(self):
         self.disable_leak_check()

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -745,6 +745,33 @@ def unicode_concat(a, b):
         return concat_impl
 
 
+@overload(operator.mul)
+def unicode_repeat(a, b):
+    if isinstance(a, types.UnicodeType) and isinstance(b, types.Integer):
+        def repeat_impl(a, b):
+            new_length = a._length * b
+            new_kind = a._kind
+            result = _empty_string(new_kind, new_length)
+            len_a = len(a)
+            for j in range(b):
+                for i in range(len_a):
+                    _set_code_point(result, len_a*j + i, _get_code_point(a, i))
+            return result
+        return repeat_impl
+
+    elif isinstance(a, types.Integer) and isinstance(b, types.UnicodeType):
+        def repeat_impl(a, b):
+            new_length = b._length * a
+            new_kind = b._kind
+            result = _empty_string(new_kind, new_length)
+            len_b = len(b)
+            for j in range(a):
+                for i in range(len_b):
+                    _set_code_point(result, len_b*j + i, _get_code_point(b, i))
+            return result
+        return repeat_impl
+
+
 @lower_builtin('getiter', types.UnicodeType)
 def getiter_unicode(context, builder, sig, args):
     [ty] = sig.args

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -760,14 +760,17 @@ def _repeat_impl(str_arg, mult_arg):
             len_a = len(str_arg)
             _strncpy(result, 0, str_arg, 0, len_a)
             # loop through powers of 2 for efficient copying
-            floor_log = floor(log(mult_arg) / log(2))
-            for j in range(floor_log):
-                _strncpy(result, 2**j * len_a, result, 0, 2**j * len_a)
-            # complete the rest of the copies
-            rest = mult_arg - 2 ** floor_log
-            _strncpy(result, 2**floor_log * len_a,
-                     result, (2**floor_log - rest) * len_a, rest * len_a)
-            return result
+            copy_size = len_a
+            while 2 * copy_size <= new_length:
+                _strncpy(result, copy_size, result, 0, copy_size)
+                copy_size *= 2
+
+            if not 2 * copy_size == new_length:
+                # if copy_size not an exact multiple it then needs
+                # to complete the rest of the copies
+                rest = new_length - copy_size
+                _strncpy(result, copy_size, result, copy_size - rest, rest)
+                return result
 
 
 @overload(operator.mul)


### PR DESCRIPTION
This PR fixes #3834. It uses the extension api via `@overload(operator.mul)`.

I have added unit tests, which pass.


