### PR TITLE
cuda graph api proposal

### DIFF
--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -20,6 +20,7 @@ cu_function_attribute = c_int
 cu_ipc_mem_handle = (c_byte * _extras.CUDA_IPC_HANDLE_SIZE)   # 64 bytes wide
 
 cu_occupancy_b2d_size = CFUNCTYPE(c_size_t, c_int)
+cu_host_fn = CFUNCTYPE(None, c_void_p)
 
 
 API_PROTOTYPES = {

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -369,6 +369,9 @@ API_PROTOTYPES = {
 
 # CUresult cuGraphAddMemsetNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS* memsetParams, CUcontext ctx )
 
+'cuGraphAddMemsetNode': (c_int,
+                         c_void_p, c_void_p, c_void_p, c_uint, c_void_p, cu_context),
+
 # CUresult cuGraphChildGraphNodeGetGraph ( CUgraphNode hNode, CUgraph* phGraph )
 
 # CUresult cuGraphClone ( CUgraph* phGraphClone, CUgraph originalGraph )

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -357,6 +357,9 @@ API_PROTOTYPES = {
 
 # CUresult cuGraphAddHostNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_HOST_NODE_PARAMS* nodeParams )
 
+'cuGraphAddHostNode': (c_int,
+                       c_void_p, c_void_p, c_void_p, c_uint, c_void_p),
+
 # CUresult cuGraphAddKernelNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_KERNEL_NODE_PARAMS* nodeParams )
 
 'cuGraphAddKernelNode': (c_int,

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -13,6 +13,7 @@ cu_function = c_void_p          # an opaque handle
 cu_device_ptr = c_size_t        # defined as unsigned int on 32-bit
                                 # and unsigned long long on 64-bit machine
 cu_stream = c_void_p            # an opaque handle
+cu_array = c_void_p             # an opaque handle
 cu_event = c_void_p
 cu_link_state = c_void_p
 cu_function_attribute = c_int
@@ -362,6 +363,9 @@ API_PROTOTYPES = {
                          c_void_p, c_void_p, c_void_p, c_uint, c_void_p),
 
 # CUresult cuGraphAddMemcpyNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_MEMCPY3D* copyParams, CUcontext ctx )
+
+'cuGraphAddMemcpyNode': (c_int,
+                         c_void_p, c_void_p, c_void_p, c_uint, c_void_p, cu_context),
 
 # CUresult cuGraphAddMemsetNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS* memsetParams, CUcontext ctx )
 

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -382,6 +382,8 @@ API_PROTOTYPES = {
 
 # CUresult cuGraphDestroy ( CUgraph hGraph )
 
+'cuGraphDestroy': (c_int, c_void_p),
+
 # CUresult cuGraphDestroyNode ( CUgraphNode hNode )
 
 # CUresult cuGraphExecDestroy ( CUgraphExec hGraphExec )

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -345,4 +345,80 @@ API_PROTOTYPES = {
 'cuDeviceCanAccessPeer': (c_int,
                           POINTER(c_int), cu_device, cu_device),
 
+# CUresult cuGraphAddChildGraphNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUgraph childGraph )
+
+# CUresult cuGraphAddDependencies ( CUgraph hGraph, const CUgraphNode* from, const CUgraphNode* to, size_t numDependencies )
+
+# CUresult cuGraphAddEmptyNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies )
+
+# CUresult cuGraphAddHostNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_HOST_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphAddKernelNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_KERNEL_NODE_PARAMS* nodeParams )
+
+'cuGraphAddKernelNode': (c_int,
+                         c_void_p, c_void_p, c_void_p, c_uint, c_void_p),
+
+# CUresult cuGraphAddMemcpyNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_MEMCPY3D* copyParams, CUcontext ctx )
+
+# CUresult cuGraphAddMemsetNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_MEMSET_NODE_PARAMS* memsetParams, CUcontext ctx )
+
+# CUresult cuGraphChildGraphNodeGetGraph ( CUgraphNode hNode, CUgraph* phGraph )
+
+# CUresult cuGraphClone ( CUgraph* phGraphClone, CUgraph originalGraph )
+
+# CUresult cuGraphCreate ( CUgraph* phGraph, unsigned int  flags )
+
+'cuGraphCreate': (c_int, c_void_p, c_uint),
+
+# CUresult cuGraphDestroy ( CUgraph hGraph )
+
+# CUresult cuGraphDestroyNode ( CUgraphNode hNode )
+
+# CUresult cuGraphExecDestroy ( CUgraphExec hGraphExec )
+
+# CUresult cuGraphExecKernelNodeSetParams ( CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphGetEdges ( CUgraph hGraph, CUgraphNode* from, CUgraphNode* to, size_t* numEdges )
+
+# CUresult cuGraphGetNodes ( CUgraph hGraph, CUgraphNode* nodes, size_t* numNodes )
+
+# CUresult cuGraphGetRootNodes ( CUgraph hGraph, CUgraphNode* rootNodes, size_t* numRootNodes )
+
+# CUresult cuGraphHostNodeGetParams ( CUgraphNode hNode, CUDA_HOST_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphHostNodeSetParams ( CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphInstantiate ( CUgraphExec* phGraphExec, CUgraph hGraph, CUgraphNode* phErrorNode, char* logBuffer, size_t bufferSize )
+
+'cuGraphInstantiate': (c_int, c_void_p, c_void_p, c_void_p, c_void_p, c_uint),
+
+# CUresult cuGraphKernelNodeGetParams ( CUgraphNode hNode, CUDA_KERNEL_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphKernelNodeSetParams ( CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS* nodeParams )
+
+'cuGraphKernelNodeSetParams': (c_int,
+                               c_void_p, c_void_p),
+
+# CUresult cuGraphLaunch ( CUgraphExec hGraphExec, CUstream hStream )
+
+'cuGraphLaunch': (c_int, c_void_p, c_void_p),
+
+# CUresult cuGraphMemcpyNodeGetParams ( CUgraphNode hNode, CUDA_MEMCPY3D* nodeParams )
+
+# CUresult cuGraphMemcpyNodeSetParams ( CUgraphNode hNode, const CUDA_MEMCPY3D* nodeParams )
+
+# CUresult cuGraphMemsetNodeGetParams ( CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphMemsetNodeSetParams ( CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS* nodeParams )
+
+# CUresult cuGraphNodeFindInClone ( CUgraphNode* phNode, CUgraphNode hOriginalNode, CUgraph hClonedGraph )
+
+# CUresult cuGraphNodeGetDependencies ( CUgraphNode hNode, CUgraphNode* dependencies, size_t* numDependencies )
+
+# CUresult cuGraphNodeGetDependentNodes ( CUgraphNode hNode, CUgraphNode* dependentNodes, size_t* numDependentNodes )
+
+# CUresult cuGraphNodeGetType ( CUgraphNode hNode, CUgraphNodeType* type )
+
+# CUresult cuGraphRemoveDependencies ( CUgraph hGraph, const CUgraphNode* from, const CUgraphNode* to, size_t numDependencies )
+
 }

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -351,6 +351,9 @@ API_PROTOTYPES = {
 
 # CUresult cuGraphAddEmptyNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies )
 
+'cuGraphAddEmptyNode': (c_int,
+                        c_void_p, c_void_p, c_void_p, c_uint),
+
 # CUresult cuGraphAddHostNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_HOST_NODE_PARAMS* nodeParams )
 
 # CUresult cuGraphAddKernelNode ( CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_KERNEL_NODE_PARAMS* nodeParams )

--- a/numba/cuda/graph.py
+++ b/numba/cuda/graph.py
@@ -2,6 +2,7 @@ from ctypes import c_void_p, addressof, c_uint, POINTER, Structure
 from numba.cuda.cudadrv.driver import driver, is_device_memory, device_ctypes_pointer, byref
 from numba.cuda.compiler import AutoJitCUDAKernel, CUDAKernel
 
+
 class KernelParams(Structure):
     _fields_ = [
         ('func', c_void_p),
@@ -16,18 +17,20 @@ class KernelParams(Structure):
         ('extra', POINTER(c_void_p)),
     ]
 
+
 class Node:
     pass
 
+
 class KernelNode(Node):
-    def __init__(self, kernel, args = None, deps = None, params = None):
+    def __init__(self, kernel, args=None, deps=None, params=None):
         self.kernel = kernel
         self.args = args or []
         self.deps = deps or []
         self.params = params or { }
         self.builded = { }
         super().__init__()
-    
+
     def _get_params(self):
         params = KernelParams()
         params.blockDimX = self.params.get('blockDimX', 1)
@@ -49,7 +52,7 @@ class KernelNode(Node):
         retr, kernel_args = [], []
         for t, v in zip(kernel.argument_types, self.args):
             kernel._prepare_args(t, v, 0, retr, kernel_args)
-        
+
         # TODO: take care of retr after graph launched
         if len(retr):
             raise Exception('host array as kernel node args not supported yet')
@@ -64,8 +67,8 @@ class KernelNode(Node):
         params.kernelParams = (c_void_p * len(param_vals))(*param_vals) if len(param_vals) else None
         params.extra = self.params.get('extra', None)
         return params
-    
-    def build(self, graph = None):
+
+    def build(self, graph=None):
         if not graph:
             graph = Graph()
 
@@ -82,6 +85,7 @@ class KernelNode(Node):
         driver.cuGraphAddKernelNode(byref(builded.handle), graph.handle, dep_arr, dep_num, byref(params))
         return builded
 
+
 class BuildedNode:
     def __init__(self, handle, graph):
         self.handle = handle
@@ -90,21 +94,23 @@ class BuildedNode:
     def instantiate(self):
         return GraphExec(self.graph)
 
-    def launch(self, stream = None):
+    def launch(self, stream=None):
         return GraphExec(self.graph).launch(stream)
 
+
 class Graph:
-    def __init__(self, flags = 0):
+    def __init__(self, flags=0):
         self.handle = c_void_p()
         driver.cuGraphCreate(byref(self.handle), flags)
 
     def instantiate(self):
         return GraphExec(self)
 
+
 class GraphExec:
     def __init__(self, graph):
         self.handle = c_void_p()
         driver.cuGraphInstantiate(byref(self.handle), graph.handle, c_void_p(), c_void_p(), 0)
-    
-    def launch(self, stream = None):
+
+    def launch(self, stream=None):
         driver.cuGraphLaunch(self.handle, stream.handle if stream else 0)

--- a/numba/cuda/graph.py
+++ b/numba/cuda/graph.py
@@ -204,7 +204,23 @@ class MemsetNode(Node):
         return builded
 
 
-class KernelNode(Node):
+class KernelNodeMeta(type):
+    def __getitem__(self, config):
+        def makeKernelNode(kernel, args=None, deps=None, params=None):
+            if len(config) not in [2, 3]:
+                raise ValueError('must specify at least the griddim and blockdim')
+            def_pars = {
+                'gridDim': config[0],
+                'blockDim': config[1],
+                'sharedMemBytes': config[2] if len(config) > 2 else 0,
+            }
+            if params:
+                def_pars.update(params)
+            return KernelNode(kernel, args, deps, def_pars)
+        return makeKernelNode
+
+
+class KernelNode(Node, metaclass=KernelNodeMeta):
     def __init__(self, kernel, args=None, deps=None, params=None):
         self.kernel = kernel
         self.args = args or []

--- a/numba/cuda/graph.py
+++ b/numba/cuda/graph.py
@@ -20,11 +20,11 @@ class Node:
     pass
 
 class KernelNode(Node):
-    def __init__(self, kernel, args = [], deps = [], params = { }):
+    def __init__(self, kernel, args = None, deps = None, params = None):
         self.kernel = kernel
-        self.args = args
-        self.deps = deps
-        self.params = params
+        self.args = args or []
+        self.deps = deps or []
+        self.params = params or { }
         self.builded = { }
         super().__init__()
     

--- a/numba/cuda/graph.py
+++ b/numba/cuda/graph.py
@@ -1,0 +1,110 @@
+from ctypes import c_void_p, addressof, c_uint, POINTER, Structure
+from numba.cuda.cudadrv.driver import driver, is_device_memory, device_ctypes_pointer, byref
+from numba.cuda.compiler import AutoJitCUDAKernel, CUDAKernel
+
+class KernelParams(Structure):
+    _fields_ = [
+        ('func', c_void_p),
+        ('gridDimX', c_uint),
+        ('gridDimY', c_uint),
+        ('gridDimZ', c_uint),
+        ('blockDimX', c_uint),
+        ('blockDimY', c_uint),
+        ('blockDimZ', c_uint),
+        ('sharedMemBytes', c_uint),
+        ('kernelParams', POINTER(c_void_p)),
+        ('extra', POINTER(c_void_p)),
+    ]
+
+class Node:
+    pass
+
+class KernelNode(Node):
+    def __init__(self, kernel, args = [], deps = [], params = { }):
+        self.kernel = kernel
+        self.args = args
+        self.deps = deps
+        self.params = params
+        self.builded = { }
+        super().__init__()
+    
+    def _get_params(self):
+        params = KernelParams()
+        params.blockDimX = self.params.get('blockDimX', 1)
+        params.blockDimY = self.params.get('blockDimY', 1)
+        params.blockDimZ = self.params.get('blockDimZ', 1)
+        params.gridDimX = self.params.get('gridDimX', 1)
+        params.gridDimY = self.params.get('gridDimY', 1)
+        params.gridDimZ = self.params.get('gridDimZ', 1)
+        params.sharedMemBytes = self.params.get('sharedMemBytes', 0)
+
+        if isinstance(self.kernel, AutoJitCUDAKernel):
+            kernel = self.kernel.specialize(*self.args)
+        elif isinstance(self.kernel, CUDAKernel):
+            kernel = self.kernel
+        else:
+            raise Exception('invalid kernel type "%s"' % type(self.kernel).__name__)
+        params.func = kernel._func.get().handle
+
+        retr, kernel_args = [], []
+        for t, v in zip(kernel.argument_types, self.args):
+            kernel._prepare_args(t, v, 0, retr, kernel_args)
+        
+        # TODO: take care of retr after graph launched
+        if len(retr):
+            raise Exception('host array as kernel node args not supported yet')
+
+        param_vals = []
+        for arg in kernel_args:
+            if is_device_memory(arg):
+                param_vals.append(addressof(device_ctypes_pointer(arg)))
+            else:
+                param_vals.append(addressof(arg))
+
+        params.kernelParams = (c_void_p * len(param_vals))(*param_vals) if len(param_vals) else None
+        params.extra = self.params.get('extra', None)
+        return params
+    
+    def build(self, graph = None):
+        if not graph:
+            graph = Graph()
+
+        if graph in self.builded:
+            return self.builded[graph]
+
+        # FIXME: it's strange but we have to build depedencies before other operations
+        dep_val = [dep.build(graph).handle for dep in self.deps]
+        dep_num = len(dep_val)
+        dep_arr = (c_void_p * dep_num)(*dep_val) if dep_num else None
+
+        params = self._get_params()
+        builded = self.builded[graph] = BuildedNode(c_void_p(), graph)
+        driver.cuGraphAddKernelNode(byref(builded.handle), graph.handle, dep_arr, dep_num, byref(params))
+        return builded
+
+class BuildedNode:
+    def __init__(self, handle, graph):
+        self.handle = handle
+        self.graph = graph
+
+    def instantiate(self):
+        return GraphExec(self.graph)
+
+    def launch(self, stream = None):
+        return GraphExec(self.graph).launch(stream)
+
+class Graph:
+    def __init__(self, flags = 0):
+        self.handle = c_void_p()
+        driver.cuGraphCreate(byref(self.handle), flags)
+
+    def instantiate(self):
+        return GraphExec(self)
+
+class GraphExec:
+    def __init__(self, graph):
+        self.handle = c_void_p()
+        driver.cuGraphInstantiate(byref(self.handle), graph.handle, c_void_p(), c_void_p(), 0)
+    
+    def launch(self, stream = None):
+        driver.cuGraphLaunch(self.handle, stream.handle if stream else 0)

--- a/numba/cuda/tests/graph/__init__.py
+++ b/numba/cuda/tests/graph/__init__.py
@@ -1,0 +1,6 @@
+from numba.testing import load_testsuite
+import os
+
+
+def load_tests(loader, tests, pattern):
+    return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -4,8 +4,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba.cuda.testing import SerialMixin
-from numba.types import CPointer
-from numba import cuda, void, f8, cfunc
+from numba import cuda, void, f8
 
 from numba.cuda.graph import KernelNode, EmptyNode, MemcpyDtoHNode, MemcpyHtoDNode, MemsetNode, HostNode
 

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -128,6 +128,26 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
 
         self.assertTrue(np.all(harr == [3]))
 
+    def test_graph_destroy(self):
+        arr = cuda.to_device(np.array([1.]))
+
+        @cuda.jit
+        def k1(a):
+            a[0] += 2
+
+        n1 = KernelNode(k1, [arr])
+        g = n1.build()
+        g.launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [3]))
+
+        g.destroy()
+        with self.assertRaises(Exception) as raises:
+            g.launch()
+
+        self.assertTrue('graph already destroyed!', str(raises.exception))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -71,7 +71,19 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
 
         self.assertTrue(np.all(arr.copy_to_host() == [4, 1, 1, 5, 1, 1]))
 
+        n1 = KernelNode[4, 5](k1, [arr])
+        n1.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [4, 1, 1, 5, 1, 1]))
+
         n1 = KernelNode(k1, [arr], params={ 'gridDim': (1, 2, 3), 'blockDim': (4, 5, 6) })
+        n1.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [1, 2, 3, 4, 5, 6]))
+
+        n1 = KernelNode[(1, 2, 3), (4, 5, 6)](k1, [arr])
         n1.build().launch()
         cuda.synchronize()
 

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -8,13 +8,16 @@ from numba import cuda, void, f8
 
 from numba.cuda.graph import KernelNode
 
