### PR TITLE
Add np.cross support

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -319,6 +319,9 @@ The following top-level functions are supported:
   SciPy >= 0.16; extreme value handling per NumPy 1.11+)
 * :func:`numpy.correlate` (only the 2 first arguments)
 * :func:`numpy.cov` (only the 5 first arguments, requires NumPy >= 1.10 and SciPy >= 0.16)
+* :func:`numpy.cross` (only the 2 first arguments; at least one of the input
+  arrays should have `shape[-1] == 3` - the case where `shape[-1] == 2` for both
+  arrays will be supported in a separate implementation)
 * :func:`numpy.delete` (only the 2 first arguments)
 * :func:`numpy.diag`
 * :func:`numpy.digitize`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -320,8 +320,7 @@ The following top-level functions are supported:
 * :func:`numpy.correlate` (only the 2 first arguments)
 * :func:`numpy.cov` (only the 5 first arguments, requires NumPy >= 1.10 and SciPy >= 0.16)
 * :func:`numpy.cross` (only the 2 first arguments; at least one of the input
-  arrays should have `shape[-1] == 3` - the case where `shape[-1] == 2` for both
-  arrays will be supported in a separate implementation)
+  arrays should have `shape[-1] == 3`)
 * :func:`numpy.delete` (only the 2 first arguments)
 * :func:`numpy.diag`
 * :func:`numpy.digitize`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3993,23 +3993,23 @@ def _cross_impl(a, b):
 
 @overload(np.cross)
 def np_cross(a, b):
-    if type_can_asarray(a) and type_can_asarray(b):
-        def impl(a, b):
-            a_ = np.asarray(a)
-            b_ = np.asarray(b)
-            if a_.shape[-1] not in (2, 3) or b_.shape[-1] not in (2, 3):
-                raise ValueError((
-                    "incompatible dimensions for cross product\n"
-                    "(dimension must be 2 or 3)"
-                ))
+    if not type_can_asarray(a) or not type_can_asarray(b):
+        raise TypingError("Inputs must be array-like.")
 
-            if a_.shape[-1] == 3 or b_.shape[-1] == 3:
-                return _cross_impl(a_, b_)
-            else:
-                raise ValueError((
-                    "Dimensions for both inputs is 2 "
-                    "(currently not supported)."
-                ))
-        return impl
-    else:
-        raise ValueError("Inputs must be array-like.")
+    def impl(a, b):
+        a_ = np.asarray(a)
+        b_ = np.asarray(b)
+        if a_.shape[-1] not in (2, 3) or b_.shape[-1] not in (2, 3):
+            raise ValueError((
+                "incompatible dimensions for cross product\n"
+                "(dimension must be 2 or 3)"
+            ))
+
+        if a_.shape[-1] == 3 or b_.shape[-1] == 3:
+            return _cross_impl(a_, b_)
+        else:
+            raise ValueError((
+                "Dimensions for both inputs is 2 "
+                "(currently not supported)."
+            ))
+    return impl

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3949,6 +3949,7 @@ def np_kaiser(M, beta):
 
     return np_kaiser_impl
 
+
 @register_jitable
 def cross_operation(a, b, cp):
     a0 = a[..., 0]

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4021,9 +4021,49 @@ def np_cross(a, b):
 
             return cp
 
+        def np_cross_impl_mixdim(a, b):
+            # assume a.ndim == 1 and b.ndim > 1
+            if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
+                raise ValueError('dimension must be 2 or 3')
+
+            if a.shape[-1] == 3 or b.shape[-1] == 3:
+                # we can't use np.broadcast; use np.add
+                # since we only need the broadcast shape
+                shape_ = np.add(a[..., 0], b[..., 0]).shape
+                cp = np.empty(shape_ + (3,), dtype)
+                a0 = a[0]
+                a1 = a[1]
+                if a.shape[-1] == 3:
+                    a2 = a[2]
+                else:
+                    a2 = 0
+                b0 = b[..., 0]
+                b1 = b[..., 1]
+                if b.shape[-1] == 3:
+                    b2 = b[..., 2]
+                else:
+                    b2 = np.zeros_like(b1)
+
+                cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
+                cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
+                cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
+
+                cp[..., 0] = cp0
+                cp[..., 1] = cp1
+                cp[..., 2] = cp2
+            else:
+                raise ValueError('You must use numba.cross2d.')
+
+            return cp
+
 
         if a.ndim > 1 and b.ndim > 1:
             return np_cross_impl_ndim
         elif a.ndim == 1 and b.ndim == 1:
             return np_cross_impl_1dim
