### PR TITLE
Fix #4387. Limit the number of return types for recursive functions

### DIFF
--- a/numba/tests/recursion_usecases.py
+++ b/numba/tests/recursion_usecases.py
@@ -215,3 +215,14 @@ def make_optional_return_case(jit=lambda x: x):
             return x * bar(out)
 
     return bar
+
+
+def make_growing_tuple_case(jit=lambda x: x):
+    # From issue #4387
+    @jit
+    def make_list(n):
+        if n <= 0:
+            return None
+
+        return (n, make_list(n - 1))
+    return make_list

--- a/numba/tests/test_recursion.py
+++ b/numba/tests/test_recursion.py
@@ -64,6 +64,7 @@ class TestSelfRecursion(TestCase):
             str(raises.exception),
         )
 
+
 class TestMutualRecursion(TestCase):
 
     def setUp(self):

--- a/numba/tests/test_recursion.py
+++ b/numba/tests/test_recursion.py
@@ -55,6 +55,14 @@ class TestSelfRecursion(TestCase):
         for arg in (0, 5, 10, 15):
             self.assertEqual(pfunc(arg), cfunc(arg))
 
+    def test_growing_return_tuple(self):
+        cfunc = self.mod.make_growing_tuple_case(jit(nopython=True))
+        with self.assertRaises(TypingError) as raises:
+            cfunc(100)
+        self.assertIn(
+            "Return type of recursive function does not converge",
+            str(raises.exception),
+        )
 
 class TestMutualRecursion(TestCase):
 

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1320,6 +1320,8 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
 
             sig = typing.signature(return_type, *args)
             sig.pysig = pysig
+            # Keep track of unique return_type
+            frame.add_return_type(return_type)
             return sig
         else:
             # Normal non-recursive call

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -8,7 +8,7 @@ import contextlib
 import operator
 
 import numba
-from numba import types, errors
+from numba import types, errors, config
 from numba.typeconv import Conversion, rules
 from . import templates
 from .typeof import typeof, Purpose
@@ -110,9 +110,22 @@ class CallFrame(object):
         self.typeinfer = typeinfer
         self.func_id = func_id
         self.args = args
+        self._inferred_retty = set()
 
     def __repr__(self):
         return "CallFrame({}, {})".format(self.func_id, self.args)
+
+    def add_return_type(self, return_type):
+        """Add *return_type* to the list of inferred return-types.
+        If there are too many, raise `TypingError`.
+        """
+        # The maximum limit is picked arbitrarily.
+        # Don't think that this needs to be user configurable.
+        RETTY_LIMIT = 16
+        self._inferred_retty.add(return_type)
+        if len(self._inferred_retty) >= RETTY_LIMIT:
+            m = "Return type of recursive function does not converge"
+            raise errors.TypingError(m)
 
 
 class BaseContext(object):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -8,7 +8,7 @@ import contextlib
 import operator
 
 import numba
-from numba import types, errors, config
+from numba import types, errors
 from numba.typeconv import Conversion, rules
 from . import templates
 from .typeof import typeof, Purpose


### PR DESCRIPTION
to stop infinite loop at type inference

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
