### PR TITLE
Add axis argument for `np.mean`

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -182,7 +182,6 @@ The following methods of Numpy arrays are supported in their basic form
 * :meth:`~numpy.ndarray.cumprod`
 * :meth:`~numpy.ndarray.cumsum`
 * :meth:`~numpy.ndarray.max`
-* :meth:`~numpy.ndarray.mean`
 * :meth:`~numpy.ndarray.min`
 * :meth:`~numpy.ndarray.nonzero`
 * :meth:`~numpy.ndarray.prod`
@@ -206,6 +205,8 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.flatten` (no order argument; 'C' order only)
 * :meth:`~numpy.ndarray.item` (without arguments)
 * :meth:`~numpy.ndarray.itemset` (only the 1-argument form)
+* :meth:`~numpy.ndarray.mean` (with or without the ``axis`` argument.
+  ``axis`` only supports ``integer`` values)
 * :meth:`~numpy.ndarray.ravel` (no order argument; 'C' order only)
 * :meth:`~numpy.ndarray.repeat` (no axis argument)
 * :meth:`~numpy.ndarray.reshape` (only the 1-argument form)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -173,7 +173,7 @@ def array_sum(context, builder, sig, args):
 
 
 @register_jitable
-def _array_sum_axis_nop(arr, v):
+def _array_axis_nop(arr, v):
     return arr
 
 
@@ -199,7 +199,7 @@ def array_sum_axis(context, builder, sig, args):
     if getattr(retty, 'ndim', None) is None:
         op = np.take
     else:
-        op = _array_sum_axis_nop
+        op = _array_axis_nop
     [ty_array, ty_axis] = sig.args
     is_axis_const = False
     const_axis_val = 0
@@ -346,6 +346,103 @@ def array_mean(context, builder, sig, args):
                                    locals=dict(c=sig.return_type))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+@lower_builtin(np.mean, types.Array, types.intp)
+@lower_builtin(np.mean, types.Array, types.IntegerLiteral)
+@lower_builtin("array.mean", types.Array, types.intp)
+@lower_builtin("array.mean", types.Array, types.IntegerLiteral)
+def array_mean_axis(context, builder, sig, args):
+    """
+    The third parameter to gen_index_tuple that generates the indexing
+    tuples has to be a const so we can't just pass "axis" through since
+    that isn't const.  We can check for specific values and have
+    different instances that do take consts.  Supporting axis summation
+    only up to the fourth dimension for now.
+    """
+    # typing/arraydecl.py:sum_expand defines the return type for sum with axis.
+    # It is one dimension less than the input array.
+
+    retty = sig.return_type
+    zero = getattr(retty, 'dtype', retty)(0)
+    # if the return is scalar in type then "take" the 0th element of the
+    # 0d array accumulator as the return value
+    if not hasattr(retty, 'ndim'): #getattr(retty, 'ndim', None) is None:
+        op = np.take
+    else:
+        op = _array_axis_nop
+    [ty_array, ty_axis] = sig.args
+    is_axis_const = False
+    const_axis_val = 0
+    if isinstance(ty_axis, types.Literal):
+        # this special-cases for constant axis
+        const_axis_val = ty_axis.literal_value
+        # fix negative axis
+        if const_axis_val < 0:
+            const_axis_val = ty_array.ndim + const_axis_val
+        if const_axis_val < 0 or const_axis_val > ty_array.ndim:
+            raise ValueError("'axis' entry is out of bounds")
+
+        ty_axis = context.typing_context.resolve_value_type(const_axis_val)
+        axis_val = context.get_constant(ty_axis, const_axis_val)
+        # rewrite arguments
+        args = args[0], axis_val
+        # rewrite sig
+        sig = sig.replace(args=[ty_array, ty_axis])
+        is_axis_const = True
+
+    def array_mean_impl_axis(arr, axis):
+        ndim = arr.ndim
+
+        if not is_axis_const:
+            # Catch where axis is negative or greater than 3.
+            if axis < 0 or axis > 3:
+                raise ValueError("Numba does not support mean with axis "
+                                 "parameter outside the range 0 to 3.")
+
+        # Catch the case where the user misspecifies the axis to be
+        # more than the number of the array's dimensions.
+        if axis >= ndim:
+            raise ValueError("axis is out of bounds for array")
+
+        # Convert the shape of the input array to a list.
+        ashape = list(arr.shape)
+        # Get the length of the axis dimension.
+        axis_len = ashape[axis]
+        # Remove the axis dimension from the list of dimensional lengths.
+        ashape.pop(axis)
+        # Convert this shape list back to a tuple using above intrinsic.
+        ashape_without_axis = _create_tuple_result_shape(ashape, arr.shape)
+        # Tuple needed here to create output array with correct size.
+        result = np.full(ashape_without_axis, zero, type(zero))
+
+        # Iterate through the axis dimension.
+        for axis_index in range(axis_len):
+            if is_axis_const:
+                # constant specialized version works for any valid axis value
+                index_tuple_generic = _gen_index_tuple(arr.shape, axis_index,
+                                                       const_axis_val)
+                result += arr[index_tuple_generic]
+            else:
+                # Generate a tuple used to index the input array.
+                # The tuple is ":" in all dimensions except the axis
+                # dimension where it is "axis_index".
+                if axis == 0:
+                    index_tuple1 = _gen_index_tuple(arr.shape, axis_index, 0)
+                    result += arr[index_tuple1]
+                elif axis == 1:
+                    index_tuple2 = _gen_index_tuple(arr.shape, axis_index, 1)
+                    result += arr[index_tuple2]
+                elif axis == 2:
+                    index_tuple3 = _gen_index_tuple(arr.shape, axis_index, 2)
+                    result += arr[index_tuple3]
+                elif axis == 3:
+                    index_tuple4 = _gen_index_tuple(arr.shape, axis_index, 3)
+                    result += arr[index_tuple4]
+        
+        result /= axis_len
+        return op(result, 0)
+
+    res = context.compile_internal(builder, array_mean_impl_axis, sig, args)
+    return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 @lower_builtin(np.var, types.Array)
 @lower_builtin("array.var", types.Array)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -346,6 +346,7 @@ def array_mean(context, builder, sig, args):
                                    locals=dict(c=sig.return_type))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
+
 @lower_builtin(np.mean, types.Array, types.intp)
 @lower_builtin(np.mean, types.Array, types.IntegerLiteral)
 @lower_builtin("array.mean", types.Array, types.intp)
@@ -437,12 +438,13 @@ def array_mean_axis(context, builder, sig, args):
                 elif axis == 3:
                     index_tuple4 = _gen_index_tuple(arr.shape, axis_index, 3)
                     result += arr[index_tuple4]
-        
+
         result /= axis_len
         return op(result, 0)
 
     res = context.compile_internal(builder, array_mean_impl_axis, sig, args)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
+
 
 @lower_builtin(np.var, types.Array)
 @lower_builtin("array.var", types.Array)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -377,10 +377,10 @@ class Numpy_method_redirection(AbstractTemplate):
     def generic(self, args, kws):
         pysig = None
         if kws:
-            if self.method_name == 'sum':
-                def sum_stub(arr, axis):
+            if self.method_name in ['sum', 'mean']:
+                def axis_stub(arr, axis):
                     pass
-                pysig = utils.pysignature(sum_stub)
+                pysig = utils.pysignature(axis_stub)
             elif self.method_name == 'argsort':
                 def argsort_stub(arr, kind='quicksort'):
                     pass


### PR DESCRIPTION
Support integer axis arguments for `np.mean` in a similar fashion to `np.sum`.