+        else:
+            if a.ndim == 1:
+                return np_cross_impl_mixdim
+            else:
+                return lambda x, y: np_cross_impl_mixdim(y, x)
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4016,7 +4016,7 @@ def np_cross(a, b):
         def np_cross_impl_1dim(a, b):
             """
             np.cross implementation for the case where both
-            a.ndim == 1 and `b.ndim == 1.
+            a.ndim == 1 and b.ndim == 1.
             """
 
             if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3952,18 +3952,20 @@ def np_kaiser(M, beta):
 
 @register_jitable
 def cross_operation(a, b, cp):
+    dta = a.dtype
     a0 = a[..., 0]
     a1 = a[..., 1]
     if a.shape[-1] == 3:
         a2 = a[..., 2]
     else:
-        a2 = np.multiply(0, a0)
+        a2 = np.multiply(dta.type(0), a0)
+    dtb = b.dtype
     b0 = b[..., 0]
     b1 = b[..., 1]
     if b.shape[-1] == 3:
         b2 = b[..., 2]
     else:
-        b2 = np.multiply(0, b0)
+        b2 = np.multiply(dtb.type(0), b0)
 
     cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
     cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4089,7 +4089,6 @@ def np_cross(a, b):
 
             return cp
 
-
         if a.ndim > 1 and b.ndim > 1:
             return np_cross_impl_ndim
         elif a.ndim == 1 and b.ndim == 1:
@@ -4099,4 +4098,3 @@ def np_cross(a, b):
                 return np_cross_impl_mixdim
             else:
                 return lambda x, y: np_cross_impl_mixdim(y, x)
-

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3951,29 +3951,29 @@ def np_kaiser(M, beta):
 
 
 @register_jitable
-def cross_operation(a, b, cp):
-    dta = a.dtype
-    a0 = a[..., 0]
-    a1 = a[..., 1]
-    if a.shape[-1] == 3:
-        a2 = a[..., 2]
+def cross_preprocessing(x):
+    dt = x.dtype
+    x0 = x[..., 0]
+    x1 = x[..., 1]
+    if x.shape[-1] == 3:
+        x2 = x[..., 2]
     else:
-        a2 = np.multiply(dta.type(0), a0)
-    dtb = b.dtype
-    b0 = b[..., 0]
-    b1 = b[..., 1]
-    if b.shape[-1] == 3:
-        b2 = b[..., 2]
-    else:
-        b2 = np.multiply(dtb.type(0), b0)
+        x2 = np.multiply(dt.type(0), x0)
+    return x0, x1, x2
+
+
+@register_jitable
+def cross_operation(a, b, out):
+    a0, a1, a2 = cross_preprocessing(a)
+    b0, b1, b2 = cross_preprocessing(b)
 
     cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
     cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
     cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
 
-    cp[..., 0] = cp0
-    cp[..., 1] = cp1
-    cp[..., 2] = cp2
+    out[..., 0] = cp0
+    out[..., 1] = cp1
+    out[..., 2] = cp2
 
 
 @overload(np.cross)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3949,6 +3949,29 @@ def np_kaiser(M, beta):
 
     return np_kaiser_impl
 
