### PR TITLE
[WIP] Make interpreter.py emit SSA form from bytecode

### DIFF
--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -41,7 +41,7 @@ def compute_use_defs(blocks):
                 elif isinstance(stmt.value, ir.Var):
                     rhs_set = set([stmt.value.name])
                 elif isinstance(stmt.value, (ir.Arg, ir.Const, ir.Global,
-                                             ir.FreeVar)):
+                                             ir.FreeVar, ir.Uninit)):
                     rhs_set = ()
                 else:
                     raise AssertionError('unreachable', type(stmt.value))

--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -41,7 +41,7 @@ def compute_use_defs(blocks):
                 elif isinstance(stmt.value, ir.Var):
                     rhs_set = set([stmt.value.name])
                 elif isinstance(stmt.value, (ir.Arg, ir.Const, ir.Global,
-                                             ir.FreeVar, ir.Uninit)):
+                                             ir.FreeVar)):
                     rhs_set = ()
                 else:
                     raise AssertionError('unreachable', type(stmt.value))

--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -2089,7 +2089,9 @@ class ArrayAnalysis(object):
         if len(args) < 2:
             return []
 
-        msg = "Sizes of {} do not match on {}".format(', '.join(arg_names), loc)
+        def _strip(x):
+            return x.split('.')[0]
+        msg = "Sizes of {} do not match on {}".format(', '.join(map(_strip, arg_names)), loc)
         msg_val = ir.Const(msg, loc)
         msg_typ = types.StringLiteral(msg)
         msg_var = ir.Var(scope, mk_unique_var("msg"), loc)

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -1118,8 +1118,11 @@ def type_inference_stage(typingctx, interp, args, return_type, locals={}):
             infer.seed_return(return_type)
 
         # Seed local types
-        for k, v in locals.items():
-            infer.seed_type(k, v)
+        # XXX hackie fix for locals X SSA
+        for var in interp._definitions:
+            ty = locals.get(var.split('.')[0])
+            if ty is not None:
+                infer.seed_type(var, ty)
 
         infer.build_constraint()
         infer.propagate()

--- a/numba/dataflow.py
+++ b/numba/dataflow.py
@@ -47,6 +47,12 @@ class DataFlowAnalysis(object):
         domfront = self.cfa.graph.dominance_frontier()
         phisite = collections.defaultdict(set)
         for var in self.defsites.keys():
+            if var.startswith('__sentinel__') or var.startswith('parfor__'):
+                continue
+            if len(self.defsites[var]) == 1:
+                # Skip if it's only defined once
+                continue
+
             defsites = self.defsites[var]
             w = set(defsites)
             while w:

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -224,6 +224,15 @@ class AbstractRHS(object):
     """
 
 
+class Uninit(AbstractRHS):
+    def __init__(self, loc):
+        self.loc = loc
+
+    def __repr__(self):
+        return "(Uninitialized)"
+
+
+
 class Inst(AbstractRHS):
     """
     Base class for all IR instructions.
@@ -1260,3 +1269,5 @@ class UndefinedType(object):
         return "Undefined"
 
 UNDEFINED = UndefinedType()
+
+

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -224,15 +224,6 @@ class AbstractRHS(object):
     """
 
 
-class Uninit(AbstractRHS):
-    def __init__(self, loc):
-        self.loc = loc
-
-    def __repr__(self):
-        return "(Uninitialized)"
-
-
-
 class Inst(AbstractRHS):
     """
     Base class for all IR instructions.
@@ -320,6 +311,12 @@ class Expr(Inst):
             self.__dict__[name] = value
         else:
             self._kws[name] = value
+
+    @classmethod
+    def uninitialized(cls, loc):
+        assert isinstance(loc, Loc)
+        op = 'uninitialized'
+        return cls(op=op, loc=loc)
 
     @classmethod
     def binop(cls, fn, lhs, rhs, loc):

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -488,10 +488,6 @@ class Lower(BaseLower):
             self.incref(ty, res)
             return res
 
-        elif isinstance(value, ir.Uninit):
-            res = self.context.get_constant_null(ty)
-            return res
-
         raise NotImplementedError(type(value), value)
 
     def lower_yield(self, retty, inst):
