### PR TITLE
Add Basic CUDA Coordination Group Support

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -540,7 +540,8 @@ class CUDAKernel(CUDAKernelBase):
                           griddim=self.griddim,
                           blockdim=self.blockdim,
                           stream=self.stream,
-                          sharedmem=self.sharedmem)
+                          sharedmem=self.sharedmem,
+                          cooperative=self.cooperative)
 
     def bind(self):
         """
@@ -811,7 +812,8 @@ class AutoJitCUDAKernel(CUDAKernelBase):
         Specialize and invoke this kernel with *args*.
         '''
         kernel = self.specialize(*args)
-        cfg = kernel[self.griddim, self.blockdim, self.stream, self.sharedmem]
+        cfg = kernel[self.griddim, self.blockdim,
+                     self.stream, self.sharedmem, self.cooperative]
         cfg(*args)
 
     def specialize(self, *args):

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -255,12 +255,13 @@ class ExternFunction(object):
 
 
 class ForAll(object):
-    def __init__(self, kernel, ntasks, tpb, stream, sharedmem):
+    def __init__(self, kernel, ntasks, tpb, stream, sharedmem, cooperative):
         self.kernel = kernel
         self.ntasks = ntasks
         self.thread_per_block = tpb
         self.stream = stream
         self.sharedmem = sharedmem
+        self.cooperative = cooperative
 
     def __call__(self, *args):
         if isinstance(self.kernel, AutoJitCUDAKernel):
@@ -273,7 +274,8 @@ class ForAll(object):
         blkct = (self.ntasks + tpbm1) // tpb
 
         return kernel.configure(blkct, tpb, stream=self.stream,
-                                sharedmem=self.sharedmem)(*args)
+                                sharedmem=self.sharedmem,
+                                cooperative=self.cooperative)(*args)
 
     def _compute_thread_per_block(self, kernel):
         tpb = self.thread_per_block
@@ -317,6 +319,7 @@ class CUDAKernelBase(object):
         self.blockdim = (1, 1, 1)
         self.sharedmem = 0
         self.stream = 0
+        self.cooperative = False
 
     def copy(self):
         """
@@ -330,7 +333,7 @@ class CUDAKernelBase(object):
         new.__dict__.update(self.__dict__)
         return new
 
-    def configure(self, griddim, blockdim, stream=0, sharedmem=0):
+    def configure(self, griddim, blockdim, stream=0, sharedmem=0, cooperative=False):
         griddim, blockdim = normalize_kernel_dimensions(griddim, blockdim)
 
         clone = self.copy()
@@ -338,14 +341,15 @@ class CUDAKernelBase(object):
         clone.blockdim = tuple(blockdim)
         clone.stream = stream
         clone.sharedmem = sharedmem
+        clone.cooperative = cooperative
         return clone
 
     def __getitem__(self, args):
-        if len(args) not in [2, 3, 4]:
+        if len(args) not in [2, 3, 4, 5]:
             raise ValueError('must specify at least the griddim and blockdim')
         return self.configure(*args)
 
-    def forall(self, ntasks, tpb=0, stream=0, sharedmem=0):
+    def forall(self, ntasks, tpb=0, stream=0, sharedmem=0, cooperative=False):
         """Returns a configured kernel for 1D kernel of given number of tasks
         ``ntasks``.
 
@@ -353,21 +357,22 @@ class CUDAKernelBase(object):
         - the kernel 1-to-1 maps global thread id ``cuda.grid(1)`` to tasks.
         - the kernel must check if the thread id is valid."""
 
-        return ForAll(self, ntasks, tpb=tpb, stream=stream, sharedmem=sharedmem)
+        return ForAll(self, ntasks, tpb=tpb, stream=stream,
+                      sharedmem=sharedmem, cooperative=cooperative)
 
     def _serialize_config(self):
         """
         Helper for serializing the grid, block and shared memory configuration.
         CUDA stream config is not serialized.
         """
-        return self.griddim, self.blockdim, self.sharedmem
+        return self.griddim, self.blockdim, self.sharedmem, self.cooperative
 
     def _deserialize_config(self, config):
         """
         Helper for deserializing the grid, block and shared memory
         configuration.
         """