+
 class TestCudaGraph(SerialMixin, unittest.TestCase):
 
     def test_cuda_kernel(self):
         arr = cuda.to_device(np.array([1.]))
+
         @cuda.jit(void(f8[:]))
         def k1(a):
             a[0] += 2
+
         @cuda.jit(void(f8[:]))
         def k2(a):
             a[0] *= 3
@@ -28,9 +31,11 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
 
     def test_auto_cuda_kernel(self):
         arr = cuda.to_device(np.array([1.]))
+
         @cuda.jit
         def k1(a):
             a[0] += 2
+
         @cuda.jit
         def k2(a):
             a[0] *= 3
@@ -41,6 +46,7 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         cuda.synchronize()
 
         self.assertTrue(np.all(arr.copy_to_host() == [9]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -164,15 +164,18 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
     def test_host_node(self):
         arr = np.array([1.])
 
-        @cfunc(void(CPointer(f8)))
-        def k1(a):
-            a[0] += 2
+        def k1(a, n):
+            a[0] += n
 
-        n1 = HostNode(k1, [arr])
-        n1.build().launch()
+        def k2(a, n):
+            a[0] *= n
+
+        n1 = HostNode(k1, [arr, 2])
+        n2 = HostNode(k2, [arr, 3], [n1])
+        n2.build().launch()
         cuda.synchronize()
 
-        self.assertTrue(np.all(arr == [3]))
+        self.assertTrue(np.all(arr == [9]))
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy as np
+
+from numba import unittest_support as unittest
+from numba.cuda.testing import SerialMixin
+from numba import cuda, void, f8
+
+from numba.cuda.graph import KernelNode
+
+class TestCudaGraph(SerialMixin, unittest.TestCase):
+
+    def test_cuda_kernel(self):
+        arr = cuda.to_device(np.array([1.]))
+        @cuda.jit(void(f8[:]))
+        def k1(a):
+            a[0] += 2
+        @cuda.jit(void(f8[:]))
+        def k2(a):
+            a[0] *= 3
+
+        n1 = KernelNode(k1, [arr], [])
+        n2 = KernelNode(k2, [arr], [n1])
+        n2.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [9]))
+
+    def test_auto_cuda_kernel(self):
+        arr = cuda.to_device(np.array([1.]))
+        @cuda.jit
+        def k1(a):
+            a[0] += 2
+        @cuda.jit
+        def k2(a):
+            a[0] *= 3
+
+        n1 = KernelNode(k1, [arr], [])
+        n2 = KernelNode(k2, [arr], [n1])
+        n2.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [9]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -48,10 +48,25 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
 
         self.assertTrue(np.all(arr.copy_to_host() == [9]))
 
