### PR TITLE
Add allocation hoisting info to LICM section at diagnostic L4

### DIFF
--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -824,10 +824,12 @@ class ParforDiagnostics(object):
         if level in (2, 3, 4):
             print_pre_optimised = True
 
+        if level in (3, 4):
+            print_allocation_hoist = True
+
         if level == 3:
             print_fusion_summary = True
             print_loopnest_rewrite = True
-            print_allocation_hoist = True
 
         if level == 4:
             print_fusion_search = True


### PR DESCRIPTION
This makes it so that allocation hoisting is spelled out at L4
and L3 of parfors diagnostics. It's easier interpreting the
instruction hoisting section in L4 if the allocation hoists are
noted a priori.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
