### PR TITLE
[WIP] make `@lower_constant` return new references

### DIFF
--- a/numba/charseq.py
+++ b/numba/charseq.py
@@ -5,6 +5,7 @@ from llvmlite import ir
 
 from numba import njit, types, cgutils, unicode
 from numba.extending import overload, intrinsic, overload_method, lower_cast
+from numba.targets.imputils import RefType
 
 # bytes and str arrays items are of type CharSeq and UnicodeCharSeq,
 # respectively.  See numpy/types/npytypes.py for CharSeq,
@@ -157,7 +158,7 @@ def unicode_charseq_get_value(a, i):
 #
 
 
-@lower_cast(types.Bytes, types.CharSeq)
+@lower_cast(types.Bytes, types.CharSeq, ref_type=RefType.BORROWED)
 def bytes_to_charseq(context, builder, fromty, toty, val):
     barr = cgutils.create_struct_proxy(fromty)(context, builder, value=val)
     src = builder.bitcast(barr.data, ir.IntType(8).as_pointer())
@@ -202,7 +203,7 @@ def _make_constant_bytes(context, builder, nbytes):
     return bstr
 
 
-@lower_cast(types.CharSeq, types.Bytes)
+@lower_cast(types.CharSeq, types.Bytes, ref_type=RefType.BORROWED)
 def charseq_to_bytes(context, builder, fromty, toty, val):
     bstr = _make_constant_bytes(context, builder, val.type.count)
     rawptr = cgutils.alloca_once_value(builder, value=val)
@@ -211,7 +212,7 @@ def charseq_to_bytes(context, builder, fromty, toty, val):
     return bstr
 
 
-@lower_cast(types.UnicodeType, types.Bytes)
+@lower_cast(types.UnicodeType, types.Bytes, ref_type=RefType.BORROWED)
 def unicode_to_bytes_cast(context, builder, fromty, toty, val):
     uni_str = cgutils.create_struct_proxy(fromty)(context, builder, value=val)
     src1 = builder.bitcast(uni_str.data, ir.IntType(8).as_pointer())
@@ -240,7 +241,7 @@ def _unicode_to_bytes(typingctx, s):
     return sig, codegen
 
 
-@lower_cast(types.UnicodeType, types.UnicodeCharSeq)
+@lower_cast(types.UnicodeType, types.UnicodeCharSeq, ref_type=RefType.BORROWED)
 def unicode_to_unicode_charseq(context, builder, fromty, toty, val):
     uni_str = cgutils.create_struct_proxy(fromty)(context, builder, value=val)
     src1 = builder.bitcast(uni_str.data, ir.IntType(8).as_pointer())

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -454,7 +454,6 @@ class Lower(BaseLower):
         if isinstance(value, (ir.Const, ir.Global, ir.FreeVar)):
             res = self.context.get_constant_generic(self.builder, ty,
                                                     value.value)
-            self.incref(ty, res)
             return res
 
         elif isinstance(value, ir.Expr):
@@ -482,7 +481,7 @@ class Lower(BaseLower):
             else:
                 val = self.fnargs[value.index]
                 res = self.context.cast(self.builder, val, argty, ty)
-            self.incref(ty, res)
+                self.incref(ty, res)
             return res
 
         elif isinstance(value, ir.Yield):
@@ -640,6 +639,8 @@ class Lower(BaseLower):
                 return self._cast_var(var, signature.args[index])
 
             def default_handler(index, param, default):
