### PR TITLE
New compiler.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,7 +29,6 @@ exclude =
     numba/smartarray.py
     numba/transforms.py
     numba/tracing.py
-    numba/compiler.py
     numba/ctypes_support.py
     numba/withcontexts.py
     numba/_version.py

--- a/docs/source/developer/custom_pipeline.rst
+++ b/docs/source/developer/custom_pipeline.rst
@@ -10,24 +10,16 @@ Notes on Custom Pipelines
 
 
 For library developers looking for a way to extend or modify the compiler
-behavior, you can do so by defining a custom compiler pipeline by inheriting
-from ``numba.compiler.BasePipeline``.  The default numba pipeline is defined
-as ``numba.compiler.Pipeline``, implementing the ``.define_pipelines()``
+behavior, you can do so by defining a custom compiler by inheriting from
+``numba.compiler.CompilerBase``.  The default Numba compiler is defined
+as ``numba.compiler.Compiler``, implementing the ``.define_pipelines()``
 method, which adds the *nopython-mode*, *object-mode* and *interpreted-mode*
-pipelines.  These three pipelines are defined in ``BasePipeline`` by the
-methods ``.define_nopython_pipeline``, ``.define_objectmode_pipeline``
-and ``.define_interpreted_pipeline``, respectively..
+pipelines.  These three pipelines are defined in
+``numba.compiler.DefaultPassBuilder`` by the methods
+``.define_nopython_pipeline``, ``.define_objectmode_pipeline`` and
+``.define_interpreted_pipeline``, respectively.
 
-To use a custom subclass of ``BasePipeline``, supply it as the
+To use a custom subclass of ``CompilerBase``, supply it as the
 ``pipeline_class`` keyword argument to the ``@jit`` and ``@generated_jit``
 decorators.  By doing so, the effect of the custom pipeline is limited to the
 function being decorated.
-
-Below are the common methods available to implementors of the ``BasePipeline``
-class:
-
-.. autoclass:: numba.compiler.BasePipeline
-    :members: add_cleanup_stage, add_lowering_stage, add_optimization_stage,
-              add_pre_typing_stage, add_preprocessing_stage, add_typing_stage,
-              define_nopython_pipeline, define_objectmode_pipeline,
-              define_interpreted_pipeline

--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -14,7 +14,7 @@ from .dispatcher import _FunctionCompiler
 from .targets import registry
 from .typing import signature
 from .typing.ctypes_utils import to_ctypes
-
+from .compiler_lock import global_compiler_lock
 
 class _CFuncCompiler(_FunctionCompiler):
 
@@ -38,7 +38,7 @@ class CFunc(object):
     _targetdescr = registry.cpu_target
 
     def __init__(self, pyfunc, sig, locals, options,
-                 pipeline_class=compiler.Pipeline):
+                 pipeline_class=compiler.Compiler):
         args, return_type = sig
         if return_type is None:
             raise TypeError("C callback needs an explicit return type")
@@ -60,7 +60,7 @@ class CFunc(object):
     def enable_caching(self):
         self._cache = FunctionCache(self._pyfunc)
 
-    @compiler.global_compiler_lock
+    @global_compiler_lock
     def compile(self):
         # Try to load from cache
         cres = self._cache.load_overload(self._sig, self._targetdescr.target_context)

--- a/numba/ccallback.py
+++ b/numba/ccallback.py
@@ -16,6 +16,7 @@ from .typing import signature
 from .typing.ctypes_utils import to_ctypes
 from .compiler_lock import global_compiler_lock
 
+
 class _CFuncCompiler(_FunctionCompiler):
 
     def _customize_flags(self, flags):

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -1,30 +1,32 @@
 from __future__ import print_function, division, absolute_import
 
-from contextlib import contextmanager
-from collections import namedtuple, defaultdict
+from collections import namedtuple
 import sys
 import copy
 import warnings
-import traceback
 from .tracing import event
 
-from numba import (bytecode, interpreter, funcdesc, postproc,
-                   typing, typeinfer, lowering, pylowering, utils, config,
-                   errors, types, ir, rewrites, transforms)
+from numba import (bytecode, interpreter, postproc, typing,  utils, config,
+                   errors,)
 from numba.targets import cpu, callconv
-from numba.annotations import type_annotations
-from numba.parfor import PreParforPass, ParforPass, Parfor, ParforDiagnostics
+from numba.parfor import ParforDiagnostics
 from numba.inline_closurecall import InlineClosureCallPass
 from numba.errors import CompilerError
-from numba.ir_utils import (raise_on_unsupported_feature, warn_deprecated,
-                            check_and_legalize_ir, InlineInlinables,
-                            InlineOverloads)
 
-from numba.compiler_lock import global_compiler_lock
-from numba.analysis import dead_branch_prune, rewrite_semantic_constants
+from .compiler_machinery import PassManager
 
-# terminal color markup
-_termcolor = errors.termcolor()
+from .untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                             IRProcessing, DeadBranchPrune,
+                             RewriteSemanticConstants, InlineClosureLikes,
+                             GenericRewrites, WithLifting, InlineInlinables)
+
+from .typed_passes import (NopythonTypeInference, AnnotateTypes,
+                           NopythonRewrites, PreParforPass, ParforPass,
+                           DumpParforDiagnostics, IRLegalization,
+                           NoPythonBackend, InlineOverloads)
+
+from .object_mode_passes import (ObjectModeFrontEnd, ObjectModeBackEnd,
+                                 CompileInterpMode)
 
 
 class Flags(utils.ConfigOptions):
@@ -81,10 +83,14 @@ CR_FIELDS = ["typing_context",
              # List of functions to call to initialize on unserialization
              # (i.e cache load).
              "reload_init",
-            ]
+             ]
 
 
 class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
+    """
+    A structure holding results from the compilation of a function.
+    """
+
     __slots__ = ()
 
     def _reduce(self):
@@ -126,7 +132,7 @@ class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
                  lifted=lifted,
                  typing_error=None,
                  call_helper=None,
-                 metadata=None, # Do not store, arbitrary and potentially large!
+                 metadata=None,  # Do not store, arbitrary and potentially large!
                  reload_init=reload_init,
                  )
         return cr
@@ -170,7 +176,7 @@ def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
     # Register the contexts in case for nested @jit or @overload calls
     with cpu_target.nested_context(typingctx, targetctx):
         return compile_extra(typingctx, targetctx, func, args, return_type,
-                            flags, locals)
+                             flags, locals)
 
 
 def run_frontend(func, inline_closures=False):
@@ -196,7 +202,7 @@ def run_frontend(func, inline_closures=False):
 
 class _CompileStatus(object):
     """
-    Used like a C record
+    Describes the state of compilation. Used like a C record.
     """
     __slots__ = ['fail_reason', 'can_fallback', 'can_giveup']
 
@@ -213,747 +219,24 @@ class _CompileStatus(object):
 
 
 class _EarlyPipelineCompletion(Exception):
+    """
+    Raised to indicate that a pipeline has completed early
+    """
+
     def __init__(self, result):
         self.result = result
 
 
-class _PipelineManager(object):
-    def __init__(self):
-        self.pipeline_order = []
-        self.pipeline_stages = {}
-        self._finalized = False
-
-    def create_pipeline(self, pipeline_name):
-        assert not self._finalized, "Pipelines can no longer be added"
-        self.pipeline_order.append(pipeline_name)
-        self.pipeline_stages[pipeline_name] = []
-        self.current = pipeline_name
-
-    def add_stage(self, stage_function, stage_description):
-        assert not self._finalized, "Stages can no longer be added."
-        current_pipeline_name = self.pipeline_order[-1]
-        func_desc_tuple = (stage_function, stage_description)
-        self.pipeline_stages[current_pipeline_name].append(func_desc_tuple)
-
-    def finalize(self):
-        self._finalized = True
-
-    def _patch_error(self, desc, exc):
-        """
-        Patches the error to show the stage that it arose in.
-        """
-        newmsg = "{desc}\n{exc}".format(desc=desc, exc=exc)
-
-        # For python2, attach the traceback of the previous exception.
-        if not utils.IS_PY3 and config.FULL_TRACEBACKS:
-            # strip the new message to just print the error string and not
-            # the marked up source etc (this is handled already).
-            stripped = _termcolor.errmsg(newmsg.split('\n')[1])
-            fmt = "Caused By:\n{tb}\n{newmsg}"
-            newmsg = fmt.format(tb=traceback.format_exc(), newmsg=stripped)
-
-        exc.args = (newmsg,)
-        return exc
-
-    @global_compiler_lock
-    def run(self, status):
-        assert self._finalized, "PM must be finalized before run()"
-        for pipeline_name in self.pipeline_order:
-            event("Pipeline: %s" % pipeline_name)
-            is_final_pipeline = pipeline_name == self.pipeline_order[-1]
-            for stage, stage_name in self.pipeline_stages[pipeline_name]:
-                try:
-                    event("-- %s" % stage_name)
-                    stage()
-                except _EarlyPipelineCompletion as e:
-                    return e.result
-                except Exception as e:
-                    msg = "Failed in %s mode pipeline (step: %s)" % \
-                        (pipeline_name, stage_name)
-                    patched_exception = self._patch_error(msg, e)
-                    # No more fallback pipelines?
-                    if is_final_pipeline:
-                        raise patched_exception
-                    # Go to next fallback pipeline
-                    else:
-                        status.fail_reason = patched_exception
-                        break
-            else:
-                return None
-
-        # TODO save all error information
-        raise CompilerError("All pipelines have failed")
-
-
-class BasePipeline(object):
-    """
-    Stores and manages states for the compiler pipeline
-    """
-    def __init__(self, typingctx, targetctx, library, args, return_type, flags,
-                 locals):
-        # Make sure the environment is reloaded
-        config.reload_config()
-        typingctx.refresh()
-        targetctx.refresh()
-
-        self.typingctx = typingctx
-        self.targetctx = _make_subtarget(targetctx, flags)
-        self.library = library
-        self.args = args
-        self.return_type = return_type
-        self.flags = flags
-        self.locals = locals
-
-        # Results of various steps of the compilation pipeline
-        self.bc = None
-        self.func_id = None
-        self.func_ir = None
-        self.lifted = None
-        self.lifted_from = None
-        self.typemap = None
-        self.calltypes = None
-        self.type_annotation = None
-        self.metadata = {} # holds arbitrary inter-pipeline stage meta data
-        self.reload_init = []
-
-        # parfor diagnostics info, add to metadata
-        self.parfor_diagnostics = ParforDiagnostics()
-        self.metadata['parfor_diagnostics'] = self.parfor_diagnostics
-
-        self.status = _CompileStatus(
-            can_fallback=self.flags.enable_pyobject,
-            can_giveup=config.COMPATIBILITY_MODE
-        )
-
-    @contextmanager
-    def fallback_context(self, msg):
-        """
-        Wraps code that would signal a fallback to object mode
-        """
-        try:
-            yield
-        except Exception as e:
-            if not self.status.can_fallback:
-                raise
-            else:
-                if utils.PYVERSION >= (3,):
-                    # Clear all references attached to the traceback
-                    e = e.with_traceback(None)
-                # this emits a warning containing the error message body in the
-                # case of fallback from npm to objmode
-                loop_lift = '' if self.flags.enable_looplift else 'OUT'
-                msg_rewrite = ("\nCompilation is falling back to object mode "
-                               "WITH%s looplifting enabled because %s"
-                               % (loop_lift, msg))
-                warnings.warn_explicit('%s due to: %s' % (msg_rewrite, e),
-                                       errors.NumbaWarning,
-                                       self.func_id.filename,
-                                       self.func_id.firstlineno)
-                raise
-
-    @contextmanager
-    def giveup_context(self, msg):
-        """
-        Wraps code that would signal a fallback to interpreter mode
-        """
-        try:
-            yield
-        except Exception as e:
-            if not self.status.can_giveup:
-                raise
-            else:
-                if utils.PYVERSION >= (3,):
-                    # Clear all references attached to the traceback
-                    e = e.with_traceback(None)
-                warnings.warn_explicit('%s: %s' % (msg, e),
-                                       errors.NumbaWarning,
-                                       self.func_id.filename,
-                                       self.func_id.firstlineno)
-
-                raise
-
-    def extract_bytecode(self, func_id):
-        """
-        Extract bytecode from function
-        """
-        bc = bytecode.ByteCode(func_id)
-        if config.DUMP_BYTECODE:
-            print(bc.dump())
-
-        return bc
-
-    def compile_extra(self, func):
-        self.func_id = bytecode.FunctionIdentity.from_function(func)
-
-        try:
-            bc = self.extract_bytecode(self.func_id)
-        except Exception as e:
-            if self.status.can_giveup:
-                self.stage_compile_interp_mode()
-                return self.cr
-            else:
-                raise e
-
-        self.bc = bc
-        self.lifted = ()
-        self.lifted_from = None
-        return self._compile_bytecode()
-
-    def compile_ir(self, func_ir, lifted=(), lifted_from=None):
-        self.func_id = func_ir.func_id
-        self.lifted = lifted
-        self.lifted_from = lifted_from
-
-        self._set_and_check_ir(func_ir)
-        return self._compile_ir()
-
-    def stage_analyze_bytecode(self):
-        """
-        Analyze bytecode and translating to Numba IR
-        """
-        func_ir = translate_stage(self.func_id, self.bc)
-        self._set_and_check_ir(func_ir)
-
-    def _set_and_check_ir(self, func_ir):
-        self.func_ir = func_ir
-        self.nargs = self.func_ir.arg_count
-        if not self.args and self.flags.force_pyobject:
-            # Allow an empty argument types specification when object mode
-            # is explicitly requested.
-            self.args = (types.pyobject,) * self.nargs
-        elif len(self.args) != self.nargs:
-            raise TypeError("Signature mismatch: %d argument types given, "
-                            "but function takes %d arguments"
-                            % (len(self.args), self.nargs))
-
-    def stage_process_ir(self):
-        ir_processing_stage(self.func_ir)
-
-    def frontend_looplift(self):
-        """
-        Loop lifting analysis and transformation
-        """
-        loop_flags = self.flags.copy()
-        outer_flags = self.flags.copy()
-        # Do not recursively loop lift
-        outer_flags.unset('enable_looplift')
-        loop_flags.unset('enable_looplift')
-        if not self.flags.enable_pyobject_looplift:
-            loop_flags.unset('enable_pyobject')
-
-        main, loops = transforms.loop_lifting(self.func_ir,
-                                              typingctx=self.typingctx,
-                                              targetctx=self.targetctx,
-                                              locals=self.locals,
-                                              flags=loop_flags)
-        if loops:
-            # Some loops were extracted
-            if config.DEBUG_FRONTEND or config.DEBUG:
-                for loop in loops:
-                    print("Lifting loop", loop.get_source_location())
-
-            cres = compile_ir(self.typingctx, self.targetctx, main,
-                              self.args, self.return_type,
-                              outer_flags, self.locals,
-                              lifted=tuple(loops), lifted_from=None,
-                              is_lifted_loop=True)
-            return cres
-
-    def stage_frontend_withlift(self):
-        """
-        Extract with-contexts
-        """
-        main, withs = transforms.with_lifting(
-            func_ir=self.func_ir,
-            typingctx=self.typingctx,
-            targetctx=self.targetctx,
-            flags=self.flags,
-            locals=self.locals,
-            )
-        if withs:
-            cres = compile_ir(self.typingctx, self.targetctx, main,
-                              self.args, self.return_type,
-                              self.flags, self.locals,
-                              lifted=tuple(withs), lifted_from=None,
-                              pipeline_class=type(self))
-            raise _EarlyPipelineCompletion(cres)
-
-    def stage_objectmode_frontend(self):
-        """
-        Front-end: Analyze bytecode, generate Numba IR, infer types
-        """
-        if self.flags.enable_looplift:
-            assert not self.lifted
-            cres = self.frontend_looplift()
-            if cres is not None:
-                raise _EarlyPipelineCompletion(cres)
-
-        # Fallback typing: everything is a python object
-        self.typemap = defaultdict(lambda: types.pyobject)
-        self.calltypes = defaultdict(lambda: types.pyobject)
-        self.return_type = types.pyobject
-
-    def stage_dead_branch_prune(self):
-        """
-        This prunes dead branches, a dead branch is one which is derivable as
-        not taken at compile time purely based on const/literal evaluation.
-        """
-        assert self.func_ir
-        msg = ('Internal error in pre-inference dead branch pruning '
-               'pass encountered during compilation of '
-               'function "%s"' % (self.func_id.func_name,))
-        with self.fallback_context(msg):
-            rewrite_semantic_constants(self.func_ir, self.args)
-            dead_branch_prune(self.func_ir, self.args)
-
-        if config.DEBUG or config.DUMP_IR:
-            print('branch_pruned_ir'.center(80, '-'))
-            print(self.func_ir.dump())
-            print('end branch_pruned_ir'.center(80, '-'))
-
-    def stage_nopython_frontend(self):
-        """
-        Type inference and legalization
-        """
-        with self.fallback_context('Function "%s" failed type inference'
-                                   % (self.func_id.func_name,)):
-            # Type inference
-            typemap, return_type, calltypes = type_inference_stage(
-                self.typingctx,
-                self.func_ir,
-                self.args,
-                self.return_type,
-                self.locals)
-            self.typemap = typemap
-            self.return_type = return_type
-            self.calltypes = calltypes
-
-        with self.fallback_context('Function "%s" has invalid return type'
-                                   % (self.func_id.func_name,)):
-            legalize_return_type(self.return_type, self.func_ir,
-                                 self.targetctx)
-
-    def stage_generic_rewrites(self):
-        """
-        Perform any intermediate representation rewrites before type
-        inference.
-        """
-        assert self.func_ir
-        msg = ('Internal error in pre-inference rewriting '
-               'pass encountered during compilation of '
-               'function "%s"' % (self.func_id.func_name,))
-        with self.fallback_context(msg):
-            rewrites.rewrite_registry.apply('before-inference',
-                                            self, self.func_ir)
-
-    def stage_nopython_rewrites(self):
-        """
-        Perform any intermediate representation rewrites after type
-        inference.
-        """
-        # Ensure we have an IR and type information.
-        assert self.func_ir
-        assert isinstance(getattr(self, 'typemap', None), dict)
-        assert isinstance(getattr(self, 'calltypes', None), dict)
-        msg = ('Internal error in post-inference rewriting '
-               'pass encountered during compilation of '
-               'function "%s"' % (self.func_id.func_name,))
-        with self.fallback_context(msg):
-            rewrites.rewrite_registry.apply('after-inference',
-                                            self, self.func_ir)
-
-    def stage_inline_inlinables_pass(self):
-        inlineinline = InlineInlinables(self.func_ir)
-        inlineinline.run()
-
-    def stage_inline_overloads_pass(self):
-        inlineoverloads = InlineOverloads(self.func_ir, self.typingctx,
-                                          self.targetctx,
-                                          self.type_annotation)
-        inlineoverloads.run()
-
-    def stage_pre_parfor_pass(self):
-        """
-        Preprocessing for data-parallel computations.
-        """
-        # Ensure we have an IR and type information.
-        assert self.func_ir
-        preparfor_pass = PreParforPass(
-            self.func_ir,
-            self.type_annotation.typemap,
-            self.type_annotation.calltypes, self.typingctx,
-            self.flags.auto_parallel,
-            self.parfor_diagnostics.replaced_fns
-            )
-
-        preparfor_pass.run()
-
-    def stage_parfor_pass(self):
-        """
-        Convert data-parallel computations into Parfor nodes
-        """
-        # Ensure we have an IR and type information.
-        assert self.func_ir
-        parfor_pass = ParforPass(self.func_ir, self.type_annotation.typemap,
-            self.type_annotation.calltypes, self.return_type, self.typingctx,
-            self.flags.auto_parallel, self.flags, self.parfor_diagnostics)
-        parfor_pass.run()
-
-        # check the parfor pass worked and warn if it didn't
-        has_parfor = False
-        for blk in self.func_ir.blocks.values():
-            for stmnt in blk.body:
-                if isinstance(stmnt, Parfor):
-                    has_parfor = True
-                    break
-            else:
-                continue
-            break
-
-        if not has_parfor:
-            # parfor calls the compiler chain again with a string
-            if not self.func_ir.loc.filename == '<string>':
-                url = ("http://numba.pydata.org/numba-doc/latest/user/"
-                       "parallel.html#diagnostics")
-                msg = ("\nThe keyword argument 'parallel=True' was specified "
-                       "but no transformation for parallel execution was "
-                       "possible.\n\nTo find out why, try turning on parallel "
-                       "diagnostics, see %s for help." % url)
-                warnings.warn(errors.NumbaPerformanceWarning(msg,
-                                                             self.func_ir.loc))
-        # Add reload function to initialize the parallel backend.
-        self.reload_init.append(_reload_parfors)
-
-    def stage_inline_pass(self):
-        """
-        Inline calls to locally defined closures.
-        """
-        # Ensure we have an IR and type information.
-        assert self.func_ir
-
-        # if the return type is a pyobject, there's no type info available and
-        # no ability to resolve certain typed function calls in the array
-        # inlining code, use this variable to indicate
-        typed_pass = not isinstance(self.return_type, types.misc.PyObject)
-        inline_pass = InlineClosureCallPass(self.func_ir,
-                                            self.flags.auto_parallel,
-                                            self.parfor_diagnostics.replaced_fns,
-                                            typed_pass)
-        inline_pass.run()
-        # Remove all Dels, and re-run postproc
-        post_proc = postproc.PostProcessor(self.func_ir)
-        post_proc.run()
-
-        if config.DEBUG or config.DUMP_IR:
-            name = self.func_ir.func_id.func_qualname
-            print(("IR DUMP: %s" % name).center(80, "-"))
-            self.func_ir.dump()
-
-    def stage_annotate_type(self):
-        """
-        Create type annotation after type inference
-        """
-        self.type_annotation = type_annotations.TypeAnnotation(
-            func_ir=self.func_ir,
-            typemap=self.typemap,
-            calltypes=self.calltypes,
-            lifted=self.lifted,
-            lifted_from=self.lifted_from,
-            args=self.args,
-            return_type=self.return_type,
-            html_output=config.HTML)
-
-        if config.ANNOTATE:
-            print("ANNOTATION".center(80, '-'))
-            print(self.type_annotation)
-            print('=' * 80)
-        if config.HTML:
-            with open(config.HTML, 'w') as fout:
-                self.type_annotation.html_annotate(fout)
-
-    def stage_dump_diagnostics(self):
-        if self.flags.auto_parallel.enabled:
-            if config.PARALLEL_DIAGNOSTICS:
-                if self.parfor_diagnostics is not None:
-                    self.parfor_diagnostics.dump(config.PARALLEL_DIAGNOSTICS)
-                else:
-                    raise RuntimeError("Diagnostics failed.")
-
-    def backend_object_mode(self):
-        """
-        Object mode compilation
-        """
-        with self.giveup_context("Function %s failed at object mode lowering"
-                                 % (self.func_id.func_name,)):
-            if len(self.args) != self.nargs:
-                # append missing
-                self.args = (tuple(self.args) + (types.pyobject,) *
-                             (self.nargs - len(self.args)))
-
-            return py_lowering_stage(self.targetctx,
-                                     self.library,
-                                     self.func_ir,
-                                     self.flags)
-
-    def backend_nopython_mode(self):
-        """Native mode compilation"""
-        msg = ("Function %s failed at nopython "
-               "mode lowering" % (self.func_id.func_name,))
-        with self.fallback_context(msg):
-            return native_lowering_stage(
-                self.targetctx,
-                self.library,
-                self.func_ir,
-                self.typemap,
-                self.return_type,
-                self.calltypes,
-                self.flags,
-                self.metadata)
-
-    def _backend(self, lowerfn, objectmode):
-        """
-        Back-end: Generate LLVM IR from Numba IR, compile to machine code
-        """
-        if self.library is None:
-            codegen = self.targetctx.codegen()
-            self.library = codegen.create_library(self.func_id.func_qualname)
-            # Enable object caching upfront, so that the library can
-            # be later serialized.
-            self.library.enable_object_caching()
-
-        lowered = lowerfn()
-        signature = typing.signature(self.return_type, *self.args)
-        self.cr = compile_result(
-            typing_context=self.typingctx,
-            target_context=self.targetctx,
-            entry_point=lowered.cfunc,
-            typing_error=self.status.fail_reason,
-            type_annotation=self.type_annotation,
-            library=self.library,
-            call_helper=lowered.call_helper,
-            signature=signature,
-            objectmode=objectmode,
-            interpmode=False,
-            lifted=self.lifted,
-            fndesc=lowered.fndesc,
-            environment=lowered.env,
-            metadata=self.metadata,
-            reload_init=self.reload_init,
-            )
-
-    def stage_objectmode_backend(self):
-        """
-        Lowering for object mode
-        """
-        lowerfn = self.backend_object_mode
-        self._backend(lowerfn, objectmode=True)
-
-        # Warn, deprecated behaviour, code compiled in objmode without
-        # force_pyobject indicates fallback from nopython mode
-        if not self.flags.force_pyobject:
-            # first warn about object mode and yes/no to lifted loops
-            if len(self.lifted) > 0:
-                warn_msg = ('Function "%s" was compiled in object mode without'
-                            ' forceobj=True, but has lifted loops.' %
-                            (self.func_id.func_name,))
-            else:
-                warn_msg = ('Function "%s" was compiled in object mode without'
-                            ' forceobj=True.' % (self.func_id.func_name,))
-            warnings.warn(errors.NumbaWarning(warn_msg,
-                                              self.func_ir.loc))
-
-            url = ("http://numba.pydata.org/numba-doc/latest/reference/"
-                   "deprecation.html#deprecation-of-object-mode-fall-"
-                   "back-behaviour-when-using-jit")
-            msg = ("\nFall-back from the nopython compilation path to the "
-                   "object mode compilation path has been detected, this is "
-                   "deprecated behaviour.\n\nFor more information visit %s" %
-                   url)
-            warnings.warn(errors.NumbaDeprecationWarning(msg, self.func_ir.loc))
-            if self.flags.release_gil:
-                warn_msg = ("Code running in object mode won't allow parallel"
-                            " execution despite nogil=True.")
-                warnings.warn_explicit(warn_msg, errors.NumbaWarning,
-                                       self.func_id.filename,
-                                       self.func_id.firstlineno)
-
-    def stage_nopython_backend(self):
-        """
-        Do lowering for nopython
-        """
-        lowerfn = self.backend_nopython_mode
-        self._backend(lowerfn, objectmode=False)
-
-    def stage_compile_interp_mode(self):
-        """
-        Just create a compile result for interpreter mode
-        """
-        args = [types.pyobject] * len(self.args)
-        signature = typing.signature(types.pyobject, *args)
-        self.cr = compile_result(typing_context=self.typingctx,
-                                 target_context=self.targetctx,
-                                 entry_point=self.func_id.func,
-                                 typing_error=self.status.fail_reason,
-                                 type_annotation="<Interpreter mode function>",
-                                 signature=signature,
-                                 objectmode=False,
-                                 interpmode=True,
-                                 lifted=(),
-                                 fndesc=None,)
-
-    def stage_ir_legalization(self):
-        raise_on_unsupported_feature(self.func_ir, self.typemap)
-        warn_deprecated(self.func_ir, self.typemap)
-        # NOTE: this function call must go last, it checks and fixes invalid IR!
-        check_and_legalize_ir(self.func_ir)
-
-    def stage_cleanup(self):
-        """
-        Cleanup intermediate results to release resources.
-        """
-
-    def define_pipelines(self, pm):
-        """Child classes override this to customize the pipeline.
-        """
-        raise NotImplementedError()
-
-    def add_preprocessing_stage(self, pm):
-        """Add the preprocessing stage that analyzes the bytecode to prepare
-        the Numba IR.
-        """
-        if self.func_ir is None:
-            pm.add_stage(self.stage_analyze_bytecode, "analyzing bytecode")
-        pm.add_stage(self.stage_process_ir, "processing IR")
-
-    def add_pre_typing_stage(self, pm):
-        """Add any stages that go before type-inference.
-        The current stages contain type-agnostic rewrite passes.
-        """
-        if not self.flags.no_rewrites:
-            pm.add_stage(self.stage_generic_rewrites, "nopython rewrites")
-            pm.add_stage(self.stage_dead_branch_prune, "dead branch pruning")
-
-        # run closure inlining
-        pm.add_stage(self.stage_inline_pass,
-                     "inline calls to locally defined closures")
-
-        # inline functions that have been determined as inlinable and rerun
-        # branch pruning this needs to be run after closures are inlined as
-        # the IR repr of a closure masks call sites if an inlinable is called
-        # inside a closure
-        pm.add_stage(self.stage_inline_inlinables_pass, "inline inlinables")
-        if not self.flags.no_rewrites:
-            pm.add_stage(self.stage_dead_branch_prune, "dead branch pruning")
-
-    def add_typing_stage(self, pm):
-        """Add the type-inference stage necessary for nopython mode.
-        """
-        pm.add_stage(self.stage_nopython_frontend, "nopython frontend")
-        pm.add_stage(self.stage_annotate_type, "annotate type")
-
-    def add_optimization_stage(self, pm):
-        """Add optimization stages.
-        """
-        pm.add_stage(self.stage_inline_overloads_pass, "inline overloads")
-        if self.flags.auto_parallel.enabled:
-            pm.add_stage(self.stage_pre_parfor_pass,
-                         "Preprocessing for parfors")
-        if not self.flags.no_rewrites:
-            pm.add_stage(self.stage_nopython_rewrites, "nopython rewrites")
-        if self.flags.auto_parallel.enabled:
-            pm.add_stage(self.stage_parfor_pass, "convert to parfors")
-
-    def add_lowering_stage(self, pm):
-        """Add the lowering (code-generation) stage for nopython-mode
-        """
-        pm.add_stage(self.stage_nopython_backend, "nopython mode backend")
-
-    def add_cleanup_stage(self, pm):
-        """Add the clean-up stage to remove intermediate results.
-        """
-        pm.add_stage(self.stage_cleanup, "cleanup intermediate results")
-
-    def add_with_handling_stage(self, pm):
-        pm.add_stage(self.stage_frontend_withlift, "Handle with contexts")
-
-    def define_nopython_pipeline(self, pm, name='nopython'):
-        """Add the nopython-mode pipeline to the pipeline manager
-        """
-        pm.create_pipeline(name)
-        self.add_preprocessing_stage(pm)
-        self.add_with_handling_stage(pm)
-        self.add_pre_typing_stage(pm)
-        self.add_typing_stage(pm)
-        self.add_optimization_stage(pm)
-        pm.add_stage(self.stage_ir_legalization,
-                     "ensure IR is legal prior to lowering")
-        self.add_lowering_stage(pm)
-        pm.add_stage(self.stage_dump_diagnostics, "dump diagnostics")
-        self.add_cleanup_stage(pm)
-
-    def define_objectmode_pipeline(self, pm, name='object'):
-        """Add the object-mode pipeline to the pipeline manager
-        """
-        pm.create_pipeline(name)
-        self.add_preprocessing_stage(pm)
-        pm.add_stage(self.stage_objectmode_frontend,
-                     "object mode frontend")
-        pm.add_stage(self.stage_inline_pass,
-                     "inline calls to locally defined closures")
-        pm.add_stage(self.stage_annotate_type, "annotate type")
-        pm.add_stage(self.stage_ir_legalization,
-                     "ensure IR is legal prior to lowering")
-        pm.add_stage(self.stage_objectmode_backend, "object mode backend")
-        self.add_cleanup_stage(pm)
-
-    def define_interpreted_pipeline(self, pm, name="interp"):
-        """Add the interpreted-mode (fallback) pipeline to the pipeline manager
-        """
-        pm.create_pipeline(name)
-        pm.add_stage(self.stage_compile_interp_mode,
-                     "compiling with interpreter mode")
-        self.add_cleanup_stage(pm)
-
-    def _compile_core(self):
-        """
-        Populate and run compiler pipeline
-        """
-        pm = _PipelineManager()
-        self.define_pipelines(pm)
-        pm.finalize()
-        res = pm.run(self.status)
-        if res is not None:
-            # Early pipeline completion
-            return res
+class StateDict(dict):
+
+    def __getattr__(self, attr):
+        if attr in self.keys():
+            return self[attr]
         else:
