### PR TITLE
Fix numba.jit parameter name signature_or_function

### DIFF
--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -45,7 +45,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
 
     Args
     -----
-    signature:
+    signature_or_function:
         The (optional) signature or list of signatures to be compiled.
         If not passed, required signatures will be compiled when the
         decorated function is called, depending on the argument values.


### PR DESCRIPTION
Documented name `numba.jit(signature=...)` does not match signature `numba.jit(signature_or_function=...)`. Updating docstring.