### PR TITLE
Update CUDA Array Interface & Enforce Numba compliance

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -94,13 +94,13 @@ include:
 Differences with CUDA Array Interface (Version 0) 
 -------------------------------------------------
 
-The Version 0 of the CUDA Array Interface did not have the optional **mask**
+Version 0 of the CUDA Array Interface did not have the optional **mask**
 attribute to support masked arrays.
 
 
 Differences with CUDA Array Interface (Version 1)
 -------------------------------------------------
 
-The Versions 0 & 1 of the CUDA Array Interface neither clarified the
+Versions 0 and 1 of the CUDA Array Interface neither clarified the
 **strides** attribute for C-contiguous arrays nor specified the treatment for
 zero-size arrays.

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -94,13 +94,13 @@ include:
 Differences with CUDA Array Interface (Version 0) 
 -------------------------------------------------
 
-The version 0 CUDA Array Interface did not have the optional **mask**
+The Version 0 of the CUDA Array Interface did not have the optional **mask**
 attribute to support masked arrays.
 
 
 Differences with CUDA Array Interface (Version 1)
 -------------------------------------------------
 
-The version 0 & 1 CUDA Array Interface neither clarified the **strides**
-attribute for C-contiguous arrays nor specified the treatment for zero-size
-arrays.
+The Versions 0 & 1 of the CUDA Array Interface neither clarified the
+**strides** attribute for C-contiguous arrays nor specified the treatment for
+zero-size arrays.

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -34,8 +34,9 @@ contain the following entries:
 
 - **data**: `(integer, boolean)`
 
-    The **data** is a 2-tuple.  The first element data pointer
+    The **data** is a 2-tuple.  The first element is the data pointer
     as a Python `int` (or `long`).  The data must be device-accessible.
+    For zero-size arrays, use `0` here.
     The second element is the read-only flag as a Python `bool`.
 
     Because the user of the interface may or may not be in the same context,
@@ -49,14 +50,15 @@ contain the following entries:
     An integer for the version of the interface being exported.
     The current version is *2*.
 
-- **strides**: ``None`` or ``(integer, ...)``
-
-    If it is ``None``, the array is in C-contiguous layout. Otherwise, a tuple
-    of `int` (or `long`) is explicitly given for representing the number of
-    bytes to skip to access the next element at each dimension.
-
 
 The following are optional entries:
+
+- **strides**: ``None`` or ``(integer, ...)``
+
+    If **strides** is not given, or it is ``None``, the array is in
+    C-contiguous layout. Otherwise, a tuple of `int` (or `long`) is explicitly
+    given for representing the number of bytes to skip to access the next
+    element at each dimension.
 
 - **descr**
 
@@ -99,5 +101,6 @@ attribute to support masked arrays.
 Differences with CUDA Array Interface (Version 1)
 -------------------------------------------------
 
-The version 0 & 1 CUDA Array Interface did not make the **strides** attribute
-mandatory.
+The version 0 & 1 CUDA Array Interface neither clarified the **strides**
+attribute for C-contiguous arrays nor specified the treatment for zero-size
+arrays.

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -20,8 +20,8 @@ Python Interface Specification
 
 .. note:: Experimental feature.  Specification may change.
 
-The ``__cuda_array_interface__`` attribute is a dictionary-like object that
-must contain the following entries:
+The ``__cuda_array_interface__`` attribute returns a dictionary that must
+contain the following entries:
 
 - **shape**: ``(integer, ...)``
 

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -47,16 +47,16 @@ must contain the following entries:
 - **version**: `integer`
 
     An integer for the version of the interface being exported.
-    The current version is *1*.
-
-
-The following are optional entries:
+    The current version is *2*.
 
 - **strides**: ``None`` or ``(integer, ...)``
 
-    A tuple of `int` (or `long`) representing the number of bytes to skip to
-    access the next element at each dimension. If it is ``None``, the array is
-    assumed to be in C-contiguous layout.
+    If it is ``None``, the array is in C-contiguous layout. Otherwise, a tuple
+    of `int` (or `long`) is explicitly given for representing the number of
+    bytes to skip to access the next element at each dimension.
+
+
+The following are optional entries:
 
 - **descr**
 
@@ -94,3 +94,10 @@ Differences with CUDA Array Interface (Version 0)
 
 The version 0 CUDA Array Interface did not have the optional **mask**
 attribute to support masked arrays.
