### PR TITLE
Prevent taking the GIL in ForAll

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -15,6 +15,7 @@ from numba import config, compiler, types, sigutils
 from numba.typing.templates import AbstractTemplate, ConcreteTemplate
 from numba import funcdesc, typing, utils, serialize
 from numba.compiler_lock import global_compiler_lock
+from numba import cfunc
 
 from .cudadrv.autotune import AutoTuner
 from .cudadrv.devices import get_context
@@ -253,6 +254,10 @@ class ExternFunction(object):
         self.sig = sig
 
 
+@cfunc("uint64(int32)")
+def _b2d_func(tpb):
+    return 0
+
 
 class ForAll(object):
     def __init__(self, kernel, ntasks, tpb, stream, sharedmem):
@@ -285,7 +290,7 @@ class ForAll(object):
             ctx = get_context()
             kwargs = dict(
                 func=kernel._func.get(),
-                b2d_func=lambda tpb: 0,
+                b2d_func=_b2d_func.address,
                 memsize=self.sharedmem,
                 blocksizelimit=1024,
             )


### PR DESCRIPTION
This is the result of a long-running bug and discussion, detailed in https://github.com/rapidsai/ucx-py/issues/187.

To summarize, calling `ForAll` incurs in a `cuOccupancyMaxPotentialBlockSize` that takes two functions pointers, one being the CUDA kernel, and the other a function to calculate the require shared memory. The latter was a Python lambda before this PR, which caused the `cuOccupancyMaxPotentialBlockSize` to ultimately end up trying to take the GIL. To prevent that from happening, we can pass the pointer to a pure C function instead.

I have added no further tests since we could only reproduce this issue on very long and complex pipelines. Suggestions on how we could add tests for this are much appreciated.

Finally, I'm not sure if defining the C function via a `@cfunc` decorator is the preferred way, nor if this is the preferred place for the `_b2d_func` to live, please let me know if not.

cc @quasiben @kkraus14 @shwina @mt-jones @Akshay-Venkatesh @mrocklin