### PR TITLE
Fix error with pickling unicode

### DIFF
--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -477,17 +477,11 @@ class ContextManager(Callable, Phantom):
 class UnicodeType(IterableType):
 
     def __init__(self, name):
-        # this is updated on first call to `.iterator_type`.
-        self._iterator_type = None
         super(UnicodeType, self).__init__(name)
 
     @property
     def iterator_type(self):
-        # lazily grab the iterator_type, self needs to init before the
-        # iterator_type is instantiated else variety of pickle failures
-        if self._iterator_type is None:
-            self._iterator_type = UnicodeIteratorType(self)
-        return self._iterator_type
+        return UnicodeIteratorType(self)
 
 
 class UnicodeIteratorType(SimpleIteratorType):


### PR DESCRIPTION
Fixes CI failure on master.

Minimal tests to trigger error is:

```
python runtests.py  numba.tests.test_unicode.TestUnicode.test_join_interleave_str numba.tests.test_types.TestPickling.test_predefined_types -v
```