### PR TITLE
Add exception chaining for better error context

### DIFF
--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -147,20 +147,21 @@ class ConstraintNetwork(object):
                     constraint(typeinfer)
                 except TypingError as e:
                     _logger.debug("captured error", exc_info=e)
-                    e = TypingError(str(e),
-                                    loc=constraint.loc,
-                                    highlighting=False)
-                    errors.append(e)
+                    new_exc = TypingError(
+                        str(e), loc=constraint.loc,
+                        highlighting=False,
+                    )
+                    errors.append(utils.chain_exception(new_exc, e))
                 except Exception as e:
                     _logger.debug("captured error", exc_info=e)
                     msg = ("Internal error at {con}.\n"
                            "{err}\nEnable logging at debug level for details.")
-                    e = TypingError(
+                    new_exc = TypingError(
                         msg.format(con=constraint, err=str(e)),
                         loc=constraint.loc,
                         highlighting=False,
                     )
-                    errors.append(e)
+                    errors.append(utils.chain_exception(new_exc, e))
         return errors
 
 

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -21,7 +21,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
-from numba.config import PYVERSION, MACHINE_BITS
+from numba.config import PYVERSION, MACHINE_BITS, DEVELOPER_MODE
 
 
 IS_PY3 = PYVERSION >= (3, 0)
@@ -762,5 +762,6 @@ def chain_exception(new_exc, old_exc):
     """Set the __cause__ attribute on *new_exc* for explicit exception
     chaining.  Returns the inplace modified *new_exc*.
     """
-    new_exc.__cause__ = old_exc
+    if DEVELOPER_MODE:
+        new_exc.__cause__ = old_exc
     return new_exc

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -756,3 +756,11 @@ class finalize:
 # dummy invocation to force _at_shutdown() to be registered
 finalize(lambda: None, lambda: None)
 assert finalize._registered_with_atexit
+
+
+def chain_exception(new_exc, old_exc):
+    """Set the __cause__ attribute on *new_exc* for explicit exception
+    chaining.  Returns the inplace modified *new_exc*.
+    """
+    new_exc.__cause__ = old_exc
+    return new_exc


### PR DESCRIPTION
On py3, setting the `__cause__` on exception enables exception chaining to that we can pinpoint to actual source of the error during type inference.  

Note for reviewers, is the extra traceback making the error messages too scary for users?