### PR TITLE
Make List.__getitem__ accept unsigned parameters

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -51,6 +51,8 @@ _meminfo_listptr = types.MemInfoPointer(types.voidptr)
 
 INDEXTY = types.intp
 
+index_type = types.integer_domain
+
 
 @register_model(ListType)
 class ListModel(models.StructModel):
@@ -562,7 +564,7 @@ def impl_getitem(l, index):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.index_type:
+    if index in index_type:
         def integer_impl(l, index):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -630,7 +632,7 @@ def impl_setitem(l, index, item):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.index_type:
+    if index in index_type:
         def impl_integer(l, index, item):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -704,7 +706,7 @@ def impl_pop(l, index=-1):
 
     # FIXME: this type check works, but it isn't clear why and if it optimal
     if (isinstance(index, int)
-            or index in types.index_type
+            or index in index_type
             or isinstance(index, types.Omitted)):
         def impl(l, index=-1):
             if len(l) == 0:
@@ -759,7 +761,7 @@ def impl_delitem(l, index):
     if not isinstance(l, types.ListType):
         return
 
-    if index in types.index_type:
+    if index in index_type:
         def integer_impl(l, index):
             l.pop(index)
 
@@ -861,7 +863,7 @@ def impl_insert(l, index, item):
     if not isinstance(l, types.ListType):
         return
 
-    if index in types.index_type:
+    if index in index_type:
         def impl(l, index, item):
             # If the index is larger than the size of the list or if the list is
             # empty, just append.
@@ -962,7 +964,7 @@ def impl_index(l, item, start=None, end=None):
 
     def check_arg(arg, name):
         if not (arg is None
-                or arg in types.index_type
+                or arg in index_type
                 or isinstance(arg, (types.Omitted, types.NoneType))):
             raise TypingError("{} argument for index must be an integer"
                               .format(name))

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -562,7 +562,7 @@ def impl_getitem(l, index):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.integer_domain:
+    if index in types.index_type:
         def integer_impl(l, index):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -584,7 +584,7 @@ def impl_getitem(l, index):
         return slice_impl
 
     else:
-        raise TypingError("list indices must be signed integers or slices")
+        raise TypingError("list indices must be integers or slices")
 
 
 @intrinsic
@@ -630,7 +630,7 @@ def impl_setitem(l, index, item):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.integer_domain:
+    if index in types.index_type:
         def impl_integer(l, index, item):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -692,7 +692,7 @@ def impl_setitem(l, index, item):
         return impl_slice
 
     else:
-        raise TypingError("list indices must be signed integers or slices")
+        raise TypingError("list indices must be integers or slices")
 
 
 @overload_method(types.ListType, 'pop')
@@ -704,7 +704,7 @@ def impl_pop(l, index=-1):
 
     # FIXME: this type check works, but it isn't clear why and if it optimal
     if (isinstance(index, int)
-            or index in types.integer_domain
+            or index in types.index_type
             or isinstance(index, types.Omitted)):
         def impl(l, index=-1):
             if len(l) == 0:
@@ -759,7 +759,7 @@ def impl_delitem(l, index):
     if not isinstance(l, types.ListType):
         return
 
-    if index in types.integer_domain:
+    if index in types.index_type:
         def integer_impl(l, index):
             l.pop(index)
 
@@ -775,7 +775,7 @@ def impl_delitem(l, index):
         return slice_impl
 
     else:
-        raise TypingError("list indices must be signed integers or slices")
+        raise TypingError("list indices must be integers or slices")
 
 
 @overload(operator.contains)
@@ -861,7 +861,7 @@ def impl_insert(l, index, item):
     if not isinstance(l, types.ListType):
         return
 
-    if index in types.signed_domain:
+    if index in types.index_type:
         def impl(l, index, item):
             # If the index is larger than the size of the list or if the list is
             # empty, just append.
@@ -895,7 +895,7 @@ def impl_insert(l, index, item):
             sig = typing.signature(types.void, l, INDEXTY, itemty)
             return sig, impl
     else:
-        raise TypingError("list insert indices must be signed integers")
+        raise TypingError("list insert indices must be integers")
 
 
 @overload_method(types.ListType, 'remove')
