### PR TITLE
Unicode array support

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -44,6 +44,9 @@ from numba.withcontexts import objmode_context as objmode
 # Initialize typed containers
 import numba.typed
 
+# Enable bytes/unicode array support
+import numba.charseq
+
 # Keep this for backward compatibility.
 test = runtests.main
 

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -44,8 +44,10 @@ from numba.withcontexts import objmode_context as objmode
 # Initialize typed containers
 import numba.typed
 
-# Enable bytes/unicode array support
-import numba.charseq
+# Enable bytes/unicode array support (Python 3.x only)
+from .utils import IS_PY3
+if IS_PY3:
+    import numba.charseq
 
 # Keep this for backward compatibility.
 test = runtests.main

--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -600,9 +600,7 @@ def charseq_str(s):
 @overload(bytes)
 def charseq_bytes(s):
     if isinstance(s, types.CharSeq):
-        def bytes_impl(s):
-            return s
-        return bytes_impl
+        return lambda s: s
 
 
 @overload_method(types.UnicodeCharSeq, '__hash__')

--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -1,5 +1,4 @@
-""" Implements support for bytes and str (unicode) arrays.
-"""
+"""Implements operations on bytes and str (unicode) array items."""
 import operator
 import numpy as np
 from llvmlite import ir
@@ -10,7 +9,9 @@ from numba.extending import overload, intrinsic
 # bytes and str arrays items are of type CharSeq and UnicodeCharSeq,
 # respectively.  See numpy/types/npytypes.py for CharSeq,
 # UnicodeCharSeq definitions.  The corresponding data models are
-# defined in numpy/datamodel/models.py
+# defined in numpy/datamodel/models.py. Boxing/unboxing of item types
+# are defined in numpy/targets/boxing.py, see box_unicodecharseq,
+# unbox_unicodecharseq, box_charseq, unbox_charseq.
 
 s1_dtype = np.dtype('S1')
 assert s1_dtype.itemsize == 1

--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -165,7 +165,7 @@ def bytes_to_charseq(context, builder, fromty, toty, val):
 
     lty = context.get_value_type(toty)
     dstint_t = ir.IntType(8)
-    dst_ptr = builder.alloca(lty)
+    dst_ptr = cgutils.alloca_once(builder, lty)
     dst = builder.bitcast(dst_ptr, dstint_t.as_pointer())
 
     dst_length = ir.Constant(src_length.type, toty.count)
@@ -196,8 +196,9 @@ def _make_constant_bytes(context, builder, nbytes):
     bstr.itemsize = ir.Constant(bstr.itemsize.type, 1)
     bstr.data = context.nrt.meminfo_data(builder, bstr.meminfo)
     bstr.parent = cgutils.get_null_value(bstr.parent.type)
-    # bstr.shapes = ?
-    # bstr.strides = ?
+    # bstr.shape and bstr.strides are not used
+    bstr.shape = cgutils.get_null_value(bstr.shape.type)
+    bstr.strides = cgutils.get_null_value(bstr.strides.type)
     return bstr
 
 
@@ -252,7 +253,7 @@ def unicode_to_unicode_charseq(context, builder, fromty, toty, val):
 
     lty = context.get_value_type(toty)
     dstint_t = ir.IntType(8 * unicode_byte_width)
-    dst_ptr = builder.alloca(lty)
+    dst_ptr = cgutils.alloca_once(builder, lty)
     dst = builder.bitcast(dst_ptr, dstint_t.as_pointer())
 
     dst_length = ir.Constant(src_length.type, toty.count)

--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -1,0 +1,183 @@
+""" Implements support for bytes and str (unicode) arrays.
+"""
+import operator
+import numpy as np
+from llvmlite import ir
+
+from numba import njit, types, cgutils
+from numba.extending import overload, intrinsic
+
+# bytes and str arrays items are of type CharSeq and UnicodeCharSeq,
+# respectively.  See numpy/types/npytypes.py for CharSeq,
+# UnicodeCharSeq definitions.  The corresponding data models are
+# defined in numpy/datamodel/models.py
+
+s1_dtype = np.dtype('S1')
+assert s1_dtype.itemsize == 1
+
+u1_dtype = np.dtype('U1')
+unicode_byte_width = u1_dtype.itemsize
+unicode_uint = {1: np.uint8, 2: np.uint16, 4: np.uint32}[unicode_byte_width]
+
+
+# this is modified version of numba.unicode.make_deref_codegen
+def make_deref_codegen(bitsize):
+    def codegen(context, builder, signature, args):
+        data, idx = args
+        # XXX how to access data (of type CharSeq/UnicodeCharSeq)
+        # without alloca?
+        rawptr = cgutils.alloca_once_value(builder, value=data)
+        ptr = builder.bitcast(rawptr, ir.IntType(bitsize).as_pointer())
+        ch = builder.load(builder.gep(ptr, [idx]))
+        return builder.zext(ch, ir.IntType(32))
+    return codegen
+
+
+@intrinsic
+def deref_uint8(typingctx, data, offset):
+    sig = types.uint32(data, types.intp)
+    return sig, make_deref_codegen(8)
+
+
+@intrinsic
+def deref_uint16(typingctx, data, offset):
+    sig = types.uint32(data, types.intp)
+    return sig, make_deref_codegen(16)
+
+
+@intrinsic
+def deref_uint32(typingctx, data, offset):
+    sig = types.uint32(data, types.intp)
+    return sig, make_deref_codegen(32)
+
+
+@njit(_nrt=False)
+def charseq_get_code(a, i):
+    """Access i-th item of CharSeq instance via code value
+    """
+    return deref_uint8(a, i)
+
+
+@njit
+def charseq_get_value(a, i):
+    """Access i-th item of CharSeq instance via code value.
+
+    null code is interpreted as IndexError
+    """
+    code = charseq_get_code(a, i)
+    if code == 0:
+        raise IndexError('index out of range')
+    return code
+
+
+@njit(_nrt=False)
+def unicode_charseq_get_code(a, i):
+    """Access i-th item of UnicodeCharSeq instance via code value
+    """
+    if unicode_byte_width == 4:
+        return deref_uint32(a, i)
+    elif unicode_byte_width == 2:
+        return deref_uint16(a, i)
+    elif unicode_byte_width == 1:
+        return deref_uint8(a, i)
+    else:
+        raise NotImplementedError(
+            'unicode_charseq_get_code: unicode_byte_width not in [1, 2, 4]')
+
+
+@njit
+def unicode_charseq_get_value(a, i):
+    """Access i-th item of UnicodeCharSeq instance via unicode value
+
+    null code is interpreted as IndexError
+    """
+    code = unicode_charseq_get_code(a, i)
+    if code == 0:
+        raise IndexError('index out of range')
+    # Return numpy equivalent of `chr(code)`
+    return np.array(code, unicode_uint).view(u1_dtype)[()]
+
+#
+#   Operators on bytes/unicode array items
+#
+
+
+@overload(operator.getitem)
+def charseq_getitem(s, i):
+    return_impl = False
+    if isinstance(i, types.Integer):
+        if isinstance(s, types.CharSeq):
+            return_impl = True
+            get_value = charseq_get_value
+        if isinstance(s, types.UnicodeCharSeq):
+            return_impl = True
+            get_value = unicode_charseq_get_value
+    if return_impl:
+        max_i = s.count
+        msg = 'index out of range [0, %s]' % (max_i - 1)
+
+        def getitem_impl(s, i):
+            if i < max_i and i >= 0:
+                return get_value(s, i)
+            raise IndexError(msg)
+        return getitem_impl
+
+
+@overload(len)
+def charseq_len(s):
+    return_impl = False
+    if isinstance(s, types.CharSeq):
+        return_impl = True
+        get_code = charseq_get_code
+    if isinstance(s, types.UnicodeCharSeq):
+        return_impl = True
+        get_code = unicode_charseq_get_code
+    if return_impl:
+        n = s.count
+        if n == 0:
+            def len_impl(s):
+                return 0
+        else:
+            def len_impl(s):
+                # return the index of the last non-null value (numpy
+                # behavior)
+                i = n
+                code = 0
+                while code == 0:
+                    i = i - 1
+                    code = get_code(s, i)
+                return i + 1
+        return len_impl
+
+
+@overload(operator.eq)
+def charseq_eq(a, b):
+    return_impl = False
+    if isinstance(a, types.CharSeq) and isinstance(b, types.CharSeq):
+        return_impl = True
+        left_code = charseq_get_code
+        right_code = charseq_get_code
+    if isinstance(a, types.UnicodeCharSeq) and isinstance(b, types.UnicodeCharSeq):
+        return_impl = True
+        left_code = unicode_charseq_get_code
+        right_code = unicode_charseq_get_code
+    if return_impl:
+        def eq_impl(a, b):
+            n = len(a)
+            if n != len(b):
+                return False
+            for i in range(n):
+                if left_code(a, i) != right_code(b, i):
+                    return False
+            return True
+        return eq_impl
+
+
+@overload(operator.ne)
+def charseq_ne(a, b):
+    if ((isinstance(a, types.CharSeq) and isinstance(b, types.CharSeq))
+        or (isinstance(a, types.UnicodeCharSeq)
+            and isinstance(b, types.UnicodeCharSeq))):
+        def ne_impl(a, b):
+            return not (a == b)
+        return ne_impl

