### PR TITLE
[WIP] Support jit_options/inline for overload_method

### DIFF
--- a/numba/extending.py
+++ b/numba/extending.py
@@ -146,7 +146,7 @@ def register_jitable(*args, **kwargs):
         return wrap(*args)
 
 
-def overload_attribute(typ, attr):
+def overload_attribute(typ, attr, jit_options={}):
     """
     A decorator marking the decorated function as typing and implementing
     attribute *attr* for the given Numba type in nopython mode.
@@ -162,15 +162,20 @@ def overload_attribute(typ, attr):
     # TODO implement setters
     from .typing.templates import make_overload_attribute_template
 
+    # set default options
+    opts = _overload_default_jit_options.copy()
+    opts.update(jit_options)  # let user options override
+
     def decorate(overload_func):
-        template = make_overload_attribute_template(typ, attr, overload_func)
+        template = make_overload_attribute_template(
+            typ, attr, overload_func, opts)
         infer_getattr(template)
         return overload_func
 
     return decorate
 
 
-def overload_method(typ, attr):
+def overload_method(typ, attr, jit_options={}):
     """
     A decorator marking the decorated function as typing and implementing
     attribute *attr* for the given Numba type in nopython mode.
@@ -190,8 +195,13 @@ def overload_method(typ, attr):
     """
     from .typing.templates import make_overload_method_template
 
+    # set default options
+    opts = _overload_default_jit_options.copy()
+    opts.update(jit_options)  # let user options override
+
     def decorate(overload_func):
-        template = make_overload_method_template(typ, attr, overload_func)
+        template = make_overload_method_template(typ, attr, overload_func,
+                                                 opts)
         infer_getattr(template)
         return overload_func
 

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -146,7 +146,7 @@ def register_jitable(*args, **kwargs):
         return wrap(*args)
 
 
-def overload_attribute(typ, attr, jit_options={}):
+def overload_attribute(typ, attr, jit_options={}, inline='never'):
     """
     A decorator marking the decorated function as typing and implementing
     attribute *attr* for the given Numba type in nopython mode.
@@ -168,14 +168,14 @@ def overload_attribute(typ, attr, jit_options={}):
 
     def decorate(overload_func):
         template = make_overload_attribute_template(
-            typ, attr, overload_func, opts)
+            typ, attr, overload_func, opts, inline)
         infer_getattr(template)
         return overload_func
 
     return decorate
 
 
-def overload_method(typ, attr, jit_options={}):
+def overload_method(typ, attr, jit_options={}, inline='never'):
     """
     A decorator marking the decorated function as typing and implementing
     attribute *attr* for the given Numba type in nopython mode.
@@ -201,7 +201,7 @@ def overload_method(typ, attr, jit_options={}):
 
     def decorate(overload_func):
         template = make_overload_method_template(typ, attr, overload_func,
-                                                 opts)
+                                                 opts, inline)
         infer_getattr(template)
         return overload_func
 

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -686,7 +686,7 @@ class _OverloadAttributeTemplate(AttributeTemplate):
 
     @classmethod
     def _get_dispatcher(cls, context, typ, attr, sig_args, sig_kws,
-                                                                  jit_options):
+                        jit_options):
         """
         Get the compiled dispatcher implementing the attribute for
         the given formal signature.


### PR DESCRIPTION
This PR reduces the feature disparity between `@overload` and `@overload_method` and `@overload_attribute` by adding support for `jit_options` and `inline` arguments. 

The code paths for `overload` and `overload_method` are quite different which is not ideal and causes some code duplication.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
