### PR TITLE
Support `dict()` and `{}`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -360,7 +360,6 @@ exclude =
     numba/typing/setdecl.py
     numba/typing/npydecl.py
     numba/typing/arraydecl.py
-    numba/typing/context.py
     numba/typing/collections.py
     numba/typing/ctypes_utils.py
     numba/typing/enumdecl.py

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -315,12 +315,17 @@ dict
   ``numba.typed.Dict`` is an experimental feature.  The API may change
   in the future releases.
 
-Numba does not directly support the Python ``dict`` because it is an untyped
+.. note::
+  ``dict()`` was not supported in previous versions.  Currently, calling
+  ``dict()`` is translated to ``numba.typed.Dict()``.
+
+Numba does not fully support the Python ``dict`` because it is an untyped
 container that can have any Python types as members. To generate efficient
 machine code, Numba needs the keys and the values of the dictionary to have
 fixed types, declared in advance. To achieve this, Numba has a typed dictionary,
-``numba.typed.Dict``, for which the user must explicitly declare the key-type
-and the value-type using the ``Dict.empty()`` constructor method.
+``numba.typed.Dict``, for which the type-inferencer must be able to infer the
+key-value types by usage, or the user must explicitly declare the key-value
+type using the ``Dict.empty()`` constructor method.
 This typed dictionary has the same API as the Python ``dict``,  it implements
 the ``collections.MutableMapping`` interface and is usable in both interpreted
 Python code and JIT-compiled Numba functions.
@@ -334,11 +339,6 @@ An important difference of the typed dictionary in comparison to Python's
 ``dict`` is that **implicit casting** occurs when a key or value is stored.
 As a result the *setitem* operation may fail should the type-casting fail.
 
-.. note::
-  A ``numba.typed.Dict`` cannot yet be constructed with ``Dict()``, the
-  ``Dict.empty(key_type, value_type)`` class method must be used to construct a
-  typed dictionary instead.
-
 It should be noted that the Numba typed dictionary is implemented using the same
 algorithm as the CPython 3.7 dictionary. As a consequence, the typed dictionary
 is ordered and has the same collision resolution as the CPython implementation.
@@ -349,6 +349,17 @@ dictionary, most notably the Numba ``Set`` and ``List`` types are currently
 unsupported. Acceptable key/value types include but are not limited to: unicode
 strings, arrays, scalars, tuples. It is expected that these limitations will
 be relaxed as Numba continues to improve.
+
+Here's an example of using ``dict()`` and ``{}`` to create ``numba.typed.Dict``
+instances and letting the compiler infer the key-value types:
+
+.. literalinclude:: ../../../examples/dict_usage.py
+   :language: python
+   :caption: from ``ex_inferred_dict_njit`` of ``examples/dict_usage.py``
+   :start-after: magictoken.ex_inferred_dict_njit.begin
+   :end-before: magictoken.ex_inferred_dict_njit.end
+   :dedent: 4
+   :linenos:
 
 Here's an example of creating a ``numba.typed.Dict`` instance from interpreted
 code and using the dictionary in jit code:

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -328,9 +328,9 @@ Numba does not fully support the Python ``dict`` because it is an untyped
 container that can have any Python types as members. To generate efficient
 machine code, Numba needs the keys and the values of the dictionary to have
 fixed types, declared in advance. To achieve this, Numba has a typed dictionary,
-``numba.typed.Dict``, for which the type-inference mechanism must be able to infer the
-key-value types by use, or the user must explicitly declare the key-value
-type using the ``Dict.empty()`` constructor method.
+``numba.typed.Dict``, for which the type-inference mechanism must be able to
+infer the key-value types by use, or the user must explicitly declare the
+key-value type using the ``Dict.empty()`` constructor method.
 This typed dictionary has the same API as the Python ``dict``,  it implements
 the ``collections.MutableMapping`` interface and is usable in both interpreted
 Python code and JIT-compiled Numba functions.

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -316,8 +316,13 @@ dict
   in the future releases.
 
 .. note::
