### PR TITLE
[WIP] Make `@lower_cast`and `@lower_constant` return new references

### DIFF
--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -592,7 +592,8 @@ class TraceRunner(object):
     def op_YIELD_VALUE(self, state, inst):
         val = state.pop()
         res = state.make_temp()
-        state.append(inst, value=val, res=res)
+        castval = state.make_temp()
+        state.append(inst, value=val, castval=castval, res=res)
         state.push(res)
 
     def op_RAISE_VARARGS(self, state, inst):

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -35,8 +35,10 @@ Status = namedtuple("Status",
 int32_t = ir.IntType(32)
 errcode_t = int32_t
 
+
 def _const_int(code):
     return ir.Constant(errcode_t, code)
+
 
 RETCODE_OK = _const_int(0)
 RETCODE_EXC = _const_int(-1)
@@ -47,8 +49,6 @@ RETCODE_STOPIT = _const_int(-3)
 FIRST_USEREXC = 1
 
 RETCODE_USEREXC = _const_int(FIRST_USEREXC)
-
-
 
 
 class BaseCallConv(object):
@@ -74,11 +74,9 @@ class BaseCallConv(object):
             self.return_native_none(builder)
 
         elif not isinstance(valty, types.Optional):
-            # Value is not an optional, need a cast
-            if valty != retty.type:
-                value = self.context.cast(builder, value, fromty=valty,
-                                          toty=retty.type)
-            retval = self.context.get_return_value(builder, retty.type, value)
+            castval = self.context.cast(builder, value, fromty=valty, toty=retty.type)
+            self.context.decref(builder, valty, value)
+            retval = self.context.get_return_value(builder, retty.type, castval)
             self.return_value(builder, retval)
 
         else:

--- a/numba/core/dataflow.py
+++ b/numba/core/dataflow.py
@@ -640,7 +640,8 @@ class DataFlowAnalysis(object):
     def op_YIELD_VALUE(self, info, inst):
         val = info.pop()
         res = info.make_temp()
-        info.append(inst, value=val, res=res)
+        castval = info.make_temp()
+        info.append(inst, value=val, castval=castval, res=res)
         info.push(res)
 
     def op_SETUP_LOOP(self, info, inst):

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -1210,10 +1210,11 @@ class Interpreter(object):
             stmt = ir.Raise(exception=exc, loc=self.loc)
             self.current_block.append(stmt)
 
-    def op_YIELD_VALUE(self, inst, value, res):
+    def op_YIELD_VALUE(self, inst, value, castval, res):
         # initialize index to None.  it's being set later in post-processing
         index = None
-        inst = ir.Yield(value=self.get(value), index=index, loc=self.loc)
+        self.store(ir.Expr.cast(self.get(value), loc=self.loc), castval)
+        inst = ir.Yield(value=self.get(castval), index=index, loc=self.loc)
         return self.store(inst, res)
 
     def op_MAKE_FUNCTION(self, inst, name, code, closure, annotations, kwdefaults, defaults, res):

--- a/numba/core/unsafe/refcount.py
+++ b/numba/core/unsafe/refcount.py
@@ -37,6 +37,7 @@ def dump_refcount(typingctx, obj):
                 # "%zu" is not portable.  just truncate refcount to 32-bit.
                 # that's good enough for a debugging util.
                 refct_32bit = builder.trunc(refct, ir.IntType(32))
+
                 printed = cgutils.snprintf_stackbuffer(
                     builder, 30, "%d [%p]", refct_32bit, miptr
                 )
@@ -73,6 +74,7 @@ def get_refcount(typingctx, obj):
                 refctptr = cgutils.gep_inbounds(builder, miptr, 0, 0)
                 refct = builder.load(refctptr)
                 refct_32bit = builder.trunc(refct, ir.IntType(32))
+
                 refcounts.append(refct_32bit)
         return refcounts[0]
 

--- a/numba/cpython/enumimpl.py
+++ b/numba/cpython/enumimpl.py
@@ -3,9 +3,10 @@ Implementation of enums.
 """
 import operator
 
-from numba.core.imputils import (lower_builtin, lower_getattr,
-                                 lower_getattr_generic, lower_cast,
-                                 lower_constant, impl_ret_untracked)
+from numba.core.imputils import (
+    lower_builtin, lower_getattr, lower_getattr_generic, lower_cast,
+    lower_constant, impl_ret_untracked, RefType
+)
 from numba.core import types
 
 
@@ -44,7 +45,7 @@ def enum_value(context, builder, ty, val):
     return val
 
 
-@lower_cast(types.IntEnumMember, types.Integer)
+@lower_cast(types.IntEnumMember, types.Integer, ref_type=RefType.UNTRACKED)
 def int_enum_to_int(context, builder, fromty, toty, val):
     """
     Convert an IntEnum member to its raw integer value.
@@ -52,7 +53,7 @@ def int_enum_to_int(context, builder, fromty, toty, val):
     return context.cast(builder, val, fromty.dtype, toty)
 
 
-@lower_constant(types.EnumMember)
+@lower_constant(types.EnumMember, ref_type=RefType.UNTRACKED)
 def enum_constant(context, builder, ty, pyval):
     """
     Return a LLVM constant representing enum member *pyval*.

--- a/numba/cpython/iterators.py
+++ b/numba/cpython/iterators.py
@@ -43,8 +43,9 @@ def make_enumerate_object(context, builder, sig, args):
     res = enum._getvalue()
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
+
 @lower_builtin('iternext', types.EnumerateType)
-@iternext_impl(RefType.BORROWED)
+@iternext_impl(RefType.NEW)
 def iternext_enumerate(context, builder, sig, args, result):
     [enumty] = sig.args
     [enum] = args
@@ -61,15 +62,10 @@ def iternext_enumerate(context, builder, sig, args, result):
 
     with builder.if_then(is_valid):
         srcval = srcres.yielded_value()
-        # As a iternext_impl function, this will incref the yielded value.
-        # We need to release the new reference from call_iternext.
-        if context.enable_nrt:
-            context.nrt.decref(builder, enumty.yield_type[1], srcval)
         result.yield_(context.make_tuple(builder, enumty.yield_type,
                                          [count, srcval]))
 
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # builtin `zip` implementation
 
 @lower_builtin(zip, types.VarArg(types.Any))

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -8,10 +8,10 @@ from llvmlite import ir
 from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
-from numba.core.imputils import (lower_builtin, lower_getattr,
-                                    lower_getattr_generic, lower_cast,
-                                    lower_constant, impl_ret_borrowed,
-                                    impl_ret_untracked)
+from numba.core.imputils import (
+    lower_builtin, lower_getattr, lower_cast, lower_constant,
+    impl_ret_untracked, RefType
+)
 from numba.core import typing, types, utils, errors, cgutils, optional
 from numba.core.extending import intrinsic, overload_method
 from numba.cpython.unsafe.numbers import viewer
@@ -1217,15 +1217,15 @@ for ty in (types.Integer, types.Float, types.Complex):
 lower_builtin(operator.not_, types.boolean)(number_not_impl)
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Hashing numbers, see hashing.py
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Implicit casts between numerics
 
-@lower_cast(types.IntegerLiteral, types.Integer)
-@lower_cast(types.IntegerLiteral, types.Float)
-@lower_cast(types.IntegerLiteral, types.Complex)
+@lower_cast(types.IntegerLiteral, types.Integer, ref_type=RefType.UNTRACKED)
+@lower_cast(types.IntegerLiteral, types.Float, ref_type=RefType.UNTRACKED)
+@lower_cast(types.IntegerLiteral, types.Complex, ref_type=RefType.UNTRACKED)
 def literal_int_to_number(context, builder, fromty, toty, val):
     lit = context.get_constant_generic(
         builder,
@@ -1235,7 +1235,7 @@ def literal_int_to_number(context, builder, fromty, toty, val):
     return context.cast(builder, lit, fromty.literal_type, toty)
 
 
-@lower_cast(types.Integer, types.Integer)
+@lower_cast(types.Integer, types.Integer, ref_type=RefType.UNTRACKED)
 def integer_to_integer(context, builder, fromty, toty, val):
     if toty.bitwidth == fromty.bitwidth:
         # Just a change of signedness
@@ -1250,11 +1250,11 @@ def integer_to_integer(context, builder, fromty, toty, val):
         # Unsigned upcast
         return builder.zext(val, context.get_value_type(toty))
 
-@lower_cast(types.Integer, types.voidptr)
+@lower_cast(types.Integer, types.voidptr, ref_type=RefType.UNTRACKED)
 def integer_to_voidptr(context, builder, fromty, toty, val):
     return builder.inttoptr(val, context.get_value_type(toty))
 
-@lower_cast(types.Float, types.Float)
+@lower_cast(types.Float, types.Float, ref_type=RefType.UNTRACKED)
 def float_to_float(context, builder, fromty, toty, val):
     lty = context.get_value_type(toty)
     if fromty.bitwidth < toty.bitwidth:
@@ -1262,7 +1262,7 @@ def float_to_float(context, builder, fromty, toty, val):
     else:
         return builder.fptrunc(val, lty)
 
-@lower_cast(types.Integer, types.Float)
+@lower_cast(types.Integer, types.Float, ref_type=RefType.UNTRACKED)
 def integer_to_float(context, builder, fromty, toty, val):
     lty = context.get_value_type(toty)
     if fromty.signed:
@@ -1270,7 +1270,7 @@ def integer_to_float(context, builder, fromty, toty, val):
     else:
         return builder.uitofp(val, lty)
 
-@lower_cast(types.Float, types.Integer)
+@lower_cast(types.Float, types.Integer, ref_type=RefType.UNTRACKED)
 def float_to_integer(context, builder, fromty, toty, val):
     lty = context.get_value_type(toty)
     if toty.signed:
@@ -1278,8 +1278,8 @@ def float_to_integer(context, builder, fromty, toty, val):
     else:
         return builder.fptoui(val, lty)
 
-@lower_cast(types.Float, types.Complex)
-@lower_cast(types.Integer, types.Complex)
+@lower_cast(types.Float, types.Complex, ref_type=RefType.UNTRACKED)
+@lower_cast(types.Integer, types.Complex, ref_type=RefType.UNTRACKED)
 def non_complex_to_complex(context, builder, fromty, toty, val):
     real = context.cast(builder, val, fromty, toty.underlying_float)
     imag = context.get_constant(toty.underlying_float, 0)
@@ -1289,7 +1289,7 @@ def non_complex_to_complex(context, builder, fromty, toty, val):
     cmplx.imag = imag
     return cmplx._getvalue()
 
-@lower_cast(types.Complex, types.Complex)
+@lower_cast(types.Complex, types.Complex, ref_type=RefType.UNTRACKED)
 def complex_to_complex(context, builder, fromty, toty, val):
     srcty = fromty.underlying_float
     dstty = toty.underlying_float
@@ -1300,18 +1300,20 @@ def complex_to_complex(context, builder, fromty, toty, val):
     dst.imag = context.cast(builder, src.imag, srcty, dstty)
     return dst._getvalue()
 
-@lower_cast(types.Any, types.Boolean)
+
+@lower_cast(types.Any, types.Boolean, ref_type=RefType.UNTRACKED)
 def any_to_boolean(context, builder, fromty, toty, val):
     return context.is_true(builder, fromty, val)
 
-@lower_cast(types.Boolean, types.Number)
+
+@lower_cast(types.Boolean, types.Number, ref_type=RefType.UNTRACKED)
 def boolean_to_any(context, builder, fromty, toty, val):
     # Casting from boolean to anything first casts to int32
     asint = builder.zext(val, Type.int())
     return context.cast(builder, asint, types.int32, toty)
 
 
-@lower_cast(types.IntegerLiteral, types.Boolean)
+@lower_cast(types.IntegerLiteral, types.Boolean, ref_type=RefType.UNTRACKED)
 def literal_int_to_boolean(context, builder, fromty, toty, val):
     lit = context.get_constant_generic(
         builder,
@@ -1320,25 +1322,26 @@ def literal_int_to_boolean(context, builder, fromty, toty, val):
         )
     return context.is_true(builder, fromty.literal_type, lit)
 
-#-------------------------------------------------------------------------------
-# Constants
 
-@lower_constant(types.Complex)
+# -----------------------------------------------------------------------------
+# Constants
+@lower_constant(types.Complex, ref_type=RefType.UNTRACKED)
 def constant_complex(context, builder, ty, pyval):
     fty = ty.underlying_float
     real = context.get_constant_generic(builder, fty, pyval.real)
     imag = context.get_constant_generic(builder, fty, pyval.imag)
     return ir.Constant.literal_struct((real, imag))
 
-@lower_constant(types.Integer)
-@lower_constant(types.Float)
-@lower_constant(types.Boolean)
+
+@lower_constant(types.Integer, ref_type=RefType.UNTRACKED)
+@lower_constant(types.Float, ref_type=RefType.UNTRACKED)
+@lower_constant(types.Boolean, ref_type=RefType.UNTRACKED)
 def constant_integer(context, builder, ty, pyval):
     lty = context.get_value_type(ty)
     return lty(pyval)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # View
 
 def scalar_view(scalar, viewty):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1224,6 +1224,7 @@ def set_add(context, builder, sig, args):
 
     return context.get_dummy_value()
 
+
 @lower_builtin("set.discard", types.Set, types.Any)
 def set_discard(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
@@ -1398,6 +1399,7 @@ def set_isdisjoint(context, builder, sig, args):
 
     return inst.isdisjoint(other)
 
+
 @lower_builtin(operator.le, types.Set, types.Set)
 @lower_builtin("set.issubset", types.Set, types.Set)
 def set_issubset(context, builder, sig, args):
@@ -1405,6 +1407,7 @@ def set_issubset(context, builder, sig, args):
     other = SetInstance(context, builder, sig.args[1], args[1])
 
     return inst.issubset(other)
+
 
 @lower_builtin(operator.ge, types.Set, types.Set)
 @lower_builtin("set.issuperset", types.Set, types.Set)
@@ -1414,12 +1417,14 @@ def set_issuperset(context, builder, sig, args):
 
     return context.compile_internal(builder, superset_impl, sig, args)
 
+
 @lower_builtin(operator.eq, types.Set, types.Set)
 def set_isdisjoint(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     other = SetInstance(context, builder, sig.args[1], args[1])
 
     return inst.equals(other)
+
 
 @lower_builtin(operator.ne, types.Set, types.Set)
 def set_ne(context, builder, sig, args):
@@ -1428,6 +1433,7 @@ def set_ne(context, builder, sig, args):
 
     return context.compile_internal(builder, ne_impl, sig, args)
 
+
 @lower_builtin(operator.lt, types.Set, types.Set)
 def set_lt(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
@@ -1435,12 +1441,14 @@ def set_lt(context, builder, sig, args):
 
     return inst.issubset(other, strict=True)
 
+
 @lower_builtin(operator.gt, types.Set, types.Set)
 def set_gt(context, builder, sig, args):
     def gt_impl(a, b):
         return b < a
 
     return context.compile_internal(builder, gt_impl, sig, args)
+
 
 @lower_builtin(operator.is_, types.Set, types.Set)
 def set_is(context, builder, sig, args):
@@ -1454,7 +1462,7 @@ def set_is(context, builder, sig, args):
 # -----------------------------------------------------------------------------
 # Implicit casting
 
-@lower_cast(types.Set, types.Set)
+@lower_cast(types.Set, types.Set, ref_type=RefType.BORROWED)
 def set_to_set(context, builder, fromty, toty, val):
     # Casting from non-reflected to reflected
     assert fromty.dtype == toty.dtype

--- a/numba/experimental/function_type.py
+++ b/numba/experimental/function_type.py
@@ -5,7 +5,7 @@ instances of a first-class function type.
 from numba.extending import typeof_impl
 from numba.extending import models, register_model
 from numba.extending import unbox, NativeValue, box
-from numba.core.imputils import lower_constant, lower_cast
+from numba.core.imputils import lower_constant, lower_cast, RefType
 from numba.core.ccallback import CFunc
 from numba.core import cgutils
 from llvmlite import ir
@@ -61,13 +61,13 @@ class FunctionModel(models.StructModel):
         super(FunctionModel, self).__init__(dmm, fe_type, members)
 
 
-@lower_constant(types.Dispatcher)
+@lower_constant(types.Dispatcher, RefType.UNTRACKED)
 def lower_constant_dispatcher(context, builder, typ, pyval):
     return context.add_dynamic_addr(builder, id(pyval),
                                     info=type(pyval).__name__)
 
 
-@lower_constant(FunctionType)
+@lower_constant(FunctionType, RefType.UNTRACKED)
 def lower_constant_function_type(context, builder, typ, pyval):
     typ = typ.get_precise()
 
@@ -239,13 +239,13 @@ def box_function_type(typ, val, c):
     return cfunc
 
 
-@lower_cast(UndefinedFunctionType, FunctionType)
+@lower_cast(UndefinedFunctionType, FunctionType, RefType.UNTRACKED)
 def lower_cast_function_type_to_function_type(
         context, builder, fromty, toty, val):
     return val
 
 
-@lower_cast(types.Dispatcher, FunctionType)
+@lower_cast(types.Dispatcher, FunctionType, RefType.UNTRACKED)
 def lower_cast_dispatcher_to_function_type(context, builder, fromty, toty, val):
     toty = toty.get_precise()
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2131,8 +2131,8 @@ def array_ctypes_data(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 
-@lower_cast(types.ArrayCTypes, types.CPointer)
-@lower_cast(types.ArrayCTypes, types.voidptr)
+@lower_cast(types.ArrayCTypes, types.CPointer, ref_type=RefType.UNTRACKED)
+@lower_cast(types.ArrayCTypes, types.voidptr, ref_type=RefType.UNTRACKED)
 def array_ctypes_to_pointer(context, builder, fromty, toty, val):
     ctinfo = context.make_helper(builder, fromty, value=val)
     res = ctinfo.data
@@ -2442,7 +2442,7 @@ def record_setitem(context, builder, sig, args):
 # Constant arrays and records
 
 
-@lower_constant(types.Array)
+@lower_constant(types.Array, ref_type=RefType.BORROWED)
 def constant_array(context, builder, ty, pyval):
     """
     Create a constant array (mechanism is target-dependent).
@@ -2450,7 +2450,7 @@ def constant_array(context, builder, ty, pyval):
     return context.make_constant_array(builder, ty, pyval)
 
 
-@lower_constant(types.Record)
+@lower_constant(types.Record, ref_type=RefType.BORROWED)
 def constant_record(context, builder, ty, pyval):
     """
     Create a record constant as a stack-allocated array of bytes.
@@ -2460,7 +2460,7 @@ def constant_record(context, builder, ty, pyval):
     return cgutils.alloca_once_value(builder, val)
 
 
-@lower_constant(types.Bytes)
+@lower_constant(types.Bytes, ref_type=RefType.UNTRACKED)
 def constant_bytes(context, builder, ty, pyval):
     """
     Create a constant array from bytes (mechanism is target-dependent).
@@ -5040,7 +5040,7 @@ def array_argsort(context, builder, sig, args):
 # ------------------------------------------------------------------------------
 # Implicit cast
 
-@lower_cast(types.Array, types.Array)
+@lower_cast(types.Array, types.Array, ref_type=RefType.BORROWED)
 def array_to_array(context, builder, fromty, toty, val):
     # Type inference should have prevented illegal array casting.
     assert fromty.mutable != toty.mutable or toty.layout == 'A'

--- a/numba/np/npdatetime.py
+++ b/numba/np/npdatetime.py
@@ -9,8 +9,9 @@ from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
 from numba.core import types, cgutils
-from numba.core.imputils import (lower_builtin, lower_constant,
-                                    impl_ret_untracked)
+from numba.core.imputils import (
+    lower_builtin, lower_constant, impl_ret_untracked, RefType
+)
 from numba.np import npdatetime_helpers, numpy_support, npyfuncs
 
 # datetime64 and timedelta64 use the same internal representation
@@ -122,8 +123,8 @@ leap_year_months_acc = make_constant_array(
     [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335])
 
 
-@lower_constant(types.NPDatetime)
-@lower_constant(types.NPTimedelta)
+@lower_constant(types.NPDatetime, ref_type=RefType.UNTRACKED)
+@lower_constant(types.NPTimedelta, ref_type=RefType.UNTRACKED)
 def datetime_constant(context, builder, ty, pyval):
     return DATETIME64(pyval.astype(np.int64))
 

--- a/numba/np/ufunc/array_exprs.py
+++ b/numba/np/ufunc/array_exprs.py
@@ -389,8 +389,15 @@ def _lower_array_expr(lowerer, expr):
                          for val, inty, outty in arg_zip]
             result = self.context.call_internal(
                 builder, cres.fndesc, inner_sig, cast_args)