@@ -962,7 +962,7 @@ def impl_index(l, item, start=None, end=None):
 
     def check_arg(arg, name):
         if not (arg is None
-                or arg in types.integer_domain
+                or arg in types.index_type
                 or isinstance(arg, (types.Omitted, types.NoneType))):
             raise TypingError("{} argument for index must be an integer"
                               .format(name))

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -462,7 +462,9 @@ def handle_index(l, index):
     """
     # convert negative indices to positive ones
     if index < 0:
-        index = type(index)(len(l)) + index
+        # len(l) has always type 'int64'
+        # while index can be an signed/unsigned integer
+        index = type(index)(len(l) + index)
     # check that the index is in range
     if not (0 <= index < len(l)):
         raise IndexError("list index out of range")

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -562,7 +562,7 @@ def impl_getitem(l, index):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.signed_domain:
+    if index in types.integer_domain:
         def integer_impl(l, index):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -462,7 +462,7 @@ def handle_index(l, index):
     """
     # convert negative indices to positive ones
     if index < 0:
-        index = len(l) + index
+        index = type(index)(len(l)) + index
     # check that the index is in range
     if not (0 <= index < len(l)):
         raise IndexError("list index out of range")

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -630,7 +630,7 @@ def impl_setitem(l, index, item):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in types.signed_domain:
+    if index in types.integer_domain:
         def impl_integer(l, index, item):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -704,7 +704,7 @@ def impl_pop(l, index=-1):
 
     # FIXME: this type check works, but it isn't clear why and if it optimal
     if (isinstance(index, int)
-            or index in types.signed_domain
+            or index in types.integer_domain
             or isinstance(index, types.Omitted)):
         def impl(l, index=-1):
             if len(l) == 0:
@@ -719,7 +719,7 @@ def impl_pop(l, index=-1):
         return impl
 
     else:
-        raise TypingError("argument for pop must be a signed integer")
+        raise TypingError("argument for pop must be an integer")
 
 
 @intrinsic
@@ -759,7 +759,7 @@ def impl_delitem(l, index):
     if not isinstance(l, types.ListType):
         return
 
-    if index in types.signed_domain:
+    if index in types.integer_domain:
         def integer_impl(l, index):
             l.pop(index)
 
@@ -962,9 +962,9 @@ def impl_index(l, item, start=None, end=None):
 
     def check_arg(arg, name):
         if not (arg is None
-                or arg in types.signed_domain
+                or arg in types.integer_domain
                 or isinstance(arg, (types.Omitted, types.NoneType))):
