### PR TITLE
Add signature parameter to inspect_types

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -383,7 +383,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
 
         return dict((sig, self.inspect_asm(sig)) for sig in self.signatures)
 
-    def inspect_types(self, file=None, **kwargs):
+    def inspect_types(self, file=None, signature=None, **kwargs):
         """
         print or return annotated source with Numba intermediate IR
 
@@ -394,11 +394,15 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         pretty = kwargs.get('pretty', False)
         style = kwargs.get('style', 'default')
 
+        overloads = self.overloads
+        if signature is not None:
+            overloads = {signature: self.overloads[signature]}
+
         if not pretty:
             if file is None:
                 file = sys.stdout
 
-            for ver, res in utils.iteritems(self.overloads):
+            for ver, res in utils.iteritems(overloads):
                 print("%s %s" % (self.py_func.__name__, ver), file=file)
                 print('-' * 80, file=file)
                 print(res.type_annotation, file=file)

--- a/numba/pretty_annotate.py
+++ b/numba/pretty_annotate.py
@@ -246,13 +246,12 @@ class Annotate:
     Function annotations persist across compilation for newly encountered
     type signatures and as a result annotations are shown for all signatures.
     """
-    def __init__(self, function, **kwargs):
+    def __init__(self, function, signature=None, **kwargs):
 
         style = kwargs.get('style', 'default')
         if not function.signatures:
             raise ValueError('function need to be jitted for at least one signature')
-        for sig in function.signatures:
-            ann = function.get_annotation_info(sig)
+        ann = function.get_annotation_info(signature=signature)
         self.ann = ann
 
         for k,v in ann.items():

--- a/numba/pretty_annotate.py
+++ b/numba/pretty_annotate.py
@@ -228,23 +228,39 @@ class Annotate:
     Example:
 
     >>> import numba
-    ... from numba.pretty_annotate import Annotate
-    ...
-    ... @numba.jit
+    >>> from numba.pretty_annotate import Annotate
+    >>> @numba.jit
     ... def test(q):
     ...     res = 0
     ...     for i in range(q):
     ...         res += i
     ...     return res
     ...
-    ... test(10)
-    ... Annotate(test)
+    >>> test(10)
+    45
+    >>> Annotate(test)
 
     The last line will return an HTML and/or ANSI representation that will be
     displayed accordingly in Jupyter/IPython.
 
     Function annotations persist across compilation for newly encountered
-    type signatures and as a result annotations are shown for all signatures.
+    type signatures and as a result annotations are shown for all signatures
+    by default.
+
+    Annotations for a specific signature can be shown by using the
+    ``signature`` parameter.
+
+    >>> @numba.jit
+    ... def add(x, y):
+    ...     return x + y
+    ...
+    >>> add(1, 2)
+    3
+    >>> add(1.3, 5.7)
+    7.0
+    >>> add.signatures
+    [(int64, int64), (float64, float64)]
+    >>> Annotate(add, signature=add.signatures[1])  # annotation for (float64, float64)
     """
     def __init__(self, function, signature=None, **kwargs):
 

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -867,7 +867,7 @@ class TestDispatcherMethods(TestCase):
             foo.inspect_types()
         assert expected in out.getvalue()
 
-    def test_inspect_types_signature(self):
+    def test_inspect_types_with_signature(self):
         @jit
         def foo(a):
             return a + 1
@@ -884,7 +884,7 @@ class TestDispatcherMethods(TestCase):
         with captured_stdout() as second:
             foo.inspect_types(signature=foo.signatures[1])
 
-        assert total.getvalue() == first.getvalue() + second.getvalue()
+        self.assertEqual(total.getvalue(), first.getvalue() + second.getvalue())
 
     @unittest.skipIf(jinja2 is None, "please install the 'jinja2' package")
     @unittest.skipIf(pygments is None, "please install the 'pygments' package")
@@ -925,7 +925,7 @@ class TestDispatcherMethods(TestCase):
         expected = dict(chain.from_iterable(foo.get_annotation_info(i).items()
                                             for i in foo.signatures))
         result = foo.get_annotation_info()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_issue_with_array_layout_conflict(self):
         """

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -12,6 +12,8 @@ import warnings
 import inspect
 import pickle
 import weakref
+import collections
+from itertools import chain
 
 try:
     import jinja2
@@ -911,6 +913,19 @@ class TestDispatcherMethods(TestCase):
 
         self.assertIn("`file` must be None if `pretty=True`",
                       str(raises.exception))
+
+    def test_get_annotation_info(self):
+        @jit
+        def foo(a):
+            return a + 1
+
+        foo(1)
+        foo(1.3)
+
+        expected = dict(chain.from_iterable(foo.get_annotation_info(i).items()
+                                            for i in foo.signatures))
+        result = foo.get_annotation_info()
+        assert expected == result
 
     def test_issue_with_array_layout_conflict(self):
         """

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -859,6 +859,31 @@ class TestDispatcherMethods(TestCase):
         # Exercise the method
         foo.inspect_types(utils.StringIO())
 
+        # Test output
+        expected = str(foo.overloads[foo.signatures[0]].type_annotation)
+        with captured_stdout() as out:
+            foo.inspect_types()
+        assert expected in out.getvalue()
+
+    def test_inspect_types_signature(self):
+        @jit
+        def foo(a):
+            return a + 1
+
+        foo(1)
+        foo(1.0)
+        # Inspect all signatures
+        with captured_stdout() as total:
+            foo.inspect_types()
+        # Inspect first signature
+        with captured_stdout() as first:
+            foo.inspect_types(signature=foo.signatures[0])
+        # Inspect second signature
+        with captured_stdout() as second:
+            foo.inspect_types(signature=foo.signatures[1])
+
+        assert total.getvalue() == first.getvalue() + second.getvalue()
+
     @unittest.skipIf(jinja2 is None, "please install the 'jinja2' package")
     @unittest.skipIf(pygments is None, "please install the 'pygments' package")
     def test_inspect_types_pretty(self):


### PR DESCRIPTION
This PR adds a `signature=` parameter to the dispatcher `inspect_types()` method.

Fixes #4127