+@register_jitable
+def cross_operation(a, b, cp):
+    a0 = a[..., 0]
+    a1 = a[..., 1]
+    if a.shape[-1] == 3:
+        a2 = a[..., 2]
+    else:
+        a2 = np.multiply(0, a0)
+    b0 = b[..., 0]
+    b1 = b[..., 1]
+    if b.shape[-1] == 3:
+        b2 = b[..., 2]
+    else:
+        b2 = np.multiply(0, b0)
+
+    cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
+    cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
+    cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
+
+    cp[..., 0] = cp0
+    cp[..., 1] = cp1
+    cp[..., 2] = cp2
+
 
 @overload(np.cross)
 def np_cross(a, b):
@@ -3980,27 +4003,7 @@ def np_cross(a, b):
                 # to create a container for cp
                 shape_ = np.add(a[..., 0], b[..., 0]).shape
                 cp = np.empty(shape_ + (3,), dtype)
-
-                a0 = a[..., 0]
-                a1 = a[..., 1]
-                if a.shape[-1] == 3:
-                    a2 = a[..., 2]
-                else:
-                    a2 = np.multiply(0, a0)
-                b0 = b[..., 0]
-                b1 = b[..., 1]
-                if b.shape[-1] == 3:
-                    b2 = b[..., 2]
-                else:
-                    b2 = np.multiply(0, b0)
-
-                cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
-                cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
-                cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
-
-                cp[..., 0] = cp0
-                cp[..., 1] = cp1
-                cp[..., 2] = cp2
+                cross_operation(a, b, cp)
 
             else:
                 raise ValueError(cross2d_msg)
@@ -4018,28 +4021,7 @@ def np_cross(a, b):
 
             if a.shape[-1] == 3 or b.shape[-1] == 3:
                 cp = np.empty((3,), dtype)
-
-                a0 = a[0]
-                a1 = a[1]
-                if a.shape[-1] == 3:
-                    a2 = a[2]
-                else:
-                    a2 = 0
-                b0 = b[0]
-                b1 = b[1]
-                if b.shape[-1] == 3:
-                    b2 = b[2]
-                else:
-                    b2 = 0
-
-                cp0 = a1 * b2 - a2 * b1
-                cp1 = a2 * b0 - a0 * b2
-                cp2 = a0 * b1 - a1 * b0
-
-                cp[0] = cp0
-                cp[1] = cp1
-                cp[2] = cp2
-
+                cross_operation(a, b, cp)
             else:
                 raise ValueError(cross2d_msg)
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3954,8 +3954,34 @@ def np_kaiser(M, beta):
 def np_cross(a, b):
     if isinstance(a, types.Array) and isinstance(b, types.Array):
 
+        dtype = np.promote_types(as_dtype(a.dtype), as_dtype(b.dtype))
+
         def np_cross_impl(a, b):
-            # TODO: implement
-            pass
+            if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
+                raise ValueError('dimension must be 2 or 3')
+
+
+            # Create the output array
+
+            if a.shape[-1] == 3 or b.shape[-1] == 3:
+                # Case: last output dim has 3 elements
+                if a.ndim == 1 and b.ndim == 1:
+                    # Case: inputs are 1D arrays
+                    cp = np.empty((3,), dtype)
+                else:
+                    # Case: inputs are ND arrays
+
+                    # we can't use np.broadcast; use np.add
+                    # since we only need the broadcast shape
+                    shape_ = np.add(a[..., 0], b[..., 0]).shape
+                    cp = np.empty(shape_ + (3,), dtype)
+            else:
+                # Case: last output dim is scalar
+                # TODO
+                pass
+
+            # TODO: populate cp values
+
+            return cp
 
         return np_cross_impl

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3987,7 +3987,7 @@ def np_cross(a, b):
         )
         cross2d_msg = (
             "dimensions for both inputs is 2.\n"
-            "Please use numba.cross2d"
+            "Please use numba.cross2d (to be implemented)"
         )
 
         def np_cross_impl_ndim(a, b):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3985,9 +3985,8 @@ def np_cross(a, b):
             "incompatible dimensions for cross product\n"
             "(dimension must be 2 or 3)"
         )
