### PR TITLE
Make hashing cacheable

### DIFF
--- a/numba/targets/hashing.py
+++ b/numba/targets/hashing.py
@@ -659,4 +659,3 @@ def unicode_hash(val):
             return _Py_HashBytes(val._data, kindwidth * _len)
 
     return impl
-

--- a/numba/targets/hashing.py
+++ b/numba/targets/hashing.py
@@ -585,7 +585,7 @@ def _inject_hashsecret_read(tyctx, name):
         raise errors.TypingError("requires literal string")
 
     sym = _hashsecret[name.literal_value].symbol
-    resty = _Py_uhash_t
+    resty = types.uint64
     sig = resty(name)
 
     def impl(cgctx, builder, sig, args):

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -1,6 +1,7 @@
 """
 Assorted utilities for use in tests.
 """
+from __future__ import print_function
 
 import cmath
 import contextlib
@@ -16,6 +17,7 @@ import tempfile
 import time
 import io
 import ctypes
+import multiprocessing as mp
 
 import numpy as np
 
@@ -714,3 +716,57 @@ def redirect_c_stdout():
     """
     fd = sys.__stdout__.fileno()
     return redirect_fd(fd)
+
+
+def run_in_new_process_caching(func, cache_dir_prefix=__name__, verbose=True):
+    """Spawn a new process to run `func` with a temporary cache directory.
+
+    The childprocess's stdout and stderr will be captured and redirected to
+    the current process's stdout and stderr.
+
+    Returns
+    -------
+    ret : dict
+        exitcode: 0 for success. 1 for exception-raised.
+        stdout: str
+        stderr: str
+    """
+    ctx = mp.get_context('spawn')
+    qout = ctx.Queue()
+    cache_dir = temp_directory(cache_dir_prefix)
+    with override_env_config('NUMBA_CACHE_DIR', cache_dir):
+        proc = ctx.Process(target=_remote_runner, args=[func, qout])
+        proc.start()
+        proc.join()
+        stdout = qout.get_nowait()
+        stderr = qout.get_nowait()
+        if verbose and stdout.strip():
+            print()
+            print('STDOUT'.center(80, '-'))
+            print(stdout)
+        if verbose and stderr.strip():
+            print(file=sys.stderr)
+            print('STDERR'.center(80, '-'), file=sys.stderr)
+            print(stderr, file=sys.stderr)
+    return {
+        'exitcode': proc.exitcode,
+        'stdout': stdout,
+        'stderr': stderr,
+    }
+
+
+def _remote_runner(fn, qout):
+    """Used by `run_in_new_process_caching()`
+    """
+    with captured_stderr() as stderr:
+        with captured_stdout() as stdout:
+            try:
+                fn()
+            except Exception:
+                traceback.print_exc()
+                exitcode = 1
+            else:
+                exitcode = 0
+        qout.put(stdout.getvalue())
+    qout.put(stderr.getvalue())
+    sys.exit(exitcode)

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,0 +1,97 @@
+from __future__ import print_function, absolute_import, division
+
+import sys
+import os
+import multiprocessing as mp
+import traceback
+
+from numba import njit
+from .support import (
+    TestCase,
+    temp_directory,
+    override_env_config,
+    captured_stdout,
+    captured_stderr,
+)
+
+
+def constant_unicode_cache():
+    c = "abcd"
+    return hash(c), c
+
+
+def check_constant_unicode_cache():
+    pyfunc = constant_unicode_cache
+    cfunc = njit(cache=True)(pyfunc)
+    exp_hv, exp_str = pyfunc()
+    got_hv, got_str = cfunc()
+    assert exp_hv == got_hv
+    assert exp_str == got_str
+
+
+def dict_cache():
+    return {'a': 1, 'b': 2}
+
+
+def check_dict_cache():
+    pyfunc = dict_cache
+    cfunc = njit(cache=True)(pyfunc)
+    exp = pyfunc()
+    got = cfunc()
+    assert exp == got
+
+
+class TestCaching(TestCase):
+    def run_test(self, func):
+        func()
+        ctx = mp.get_context('spawn')
+        qout = ctx.Queue()
+        cache_dir = temp_directory(__name__)
+        with override_env_config('NUMBA_CACHE_DIR', cache_dir):
+            proc = ctx.Process(target=_remote_runner, args=[func, qout])
+            proc.start()
+            stdout = qout.get()
+            stderr = qout.get()
+            if stdout.strip():
+                print()
+                print('STDOUT'.center(80, '-'))
+                print(stdout)
+            if stderr.strip():
+                print()
+                print('STDERR'.center(80, '-'))
+                print(stderr)
+            proc.join()
+            self.assertEqual(proc.exitcode, 0)
+
+
+    # The following is used to auto populate test methods into this class
+
+    def _make_test(fn):
+        def udt(self):
+            self.run_test(fn)
+        return udt
+
+    for k, v in globals().items():
+        prefix = 'check_'
+        if k.startswith(prefix):
+            locals()['test_' + k[len(prefix):]] = _make_test(v)
+
+
+def _remote_runner(fn, qout):
+    with captured_stderr() as stderr:
+        with captured_stdout() as stdout:
+            try:
+                fn()
+            except Exception:
+                print(traceback.format_exc(), file=sys.stderr)
+                exitcode = 1
+            else:
+                exitcode = 0
+        qout.put(stdout.getvalue())
+    qout.put(stderr.getvalue())
+    sys.exit(exitcode)
+
+
+def _remote_wrapper(fn):
+    _remote_wrapper()
+

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -12,6 +12,7 @@ from .support import (
     override_env_config,
     captured_stdout,
     captured_stderr,
+    SerialMixin,
 )
 
 
@@ -41,7 +42,8 @@ def check_dict_cache():
     assert exp == got
 
 
-class TestCaching(TestCase):
+class TestCaching(SerialMixin, TestCase):
+
     def run_test(self, func):
         func()
         ctx = mp.get_context('spawn')
@@ -62,7 +64,6 @@ class TestCaching(TestCase):
                 print(stderr)
             proc.join()
             self.assertEqual(proc.exitcode, 0)
-
 
     # The following is used to auto populate test methods into this class
 

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -85,7 +85,7 @@ def compile_time_get_string_data(obj):
     length = c_ssize_t()
     kind = c_int()
     is_ascii = c_uint()
-    hashv = c_ssize_t()
+    hashv = c_ssize_t()  # this value will be ignored
     data = fn(obj, byref(length), byref(kind), byref(is_ascii), byref(hashv))
     if data is None:
         raise ValueError("cannot extract unicode data from the given string")
@@ -94,7 +94,10 @@ def compile_time_get_string_data(obj):
     is_ascii = is_ascii.value
     nbytes = (length + 1) * _kind_to_byte_width(kind)
     out = (c_ubyte * nbytes).from_address(data)
-    return bytes(out), length, kind, is_ascii, hashv.value
+    # Set hash to -1 to indicate that it should be computed.
+    # We cannot bake in the hash value because of hashseed randomization.
+    hashv = -1
+    return bytes(out), length, kind, is_ascii, hashv
 
 
 def make_string_from_constant(context, builder, typ, literal_string):

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -85,7 +85,7 @@ def compile_time_get_string_data(obj):
     length = c_ssize_t()
     kind = c_int()
     is_ascii = c_uint()
-    hashv = c_ssize_t()  # this value will be ignored
+    hashv = c_ssize_t()
     data = fn(obj, byref(length), byref(kind), byref(is_ascii), byref(hashv))
     if data is None:
         raise ValueError("cannot extract unicode data from the given string")
@@ -94,10 +94,7 @@ def compile_time_get_string_data(obj):
     is_ascii = is_ascii.value
     nbytes = (length + 1) * _kind_to_byte_width(kind)
     out = (c_ubyte * nbytes).from_address(data)
-    # Set hash to -1 to indicate that it should be computed.
-    # We cannot bake in the hash value because of hashseed randomization.
-    hashv = -1
-    return bytes(out), length, kind, is_ascii, hashv
+    return bytes(out), length, kind, is_ascii, hashv.value
 
 
 def make_string_from_constant(context, builder, typ, literal_string):
@@ -114,7 +111,9 @@ def make_string_from_constant(context, builder, typ, literal_string):
     uni_str.length = uni_str.length.type(length)
     uni_str.kind = uni_str.kind.type(kind)
     uni_str.is_ascii = uni_str.is_ascii.type(is_ascii)
-    uni_str.hash = uni_str.hash.type(hashv)
+    # Set hash to -1 to indicate that it should be computed.
+    # We cannot bake in the hash value because of hashseed randomization.
+    uni_str.hash = uni_str.hash.type(-1)
     return uni_str._getvalue()
 
 


### PR DESCRIPTION
as titled.

Details:

Before this patch, numba extracts the CPython hash-secret at runtime and reference to it from compiled code as constants.  Even though it could be cached, the behavior will be unexpected because the hash value will be different due to python's hashseed randomization.  The fix is the abstract the hashsecret into a runtime symbol that is updated by the running process.