### PR TITLE
hyperlink repomap

### DIFF
--- a/docs/source/_ext/ghfiles.py
+++ b/docs/source/_ext/ghfiles.py
@@ -1,0 +1,62 @@
+import os.path as path
+import subprocess
+import shlex
+from sphinx.util import logging
+from docutils import nodes
+logger = logging.getLogger(__name__)
+
+
+# use an old git trick, to get the top-level, could have used ../ etc.. but
+# this will be fine..
+top = subprocess.check_output(shlex.split(
+    "git rev-parse --show-toplevel")).strip().decode("utf-8")
+
+
+def make_ref(text):
+    """ Make hyperlink to Github """
+    full_path = path.join(top, text)
+    if path.isfile(full_path):
+        ref = "https://github.com/numba/numba/blob/master/" + text
+    elif path.isdir(full_path):
+        ref = "https://www.github.com/numba/numba/tree/master/" + text
+    else:
+        print("Failed to find file:" + text)
+        ref = "https://www.github.com/numba/numba"
+    return ref
+
+
+def intersperse(lst, item):
+    """ Insert item between each item in lst. """
+    result = [item] * (len(lst) * 2 - 1)
+    result[0::2] = lst
+    return result
+
+
+def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    my_nodes = []
+    if "{" in text:  # myfile.{c, h} - make two nodes
+        base = text[:text.find(".") + 1]
+        exts = text[text.find("{") + 1:text.find("}")].split(",")
+        for e in exts:
+            node = nodes.reference(rawtext, base + e, refuri=make_ref(base + e), **options)
+            my_nodes.append(node)
+    elif "*" in text:  # path/*_files.py - link to directory
+        ref = text[:text.rfind("/") + 1]
+        node = nodes.reference(rawtext, text, refuri=make_ref(ref), **options)
+        my_nodes.append(node)
+    else:  # everything else is taken verbatim
+        node = nodes.reference(rawtext, text, refuri=make_ref(text), **options)
+        my_nodes.append(node)
+
+    # insert seperators if needed
+    if len(my_nodes) > 1:
+        my_nodes = intersperse(my_nodes, nodes.Text(" | "))
+    return my_nodes, []
+
+
+def setup(app):
+    logger.info('Initializing ghfiles plugin')
+    app.add_role('ghfile', ghfile_role)
+
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
+    return metadata

--- a/docs/source/_ext/ghfiles.py
+++ b/docs/source/_ext/ghfiles.py
@@ -20,7 +20,7 @@ def make_ref(text):
     elif path.isdir(full_path):
         ref = "https://www.github.com/numba/numba/tree/master/" + text
     else:
-        print("Failed to find file:" + text)
+        logger.warn("Failed to find file in repomap: " + text)
         ref = "https://www.github.com/numba/numba"
     return ref
 

--- a/docs/source/_ext/ghfiles.py
+++ b/docs/source/_ext/ghfiles.py
@@ -16,7 +16,7 @@ def make_ref(text):
     """ Make hyperlink to Github """
     full_path = path.join(top, text)
     if path.isfile(full_path):
-        ref = "https://github.com/numba/numba/blob/master/" + text
+        ref = "https://www.github.com/numba/numba/blob/master/" + text
     elif path.isdir(full_path):
         ref = "https://www.github.com/numba/numba/tree/master/" + text
     else:
@@ -26,7 +26,14 @@ def make_ref(text):
 
 
 def intersperse(lst, item):
-    """ Insert item between each item in lst. """
+    """ Insert item between each item in lst.
+
+    Copied under CC-BY-SA from stackoverflow at:
+
+    https://stackoverflow.com/questions/5920643/
+    add-an-item-between-each-item-already-in-the-list
+
+    """
     result = [item] * (len(lst) * 2 - 1)
     result[0::2] = lst
     return result
@@ -35,16 +42,19 @@ def intersperse(lst, item):
 def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """ Emit hyperlink nodes for a given file in repomap. """
     my_nodes = []
-    if "{" in text:  # myfile.{c, h} - make two nodes
+    if "{" in text:  # myfile.{c,h} - make two nodes
         # could have used regexes, but this will be fine..
         base = text[:text.find(".") + 1]
         exts = text[text.find("{") + 1:text.find("}")].split(",")
         for e in exts:
-            node = nodes.reference(rawtext, base + e, refuri=make_ref(base + e), **options)
+            node = nodes.reference(rawtext,
+                                   base + e,
+                                   refuri=make_ref(base + e),
+                                   **options)
             my_nodes.append(node)
     elif "*" in text:  # path/*_files.py - link to directory
         # Could have used something from os.path, but this will be fine..
-        ref = text[:text.rfind("/") + 1]
+        ref = path.dirname(text) + path.sep
         node = nodes.reference(rawtext, text, refuri=make_ref(ref), **options)
         my_nodes.append(node)
     else:  # everything else is taken verbatim

--- a/docs/source/_ext/ghfiles.py
+++ b/docs/source/_ext/ghfiles.py
@@ -33,14 +33,17 @@ def intersperse(lst, item):
 
 
 def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    """ Emit hyperlink nodes for a given file in repomap. """
     my_nodes = []
     if "{" in text:  # myfile.{c, h} - make two nodes
+        # could have used regexes, but this will be fine..
         base = text[:text.find(".") + 1]
         exts = text[text.find("{") + 1:text.find("}")].split(",")
         for e in exts:
             node = nodes.reference(rawtext, base + e, refuri=make_ref(base + e), **options)
             my_nodes.append(node)
     elif "*" in text:  # path/*_files.py - link to directory
+        # Could have used something from os.path, but this will be fine..
         ref = text[:text.rfind("/") + 1]
         node = nodes.reference(rawtext, text, refuri=make_ref(ref), **options)
         my_nodes.append(node)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,10 @@ extensions = [
     #'sphinx.ext.graphviz',
 ]
 
+# Adding the github files extension
+sys.path.append(os.path.abspath("./_ext"))
+extensions.append('ghfiles')
+
 todo_include_todos = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ extensions = [
 ]
 
 # Adding the github files extension
-sys.path.append(os.path.abspath("./_ext"))
+sys.path.append(os.path.abspath(os.path.join(".", "_ext")))
 extensions.append('ghfiles')
 
 todo_include_todos = True

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -17,66 +17,66 @@ Support Files
 Build and Packaging
 '''''''''''''''''''
 
-- ``setup.py`` - Standard Python distutils/setuptools script
-- ``MANIFEST.in`` - Distutils packaging instructions
-- ``requirements.txt`` - Pip package requirements, not used by conda
-- ``versioneer.py`` - Handles automatic setting of version in
+- :ghfile:`setup.py` - Standard Python distutils/setuptools script
+- :ghfile:`MANIFEST.in` - Distutils packaging instructions
+- :ghfile:`requirements.txt` - Pip package requirements, not used by conda
+- :ghfile:`versioneer.py` - Handles automatic setting of version in
   installed package from git tags
-- ``.flake8`` - Preferences for code formatting.  Files should be
+- :ghfile:`.flake8` - Preferences for code formatting.  Files should be
   fixed and removed from the exception list as time allows.
-- ``buildscripts/condarecipe.local`` - Conda build recipe
-- ``buildscripts/remove_unwanted_files.py`` - Helper script to remove
+- :ghfile:`buildscripts/condarecipe.local` - Conda build recipe
+- :ghfile:`buildscripts/remove_unwanted_files.py` - Helper script to remove
   files that will not compile under Python 2. Used by build recipes.
