### PR TITLE
Loosen up typed container casting checks

### DIFF
--- a/numba/errors.py
+++ b/numba/errors.py
@@ -65,6 +65,12 @@ class NumbaParallelSafetyWarning(NumbaWarning):
     might not have parallel semantics.
     """
 
+
+class NumbaTypeSafetyWarning(NumbaWarning):
+    """
+    Warning category for unsafe casting operations.
+    """
+
 # These are needed in the color formatting of errors setup
 
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -18,6 +18,7 @@ import time
 import io
 import ctypes
 import multiprocessing as mp
+from contextlib import contextmanager
 
 import numpy as np
 
@@ -26,6 +27,7 @@ from numba.compiler import compile_extra, compile_isolated, Flags, DEFAULT_FLAGS
 from numba.targets import cpu
 import numba.unittest_support as unittest
 from numba.runtime import rtsys
+from numba.six import PY2
 
 
 enable_pyobj_flags = Flags()
@@ -422,6 +424,14 @@ class TestCase(unittest.TestCase):
         got = cfunc()
         self.assertPreciseEqual(got, expected)
         return got, expected
+
+    if PY2:
+        @contextmanager
+        def subTest(self, *args, **kwargs):
+            """A stub TestCase.subTest backport.
+            This implementation is a no-op.
+            """
+            yield
 
 
 class SerialMixin(object):

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1336,6 +1336,25 @@ class TestDictInferred(TestCase):
             str(raises.exception),
         )
 
+    def test_conflict_key_type_non_number(self):
+        # Allow non-number types to cast unsafely
+        @njit
+        def foo(k1, v1, k2):
+            d = Dict()
+            d[k1] = v1
+            return d, d[k2]
+
+        # k2 will unsafetly downcast typeof(k1)
+        k1 = (np.int8(1), np.int8(2))
+        k2 = (np.int32(1), np.int32(2))
+        v1 = np.intp(123)
+
+        d, dk2 = foo(k1, v1, k2)
+
+        keys = list(d.keys())
+        self.assertEqual(keys[0], (1, 2))
+        self.assertEqual(dk2, d[(np.int32(1), np.int32(2))])
+
     def test_ifelse_filled_both_branches(self):
         @njit
         def foo(k, v):

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -8,6 +8,7 @@ in test_dictimpl.py.
 from __future__ import print_function, absolute_import, division
 
 import sys
+import warnings
 
 import numpy as np
 
@@ -1349,7 +1350,12 @@ class TestDictInferred(TestCase):
         k2 = (np.int32(1), np.int32(2))
         v1 = np.intp(123)
 
-        d, dk2 = foo(k1, v1, k2)
+        with warnings.catch_warnings(record=True) as w:
+            d, dk2 = foo(k1, v1, k2)
+        self.assertEqual(len(w), 1)
+        # Make sure the warning is about unsafe cast
+        self.assertIn('unsafe cast from tuple(int32 x 2) to tuple(int8 x 2)',
+                      str(w[0]))
 
         keys = list(d.keys())
         self.assertEqual(keys[0], (1, 2))

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1345,7 +1345,7 @@ class TestDictInferred(TestCase):
             d[k1] = v1
             return d, d[k2]
 
-        # k2 will unsafetly downcast typeof(k1)
+        # k2 will unsafely downcast typeof(k1)
         k1 = (np.int8(1), np.int8(2))
         k2 = (np.int32(1), np.int32(2))
         v1 = np.intp(123)

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -1451,6 +1451,6 @@ class TestItemCasting(TestCase):
         with self.assertRaises(TypingError) as raises:
             foo()
         self.assertIn(
-            'cannot safely cast int32 to unicode_type',
+            'Cannot cast int32 to unicode_type',
             str(raises.exception),
         )

--- a/numba/tests/test_typedobjectutils.py
+++ b/numba/tests/test_typedobjectutils.py
@@ -7,7 +7,7 @@ import warnings
 
 
 from numba import types
-from .support import TestCase, unittest
+from .support import TestCase
 from numba.typedobjectutils import _sentry_safe_cast
 
 

--- a/numba/tests/test_typedobjectutils.py
+++ b/numba/tests/test_typedobjectutils.py
@@ -57,7 +57,7 @@ class TestTypedObjectUtils(TestCase):
             # float to complex cases
             (types.float32, types.complex128),
             (types.float64, types.complex128),
-            # tuple-of-ints to tuple-of-floats,
+            # tuple-of-ints to tuple-of-ints,
             (types.Tuple([types.int32]), types.Tuple([types.int64])),
         ]
 

--- a/numba/tests/test_typedobjectutils.py
+++ b/numba/tests/test_typedobjectutils.py
@@ -1,0 +1,69 @@
+"""
+Unit-tests for `typedobjectutils.py`
+"""
+from __future__ import print_function, absolute_import, division
+
+import warnings
+
+
+from numba import types
+from .support import TestCase, unittest
+from numba.typedobjectutils import _sentry_safe_cast
+
+
+class TestTypedObjectUtils(TestCase):
+    def test_sentry_safe_cast_warnings(self):
+        warn_cases = []
+        warn_cases += [
+            # integer cases
+            (types.int32, types.int16),
+            (types.int32, types.uint32),
+            (types.int64, types.uint32),
+            # float cases
+            (types.float64, types.float32),
+            # complex cases
+            (types.complex128, types.complex64),
+            # int to float cases
+            (types.int32, types.float32),
+            (types.int64, types.float32),
+            # tuple-of-ints to tuple-of-floats,
+            (types.Tuple([types.int32]), types.Tuple([types.float32])),
+        ]
+
+        for fromty, toty in warn_cases:
+            with self.subTest(fromty=fromty, toty=toty):
+                with warnings.catch_warnings(record=True) as w:
+                    _sentry_safe_cast(fromty, toty)
+                self.assertEqual(len(w), 1)
+                # Make sure the warning is about unsafe cast
+                self.assertIn(
+                    "unsafe cast from {} to {}".format(fromty, toty),
+                    str(w[0]),
+                )
+
+    def test_sentry_safe_cast_no_warn(self):
+        ok_cases = []
+        ok_cases += [
+            # integer cases
+            (types.int32, types.int64),
+            (types.uint8, types.int32),
+            # float cases
+            (types.float32, types.float64),
+            # complex cases
+            (types.complex64, types.complex128),
+            # int to float cases
+            (types.int32, types.float64),
+            (types.uint8, types.float32),
+            # float to complex cases
+            (types.float32, types.complex128),
+            (types.float64, types.complex128),
+            # tuple-of-ints to tuple-of-floats,
+            (types.Tuple([types.int32]), types.Tuple([types.int64])),
+        ]
+
+        for fromty, toty in ok_cases:
+            with self.subTest(fromty=fromty, toty=toty):
+                with warnings.catch_warnings(record=True) as w:
+                    _sentry_safe_cast(fromty, toty)
+                # Expect no warnings
+                self.assertEqual(len(w), 0)

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -44,7 +44,7 @@ def _sentry_safe_cast(fromty, toty):
     by = tyctxt.can_convert(fromty, toty)
 
     def warn():
-        m = 'unsafe cast from {} to {}. Precision maybe lost.'
+        m = 'unsafe cast from {} to {}. Precision may be lost.'
         warnings.warn(m.format(fromty, toty),
                       category=NumbaTypeSafetyWarning)
 

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -1,6 +1,7 @@
 """ Common compiler level utilities for typed dict and list. """
 
 import operator
+import warnings
 
 from llvmlite import ir
 from llvmlite.llvmpy.core import Builder
@@ -11,7 +12,7 @@ from numba import typing
 from numba.targets.registry import cpu_target
 from numba.typeconv import Conversion
 from numba.extending import intrinsic
-from numba.errors import TypingError
+from numba.errors import TypingError, NumbaTypeSafetyWarning
 
 
 def _as_bytes(builder, ptr):
@@ -39,20 +40,34 @@ def _sentry_safe_cast(fromty, toty):
     """Check and raise TypingError if *fromty* cannot be safely cast to *toty*
     """
     tyctxt = cpu_target.typing_context
+    fromty, toty = map(types.unliteral, (fromty, toty))
     by = tyctxt.can_convert(fromty, toty)
+
+    def warn():
+        m = 'unsafe cast from {} to {}. Precision maybe lost.'
+        warnings.warn(m.format(fromty, toty),
+                      category=NumbaTypeSafetyWarning)
+
+    isint = lambda x: isinstance(x, types.Integer)
+    isflt = lambda x: isinstance(x, types.Float)
     # Only check against numeric types.
-    if isinstance(toty, types.Number) and by is None or by > Conversion.safe:
-        if isinstance(fromty, types.Integer) and isinstance(toty, types.Integer):
+    if by is None or by > Conversion.safe:
+        if isint(fromty) and isint(toty):
             # Accept if both types are ints
-            return
-        if isinstance(fromty, types.Integer) and isinstance(toty, types.Float):
+            warn()
+        elif isint(fromty) and isflt(toty):
             # Accept if ints to floats
-            return
-        if isinstance(fromty, types.Float) and isinstance(toty, types.Float):
+            warn()
+        elif isflt(fromty) and isflt(toty):
             # Accept if floats to floats
-            return
-        m = 'cannot safely cast {} to {}. Please cast explicitly.'
-        raise TypingError(m.format(fromty, toty))
+            warn()
+        elif not isinstance(toty, types.Number):
+            # Non-numbers
+            warn()
+        else:
+            # Make it a hard error for numeric type that changes domain.
+            m = 'cannot safely cast {} to {}. Please cast explicitly.'
+            raise TypingError(m.format(fromty, toty))
 
 
 def _sentry_safe_cast_default(default, valty):

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -40,7 +40,8 @@ def _sentry_safe_cast(fromty, toty):
     """
     tyctxt = cpu_target.typing_context
     by = tyctxt.can_convert(fromty, toty)
