### PR TITLE
Add dominator tree

### DIFF
--- a/numba/controlflow.py
+++ b/numba/controlflow.py
@@ -124,6 +124,7 @@ class CFGraph(object):
         self._find_post_dominators()
         self._find_immediate_dominators()
         self._find_dominance_frontier()
+        self._find_dominator_tree()
 
     def dominators(self):
         """
@@ -163,6 +164,15 @@ class CFGraph(object):
         stricly dominanted by N
         """
         return self._df
+
+    def dominator_tree(self):
+        """
+        return a dictionary of {node -> set(nodes)} mapping each node to
+        the set of nodes it dominates
+
+        The domtree(B) is the closest strict set of nodes that B dominates
+        """
+        return self._domtree
 
     def descendents(self, node):
         """
@@ -367,6 +377,20 @@ class CFGraph(object):
                     changed = True
 
         self._idom = idom
+
+    def _find_dominator_tree(self):
+        idom = self._idom
+        domtree = {}
+
+        for u, v in idom.items():
+            # v dominates u
+            if u not in domtree:
+                domtree[u] = set()
+
+            if u != v:
+                domtree[v].add(u)
+
+        self._domtree = domtree
 
     def _find_dominance_frontier(self):
         idom = self._idom

--- a/numba/controlflow.py
+++ b/numba/controlflow.py
@@ -384,6 +384,8 @@ class CFGraph(object):
 
         for u, v in idom.items():
             # v dominates u
+            if v not in domtree:
+                domtree[v] = set()
             if u not in domtree:
                 domtree[u] = set()
 

--- a/numba/controlflow.py
+++ b/numba/controlflow.py
@@ -168,7 +168,7 @@ class CFGraph(object):
     def dominator_tree(self):
         """
         return a dictionary of {node -> set(nodes)} mapping each node to
-        the set of nodes it dominates
+        the set of nodes it immediately dominates
 
         The domtree(B) is the closest strict set of nodes that B dominates
         """
@@ -380,15 +380,12 @@ class CFGraph(object):
 
     def _find_dominator_tree(self):
         idom = self._idom
-        domtree = {}
+        domtree = collections.defaultdict(set)
 
         for u, v in idom.items():
             # v dominates u
-            if v not in domtree:
-                domtree[v] = set()
             if u not in domtree:
                 domtree[u] = set()
-
             if u != v:
                 domtree[v].add(u)
 

--- a/numba/tests/test_flow_control.py
+++ b/numba/tests/test_flow_control.py
@@ -818,6 +818,32 @@ class TestCFGraph(TestCase):
                                16: [16],
                                })
 
+    def test_dominator_tree(self):
+        def check(graph, expected):
+            domtree = graph.dominator_tree()
+            self.assertEqual(domtree, expected)
+
+        check(self.loopless1(),
+              {0: {12, 18, 21}, 12: set(), 18: set(), 21: set()})
+        check(self.loopless2(),
+              {12: set(), 18: set(), 21: {34, 42}, 34: set(), 42: set(),
+               99: {18, 12, 21}})
+        check(self.loopless1_dead_nodes(),
+              {0: {12, 18, 21}, 12: set(), 18: set(), 21: set()})
+        check(self.multiple_loops(),
+              {0: {7}, 7: {10, 60}, 60: {61}, 61: {68}, 68: {71, 87},
+               87: {88}, 88: set(), 71: {80}, 80: set(), 10: {13},
+               13: {20}, 20: {56, 23}, 23: {32, 44}, 44: set(),
+               32: set(), 56: {57}, 57: set()})
+        check(self.multiple_exits(),
+              {0: {7}, 7: {10, 36, 37}, 36: set(), 10: {19, 23},
+               23: {29}, 29: set(), 37: set(), 19: set()})
+        check(self.infinite_loop1(),
+              {0: {10, 6}, 6: set(), 10: {13}, 13: {26, 19}, 19: set(),
+               26: set()})
+        check(self.infinite_loop2(),
+              {0: {3}, 3: {16, 9}, 9: set(), 16: set()})
+
     def test_immediate_dominators(self):
         def check(graph, expected):
             idoms = graph.immediate_dominators()


### PR DESCRIPTION
Following up on #4149 and #4177. This pull request implements a dominator tree. 

This is part of the algorithm for renaming variables when inserting PHI nodes.