### PR TITLE
Update to inliner cost model information.

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -2107,7 +2107,7 @@ class InlineInlinables(object):
                             # yes, it has a cost model, use it to determine
                             # whether to do the inline
                             py_func_ir = run_frontend(pyfunc)
-                            do_inline = inline_type(self.func_ir, py_func_ir)
+                            do_inline = inline_type(expr, self.func_ir, py_func_ir)
                         # if do_inline is True then inline!
                         if do_inline:
                             inline_closure_call(self.func_ir,
@@ -2236,7 +2236,7 @@ class InlineOverloads(object):
             # must be a cost-model function, run the function
             iinfo = template._inline_overloads[sig.args]['iinfo']
             if inline_type.has_cost_model:
-                do_inline = inline_type.value(caller_inline_info, iinfo)
+                do_inline = inline_type.value(expr, caller_inline_info, iinfo)
             else:
                 assert 'unreachable'
 

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -332,10 +332,14 @@ class TestFunctionInlining(InliningBase):
 
     def test_inlining_models(self):
 
-        def s17_caller_model(caller_info, callee_info):
+        def s17_caller_model(expr, caller_info, callee_info):
+            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(caller_info)
 
-        def s17_callee_model(caller_info, callee_info):
+        def s17_callee_model(expr, caller_info, callee_info):
+            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(callee_info)
 
         # caller has sentinel
@@ -646,10 +650,14 @@ class TestOverloadInlining(InliningBase):
 
     def test_inlining_models(self):
 
-        def s17_caller_model(caller_info, callee_info):
+        def s17_caller_model(expr, caller_info, callee_info):
+            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(caller_info.func_ir)
 
-        def s17_callee_model(caller_info, callee_info):
+        def s17_callee_model(expr, caller_info, callee_info):
+            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(callee_info.func_ir)
 
         # caller has sentinel

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -329,12 +329,12 @@ class TestFunctionInlining(InliningBase):
     def test_inlining_models(self):
 
         def s17_caller_model(expr, caller_info, callee_info):
-            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertIsInstance(expr, ir.Expr)
             self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(caller_info)
 
         def s17_callee_model(expr, caller_info, callee_info):
-            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertIsInstance(expr, ir.Expr)
             self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(callee_info)
 
@@ -647,12 +647,12 @@ class TestOverloadInlining(InliningBase):
     def test_inlining_models(self):
 
         def s17_caller_model(expr, caller_info, callee_info):
-            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertIsInstance(expr, ir.Expr)
             self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(caller_info.func_ir)
 
         def s17_callee_model(expr, caller_info, callee_info):
-            self.assertTrue(isinstance(expr, ir.Expr))
+            self.assertIsInstance(expr, ir.Expr)
             self.assertEqual(expr.op, "call")
             return self.sentinel_17_cost_model(callee_info.func_ir)
 


### PR DESCRIPTION
This adds the call expr that is requesting inlining to
the information provided to the cost model. This is so it
is possible to e.g. decide to inline based on the location of
the call with respect to the rest of the block/IR.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
