### PR TITLE
Add a newline in patched errors

### DIFF
--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -336,7 +336,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             """
             if config.SHOW_HELP:
                 help_msg = errors.error_extras[issue_type]
-                e.patch_message('\n'.join((str(e), help_msg)))
+                e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
             if config.FULL_TRACEBACKS:
                 raise e
             else:
@@ -390,7 +390,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             if config.SHOW_HELP:
                 if hasattr(e, 'patch_message'):
                     help_msg = errors.error_extras['reportable']
-                    e.patch_message('\n'.join((str(e), help_msg)))
+                    e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
             # ignore the FULL_TRACEBACKS config, this needs reporting!
             raise e
 

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -336,7 +336,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             """
             if config.SHOW_HELP:
                 help_msg = errors.error_extras[issue_type]
-                e.patch_message(''.join(e.args) + help_msg)
+                e.patch_message('\n'.join((str(e), help_msg)))
             if config.FULL_TRACEBACKS:
                 raise e
             else:
@@ -390,7 +390,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             if config.SHOW_HELP:
                 if hasattr(e, 'patch_message'):
                     help_msg = errors.error_extras['reportable']
-                    e.patch_message(''.join(e.args) + help_msg)
+                    e.patch_message('\n'.join((str(e), help_msg)))
             # ignore the FULL_TRACEBACKS config, this needs reporting!
             raise e
 


### PR DESCRIPTION
Adds a blankline between the original error message and the help
message. This makes it easier to read as a user.

Changes

```python-traceback
TypingError: `a` must be a NumPy ndarray
This is not usually a problem with Numba itself but instead often caused by
the use of unsupported features or an issue in resolving types.

To see Python/NumPy features supported by the latest release of Numba visit:
http://numba.pydata.org/numba-doc/latest/reference/pysupported.html
and
http://numba.pydata.org/numba-doc/latest/reference/numpysupported.html

For more information about typing errors and how to debug them visit:
http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-doesn-t-compile

If you think your code should work with Numba, please report the error message
and traceback, along with a minimal reproducer at:
https://github.com/numba/numba/issues/new
```

to 

```python-traceback
TypingError: `a` must be a NumPy ndarray

This is not usually a problem with Numba itself but instead often caused by
the use of unsupported features or an issue in resolving types.

To see Python/NumPy features supported by the latest release of Numba visit:
http://numba.pydata.org/numba-doc/latest/reference/pysupported.html
and
http://numba.pydata.org/numba-doc/latest/reference/numpysupported.html

For more information about typing errors and how to debug them visit:
http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-doesn-t-compile

If you think your code should work with Numba, please report the error message
and traceback, along with a minimal reproducer at:
https://github.com/numba/numba/issues/new
```