+    def test_func_as_kernel(self):
+        arr = cuda.to_device(np.array([1.]))
+
+        def k1(a):
+            a[0] += 2
+
+        def k2(a):
+            a[0] *= 3
+
+        n1 = KernelNode(k1, [arr])
+        n2 = KernelNode(k2, [arr], [n1])
+        n2.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [9]))
+
     def test_kernel_dim(self):
         arr = cuda.to_device(np.zeros(6))
 
-        @cuda.jit
         def k1(a):
             a[0] = cuda.gridDim.x
             a[1] = cuda.gridDim.y
@@ -93,11 +108,9 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
     def test_empty_node(self):
         arr = cuda.to_device(np.array([1.]))
 
-        @cuda.jit
         def k1(a):
             a[0] += 2
 
-        @cuda.jit
         def k2(a):
             a[0] *= 3
 
@@ -113,7 +126,6 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         harr = np.array([1.])
         darr = cuda.device_array_like(harr)
 
-        @cuda.jit
         def k1(a):
             a[0] += 2
 
@@ -129,7 +141,6 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         harr = np.array([0]).astype(np.int32)
         darr = cuda.device_array_like(harr)
 
-        @cuda.jit
         def k1(a):
             a[0] += 2
 
@@ -144,7 +155,6 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
     def test_graph_destroy(self):
         arr = cuda.to_device(np.array([1.]))
 
