### PR TITLE
Fix inplace operator error for arrays

### DIFF
--- a/numba/targets/npyimpl.py
+++ b/numba/targets/npyimpl.py
@@ -495,7 +495,7 @@ def register_binary_operator_kernel(op, kernel, inplace=False):
         # The visible signature is (A, B) -> A
         # The implementation's signature (with explicit output)
         # is (A, B, A) -> A
-        args = args + (args[0],)
+        args = tuple(args) + (args[0],)
         sig = typing.signature(sig.return_type, *sig.args + (sig.args[0],))
         return numpy_ufunc_kernel(context, builder, sig, args, kernel,
                                   explicit_output=True)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -6,6 +6,7 @@ import re
 import sys
 import warnings
 import threading
+import operator
 
 import numpy as np
 
@@ -17,7 +18,7 @@ from numba import jit, vectorize
 from numba.config import PYVERSION
 from numba.errors import LoweringError, TypingError
 from .support import TestCase, CompilationCache, MemoryLeakMixin, tag
-from numba.six import exec_
+from numba.six import exec_, string_types
 from numba.typing.npydecl import supported_ufuncs, all_ufuncs
 
 is32bits = tuple.__itemsize__ == 4
@@ -95,10 +96,19 @@ def _make_binary_ufunc_op_usecase(ufunc_op):
 
 
 def _make_inplace_ufunc_op_usecase(ufunc_op):
-    ldict = {}
-    exec_("def fn(x,y):\n    x{0}y".format(ufunc_op), globals(), ldict)
-    fn = ldict["fn"]
-    fn.__name__ = "usecase_{0}".format(hash(ufunc_op))
+    """Generates a function to be compiled that performs an inplace operation
+
+    ufunc_op can be a string like '+=' or a function like operator.iadd
+    """
+    if isinstance(ufunc_op, string_types):
+        ldict = {}
+        exec_("def fn(x,y):\n    x{0}y".format(ufunc_op), globals(), ldict)
+        fn = ldict["fn"]
+        fn.__name__ = "usecase_{0}".format(hash(ufunc_op))
+    else:
+        def inplace_op(x, y):
+            ufunc_op(x, y)
+        fn = inplace_op
     return fn
 
 
@@ -1074,43 +1084,55 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
     @tag('important')
     def test_inplace_add(self):
         self.inplace_float_op_test('+=', [-1, 1.5, 3], [-5, 0, 2.5])
+        self.inplace_float_op_test(operator.iadd, [-1, 1.5, 3], [-5, 0, 2.5])
 
     @tag('important')
     def test_inplace_sub(self):
         self.inplace_float_op_test('-=', [-1, 1.5, 3], [-5, 0, 2.5])
+        self.inplace_float_op_test(operator.isub, [-1, 1.5, 3], [-5, 0, 2.5])
 
     @tag('important')
     def test_inplace_mul(self):
         self.inplace_float_op_test('*=', [-1, 1.5, 3], [-5, 0, 2.5])
+        self.inplace_float_op_test(operator.imul, [-1, 1.5, 3], [-5, 0, 2.5])
 
     def test_inplace_floordiv(self):
         self.inplace_float_op_test('//=', [-1, 1.5, 3], [-5, 1.25, 2.5])
+        self.inplace_float_op_test(operator.ifloordiv, [-1, 1.5, 3], [-5, 1.25, 2.5])
 
     def test_inplace_div(self):
         self.inplace_float_op_test('/=', [-1, 1.5, 3], [-5, 0, 2.5])
+        self.inplace_float_op_test(operator.itruediv, [-1, 1.5, 3], [-5, 1.25, 2.5])
 
     def test_inplace_remainder(self):
         self.inplace_float_op_test('%=', [-1, 1.5, 3], [-5, 2, 2.5])
+        self.inplace_float_op_test(operator.imod, [-1, 1.5, 3], [-5, 2, 2.5])
 
     @tag('important')
     def test_inplace_pow(self):
         self.inplace_float_op_test('**=', [-1, 1.5, 3], [-5, 2, 2.5])
+        self.inplace_float_op_test(operator.ipow, [-1, 1.5, 3], [-5, 2, 2.5])
 
     def test_inplace_and(self):
         self.inplace_bitwise_op_test('&=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+        self.inplace_bitwise_op_test(operator.iand, [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
 
     def test_inplace_or(self):
         self.inplace_bitwise_op_test('|=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+        self.inplace_bitwise_op_test(operator.ior, [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
 
     def test_inplace_xor(self):
         self.inplace_bitwise_op_test('^=', [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
+        self.inplace_bitwise_op_test(operator.ixor, [0, 1, 2, 3, 51], [0, 13, 16, 42, 255])
 
     @tag('important')
     def test_inplace_lshift(self):
         self.inplace_int_op_test('<<=', [0, 5, -10, -51], [0, 1, 4, 14])
+        self.inplace_int_op_test(operator.ilshift, [0, 5, -10, -51], [0, 1, 4, 14])
 
     def test_inplace_rshift(self):
         self.inplace_int_op_test('>>=', [0, 5, -10, -51], [0, 1, 4, 14])
+        self.inplace_int_op_test(operator.irshift, [0, 5, -10, -51], [0, 1, 4, 14])
 
     def test_unary_positive_array_op(self):
         '''


### PR DESCRIPTION
This PR fixes a bug when inplace operators are used explicitly on arrays (e.g. `operator.iadd(A, B)` vs. `A += B`) 

Minimal reproducer (broken on current `master`, works on this branch):

```python
from numba import njit
import numpy as np
import operator

@njit
def f(A):
    return operator.iadd(A, A)

f(np.array([1,3]))
```

Fixes #4131