### PR TITLE
Support contains for range

### DIFF
--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -2,6 +2,8 @@
 Implementation of the range object for fixed-size integers.
 """
 
+import operator
+
 import llvmlite.llvmpy.core as lc
 
 from numba import types, cgutils, prange
@@ -10,7 +12,7 @@ from .arrayobj import make_array
 from .imputils import (lower_builtin, lower_cast,
                        iterator_impl, impl_ret_untracked)
 from numba.typing import signature
-from numba.extending import intrinsic, overload, overload_attribute
+from numba.extending import intrinsic, overload, overload_attribute, register_jitable
 from numba.parfor import internal_prange
 
 def make_range_iterator(typ):
@@ -228,6 +230,49 @@ def make_range_attr(index, attribute):
         def get(rnge):
             return rangetype_attr_getter(rnge)
         return get
+
+
+@register_jitable
+def impl_contains_helper(robj, val):
+    if robj.step > 0 and (val < robj.start or val >= robj.stop):
+        return False
+    elif robj.step < 0 and (val <= robj.stop or val > robj.start):
+        return False
+
+    return ((val - robj.start) % robj.step) == 0
+
+
+@overload(operator.contains)
+def impl_contains(robj, val):
+    def impl_false(robj, val):
+        return False
+
+    if not isinstance(robj, types.RangeType):
+        return
+
+    elif isinstance(val, (types.Integer, types.Boolean)):
+        return impl_contains_helper
+
+    elif isinstance(val, types.Float):
+        def impl(robj, val):
+            if val % 1 != 0:
+                return False
+            else:
+                return impl_contains_helper(robj, int(val))
+        return impl
+
+    elif isinstance(val, types.Complex):
+        def impl(robj, val):
+            if val.imag != 0:
+                return False
+            elif val.real % 1 != 0:
+                return False
+            else:
+                return impl_contains_helper(robj, int(val.real))
+        return impl
+
+    elif not isinstance(val, types.Number):
+        return impl_false
 
 
 for ix, attr in enumerate(('start', 'stop', 'step')):

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -67,10 +67,7 @@ def range_contains(val, start, stop, step):
     r1 = range(start)
     r2 = range(start, stop)
     r3 = range(start, stop, step)
-    tmp = []
-    for r in (r1, r2, r3):
-        tmp.append(val in r)
-    return tmp
+    return [val in r for r in (r1, r2, r3)]
 
 
 class TestRange(unittest.TestCase):
@@ -191,24 +188,34 @@ class TestRange(unittest.TestCase):
     def test_range_contains(self):
         pyfunc = range_contains
         arglist = [(0, 0, 1),
+                   (-1, 0, 1),
+                   (1, 0, -1),
                    (0, -1, 1),
+                   (0, 1, -1),
                    (-1, 1, 1),
                    (-1, 4, 1),
                    (-1, 4, 10),
                    (5, -5, -2),]
 
-        vallist = [-10, -6, -5, -4, -2, -1, 0,
-                1, 2, 4, 5, 6, 10, -1.1, False, True,
-                1 + 0j, 1 + 1j, 1.1 + 0j, 1.0 + 1.1j]
+        bool_vals = [True, False]
+        int_vals = [-10, -6, -5, -4, -2, -1, 0,
+                     1, 2, 4, 5, 6, 10]
+        float_vals = [-1.1, -1.0, 0.0, 1.0, 1.1]
+        complex_vals = [1 + 0j, 1 + 1j, 1.1 + 0j, 1.0 + 1.1j]
+
+        vallist = (bool_vals + int_vals + float_vals
+                + complex_vals)
 
         cfunc = njit(pyfunc)
         for arg in arglist:
             for val in vallist:
                 self.assertEqual(cfunc(val, *arg), pyfunc(val, *arg))
 
+        non_numeric_vals = [{'a': 1}, [1, ], 'abc', (1,)]
+
         cfunc_obj = jit(pyfunc, forceobj=True)
         for arg in arglist:
-            for val in [{'a': 1}, [1,], 'abc']:
+            for val in non_numeric_vals:
                 self.assertEqual(cfunc_obj(val, *arg), pyfunc(val, *arg))
 
 

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -7,7 +7,7 @@ import sys
 import numpy
 
 from numba.compiler import compile_isolated
-from numba import types, utils
+from numba import types, utils, jit, njit
 from .support import tag
 
 
@@ -62,6 +62,16 @@ def range_attrs(start, stop, step):
     for r in (r1, r2, r3):
         tmp.append((r.start, r.stop, r.step))
     return tmp
+
+def range_contains(val, start, stop, step):
+    r1 = range(start)
+    r2 = range(start, stop)
+    r3 = range(start, stop, step)
+    tmp = []
+    for r in (r1, r2, r3):
+        tmp.append(val in r)
+    return tmp
+
 
 class TestRange(unittest.TestCase):
 
@@ -176,6 +186,31 @@ class TestRange(unittest.TestCase):
         cfunc = cres.entry_point
         for arg in arglist:
             self.assertEqual(cfunc(*arg), pyfunc(*arg))
+
+    @tag('important')
+    def test_range_contains(self):
+        pyfunc = range_contains
+        arglist = [(0, 0, 1),
+                   (0, -1, 1),
+                   (-1, 1, 1),
+                   (-1, 4, 1),
+                   (-1, 4, 10),
+                   (5, -5, -2),]
+
+        vallist = [-10, -6, -5, -4, -2, -1, 0,
+                1, 2, 4, 5, 6, 10, -1.1, False, True,
+                1 + 0j, 1 + 1j, 1.1 + 0j, 1.0 + 1.1j]
+
+        cfunc = njit(pyfunc)
+        for arg in arglist:
+            for val in vallist:
+                self.assertEqual(cfunc(val, *arg), pyfunc(val, *arg))
+
+        cfunc_obj = jit(pyfunc, forceobj=True)
+        for arg in arglist:
+            for val in [{'a': 1}, [1,], 'abc']:
+                self.assertEqual(cfunc_obj(val, *arg), pyfunc(val, *arg))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses #4109 based on the python code in:
https://github.com/python/cpython/blob/master/Objects/rangeobject.c#L337-L379
.
There are a few issues that I'm unsure of how to handle:

- When testing with an imaginary `val`, I get the following error (I removed the test case, but will add it back in later):

```python
======================================================================
ERROR: test_range_contains (numba.tests.test_range.TestRange)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/xyz/Projects/github/numba/numba/tests/test_range.py", line 206, in test_range_contains
    self.assertEqual(cfunc(val, *arg), pyfunc(val, *arg))
  File "/Users/xyz/Projects/github/numba/numba/dispatcher.py", line 351, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/Users/xyz/Projects/github/numba/numba/dispatcher.py", line 318, in error_rewrite
    reraise(type(e), e, None)
  File "/Users/xyz/Projects/github/numba/numba/six.py", line 658, in reraise
    raise value.with_traceback(tb)
numba.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Invalid use of Function(<built-in function contains>) with argument(s) of type(s): (range_state_int64, complex128)
 * parameterized
In definition 0:
    All templates rejected with literals.
In definition 1:
    All templates rejected without literals.
In definition 2:
    AttributeError: 'Complex' object has no attribute 'imag'
    raised from /Users/xyz/Projects/github/numba/numba/targets/rangeobj.py:260
In definition 3:
    AttributeError: 'Complex' object has no attribute 'imag'
    raised from /Users/xyz/Projects/github/numba/numba/targets/rangeobj.py:260
In definition 4:
    All templates rejected with literals.
In definition 5:
    All templates rejected without literals.
In definition 6:
    All templates rejected with literals.
In definition 7:
    All templates rejected without literals.
In definition 8:
    All templates rejected with literals.
In definition 9:
    All templates rejected without literals.
This error is usually caused by passing an argument of a type that is unsupported by the named function.
[1] During: typing of intrinsic-call at /Users/xyz/Projects/github/numba/numba/tests/test_range.py (72)

File "numba/tests/test_range.py", line 72:
def range_contains(val, start, stop, step):
    <source elided>
    for r in (r1, r2, r3):
        tmp.append(val in r)
        ^
```

It seems like `val` should have an `.imag` attribute, but maybe I'm missing something.

- There is some behavior around float in range, imaginary in range, and non-numerical object in range, that python displays, that I'm trying to capture correctly. 
    - Floats e.g `1.0 in range(10) is True`, but any non-zero decimal value returns `False`. 
    - Complex with non-zero imaginary parts always return False, but if the imaginary part is zero, it evaluate like a standard `int`
    - For any non-numerical object, `x in range(N)` appears to always return `False`, but it looks like from the python C-code, they actually default to a full iteration search using `_PySequence_IterSearch`, which is born out by running `timeit` on something like `{'a': 1} in range(N)`, varying `N`. I'm just automatically returning `False`, but maybe I'm missing a case. I'm not sure why CPython is executing a search since you know all of the items in `range(N)` are integers.

    I think I've captured all of the edge cases, but I'm not 100% sure