### PR TITLE
Abandon branch pruning if an arg name is redefined.

### DIFF
--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -329,12 +329,11 @@ def dead_branch_prune(func_ir, called_args):
     class Unknown(object):
         pass
 
-    def resolve_input_arg_const(input_arg):
+    def resolve_input_arg_const(input_arg_idx):
         """
         Resolves an input arg to a constant (if possible)
         """
-        idx = func_ir.arg_names.index(input_arg)
-        input_arg_ty = called_args[idx]
+        input_arg_ty = called_args[input_arg_idx]
 
         # comparing to None?
         if isinstance(input_arg_ty, types.NoneType):
@@ -369,12 +368,11 @@ def dead_branch_prune(func_ir, called_args):
             prune = prune_by_value
             for arg in [condition.lhs, condition.rhs]:
                 resolved_const = Unknown()
-                if arg.name in func_ir.arg_names:
-                    # make sure there's no redefinition of an arg name
-                    if len(func_ir._definitions[arg.name]) == 1:
-                        # it's an e.g. literal argument to the function
-                        resolved_const = resolve_input_arg_const(arg.name)
-                        prune = prune_by_type
+                arg_def = guard(get_definition, func_ir, arg)
+                if isinstance(arg_def, ir.Arg):
+                    # it's an e.g. literal argument to the function
+                    resolved_const = resolve_input_arg_const(arg_def.index)
+                    prune = prune_by_type
                 else:
                     # it's some const argument to the function, cannot use guard
                     # here as the const itself may be None

--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -304,7 +304,7 @@ def dead_branch_prune(func_ir, called_args):
         if lhs_none or rhs_none:
             try:
                 take_truebr = condition.fn(lhs_cond, rhs_cond)
-            except:
+            except Exception:
                 return False, None
             if DEBUG > 0:
                 kill = branch.falsebr if take_truebr else branch.truebr
@@ -318,7 +318,7 @@ def dead_branch_prune(func_ir, called_args):
         lhs_cond, rhs_cond = conds
         try:
             take_truebr = condition.fn(lhs_cond, rhs_cond)
-        except:
+        except Exception:
             return False, None
         if DEBUG > 0:
             kill = branch.falsebr if take_truebr else branch.truebr

--- a/numba/tests/test_analysis.py
+++ b/numba/tests/test_analysis.py
@@ -81,6 +81,9 @@ class TestBranchPrune(MemoryLeakMixin, TestCase):
                 expect_removed.append(branch.falsebr)
             elif prune is None:
                 pass  # nothing should be removed!
+            elif prune == 'both':
+                expect_removed.append(branch.falsebr)
+                expect_removed.append(branch.truebr)
             else:
                 assert 0, "unreachable"
 
@@ -92,9 +95,9 @@ class TestBranchPrune(MemoryLeakMixin, TestCase):
         try:
             self.assertEqual(new_labels, original_labels - set(expect_removed))
         except AssertionError as e:
-            print("new_labels", new_labels)
-            print("original_labels", original_labels)
-            print("expect_removed", expect_removed)
+            print("new_labels", sorted(new_labels))
+            print("original_labels", sorted(original_labels))
+            print("expect_removed", sorted(expect_removed))
             raise e
 
         cres = compile_isolated(func, args_tys)
@@ -376,3 +379,127 @@ class TestBranchPrune(MemoryLeakMixin, TestCase):
         self.assertEqual(bug(np.arange(10).reshape((2, 5)), 10), [])
         self.assertEqual(bug(np.arange(10).reshape((2, 5)), None), [])
         self.assertFalse(bug.nopython_signatures)
+
+
+    def test_redefined_variables_are_not_considered_in_prune(self):
+        # see issue #4163, checks that if a variable that is an argument is
+        # redefined in the user code it is not considered const
+
+        def impl(array, a=None):
+            if a is None:
+                a = 0
+            if a < 0:
+                return 10
+            return 30
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.NoneType('none'),),
+                          [None, None],
+                          np.zeros((2, 3)), None)
+
+    def test_comparison_operators(self):
+        # see issue #4163, checks that a variable that is an argument and has
+        # value None survives TypeError from invalid comparison which should be
+        # dead
+
+        def impl(array, a=None):
+            x = 0
+            if a is None:
+                return 10 # dynamic exec would return here
+            # static analysis requires that this is executed with a=None,
+            # hence TypeError
+            if a < 0:
+                return 20
+            return x
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.NoneType('none'),),
+                          [False, 'both'],
+                          np.zeros((2, 3)), None)
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.float64,),
+                          [None, None],
+                          np.zeros((2, 3)), 12.)
+
+    def test_redefinition_analysis_same_block(self):
+        # checks that a redefinition in a block with prunable potential doesn't
+        # break
+
+        def impl(array, x, a=None):
+            b = 0
+            if x < 4:
+                b = 12
+            if a is None:
+                a = 0
+            else:
+                b = 12
+            if a < 0:
+                return 10
+            return 30 + b + a
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.float64, types.NoneType('none'),),
+                          [None, None, None],
+                          np.zeros((2, 3)), 1., None)
+
+    def test_redefinition_analysis_different_block_can_exec(self):
+        # checks that a redefinition in a block that may be executed prevents
+        # pruning
+
+        def impl(array, x, a=None):
+            b = 0
+            if x > 5:
+                a = 11 # a redefined, cannot tell statically if this will exec
+            if x < 4:
+                b = 12
+            if a is None: # cannot prune, cannot determine if re-defn occurred
+                b += 5
+            else:
+                b += 7
+                if a < 0:
+                    return 10
+            return 30 + b
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.float64, types.NoneType('none'),),
+                          [None, None, None, None],
+                          np.zeros((2, 3)), 1., None)
+
+
+    def test_redefinition_analysis_different_block_cannot_exec(self):
+        # checks that a redefinition in a block guarded by something that
+        # has prune potential
+
+        def impl(array, x=None, a=None):
+            b = 0
+            if x is not None:
+                a = 11
+            if a is None:
+                b += 5
+            else:
+                b += 7
+            return 30 + b
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.NoneType('none'), types.NoneType('none')),
+                          [True, None],
+                          np.zeros((2, 3)), None, None)
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.NoneType('none'), types.float64),
+                          [True, None],
+                          np.zeros((2, 3)), None, 1.2)
+
+        self.assert_prune(impl,
+                          (types.Array(types.float64, 2, 'C'),
+                           types.float64, types.NoneType('none')),
+                          [None, None],
+                          np.zeros((2, 3)), 1.2, None)

--- a/numba/tests/test_analysis.py
+++ b/numba/tests/test_analysis.py
@@ -380,7 +380,6 @@ class TestBranchPrune(MemoryLeakMixin, TestCase):
         self.assertEqual(bug(np.arange(10).reshape((2, 5)), None), [])
         self.assertFalse(bug.nopython_signatures)
 
-
     def test_redefined_variables_are_not_considered_in_prune(self):
         # see issue #4163, checks that if a variable that is an argument is
         # redefined in the user code it is not considered const
@@ -470,7 +469,6 @@ class TestBranchPrune(MemoryLeakMixin, TestCase):
                            types.float64, types.NoneType('none'),),
                           [None, None, None, None],
                           np.zeros((2, 3)), 1., None)
-
 
     def test_redefinition_analysis_different_block_cannot_exec(self):
         # checks that a redefinition in a block guarded by something that


### PR DESCRIPTION
This makes it so that branch pruning for a given input arg is
abandoned if an input arg is redefined in the user code as its
value potentially becomes non-const (and no const-prop analysis
yet to figure it out).

Fixes #4163

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
