### PR TITLE
Implement np.count_nonzero

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -317,7 +317,7 @@ The following top-level functions are supported:
 * :func:`numpy.corrcoef` (only the 3 first arguments, requires NumPy >= 1.10 and
   SciPy >= 0.16; extreme value handling per NumPy 1.11+)
 * :func:`numpy.correlate` (only the 2 first arguments)
-* :func:`numpy.count_nonzero` (axis only support scalar values)
+* :func:`numpy.count_nonzero` (axis only supports scalar values)
 * :func:`numpy.cov` (only the 5 first arguments, requires NumPy >= 1.10 and SciPy >= 0.16)
 * :func:`numpy.delete` (only the 2 first arguments)
 * :func:`numpy.diag`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -317,6 +317,7 @@ The following top-level functions are supported:
 * :func:`numpy.corrcoef` (only the 3 first arguments, requires NumPy >= 1.10 and
   SciPy >= 0.16; extreme value handling per NumPy 1.11+)
 * :func:`numpy.correlate` (only the 2 first arguments)
+* :func:`numpy.count_nonzero` (axis only support scalar values)
 * :func:`numpy.cov` (only the 5 first arguments, requires NumPy >= 1.10 and SciPy >= 0.16)
 * :func:`numpy.delete` (only the 2 first arguments)
 * :func:`numpy.diag`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -10,7 +10,6 @@ from enum import IntEnum
 from functools import partial
 
 import numpy as np
-from numpy.lib import NumpyVersion
 
 from llvmlite import ir
 import llvmlite.llvmpy.core as lc
@@ -2873,10 +2872,10 @@ def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
         raise TypingError("The argument to np.count_nonzero must be array-like")
 
-    if (NumpyVersion(np.__version__) < '1.12.0'):
-        raise TypingError("axis is not supported on Numpy versions < 1.12.0")
+    if (numpy_version < (1, 12)):
+        raise TypingError("axis is not supported for NumPy versions < 1.12.0")
 
-    if (axis in (None, types.none)):
+    if _is_nonelike(axis):
         def impl(arr, axis=None):
             arr2 = np.ravel(arr)
             return np.sum(arr2 != 0)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -28,7 +28,6 @@ from .linalg import ensure_blas
 
 from numba.extending import intrinsic
 from numba.errors import RequireLiteralValue, TypingError
-import warnings
 
 def _check_blas():
     # Checks if a BLAS is available so e.g. dot will work
@@ -2874,10 +2873,10 @@ def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
         raise errors.TypingError("The argument to np.count_nonzero must be array-like")
     
-    if (NumpyVersion(np.__version__) < '1.12.0') and (axis in (None, types.none)):
-        warnings.warn("axis is not supported on Numpy versions < '1.12.0'")
+    if (NumpyVersion(np.__version__) < '1.12.0'):
+        raise TypingError("axis is not supported on Numpy versions < 1.12.0")
 
-    if (axis in (None, types.none)) or (NumpyVersion(np.__version__) < '1.12.0'):
+    if (axis in (None, types.none)):
         def impl(arr, axis=None):
             arr2 = np.ravel(arr)
             return np.sum(arr2 != 0)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -10,6 +10,7 @@ from enum import IntEnum
 from functools import partial
 
 import numpy as np
+from numpy.lib import NumpyVersion
 
 from llvmlite import ir
 import llvmlite.llvmpy.core as lc
@@ -27,6 +28,7 @@ from .linalg import ensure_blas
 
 from numba.extending import intrinsic
 from numba.errors import RequireLiteralValue, TypingError
+import warnings
 
 def _check_blas():
     # Checks if a BLAS is available so e.g. dot will work
@@ -2871,8 +2873,11 @@ def np_imag(a):
 def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
         raise errors.TypingError("The argument to np.count_nonzero must be array-like")
+    
+    if (NumpyVersion(np.__version__) < '1.12.0') and (axis in (None, types.none)):
+        warnings.warn("axis is not supported on Numpy versions < '1.12.0'")
 