--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -188,7 +188,7 @@ def unicode_to_unicode_charseq(context, builder, fromty, toty, val):
                 builder.store(in_val, builder.gep(dst, [loop.index]))
         else:
             context.call_conv.return_user_exc(
-                builder, RuntimeError,
+                builder, ValueError,
                 ("cannot cast 16-bit unicode_type to %s-bit %s"
                  % (unicode_byte_width * 8, toty)))
 
@@ -200,7 +200,7 @@ def unicode_to_unicode_charseq(context, builder, fromty, toty, val):
                 builder.store(in_val, builder.gep(dst, [loop.index]))
         else:
             context.call_conv.return_user_exc(
-                builder, RuntimeError,
+                builder, ValueError,
                 ("cannot cast 32-bit unicode_type to %s-bit %s"
                  % (unicode_byte_width * 8, toty)))
 
@@ -342,16 +342,18 @@ def charseq_str(s):
         return str_impl
 
 
+@overload_method(types.UnicodeCharSeq, '__hash__')
 @overload_method(types.CharSeq, '__hash__')
 def charseq_hash(s):
     def impl(s):
-        # Assuming hash(bytes(s)) == hash(s)
+        # note that hash(bytes(s)) == hash(s)
         return hash(str(s))
     return impl
 
 
-@overload_method(types.UnicodeCharSeq, '__hash__')
-def unicode_charseq_hash(s):
+@overload_method(types.UnicodeCharSeq, 'isupper')
+def unicode_charseq_isupper(s):
     def impl(s):
-        return hash(str(s))
+        # workaround unicode_type.isupper bug: it returns int value
+        return not not str(s).isupper()
     return impl

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -974,6 +974,24 @@ class UnicodeCharSeq(DataModel):
     def get_data_type(self):
         return self._be_type
 
+    def as_data(self, builder, value):
+        return value
+
+    def from_data(self, builder, value):
+        return value
+
+    def as_return(self, builder, value):
+        return value
+
+    def from_return(self, builder, value):
+        return value
+
+    def as_argument(self, builder, value):
+        return value
+
+    def from_argument(self, builder, value):
+        return value
+
 
 @register_default(types.CharSeq)
 class CharSeq(DataModel):

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -203,6 +203,32 @@ def unbox_record(typ, obj, c):
     return NativeValue(val, cleanup=cleanup, is_error=is_error)
 
 
+
+@box(types.UnicodeCharSeq)
+def box_unicodecharseq(typ, val, c):
+    # XXX could kind be determined from strptr?
+    unicode_kind = {
+        1: c.pyapi.py_unicode_1byte_kind,
+        2: c.pyapi.py_unicode_2byte_kind,
+        4: c.pyapi.py_unicode_4byte_kind}[numpy_support.sizeof_unicode_char]
+    kind = c.context.get_constant(types.int32, unicode_kind)
+    rawptr = cgutils.alloca_once_value(c.builder, value=val)
+    strptr = c.builder.bitcast(rawptr, c.pyapi.cstring)
+
+    fullsize = c.context.get_constant(types.intp, typ.count)
+    zero = fullsize.type(0)
+    one = fullsize.type(1)
+    step = fullsize.type(numpy_support.sizeof_unicode_char)
+    count = cgutils.alloca_once_value(c.builder, zero)
+    with cgutils.loop_nest(c.builder, [fullsize], fullsize.type) as [idx]:
+        # Get char at idx
+        ch = c.builder.load(c.builder.gep(strptr, [c.builder.mul(idx, step)]))
+        # If the char is a non-null-byte, store the next index as count
+        with c.builder.if_then(cgutils.is_not_null(c.builder, ch)):
+            c.builder.store(c.builder.add(idx, one), count)
+    strlen = c.builder.load(count)
+    return c.pyapi.string_from_kind_and_data(kind, strptr, strlen)
+
 @box(types.CharSeq)
 def box_charseq(typ, val, c):
     rawptr = cgutils.alloca_once_value(c.builder, value=val)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -261,6 +261,12 @@ if IS_PY3:
         return NativeValue(ret, is_error=c.builder.not_(ok))
 
 
+    @box(types.Bytes)
+    def box_bytes(typ, val, c):
+        obj = c.context.make_helper(c.builder, typ, val)
+        return c.pyapi.bytes_from_string_and_size(obj.data, obj.nitems)
+
+
 @box(types.CharSeq)
 def box_charseq(typ, val, c):
     rawptr = cgutils.alloca_once_value(c.builder, value=val)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -203,61 +203,62 @@ def unbox_record(typ, obj, c):
         c.pyapi.release_buffer(buf)
     return NativeValue(val, cleanup=cleanup, is_error=is_error)
 
+if IS_PY3:
 
-@box(types.UnicodeCharSeq)
-def box_unicodecharseq(typ, val, c):
-    # XXX could kind be determined from strptr?
-    unicode_kind = {
-        1: c.pyapi.py_unicode_1byte_kind,
-        2: c.pyapi.py_unicode_2byte_kind,
-        4: c.pyapi.py_unicode_4byte_kind}[numpy_support.sizeof_unicode_char]
-    kind = c.context.get_constant(types.int32, unicode_kind)
-    rawptr = cgutils.alloca_once_value(c.builder, value=val)
-    strptr = c.builder.bitcast(rawptr, c.pyapi.cstring)
+    @box(types.UnicodeCharSeq)
+    def box_unicodecharseq(typ, val, c):
+        # XXX could kind be determined from strptr?
+        unicode_kind = {
+            1: c.pyapi.py_unicode_1byte_kind,
+            2: c.pyapi.py_unicode_2byte_kind,
+            4: c.pyapi.py_unicode_4byte_kind}[numpy_support.sizeof_unicode_char]
+        kind = c.context.get_constant(types.int32, unicode_kind)
+        rawptr = cgutils.alloca_once_value(c.builder, value=val)
+        strptr = c.builder.bitcast(rawptr, c.pyapi.cstring)
 
