### PR TITLE
Fix nump1.17 random function non-aliasing

### DIFF
--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -219,6 +219,8 @@ def random_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 @lower("np.random.random")
+@lower("np.random.random_sample")
+@lower("np.random.ranf")
 def random_impl(context, builder, sig, args):
     state_ptr = get_state_ptr(context, builder, "np")
     res = get_next_double(context, builder, state_ptr)

--- a/numba/targets/randomimpl.py
+++ b/numba/targets/randomimpl.py
@@ -220,6 +220,7 @@ def random_impl(context, builder, sig, args):
 
 @lower("np.random.random")
 @lower("np.random.random_sample")
+@lower("np.random.sample")
 @lower("np.random.ranf")
 def random_impl(context, builder, sig, args):
     state_ptr = get_state_ptr(context, builder, "np")

--- a/numba/typing/randomdecl.py
+++ b/numba/typing/randomdecl.py
@@ -7,6 +7,7 @@ import numpy as np
 from .. import types
 from .templates import (ConcreteTemplate, AbstractTemplate, AttributeTemplate,
                         CallableTemplate, Registry, signature)
+from ..numpy_support import version as np_version
 
 
 registry = Registry()
@@ -98,8 +99,6 @@ class Random_getrandbits(ConcreteTemplate):
 
 @infer_global(random.random, typing_key="random.random")
 @infer_global(np.random.random, typing_key="np.random.random")
-@infer_global(np.random.random_sample, typing_key="np.random.random_sample")
-@infer_global(np.random.ranf, typing_key="np.random.ranf")
 class Random_random(ConcreteRandomTemplate):
     cases = [signature(types.float64)]
 
@@ -107,6 +106,20 @@ class Random_random(ConcreteRandomTemplate):
         def typer(size=None):
             return self.array_typer(size)()
         return typer
+
+if np_version >= (1, 17):
+    infer_global(
+        np.random.random_sample,
+        typing_key="np.random.random_sample",
+    )(Random_random)
+    infer_global(
+        np.random.sample,
+        typing_key="np.random.sample",
+    )(Random_random)
+    infer_global(
+        np.random.ranf,
+        typing_key="np.random.ranf",
+    )(Random_random)
 
 
 @infer_global(random.randint, typing_key="random.randint")

--- a/numba/typing/randomdecl.py
+++ b/numba/typing/randomdecl.py
@@ -98,6 +98,8 @@ class Random_getrandbits(ConcreteTemplate):
 
 @infer_global(random.random, typing_key="random.random")
 @infer_global(np.random.random, typing_key="np.random.random")
+@infer_global(np.random.random_sample, typing_key="np.random.random_sample")
+@infer_global(np.random.ranf, typing_key="np.random.ranf")
 class Random_random(ConcreteRandomTemplate):
     cases = [signature(types.float64)]
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

In Numpy1.17, the aliasing of `np.random.random` to `ranf`, `random_sample`, and `sample` is removed.  This patch makes explicitly registration of these symbols.