-  ``dict()`` was not supported in previous versions.  Currently, calling
+  ``dict()`` was not supported in versions prior to 0.44.  Currently, calling
   ``dict()`` translates to calling ``numba.typed.Dict()``.
+
+Numba only supports the use of ``dict()`` without any arguments.  Such use is
+semantically equivalent to ``{}`` and ``numba.typed.Dict()``.  It will create
+an instance of ``numba.typed.Dict`` where the key-value types will be later
+inferred by usage.
 
 Numba does not fully support the Python ``dict`` because it is an untyped
 container that can have any Python types as members. To generate efficient

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -317,14 +317,14 @@ dict
 
 .. note::
   ``dict()`` was not supported in previous versions.  Currently, calling
-  ``dict()`` is translated to ``numba.typed.Dict()``.
+  ``dict()`` translates to calling ``numba.typed.Dict()``.
 
 Numba does not fully support the Python ``dict`` because it is an untyped
 container that can have any Python types as members. To generate efficient
 machine code, Numba needs the keys and the values of the dictionary to have
 fixed types, declared in advance. To achieve this, Numba has a typed dictionary,
-``numba.typed.Dict``, for which the type-inferencer must be able to infer the
-key-value types by usage, or the user must explicitly declare the key-value
+``numba.typed.Dict``, for which the type-inference mechanism must be able to infer the
+key-value types by use, or the user must explicitly declare the key-value
 type using the ``Dict.empty()`` constructor method.
 This typed dictionary has the same API as the Python ``dict``,  it implements
 the ``collections.MutableMapping`` interface and is usable in both interpreted

--- a/examples/dict_usage.py
+++ b/examples/dict_usage.py
@@ -83,8 +83,8 @@ def ex_inferred_dict_njit():
     def foo():
         d = dict()
         k = {1: np.arange(1), 2: np.arange(2)}
-        # The following tells the compiler what the key type and the value type are
-        # for `d`.
+        # The following tells the compiler what the key type and the value
+        # type are for `d`.
         d[3] = np.arange(3)
         d[5] = np.arange(5)
         return d, k

--- a/examples/dict_usage.py
+++ b/examples/dict_usage.py
@@ -72,3 +72,28 @@ def ex_typed_dict_njit():
     # magictoken.ex_typed_dict_njit.end
     np.testing.assert_array_equal(d['posx'], [0, 1, 2])
     np.testing.assert_array_equal(d['posy'], [3, 4, 5])
+
+
+def ex_inferred_dict_njit():
+    # magictoken.ex_inferred_dict_njit.begin
+    from numba import njit
+    import numpy as np
+
+    @njit
+    def foo():
+        d = dict()
+        k = {1: np.arange(1), 2: np.arange(2)}
+        # The following tells the compiler what key type and value type are
+        # for `d`.
+        d[3] = np.arange(3)
+        d[5] = np.arange(5)
+        return d, k
+
+    d, k = foo()
+    print(d)    # {3: [0 1 2], 5: [0 1 2 3 4]}
+    print(k)    # {1: [0], 2: [0 1]}
+    # magictoken.ex_inferred_dict_njit.end
+    np.testing.assert_array_equal(d[3], [0, 1, 2])
+    np.testing.assert_array_equal(d[5], [0, 1, 2, 3, 4])
+    np.testing.assert_array_equal(k[1], [0])
+    np.testing.assert_array_equal(k[2], [0, 1])

--- a/examples/dict_usage.py
+++ b/examples/dict_usage.py
@@ -83,7 +83,7 @@ def ex_inferred_dict_njit():
     def foo():
         d = dict()
         k = {1: np.arange(1), 2: np.arange(2)}
-        # The following tells the compiler what key type and value type are
+        # The following tells the compiler what the key type and the value type are
         # for `d`.
         d[3] = np.arange(3)
         d[5] = np.arange(5)

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -37,6 +37,9 @@ from .jitclass import jitclass
 import numba.withcontexts
 from numba.withcontexts import objmode_context as objmode
 