-    fullsize = c.context.get_constant(types.intp, typ.count)
-    zero = fullsize.type(0)
-    one = fullsize.type(1)
-    step = fullsize.type(numpy_support.sizeof_unicode_char)
-    count = cgutils.alloca_once_value(c.builder, zero)
-    with cgutils.loop_nest(c.builder, [fullsize], fullsize.type) as [idx]:
-        # Get char at idx
-        ch = c.builder.load(c.builder.gep(strptr, [c.builder.mul(idx, step)]))
-        # If the char is a non-null-byte, store the next index as count
-        with c.builder.if_then(cgutils.is_not_null(c.builder, ch)):
-            c.builder.store(c.builder.add(idx, one), count)
-    strlen = c.builder.load(count)
-    return c.pyapi.string_from_kind_and_data(kind, strptr, strlen)
+        fullsize = c.context.get_constant(types.intp, typ.count)
+        zero = fullsize.type(0)
+        one = fullsize.type(1)
+        step = fullsize.type(numpy_support.sizeof_unicode_char)
+        count = cgutils.alloca_once_value(c.builder, zero)
+        with cgutils.loop_nest(c.builder, [fullsize], fullsize.type) as [idx]:
+            # Get char at idx
+            ch = c.builder.load(c.builder.gep(strptr, [c.builder.mul(idx, step)]))
+            # If the char is a non-null-byte, store the next index as count
+            with c.builder.if_then(cgutils.is_not_null(c.builder, ch)):
+                c.builder.store(c.builder.add(idx, one), count)
+        strlen = c.builder.load(count)
+        return c.pyapi.string_from_kind_and_data(kind, strptr, strlen)
 
 
-@unbox(types.UnicodeCharSeq)
-def unbox_unicodecharseq(typ, obj, c):
-    lty = c.context.get_value_type(typ)
+    @unbox(types.UnicodeCharSeq)
+    def unbox_unicodecharseq(typ, obj, c):
+        lty = c.context.get_value_type(typ)
 
-    ok, buffer, size, kind, is_ascii, hashv = \
-        c.pyapi.string_as_string_size_and_kind(obj)
+        ok, buffer, size, kind, is_ascii, hashv = \
+            c.pyapi.string_as_string_size_and_kind(obj)
 
-    # If conversion is ok, copy the buffer to the output storage.
-    with cgutils.if_likely(c.builder, ok):
-        # Check if the returned string size fits in the charseq
-        storage_size = ir.Constant(size.type, typ.count)
-        size_fits = c.builder.icmp_unsigned("<=", size, storage_size)
+        # If conversion is ok, copy the buffer to the output storage.
+        with cgutils.if_likely(c.builder, ok):
+            # Check if the returned string size fits in the charseq
+            storage_size = ir.Constant(size.type, typ.count)
+            size_fits = c.builder.icmp_unsigned("<=", size, storage_size)
 
-        # Allow truncation of string
-        size = c.builder.select(size_fits, size, storage_size)
+            # Allow truncation of string
+            size = c.builder.select(size_fits, size, storage_size)
 
-        # Initialize output to zero bytes
-        null_string = ir.Constant(lty, None)
-        outspace  = cgutils.alloca_once_value(c.builder, null_string)
+            # Initialize output to zero bytes
+            null_string = ir.Constant(lty, None)
+            outspace  = cgutils.alloca_once_value(c.builder, null_string)
 
-        # We don't need to set the NULL-terminator because the storage
-        # is already zero-filled.
-        cgutils.memcpy(c.builder,
-                       c.builder.bitcast(outspace, buffer.type),
-                       buffer, size)
+            # We don't need to set the NULL-terminator because the storage
+            # is already zero-filled.
+            cgutils.memcpy(c.builder,
+                           c.builder.bitcast(outspace, buffer.type),
+                           buffer, size)
 
-    ret = c.builder.load(outspace)
-    return NativeValue(ret, is_error=c.builder.not_(ok))
+        ret = c.builder.load(outspace)
+        return NativeValue(ret, is_error=c.builder.not_(ok))
 
 
 @box(types.CharSeq)

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -149,7 +149,8 @@ class TestCase(unittest.TestCase):
 
 
     _bool_types = (bool, np.bool_)
-    _exact_typesets = [_bool_types, utils.INT_TYPES, (str,), (np.integer,), (utils.text_type), ]
+    _exact_typesets = [_bool_types, utils.INT_TYPES, (str,), (np.integer,),
+                       (utils.text_type), (bytes, np.bytes_)]
     _approx_typesets = [(float,), (complex,), (np.inexact)]
     _sequence_typesets = [(tuple, list)]
     _float_types = (float, np.floating)

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -140,10 +140,18 @@ class TestUnicodeArray(TestCase):
     def test_setitem2(self):
         pyfunc = setitem2
         cfunc = jit(nopython=True)(pyfunc)
+
         x1 = np.array(['123', 'ABC'])
         x2 = np.array(['123', 'ABC'])
         y1 = pyfunc(x1, 0, x1, 1)
-        y2 = cfunc(x2, 0, x1, 1)
+        y2 = cfunc(x2, 0, x2, 1)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array([b'123', b'ABC'])
+        x2 = np.array([b'123', b'ABC'])
+        y1 = pyfunc(x1, 0, x1, 1)
+        y2 = cfunc(x2, 0, x2, 1)
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
@@ -152,7 +160,7 @@ class TestUnicodeArray(TestCase):
         z1 = np.array('ABC')
         z2 = np.array('ABC')
         y1 = pyfunc(x1, (), z1, ())
-        y2 = cfunc(x2, (), z1, ())
+        y2 = cfunc(x2, (), z2, ())
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
@@ -165,13 +173,23 @@ class TestUnicodeArray(TestCase):
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
+        # bytes
+        x1 = np.array(b'123')
+        x2 = np.array(b'123')
+        z1 = b'ABC',
+        z2 = b'ABC',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
         # UTF-8
         x1 = np.array('123')
         x2 = np.array('123')
         z1 = 'ABC',
         z2 = 'ABC',
         y1 = pyfunc(x1, (), z1, 0)