-        cross2d_msg = (
-            "dimensions for both inputs is 2.\n"
-            "Please use numba.cross2d (to be implemented)"
+        not_supported_2d_msg = (
+            "Dimensions for both inputs is 2 (currently not supported)."
         )
 
         def np_cross_impl_ndim(a, b):
@@ -4009,7 +4008,7 @@ def np_cross(a, b):
                 cross_operation(a, b, cp)
 
             else:
-                raise ValueError(cross2d_msg)
+                raise ValueError(not_supported_2d_msg)
 
             return cp
 
@@ -4026,7 +4025,7 @@ def np_cross(a, b):
                 cp = np.empty((3,), dtype)
                 cross_operation(a, b, cp)
             else:
-                raise ValueError(cross2d_msg)
+                raise ValueError(not_supported_2d_msg)
 
             return cp
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3975,13 +3975,26 @@ def np_cross(a, b):
                     # since we only need the broadcast shape
                     shape_ = np.add(a[..., 0], b[..., 0]).shape
                     cp = np.empty(shape_ + (3,), dtype)
+                    a0 = a[..., 0]
+                    a1 = a[..., 1]
+                    a2 = a[..., 2]
+                    b0 = b[..., 0]
+                    b1 = b[..., 1]
+                    b2 = b[..., 2]
+
+                    cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
+                    cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
+                    cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
+
+                    cp[..., 0] = cp0
+                    cp[..., 1] = cp1
+                    cp[..., 2] = cp2
             else:
-                # Case: last output dim is scalar
-                # TODO
-                pass
+                raise ValueError('You must use numba.cross2d.')
 
             # TODO: populate cp values
 
             return cp
 
         return np_cross_impl
+

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3948,3 +3948,14 @@ def np_kaiser(M, beta):
         return _i0n(n, alpha, beta)
 
     return np_kaiser_impl
+
+
+@overload(np.cross)
+def np_cross(a, b):
+    if isinstance(a, types.Array) and isinstance(b, types.Array):
+
+        def np_cross_impl(a, b):
+            # TODO: implement
+            pass
+
+        return np_cross_impl

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3977,10 +3977,16 @@ def np_cross(a, b):
                     cp = np.empty(shape_ + (3,), dtype)
                     a0 = a[..., 0]
                     a1 = a[..., 1]
-                    a2 = a[..., 2]
+                    if a.shape[-1] == 3:
+                        a2 = a[..., 2]
+                    else:
+                        a2 = np.zeros_like(a1)
                     b0 = b[..., 0]
                     b1 = b[..., 1]
-                    b2 = b[..., 2]
+                    if b.shape[-1] == 3:
+                        b2 = b[..., 2]
+                    else:
+                        b2 = np.zeros_like(b1)
 
                     cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
                     cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3951,19 +3951,17 @@ def np_kaiser(M, beta):
 
 
 @register_jitable
-def _cross_preprocessing(x):
-    dt = x.dtype
-    x0 = x[..., 0]
-    x1 = x[..., 1]
-    if x.shape[-1] == 3:
-        x2 = x[..., 2]
-    else:
-        x2 = np.multiply(dt.type(0), x0)
-    return x0, x1, x2
-
-
-@register_jitable
 def _cross_operation(a, b, out):
+
+    def _cross_preprocessing(x):
+        x0 = x[..., 0]
+        x1 = x[..., 1]
+        if x.shape[-1] == 3:
+            x2 = x[..., 2]
+        else:
+            x2 = np.multiply(x.dtype.type(0), x0)
+        return x0, x1, x2
+
     a0, a1, a2 = _cross_preprocessing(a)
     b0, b1, b2 = _cross_preprocessing(b)
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3986,13 +3986,13 @@ def np_cross(a, b):
                 if a.shape[-1] == 3:
                     a2 = a[..., 2]
                 else:
-                    a2 = np.zeros_like(a1)
+                    a2 = np.multiply(0, a0)
                 b0 = b[..., 0]
                 b1 = b[..., 1]
                 if b.shape[-1] == 3:
                     b2 = b[..., 2]
                 else:
-                    b2 = np.zeros_like(b1)
+                    b2 = np.multiply(0, b0)
 
                 cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
                 cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
@@ -4045,94 +4045,7 @@ def np_cross(a, b):
 
             return cp
 
-        def np_cross_impl_mixdim_a(a, b):
-            """
-            np.cross implementation for the case where a.ndim == 1
-            and b.ndim > 1.
-            """
-
-            if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
-                raise ValueError(wrong_dim_msg)
-
-            if a.shape[-1] == 3 or b.shape[-1] == 3:
-                # we can't use np.broadcast; use np.add
-                # since we only need the broadcast shape
-                shape_ = np.add(a[..., 0], b[..., 0]).shape
-                cp = np.empty(shape_ + (3,), dtype)
-
-                a0 = a[0]
-                a1 = a[1]
-                if a.shape[-1] == 3:
-                    a2 = a[2]
-                else:
-                    a2 = 0
-                b0 = b[..., 0]
-                b1 = b[..., 1]
-                if b.shape[-1] == 3:
-                    b2 = b[..., 2]
-                else:
-                    b2 = np.zeros_like(b1)
-
-                cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
-                cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
-                cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
-
-                cp[..., 0] = cp0
-                cp[..., 1] = cp1
-                cp[..., 2] = cp2
-
-            else:
-                raise ValueError(cross2d_msg)
-
-            return cp
-
-        def np_cross_impl_mixdim_b(a, b):
-            """
-            np.cross implementation for the case where a.ndim > 1
-            and b.ndim == 1.
-            """
-
-            if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
-                raise ValueError(wrong_dim_msg)
-
-            if a.shape[-1] == 3 or b.shape[-1] == 3:
-                # we can't use np.broadcast; use np.add
-                # since we only need the broadcast shape
-                shape_ = np.add(a[..., 0], b[..., 0]).shape
-                cp = np.empty(shape_ + (3,), dtype)
-
-                a0 = a[..., 0]
-                a1 = a[..., 1]
-                if a.shape[-1] == 3:
-                    a2 = a[..., 2]
-                else:
-                    a2 = np.zeros_like(a1)
-                b0 = b[0]
-                b1 = b[1]
-                if b.shape[-1] == 3:
-                    b2 = b[2]
-                else:
-                    b2 = 0
-
-                cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
-                cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
-                cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
-
-                cp[..., 0] = cp0
-                cp[..., 1] = cp1
-                cp[..., 2] = cp2
-
-            else:
-                raise ValueError(cross2d_msg)
-
-            return cp
-
-        if a.ndim > 1 and b.ndim > 1:
-            return np_cross_impl_ndim
-        elif a.ndim == 1 and b.ndim == 1:
+        if a.ndim == 1 and b.ndim == 1:
             return np_cross_impl_1dim
         else:
-            if a.ndim == 1:
-                return np_cross_impl_mixdim_a
-            else:
-                return np_cross_impl_mixdim_b
+            return np_cross_impl_ndim

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3990,8 +3990,8 @@ def np_cross(a, b):
 
         def np_cross_impl_ndim(a, b):
             """
-            np.cross implementation for the case where both
-            a.ndim > 1 and b.ndim > 1.
+            np.cross implementation for the case where
+            a.ndim > 1 or b.ndim > 1.
             """
 
             if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4045,13 +4045,10 @@ def np_cross(a, b):
 
             return cp
 
-        def np_cross_impl_mixdim(a, b):
+        def np_cross_impl_mixdim_a(a, b):
             """
             np.cross implementation for the case where a.ndim == 1
-            and b.ndim >= 1. We can assume it's `a` the 1-dim input
-            without loosing generality since we can reverse the
-            position of the arguments with the use of a lambda
-            function.
+            and b.ndim > 1.
             """
 
             if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
@@ -4089,12 +4086,53 @@ def np_cross(a, b):
 
             return cp
 
+        def np_cross_impl_mixdim_b(a, b):
+            """
+            np.cross implementation for the case where a.ndim > 1
+            and b.ndim == 1.
+            """
+
+            if a.shape[-1] not in (2, 3) or b.shape[-1] not in (2, 3):
+                raise ValueError(wrong_dim_msg)
+
+            if a.shape[-1] == 3 or b.shape[-1] == 3:
+                # we can't use np.broadcast; use np.add
+                # since we only need the broadcast shape
+                shape_ = np.add(a[..., 0], b[..., 0]).shape
+                cp = np.empty(shape_ + (3,), dtype)
+
+                a0 = a[..., 0]
+                a1 = a[..., 1]
+                if a.shape[-1] == 3:
+                    a2 = a[..., 2]
+                else:
+                    a2 = np.zeros_like(a1)
+                b0 = b[0]
+                b1 = b[1]
+                if b.shape[-1] == 3:
+                    b2 = b[2]
+                else:
+                    b2 = 0
+
+                cp0 = np.multiply(a1, b2) - np.multiply(a2, b1)
+                cp1 = np.multiply(a2, b0) - np.multiply(a0, b2)
+                cp2 = np.multiply(a0, b1) - np.multiply(a1, b0)
+
+                cp[..., 0] = cp0
+                cp[..., 1] = cp1
+                cp[..., 2] = cp2
+
+            else:
+                raise ValueError(cross2d_msg)
+
+            return cp
+
         if a.ndim > 1 and b.ndim > 1:
             return np_cross_impl_ndim
         elif a.ndim == 1 and b.ndim == 1:
             return np_cross_impl_1dim
         else:
             if a.ndim == 1:
-                return np_cross_impl_mixdim
+                return np_cross_impl_mixdim_a
             else:
-                return lambda x, y: np_cross_impl_mixdim(y, x)
+                return np_cross_impl_mixdim_b

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2938,6 +2938,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5, 6], [1, 2, 3]])
             ),
