### PR TITLE
Use callable instead of checking __module__

### DIFF
--- a/numba/extending.py
+++ b/numba/extending.py
@@ -39,7 +39,7 @@ def type_callable(func):
         class_dict = dict(key=func, generic=generic)
         template = type(name, bases, class_dict)
         infer(template)
-        if hasattr(func, '__module__'):
+        if callable(func):
             infer_global(func, types.Function(template))
 
     return decorate
@@ -91,7 +91,7 @@ def overload(func, jit_options={}, strict=True):
     def decorate(overload_func):
         template = make_overload_template(func, overload_func, opts, strict)
         infer(template)
-        if hasattr(func, '__module__'):
+        if callable(func):
             infer_global(func, types.Function(template))
         return overload_func
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -411,6 +411,18 @@ def mk_func_test_impl():
     mk_func_input(lambda a: a)
 
 
+# -----------------------------------------------------------------------
+
+
+@overload(np.exp)
+def overload_np_exp(obj):
+    if isinstance(obj, MyDummyType):
+        def imp(obj):
+            # Returns a constant if a MyDummyType is seen
+            return 0xdeadbeef
+        return imp
+
+
 class TestLowLevelExtending(TestCase):
     """
     Test the low-level two-tier extension API.
@@ -962,6 +974,16 @@ class TestHighLevelExtending(TestCase):
         A = np.zeros(1)
         bar(A)
         self.assertEqual(bar(A), 0xcafe)
+
+    def test_overload_ufunc(self):
+        # Issue #4133.
+        # Use an extended type (MyDummyType) to use with a customized
+        # ufunc (np.exp).
+        @njit
+        def test():
+            return np.exp(mydummy)
+
+        self.assertEqual(test(), 0xdeadbeef)
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):


### PR DESCRIPTION
Fixes #4133.

Old code uses `hasattr(obj, __module__)` to check whether `obj` should be registered as a recognized global variable.  It is solely used to distinguish old-style lowering registration using `str` vs new-style overload using actual callable objects.  This patch replaces the check to a `callable(obj)` to match the intent and to fix issue like #4133.