-        y2 = cfunc(x2, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
@@ -195,23 +213,43 @@ class TestUnicodeArray(TestCase):
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
-        # assign longer value
+        # UTF-8, assign longer value (truncates as in numpy)
         x1 = np.array('123')
         x2 = np.array('123')
         z1 = 'ABCD',
         z2 = 'ABCD',
         y1 = pyfunc(x1, (), z1, 0)
-        y2 = cfunc(x2, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
-        # assign shorter value
+        # UTF-8, assign shorter value
         x1 = np.array('123')
         x2 = np.array('123')
         z1 = 'AB',
         z2 = 'AB',
         y1 = pyfunc(x1, (), z1, 0)
-        y2 = cfunc(x2, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # bytes, assign longer value (truncates as in numpy)
+        x1 = np.array(b'123')
+        x2 = np.array(b'123')
+        z1 = b'ABCD',
+        z2 = b'ABCD',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # bytes, assign shorter value
+        x1 = np.array(b'123')
+        x2 = np.array(b'123')
+        z1 = b'AB',
+        z2 = b'AB',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -29,6 +29,11 @@ def setitem2(x, i, y, j):
     return x
 
 
+def setitem_literal(x, i):
+    x[i] = '123'
+    return x
+
+
 def getitem_key(x, y, j):
     x[y[j]] = 123
 
@@ -43,6 +48,26 @@ def equal_getitem(x, i, j):
 
 def notequal_getitem(x, i, j):
     return x[i] != x[j]
+
+
+def lessthan_getitem(x, i, j):
+    return x[i] < x[j]
+
+
+def greaterthan_getitem(x, i, j):
+    return x[i] > x[j]
+
+
+def lessequal_getitem(x, i, j):
+    return x[i] <= x[j]
+
+
+def greaterequal_getitem(x, i, j):
+    return x[i] >= x[j]
+
+
+def contains_getitem2(x, i, y, j):
+    return x[i] in y[j]
 
 
 def equal_getitem_value(x, i, v):
@@ -69,8 +94,16 @@ def return_isupper(x, i):
     return x[i].isupper()
 
 
+def return_upper(x, i):
+    return x[i].upper()
+
+
 def return_str(x, i):
     return str(x[i])
+
+
+def return_bytes(x, i):
+    return bytes(x[i])
 
 
 def return_hash(x, i):
@@ -279,6 +312,31 @@ class TestUnicodeArray(TestCase):
         self.assertPreciseEqual(x1, x2)
         self.assertPreciseEqual(y1, y2)
 
+    def test_setitem_literal(self):
+        pyfunc = setitem_literal
+        cfunc = jit(nopython=True)(pyfunc)
+
+        x1 = np.array('ABC')
+        x2 = np.array('ABC')
+        y1 = pyfunc(x1, ())
+        y2 = cfunc(x2, ())
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array(['ABC', '5678'])
+        x2 = np.array(['ABC', '5678'])
+        y1 = pyfunc(x1, 0)
+        y2 = cfunc(x2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array(['ABC', '5678'])
+        x2 = np.array(['ABC', '5678'])
+        y1 = pyfunc(x1, 1)
+        y2 = cfunc(x2, 1)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
     def test_return_len(self):
         pyfunc = return_len
         cfunc = jit(nopython=True)(pyfunc)
@@ -317,6 +375,18 @@ class TestUnicodeArray(TestCase):
     def test_notequal_getitem(self):
         self._test_op_getitem(notequal_getitem)
 
+    def test_lessthan_getitem(self):
+        self._test_op_getitem(lessthan_getitem)
+
+    def test_greaterthan_getitem(self):
+        self._test_op_getitem(greaterthan_getitem)
+
+    def test_lessequal_getitem(self):
+        self._test_op_getitem(lessequal_getitem)
+
+    def test_greaterequal_getitem(self):
+        self._test_op_getitem(greaterequal_getitem)
+
     def _test_op_getitem_value(self, pyfunc):
         cfunc = jit(nopython=True)(pyfunc)
         self._test(pyfunc, cfunc, np.array([1, 2]), 0, 1)
@@ -336,6 +406,20 @@ class TestUnicodeArray(TestCase):
     def test_notequal_getitem_value(self):
         self._test_op_getitem_value(notequal_getitem_value)
 
+    def test_contains_getitem2(self):
+        pyfunc = contains_getitem2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        x = np.array('123')
+        y = np.array('12345')
+        self._test(pyfunc, cfunc, x, (), y, ())
+        self._test(pyfunc, cfunc, y, (), x, ())
+
+        x = np.array(b'123')
+        y = np.array(b'12345')
+        self._test(pyfunc, cfunc, x, (), y, ())
+        self._test(pyfunc, cfunc, y, (), x, ())
+
     @require_py37
     def test_return_isascii(self):
         pyfunc = return_isascii
@@ -351,11 +435,29 @@ class TestUnicodeArray(TestCase):
         self._test(pyfunc, cfunc, np.array('abc'), ())
         self._test(pyfunc, cfunc, np.array(['abc']), 0)
 
+        self._test(pyfunc, cfunc, np.array(b'abc'), ())
+        self._test(pyfunc, cfunc, np.array([b'abc']), 0)
+
     def test_return_str(self):
         pyfunc = return_str
         cfunc = jit(nopython=True)(pyfunc)
         self._test(pyfunc, cfunc, np.array('1234'), ())
         self._test(pyfunc, cfunc, np.array(['1234']), 0)
+
+    def test_return_bytes(self):
+        pyfunc = return_bytes
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array(b'1234'), ())
+        self._test(pyfunc, cfunc, np.array([b'1234']), 0)
+
+    def test_return_upper(self):
+        pyfunc = return_upper
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array('abc'), ())
+        self._test(pyfunc, cfunc, np.array(['abc']), 0)
+
+        self._test(pyfunc, cfunc, np.array(b'abc'), ())
+        self._test(pyfunc, cfunc, np.array([b'abc']), 0)
 
     def test_hash(self):
         pyfunc = return_hash

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -7,6 +7,7 @@ from numba import jit, utils
 from numba.tests.support import TestCase
 
 skip_py2 = unittest.skipIf(not utils.IS_PY3, "not supported in Python 2")
+require_py37 = unittest.skipIf(utils.PYVERSION < (3, 7), "requires Python 3.7+")
 
 
 def getitem(x, i):
@@ -15,6 +16,16 @@ def getitem(x, i):
 
 def getitem2(x, i, j):
     return x[i][j]
+
+
+def setitem(x, i, v):
+    x[i] = v
+    return x
+
+
+def setitem2(x, i, y, j):
+    x[i] = y[j]
+    return x
 
 
 def return_len(x, i):
@@ -104,6 +115,106 @@ class TestUnicodeArray(TestCase):
         self._test(pyfunc, cfunc, np.array(['12', '3']), 0)
         self._test(pyfunc, cfunc, np.array(['12', '3']), 1)
 
+    def test_setitem(self):
+        pyfunc = setitem
+        cfunc = jit(nopython=True)(pyfunc)
+
+        x = np.array(12)
+        self._test(pyfunc, cfunc, x, (), 34)
+
+        if 0:
+            x1 = np.array(b'123')
+            x2 = np.array(b'123')
+            y1 = pyfunc(x1, (), b'34')
+            y2 = cfunc(x2, (), b'34')
+            self.assertPreciseEqual(x1, x2)
+            self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array(['123'])
+        x2 = np.array(['123'])
+        y1 = pyfunc(x1, 0, '34')
+        y2 = cfunc(x2, 0, '34')
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+    def test_setitem2(self):
+        pyfunc = setitem2
+        cfunc = jit(nopython=True)(pyfunc)
+        x1 = np.array(['123', 'ABC'])
+        x2 = np.array(['123', 'ABC'])
+        y1 = pyfunc(x1, 0, x1, 1)
+        y2 = cfunc(x2, 0, x1, 1)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = np.array('ABC')
+        z2 = np.array('ABC')
+        y1 = pyfunc(x1, (), z1, ())
+        y2 = cfunc(x2, (), z1, ())
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        x1 = np.array(123)
+        x2 = np.array(123)
+        z1 = 456,
+        z2 = 456,
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # UTF-8
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = 'ABC',
+        z2 = 'ABC',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z1, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # UTF-16
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = 'AB\u01e9',
+        z2 = 'AB\u01e9',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # UTF-32
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = 'AB\U00108a0e',
+        z2 = 'AB\U00108a0e',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z2, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # assign longer value
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = 'ABCD',
+        z2 = 'ABCD',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z1, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
+        # assign shorter value
+        x1 = np.array('123')
+        x2 = np.array('123')
+        z1 = 'AB',
+        z2 = 'AB',
+        y1 = pyfunc(x1, (), z1, 0)
+        y2 = cfunc(x2, (), z1, 0)
+        self.assertPreciseEqual(x1, x2)
+        self.assertPreciseEqual(y1, y2)
+
     def test_return_len(self):
         pyfunc = return_len
         cfunc = jit(nopython=True)(pyfunc)
@@ -161,6 +272,7 @@ class TestUnicodeArray(TestCase):
     def test_notequal_getitem_value(self):
         self._test_op_getitem_value(notequal_getitem_value)
 
+    @require_py37
     def test_return_isascii(self):
         pyfunc = return_isascii
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -1,10 +1,16 @@
 from __future__ import print_function, unicode_literals
 
+import unittest
 import numpy as np
 
 import numba.unittest_support as unittest
-from numba import jit
+from numba import jit, utils
 from numba.tests.support import TestCase
+
+if not utils.IS_PY3:
+    raise unittest.SkipTest(
+        "Operations on arrays with unicode/bytes items are implemented for"
+        " Python 3 only")
 
 
 def getitem(x, i):

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -522,6 +522,16 @@ class TestUnicodeArray(TestCase):
         self._test(pyfunc, cfunc, x, (), y, ())
         self._test(pyfunc, cfunc, y, (), x, ())
 
+        x = ('123',)
+        y = np.array('12345')
+        self._test(pyfunc, cfunc, x, 0, y, ())
+        self._test(pyfunc, cfunc, y, (), x, 0)
+
+        x = (b'123',)
+        y = np.array(b'12345')
+        self._test(pyfunc, cfunc, x, 0, y, ())
+        self._test(pyfunc, cfunc, y, (), x, 0)
+
     @require_py37
     def test_return_isascii(self):
         pyfunc = return_isascii

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -1,0 +1,72 @@
+from __future__ import print_function, unicode_literals
+
+import sys
+import numpy as np
+
+import numba.unittest_support as unittest
+from numba import jit
+from numba.tests.support import TestCase
+
+def getitem(x, i):
+    x[i]
+
+def return_getitem(x, i):
+    return x[i]
+
+def equal_getitem(x, i, j):
+    x[i] == x[j]
+
+def add_getitem(x, i, j):
+    x[i] + x[j]
+
+class TestUnicodeArray(TestCase):
+    
+    def _test(self, pyfunc, *args, **kwargs):
+        expected = pyfunc(*args, **kwargs)
+        cfunc = jit(nopython=True)(pyfunc)
+        self.assertPreciseEqual(cfunc(*args, **kwargs), expected)
+    
+    def test_getitem(self):
+        pyfunc = getitem
+        self._test(pyfunc, np.array([1, 2]), 1)
+        self._test(pyfunc, '12', 1)
+        self._test(pyfunc, b'12', 1)
+        self._test(pyfunc, np.array(b'12'), ())
+        self._test(pyfunc, np.array('12'), ())
+        self._test(pyfunc, np.array([b'12', b'3']), 0)
+        self._test(pyfunc, np.array([b'12', b'3']), 1)
+        self._test(pyfunc, np.array(['12', '3']), 0)
+        self._test(pyfunc, np.array(['12', '3']), 1)
+
+    def test_return_getitem(self):
+        pyfunc = return_getitem
+        self._test(pyfunc, np.array([1, 2]), 1)
+        self._test(pyfunc, '12', 1)
+        self._test(pyfunc, b'12', 1)
+        self._test(pyfunc, np.array(b'12'), ())
+        self._test(pyfunc, np.array('1234'), ())
+        self._test(pyfunc, np.array([b'12', b'3']), 0)
+        self._test(pyfunc, np.array([b'12', b'3']), 1)
+        self._test(pyfunc, np.array(['12', '3']), 0)
+        self._test(pyfunc, np.array(['12', '3']), 1)
+
+    def test_equal_getitem(self):
+        pyfunc = equal_getitem
+        self._test(pyfunc, np.array([1, 2]), 0, 1)
+        self._test(pyfunc, '12', 0, 1)
+        self._test(pyfunc, b'12', 0, 1)
+        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
+        #self._test(pyfunc, np.array('1234'), (), ())  # fails as unsupported
+        #self._test(pyfunc, np.array([b'1', b'2']), 0, 1)  # fails as unsupported
+        #self._test(pyfunc, np.array(['1', '2']), 0, 1)  # fails as unsupported
+
+    def test_add_getitem(self):
+        pyfunc = add_getitem
+        self._test(pyfunc, np.array([1, 2]), 0, 1)
+        self._test(pyfunc, '12', 0, 1)
+        self._test(pyfunc, b'12', 0, 1)
+        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
+        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -1,72 +1,116 @@
 from __future__ import print_function, unicode_literals
 
-import sys
 import numpy as np
 
 import numba.unittest_support as unittest
 from numba import jit
 from numba.tests.support import TestCase
 
-def getitem(x, i):
-    x[i]
 
-def return_getitem(x, i):
+def getitem(x, i):
     return x[i]
 
-def equal_getitem(x, i, j):
-    x[i] == x[j]
 
-def add_getitem(x, i, j):
-    x[i] + x[j]
+def getitem2(x, i, j):
+    return x[i][j]
+
+
+def return_len(x, i):
+    return len(x[i])
+
+
+def equal_getitem(x, i, j):
+    return x[i] == x[j]
+
+
+def notequal_getitem(x, i, j):
+    return x[i] != x[j]
+
 
 class TestUnicodeArray(TestCase):
-    
-    def _test(self, pyfunc, *args, **kwargs):
+
+    def _test(self, pyfunc, cfunc, *args, **kwargs):
         expected = pyfunc(*args, **kwargs)
-        cfunc = jit(nopython=True)(pyfunc)
         self.assertPreciseEqual(cfunc(*args, **kwargs), expected)
-    
+
+    def test_getitem2(self):
+        cgetitem2 = jit(nopython=True)(getitem2)
+
+        arr = np.array(b'12')
+        self.assertPreciseEqual(cgetitem2(arr, (), 0), getitem2(arr, (), 0))
+        with self.assertRaisesRegex(IndexError, 'index out of range'):
+            cgetitem2(arr, (), 2)
+
+        arr = np.array('12')
+        self.assertPreciseEqual(cgetitem2(arr, (), 0), getitem2(arr, (), 0))
+        with self.assertRaisesRegex(IndexError, 'index out of range'):
+            cgetitem2(arr, (), 2)
+
+        arr = np.array([b'12', b'3'])
+        self.assertPreciseEqual(cgetitem2(arr, 0, 0), getitem2(arr, 0, 0))
+        self.assertPreciseEqual(cgetitem2(arr, 0, 1), getitem2(arr, 0, 1))
+        self.assertPreciseEqual(cgetitem2(arr, 1, 0), getitem2(arr, 1, 0))
+        with self.assertRaisesRegex(IndexError, 'index out of range'):
+            cgetitem2(arr, 1, 1)
+
+        arr = np.array(['12', '3'])
+        self.assertPreciseEqual(cgetitem2(arr, 0, 0), getitem2(arr, 0, 0))
+        self.assertPreciseEqual(cgetitem2(arr, 0, 1), getitem2(arr, 0, 1))
+        self.assertPreciseEqual(cgetitem2(arr, 1, 0), getitem2(arr, 1, 0))
+        with self.assertRaisesRegex(IndexError, 'index out of range'):
+            cgetitem2(arr, 1, 1)
+
     def test_getitem(self):
         pyfunc = getitem
-        self._test(pyfunc, np.array([1, 2]), 1)
-        self._test(pyfunc, '12', 1)
-        self._test(pyfunc, b'12', 1)
-        self._test(pyfunc, np.array(b'12'), ())
-        self._test(pyfunc, np.array('12'), ())
-        self._test(pyfunc, np.array([b'12', b'3']), 0)
-        self._test(pyfunc, np.array([b'12', b'3']), 1)
-        self._test(pyfunc, np.array(['12', '3']), 0)
-        self._test(pyfunc, np.array(['12', '3']), 1)
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, b'12', 1)
+        self._test(pyfunc, cfunc, np.array(b'12'), ())
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 0)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 1)
 
