### PR TITLE
Raise informative error for np.kron array order

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -235,7 +235,7 @@ Basic linear algebra is supported on 1-D and 2-D contiguous arrays of
 floating-point and complex numbers:
 
 * :func:`numpy.dot`
-* :func:`numpy.kron`
+* :func:`numpy.kron` ('C' and 'F' order only)
 * :func:`numpy.outer`
 * :func:`numpy.trace` (only the first argument).
 * :func:`numpy.vdot`

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -2683,7 +2683,11 @@ else:
 def _kron_normaliser_impl(x):
     # makes x into a 2d array
     if isinstance(x, types.Array):
-        if x.ndim == 2:
+        if x.layout not in ('C', 'F'):
+            raise TypingError("np.linalg.kron only supports 'C' or 'F' layout "
+                              "input arrays. Receieved an input of "
+                              "layout '{}'.".format(x.layout))
+        elif x.ndim == 2:
             @register_jitable
             def nrm_shape(x):
                 xn = x.shape[-1]

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2448,6 +2448,10 @@ class TestBasics(TestLinalgSystems):  # TestLinalgSystems for 1d test
 
         self._assert_wrong_dim("kron", cfunc)
 
+        args = (np.empty(10)[::2], np.empty(10)[::2])
+        msg = "only supports 'C' or 'F' layout"
+        self.assert_error(cfunc, args, msg, err=errors.TypingError)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR raises an informative error when input arrays to `np.kron` have an unsupported order (i.e. are not `'C'` or `'F'`).

Closes #4097. 