-- ``buildscripts/condarecipe_clone_icc_rt`` - Recipe to build a
+- :ghfile:`buildscripts/condarecipe_clone_icc_rt` - Recipe to build a
   standalone icc_rt package.
 
 
 Continuous Integration
 ''''''''''''''''''''''
-- ``.binstar.yml`` - Binstar Build CI config (inactive)
-- ``azure-pipelines.yml`` - Azure Pipelines CI config (active:
+- :ghfile:`.binstar.yml` - Binstar Build CI config (inactive)
+- :ghfile:`azure-pipelines.yml` - Azure Pipelines CI config (active:
   Win/Mac/Linux)
-- ``buildscripts/azure/`` - Azure Pipeline configuration for specific
+- :ghfile:`buildscripts/azure/` - Azure Pipeline configuration for specific
   platforms
-- ``.travis.yml`` - Travis CI config (active: Mac/Linux, will be
+- :ghfile:`.travis.yml` - Travis CI config (active: Mac/Linux, will be
   dropped in the future)
-- ``appveyor.yml`` - Appveyor CI config (inactive: Win)
-- ``buildscripts/appveyor/`` - Appveyor build scripts
-- ``buildscripts/incremental/`` - Generic scripts for building Numba
+- :ghfile:`appveyor.yml` - Appveyor CI config (inactive: Win)
+- :ghfile:`buildscripts/appveyor/` - Appveyor build scripts
+- :ghfile:`buildscripts/incremental/` - Generic scripts for building Numba
   on various CI systems
-- ``codecov.yml`` - Codecov.io coverage reporting
+- :ghfile:`codecov.yml` - Codecov.io coverage reporting
 
 
 Documentation / Examples
 ''''''''''''''''''''''''
-- ``LICENSE`` - License for Numba
-- ``LICENSES.third-party`` - License for third party code vendored
+- :ghfile:`LICENSE` - License for Numba
+- :ghfile:`LICENSES.third-party` - License for third party code vendored
   into Numba
-- ``README.rst`` - README for repo, also uploaded to PyPI
-- ``CONTRIBUTING.md`` - Documentation on how to contribute to project
+- :ghfile:`README.rst` - README for repo, also uploaded to PyPI
+- :ghfile:`CONTRIBUTING.md` - Documentation on how to contribute to project
   (out of date, should be updated to point to Sphinx docs)
-- ``AUTHORS`` - List of Github users who have contributed PRs (out of
+- :ghfile:`AUTHORS` - List of Github users who have contributed PRs (out of
   date)
-- ``CHANGE_LOG`` - History of Numba releases, also directly embedded
+- :ghfile:`CHANGE_LOG` - History of Numba releases, also directly embedded
   into Sphinx documentation
-- ``docs/`` - Documentation source
-- ``docs/_templates/`` - Directory for templates (to override defaults
+- :ghfile:`docs/` - Documentation source
+- :ghfile:`docs/_templates/` - Directory for templates (to override defaults
   with Sphinx theme)
-- ``docs/Makefile`` - Used to build Sphinx docs with ``make``
-- ``docs/source`` - ReST source for Numba documentation
-- ``docs/_static/`` - Static CSS and image assets for Numba docs
-- ``docs/gh-pages.py`` - Utility script to update Numba docs (stored
+- :ghfile:`docs/Makefile` - Used to build Sphinx docs with ``make``
+- :ghfile:`docs/source` - ReST source for Numba documentation
+- :ghfile:`docs/_static/` - Static CSS and image assets for Numba docs
+- :ghfile:`docs/gh-pages.py` - Utility script to update Numba docs (stored
   as gh-pages)
-- ``docs/make.bat`` - Not used (remove?)
-- ``examples/`` - Example scripts demonstrating numba (re/move to
+- :ghfile:`docs/make.bat` - Not used (remove?)
+- :ghfile:`examples/` - Example scripts demonstrating numba (re/move to
   numba-examples repo?)
-- ``examples/notebooks/`` - Example notebooks (re/move to
+- :ghfile:`examples/notebooks/` - Example notebooks (re/move to
   numba-examples repo?)
-- ``benchmarks/`` - Benchmark scripts (re/move to numba-examples
+- :ghfile:`benchmarks/` - Benchmark scripts (re/move to numba-examples
   repo?)
-- ``tutorials/`` - Tutorial notebooks (definitely out of date, should
+- :ghfile:`tutorials/` - Tutorial notebooks (definitely out of date, should
   remove and direct to external tutorials)
-- ``numba/scripts/generate_lower_listing.py`` - Dump all registered
+- :ghfile:`numba/scripts/generate_lower_listing.py` - Dump all registered
   implementations decorated with ``@lower*`` for reference
   documentation.  Currently misses implementations from the higher
   level extension API.
@@ -88,7 +88,7 @@ Numba Source Code
 
 Numba ships with both the source code and tests in one package.
 
-- ``numba/`` - all of the source code and tests
+- :ghfile:`numba/` - all of the source code and tests
 
 
 Public API
@@ -96,103 +96,103 @@ Public API
 
 These define aspects of the public Numba interface.
 
-- ``numba/decorators.py`` - User-facing decorators for compiling
+- :ghfile:`numba/decorators.py` - User-facing decorators for compiling
   regular functions on the CPU
-- ``numba/extending.py`` - Public decorators for extending Numba
+- :ghfile:`numba/extending.py` - Public decorators for extending Numba
   (``overload``, ``intrinsic``, etc)
-- ``numba/ccallback.py`` - ``@cfunc`` decorator for compiling
+- :ghfile:`numba/ccallback.py` - ``@cfunc`` decorator for compiling
   functions to a fixed C signature.  Used to make callbacks.
-- ``numba/npyufunc/decorators.py`` - ufunc/gufunc compilation
+- :ghfile:`numba/npyufunc/decorators.py` - ufunc/gufunc compilation
   decorators
-- ``numba/config.py`` - Numba global config options and environment
+- :ghfile:`numba/config.py` - Numba global config options and environment
   variable handling
-- ``numba/annotations`` - Gathering and printing type annotations of
+- :ghfile:`numba/annotations` - Gathering and printing type annotations of
   Numba IR
-- ``numba/pretty_annotate.py`` - Code highlighting of Numba functions
+- :ghfile:`numba/pretty_annotate.py` - Code highlighting of Numba functions
   and types (both ANSI terminal and HTML)
 
 
 Dispatching
 '''''''''''
 
-- ``numba/dispatcher.py`` - Dispatcher objects are compiled functions
+- :ghfile:`numba/dispatcher.py` - Dispatcher objects are compiled functions
   produced by ``@jit``.  A dispatcher has different implementations
   for different type signatures.
-- ``numba/_dispatcher.{h,c}`` - C interface to C++ dispatcher
+- :ghfile:`numba/_dispatcher.{h,c}` - C interface to C++ dispatcher
   implementation