+                # TODO: not entirely sure we are handling new refcount convention correctly
+                #  here. .get_constant* returns new references now
                 return self.context.get_constant_generic(
                     self.builder, signature.args[index], default)
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -2066,8 +2066,8 @@ def array_ctypes_data(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 
-@lower_cast(types.ArrayCTypes, types.CPointer)
-@lower_cast(types.ArrayCTypes, types.voidptr)
+@lower_cast(types.ArrayCTypes, types.CPointer, ref_type=RefType.UNTRACKED)
+@lower_cast(types.ArrayCTypes, types.voidptr, ref_type=RefType.UNTRACKED)
 def array_ctypes_to_pointer(context, builder, fromty, toty, val):
     ctinfo = context.make_helper(builder, fromty, value=val)
     res = ctinfo.data
@@ -2375,7 +2375,7 @@ def record_setitem(context, builder, sig, args):
 # Constant arrays and records
 
 
-@lower_constant(types.Array)
+@lower_constant(types.Array, ref_type=RefType.BORROWED)
 def constant_array(context, builder, ty, pyval):
     """
     Create a constant array (mechanism is target-dependent).
@@ -2383,7 +2383,7 @@ def constant_array(context, builder, ty, pyval):
     return context.make_constant_array(builder, ty, pyval)
 
 
-@lower_constant(types.Record)
+@lower_constant(types.Record, ref_type=RefType.BORROWED)
 def constant_record(context, builder, ty, pyval):
     """
     Create a record constant as a stack-allocated array of bytes.
@@ -2393,7 +2393,7 @@ def constant_record(context, builder, ty, pyval):
     return cgutils.alloca_once_value(builder, val)
 
 
-@lower_constant(types.Bytes)
+@lower_constant(types.Bytes, ref_type=RefType.UNTRACKED)
 def constant_bytes(context, builder, ty, pyval):
     """
     Create a constant array from bytes (mechanism is target-dependent).
@@ -4792,7 +4792,7 @@ def array_argsort(context, builder, sig, args):
 # -----------------------------------------------------------------------------
 # Implicit cast
 
-@lower_cast(types.Array, types.Array)
+@lower_cast(types.Array, types.Array, ref_type=RefType.BORROWED)
 def array_to_array(context, builder, fromty, toty, val):
     # Type inference should have prevented illegal array casting.
     assert fromty.mutable != toty.mutable or toty.layout == 'A'

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -20,7 +20,7 @@ from numba.compiler_lock import global_compiler_lock
 from numba.pythonapi import PythonAPI
 from . import arrayobj, builtins, imputils
 from .imputils import (user_function, user_generator,
-                       builtin_registry, impl_ret_borrowed,
+                       builtin_registry, impl_ret_borrowed, impl_ret_new_ref,
                        RegistryLoader)
 from numba import datamodel
 
@@ -587,7 +587,7 @@ class BaseContext(object):
                 pyval = getattr(typ.pymod, attr)
                 llval = self.get_constant(attrty, pyval)
                 def imp(context, builder, typ, val, attr):
-                    return impl_ret_borrowed(context, builder, attrty, llval)
+                    return impl_ret_new_ref(context, builder, attrty, llval)
                 return imp
 
         # Lookup specific getattr implementation for this type and attribute

--- a/numba/targets/enumimpl.py
+++ b/numba/targets/enumimpl.py
@@ -4,7 +4,7 @@ Implementation of enums.
 import operator
 
 from .imputils import (lower_builtin, lower_getattr, lower_getattr_generic,
-                       lower_cast, lower_constant, impl_ret_untracked)
+                       lower_cast, lower_constant, impl_ret_untracked, RefType)
 from .. import types
 
 
@@ -43,7 +43,7 @@ def enum_value(context, builder, ty, val):
     return val
 
 
-@lower_cast(types.IntEnumMember, types.Integer)
+@lower_cast(types.IntEnumMember, types.Integer, ref_type=RefType.UNTRACKED)
 def int_enum_to_int(context, builder, fromty, toty, val):
     """
     Convert an IntEnum member to its raw integer value.
@@ -51,7 +51,7 @@ def int_enum_to_int(context, builder, fromty, toty, val):
     return context.cast(builder, val, fromty.dtype, toty)
 
 
-@lower_constant(types.EnumMember)
+@lower_constant(types.EnumMember, ref_type=RefType.UNTRACKED)
 def enum_constant(context, builder, ty, pyval):
     """
     Return a LLVM constant representing enum member *pyval*.

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -37,7 +37,7 @@ class RefType(Enum):
 # extension API users' perspective it is desirable that casts and lower constant return new references.
 # This and the new optional arg on Registry.lower_cast|lower_constant should allow to isolate the implementations
 # from the switch (at least old impls will keep working)
-LOWER_CONSTANT_RETURNS_NEW_REFS = False
+LOWER_CONSTANT_RETURNS_NEW_REFS = True
 CAST_RETURNS_NEW_REFS = False
 
 

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -1086,7 +1086,7 @@ def sorted_impl(context, builder, sig, args):
 # -----------------------------------------------------------------------------
 # Implicit casting
 
-@lower_cast(types.List, types.List)
+@lower_cast(types.List, types.List, ref_type=RefType.BORROWED)
 def list_to_list(context, builder, fromty, toty, val):
     # Casting from non-reflected to reflected
     assert fromty.dtype == toty.dtype

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -9,7 +9,7 @@ from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
 
 from numba import npdatetime, types, cgutils, numpy_support
-from .imputils import lower_builtin, lower_constant, impl_ret_untracked
+from .imputils import lower_builtin, lower_constant, impl_ret_untracked, RefType
 from ..utils import IS_PY3
 
 
@@ -122,8 +122,8 @@ leap_year_months_acc = make_constant_array(
     [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335])
 
 
-@lower_constant(types.NPDatetime)
-@lower_constant(types.NPTimedelta)
+@lower_constant(types.NPDatetime, ref_type=RefType.UNTRACKED)
+@lower_constant(types.NPTimedelta, ref_type=RefType.UNTRACKED)
 def datetime_constant(context, builder, ty, pyval):
     return DATETIME64(pyval.astype(np.int64))
 

--- a/numba/targets/optional.py
+++ b/numba/targets/optional.py
@@ -5,7 +5,7 @@ import operator
 from numba import types, cgutils, typing
 
 from .imputils import (lower_cast, lower_builtin, lower_getattr_generic,
-                       impl_ret_untracked, lower_setattr_generic)
+                       impl_ret_untracked, lower_setattr_generic, RefType)
 
 
 def always_return_true_impl(context, builder, sig, args):
@@ -70,7 +70,7 @@ def optional_setattr(context, builder, sig, args, attr):
     return imp(builder, (target, val))
 
 
-@lower_cast(types.Optional, types.Optional)
+@lower_cast(types.Optional, types.Optional, ref_type=RefType.BORROWED)
 def optional_to_optional(context, builder, fromty, toty, val):
     """
     The handling of optional->optional cast must be special cased for
@@ -101,7 +101,7 @@ def optional_to_optional(context, builder, fromty, toty, val):
     return outoptval._getvalue()
 
 
-@lower_cast(types.Any, types.Optional)
+@lower_cast(types.Any, types.Optional, ref_type=RefType.BORROWED)
 def any_to_optional(context, builder, fromty, toty, val):
     if fromty == types.none:
         return context.make_optional_none(builder, toty.type)
@@ -110,8 +110,8 @@ def any_to_optional(context, builder, fromty, toty, val):
         return context.make_optional_value(builder, toty.type, val)
 
 
-@lower_cast(types.Optional, types.Any)
-@lower_cast(types.Optional, types.Boolean)
+@lower_cast(types.Optional, types.Any, ref_type=RefType.BORROWED)
+@lower_cast(types.Optional, types.Boolean, ref_type=RefType.BORROWED)
 def optional_to_any(context, builder, fromty, toty, val):
     optval = context.make_helper(builder, fromty, value=val)
     validbit = cgutils.as_bool_bit(builder, optval.valid)

--- a/numba/targets/rangeobj.py
+++ b/numba/targets/rangeobj.py
@@ -10,7 +10,7 @@ from numba import types, cgutils, prange
 from .listobj import ListIterInstance
 from .arrayobj import make_array
 from .imputils import (lower_builtin, lower_cast,
-                       iterator_impl, impl_ret_untracked)
+                       iterator_impl, impl_ret_untracked, RefType)
 from numba.typing import signature
 from numba.extending import intrinsic, overload, overload_attribute, register_jitable
 from numba.parfor import internal_prange