-    def test_return_getitem(self):
-        pyfunc = return_getitem
-        self._test(pyfunc, np.array([1, 2]), 1)
-        self._test(pyfunc, '12', 1)
-        self._test(pyfunc, b'12', 1)
-        self._test(pyfunc, np.array(b'12'), ())
-        self._test(pyfunc, np.array('1234'), ())
-        self._test(pyfunc, np.array([b'12', b'3']), 0)
-        self._test(pyfunc, np.array([b'12', b'3']), 1)
-        self._test(pyfunc, np.array(['12', '3']), 0)
-        self._test(pyfunc, np.array(['12', '3']), 1)
+        self._test(pyfunc, cfunc, '12', 1)
+        self._test(pyfunc, cfunc, np.array('12'), ())
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 0)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 1)
+
+    def test_return_len(self):
+        pyfunc = return_len
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array(b'12'), ())
+        self._test(pyfunc, cfunc, np.array('12'), ())
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 0)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 0)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 1)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 1)
+
+    def _test_op_getitem(self, pyfunc):
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array([1, 2]), 0, 1)
+        self._test(pyfunc, cfunc, '12', 0, 1)
+        self._test(pyfunc, cfunc, b'12', 0, 1)
+        self._test(pyfunc, cfunc, np.array(b'12'), (), ())
+        self._test(pyfunc, cfunc, np.array('1234'), (), ())
+
+        self._test(pyfunc, cfunc, np.array([b'1', b'2']), 0, 0)
+        self._test(pyfunc, cfunc, np.array([b'1', b'2']), 0, 1)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 0, 0)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 1, 1)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 0, 1)
+        self._test(pyfunc, cfunc, np.array([b'12', b'3']), 1, 0)
+
+        self._test(pyfunc, cfunc, np.array(['1', '2']), 0, 0)
+        self._test(pyfunc, cfunc, np.array(['1', '2']), 0, 1)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 0, 0)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 1, 1)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 0, 1)
+        self._test(pyfunc, cfunc, np.array(['12', '3']), 1, 0)
 
     def test_equal_getitem(self):