+# Initialize typed containers
+import numba.typed
+
 # Keep this for backward compatibility.
 test = runtests.main
 

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -1195,3 +1195,16 @@ def impl_iterator_iternext(context, builder, sig, args, result):
         else:
             # unreachable
             raise AssertionError('unknown type: {}'.format(iter_type.iterable))
+
+
+def build_map(context, builder, dict_type, items):
+    from numba.typed import Dict
+
+    sig = typing.signature(dict_type)
+    kt, vt = dict_type.key_type, dict_type.value_type
+
+    def call_ctor():
+        return Dict.empty(kt, vt)
+
+    args = ()
+    return context.compile_internal(builder, call_ctor, sig, args)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -1064,6 +1064,11 @@ class Lower(BaseLower):
                         for val, fromty in zip(itemvals, itemtys)]
             return self.context.build_set(self.builder, resty, castvals)
 
+        elif expr.op == "build_map":
+            items = expr.items
+            assert not items
+            return self.context.build_map(self.builder, resty, [])
+
         elif expr.op == "cast":
             val = self.loadvar(expr.value.name)
             ty = self.typeof(expr.value.name)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -1066,8 +1066,20 @@ class Lower(BaseLower):
 
         elif expr.op == "build_map":
             items = expr.items
-            assert not items
-            return self.context.build_map(self.builder, resty, [])
+            keys, values = [], []
+            key_types, value_types = [], []
+            for k, v in items:
+                key = self.loadvar(k.name)
+                keytype = self.typeof(k.name)
+                val = self.loadvar(v.name)
+                valtype = self.typeof(v.name)
+                keys.append(key)
+                values.append(val)
+                key_types.append(keytype)
+                value_types.append(valtype)
+            return self.context.build_map(self.builder, resty,
+                                          list(zip(key_types, value_types)),
+                                          list(zip(keys, values)))
 
         elif expr.op == "cast":
             val = self.loadvar(expr.value.name)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -355,6 +355,11 @@ class Lower(BaseLower):
             assert signature is not None
             return self.lower_setitem(inst.target, inst.index, inst.value, signature)
 
+        elif isinstance(inst, ir.StoreMap):
+            signature = self.fndesc.calltypes[inst]
+            assert signature is not None
+            return self.lower_setitem(inst.dct, inst.key, inst.value, signature)
+
         elif isinstance(inst, ir.DelItem):
             target = self.loadvar(inst.target.name)
             index = self.loadvar(inst.index.name)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -11,7 +11,9 @@ from numba.callwrapper import PyCallWrapper
 from .base import BaseContext, PYOBJECT
 from numba import utils, cgutils, types
 from numba.utils import cached_property
-from numba.targets import callconv, codegen, externals, intrinsics, listobj, setobj
+from numba.targets import (
+    callconv, codegen, externals, intrinsics, listobj, setobj, dictimpl,
+)
 from .options import TargetOptions
 from numba.runtime import rtsys
 from numba.compiler_lock import global_compiler_lock

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -127,6 +127,12 @@ class CPUContext(BaseContext):
         """
         return setobj.build_set(self, builder, set_type, items)
 
+    def build_map(self, builder, dict_type, items):
+        from numba import dictobject
+
+        return dictobject.build_map(self, builder, dict_type, items)
+
+
     def post_lowering(self, mod, library):
         if self.fastmath:
             fastmathpass.rewrite_module(mod, self.fastmath)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -127,10 +127,10 @@ class CPUContext(BaseContext):
         """
         return setobj.build_set(self, builder, set_type, items)
 
-    def build_map(self, builder, dict_type, items):
+    def build_map(self, builder, dict_type, item_types, items):
         from numba import dictobject
 
-        return dictobject.build_map(self, builder, dict_type, items)
+        return dictobject.build_map(self, builder, dict_type, item_types, items)
 
 
     def post_lowering(self, mod, library):

