### PR TITLE
Call branch pruning in inline_closure_call()

### DIFF
--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -323,12 +323,11 @@ def dead_branch_prune(func_ir, called_args):
     class Unknown(object):
         pass
 
-    def resolve_input_arg_const(input_arg):
+    def resolve_input_arg_const(input_arg_idx):
         """
         Resolves an input arg to a constant (if possible)
         """
-        idx = func_ir.arg_names.index(input_arg)
-        input_arg_ty = called_args[idx]
+        input_arg_ty = called_args[input_arg_idx]
 
         # comparing to None?
         if isinstance(input_arg_ty, types.NoneType):
@@ -363,9 +362,10 @@ def dead_branch_prune(func_ir, called_args):
             prune = prune_by_value
             for arg in [condition.lhs, condition.rhs]:
                 resolved_const = Unknown()
-                if arg.name in func_ir.arg_names:
+                arg_def = get_definition(func_ir, arg)
+                if isinstance(arg_def, ir.Arg):
                     # it's an e.g. literal argument to the function
-                    resolved_const = resolve_input_arg_const(arg.name)
+                    resolved_const = resolve_input_arg_const(arg_def.index)
                     prune = prune_by_type
                 else:
                     # it's some const argument to the function, cannot use guard

--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -362,7 +362,7 @@ def dead_branch_prune(func_ir, called_args):
             prune = prune_by_value
             for arg in [condition.lhs, condition.rhs]:
                 resolved_const = Unknown()
-                arg_def = get_definition(func_ir, arg)
+                arg_def = guard(get_definition, func_ir, arg)
                 if isinstance(arg_def, ir.Arg):
                     # it's an e.g. literal argument to the function
                     resolved_const = resolve_input_arg_const(arg_def.index)

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -325,6 +325,9 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
 
     if typingctx:
         from numba import compiler
+        # call branch pruning to simplify IR and avoid inference errors
+        callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
+        numba.analysis.dead_branch_prune(callee_ir, arg_typs)
         try:
             f_typemap, f_return_type, f_calltypes = compiler.type_inference_stage(
                     typingctx, callee_ir, arg_typs, None)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
As title. Enables using constant expressions like `None` checks in ParallelAccelerator-like function replacements.
