### PR TITLE
Fix #4223. Looplifting error due to StaticSetItem in objectmode

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -432,7 +432,8 @@ class BasePipeline(object):
             cres = compile_ir(self.typingctx, self.targetctx, main,
                               self.args, self.return_type,
                               outer_flags, self.locals,
-                              lifted=tuple(loops), lifted_from=None)
+                              lifted=tuple(loops), lifted_from=None,
+                              is_lifted_loop=True)
             return cres
 
     def stage_frontend_withlift(self):

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -998,11 +998,13 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
         # that's usable from above.
         rw_cres = None
         if not flags.no_rewrites:
-            try:
-                rw_cres = compile_local(func_ir.copy(), flags)
-            except Exception:
-                pass
-
+            # Suppress warnings in compilation retry
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", errors.NumbaWarning)
+                try:
+                    rw_cres = compile_local(func_ir.copy(), flags)
+                except Exception:
+                    pass
         # if the rewrite variant of compilation worked, use it, else use
         # the norewrites backup
         if rw_cres is not None:

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -557,5 +557,27 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         f(1)
         self.assertEqual(len(f.overloads[f.signatures[0]].lifted), 1)
 
+    def test_lift_objectmode_issue_4223(self):
+        from numba import jit
+
+        @jit
+        def foo(a, b, c, d, x0, y0, n):
+            xs, ys = np.zeros(n), np.zeros(n)
+            xs[0], ys[0] = x0, y0
+            for i in np.arange(n-1):
+                xs[i+1] = np.sin(a * ys[i]) + c * np.cos(a * xs[i])
+                ys[i+1] = np.sin(b * xs[i]) + d * np.cos(b * ys[i])
+            object() # ensure object mode
+            return xs, ys
+
+        kwargs = dict(a=1.7, b=1.7, c=0.6, d=1.2, x0=0, y0=0, n=200)
+        got = foo(**kwargs)
+        expected = foo.py_func(**kwargs)
+        self.assertPreciseEqual(got[0], expected[0])
+        self .assertPreciseEqual(got[1], expected[1])
+        [lifted] = foo.overloads[foo.signatures[0]].lifted
+        self.assertEqual(len(lifted.nopython_signatures), 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #4223

Set `is_lifted_loop=True` for the host function.