### PR TITLE
Resolves #4007.

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -701,6 +701,10 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                 if (isinstance(expr, ir.Expr) and expr.op == 'getattr'
                         and expr.attr in ['T', 'ctypes', 'flat']):
                     _add_alias(lhs, expr.value.name, alias_map, arg_aliases)
+                # a = b.c.  a should alias b
+                if (isinstance(expr, ir.Expr) and expr.op == 'getattr'
+                        and expr.value.name in arg_aliases):
+                    _add_alias(lhs, expr.value.name, alias_map, arg_aliases)
                 # calls that can create aliases such as B = A.ravel()
                 if isinstance(expr, ir.Expr) and expr.op == 'call':
                     fdef = guard(find_callname, func_ir, expr, typemap)


### PR DESCRIPTION
Makes "a" and "b" argument alias in a = b.c if b is an argument alias.