### PR TITLE
Fix function definition finding logic for commented def

### DIFF
--- a/numba/ir.py
+++ b/numba/ir.py
@@ -59,7 +59,9 @@ class Loc(object):
         fn_name = None
         lines = self.get_lines()
         for x in reversed(lines[:self.line - 1]):
-            if 'def ' in x:
+            # the strip and startswith is to handle user code with commented out
+            # 'def' or use of 'def' in a docstring.
+            if x.strip().startswith('def '):
                 fn_name = x
                 break
 

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -75,6 +75,26 @@ class TestMiscErrorHandling(unittest.TestCase):
         a = np.array([1.0],dtype=np.float64)
         fn(a) # should not raise
 
+    def test_commented_func_definition_is_not_a_definition(self):
+        # See issue #4056, the commented def should not be found as the
+        # definition for reporting purposes when creating the synthetic
+        # traceback because it is commented! Use of def in docstring would also
+        # cause this issue hence is tested.
+
+        def foo_commented():
+            #def commented_definition()
+            raise Exception('test_string')
+
+        def foo_docstring():
+            """ def docstring containing def might match function definition!"""
+            raise Exception('test_string')
+
+        for func in (foo_commented, foo_docstring):
+            with self.assertRaises(Exception) as raises:
+                func()
+
+            self.assertIn("test_string", str(raises.exception))
+
     def test_use_of_ir_unknown_loc(self):
         # for context see # 3390
         import numba


### PR DESCRIPTION
As title. Also handles and tests cases where a user has used
'def' in a docstring.

Fixes #4056

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
