### PR TITLE
Replace use of `np.prod` with `functools.reduce` for computing size from shape

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -8,6 +8,7 @@ from __future__ import print_function, absolute_import, division
 import warnings
 import math
 import functools
+import operator
 import copy
 from numba import six
 from ctypes import c_void_p
@@ -92,7 +93,7 @@ class DeviceNDArrayBase(object):
         self.shape = tuple(shape)
         self.strides = tuple(strides)
         self.dtype = np.dtype(dtype)
-        self.size = int(np.prod(self.shape))
+        self.size = int(functools.reduce(operator.mul, self.shape, 1))
         # prepare gpu memory
         if self.size > 0:
             if gpu_data is None:
@@ -566,7 +567,7 @@ class DeviceNDArray(DeviceNDArrayBase):
 
         # (3) do the copy
 
-        n_elements = np.prod(lhs.shape)
+        n_elements = functools.reduce(operator.mul, lhs.shape, 1)
         _assign_kernel(lhs.ndim).forall(n_elements, stream=stream)(lhs, rhs)
 
 

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -162,7 +162,7 @@ class Array(object):
         self.shape = tuple(dim.size for dim in self.dims)
         self.strides = tuple(dim.stride for dim in self.dims)
         self.itemsize = itemsize
-        self.size = np.prod(self.shape)
+        self.size = functools.reduce(operator.mul, self.shape, 1)
         self.extent = self._compute_extent()
         self.flags = self._compute_layout()
 
@@ -272,7 +272,7 @@ class Array(object):
         if order not in 'CFA':
             raise ValueError('order not C|F|A')
 
-        newsize = np.prod(newdims)
+        newsize = functools.reduce(operator.mul, newdims, 1)
 
         if order == 'A':
             order = 'F' if self.is_f_contig else 'C'


### PR DESCRIPTION
This PR replaces the use of `np.prod()` with `functools.reduce` for computing the product of values in a tuple.

For reasonable values of a tuple `shape`, `np.prod(shape)` is significantly slower than `reduce(operator.mul, shape, 1)` -- especially for the more typical case of small `shape`. We run into this bottleneck when constructing `DeviceNDArray` objects from a device pointer in the [cudf](https://github.com/rapidsai/cudf/) project.

## `prod`:

```python
In [1]: import operator, functools

In [2]: import numpy as np

In [3]: shape = tuple(range(1))

In [4]: %timeit np.prod(shape)
3.99 µs ± 10.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [5]: shape = tuple(range(2))

In [6]: %timeit np.prod(shape)
4.02 µs ± 28.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [7]: shape = tuple(range(10))

In [8]: %timeit np.prod(shape)
4.46 µs ± 18.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [9]: shape = tuple(range(100))

In [10]: %timeit np.prod(shape)
8.64 µs ± 11 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [11]: shape = tuple(range(1000))

In [12]: %timeit np.prod(shape)
52.1 µs ± 602 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

## `reduce`:

```python
In [13]: shape = tuple(range(1))

In [14]: %timeit functools.reduce(operator.mul, shape)
153 ns ± 0.0157 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [15]: shape = tuple(range(2))

In [16]: %timeit functools.reduce(operator.mul, shape)
181 ns ± 0.0921 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [17]: shape = tuple(range(10))

In [18]: %timeit functools.reduce(operator.mul, shape)
425 ns ± 0.354 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [19]: shape = tuple(range(100))

In [20]: %timeit functools.reduce(operator.mul, shape)
2.95 µs ± 4.84 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [21]: shape = tuple(range(1000))

In [22]: %timeit functools.reduce(operator.mul, shape)
28.2 µs ± 48.2 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

cc: @seibert @sklam 