### PR TITLE
Change IPython cache dir name to numba_cache

### DIFF
--- a/numba/caching.py
+++ b/numba/caching.py
@@ -290,7 +290,7 @@ class _IPythonCacheLocator(_CacheLocator):
         except ImportError:
             # older IPython version
             from IPython.utils.path import get_ipython_cache_dir
-        return os.path.join(get_ipython_cache_dir(), 'numba')
+        return os.path.join(get_ipython_cache_dir(), 'numba_cache')
 
     def get_source_stamp(self):
         return hashlib.sha256(self._bytes_source).hexdigest()


### PR DESCRIPTION
This PR changes the IPython cache dir sub-dir name from `numba` to `numba_cache`.
Fixes #4040 as suggested by @stuartarchibald in https://github.com/numba/numba/issues/4040#issuecomment-488647247