### PR TITLE
Type-inferred dictionary

### DIFF
--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -830,7 +830,15 @@ def impl_setitem(d, key, value):
             raise ValueError('key comparison failed')
         else:
             raise RuntimeError('dict.__setitem__ failed unexpectedly')
-    return impl
+
+    if d.is_precise():
+        return impl
+    else:
+        # Handle the imprecise case.
+        d = types.DictType(key, value)
+        keyty, valty = d.key_type, d.value_type
+        sig = typing.signature(types.void, d, keyty, valty)
+        return sig, impl
 
 
 @overload_method(types.DictType, 'get')

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -832,11 +832,14 @@ def impl_setitem(d, key, value):
             raise RuntimeError('dict.__setitem__ failed unexpectedly')
 
     if d.is_precise():
+        # Handle the precise case.
         return impl
     else:
         # Handle the imprecise case.
-        d = types.DictType(key, value)
+        d = d.refine(key, value)
+        # Re-bind the key type and value type to match the arguments.
         keyty, valty = d.key_type, d.value_type
+        # Create the signature that we wanted this impl to have.
         sig = typing.signature(types.void, d, keyty, valty)
         return sig, impl
 

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -76,7 +76,7 @@ def overload(func, jit_options={}, strict=True):
     is enforced by the **strict** keyword argument, it is recommended that this
     is set to True (default).
 
-    To handle implementation that accepts imprecise types, an overload
+    To handle a function that accepts imprecise types, an overload
     definition can return 2-tuple of ``(signature, impl_function)``, where
     the ``signature`` is a ``typing.Signature`` specifying the precise
     signature to be used; and ``impl_function`` is the same implementation

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -75,6 +75,12 @@ def overload(func, jit_options={}, strict=True):
     Overloading strictness (that the typing and implementing signatures match)
     is enforced by the **strict** keyword argument, it is recommended that this
     is set to True (default).
+
+    To handle implementation that accepts imprecise types, an overload
+    definition can return 2-tuple of ``(signature, impl_function)``, where
+    the ``signature`` is a ``typing.Signature`` specifying the precise
+    signature to be used; and ``impl_function`` is the same implementation
+    function as in the simple case.
     """
     from .typing.templates import make_overload_template, infer_global
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -508,7 +508,7 @@ def redirect_type_ctor(context, builder, sig, args):
         d = Dict()
 
     `d` will be typed as `TypeRef[DictType]()`.  Thus, it will call into this
-    implementation.  We will need to redirect the lowering to a function
+    implementation.  We need to redirect the lowering to a function
     named ``numba_typeref_ctor``.
     """
     cls = sig.return_type

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -518,7 +518,7 @@ def redirect_type_ctor(context, builder, sig, args):
 
     # Pack arguments into a tuple for `*args`
     ctor_args = types.Tuple.from_types(sig.args)
