### PR TITLE
np.alen

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -298,6 +298,7 @@ Other functions
 
 The following top-level functions are supported:
 
+* :func:`numpy.alen`
 * :func:`numpy.arange`
 * :func:`numpy.argsort` (``kind`` key word argument supported for values
   ``'quicksort'`` and ``'mergesort'``)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2867,6 +2867,17 @@ def np_imag(a):
 #----------------------------------------------------------------------------
 # Misc functions
 
+@overload(np.alen)
+def np_alen(a):
+    if not type_can_asarray(a):
+        raise errors.TypingError("The argument to np.shape must be array-like")
+
+    def impl(a):
+        return np.asarray(a).shape[0]
+    return impl
+
+
+
 np_delete_handler_isslice = register_jitable(lambda x : x)
 np_delete_handler_isarray = register_jitable(lambda x : np.asarray(x))
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2872,14 +2872,9 @@ def np_alen(a):
     if not isinstance(a, (types.Array, types.UnicodeType)):
         raise TypingError("The argument to np.alen must be array-like or a string")
 
-    if isinstance(a, types.Array):
-        def impl_arr(a):
-            return np.asarray(a).shape[0]
-        return impl_arr
-    else:
-        def impl_str(a):
-            return len(a)
-        return impl_str
+    def impl(a):
+        return len(a)
+    return impl
 
 
 np_delete_handler_isslice = register_jitable(lambda x : x)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2869,13 +2869,17 @@ def np_imag(a):
 
 @overload(np.alen)
 def np_alen(a):
-    if not type_can_asarray(a):
-        raise errors.TypingError("The argument to np.shape must be array-like")
+    if not isinstance(a, (types.Array, types.UnicodeType)):
+        raise TypingError("The argument to np.alen must be array-like or a string")
 
-    def impl(a):
-        return np.asarray(a).shape[0]
-    return impl
-
+    if isinstance(a, types.Array):
+        def impl_arr(a):
+            return np.asarray(a).shape[0]
+        return impl_arr
+    else:
+        def impl_str(a):
+            return len(a)
+        return impl_str
 
 
 np_delete_handler_isslice = register_jitable(lambda x : x)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -385,6 +385,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield np.array([[1, 2], [3, 4]])
             yield np.arange(10)
             yield np.arange(3 * 4 * 5).reshape(3, 4, 5)
+            yield "abcd"
+            yield ""
 
         pyfunc = alen
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -33,6 +33,10 @@ def angle2(x, deg):
     return np.angle(x, deg)
 
 
+def alen(arr):
+    return np.alen(arr)
+
+
 def delete(arr, obj):
     return np.delete(arr, obj)
 
@@ -374,6 +378,21 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x_values = np.array(x_values)
         x_types = [types.complex64, types.complex128]
         check(x_types, x_values)
+
+    def test_alen(self):
+        def arrays():
+            yield np.array([])
+            yield np.array([[1, 2], [3, 4]])
+            yield np.arange(10)
+            yield np.arange(3 * 4 * 5).reshape(3, 4, 5)
+
+        pyfunc = alen
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for arr in arrays():
+            expected = pyfunc(arr)
+            got = cfunc(arr)
+            self.assertPreciseEqual(expected, got)
 
     # hits "Invalid PPC CTR loop!" issue on power systems, see e.g. #4026
     @unittest.skipIf(platform.machine() == 'ppc64le', "LLVM bug")


### PR DESCRIPTION
This PR implements `np.alen`. 

I didn't include any test using regular lists because the usage of [reflection lists](http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types) is being deprecated.