### PR TITLE
Removes stale azure comment

### DIFF
--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -14,7 +14,6 @@ jobs:
 
   steps:
     - script: |
-        # Sleep 10 seconds because of race condition with background apt process
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh


### PR DESCRIPTION
The `sleep` command was removed in  #3371, this PR removes the accompanying comment. Closes #4430. 