-    # Make signature T(T, *args) where T is cls
+    # Make signature T(TypeRef[T], *args) where T is cls
     sig = typing.signature(cls, types.TypeRef(cls), ctor_args)
 
     args = (context.get_dummy_value(),   # Type object has no runtime repr.

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -459,7 +459,7 @@ def force_error_model(context, model_name='numpy'):
 
 
 def numba_typeref_ctor(*args, **kwargs):
-    """A stub for use internally by numba during when a call is emitted
+    """A stub for use internally by Numba when a call is emitted
     on a TypeRef.
     """
-    raise NotImplementedError("The function is not to be executed.")
+    raise NotImplementedError("This function should not be executed.")

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -456,3 +456,10 @@ def force_error_model(context, model_name='numpy'):
         yield
     finally:
         context.error_model = old_error_model
+
+
+def numba_typeref_ctor(*args, **kwargs):
+    """A stub for use internally by numba during when a call is emitted
+    on a TypeRef.
+    """
+

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -462,4 +462,4 @@ def numba_typeref_ctor(*args, **kwargs):
     """A stub for use internally by numba during when a call is emitted
     on a TypeRef.
     """
-
+    raise NotImplementedError("The function is not to be executed.")

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1403,3 +1403,61 @@ class TestDictInferred(TestCase):
         self.assertEqual(ct, 0)
         self.assertEqual(dict(d), {})
         self.assertEqual(n, 0)
+
+
+class TestNonCompiledInfer(TestCase):
+    def test_check_untyped_dict_ops(self):
+        # Check operation on untyped dictionary
+        d = Dict()
+        self.assertTrue(d._not_typed)
+        self.assertEqual(len(d), 0)
+        self.assertEqual(str(d), str({}))
+        self.assertEqual(list(iter(d)), [])
+        # Test __getitem__
+        with self.assertRaises(KeyError) as raises:
+            d[1]
+        self.assertEqual(str(raises.exception), str(KeyError(1)))
+        # Test __delitem__
+        with self.assertRaises(KeyError) as raises:
+            del d[1]
+        self.assertEqual(str(raises.exception), str(KeyError(1)))
+        # Test .pop
+        with self.assertRaises(KeyError):
+            d.pop(1)
+        self.assertEqual(str(raises.exception), str(KeyError(1)))
+        # Test .pop
+        self.assertIs(d.pop(1, None), None)
+        # Test .get
+        self.assertIs(d.get(1), None)
+        # Test .popitem
+        with self.assertRaises(KeyError) as raises:
+            d.popitem()
+        self.assertEqual(str(raises.exception),
+                         str(KeyError('dictionary is empty')))
+        # Test setdefault(k)
+        with self.assertRaises(TypeError) as raises:
+            d.setdefault(1)
+        self.assertEqual(
+            str(raises.exception),
+            str(TypeError('invalid operation on untyped dictionary')),
+        )
+        # Test __contains__
+        self.assertFalse(1 in d)
+        # It's untyped
+        self.assertTrue(d._not_typed)
+
+    def test_getitem(self):
+        # Test __getitem__
+        d = Dict()
+        d[1] = 2
+        # It's typed now
+        self.assertFalse(d._not_typed)
+        self.assertEqual(d[1], 2)
+
+    def test_setdefault(self):
+        # Test setdefault(k, d)
+        d = Dict()
+        d.setdefault(1, 2)
+        # It's typed now
+        self.assertFalse(d._not_typed)
+        self.assertEqual(d[1], 2)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1264,15 +1264,14 @@ class TestDictForbiddenTypes(TestCase):
 
 
 class TestDictInferred(TestCase):
-    @skip_py2
     def test_simple_literal(self):
         @njit
         def foo():
             d = Dict()
-            d['123'] = 321
+            d[123] = 321
             return d
 
-        k, v = '123', 321
+        k, v = 123, 321
         d = foo()
         self.assertEqual(dict(d), {k: v})
         self.assertEqual(typeof(d).key_type, typeof(k))
@@ -1285,7 +1284,7 @@ class TestDictInferred(TestCase):
             d[k] = v
             return d
 
-        k, v = '123', 321
+        k, v = 123, 321
         d = foo(k, v)
         self.assertEqual(dict(d), {k: v})
         self.assertEqual(typeof(d).key_type, typeof(k))
@@ -1299,7 +1298,7 @@ class TestDictInferred(TestCase):
             d[k] = w
             return d
 
-        k, v, w = '123', 32.1, 321
+        k, v, w = 123, 32.1, 321
         d = foo(k, v, w)
         self.assertEqual(dict(d), {k: w})
         self.assertEqual(typeof(d).key_type, typeof(k))
@@ -1313,7 +1312,7 @@ class TestDictInferred(TestCase):
             d[k] = w
             return d
 
-        k, v, w = '123', 321, 32.1
+        k, v, w = 123, 321, 32.1
         with self.assertRaises(TypingError) as raises:
             foo(k, v, w)
         self.assertIn(
@@ -1325,33 +1324,33 @@ class TestDictInferred(TestCase):
         @njit
         def foo(k, v):
             d = Dict()
-            if len(k):
+            if k:
                 d[k] = v
             else:
-                d['what'] = v + 1
+                d[0xdead] = v + 1
 
             return d
 
-        k, v = '123', 321
+        k, v = 123, 321
         d = foo(k, v)
         self.assertEqual(dict(d), {k: v})
-        k, v = '', 0
+        k, v = 0, 0
         d = foo(k, v)
-        self.assertEqual(dict(d), {'what': v + 1})
+        self.assertEqual(dict(d), {0xdead: v + 1})
 
     def test_ifelse_empty_one_branch(self):
         @njit
         def foo(k, v):
             d = Dict()
-            if len(k):
+            if k:
                 d[k] = v
 
             return d
 
-        k, v = '123', 321
+        k, v = 123, 321
         d = foo(k, v)
         self.assertEqual(dict(d), {k: v})
-        k, v = '', 0
+        k, v = 0, 0
         d = foo(k, v)
         self.assertEqual(dict(d), {})
         self.assertEqual(typeof(d).key_type, typeof(k))
@@ -1366,7 +1365,7 @@ class TestDictInferred(TestCase):
             return d
 
         vs = list(range(4))
-        ks = list(map('k{}'.format, vs))
+        ks = list(map(lambda x : x + 100, vs))
         d = foo(ks, vs)
         self.assertEqual(dict(d), dict(zip(ks, vs)))
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -19,7 +19,6 @@ from numba.utils import IS_PY3
 from numba.errors import TypingError
 from .support import TestCase, MemoryLeakMixin, unittest
 
-
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
 
 

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -124,7 +124,7 @@ class Dict(MutableMapping):
     @property
     def _typed(self):
         """Returns True if the dictionary is not untyped.
-ht        """
+        """
         return self._dict_type is not None
 
     def _initialise_dict(self, key, value):

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -219,3 +219,4 @@ def unbox_dicttype(typ, val, c):
     c.pyapi.decref(miptr)
 
     return NativeValue(dctobj)
+

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -122,39 +122,39 @@ class Dict(MutableMapping):
         return self._dict_type
 
     @property
-    def _not_typed(self):
+    def _typed(self):
         """Returns True if the dictionary is not untyped.
 ht        """
-        return self._dict_type is None
+        return self._dict_type is not None
 
-    def _initial_dict(self, key, value):
+    def _initialise_dict(self, key, value):
         dcttype = types.DictType(typeof(key), typeof(value))
         self._dict_type, self._opaque = self._parse_arg(dcttype)
 
     def __getitem__(self, key):
-        if self._not_typed:
+        if not self._typed:
             raise KeyError(key)
         else:
             return _getitem(self, key)
 
     def __setitem__(self, key, value):
-        if self._not_typed:
-            self._initial_dict(key, value)
+        if not self._typed:
+            self._initialise_dict(key, value)
         return _setitem(self, key, value)
 
     def __delitem__(self, key):
-        if self._not_typed:
+        if not self._typed:
             raise KeyError(key)
         _delitem(self, key)
 
     def __iter__(self):
-        if self._not_typed:
+        if not self._typed:
             return iter(())
         else:
             return iter(_iter(self))
 
     def __len__(self):
-        if self._not_typed:
+        if not self._typed:
             return 0
         else:
             return _length(self)
@@ -177,14 +177,14 @@ ht        """
         return "{prefix}({body})".format(prefix=prefix, body=body)
 
     def get(self, key, default=None):
-        if self._not_typed:
+        if not self._typed:
             return default
         return _get(self, key, default)
 
     def setdefault(self, key, default=None):
-        if self._not_typed:
+        if not self._typed:
             if default is not None:
-                self._initial_dict(key, default)
+                self._initialise_dict(key, default)
         return _setdefault(self, key, default)
 
     def popitem(self):

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -90,8 +90,8 @@ class Dict(MutableMapping):
 
     def __init__(self, **kwargs):
         """
-        For user, the constructor does not take any parameters.
-        The keyword arguments are for internally use.
+        For users, the constructor does not take any parameters.
+        The keyword arguments are for internal use only.
 
         Parameters
         ----------
@@ -266,7 +266,7 @@ def unbox_dicttype(typ, val, c):
 
 
 #
-# The following contains logic for the type-inferred constructor
+# The following contains the logic for the type-inferred constructor
 #
 
 
@@ -306,7 +306,7 @@ def impl_numba_typeref_ctor(cls):
     value_type = types.TypeRef(dict_ty.value_type)
 
     def impl(cls):
-        # Simply call the empty with the key/value types from *cls*
+        # Simply call .empty() with the key/value types from *cls*
         return Dict.empty(key_type, value_type)
 
     return impl

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -123,7 +123,7 @@ class Dict(MutableMapping):
 
     @property
     def _typed(self):
-        """Returns True if the dictionary is not untyped.
+        """Returns True if the dictionary is typed.
         """
         return self._dict_type is not None
 

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -284,12 +284,14 @@ def typeddict_call(context):
 @overload(numba_typeref_ctor)
 def impl_numba_typeref_ctor(cls):
     """
-    Defines ``Dict()``, the typed-inferred version of the dictionary ctor.
+    Defines ``Dict()``, the type-inferred version of the dictionary ctor.
 
     Parameters
     ----------
     cls : TypeRef
         Expecting a TypeRef of a precise DictType.
+
+    See also: `redirect_type_ctor` in numba/target/bulitins.py
     """
     dict_ty = cls.instance_type
     if not isinstance(dict_ty, types.DictType):

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -488,7 +488,7 @@ class CallConstraint(object):
         self._add_refine_map(typeinfer, typevars, sig)
 
     def _add_refine_map(self, typeinfer, typevars, sig):
-        """Add this expression to the refinemap base on the type of target_type
+        """Add this expression to the refine_map base on the type of target_type
         """
         target_type = typevars[self.target].getone()
         # Array
@@ -510,7 +510,7 @@ class CallConstraint(object):
                 newtype = aryty.copy(dtype=updated_type.dtype)
                 typeinfer.add_type(self.args[0].name, newtype, loc=self.loc)
         else:
-            m = 'no refinement implemented for function {} updating to {}'
+            m = 'no type refinement implemented for function {} updating to {}'
             raise TypingError(m.format(self.func, updated_type))
 
     def get_call_signature(self):
@@ -576,7 +576,7 @@ class SetItemRefinement(object):
         if isinstance(targetty, types.DictType) and not targetty.is_precise():
             refined = targetty.refine(idxty, valty)
             typeinfer.add_type(
-                self.target.name,refined,
+                self.target.name, refined,
                 loc=self.loc,
             )
 

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -14,7 +14,6 @@ Constraints push types forward following the dataflow.
 
 from __future__ import print_function, division, absolute_import
 
-import logging
 import operator
 import contextlib
 import itertools
@@ -26,9 +25,6 @@ from numba import ir, types, utils, config, typing
 from .errors import (TypingError, UntypedAttributeError, new_error_context,
                      termcolor, UnsupportedError)
 from .funcdesc import qualifying_prefix
-
-
-_logger = logging.getLogger(__name__)
 
 
 class NOTSET:
@@ -142,7 +138,6 @@ class ConstraintNetwork(object):
         errors = []
         for constraint in self.constraints:
             loc = constraint.loc
-            _logger.debug("propagate: %r (%s)", constraint, loc)
             with typeinfer.warnings.catch_warnings(filename=loc.filename,
                                                    lineno=loc.line):
                 try:
@@ -577,8 +572,6 @@ class SetItemConstraint(object):
             targetty = typevars[self.target.name].getone()
             idxty = typevars[self.index.name].getone()
             valty = typevars[self.value.name].getone()
-
-            _logger.debug("setitem targetty=%s", targetty)
 
             if not targetty.is_precise() and isinstance(targetty, types.DictType):
                 typeinfer.add_type(

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -485,7 +485,11 @@ class CallConstraint(object):
                     sig = sig.replace(return_type=targetty)
 
         self.signature = sig
+        self._add_refine_map(typeinfer, typevars, sig)
 
+    def _add_refine_map(self, typeinfer, typevars, sig):
+        """Add this expression to the refinemap base on the type of target_type
+        """
         target_type = typevars[self.target].getone()
         if (isinstance(target_type, types.Array)
                 and isinstance(sig.return_type.dtype, types.Undefined)):
@@ -504,8 +508,8 @@ class CallConstraint(object):
                 newtype = aryty.copy(dtype=updated_type.dtype)
                 typeinfer.add_type(self.args[0].name, newtype, loc=self.loc)
         else:
-            raise TypingError((self.func, updated_type))
-
+            m = 'no refinement implemented for function {} updating to {}'
+            raise TypingError(m.format(self.func, updated_type))
 
     def get_call_signature(self):
         return self.signature
@@ -556,7 +560,24 @@ class GetAttrConstraint(object):
             value=self.value, attr=self.attr)
 
 
-class SetItemConstraint(object):
+class SetItemRefinement(object):
+
+    def _refine_target_type(self, typeinfer, targetty, idxty, valty, sig):
+        """Refine the target-type given the known index type and value type.
+        """
+        # For array setitem, refine imprecise array dtype
+        if _is_array_not_precise(targetty):
+            typeinfer.add_type(self.target.name, sig.args[0], loc=self.loc)
+        # For Dict setitem
+        if isinstance(targetty, types.DictType) and not targetty.is_precise():
+            refined = targetty.refine(idxty, valty)
+            typeinfer.add_type(
+                self.target.name,refined,
+                loc=self.loc,
+            )
+
+
+class SetItemConstraint(SetItemRefinement):
     def __init__(self, target, index, value, loc):
         self.target = target
         self.index = index
@@ -573,30 +594,19 @@ class SetItemConstraint(object):
             idxty = typevars[self.index.name].getone()
             valty = typevars[self.value.name].getone()
 
-            if not targetty.is_precise() and isinstance(targetty, types.DictType):
-                typeinfer.add_type(
-                    self.target.name,
-                    targetty.refine(idxty, valty),
-                    loc=self.loc,
-                )
-
             sig = typeinfer.context.resolve_setitem(targetty, idxty, valty)
             if sig is None:
                 raise TypingError("Cannot resolve setitem: %s[%s] = %s" %
                                   (targetty, idxty, valty), loc=self.loc)
 
-            # For array setitem, refine imprecise array dtype
-            if _is_array_not_precise(targetty):
-                assert sig.args[0].is_precise()
-                typeinfer.add_type(self.target.name, sig.args[0], loc=self.loc)
-
             self.signature = sig
+            self._refine_target_type(typeinfer, targetty, idxty, valty, sig)
 
     def get_call_signature(self):
         return self.signature
 
 
-class StaticSetItemConstraint(object):
+class StaticSetItemConstraint(SetItemRefinement):
     def __init__(self, target, index, index_var, value, loc):
         self.target = target
         self.index = index
@@ -614,13 +624,6 @@ class StaticSetItemConstraint(object):
             idxty = typevars[self.index_var.name].getone()
             valty = typevars[self.value.name].getone()
 
-            if not targetty.is_precise() and isinstance(targetty, types.DictType):
-                typeinfer.add_type(
-                    self.target.name,
-                    targetty.refine(idxty, valty),
-                    loc=self.loc,
-                )
-
             sig = typeinfer.context.resolve_static_setitem(targetty,
                                                            self.index, valty)
             if sig is None:
@@ -628,7 +631,9 @@ class StaticSetItemConstraint(object):
             if sig is None:
                 raise TypingError("Cannot resolve setitem: %s[%r] = %s" %
                                   (targetty, self.index, valty), loc=self.loc)
+
             self.signature = sig
+            self._refine_target_type(typeinfer, targetty, idxty, valty, sig)
 
     def get_call_signature(self):
         return self.signature

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -491,9 +491,11 @@ class CallConstraint(object):
         """Add this expression to the refinemap base on the type of target_type
         """
         target_type = typevars[self.target].getone()
+        # Array
         if (isinstance(target_type, types.Array)
                 and isinstance(sig.return_type.dtype, types.Undefined)):
             typeinfer.refine_map[self.target] = self
+        # DictType
         if isinstance(target_type, types.DictType) and not target_type.is_precise():
             typeinfer.refine_map[self.target] = self
 
@@ -561,7 +563,9 @@ class GetAttrConstraint(object):
 
 
 class SetItemRefinement(object):
-
+    """A mixin class to provide the common refinement logic in setitem
+    and static setitem.
+    """
     def _refine_target_type(self, typeinfer, targetty, idxty, valty, sig):
         """Refine the target-type given the known index type and value type.
         """
@@ -631,7 +635,6 @@ class StaticSetItemConstraint(SetItemRefinement):
             if sig is None:
                 raise TypingError("Cannot resolve setitem: %s[%r] = %s" %
                                   (targetty, self.index, valty), loc=self.loc)
-
             self.signature = sig
             self._refine_target_type(typeinfer, targetty, idxty, valty, sig)
 

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -456,6 +456,8 @@ class DictType(IterableType):
     def __init__(self, keyty, valty):
         assert not isinstance(keyty, TypeRef)
         assert not isinstance(valty, TypeRef)
+        keyty = unliteral(keyty)
+        valty = unliteral(valty)
         _sentry_forbidden_types(keyty, valty)
         self.key_type = keyty
         self.value_type = valty
@@ -467,9 +469,28 @@ class DictType(IterableType):
         )
         super(DictType, self).__init__(name)
 
