### PR TITLE
Add FAQ entry explaining Numba project name

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -272,10 +272,10 @@ value, for example::
 Miscellaneous
 =============
 
-Where does the project name Numba come from?
---------------------------------------------
+Where does the project name "Numba" come from?
+----------------------------------------------
 
-"Numba" is a combination of "Numpy" and "Mamba". Mambas are some of the fastest
+"Numba" is a combination of "NumPy" and "Mamba". Mambas are some of the fastest
 snakes in the world, and Numba makes your Python code fast.
 
 How do I reference/cite/acknowledge Numba in other work?

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -272,6 +272,12 @@ value, for example::
 Miscellaneous
 =============
 
+Where does the project name Numba come from?
+--------------------------------------------
+
+"Numba" is a combination of "Numpy" and "Mamba". Mambas are some of the fastest
+snakes in the world, and Numba makes your Python code fast.
+
 How do I reference/cite/acknowledge Numba in other work?
 --------------------------------------------------------
 For academic use, the best option is to cite our ACM Proceedings: `Numba: a


### PR DESCRIPTION
This PR adds a FAQ entry explaining the Numba project name.

I'm giving a talk on Numba at a small meeting on Friday, and this was one of the things I was wondering for the introduction part. I did find this explanation for "Numba" mentioning Mamba in some YouTube video from ~ 2012, don't have the link at the moment.