### PR TITLE
Remove multiply defined variables from all blocks' equivalence sets.

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1004,7 +1004,8 @@ class ArrayAnalysis(object):
     def _define(self, equiv_set, var, typ, value):
         self.typemap[var.name] = typ
         self.func_ir._definitions[var.name] = [value]
-        equiv_set.define(var, self.func_ir, typ)
+        redefineds = set()
+        equiv_set.define(var, redefineds, self.func_ir, typ)
 
     def _analyze_inst(self, label, scope, equiv_set, inst, redefined):
         pre = []

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2800,6 +2800,10 @@ class TestParforsMisc(TestParforsBase):
     """
     _numba_parallel_test_ = False
 
+    def check(self, pyfunc, *args, **kwargs):
+        cfunc, cpfunc = self.compile_all(pyfunc, *args)
+        self.check_parfors_vs_others(pyfunc, cfunc, cpfunc, *args, **kwargs)
+
     @skip_unsupported
     def test_no_warn_if_cache_set(self):
 
@@ -2853,6 +2857,17 @@ class TestParforsMisc(TestParforsBase):
             # recover global state
             numba.parfor.sequential_parfor_lowering = old_seq_flag
 
+    @skip_unsupported
+    def test_alias_analysis_for_parfor1(self):
+        def test_impl():
+            acc = 0
+            for _ in range(4):
+                acc += 1
+
+            data = np.zeros((acc,))
+            return data
+
+        self.check(test_impl)
 
 @skip_unsupported
 class TestParforsDiagnostics(TestParforsBase):


### PR DESCRIPTION
Resolves issue #4658. 

If you have something like:
acc = 0
for _ in range(...):
    acc += 1
np.zeros((acc,))

...then the np.zeros block only follows the loop header which has only seen the block with "acc = 0" and so 0 is substituted for the acc in np.zeros.  This PR just says that if any block notices that a variable is multiply defined then remove that variable from every blocks' equivalence set.  In this way, the block containing np.zeros will not see acc in the equivalence set and will not do any replacements.  This is perhaps overly strict in that it would stop valid replacements in prior blocks before a variable was multiply defined but it is the simplest likely to be correct implementation.