+    def is_precise(self):
+        return not any([
+            isinstance(self.key_type, Undefined),
+            isinstance(self.value_type, Undefined),
+        ])
+
     @property
     def iterator_type(self):
         return DictKeysIterableType(self).iterator_type
+
+    @classmethod
+    def refine(cls, keyty, valty):
+        return cls(keyty, valty)
+
+    def unify(self, typingctx, other):
+        """
+        Unify this with the *other* Array.
+        """
+        # If other is array and the ndim matches
+        if isinstance(other, DictType):
+            if not other.is_precise():
+                return self
 
 
 class DictItemsIterableType(SimpleIterableType):

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -489,9 +489,9 @@ class DictType(IterableType):
 
     def unify(self, typingctx, other):
         """
-        Unify this with the *other* Array.
+        Unify this with the *other* dictionary.
         """
-        # If other is array and the ndim matches
+        # If other is dict
         if isinstance(other, DictType):
             if not other.is_precise():
                 return self

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -470,10 +470,10 @@ class DictType(IterableType):
         super(DictType, self).__init__(name)
 
     def is_precise(self):
-        return not any([
+        return not any((
             isinstance(self.key_type, Undefined),
             isinstance(self.value_type, Undefined),
-        ])
+        ))
 
     @property
     def iterator_type(self):
