### PR TITLE
Expose numba CLI via python -m numba

### DIFF
--- a/docs/source/user/cli.rst
+++ b/docs/source/user/cli.rst
@@ -1,0 +1,170 @@
+.. _cli:
+
+Command line interface
+======================
+
+.. _cli_overview:
+
+Overview
+--------
+
+Numba is a Python package, usually you ``import numba`` from Python and use the
+Python application programming interface (API). However, Numba also ships with a
+command line interface (CLI), i.e. a tool ``numba`` that you gets installed when
+you install Numba.
+
+Currently, the only purpose of the CLI is to allow you to quickly show some
+information about your system and installation, or to quickly get some debugging
+information for a Python script using Numba. To see which options are available,
+use ``numba --help``:
+
+::
+
+    $ numba --help
+    usage: numba [-h] [--annotate] [--dump-llvm] [--dump-optimized]
+                 [--dump-assembly] [--dump-cfg] [--dump-ast]
+                 [--annotate-html ANNOTATE_HTML] [-s]
+                 [filename]
+
+    positional arguments:
+      filename              Python source filename
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --annotate            Annotate source
+      --dump-llvm           Print generated llvm assembly
+      --dump-optimized      Dump the optimized llvm assembly
+      --dump-assembly       Dump the LLVM generated assembly
+      --dump-cfg            [Deprecated] Dump the control flow graph
+      --dump-ast            [Deprecated] Dump the AST
+      --annotate-html ANNOTATE_HTML
+                            Output source annotation as html
+      -s, --sysinfo         Output system information for bug reporting
+
+Sometimes it can happen that you get a "command not found" error when you type
+``numba``, because your ``PATH`` isn't configured properly. In that case you can
+use the equivalent commmand ``python -m numba``. If that still gives "command
+not found", try to ``import numba`` as suggested here:
+:ref:`numba-source-install-check`.
+
+.. _cli_sysinfo:
+
+System information
+------------------
+
+The ``numba --sysinfo`` (or ``numba -s`` for short) command prints a lot of
+information about your system and your Numba installation and relevant
+dependencies.
+
+You can execute it from the terminal like this::
+
+    $ numba -s
+    $ python -m numba -s
+
+To see your system information from IPython or Jupyter, prefix the command with
+an exclamation mark like this::
+
+    !numba -s
+    !python -m numba -s
+
+The two versions ``numba`` and ``python -m numba`` are the same. The first is
+shorter to type, but if you get a "command not found" error because your
+``PATH`` doesn't contain the location where ``numba`` is installed, having the
+``python -m numba`` variant is useful.
+
+Example output::
+
+    System info:
+    --------------------------------------------------------------------------------
+    __Time Stamp__
+    2019-05-07 14:15:39.733994
+
+    __Hardware Information__
+    Machine                                       : x86_64
+    CPU Name                                      : haswell
+    CPU count                                     : 8
+    CPU Features                                  : 
+    aes avx avx2 bmi bmi2 cmov cx16 f16c fma fsgsbase invpcid lzcnt mmx movbe pclmul
+    popcnt rdrnd sahf sse sse2 sse3 sse4.1 sse4.2 ssse3 xsave xsaveopt
+
+    __OS Information__
+    Platform                                      : Darwin-18.5.0-x86_64-i386-64bit
+    Release                                       : 18.5.0
+    System Name                                   : Darwin
+    Version                                       : Darwin Kernel Version 18.5.0: Mon Mar 11 20:40:32 PDT 2019; root:xnu-4903.251.3~3/RELEASE_X86_64
+    OS specific info                              : 10.14.4   x86_64
+
+    __Python Information__
+    Python Compiler                               : Clang 4.0.1 (tags/RELEASE_401/final)
+    Python Implementation                         : CPython
+    Python Version                                : 3.7.3
+    Python Locale                                 : en_US UTF-8
+
+    __LLVM information__
+    LLVM version                                  : 7.0.0
+
+    __CUDA Information__
+    CUDA driver library cannot be found or no CUDA enabled devices are present.
+    Error class: <class 'numba.cuda.cudadrv.error.CudaSupportError'>
+
+    __ROC Information__
+    ROC available                                 : False
+    Error initialising ROC due to                 : No ROC toolchains found.
+    No HSA Agents found, encountered exception when searching:
+    Error at driver init: 
+
+    HSA is not currently supported on this platform (darwin).
+    :
+
+    __SVML Information__
+    SVML state, config.USING_SVML                 : False
+    SVML library found and loaded                 : False
+    llvmlite using SVML patched LLVM              : True
+    SVML operational                              : False
+
+    __Threading Layer Information__
+    TBB Threading layer available                 : False
+    +--> Disabled due to                          : Unknown import problem.
+    OpenMP Threading layer available              : False
+    +--> Disabled due to                          : Unknown import problem.
+    Workqueue Threading layer available           : True
+
+    __Numba Environment Variable Information__
+    None set.
+
+    __Conda Information__
+    conda_build_version                           : 3.17.8
+    conda_env_version                             : 4.6.14
+    platform                                      : osx-64
+    python_version                                : 3.7.3.final.0
+    root_writable                                 : True
+
+    __Current Conda Env__
+    (output truncated due to length)
+
+
+.. _cli_debug:
+
+Debugging
+---------
+
+As shown in the help output above, the ``numba`` command includes options that
+can help you to debug Numba.
+
+To try it out, create an example script called ``myscript.py``::
+
+    import numba
+
+    @numba.jit
+    def f(x):
+        return 2 * x
+    
+    f(42)
+
+and then execute one of the following commands::
+
+    $ numba myscript.py --annotate
+    $ numba myscript.py --annotate-html myscript.html
+    $ numba myscript.py --dump-llvm
+    $ numba myscript.py --dump-optimized
+    $ numba myscript.py --dump-assembly

