### PR TITLE
Make numba.dummyarray.Array iterable

### DIFF
--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -70,6 +70,8 @@ class Dim(object):
             return ret
         else:
             sliced = self[item:item + 1]
+            if sliced.size != 1:
+                raise IndexError
             return Dim(
                 start=sliced.start,
                 stop=sliced.stop,

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -262,6 +262,20 @@ class TestExtent(unittest.TestCase):
         self.assertEqual(len(list(arr[::2].iter_contiguous_extent())), 2)
 
 
+class TestIterate(unittest.TestCase):
+    def test_for_loop(self):
+        # for #4201
+        N = 5
+        nparr = np.empty(N)
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+
+        x = 0  # just a placeholder
+        # this loop should not raise AssertionError
+        for val in arr:
+            x = val
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Fixed #4201. @sklam we need this and #4609 to test Numba device arrays in mpi4py, so I went ahead and fixed it myself. Please take a look. (It doesn't have to be included in 0.46RC, so no rush.)

Thanks!