### PR TITLE
Prevent CUDA kernel launch without a specified launch config.

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -313,8 +313,8 @@ class CUDAKernelBase(object):
     """
 
     def __init__(self):
-        self.griddim = (1, 1)
-        self.blockdim = (1, 1, 1)
+        self.griddim = None
+        self.blockdim = None
         self.sharedmem = 0
         self.stream = 0
 

--- a/numba/cuda/errors.py
+++ b/numba/cuda/errors.py
@@ -13,6 +13,16 @@ class KernelRuntimeError(RuntimeError):
         msg = t % (self.tid, self.ctaid, self.msg)
         super(KernelRuntimeError, self).__init__(msg)
 
+_launch_help_url = ("https://numba.pydata.org/numba-doc/"
+                    "latest/cuda/kernels.html#kernel-invocation")
+_missing_launch_config_msg = """
+Kernel launch configuration was not specified. Use the syntax:
+
+kernel_function[blockspergrid, threadsperblock](arg0, arg1, ..., argn)
+
+See {} for help.
+
+""".format(_launch_help_url)
 
 def normalize_kernel_dimensions(griddim, blockdim):
     """
@@ -34,6 +44,9 @@ def normalize_kernel_dimensions(griddim, blockdim):
         while len(dim) < 3:
             dim.append(1)
         return dim
+
+    if None in (griddim, blockdim):
+        raise ValueError(_missing_launch_config_msg)
 
     griddim = check_dim(griddim, 'griddim')
     blockdim = check_dim(blockdim, 'blockdim')


### PR DESCRIPTION
This patch prevents the launch of a CUDA kernel with no
configuration as this causes confusion for (especially) first time
users. Current behaviour is that if no launch config is specified
then a default everything-set-to-1 config is used, new behaviour is
that if no launch config is specified then an exception is raised
pointing users to the syntax and documentation.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
