### PR TITLE
Fix np1.17 isnan, isinf, isfinite ufuncs

### DIFF
--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -34,6 +34,7 @@ FLOAT_SIGN_MASK = 0x80000000
 DOUBLE_ABS_MASK = 0x7fffffffffffffff
 DOUBLE_SIGN_MASK = 0x8000000000000000
 
+
 def is_nan(builder, val):
     """
     Return a condition testing whether *val* is a NaN.

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -1696,6 +1696,11 @@ def np_complex_fmin_impl(context, builder, sig, args):
 ########################################################################
 # NumPy floating point misc
 
+def np_int_isnan_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
+    return cgutils.false_bit
+
+
 def np_real_isnan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
     return mathimpl.is_nan(builder, args[0])
@@ -1710,6 +1715,11 @@ def np_complex_isnan_impl(context, builder, sig, args):
     return cmathimpl.is_nan(builder, complex_val)
 
 
+def np_int_isfinite_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
+    return cgutils.true_bit
+
+
 def np_real_isfinite_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
     return mathimpl.is_finite(builder, args[0])
@@ -1721,6 +1731,11 @@ def np_complex_isfinite_impl(context, builder, sig, args):
     ty, = sig.args
     complex_val = context.make_complex(builder, ty, value=x)
     return cmathimpl.is_finite(builder, complex_val)
+
+
+def np_int_isinf_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
+    return cgutils.false_bit
 
 
 def np_real_isinf_impl(context, builder, sig, args):

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -11,7 +11,7 @@ import math
 from llvmlite.llvmpy import core as lc
 
 from .. import cgutils, typing, types, lowering, errors
-from . import cmathimpl, mathimpl, numbers
+from . import cmathimpl, mathimpl, numbers, npdatetime
 
 # some NumPy constants. Note that we could generate some of them using
 # the math library, but having the values copied from npy_math seems to
@@ -1718,6 +1718,11 @@ def np_complex_isnan_impl(context, builder, sig, args):
 def np_int_isfinite_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
     return cgutils.true_bit
+
+
+def np_datetime_isfinite_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
+    return builder.icmp_unsigned('!=', args[0], npdatetime.NAT)
 
 
 def np_real_isfinite_impl(context, builder, sig, args):

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -853,6 +853,9 @@ def _fill_ufunc_db(ufunc_db):
         'Q->?': npyfuncs.np_int_isfinite_impl,
         # boolean
         '?->?': npyfuncs.np_int_isfinite_impl,
+        # datetime & timedelta
+        'M->?': npyfuncs.np_datetime_isfinite_impl,
+        'm->?': npyfuncs.np_datetime_isfinite_impl,
     }
 
     ufunc_db[np.signbit] = {

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -788,6 +788,21 @@ def _fill_ufunc_db(ufunc_db):
         'd->?': npyfuncs.np_real_isnan_impl,
         'F->?': npyfuncs.np_complex_isnan_impl,
         'D->?': npyfuncs.np_complex_isnan_impl,
+        # int8
+        'b->?': npyfuncs.np_int_isnan_impl,
+        'B->?': npyfuncs.np_int_isnan_impl,
+        # int16
+        'h->?': npyfuncs.np_int_isnan_impl,
+        'H->?': npyfuncs.np_int_isnan_impl,
+        # int32
+        'i->?': npyfuncs.np_int_isnan_impl,
+        'I->?': npyfuncs.np_int_isnan_impl,
+        # int64
+        'l->?': npyfuncs.np_int_isnan_impl,
+        'L->?': npyfuncs.np_int_isnan_impl,
+        # intp
+        'q->?': npyfuncs.np_int_isnan_impl,
+        'Q->?': npyfuncs.np_int_isnan_impl,
     }
 
     ufunc_db[np.isinf] = {
@@ -795,6 +810,21 @@ def _fill_ufunc_db(ufunc_db):
         'd->?': npyfuncs.np_real_isinf_impl,
         'F->?': npyfuncs.np_complex_isinf_impl,
         'D->?': npyfuncs.np_complex_isinf_impl,
+        # int8
+        'b->?': npyfuncs.np_int_isinf_impl,
+        'B->?': npyfuncs.np_int_isinf_impl,
+        # int16
+        'h->?': npyfuncs.np_int_isinf_impl,
+        'H->?': npyfuncs.np_int_isinf_impl,
+        # int32
+        'i->?': npyfuncs.np_int_isinf_impl,
+        'I->?': npyfuncs.np_int_isinf_impl,
+        # int64
+        'l->?': npyfuncs.np_int_isinf_impl,
+        'L->?': npyfuncs.np_int_isinf_impl,
+        # intp
+        'q->?': npyfuncs.np_int_isinf_impl,
+        'Q->?': npyfuncs.np_int_isinf_impl,
     }
 
     ufunc_db[np.isfinite] = {
@@ -802,6 +832,21 @@ def _fill_ufunc_db(ufunc_db):
         'd->?': npyfuncs.np_real_isfinite_impl,
         'F->?': npyfuncs.np_complex_isfinite_impl,
         'D->?': npyfuncs.np_complex_isfinite_impl,
+        # int8
+        'b->?': npyfuncs.np_int_isfinite_impl,
+        'B->?': npyfuncs.np_int_isfinite_impl,
+        # int16
+        'h->?': npyfuncs.np_int_isfinite_impl,
+        'H->?': npyfuncs.np_int_isfinite_impl,
+        # int32
+        'i->?': npyfuncs.np_int_isfinite_impl,
+        'I->?': npyfuncs.np_int_isfinite_impl,
+        # int64
+        'l->?': npyfuncs.np_int_isfinite_impl,
+        'L->?': npyfuncs.np_int_isfinite_impl,
+        # intp
+        'q->?': npyfuncs.np_int_isfinite_impl,
+        'Q->?': npyfuncs.np_int_isfinite_impl,
     }
 
     ufunc_db[np.signbit] = {

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -803,6 +803,8 @@ def _fill_ufunc_db(ufunc_db):
         # intp
         'q->?': npyfuncs.np_int_isnan_impl,
         'Q->?': npyfuncs.np_int_isnan_impl,
+        # boolean
+        '?->?': npyfuncs.np_int_isnan_impl,
     }
 
     ufunc_db[np.isinf] = {
@@ -825,6 +827,8 @@ def _fill_ufunc_db(ufunc_db):
         # intp
         'q->?': npyfuncs.np_int_isinf_impl,
         'Q->?': npyfuncs.np_int_isinf_impl,
+        # boolean
+        '?->?': npyfuncs.np_int_isinf_impl,
     }
 
     ufunc_db[np.isfinite] = {
@@ -847,6 +851,8 @@ def _fill_ufunc_db(ufunc_db):
         # intp
         'q->?': npyfuncs.np_int_isfinite_impl,
         'Q->?': npyfuncs.np_int_isfinite_impl,
+        # boolean
+        '?->?': npyfuncs.np_int_isfinite_impl,
     }
 
     ufunc_db[np.signbit] = {

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -139,6 +139,13 @@ class BaseUFuncTest(MemoryLeakMixin):
             (np.array([-1,0,1], dtype='i8'), types.Array(types.int64, 1, 'C')),
             (np.array([-0.5, 0.0, 0.5], dtype='f4'), types.Array(types.float32, 1, 'C')),
             (np.array([-0.5, 0.0, 0.5], dtype='f8'), types.Array(types.float64, 1, 'C')),
+
+            (np.array([0,1], dtype=np.int8), types.Array(types.int8, 1, 'C')),
+            (np.array([0,1], dtype=np.int16), types.Array(types.int16, 1, 'C')),
+            (np.array([0,1], dtype=np.uint8), types.Array(types.uint8, 1, 'C')),
+            (np.array([0,1], dtype=np.uint16), types.Array(types.uint16, 1, 'C')),
+
+            (np.array([False,True], dtype=np.bool_), types.Array(types.bool_, 1, 'C')),
             ]
         self.cache = CompilationCache()
 
@@ -619,7 +626,7 @@ class TestUFuncs(BaseUFuncTest, TestCase):
 
     @tag('important')
     def test_isnan_ufunc(self, flags=no_pyobj_flags):
-        self.unary_ufunc_test(np.isnan, flags=flags)
+        self.unary_ufunc_test(np.isnan, flags=flags, kinds='ifcb')
 
     @tag('important')
     def test_signbit_ufunc(self, flags=no_pyobj_flags):

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -144,8 +144,6 @@ class BaseUFuncTest(MemoryLeakMixin):
             (np.array([0,1], dtype=np.int16), types.Array(types.int16, 1, 'C')),
             (np.array([0,1], dtype=np.uint8), types.Array(types.uint8, 1, 'C')),
             (np.array([0,1], dtype=np.uint16), types.Array(types.uint16, 1, 'C')),
-
-            (np.array([False,True], dtype=np.bool_), types.Array(types.bool_, 1, 'C')),
             ]
         self.cache = CompilationCache()
 
@@ -616,17 +614,33 @@ class TestUFuncs(BaseUFuncTest, TestCase):
 
     ############################################################################
     # Floating functions
+
+    def bool_additional_inputs(self):
+        return [
+            (np.array([True, False], dtype=np.bool_),
+             types.Array(types.bool_, 1, 'C')),
+            ]
+
     @tag('important')
     def test_isfinite_ufunc(self, flags=no_pyobj_flags):
-        self.unary_ufunc_test(np.isfinite, flags=flags)
+        self.unary_ufunc_test(
+            np.isfinite, flags=flags, kinds='ifcb',
+            additional_inputs=self.bool_additional_inputs(),
+        )
 
     @tag('important')
     def test_isinf_ufunc(self, flags=no_pyobj_flags):
-        self.unary_ufunc_test(np.isinf, flags=flags)
+        self.unary_ufunc_test(
+            np.isinf, flags=flags, kinds='ifcb',
+            additional_inputs=self.bool_additional_inputs(),
+        )
 
     @tag('important')
     def test_isnan_ufunc(self, flags=no_pyobj_flags):
-        self.unary_ufunc_test(np.isnan, flags=flags, kinds='ifcb')
+        self.unary_ufunc_test(
+            np.isnan, flags=flags, kinds='ifcb',
+            additional_inputs=self.bool_additional_inputs(),
+        )
 
     @tag('important')
     def test_signbit_ufunc(self, flags=no_pyobj_flags):


### PR DESCRIPTION
Closes https://github.com/numba/numba/issues/4319.

Numpy1.17 added specialized loops for `isnan`, `isinf` and `isfinite` for boolean and integer dtypes.  This patch adds those specialization into numba.