### PR TITLE
[WIP] Entrypoints for numba extensions

### DIFF
--- a/docs/source/extending/entrypoints.rst
+++ b/docs/source/extending/entrypoints.rst
@@ -1,0 +1,45 @@
+Registering Extensions with Entry Points
+========================================
+
+Often, third party packages will have a user-facing API as well as define
+extensions to the Numba compiler.  In those situations, the new types and
+overloads can registered with Numba when the package is imported by the user.
+However, there are situations where a Numba extension would not normally be
+imported directly by the user, but must still be registered with the Numba
+compiler.  An example of this is the `numba-scipy
+<https://github.com/numba/numba-scipy>`_ package, which adds support for some
+SciPy functions to Numba.  The end user does not need to ``import
+numba_scipy`` to enable compiler support for SciPy.  The extension only needs
+to be installed into the Python environment.
+
+Numba discovers extensions with the `entry points
+<https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`_
+feature of ``setuptools``.  This allows a Python package to register an
+initializer function that will be called when the ``numba`` module is
+imported.
+
+
+Adding Support for the "Init" Entry Point
+-----------------------------------------
+
+A package can register an initialization function with Numba by adding the
+``entry_points`` argument to the ``setup()`` function call in ``setup.py``:
+
+.. code-block:: python
+
+    setup(
+        ...,
+        entry_points={
+            "numba_extensions": [
+                "init = numba_scipy:_init_extension",
+            ],
+        },
+        ...
+    )
+
+Numba currently only looks for the ``init`` entry point in the
+``numba_extensions`` group.  The entry point should be a function (any name,
+as long as it matches what is listed in ``setup.py``) that takes no arguments,
+and the return value is ignored.  This function should register types,
+overloads, or call other Numba extension APIs.  The order of initialization of
+extensions is undefined.

--- a/docs/source/extending/index.rst
+++ b/docs/source/extending/index.rst
@@ -22,9 +22,9 @@ the :doc:`architecture document <../developer/architecture>`.
 
 
 .. toctree::
-
    high-level.rst
    low-level.rst
    interval-example.rst
    overloading-guide.rst
+   entrypoints.rst
 

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -11,7 +11,7 @@ from . import config, sigutils
 from .errors import DeprecationError, NumbaDeprecationWarning
 from .targets import registry
 from .stencil import stencil
-
+import numba.entrypoints
 
 
 # -----------------------------------------------------------------------------
@@ -164,6 +164,9 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
 
 
 def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
+    # Ensure extensions have been loaded
+    numba.entrypoints.init_all()
+
     dispatcher = registry.dispatcher_registry[target]
 
     def wrapper(func):

--- a/numba/entrypoints.py
+++ b/numba/entrypoints.py
@@ -1,0 +1,23 @@
+import logging
+
+from pkg_resources import iter_entry_points
+
+_already_initialized = False
+logger = logging.getLogger(__name__)
+
+
+def init_all():
+    '''Execute all `numba_extensions` entry points with the name `init`
+
+    If extensions have already been initialized, this function does nothing.
+    '''
+    global _already_initialized
+    if _already_initialized:
+        return
+
+    for entry_point in iter_entry_points('numba_extensions', 'init'):
+        logger.debug('Loading extension:', entry_point)
+        func = entry_point.load()
+        func()
+
+    _already_initialized = True

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -1,0 +1,50 @@
+import sys
+import types
+
+import pkg_resources
+
+from .support import TestCase
+
+
+class TestEntrypoints(TestCase):
+    """
+    Test registration of init() functions from Numba extensions
+    """
+
+    def test_init_entrypoint(self):
+        # loosely based on Pandas test from:
+        #   https://github.com/pandas-dev/pandas/pull/27488
+
+        # FIXME: Python 2 workaround because nonlocal doesn't exist
+        counters = {'init': 0}
+
+        def init_function():
+            counters['init'] += 1
+
+        mod = types.ModuleType("_test_numba_extension")
+        mod.init_func = init_function
+        sys.modules[mod.__name__] = mod
+
+        # We are registering an entry point using the "numba" package
+        # ("distribution" in pkg_resources-speak) itself, though these are
+        # normally registered by other packages.
+        dist = "numba"
+        entrypoints = pkg_resources.get_entry_map(dist)
+        my_entrypoint = pkg_resources.EntryPoint(
+            "init", # name of entry point
+            mod.__name__, # module with entry point object
+            attrs=['init_func'], # name of entry point object
+            dist=pkg_resources.get_distribution(dist)
+        )
+        entrypoints.setdefault('numba_extensions', {})['init'] = my_entrypoint
+
+        import numba.entrypoints
+        numba.entrypoints._already_initialized = False  # Allow reinitialization
+        numba.entrypoints.init_all()
+
+        # was our init function called?
+        self.assertEqual(counters['init'], 1)
+
+        # ensure we do not initialize twice
+        numba.entrypoints.init_all()
+        self.assertEqual(counters['init'], 1)


### PR DESCRIPTION
This adds support for a `numba_extensions` entry point that can be used for third-party packages to register types and overloads automatically when Numba is used.

The main blocker on this PR is figuring out where to actually trigger the load of the extensions, because doing it in `numba.__init__` creates a circular import problem.  Ideally it would be triggered when `numba.__init__` finished importing, but I can't find a way to do that.  The interim solution used here (stuffing the load into the decorator) is wrong and needs to be replaced before this PR is merged.