### PR TITLE
test-suite instrumentation

### DIFF
--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -644,7 +644,7 @@ class ParallelTestRunner(runner.TextTestRunner):
         chunk_size = 500
         splitted_tests = [self._ptests[i:i + chunk_size]
                           for i in range(0, len(self._ptests), chunk_size)]
-
+        t = time.time()
         for tests in splitted_tests:
             pool = multiprocessing.Pool(self.nprocs)
             try:
@@ -664,9 +664,15 @@ class ParallelTestRunner(runner.TextTestRunner):
             finally:
                 # Always join the pool (this is necessary for coverage.py)
                 pool.join()
+        parallel_time = time.time() - t
         if not result.shouldStop:
+            t = time.time()
             stests = SerialSuite(self._stests)
             stests.run(result)
+            serial_time = time.time() - t
+            print()
+            print("Total time parallel tests: '{}'".format(parallel_time))
+            print("Total time serial tests: '{}'".format(serial_time))
             return result
 
     def _run_parallel_tests(self, result, pool, child_runner, tests):
@@ -693,6 +699,8 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     def run(self, test):
         self._ptests, self._stests = _split_nonparallel_tests(test)
+        print("Number of parallel test functions: '{}'".format(len(self._ptests)))
+        print("Total serial test functions: '{}'".format(len(self._stests)))
         # This will call self._run_inner() on the created result object,
         # and print out the detailed test results at the end.
         return super(ParallelTestRunner, self).run(self._run_inner)

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -496,8 +496,9 @@ class DurationLog(object):
             self.duration_log.close()
             self.duration_log = None
 
-    def write_entry(self, test_id, duration):
-        print("{},{}".format(test_id, duration), file=self.duration_log)
+    def write_entry(self, test_id, type_,duration):
+        print("{},{},{}".format(test_id, type_, duration),
+              file=self.duration_log)
 
 
 class ParallelTestResult(runner.TextTestResult):
@@ -538,7 +539,7 @@ class SerialTestResult(runner.TextTestResult):
         end = time.time()
         start = self.test_start_times[test]
         duration = end - start
-        self.duration_log.write_entry(test, duration)
+        self.duration_log.write_entry(test, "serial", duration)
 
 
 class _MinimalResult(object):
@@ -751,6 +752,7 @@ class ParallelTestRunner(runner.TextTestRunner):
                 result.add_results(child_result)
                 remaining_ids.discard(child_result.test_id)
                 self.duration_log.write_entry(child_result.test_id,
+                                              "parallel",
                                               child_result.duration)
                 if child_result.shouldStop:
                     result.shouldStop = True

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -488,6 +488,7 @@ class DurationLog(object):
 
     def open(self):
         self.duration_log = open(self.file_name, "w+")
+        print("name, type, duration", file=self.duration_log)
 
     def close(self):
         if self.duration_log:

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -539,7 +539,9 @@ class SerialTestResult(runner.TextTestResult):
         end = time.time()
         start = self.test_start_times[test]
         duration = end - start
-        self.duration_log.write_entry(test, "serial", duration)
+        function, class_ = str(test).split()
+        test_id = "{}.{}".format(class_.strip("()"), function)
+        self.duration_log.write_entry(test_id, "serial", duration)
 
 
 class _MinimalResult(object):

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -488,7 +488,7 @@ class DurationLog(object):
 
     def open(self):
         self.duration_log = open(self.file_name, "w+")
-        print("name, type, duration", file=self.duration_log)
+        print("name,type,duration", file=self.duration_log)
 
     def close(self):
         if self.duration_log:

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -728,11 +728,24 @@ class ParallelTestRunner(runner.TextTestRunner):
             serial_time = time.time() - t
             result.add_results(sresult)
             print()
+            print("Number of parallel test functions: '{}'".format(len(self._ptests)))
+            print("Total serial test functions: '{}'".format(len(self._stests)))
             print("Total time parallel tests: '{}'".format(parallel_time))
             print("Total time serial tests: '{}'".format(serial_time))
             self.duration_log.close()
             print("Duration log has been written to: '{}'."
                   .format(self.duration_log.file_name))
+            try:
+                import pandas
+            except:
+                "Unable to analyse duration log, please install pandas."
+            else:
+                df = pandas.read_csv("duration_log.csv")
+                pandas.options.display.max_colwidth = 120
+                print("Top 20 functions")
+                print(df.sort_values(by='duration').tail(20))
+                print("Total test functions by type from duration log")
+                print(df.groupby(by='type').count()["name"])
             return result
 
     def _run_parallel_tests(self, result, pool, child_runner, tests):
@@ -762,8 +775,6 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     def run(self, test):
         self._ptests, self._stests = _split_nonparallel_tests(test)
-        print("Number of parallel test functions: '{}'".format(len(self._ptests)))
-        print("Total serial test functions: '{}'".format(len(self._stests)))
         # This will call self._run_inner() on the created result object,
         # and print out the detailed test results at the end.
         return super(ParallelTestRunner, self).run(self._run_inner)


### PR DESCRIPTION
This adds two important metrics to the the test-suite runner:

a) At the start of the test run, print the total number of serial and
parallel tests.

b) At the end of the test-run, print the total time taken for parallel
and for serial tests.