### PR TITLE
Set maximum name size to maximum allowable value

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -102,6 +102,11 @@ def _ensure_llvm():
                "Please update llvmlite." %
                (_min_llvm_version + llvm_version_info))
         raise ImportError(msg)
+    
+    try:
+        llvmlite.binding.set_option("tmp", "-non-global-value-max-name-size=4294967295")
+    except:
+        pass
 
     check_jit_execution()
 


### PR DESCRIPTION
Fix for #3876 without needing to patch LLVM.