-        self.griddim, self.blockdim, self.sharedmem = config
+        self.griddim, self.blockdim, self.sharedmem, self.cooperative = config
 
 
 class CachedPTX(object):
@@ -586,7 +591,8 @@ class CUDAKernel(CUDAKernelBase):
         print(self._type_annotation, file=file)
         print('=' * 80, file=file)
 
-    def _kernel_call(self, args, griddim, blockdim, stream=0, sharedmem=0):
+    def _kernel_call(self, args, griddim, blockdim, stream=0, sharedmem=0,
+                     cooperative=False):
         # Prepare kernel
         cufunc = self._func.get()
 
@@ -607,7 +613,8 @@ class CUDAKernel(CUDAKernelBase):
         # Configure kernel
         cu_func = cufunc.configure(griddim, blockdim,
                                    stream=stream,
-                                   sharedmem=sharedmem)
+                                   sharedmem=sharedmem,
+                                   cooperative=cooperative)
         # Invoke kernel
         cu_func(*kernelargs)
 

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -138,6 +138,19 @@ class Cuda_syncwarp(ConcreteTemplate):
     key = cuda.syncwarp
     cases = [signature(types.none, types.i4)]
 
+@intrinsic
+class Cuda_this_grid(ConcreteTemplate):
+    key = cuda.this_grid
+    cases = [signature(types.int64)]
+
+@intrinsic
+class Cuda_sync_group(ConcreteTemplate):
+    key = cuda.sync_group
+
+    # no flags, they're inserted as a constant 0 by the
+    # PTX lowering step
+    cases = [signature(types.int32, types.int64)]
+
 
 @intrinsic
 class Cuda_shfl_sync_intrinsic(ConcreteTemplate):
@@ -440,6 +453,12 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_gridsize(self, mod):
         return types.Macro(Cuda_gridsize)
+
+    def resolve_this_grid(self, mod):
+        return types.Function(Cuda_this_grid)
+
+    def resolve_sync_group(self, mod):
+        return types.Function(Cuda_sync_group)
 
     def resolve_threadIdx(self, mod):
         return types.Module(cuda.threadIdx)

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1545,7 +1545,7 @@ class Function(object):
             flag = enums.CU_FUNC_CACHE_PREFER_NONE
         driver.cuFuncSetCacheConfig(self.handle, flag)
 
-    def configure(self, griddim, blockdim, sharedmem=0, stream=0):
+    def configure(self, griddim, blockdim, sharedmem=0, stream=0, cooperative=False):
         while len(griddim) < 3:
             griddim += (1,)
 
@@ -1556,6 +1556,7 @@ class Function(object):
         inst.griddim = griddim
         inst.blockdim = blockdim
         inst.sharedmem = sharedmem
+        inst.cooperative = cooperative
         if stream:
             inst.stream = stream
         else:
@@ -1572,7 +1573,7 @@ class Function(object):
             streamhandle = None
 
         launch_kernel(self.handle, self.griddim, self.blockdim,
-                      self.sharedmem, streamhandle, args)
+                      self.sharedmem, streamhandle, args, self.cooperative)
 
     @property
     def device(self):
@@ -1597,7 +1598,7 @@ class Function(object):
                         maxthreads=maxtpb)
 
 
-def launch_kernel(cufunc_handle, griddim, blockdim, sharedmem, hstream, args):
+def launch_kernel(cufunc_handle, griddim, blockdim, sharedmem, hstream, args, cooperative=False):
     gx, gy, gz = griddim
     bx, by, bz = blockdim
 
@@ -1610,13 +1611,21 @@ def launch_kernel(cufunc_handle, griddim, blockdim, sharedmem, hstream, args):
 
     params = (c_void_p * len(param_vals))(*param_vals)
 