+
+
+Differences with CUDA Array Interface (Version 1)
+-------------------------------------------------
+
+The version 0 & 1 CUDA Array Interface did not make the **strides** attribute
+mandatory.

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -55,7 +55,7 @@ def from_cuda_array_interface(desc, owner=None):
 
 def as_cuda_array(obj):
     """Create a DeviceNDArray from any object that implements
-    the cuda-array-interface.
+    the :ref:`cuda array interface <cuda-array-interface>`.
 
     A view of the underlying GPU buffer is created.  No copying of the data
     is done.  The resulting DeviceNDArray will acquire a reference from `obj`.
@@ -68,7 +68,7 @@ def as_cuda_array(obj):
 
 
 def is_cuda_array(obj):
-    """Test if the object has defined the `__cuda_array_interface__`.
+    """Test if the object has defined the `__cuda_array_interface__` attribute.
 
     Does not verify the validity of the interface.
     """

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -116,10 +116,20 @@ class DeviceNDArrayBase(object):
 
     @property
     def __cuda_array_interface__(self):
+        if self.device_ctypes_pointer.value is not None:
+            ptr = self.device_ctypes_pointer.value
+        else:
+            ptr = 0
+
+        if array_core(self).flags['C_CONTIGUOUS']:
+            strides = None
+        else:
+            strides = tuple(self.strides)
+
         return {
             'shape': tuple(self.shape),
-            'strides': tuple(self.strides),
-            'data': (self.device_ctypes_pointer.value, False),
+            'strides': strides,
+            'data': (ptr, False),
             'typestr': self.dtype.str,
             'version': 1,
         }

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1746,8 +1746,9 @@ def get_devptr_for_active_ctx(ptr):
     pointer.
     """
     devptr = c_void_p(0)
-    attr = enums.CU_POINTER_ATTRIBUTE_DEVICE_POINTER
-    driver.cuPointerGetAttribute(byref(devptr), attr, ptr)
+    if ptr != 0:
+        attr = enums.CU_POINTER_ATTRIBUTE_DEVICE_POINTER
+        driver.cuPointerGetAttribute(byref(devptr), attr, ptr)
     return devptr
 
 

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -232,7 +232,8 @@ class TestCudaArrayInterface(CUDATestCase):
             if x < N:
                 arr[x] += 1
 
-        add_one[1, 10](c_arr)  # this should pass
+        d_arr = MyArray(c_arr)
+        add_one[1, 10](d_arr)  # this should pass
 
     def test_strides(self):
         # for #4175

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -220,6 +220,21 @@ class TestCudaArrayInterface(CUDATestCase):
         expected_msg = 'Masked arrays are not supported'
         self.assertIn(expected_msg, str(raises.exception))
 
+    def test_zero_size_array(self):
+        # for #4175
+        c_arr = cuda.device_array(0)
+        self.assertEqual(c_arr.__cuda_array_interface__['data'][0], 0)
+
+    def test_strides(self):
+        # for #4175
+        # First, test C-contiguous array
+        c_arr = cuda.device_array((2, 3, 4))
+        self.assertEqual(c_arr.__cuda_array_interface__['strides'], None)
+
+        # Second, test non C-contiguous array
+        c_arr = c_arr[:, 1, :]
+        self.assertNotEqual(c_arr.__cuda_array_interface__['strides'], None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -225,6 +225,15 @@ class TestCudaArrayInterface(CUDATestCase):
         c_arr = cuda.device_array(0)
         self.assertEqual(c_arr.__cuda_array_interface__['data'][0], 0)
 
+        @cuda.jit
+        def add_one(arr):
+            x = cuda.grid(1)
+            N = arr.shape[0]
+            if x < N:
+                arr[x] += 1
+
+        add_one[1, 10](c_arr)  # this should pass
+
     def test_strides(self):
         # for #4175
         # First, test C-contiguous array


### PR DESCRIPTION
Closes #4175. Fixes #4140.

Changes (**UPDATED**): 
- `__cuda_array_interface__` is now always a Python dict (see below)
- clarified that when `strides` is missing or when `strides=None` it's meant to be used as a flag to indicate C contiguity (in line with Numpy's `__array_interface__`, see discussions in #4175 and https://github.com/numba/numba/pull/4609#discussion_r328986919)
- added that the data pointer is `0` for zero-sized arrays
- added two tests for compliance
- bumped `__cuda_array_interface__` version to 2
- updated docs

Note that I slightly modified the language in the doc to enforce `__cuda_array_interface__` to be a Python dict. This allows cleaner treatment on the C/Cython side. For example, instead of
```python
cdef object cu_arr_dict = arr.__cuda_array_interface__
```
we can do 
```python
cdef dict cu_arr_dict = arr.__cuda_array_interface__
```
potentially allowing further optimization by the compiler. While this change again aligns with `__array_interface__` in NumPy and doesn't break backward compatibility with downstream libraries AFAIK, it hasn't been discussed before so I raise it here.

Once this PR is merged, downstream consumers & library providers of `__cuda_array_interface__` should be notified.

cc: @pentschev @stuartarchibald @kkraus14 @dalcinl