+            (
+                np.array([[1, 2, 3], [4, 5, 6]]),
+                np.array([[4, 5], [1, 2]])
+            ),
             #(np.array([1, 2, 3]), np.array([4, 5, 6])),
             #(np.array([1, 2]), np.array([4, 5, 6])),
             #(np.array([1, 2]), np.array([4, 5])),

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2944,10 +2944,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             ),
             (np.array([1, 2, 3]), np.array([4, 5, 6])),
             (np.array([1, 2]), np.array([4, 5, 6])),
-            #(
-            #    np.array([1, 2, 3]),
-            #    np.array([[4, 5, 6], [1, 2, 3]])
-            #)
+            (
+                np.array([1, 2, 3]),
+                np.array([[4, 5, 6], [1, 2, 3]])
+            )
             #(np.array([1, 2]), np.array([4, 5])),
 
         ]

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2934,26 +2934,32 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         pyfunc = np_cross
         cfunc = jit(nopython=True)(pyfunc)
         pairs = [
+            # 3x3 (n-dims)
             (
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5, 6], [1, 2, 3]])
             ),
+            # 2x3 (n-dims)
             (
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5], [1, 2]])
             ),
+            # 3x3 (1-dim)
             (
                 np.array([1, 2, 3]),
                 np.array([4, 5, 6])
             ),