--- a/docs/source/user/cli.rst
+++ b/docs/source/user/cli.rst
@@ -149,7 +149,7 @@ Debugging
 ---------
 
 As shown in the help output above, the ``numba`` command includes options that
-can help you to debug Numba.
+can help you to debug Numba compiled code.
 
 To try it out, create an example script called ``myscript.py``::
 

--- a/docs/source/user/cli.rst
+++ b/docs/source/user/cli.rst
@@ -3,22 +3,44 @@
 Command line interface
 ======================
 
-.. _cli_overview:
-
-Overview
---------
-
 Numba is a Python package, usually you ``import numba`` from Python and use the
 Python application programming interface (API). However, Numba also ships with a
-command line interface (CLI), i.e. a tool ``numba`` that you gets installed when
-you install Numba.
+command line interface (CLI), i.e. a tool ``numba`` that is installed when you
+install Numba.
 
 Currently, the only purpose of the CLI is to allow you to quickly show some
 information about your system and installation, or to quickly get some debugging
-information for a Python script using Numba. To see which options are available,
-use ``numba --help``:
+information for a Python script using Numba.
 
-::
+.. _cli_usage:
+
+Usage
+-----
+
+To use the Numba CLI from the terminal, use ``numba`` followed by the options
+and arguments like ``--help`` or ``-s``, as explained below.
+
+Sometimes it can happen that you get a "command not found" error when you type
+``numba``, because your ``PATH`` isn't configured properly. In that case you can
+use the equivalent commmand ``python -m numba``. If that still gives "command
+not found", try to ``import numba`` as suggested here:
+:ref:`numba-source-install-check`.
+
+The two versions ``numba`` and ``python -m numba`` are the same. The first is
+shorter to type, but if you get a "command not found" error because your
+``PATH`` doesn't contain the location where ``numba`` is installed, having the
+``python -m numba`` variant is useful.
+
+To use the Numba CLI from IPython or Jupyter, use ``!numba``, i.e. prefix the
+command with an exclamation mark. This is a general IPython/Jupyter feature to
+execute shell commands, it is not available in the regular ``python`` terminal.
+
+.. _cli_help:
+
+Help
+----
+
+To see all available options, use ``numba --help``::
 
     $ numba --help
     usage: numba [-h] [--annotate] [--dump-llvm] [--dump-optimized]
@@ -41,38 +63,21 @@ use ``numba --help``:
                             Output source annotation as html
       -s, --sysinfo         Output system information for bug reporting
 