-        @cuda.jit
         def k1(a):
             a[0] += 2
 

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -19,7 +19,7 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         def k2(a):
             a[0] *= 3
 
-        n1 = KernelNode(k1, [arr], [])
+        n1 = KernelNode(k1, [arr])
         n2 = KernelNode(k2, [arr], [n1])
         n2.build().launch()
         cuda.synchronize()
@@ -35,7 +35,7 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         def k2(a):
             a[0] *= 3
 
-        n1 = KernelNode(k1, [arr], [])
+        n1 = KernelNode(k1, [arr])
         n2 = KernelNode(k2, [arr], [n1])
         n2.build().launch()
         cuda.synchronize()

--- a/numba/cuda/tests/graph/test_graph.py
+++ b/numba/cuda/tests/graph/test_graph.py
@@ -6,7 +6,7 @@ from numba import unittest_support as unittest
 from numba.cuda.testing import SerialMixin
 from numba import cuda, void, f8
 
-from numba.cuda.graph import KernelNode
+from numba.cuda.graph import KernelNode, EmptyNode
 
 
 class TestCudaGraph(SerialMixin, unittest.TestCase):
@@ -76,6 +76,25 @@ class TestCudaGraph(SerialMixin, unittest.TestCase):
         cuda.synchronize()
 
         self.assertTrue(np.all(arr.copy_to_host() == [1, 2, 3, 4, 5, 6]))