+            # 2x3 (1-dim)
             (
                 np.array([1, 2]),
                 np.array([4, 5, 6])
             ),
+            # 3x3 (with broadcasting 1d x 2d)
             (
                 np.array([1, 2, 3]),
                 np.array([[4, 5, 6], [1, 2, 3]])
             ),
+            # 3x3 (with broadcasting 2d x 1d)
             (
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([1, 2, 3])

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2949,6 +2949,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array([1, 2, 3]),
                 np.array([4, 5, 6])
             ),
+            # 3x3 array-like (1-dim)
+            (
+                (1, 2, 3),
+                (4, 5, 6)
+            ),
             # 2x3 (1-dim)
             (
                 np.array([1, 2]),

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2939,15 +2939,15 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5, 6], [1, 2, 3]])
             ),
-            # 2x3 (n-dims)
+            # 2x3 array-like (n-dims)
             (
                 np.array([[1, 2, 3], [4, 5, 6]]),
-                np.array([[4, 5], [1, 2]])
+                ((4, 5), (1, 2))
             ),
-            # 3x3 (1-dim)
+            # 3x3 (1-dim) with type promotion
             (
-                np.array([1, 2, 3]),
-                np.array([4, 5, 6])
+                np.array([1, 2, 3], dtype=np.int64),
+                np.array([4, 5, 6], dtype=np.float64)
             ),
             # 3x3 array-like (1-dim)
             (
@@ -2968,6 +2968,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             (
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([1, 2, 3])
+            ),
+            # 3x2 (with higher order broadcasting)
+            (
+                np.arange(36).reshape(6, 2, 3),
+                np.arange(4).reshape(2, 2)
             )
         ]
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2933,12 +2933,19 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
     def test_cross(self):
         pyfunc = np_cross
         cfunc = jit(nopython=True)(pyfunc)
