### PR TITLE
remove unused import

### DIFF
--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -19,7 +19,6 @@ import operator
 import contextlib
 import itertools
 from pprint import pprint
-import traceback
 from collections import OrderedDict
 
 from numba import ir, types, utils, config, typing


### PR DESCRIPTION
The PR at https://github.com/numba/numba/pull/3646 removed use of the
`traceback` module but didn't remove the import. Hence the `Linux
py35_np111_cov` build on Azure that does a `flake8` check reported the
following error:

```
numba/typeinfer.py:22:1: F401 'traceback' imported but unused
```

This PR fixes that.