-    if by is None or by > Conversion.safe:
+    # Only check against numeric types.
+    if isinstance(toty, types.Number) and by is None or by > Conversion.safe:
         if isinstance(fromty, types.Integer) and isinstance(toty, types.Integer):
             # Accept if both types are ints
             return
@@ -50,7 +51,8 @@ def _sentry_safe_cast(fromty, toty):
         if isinstance(fromty, types.Float) and isinstance(toty, types.Float):
             # Accept if floats to floats
             return
-        raise TypingError('cannot safely cast {} to {}'.format(fromty, toty))
+        m = 'cannot safely cast {} to {}. Please cast explicitly.'
+        raise TypingError(m.format(fromty, toty))
 
 
 def _sentry_safe_cast_default(default, valty):

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -50,6 +50,7 @@ def _sentry_safe_cast(fromty, toty):
 
     isint = lambda x: isinstance(x, types.Integer)
     isflt = lambda x: isinstance(x, types.Float)
+    iscmplx = lambda x: isinstance(x, types.Complex)
     # Only check against numeric types.
     if by is None or by > Conversion.safe:
         if isint(fromty) and isint(toty):
@@ -60,6 +61,9 @@ def _sentry_safe_cast(fromty, toty):
             warn()
         elif isflt(fromty) and isflt(toty):
             # Accept if floats to floats
+            warn()
+        elif iscmplx(fromty) and iscmplx(toty):
+            # Accept if complex to complex
             warn()
         elif not isinstance(toty, types.Number):
             # Non-numbers


### PR DESCRIPTION
Fix #4307.

- Keep raising exceptions for cross domain cast for numbers.
- Warn but permit on other type of unsafe cast.