-        # TODO: define meaningful set of (a,b) pairs to test
-        a = np.array((1, 0, 0))
-        b = np.array((0, 1, 0))
-        expected = pyfunc(a, b)
-        got = cfunc(a, b)
-        self.assertPreciseEqual(expected, got)
+        pairs = [
+            (np.array([1, 2, 3]), np.array([4, 5, 6])),
+            #(np.array([[1, 2, 3], [4, 5, 6]]), np.array([[4, 5, 6], [1, 2, 3]])),
+            #(np.array([1, 2]), np.array([4, 5, 6])),
+            #(np.array([1, 2]), np.array([4, 5])),
+
+        ]
+        for x, y in pairs:
+            expected = pyfunc(x, y)
+            got = cfunc(x, y)
+            self.assertPreciseEqual(expected, got)
+
+    # TODO check exceptions for np.cross
 
 
 class TestNPMachineParameters(TestCase):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2971,6 +2971,55 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(x, y)
             self.assertPreciseEqual(expected, got)
 
+    def test_cross_exceptions(self):
+        pyfunc = np_cross
+        cfunc = jit(nopython=True)(pyfunc)
+        self.disable_leak_check()
+
+        # test incompatible dimensions for ndim == 1
+        with self.assertRaises(ValueError) as raises:
+            cfunc(
+                np.arange(4),
+                np.arange(3)
+            )
+        self.assertIn(
+            'incompatible dimensions',
+            str(raises.exception)
+        )
+
+        # test 2d cross product error for ndim == 1
+        with self.assertRaises(ValueError) as raises:
+            cfunc(
+                np.array((1, 2)),
+                np.array((3, 4))
+            )
+        self.assertIn(
+            'cross2d',
+            str(raises.exception)
+        )
+
+        # test incompatible dimensions for ndim > 1
+        with self.assertRaises(ValueError) as raises:
+            cfunc(
+                np.arange(8).reshape((2, 4)),
+                np.arange(6)[::-1].reshape((2, 3))
+            )
+        self.assertIn(
+            'incompatible dimensions',
+            str(raises.exception)
+        )
+
+        # test 2d cross product error for ndim == 1
+        with self.assertRaises(ValueError) as raises:
+            cfunc(
+                np.arange(8).reshape((4, 2)),
+                np.arange(8)[::-1].reshape((4, 2))
+            )
+        self.assertIn(
+            'cross2d',
+            str(raises.exception)
+        )
+
 
 class TestNPMachineParameters(TestCase):
     # tests np.finfo, np.iinfo, np.MachAr

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -221,6 +221,10 @@ def np_kaiser(M, beta):
     return np.kaiser(M, beta)
 
 
