### PR TITLE
Correct runtests command in contributing.rst

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -176,12 +176,12 @@ following test runner options:
 * The ``--failed-first`` option is added to capture the list of failed tests
   and to re-execute them first::
 
-    $ python -m numba.runtests --failed-first -mvb
+    $ python -m numba.runtests --failed-first -m -v -b
 
 * The ``--last-failed`` option is used with ``--failed-first`` to execute
   the previously failed tests only::
 
-    $ python -m numba.runtests --last-failed -mvb
+    $ python -m numba.runtests --last-failed -m -v -b
 
 Development rules
 -----------------


### PR DESCRIPTION
The current command in `contributing.rst` doesn't work for me:
```
$ python -m numba.runtests --failed-first -mvb
Running 6661 tests
Flags ['-mvb']
usage: runtests.py [-h] [-v] [-q] [--locals] [-f] [-c] [-b]
                   [-k TESTNAMEPATTERNS] [-R] [-m [MULTIPROCESS]] [-l]
                   [--tags TAGS] [--exclude-tags EXCLUDE_TAGS]
                   [--random RANDOM_SELECT] [--profile]
                   [tests [tests ...]]
runtests.py: error: argument -m/--multiprocess: invalid int value: 'vb'
```
This PR changes to `-m -v -b` which works.