### PR TITLE
Include numba version in reportable error message

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -8,6 +8,10 @@ import re
 import sys
 import warnings
 
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+
 from . import config, errors, _runtests as runtests, types
 
 # Re-export typeof
@@ -174,7 +178,3 @@ import llvmlite
 Is set to True if Intel SVML is in use.
 """
 config.USING_SVML = _try_enable_svml()
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -345,8 +345,9 @@ https://github.com/numba/numba/issues/new
 reportable_issue_info = """
 -------------------------------------------------------------------------------
 This should not have happened, a problem has occurred in Numba's internals.
+You are currently using Numba version %s.
 %s
-""" % feedback_details
+""" % (numba.__version__, feedback_details)
 
 error_extras = dict()
 error_extras['unsupported_error'] = unsupported_error_info


### PR DESCRIPTION
This PR adds the current numba version to the reportable error message.

Example to raise such an error:
```python
from numba import njit, prange 
import numpy as np 

@njit(parallel=True) 
def foo(): 
    return np.array([x for x in prange(10)]) 

foo()  
```

<details>
<summary>Output:</summary>

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/github/numba/numba/numba/errors.py in new_error_context(fmt_, *args, **kwargs)
    661     try:
--> 662         yield
    663     except NumbaError as e:

~/github/numba/numba/numba/lowering.py in lower_block(self, block)
    260                                    loc=self.loc, errcls_=defaulterrcls):
--> 261                 self.lower_inst(inst)
    262 

~/github/numba/numba/numba/lowering.py in lower_inst(self, inst)
    303             ty = self.typeof(inst.target.name)
--> 304             val = self.lower_assign(ty, inst)
    305             self.storevar(val, inst.target.name)

~/github/numba/numba/numba/lowering.py in lower_assign(self, ty, inst)
    461         elif isinstance(value, ir.Expr):
--> 462             return self.lower_expr(ty, value)
    463 

~/github/numba/numba/numba/lowering.py in lower_expr(self, resty, expr)
    944         elif expr.op in ('getiter', 'iternext'):
--> 945             val = self.loadvar(expr.value.name)
    946             ty = self.typeof(expr.value.name)

~/github/numba/numba/numba/lowering.py in loadvar(self, name)
   1131         """
-> 1132         ptr = self.getvar(name)
   1133         return self.builder.load(ptr)

~/github/numba/numba/numba/lowering.py in getvar(self, name)
   1125         """
-> 1126         return self.varmap[name]
   1127 

KeyError: '$0.8'

During handling of the above exception, another exception occurred:

LoweringError                             Traceback (most recent call last)
<ipython-input-1-2a5cdefecbca> in <module>
      6     return np.array([x for x in prange(10)])
      7 
----> 8 foo()

~/github/numba/numba/numba/dispatcher.py in _compile_for_args(self, *args, **kws)
    368                     e.patch_message(''.join(e.args) + help_msg)
    369             # ignore the FULL_TRACEBACKS config, this needs reporting!
--> 370             raise e
    371 
    372     def inspect_llvm(self, signature=None):

~/github/numba/numba/numba/dispatcher.py in _compile_for_args(self, *args, **kws)
    325                 argtypes.append(self.typeof_pyval(a))
    326         try:
--> 327             return self.compile(tuple(argtypes))
    328         except errors.TypingError as e:
    329             # Intercept typing error that may be due to an argument

~/github/numba/numba/numba/compiler_lock.py in _acquire_compile_lock(*args, **kwargs)
     30         def _acquire_compile_lock(*args, **kwargs):
     31             with self:
---> 32                 return func(*args, **kwargs)
     33         return _acquire_compile_lock
     34 

~/github/numba/numba/numba/dispatcher.py in compile(self, sig)
    657 
    658             self._cache_misses[sig] += 1
--> 659             cres = self._compiler.compile(args, return_type)
    660             self.add_overload(cres)
    661             self._cache.save_overload(sig, cres)

~/github/numba/numba/numba/dispatcher.py in compile(self, args, return_type)
     81                                       args=args, return_type=return_type,
     82                                       flags=flags, locals=self.locals,
---> 83                                       pipeline_class=self.pipeline_class)
     84         # Check typing error if object mode is used
     85         if cres.typing_error is not None and not flags.enable_pyobject:

~/github/numba/numba/numba/compiler.py in compile_extra(typingctx, targetctx, func, args, return_type, flags, locals, library, pipeline_class)
    953     pipeline = pipeline_class(typingctx, targetctx, library,
    954                               args, return_type, flags, locals)
--> 955     return pipeline.compile_extra(func)
    956 
    957 

~/github/numba/numba/numba/compiler.py in compile_extra(self, func)
    375         self.lifted = ()
    376         self.lifted_from = None
--> 377         return self._compile_bytecode()
    378 
    379     def compile_ir(self, func_ir, lifted=(), lifted_from=None):

