### PR TITLE
Reduce usage of inttoptr

### DIFF
--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -135,9 +135,13 @@ def _box_class_instance(typ, val, c):
     # Create Box instance
     box_subclassed = _specialize_box(typ)
     # Note: the ``box_subclassed`` is kept alive by the cache
-    int_addr_boxcls = c.context.get_constant(types.uintp, id(box_subclassed))
+    voidptr_boxcls = c.context.add_dynamic_addr(
+        c.builder,
+        id(box_subclassed),
+        info="box_class_instance",
+    )
+    box_cls = c.builder.bitcast(voidptr_boxcls, c.pyapi.pyobj)
 
-    box_cls = c.builder.inttoptr(int_addr_boxcls, c.pyapi.pyobj)
     box = c.pyapi.call_function_objargs(box_cls, ())
 
     # Initialize Box instance

--- a/numba/npyufunc/parfor.py
+++ b/numba/npyufunc/parfor.py
@@ -1451,7 +1451,7 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
 
     # ----------------------------------------------------------------------------
     # prepare data
-    data = builder.inttoptr(zero, byte_ptr_t)
+    data = cgutils.get_null_value(byte_ptr_t)
 
     fnty = lc.Type.function(lc.Type.void(), [byte_ptr_ptr_t, intp_ptr_t,
                                              intp_ptr_t, byte_ptr_t])

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -2264,10 +2264,9 @@ def array_record_getattr(context, builder, typ, value, attr):
 
     constoffset = context.get_constant(types.intp, offset)
 
-    llintp = context.get_value_type(types.intp)
-    newdata = builder.add(builder.ptrtoint(array.data, llintp), constoffset)
-    newdataptr = builder.inttoptr(newdata, rary.data.type)
-
+    newdataptr = cgutils.pointer_add(
+        builder, array.data, constoffset,  return_type=rary.data.type,
+    )
     datasize = context.get_abi_sizeof(context.get_data_type(dtype))
     populate_array(rary,
                    data=newdataptr,


### PR DESCRIPTION
We should avoid using `IRBuilder.inttoptr` for storing constant runtime addresses in the IR.  We need to use `<TargetContext>.add_dynamic_addr` so we mark where runtime addresses are used and indicate the caching layer that caching to not allowed.