-            raise TypingError("{} argument for index must be a signed integer"
+            raise TypingError("{} argument for index must be an integer"
                               .format(name))
     check_arg(start, "start")
     check_arg(end, "end")

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -51,7 +51,7 @@ _meminfo_listptr = types.MemInfoPointer(types.voidptr)
 
 INDEXTY = types.intp
 
-index_type = types.integer_domain
+index_types = types.integer_domain
 
 
 @register_model(ListType)
@@ -564,7 +564,7 @@ def impl_getitem(l, index):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in index_type:
+    if index in index_types:
         def integer_impl(l, index):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -632,7 +632,7 @@ def impl_setitem(l, index, item):
     indexty = INDEXTY
     itemty = l.item_type
 
-    if index in index_type:
+    if index in index_types:
         def impl_integer(l, index, item):
             index = handle_index(l, index)
             castedindex = _cast(index, indexty)
@@ -761,7 +761,7 @@ def impl_delitem(l, index):
     if not isinstance(l, types.ListType):
         return
 
-    if index in index_type:
+    if index in index_types:
         def integer_impl(l, index):
             l.pop(index)
 
@@ -863,7 +863,7 @@ def impl_insert(l, index, item):
     if not isinstance(l, types.ListType):
         return
 
-    if index in index_type:
+    if index in index_types:
         def impl(l, index, item):
             # If the index is larger than the size of the list or if the list is
             # empty, just append.

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -706,7 +706,7 @@ def impl_pop(l, index=-1):
 
     # FIXME: this type check works, but it isn't clear why and if it optimal
     if (isinstance(index, int)
-            or index in index_type
+            or index in index_types
             or isinstance(index, types.Omitted)):
         def impl(l, index=-1):
             if len(l) == 0:
@@ -964,7 +964,7 @@ def impl_index(l, item, start=None, end=None):
 
     def check_arg(arg, name):
         if not (arg is None
-                or arg in index_type
+                or arg in index_types
                 or isinstance(arg, (types.Omitted, types.NoneType))):
             raise TypingError("{} argument for index must be an integer"
                               .format(name))

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -663,7 +663,7 @@ class TestPop(MemoryLeakMixin, TestCase):
             with self.assertRaises(TypingError) as raises:
                 foo(i)
             self.assertIn(
-                "argument for pop must be a signed integer",
+                "argument for pop must be an integer",
                 str(raises.exception),
             )
 
@@ -1242,7 +1242,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             foo()
         self.assertIn(
-            "start argument for index must be a signed integer",
+            "start argument for index must be an integer",
             str(raises.exception),
         )
 
@@ -1257,7 +1257,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             foo()
         self.assertIn(
-            "end argument for index must be a signed integer",
+            "end argument for index must be an integer",
             str(raises.exception),
         )
 

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -144,7 +144,7 @@ class TestGetitem(MemoryLeakMixin, TestCase):
             with self.assertRaises(TypingError) as raises:
                 foo(i)
             self.assertIn(
-                "list indices must be signed integers or slices",
+                "list indices must be integers or slices",
                 str(raises.exception),
             )
 
@@ -487,7 +487,7 @@ class TestSetitem(MemoryLeakMixin, TestCase):
             with self.assertRaises(TypingError) as raises:
                 foo(i)
             self.assertIn(
-                "list indices must be signed integers or slices",
+                "list indices must be integers or slices",
                 str(raises.exception),
             )
 
@@ -957,7 +957,7 @@ class TestInsert(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             foo()
         self.assertIn(
-            "list insert indices must be signed integers",
+            "list insert indices must be integers",
             str(raises.exception),
         )
 

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 
 from numba import njit
-from numba import int32, float32, types
+from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.utils import IS_PY3
@@ -149,6 +149,21 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(L.pop(ui32_2), 3)
         self.assertEqual(L.pop(ui32_1), 2)
         self.assertEqual(L.pop(ui32_0), 123)
+
+    def test_unsigned_prange(self):
+        @njit
+        def foo(a):
+            r = types.uint64(3)
+            s = types.uint64(0)
+            for i in prange(r):
+                s = s + a[i]
+            return s
+
+        a = List.empty_list(types.uint64)
+        a.append(types.uint64(12))
+        a.append(types.uint64(1))
+        a.append(types.uint64(7))
+        self.assertEqual(foo(a), 20)
 
     def test_compiled(self):
         @njit

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -47,11 +47,6 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(l[-3], 10)
         self.assertEqual(l[-2], 11)
         self.assertEqual(l[-1], 12)
-        # getitem using an unsigned integer
-        ui32_0 = types.uint32(0)
-        ui32_1 = types.uint32(1)
-        self.assertEqual(l[ui32_0], 10)
-        self.assertEqual(l[ui32_1], 11)
         # __iter__
         # the default __iter__ from MutableSequence will raise an IndexError
         # via __getitem__ and thus leak an exception, so this shouldn't
@@ -105,6 +100,54 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertNotEqual(l, new)
         # index
         self.assertEqual(l.index(15), 4)
+
+    def test_unsigned_access(self):
+        L = List.empty_list(int32)
+        ui32_0 = types.uint32(0)
+        ui32_1 = types.uint32(1)
+        ui32_2 = types.uint32(2)
+
+        L.append(10)
+        L.append(11)
+        L.append(12)
+        self.assertEqual(len(L), 3)
+
+        # getitem
+        self.assertEqual(L[ui32_0], 10)
+        self.assertEqual(L[ui32_1], 11)
+        self.assertEqual(L[ui32_2], 12)
+
+        # setitem
+        L[ui32_0] = 123
+        L[ui32_1] = 456
+        L[ui32_2] = 789
+        self.assertEqual(L[ui32_0], 123)
+        self.assertEqual(L[ui32_1], 456)
+        self.assertEqual(L[ui32_2], 789)
+
+        # index 
+        ui32_123 = types.uint32(123)
+        ui32_456 = types.uint32(456)
+        ui32_789 = types.uint32(789)
+        self.assertEqual(L.index(ui32_123), 0)
+        self.assertEqual(L.index(ui32_456), 1)
+        self.assertEqual(L.index(ui32_789), 2)
+
+        # delitem
+        L.__delitem__(ui32_2)
+        del L[ui32_1]
+        self.assertEqual(len(L), 1)
+        self.assertEqual(L[ui32_0], 123)
+
+        # pop
+        L.append(2)
+        L.append(3)
+        L.append(4)
+        self.assertEqual(len(L), 4)
+        self.assertEqual(L.pop(), 4)
+        self.assertEqual(L.pop(ui32_2), 3)
+        self.assertEqual(L.pop(ui32_1), 2)
+        self.assertEqual(L.pop(ui32_0), 123)
 
     def test_compiled(self):
         @njit

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -2,6 +2,8 @@ from __future__ import print_function, absolute_import, division
 
 from itertools import product
 
+import sys
+
 import numpy as np
 
 from numba import njit
@@ -15,6 +17,10 @@ from .support import TestCase, MemoryLeakMixin, unittest
 from numba.unsafe.refcount import get_refcount
 
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
+
+_windows_py27 = (sys.platform.startswith('win32') and
+                 sys.version_info[:2] == (2, 7))
+_32bit = sys.maxsize <= 2 ** 32
 
 
 def to_tl(l):
@@ -150,6 +156,12 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(L.pop(ui32_1), 2)
         self.assertEqual(L.pop(ui32_0), 123)
 
+    # @unittest.skipIf(config.IS_32BITS,
+    #                  "prange is not supported on 32 bit hardware")
+    # @unittest.skipIf(config.IS_WIN32 and (not IS_PY3),
+    #                  "parallel target is not supported on Windows with PY2")
+    @unittest.skipIf(not (_windows_py27 or _32bit),
+                     "prange not supported on windows w/ PY2 or 32 bit hardware")
     def test_unsigned_prange(self):
         @njit(parallel=True)
         def foo(a):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -107,9 +107,10 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         ui32_1 = types.uint32(1)
         ui32_2 = types.uint32(2)
 
-        L.append(10)
-        L.append(11)
-        L.append(12)
+        # insert
+        L.append(types.uint32(10))
+        L.append(types.uint32(11))
+        L.append(types.uint32(12))
         self.assertEqual(len(L), 3)
 
         # getitem

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -125,7 +125,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(L[ui32_1], 456)
         self.assertEqual(L[ui32_2], 789)
 
-        # index 
+        # index
         ui32_123 = types.uint32(123)
         ui32_456 = types.uint32(456)
         ui32_789 = types.uint32(789)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -2,8 +2,6 @@ from __future__ import print_function, absolute_import, division
 
 from itertools import product
 
-import sys
-
 import numpy as np
 
 from numba import njit
@@ -16,11 +14,9 @@ from .support import TestCase, MemoryLeakMixin, unittest
 
 from numba.unsafe.refcount import get_refcount
 
-skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
+from .test_parfors import skip_unsupported as parfors_skip_unsupported
 
-_windows_py27 = (sys.platform.startswith('win32') and
-                 sys.version_info[:2] == (2, 7))
-_32bit = sys.maxsize <= 2 ** 32
+skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
 
 
 def to_tl(l):
@@ -156,12 +152,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(L.pop(ui32_1), 2)
         self.assertEqual(L.pop(ui32_0), 123)
 
-    # @unittest.skipIf(config.IS_32BITS,
-    #                  "prange is not supported on 32 bit hardware")
-    # @unittest.skipIf(config.IS_WIN32 and (not IS_PY3),
-    #                  "parallel target is not supported on Windows with PY2")
-    @unittest.skipIf(not (_windows_py27 or _32bit),
-                     "prange not supported on windows w/ PY2 or 32 bit hardware")
+    @parfors_skip_unsupported
     def test_unsigned_prange(self):
         @njit(parallel=True)
         def foo(a):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -47,6 +47,11 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(l[-3], 10)
         self.assertEqual(l[-2], 11)
         self.assertEqual(l[-1], 12)
+        # getitem using an unsigned integer
+        ui32_0 = types.uint32(0)
+        ui32_1 = types.uint32(1)
+        self.assertEqual(l[ui32_0], 10)
+        self.assertEqual(l[ui32_1], 11)
         # __iter__
         # the default __iter__ from MutableSequence will raise an IndexError
         # via __getitem__ and thus leak an exception, so this shouldn't

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -151,7 +151,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         self.assertEqual(L.pop(ui32_0), 123)
 
     def test_unsigned_prange(self):
-        @njit
+        @njit(parallel=True)
         def foo(a):
             r = types.uint64(3)
             s = types.uint64(0)

--- a/numba/types/__init__.py
+++ b/numba/types/__init__.py
@@ -73,8 +73,6 @@ real_domain = frozenset([float32, float64])
 complex_domain = frozenset([complex64, complex128])
 number_domain = real_domain | integer_domain | complex_domain
 
-index_type = integer_domain
-
 # Aliases to Numpy type names
 
 b1 = bool_

--- a/numba/types/__init__.py
+++ b/numba/types/__init__.py
@@ -73,6 +73,8 @@ real_domain = frozenset([float32, float64])
 complex_domain = frozenset([complex64, complex128])
 number_domain = real_domain | integer_domain | complex_domain
 
+index_type = integer_domain
+
 # Aliases to Numpy type names
 
 b1 = bool_


### PR DESCRIPTION
Fix #4509 

Not related to this issue but there is also a warning in the tests because of the type of the list:
https://github.com/numba/numba/blob/60d2bddd0a9ddf84cf900a70e4b7e17bcbe5dc87/numba/tests/test_typedlist.py#L30-L34

```
/numba/numba/typed/typedlist.py:39: NumbaTypeSafetyWarning: unsafe cast from int64 to int32. Precision may be lost.
  l.append(item)
```

Replacing `int32` by `int64` fix the warning.

