### PR TITLE
Fix #4156.  Problem with defining in-loop variables.

### DIFF
--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -364,15 +364,16 @@ def alloca_once(builder, ty, size=None, name='', zfill=False):
     pointed by ``builder`` withe llvm type ``ty``.  The optional ``size`` arg
     set the number of element to allocate.  The default is 1.  The optional
     ``name`` arg set the symbol name inside the llvm IR for debugging.
-    If ``zfill`` is set, also filling zeros to the memory.
+    If ``zfill`` is set, also filling zeros to the memory at the current
+    use-site location.  Note that the memory is always zero-filled after the
+    ``alloca`` at init-site (the entry block).
     """
     if isinstance(size, utils.INT_TYPES):
         size = ir.Constant(intp_t, size)
     with builder.goto_entry_block():
         ptr = builder.alloca(ty, size=size, name=name)
-        # Zero-fill at the init-site
-        if zfill:
-            builder.store(ty(None), ptr)
+        # Always zero-fill at init-site.  This is safe.
+        builder.store(ty(None), ptr)
     # Also zero-fill at the use-site
     if zfill:
         builder.store(ty(None), ptr)

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -364,7 +364,7 @@ def alloca_once(builder, ty, size=None, name='', zfill=False):
     pointed by ``builder`` withe llvm type ``ty``.  The optional ``size`` arg
     set the number of element to allocate.  The default is 1.  The optional
     ``name`` arg set the symbol name inside the llvm IR for debugging.
-    If ``zfill`` is set, also filling zeros to the memory at the current
+    If ``zfill`` is set, fill the memory with zeros at the current
     use-site location.  Note that the memory is always zero-filled after the
     ``alloca`` at init-site (the entry block).
     """

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -1185,7 +1185,7 @@ class Lower(BaseLower):
                     self.builder.store(lltype(None), aptr)
         # Not in loops?
         else:
-            # Zerofill at use-site
+            # Zero-fill at use-site
             self.builder.store(lltype(None), aptr)
 
         if is_uservar:

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -14,6 +14,7 @@ from .errors import (LoweringError, new_error_context, TypingError,
                      LiteralTypingError)
 from .targets import removerefctpass
 from .funcdesc import default_mangler
+from .analysis import compute_cfg_from_blocks
 from . import debuginfo
 
 
@@ -86,6 +87,7 @@ class BaseLower(object):
         self.call_conv = context.call_conv
         self.generator_info = func_ir.generator_info
         self.metadata = metadata
+        self.cfg = compute_cfg_from_blocks(self.blocks)
 
         # Initialize LLVM
         self.module = self.library.create_ir_module(self.fndesc.unique_name)
@@ -238,6 +240,7 @@ class BaseLower(object):
             self.fndesc.unique_name))
         # Lower all blocks
         for offset, block in sorted(self.blocks.items()):
+            self._current_block_offset = offset
             bb = self.blkmap[offset]
             self.builder.position_at_end(bb)
             self.lower_block(block)
@@ -1169,7 +1172,22 @@ class Lower(BaseLower):
         # Is user variable?
         is_uservar = not name.startswith('$')
         # Allocate space for variable
-        aptr = cgutils.alloca_once(self.builder, lltype, name=name, zfill=True)
+        aptr = cgutils.alloca_once(self.builder, lltype,
+                                   name=name, zfill=False)
+        # Zero-fill differently if we are in loops
+        loops = self.cfg.in_loops(self._current_block_offset)
+        # In loops?
+        if loops:
+            innermost = loops[0]
+            # Zero fill at all loop-entries.
+            for ent in innermost.entries:
+                with self.builder.goto_block(self.blkmap[ent]):
+                    self.builder.store(lltype(None), aptr)
+        # Not in loops?
+        else:
+            # Zerofill at use-site
+            self.builder.store(lltype(None), aptr)
+
         if is_uservar:
             # Emit debug info for user variable
             sizeof = self.context.get_abi_sizeof(lltype)

--- a/numba/tests/test_lowering.py
+++ b/numba/tests/test_lowering.py
@@ -1,0 +1,40 @@
+"""
+Tests for lowering specific errors.
+"""
+
+
+from __future__ import print_function
+
+import numpy as np
+from numba import njit
+
+from .support import MemoryLeakMixin, TestCase
+
+
+class TestLowering(MemoryLeakMixin, TestCase):
+    def test_issue4156_loop_vars_leak(self):
+        """Test issues with zero-filling of refct'ed variables inside loops.
+
+        Before the fix, the in-loop variables are always zero-filled at
+        their definition location.  As a result, their state from the previous
+        iteration is erased.  No decref is applied.  To fix this, the
+        zero-filling must only happen in the loop entries.  The loop variables
+        are technically defined once per function (one alloca per definition
+        per function) but semantically defined once per loop.  The zero-filling
+        at the loop-entries emulate the semantic behavior.
+        """
+        @njit
+        def udt(N):
+            sum_vec = np.zeros(3)
+            for n in range(N):
+                if n >= 0:
+                    # `vec` would leak without the fix.
+                    vec = np.ones(1)
+                if n >= 0:
+                    sum_vec += vec[0]
+
+            return sum_vec
+
+        got = udt(4)
+        expect = udt.py_func(4)
+        self.assertPreciseEqual(got, expect)

