### PR TITLE
[WIP] Fixing wrong dtype of array inside reflected list #4028

### DIFF
--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -19,10 +19,6 @@ from numba.utils import IS_PY3
 from numba import sigutils, types, typing
 from numba.types.abstract import _typecache
 from numba import jit, numpy_support, typeof
-from numba.extending import overload
-from numba import generated_jit
-from numba import int64
-
 from numba.numpy_support import version as numpy_version
 from .support import TestCase, tag
 from .enum_usecases import *
@@ -214,6 +210,12 @@ class TestTypes(TestCase):
         ty = types.NPTimedelta('')
         self.assertPreciseEqual(ty(5), np.timedelta64(5))
         self.assertPreciseEqual(ty('NaT'), np.timedelta64('NaT'))
+
+    def test_list_type_getitem(self):
+        for listty in (types.int64, types.Array(types.float64, 1, 'C')):
+            l_int = types.List(listty)
+            self.assertTrue(isinstance(l_int, types.List))
+            self.assertTrue(isinstance(l_int[0], type(listty)))
 
 
 class TestNumbers(TestCase):
@@ -579,43 +581,6 @@ class TestDType(TestCase):
             return a.type(0)
         jit_impl = jit(nopython=True)(impl)
         self.assertEqual(impl(), jit_impl())
-
-class TestContainers(TestCase):
-    def test_list_type(self):
-        @generated_jit(nopython=True)
-        def test_foo(arg):
-            self.assertTrue(isinstance(arg, types.List))
-            return lambda arg:arg
-
-        a_list = [1, 2]
-        test_foo(a_list)
-
-    def test_list_content_type_int(self):
-        @generated_jit(nopython=True)
-        def test_foo(arg):
-            self.assertTrue(isinstance(arg[0], types.Integer))
-            return lambda arg: arg
-
-        a_list = [1, 2]
-        test_foo(a_list)
-
-    def test_list_content_type_arr(self):
-        @generated_jit(nopython=True)
-        def test_foo(arg):
-            self.assertTrue(isinstance(arg[0], types.Array))
-            return lambda arg: arg
-
-        a_list = [np.zeros(2, 'int64')]
-        test_foo(a_list)
-
-    def test_list_content_dtype(self):
-        @generated_jit(nopython=True)
-        def test_foo(arg):
-            self.assertTrue(isinstance(arg[0].dtype, types.Integer))
-            return lambda arg: arg
-
-        a_list = [np.zeros(2, 'int64')]
-        test_foo(a_list)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -19,6 +19,10 @@ from numba.utils import IS_PY3
 from numba import sigutils, types, typing
 from numba.types.abstract import _typecache
 from numba import jit, numpy_support, typeof
+from numba.extending import overload
+from numba import generated_jit
+from numba import int64
+
 from numba.numpy_support import version as numpy_version
 from .support import TestCase, tag
 from .enum_usecases import *
@@ -575,6 +579,44 @@ class TestDType(TestCase):
             return a.type(0)
         jit_impl = jit(nopython=True)(impl)
         self.assertEqual(impl(), jit_impl())
+
+class TestContainers(TestCase):
+    def test_list_type(self):
+        @generated_jit(nopython=True)
+        def test_foo(arg):
+            self.assertTrue(isinstance(arg, types.List))
+            return lambda arg:arg
+
+        a_list = [1, 2]
+        test_foo(a_list)
+
+    def test_list_content_type_int(self):
+        @generated_jit(nopython=True)
+        def test_foo(arg):
+            self.assertTrue(isinstance(arg[0], types.Integer))
+            return lambda arg: arg
+
+        a_list = [1, 2]
+        test_foo(a_list)
+
+    def test_list_content_type_arr(self):
+        @generated_jit(nopython=True)
+        def test_foo(arg):
+            self.assertTrue(isinstance(arg[0], types.Array))
+            return lambda arg: arg
+
+        a_list = [np.zeros(2, 'int64')]
+        test_foo(a_list)
+
+    def test_list_content_dtype(self):
+        @generated_jit(nopython=True)
+        def test_foo(arg):
+            self.assertTrue(isinstance(arg[0].dtype, types.Integer))
+            return lambda arg: arg
+
+        a_list = [np.zeros(2, 'int64')]
+        test_foo(a_list)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -359,6 +359,13 @@ class List(MutableSequence):
     def is_precise(self):
         return self.dtype.is_precise()
 
+    def __getitem__(self, args):
+        """
+        Overrides the default __getitem__ from Type.
+        """
+        return self.dtype(dtype=self.dtype.dtype, ndim=self.dtype.ndim,
+                          layout=self.dtype.layout)
+
 
 class ListIter(BaseContainerIterator):
     """

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -363,8 +363,7 @@ class List(MutableSequence):
         """
         Overrides the default __getitem__ from Type.
         """
-        return self.dtype(dtype=self.dtype.dtype, ndim=self.dtype.ndim,
-                          layout=self.dtype.layout)
+        return self.dtype
 
 
 class ListIter(BaseContainerIterator):


### PR DESCRIPTION
fixes #4028 

Overrides default `__getitem__` for List so the contained type is returned.

@stuartarchibald: where should the tests go? `test_lists` or `test_types`?

First time looking at the type system, so I am still finding my way around. The return at the moment is 
```
self.dtype(dtype=self.dtype.dtype, ndim=self.dtype.ndim,
                          layout=self.dtype.layout)
```
but I am wondering whether it should be
```
type(self.dtype)(dtype=self.dtype.dtype, ndim=self.dtype.ndim,
                          layout=self.dtype.layout)
```
