### PR TITLE
Overload np.array to accept arrays

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -302,7 +302,7 @@ The following top-level functions are supported:
 * :func:`numpy.arange`
 * :func:`numpy.argsort` (``kind`` key word argument supported for values
   ``'quicksort'`` and ``'mergesort'``)
-* :func:`numpy.array` (only the 2 first arguments)
+* :func:`numpy.array` (only the 3 first arguments)
 * :func:`numpy.asarray` (only the 2 first arguments)
 * :func:`numpy.asfortranarray` (only the first argument)
 * :func:`numpy.atleast_1d`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3666,11 +3666,25 @@ def _is_nonelike(ty):
     return (ty is None) or isinstance(ty, types.NoneType)
 
 
+def _is_booleanlike(ty):
+    return (ty is True) or (ty is False) or isinstance(ty, types.Boolean)
+
+
 @overload(np.array)
 def np_array(a, dtype=None, copy=True):
 
     if not type_can_asarray(a):
         return None
+
+    if isinstance(dtype, types.Optional):
+        dtype = dtype.type
+    if not isinstance(dtype, types.DTypeSpec) and not _is_nonelike(dtype):
+        raise TypingError("'dtype' must be a valid NumPy type object")
+
+    if isinstance(copy, types.Optional):
+        copy = copy.type
+    if not _is_booleanlike(copy):
+        raise TypingError("'copy' must be a boolean")
 
     impl = None
     if isinstance(a, types.Array):
@@ -3713,6 +3727,11 @@ def np_asarray(a, dtype=None):
     # accepted types implementations below!
     if not type_can_asarray(a):
         return None
+
+    if isinstance(dtype, types.Optional):
+        dtype = dtype.type
+    if not isinstance(dtype, types.DTypeSpec) and not _is_nonelike(dtype):
+        raise TypingError("'dtype' must be a valid NumPy type object")
 
     impl = None
     if isinstance(a, types.Array):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -3669,8 +3669,6 @@ def _is_nonelike(ty):
 @overload(np.array)
 def np_array(a, dtype=None, copy=True):
 
-    # developer note... keep this function (type_can_asarray) in sync with the
-    # accepted types implementations below!
     if not type_can_asarray(a):
         return None
 
@@ -3679,13 +3677,13 @@ def np_array(a, dtype=None, copy=True):
         if _is_nonelike(dtype) or a.dtype == dtype.dtype:
             def impl(a, dtype=None, copy=True):
                 if copy:
-                    return a.copy()
+                    return np.copy(a)
                 else:
                     return a
         else:
             def impl(a, dtype=None, copy=True):
                 if copy:
-                    return a.astype(dtype).copy()
+                    return np.copy(a.astype(dtype))
                 else:
                     return a.astype(dtype)
     elif isinstance(a, (types.Sequence, types.Tuple)):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -1130,10 +1130,6 @@ class TestNpArray(MemoryLeakMixin, BaseTest):
                 yield
             self.assertIn(msg, str(raises.exception))
 
-        with check_raises(('array(float64, 1d, C) not allowed in a '
-                           'homogeneous sequence')):
-            cfunc(np.array([1.]))
-
         with check_raises(('type (int64, reflected list(int64)) does '
                           'not have a regular shape')):
             cfunc((np.int64(1), [np.int64(2)]))

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2673,7 +2673,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 if dtypes:
                     for dt in dtypes:
                         params['dtype'] = dt
-                        pass_through = not expect_copy and (dt is None or dt==x.dtype)
+                        pass_through = not expect_copy and (dt is None or dt == x.dtype)
                         check_pass_through(cfunc, pass_through, params)
                 else:
                     pass_through = not expect_copy


### PR DESCRIPTION
Adds support for calls to `np.array(a)` inside jitted functions, where `a` is a numpy array (which closes #4470), as well as support for the `copy` keyword argument to `np.array`.  Also adds tests for these features.

This overload is essentially a minor generalization of the overload for `np.asarray` (which is the next function in `arraymath.py`).  Unfortunately, I couldn't manage to just use this more general version to replace the `np.asarray` overload because of the different number of (optional) arguments, so this violates DRY a bit.  If I'm being silly, please let me know how to make it work.