-    driver.cuLaunchKernel(cufunc_handle,
-                          gx, gy, gz,
-                          bx, by, bz,
-                          sharedmem,
-                          hstream,
-                          params,
-                          None)
+    if cooperative:
+        driver.cuLaunchCooperativeKernel(cufunc_handle,
+                                         gx, gy, gz,
+                                         bx, by, bz,
+                                         sharedmem,
+                                         hstream,
+                                         params)
+    else:
+        driver.cuLaunchKernel(cufunc_handle,
+                              gx, gy, gz,
+                              bx, by, bz,
+                              sharedmem,
+                              hstream,
+                              params,
+                              None)
 
 
 FILE_EXTENSION_MAP = {

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -169,6 +169,18 @@ API_PROTOTYPES = {
                          c_uint, c_uint, c_uint, c_uint, cu_stream,
                          POINTER(c_void_p), POINTER(c_void_p)),
 
+# CUresult cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX,
+#                                   unsigned int gridDimY,
+#                                   unsigned int gridDimZ,
+#                                   unsigned int blockDimX,
+#                                   unsigned int blockDimY,
+#                                   unsigned int blockDimZ,
+#                                   unsigned int sharedMemBytes,
+#                                   CUstream hStream, void **kernelParams)
+'cuLaunchCooperativeKernel': (c_int, cu_function, c_uint, c_uint, c_uint,
+                             c_uint, c_uint, c_uint, c_uint, cu_stream,
+                             POINTER(c_void_p)),
+
 #  CUresult cuMemHostAlloc	(	void ** 	pp,
 #                               size_t 	bytesize,
 #                               unsigned int 	Flags

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -81,6 +81,24 @@ def ptx_gridsize3d(context, builder, sig, args):
     return cgutils.pack_array(builder, [r1, r2, r3])
 
 
+@lower(stubs.this_grid)
+def ptx_this_grid(context, builder, sig, args):
+    one = context.get_constant(types.int32, 1)
+    lmod = builder.module
+    return builder.call(
+        nvvmutils.declare_cudaCGGetIntrinsicHandle(lmod),
+        (one,))
+
+
+@lower(stubs.sync_group, types.int64)
+def ptx_sync_group(context, builder, sig, args):
+    flags = context.get_constant(types.int32, 0)
+    lmod = builder.module
+    return builder.call(
+        nvvmutils.declare_cudaCGSynchronize(lmod),
+        (*args, flags))
+
+
 # -----------------------------------------------------------------------------
 
 def ptx_sreg_template(sreg):

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -62,7 +62,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
             else:
                 def autojitwrapper(func):
                     return jit(func, device=device, bind=bind, debug=debug,
-                               **kws)
+                               link=link, **kws)
 
             return autojitwrapper
         # func_or_sig is a function
@@ -71,10 +71,12 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
                 return FakeCUDAKernel(func_or_sig, device=device, fastmath=fastmath,
                                       debug=debug)
             elif device:
-                return jitdevice(func_or_sig, debug=debug, **kws)
+                return jitdevice(func_or_sig, debug=debug,
+                                 link=link, **kws)
             else:
                 targetoptions = kws.copy()
                 targetoptions['debug'] = debug
+                targetoptions['link'] = link
                 return AutoJitCUDAKernel(func_or_sig, bind=bind, targetoptions=targetoptions)
 
     else:

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -7,7 +7,8 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     const, grid, gridsize, atomic, shfl_sync_intrinsic,
                     vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
-                    threadfence, selp, popc, brev, clz, ffs, fma)
+                    threadfence, selp, popc, brev, clz, ffs, fma,
+                    this_grid, sync_group)
 from .cudadrv.error import CudaSupportError
 from .cudadrv import nvvm
 from . import initialize

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -58,6 +58,20 @@ def declare_atomic_min_float64(lmod):
     return lmod.get_or_insert_function(fnty, fname)
 
 