--- a/numba/tests/test_practical_lowering_issues.py
+++ b/numba/tests/test_practical_lowering_issues.py
@@ -15,13 +15,14 @@ class TestLowering(MemoryLeakMixin, TestCase):
     def test_issue4156_loop_vars_leak(self):
         """Test issues with zero-filling of refct'ed variables inside loops.
 
-        Before the fix, the in-loop variables are always zero-filled at
-        their definition location.  As a result, their state from the previous
-        iteration is erased.  No decref is applied.  To fix this, the
-        zero-filling must only happen in the loop entries.  The loop variables
-        are technically defined once per function (one alloca per definition
-        per function) but semantically defined once per loop.  The zero-filling
-        at the loop-entries emulate the semantic behavior.
+        Before the fix, the in-loop variables are always zero-filled at their
+        definition location. As a result, their state from the previous
+        iteration is erased. No decref is applied. To fix this, the
+        zero-filling must only happen once after the alloca at the function
+        entry block. The loop variables are technically defined once per
+        function (one alloca per definition per function), but semantically
+        defined once per assignment. Semantically, their lifetime stop only
+        when the variable is re-assigned or when the function ends.
         """
         @njit
         def udt(N):
@@ -32,6 +33,98 @@ class TestLowering(MemoryLeakMixin, TestCase):
                     vec = np.ones(1)
                 if n >= 0:
                     sum_vec += vec[0]
+
+            return sum_vec
+
+        got = udt(4)
+        expect = udt.py_func(4)
+        self.assertPreciseEqual(got, expect)
+
+    def test_issue4156_loop_vars_leak_variant1(self):
+        """Variant of test_issue4156_loop_vars_leak.
+
+        Adding an outer loop.
+        """
+        @njit
+        def udt(N):
+            sum_vec = np.zeros(3)
+            for x in range(N):
+                for y in range(N):
+                    n = x + y
+                    if n >= 0:
+                        # `vec` would leak without the fix.
+                        vec = np.ones(1)
+                    if n >= 0:
+                        sum_vec += vec[0]
+
+            return sum_vec
+
+        got = udt(4)
+        expect = udt.py_func(4)
+        self.assertPreciseEqual(got, expect)
+
+    def test_issue4156_loop_vars_leak_variant2(self):
+        """Variant of test_issue4156_loop_vars_leak.
+
+        Adding deeper outer loop.
+        """
+        @njit
+        def udt(N):
+            sum_vec = np.zeros(3)
+            for z in range(N):
+                for x in range(N):
+                    for y in range(N):
+                        n = x + y + z
+                        if n >= 0:
+                            # `vec` would leak without the fix.
+                            vec = np.ones(1)
+                        if n >= 0:
+                            sum_vec += vec[0]
+
+            return sum_vec
+
+        got = udt(4)
+        expect = udt.py_func(4)
+        self.assertPreciseEqual(got, expect)
+
+    def test_issue4156_loop_vars_leak_variant3(self):
+        """Variant of test_issue4156_loop_vars_leak.
+
+        Adding inner loop around allocation
+        """
+        @njit
+        def udt(N):
+            sum_vec = np.zeros(3)
+            for z in range(N):
+                for x in range(N):
+                    n = x + z
+                    if n >= 0:
+                        for y in range(N):
+                            # `vec` would leak without the fix.
+                            vec = np.ones(y)
+                    if n >= 0:
+                        sum_vec += vec[0]
+
+            return sum_vec
+
+        got = udt(4)
+        expect = udt.py_func(4)
+        self.assertPreciseEqual(got, expect)
+
+    def test_issue4156_loop_vars_leak_variant4(self):
+        """Variant of test_issue4156_loop_vars_leak.
+
+        Interleaves loops and allocations
+        """
+        @njit
+        def udt(N):
+            sum_vec = 0
+
+            for n in range(N):
+                vec = np.zeros(7)
+                for n in range(N):
+                    z = np.zeros(7)
+                sum_vec += vec[0] + z[0]
 
             return sum_vec
 

--- a/numba/tests/test_practical_lowering_issues.py
+++ b/numba/tests/test_practical_lowering_issues.py
@@ -1,5 +1,5 @@
 """
-Tests for lowering specific errors.
+Tests for practical lowering specific errors.
 """
 
 


### PR DESCRIPTION
Fixes #4156.

~See explanation at: https://github.com/numba/numba/pull/4183/files#diff-5fc786a9c7a98dea499366e718e3e9deR16~

Updated explanation.  Lowering do not need to zfill variables at site of first-assignment (the defining assignment).

Update: This is regression caused by https://github.com/numba/numba/pull/3694