### PR TITLE
Update min/argmin and max/argmax to handle non-leading nans

### DIFF
--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -422,6 +422,8 @@ def array_min(context, builder, sig, args):
 
             it = np.nditer(arry)
             min_value = next(it).take(0)
+            if np.isnan(min_value):
+                return min_value
 
             for view in it:
                 v = view.item()
@@ -462,6 +464,8 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
+            if np.isnan(max_value):
+                return max_value
 
             for view in it:
                 v = view.item()
@@ -549,6 +553,8 @@ def array_argmin(context, builder, sig, args):
                 min_value = v
                 min_idx = 0
                 break
+            if np.isnan(min_value):
+                return min_idx
 
             idx = 0
             for v in arry.flat:
@@ -593,6 +599,8 @@ def array_argmax(context, builder, sig, args):
                 max_value = v
                 max_idx = 0
                 break
+            if np.isnan(max_value):
+                return max_idx
 
             idx = 0
             for v in arry.flat:

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -415,6 +415,22 @@ def array_min(context, builder, sig, args):
                         min_value = v
             return min_value
 
+    elif isinstance(ty, types.Float):
+        def array_min_impl(arry):
+            if arry.size == 0:
+                raise ValueError(MSG)
+
+            it = np.nditer(arry)
+            min_value = next(it).take(0)
+
+            for view in it:
+                v = view.item()
+                if np.isnan(v):
+                    return v
+                if v < min_value:
+                    min_value = v
+            return min_value
+
     else:
         def array_min_impl(arry):
             if arry.size == 0:
@@ -455,6 +471,23 @@ def array_max(context, builder, sig, args):
                     if v.imag > max_value.imag:
                         max_value = v
             return max_value
+
+    elif isinstance(ty, types.Float):
+        def array_max_impl(arry):
+            if arry.size == 0:
+                raise ValueError(MSG)
+
+            it = np.nditer(arry)
+            max_value = next(it).take(0)
+
+            for view in it:
+                v = view.item()
+                if np.isnan(v):
+                    return v
+                if v > max_value:
+                    max_value = v
+            return max_value
+
     else:
         def array_max_impl(arry):
             if arry.size == 0:
@@ -508,6 +541,25 @@ def array_argmin(context, builder, sig, args):
                 idx += 1
             return min_idx
 
+    elif isinstance(ty, types.Float):
+        def array_argmin_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmin of an empty sequence")
+            for v in arry.flat:
+                min_value = v
+                min_idx = 0
+                break
+
+            idx = 0
+            for v in arry.flat:
+                if np.isnan(v):
+                    return idx
+                if v < min_value:
+                    min_value = v
+                    min_idx = idx
+                idx += 1
+            return min_idx
+
     else:
         def array_argmin_impl(arry):
             if arry.size == 0:
@@ -531,21 +583,43 @@ def array_argmin(context, builder, sig, args):
 @lower_builtin(np.argmax, types.Array)
 @lower_builtin("array.argmax", types.Array)
 def array_argmax(context, builder, sig, args):
-    def array_argmax_impl(arry):
-        if arry.size == 0:
-            raise ValueError("attempt to get argmax of an empty sequence")
-        for v in arry.flat:
-            max_value = v
-            max_idx = 0
-            break
+    ty = sig.args[0].dtype
 
-        idx = 0
-        for v in arry.flat:
-            if v > max_value:
+    if isinstance(ty, types.Float):
+        def array_argmax_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmax of an empty sequence")
+            for v in arry.flat:
                 max_value = v
-                max_idx = idx
-            idx += 1
-        return max_idx
+                max_idx = 0
+                break
+
+            idx = 0
+            for v in arry.flat:
+                if np.isnan(v):
+                    return idx
+                if v > max_value:
+                    max_value = v
+                    max_idx = idx
+                idx += 1
+            return max_idx
+
+    else:
+        def array_argmax_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmax of an empty sequence")
+            for v in arry.flat:
+                max_value = v
+                max_idx = 0
+                break
+
+            idx = 0
+            for v in arry.flat:
+                if v > max_value:
+                    max_value = v
+                    max_idx = idx
+                idx += 1
+            return max_idx
     res = context.compile_internal(builder, array_argmax_impl, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -464,8 +464,6 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
-            if np.isnan(max_value):
-                return max_value
 
             for view in it:
                 v = view.item()
@@ -483,6 +481,8 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
+            if np.isnan(max_value):
+                return max_value
 
             for view in it:
                 v = view.item()

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -212,6 +212,8 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         check(arr)
         arr = np.float64(['nan', -1.5, 2.5, 'nan', 'inf', '-inf', 3.0])
         check(arr)
+        arr = np.float64([5.0, 'nan', -1.5, 'nan'])
+        check(arr)
         if all_nans:
             # Only NaNs
             arr = np.float64(['nan', 'nan'])


### PR DESCRIPTION
This PR adds `np.isnan` checks to ensure that we match the corresponding NumPy behavior. 

Partially addresses #4125. There is also a similar issue with datetime NaT values. 