### PR TITLE
Extend `__cuda_array_interface__` with optional mask attribute, bump version to 1

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -47,7 +47,7 @@ must contain the following entries:
 - **version**: `integer`
 
     An integer for the version of the interface being exported.
-    The current version is *0* since it is still experimental.
+    The current version is *1*.
 
 
 The following are optional entries:
@@ -63,6 +63,15 @@ The following are optional entries:
     This is for describing more complicated types.  This follows the same
     specification as in the `numpy array interface`_.
 
+- **mask**: ``None`` or object exposing the ``__cuda_array_interface__``
+
+    If ``None`` then all values in **data** are valid. All elements of the mask
+    array should be interpreted only as true or not true indicating which
+    elements of this array are valid. This has the same definition as *mask*
+    in the `numpy array interface`_.
+
+
+
 
 Additional information about the data pointer can be retrieved using
 ``cuPointerGetAttribute`` or ``cudaPointerGetAttributes``.  Such information
@@ -74,3 +83,10 @@ include:
 
 
 .. _numpy array interface: https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.interface.html#__array_interface__
+
+
+Differences with CUDA Array Interface (Version 0) 
+-------------------------------------------------
+
+The version 0 CUDA Array Interface did not have the optional **mask**
+attribute to support masked arrays.

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -70,6 +70,10 @@ The following are optional entries:
     elements of this array are valid. This has the same definition as *mask*
     in the `numpy array interface`_.
 
+    .. note:: Numba does not currently support working with masked CUDA arrays
+              and will raise a `NotImplementedError` exception if one is passed
+              to a GPU function.
+
 
 
 

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -30,6 +30,13 @@ def from_cuda_array_interface(desc, owner=None):
     The *owner* is the owner of the underlying memory.
     The resulting DeviceNDArray will acquire a reference from it.
     """
+    version = desc.get('version')
+    if version == 1:
+        mask = desc.get('mask')
+        # Would ideally be better to detect if the mask is all valid
+        if mask is not None:
+            raise NotImplementedError('Masked arrays are not supported')
+
     shape = desc['shape']
     strides = desc.get('strides')
     dtype = np.dtype(desc['typestr'])

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -120,7 +120,7 @@ class DeviceNDArrayBase(object):
             'strides': tuple(self.strides),
             'data': (self.device_ctypes_pointer.value, False),
             'typestr': self.dtype.str,
-            'version': 0,
+            'version': 1,
         }
 
     def bind(self, stream=0):

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -205,6 +205,21 @@ class TestCudaArrayInterface(CUDATestCase):
         expected_msg = 'D->H copy not implemented for negative strides'
         self.assertIn(expected_msg, str(raises.exception))
 
+    def test_masked_array(self):
+        h_arr = np.random.random(10)
+        h_mask = np.random.randint(2, size=10, dtype='bool')
+        c_arr = cuda.to_device(h_arr)
+        c_mask = cuda.to_device(h_mask)
+
+        # Manually create a masked CUDA Array Interface dictionary
+        masked_cuda_array_interface = c_arr.__cuda_array_interface__.copy()
+        masked_cuda_array_interface['mask'] = c_mask
+
+        with self.assertRaises(NotImplementedError) as raises:
+            cuda.from_cuda_array_interface(masked_cuda_array_interface)
+        expected_msg = 'Masked arrays are not supported'
+        self.assertIn(expected_msg, str(raises.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #4130 

This PR adds an optional `mask` attribute to the `__cuda_array_interface__` specification.

Additionally, it has Numba throw a `NotImplementedError` if it receives a `__cuda_array_interface__` dictionary with the mask attribute specified. This could be extended in the future to detect if the mask is all valid and could be be effectively ignored, but it was outside the scope of this PR.
