### PR TITLE
Added support for slice.indices

### DIFF
--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -7,7 +7,7 @@ import itertools
 from llvmlite import ir
 
 from numba.six.moves import zip_longest
-from numba import cgutils, types, typing
+from numba import cgutils, types, typing, utils
 from .imputils import (lower_builtin, lower_getattr,
                        iternext_impl, impl_ret_borrowed,
                        impl_ret_new_ref, impl_ret_untracked)
@@ -214,11 +214,13 @@ def slice_indices(context, builder, sig, args):
     length = args[1]
     sli = context.make_helper(builder, sig.args[0], args[0])
 
-    with builder.if_then(cgutils.is_neg_int(builder, length), likely=False):
-        context.call_conv.return_user_exc(
-            builder, ValueError,
-            ("length should not be negative",)
-        )
+    if utils.IS_PY3:
+        # Negative values allowed in python2.7, see changelog for python 3.4
+        with builder.if_then(cgutils.is_neg_int(builder, length), likely=False):
+            context.call_conv.return_user_exc(
+                builder, ValueError,
+                ("length should not be negative",)
+            )
     with builder.if_then(cgutils.is_scalar_zero(builder, sli.step), likely=False):
         context.call_conv.return_user_exc(
             builder, ValueError,

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -207,3 +207,12 @@ def slice_step_impl(context, builder, typ, value):
         return sli.step
     else:
         return context.get_constant(types.intp, 1)
+
+
+@lower_builtin("slice.indices", types.SliceType, types.Integer)
+def slice_indices(context, builder, sig, args):
+    size = args[1]
+    sli = context.make_helper(builder, sig.args[0], args[0])
+    fix_slice(builder, sli, size)
+    out_tuple = context.make_tuple(builder, sig.return_type, (sli.start, sli.stop, sli.step))
+    return out_tuple

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -234,5 +234,3 @@ def slice_indices(context, builder, sig, args):
         sig.return_type,
         (sli.start, sli.stop, sli.step)
     )
-
-    return out_tuple

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -104,7 +104,8 @@ class TestSlices(TestCase):
                     cfunc(s, l)
                 continue
             if l < 0 and not utils.IS_PY3:
-                # Passing a negative length to slice.indices in python2 is undefined
+                # Passing a negative length to slice.indices in python2 is
+                # undefined. See https://bugs.python.org/issue14794#msg174678
                 continue
             self.assertPreciseEqual(expected, cfunc(s, l))
 

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -54,7 +54,6 @@ class TestSlices(MemoryLeakMixin, TestCase):
                                                         step_cases):
             check(a, b, c, d, e, f)
 
-        self.disable_leak_check()  # Exceptions leak refs
         # Some member is neither integer nor None
         with self.assertRaises(TypeError):
             cfunc(slice(1.5, 1, 1))
@@ -97,8 +96,6 @@ class TestSlices(MemoryLeakMixin, TestCase):
 
         cfunc = jit(nopython=True)(slice_indices)
 
-        self.disable_leak_check()  # Exceptions leak references
-
         for s, l in product(slices, lengths):
             if l < 0 and not utils.IS_PY3:
                 # Passing a negative length to slice.indices in python2 is
@@ -115,8 +112,6 @@ class TestSlices(MemoryLeakMixin, TestCase):
     def test_slice_indices_examples(self):
         """Test that a numba slice returns same result for .indices as a python one."""
         cslice_indices = jit(nopython=True)(slice_indices)
-
-        self.disable_leak_check()  # Exceptions leak references
 
         # slice.indices shouldn't allow negative lengths
         if utils.IS_PY3:

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -726,6 +726,11 @@ class SliceAttribute(AttributeTemplate):
     def resolve_step(self, ty):
         return types.intp
 
+    @bound_function("slice.indices")
+    def resolve_indices(self, ty, args, kws):
+        assert not kws
+        return signature(types.UniTuple(types.intp, 3), types.intp)
+
 
 #-------------------------------------------------------------------------------
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -729,6 +729,15 @@ class SliceAttribute(AttributeTemplate):
     @bound_function("slice.indices")
     def resolve_indices(self, ty, args, kws):
         assert not kws
+        if len(args) != 1:
+            raise TypeError(
+                "indices() takes exactly one argument (%d given)" % len(args)
+            )
+        typ, = args
+        if not isinstance(typ, types.Integer):
+            raise TypeError(
+                "'%s' object cannot be interpreted as an integer" % typ
+            )
         return signature(types.UniTuple(types.intp, 3), types.intp)
 
 


### PR DESCRIPTION
Fixes #1349 

(unless full support would now involve being able to pass `slice`s back to python?)

This PR adds support for the `slice.indices` method in compiled code. This was discussed [a bit on gitter](https://gitter.im/numba/numba?at=5da008c457c2517c6aea1084). It was my first time working with any of the extending code, so this could definitely use a looking over 🤞.