-            assert self.cr is not None
-            return self.cr
+            raise KeyError
 
-    def _compile_bytecode(self):
-        """
-        Populate and run pipeline for bytecode input
-        """
-        assert self.func_ir is None
-        return self._compile_core()
-
-    def _compile_ir(self):
-        """
-        Populate and run pipeline for IR input
-        """
-        assert self.func_ir is not None
-        return self._compile_core()
-
-
-class Pipeline(BasePipeline):
-    """The default compiler pipeline
-    """
-    def define_pipelines(self, pm):
-        if not self.flags.force_pyobject:
-            self.define_nopython_pipeline(pm)
-        if self.status.can_fallback or self.flags.force_pyobject:
-            self.define_objectmode_pipeline(pm)
-        if self.status.can_giveup:
-            self.define_interpreted_pipeline(pm)
+    def __setattr__(self, attr, value):
+        self[attr] = value
 
 
 def _make_subtarget(targetctx, flags):
@@ -977,8 +260,235 @@ def _make_subtarget(targetctx, flags):
     return targetctx.subtarget(**subtargetoptions)
 
 
+class CompilerBase(object):
+    """
+    Stores and manages states for the compiler
+    """
+
+    def __init__(self, typingctx, targetctx, library, args, return_type, flags,
+                 locals):
+        # Make sure the environment is reloaded
+        config.reload_config()
+        typingctx.refresh()
+        targetctx.refresh()
+
+        self.state = StateDict()
+
+        self.state.typingctx = typingctx
+        self.state.targetctx = _make_subtarget(targetctx, flags)
+        self.state.library = library
+        self.state.args = args
+        self.state.return_type = return_type
+        self.state.flags = flags
+        self.state.locals = locals
+
+        # Results of various steps of the compilation pipeline
+        self.state.bc = None
+        self.state.func_id = None
+        self.state.func_ir = None
+        self.state.lifted = None
+        self.state.lifted_from = None
+        self.state.typemap = None
+        self.state.calltypes = None
+        self.state.type_annotation = None
+        self.state.metadata = {}  # holds arbitrary inter-pipeline stage meta data
+        self.state.reload_init = []
+        self.state.pipeline = self
+
+        # parfor diagnostics info, add to metadata
+        self.state.parfor_diagnostics = ParforDiagnostics()
+        self.state.metadata['parfor_diagnostics'] = self.state.parfor_diagnostics
+
+        self.state.status = _CompileStatus(
+            can_fallback=self.state.flags.enable_pyobject,
+            can_giveup=config.COMPATIBILITY_MODE
+        )
+
+    def compile_extra(self, func):
+        self.state.func_id = bytecode.FunctionIdentity.from_function(func)
+        try:
+            ExtractByteCode().run_pass(self.state)
+        except Exception as e:
+            if self.state.status.can_giveup:
+                CompileInterpMode().run_pass(self.state)
+                return self.state.cr
+            else:
+                raise e
+
+        self.state.lifted = ()
+        self.state.lifted_from = None
+        return self._compile_bytecode()
+
+    def compile_ir(self, func_ir, lifted=(), lifted_from=None):
+        self.state.func_id = func_ir.func_id
+        self.state.lifted = lifted
+        self.state.lifted_from = lifted_from
+        self.state.func_ir = func_ir
+        self.state.nargs = self.state.func_ir.arg_count
+
+        FixupArgs().run_pass(self.state)
+        return self._compile_ir()
+
+    def define_pipelines(self):
+        """Child classes override this to customize the pipelines in use.
+        """
+        raise NotImplementedError()
+
+    def _compile_core(self):
+        """
+        Populate and run compiler pipeline
+        """
+        pms = self.define_pipelines()
+        for pm in pms:
+            pipeline_name = pm.pipeline_name
+            event("Pipeline: %s" % pipeline_name)
+            self.state.metadata['pipeline_times'] = {pipeline_name:
+                                                     pm.exec_times}
+            is_final_pipeline = pm == pms[-1]
+            res = None
+            try:
+                pm.run(self.state)
+                if self.state.cr is not None:
+                    break
+            except _EarlyPipelineCompletion as e:
+                res = e.result
+                break
+            except Exception as e:
+                self.state.status.fail_reason = e
+                if is_final_pipeline:
+                    raise e
+        else:
+            raise CompilerError("All available pipelines exhausted")
+
+        if res is not None:
+            # Early pipeline completion
+            return res
+        else:
+            assert self.state.cr is not None
+            return self.state.cr
+
+    def _compile_bytecode(self):
+        """
+        Populate and run pipeline for bytecode input
+        """
+        assert self.state.func_ir is None
+        return self._compile_core()
+
+    def _compile_ir(self):
+        """
+        Populate and run pipeline for IR input
+        """
+        assert self.state.func_ir is not None
+        return self._compile_core()
+
+
+class Compiler(CompilerBase):
+    """The default compiler
+    """
+
+    def define_pipelines(self):
+        # this maintains the objmode fallback behaviour
+        pms = []
+        if not self.state.flags.force_pyobject:
+            pms.append(DefaultPassBuilder.define_nopython_pipeline(self.state))
+        if self.state.status.can_fallback or self.state.flags.force_pyobject:
+            pms.append(DefaultPassBuilder.define_objectmode_pipeline(self.state))
+        if self.state.status.can_giveup:
+            pms.append(DefaultPassBuilder.define_interpreted_pipeline(self.state))
+        return pms
+
+
+class DefaultPassBuilder:
+    """
+    This is the default pass builder, it contains the "classic" default
+    pipelines as pre-canned PassManager instances:
+      - nopython
+      - objectmode
+      - interpreted
+    """
+
+    @staticmethod
+    def define_nopython_pipeline(state, name='nopython'):
+        """Returns an nopython mode pipeline based PassManager
+        """
+        pm = PassManager(name)
+        if state.func_ir is None:
+            pm.add_pass(TranslateByteCode, "analyzing bytecode")
+            pm.add_pass(FixupArgs, "fix up args")
+        pm.add_pass(IRProcessing, "processing IR")
+
+        pm.add_pass(WithLifting, "Handle with contexts")
+
+        # pre typing
+        if not state.flags.no_rewrites:
+            pm.add_pass(GenericRewrites, "nopython rewrites")
+            pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+        pm.add_pass(InlineClosureLikes,
+                    "inline calls to locally defined closures")
+
+        # inline functions that have been determined as inlinable and rerun
+        # branch pruning this needs to be run after closures are inlined as
+        # the IR repr of a closure masks call sites if an inlinable is called
+        # inside a closure
+        pm.add_pass(InlineInlinables, "inline inlinable functions")
+        if not state.flags.no_rewrites:
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+
+        # typing
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+        pm.add_pass(AnnotateTypes, "annotate types")
+
+        # optimisation
+        pm.add_pass(InlineOverloads, "inline overloaded functions")
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(PreParforPass, "Preprocessing for parfors")
+        if not state.flags.no_rewrites:
+            pm.add_pass(NopythonRewrites, "nopython rewrites")
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(ParforPass, "convert to parfors")
+
+        # legalise
+        pm.add_pass(IRLegalization,
+                    "ensure IR is legal prior to lowering")
+
+        # lower
+        pm.add_pass(NoPythonBackend, "nopython mode backend")
+        pm.add_pass(DumpParforDiagnostics, "dump parfor diagnostics")
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_objectmode_pipeline(state, name='object'):
+        """Returns an object-mode pipeline based PassManager
+        """
+        pm = PassManager(name)
+        if state.func_ir is None:
+            pm.add_pass(TranslateByteCode, "analyzing bytecode")
+            pm.add_pass(FixupArgs, "fix up args")
+        pm.add_pass(IRProcessing, "processing IR")
+
+        pm.add_pass(ObjectModeFrontEnd, "object mode frontend")
+        pm.add_pass(InlineClosureLikes, "inline calls to locally defined closures")
+        pm.add_pass(AnnotateTypes, "annotate types")
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        pm.add_pass(ObjectModeBackEnd, "object mode backend")
+        pm.finalize()
+        return pm
+
+    @staticmethod
+    def define_interpreted_pipeline(state, name="interpreted"):
+        """Returns an interpreted mode pipeline based PassManager
+        """
+        pm = PassManager(name)
+        pm.add_pass(CompileInterpMode,
+                    "compiling with interpreter mode")
+        pm.finalize()
+        return pm
+
+
 def compile_extra(typingctx, targetctx, func, args, return_type, flags,
-                  locals, library=None, pipeline_class=Pipeline):
+                  locals, library=None, pipeline_class=Compiler):
     """Compiler entry point
 
     Parameter
@@ -998,7 +508,7 @@ def compile_extra(typingctx, targetctx, func, args, return_type, flags,
     library : numba.codegen.CodeLibrary
         Used to store the compiled code.
         If it is ``None``, a new CodeLibrary is used.
-    pipeline_class : type like numba.compiler.BasePipeline
+    pipeline_class : type like numba.compiler.CompilerBase
         compiler pipeline
     """
     pipeline = pipeline_class(typingctx, targetctx, library,
@@ -1008,7 +518,7 @@ def compile_extra(typingctx, targetctx, func, args, return_type, flags,
 
 def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
                locals, lifted=(), lifted_from=None, is_lifted_loop=False,
-               library=None, pipeline_class=Pipeline):
+               library=None, pipeline_class=Compiler):
     """
     Compile a function with the given IR.
 
@@ -1067,7 +577,7 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
         pipeline = pipeline_class(typingctx, targetctx, library,
                                   args, return_type, flags, locals)
         return pipeline.compile_ir(func_ir=func_ir, lifted=lifted,
-                                lifted_from=lifted_from)
+                                   lifted_from=lifted_from)
 
 
 def compile_internal(typingctx, targetctx, library,
@@ -1075,147 +585,6 @@ def compile_internal(typingctx, targetctx, library,
     """
     For internal use only.
     """
-    pipeline = Pipeline(typingctx, targetctx, library,
+    pipeline = Compiler(typingctx, targetctx, library,
                         args, return_type, flags, locals)
     return pipeline.compile_extra(func)
-
-
-def legalize_return_type(return_type, interp, targetctx):
-    """
-    Only accept array return type iff it is passed into the function.
-    Reject function object return types if in nopython mode.
-    """
-    if not targetctx.enable_nrt and isinstance(return_type, types.Array):
-        # Walk IR to discover all arguments and all return statements
-        retstmts = []
-        caststmts = {}
-        argvars = set()
-        for bid, blk in interp.blocks.items():
-            for inst in blk.body:
-                if isinstance(inst, ir.Return):
-                    retstmts.append(inst.value.name)
-                elif isinstance(inst, ir.Assign):
-                    if (isinstance(inst.value, ir.Expr)
-                            and inst.value.op == 'cast'):
-                        caststmts[inst.target.name] = inst.value
-                    elif isinstance(inst.value, ir.Arg):
-                        argvars.add(inst.target.name)
-
-        assert retstmts, "No return statements?"
-
-        for var in retstmts:
-            cast = caststmts.get(var)
-            if cast is None or cast.value.name not in argvars:
-                raise TypeError("Only accept returning of array passed into "
-                                "the function as argument")
-
-    elif (isinstance(return_type, types.Function) or
-            isinstance(return_type, types.Phantom)):
-        msg = "Can't return function object ({}) in nopython mode"
-        raise TypeError(msg.format(return_type))
-
-
-def translate_stage(func_id, bytecode):
-    interp = interpreter.Interpreter(func_id)
-    return interp.interpret(bytecode)
-
-
-def ir_processing_stage(func_ir):
-    post_proc = postproc.PostProcessor(func_ir)
-    post_proc.run()
-
-    if config.DEBUG or config.DUMP_IR:
-        name = func_ir.func_id.func_qualname
-        print(("IR DUMP: %s" % name).center(80, "-"))
-        func_ir.dump()
-        if func_ir.is_generator:
-            print(("GENERATOR INFO: %s" % name).center(80, "-"))
-            func_ir.dump_generator_info()
-
-    return func_ir
-
-
-def type_inference_stage(typingctx, interp, args, return_type, locals={}):
-    if len(args) != interp.arg_count:
-        raise TypeError("Mismatch number of argument types")
-
-    warnings = errors.WarningsFixer(errors.NumbaWarning)
-    infer = typeinfer.TypeInferer(typingctx, interp, warnings)
-    with typingctx.callstack.register(infer, interp.func_id, args):
-        # Seed argument types
-        for index, (name, ty) in enumerate(zip(interp.arg_names, args)):
-            infer.seed_argument(name, index, ty)
-
-        # Seed return type
-        if return_type is not None:
-            infer.seed_return(return_type)
-
-        # Seed local types
-        for k, v in locals.items():
-            infer.seed_type(k, v)
-
-        infer.build_constraint()
-        infer.propagate()
-        typemap, restype, calltypes = infer.unify()
-
-    # Output all Numba warnings
-    warnings.flush()
-
-    return typemap, restype, calltypes
-
-
-def native_lowering_stage(targetctx, library, interp, typemap, restype,
-                          calltypes, flags, metadata):
-    # Lowering
-    fndesc = funcdesc.PythonFunctionDescriptor.from_specialized_function(
-        interp, typemap, restype, calltypes, mangler=targetctx.mangler,
-        inline=flags.forceinline, noalias=flags.noalias)
-
-    with targetctx.push_code_library(library):
-        lower = lowering.Lower(targetctx, library, fndesc, interp,
-                               metadata=metadata)
-        lower.lower()
-        if not flags.no_cpython_wrapper:
-            lower.create_cpython_wrapper(flags.release_gil)
-        env = lower.env
-        call_helper = lower.call_helper
-        del lower
-
-    if flags.no_compile:
-        return _LowerResult(fndesc, call_helper, cfunc=None, env=env)
-    else:
-        # Prepare for execution
-        cfunc = targetctx.get_executable(library, fndesc, env)
-        # Insert native function for use by other jitted-functions.
-        # We also register its library to allow for inlining.
-        targetctx.insert_user_function(cfunc, fndesc, [library])
-        return _LowerResult(fndesc, call_helper, cfunc=cfunc, env=env)
-
-
-def py_lowering_stage(targetctx, library, interp, flags):
-    fndesc = funcdesc.PythonFunctionDescriptor.from_object_mode_function(
-        interp
-        )
-    with targetctx.push_code_library(library):
-        lower = pylowering.PyLower(targetctx, library, fndesc, interp)
-        lower.lower()
-        if not flags.no_cpython_wrapper:
-            lower.create_cpython_wrapper()
-        env = lower.env
-        call_helper = lower.call_helper
-        del lower
-
-    if flags.no_compile:
-        return _LowerResult(fndesc, call_helper, cfunc=None, env=env)
-    else:
-        # Prepare for execution
-        cfunc = targetctx.get_executable(library, fndesc, env)
-        return _LowerResult(fndesc, call_helper, cfunc=cfunc, env=env)
-
-
-def _reload_parfors():
-    """Reloader for cached parfors
-    """
-    # Re-initialize the parallel backend when load from cache.
-    from numba.npyufunc.parallel import _launch_threads
-    _launch_threads()

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -293,6 +293,8 @@ class CompilerBase(object):
         self.state.type_annotation = None
         self.state.metadata = {}  # holds arbitrary inter-pipeline stage meta data
         self.state.reload_init = []
+        # hold this for e.g. with_lifting, null out on exit
+        self.state.pipeline = self
 
         # parfor diagnostics info, add to metadata
         self.state.parfor_diagnostics = ParforDiagnostics()
@@ -359,6 +361,10 @@ class CompilerBase(object):
         else:
             raise CompilerError("All available pipelines exhausted")
 
+        # Pipeline is done, remove self reference to release refs to user code
+        self.state.pipeline = None
+
+        # organise a return
         if res is not None:
             # Early pipeline completion
             return res

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -403,7 +403,7 @@ class Compiler(CompilerBase):
         return pms
 
 
-class DefaultPassBuilder:
+class DefaultPassBuilder(object):
     """
     This is the default pass builder, it contains the "classic" default
     pipelines as pre-canned PassManager instances:

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -293,7 +293,6 @@ class CompilerBase(object):
         self.state.type_annotation = None
         self.state.metadata = {}  # holds arbitrary inter-pipeline stage meta data
         self.state.reload_init = []