+
+    def test_empty_node(self):
+        arr = cuda.to_device(np.array([1.]))
+
+        @cuda.jit
+        def k1(a):
+            a[0] += 2
+
+        @cuda.jit
+        def k2(a):
+            a[0] *= 3
+
+        n1 = KernelNode(k1, [arr])
+        n2 = KernelNode(k2, [arr], [n1])
+        n3 = EmptyNode([n2])
+        n3.build().launch()
+        cuda.synchronize()
+
+        self.assertTrue(np.all(arr.copy_to_host() == [9]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello! This PR implements simple cuda graph API for numba (in response to #3327), as is shown in the following snippet:

```python
import numpy as np
from numba import cuda
from numba.cuda.graph import KernelNode

arr = cuda.to_device(np.array([1.]))

@cuda.jit
def k1(a):
    a[0] += 2
    print('k1', a[0])

@cuda.jit
def k2(a):
    a[0] *= 3
    print('k2', a[0])

# define new kernel nodes
n1 = KernelNode(k1, [arr])
n2 = KernelNode(k2, [arr], [n1])

# before the node is builded, the arguments and dependencies can be altered
n3 = KernelNode(k2)
n3.args.append(arr)
n3.deps.append(n2)

# build the graph
g = n3.build()

# short for g.instantiate().launch()
g.launch()

cuda.synchronize()

```

And another example for `KernelNode`, `MemcpyHtoDNode`, `MemcpyDtoHNode`, `HostNode`:
```python
import numpy as np
from numba import cuda
from numba.cuda.graph import KernelNode, MemcpyHtoDNode, MemcpyDtoHNode, HostNode

host_arr = np.array([1.])
dev_arr = cuda.device_array_like(host_arr)


def k1(a):
    cuda.atomic.add(a, 0, 2)
    print('this runs on device and a[0] =', a[0], ', grid =', cuda.grid(1))


def h1(a):
    print('this runs on host and a[0] =', a[0])


n0 = MemcpyHtoDNode(dev_arr, host_arr, host_arr.nbytes)
n1 = KernelNode[4, 1](k1, [dev_arr], [n0])
n2 = MemcpyDtoHNode(host_arr, dev_arr, host_arr.nbytes, [n1])
n3 = HostNode(h1, [host_arr], [n2])

n3.build().launch()
cuda.synchronize()
```

I tried to make the API simple and flexible by making the following decisions:
* Nodes are not binded to specific graph so you can alter it and build it later
* Host arrays are not supported as it's hard to decide when to copy data back

And the following features are in plan:
* [x] `graph.destroy()` and ~~`graph.clone()`~~
  * [x] `graph.destroy()`
  * ~~[ ] `graph.clone()` (Do we really need this?)~~
* [x] `MemcpyNode`, `MemsetNode`, `HostNode` and `EmptyNode`
  * [x] `MemcpyNode`
  * [x] `MemsetNode`
  * [x] `EmptyNode`
  * [x] `HostNode` (CFUNCTYPE is used)

As you see the API is far from complete so please feel free to add comments :)

PS: For tests run the following command in terminal:
```bash
python -m numba.runtests numba.cuda.tests.graph.test_graph
```
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