@@ -481,7 +481,11 @@ class DictType(IterableType):
 
     @classmethod
     def refine(cls, keyty, valty):
-        return cls(keyty, valty)
+        """Refine to a precise dictionary type
+        """
+        res = cls(keyty, valty)
+        res.is_precise()
+        return res
 
     def unify(self, typingctx, other):
         """

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -755,17 +755,22 @@ class TypeRefAttribute(AttributeTemplate):
         ty = classty.instance_type
 
         if isinstance(ty, types.Number):
+            # FIXME
             def typer(val):
                 # Scalar constructor, e.g. int32(42)
                 return ty
 
             return types.Function(make_callable_template(key=ty, typer=typer))
 
-        if ty is types.DictType:
-            def typer():
-                return types.DictType(keyty=types.undefined, valty=types.undefined)
+        if isinstance(ty, type) and issubclass(ty, types.Type):
+            # Redirect the typing to a:
+            #   @type_callable(ty)
+            #   def typeddict_call(context):
+            #        ...
+            def redirect(*args, **kwargs):
+                return self.context.resolve_function_type(ty, args, kwargs)
+            return types.Function(make_callable_template(key=ty, typer=redirect))
 
-            return types.Function(make_callable_template(key=ty, typer=typer))
 
 #------------------------------------------------------------------------------
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -754,14 +754,6 @@ class TypeRefAttribute(AttributeTemplate):
         """
         ty = classty.instance_type
 
