### PR TITLE
Make type.Optional str more representative

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -67,6 +67,15 @@ Glossary
       no faster than Python interpreted code, unless the Numba compiler can
       take advantage of :term:`loop-jitting`.
 
+   ``OptionalType``
+     An ``OptionalType`` is effectively a type union of a ``type`` and ``None``.
+     They typically occur in practice due to a variable being set to ``None``
+     and then in a branch the variable being set to some other value. It's
+     often not possible at compile time to determine if the branch will execute
+     so to permit :term:`type inference` to complete, the type of the variable
+     becomes the union of a ``type`` (from the value) and ``None``,
+     i.e. ``OptionalType(type)``.
+
    type inference
       The process by which Numba determines the specialized types of all
       values within a function being compiled.  Type inference can fail

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -137,7 +137,7 @@ class TestCompiledDict(TestCase):
         with self.assertRaises(TypingError) as raises:
             foo(True)
         self.assertIn(
-            "Dict.value_type cannot be of type float64 or None",
+            "Dict.value_type cannot be of type OptionalType(float64)",
             str(raises.exception),
         )
 
@@ -151,7 +151,7 @@ class TestCompiledDict(TestCase):
         with self.assertRaises(TypingError) as raises:
             foo(True)
         self.assertIn(
-            "Dict.key_type cannot be of type float64 or None",
+            "Dict.key_type cannot be of type OptionalType(float64)",
             str(raises.exception),
         )
 

--- a/numba/tests/test_dicts.py
+++ b/numba/tests/test_dicts.py
@@ -137,7 +137,7 @@ class TestCompiledDict(TestCase):
         with self.assertRaises(TypingError) as raises:
             foo(True)
         self.assertIn(
-            "Dict.value_type cannot be of type ?float64",
+            "Dict.value_type cannot be of type float64 or None",
             str(raises.exception),
         )
 
@@ -151,7 +151,7 @@ class TestCompiledDict(TestCase):
         with self.assertRaises(TypingError) as raises:
             foo(True)
         self.assertIn(
-            "Dict.key_type cannot be of type ?float64",
+            "Dict.key_type cannot be of type float64 or None",
             str(raises.exception),
         )
 

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -209,7 +209,7 @@ class Optional(Type):
         assert not isinstance(typ, (Optional, NoneType))
         typ = unliteral(typ)
         self.type = typ
-        name = "OptionalType(%s)" % typ
+        name = "OptionalType(%s) i.e. the type '%s or None'" % (typ, typ)
         super(Optional, self).__init__(name)
 
     @property

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -208,7 +208,7 @@ class Optional(Type):
     def __init__(self, typ):
         assert not isinstance(typ, (Optional, NoneType))
         self.type = unliteral(typ)
-        name = "?%s" % typ
+        name = "%s or None" % typ
         super(Optional, self).__init__(name)
 
     @property

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -209,7 +209,7 @@ class Optional(Type):
         assert not isinstance(typ, (Optional, NoneType))
         typ = unliteral(typ)
         self.type = typ
-        name = "%s or None" % typ
+        name = "OptionalType(%s)" % typ
         super(Optional, self).__init__(name)
 
     @property


### PR DESCRIPTION
Fixes #4025. Replace '?' with a 'or None' message on optional types.