### PR TITLE
An option to render the IR CFG into files during compilation.

### DIFF
--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -404,6 +404,7 @@ class BasePipeline(object):
         """
         func_ir = translate_stage(self.func_id, self.bc)
         self._set_and_check_ir(func_ir)
+        debug_ir_cfg(func_ir, "postbytecode")
 
     def _set_and_check_ir(self, func_ir):
         self.func_ir = func_ir
@@ -695,6 +696,7 @@ class BasePipeline(object):
         """
         Back-end: Generate LLVM IR from Numba IR, compile to machine code
         """
+        debug_ir_cfg(self.func_ir, 'prelower')
         if self.library is None:
             codegen = self.targetctx.codegen()
             self.library = codegen.create_library(self.func_id.func_qualname)
@@ -912,6 +914,19 @@ class BasePipeline(object):
         """
         assert self.func_ir is not None
         return self._compile_core()
+
+
+def debug_ir_cfg(func_ir, level):
+    """Render IR CFG into a PDF file. if *level* is set
+
+    Writes to file ``<level>.<func_ir.unique_name>.pdf``.
+    See ``numba.config.VISUALIZE_IR_CFG``
+    """
+    options = set(config.VISUALIZE_IR_CFG.split(','))
+    if 'all' in options or level in options :
+        func_ir.visualize_cfg(
+            filename="{}.{}".format(level, func_ir.func_id.unique_name),
+        ).render(cleanup=True)
 
 
 class Pipeline(BasePipeline):

--- a/numba/config.py
+++ b/numba/config.py
@@ -185,6 +185,9 @@ class _EnvReloader(object):
         DUMP_IR = _readenv("NUMBA_DUMP_IR", int,
                            DEBUG_FRONTEND or DEBUG_TYPEINFER)
 
+        # Force dump of Numba IR CFG in PDF
+        VISUALIZE_IR_CFG = _readenv("NUMBA_VISUALIZE_IR_CFG", int, 0)
+
         # print debug info of analysis and optimization on array operations
         DEBUG_ARRAY_OPT = _readenv("NUMBA_DEBUG_ARRAY_OPT", int, 0)
 

--- a/numba/config.py
+++ b/numba/config.py
@@ -186,7 +186,12 @@ class _EnvReloader(object):
                            DEBUG_FRONTEND or DEBUG_TYPEINFER)
 
         # Force dump of Numba IR CFG in PDF
-        VISUALIZE_IR_CFG = _readenv("NUMBA_VISUALIZE_IR_CFG", int, 0)
+        # Available options are:
+        # - postbytecode: post bytecode analysis
+        # - prelower: pre-lowering
+        # - all: all of the above.
+        # Multiple options can be set using comma (,) as the separator.
+        VISUALIZE_IR_CFG = _readenv("NUMBA_VISUALIZE_IR_CFG", str, "")
 
         # print debug info of analysis and optimization on array operations
         DEBUG_ARRAY_OPT = _readenv("NUMBA_DEBUG_ARRAY_OPT", int, 0)

--- a/numba/controlflow.py
+++ b/numba/controlflow.py
@@ -279,14 +279,7 @@ class CFGraph(object):
         g : graphviz.Digraph
             Use `g.view()` to open the graph in the default PDF application.
         """
-
-        try:
-            import graphviz as gv
-        except ImportError:
-            raise ImportError(
-                "The feature requires `graphviz` but it is not available. "
-                "Please install with `pip install graphviz`"
-            )
+        gv = utils.import_graphviz()
         g = gv.Digraph(filename=filename)
         # Populate the nodes
         for n in self._nodes:

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -1397,7 +1397,8 @@ class FunctionIR(object):
                 block.dump(file=buf)
                 body = ''.join(['{}\l'.format(ln)
                                 for ln in buf.getvalue().split('\n')])
-            g.node(str(label), label=body, shape='rect')
+            g.node(str(label), label='block {}:\n{}'.format(label, body),
+                   shape='rect', fontname="monospace")
         for label, block in self.blocks.items():
             for target in block.terminator.get_targets():
                 g.edge(str(label), str(target))

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -85,6 +85,9 @@ class BaseLower(object):
         self.fndesc = fndesc
         self.blocks = utils.SortedMap(utils.iteritems(func_ir.blocks))
         self.func_ir = func_ir
+        if config.VISUALIZE_IR_CFG:
+            filename = 'prelower.{}'.format(fndesc.llvm_func_name)
+            self.func_ir.visualize_cfg(filename=filename).render(cleanup=True)
         self.call_conv = context.call_conv
         self.generator_info = func_ir.generator_info
         self.metadata = metadata

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -85,9 +85,6 @@ class BaseLower(object):
         self.fndesc = fndesc
         self.blocks = utils.SortedMap(utils.iteritems(func_ir.blocks))
         self.func_ir = func_ir
-        if config.VISUALIZE_IR_CFG:
-            filename = 'prelower.{}'.format(fndesc.llvm_func_name)
-            self.func_ir.visualize_cfg(filename=filename).render(cleanup=True)
         self.call_conv = context.call_conv
         self.generator_info = func_ir.generator_info
         self.metadata = metadata

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -765,3 +765,16 @@ class finalize:
 # dummy invocation to force _at_shutdown() to be registered
 finalize(lambda: None, lambda: None)
 assert finalize._registered_with_atexit
+
+
+def import_graphviz():
+    """Tries to import the optional dependency "graphviz"
+    """
+    try:
+        import graphviz as gv
+    except ImportError:
+        raise ImportError(
+            "The feature requires `graphviz` but it is not available. "
+            "Please install with `pip install graphviz`"
+        )
+    return gv


### PR DESCRIPTION
Add environment variable `NUMBA_VISUALIZE_IR_CFG=<options>` to enable rendering of the CFG of the Numba-IR at different points in the compilation pipeline.

Currently, the available options are: `prelower`, `postbytecode`.

Early review and suggestions welcomed.

TODOs:

- [ ] add test
- [ ] add docs