-        pyfunc = equal_getitem
-        self._test(pyfunc, np.array([1, 2]), 0, 1)
-        self._test(pyfunc, '12', 0, 1)
-        self._test(pyfunc, b'12', 0, 1)
-        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
-        #self._test(pyfunc, np.array('1234'), (), ())  # fails as unsupported
-        #self._test(pyfunc, np.array([b'1', b'2']), 0, 1)  # fails as unsupported
-        #self._test(pyfunc, np.array(['1', '2']), 0, 1)  # fails as unsupported
+        self._test_op_getitem(equal_getitem)
 
-    def test_add_getitem(self):
-        pyfunc = add_getitem
-        self._test(pyfunc, np.array([1, 2]), 0, 1)
-        self._test(pyfunc, '12', 0, 1)
-        self._test(pyfunc, b'12', 0, 1)
-        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
-        #self._test(pyfunc, np.array(b'12'), (), ())  # fails as unsupported
-        
+    def test_notequal_getitem(self):
+        self._test_op_getitem(notequal_getitem)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -110,6 +110,106 @@ def return_hash(x, i):
     return hash(x[i])
 
 
+def return_find(x, i, y, j):
+    return x[i].find(y[j])
+
+
+def return_startswith(x, i, y, j):
+    return x[i].startswith(y[j])
+
+
+def return_endswith(x, i, y, j):
+    return x[i].endswith(y[j])
+
+
+def return_split1(x, i):
+    return x[i].split()
+
+
+def return_split2(x, i, y, j):
+    return x[i].split(y[j])
+
+
+def return_split3(x, i, y, j, maxsplit):
+    return x[i].split(sep=y[j], maxsplit=maxsplit)
+
+
+# NOT IMPLEMENTED: tests for rsplit
+
+
+def return_center1(x, i, w):
+    return x[i].center(w)
+
+
+def return_center2(x, i, w, y, j):
+    return x[i].center(w, y[j])
+
+
+def return_ljust1(x, i, w):
+    return x[i].ljust(w)
+
+
+def return_ljust2(x, i, w, y, j):
+    return x[i].ljust(w, y[j])
+
+
+def return_rjust1(x, i, w):
+    return x[i].rjust(w)
+
+
+def return_rjust2(x, i, w, y, j):
+    return x[i].rjust(w, y[j])
+
+
+def return_join(x, i, y, j, z, k):
+    return x[i].join([y[j], z[k]])
+
+
+def return_zfill(x, i, w):
+    return x[i].zfill(w)
+
+
+def return_lstrip1(x, i):
+    return x[i].lstrip()
+
+
+def return_lstrip2(x, i, y, j):
+    return x[i].lstrip(y[j])
+
+
+def return_rstrip1(x, i):
+    return x[i].rstrip()
+
+
+def return_rstrip2(x, i, y, j):
+    return x[i].rstrip(y[j])
+
+
+def return_strip1(x, i):
+    return x[i].strip()
+
+
+def return_strip2(x, i, y, j):
+    return x[i].strip(y[j])
+
+
+def return_add(x, i, y, j):
+    return x[i] + y[j]
+
+
+def return_iadd(x, i, y, j):
+    x[i] += y[j]
+    return x[i]
+
+
+def return_mul(x, i, y, j):
+    return x[i] * y[j]  # one of the operants must be integer
+
+
+def return_not(x, i):
+    return not x[i]
+
+
 @skip_py2
 class TestUnicodeArray(TestCase):
 
@@ -340,6 +440,8 @@ class TestUnicodeArray(TestCase):
     def test_return_len(self):
         pyfunc = return_len
         cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array(''), ())
+        self._test(pyfunc, cfunc, np.array(b''), ())
         self._test(pyfunc, cfunc, np.array(b'12'), ())
         self._test(pyfunc, cfunc, np.array('12'), ())
         self._test(pyfunc, cfunc, np.array([b'12', b'3']), 0)
@@ -476,6 +578,246 @@ class TestUnicodeArray(TestCase):
 
         self._test(pyfunc, cfunc, np.array(b'1234'), ())
         self._test(pyfunc, cfunc, np.array([b'1234']), 0)
