### PR TITLE
Bump cuda array interface to version 2

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -1,8 +1,8 @@
 .. _cuda-array-interface:
 
-====================
-CUDA Array Interface
-====================
+================================
+CUDA Array Interface (Version 2)
+================================
 
 The *cuda array inteface* is created for interoperability between different
 implementation of GPU array-like objects in various projects.  The idea is
@@ -91,7 +91,7 @@ include:
 .. _numpy array interface: https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.interface.html#__array_interface__
 
 
-Differences with CUDA Array Interface (Version 0) 
+Differences with CUDA Array Interface (Version 0)
 -------------------------------------------------
 
 Version 0 of the CUDA Array Interface did not have the optional **mask**

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -31,7 +31,8 @@ def from_cuda_array_interface(desc, owner=None):
     The resulting DeviceNDArray will acquire a reference from it.
     """
     version = desc.get('version')
-    if version == 1:
+    # Mask introduced in version 1
+    if 1 <= version:
         mask = desc.get('mask')
         # Would ideally be better to detect if the mask is all valid
         if mask is not None:

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -131,7 +131,7 @@ class DeviceNDArrayBase(object):
             'strides': strides,
             'data': (ptr, False),
             'typestr': self.dtype.str,
-            'version': 1,
+            'version': 2,
         }
 
     def bind(self, stream=0):

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -245,6 +245,22 @@ class TestCudaArrayInterface(CUDATestCase):
         c_arr = c_arr[:, 1, :]
         self.assertNotEqual(c_arr.__cuda_array_interface__['strides'], None)
 
+    def test_consuming_strides(self):
+        hostarray = np.arange(10).reshape(2, 5)
+        face = cuda.to_device(hostarray).__cuda_array_interface__
+        self.assertIsNone(face['strides'])
+        np.testing.assert_array_equal(
+            cuda.from_cuda_array_interface(face).copy_to_host(),
+            hostarray,
+        )
+        # Try non-NULL strides
+        face['strides'] = hostarray.strides
+        self.assertIsNotNone(face['strides'])
+        np.testing.assert_array_equal(
+            cuda.from_cuda_array_interface(face).copy_to_host(),
+            hostarray,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -249,17 +249,15 @@ class TestCudaArrayInterface(CUDATestCase):
         hostarray = np.arange(10).reshape(2, 5)
         face = cuda.to_device(hostarray).__cuda_array_interface__
         self.assertIsNone(face['strides'])
-        np.testing.assert_array_equal(
-            cuda.from_cuda_array_interface(face).copy_to_host(),
-            hostarray,
-        )
+        got = cuda.from_cuda_array_interface(face).copy_to_host()
+        np.testing.assert_array_equal(got, hostarray)
+        self.assertTrue(got.flags['C_CONTIGUOUS'])
         # Try non-NULL strides
         face['strides'] = hostarray.strides
         self.assertIsNotNone(face['strides'])
-        np.testing.assert_array_equal(
-            cuda.from_cuda_array_interface(face).copy_to_host(),
-            hostarray,
-        )
+        got = cuda.from_cuda_array_interface(face).copy_to_host()
+        np.testing.assert_array_equal(got, hostarray)
+        self.assertTrue(got.flags['C_CONTIGUOUS'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#4609 bumped the cuda_array_interface version to 2 in the docs but not in the code.
This bumps the version and added an extra test to check that unnecessary non-None strides still works.