--- a/numba/targets/dictimpl.py
+++ b/numba/targets/dictimpl.py
@@ -1,0 +1,17 @@
+from numba.targets.imputils import lower_builtin
+
+
+@lower_builtin(dict)
+def impl_dict(context, builder, sig, args):
+    """
+    The `dict()` implementation simply forwards the work to `Dict.empty()`.
+    """
+    from numba.typed import Dict
+
+    dicttype = sig.return_type
+    kt, vt = dicttype.key_type, dicttype.value_type
+
+    def call_ctor():
+        return Dict.empty(kt, vt)
+
+    return context.compile_internal(builder, call_ctor, sig, args)

--- a/numba/targets/dictimpl.py
+++ b/numba/targets/dictimpl.py
@@ -1,3 +1,6 @@
+"""
+This file implement the lowering for `dict()`
+"""
 from numba.targets.imputils import lower_builtin
 
 

--- a/numba/targets/dictimpl.py
+++ b/numba/targets/dictimpl.py
@@ -1,5 +1,5 @@
 """
-This file implement the lowering for `dict()`
+This file implements the lowering for `dict()`
 """
 from numba.targets.imputils import lower_builtin
 

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -52,5 +52,22 @@ class TestCompiledDict(TestCase):
         self.assertEqual(d, {1: 2})
 
 
+    def test_use_curlybraces_with_init1(self):
+        @njit
+        def foo():
+            return {1: 2}
+
+        d = foo()
+        self.assertEqual(d, {1: 2})
+
+    def test_use_curlybraces_with_initmany(self):
+        @njit
+        def foo():
+            return {1: 2.2, 3: 4.4, 5: 6.6}
+
+        d = foo()
+        self.assertEqual(d, {1: 2.2, 3: 4.4, 5: 6.6})
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -128,7 +128,7 @@ class TestCompiledDict(TestCase):
 
 
     def test_dict_use_with_optional_value(self):
-        # Test that Optinoal cannot be used as value for Dict
+        # Test that Optional cannot be used as value for Dict
         @njit
         def foo(choice):
             k = {1: 2.5 if choice else None}

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -26,6 +26,7 @@ class DictTestCase(TestCase):
 # XXX: requires this import sideeffect
 import numba.typed
 
