### PR TITLE
test using jitclass in typed-list

### DIFF
--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -738,5 +738,7 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
         def bag_equal(one, two):
             # jitclasses couldn't override __eq__ at time of writing
-            return one.value == two.value and all(one.array == two.array)
-        self.assertTrue(all([bag_equal(a,b) for a,b in zip(expected, got)]))
+            self.assertEqual(one.value, two.value)
+            np.testing.assert_allclose(one.array, two.array)
+
+        [bag_equal(a, b) for a, b in zip(expected, got)]

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -725,12 +725,6 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
                     self.array[i] += val
                 return self.array
 
-            def __eq__(self, other):
-                return self.value == other.value and all(self == other)
-
-            def __ne__(self, other):
-                return not self == other
-
         @njit
         def foo():
             l = List()
@@ -741,4 +735,8 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
         expected = foo.py_func()
         got = foo()
-        self.assertEqual(expected, got)
+
+        def bag_equal(one, two):
+            # jitclasses couldn't override __eq__ at time of writing
+            return one.value == two.value and all(one.array == two.array)
+        self.assertTrue([bag_equal(a,b) for a,b in zip(expected, got)])

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -739,4 +739,4 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
         def bag_equal(one, two):
             # jitclasses couldn't override __eq__ at time of writing
             return one.value == two.value and all(one.array == two.array)
-        self.assertTrue([bag_equal(a,b) for a,b in zip(expected, got)])
+        self.assertTrue(all([bag_equal(a,b) for a,b in zip(expected, got)]))


### PR DESCRIPTION
Setting up a list with jitclasses seems to be fine, but they can not be
compared yet.