@@ -172,7 +172,7 @@ range_impl_map = {
 for int_type, state_types in range_impl_map.items():
     make_range_impl(int_type, *state_types)
 
-@lower_cast(types.RangeType, types.RangeType)
+@lower_cast(types.RangeType, types.RangeType, ref_type=RefType.UNTRACKED)
 def range_to_range(context, builder, fromty, toty, val):
     olditems = cgutils.unpack_tuple(builder, val, 3)
     items = [context.cast(builder, v, fromty.dtype, toty.dtype)

--- a/numba/targets/setobj.py
+++ b/numba/targets/setobj.py
@@ -1464,7 +1464,7 @@ def set_is(context, builder, sig, args):
 # -----------------------------------------------------------------------------
 # Implicit casting
 
-@lower_cast(types.Set, types.Set)
+@lower_cast(types.Set, types.Set, ref_type=RefType.BORROWED)
 def set_to_set(context, builder, fromty, toty, val):
     # Casting from non-reflected to reflected
     assert fromty.dtype == toty.dtype

--- a/numba/targets/tupleobj.py
+++ b/numba/targets/tupleobj.py
@@ -108,8 +108,8 @@ def namedtuple_getattr(context, builder, typ, value, attr):
     return impl_ret_borrowed(context, builder, typ[index], res)
 
 
-@lower_constant(types.UniTuple)
-@lower_constant(types.NamedUniTuple)
+@lower_constant(types.UniTuple, ref_type=RefType.BORROWED)
+@lower_constant(types.NamedUniTuple, ref_type=RefType.BORROWED)
 def unituple_constant(context, builder, ty, pyval):
     """
     Create a homogeneous tuple constant.
@@ -120,8 +120,8 @@ def unituple_constant(context, builder, ty, pyval):
         context, builder, ty, cgutils.pack_array(builder, consts),
     )
 
-@lower_constant(types.Tuple)
-@lower_constant(types.NamedTuple)
+@lower_constant(types.Tuple, ref_type=RefType.BORROWED)
+@lower_constant(types.NamedTuple, ref_type=RefType.BORROWED)
 def unituple_constant(context, builder, ty, pyval):
     """
     Create a heterogeneous tuple constant.
@@ -264,7 +264,7 @@ def static_getitem_tuple(context, builder, sig, args):
 #------------------------------------------------------------------------------
 # Implicit conversion
 
-@lower_cast(types.BaseTuple, types.BaseTuple)
+@lower_cast(types.BaseTuple, types.BaseTuple, ref_type=RefType.BORROWED)
 def tuple_to_tuple(context, builder, fromty, toty, val):
     if (isinstance(fromty, types.BaseNamedTuple)
         or isinstance(toty, types.BaseNamedTuple)):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -14,6 +14,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba import njit, jit, types, errors, typing, compiler
 from numba.targets.registry import cpu_target
+from numba.targets.imputils import RefType
 from numba.compiler import compile_isolated
 from .support import (TestCase, captured_stdout, tag, temp_directory,
                       override_config)
@@ -67,7 +68,7 @@ mydummy = MyDummy()
 def typeof_mydummy(val, c):
     return mydummy_type
 
-@lower_cast(MyDummyType, types.Number)
+@lower_cast(MyDummyType, types.Number, ref_type=RefType.UNTRACKED)
 def mydummy_to_number(context, builder, fromty, toty, val):
     """
     Implicit conversion from MyDummy to int.

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -120,7 +120,7 @@ def make_string_from_constant(context, builder, typ, literal_string):
     return uni_str._getvalue()
 
 
-@lower_cast(types.StringLiteral, types.unicode_type)
+@lower_cast(types.StringLiteral, types.unicode_type, ref_type=RefType.BORROWED)
 def cast_from_literal(context, builder, fromty, toty, val):
     return make_string_from_constant(
         context, builder, toty, fromty.literal_value,
@@ -129,7 +129,7 @@ def cast_from_literal(context, builder, fromty, toty, val):
 
 # CONSTANT
 
-@lower_constant(types.unicode_type)
+@lower_constant(types.unicode_type, ref_type=RefType.BORROWED)
 def constant_unicode(context, builder, typ, pyval):
     return make_string_from_constant(context, builder, typ, pyval)
 


### PR DESCRIPTION
Step 1/2 for #4494. This is based on #4506 and sets `LOWER_CONSTANT_RETURNS_NEW_REFS =True`. All usages of `Context.get_constant*` have to be changed to the new refcounting conventions. Luckily, the vast majority of these are not returning memory-managed types (ie no change neccessary).