~/github/numba/numba/numba/compiler.py in _compile_bytecode(self)
    884         """
    885         assert self.func_ir is None
--> 886         return self._compile_core()
    887 
    888     def _compile_ir(self):

~/github/numba/numba/numba/compiler.py in _compile_core(self)
    871         self.define_pipelines(pm)
    872         pm.finalize()
--> 873         res = pm.run(self.status)
    874         if res is not None:
    875             # Early pipeline completion

~/github/numba/numba/numba/compiler_lock.py in _acquire_compile_lock(*args, **kwargs)
     30         def _acquire_compile_lock(*args, **kwargs):
     31             with self:
---> 32                 return func(*args, **kwargs)
     33         return _acquire_compile_lock
     34 

~/github/numba/numba/numba/compiler.py in run(self, status)
    252                     # No more fallback pipelines?
    253                     if is_final_pipeline:
--> 254                         raise patched_exception
    255                     # Go to next fallback pipeline
    256                     else:

~/github/numba/numba/numba/compiler.py in run(self, status)
    243                 try:
    244                     event("-- %s" % stage_name)
--> 245                     stage()
    246                 except _EarlyPipelineCompletion as e:
    247                     return e.result

~/github/numba/numba/numba/compiler.py in stage_nopython_backend(self)
    745         """
    746         lowerfn = self.backend_nopython_mode
--> 747         self._backend(lowerfn, objectmode=False)
    748 
    749     def stage_compile_interp_mode(self):

~/github/numba/numba/numba/compiler.py in _backend(self, lowerfn, objectmode)
    685             self.library.enable_object_caching()
    686 
--> 687         lowered = lowerfn()
    688         signature = typing.signature(self.return_type, *self.args)
    689         self.cr = compile_result(

~/github/numba/numba/numba/compiler.py in backend_nopython_mode(self)
    672                 self.calltypes,
    673                 self.flags,
--> 674                 self.metadata)
    675 
    676     def _backend(self, lowerfn, objectmode):

~/github/numba/numba/numba/compiler.py in native_lowering_stage(targetctx, library, interp, typemap, restype, calltypes, flags, metadata)
   1122         lower = lowering.Lower(targetctx, library, fndesc, interp,
   1123                                metadata=metadata)
-> 1124         lower.lower()
   1125         if not flags.no_cpython_wrapper:
   1126             lower.create_cpython_wrapper(flags.release_gil)

~/github/numba/numba/numba/lowering.py in lower(self)
    175         if self.generator_info is None:
    176             self.genlower = None
--> 177             self.lower_normal_function(self.fndesc)
    178         else:
    179             self.genlower = self.GeneratorLower(self)

~/github/numba/numba/numba/lowering.py in lower_normal_function(self, fndesc)
    216         # Init argument values
    217         self.extract_function_arguments()
--> 218         entry_block_tail = self.lower_function_body()
    219 
    220         # Close tail of entry block

~/github/numba/numba/numba/lowering.py in lower_function_body(self)
    244             bb = self.blkmap[offset]
    245             self.builder.position_at_end(bb)
--> 246             self.lower_block(block)
    247 
    248         self.post_lower()

~/github/numba/numba/numba/lowering.py in lower_block(self, block)
    259             with new_error_context('lowering "{inst}" at {loc}', inst=inst,
    260                                    loc=self.loc, errcls_=defaulterrcls):
--> 261                 self.lower_inst(inst)
    262 
    263     def create_cpython_wrapper(self, release_gil=False):

~/miniconda/envs/numba-dev/lib/python3.6/contextlib.py in __exit__(self, type, value, traceback)
     97                 value = type()
     98             try:
---> 99                 self.gen.throw(type, value, traceback)
    100             except StopIteration as exc:
    101                 # Suppress StopIteration *unless* it's the same exception that

~/github/numba/numba/numba/errors.py in new_error_context(fmt_, *args, **kwargs)
    668         from numba import config
    669         tb = sys.exc_info()[2] if config.FULL_TRACEBACKS else None
--> 670         six.reraise(type(newerr), newerr, tb)
    671 
    672 

~/github/numba/numba/numba/six.py in reraise(tp, value, tb)
    657         if value.__traceback__ is not tb:
    658             raise value.with_traceback(tb)
--> 659         raise value
    660 
    661 else:

LoweringError: Failed in nopython mode pipeline (step: nopython mode backend)
'$0.8'

File "<ipython-input-1-2a5cdefecbca>", line 6:
def foo(): 
    return np.array([x for x in prange(10)]) 
    ^

[1] During: lowering "$implicit0.0.30 = getiter(value=$0.8)" at <ipython-input-1-2a5cdefecbca> (6)
-------------------------------------------------------------------------------
This should not have happened, a problem has occurred in Numba's internals.
You are currently using Numba version 0.44.0dev0+718.g08a074de9.dirty.

Please report the error message and traceback, along with a minimal reproducer
at: https://github.com/numba/numba/issues/new

If more help is needed please feel free to speak to the Numba core developers
directly at: https://gitter.im/numba/numba

Thanks in advance for your help in improving Numba!


```
</details>

Closes #3929 
