### PR TITLE
add sometrue and alltrue

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -174,6 +174,7 @@ The following methods of Numpy arrays are supported in their basic form
 (without any optional arguments):
 
 * :meth:`~numpy.ndarray.all`
+* :meth:`~numpy.ndarray.alltrue`
 * :meth:`~numpy.ndarray.any`
 * :meth:`~numpy.ndarray.argmax`
 * :meth:`~numpy.ndarray.argmin`
@@ -186,6 +187,7 @@ The following methods of Numpy arrays are supported in their basic form
 * :meth:`~numpy.ndarray.min`
 * :meth:`~numpy.ndarray.nonzero`
 * :meth:`~numpy.ndarray.prod`
+* :meth:`~numpy.ndarray.sometrue`
 * :meth:`~numpy.ndarray.std`
 * :meth:`~numpy.ndarray.take`
 * :meth:`~numpy.ndarray.var`

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -573,6 +573,13 @@ def np_all(a):
     return flat_all
 
 
+@overload(np.alltrue)
+def np_alltrue(a):
+    def impl(a):
+        return np.all(a)
+    return impl
+
+
 @overload(np.any)
 @overload_method(types.Array, "any")
 def np_any(a):
@@ -583,6 +590,13 @@ def np_any(a):
         return False
 
     return flat_any
+
+
+@overload(np.sometrue)
+def np_sometrue(a):
+    def impl(a):
+        return np.any(a)
+    return impl
 
 
 def get_isnan(dtype):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -17,11 +17,17 @@ def array_all(arr):
 def array_all_global(arr):
     return np.all(arr)
 
+def array_alltrue_global(arr):
+    return np.alltrue(arr)
+
 def array_any(arr):
     return arr.any()
 
 def array_any_global(arr):
     return np.any(arr)
+
+def array_sometrue_global(arr):
+    return np.sometrue(arr)
 
 def array_cumprod(arr):
     return arr.cumprod()
@@ -966,7 +972,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
                            array_var, array_var_global,
                            array_std, array_std_global,
                            array_all, array_all_global,
+                           array_alltrue_global,
                            array_any, array_any_global,
+                           array_sometrue_global,
                            array_min, array_min_global,
                            array_max, array_max_global,
                            array_nanmax, array_nanmin,


### PR DESCRIPTION
This PR implements the NumPy functions `np.sometrue` and `np.alltrue`.