### PR TITLE
Add note about np.sum

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -210,7 +210,8 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.repeat` (no axis argument)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
 * :meth:`~numpy.ndarray.sort` (without arguments)
-* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument. ``axis`` only supports ``integer`` values)
+* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument. 
+  ``axis`` only supports ``integer`` values)
 
   * If the ``axis`` argument is a compile-time constant, all valid values are supported.
     An out-of-range value will result in a ``LoweringError`` at compile-time.

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -210,7 +210,7 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.repeat` (no axis argument)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
 * :meth:`~numpy.ndarray.sort` (without arguments)
-* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument)
+* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument. ``axis`` only supports scalar values)
 
   * If the ``axis`` argument is a compile-time constant, all valid values are supported.
     An out-of-range value will result in a ``LoweringError`` at compile-time.

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -210,7 +210,7 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.repeat` (no axis argument)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)
 * :meth:`~numpy.ndarray.sort` (without arguments)
-* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument. ``axis`` only supports scalar values)
+* :meth:`~numpy.ndarray.sum` (with or without the ``axis`` argument. ``axis`` only supports ``integer`` values)
 
   * If the ``axis`` argument is a compile-time constant, all valid values are supported.
     An out-of-range value will result in a ``LoweringError`` at compile-time.


### PR DESCRIPTION
Following up on #4386. This PR adds a note about `np.sum` not supporting tuples on its `axis` parameter.