-        self.state.pipeline = self
 
         # parfor diagnostics info, add to metadata
         self.state.parfor_diagnostics = ParforDiagnostics()

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -230,10 +230,10 @@ class _EarlyPipelineCompletion(Exception):
 class StateDict(dict):
 
     def __getattr__(self, attr):
-        if attr in self.keys():
+        try:
             return self[attr]
-        else:
-            raise KeyError
+        except KeyError:
+            raise AttributeError(attr)
 
     def __setattr__(self, attr, value):
         self[attr] = value

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -340,7 +340,8 @@ class PassRegistry(object):
             assert not self._does_pass_name_alias(pass_class.name())
             pass_class.pass_id = self._id
             self._id += 1
-            self._registry[pass_class] = pass_info(pass_class(), mutates_CFG, analysis_only)
+            self._registry[pass_class] = pass_info(pass_class(), mutates_CFG,
+                                                   analysis_only)
             return pass_class
         return make_festive
 

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -15,7 +15,7 @@ from .postproc import PostProcessor
 _termcolor = errors.termcolor()
 
 
-class SimpleTimer():
+class SimpleTimer(object):
     """
     A simple context managed timer
     """
@@ -90,7 +90,7 @@ class LoweringPass(CompilerPass):
     pass
 
 
-class AnalysisUsage:
+class AnalysisUsage(object):
     """This looks and behaves like LLVM's AnalysisUsage because its like that.
     """
 
@@ -325,7 +325,7 @@ class PassManager(object):
 pass_info = namedtuple('pass_info', 'pass_inst mutates_CFG analysis_only')
 
 
-class PassRegistry:
+class PassRegistry(object):
     """
     Pass registry singleton class.
     """

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -1,13 +1,13 @@
 from __future__ import print_function, absolute_import
 
-import time
-from abc import ABC, abstractmethod
+import timeit
+from abc import abstractmethod, ABCMeta
 from collections import namedtuple, OrderedDict
 import inspect
 import traceback
 from numba.compiler_lock import global_compiler_lock
 from numba import errors
-from . import config, utils, transforms
+from . import config, utils, transforms, six
 from .tracing import event
 from .postproc import PostProcessor
 
@@ -21,14 +21,15 @@ class SimpleTimer():
     """
 
     def __enter__(self):
-        self.ts = time.time()
+        self.ts = timeit.default_timer()
         return self
 
     def __exit__(self, *exc):
-        self.elapsed = time.time() - self.ts
+        self.elapsed = timeit.default_timer() - self.ts
 
 
-class CompilerPass(ABC):
+@six.add_metaclass(ABCMeta)
+class CompilerPass(object):
 
     @abstractmethod
     def __init__(self, *args, **kwargs):

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -1,0 +1,375 @@
+from __future__ import print_function, absolute_import
+
+import time
+from abc import ABC, abstractmethod
+from collections import namedtuple, OrderedDict
+import inspect
+import traceback
+from numba.compiler_lock import global_compiler_lock
+from numba import errors
+from . import config, utils, transforms
+from .tracing import event
+from .postproc import PostProcessor
+
+# terminal color markup
+_termcolor = errors.termcolor()
+
+
+class SimpleTimer():
+    """
+    A simple context managed timer
+    """
+
+    def __enter__(self):
+        self.ts = time.time()
+        return self
+
+    def __exit__(self, *exc):
+        self.elapsed = time.time() - self.ts
+
+
+class CompilerPass(ABC):
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        self._analysis = None
+        self._pass_id = None
+
+    @classmethod
+    def name(cls):
+        return cls._name
+
+    @property
+    def pass_id(self):
+        return self._pass_id
+
+    @pass_id.setter
+    def pass_id(self, val):
+        self._pass_id = val
+
+    @property
+    def analysis(self):
+        return self._analysis
+
+    @analysis.setter
+    def analysis(self, val):
+        self._analysis = val
+
+    def run_initialisation(self, *args, **kwargs):
+        return False
+
+    @abstractmethod
+    def run_pass(self, *args, **kwargs):
+        pass
+
+    def run_finaliser(self, *args, **kwargs):
+        """
+        User defined finaliser
+        """
+        return False
+
+    def get_analysis_usage(self, AU):
+        """Override to set analysis usage
+        """
+        pass
+
+    def get_analysis(self, pass_name):
+        return self._analysis[pass_name]
+
+
+class FunctionPass(CompilerPass):
+    pass
+
+
+class AnalysisPass(CompilerPass):
+    pass
+
+
+class LoweringPass(CompilerPass):
+    pass
+
+
+class AnalysisUsage:
+    """This looks and behaves like LLVM's AnalysisUsage because its like that.
+    """
+
+    def __init__(self):
+        self._required = set()
+        self._preserved = set()
+
+    def get_required_set(self):
+        return self._required
+
+    def get_preserved_set(self):
+        return self._preserved
+
+    def add_required(self, pss):
+        self._required.add(pss)
+
+    def add_preserved(self, pss):
+        self._preserved.add(pss)
+
+    def __str__(self):
+        return "required: %s\n" % self._required
+
+
+_DEBUG = False
+
+
+def debug_print(*args, **kwargs):
+    if _DEBUG:
+        print(*args, **kwargs)
+
+
+pass_timings = namedtuple('pass_timings', 'init run finalise')
+
+
+class PassManager(object):
+    """
+    The PassManager is a named instance of a particular compilation pipeline
+    """
+    # TODO: Eventually enable this, it enforces self consistency after each pass
+    _ENFORCING = False
+
+    def __init__(self, pipeline_name):
+        """
+        Create a new pipeline with name "pipeline_name"
+        """
+        self.passes = []
+        self.exec_times = OrderedDict()
+        self._finalized = False
+        self._analysis = None
+        self._print_after = None
+        self.pipeline_name = pipeline_name
+
+    def _validate_pass(self, pass_cls):
+        if not (isinstance(pass_cls, str) or (inspect.isclass(pass_cls) and issubclass(pass_cls, CompilerPass))):
+            msg = "Pass must be referenced by name or be a subclass of a CompilerPass. Have %s" % pass_cls
+            raise TypeError(msg)
+        if isinstance(pass_cls, str):
+            pass_cls = _pass_registry.find_by_name(pass_cls)
+        else:
+            if not _pass_registry.is_registered(pass_cls):
+                raise ValueError("Pass %s is not registered" % pass_cls)
+
+    def add_pass(self, pss, description=""):
+        """
+        Add a pass to the PassManager
+        """
+        self._validate_pass(pss)
+        func_desc_tuple = (pss, description)
+        self.passes.append(func_desc_tuple)
+        self._finalized = False
+
+    def add_pass_after(self, pass_cls, location):
+        """
+        Add a pass to the PassManager after the pass "location"
+        """
+        assert self.passes
+        self._validate_pass(pass_cls)
+        self._validate_pass(location)
+        for idx, (x, _) in enumerate(self.passes):
+            if x == location:
+                break
+        else:
+            raise ValueError("Could not find pass %s" % location)
+        self.passes.insert(idx + 1, (pass_cls, str(pass_cls)))
+        # if a pass has been added, it's not finalized
+        self._finalized = False
+
+    def _debug_init(self):
+        # determine after which passes IR dumps should take place
+        print_passes = []
+        if config.DEBUG_PRINT_AFTER != "none":
+            if config.DEBUG_PRINT_AFTER == "all":
+                print_passes = [x.name() for (x, _) in self.passes]
+            else:
+                # we don't validate whether the named passes exist in this pipeline
+                # the compiler may be used reentrantly and different pipelines may
+                # contain different passes
+                splitted = config.DEBUG_PRINT_AFTER.split(',')
+                print_passes = [x.strip() for x in splitted]
+        return print_passes
+
+    def finalize(self):
+        """
+        Finalize the PassManager, after which no more passes may be added and
+        analysis etc is completed.
+        """
+        self._analysis = self.dependency_analysis()
+        self._print_after = self._debug_init()
+        self._finalized = True
+
+    @property
+    def finalized(self):
+        return self._finalized
+
+    def _patch_error(self, desc, exc):
+        """
+        Patches the error to show the stage that it arose in.
+        """
+        newmsg = "{desc}\n{exc}".format(desc=desc, exc=exc)
+
+        # For python2, attach the traceback of the previous exception.
+        if not utils.IS_PY3 and config.FULL_TRACEBACKS:
+            # strip the new message to just print the error string and not
+            # the marked up source etc (this is handled already).
+            stripped = _termcolor.errmsg(newmsg.split('\n')[1])
+            fmt = "Caused By:\n{tb}\n{newmsg}"
+            newmsg = fmt.format(tb=traceback.format_exc(), newmsg=stripped)
+
+        exc.args = (newmsg,)
+        return exc
+
+    @global_compiler_lock  # this need a lock, likely calls LLVM
+    def _runPass(self, index, pss, internal_state):
+        mutated = False
+
+        def check(func, compiler_state):
+            mangled = func(compiler_state)
+            if mangled not in (True, False):
+                msg = ("CompilerPass implementations should return True/False. "
+                       "CompilerPass with name '%s' did not.")
+                raise ValueError(msg % pss.name())
+            return mangled
+
+        # wire in the analysis info so it's accessible
+        pss.analysis = self._analysis
+
+        with SimpleTimer() as init_time:
+            mutated |= check(pss.run_initialisation, internal_state)
+        with SimpleTimer() as pass_time:
+            mutated |= check(pss.run_pass, internal_state)
+        with SimpleTimer() as finalise_time:
+            mutated |= check(pss.run_finaliser, internal_state)
+
+        if self._ENFORCING:
+            # TODO: Add in self consistency enforcement for
+            # `func_ir._definitions` etc
+            if _pass_registry.get(pss.__class__).mutates_CFG:
+                if mutated: # block level changes, rebuild all
+                    PostProcessor(internal_state.func_ir).run()
+                else: # CFG level changes rebuild CFG
+                    internal_state.func_ir.blocks = transforms.canonicalize_cfg(
+                        internal_state.func_ir.blocks)
+
+        # inject runtimes
+        pt = pass_timings(init_time.elapsed, pass_time.elapsed,
+                          finalise_time.elapsed)
+        self.exec_times["%s_%s" % (index, pss.name())] = pt
+
+        # debug print after this pass?
+        if pss.name() in self._print_after:
+            print(("%s: %s" % (self.pipeline_name, pss.name())).center(80, '-'))
+            internal_state.func_ir.dump()
+
+    def run(self, state):
+        from numba.compiler import _EarlyPipelineCompletion
+        if not self.finalized:
+            raise RuntimeError("Cannot run non-finalised pipeline")
+
+        # walk the passes and run them
+        for idx, (pss, pass_desc) in enumerate(self.passes):
+            try:
+                event("-- %s" % pass_desc)
+                pass_inst = _pass_registry.get(pss).pass_inst
+                if isinstance(pass_inst, CompilerPass):
+                    self._runPass(idx, pass_inst, state)
+                else:
+                    raise BaseException("Legacy pass in use")
+            except _EarlyPipelineCompletion as e:
+                raise e
+            except Exception as e:
+                msg = "Failed in %s mode pipeline (step: %s)" % \
+                    (self.pipeline_name, pass_desc)
+                patched_exception = self._patch_error(msg, e)
+                raise patched_exception
+
+    def dependency_analysis(self):
+        """
+        Computes dependency analysis
+        """
+        deps = dict()
+        for (pss, _) in self.passes:
+            x = _pass_registry.get(pss).pass_inst
+            au = AnalysisUsage()
+            x.get_analysis_usage(au)
+            deps[type(x)] = au
+
+        requires_map = dict()
+        for k, v in deps.items():
+            requires_map[k] = v.get_required_set()
+
+        def resolve_requires(key, rmap):
+            def walk(lkey, rmap):
+                dep_set = set(rmap[lkey])
+                if dep_set:
+                    for x in dep_set:
+                        dep_set |= (walk(x, rmap))
+                    return dep_set
+                else:
+                    return set()
+            ret = set()
+            for k in key:
+                ret |= walk(k, rmap)
+            return ret
+
+        dep_chain = dict()
+        for k, v in requires_map.items():
+            dep_chain[k] = set(v) | (resolve_requires(v, requires_map))
+
+        return dep_chain
+
+
+pass_info = namedtuple('pass_info', 'pass_inst mutates_CFG analysis_only')
+
+
+class PassRegistry:
+    """
+    Pass registry singleton class.
+    """
+
+    _id = 0
+
+    _registry = dict()
+
+    def register(self, mutates_CFG, analysis_only):
+        def make_festive(pass_class):
+            assert not self.is_registered(pass_class)
+            assert not self._does_pass_name_alias(pass_class.name())
+            pass_class.pass_id = self._id
+            self._id += 1
+            self._registry[pass_class] = pass_info(pass_class(), mutates_CFG, analysis_only)
+            return pass_class
+        return make_festive
+
+    def is_registered(self, clazz):
+        return clazz in self._registry.keys()
+
+    def get(self, clazz):
+        assert self.is_registered(clazz)
+        return self._registry[clazz]
+
+    def _does_pass_name_alias(self, check):
+        for k, v in self._registry.items():
+            if v.pass_inst.name == check:
+                return True
+        return False
+
+    def find_by_name(self, class_name):
+        assert isinstance(class_name, str)
+        for k, v in self._registry.items():
+            if v.pass_inst.name == class_name:
+                return v
+        else:
+            raise ValueError("No pass with name %s is registered" % class_name)
+
+    def dump(self):
+        for k, v in self._registry.items():
+            print("%s: %s" % (k, v))
+
+
+_pass_registry = PassRegistry()
+del PassRegistry
+
+register_pass = _pass_registry.register

--- a/numba/config.py
+++ b/numba/config.py
@@ -142,6 +142,9 @@ class _EnvReloader(object):
         # Debug flag to control compiler debug print
         DEBUG = _readenv("NUMBA_DEBUG", int, 0)
 
+        # DEBUG print IR after pass names
+        DEBUG_PRINT_AFTER = _readenv("NUMBA_DEBUG_PRINT_AFTER", str, "none")
+
         # JIT Debug flag to trigger IR instruction print
         DEBUG_JIT = _readenv("NUMBA_DEBUG_JIT", int, 0)
 

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -56,7 +56,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
         Specifies the target platform to compile for. Valid targets are cpu,
         gpu, npyufunc, and cuda. Defaults to cpu.
 
-    pipeline_class: type numba.compiler.BasePipeline
+    pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type for customizing the compilation stages.
 
     options:

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -363,15 +363,15 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
         _debug_dump(callee_ir)
 
     if typingctx:
-        from numba import compiler
+        from numba import typed_passes
         # call branch pruning to simplify IR and avoid inference errors
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         numba.analysis.dead_branch_prune(callee_ir, arg_typs)
         try:
-            f_typemap, f_return_type, f_calltypes = compiler.type_inference_stage(
+            f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
                     typingctx, callee_ir, arg_typs, None)
         except Exception:
-            f_typemap, f_return_type, f_calltypes = compiler.type_inference_stage(
+            f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
                     typingctx, callee_ir, arg_typs, None)
             pass
         canonicalize_array_math(callee_ir, f_typemap,
@@ -967,9 +967,9 @@ class RewriteArrayOfConsts(rewrites.Rewrite):
     1D array creations from a constant list, and rewriting it into
     direct initialization of array elements without creating the list.
     '''
-    def __init__(self, pipeline, *args, **kws):
-        self.typingctx = pipeline.typingctx
-        super(RewriteArrayOfConsts, self).__init__(pipeline, *args, **kws)
+    def __init__(self, state, *args, **kws):
+        self.typingctx = state.typingctx
+        super(RewriteArrayOfConsts, self).__init__(*args, **kws)
 
     def match(self, func_ir, block, typemap, calltypes):
         if len(calltypes) == 0:

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1516,7 +1516,7 @@ def compile_to_numba_ir(mk_func, glbls, typingctx=None, arg_typs=None,
     if typingctx and other typing inputs are available and update typemap and
     calltypes.
     """
