### PR TITLE
CUDA - Fix round Builtin

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -11,6 +11,7 @@ from numba.targets.imputils import Registry
 from numba import cgutils
 from numba import six
 from numba import types
+from numba.utils import IS_PY3
 from .cudadrv import nvvm
 from . import nvvmutils, stubs
 
@@ -469,6 +470,9 @@ def ptx_min_f8(context, builder, sig, args):
 @lower(round, types.f4)
 @lower(round, types.f8)
 def ptx_round(context, builder, sig, args):
+    if not IS_PY3:
+        raise NotImplementedError(
+            "round returns a float on Python 2.x")
     fn = builder.module.get_or_insert_function(
         lc.Type.function(
             lc.Type.int(64),

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -466,6 +466,19 @@ def ptx_min_f8(context, builder, sig, args):
     ])
 
 
+@lower(round, types.f4)
+@lower(round, types.f8)
+def ptx_round(context, builder, sig, args):
+    fn = builder.module.get_or_insert_function(
+        lc.Type.function(
+            lc.Type.int(64),
+            (lc.Type.double(),)),
+        '__nv_llrint')
+    return builder.call(fn, [
+        context.cast(builder, args[0], sig.args[0], types.double),
+    ])
+
+
 def _normalize_indices(context, builder, indty, inds):
     """
     Convert integer indices into tuple of intp

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -80,6 +80,10 @@ def simple_ffs(ary, c):
     ary[0] = cuda.ffs(c)
 
 
+def simple_round(ary, c):
+    ary[0] = round(c)
+
+
 def branching_with_ifs(a, b, c):
     i = cuda.grid(1)
 
@@ -375,6 +379,22 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
         ary = np.zeros(1, dtype=np.int32)
         compiled(ary)
         self.assertEquals(ary[0], 32, "CUDA semantics")
+
+    def test_round_f4(self):
+        compiled = cuda.jit("void(int64[:], float32)")(simple_round)
+        ary = np.zeros(1, dtype=np.int32)
+
+        for i in [-3.0, -2.5, -2.25, -1.5, 1.5, 2.25, 2.5, 2.75]:
+            compiled(ary, i)
+            self.assertEquals(ary[0], round(i))
+
+    def test_round_f8(self):
+        compiled = cuda.jit("void(int64[:], float64)")(simple_round)
+        ary = np.zeros(1, dtype=np.int32)
+
+        for i in [-3.0, -2.5, -2.25, -1.5, 1.5, 2.25, 2.5, 2.75]:
+            compiled(ary, i)
+            self.assertEquals(ary[0], round(i))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -4,6 +4,7 @@ import numpy as np
 import re
 from numba import cuda, int32, float32
 from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.utils import IS_PY3
 
 
 def simple_threadidx(ary):
@@ -380,6 +381,7 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
         compiled(ary)
         self.assertEquals(ary[0], 32, "CUDA semantics")
 
+    @unittest.skipUnless(IS_PY3, "round() returns float on Py2")
     def test_round_f4(self):
         compiled = cuda.jit("void(int64[:], float32)")(simple_round)
         ary = np.zeros(1, dtype=np.int32)
@@ -388,6 +390,7 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
             compiled(ary, i)
             self.assertEquals(ary[0], round(i))
 
+    @unittest.skipUnless(IS_PY3, "round() returns float on Py2")
     def test_round_f8(self):
         compiled = cuda.jit("void(int64[:], float64)")(simple_round)
         ary = np.zeros(1, dtype=np.int32)


### PR DESCRIPTION
Numba lowers `round` using the LLVM `llvm.rint.fXX` intrinsic by default, but that isn't supported in NVVM IR (https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#standard-c-library-intrinics). Use the [CUDA Math API function](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html#group__CUDA__MATH__DOUBLE_1g6d2532344fe30f7f8988e031aac8e1cd) instead. nb: I chose `llrint` over `lrint` and `rint` somewhat arbitrarily, let me know if I should use a different one. 