### PR TITLE
Fix packaging issue due to missing numba/cext

### DIFF
--- a/numba/cext/__init__.py
+++ b/numba/cext/__init__.py
@@ -1,0 +1,23 @@
+"""
+Utilities for getting information about Numba C extensions
+"""
+
+import os
+
+
+def get_extension_libs():
+    """Return the .c files in the `numba.cext` directory.
+    """
+    libs = []
+    base = get_path()
+    for fn in os.listdir(base):
+        if fn.endswith('.c'):
+            fn = os.path.join(base, fn)
+            libs.append(fn)
+    return libs
+
+
+def get_path():
+    """Returns the path to the directory for `numba.cext`.
+    """
+    return os.path.abspath(os.path.join(os.path.dirname(__file__)))

--- a/numba/pycc/cc.py
+++ b/numba/pycc/cc.py
@@ -12,21 +12,10 @@ from numba import sigutils, typing
 from numba.compiler_lock import global_compiler_lock
 from .compiler import ModuleCompiler, ExportEntry
 from .platform import Toolchain
+from numba import cext
 
 
-def _get_extension_libs():
-    libs = []
-    base = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), '..', 'cext',
-    ))
-    for fn in os.listdir(base):
-        if fn.endswith('.c'):
-            fn = os.path.join(base, fn)
-            libs.append(fn)
-    return libs
-
-
-extension_libs = _get_extension_libs()
+extension_libs = cext.get_extension_libs()
 
 
 class CC(object):


### PR DESCRIPTION
Add `__init__.py` files to ensure `numba/cext` directory is installed.
Move get_extension_libs() into `numba/cext/__init__.py`.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
