### PR TITLE
Ambiguous Documentation fix for guvectorize.

### DIFF
--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -165,7 +165,7 @@ There are two things there:
   returns a *n*-element one-dimension array;
 
 * the list of supported concrete *signatures* as per ``@vectorize``; here,
-  in the above example we demonstrate ``int64`` arrays.
+  as in the above example, we demonstrate ``int64`` arrays.
 
 .. note::
    1D array type can also receive scalar arguments (those with shape ``()``).

--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -164,8 +164,8 @@ There are two things there:
   array, a scalar (symbolically denoted by the empty tuple ``()``) and
   returns a *n*-element one-dimension array;
 
-* the list of supported concrete *signatures* as in ``@vectorize``; here we
-  only support ``int64`` arrays.
+* the list of supported concrete *signatures* are the same as in ``@vectorize``; here
+  in the above example we demonstrate ``int64`` arrays.
 
 .. note::
    1D array type can also receive scalar arguments (those with shape ``()``).

--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -164,7 +164,7 @@ There are two things there:
   array, a scalar (symbolically denoted by the empty tuple ``()``) and
   returns a *n*-element one-dimension array;
 
-* the list of supported concrete *signatures* are the same as in ``@vectorize``; here
+* the list of supported concrete *signatures* as per ``@vectorize``; here,
   in the above example we demonstrate ``int64`` arrays.
 
 .. note::


### PR DESCRIPTION
The wording is ambiguous in the second bullet point below the example code in the documentation for `guvectorize`. This fix resolves that by explicitly saying that the example for `guvectorize` only demonstrates int64 arrays but it can support every signature as in `vectorize` 
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