+
 class TestCompiledDict(TestCase):
     """Testing `dict()` and `{}` usage that are redirected to
     `numba.typed.Dict`.

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -158,12 +158,12 @@ class TestCompiledDict(TestCase):
     def test_dict_use_with_none_key(self):
         # Test that NoneType cannot be used as a key for Dict
         @njit
-        def foo(choice):
+        def foo():
             k = {None: 1}
             return k
 
         with self.assertRaises(TypingError) as raises:
-            foo(True)
+            foo()
         self.assertIn(
             "Dict.key_type cannot be of type none",
             str(raises.exception),

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -112,6 +112,35 @@ class TestCompiledDict(TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
+    def test_dict_use_with_none_value(self):
+        # Test that NoneType cannot be used as value for Dict
+        @njit
+        def foo():
+            k = {1: None}
+            return k
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "Dict.value_type cannot be of type none",
+            str(raises.exception),
+        )
+
+
+    def test_dict_use_with_optional_value(self):
+        # Test that Optinoal cannot be used as value for Dict
+        @njit
+        def foo(choice):
+            k = {1: 2.5 if choice else None}
+            return k
+
+        with self.assertRaises(TypingError) as raises:
+            foo(True)
+        self.assertIn(
+            "Dict.value_type cannot be of type ?float64",
+            str(raises.exception),
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -6,7 +6,6 @@ import numba.unittest_support as unittest
 from .support import TestCase, force_pyobj_flags
 
 
-
 def build_map():
     return {0: 1, 2: 3}
 
@@ -23,9 +22,6 @@ class DictTestCase(TestCase):
 
     def test_build_map_from_local_vars(self, flags=force_pyobj_flags):
         self.run_nullary_func(build_map_from_local_vars, flags=flags)
-
-# XXX: requires this import sideeffect
-import numba.typed
 
 
 class TestCompiledDict(TestCase):

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -101,6 +101,17 @@ class TestCompiledDict(TestCase):
         x, y = 10, 20
         self.assertEqual(foo(x, y), foo.py_func(x, y))
 
+    def test_mixed_curlybraces_and_dict(self):
+        # Test mixed use of {} and dict()
+        @njit
+        def foo():
+            k = dict()
+            k[1] = {1: 3}
+            k[2] = {4: 2}
+            return k
+
+        self.assertEqual(foo(), foo.py_func())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -141,6 +141,33 @@ class TestCompiledDict(TestCase):
             str(raises.exception),
         )
 
+    def test_dict_use_with_optional_key(self):
+        # Test that Optional cannot be used as a key for Dict
+        @njit
+        def foo(choice):
+            k = {2.5 if choice else None: 1}
+            return k
+
+        with self.assertRaises(TypingError) as raises:
+            foo(True)
+        self.assertIn(
+            "Dict.key_type cannot be of type ?float64",
+            str(raises.exception),
+        )
+
+    def test_dict_use_with_none_key(self):
+        # Test that NoneType cannot be used as a key for Dict
+        @njit
+        def foo(choice):
+            k = {None: 1}
+            return k
+
+        with self.assertRaises(TypingError) as raises:
+            foo(True)
+        self.assertIn(
+            "Dict.key_type cannot be of type none",
+            str(raises.exception),
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 
+from numba import njit
 import numba.unittest_support as unittest
 from .support import TestCase, force_pyobj_flags
+
 
 
 def build_map():
@@ -20,6 +22,33 @@ class DictTestCase(TestCase):
 
     def test_build_map_from_local_vars(self, flags=force_pyobj_flags):
         self.run_nullary_func(build_map_from_local_vars, flags=flags)
+
+# XXX: requires this import sideeffect
+import numba.typed
+
+class TestCompiledDict(TestCase):
+    """Testing `dict()` and `{}` usage that are redirected to
+    `numba.typed.Dict`.
+    """
+    def test_use_dict(self):
+        @njit
+        def foo():
+            d = dict()
+            d[1] = 2
+            return d
+
+        d = foo()
+        self.assertEqual(d, {1: 2})
+
+    def test_use_curlybraces(self):
+        @njit
+        def foo():
+            d = {}
+            d[1] = 2
+            return d
+
+        d = foo()
+        self.assertEqual(d, {1: 2})
 
 
 if __name__ == '__main__':

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -13,7 +13,6 @@ from numba.extending import (
     unbox,
     NativeValue,
     type_callable,
-    lower_builtin,
 )
 
 
@@ -311,14 +310,3 @@ def impl_numba_typeref_ctor(cls):
         return Dict.empty(key_type, value_type)
 
     return impl
-
-
-@lower_builtin(dict)
-def _(context, builder, sig, args):
-    dicttype = sig.return_type
-    kt, vt = dicttype.key_type, dicttype.value_type
-
-    def call_ctor():
-        return Dict.empty(kt, vt)
-
-    return context.compile_internal(builder, call_ctor, sig, args)

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -12,7 +12,8 @@ from numba.extending import (
     box,
     unbox,
     NativeValue,
-    type_callable
+    type_callable,
+    lower_builtin,
 )
 
 
@@ -310,3 +311,14 @@ def impl_numba_typeref_ctor(cls):
         return Dict.empty(key_type, value_type)
 
     return impl
+
+
+@lower_builtin(dict)
+def _(context, builder, sig, args):
+    dicttype = sig.return_type
+    kt, vt = dicttype.key_type, dicttype.value_type
+
+    def call_ctor():
+        return Dict.empty(kt, vt)
+
+    return context.compile_internal(builder, call_ctor, sig, args)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -274,8 +274,7 @@ class BuildMapConstraint(object):
                                                   types.undefined),
                                    loc=self.loc)
             else:
-                head = tsets[0]
-                key_type, value_type = head
+                key_type, value_type = tsets[0]
                 typeinfer.add_type(self.target,
                                    types.DictType(key_type, value_type),
                                    loc=self.loc)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -266,21 +266,19 @@ class BuildMapConstraint(object):
     def __call__(self, typeinfer):
         with new_error_context("typing of dict at {0}", self.loc):
             typevars = typeinfer.typevars
-            print('self.items', self.items)
-            tsets = [typevars[i.name].get() for i in self.items]
+            tsets = [(typevars[k.name].getone(), typevars[v.name].getone())
+                     for k, v in self.items]
             if not tsets:
                 typeinfer.add_type(self.target,
                                    types.DictType(types.undefined,
                                                   types.undefined),
                                    loc=self.loc)
             else:
-                for typs in itertools.product(*tsets):
-                    print(typs)
-                    unified = typeinfer.context.unify_types(*typs)
-                    if unified is not None:
-                        typeinfer.add_type(self.target,
-                                           self.container_type(unified),
-                                           loc=self.loc)
+                head = tsets[0]
+                key_type, value_type = head
+                typeinfer.add_type(self.target,
+                                   types.DictType(key_type, value_type),
+                                   loc=self.loc)
 
 
 class ExhaustIterConstraint(object):

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1159,6 +1159,8 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
             self.typeof_setattr(inst)
         elif isinstance(inst, ir.Print):
             self.typeof_print(inst)
+        elif isinstance(inst, ir.StoreMap):
+            self.typeof_storemap(inst)
         elif isinstance(inst, (ir.Jump, ir.Branch, ir.Return, ir.Del)):
             pass
         elif isinstance(inst, ir.StaticRaise):
@@ -1173,6 +1175,12 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
 
     def typeof_setitem(self, inst):
         constraint = SetItemConstraint(target=inst.target, index=inst.index,
+                                       value=inst.value, loc=inst.loc)
+        self.constraints.append(constraint)
+        self.calls.append((inst, constraint))
+
+    def typeof_storemap(self, inst):
+        constraint = SetItemConstraint(target=inst.dct, index=inst.key,
                                        value=inst.value, loc=inst.loc)
         self.constraints.append(constraint)
         self.calls.append((inst, constraint))

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from .abstract import *
 from .common import *
-from .misc import Undefined, unliteral
+from .misc import Undefined, unliteral, Optional, NoneType
 from ..typeconv import Conversion
 from ..errors import TypingError
 
@@ -458,6 +458,9 @@ class DictType(IterableType):
         assert not isinstance(valty, TypeRef)
         keyty = unliteral(keyty)
         valty = unliteral(valty)
+        if isinstance(valty, (Optional, NoneType)):
+            fmt = 'Dict.value_type cannot be of type {}'
+            raise TypingError(fmt.format(valty))
         _sentry_forbidden_types(keyty, valty)
         self.key_type = keyty
         self.value_type = valty

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -458,6 +458,9 @@ class DictType(IterableType):
         assert not isinstance(valty, TypeRef)
         keyty = unliteral(keyty)
         valty = unliteral(valty)
+        if isinstance(keyty, (Optional, NoneType)):
+            fmt = 'Dict.key_type cannot be of type {}'
+            raise TypingError(fmt.format(keyty))
         if isinstance(valty, (Optional, NoneType)):
             fmt = 'Dict.value_type cannot be of type {}'
             raise TypingError(fmt.format(valty))

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -207,7 +207,8 @@ class Optional(Type):
 
     def __init__(self, typ):
         assert not isinstance(typ, (Optional, NoneType))
-        self.type = unliteral(typ)
+        typ = unliteral(typ)
+        self.type = typ
         name = "?%s" % typ
         super(Optional, self).__init__(name)
 

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -307,8 +307,6 @@ class BaseContext(object):
 
     def resolve_setitem(self, target, index, value):
         assert isinstance(index, types.Type), index
-        args = target, index, value
-        kws = {}
         fnty = self.resolve_value_type(operator.setitem)
         sig = fnty.get_call_type(self, (target, index, value), {})
         return sig
@@ -382,8 +380,9 @@ class BaseContext(object):
 
     def _load_builtins(self):
         # Initialize declarations
-        from . import builtins, arraydecl, npdatetime
-        from . import ctypes_utils, bufproto
+        from . import builtins, arraydecl, npdatetime  # noqa: F401
+        from . import ctypes_utils, bufproto           # noqa: F401
+
         self.install_registry(templates.builtin_registry)
 
     def load_additional_registries(self):
@@ -663,8 +662,17 @@ class BaseContext(object):
 class Context(BaseContext):
 
     def load_additional_registries(self):
-        from . import (cffi_utils, cmathdecl, enumdecl, listdecl, mathdecl,
-                       npydecl, randomdecl, setdecl)
+        from . import (
+            cffi_utils,
+            cmathdecl,
+            enumdecl,
+            listdecl,
+            mathdecl,
+            npydecl,
+            randomdecl,
+            setdecl,
+            dictdecl,
+        )
         self.install_registry(cffi_utils.registry)
         self.install_registry(cmathdecl.registry)
         self.install_registry(enumdecl.registry)
@@ -673,3 +681,4 @@ class Context(BaseContext):
         self.install_registry(npydecl.registry)
         self.install_registry(randomdecl.registry)
         self.install_registry(setdecl.registry)
+        self.install_registry(dictdecl.registry)

--- a/numba/typing/dictdecl.py
+++ b/numba/typing/dictdecl.py
@@ -1,3 +1,6 @@
+"""
+This implement typing template for `dict()`.
+"""
 from __future__ import absolute_import, print_function
 
 from .. import types, errors

--- a/numba/typing/dictdecl.py
+++ b/numba/typing/dictdecl.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from .. import types
+from .. import types, errors
 from .templates import (
     AbstractTemplate,
     Registry,
@@ -13,9 +13,15 @@ infer_global = registry.register_global
 infer_getattr = registry.register_attr
 
 
+_message_dict_support = """
+Unsupported usage of `dict()` with arguments. \
+The only implemented usage is `dict()`.
+""".strip()
+
+
 @infer_global(dict)
 class DictBuiltin(AbstractTemplate):
     def generic(self, args, kws):
-        assert not kws
-        assert not args
+        if args or kws:
+            raise errors.TypingError(_message_dict_support)
         return signature(types.DictType(types.undefined, types.undefined))

--- a/numba/typing/dictdecl.py
+++ b/numba/typing/dictdecl.py
@@ -1,5 +1,5 @@
 """
