### PR TITLE
Deprecate the use of iternext_impl without RefType

### DIFF
--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -8,9 +8,10 @@ import collections
 import contextlib
 import inspect
 import functools
+import warnings
 from enum import Enum
 
-from .. import typing, cgutils, types, utils
+from .. import typing, cgutils, types, utils, errors
 from .. typing.templates import BaseRegistryLoader
 
 
@@ -317,7 +318,13 @@ def iternext_impl(ref_type=None):
     an _IternextResult() object easing the returning of the iternext()
     result pair.
 
-    new_ref: indicates whether the yielded item is a new ref or a borrowed
+    ref_type: If the ref_type is a numba.targets.imputils.RefType value then the
+    reference type used is that specified through the RefType enum.
+
+    For backwards compatibility Numba will, for a short period of time, maintain
+    the old interface which assumes the reference type is borrowed. This is,
+    however, deprecated behaviour and users of this API are encouraged to update
+    their code.
 
     The wrapped function will be called with the following signature:
         (context, builder, sig, args, iternext_result)
@@ -325,24 +332,43 @@ def iternext_impl(ref_type=None):
     if ref_type is None:
         raise ValueError("ref_type must be an enum member of imputils.RefType")
 
-    def outer(func):
+    if ref_type not in [x for x in RefType]:
+        # this is to make it so the pre-0.44 behaviour of defaulting to a
+        # borrowed reference type and 4 arg call site continues to work
+        url = ("http://numba.pydata.org/numba-doc/latest/reference/"
+                "deprecation.html#"
+                "deprecation-of-iternext-impl-without-a-supplied-reftype")
+        msg = ("\nThe use of iternext_impl without specifying a "
+               "numba.targets.imputils.RefType is deprecated.\n\nFor more "
+               "information visit %s" % url)
+        warnings.warn(errors.NumbaDeprecationWarning(msg), stacklevel=2)
         def wrapper(context, builder, sig, args):
             pair_type = sig.return_type
             pairobj = context.make_helper(builder, pair_type)
-            func(context, builder, sig, args,
+            ref_type(context, builder, sig, args,
                 _IternextResult(context, builder, pairobj))
-            if ref_type == RefType.NEW:
-                impl_ret = impl_ret_new_ref
-            elif ref_type == RefType.BORROWED:
-                impl_ret = impl_ret_borrowed
-            elif ref_type == RefType.UNTRACKED:
-                impl_ret = impl_ret_untracked
-            else:
-                raise ValueError("Unknown ref_type encountered")
-            return impl_ret(context, builder,
+            return impl_ret_borrowed(context, builder,
                                     pair_type, pairobj._getvalue())
         return wrapper
-    return outer
+    else:
+        def outer(func):
+            def wrapper(context, builder, sig, args):
+                pair_type = sig.return_type
+                pairobj = context.make_helper(builder, pair_type)
+                func(context, builder, sig, args,
+                    _IternextResult(context, builder, pairobj))
+                if ref_type == RefType.NEW:
+                    impl_ret = impl_ret_new_ref
+                elif ref_type == RefType.BORROWED:
+                    impl_ret = impl_ret_borrowed
+                elif ref_type == RefType.UNTRACKED:
+                    impl_ret = impl_ret_untracked
+                else:
+                    raise ValueError("Unknown ref_type encountered")
+                return impl_ret(context, builder,
+                                        pair_type, pairobj._getvalue())
+            return wrapper
+        return outer
 
 
 def call_getiter(context, builder, iterable_type, val):

--- a/numba/tests/test_deprecations.py
+++ b/numba/tests/test_deprecations.py
@@ -9,6 +9,7 @@ from numba import jit, autojit, SmartArray, cuda, config
 from numba.errors import (NumbaDeprecationWarning,
                           NumbaPendingDeprecationWarning, NumbaWarning)
 import numba.unittest_support as unittest
+from numba.targets.imputils import iternext_impl
 
 
 class TestDeprecation(unittest.TestCase):
@@ -81,6 +82,19 @@ class TestDeprecation(unittest.TestCase):
             msg = "SmartArray is deprecated"
             self.assertIn(msg, warn_msg)
             self.assertIn("http://numba.pydata.org", warn_msg)
+
+    def test_iternext_impl(self):
+        # tests deprecation of iternext_impl without a RefType supplied
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+            @iternext_impl
+            def foo(ctx, builder, sig, args, res):
+                pass
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].category, NumbaDeprecationWarning)
+            warn_msg = str(w[0].message)
+            msg = ("The use of iternext_impl without specifying a "
+                   "numba.targets.imputils.RefType is deprecated")
 
     def run_cmd(self, cmdline, env, kill_is_ok=False):
         popen = subprocess.Popen(cmdline,


### PR DESCRIPTION
This adds back in support for the old API for iternext_impl but
adds in a deprecation warning, documents and tests this.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
