### PR TITLE
Fix pickling of jitclass type

### DIFF
--- a/numba/jitclass/boxing.py
+++ b/numba/jitclass/boxing.py
@@ -78,7 +78,7 @@ def _specialize_box(typ):
         return _cache_specialized_box[typ]
     dct = {'__slots__': (),
            '_numba_type_': typ,
-           '__doc__': typ.class_type.class_def.__doc__,
+           '__doc__': typ.class_type.class_doc,
            }
     # Inject attributes as class properties
     for field in typ.struct:

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -11,7 +11,7 @@ import sys
 
 import numpy as np
 
-from numba import njit, utils
+from numba import njit, utils, jitclass
 from numba import int32, int64, float32, float64, types
 from numba import dictobject, typeof
 from numba.typed import Dict
@@ -1499,3 +1499,26 @@ class TestNonCompiledInfer(TestCase):
         # It's typed now
         self.assertTrue(d._typed)
         self.assertEqual(d[1], 2)
+
+
+@jitclass(spec=[('a', types.intp)])
+class Bag(object):
+    def __init__(self, a):
+        self.a = a
+
+    def __hash__(self):
+        return hash(self.a)
+
+
+class TestDictWithJitclass(TestCase):
+    def test_jitclass_as_value(self):
+        @njit
+        def foo(x):
+            d = Dict()
+            d[0] = x
+            d[1] = Bag(101)
+            return d
+
+        d = foo(Bag(a=100))
+        self.assertEqual(d[0].a, 100)
+        self.assertEqual(d[1].a, 101)

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -894,7 +894,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def test_pickling(self):
         @jitclass(spec=[])
-        class PickleTestSubject:
+        class PickleTestSubject(object):
             def __init__(self):
                 pass
 

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import ctypes
 import random
 import sys
+import pickle
 
 import numpy as np
 
@@ -27,6 +28,11 @@ def _get_meminfo(box):
     mi = MemInfo(ptr)
     mi.acquire()
     return mi
+
+
+class PickleTestSubject:
+    def __init__(self):
+        pass
 
 
 class TestJitClass(TestCase, MemoryLeakMixin):
@@ -890,6 +896,15 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
         # unpatched LLVMs will raise here...
         TruncatedLabel().meth2()
+
+    def test_pickling(self):
+        wrapped = jitclass(spec=[])(PickleTestSubject)
+
+        inst = wrapped()
+        ty = typeof(inst)
+        self.assertIsInstance(ty, types.ClassInstanceType)
+        pickled = pickle.dumps(ty)
+        self.assertIs(pickle.loads(pickled), ty)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -30,11 +30,6 @@ def _get_meminfo(box):
     return mi
 
 
-class PickleTestSubject:
-    def __init__(self):
-        pass
-
-
 class TestJitClass(TestCase, MemoryLeakMixin):
 
     def _check_spec(self, spec):
@@ -898,9 +893,12 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         TruncatedLabel().meth2()
 
     def test_pickling(self):
-        wrapped = jitclass(spec=[])(PickleTestSubject)
+        @jitclass(spec=[])
+        class PickleTestSubject:
+            def __init__(self):
+                pass
 
-        inst = wrapped()
+        inst = PickleTestSubject()
         ty = typeof(inst)
         self.assertIsInstance(ty, types.ClassInstanceType)
         pickled = pickle.dumps(ty)

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -393,7 +393,6 @@ class ClassType(Callable, Opaque):
         self.jitmethods = jitmethods
         self.jitprops = jitprops
         self.struct = struct
-        self.methods = dict((k, v.py_func) for k, v in self.jitmethods.items())
         fielddesc = ','.join("{0}:{1}".format(k, v) for k, v in struct.items())
         name = "{0}.{1}#{2:x}<{3}>".format(self.name_prefix, self.class_name,
                                            id(self), fielddesc)
@@ -404,6 +403,11 @@ class ClassType(Callable, Opaque):
 
     def get_call_signatures(self):
         return (), True
+
+    @property
+    def methods(self):
+        methods = dict((k, v.py_func) for k, v in self.jitmethods.items())
+        return methods
 
     @property
     def instance_type(self):

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -357,7 +357,7 @@ class ClassInstanceType(Type):
 
     @property
     def classname(self):
-        return self.class_type.class_def.__name__
+        return self.class_type.class_name
 
     @property
     def jitprops(self):
@@ -387,23 +387,31 @@ class ClassType(Callable, Opaque):
 
     def __init__(self, class_def, ctor_template_cls, struct, jitmethods,
                  jitprops):
-        self.class_def = class_def
-        self.ctor_template = self._specialize_template(ctor_template_cls)
+        self.class_name = class_def.__name__
+        self.class_doc = class_def.__doc__
+        self._ctor_template_class = ctor_template_cls
         self.jitmethods = jitmethods
         self.jitprops = jitprops
         self.struct = struct
         self.methods = dict((k, v.py_func) for k, v in self.jitmethods.items())
         fielddesc = ','.join("{0}:{1}".format(k, v) for k, v in struct.items())
-        name = "{0}.{1}#{2:x}<{3}>".format(self.name_prefix, class_def.__name__,
-                                           id(class_def), fielddesc)
+        name = "{0}.{1}#{2:x}<{3}>".format(self.name_prefix, self.class_name,
+                                           id(self), fielddesc)
         super(ClassType, self).__init__(name)
-        self.instance_type = self.instance_type_class(self)
 
     def get_call_type(self, context, args, kws):
         return self.ctor_template(context).apply(args, kws)
 
     def get_call_signatures(self):
         return (), True
+
+    @property
+    def instance_type(self):
+        return ClassInstanceType(self)
+
+    @property
+    def ctor_template(self):
+        return self._specialize_template(self._ctor_template_class)
 
     def _specialize_template(self, basecls):
         return type(basecls.__name__, (basecls,), dict(key=self))


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Related to https://github.com/numba/numba/issues/4250#issuecomment-509150125, https://github.com/numba/numba/issues/1846

Makes the type object of a jitclass pickleable.  But, jitclass instances are still not pickleable.
This is mainly to fix usability issue of jitclass instances in type inferred containers, i.e. typed-dict and typed-list.

The fix is to avoid references things that are not pickleable and breaking cyclic references by making `property` methods instead of storing the cyclic references as attributes.