-This implement typing template for `dict()`.
+This implements the typing template for `dict()`.
 """
 from __future__ import absolute_import, print_function
 
@@ -17,8 +17,8 @@ infer_getattr = registry.register_attr
 
 
 _message_dict_support = """
-Unsupported usage of `dict()` with arguments. \
-The only implemented usage is `dict()`.
+Unsupported use of `dict()` with positional or keyword argument(s). \
+The only supported use is `dict()`.
 """.strip()
 
 

--- a/numba/typing/dictdecl.py
+++ b/numba/typing/dictdecl.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, print_function
+
+from .. import types
+from .templates import (
+    AbstractTemplate,
+    Registry,
+    signature,
+)
+
+registry = Registry()
+infer = registry.register
+infer_global = registry.register_global
+infer_getattr = registry.register_attr
+
+
+@infer_global(dict)
+class DictBuiltin(AbstractTemplate):
+    def generic(self, args, kws):
+        assert not kws
+        assert not args
+        return signature(types.DictType(types.undefined, types.undefined))


### PR DESCRIPTION
Implement support for `dict()` and `{}` but not dict-comprehension.

The compiler translates `dict()` to `Dict.empty(kt, vt)` where the `kt` and `vt` are types inferred based on usage.  Thus, `dict()` is still returning a `numba.typed.Dict` in jit-code.

TODO:

- [x] write docs.