### PR TITLE
Add support for np.setxor1d

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -384,6 +384,7 @@ The following top-level functions are supported:
 * :func:`numpy.select` (only using homogeneous lists or tuples for the first
   two arguments, condlist and choicelist). Additionally, these two arguments
   can only contain arrays (unlike Numpy that also accepts tuples).
+* :func:`numpy.setxor1d` (only supports 1D arrays)
 * :func:`numpy.shape`
 * :func:`numpy.sinc`
 * :func:`numpy.sort` (no optional arguments)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4218,3 +4218,41 @@ def cross2d(a, b):
         return _cross2d_operation(a_, b_)
 
     return impl
+
+# ----------------------------------------------------------------------------
+# Set routines
+
+
+@overload(np.setxor1d)
+def np_setxor1d(ar1, ar2, assume_unique=False):
+    if not (type_can_asarray(ar1) and type_can_asarray(ar2)):
+        raise TypingError("Inputs must be array-like")
+
+    if not isinstance(assume_unique, types.Boolean):
+        raise TypingError("Argument `assume_unique` must be boolean")
+
+    if ar1.ndim != 1 or ar2.ndim != 1:
+        raise TypingError(
+            "Only 1D arrays input arrays are supported"
+            )
+
+    def impl(ar1, ar2, assume_unique=False):
+        a = np.asarray(ar1)
+        b = np.asarray(ar2)
+
+        if not assume_unique:
+            a = np.unique(a)
+            b = np.unique(b)
+
+        aux = np.concatenate((a, b))
+        if aux.size == 0:
+            return aux
+
+        aux.sort()
+        flag = np.empty(2 + aux.shape[0] - 1, dtype=np.bool_)
+        flag[0] = True
+        flag[-1] = True
+        flag[1:-1] = aux[1:] != aux[:-1]
+        return aux[flag[1:] & flag[:-1]]
+
+    return impl

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -4232,9 +4232,7 @@ def np_setxor1d(ar1, ar2, assume_unique=False):
         raise TypingError("Argument `assume_unique` must be boolean")
 
     if ar1.ndim != 1 or ar2.ndim != 1:
-        raise TypingError(
-            "Only 1D arrays input arrays are supported"
-            )
+        raise TypingError("Only 1D arrays input arrays are supported")
 
     def impl(ar1, ar2, assume_unique=False):
         a = np.asarray(ar1)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -287,6 +287,10 @@ def np_cross(a, b):
     return np.cross(a, b)
 
 
+def np_setxor1d(a, b, assume_unique=False):
+    return np.setxor1d(a, b, assume_unique)
+
+
 class TestNPFunctions(MemoryLeakMixin, TestCase):
     """
     Tests for various Numpy functions.
@@ -3433,6 +3437,32 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             'Inputs must be array-like.',
             str(raises.exception)
         )
+
+    def test_setxor1d(self):
+        np_pyfunc = np_setxor1d
+        np_nbfunc = njit(np_pyfunc)
+
+        def check(ar1, ar2, assume_unique=False):
+            expected = np_pyfunc(ar1, ar2, assume_unique)
+            got = np_nbfunc(ar1, ar2, assume_unique)
+            self.assertPreciseEqual(expected, got)
+
+        a = np.array([1, 2, 3, 2, 4])
+        b = np.array([2, 3, 5, 7, 5])
+        check(a, b)
+        check(a, b, True)
+
+        a = np.array([])
+        b = np.array([])
+        check(a, b)
+
+        a = np.arange(10).reshape((5, 2))
+        b = np.arange(3)
+        with self.assertRaises(TypingError) as raises:
+            np_nbfunc(a, b, True)
+        self.assertIn(
+                "Only 1D arrays input arrays are supported",
+                str(raises.exception))
 
 
 class TestNPMachineParameters(TestCase):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3461,8 +3461,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             np_nbfunc(a, b, True)
         self.assertIn(
-                "Only 1D arrays input arrays are supported",
-                str(raises.exception))
+            "Only 1D arrays input arrays are supported",
+            str(raises.exception))
 
 
 class TestNPMachineParameters(TestCase):


### PR DESCRIPTION
This PR is adds `np.setxor1d`, which is currently unimplemented according to #4074 

One difference between the implementation here and numpy is that numpy handles non-1d arrays if the argument `assume_unique` is `False`, since the input arrays are run through `np.unique`. If not, then the numpy function fails with errors related to the dimensionality of the arrays at one of the two calls to `np.concatenate`. If the input arrays are of incompatible shape, then they fail at the first call, else they fail at the second when they are concatentated with `[True]`. See:

https://github.com/numpy/numpy/blob/v1.17.0/numpy/lib/arraysetops.py#L436-L476

I do not believe you can test the value of the boolean arg before returning the implementation in the `overload` outer function, you end up with a type unification problem that I can't seem to get around. So I opted to just insist that all inputs are 1d. Let me know if there is a workaround for this that I'm not seeing.