### PR TITLE
 Replace GC macro with function call 

### DIFF
--- a/buildscripts/condarecipe.local/.label
+++ b/buildscripts/condarecipe.local/.label
@@ -1,0 +1,1 @@
+test_fix_py374

--- a/buildscripts/condarecipe.local/.label
+++ b/buildscripts/condarecipe.local/.label
@@ -1,1 +1,0 @@
-test_fix_py374

--- a/numba/_dynfunc.c
+++ b/numba/_dynfunc.c
@@ -49,7 +49,7 @@ env_clear(EnvironmentObject *env)
 static void
 env_dealloc(EnvironmentObject *env)
 {
-    _PyObject_GC_UNTRACK((PyObject *) env);
+    PyObject_GC_UnTrack((PyObject *) env);
     env_clear(env);
     Py_TYPE(env)->tp_free((PyObject *) env);
 }
@@ -172,7 +172,7 @@ closure_traverse(ClosureObject *clo, visitproc visit, void *arg)
 static void
 closure_dealloc(ClosureObject *clo)
 {
-    _PyObject_GC_UNTRACK((PyObject *) clo);
+    PyObject_GC_UnTrack((PyObject *) clo);
     if (clo->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *) clo);
     PyObject_Free((void *) clo->def.ml_name);
@@ -349,7 +349,7 @@ generator_clear(GeneratorObject *gen)
 static void
 generator_dealloc(GeneratorObject *gen)
 {
-    _PyObject_GC_UNTRACK((PyObject *) gen);
+    PyObject_GC_UnTrack((PyObject *) gen);
     if (gen->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *) gen);
     /* XXX The finalizer may be called after the LLVM module has been

--- a/numba/generators.py
+++ b/numba/generators.py
@@ -33,7 +33,7 @@ class GeneratorDescriptor(FunctionDescriptor):
         self = cls(fndesc.native, fndesc.modname, qualname, unique_name,
                    fndesc.doc, fndesc.typemap, restype, fndesc.calltypes,
                    args, fndesc.kws, argtypes=argtypes, mangler=mangler,
-                   inline=True, env_name=fndesc.env_name)
+                   inline=False, env_name=fndesc.env_name)
         return self
 
     @property


### PR DESCRIPTION
CPython 3.7.3->3.7.4 changed the size of PyGC_Head, the macro
_PyObject_GC_UNTRACK relied on calling sizeof() on that struct,
as it is a macro it got baked in at compile time and then
segfaults happen across the point version change as the struct
size changed.