### PR TITLE
Fix typo on urem implementation

### DIFF
--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -219,7 +219,7 @@ def np_int_urem_impl(context, builder, sig, args):
     bb_no_if = builder.basic_block
     with cgutils.if_unlikely(builder, den_not_zero):
         bb_if = builder.basic_block
-        mod = builder.srem(num,den)
+        mod = builder.urem(num,den)
 
     result = builder.phi(lty)
     result.add_incoming(ZERO, bb_no_if)


### PR DESCRIPTION
Fix issue #4665. Apparently, there was a typo in the `np_int_urem_impl` which internally was using the signed remainder instruction `srem` instead of the unsigned one `urem`. I still need to write some tests to confirm this.