### PR TITLE
 Fix slice shape assignment in array analysis

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -800,15 +800,11 @@ class SymbolicEquivSet(ShapeEquivSet):
         for names in offset_dict.values():
             self._insert(names)
 
-    def set_shape(self, obj, shape):
-        """Overload set_shape to remember shapes of SetItem IR nodes.
+    def set_shape_setitem(self, obj, shape):
+        """remember shapes of SetItem IR nodes.
         """
-        if isinstance(obj, ir.StaticSetItem) or isinstance(obj, ir.SetItem):
-            self.ext_shapes[obj] = shape
-        else:
-            assert(isinstance(obj, ir.Var))
-            typ = self.typemap[obj.name]
-            super(SymbolicEquivSet, self).set_shape(obj, shape)
+        assert isinstance(obj, ir.StaticSetItem) or isinstance(obj, ir.SetItem)
+        self.ext_shapes[obj] = shape
 
     def _get_shape(self, obj):
         """Overload _get_shape to retrieve the shape of SetItem IR nodes.
@@ -981,10 +977,7 @@ class ArrayAnalysis(object):
                                                          len(typ), shape)
 
             if shape != None:
-                if isinstance(typ, types.SliceType):
-                    equiv_set.set_shape(lhs, shape)
-                else:
-                    equiv_set.insert_equiv(lhs, shape)
+                equiv_set.insert_equiv(lhs, shape)
             equiv_set.define(lhs, self.func_ir, typ)
         elif isinstance(inst, ir.StaticSetItem) or isinstance(inst, ir.SetItem):
             index = inst.index if isinstance(inst, ir.SetItem) else inst.index_var
@@ -995,7 +988,7 @@ class ArrayAnalysis(object):
             (target_shape, pre) = result
             value_shape = equiv_set.get_shape(inst.value)
             if value_shape is (): # constant
-                equiv_set.set_shape(inst, target_shape)
+                equiv_set.set_shape_setitem(inst, target_shape)
                 return pre, []
             elif value_shape != None:
                 target_typ = self.typemap[inst.target.name]
@@ -1008,7 +1001,7 @@ class ArrayAnalysis(object):
                 n = len(shape)
                 # shape dimension must be within target dimension
                 assert(target_ndim >= n)
-                equiv_set.set_shape(inst, shape)
+                equiv_set.set_shape_setitem(inst, shape)
                 return pre + asserts, []
             else:
                 return pre, []

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -929,5 +929,24 @@ class TestArrayAnalysisParallelRequired(TestCase):
         self.assertEqual(
             njit(test_impl, parallel=True)(t_obj, X1), test_impl(t_obj, X2))
 
+    @skip_unsupported
+    def test_slice_shape_issue_3380(self):
+        # these tests shouldn't throw error in array analysis
+        def test_impl1():
+            a = slice(None, None)
+            return True
+
+        self.assertEqual(njit(test_impl1, parallel=True)(), test_impl1())
+
+        def test_impl2(A, a):
+            b = a
+            return A[b]
+
+        A = np.arange(10)
+        a = slice(None)
+        np.testing.assert_array_equal(
+            njit(test_impl2, parallel=True)(A, a), test_impl2(A, a))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This PR fixes shape assignment in array analysis for slices and clarifies the specialized paths of the code intended for `SetItem`/`StaticSetitem`. Closes #3380 .

`set_shape()` is specialized to `SetItem`/`StaticSetItem` nodes,
and slice shapes do not need its specialized path.
Confusion comes from the fact that `wrap_index` (which is related
to slices) uses the same `ext_shapes` data structure as setitem,
but is in fact independent of slice variables themselves.