### PR TITLE
BUG: Comparison for literal

### DIFF
--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1051,7 +1051,7 @@ class ArrayAnalysis(object):
             result = result[1]
             (target_shape, pre) = result
             value_shape = equiv_set.get_shape(inst.value)
-            if value_shape is (): # constant
+            if value_shape == (): # constant
                 equiv_set.set_shape_setitem(inst, target_shape)
                 return pre, []
             elif value_shape != None:


### PR DESCRIPTION
Takes care of a warning on import for Python 3.8:
```
numba/numba/array_analysis.py:1054: SyntaxWarning: "is" with a literal. Did you mean "=="?
```