### PR TITLE
CUDA: Use min/max PTX Instructions

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -413,6 +413,7 @@ def ptx_selp(context, builder, sig, args):
     test, a, b = args
     return builder.select(test, a, b)
 
+
 @lower(max, types.f4, types.f4)
 def ptx_max_f4(context, builder, sig, args):
     fn = builder.module.get_or_insert_function(
@@ -421,6 +422,7 @@ def ptx_max_f4(context, builder, sig, args):
             (lc.Type.float(), lc.Type.float())),
         '__nv_fmaxf')
     return builder.call(fn, args)
+
 
 @lower(max, types.f8, types.f4)
 @lower(max, types.f4, types.f8)
@@ -432,6 +434,7 @@ def ptx_max_f8(context, builder, sig, args):
             (lc.Type.double(), lc.Type.double())),
         '__nv_fmax')
     return builder.call(fn, args)
+
 
 @lower(min, types.f4, types.f4)
 def ptx_min_f4(context, builder, sig, args):

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -413,6 +413,47 @@ def ptx_selp(context, builder, sig, args):
     test, a, b = args
     return builder.select(test, a, b)
 
+@lower(max, types.f4, types.f4)
+def ptx_max_f4(context, builder, sig, args):
+    fn = builder.module.get_or_insert_function(
+        lc.Type.function(
+            lc.Type.float(),
+            (lc.Type.float(), lc.Type.float())),
+        '__nv_fmaxf')
+    return builder.call(fn, args)
+
+@lower(max, types.f8, types.f4)
+@lower(max, types.f4, types.f8)
+@lower(max, types.f8, types.f8)
+def ptx_max_f8(context, builder, sig, args):
+    fn = builder.module.get_or_insert_function(
+        lc.Type.function(
+            lc.Type.double(),
+            (lc.Type.double(), lc.Type.double())),
+        '__nv_fmax')
+    return builder.call(fn, args)
+
+@lower(min, types.f4, types.f4)
+def ptx_min_f4(context, builder, sig, args):
+    fn = builder.module.get_or_insert_function(
+        lc.Type.function(
+            lc.Type.float(),
+            (lc.Type.float(), lc.Type.float())),
+        '__nv_fminf')
+    return builder.call(fn, args)
+
+
+@lower(min, types.f8, types.f4)
+@lower(min, types.f4, types.f8)
+@lower(min, types.f8, types.f8)
+def ptx_min_f8(context, builder, sig, args):
+    fn = builder.module.get_or_insert_function(
+        lc.Type.function(
+            lc.Type.double(),
+            (lc.Type.double(), lc.Type.double())),
+        '__nv_fmin')
+    return builder.call(fn, args)
+
 
 def _normalize_indices(context, builder, indty, inds):
     """

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -433,7 +433,11 @@ def ptx_max_f8(context, builder, sig, args):
             lc.Type.double(),
             (lc.Type.double(), lc.Type.double())),
         '__nv_fmax')
-    return builder.call(fn, args)
+
+    return builder.call(fn, [
+        context.cast(builder, args[0], sig.args[0], types.double),
+        context.cast(builder, args[1], sig.args[1], types.double),
+    ])
 
 
 @lower(min, types.f4, types.f4)
@@ -455,7 +459,11 @@ def ptx_min_f8(context, builder, sig, args):
             lc.Type.double(),
             (lc.Type.double(), lc.Type.double())),
         '__nv_fmin')
-    return builder.call(fn, args)
+
+    return builder.call(fn, [
+        context.cast(builder, args[0], sig.args[0], types.double),
+        context.cast(builder, args[1], sig.args[1], types.double),
+    ])
 
 
 def _normalize_indices(context, builder, indty, inds):

--- a/numba/cuda/tests/cudapy/test_minmax.py
+++ b/numba/cuda/tests/cudapy/test_minmax.py
@@ -1,0 +1,91 @@
+from __future__ import print_function, absolute_import
+
+import numpy as np
+
+from numba import cuda
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+
+
+def builtin_max(A, B, C):
+    i = cuda.grid(1)
+
+    if i >= len(C):
+        return
+
+    C[i] = max(A[i], B[i])
+
+
+def builtin_min(A, B, C):
+    i = cuda.grid(1)
+
+    if i >= len(C):
+        return
+
+    C[i] = min(A[i], B[i])
+
+
+@skip_on_cudasim('Tests PTX emission')
+class TestCudaMinMax(SerialMixin, unittest.TestCase):
+    def test_max_f8(self, n=5):
+        kernel = cuda.jit(builtin_max)
+
+        c = np.zeros(n, dtype=np.float64)
+        a = np.arange(n, dtype=np.float64) + .5
+        b = np.full(n, fill_value=2, dtype=np.float64)
+
+        kernel[1, c.shape](a, b, c)
+        np.testing.assert_allclose(
+            c,
+            np.maximum(a, b))
+
+        ptx = next(p for p in kernel.inspect_asm().values())
+        assert 'max.f64' in ptx, ptx
+
+    def test_min_f8(self, n=5):
+        kernel = cuda.jit(builtin_min)
+
+        c = np.zeros(n, dtype=np.float64)
+        a = np.arange(n, dtype=np.float64) + .5
+        b = np.full(n, fill_value=2, dtype=np.float64)
+
+        kernel[1, c.shape](a, b, c)
+        np.testing.assert_allclose(
+            c,
+            np.minimum(a, b))
+
+        ptx = next(p for p in kernel.inspect_asm().values())
+        assert 'min.f64' in ptx, ptx
+
+    def test_max_f4(self, n=5):
+        kernel = cuda.jit(builtin_max)
+
+        c = np.zeros(n, dtype=np.float32)
+        a = np.arange(n, dtype=np.float32) + .5
+        b = np.full(n, fill_value=2, dtype=np.float32)
+
+        kernel[1, c.shape](a, b, c)
+        np.testing.assert_allclose(
+            c,
+            np.maximum(a, b))
+
+        ptx = next(p for p in kernel.inspect_asm().values())
+        assert 'max.f32' in ptx, ptx
+
+    def test_min_f4(self, n=5):
+        kernel = cuda.jit(builtin_min)
+
+        c = np.zeros(n, dtype=np.float32)
+        a = np.arange(n, dtype=np.float32) + .5
+        b = np.full(n, fill_value=2, dtype=np.float32)
+
+        kernel[1, c.shape](a, b, c)
+        np.testing.assert_allclose(
+            c,
+            np.minimum(a, b))
+
+        ptx = next(p for p in kernel.inspect_asm().values())
+        assert 'min.f32' in ptx, ptx
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_minmax.py
+++ b/numba/cuda/tests/cudapy/test_minmax.py
@@ -12,8 +12,7 @@ def builtin_max(A, B, C):
     if i >= len(C):
         return
 
-    cmp = max(A[i], B[i])
-    C[i] = float64(cmp)
+    C[i] = float64(max(A[i], B[i]))
 
 
 def builtin_min(A, B, C):
@@ -22,8 +21,7 @@ def builtin_min(A, B, C):
     if i >= len(C):
         return
 
-    cmp = min(A[i], B[i])
-    C[i] = float64(cmp)
+    C[i] = float64(min(A[i], B[i]))
 
 
 @skip_on_cudasim('Tests PTX emission')
@@ -43,9 +41,7 @@ class TestCudaMinMax(SerialMixin, unittest.TestCase):
         b = np.full(n, fill_value=2, dtype=dtype_right)
 
         kernel[1, c.shape](a, b, c)
-        np.testing.assert_allclose(
-            c,
-            numpy_equivalent(a, b))
+        np.testing.assert_allclose(c, numpy_equivalent(a, b))
 
         ptx = next(p for p in kernel.inspect_asm().values())
         self.assertIn(ptx_instruction, ptx)


### PR DESCRIPTION
Currently the CUDA backend emits a combination of `setp`s and `selps`, when the hardware has built-in `min` / `max` instructions! 