-    if axis in (None, types.none):
+    if (axis in (None, types.none)) or (NumpyVersion(np.__version__) < '1.12.0'):
         def impl(arr, axis=None):
             arr2 = np.ravel(arr)
             return np.sum(arr2 != 0)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2870,7 +2870,7 @@ def np_imag(a):
 @overload(np.count_nonzero)
 def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
-        raise errors.TypingError("The argument to np.shape must be array-like")
+        raise errors.TypingError("The argument to np.count_nonzero must be array-like")
 
     if axis in (None, types.none):
         def impl(arr, axis=None):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2872,7 +2872,7 @@ def np_imag(a):
 def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
         raise TypingError("The argument to np.count_nonzero must be array-like")
-    
+
     if (NumpyVersion(np.__version__) < '1.12.0'):
         raise TypingError("axis is not supported on Numpy versions < 1.12.0")
 

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2871,7 +2871,7 @@ def np_imag(a):
 @overload(np.count_nonzero)
 def np_count_nonzero(arr, axis=None):
     if not type_can_asarray(arr):
-        raise errors.TypingError("The argument to np.count_nonzero must be array-like")
+        raise TypingError("The argument to np.count_nonzero must be array-like")
     
     if (NumpyVersion(np.__version__) < '1.12.0'):
         raise TypingError("axis is not supported on Numpy versions < 1.12.0")

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -2867,6 +2867,23 @@ def np_imag(a):
 #----------------------------------------------------------------------------
 # Misc functions
 
+@overload(np.count_nonzero)
+def np_count_nonzero(arr, axis=None):
+    if not type_can_asarray(arr):
+        raise errors.TypingError("The argument to np.shape must be array-like")
+
+    if axis in (None, types.none):
+        def impl(arr, axis=None):
+            arr2 = np.ravel(arr)
+            return np.sum(arr2 != 0)
+    else:
+        def impl(arr, axis=None):
+            arr2 = arr.astype(np.bool_)
+            return np.sum(arr2, axis=axis)
+
+    return impl
+
+
 np_delete_handler_isslice = register_jitable(lambda x : x)
 np_delete_handler_isarray = register_jitable(lambda x : np.asarray(x))
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -33,7 +33,7 @@ def angle2(x, deg):
     return np.angle(x, deg)
 
 
-def count_nonzero(arr, axis=None):
+def count_nonzero(arr, axis):
     return np.count_nonzero(arr, axis)
 
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -398,20 +398,19 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             expected = pyfunc(arr, axis)
             got = cfunc(arr, axis)
             self.assertPreciseEqual(expected, got)
-            
+
     @unittest.skipUnless(NumpyVersion(np.__version__) < '1.12.0', "Numpy bug")
     def test_count_nonzero_exception(self):
         pyfunc = count_nonzero
         cfunc = jit(nopython=True)(pyfunc)
         self.disable_leak_check()
-        
+
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(3 * 4).reshape(3, 4), 0)
         self.assertIn(
             "axis is not supported on Numpy versions < 1.12.0",
             str(raises.exception)
         )