-        if isinstance(ty, types.Number):
-            # FIXME
-            def typer(val):
-                # Scalar constructor, e.g. int32(42)
-                return ty
-
-            return types.Function(make_callable_template(key=ty, typer=typer))
-
         if isinstance(ty, type) and issubclass(ty, types.Type):
             # Redirect the typing to a:
             #   @type_callable(ty)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -751,6 +751,12 @@ class TypeRefAttribute(AttributeTemplate):
     def resolve___call__(self, classty):
         """
         Resolve a number class's constructor (e.g. calling int(...))
+
+        Note:
+
+        This is needed because of the limitation of the current type-system
+        implementation.  Specially, the lack of a higher-order type
+        (i.e. passing the ``DictType`` vs ``DictType(key_type, value_type)``)
         """
         ty = classty.instance_type
 
@@ -759,6 +765,9 @@ class TypeRefAttribute(AttributeTemplate):
             #   @type_callable(ty)
             #   def typeddict_call(context):
             #        ...
+            # For example, see numba/typed/typeddict.py
+            #   @type_callable(DictType)
+            #   def typeddict_call(context):
             def redirect(*args, **kwargs):
                 return self.context.resolve_function_type(ty, args, kwargs)
             return types.Function(make_callable_template(key=ty, typer=redirect))

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -761,6 +761,12 @@ class TypeRefAttribute(AttributeTemplate):
 
             return types.Function(make_callable_template(key=ty, typer=typer))
 