-Sometimes it can happen that you get a "command not found" error when you type
-``numba``, because your ``PATH`` isn't configured properly. In that case you can
-use the equivalent commmand ``python -m numba``. If that still gives "command
-not found", try to ``import numba`` as suggested here:
-:ref:`numba-source-install-check`.
-
 .. _cli_sysinfo:
 
 System information
 ------------------
 
-The ``numba --sysinfo`` (or ``numba -s`` for short) command prints a lot of
+The ``numba -s`` (or the equivalent ``numba --sysinfo``) command prints a lot of
 information about your system and your Numba installation and relevant
 dependencies.
 
-You can execute it from the terminal like this::
-
-    $ numba -s
-    $ python -m numba -s
-
-To see your system information from IPython or Jupyter, prefix the command with
-an exclamation mark like this::
-
-    !numba -s
-    !python -m numba -s
-
-The two versions ``numba`` and ``python -m numba`` are the same. The first is
-shorter to type, but if you get a "command not found" error because your
-``PATH`` doesn't contain the location where ``numba`` is installed, having the
-``python -m numba`` variant is useful.
+Remember: you can use ``!numba -s`` with an exclamation mark to see this
+information from IPython or Jupyter.
 
 Example output::
+
+    $ numba -s
 
     System info:
     --------------------------------------------------------------------------------
@@ -141,7 +146,6 @@ Example output::
 
     __Current Conda Env__
     (output truncated due to length)
-
 
 .. _cli_debug:
 

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -18,6 +18,7 @@ User Manual
    withobjmode.rst
    performance-tips.rst
    threading-layer.rst
+   cli.rst
    troubleshoot.rst
    faq.rst
    examples.rst

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -158,6 +158,7 @@ Then you can build and install Numba from the top level of the source tree::
 
     $ python setup.py install
 
+.. _numba-source-install-check:
 
 Checking your installation
 --------------------------
@@ -172,8 +173,11 @@ You should be able to import Numba from the Python prompt::
     >>> numba.__version__
     '0.39.0+0.g4e49566.dirty'
 
-You can also try executing the `numba -s` command to report information about
-your system capabilities::
+You can also try executing the ``numba --sysinfo`` (or ``numba -s`` for short)
+command to report information about your system capabilities. See :ref:`cli` for
+further information.
+
+::
 
     $ numba -s
     System info:
@@ -212,3 +216,5 @@ your system capabilities::
                                   pci bus id: 1
 
 (output truncated due to length)
+
+

--- a/numba/__main__.py
+++ b/numba/__main__.py
@@ -1,0 +1,6 @@
+"""Expose Numba command via ``python -m numba``."""
+import sys
+from .numba_entry import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -1,0 +1,49 @@
+# Tests for the CLI
+from __future__ import print_function, division, absolute_import
+
+import os
+import subprocess
+import sys
+import threading
+
+import numba.unittest_support as unittest
+from .support import TestCase
+
+
+def run_cmd(cmdline, env=os.environ, timeout=60):
+    popen = subprocess.Popen(cmdline,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             env=env)
+
+    timeout_timer = threading.Timer(timeout, popen.kill)
+    try:
+        timeout_timer.start()
+        out, err = popen.communicate()
+        if popen.returncode != 0:
+            raise AssertionError(
+                "process failed with code %s: stderr follows\n%s\n" %
+                (popen.returncode, err.decode()))
+        return out.decode(), err.decode()
+    finally:
+        timeout_timer.cancel()
+    return None, None
+
+
+class TestCLi(TestCase):
+
+    def test_as_module_exit_code(self):
+        cmdline = [sys.executable, "-m", "numba"]
+        with self.assertRaises(AssertionError) as raises:
+            run_cmd(cmdline)
+
+        self.assertIn("process failed with code 1", str(raises.exception))
+
+    def test_as_module(self):
+        cmdline = [sys.executable, "-m", "numba", "-s"]
+        o, _ = run_cmd(cmdline)
+        self.assertIn("System info", o)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements my suggestion from #4038 to expose the Numba CLI via `python -m numba`.

There is no test, but this is hard to test, and overall it's just very few lines of code and straightforward, other projects like `pip` or many others have the same.

OK to add this?

If there's any docs updates or tests I should do, please let me know.