### PR TITLE
[WIP] Autodetect cuda libs

### DIFF
--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -16,7 +16,10 @@ else:
 
 def get_libdevice(arch):
     libdir = (os.environ.get('NUMBAPRO_LIBDEVICE') or
-              os.environ.get('NUMBAPRO_CUDALIB'))
+              os.environ.get('NUMBAPRO_CUDALIB') or
+              os.environ.get('CUDA_HOME') or
+              os.environ.get('CUDA_ROOT') or
+              os.environ.get('CUDA_PATH'))
 
     pat = r'libdevice\.%s(\.\d+)*\.bc$' % arch
     candidates = find_file(re.compile(pat), libdir)
@@ -37,7 +40,10 @@ def open_libdevice(arch):
 def get_cudalib(lib, platform=None):
     if lib == 'nvvm' and os.environ.get('NUMBAPRO_NVVM'):
         return os.environ.get('NUMBAPRO_NVVM')
-    libdir = os.environ.get('NUMBAPRO_CUDALIB')
+    libdir = (os.environ.get('NUMBAPRO_CUDALIB') or
+              os.environ.get('CUDA_HOME') or
+              os.environ.get('CUDA_ROOT') or
+              os.environ.get('CUDA_PATH'))
     candidates = find_lib(lib, libdir, platform)
     return max(candidates) if candidates else None
 

--- a/numba/findlib.py
+++ b/numba/findlib.py
@@ -44,8 +44,6 @@ def find_file(pat, libdir=None):
         libdirs = list(libdir)
     files = []
     for ldir in libdirs:
-        entries = os.listdir(ldir)
-        candidates = [os.path.join(ldir, ent)
-                      for ent in entries if pat.match(ent)]
-        files.extend([c for c in candidates if os.path.isfile(c)])
+        # Walk current directory and subdirectories, get the full path when pattern matches.
+        files.extend([os.path.join(dirname, ent) for dirname, _, entries in os.walk(ldir) for ent in entries if pat.match(ent)])
     return files


### PR DESCRIPTION
Autodetect system cuda librairies when `NUMBAPRO_*` variables are not define in the environment.
Cuda librairies lives in one of the following :
- `CUDA_HOME`
- `CUDA_ROOT`
- `CUDA_PATH`

* Missing unittest at the moment.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
