### PR TITLE
Fix static_getitem with Literal type as index

### DIFF
--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -590,6 +590,7 @@ class Lower(BaseLower):
         # Get implementation of getitem
         op = operator.getitem
         fnop = self.context.typing_context.resolve_value_type(op)
+        signature = signature.replace(args=(signature.args[0], types.unliteral(signature.args[1])))
         fnop.get_call_type(self.context.typing_context, signature.args, {})
         impl = self.context.get_function(fnop, signature)
 

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -374,8 +374,10 @@ class Lower(BaseLower):
 
             op = operator.delitem
             fnop = self.context.typing_context.resolve_value_type(op)
-            fnop.get_call_type(self.context.typing_context, signature.args, {})
-            impl = self.context.get_function(fnop, signature)
+            callsig = fnop.get_call_type(
+                self.context.typing_context, signature.args, {},
+            )
+            impl = self.context.get_function(fnop, callsig)
 
             assert targetty == signature.args[0]
             index = self.context.cast(self.builder, index, indexty,
@@ -424,8 +426,10 @@ class Lower(BaseLower):
 
         op = operator.setitem
         fnop = self.context.typing_context.resolve_value_type(op)
-        fnop.get_call_type(self.context.typing_context, signature.args, {})
-        impl = self.context.get_function(fnop, signature)
+        callsig = fnop.get_call_type(
+            self.context.typing_context, signature.args, {},
+        )
+        impl = self.context.get_function(fnop, callsig)
 
         # Convert argument to match
         if isinstance(targetty, types.Optional):
@@ -590,9 +594,10 @@ class Lower(BaseLower):
         # Get implementation of getitem
         op = operator.getitem
         fnop = self.context.typing_context.resolve_value_type(op)
-        signature = signature.replace(args=(signature.args[0], types.unliteral(signature.args[1])))
-        fnop.get_call_type(self.context.typing_context, signature.args, {})
-        impl = self.context.get_function(fnop, signature)
+        callsig = fnop.get_call_type(
+            self.context.typing_context, signature.args, {},
+        )
+        impl = self.context.get_function(fnop, callsig)
 
         argvals = (baseval, indexval)
         argtyps = (self.typeof(value.name),


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Fix an issue seen in HPAT that triggers an error in lowering static_getitem.  Rewrite passes can set the index type of static_getitem to be a `Literal[int]`. Since implementation (i.e. array.__getitem__) may not support Literal index type, `.get_call_type` would return the proper signature without the literal type but the new signature is not used when selecting the llvm function.