+def declare_cudaCGGetIntrinsicHandle(lmod):
+    fname = 'cudaCGGetIntrinsicHandle'
+    fnty = lc.Type.function(lc.Type.int(64),
+        (lc.Type.int(32),))
+    return lmod.get_or_insert_function(fnty, fname)
+
+
+def declare_cudaCGSynchronize(lmod):
+    fname = 'cudaCGSynchronize'
+    fnty = lc.Type.function(lc.Type.int(32),
+        (lc.Type.int(64), lc.Type.int(32)))
+    return lmod.get_or_insert_function(fnty, fname)
+
+
 def insert_addrspace_conv(lmod, elemtype, addrspace):
     addrspacename = {
         nvvm.ADDRSPACE_SHARED: 'shared',

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -185,6 +185,12 @@ class FakeCUDAModule(object):
     def warpsize(self):
         return 32
 
+    def this_grid(self):
+        return 0
+
+    def sync_group(self, grid):
+        return 0
+
     @property
     def laneid(self):
         return threading.current_thread().thread_id % 32

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -123,6 +123,21 @@ def grid_expand(ndim):
 
 grid = macro.Macro('ptx.grid', grid_expand, callable=True)
 
+
+class this_grid(Stub):
+    '''
+    A reference to the current grid_group.
+    '''
+    _description_ = '<this_grid()>'
+
+
+class sync_group(Stub):
+    '''
+    Synchronise the given group
+    '''
+    _description_ = '<sync_group()>'
+
+
 #-------------------------------------------------------------------------------
 # Gridsize Macro
 

--- a/numba/cuda/tests/cudapy/test_cooperative_groups.py
+++ b/numba/cuda/tests/cudapy/test_cooperative_groups.py
@@ -1,0 +1,55 @@
+from __future__ import print_function
+
+import numpy as np
+
+from numba import cuda, config
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+
+
+def this_grid(A):
+    A[0] = cuda.this_grid()
+
+
+def sync_group(A):
+    g = cuda.this_grid()
+    cuda.sync_group(g)
+    A[0] = g
+
+
+if not config.ENABLE_CUDASIM:
+    from numba.cuda.cudadrv.libs import find_lib
+
+    LINK = find_lib(
+        'cudadevrt',
+        libdir='/usr/lib64',
+        platform='linux-static')
+    assert LINK
+
+
+@skip_on_cudasim("can't link on sim")
+class TestCudaCooperativeGroups(SerialMixin, unittest.TestCase):
+    def test_this_grid(self):
+        tg = cuda.jit(
+            'void(float64[:])',
+            link=LINK,
+        )(this_grid)
+        A = np.full(1, fill_value=np.nan)
+        tg.configure(1, 1, cooperative=True)(A)
+        self.assertFalse(
+            np.isnan(A[0]),
+            'set it to something!')
+
+    def test_sync_group(self):
+        tg = cuda.jit(
+            'void(float64[:])',
+            link=LINK,
+        )(sync_group)
+        A = np.full(1, fill_value=np.nan)
+        tg.configure(1, 1, cooperative=True)(A)
+        self.assertFalse(
+            np.isnan(A[0]),
+            'set it to something!')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_cooperative_groups.py
+++ b/numba/cuda/tests/cudapy/test_cooperative_groups.py
@@ -39,6 +39,17 @@ class TestCudaCooperativeGroups(SerialMixin, unittest.TestCase):
             np.isnan(A[0]),
             'set it to something!')
 
+    def test_this_grid_autojit(self):
+        """
+        Check `link` arg being propagated
+        """
+        tg = cuda.jit(link=LINK)(this_grid)
+        A = np.full(1, fill_value=np.nan)
+        tg.configure(1, 1, cooperative=True)(A)
+        self.assertFalse(
+            np.isnan(A[0]),
+            'set it to something!')
+
     def test_sync_group(self):
         tg = cuda.jit(
             'void(float64[:])',

--- a/numba/findlib.py
+++ b/numba/findlib.py
@@ -21,6 +21,7 @@ def get_lib_dirs():
 DLLNAMEMAP = {
     'linux': r'lib%(name)s\.so\.%(ver)s$',
     'linux2': r'lib%(name)s\.so\.%(ver)s$',
+    'linux-static': r'lib%(name)s\.a$',
     'darwin': r'lib%(name)s\.%(ver)s\.dylib$',
     'win32': r'%(name)s%(ver)s\.dll$',
 }


### PR DESCRIPTION
Add support for sync'ing all the blocks in a grid. Note that this functionality depends on `libcudadevrt.a`, which isn't shipped in the Conda CUDAToolkit (see numba/conda-recipe-cudatoolkit#19), but is a Nvidia redistributable file (e.g. in package `cuda-cudart-devel-1` on Fedora). [This](https://github.com/JuliaGPU/CUDAnative.jl/blob/master/src/device/cuda/cooperative_groups.jl) was a useful reference!