-    from numba import compiler
+    from numba import typed_passes
     # mk_func can be actual function or make_function node
     if hasattr(mk_func, 'code'):
         code = mk_func.code
@@ -1543,7 +1543,7 @@ def compile_to_numba_ir(mk_func, glbls, typingctx=None, arg_typs=None,
     # perform type inference if typingctx is available and update type
     # data structures typemap and calltypes
     if typingctx:
-        f_typemap, f_return_type, f_calltypes = compiler.type_inference_stage(
+        f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
                 typingctx, f_ir, arg_typs, None)
         # remove argument entries like arg.a from typemap
         arg_names = [vname for vname in f_typemap if vname.startswith("arg.")]
@@ -1598,15 +1598,15 @@ def get_ir_of_code(glbls, fcode):
     # for example, Raise nodes need to become StaticRaise before type inference
     class DummyPipeline(object):
         def __init__(self, f_ir):
-            self.typingctx = None
-            self.targetctx = None
-            self.args = None
-            self.func_ir = f_ir
-            self.typemap = None
-            self.return_type = None
-            self.calltypes = None
-    rewrites.rewrite_registry.apply('before-inference',
-                                    DummyPipeline(ir), ir)
+            self.state = compiler.StateDict()
+            self.state.typingctx = None
+            self.state.targetctx = None
+            self.state.args = None
+            self.state.func_ir = f_ir
+            self.state.typemap = None
+            self.state.return_type = None
+            self.state.calltypes = None
+    rewrites.rewrite_registry.apply('before-inference', DummyPipeline(ir).state)
     # call inline pass to handle cases like stencils and comprehensions
     swapped = {} # TODO: get this from diagnostics store
     inline_pass = numba.inline_closurecall.InlineClosureCallPass(
@@ -2003,256 +2003,6 @@ def resolve_func_from_module(func_ir, node):
             return defn
     else:
         return None
-
-
-class InlineInlinables(object):
-    """
-    This pass will inline a function wrapped by the numba.jit decorator directly
-    into the site of its call depending on the value set in the 'inline' kwarg
-    to the decorator.
-
-    This is an untyped pass. CFG simplification is performed at the end of the
-    pass but no block level clean up is performed on the mutated IR (typing
-    information is not available to do so).
-    """
-
-    _DEBUG = False
-
-    def __init__(self, func_ir):
-        self.func_ir = func_ir
-
-    def run(self):
-        """Run inlining of inlinables
-        """
-        if config.DEBUG or self._DEBUG:
-            print('before inline'.center(80, '-'))
-            print(self.func_ir.dump())
-            print(''.center(80, '-'))
-        modified = False
-        # use a work list, look for call sites via `ir.Expr.op == call` and
-        # then pass these to `self._do_work` to make decisions about inlining.
-        work_list = list(self.func_ir.blocks.items())
-        while work_list:
-            label, block = work_list.pop()
-            for i, instr in enumerate(block.body):
-                if isinstance(instr, ir.Assign):
-                    expr = instr.value
-                    if isinstance(expr, ir.Expr) and expr.op == 'call':
-                        if guard(self._do_work, work_list, block, i, expr):
-                            modified = True
-                            break  # because block structure changed
-
-        if modified:
-            # clean up unconditional branches that appear due to inlined
-            # functions introducing blocks
-            self.func_ir.blocks = simplify_CFG(self.func_ir.blocks)
-
-        if config.DEBUG or self._DEBUG:
-            print('after inline'.center(80, '-'))
-            print(self.func_ir.dump())
-            print(''.center(80, '-'))
-
-    def _do_work(self, work_list, block, i, expr):
-        from numba.inline_closurecall import (inline_closure_call,
-                                              callee_ir_validator)
-        from numba.compiler import run_frontend
-        from numba.targets.cpu import InlineOptions
-
-        # try and get a definition for the call, this isn't always possible as
-        # it might be a eval(str)/part generated awaiting update etc. (parfors)
-        to_inline = None
-        try:
-            to_inline = self.func_ir.get_definition(expr.func)
-        except Exception as e:
-            if self._DEBUG:
-                print("Cannot find definition for %s" % expr.func)
-            return False
-        # do not handle closure inlining here, another pass deals with that.
-        if getattr(to_inline, 'op', False) == 'make_function':
-            return False
-
-        # see if the definition is a "getattr", in which case walk the IR to
-        # try and find the python function via the module from which it's
-        # imported, this should all be encoded in the IR.
-        if getattr(to_inline, 'op', False) == 'getattr':
-            val = resolve_func_from_module(self.func_ir, to_inline)
-        else:
-            # This is likely a freevar or global
-            #
-            # NOTE: getattr 'value' on a call may fail if it's an ir.Expr as
-            # getattr is overloaded to look in _kws.
-            try:
-                val = getattr(to_inline, 'value', False)
-            except Exception:
-                raise GuardException
-
-        # if something was found...
-        if val:
-            # check it's dispatcher-like, the targetoptions attr holds the
-            # kwargs supplied in the jit decorator and is where 'inline' will
-            # be if it is present.
-            topt = getattr(val, 'targetoptions', False)
-            if topt:
-                inline_type = topt.get('inline', None)
-                # has 'inline' been specified?
-                if inline_type is not None:
-                    inline_opt = InlineOptions(inline_type)
-                    # Could this be inlinable?
-                    if not inline_opt.is_never_inline:
-                        # yes, it could be inlinable
-                        do_inline = True
-                        pyfunc = val.py_func
-                        # Has it got an associated cost model?
-                        if inline_opt.has_cost_model:
-                            # yes, it has a cost model, use it to determine
-                            # whether to do the inline
-                            py_func_ir = run_frontend(pyfunc)
-                            do_inline = inline_type(self.func_ir, py_func_ir)
-                        # if do_inline is True then inline!
-                        if do_inline:
-                            inline_closure_call(self.func_ir,
-                                                pyfunc.__globals__,
-                                                block, i, pyfunc,
-                                                work_list=work_list,
-                                                callee_validator=\
-                                                callee_ir_validator)
-                            return True
-        return False
-
-
-class InlineOverloads(object):
-    """
-    This pass will inline a function wrapped by the numba.extending.overload
-    decorator directly into the site of its call depending on the value set in
-    the 'inline' kwarg to the decorator.
-
-    This is a typed pass. CFG simplification and DCE are performed on
-    completion.
-    """
-
-    _DEBUG = False
-
-    def __init__(self, func_ir, tyctx, cgctx, type_annotation):
-        self.func_ir = func_ir
-        self.tyctx = tyctx
-        self.cgctx = cgctx
-        self.type_annotation = type_annotation
-        self.typemap = type_annotation.typemap
-        self.calltypes = type_annotation.calltypes
-
-    def run(self):
-        """Run inlining of overloads
-        """
-        if config.DEBUG or self._DEBUG:
-            print('before overload inline'.center(80, '-'))
-            print(self.func_ir.dump())
-            print(''.center(80, '-'))
-        modified = False
-        work_list = list(self.func_ir.blocks.items())
-        # use a work list, look for call sites via `ir.Expr.op == call` and
-        # then pass these to `self._do_work` to make decisions about inlining.
-        while work_list:
-            label, block = work_list.pop()
-            for i, instr in enumerate(block.body):
-                if isinstance(instr, ir.Assign):
-                    expr = instr.value
-                    if isinstance(expr, ir.Expr) and expr.op == 'call':
-                        if guard(self._do_work, work_list, block, i, expr):
-                            modified = True
-                            break # because block structure changed
-
-        if config.DEBUG or self._DEBUG:
-            print('after overload inline'.center(80, '-'))
-            print(self.func_ir.dump())
-            print(''.center(80, '-'))
-
-        if modified:
-            # clean up blocks
-            dead_code_elimination(self.func_ir, typemap=self.typemap)
-            # clean up unconditional branches that appear due to inlined
-            # functions introducing blocks
-            self.func_ir.blocks = simplify_CFG(self.func_ir.blocks)
-
-        if config.DEBUG or self._DEBUG:
-            print('after overload inline DCE'.center(80, '-'))
-            print(self.func_ir.dump())
-            print(''.center(80, '-'))
-
-    def _do_work(self, work_list, block, i, expr):
-        from numba.inline_closurecall import (inline_closure_call,
-                                              callee_ir_validator)
-
-        # try and get a definition for the call, this isn't always possible as
-        # it might be a eval(str)/part generated awaiting update etc. (parfors)
-        to_inline = None
-        try:
-            to_inline = self.func_ir.get_definition(expr.func)
-        except Exception as e:
-            return False
-
-        # do not handle closure inlining here, another pass deals with that.
-        if getattr(to_inline, 'op', False) == 'make_function':
-            return False
-
-        # check this is a known and typed function
-        func_ty = self.typemap[expr.func.name]
-        if not hasattr(func_ty, 'get_call_type'):
-            return False
-
-
-        # search the templates for this overload looking for "inline"
-        templates = getattr(func_ty, 'templates', None)
-        if templates is None:
-            return False
-
-        sig = self.calltypes[expr]
-
-        impl = None
-        for template in templates:
-            inline_type = getattr(template, '_inline', None)
-            if inline_type is None:
-                # inline not defined
-                continue
-            if not inline_type.is_never_inline:
-                try:
-                    impl = template._overload_func(*sig.args)
-                    if impl is None:
-                        raise Exception # abort for this template
-                    break
-                except Exception:
-                    continue
-        else:
-            return False
-
-        # at this point we know we maybe want to inline something and there's
-        # definitely something that could be inlined.
-
-        do_inline = True
-        if not inline_type.is_always_inline:
-            from numba.typing.templates import _inline_info
-            caller_inline_info = _inline_info(self.func_ir, self.typemap,
-                                              self.calltypes, sig)
-
-            # must be a cost-model function, run the function
-            iinfo = template._inline_overloads[sig.args]['iinfo']
-            if inline_type.has_cost_model:
-                do_inline = inline_type.value(caller_inline_info, iinfo)
-            else:
-                assert 'unreachable'
-
-        if do_inline:
-            arg_typs=template._inline_overloads[sig.args]['folded_args']
-            # pass is typed so use the callee globals
-            inline_closure_call(self.func_ir, impl.__globals__,
-                                block, i, impl, typingctx=self.tyctx,
-                                arg_typs=arg_typs, typemap=self.typemap,
-                                calltypes=self.calltypes, work_list=work_list,
-                                replace_freevars=False,
-                                callee_validator=callee_ir_validator)
-            return True
-        else:
-            return False
-
 
 def check_and_legalize_ir(func_ir):
     """

--- a/numba/npyufunc/array_exprs.py
+++ b/numba/npyufunc/array_exprs.py
@@ -24,10 +24,10 @@ class RewriteArrayExprs(rewrites.Rewrite):
     rewriting those expressions to a single operation that will expand
     into something similar to a ufunc call.
     '''
-    def __init__(self, pipeline, *args, **kws):
-        super(RewriteArrayExprs, self).__init__(pipeline, *args, **kws)
+    def __init__(self, state, *args, **kws):
+        super(RewriteArrayExprs, self).__init__(state, *args, **kws)
         # Install a lowering hook if we are using this rewrite.
-        special_ops = self.pipeline.targetctx.special_ops
+        special_ops = state.targetctx.special_ops
         if 'arrayexpr' not in special_ops:
             special_ops['arrayexpr'] = _lower_array_expr
 

--- a/numba/object_mode_passes.py
+++ b/numba/object_mode_passes.py
@@ -1,0 +1,223 @@
+from __future__ import print_function, division, absolute_import
+from contextlib import contextmanager
+import warnings
+from . import (config, bytecode, interpreter, postproc, errors, types, rewrites,
+               typeinfer, funcdesc, lowering, utils, typing, pylowering,
+               transforms)
+from .compiler_machinery import FunctionPass, LoweringPass, register_pass
+from collections import defaultdict
+
+
+@contextmanager
+def giveup_context(state, msg):
+    """
+    Wraps code that would signal a fallback to interpreter mode
+    """
+    try:
+        yield
+    except Exception as e:
+        if not state.status.can_giveup:
+            raise
+        else:
+            if utils.PYVERSION >= (3,):
+                # Clear all references attached to the traceback
+                e = e.with_traceback(None)
+            warnings.warn_explicit('%s: %s' % (msg, e),
+                                   errors.NumbaWarning,
+                                   state.func_id.filename,
+                                   state.func_id.firstlineno)
+
+            raise
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ObjectModeFrontEnd(FunctionPass):
+    _name = "object_mode_front_end"
+
+    def __init__(self):
+        super().__init__()
+
+    def _frontend_looplift(self, state):
+        """
+        Loop lifting analysis and transformation
+        """
+        loop_flags = state.flags.copy()
+        outer_flags = state.flags.copy()
+        # Do not recursively loop lift
+        outer_flags.unset('enable_looplift')
+        loop_flags.unset('enable_looplift')
+        if not state.flags.enable_pyobject_looplift:
+            loop_flags.unset('enable_pyobject')
+
+        main, loops = transforms.loop_lifting(state.func_ir,
+                                              typingctx=state.typingctx,
+                                              targetctx=state.targetctx,
+                                              locals=state.locals,
+                                              flags=loop_flags)
+        if loops:
+            # Some loops were extracted
+            if config.DEBUG_FRONTEND or config.DEBUG:
+                for loop in loops:
+                    print("Lifting loop", loop.get_source_location())
+            from numba.compiler import compile_ir
+            cres = compile_ir(state.typingctx, state.targetctx, main,
+                              state.args, state.return_type,
+                              outer_flags, state.locals,
+                              lifted=tuple(loops), lifted_from=None,
+                              is_lifted_loop=True)
+            return cres
+
+    def run_pass(self, state):
+        from numba.compiler import compile_ir, _EarlyPipelineCompletion
+        # NOTE: That so much stuff, including going back into the compiler, is
+        # captured in a single pass is not ideal.
+        if state.flags.enable_looplift:
+            assert not state.lifted
+            cres = self._frontend_looplift(state)
+            if cres is not None:
+                raise _EarlyPipelineCompletion(cres)
+
+        # Fallback typing: everything is a python object
+        state.typemap = defaultdict(lambda: types.pyobject)
+        state.calltypes = defaultdict(lambda: types.pyobject)
+        state.return_type = types.pyobject
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ObjectModeBackEnd(LoweringPass):
+
+    _name = "object_mode_back_end"
+
+    def __init__(self):
+        super().__init__()
+
+    def _py_lowering_stage(self, targetctx, library, interp, flags):
+        fndesc = funcdesc.PythonFunctionDescriptor.from_object_mode_function(
+            interp
+        )
+        with targetctx.push_code_library(library):
+            lower = pylowering.PyLower(targetctx, library, fndesc, interp)
+            lower.lower()
+            if not flags.no_cpython_wrapper:
+                lower.create_cpython_wrapper()
+            env = lower.env
+            call_helper = lower.call_helper
+            del lower
+        from numba.compiler import _LowerResult  # TODO: move this
+        if flags.no_compile:
+            return _LowerResult(fndesc, call_helper, cfunc=None, env=env)
+        else:
+            # Prepare for execution
+            cfunc = targetctx.get_executable(library, fndesc, env)
+            return _LowerResult(fndesc, call_helper, cfunc=cfunc, env=env)
+
+    def run_pass(self, state):
+        """
+        Lowering for object mode
+        """
+
+        if state.library is None:
+            codegen = state.targetctx.codegen()
+            state.library = codegen.create_library(state.func_id.func_qualname)
+            # Enable object caching upfront, so that the library can
+            # be later serialized.
+            state.library.enable_object_caching()
+
+        def backend_object_mode():
+            """
+            Object mode compilation
+            """
+            with giveup_context(state,
+                                "Function %s failed at object mode lowering"
+                                % (state.func_id.func_name,)):
+                if len(state.args) != state.nargs:
+                    # append missing
+                    # BUG?: What's going on with nargs here?
+                    # check state.nargs vs self.nargs on original code
+                    state.args = (tuple(state.args) + (types.pyobject,) *
+                                  (state.nargs - len(state.args)))
+
+                return self._py_lowering_stage(state.targetctx,
+                                               state.library,
+                                               state.func_ir,
+                                               state.flags)
+
+        lowered = backend_object_mode()
+        signature = typing.signature(state.return_type, *state.args)
+        from numba.compiler import compile_result
+        state.cr = compile_result(
+            typing_context=state.typingctx,
+            target_context=state.targetctx,
+            entry_point=lowered.cfunc,
+            typing_error=state.status.fail_reason,
+            type_annotation=state.type_annotation,
+            library=state.library,
+            call_helper=lowered.call_helper,
+            signature=signature,
+            objectmode=True,
+            interpmode=False,
+            lifted=state.lifted,
+            fndesc=lowered.fndesc,
+            environment=lowered.env,
+            metadata=state.metadata,
+            reload_init=state.reload_init,
+        )
+
+        # Warn, deprecated behaviour, code compiled in objmode without
+        # force_pyobject indicates fallback from nopython mode
+        if not state.flags.force_pyobject:
+            # first warn about object mode and yes/no to lifted loops
+            if len(state.lifted) > 0:
+                warn_msg = ('Function "%s" was compiled in object mode without'
+                            ' forceobj=True, but has lifted loops.' %
+                            (state.func_id.func_name,))
+            else:
+                warn_msg = ('Function "%s" was compiled in object mode without'
+                            ' forceobj=True.' % (state.func_id.func_name,))
+            warnings.warn(errors.NumbaWarning(warn_msg,
+                                              state.func_ir.loc))
+
+            url = ("http://numba.pydata.org/numba-doc/latest/reference/"
+                   "deprecation.html#deprecation-of-object-mode-fall-"
+                   "back-behaviour-when-using-jit")
+            msg = ("\nFall-back from the nopython compilation path to the "
+                   "object mode compilation path has been detected, this is "
+                   "deprecated behaviour.\n\nFor more information visit %s" %
+                   url)
+            warnings.warn(errors.NumbaDeprecationWarning(msg, state.func_ir.loc))
+            if state.flags.release_gil:
+                warn_msg = ("Code running in object mode won't allow parallel"
+                            " execution despite nogil=True.")
+                warnings.warn_explicit(warn_msg, errors.NumbaWarning,
+                                       state.func_id.filename,
+                                       state.func_id.firstlineno)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class CompileInterpMode(LoweringPass):
+
+    _name = "compile_interp_mode"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Just create a compile result for interpreter mode
+        """
+        args = [types.pyobject] * len(state.args)
+        signature = typing.signature(types.pyobject, *args)
+        from numba.compiler import compile_result
+        state.cr = compile_result(typing_context=state.typingctx,
+                                  target_context=state.targetctx,
+                                  entry_point=state.func_id.func,
+                                  typing_error=state.status.fail_reason,
+                                  type_annotation="<Interpreter mode function>",
+                                  signature=signature,
+                                  objectmode=False,
+                                  interpmode=True,
+                                  lifted=(),
+                                  fndesc=None,)
+        return True

--- a/numba/object_mode_passes.py
+++ b/numba/object_mode_passes.py
@@ -1,8 +1,7 @@
 from __future__ import print_function, division, absolute_import
 from contextlib import contextmanager
 import warnings
-from . import (config, bytecode, interpreter, postproc, errors, types, rewrites,
-               typeinfer, funcdesc, lowering, utils, typing, pylowering,
+from . import (config, errors, types, funcdesc,  utils, typing, pylowering,
                transforms)
 from .compiler_machinery import FunctionPass, LoweringPass, register_pass
 from collections import defaultdict
@@ -35,7 +34,7 @@ class ObjectModeFrontEnd(FunctionPass):
     _name = "object_mode_front_end"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def _frontend_looplift(self, state):
         """
@@ -68,7 +67,7 @@ class ObjectModeFrontEnd(FunctionPass):
             return cres
 
     def run_pass(self, state):
-        from numba.compiler import compile_ir, _EarlyPipelineCompletion
+        from numba.compiler import _EarlyPipelineCompletion
         # NOTE: That so much stuff, including going back into the compiler, is
         # captured in a single pass is not ideal.
         if state.flags.enable_looplift:
@@ -90,7 +89,7 @@ class ObjectModeBackEnd(LoweringPass):
     _name = "object_mode_back_end"
 
     def __init__(self):
-        super().__init__()
+        LoweringPass.__init__(self)
 
     def _py_lowering_stage(self, targetctx, library, interp, flags):
         fndesc = funcdesc.PythonFunctionDescriptor.from_object_mode_function(
@@ -201,7 +200,7 @@ class CompileInterpMode(LoweringPass):
     _name = "compile_interp_mode"
 
     def __init__(self):
-        super().__init__()
+        LoweringPass.__init__(self)
 
     def run_pass(self, state):
         """

--- a/numba/rewrites/registry.py
+++ b/numba/rewrites/registry.py
@@ -9,10 +9,10 @@ class Rewrite(object):
     '''Defines the abstract base class for Numba rewrites.
     '''
 
-    def __init__(self, pipeline):
+    def __init__(self, state=None):
         '''Constructor for the Rewrite class.
         '''
-        self.pipeline = pipeline
+        pass
 
     def match(self, func_ir, block, typemap, calltypes):
         '''Overload this method to check an IR block for matching terms in the
@@ -53,21 +53,21 @@ class RewriteRegistry(object):
             return rewrite_cls
         return do_register
 
-    def apply(self, kind, pipeline, func_ir):
+    def apply(self, kind, state):
         '''Given a pipeline and a dictionary of basic blocks, exhaustively
         attempt to apply all registered rewrites to all basic blocks.
         '''
         assert kind in self._kinds
-        blocks = func_ir.blocks
+        blocks = state.func_ir.blocks
         old_blocks = blocks.copy()
         for rewrite_cls in self.rewrites[kind]:
             # Exhaustively apply a rewrite until it stops matching.
-            rewrite = rewrite_cls(pipeline)
+            rewrite = rewrite_cls(state)
             work_list = list(blocks.items())
             while work_list:
                 key, block = work_list.pop()
-                matches = rewrite.match(func_ir, block, pipeline.typemap,
-                                        pipeline.calltypes)
+                matches = rewrite.match(state.func_ir, block, state.typemap,
+                                        state.calltypes)
                 if matches:
                     if config.DEBUG or config.DUMP_IR:
                         print("_" * 70)
@@ -92,7 +92,7 @@ class RewriteRegistry(object):
         # see #4093 for context. This has to be run here opposed to in
         # apply() as the CFG needs computing so full IR is needed.
         from numba import postproc
-        post_proc = postproc.PostProcessor(func_ir)
+        post_proc = postproc.PostProcessor(state.func_ir)
         post_proc.run()
 
 

--- a/numba/stencil.py
+++ b/numba/stencil.py
@@ -8,7 +8,8 @@ import copy
 import numpy as np
 from llvmlite import ir as lir
 
-from numba import compiler, types, ir_utils, ir, typing, numpy_support, utils
+from numba import (compiler, types, ir_utils, ir, typing, numpy_support, utils,
+                   typed_passes)
 from numba import config
 from numba.typing.templates import (CallableTemplate, signature, infer_global,
                                     AbstractTemplate)
@@ -332,7 +333,7 @@ class StencilFunc(object):
             raise ValueError("The first argument to a stencil kernel must "
                              "be the primary input array.")
 
-        typemap, return_type, calltypes = compiler.type_inference_stage(
+        typemap, return_type, calltypes = typed_passes.type_inference_stage(
                 self._typingctx,
                 self.kernel_ir,
                 argtys,

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -119,8 +119,6 @@ class ArrayAnalysisTester(Compiler):
         """
         Populate and run compiler pipeline
         """
-        self.func_id = bytecode.FunctionIdentity.from_function(func)
-
         self.state.func_id = bytecode.FunctionIdentity.from_function(func)
         ExtractByteCode().run_pass(self.state)
 

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -87,7 +87,7 @@ class ArrayAnalysisPass(FunctionPass):
     _name = "array_analysis_pass"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         state.array_analysis = ArrayAnalysis(state.typingctx, state.func_ir,

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -11,10 +11,19 @@ from numba import (njit, typeof, types, typing, typeof, ir, utils, bytecode,
     jitclass, prange)
 from .support import TestCase, tag
 from numba.array_analysis import EquivSet, ArrayAnalysis
-from numba.compiler import Pipeline, Flags, _PipelineManager
+from numba.compiler import Compiler, Flags, PassManager
 from numba.targets import cpu, registry
 from numba.numpy_support import version as numpy_version
 from numba.ir_utils import remove_dead
+from numba.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                             IRProcessing, DeadBranchPrune,
+                             RewriteSemanticConstants, GenericRewrites,
+                             WithLifting, PreserveIR, InlineClosureLikes)
+
+from numba.typed_passes import (NopythonTypeInference, AnnotateTypes,
+                                NopythonRewrites, IRLegalization)
+
+from numba.compiler_machinery import FunctionPass, PassManager, register_pass
 
 # for parallel tests, marking that Windows with Python 2.7 is not supported
 _windows_py27 = (sys.platform.startswith('win32') and
@@ -73,7 +82,25 @@ class TestEquivSet(TestCase):
         self.assertFalse(r.is_equiv('c', 'd'))
 
 
-class ArrayAnalysisTester(Pipeline):
+@register_pass(analysis_only=False, mutates_CFG=True)
+class ArrayAnalysisPass(FunctionPass):
+    _name = "array_analysis_pass"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        state.array_analysis = ArrayAnalysis(state.typingctx, state.func_ir,
+                                             state.type_annotation.typemap,
+                                             state.type_annotation.calltypes)
+        state.array_analysis.run(state.func_ir.blocks)
+        state.func_ir_copies.append(state.func_ir.copy())
+        if state.test_idempotence and len(state.func_ir_copies) > 1:
+            state.test_idempotence(state.func_ir_copies)
+        return False
+
+
+class ArrayAnalysisTester(Compiler):
 
     @classmethod
     def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
@@ -94,51 +121,46 @@ class ArrayAnalysisTester(Pipeline):
         """
         self.func_id = bytecode.FunctionIdentity.from_function(func)
 
-        try:
-            bc = self.extract_bytecode(self.func_id)
-        except Exception as e:
-            raise e
+        self.state.func_id = bytecode.FunctionIdentity.from_function(func)
+        ExtractByteCode().run_pass(self.state)
 
-        self.bc = bc
-        self.lifted = ()
-        self.lifted_from = None
+        self.state.lifted = ()
+        self.state.lifted_from = None
+        state = self.state
+        state.func_ir_copies = []
+        state.test_idempotence = test_idempotence
 
-        pm = _PipelineManager()
+        name = 'array_analysis_testing'
+        pm = PassManager(name)
+        pm.add_pass(TranslateByteCode, "analyzing bytecode")
+        pm.add_pass(FixupArgs, "fix up args")
+        pm.add_pass(IRProcessing, "processing IR")
+        # pre typing
+        if not state.flags.no_rewrites:
+            pm.add_pass(GenericRewrites, "nopython rewrites")
+            pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+        pm.add_pass(InlineClosureLikes,
+                    "inline calls to locally defined closures")
+        # typing
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+        pm.add_pass(AnnotateTypes, "annotate types")
 
-        pm.create_pipeline("nopython")
-        if self.func_ir is None:
-            pm.add_stage(self.stage_analyze_bytecode, "analyzing bytecode")
-        pm.add_stage(self.stage_process_ir, "processing IR")
-        if not self.flags.no_rewrites:
-            if self.status.can_fallback:
-                pm.add_stage(
-                    self.stage_preserve_ir, "preserve IR for fallback")
-            pm.add_stage(self.stage_generic_rewrites, "nopython rewrites")
-        pm.add_stage(
-            self.stage_inline_pass, "inline calls to locally defined closures")
-        pm.add_stage(self.stage_nopython_frontend, "nopython frontend")
-        pm.add_stage(self.stage_annotate_type, "annotate type")
-        if not self.flags.no_rewrites:
-            pm.add_stage(self.stage_nopython_rewrites, "nopython rewrites")
-        func_ir_copies = []
+        if not state.flags.no_rewrites:
+            pm.add_pass(NopythonRewrites, "nopython rewrites")
 
-        def stage_array_analysis():
-            self.array_analysis = ArrayAnalysis(self.typingctx, self.func_ir,
-                                                self.type_annotation.typemap,
-                                                self.type_annotation.calltypes)
-            self.array_analysis.run(self.func_ir.blocks)
-            func_ir_copies.append(self.func_ir.copy())
-            if test_idempotence and len(func_ir_copies) > 1:
-                test_idempotence(func_ir_copies)
-
-        pm.add_stage(stage_array_analysis, "analyze array equivalences")
+        # Array Analysis pass
+        pm.add_pass(ArrayAnalysisPass, "array analysis")
         if test_idempotence:
             # Do another pass of array analysis to test idempotence
-            pm.add_stage(stage_array_analysis, "analyze array equivalences")
+            pm.add_pass(ArrayAnalysisPass, "idempotence array analysis")
+        # legalise
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
 
+        # partial compile
         pm.finalize()
-        res = pm.run(self.status)
-        return self.array_analysis
+        pm.run(state)
+        return state.array_analysis
 
 
 class TestArrayAnalysis(TestCase):

--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -7,7 +7,7 @@ import numpy as np
 from numba import njit, vectorize
 from numba import unittest_support as unittest
 from numba import compiler, typing, typeof, ir, utils, types
-from numba.compiler import Pipeline, _PipelineManager, Flags
+from numba.compiler import Compiler, Flags
 from numba.targets import cpu
 from .support import MemoryLeakMixin, TestCase
 
@@ -75,7 +75,7 @@ def distance_matrix(vectors):
     return result
 
 
-class RewritesTester(Pipeline):
+class RewritesTester(Compiler):
     @classmethod
     def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
                     library=None, typing_context=None, target_context=None):
@@ -137,9 +137,9 @@ class TestArrayExpressions(MemoryLeakMixin, TestCase):
         np.testing.assert_array_equal(expected, actual)
         np.testing.assert_array_equal(control, actual)
 
-        ir0 = control_pipeline.func_ir.blocks
-        ir1 = test_pipeline.func_ir.blocks
-        ir2 = control_pipeline2.func_ir.blocks
+        ir0 = control_pipeline.state.func_ir.blocks
+        ir1 = test_pipeline.state.func_ir.blocks
+        ir2 = control_pipeline2.state.func_ir.blocks
         self.assertEqual(len(ir0), len(ir1))
         self.assertEqual(len(ir0), len(ir2))
         # The rewritten IR should be smaller than the original.
@@ -282,8 +282,8 @@ class TestArrayExpressions(MemoryLeakMixin, TestCase):
         scalar optimizations such as rewriting `x ** 2`.
         """
         ns = self._test_cube_function()
-        self._assert_total_rewrite(ns.control_pipeline.func_ir.blocks,
-                                   ns.test_pipeline.func_ir.blocks,
+        self._assert_total_rewrite(ns.control_pipeline.state.func_ir.blocks,
+                                   ns.test_pipeline.state.func_ir.blocks,
                                    trivial=True)
 
     def test_complicated_expr(self):
@@ -293,8 +293,8 @@ class TestArrayExpressions(MemoryLeakMixin, TestCase):
         array expressions.
         '''
         ns = self._test_root_function()
-        self._assert_total_rewrite(ns.control_pipeline.func_ir.blocks,
-                                   ns.test_pipeline.func_ir.blocks)
+        self._assert_total_rewrite(ns.control_pipeline.state.func_ir.blocks,
+                                   ns.test_pipeline.state.func_ir.blocks)
 
     def test_common_subexpressions(self, fn=neg_root_common_subexpr):
         '''
@@ -302,8 +302,8 @@ class TestArrayExpressions(MemoryLeakMixin, TestCase):
         subexpressions properly.
         '''
         ns = self._test_root_function(fn)
-        ir0 = ns.control_pipeline.func_ir.blocks
-        ir1 = ns.test_pipeline.func_ir.blocks
+        ir0 = ns.control_pipeline.state.func_ir.blocks
+        ir1 = ns.test_pipeline.state.func_ir.blocks
         self.assertEqual(len(ir0), len(ir1))
         self.assertGreater(len(ir0[0].body), len(ir1[0].body))
         self.assertEqual(len(list(self._get_array_exprs(ir0[0].body))), 0)
@@ -356,24 +356,24 @@ class TestArrayExpressions(MemoryLeakMixin, TestCase):
         np.testing.assert_array_almost_equal(expected, control)
         np.testing.assert_array_almost_equal(expected, actual)
 
-        self._assert_total_rewrite(control_pipeline.func_ir.blocks,
-                                   test_pipeline.func_ir.blocks)
+        self._assert_total_rewrite(control_pipeline.state.func_ir.blocks,
+                                   test_pipeline.state.func_ir.blocks)
 
     def test_cmp_op(self):
         '''
         Verify that comparison operators are supported by the rewriter.
         '''
         ns = self._test_root_function(are_roots_imaginary)
-        self._assert_total_rewrite(ns.control_pipeline.func_ir.blocks,
-                                   ns.test_pipeline.func_ir.blocks)
+        self._assert_total_rewrite(ns.control_pipeline.state.func_ir.blocks,
+                                   ns.test_pipeline.state.func_ir.blocks)
 
     def test_explicit_output(self):
         """
         Check that ufunc calls with explicit outputs are not rewritten.
         """
         ns = self._test_explicit_output_function(explicit_output)
-        self._assert_no_rewrite(ns.control_pipeline.func_ir.blocks,
-                                ns.test_pipeline.func_ir.blocks)
+        self._assert_no_rewrite(ns.control_pipeline.state.func_ir.blocks,
+                                ns.test_pipeline.state.func_ir.blocks)
 
 
 class TestRewriteIssues(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_copy_propagate.py
+++ b/numba/tests/test_copy_propagate.py
@@ -9,8 +9,10 @@ from numba import types
 from numba.targets.registry import cpu_target
 from numba import config
 from numba.annotations import type_annotations
-from numba.ir_utils import copy_propagate, apply_copy_propagate, get_name_var_table
+from numba.ir_utils import (copy_propagate, apply_copy_propagate,
+                            get_name_var_table)
 from numba import ir
+from numba.typed_passes import type_inference_stage
 from numba import unittest_support as unittest
 
 def test_will_propagate(b, z, w):
@@ -62,7 +64,7 @@ class TestCopyPropagate(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = compiler.type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
             #print("typemap = ", typemap)
             #print("return_type = ", return_type)
             type_annotation = type_annotations.TypeAnnotation(
@@ -89,7 +91,7 @@ class TestCopyPropagate(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = compiler.type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
             type_annotation = type_annotations.TypeAnnotation(
                 func_ir=test_ir,
                 typemap=typemap,

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 import random
 import threading
+import gc
 
 from numba import unittest_support as unittest
 from numba.errors import TypingError
@@ -197,10 +198,12 @@ class TestDynArray(NrtRefCtTest, TestCase):
         np.testing.assert_equal(out, np.ones(4, dtype=np.float32))
 
         del out
+        gc.collect()
         # out is only referenced by cfunc
         self.assertEqual(initrefct + 1, sys.getrefcount(y))
 
         del cfunc
+        gc.collect()
         # y is no longer referenced by cfunc
         self.assertEqual(initrefct, sys.getrefcount(y))
 

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -8,6 +8,16 @@ from numba import unittest_support as unittest
 from numba import errors, utils
 import numpy as np
 
+
+from numba.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                                  IRProcessing,)
+
+from numba.typed_passes import (NopythonTypeInference, DeadCodeElimination,
+                                NativeLowering,
+                                IRLegalization, NoPythonBackend)
+
+from numba.compiler_machinery import FunctionPass, PassManager, register_pass
+
 from .support import skip_parfors_unsupported
 
 # used in TestMiscErrorHandling::test_handling_of_write_to_*_global
@@ -100,26 +110,21 @@ class TestMiscErrorHandling(unittest.TestCase):
     def test_use_of_ir_unknown_loc(self):
         # for context see # 3390
         import numba
-        class TestPipeline(numba.compiler.BasePipeline):
-            def define_pipelines(self, pm):
-                pm.create_pipeline('test_loc')
-                self.add_preprocessing_stage(pm)
-                self.add_with_handling_stage(pm)
-                self.add_pre_typing_stage(pm)
+        class TestPipeline(numba.compiler.CompilerBase):
+            def define_pipelines(self):
+                name = 'bad_DCE_pipeline'
+                pm = PassManager(name)
+                pm.add_pass(TranslateByteCode, "analyzing bytecode")
+                pm.add_pass(FixupArgs, "fix up args")
+                pm.add_pass(IRProcessing, "processing IR")
                 # remove dead before type inference so that the Arg node is removed
                 # and the location of the arg cannot be found
-                pm.add_stage(self.rm_dead_stage,
-                            "remove dead before type inference for testing")
-                self.add_typing_stage(pm)
-                self.add_optimization_stage(pm)
-                pm.add_stage(self.stage_ir_legalization,
-                            "ensure IR is legal prior to lowering")
-                self.add_lowering_stage(pm)
-                self.add_cleanup_stage(pm)
-
-            def rm_dead_stage(self):
-                numba.ir_utils.remove_dead(
-                    self.func_ir.blocks, self.func_ir.arg_names, self.func_ir)
+                pm.add_pass(DeadCodeElimination, "DCE")
+                # typing
+                pm.add_pass(NopythonTypeInference, "nopython frontend")
+                pm.add_pass(NoPythonBackend, "nopython mode backend")
+                pm.finalize()
+                return [pm]
 
         @numba.jit(pipeline_class=TestPipeline)
         def f(a):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import njit, jit, types, errors, typing, compiler
+from numba.typed_passes import type_inference_stage
 from numba.targets.registry import cpu_target
 from numba.compiler import compile_isolated
 from .support import (TestCase, captured_stdout, tag, temp_directory,
@@ -459,7 +460,7 @@ class TestLowLevelExtending(TestCase):
         test_ir = compiler.run_frontend(mk_func_test_impl)
         typingctx = cpu_target.typing_context
         typingctx.refresh()
-        typemap, _, _ = compiler.type_inference_stage(
+        typemap, _, _ = type_inference_stage(
             typingctx, test_ir, (), None)
         self.assertTrue(any(isinstance(a, types.MakeFunctionLiteral)
                             for a in typemap.values()))

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -12,6 +12,18 @@ from numba.targets.registry import CPUDispatcher
 from numba.inline_closurecall import inline_closure_call
 from .test_parfors import skip_unsupported
 
+from numba.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                             IRProcessing, DeadBranchPrune,
+                             RewriteSemanticConstants, GenericRewrites,
+                             WithLifting, PreserveIR, InlineClosureLikes)
+
+from numba.typed_passes import (NopythonTypeInference, AnnotateTypes,
+                           NopythonRewrites, PreParforPass, ParforPass,
+                           DumpParforDiagnostics, NativeLowering,
+                           IRLegalization, NoPythonBackend)
+
+from numba.compiler_machinery import FunctionPass, PassManager, register_pass
+
 @jit((types.int32,), nopython=True)
 def inner(a):
     return a + 1
@@ -30,45 +42,74 @@ def outer_multiple(a):
 def __dummy__():
     return
 
-class InlineTestPipeline(numba.compiler.BasePipeline):
-    """compiler pipeline for testing inlining after optimization
-    """
-    def define_pipelines(self, pm):
-        name = 'inline_test'
-        pm.create_pipeline(name)
-        self.add_preprocessing_stage(pm)
-        self.add_with_handling_stage(pm)
-        self.add_pre_typing_stage(pm)
-        self.add_typing_stage(pm)
-        pm.add_stage(self.stage_pre_parfor_pass, "Preprocessing for parfors")
-        if not self.flags.no_rewrites:
-            pm.add_stage(self.stage_nopython_rewrites, "nopython rewrites")
-        if self.flags.auto_parallel.enabled:
-            pm.add_stage(self.stage_parfor_pass, "convert to parfors")
-        pm.add_stage(self.stage_inline_test_pass, "inline test")
-        pm.add_stage(self.stage_ir_legalization,
-                "ensure IR is legal prior to lowering")
-        self.add_lowering_stage(pm)
-        self.add_cleanup_stage(pm)
-        pm.add_stage(self.stage_preserve_final_ir, "preserve IR")
+@register_pass(analysis_only=False, mutates_CFG=True)
+class InlineTestPass(FunctionPass):
+    _name = "inline_test_pass"
 
-    def stage_preserve_final_ir(self):
-        self.metadata['final_func_ir'] = self.func_ir.copy()
+    def __init__(self):
+        super().__init__()
 
-    def stage_inline_test_pass(self):
+    def run_pass(self, state):
         # assuming the function has one block with one call inside
-        assert len(self.func_ir.blocks) == 1
-        block = list(self.func_ir.blocks.values())[0]
+        assert len(state.func_ir.blocks) == 1
+        block = list(state.func_ir.blocks.values())[0]
         for i, stmt in enumerate(block.body):
-            if guard(find_callname,self.func_ir, stmt.value) is not None:
-                inline_closure_call(self.func_ir, {}, block, i, lambda: None,
-                    self.typingctx, (), self.typemap, self.calltypes)
+            if guard(find_callname,state.func_ir, stmt.value) is not None:
+                inline_closure_call(state.func_ir, {}, block, i, lambda: None,
+                    state.typingctx, (), state.type_annotation.typemap,
+                    state.type_annotation.calltypes)
                 # also fix up the IR so that ir.Dels appear correctly/in correct
                 # locations
-                post_proc = numba.postproc.PostProcessor(self.func_ir)
+                post_proc = numba.postproc.PostProcessor(state.func_ir)
                 post_proc.run()
                 break
+        return True
 
+
+def gen_pipeline(state, test_pass):
+        name = 'inline_test'
+        pm = PassManager(name)
+        pm.add_pass(TranslateByteCode, "analyzing bytecode")
+        pm.add_pass(FixupArgs, "fix up args")
+        pm.add_pass(IRProcessing, "processing IR")
+        pm.add_pass(WithLifting, "Handle with contexts")
+        # pre typing
+        if not state.flags.no_rewrites:
+            pm.add_pass(GenericRewrites, "nopython rewrites")
+            pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+            pm.add_pass(DeadBranchPrune, "dead branch pruning")
+        pm.add_pass(InlineClosureLikes,
+                    "inline calls to locally defined closures")
+        # typing
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+        pm.add_pass(AnnotateTypes, "annotate types")
+
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(PreParforPass, "Preprocessing for parfors")
+        if not state.flags.no_rewrites:
+            pm.add_pass(NopythonRewrites, "nopython rewrites")
+        if state.flags.auto_parallel.enabled:
+            pm.add_pass(ParforPass, "convert to parfors")
+
+        pm.add_pass(test_pass, "inline test")
+
+        # legalise
+        pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+
+        pm.add_pass(PreserveIR, "preserve IR")
+
+        # lower
+        pm.add_pass(NoPythonBackend, "nopython mode backend")
+        pm.add_pass(DumpParforDiagnostics, "dump parfor diagnostics")
+        return pm
+
+class InlineTestPipeline(numba.compiler.CompilerBase):
+    """compiler pipeline for testing inlining after optimization
+    """
+    def define_pipelines(self):
+        pm = gen_pipeline(self.state, InlineTestPass)
+        pm.finalize()
+        return [pm]
 
 class TestInlining(TestCase):
     """
@@ -203,19 +244,33 @@ class TestInlining(TestCase):
         def test_impl(A=None):
             return foo(A)
 
-        class InlineTestPipelinePrune(InlineTestPipeline):
-            def stage_inline_test_pass(self):
+        @register_pass(analysis_only=False, mutates_CFG=True)
+        class PruningInlineTestPass(FunctionPass):
+            _name = "pruning_inline_test_pass"
+
+            def __init__(self):
+                super().__init__()
+
+            def run_pass(self, state):
                 # assuming the function has one block with one call inside
-                assert len(self.func_ir.blocks) == 1
-                block = list(self.func_ir.blocks.values())[0]
+                assert len(state.func_ir.blocks) == 1
+                block = list(state.func_ir.blocks.values())[0]
                 for i, stmt in enumerate(block.body):
-                    if (guard(find_callname, self.func_ir, stmt.value)
+                    if (guard(find_callname, state.func_ir, stmt.value)
                             is not None):
-                        inline_closure_call(self.func_ir, {}, block, i,
-                            foo.py_func, self.typingctx,
-                            (self.typemap[stmt.value.args[0].name],),
-                            self.typemap, self.calltypes)
+                        inline_closure_call(state.func_ir, {}, block, i,
+                            foo.py_func, state.typingctx,
+                            (state.type_annotation.typemap[stmt.value.args[0].name],),
+                            state.type_annotation.typemap, state.calltypes)
                         break
+                return True
+
+        class InlineTestPipelinePrune(numba.compiler.CompilerBase):
+
+            def define_pipelines(self):
+                pm = gen_pipeline(self.state, PruningInlineTestPass)
+                pm.finalize()
+                return [pm]
 
         # make sure inline_closure_call runs in full pipeline
         j_func = njit(pipeline_class=InlineTestPipelinePrune)(test_impl)
@@ -224,7 +279,7 @@ class TestInlining(TestCase):
         self.assertEqual(test_impl(), j_func())
 
         # make sure IR doesn't have branches
-        fir = j_func.overloads[(types.Omitted(None),)].metadata['final_func_ir']
+        fir = j_func.overloads[(types.Omitted(None),)].metadata['preserved_ir']
         fir.blocks = numba.ir_utils.simplify_CFG(fir.blocks)
         self.assertEqual(len(fir.blocks), 1)
 

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -47,7 +47,7 @@ class InlineTestPass(FunctionPass):
     _name = "inline_test_pass"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         # assuming the function has one block with one call inside
@@ -249,7 +249,7 @@ class TestInlining(TestCase):
             _name = "pruning_inline_test_pass"
 
             def __init__(self):
-                super().__init__()
+                FunctionPass.__init__(self)
 
             def run_pass(self, state):
                 # assuming the function has one block with one call inside

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -10,7 +10,6 @@ import numpy as np
 import numba
 from numba import njit, ir, types
 from numba.extending import overload
-from numba.ir_utils import dead_code_elimination
 from numba.targets.cpu import InlineOptions
 from numba.compiler import DefaultPassBuilder
 from numba.typed_passes import DeadCodeElimination, IRLegalization
@@ -22,7 +21,6 @@ from .support import TestCase, unittest
 class InlineTestPipeline(numba.compiler.CompilerBase):
     """ Same as the standard pipeline, but preserves the func_ir into the
     metadata store"""
-
 
     def define_pipelines(self):
         pipeline = DefaultPassBuilder.define_nopython_pipeline(self.state,

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -12,32 +12,30 @@ from numba import njit, ir, types
 from numba.extending import overload
 from numba.ir_utils import dead_code_elimination
 from numba.targets.cpu import InlineOptions
+from numba.compiler import DefaultPassBuilder
+from numba.typed_passes import DeadCodeElimination, IRLegalization
+from numba.untyped_passes import PreserveIR
 from itertools import product
 from .support import TestCase, unittest
 
 
-class InlineTestPipeline(numba.compiler.BasePipeline):
+class InlineTestPipeline(numba.compiler.CompilerBase):
     """ Same as the standard pipeline, but preserves the func_ir into the
     metadata store"""
 
-    def stage_preserve_final_ir(self):
-        self.metadata['final_func_ir'] = self.func_ir.copy()
 
-    def stage_dce(self):
-        dead_code_elimination(self.func_ir, self.typemap)
-
-    def define_pipelines(self, pm):
-        self.define_nopython_pipeline(pm)
+    def define_pipelines(self):
+        pipeline = DefaultPassBuilder.define_nopython_pipeline(self.state,
+                                                               "inliner_custom_pipe")
         # mangle the default pipeline and inject DCE and IR preservation ahead
         # of legalisation
-        allstages = pm.pipeline_stages['nopython']
-        new_pipe = []
-        for x in allstages:
-            if x[0] == self.stage_ir_legalization:
-                new_pipe.append((self.stage_dce, "DCE"))
-                new_pipe.append((self.stage_preserve_final_ir, "preserve IR"))
-            new_pipe.append(x)
-        pm.pipeline_stages['nopython'] = new_pipe
+
+        # TODO: add a way to not do this! un-finalizing is not a good idea
+        pipeline._finalized = False
+        pipeline.add_pass_after(DeadCodeElimination, IRLegalization)
+        pipeline.add_pass_after(PreserveIR, DeadCodeElimination)
+        pipeline.finalize()
+        return [pipeline]
 
 
 # this global has the same name as the the global in inlining_usecases.py, it
@@ -97,7 +95,7 @@ class InliningBase(TestCase):
         self.assertEqual(test_impl(*args), j_func(*args))
 
         # make sure IR doesn't have branches
-        fir = j_func.overloads[j_func.signatures[0]].metadata['final_func_ir']
+        fir = j_func.overloads[j_func.signatures[0]].metadata['preserved_ir']
         fir.blocks = numba.ir_utils.simplify_CFG(fir.blocks)
         if self._DEBUG:
             print("FIR".center(80, "-"))

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -2,7 +2,7 @@ import numba
 from .support import TestCase, unittest
 from numba import compiler, jitclass, ir
 from numba.targets.registry import cpu_target
-from numba.compiler import Pipeline, Flags, _PipelineManager
+from numba.compiler import Pipeline, Flags, PassManager
 from numba.targets import registry
 from numba import types, ir_utils, bytecode
 
@@ -70,13 +70,13 @@ class TestIrUtils(TestCase):
                 self.bc = self.extract_bytecode(self.func_id)
                 self.lifted = []
 
-                pm = _PipelineManager()
+                pm = PassManager()
                 pm.create_pipeline("pipeline")
                 self.add_preprocessing_stage(pm)
                 self.add_pre_typing_stage(pm)
                 self.add_typing_stage(pm)
                 if DCE is True:
-                    pm.add_stage(self.rm_dead_stage, "DCE after typing")
+                    pm.add_pass(self.rm_dead_stage, "DCE after typing")
                 pm.finalize()
                 pm.run(self.status)
                 return self.func_ir

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -2,10 +2,15 @@ import numba
 from .support import TestCase, unittest
 from numba import compiler, jitclass, ir
 from numba.targets.registry import cpu_target
-from numba.compiler import Pipeline, Flags, PassManager
+from numba.compiler import CompilerBase, Flags
+from numba.compiler_machinery import PassManager
 from numba.targets import registry
 from numba import types, ir_utils, bytecode
+from numba.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                                  IRProcessing,)
 
+from numba.typed_passes import (NopythonTypeInference, type_inference_stage,
+                                DeadCodeElimination)
 
 # global constant for testing find_const
 GLOBAL_B = 11
@@ -32,7 +37,7 @@ class TestIrUtils(TestCase):
 
         test_ir = compiler.run_frontend(test_func)
         typingctx = cpu_target.typing_context
-        typemap, _, _ = compiler.type_inference_stage(
+        typemap, _, _ = type_inference_stage(
             typingctx, test_ir, (), None)
         matched_call = ir_utils.find_callname(
             test_ir, test_ir.blocks[0].body[14].value, typemap)
@@ -42,7 +47,7 @@ class TestIrUtils(TestCase):
 
     def test_dead_code_elimination(self):
 
-        class Tester(Pipeline):
+        class Tester(CompilerBase):
 
             @classmethod
             def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
@@ -58,28 +63,26 @@ class TestIrUtils(TestCase):
                 return cls(typing_context, target_context, library, args,
                            return_type, flags, locals)
 
-            def rm_dead_stage(self):
-                ir_utils.dead_code_elimination(
-                    self.func_ir, typemap=self.typemap)
-
             def compile_to_ir(self, func, DCE=False):
                 """
                 Compile and return IR
                 """
-                self.func_id = bytecode.FunctionIdentity.from_function(func)
-                self.bc = self.extract_bytecode(self.func_id)
-                self.lifted = []
+                func_id = bytecode.FunctionIdentity.from_function(func)
+                self.state.func_id = func_id
+                ExtractByteCode().run_pass(self.state)
+                state = self.state
 
-                pm = PassManager()
-                pm.create_pipeline("pipeline")
-                self.add_preprocessing_stage(pm)
-                self.add_pre_typing_stage(pm)
-                self.add_typing_stage(pm)
+                name = "DCE_testing"
+                pm = PassManager(name)
+                pm.add_pass(TranslateByteCode, "analyzing bytecode")
+                pm.add_pass(FixupArgs, "fix up args")
+                pm.add_pass(IRProcessing, "processing IR")
+                pm.add_pass(NopythonTypeInference, "nopython frontend")
                 if DCE is True:
-                    pm.add_pass(self.rm_dead_stage, "DCE after typing")
+                    pm.add_pass(DeadCodeElimination, "DCE after typing")
                 pm.finalize()
-                pm.run(self.status)
-                return self.func_ir
+                pm.run(state)
+                return state.func_ir
 
         def check_initial_ir(the_ir):
             # dead stuff:
@@ -87,7 +90,7 @@ class TestIrUtils(TestCase):
             # an assign of above into to variable `dead`
             # del of both of the above
             # a const int above 0xdeaddead
-            # an assign of said into to variable `deaddead`
+            # an assign of said int to variable `deaddead`
             # del of both of the above
             # this is 8 things to remove
 

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -9,8 +9,8 @@ import re
 import numpy as np
 
 from numba import unittest_support as unittest
-from numba import njit, targets, typing
-from numba.compiler import compile_isolated, Flags, types
+from numba import njit, targets, typing, types
+from numba.compiler import compile_isolated, Flags
 from numba.runtime import rtsys
 from numba.runtime import nrtopt
 from numba.extending import intrinsic

--- a/numba/tests/test_obj_lifetime.py
+++ b/numba/tests/test_obj_lifetime.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import collections
 import sys
 import weakref
+import gc
 
 import numba.unittest_support as unittest
 from numba.controlflow import CFGraph, Loop
@@ -334,6 +335,7 @@ class TestObjLifetime(TestCase):
         with self.assertRefCount(rec):
             gen = cfunc(rec)
             del gen
+            gc.collect()
             self.assertFalse(rec.alive)
         # Stop iterating before exhaustion
         rec = RefRecorder()
@@ -342,6 +344,7 @@ class TestObjLifetime(TestCase):
             next(gen)
             self.assertTrue(rec.alive)
             del gen
+            gc.collect()
             self.assertFalse(rec.alive)
 
     def test_generator1(self):

--- a/numba/tests/test_pipeline.py
+++ b/numba/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from numba.compiler import Pipeline
+from numba.compiler import Compiler
 from numba import jit, generated_jit, types, objmode
 from numba.ir import FunctionIR
 from .support import TestCase
@@ -11,7 +11,7 @@ class TestCustomPipeline(TestCase):
         super(TestCustomPipeline, self).setUp()
 
         # Define custom pipeline class
-        class CustomPipeline(Pipeline):
+        class CustomPipeline(Compiler):
             custom_pipeline_cache = []
 
             def compile_extra(self, func):

--- a/numba/tests/test_practical_lowering_issues.py
+++ b/numba/tests/test_practical_lowering_issues.py
@@ -7,7 +7,9 @@ from __future__ import print_function
 
 import numpy as np
 from numba import njit, types, ir
-from numba.compiler import Pipeline
+from numba.compiler import CompilerBase, DefaultPassBuilder
+from numba.typed_passes import NopythonTypeInference
+from numba.compiler_machinery import register_pass, FunctionPass
 
 from .support import MemoryLeakMixin, TestCase
 
@@ -136,18 +138,34 @@ class TestLowering(MemoryLeakMixin, TestCase):
     def test_issue_with_literal_in_static_getitem(self):
         """Test an issue with literal type used as index of static_getitem
         """
-        class CustomPipeline(Pipeline):
-            def stage_nopython_backend(self):
+
+        @register_pass(mutates_CFG=False, analysis_only=False)
+        class ForceStaticGetitemLiteral(FunctionPass):
+
+            _name = "force_static_getitem_literal"
+
+            def __init__(self):
+                FunctionPass.__init__(self)
+
+            def run_pass(self, state):
                 repl = {}
                 # Force the static_getitem to have a literal type as
                 # index to replicate the problem.
-                for inst, sig in self.calltypes.items():
+                for inst, sig in state.calltypes.items():
                     if isinstance(inst, ir.Expr) and inst.op == 'static_getitem':
                         [obj, idx] = sig.args
-                        new_sig = sig.replace(args=(obj, types.literal(inst.index)))
+                        new_sig = sig.replace(args=(obj,
+                                                    types.literal(inst.index)))
                         repl[inst] = new_sig
-                self.calltypes.update(repl)
-                super(CustomPipeline, self).stage_nopython_backend()
+                state.calltypes.update(repl)
+                return True
+
+        class CustomPipeline(CompilerBase):
+            def define_pipelines(self):
+                pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
+                pm.add_pass_after(ForceStaticGetitemLiteral, NopythonTypeInference)
+                pm.finalize()
+                return [pm]
 
         @njit(pipeline_class=CustomPipeline)
         def foo(arr):

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -74,15 +74,11 @@ class TestRemoveDead(unittest.TestCase):
         typingctx = typing.Context()
         targetctx = cpu.CPUContext(typingctx)
         test_ir = compiler.run_frontend(test_will_propagate)
-        #print("Num blocks = ", len(test_ir.blocks))
-        #print(test_ir.dump())
         with cpu_target.nested_context(typingctx, targetctx):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
             typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
-            #print("typemap = ", typemap)
-            #print("return_type = ", return_type)
             type_annotation = type_annotations.TypeAnnotation(
                 func_ir=test_ir,
                 typemap=typemap,
@@ -244,7 +240,7 @@ class TestRemoveDead(unittest.TestCase):
             _name = "limited_parfor"
 
             def __init__(self):
-                super().__init__()
+                FunctionPass.__init__(self)
 
             def run_pass(self, state):
                 parfor_pass = numba.parfor.ParforPass(

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -14,7 +14,18 @@ from numba.annotations import type_annotations
 from numba.ir_utils import (copy_propagate, apply_copy_propagate,
                             get_name_var_table, remove_dels, remove_dead,
                             remove_call_handlers, alias_func_extensions)
+from numba.typed_passes import type_inference_stage
 from numba import ir
+from numba.compiler_machinery import FunctionPass, register_pass, PassManager
+from numba.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+                             IRProcessing, DeadBranchPrune,
+                             RewriteSemanticConstants, GenericRewrites,
+                             WithLifting, PreserveIR, InlineClosureLikes)
+
+from numba.typed_passes import (NopythonTypeInference, AnnotateTypes,
+                           NopythonRewrites, PreParforPass, ParforPass,
+                           DumpParforDiagnostics, NativeLowering,
+                           IRLegalization, NoPythonBackend)
 from numba import unittest_support as unittest
 import numpy as np
 from .matmul_usecase import needs_blas
@@ -69,7 +80,7 @@ class TestRemoveDead(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = compiler.type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
             #print("typemap = ", typemap)
             #print("return_type = ", return_type)
             type_annotation = type_annotations.TypeAnnotation(
@@ -228,39 +239,63 @@ class TestRemoveDead(unittest.TestCase):
 
             return B
 
-        class TestPipeline(numba.compiler.Pipeline):
+        @register_pass(analysis_only=False, mutates_CFG=True)
+        class LimitedParfor(FunctionPass):
+            _name = "limited_parfor"
+
+            def __init__(self):
+                super().__init__()
+
+            def run_pass(self, state):
+                parfor_pass = numba.parfor.ParforPass(
+                    state.func_ir,
+                    state.type_annotation.typemap,
+                    state.type_annotation.calltypes,
+                    state.return_type,
+                    state.typingctx,
+                    state.flags.auto_parallel,
+                    state.flags,
+                    state.parfor_diagnostics
+                )
+                remove_dels(state.func_ir.blocks)
+                parfor_pass.array_analysis.run(state.func_ir.blocks)
+                parfor_pass._convert_loop(state.func_ir.blocks)
+                remove_dead(state.func_ir.blocks,
+                            state.func_ir.arg_names,
+                            state.func_ir,
+                            state.type_annotation.typemap)
+                numba.parfor.get_parfor_params(state.func_ir.blocks,
+                                                parfor_pass.options.fusion,
+                                                parfor_pass.nested_fusion_info)
+                return True
+
+        class TestPipeline(numba.compiler.Compiler):
             """Test pipeline that just converts prange() to parfor and calls
             remove_dead(). Copy propagation can replace B in the example code
             which this pipeline avoids.
             """
-            def define_pipelines(self, pm):
-                pm.create_pipeline("test parfor aliasing")
-                self.add_preprocessing_stage(pm)
-                self.add_pre_typing_stage(pm)
-                self.add_typing_stage(pm)
-                pm.add_stage(
-                    self.stage_limited_parfor, "just prange and rm dead")
-                self.add_lowering_stage(pm)
-                self.add_cleanup_stage(pm)
+            def define_pipelines(self):
+                name = 'test parfor aliasing'
+                pm = PassManager(name)
+                pm.add_pass(TranslateByteCode, "analyzing bytecode")
+                pm.add_pass(FixupArgs, "fix up args")
+                pm.add_pass(IRProcessing, "processing IR")
+                pm.add_pass(WithLifting, "Handle with contexts")
+                # pre typing
+                if not self.state.flags.no_rewrites:
+                    pm.add_pass(GenericRewrites, "nopython rewrites")
+                    pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+                    pm.add_pass(DeadBranchPrune, "dead branch pruning")
+                pm.add_pass(InlineClosureLikes,
+                            "inline calls to locally defined closures")
+                # typing
+                pm.add_pass(NopythonTypeInference, "nopython frontend")
+                pm.add_pass(AnnotateTypes, "annotate types")
 
-            def stage_limited_parfor(self):
-                parfor_pass = numba.parfor.ParforPass(
-                    self.func_ir,
-                    self.type_annotation.typemap,
-                    self.type_annotation.calltypes,
-                    self.return_type,
-                    self.typingctx,
-                    self.flags.auto_parallel,
-                    self.flags,
-                    self.parfor_diagnostics
-                )
-                remove_dels(self.func_ir.blocks)
-                parfor_pass.array_analysis.run(self.func_ir.blocks)
-                parfor_pass._convert_loop(self.func_ir.blocks)
-                remove_dead(self.func_ir.blocks, self.func_ir.arg_names,
-                    self.func_ir, self.type_annotation.typemap)
-                numba.parfor.get_parfor_params(self.func_ir.blocks,
-                    parfor_pass.options.fusion, parfor_pass.nested_fusion_info)
+                # lower
+                pm.add_pass(NoPythonBackend, "nopython mode backend")
+                pm.finalize()
+                return [pm]
 
         test_res = numba.jit(pipeline_class=TestPipeline)(func)()
         py_res = func()

--- a/numba/typed_passes.py
+++ b/numba/typed_passes.py
@@ -1,0 +1,560 @@
+from __future__ import print_function, division, absolute_import
+from contextlib import contextmanager
+import warnings
+
+from . import (config,  errors, types, rewrites, typeinfer, funcdesc, lowering,
+               utils, typing, ir)
+
+from .parfor import PreParforPass as _parfor_PreParforPass
+from .parfor import ParforPass as _parfor_ParforPass
+from .parfor import Parfor
+
+from .compiler_machinery import FunctionPass, LoweringPass, register_pass
+from .annotations import type_annotations
+from .ir_utils import (raise_on_unsupported_feature, warn_deprecated,
+                       check_and_legalize_ir, guard, dead_code_elimination,
+                       simplify_CFG)
+
+
+@contextmanager
+def fallback_context(state, msg):
+    """
+    Wraps code that would signal a fallback to object mode
+    """
+    try:
+        yield
+    except Exception as e:
+        if not state.status.can_fallback:
+            raise
+        else:
+            if utils.PYVERSION >= (3,):
+                # Clear all references attached to the traceback
+                e = e.with_traceback(None)
+            # this emits a warning containing the error message body in the
+            # case of fallback from npm to objmode
+            loop_lift = '' if state.flags.enable_looplift else 'OUT'
+            msg_rewrite = ("\nCompilation is falling back to object mode "
+                           "WITH%s looplifting enabled because %s"
+                           % (loop_lift, msg))
+            warnings.warn_explicit('%s due to: %s' % (msg_rewrite, e),
+                                   errors.NumbaWarning,
+                                   state.func_id.filename,
+                                   state.func_id.firstlineno)
+            raise
+
+
+def type_inference_stage(typingctx, interp, args, return_type, locals={}):
+    if len(args) != interp.arg_count:
+        raise TypeError("Mismatch number of argument types")
+
+    warnings = errors.WarningsFixer(errors.NumbaWarning)
+    infer = typeinfer.TypeInferer(typingctx, interp, warnings)
+    with typingctx.callstack.register(infer, interp.func_id, args):
+        # Seed argument types
+        for index, (name, ty) in enumerate(zip(interp.arg_names, args)):
+            infer.seed_argument(name, index, ty)
+
+        # Seed return type
+        if return_type is not None:
+            infer.seed_return(return_type)
+
+        # Seed local types
+        for k, v in locals.items():
+            infer.seed_type(k, v)
+
+        infer.build_constraint()
+        infer.propagate()
+        typemap, restype, calltypes = infer.unify()
+
+    # Output all Numba warnings
+    warnings.flush()
+
+    return typemap, restype, calltypes
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NopythonTypeInference(FunctionPass):
+    _name = "nopython_type_inference"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Type inference and legalization
+        """
+        with fallback_context(state, 'Function "%s" failed type inference'
+                              % (state.func_id.func_name,)):
+            # Type inference
+            typemap, return_type, calltypes = type_inference_stage(
+                state.typingctx,
+                state.func_ir,
+                state.args,
+                state.return_type,
+                state.locals)
+            state.typemap = typemap
+            state.return_type = return_type
+            state.calltypes = calltypes
+
+        def legalize_return_type(return_type, interp, targetctx):
+            """
+            Only accept array return type iff it is passed into the function.
+            Reject function object return types if in nopython mode.
+            """
+            if not targetctx.enable_nrt and isinstance(return_type, types.Array):
+                # Walk IR to discover all arguments and all return statements
+                retstmts = []
+                caststmts = {}
+                argvars = set()
+                for bid, blk in interp.blocks.items():
+                    for inst in blk.body:
+                        if isinstance(inst, ir.Return):
+                            retstmts.append(inst.value.name)
+                        elif isinstance(inst, ir.Assign):
+                            if (isinstance(inst.value, ir.Expr)
+                                    and inst.value.op == 'cast'):
+                                caststmts[inst.target.name] = inst.value
+                            elif isinstance(inst.value, ir.Arg):
+                                argvars.add(inst.target.name)
+
+                assert retstmts, "No return statements?"
+
+                for var in retstmts:
+                    cast = caststmts.get(var)
+                    if cast is None or cast.value.name not in argvars:
+                        raise TypeError("Only accept returning of array passed into "
+                                        "the function as argument")
+
+            elif (isinstance(return_type, types.Function) or
+                    isinstance(return_type, types.Phantom)):
+                msg = "Can't return function object ({}) in nopython mode"
+                raise TypeError(msg.format(return_type))
+
+        with fallback_context(state, 'Function "%s" has invalid return type'
+                              % (state.func_id.func_name,)):
+            legalize_return_type(state.return_type, state.func_ir,
+                                 state.targetctx)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class AnnotateTypes(FunctionPass):
+    _name = "annotate_types"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Create type annotation after type inference
+        """
+        state.type_annotation = type_annotations.TypeAnnotation(
+            func_ir=state.func_ir,
+            typemap=state.typemap,
+            calltypes=state.calltypes,
+            lifted=state.lifted,
+            lifted_from=state.lifted_from,
+            args=state.args,
+            return_type=state.return_type,
+            html_output=config.HTML)
+
+        if config.ANNOTATE:
+            print("ANNOTATION".center(80, '-'))
+            print(state.type_annotation)
+            print('=' * 80)
+        if config.HTML:
+            with open(config.HTML, 'w') as fout:
+                state.type_annotation.html_annotate(fout)
+        return False
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NopythonRewrites(FunctionPass):
+    _name = "nopython_rewrites"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Perform any intermediate representation rewrites after type
+        inference.
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        assert isinstance(getattr(state, 'typemap', None), dict)
+        assert isinstance(getattr(state, 'calltypes', None), dict)
+        msg = ('Internal error in post-inference rewriting '
+               'pass encountered during compilation of '
+               'function "%s"' % (state.func_id.func_name,))
+        with fallback_context(state, msg):
+            rewrites.rewrite_registry.apply('after-inference', state)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class PreParforPass(FunctionPass):
+
+    _name = "pre_parfor_pass"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Preprocessing for data-parallel computations.
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        preparfor_pass = _parfor_PreParforPass(
+            state.func_ir,
+            state.type_annotation.typemap,
+            state.type_annotation.calltypes, state.typingctx,
+            state.flags.auto_parallel,
+            state.parfor_diagnostics.replaced_fns
+        )
+
+        preparfor_pass.run()
+        return True
+
+
+# this is here so it pickles and for no other reason
+def _reload_parfors():
+    """Reloader for cached parfors
+    """
+    # Re-initialize the parallel backend when load from cache.
+    from numba.npyufunc.parallel import _launch_threads
+    _launch_threads()
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforPass(FunctionPass):
+
+    _name = "parfor_pass"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Convert data-parallel computations into Parfor nodes
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        parfor_pass = _parfor_ParforPass(state.func_ir, state.type_annotation.typemap,
+                                         state.type_annotation.calltypes, state.return_type, state.typingctx,
+                                         state.flags.auto_parallel, state.flags, state.parfor_diagnostics)
+        parfor_pass.run()
+
+        # check the parfor pass worked and warn if it didn't
+        has_parfor = False
+        for blk in state.func_ir.blocks.values():
+            for stmnt in blk.body:
+                if isinstance(stmnt, Parfor):
+                    has_parfor = True
+                    break
+            else:
+                continue
+            break
+
+        if not has_parfor:
+            # parfor calls the compiler chain again with a string
+            if not state.func_ir.loc.filename == '<string>':
+                url = ("http://numba.pydata.org/numba-doc/latest/user/"
+                       "parallel.html#diagnostics")
+                msg = ("\nThe keyword argument 'parallel=True' was specified "
+                       "but no transformation for parallel execution was "
+                       "possible.\n\nTo find out why, try turning on parallel "
+                       "diagnostics, see %s for help." % url)
+                warnings.warn(errors.NumbaPerformanceWarning(msg,
+                                                             state.func_ir.loc))
+
+        # Add reload function to initialize the parallel backend.
+        state.reload_init.append(_reload_parfors)
+        return True
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class DumpParforDiagnostics(FunctionPass):
+
+    _name = "dump_parfor_diagnostics"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        if state.flags.auto_parallel.enabled:
+            if config.PARALLEL_DIAGNOSTICS:
+                if state.parfor_diagnostics is not None:
+                    state.parfor_diagnostics.dump(config.PARALLEL_DIAGNOSTICS)
+                else:
+                    raise RuntimeError("Diagnostics failed.")
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NativeLowering(LoweringPass):
+
+    _name = "native_lowering"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        targetctx = state.targetctx
+        library = state.library
+        interp = state.func_ir  # why is it called this?!
+        typemap = state.typemap
+        restype = state.return_type
+        calltypes = state.calltypes
+        flags = state.flags
+        metadata = state.metadata
+
+        msg = ("Function %s failed at nopython "
+               "mode lowering" % (state.func_id.func_name,))
+        with fallback_context(state, msg):
+            # Lowering
+            fndesc = funcdesc.PythonFunctionDescriptor.from_specialized_function(
+                interp, typemap, restype, calltypes, mangler=targetctx.mangler,
+                inline=flags.forceinline, noalias=flags.noalias)
+
+            with targetctx.push_code_library(library):
+                lower = lowering.Lower(targetctx, library, fndesc, interp,
+                                       metadata=metadata)
+                lower.lower()
+                if not flags.no_cpython_wrapper:
+                    lower.create_cpython_wrapper(flags.release_gil)
+                env = lower.env
+                call_helper = lower.call_helper
+                del lower
+
+            from numba.compiler import _LowerResult  # TODO: move this
+            if flags.no_compile:
+                state['cr'] = _LowerResult(fndesc, call_helper, cfunc=None, env=env)
+            else:
+                # Prepare for execution
+                cfunc = targetctx.get_executable(library, fndesc, env)
+                # Insert native function for use by other jitted-functions.
+                # We also register its library to allow for inlining.
+                targetctx.insert_user_function(cfunc, fndesc, [library])
+                state['cr'] = _LowerResult(fndesc, call_helper, cfunc=cfunc, env=env)
+        return True
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class IRLegalization(FunctionPass):
+
+    _name = "ir_legalisation"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        raise_on_unsupported_feature(state.func_ir, state.typemap)
+        warn_deprecated(state.func_ir, state.typemap)
+        # NOTE: this function call must go last, it checks and fixes invalid IR!
+        check_and_legalize_ir(state.func_ir)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class NoPythonBackend(FunctionPass):
+
+    _name = "nopython_backend"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Back-end: Generate LLVM IR from Numba IR, compile to machine code
+        """
+        if state.library is None:
+            codegen = state.targetctx.codegen()
+            state.library = codegen.create_library(state.func_id.func_qualname)
+            # Enable object caching upfront, so that the library can
+            # be later serialized.
+            state.library.enable_object_caching()
+
+        NativeLowering().run_pass(state) # TODO: Pull this out into the pipeline
+        lowered = state['cr']
+        signature = typing.signature(state.return_type, *state.args)
+
+        from numba.compiler import compile_result
+        state.cr = compile_result(
+            typing_context=state.typingctx,
+            target_context=state.targetctx,
+            entry_point=lowered.cfunc,
+            typing_error=state.status.fail_reason,
+            type_annotation=state.type_annotation,
+            library=state.library,
+            call_helper=lowered.call_helper,
+            signature=signature,
+            objectmode=False,
+            interpmode=False,
+            lifted=state.lifted,
+            fndesc=lowered.fndesc,
+            environment=lowered.env,
+            metadata=state.metadata,
+            reload_init=state.reload_init,
+        )
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineOverloads(FunctionPass):
+    """
+    This pass will inline a function wrapped by the numba.extending.overload
+    decorator directly into the site of its call depending on the value set in
+    the 'inline' kwarg to the decorator.
+
+    This is a typed pass. CFG simplification and DCE are performed on
+    completion.
+    """
+
+    _name = "inline_overloads"
+
+    def __init__(self):
+        super().__init__()
+
+    _DEBUG = False
+
+    def run_pass(self, state):
+        """Run inlining of overloads
+        """
+        if config.DEBUG or self._DEBUG:
+            print('before overload inline'.center(80, '-'))
+            print(state.func_ir.dump())
+            print(''.center(80, '-'))
+        modified = False
+        work_list = list(state.func_ir.blocks.items())
+        # use a work list, look for call sites via `ir.Expr.op == call` and
+        # then pass these to `self._do_work` to make decisions about inlining.
+        while work_list:
+            label, block = work_list.pop()
+            for i, instr in enumerate(block.body):
+                if isinstance(instr, ir.Assign):
+                    expr = instr.value
+                    if isinstance(expr, ir.Expr) and expr.op == 'call':
+                        if guard(self._do_work, state, work_list, block, i,
+                                 expr):
+                            modified = True
+                            break  # because block structure changed
+
+        if config.DEBUG or self._DEBUG:
+            print('after overload inline'.center(80, '-'))
+            print(state.func_ir.dump())
+            print(''.center(80, '-'))
+
+        if modified:
+            # clean up blocks
+            dead_code_elimination(state.func_ir,
+                                  typemap=state.type_annotation.typemap)
+            # clean up unconditional branches that appear due to inlined
+            # functions introducing blocks
+            state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
+
+        if config.DEBUG or self._DEBUG:
+            print('after overload inline DCE'.center(80, '-'))
+            print(state.func_ir.dump())
+            print(''.center(80, '-'))
+
+        return True
+
+    def _do_work(self, state, work_list, block, i, expr):
+        from numba.inline_closurecall import (inline_closure_call,
+                                              callee_ir_validator)
+
+        # try and get a definition for the call, this isn't always possible as
+        # it might be a eval(str)/part generated awaiting update etc. (parfors)
+        to_inline = None
+        try:
+            to_inline = state.func_ir.get_definition(expr.func)
+        except Exception:
+            return False
+
+        # do not handle closure inlining here, another pass deals with that.
+        if getattr(to_inline, 'op', False) == 'make_function':
+            return False
+
+        # check this is a known and typed function
+        try:
+            func_ty = state.type_annotation.typemap[expr.func.name]
+        except KeyError:
+            # e.g. Calls to CUDA Intrinsic have no mapped type so KeyError
+            return False
+        if not hasattr(func_ty, 'get_call_type'):
+            return False
+
+        # search the templates for this overload looking for "inline"
+        templates = getattr(func_ty, 'templates', None)
+        if templates is None:
+            return False
+
+        sig = state.type_annotation.calltypes[expr]
+
+        impl = None
+        for template in templates:
+            inline_type = getattr(template, '_inline', None)
+            if inline_type is None:
+                # inline not defined
+                continue
+            if not inline_type.is_never_inline:
+                try:
+                    impl = template._overload_func(*sig.args)
+                    if impl is None:
+                        raise Exception  # abort for this template
+                    break
+                except Exception:
+                    continue
+        else:
+            return False
+
+        # at this point we know we maybe want to inline something and there's
+        # definitely something that could be inlined.
+
+        do_inline = True
+        if not inline_type.is_always_inline:
+            from numba.typing.templates import _inline_info
+            caller_inline_info = _inline_info(state.func_ir,
+                                              state.type_annotation.typemap,
+                                              state.type_annotation.calltypes,
+                                              sig)
+
+            # must be a cost-model function, run the function
+            iinfo = template._inline_overloads[sig.args]['iinfo']
+            if inline_type.has_cost_model:
+                do_inline = inline_type.value(caller_inline_info, iinfo)
+            else:
+                assert 'unreachable'
+
+        if do_inline:
+            arg_typs = template._inline_overloads[sig.args]['folded_args']
+            # pass is typed so use the callee globals
+            inline_closure_call(state.func_ir, impl.__globals__,
+                                block, i, impl, typingctx=state.typingctx,
+                                arg_typs=arg_typs,
+                                typemap=state.type_annotation.typemap,
+                                calltypes=state.type_annotation.calltypes,
+                                work_list=work_list,
+                                replace_freevars=False,
+                                callee_validator=callee_ir_validator)
+            return True
+        else:
+            return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class DeadCodeElimination(FunctionPass):
+    """
+    Does dead code elimination
+    """
+
+    _name = "dead_code_elimination"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        dead_code_elimination(state.func_ir, state.typemap)
+        return True

--- a/numba/typed_passes.py
+++ b/numba/typed_passes.py
@@ -77,7 +77,7 @@ class NopythonTypeInference(FunctionPass):
     _name = "nopython_type_inference"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -142,7 +142,7 @@ class AnnotateTypes(FunctionPass):
     _name = "annotate_types"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -173,7 +173,7 @@ class NopythonRewrites(FunctionPass):
     _name = "nopython_rewrites"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -198,7 +198,7 @@ class PreParforPass(FunctionPass):
     _name = "pre_parfor_pass"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -233,7 +233,7 @@ class ParforPass(FunctionPass):
     _name = "parfor_pass"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -280,7 +280,7 @@ class DumpParforDiagnostics(FunctionPass):
     _name = "dump_parfor_diagnostics"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         if state.flags.auto_parallel.enabled:
@@ -298,7 +298,7 @@ class NativeLowering(LoweringPass):
     _name = "native_lowering"
 
     def __init__(self):
-        super().__init__()
+        LoweringPass.__init__(self)
 
     def run_pass(self, state):
         targetctx = state.targetctx
@@ -347,7 +347,7 @@ class IRLegalization(FunctionPass):
     _name = "ir_legalisation"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         raise_on_unsupported_feature(state.func_ir, state.typemap)
@@ -363,7 +363,7 @@ class NoPythonBackend(FunctionPass):
     _name = "nopython_backend"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -415,7 +415,7 @@ class InlineOverloads(FunctionPass):
     _name = "inline_overloads"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     _DEBUG = False
 
@@ -553,7 +553,7 @@ class DeadCodeElimination(FunctionPass):
     _name = "dead_code_elimination"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         dead_code_elimination(state.func_ir, state.typemap)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -438,12 +438,12 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         if not self._inline.is_never_inline:
             # need to run the compiler front end up to type inference to compute
             # a signature
-            from numba import compiler
+            from numba import compiler, typed_passes
             ir = compiler.run_frontend(disp_type.dispatcher.py_func)
             resolve = disp_type.dispatcher.get_call_template
             template, pysig, folded_args, kws = resolve(new_args, kws)
 
-            typemap, return_type, calltypes = compiler.type_inference_stage(
+            typemap, return_type, calltypes = typed_passes.type_inference_stage(
                 self.context, ir, folded_args, None)
             sig = Signature(return_type, folded_args, None)
             # this stores a load of info for the cost model function if supplied

--- a/numba/untyped_passes.py
+++ b/numba/untyped_passes.py
@@ -1,0 +1,393 @@
+from __future__ import print_function, division, absolute_import
+from .compiler_machinery import FunctionPass, register_pass
+from . import (config, bytecode, interpreter, postproc, errors, types, rewrites,
+               transforms, ir, utils)
+import warnings
+from .analysis import dead_branch_prune, rewrite_semantic_constants
+from contextlib import contextmanager
+from .inline_closurecall import InlineClosureCallPass
+from .ir_utils import (guard, resolve_func_from_module, simplify_CFG,
+                       GuardException)
+
+
+@contextmanager
+def fallback_context(state, msg):
+    """
+    Wraps code that would signal a fallback to object mode
+    """
+    try:
+        yield
+    except Exception as e:
+        if not state.status.can_fallback:
+            raise
+        else:
+            if utils.PYVERSION >= (3,):
+                # Clear all references attached to the traceback
+                e = e.with_traceback(None)
+            # this emits a warning containing the error message body in the
+            # case of fallback from npm to objmode
+            loop_lift = '' if state.flags.enable_looplift else 'OUT'
+            msg_rewrite = ("\nCompilation is falling back to object mode "
+                           "WITH%s looplifting enabled because %s"
+                           % (loop_lift, msg))
+            warnings.warn_explicit('%s due to: %s' % (msg_rewrite, e),
+                                   errors.NumbaWarning,
+                                   state.func_id.filename,
+                                   state.func_id.firstlineno)
+            raise
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ExtractByteCode(FunctionPass):
+    _name = "extract_bytecode"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Extract bytecode from function
+        """
+        func_id = state['func_id']
+        bc = bytecode.ByteCode(func_id)
+        if config.DUMP_BYTECODE:
+            print(bc.dump())
+
+        state['bc'] = bc
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class TranslateByteCode(FunctionPass):
+    _name = "translate_bytecode"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Analyze bytecode and translating to Numba IR
+        """
+        func_id = state['func_id']
+        bc = state['bc']
+        interp = interpreter.Interpreter(func_id)
+        func_ir = interp.interpret(bc)
+        state["func_ir"] = func_ir
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class FixupArgs(FunctionPass):
+    _name = "fixup_args"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        state['nargs'] = state['func_ir'].arg_count
+        if not state['args'] and state['flags'].force_pyobject:
+            # Allow an empty argument types specification when object mode
+            # is explicitly requested.
+            state['args'] = (types.pyobject,) * state['nargs']
+        elif len(state['args']) != state['nargs']:
+            raise TypeError("Signature mismatch: %d argument types given, "
+                            "but function takes %d arguments"
+                            % (len(state['args']), state['nargs']))
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class IRProcessing(FunctionPass):
+    _name = "ir_processing"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        func_ir = state['func_ir']
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+
+        if config.DEBUG or config.DUMP_IR:
+            name = func_ir.func_id.func_qualname
+            print(("IR DUMP: %s" % name).center(80, "-"))
+            func_ir.dump()
+            if func_ir.is_generator:
+                print(("GENERATOR INFO: %s" % name).center(80, "-"))
+                func_ir.dump_generator_info()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class RewriteSemanticConstants(FunctionPass):
+    _name = "rewrite_semantic_constants"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        This prunes dead branches, a dead branch is one which is derivable as
+        not taken at compile time purely based on const/literal evaluation.
+        """
+        assert state.func_ir
+        msg = ('Internal error in pre-inference dead branch pruning '
+               'pass encountered during compilation of '
+               'function "%s"' % (state.func_id.func_name,))
+        with fallback_context(state, msg):
+            rewrite_semantic_constants(state.func_ir, state.args)
+
+        if config.DEBUG or config.DUMP_IR:
+            print('branch_pruned_ir'.center(80, '-'))
+            print(state.func_ir.dump())
+            print('end branch_pruned_ir'.center(80, '-'))
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class DeadBranchPrune(FunctionPass):
+    _name = "dead_branch_prune"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        This prunes dead branches, a dead branch is one which is derivable as
+        not taken at compile time purely based on const/literal evaluation.
+        """
+
+        # purely for demonstration purposes, obtain the analysis from a pass
+        # declare as a required dependent
+        semantic_const_analysis = self.get_analysis(type(self))  # noqa
+
+        assert state.func_ir
+        msg = ('Internal error in pre-inference dead branch pruning '
+               'pass encountered during compilation of '
+               'function "%s"' % (state.func_id.func_name,))
+        with fallback_context(state, msg):
+            dead_branch_prune(state.func_ir, state.args)
+
+        if config.DEBUG or config.DUMP_IR:
+            print('branch_pruned_ir'.center(80, '-'))
+            print(state.func_ir.dump())
+            print('end branch_pruned_ir'.center(80, '-'))
+
+        return True
+
+    def get_analysis_usage(self, AU):
+        AU.add_required(RewriteSemanticConstants)
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineClosureLikes(FunctionPass):
+    _name = "inline_closure_likes"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+
+        # if the return type is a pyobject, there's no type info available and
+        # no ability to resolve certain typed function calls in the array
+        # inlining code, use this variable to indicate
+        typed_pass = not isinstance(state.return_type, types.misc.PyObject)
+        inline_pass = InlineClosureCallPass(state.func_ir,
+                                            state.flags.auto_parallel,
+                                            state.parfor_diagnostics.replaced_fns,
+                                            typed_pass)
+        inline_pass.run()
+        # Remove all Dels, and re-run postproc
+        post_proc = postproc.PostProcessor(state.func_ir)
+        post_proc.run()
+
+        if config.DEBUG or config.DUMP_IR:
+            name = state.func_ir.func_id.func_qualname
+            print(("IR DUMP: %s" % name).center(80, "-"))
+            state.func_ir.dump()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class GenericRewrites(FunctionPass):
+    _name = "generic_rewrites"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Perform any intermediate representation rewrites before type
+        inference.
+        """
+        assert state.func_ir
+        msg = ('Internal error in pre-inference rewriting '
+               'pass encountered during compilation of '
+               'function "%s"' % (state.func_id.func_name,))
+        with fallback_context(state, msg):
+            rewrites.rewrite_registry.apply('before-inference', state)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class WithLifting(FunctionPass):
+    _name = "with_lifting"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """
+        Extract with-contexts
+        """
+        main, withs = transforms.with_lifting(
+            func_ir=state.func_ir,
+            typingctx=state.typingctx,
+            targetctx=state.targetctx,
+            flags=state.flags,
+            locals=state.locals,
+        )
+        if withs:
+            from numba.compiler import compile_ir, _EarlyPipelineCompletion
+            cres = compile_ir(state.typingctx, state.targetctx, main,
+                              state.args, state.return_type,
+                              state.flags, state.locals,
+                              lifted=tuple(withs), lifted_from=None,
+                              pipeline_class=type(state.pipeline))
+            raise _EarlyPipelineCompletion(cres)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class InlineInlinables(FunctionPass):
+    """
+    This pass will inline a function wrapped by the numba.jit decorator directly
+    into the site of its call depending on the value set in the 'inline' kwarg
+    to the decorator.
+
+    This is an untyped pass. CFG simplification is performed at the end of the
+    pass but no block level clean up is performed on the mutated IR (typing
+    information is not available to do so).
+    """
+    _name = "inline_inlinables"
+    _DEBUG = False
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        """Run inlining of inlinables
+        """
+        if config.DEBUG or self._DEBUG:
+            print('before inline'.center(80, '-'))
+            print(state.func_ir.dump())
+            print(''.center(80, '-'))
+        modified = False
+        # use a work list, look for call sites via `ir.Expr.op == call` and
+        # then pass these to `self._do_work` to make decisions about inlining.
+        work_list = list(state.func_ir.blocks.items())
+        while work_list:
+            label, block = work_list.pop()
+            for i, instr in enumerate(block.body):
+                if isinstance(instr, ir.Assign):
+                    expr = instr.value
+                    if isinstance(expr, ir.Expr) and expr.op == 'call':
+                        if guard(self._do_work, state, work_list, block, i,
+                                 expr):
+                            modified = True
+                            break  # because block structure changed
+
+        if modified:
+            # clean up unconditional branches that appear due to inlined
+            # functions introducing blocks
+            state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
+
+        if config.DEBUG or self._DEBUG:
+            print('after inline'.center(80, '-'))
+            print(state.func_ir.dump())
+            print(''.center(80, '-'))
+        return True
+
+    def _do_work(self, state, work_list, block, i, expr):
+        from numba.inline_closurecall import (inline_closure_call,
+                                              callee_ir_validator)
+        from numba.compiler import run_frontend
+        from numba.targets.cpu import InlineOptions
+
+        # try and get a definition for the call, this isn't always possible as
+        # it might be a eval(str)/part generated awaiting update etc. (parfors)
+        to_inline = None
+        try:
+            to_inline = state.func_ir.get_definition(expr.func)
+        except Exception:
+            if self._DEBUG:
+                print("Cannot find definition for %s" % expr.func)
+            return False
+        # do not handle closure inlining here, another pass deals with that.
+        if getattr(to_inline, 'op', False) == 'make_function':
+            return False
+
+        # see if the definition is a "getattr", in which case walk the IR to
+        # try and find the python function via the module from which it's
+        # imported, this should all be encoded in the IR.
+        if getattr(to_inline, 'op', False) == 'getattr':
+            val = resolve_func_from_module(state.func_ir, to_inline)
+        else:
+            # This is likely a freevar or global
+            #
+            # NOTE: getattr 'value' on a call may fail if it's an ir.Expr as
+            # getattr is overloaded to look in _kws.
+            try:
+                val = getattr(to_inline, 'value', False)
+            except Exception:
+                raise GuardException
+
+        # if something was found...
+        if val:
+            # check it's dispatcher-like, the targetoptions attr holds the
+            # kwargs supplied in the jit decorator and is where 'inline' will
+            # be if it is present.
+            topt = getattr(val, 'targetoptions', False)
+            if topt:
+                inline_type = topt.get('inline', None)
+                # has 'inline' been specified?
+                if inline_type is not None:
+                    inline_opt = InlineOptions(inline_type)
+                    # Could this be inlinable?
+                    if not inline_opt.is_never_inline:
+                        # yes, it could be inlinable
+                        do_inline = True
+                        pyfunc = val.py_func
+                        # Has it got an associated cost model?
+                        if inline_opt.has_cost_model:
+                            # yes, it has a cost model, use it to determine
+                            # whether to do the inline
+                            py_func_ir = run_frontend(pyfunc)
+                            do_inline = inline_type(state.func_ir, py_func_ir)
+                        # if do_inline is True then inline!
+                        if do_inline:
+                            inline_closure_call(state.func_ir,
+                                                pyfunc.__globals__,
+                                                block, i, pyfunc,
+                                                work_list=work_list,
+                                                callee_validator=callee_ir_validator)
+                            return True
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class PreserveIR(FunctionPass):
+    """
+    Preserves the IR in the metadata
+    """
+
+    _name = "preserve_ir"
+
+    def __init__(self):
+        super().__init__()
+
+    def run_pass(self, state):
+        state.metadata['preserved_ir'] = state.func_ir.copy()
+        return False

--- a/numba/untyped_passes.py
+++ b/numba/untyped_passes.py
@@ -42,7 +42,7 @@ class ExtractByteCode(FunctionPass):
     _name = "extract_bytecode"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -62,7 +62,7 @@ class TranslateByteCode(FunctionPass):
     _name = "translate_bytecode"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -81,7 +81,7 @@ class FixupArgs(FunctionPass):
     _name = "fixup_args"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         state['nargs'] = state['func_ir'].arg_count
@@ -101,7 +101,7 @@ class IRProcessing(FunctionPass):
     _name = "ir_processing"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         func_ir = state['func_ir']
@@ -123,7 +123,7 @@ class RewriteSemanticConstants(FunctionPass):
     _name = "rewrite_semantic_constants"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -149,7 +149,7 @@ class DeadBranchPrune(FunctionPass):
     _name = "dead_branch_prune"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -184,7 +184,7 @@ class InlineClosureLikes(FunctionPass):
     _name = "inline_closure_likes"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         # Ensure we have an IR and type information.
@@ -215,7 +215,7 @@ class GenericRewrites(FunctionPass):
     _name = "generic_rewrites"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -236,7 +236,7 @@ class WithLifting(FunctionPass):
     _name = "with_lifting"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """
@@ -275,7 +275,7 @@ class InlineInlinables(FunctionPass):
     _DEBUG = False
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         """Run inlining of inlinables
@@ -386,7 +386,7 @@ class PreserveIR(FunctionPass):
     _name = "preserve_ir"
 
     def __init__(self):
-        super().__init__()
+        FunctionPass.__init__(self)
 
     def run_pass(self, state):
         state.metadata['preserved_ir'] = state.func_ir.copy()


### PR DESCRIPTION
This PR is large, both in terms of churn and in terms of conceptual change.

The intent is as follows:

1. Redesign the Numba pipeline to be a bit more like that which is in LLVM. This
   to comprise:
   1. Passes must extend from a base class and implement defined methods.
   2. Passes must be registered with a pass registry.
   3. Instances of a `PassManager` class are used to orchestrate a "pipeline" of
      passes to execute.
   4. A `CompilerBase` class instance holds the state, the `PassManager`
      orchestrated passes operate on this state.
   5. A `DefaultPassBuilder` class provides static methods defining default or
      commonly used pipelines.

2. In addition, points for future work on safety and optimisation are added.
   1. `AnalysisUsage` cf. that in LLVM is stubbed out to permit eventual
      declaration of analysis dependencies between passes.
   2. Passes must return True/False depending on whether statement level changes
      have been made.
   3. At registration time passes must declare whether they mutate the CFG and
      whether they are analysis only passes.
   4. A simple timer is present to capture the execution time spent in each pass
      for a given pipeline execution.
   5. Basic support for `print_after` like functionality to print the IR
      following any transform is added.

The approach taken in this PR:
1. Each "stage" in the old compiler pipeline is now approximately a single new
   compiler pass.
2. The new compiler passes are split largely into two categories, those which
   are untyped (i.e. do not need type information and run before type inference)
   and those which are typed (i.e. need type information and run after type
   inference). These can be found in `numba.untyped_passes` and
   `numba.typed_passes` respectively. Passes relating object mode are in
   `numba.object_mode_passes`.
3. The fundamental types and machinery to build the new compilation chain can be
   found in `numba.compiler_machinery`. This includes the `PassManager`, the
   base class for passes `CompilerPass`, and the `pass_registry` decorator (used
   for registering new passes).
4. The original `compiler.py` has been heavily refactored to make use of the
   more modular design described above. Most notably the `CompilerBase` class is
   now responsible for determining how to execute pipelines defined by
   `PassManager` instances with each `PassManager` holding a single pipeline.
   The compilation state information is also attached to the `CompilerBase`
   class and is not part of a `PassManager`. This makes it easier for users
   building their own compilers to not have to subscribe to the Numba JIT
   compilation semantics, the `Compiler` state can be user defined as can the
   pipeline managed by the `PassManager` itself (along with all the passes and
   their execution order).
5. A large amount of "fixing" was required throughout the code base to
   accommodate the above.

Outstanding items/areas of concern:
1. Does this meet the needs of Numba? Is it too complicated?
2. Is the `CompilerPass` design and its registration mechanism reasonable?
   - Could be based on class instances instead of classes themselves to allow
     more configuration from the same code. But equally inheritance/composition
     could achieve the same.
   - Could/should pipelines be derived and manipulated more easily?
3. Is this sufficiently recognisable in terms of compiler design to permit
   getting up to speed quickly (along with new docs/examples).
4. With respect to object mode deprecation, does this design permit/allow a
   "mode" based pipeline as default? It seems like it could with separate
   compiler instances extending from `CompilerBase` each defining a single
   pipeline via the `define_pipelines()` method with new named pipelines for
   each purpose added to the `DefaultPassBuilder`.

Work left on this PR:
1. Fix any failing tests.
2. Write new unit tests as needed.
2. Documentation.
3. Further code clean up/refactoring, there's some duplication between the modules holding passes.