### PR TITLE
pin to MKL BLAS for testing to get consistent results

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     # build flag issues triggering UB
     - tbb >=2018.0.5           # [not ((armv6l or armv7l or aarch64) or (win and py27))]
     # avoid confusion from openblas bugs
-    - libopenblas !=0.3.6
+    - libopenblas !=0.3.6      # [x86_64]
 test:
   requires:
     - jinja2

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -47,6 +47,8 @@ requirements:
     # If TBB is present it must be at least this version from Anaconda due to
     # build flag issues triggering UB
     - tbb >=2018.0.5           # [not ((armv6l or armv7l or aarch64) or (win and py27))]
+    # avoid confusion from openblas bugs
+    - libopenblas !=0.3.6
 test:
   requires:
     - jinja2
@@ -54,8 +56,6 @@ test:
     - cffi
     # temporarily disable scipy testing on ARM, need to build out more packages
     - scipy                    # [not (armv6l or armv7l)]
-    - blas ==1.0=mkl           # [x86 or x86_64]
-    # avoid confusion from openblas bugs
     - ipython                  # [not (armv6l or armv7l)]
     - setuptools
     - faulthandler             # [py27 and (not (armv6l or armv7l))]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -54,6 +54,8 @@ test:
     - cffi
     # temporarily disable scipy testing on ARM, need to build out more packages
     - scipy                    # [not (armv6l or armv7l)]
+    - blas ==1.0=mkl           # [x86 or x86_64]
+    # avoid confusion from openblas bugs
     - ipython                  # [not (armv6l or armv7l)]
     - setuptools
     - faulthandler             # [py27 and (not (armv6l or armv7l))]


### PR DESCRIPTION
With NumPy 1.14 and SciPy 1.2.1, conda is selecting the OpenBLAS build of NumPy rather than the MKL build during testing.  This is leading to test failures that seem to be due to bugs in OpenBLAS 0.3.6 (not present in 0.3.3).  This recipe change should cause our CI to always pick the MKL build for testing so we aren't chasing unrelated OpenBLAS bugs.