-- ``numba/_dispatcherimpl.cpp`` - C++ dispatcher implementation (for
+- :ghfile:`numba/_dispatcherimpl.cpp` - C++ dispatcher implementation (for
   speed on common data types)
 
 
 Compiler Pipeline
 '''''''''''''''''
 
-- ``numba/compiler.py`` - Compiler pipelines and flags
-- ``numba/errors.py`` - Numba exception and warning classes 
-- ``numba/ir.py`` - Numba IR data structure objects
-- ``numba/bytecode.py`` - Bytecode parsing and function identity (??)
-- ``numba/interpreter.py`` - Translate Python interpreter bytecode to
+- :ghfile:`numba/compiler.py` - Compiler pipelines and flags
+- :ghfile:`numba/errors.py` - Numba exception and warning classes 
+- :ghfile:`numba/ir.py` - Numba IR data structure objects
+- :ghfile:`numba/bytecode.py` - Bytecode parsing and function identity (??)
+- :ghfile:`numba/interpreter.py` - Translate Python interpreter bytecode to
   Numba IR
-- ``numba/analysis.py`` - Utility functions to analyze Numba IR
+- :ghfile:`numba/analysis.py` - Utility functions to analyze Numba IR
   (variable lifetime, prune branches, etc)
-- ``numba/dataflow.py`` - Dataflow analysis for Python bytecode (used
+- :ghfile:`numba/dataflow.py` - Dataflow analysis for Python bytecode (used
   in analysis.py)
-- ``numba/controlflow.py`` - Control flow analysis of Numba IR and
+- :ghfile:`numba/controlflow.py` - Control flow analysis of Numba IR and
   Python bytecode
-- ``numba/typeinfer.py`` - Type inference algorithm
-- ``numba/transforms.py`` - Numba IR transformations
-- ``numba/rewrites`` - Rewrite passes used by compiler
-- ``numba/rewrites/__init__.py`` - Loads all rewrite passes so they
+- :ghfile:`numba/typeinfer.py` - Type inference algorithm
+- :ghfile:`numba/transforms.py` - Numba IR transformations
+- :ghfile:`numba/rewrites` - Rewrite passes used by compiler
+- :ghfile:`numba/rewrites/__init__.py` - Loads all rewrite passes so they
   are put into the registry
-- ``numba/rewrites/registry.py`` - Registry object for collecting
+- :ghfile:`numba/rewrites/registry.py` - Registry object for collecting
   rewrite passes
-- ``numba/rewrites/ir_print.py`` - Write print() calls into special
+- :ghfile:`numba/rewrites/ir_print.py` - Write print() calls into special
   print nodes in the IR
-- ``numba/rewrites/static_raise.py`` - Converts exceptions with static
+- :ghfile:`numba/rewrites/static_raise.py` - Converts exceptions with static
   arguments into a special form that can be lowered
-- ``numba/rewrites/macros.py`` - Generic support for macro expansion
+- :ghfile:`numba/rewrites/macros.py` - Generic support for macro expansion
   in the Numba IR
-- ``numba/rewrites/static_getitem.py`` - Rewrites getitem and setitem
+- :ghfile:`numba/rewrites/static_getitem.py` - Rewrites getitem and setitem
   with constant arguments to allow type inference
-- ``numba/rewrites/static_binop.py`` - Rewrites binary operations
+- :ghfile:`numba/rewrites/static_binop.py` - Rewrites binary operations
   (specifically ``**``) with constant arguments so faster code can be
   generated
-- ``numba/inline_closurecall.py`` - Inlines body of closure functions
+- :ghfile:`numba/inline_closurecall.py` - Inlines body of closure functions
   to call site.  Support for array comprehensions, reduction inlining, 
   and stencil inlining.
-- ``numba/macro.py`` - Alias to ``numba.rewrites.macros``
-- ``numba/postproc.py`` - Postprocessor for Numba IR that computes
+- :ghfile:`numba/macro.py` - Alias to ``numba.rewrites.macros``
+- :ghfile:`numba/postproc.py` - Postprocessor for Numba IR that computes
   variable lifetime, inserts del operations, and handles generators
-- ``numba/lowering.py`` - General implementation of lowering Numba IR
+- :ghfile:`numba/lowering.py` - General implementation of lowering Numba IR
   to LLVM
-- ``numba/withcontexts.py`` - General scaffolding for implementing
+- :ghfile:`numba/withcontexts.py` - General scaffolding for implementing
   context managers in nopython mode, and the objectmode context
   manager
-- ``numba/pylowering.py`` - Lowering of Numba IR in object mode
-- ``numba/pythonapi.py`` - LLVM IR code generation to interface with
+- :ghfile:`numba/pylowering.py` - Lowering of Numba IR in object mode
+- :ghfile:`numba/pythonapi.py` - LLVM IR code generation to interface with
   CPython API
 
 
 Type Management
 '''''''''''''''
 
-- ``numba/typeconv/`` - Implementation of type casting and type
+- :ghfile:`numba/typeconv/` - Implementation of type casting and type
   signature matching in both C++ and Python
-- ``numba/capsulethunk.h`` - Used by typeconv
-- ``numba/types/`` - definition of the Numba type hierarchy, used
+- :ghfile:`numba/capsulethunk.h` - Used by typeconv
+- :ghfile:`numba/types/` - definition of the Numba type hierarchy, used
   everywhere in compiler to select implementations
-- ``numba/consts.py`` - Constant inference (used to make constant
+- :ghfile:`numba/consts.py` - Constant inference (used to make constant
   values available during codegen when possible)
-- ``numba/datamodel`` - LLVM IR representations of data types in
+- :ghfile:`numba/datamodel` - LLVM IR representations of data types in
   different contexts
-- ``numba/datamodel/models.py`` - Models for most standard types
-- ``numba/datamodel/registry.py`` - Decorator to register new data
+- :ghfile:`numba/datamodel/models.py` - Models for most standard types
+- :ghfile:`numba/datamodel/registry.py` - Decorator to register new data
   models
-- ``numba/datamodel/packer.py`` - Pack typed values into a data
+- :ghfile:`numba/datamodel/packer.py` - Pack typed values into a data
   structure
-- ``numba/datamodel/testing.py`` - Data model tests (this should
+- :ghfile:`numba/datamodel/testing.py` - Data model tests (this should
   move??)
-- ``numba/datamodel/manager.py`` - Map types to data models
+- :ghfile:`numba/datamodel/manager.py` - Map types to data models
 
 
 Compiled Extensions
@@ -203,27 +203,27 @@ functionality, like dispatching and type matching where performance
 matters, and it is more convenient to encapsulate direct interaction
 with CPython APIs.
 
-- ``numba/_arraystruct.h`` - Struct for holding NumPy array
+- :ghfile:`numba/_arraystruct.h` - Struct for holding NumPy array
   attributes.  Used in helperlib and the Numba Runtime.
-- ``numba/_helperlib.c`` - C functions required by Numba compiled code
+- :ghfile:`numba/_helperlib.c` - C functions required by Numba compiled code
   at runtime.  Linked into ahead-of-time compiled modules
-- ``numba/_helpermod.c`` - Python extension module with pointers to
+- :ghfile:`numba/_helpermod.c` - Python extension module with pointers to
   functions from ``_helperlib.c`` and ``_npymath_exports.c``
-- ``numba/_npymath_exports.c`` - Export function pointer table to
+- :ghfile:`numba/_npymath_exports.c` - Export function pointer table to
   NumPy C math functions
-- ``numba/_dynfuncmod.c`` - Python extension module exporting
+- :ghfile:`numba/_dynfuncmod.c` - Python extension module exporting
   _dynfunc.c functionality
-- ``numba/_dynfunc.c`` - C level Environment and Closure objects (keep
+- :ghfile:`numba/_dynfunc.c` - C level Environment and Closure objects (keep
   in sync with numba/target/base.py)
-- ``numba/mathnames.h`` - Macros for defining names of math functions
-- ``numba/_pymodule.h`` - C macros for Python 2/3 portable naming of C
+- :ghfile:`numba/mathnames.h` - Macros for defining names of math functions
+- :ghfile:`numba/_pymodule.h` - C macros for Python 2/3 portable naming of C
   API functions
-- ``numba/_math_c99.{h,c}`` - C99 math compatibility (needed Python
+- :ghfile:`numba/_math_c99.{h,c}` - C99 math compatibility (needed Python
   2.7 on Windows, compiled with VS2008)
-- ``numba/mviewbuf.c`` - Handles Python memoryviews
-- ``numba/_typeof.{h,c}`` - C implementation of type fingerprinting,
+- :ghfile:`numba/mviewbuf.c` - Handles Python memoryviews
+- :ghfile:`numba/_typeof.{h,c}` - C implementation of type fingerprinting,
   used by dispatcher
-- ``numba/_numba_common.h`` - Portable C macro for marking symbols
+- :ghfile:`numba/_numba_common.h` - Portable C macro for marking symbols
   that can be shared between object files, but not outside the
   library.
 
@@ -232,87 +232,87 @@ with CPython APIs.
 Misc Support
 ''''''''''''
 
-- ``numba/_version.py`` - Updated by versioneer
-- ``numba/runtime`` - Language runtime.  Currently manages
+- :ghfile:`numba/_version.py` - Updated by versioneer
+- :ghfile:`numba/runtime` - Language runtime.  Currently manages
   reference-counted memory allocated on the heap by Numba-compiled
   functions
-- ``numba/ir_utils.py`` - Utility functions for working with Numba IR
+- :ghfile:`numba/ir_utils.py` - Utility functions for working with Numba IR
   data structures
-- ``numba/cgutils.py`` - Utility functions for generating common code
+- :ghfile:`numba/cgutils.py` - Utility functions for generating common code
   patterns in LLVM IR
-- ``numba/six.py`` - Vendored subset of ``six`` package for Python 2 +
+- :ghfile:`numba/six.py` - Vendored subset of ``six`` package for Python 2 +
   3 compatibility
-- ``numba/io_support.py`` - Workaround for various names of StringIO
+- :ghfile:`numba/io_support.py` - Workaround for various names of StringIO
   in different Python versions (should this be in six?)
-- ``numba/utils.py`` - Python 2 backports of Python 3 functionality
+- :ghfile:`numba/utils.py` - Python 2 backports of Python 3 functionality
   (also imports local copy of ``six``)
-- ``numba/appdirs.py`` - Vendored package for determining application
+- :ghfile:`numba/appdirs.py` - Vendored package for determining application
   config directories on every platform
-- ``numba/compiler_lock.py`` - Global compiler lock because Numba's usage
+- :ghfile:`numba/compiler_lock.py` - Global compiler lock because Numba's usage
   of LLVM is not thread-safe
-- ``numba/special.py`` - Python stub implementations of special Numba
+- :ghfile:`numba/special.py` - Python stub implementations of special Numba
   functions (prange, gdb*)
-- ``numba/servicelib/threadlocal.py`` - Thread-local stack used by GPU
+- :ghfile:`numba/servicelib/threadlocal.py` - Thread-local stack used by GPU
   targets
-- ``numba/servicelib/service.py`` - Should be removed?
-- ``numba/itanium_mangler.py`` - Python implementation of Itanium C++
+- :ghfile:`numba/servicelib/service.py` - Should be removed?
+- :ghfile:`numba/itanium_mangler.py` - Python implementation of Itanium C++
   name mangling
-- ``numba/findlib.py`` - Helper function for locating shared libraries
+- :ghfile:`numba/findlib.py` - Helper function for locating shared libraries
   on all platforms
-- ``numba/debuginfo.py`` - Helper functions to construct LLVM IR debug
+- :ghfile:`numba/debuginfo.py` - Helper functions to construct LLVM IR debug
   info
-- ``numba/unsafe`` - ``@intrinsic`` helper functions that can be used
+- :ghfile:`numba/unsafe` - ``@intrinsic`` helper functions that can be used
   to implement direct memory/pointer manipulation from nopython mode
   functions
-- ``numba/unsafe/refcount.py`` - Read reference count of object
-- ``numba/unsafe/tuple.py`` - Replace a value in a tuple slot
-- ``numba/unsafe/ndarray.py`` - NumPy array helpers
-- ``numba/unsafe/bytes.py`` - Copying and dereferencing data from void
+- :ghfile:`numba/unsafe/refcount.py` - Read reference count of object
+- :ghfile:`numba/unsafe/tuple.py` - Replace a value in a tuple slot
+- :ghfile:`numba/unsafe/ndarray.py` - NumPy array helpers
+- :ghfile:`numba/unsafe/bytes.py` - Copying and dereferencing data from void
   pointers
-- ``numba/dummyarray.py`` - Used by GPU backends to hold array information
+- :ghfile:`numba/dummyarray.py` - Used by GPU backends to hold array information
   on the host, but not the data.
-- ``numba/callwrapper.py`` - Handles argument unboxing and releasing
+- :ghfile:`numba/callwrapper.py` - Handles argument unboxing and releasing
   the GIL when moving from Python to nopython mode
-- ``numba/ctypes_support.py`` - Import this instead of ``ctypes`` to
+- :ghfile:`numba/ctypes_support.py` - Import this instead of ``ctypes`` to
   workaround portability issue with Python 2.7
-- ``numba/cffi_support.py`` - Alias of numba.typing.cffi_utils for
+- :ghfile:`numba/cffi_support.py` - Alias of numba.typing.cffi_utils for
   backward compatibility (still needed?)
-- ``numba/numpy_support.py`` - Helper functions for working with NumPy
+- :ghfile:`numba/numpy_support.py` - Helper functions for working with NumPy
   and translating Numba types to and from NumPy dtypes.
-- ``numba/tracing.py`` - Decorator for tracing Python calls and
+- :ghfile:`numba/tracing.py` - Decorator for tracing Python calls and
   emitting log messages
-- ``numba/funcdesc.py`` - Classes for describing function metadata
+- :ghfile:`numba/funcdesc.py` - Classes for describing function metadata
   (used in the compiler)
-- ``numba/sigutils.py`` - Helper functions for parsing and normalizing
+- :ghfile:`numba/sigutils.py` - Helper functions for parsing and normalizing
   Numba type signatures
-- ``numba/serialize.py`` - Support for pickling compiled functions
-- ``numba/caching.py`` - Disk cache for compiled functions
-- ``numba/npdatetime.py`` - Helper functions for implementing NumPy
+- :ghfile:`numba/serialize.py` - Support for pickling compiled functions
+- :ghfile:`numba/caching.py` - Disk cache for compiled functions
+- :ghfile:`numba/npdatetime.py` - Helper functions for implementing NumPy
   datetime64 support
 
 
 Core Python Data Types
 ''''''''''''''''''''''
 
-- ``numba/_hashtable.{h,c}`` - Adaptation of the Python 3.7 hash table
+- :ghfile:`numba/_hashtable.{h,c}` - Adaptation of the Python 3.7 hash table
   implementation
-- ``numba/_dictobject.{h,c}`` - C level implementation of typed
+- :ghfile:`numba/_dictobject.{h,c}` - C level implementation of typed
   dictionary
-- ``numba/dictobject.py`` - Nopython mode wrapper for typed dictionary
-- ``numba/unicode.py`` - Unicode strings (Python 3.5 and later)
-- ``numba/typed`` - Python interfaces to statically typed containers
-- ``numba/typed/typeddict.py`` - Python interface to typed dictionary
-- ``numba/jitclass`` - Implementation of JIT compilation of Python
+- :ghfile:`numba/dictobject.py` - Nopython mode wrapper for typed dictionary
+- :ghfile:`numba/unicode.py` - Unicode strings (Python 3.5 and later)
+- :ghfile:`numba/typed` - Python interfaces to statically typed containers
+- :ghfile:`numba/typed/typeddict.py` - Python interface to typed dictionary
+- :ghfile:`numba/jitclass` - Implementation of JIT compilation of Python
   classes
-- ``numba/generators.py`` - Support for lowering Python generators
+- :ghfile:`numba/generators.py` - Support for lowering Python generators
 
 
 Math
 ''''
 
-- ``numba/_random.c`` - Reimplementation of NumPy / CPython random
+- :ghfile:`numba/_random.c` - Reimplementation of NumPy / CPython random
   number generator
-- ``numba/_lapack.c`` - Wrappers for calling BLAS and LAPACK functions
+- :ghfile:`numba/_lapack.c` - Wrappers for calling BLAS and LAPACK functions
   (requires SciPy)
 
 
@@ -322,28 +322,28 @@ ParallelAccelerator
 Code transformation passes that extract parallelizable code from
 a function and convert it into multithreaded gufunc calls.
 
-- ``numba/parfor.py`` - General ParallelAccelerator
-- ``numba/stencil.py`` - Stencil function decorator (implemented
+- :ghfile:`numba/parfor.py` - General ParallelAccelerator
+- :ghfile:`numba/stencil.py` - Stencil function decorator (implemented
   without ParallelAccelerator)
-- ``numba/stencilparfor.py`` - ParallelAccelerator implementation of
+- :ghfile:`numba/stencilparfor.py` - ParallelAccelerator implementation of
   stencil
-- ``numba/array_analysis.py`` - Array analysis passes used in
+- :ghfile:`numba/array_analysis.py` - Array analysis passes used in
   ParallelAccelerator
 
 
 Deprecated Functionality
 ''''''''''''''''''''''''
 
-- ``numba/smartarray.py`` - Experiment with an array object that has
+- :ghfile:`numba/smartarray.py` - Experiment with an array object that has
   both CPU and GPU backing.  Should be removed in future.
 
 
 Debugging Support
 '''''''''''''''''
 
-- ``numba/targets/gdb_hook.py`` - Hooks to jump into GDB from nopython
+- :ghfile:`numba/targets/gdb_hook.py` - Hooks to jump into GDB from nopython
   mode
-- ``numba/targets/cmdlang.gdb`` - Commands to setup GDB for setting
+- :ghfile:`numba/targets/cmdlang.gdb` - Commands to setup GDB for setting
   explicit breakpoints from Python
 
 
@@ -355,33 +355,33 @@ declaration of allowed type signatures from the definition of
 implementations.  This package contains registries of type signatures
 that must be matched during type inference.
 
-- ``numba/typing`` - Type signature module
-- ``numba/typing/templates.py`` - Base classes for type signature
+- :ghfile:`numba/typing` - Type signature module
+- :ghfile:`numba/typing/templates.py` - Base classes for type signature
   templates
-- ``numba/typing/cmathdecl.py`` - Python complex math (``cmath``)
+- :ghfile:`numba/typing/cmathdecl.py` - Python complex math (``cmath``)
   module
-- ``numba/typing/bufproto.py`` - Interpreting objects supporting the
+- :ghfile:`numba/typing/bufproto.py` - Interpreting objects supporting the
   buffer protocol
-- ``numba/typing/mathdecl.py`` - Python ``math`` module
-- ``numba/typing/listdecl.py`` - Python lists
-- ``numba/typing/builtins.py`` - Python builtin global functions and
+- :ghfile:`numba/typing/mathdecl.py` - Python ``math`` module
+- :ghfile:`numba/typing/listdecl.py` - Python lists
+- :ghfile:`numba/typing/builtins.py` - Python builtin global functions and
   operators
-- ``numba/typing/randomdecl.py`` - Python and NumPy ``random`` modules
-- ``numba/typing/setdecl.py`` - Python sets
-- ``numba/typing/npydecl.py`` - NumPy ndarray (and operators), NumPy
+- :ghfile:`numba/typing/randomdecl.py` - Python and NumPy ``random`` modules
+- :ghfile:`numba/typing/setdecl.py` - Python sets
+- :ghfile:`numba/typing/npydecl.py` - NumPy ndarray (and operators), NumPy
   functions
-- ``numba/typing/arraydecl.py`` - Python ``array`` module
-- ``numba/typing/context.py`` - Implementation of typing context
+- :ghfile:`numba/typing/arraydecl.py` - Python ``array`` module
+- :ghfile:`numba/typing/context.py` - Implementation of typing context
   (class that collects methods used in type inference)
-- ``numba/typing/collections.py`` - Generic container operations and
+- :ghfile:`numba/typing/collections.py` - Generic container operations and
   namedtuples
-- ``numba/typing/ctypes_utils.py`` - Typing ctypes-wrapped function
+- :ghfile:`numba/typing/ctypes_utils.py` - Typing ctypes-wrapped function
   pointers
-- ``numba/typing/enumdecl.py`` - Enum types
-- ``numba/typing/cffi_utils.py`` - Typing of CFFI objects
-- ``numba/typing/typeof.py`` - Implementation of typeof operations
+- :ghfile:`numba/typing/enumdecl.py` - Enum types
+- :ghfile:`numba/typing/cffi_utils.py` - Typing of CFFI objects
+- :ghfile:`numba/typing/typeof.py` - Implementation of typeof operations
   (maps Python object to Numba type)
-- ``numba/typing/npdatetime.py`` - Datetime dtype support for NumPy
+- :ghfile:`numba/typing/npdatetime.py` - Datetime dtype support for NumPy
   arrays
 
 
@@ -394,98 +394,98 @@ Note that some of these modules do not have counterparts in the typing
 package because newer Numba extension APIs (like overload) allow
 typing and implementation to be specified together.
 
-- ``numba/targets`` - Implementations of compilable operations
-- ``numba/targets/cpu.py`` - Context for code gen on CPU
-- ``numba/targets/base.py`` - Base class for all target contexts
-- ``numba/targets/codegen.py`` - Driver for code generation
-- ``numba/targets/boxing.py`` - Boxing and unboxing for most data
+- :ghfile:`numba/targets` - Implementations of compilable operations
+- :ghfile:`numba/targets/cpu.py` - Context for code gen on CPU
+- :ghfile:`numba/targets/base.py` - Base class for all target contexts
+- :ghfile:`numba/targets/codegen.py` - Driver for code generation
+- :ghfile:`numba/targets/boxing.py` - Boxing and unboxing for most data
   types
-- ``numba/targets/intrinsics.py`` - Utilities for converting LLVM
+- :ghfile:`numba/targets/intrinsics.py` - Utilities for converting LLVM
   intrinsics to other math calls
-- ``numba/targets/callconv.py`` - Implements different calling
+- :ghfile:`numba/targets/callconv.py` - Implements different calling
   conventions for Numba-compiled functions
-- ``numba/targets/iterators.py`` - Iterable data types and iterators
-- ``numba/targets/hashing.py`` - Hashing algorithms
-- ``numba/targets/ufunc_db.py`` - Big table mapping types to ufunc
+- :ghfile:`numba/targets/iterators.py` - Iterable data types and iterators
+- :ghfile:`numba/targets/hashing.py` - Hashing algorithms
+- :ghfile:`numba/targets/ufunc_db.py` - Big table mapping types to ufunc
   implementations
-- ``numba/targets/setobj.py`` - Python set type
-- ``numba/targets/options.py`` - Container for options that control
+- :ghfile:`numba/targets/setobj.py` - Python set type
+- :ghfile:`numba/targets/options.py` - Container for options that control
   lowering
-- ``numba/targets/printimpl.py`` - Print function
-- ``numba/targets/smartarray.py`` - Smart array (deprecated)
-- ``numba/targets/cmathimpl.py`` - Python complex math module
-- ``numba/targets/optional.py`` - Special type representing value or
+- :ghfile:`numba/targets/printimpl.py` - Print function
+- :ghfile:`numba/targets/smartarray.py` - Smart array (deprecated)
+- :ghfile:`numba/targets/cmathimpl.py` - Python complex math module
+- :ghfile:`numba/targets/optional.py` - Special type representing value or
   ``None``
-- ``numba/targets/tupleobj.py`` - Tuples (statically typed as
+- `:ghfile:numba/targets/tupleobj.py` - Tuples (statically typed as
   immutable struct)
-- ``numba/targets/mathimpl.py`` - Python ``math`` module
-- ``numba/targets/heapq.py`` - Python ``heapq`` module
-- ``numba/targets/registry.py`` - Registry object for collecting
+- :ghfile:`numba/targets/mathimpl.py` - Python ``math`` module
+- :ghfile:`numba/targets/heapq.py` - Python ``heapq`` module
+- :ghfile:`numba/targets/registry.py` - Registry object for collecting
   implementations for a specific target
-- ``numba/targets/imputils.py`` - Helper functions for lowering
-- ``numba/targets/builtins.py`` - Python builtin functions and
+- :ghfile:`numba/targets/imputils.py` - Helper functions for lowering
+- :ghfile:`numba/targets/builtins.py` - Python builtin functions and
   operators
-- ``numba/targets/externals.py`` - Registers external C functions
+- :ghfile:`numba/targets/externals.py` - Registers external C functions
   needed to link generated code
-- ``numba/targets/quicksort.py`` - Quicksort implementation used with
+- :ghfile:`numba/targets/quicksort.py` - Quicksort implementation used with
   list and array objects
-- ``numba/targets/mergesort.py`` - Mergesort implementation used with
+- :ghfile:`numba/targets/mergesort.py` - Mergesort implementation used with
   array objects
-- ``numba/targets/randomimpl.py`` - Python and NumPy ``random``
+- :ghfile:`numba/targets/randomimpl.py` - Python and NumPy ``random``
   modules
-- ``numba/targets/npyimpl.py`` - Implementations of most NumPy ufuncs
-- ``numba/targets/slicing.py`` - Slice objects, and index calculations
+- :ghfile:`numba/targets/npyimpl.py` - Implementations of most NumPy ufuncs
+- :ghfile:`numba/targets/slicing.py` - Slice objects, and index calculations
   used in slicing
-- ``numba/targets/numbers.py`` - Numeric values (int, float, etc)
-- ``numba/targets/listobj.py`` - Python lists
-- ``numba/targets/fastmathpass.py`` - Rewrite pass to add fastmath
+- :ghfile:`numba/targets/numbers.py` - Numeric values (int, float, etc)
+- :ghfile:`numba/targets/listobj.py` - Python lists
+- :ghfile:`numba/targets/fastmathpass.py` - Rewrite pass to add fastmath
   attributes to function call sites and binary operations
-- ``numba/targets/removerefctpass.py`` - Rewrite pass to remove
+- :ghfile:`numba/targets/removerefctpass.py` - Rewrite pass to remove
   unnecessary incref/decref pairs
-- ``numba/targets/cffiimpl.py`` - CFFI functions
-- ``numba/targets/descriptors.py`` - empty base class for all target
+- :ghfile:`numba/targets/cffiimpl.py` - CFFI functions
+- :ghfile:`numba/targets/descriptors.py` - empty base class for all target
   descriptors (is this needed?)
-- ``numba/targets/arraymath.py`` - Math operations on arrays (both
+- :ghfile:`numba/targets/arraymath.py` - Math operations on arrays (both
   Python and NumPy)
-- ``numba/targets/linalg.py`` - NumPy linear algebra operations
-- ``numba/targets/rangeobj.py`` - Python `range` objects
-- ``numba/targets/npyfuncs.py`` - Kernels used in generating some
+- :ghfile:`numba/targets/linalg.py` - NumPy linear algebra operations
+- :ghfile:`numba/targets/rangeobj.py` - Python `range` objects
+- :ghfile:`numba/targets/npyfuncs.py` - Kernels used in generating some
   NumPy ufuncs
-- ``numba/targets/arrayobj.py`` - Array operations (both NumPy and
+- :ghfile:`numba/targets/arrayobj.py` - Array operations (both NumPy and
   buffer protocol)
-- ``numba/targets/enumimpl.py`` - Enum objects
-- ``numba/targets/polynomial.py`` - ``numpy.roots`` function
-- ``numba/targets/npdatetime.py`` - NumPy datetime operations
+- :ghfile:`numba/targets/enumimpl.py` - Enum objects
+- :ghfile:`numba/targets/polynomial.py` - ``numpy.roots`` function
+- :ghfile:`numba/targets/npdatetime.py` - NumPy datetime operations
 
 
 Ufunc Compiler and Runtime
 ''''''''''''''''''''''''''
 
-- ``numba/npyufunc`` - ufunc compiler implementation
-- ``numba/npyufunc/_internal.{h,c}`` - Python extension module with
+- :ghfile:`numba/npyufunc` - ufunc compiler implementation
+- :ghfile:`numba/npyufunc/_internal.{h,c}` - Python extension module with
   helper functions that use CPython & NumPy C API
-- ``numba/npyufunc/_ufunc.c`` - Used by `_internal.c`
-- ``numba/npyufunc/deviceufunc.py`` - Custom ufunc dispatch for
+- :ghfile:`numba/npyufunc/_ufunc.c` - Used by `_internal.c`
+- :ghfile:`numba/npyufunc/deviceufunc.py` - Custom ufunc dispatch for
   non-CPU targets
-- ``numba/npyufunc/gufunc_scheduler.{h,cpp}`` - Schedule work chunks
+- :ghfile:`numba/npyufunc/gufunc_scheduler.{h,cpp}` - Schedule work chunks
   to threads
-- ``numba/npyufunc/dufunc.py`` - Special ufunc that can compile new
+- :ghfile:`numba/npyufunc/dufunc.py` - Special ufunc that can compile new
   implementations at call time
-- ``numba/npyufunc/ufuncbuilder.py`` - Top-level orchestration of
+- :ghfile:`numba/npyufunc/ufuncbuilder.py` - Top-level orchestration of
   ufunc/gufunc compiler pipeline
-- ``numba/npyufunc/sigparse.py`` - Parser for generalized ufunc
+- :ghfile:`numba/npyufunc/sigparse.py` - Parser for generalized ufunc
   indexing signatures
-- ``numba/npyufunc/parfor.py`` - gufunc lowering for
+- :ghfile:`numba/npyufunc/parfor.py` - gufunc lowering for
   ParallelAccelerator
-- ``numba/npyufunc/parallel.py`` - Codegen for ``parallel`` target
-- ``numba/npyufunc/array_exprs.py`` - Rewrite pass for turning array
+- :ghfile:`numba/npyufunc/parallel.py` - Codegen for ``parallel`` target
+- :ghfile:`numba/npyufunc/array_exprs.py` - Rewrite pass for turning array
   expressions in regular functions into ufuncs
-- ``numba/npyufunc/wrappers.py`` - Wrap scalar function kernel with
+- :ghfile:`numba/npyufunc/wrappers.py` - Wrap scalar function kernel with
   loops
-- ``numba/npyufunc/workqueue.{h,c}`` - Threading backend based on
+- :ghfile:`numba/npyufunc/workqueue.{h,c}` - Threading backend based on
   pthreads/Windows threads and queues
-- ``numba/npyufunc/omppool.cpp`` - Threading backend based on OpenMP
-- ``numba/npyufunc/tbbpool.cpp`` - Threading backend based on TBB
+- :ghfile:`numba/npyufunc/omppool.cpp` - Threading backend based on OpenMP
+- :ghfile:`numba/npyufunc/tbbpool.cpp` - Threading backend based on TBB
 
 
 
@@ -494,54 +494,54 @@ Unit Tests (CPU)
 
 CPU unit tests (GPU target unit tests listed in later sections
 
-- ``runtests.py`` - Convenience script that launches test runner and
+- :ghfile:`runtests.py` - Convenience script that launches test runner and
   turns on full compiler tracebacks
-- ``run_coverage.py`` - Runs test suite with coverage tracking enabled
-- ``.coveragerc`` - Coverage.py configuration
-- ``numba/runtests.py`` - Entry point to unittest runner
-- ``numba/_runtests.py`` - Implementation of custom test runner
+- :ghfile:`run_coverage.py` - Runs test suite with coverage tracking enabled
+- :ghfile:`.coveragerc` - Coverage.py configuration
+- :ghfile:`numba/runtests.py` - Entry point to unittest runner
+- :ghfile:`numba/_runtests.py` - Implementation of custom test runner
   command line interface
-- ``numba/tests/test_*`` - Test cases
-- ``numba/tests/*_usecases.py`` - Python functions compiled by some
+- :ghfile:`numba/tests/test_*` - Test cases
+- :ghfile:`numba/tests/*_usecases.py` - Python functions compiled by some
   unit tests
-- ``numba/tests/support.py`` - Helper functions for testing and
+- :ghfile:`numba/tests/support.py` - Helper functions for testing and
   special TestCase implementation
-- ``numba/tests/dummy_module.py`` - Module used in
+- :ghfile:`numba/tests/dummy_module.py` - Module used in
   ``test_dispatcher.py``
-- ``numba/tests/npyufunc`` - ufunc / gufunc compiler tests
-- ``numba/unittest_support.py`` - Import instead of unittest to handle
+- :ghfile:`numba/tests/npyufunc` - ufunc / gufunc compiler tests
+- :ghfile:`numba/unittest_support.py` - Import instead of unittest to handle
   portability issues
-- ``numba/testing`` - Support code for testing
-- ``numba/testing/ddt.py`` - decorators for test cases
-- ``numba/testing/loader.py`` - Find tests on disk
-- ``numba/testing/notebook.py`` - Support for testing notebooks
-- ``numba/testing/main.py`` - Numba test runner
+- :ghfile:`numba/testing` - Support code for testing
+- :ghfile:`numba/testing/ddt.py` - decorators for test cases
+- :ghfile:`numba/testing/loader.py` - Find tests on disk
+- :ghfile:`numba/testing/notebook.py` - Support for testing notebooks
+- :ghfile:`numba/testing/main.py` - Numba test runner
 
 
 Command Line Utilities
 ''''''''''''''''''''''
-- ``bin/numba`` - Command line stub, delegates to main in
+- :ghfile:`bin/numba` - Command line stub, delegates to main in
   ``numba_entry.py``
-- ``numba/numba_entry.py`` - Main function for ``numba`` command line
+- :ghfile:`numba/numba_entry.py` - Main function for ``numba`` command line
   tool
-- ``numba/pycc`` - Ahead of time compilation of functions to shared
+- :ghfile:`numba/pycc` - Ahead of time compilation of functions to shared
   library extension
-- ``numba/pycc/__init__.py`` - Main function for ``pycc`` command line
+- :ghfile:`numba/pycc/__init__.py` - Main function for ``pycc`` command line
   tool
-- ``numba/pycc/cc.py`` - User-facing API for tagging functions to
+- :ghfile:`numba/pycc/cc.py` - User-facing API for tagging functions to
   compile ahead of time
-- ``numba/pycc/compiler.py`` - Compiler pipeline for creating
+- :ghfile:`numba/pycc/compiler.py` - Compiler pipeline for creating
   standalone Python extension modules
-- ``numba/pycc/llvm_types.py`` - Aliases to LLVM data types used by
+- :ghfile:`numba/pycc/llvm_types.py` - Aliases to LLVM data types used by
   ``compiler.py``
-- ``numba/pycc/pycc`` - Stub to call main function.  Is this still
+- :ghfile:`numba/pycc/pycc` - Stub to call main function.  Is this still
   used?
-- ``numba/pycc/modulemixin.c`` - C file compiled into every compiled
+- :ghfile:`numba/pycc/modulemixin.c` - C file compiled into every compiled
   extension.  Pulls in C source from Numba core that is needed to make
   extension standalone
-- ``numba/pycc/platform.py`` - Portable interface to platform-specific
+- :ghfile:`numba/pycc/platform.py` - Portable interface to platform-specific
   compiler toolchains
-- ``numba/pycc/decorators.py`` - Deprecated decorators for tagging
+- :ghfile:`numba/pycc/decorators.py` - Deprecated decorators for tagging
   functions to compile.  Use ``cc.py`` instead.
 
 
@@ -550,55 +550,55 @@ CUDA GPU Target
 
 Note that the CUDA target does reuse some parts of the CPU target.
 
-- ``numba/cuda/`` - The implementation of the CUDA (NVIDIA GPU) target
+- :ghfile:`numba/cuda/` - The implementation of the CUDA (NVIDIA GPU) target
   and associated unit tests
-- ``numba/cuda/decorators.py`` - Compiler decorators for CUDA kernels
+- :ghfile:`numba/cuda/decorators.py` - Compiler decorators for CUDA kernels
   and device functions
-- ``numba/cuda/dispatcher.py`` - Dispatcher for CUDA JIT functions
-- ``numba/cuda/printimpl.py`` - Special implementation of device printing
-- ``numba/cuda/libdevice.py`` - Registers libdevice functions
-- ``numba/cuda/kernels/`` - Custom kernels for reduction and transpose 
-- ``numba/cuda/device_init.py`` - Initializes the CUDA target when
+- :ghfile:`numba/cuda/dispatcher.py` - Dispatcher for CUDA JIT functions
+- :ghfile:`numba/cuda/printimpl.py` - Special implementation of device printing
+- :ghfile:`numba/cuda/libdevice.py` - Registers libdevice functions
+- :ghfile:`numba/cuda/kernels/` - Custom kernels for reduction and transpose 
+- :ghfile:`numba/cuda/device_init.py` - Initializes the CUDA target when
   imported
-- ``numba/cuda/compiler.py`` - Compiler pipeline for CUDA target
-- ``numba/cuda/intrinsic_wrapper.py`` - CUDA device intrinsics
+- :ghfile:`numba/cuda/compiler.py` - Compiler pipeline for CUDA target
+- :ghfile:`numba/cuda/intrinsic_wrapper.py` - CUDA device intrinsics
   (shuffle, ballot, etc)
-- ``numba/cuda/initialize.py`` - Defered initialization of the CUDA
+- :ghfile:`numba/cuda/initialize.py` - Defered initialization of the CUDA
   device and subsystem.  Called only when user imports ``numba.cuda``
-- ``numba/cuda/simulator_init.py`` - Initalizes the CUDA simulator
+- :ghfile:`numba/cuda/simulator_init.py` - Initalizes the CUDA simulator
   subsystem (only when user requests it with env var)
-- ``numba/cuda/random.py`` - Implementation of random number generator
-- ``numba/cuda/api.py`` - User facing APIs imported into ``numba.cuda.*``
-- ``numba/cuda/stubs.py`` - Python placeholders for functions that
+- :ghfile:`numba/cuda/random.py` - Implementation of random number generator
+- :ghfile:`numba/cuda/api.py` - User facing APIs imported into ``numba.cuda.*``
+- :ghfile:`numba/cuda/stubs.py` - Python placeholders for functions that
   only can be used in GPU device code
-- ``numba/cuda/simulator/`` - Simulate execution of CUDA kernels in
+- :ghfile:`numba/cuda/simulator/` - Simulate execution of CUDA kernels in
   Python interpreter
-- ``numba/cuda/vectorizers.py`` - Subclasses of ufunc/gufunc compilers
+- :ghfile:`numba/cuda/vectorizers.py` - Subclasses of ufunc/gufunc compilers
   for CUDA
-- ``numba/cuda/args.py`` - Management of kernel arguments, including
+- :ghfile:`numba/cuda/args.py` - Management of kernel arguments, including
   host<->device transfers
-- ``numba/cuda/target.py`` - Typing and target contexts for GPU
-- ``numba/cuda/cudamath.py`` - Type signatures for math functions in
+- :ghfile:`numba/cuda/target.py` - Typing and target contexts for GPU
+- :ghfile:`numba/cuda/cudamath.py` - Type signatures for math functions in
   CUDA Python
-- ``numba/cuda/errors.py`` - Validation of kernel launch configuration
-- ``numba/cuda/nvvmutils.py`` - Helper functions for generating
+- :ghfile:`numba/cuda/errors.py` - Validation of kernel launch configuration
+- :ghfile:`numba/cuda/nvvmutils.py` - Helper functions for generating
   NVVM-specific IR
-- ``numba/cuda/testing.py`` - Support code for creating CUDA unit
+- :ghfile:`numba/cuda/testing.py` - Support code for creating CUDA unit
   tests and capturing standard out
-- ``numba/cuda/cudadecl.py`` - Type signatures of CUDA API (threadIdx,
+- :ghfile:`numba/cuda/cudadecl.py` - Type signatures of CUDA API (threadIdx,
   blockIdx, atomics) in Python on GPU
-- ``numba/cuda/cudaimpl.py`` - Implementations of CUDA API functions
+- :ghfile:`numba/cuda/cudaimpl.py` - Implementations of CUDA API functions
   on GPU
-- ``numba/cuda/codegen.py`` - Code generator object for CUDA target
-- ``numba/cuda/cudadrv/`` - Wrapper around CUDA driver API
-- ``numba/cuda/tests/`` - CUDA unit tests, skipped when CUDA is not
+- :ghfile:`numba/cuda/codegen.py` - Code generator object for CUDA target
+- :ghfile:`numba/cuda/cudadrv/` - Wrapper around CUDA driver API
+- :ghfile:`numba/cuda/tests/` - CUDA unit tests, skipped when CUDA is not
   detected
-- ``numba/cuda/tests/cudasim/`` - Tests of CUDA simulator
-- ``numba/cuda/tests/nocuda/`` - Tests for NVVM functionality when
+- :ghfile:`numba/cuda/tests/cudasim/` - Tests of CUDA simulator
+- :ghfile:`numba/cuda/tests/nocuda/` - Tests for NVVM functionality when
   CUDA not present
-- ``numba/cuda/tests/cudapy/`` - Tests of compiling Python functions
+- :ghfile:`numba/cuda/tests/cudapy/` - Tests of compiling Python functions
   for GPU
-- ``numba/cuda/tests/cudadrv/`` - Tests of Python wrapper around CUDA
+- :ghfile:`numba/cuda/tests/cudadrv/` - Tests of Python wrapper around CUDA
   API
 
 
@@ -610,37 +610,37 @@ duplicates some code from CUDA target.  A future refactoring could
 pull out the common subset of CUDA and ROCm.  An older version of this
 target was based on the HSA API, so "hsa" appears in many places.
 
-- ``numba/roc`` - ROCm GPU target for AMD GPUs
-- ``numba/roc/descriptor.py`` - TargetDescriptor subclass for ROCm
+- :ghfile:`numba/roc` - ROCm GPU target for AMD GPUs
+- :ghfile:`numba/roc/descriptor.py` - TargetDescriptor subclass for ROCm
   target
-- ``numba/roc/enums.py`` - Internal constants
-- ``numba/roc/mathdecl.py`` - Declarations of math functions that can
+- :ghfile:`numba/roc/enums.py` - Internal constants
+- :ghfile:`numba/roc/mathdecl.py` - Declarations of math functions that can
   be used on device
-- ``numba/roc/mathimpl.py`` - Implementations of math functions for
+- :ghfile:`numba/roc/mathimpl.py` - Implementations of math functions for
   device
-- ``numba/roc/compiler.py`` - Compiler pipeline for ROCm target
-- ``numba/roc/hlc`` - Wrapper around LLVM interface for AMD GPU
-- ``numba/roc/initialize.py`` - Register ROCm target for ufunc/gufunc
+- :ghfile:`numba/roc/compiler.py` - Compiler pipeline for ROCm target
+- :ghfile:`numba/roc/hlc` - Wrapper around LLVM interface for AMD GPU
+- :ghfile:`numba/roc/initialize.py` - Register ROCm target for ufunc/gufunc
   compiler
-- ``numba/roc/hsadecl.py`` - Type signatures for ROCm device API in
+- :ghfile:`numba/roc/hsadecl.py` - Type signatures for ROCm device API in
   Python
-- ``numba/roc/hsaimpl.py`` - Implementations of ROCm device API
-- ``numba/roc/dispatch.py`` - ufunc/gufunc dispatcher
-- ``numba/roc/README.md`` - Notes on testing target (should be
+- :ghfile:`numba/roc/hsaimpl.py` - Implementations of ROCm device API
+- :ghfile:`numba/roc/dispatch.py` - ufunc/gufunc dispatcher
+- :ghfile:`numba/roc/README.md` - Notes on testing target (should be
   deleted)
-- ``numba/roc/api.py`` - Host API for ROCm actions
-- ``numba/roc/gcn_occupancy.py`` - Heuristic to compute occupancy of
+- :ghfile:`numba/roc/api.py` - Host API for ROCm actions
+- :ghfile:`numba/roc/gcn_occupancy.py` - Heuristic to compute occupancy of
   kernels
-- ``numba/roc/stubs.py`` - Host stubs for device functions
-- ``numba/roc/vectorizers.py`` - Builds ufuncs
-- ``numba/roc/target.py`` - Target and typing contexts
-- ``numba/roc/hsadrv`` - Python wrapper around ROCm (based on HSA)
+- :ghfile:`numba/roc/stubs.py` - Host stubs for device functions
+- :ghfile:`numba/roc/vectorizers.py` - Builds ufuncs
+- :ghfile:`numba/roc/target.py` - Target and typing contexts
+- :ghfile:`numba/roc/hsadrv` - Python wrapper around ROCm (based on HSA)
   driver API calls
-- ``numba/roc/codegen.py`` - Codegen subclass for ROCm target
-- ``numba/roc/decorators.py`` - ``@jit`` decorator for kernels and
+- :ghfile:`numba/roc/codegen.py` - Codegen subclass for ROCm target
+- :ghfile:`numba/roc/decorators.py` - ``@jit`` decorator for kernels and
   device functions
-- ``numba/roc/tests`` - Unit tests for ROCm target
-- ``numba/roc/tests/hsapy`` - Tests of compiling ROCm kernels written
+- :ghfile:`numba/roc/tests` - Unit tests for ROCm target
+- :ghfile:`numba/roc/tests/hsapy` - Tests of compiling ROCm kernels written
   in Python syntax
-- ``numba/roc/tests/hsadrv`` - Tests of Python wrapper on platform
+- :ghfile:`numba/roc/tests/hsadrv` - Tests of Python wrapper on platform
   API.

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -40,7 +40,6 @@ Continuous Integration
   platforms
 - :ghfile:`.travis.yml` - Travis CI config (active: Mac/Linux, will be
   dropped in the future)
-- :ghfile:`appveyor.yml` - Appveyor CI config (inactive: Win)
 - :ghfile:`buildscripts/appveyor/` - Appveyor build scripts
 - :ghfile:`buildscripts/incremental/` - Generic scripts for building Numba
   on various CI systems


### PR DESCRIPTION
When browsing the repomap I often find myself wanting to click on a file
to view it in github. This implements a custom Sphinx role to insert
exactly those hyperlinks. It has two exceptions, if curly braces are
encountered, e.g. `file.{c, h}` two nodes will be inserted, one for each
file, including a separator between them. If a glob (`*`) is
encountered, a link to the directory is inserted.  Otherwise the text is
linked verbatim. This also has the nice side-effect of checking that all
files mentioned in the repomap really do exist. And in this case
`appveyor.yml` seems to no longer exist so it should probably be
removed. Switching to this role for all files in repomap is also done.