### PR TITLE
Prevent zero division error in np.linalg.cond

### DIFF
--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2052,6 +2052,13 @@ class TestLinalgCond(TestLinalgBase):
         for sz in [(0, 1), (1, 0), (0, 0)]:
             self.assert_raise_on_empty(cfunc, (np.empty(sz),))
 
+        # singular systems to trip divide-by-zero
+        x = np.array([[1, 0], [0, 0]], dtype=np.float64)
+        check(x)
+        check(x, p=2)
+        x = np.array([[0, 0], [0, 0]], dtype=np.float64)
+        check(x, p=-2)
+
         # try an ill-conditioned system with 2-norm, make sure np raises an
         # overflow warning as the result is `+inf` and that the result from
         # numba matches.

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2053,11 +2053,14 @@ class TestLinalgCond(TestLinalgBase):
             self.assert_raise_on_empty(cfunc, (np.empty(sz),))
 
         # singular systems to trip divide-by-zero
-        x = np.array([[1, 0], [0, 0]], dtype=np.float64)
-        check(x)
-        check(x, p=2)
-        x = np.array([[0, 0], [0, 0]], dtype=np.float64)
-        check(x, p=-2)
+        # only for np > 1.14, before this norm was computed via inversion which
+        # will fail with numpy.linalg.linalg.LinAlgError: Singular matrix
+        if numpy_version > (1, 14):
+            x = np.array([[1, 0], [0, 0]], dtype=np.float64)
+            check(x)
+            check(x, p=2)
+            x = np.array([[0, 0], [0, 0]], dtype=np.float64)
+            check(x, p=-2)
 
         # try an ill-conditioned system with 2-norm, make sure np raises an
         # overflow warning as the result is `+inf` and that the result from


### PR DESCRIPTION
A singular matrix with a minimum singular value of zero could trip
a zero division error in the current impl, this fixes it and also
makes use of branch pruning to reduce the size of the code.

Fixes #3992

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