+def np_cross(a, b):
+    return np.cross(a, b)
+
+
 class TestNPFunctions(MemoryLeakMixin, TestCase):
     """
     Tests for various Numpy functions.
@@ -2925,6 +2929,16 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             with self.assertRaises(TypingError) as raises:
                 np_nbfunc(5, beta)
             self.assertIn("beta must be an integer or float", str(raises.exception))
+
+    def test_cross(self):
+        pyfunc = np_cross
+        cfunc = jit(nopython=True)(pyfunc)
+        # TODO: define meaningful set of (a,b) pairs to test
+        a = np.array((1, 0, 0))
+        b = np.array((0, 1, 0))
+        expected = pyfunc(a, b)
+        got = cfunc(a, b)
+        self.assertPreciseEqual(expected, got)
 
 
 class TestNPMachineParameters(TestCase):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2934,8 +2934,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         pyfunc = np_cross
         cfunc = jit(nopython=True)(pyfunc)
         pairs = [
-            (np.array([1, 2, 3]), np.array([4, 5, 6])),
-            #(np.array([[1, 2, 3], [4, 5, 6]]), np.array([[4, 5, 6], [1, 2, 3]])),
+            (
+                np.array([[1, 2, 3], [4, 5, 6]]),
+                np.array([[4, 5, 6], [1, 2, 3]])
+            ),
+            #(np.array([1, 2, 3]), np.array([4, 5, 6])),
             #(np.array([1, 2]), np.array([4, 5, 6])),
             #(np.array([1, 2]), np.array([4, 5])),
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2953,6 +2953,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             (
                 np.array([1, 2, 3]),
                 np.array([[4, 5, 6], [1, 2, 3]])
+            ),
+            (
+                np.array([[1, 2, 3], [4, 5, 6]]),
+                np.array([1, 2, 3])
             )
         ]
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2942,8 +2942,12 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5], [1, 2]])
             ),
-            #(np.array([1, 2, 3]), np.array([4, 5, 6])),
-            #(np.array([1, 2]), np.array([4, 5, 6])),
+            (np.array([1, 2, 3]), np.array([4, 5, 6])),
+            (np.array([1, 2]), np.array([4, 5, 6])),
+            #(
+            #    np.array([1, 2, 3]),
+            #    np.array([[4, 5, 6], [1, 2, 3]])
+            #)
             #(np.array([1, 2]), np.array([4, 5])),
 
         ]

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2942,21 +2942,24 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array([[1, 2, 3], [4, 5, 6]]),
                 np.array([[4, 5], [1, 2]])
             ),
-            (np.array([1, 2, 3]), np.array([4, 5, 6])),
-            (np.array([1, 2]), np.array([4, 5, 6])),
+            (
+                np.array([1, 2, 3]),
+                np.array([4, 5, 6])
+            ),
+            (
+                np.array([1, 2]),
+                np.array([4, 5, 6])
+            ),
             (
                 np.array([1, 2, 3]),
                 np.array([[4, 5, 6], [1, 2, 3]])
             )
-            #(np.array([1, 2]), np.array([4, 5])),
-
         ]
+
         for x, y in pairs:
             expected = pyfunc(x, y)
             got = cfunc(x, y)
             self.assertPreciseEqual(expected, got)
-
-    # TODO check exceptions for np.cross
 
 
 class TestNPMachineParameters(TestCase):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2994,7 +2994,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.array((3, 4))
             )
         self.assertIn(
-            'cross2d',
+            'Dimensions for both inputs is 2',
             str(raises.exception)
         )
 
@@ -3016,7 +3016,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 np.arange(8)[::-1].reshape((4, 2))
             )
         self.assertIn(
-            'cross2d',
+            'Dimensions for both inputs is 2',
             str(raises.exception)
         )
 


### PR DESCRIPTION
Adding support for [np.cross](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.cross.html) to address missing numpy features mentioned in #4074.