### PR TITLE
Fixed two module teardown races in py2.

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -50,6 +50,8 @@ class Environment(_dynfunc.Environment):
             return
         if _keepalive is None:
             return
+        if time is None or time.time is None:
+            return
         _keepalive.append((time.time(), self))
         if len(_keepalive) > 10:
             cur = time.time()


### PR DESCRIPTION
Commit 52caaf2ccd78aee4995fe3e1aca16af271b9d944 introduced two
single-threaded race conditions in Python 2 between the module
teardown mechanism and Environment.__del__.

 - If the numba.lowering module is torn down too early, its `time`
   global variable (referencing the time module) can be reset to
   None. The commit avoids a similar race with the _keepalive global
   variable, but that extra None-checking logic is missing for the
   time module. In practice, this race is almost never lost.

 - If the time module is torn down before the last Environment.__del__
   method is called, but before numba.lowering is torn down then
   time.time will be None. In practice, this is the race that is
   frequently lost when certain complex applications exit. In such
   situations, the following message is printed to stderr:

      Exception TypeError: "'NoneType' object is not callable" in
      <bound method Environment.__del__ of <numba.lowering.Environment
      object at ...>> ignored

This commit fixes both races.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
