### PR TITLE
Fix example in guvectorize docstring.

### DIFF
--- a/numba/npyufunc/decorators.py
+++ b/numba/npyufunc/decorators.py
@@ -163,7 +163,7 @@ def guvectorize(ftylist, signature, **kws):
         @guvectorize(['void(int32[:,:], int32[:,:], int32[:,:])',
                       'void(float32[:,:], float32[:,:], float32[:,:])'],
                       '(x, y),(x, y)->(x, y)')
-        def add_2d_array(a, b):
+        def add_2d_array(a, b, c):
             for i in range(c.shape[0]):
                 for j in range(c.shape[1]):
                     c[i, j] = a[i, j] + b[i, j]

--- a/tutorials/Numpy and numba.ipynb
+++ b/tutorials/Numpy and numba.ipynb
@@ -1065,7 +1065,7 @@
         "        @guvectorize(['void(int32[:,:], int32[:,:], int32[:,:])',\n",
         "                      'void(float32[:,:], float32[:,:], float32[:,:])'],\n",
         "                      '(x, y),(x, y)->(x, y)')\n",
-        "        def add_2d_array(a, b):\n",
+        "        def add_2d_array(a, b, c):\n",
         "            for i in range(c.shape[0]):\n",
         "                for j in range(c.shape[1]):\n",
         "                    c[i, j] = a[i, j] + b[i, j]\n",


### PR DESCRIPTION
In the `guvectorize` docstring the  example `add_2d_array` function does not compile as it is written because the function signature is missing it's third argument, the output.  This PR adds the argument in numba/npyufunc/decorators.py and in the example notebook, tutorials/Numpy and numba.ipynb, where the incorrect docstring also appears.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
