### PR TITLE
Support len() of multi-dim arrays in array analysis

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1265,7 +1265,7 @@ class ArrayAnalysis(object):
             if rhs_rel < 0:
                 # Indicate we will need to replace the slice var.
                 need_replacement = True
-                explicit_neg_var, explicit_neg_typ = self.gen_explicit_neg(rhs, 
+                explicit_neg_var, explicit_neg_typ = self.gen_explicit_neg(rhs,
                     rhs_rel, rhs_typ, size_typ, loc, scope, dsize, stmts, equiv_set)
                 replacement_slice.args = (lhs, explicit_neg_var)
                 # Update rhs information with the negative removed.
@@ -1523,10 +1523,8 @@ class ArrayAnalysis(object):
         var = args[0]
         typ = self.typemap[var.name]
         require(isinstance(typ, types.ArrayCompatible))
-        if typ.ndim == 1:
-            shape = equiv_set._get_shape(var)
-            return shape[0], [], shape[0]
-        return None
+        shape = equiv_set._get_shape(var)
+        return shape[0], [], shape[0]
 
     def _analyze_op_call_numba_array_analysis_assert_equiv(self, scope,
                                                         equiv_set, args, kws):

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -354,10 +354,11 @@ class TestArrayAnalysis(TestCase):
             c = a[1:,:]
             d = b[:-1,:]
             e = c.shape[0]
-            f = len(d)
+            f = d.shape[0]
+            g = len(d)
             return e == f
         self._compile_and_test(test_12, (),
-                               equivs=[self.with_equiv('e', 'f')])
+                               equivs=[self.with_equiv('e', 'f', 'g')])
 
         def test_tup_arg(T):
             T2 = T

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -354,7 +354,7 @@ class TestArrayAnalysis(TestCase):
             c = a[1:,:]
             d = b[:-1,:]
             e = c.shape[0]
-            f = d.shape[0]
+            f = len(d)
             return e == f
         self._compile_and_test(test_12, (),
                                equivs=[self.with_equiv('e', 'f')])


### PR DESCRIPTION
As title. The check for 1D array in `len` handling of array analysis is unnecessary.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