-        
 
     # hits "Invalid PPC CTR loop!" issue on power systems, see e.g. #4026
     @unittest.skipIf(platform.machine() == 'ppc64le', "LLVM bug")

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -406,7 +406,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(3 * 4).reshape(3, 4), 0)
         self.assertIn(
-            "axis is not supported on NumPy versions < 1.12.0",
+            "axis is not supported for NumPy versions < 1.12.0",
             str(raises.exception)
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -379,7 +379,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x_types = [types.complex64, types.complex128]
         check(x_types, x_values)
 
-    @unittest.skipIf(np_version < (1, 12), "Numpy Unsupported")
+    @unittest.skipIf(np_version < (1, 12), "NumPy Unsupported")
     def test_count_nonzero(self):
 
         def arrays():
@@ -398,7 +398,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(arr, axis)
             self.assertPreciseEqual(expected, got)
 
-    @unittest.skipUnless(np_version < (1, 12), "Numpy Unsupported")
+    @unittest.skipUnless(np_version < (1, 12), "NumPy Unsupported")
     def test_count_nonzero_exception(self):
         pyfunc = count_nonzero
         cfunc = jit(nopython=True)(pyfunc)
@@ -406,7 +406,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(3 * 4).reshape(3, 4), 0)
         self.assertIn(
-            "axis is not supported on Numpy versions < 1.12.0",
+            "axis is not supported on NumPy versions < 1.12.0",
             str(raises.exception)
         )
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -34,7 +34,7 @@ def angle2(x, deg):
 
 
 def count_nonzero(arr, axis):
-    return np.count_nonzero(arr, axis)
+    return np.count_nonzero(arr, axis=axis)
 
 
 def delete(arr, obj):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -7,7 +7,6 @@ import platform
 from functools import partial
 
 import numpy as np
-from numpy.lib import NumpyVersion
 
 from numba import unittest_support as unittest
 from numba.compiler import Flags
@@ -380,7 +379,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x_types = [types.complex64, types.complex128]
         check(x_types, x_values)
 
-    @unittest.skipIf(NumpyVersion(np.__version__) < '1.12.0', "Numpy bug")
+    @unittest.skipIf(np_version < (1, 12), "Numpy Unsupported")
     def test_count_nonzero(self):
 
         def arrays():
@@ -399,11 +398,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             got = cfunc(arr, axis)
             self.assertPreciseEqual(expected, got)
 
-    @unittest.skipUnless(NumpyVersion(np.__version__) < '1.12.0', "Numpy bug")
+    @unittest.skipUnless(np_version < (1, 12), "Numpy Unsupported")
     def test_count_nonzero_exception(self):
         pyfunc = count_nonzero
         cfunc = jit(nopython=True)(pyfunc)
-        self.disable_leak_check()
 
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(3 * 4).reshape(3, 4), 0)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -33,6 +33,10 @@ def angle2(x, deg):
     return np.angle(x, deg)
 
 
+def count_nonzero(arr, axis=None):
+    return np.count_nonzero(arr, axis)
+
+
 def delete(arr, obj):
     return np.delete(arr, obj)
 
@@ -374,6 +378,25 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         x_values = np.array(x_values)
         x_types = [types.complex64, types.complex128]
         check(x_types, x_values)
+
+    def test_count_nonzero(self):
+
+        def arrays():
+            yield np.array([]), None
+            yield np.zeros(10), None
+            yield np.arange(10), None
+            yield np.arange(3 * 4 * 5).reshape(3, 4, 5), None
+            yield np.arange(3 * 4).reshape(3, 4), 0
+            yield np.arange(3 * 4).reshape(3, 4), 1
+            # yield np.arange(3 * 4 * 5).reshape((3, 4, 5)), (0, 1)
+
+        pyfunc = count_nonzero
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for arr, axis in arrays():
+            expected = pyfunc(arr, axis)
+            got = cfunc(arr, axis)
+            self.assertPreciseEqual(expected, got)
 
     # hits "Invalid PPC CTR loop!" issue on power systems, see e.g. #4026
     @unittest.skipIf(platform.machine() == 'ppc64le', "LLVM bug")

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -388,7 +388,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield np.arange(3 * 4 * 5).reshape(3, 4, 5), None
             yield np.arange(3 * 4).reshape(3, 4), 0
             yield np.arange(3 * 4).reshape(3, 4), 1
-            # yield np.arange(3 * 4 * 5).reshape((3, 4, 5)), (0, 1)
 
         pyfunc = count_nonzero
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
This PR implements `np.count_nonzero`. I didn't include tests with `axis` as a tuple because `np.sum` does not support it at this time. Maybe this observation should be included on `numpysupported.rst` as well.