-            return self.cast(result, inner_sig.return_type,
-                             self.outer_sig.return_type)
+
+            castres = self.cast(result, inner_sig.return_type,
+                                self.outer_sig.return_type)
+
+            for val, ty in zip(cast_args, inner_sig.args):
+                self.context.decref(self.builder, ty, val)
+            self.context.decref(self.builder, inner_sig.return_type, result)
+
+            return castres
 
     args = [lowerer.loadvar(name) for name in expr_args]
     return npyimpl.numpy_ufunc_kernel(

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -45,7 +45,13 @@ def make_dufunc_kernel(_dufunc):
             _, res = self.context.call_conv.call_function(
                 self.builder, entry_point, isig.return_type, isig.args,
                 cast_args)
-            return self.cast(res, isig.return_type, osig.return_type)
+            castres = self.cast(res, isig.return_type, osig.return_type)
+
+            for val, ty in zip(cast_args, isig.args):
+                self.context.decref(self.builder, ty, val)
+            self.context.decref(self.builder, isig.return_type, res)
+
+            return castres
 
     DUFuncKernel.__name__ += _dufunc.ufunc.__name__
     return DUFuncKernel

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -24,12 +24,14 @@ def _build_set_literal_usecase(code, args):
     code = code % {'initializer': ', '.join(repr(arg) for arg in args)}
     return compile_function('build_set', code, globals())
 
+
 def set_literal_return_usecase(args):
     code = """if 1:
     def build_set():
         return {%(initializer)s}
     """
     return _build_set_literal_usecase(code, args)
+
 
 def set_literal_convert_usecase(args):
     code = """if 1:
@@ -45,9 +47,11 @@ def empty_constructor_usecase():
     s.add(1)
     return len(s)
 
+
 def constructor_usecase(arg):
     s = set(arg)
     return len(s)
+
 
 def iterator_usecase(arg):
     s = set(arg)
@@ -56,6 +60,7 @@ def iterator_usecase(arg):
         l.append(v)
     return l
 
+
 def update_usecase(a, b, c):
     s = set()
     s.update(a)
@@ -63,10 +68,12 @@ def update_usecase(a, b, c):
     s.update(c)
     return list(s)
 
+
 def bool_usecase(arg):
     # Remove one element to allow for empty sets.
     s = set(arg[1:])
     return bool(s)
+
 
 def remove_usecase(a, b):
     s = set(a)
@@ -74,11 +81,13 @@ def remove_usecase(a, b):
         s.remove(v)
     return list(s)
 
+
 def discard_usecase(a, b):
     s = set(a)
     for v in b:
         s.discard(v)
     return list(s)
+
 
 def add_discard_usecase(a, u, v):
     s = set(a)
@@ -399,7 +408,7 @@ class TestSets(BaseTest):
         b = self.duplicates_array(50)
         c = self.sparse_array(50)
         check(a, b, c)
-    
+
     def test_bool(self):
         pyfunc = bool_usecase
         check = self.unordered_checker(pyfunc)

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -25,13 +25,15 @@ def _cast(typingctx, val, typ):
     """Cast *val* to *typ*
     """
     def codegen(context, builder, signature, args):
-        [val, typ] = args
-        context.nrt.incref(builder, signature.return_type, val)
-        return val
-    # Using implicit casting in argument types
+        [val, _] = args
+        casted = context.cast(builder, val, signature.args[0],
+                              signature.return_type)
+
+        return casted
+
     casted = typ.instance_type
     _sentry_safe_cast(val, casted)
-    sig = casted(casted, typ)
+    sig = casted(val, typ)
     return sig, codegen
 
 
@@ -93,11 +95,12 @@ def _nonoptional(typingctx, val):
         raise TypeError('expected an optional')
 
     def codegen(context, builder, sig, args):
-        context.nrt.incref(builder, sig.return_type, args[0])
-        return args[0]
+        casted = context.cast(builder, args[0], sig.args[0], sig.return_type)
+
+        return casted
 
     casted = val.type
-    sig = casted(casted)
+    sig = casted(val)
     return sig, codegen
 
 


### PR DESCRIPTION
Implements #4494 mainly using implicit casts. The new behaviour can be turned off by setting `NUMBA_CAST_RETURNS_NEW_REFS=0` and `NUMBA_LOWER_CONST_RETURNS_NEW_REFS=0` which should behave almost exactly like `master` except for the odd trivial cast and slightly different Numba IR for `yield` statements.

This PR
1. Introduces config switches `NUMBA_CAST_RETURNS_NEW_REFS` and `NUMBA_LOWER_CONST_RETURNS_NEW_REFS` to control the casting/lower constant behaviour
2. adds a new `ref_type` argument to `@lower_cast` and `@lower_constant` to let implementations declare which convention they are following (like in `@iternext_impl`) and adapts to the convention set in the config in the wrapper
3. adds clean-up for the references created if `NUMBA_CAST_RETURNS_NEW_REFS=1` or `NUMBA_LOWER_CONST_RETURNS_NEW_REFS=1`
4. Making casts for yield values explicit (like it is already the case for return values)

Previous versions of this PR were favouring explicit casts ([see](https://github.com/numba/numba/issues/4494#issuecomment-529674586)). However, it turned out that making casts explicit requires Numba IR in SSA form and some changes to the typer. This in turn breaks many rewrites like `parfors` etc. While the previous incarnations of his PR worked for our internal code they never passed the Numba testsuite. Since porting #4445 to 0.48 looked like a significant effort we decided to go with implicit casts for now. This is also minimizing the impact on Numba IR rewrites.