+
+    def test_return_find(self):
+        pyfunc = return_find
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array('1234'), (), np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array('1234'), (), ('23',), 0)
+        self._test(pyfunc, cfunc, ('1234',), 0, np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), np.array(b'23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), (b'23',), 0)
+        self._test(pyfunc, cfunc, (b'1234',), 0, np.array(b'23'), ())
+
+    def test_return_startswith(self):
+        pyfunc = return_startswith
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1234'), (), np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array('1234'), (), ('23',), 0)
+        self._test(pyfunc, cfunc, ('1234',), 0, np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), np.array(b'23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), (b'23',), 0)
+        self._test(pyfunc, cfunc, (b'1234',), 0, np.array(b'23'), ())
+
+    def test_return_endswith(self):
+        pyfunc = return_endswith
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1234'), (), np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array('1234'), (), ('23',), 0)
+        self._test(pyfunc, cfunc, ('1234',), 0, np.array('23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), np.array(b'23'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), (), (b'23',), 0)
+        self._test(pyfunc, cfunc, (b'1234',), 0, np.array(b'23'), ())
+
+    def test_return_split1(self):
+        pyfunc = return_split1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('12 34'), ())
+        self._test(pyfunc, cfunc, np.array(b'1234'), ())
+
+    def test_return_split2(self):
+        pyfunc = return_split2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('12 34'), (), np.array(' '), ())
+        self._test(pyfunc, cfunc, np.array('12 34'), (), (' ',), 0)
+        self._test(pyfunc, cfunc, ('12 34',), 0, np.array(' '), ())
+        self._test(pyfunc, cfunc, np.array(b'12 34'), (), np.array(b' '), ())
+        self._test(pyfunc, cfunc, np.array(b'12 34'), (), (b' ',), 0)
+        self._test(pyfunc, cfunc, (b'12 34',), 0, np.array(b' '), ())
+
+    def test_return_split3(self):
+        pyfunc = return_split3
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), np.array(' '), (), 2)
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), (' ',), 0, 2)
+        self._test(pyfunc, cfunc, ('1 2 3 4',), 0, np.array(' '), (), 2)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), np.array(b' '), (), 2)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), (b' ',), 0, 2)
+        self._test(pyfunc, cfunc, (b'1 2 3 4',), 0, np.array(b' '), (), 2)
+
+    def test_return_ljust1(self):
+        pyfunc = return_ljust1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40)
+
+    def test_return_ljust2(self):
+        pyfunc = return_ljust2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, ('=',), 0)
+        self._test(pyfunc, cfunc, ('1 2 3 4',), 0, 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, np.array(b'='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, (b'=',), 0)
+        self._test(pyfunc, cfunc, (b'1 2 3 4',), 0, 40, np.array(b'='), ())
+
+    def test_return_rjust1(self):
+        pyfunc = return_rjust1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40)
+
+    def test_return_rjust2(self):
+        pyfunc = return_rjust2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, ('=',), 0)
+        self._test(pyfunc, cfunc, ('1 2 3 4',), 0, 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, np.array(b'='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, (b'=',), 0)
+        self._test(pyfunc, cfunc, (b'1 2 3 4',), 0, 40, np.array(b'='), ())
+
+    def test_return_center1(self):
+        pyfunc = return_center1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40)
+
+    def test_return_center2(self):
+        pyfunc = return_center2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40, ('=',), 0)
+        self._test(pyfunc, cfunc, ('1 2 3 4',), 0, 40, np.array('='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, np.array(b'='), ())
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40, (b'=',), 0)
+        self._test(pyfunc, cfunc, (b'1 2 3 4',), 0, 40, np.array(b'='), ())
+
+    def test_return_join(self):
+        pyfunc = return_join
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array(','), (), np.array('abc'), (), np.array('123'), ())
+        self._test(pyfunc, cfunc, np.array(','), (), np.array('abc'), (), ('123',), 0)
+        self._test(pyfunc, cfunc, (',',), 0, np.array('abc'), (), np.array('123'), ())
+        self._test(pyfunc, cfunc, (',',), 0, np.array('abc'), (), ('123',), 0)
+        self._test(pyfunc, cfunc, np.array(b','), (), np.array(b'abc'), (), np.array(b'123'), ())
+        self._test(pyfunc, cfunc, np.array(b','), (), np.array(b'abc'), (), (b'123',), 0)
+        self._test(pyfunc, cfunc, (b',',), 0, np.array(b'abc'), (), np.array(b'123'), ())
+        self._test(pyfunc, cfunc, (b',',), 0, np.array(b'abc'), (), (b'123',), 0)
+
+    def test_return_zfill(self):
+        pyfunc = return_zfill
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('1 2 3 4'), (), 40)
+        self._test(pyfunc, cfunc, np.array(b'1 2 3 4'), (), 40)
+
+    def test_return_lstrip1(self):
+        pyfunc = return_lstrip1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), ())
+
+    def test_return_lstrip2(self):
+        pyfunc = return_lstrip2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), (), np.array(' '), ())
+        self._test(pyfunc, cfunc, np.array('  123  '), (), (' ',), 0)
+        self._test(pyfunc, cfunc, ('  123  ',), 0, np.array(' '), ())
+
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), np.array(b' '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), (b' ',), 0)
+        self._test(pyfunc, cfunc, (b'  123  ',), 0, np.array(b' '), ())
+
+    def test_return_rstrip1(self):
+        pyfunc = return_rstrip1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), ())
+
+    def test_return_rstrip2(self):
+        pyfunc = return_rstrip2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), (), np.array(' '), ())
+        self._test(pyfunc, cfunc, np.array('  123  '), (), (' ',), 0)
+        self._test(pyfunc, cfunc, ('  123  ',), 0, np.array(' '), ())
+
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), np.array(b' '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), (b' ',), 0)
+        self._test(pyfunc, cfunc, (b'  123  ',), 0, np.array(b' '), ())
+
+    def test_return_strip1(self):
+        pyfunc = return_strip1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), ())
+
+    def test_return_strip2(self):
+        pyfunc = return_strip2
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('  123  '), (), np.array(' '), ())
+        self._test(pyfunc, cfunc, np.array('  123  '), (), (' ',), 0)
+        self._test(pyfunc, cfunc, ('  123  ',), 0, np.array(' '), ())
+
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), np.array(b' '), ())
+        self._test(pyfunc, cfunc, np.array(b'  123  '), (), (b' ',), 0)
+        self._test(pyfunc, cfunc, (b'  123  ',), 0, np.array(b' '), ())
+
+    def test_return_add(self):
+        pyfunc = return_add
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('ab'), (), np.array('cd'), ())
+        self._test(pyfunc, cfunc, np.array('ab'), (), ('cd',), 0)
+        self._test(pyfunc, cfunc, ('ab',), 0, np.array('cd'), ())
+
+        self._test(pyfunc, cfunc, np.array(b'ab'), (), np.array(b'cd'), ())
+        self._test(pyfunc, cfunc, np.array(b'ab'), (), (b'cd',), 0)
+        self._test(pyfunc, cfunc, (b'ab',), 0, np.array(b'cd'), ())
+
+    def test_return_iadd(self):
+        pyfunc = return_iadd
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('ab'), (), np.array('cd'), ())
+        self._test(pyfunc, cfunc, np.array('ab'), (), ('cd',), 0)
+        expected = pyfunc(['ab'], 0, np.array('cd'), ())
+        result = pyfunc(['ab'], 0, np.array('cd'), ())
+        self.assertPreciseEqual(result, expected)
+
+        self._test(pyfunc, cfunc, np.array(b'ab'), (), np.array(b'cd'), ())
+        self._test(pyfunc, cfunc, np.array(b'ab'), (), (b'cd',), 0)
+        expected = pyfunc([b'ab'], 0, np.array(b'cd'), ())
+        result = pyfunc([b'ab'], 0, np.array(b'cd'), ())
+        self.assertPreciseEqual(result, expected)
+
+    def test_return_mul(self):
+        pyfunc = return_mul
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('ab'), (), (5,), 0)
+        self._test(pyfunc, cfunc, (5,), 0, np.array('ab'), ())
+        self._test(pyfunc, cfunc, np.array(b'ab'), (), (5,), 0)
+        self._test(pyfunc, cfunc, (5,), 0, np.array(b'ab'), ())
+
+    def test_return_not(self):
+        pyfunc = return_not
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self._test(pyfunc, cfunc, np.array('ab'), ())
+        self._test(pyfunc, cfunc, np.array(b'ab'), ())
+        self._test(pyfunc, cfunc, (b'ab',), 0)
+
+        self._test(pyfunc, cfunc, np.array(''), ())
+        self._test(pyfunc, cfunc, np.array(b''), ())
+        self._test(pyfunc, cfunc, (b'',), 0)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -65,6 +65,10 @@ def return_isascii(x, i):
     return x[i].isascii()
 
 
+def return_isupper(x, i):
+    return x[i].isupper()
+
+
 def return_str(x, i):
     return str(x[i])
 
@@ -340,6 +344,12 @@ class TestUnicodeArray(TestCase):
         self._test(pyfunc, cfunc, np.array(['1234']), 0)
         self._test(pyfunc, cfunc, np.array('1234\u00e9'), ())
         self._test(pyfunc, cfunc, np.array(['1234\u00e9']), 0)
+
+    def test_return_isupper(self):
+        pyfunc = return_isupper
+        cfunc = jit(nopython=True)(pyfunc)
+        self._test(pyfunc, cfunc, np.array('abc'), ())
+        self._test(pyfunc, cfunc, np.array(['abc']), 0)
 
     def test_return_str(self):
         pyfunc = return_str

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 from .abstract import *
 from .common import *
+from .npytypes import UnicodeCharSeq
 from ..typeconv import Conversion
 from ..errors import TypingError, LiteralTypingError
 
@@ -499,6 +500,12 @@ class UnicodeType(IterableType):
     def iterator_type(self):
         return UnicodeIteratorType(self)
 
+    def can_convert_to(self, typingctx, other):
+        if isinstance(other, UnicodeCharSeq):
+            # Assuming that unicode_type itemsize is not greater than
+            # numpy.dtype('U1').itemsize that UnicodeCharSeq is based
+            # on.
+            return Conversion.safe
 
 class UnicodeIteratorType(SimpleIteratorType):
 

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 from .abstract import *
 from .common import *
-from .npytypes import UnicodeCharSeq
 from ..typeconv import Conversion
 from ..errors import TypingError, LiteralTypingError
 
@@ -500,12 +499,6 @@ class UnicodeType(IterableType):
     def iterator_type(self):
         return UnicodeIteratorType(self)
 
-    def can_convert_to(self, typingctx, other):
-        if isinstance(other, UnicodeCharSeq):
-            # Assuming that unicode_type itemsize is not greater than
-            # numpy.dtype('U1').itemsize that UnicodeCharSeq is based
-            # on.
-            return Conversion.safe
 
 class UnicodeIteratorType(SimpleIteratorType):
 

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -10,7 +10,7 @@ from .abstract import *
 from .common import *
 from ..typeconv import Conversion
 from .. import utils
-
+from .. import types
 
 class CharSeq(Type):
     """
@@ -27,6 +27,10 @@ class CharSeq(Type):
     def key(self):
         return self.count
 
+    def can_convert_from(self, typingctx, other):
+        if isinstance(other, types.Bytes):
+            return Conversion.safe
+
 
 class UnicodeCharSeq(Type):
     """
@@ -42,6 +46,13 @@ class UnicodeCharSeq(Type):
     @property
     def key(self):
         return self.count
