### PR TITLE
Fix inline assembly support on CPU.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -220,7 +220,6 @@ exclude =
     numba/tests/test_typeinfer.py
     numba/tests/test_return_values.py
     numba/tests/test_parallel_backend.py
-    numba/tests/test_nrt.py
     numba/tests/test_mangling.py
     numba/tests/test_npdatetime.py
     numba/tests/test_fancy_indexing.py

--- a/numba/targets/removerefctpass.py
+++ b/numba/targets/removerefctpass.py
@@ -17,7 +17,7 @@ class _MarkNrtCallVisitor(CallVisitor):
         self.marked = set()
 
     def visit_Call(self, instr):
-        if instr.callee.name in ('NRT_incref', 'NRT_decref'):
+        if getattr(instr.callee, 'name', '') in ('NRT_incref', 'NRT_decref'):
             self.marked.add(instr)
 
 

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 import os
+import platform
 import sys
 import re
 
@@ -12,10 +13,21 @@ from numba import njit, targets, typing
 from numba.compiler import compile_isolated, Flags, types
 from numba.runtime import rtsys
 from numba.runtime import nrtopt
+from numba.extending import intrinsic
+from numba.typing import signature
+from numba.targets.imputils import impl_ret_untracked
+from llvmlite import ir
+import llvmlite.binding as llvm
+
 from .support import MemoryLeakMixin, TestCase
 
 enable_nrt_flags = Flags()
 enable_nrt_flags.set("nrt")
+
+linux_only = unittest.skipIf(not sys.platform.startswith('linux'),
+                             'linux only test')
+x86_only = unittest.skipIf(platform.machine() not in ('i386', 'x86_64'),
+                           'x86 only test')
 
 
 class Dummy(object):
@@ -434,7 +446,7 @@ B40.backedge:                                     ; preds = %B108.endif.endif.en
 %.294 = icmp sgt i64 %lsr.iv.next, 1
 br i1 %.294, label %B42, label %B160
 }
-    '''
+    ''' # noqa
 
     def test_refct_pruning_op_recognize(self):
         input_ir = self.sample_llvm_ir
@@ -502,6 +514,36 @@ br i1 %.294, label %B42, label %B160
         llvmir = str(extend.inspect_llvm(extend.signatures[0]))
         refops = list(re.finditer(r'(NRT_incref|NRT_decref)\([^\)]+\)', llvmir))
         self.assertEqual(len(refops), 0)
+
+    @linux_only
+    @x86_only
+    def test_inline_asm(self):
+        """The InlineAsm class from llvmlite.ir has no 'name' attr the refcount
+        pruning pass should be tolerant to this"""
+        llvm.initialize()
+        llvm.initialize_native_target()
+        llvm.initialize_native_asmprinter()
+        llvm.initialize_native_asmparser()
+
+        @intrinsic
+        def bar(tyctx, x, y):
+            def codegen(cgctx, builder, sig, args):
+                (arg_0, arg_1) = args
+                fty = ir.FunctionType(ir.IntType(64), [ir.IntType(64),
+                                                       ir.IntType(64)])
+                mul = builder.asm(fty, "mov $2, $0; imul $1, $0", "=r,r,r",
+                                  (arg_0, arg_1), name="asm_mul",
+                                  side_effect=False)
+                return impl_ret_untracked(cgctx, builder, sig.return_type, mul)
+            return signature(x, x, x), codegen
+
+        @njit(['int64(int64)'])
+        def foo(x):
+            x += 1
+            z = bar(x, 2)
+            return z
+
+        self.assertEqual(foo(10), 22) # expect (10 + 1) * 2 = 22
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As title. Refcount pruning pass was failing because InlineAsm node
does not have a 'name' attr.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
