### PR TITLE
Try to fix #4352.

### DIFF
--- a/numba/cuda/cudadrv/devices.py
+++ b/numba/cuda/cudadrv/devices.py
@@ -160,6 +160,8 @@ class _Runtime(object):
                         msg = ('Numba cannot operate on non-primary'
                                ' CUDA context {:x}')
                         raise RuntimeError(msg.format(ac.context_handle.value))
+                    # Ensure the context is ready
+                    ctx.prepare_for_use()
                 return ctx
 
     def _activate_context_for(self, devnum):

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1034,7 +1034,13 @@ def _module_finalizer(context, handle):
             assert shutting_down() or handle.value not in modules
             driver.cuModuleUnload(handle)
 
-        dealloc.add_item(module_unload, handle)
+        if dealloc is not None:
+            dealloc.add_item(module_unload, handle)
+        else:
+            # Check the impossible case.
+            assert shutting_down(), (
+                "dealloc is None but interpreter is not being shutdown!"
+            )
 
     return core
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -708,14 +708,20 @@ class Context(object):
                                                              memsize, blocksizelimit, flags)
         return (gridsize.value, blocksize.value)
 
+    def prepare_for_use(self):
+        """Initialize the context for use.
+        It's safe to be called multiple times.
+        """
+        # setup *deallocations* as the context becomes active for the first time
+        if self.deallocations is None:
+            self.deallocations = _PendingDeallocs(self.get_memory_info().total)
+
     def push(self):
         """
         Pushes this context on the current CPU Thread.
         """
         driver.cuCtxPushCurrent(self.handle)
-        # setup *deallocations* as the context becomes active for the first time
-        if self.deallocations is None:
-            self.deallocations = _PendingDeallocs(self.get_memory_info().total)
+        self.prepare_for_use()
 
     def pop(self):
         """

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1040,13 +1040,7 @@ def _module_finalizer(context, handle):
             assert shutting_down() or handle.value not in modules
             driver.cuModuleUnload(handle)
 
-        if dealloc is not None:
-            dealloc.add_item(module_unload, handle)
-        else:
-            # Check the impossible case.
-            assert shutting_down(), (
-                "dealloc is None but interpreter is not being shutdown!"
-            )
+        dealloc.add_item(module_unload, handle)
 
     return core
 

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -19,6 +19,14 @@ class TestResetDevice(CUDATestCase):
                 for _ in range(2):
                     for d in devices:
                         cuda.select_device(d)
+
+                        # Exercise cuda module creation and deletion
+                        @cuda.jit
+                        def foo():
+                            pass
+                        foo()
+                        del foo
+
                         cuda.close()
             except Exception as e:
                 exception_queue.put(e)

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -19,14 +19,6 @@ class TestResetDevice(CUDATestCase):
                 for _ in range(2):
                     for d in devices:
                         cuda.select_device(d)
-
-                        # Exercise cuda module creation and deletion
-                        @cuda.jit
-                        def foo():
-                            pass
-                        foo()
-                        del foo
-
                         cuda.close()
             except Exception as e:
                 exception_queue.put(e)


### PR DESCRIPTION
Fix #4352.
~Guard against `dealloc` being cleared.~
Actual cause is when numba activate externally-attached cuda context, the Context object is not fully initialized (`.deallocations` attribute is not setup yet).  This is unrelated to the GC in CPython interpreter.