### PR TITLE
better error messages for np.transpose and tuples

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1492,7 +1492,7 @@ def array_transpose_vararg(context, builder, sig, args):
 @overload(np.transpose)
 def numpy_transpose(a, axes=None):
     if isinstance(a, types.BaseTuple):
-        raise errors.TypingError("np.transpose does not accept tuples")
+        raise errors.UnsupportedError("np.transpose does not accept tuples")
 
     if axes is None:
         def np_transpose_impl(a, axes=None):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1491,6 +1491,8 @@ def array_transpose_vararg(context, builder, sig, args):
 
 @overload(np.transpose)
 def numpy_transpose(a, axes=None):
+    if isinstance(a, types.BaseTuple):
+        raise errors.TypingError("np.transpose does not accept tuples")
 
     if axes is None:
         def np_transpose_impl(a, axes=None):

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -333,6 +333,10 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         check_err_axis_oob(arrs[3], (3, 1, 2, 5))
         check_err_axis_oob(arrs[3], (3, 1, 2, -5))
 
+        with self.assertRaises(TypingError) as e:
+            jit(nopython=True)(numpy_transpose_array)((np.array([0, 1]),))
+        self.assertIn("np.transpose does not accept tuples",
+                        str(e.exception))
 
     @tag('important')
     def test_expand_dims(self):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fixes #4053

NumPy 'transpose' does accept tuples but Numba doesn't and there is a
good reason for this. The problem is, that we don't know the shape of
the arrays contained within the tuple during the type inference phase.
If they have inhomogeneous shapes, we may end up with a ragged/jagged
array. We could check all tuples and their shapes at runtime but that
will be cumbersome. Instead, we issue a better warning instead for now.

For those wanting to use `np.argwhere` using the following snippet:

```
np.transpose(np.nonzero(a))
```

The appropriate workaround is:

```
np.transpose(np.vstack(np.nonzero(a)))
```