+        if ty is types.DictType:
+            def typer():
+                return types.DictType(keyty=types.undefined, valty=types.undefined)
+
+            return types.Function(make_callable_template(key=ty, typer=typer))
+
 #------------------------------------------------------------------------------
 
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -755,7 +755,7 @@ class TypeRefAttribute(AttributeTemplate):
         Note:
 
         This is needed because of the limitation of the current type-system
-        implementation.  Specially, the lack of a higher-order type
+        implementation.  Specifically, the lack of a higher-order type
         (i.e. passing the ``DictType`` vs ``DictType(key_type, value_type)``)
         """
         ty = classty.instance_type

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -754,14 +754,12 @@ class TypeRefAttribute(AttributeTemplate):
         """
         ty = classty.instance_type
 
-        if not isinstance(ty, types.Number):
-            raise errors.TypingError("invalid use of non-number types")
+        if isinstance(ty, types.Number):
+            def typer(val):
+                # Scalar constructor, e.g. int32(42)
+                return ty
 
-        def typer(val):
-            # Scalar constructor, e.g. int32(42)
-            return ty
-
-        return types.Function(make_callable_template(key=ty, typer=typer))
+            return types.Function(make_callable_template(key=ty, typer=typer))
 
 #------------------------------------------------------------------------------
 

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -447,11 +447,11 @@ class _OverloadFunctionTemplate(AbstractTemplate):
     def _build_impl(self, cache_key, args, kws):
         """Build and cache the implementation.
 
-        Given the postitional (`args`) and keyword arguments (`kws`), obtains
+        Given the positional (`args`) and keyword arguments (`kws`), obtains
         the `overload` implementation and wrap it in a Dispatcher object.
         The expected argument types are returned for use by type-inference.
         The expected argument types are only different from the given argument
-        types if there is a imprecise type in the given argument types.
+        types if there is an imprecise type in the given argument types.
 
         Parameters
         ----------


### PR DESCRIPTION
~~**WIP. DO NOT MERGE**~~

Support usecase like:


```python
from numba import njit
from numba.typed import Dict

@njit
def foo(k, v):
    d = Dict()
    d[k] = v
    return d
```

TODOs:
- [x] implement type-inferred dict for compiled code
- [x] implement type-inferred dict for interpreted code