### PR TITLE
fix status check in dict lookup

### DIFF
--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -593,7 +593,7 @@ def _dict_lookup(typingctx, d, key, hashval):
             ],
         )
         # Load value if output is available
-        found = builder.icmp_signed('>=', ix, ix.type(int(DKIX.EMPTY)))
+        found = builder.icmp_signed('>', ix, ix.type(int(DKIX.EMPTY)))
 
         out = context.make_optional_none(builder, td.value_type)
         pout = cgutils.alloca_once_value(builder, out)


### PR DESCRIPTION
We need to check that the ix-status is strictly greater than DKIX.EMPTY.
Because only then was the slot full (and not empty) and a value was
found indeed. The went unnoticed because in the implementation for
@overload (impl_getitem) the ix-status is checked again and an
appropriate KeyError is raised.