+
+    def can_convert_from(self, typingctx, other):
+        if isinstance(other, types.UnicodeType):
+            # Assuming that unicode_type itemsize is not greater than
+            # numpy.dtype('U1').itemsize that UnicodeCharSeq is based
+            # on.
+            return Conversion.safe
 
 
 _RecordField = collections.namedtuple(

--- a/numba/types/npytypes.py
+++ b/numba/types/npytypes.py
@@ -10,7 +10,8 @@ from .abstract import *
 from .common import *
 from ..typeconv import Conversion
 from .. import utils
-from .. import types
+from .misc import UnicodeType
+from .containers import Bytes
 
 class CharSeq(Type):
     """
@@ -28,7 +29,7 @@ class CharSeq(Type):
         return self.count
 
     def can_convert_from(self, typingctx, other):
-        if isinstance(other, types.Bytes):
+        if isinstance(other, Bytes):
             return Conversion.safe
 
 
@@ -48,7 +49,7 @@ class UnicodeCharSeq(Type):
         return self.count
 
     def can_convert_from(self, typingctx, other):
-        if isinstance(other, types.UnicodeType):
+        if isinstance(other, UnicodeType):
             # Assuming that unicode_type itemsize is not greater than
             # numpy.dtype('U1').itemsize that UnicodeCharSeq is based
             # on.

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -527,6 +527,10 @@ def unicode_find(a, b):
         def find_impl(a, b):
             return _find(substr=b, s=a)
         return find_impl
+    if isinstance(b, types.UnicodeCharSeq):
+        def find_impl(a, b):
+            return a.find(str(b))
+        return find_impl
 
 
 @overload_method(types.UnicodeType, 'startswith')
@@ -534,6 +538,10 @@ def unicode_startswith(a, b):
     if isinstance(b, types.UnicodeType):
         def startswith_impl(a, b):
             return _cmp_region(a, 0, b, 0, len(b)) == 0
+        return startswith_impl
+    if isinstance(b, types.UnicodeCharSeq):
+        def startswith_impl(a, b):
+            return a.startswith(str(b))
         return startswith_impl
 
 
@@ -546,6 +554,10 @@ def unicode_endswith(a, b):
                 return False
             return _cmp_region(a, a_offset, b, 0, len(b)) == 0
         return endswith_impl
+    if isinstance(b, types.UnicodeCharSeq):
+        def endswith_impl(a, b):
+            return a.endswith(str(b))
+        return endswith_impl
 
 
 @overload_method(types.UnicodeType, 'split')
@@ -554,6 +566,11 @@ def unicode_split(a, sep=None, maxsplit=-1):
             isinstance(maxsplit, (types.Omitted, types.Integer,
                                   types.IntegerLiteral))):
         return None  # fail typing if maxsplit is not an integer
+
+    if isinstance(sep, types.UnicodeCharSeq):
+        def split_impl(a, sep, maxsplit=1):
+            return a.split(str(sep), maxsplit=maxsplit)
+        return split_impl
 
     if isinstance(sep, types.UnicodeType):
         def split_impl(a, sep, maxsplit=-1):
@@ -632,6 +649,12 @@ def unicode_split(a, sep=None, maxsplit=-1):
 def unicode_center(string, width, fillchar=' '):
     if not isinstance(width, types.Integer):
         raise TypingError('The width must be an Integer')
+
+    if isinstance(fillchar, types.UnicodeCharSeq):
+        def center_impl(string, width, fillchar):
+            return string.center(width, str(fillchar))
+        return center_impl
+
     if not (fillchar == ' ' or isinstance(fillchar, (types.Omitted, types.UnicodeType))):
         raise TypingError('The fillchar must be a UnicodeType')
 
@@ -662,7 +685,14 @@ def unicode_center(string, width, fillchar=' '):
 def unicode_ljust(string, width, fillchar=' '):
     if not isinstance(width, types.Integer):
         raise TypingError('The width must be an Integer')
-    if not (fillchar == ' ' or isinstance(fillchar, (types.Omitted, types.UnicodeType))):
+
+    if isinstance(fillchar, types.UnicodeCharSeq):
+        def ljust_impl(string, width, fillchar):
+            return string.ljust(width, str(fillchar))
+        return ljust_impl
+
+    if not (fillchar == ' ' or isinstance(
+            fillchar, (types.Omitted, types.UnicodeType))):
         raise TypingError('The fillchar must be a UnicodeType')
 
     def ljust_impl(string, width, fillchar=' '):
@@ -685,6 +715,12 @@ def unicode_ljust(string, width, fillchar=' '):
 def unicode_rjust(string, width, fillchar=' '):
     if not isinstance(width, types.Integer):
         raise TypingError('The width must be an Integer')
+
+    if isinstance(fillchar, types.UnicodeCharSeq):
+        def rjust_impl(string, width, fillchar):
+            return string.rjust(width, str(fillchar))
+        return rjust_impl
+
     if not (fillchar == ' ' or isinstance(fillchar, (types.Omitted, types.UnicodeType))):
         raise TypingError('The fillchar must be a UnicodeType')
 
@@ -738,10 +774,16 @@ def join_list(sep, parts):
 
 @overload_method(types.UnicodeType, 'join')
 def unicode_join(sep, parts):
+
     if isinstance(parts, types.List):
         if isinstance(parts.dtype, types.UnicodeType):
             def join_list_impl(sep, parts):
                 return join_list(sep, parts)
+            return join_list_impl
+        elif isinstance(parts.dtype, types.UnicodeCharSeq):
+            def join_list_impl(sep, parts):
+                _parts = [str(p) for p in parts]
+                return join_list(sep, _parts)
             return join_list_impl
         else:
             pass  # lists of any other type not supported
@@ -817,6 +859,12 @@ def unicode_strip_types_check(chars):
 
 @overload_method(types.UnicodeType, 'lstrip')
 def unicode_lstrip(string, chars=None):
+
+    if isinstance(chars, types.UnicodeCharSeq):
+        def lstrip_impl(string, chars):
+            return string.lstrip(str(chars))
+        return lstrip_impl
+
     unicode_strip_types_check(chars)
 
     def lstrip_impl(string, chars=None):
@@ -826,6 +874,12 @@ def unicode_lstrip(string, chars=None):
 
 @overload_method(types.UnicodeType, 'rstrip')
 def unicode_rstrip(string, chars=None):
+
+    if isinstance(chars, types.UnicodeCharSeq):
+        def rstrip_impl(string, chars):
+            return string.rstrip(str(chars))
+        return rstrip_impl
+
     unicode_strip_types_check(chars)
 
     def rstrip_impl(string, chars=None):
@@ -835,6 +889,12 @@ def unicode_rstrip(string, chars=None):
 
 @overload_method(types.UnicodeType, 'strip')
 def unicode_strip(string, chars=None):
+
+    if isinstance(chars, types.UnicodeCharSeq):
+        def strip_impl(string, chars):
+            return string.strip(str(chars))
+        return strip_impl
+
     unicode_strip_types_check(chars)
 
     def strip_impl(string, chars=None):
@@ -1004,6 +1064,11 @@ def unicode_concat(a, b):
             for j in range(len(b)):
                 _set_code_point(result, len(a) + j, _get_code_point(b, j))
             return result
+        return concat_impl
+
+    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeCharSeq):
+        def concat_impl(a, b):
+            return a + str(b)
         return concat_impl
 
 

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -442,6 +442,13 @@ def _codepoint_is_ascii(ch):
 
 # PUBLIC API
 
+
+@overload(str)
+def unicode_str(s):
+    if isinstance(s, types.UnicodeType):
+        return lambda s: s
+
+
 @overload(len)
 def unicode_len(s):
     if isinstance(s, types.UnicodeType):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR implements the following operations for arrays with `str` and `bytes` items within jitted functions:
- [x] get `str`/`bytes` items
- [x] `len` on `str`/`bytes` items
- [x]  operations defined on `str`/`bytes` items: `==`, `!=`, `+`, `*`, `<`, `not`, `in`, etc
- [x] `hash` on `str`/`bytes` items
- [x] `str` on `str`/`bytes` items, `bytes` on `bytes` items
- [x] methods of `str`/`bytes` items: `istitle`, `upper`, `find`, `join`, etc
- Casting operations
  + [x] `UnicodeType` -> `UnicodeCharSeq`
  + [x] `Bytes` -> `CharSeq`
  + [x] `UnicodeType` -> `Bytes`
  + [x] `CharSeq` -> `Bytes`
- [x] unittests for all operations above

In addition, a number of `bytes` methods (if available) are now defined also for `Bytes` objects by using the corresponding implementations of `str` methods.

Closes #4416 
Closes #4018 

Only Python 3.x will be supported.