@@ -895,7 +891,9 @@ class Lower(BaseLower):
         return res
 
     def lower_expr(self, resty, expr):
-        if expr.op == 'binop':
+        if expr.op == 'uninitialized':
+             return self.context.get_constant_null(resty)
+        elif expr.op == 'binop':
             return self.lower_binop(resty, expr, expr.fn)
         elif expr.op == 'inplace_binop':
             lty = self.typeof(expr.lhs.name)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -488,6 +488,10 @@ class Lower(BaseLower):
             self.incref(ty, res)
             return res
 
+        elif isinstance(value, ir.Uninit):
+            res = self.context.get_constant_null(ty)
+            return res
+
         raise NotImplementedError(type(value), value)
 
     def lower_yield(self, retty, inst):
@@ -1121,6 +1125,10 @@ class Lower(BaseLower):
         """
         Load the given variable's value.
         """
+        # fetype = self.typeof(name)
+        # Define if not already
+        # self._alloca_var(name, fetype)
+
         ptr = self.getvar(name)
         return self.builder.load(ptr)
 

--- a/numba/pylowering.py
+++ b/numba/pylowering.py
@@ -192,9 +192,6 @@ class PyLower(BaseLower):
             return self.lower_global(value.name, value.value)
         elif isinstance(value, ir.Yield):
             return self.lower_yield(value)
-        elif isinstance(value, ir.Uninit):
-            ltype = self.context.get_value_type(types.pyobject)
-            return cgutils.get_null_value(ltype)
         elif isinstance(value, ir.Arg):
             obj = self.fnargs[value.index]
             # When an argument is omitted, the dispatcher hands it as
@@ -407,6 +404,9 @@ class PyLower(BaseLower):
             self.incref(val)
             return val
 
+        elif expr.op == 'uninitialized':
+            ltype = self.context.get_value_type(types.pyobject)
+            return cgutils.get_null_value(ltype)
         else:
             raise NotImplementedError(expr)
 

--- a/numba/pylowering.py
+++ b/numba/pylowering.py
@@ -192,6 +192,9 @@ class PyLower(BaseLower):
             return self.lower_global(value.name, value.value)
         elif isinstance(value, ir.Yield):
             return self.lower_yield(value)
+        elif isinstance(value, ir.Uninit):
+            ltype = self.context.get_value_type(types.pyobject)
+            return cgutils.get_null_value(ltype)
         elif isinstance(value, ir.Arg):
             obj = self.fnargs[value.index]
             # When an argument is omitted, the dispatcher hands it as

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1237,6 +1237,8 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
             self.typeof_expr(inst, inst.target, value)
         elif isinstance(value, ir.Yield):
             self.typeof_yield(inst, inst.target, value)
+        elif isinstance(value, ir.Uninit):
+            pass
         else:
             msg = ("Unsupported assignment encountered: %s %s" %
                    (type(value), str(value)))

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1237,8 +1237,6 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
             self.typeof_expr(inst, inst.target, value)
         elif isinstance(value, ir.Yield):
             self.typeof_yield(inst, inst.target, value)
-        elif isinstance(value, ir.Uninit):
-            pass
         else:
             msg = ("Unsupported assignment encountered: %s %s" %
                    (type(value), str(value)))
@@ -1443,6 +1441,8 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
         elif expr.op == 'make_function':
             self.lock_type(target.name, types.MakeFunctionLiteral(expr),
                            loc=inst.loc, literal_value=expr)
+        elif expr.op == 'uninitialized':
+            pass
         else:
             msg = "Unsupported op-code encountered: %s" % expr
             raise UnsupportedError(msg, loc=inst.loc)


### PR DESCRIPTION
The goal is to implement SSA form with minimal impact.

This implements an alternative approach inspired by the effort in #4177.   Instead of creating a new PHI node into the IR, variable definitions are merged like block parameters (i.e. Swift IR). The idea is similar to a inverted PHI-node.  Instead of gathering incoming variables, the "exporter" is forwarding to the outgoing node.  

Status:
- Most of non-parfor tests passes.
- Map-like parfor code seems to work.
- Trying to fix reduction parfor code, which is failing because the analysis cannot find the reduction variables.  The variable renaming at `acc += val` is not understood by parfor analysis.  