### PR TITLE
Add reference counting to register_dispatcher

### DIFF
--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -140,7 +140,7 @@ def check_access_is_preventable():
             ret = True
     finally:
         os.chmod(test_dir, 0o775)
-        shutil.rmtree(tempdir)
+        shutil.rmtree(test_dir)
     return ret
 
 _access_preventable = check_access_is_preventable()
@@ -934,7 +934,6 @@ class BaseCacheTest(TestCase):
     def tearDown(self):
         sys.modules.pop(self.modname, None)
         sys.path.remove(self.tempdir)
-        shutil.rmtree(self.tempdir)
 
     def import_module(self):
         # Import a fresh version of the test module.  All jitted functions
@@ -1311,9 +1310,9 @@ class TestCache(BaseCacheUsecasesTest):
         # Make it impossible to create the __pycache__ directory
         old_perms = os.stat(self.tempdir).st_mode
         os.chmod(self.tempdir, 0o500)
+        self.addCleanup(os.chmod, self.tempdir, old_perms)
 
         self._test_pycache_fallback()
-        os.chmod(self.tempdir, old_perms)
 
     @skip_bad_access
     @unittest.skipIf(os.name == "nt",
@@ -1324,9 +1323,9 @@ class TestCache(BaseCacheUsecasesTest):
         os.mkdir(pycache)
         old_perms = os.stat(pycache).st_mode
         os.chmod(pycache, 0o500)
+        self.addCleanup(os.chmod, pycache, old_perms)
 
         self._test_pycache_fallback()
-        os.chmod(pycache, old_perms)
 
     def test_ipython(self):
         # Test caching in an IPython session
@@ -1549,7 +1548,6 @@ def bar():
         sys.modules.pop(self.modname_bar1, None)
         sys.modules.pop(self.modname_bar2, None)
         sys.path.remove(self.tempdir)
-        shutil.rmtree(self.tempdir)
 
     def import_bar1(self):
         return import_dynamic(self.modname_bar1).bar


### PR DESCRIPTION
This PR adds a reference counter for the dispatcher registration mapping in `numba/typeinfer.py` (i.e. `_temporary_dispatcher_map`) to avoid deleting a dispatcher when it has multiple references. Note I added the failing example from the originally posted issue, which involves creating a couple of temporary modules to execute, as a regression test. Any suggestions on how this might be improved is welcome. 

Fixes #3658