### PR TITLE
[WIP] Making casts explicit in Numba IR

### DIFF
--- a/numba/consts.py
+++ b/numba/consts.py
@@ -86,6 +86,9 @@ class ConstantInference(object):
         elif expr.op == 'build_tuple':
             return tuple(self.infer_constant(i.name, loc=expr.loc) for i in
                          expr.items)
+        elif expr.op == 'cast':
+            # TODO: 4494 this is ignoring the actual cast
+            return self.infer_constant(expr.value.name)
         self._fail(expr)
 
     def _infer_call(self, func, expr):

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -503,14 +503,16 @@ class Expr(Inst):
                    index_var=index_var)
 
     @classmethod
-    def cast(cls, value, loc):
+    def cast(cls, value, loc, incoming=False):
         """
-        A node for implicit casting at the return statement
+        TODO: 4494 a node to cast vars, incoming will tell the typeinferer not to
+         back-propagate type changes of the target
         """
         assert isinstance(value, Var)
         assert isinstance(loc, Loc)
+        assert isinstance(incoming, bool)
         op = 'cast'
-        return cls(op=op, value=value, loc=loc)
+        return cls(op=op, value=value, loc=loc, incoming=incoming)
 
     @classmethod
     def make_function(cls, name, code, closure, defaults, loc):

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -318,7 +318,7 @@ def array_cumprod(context, builder, sig, args):
 
     def array_cumprod_impl(arr):
         out = np.empty(arr.size, dtype)
-        c = 1
+        c = 1   # TODO: 4494 gets picky about (not) casting literals, need constant of right type here
         for idx, v in enumerate(arr.flat):
             c *= v
             out[idx] = c

--- a/numba/targets/hashing.py
+++ b/numba/targets/hashing.py
@@ -32,10 +32,10 @@ if _py34_or_later:
     _PyHASH_INF = sys.hash_info.inf
     _PyHASH_NAN = sys.hash_info.nan
     _PyHASH_MODULUS = _Py_uhash_t(sys.hash_info.modulus)
-    _PyHASH_BITS = 31 if types.intp.bitwidth == 32 else 61  # mersenne primes
+    _PyHASH_BITS = np.uint(31 if types.intp.bitwidth == 32 else 61)  # mersenne primes
     _PyHASH_MULTIPLIER = 0xf4243  # 1000003UL
     _PyHASH_IMAG = _PyHASH_MULTIPLIER
-    _PyLong_SHIFT = sys.int_info.bits_per_digit
+    _PyLong_SHIFT = np.uint(sys.int_info.bits_per_digit)
     _Py_HASH_CUTOFF = sys.hash_info.cutoff
     _Py_hashfunc_name = sys.hash_info.algorithm
 else:
@@ -106,21 +106,22 @@ def _Py_HashDouble(v):
     while (m):
         x = ((x << 28) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - 28)
         m *= 268435456.0  # /* 2**28 */
-        e -= 28
-        y = int(m)  # /* pull out integer part */
+        e = np.int32(e - 28)   # TODO: 4494 should this work w/o explicit cast? Currently
+        #                         int binops always promote to intp
+        y = np.uint(m)  # /* pull out integer part */
         m -= y
         x += y
         if x >= _PyHASH_MODULUS:
             x -= _PyHASH_MODULUS
     # /* adjust for the exponent;  first reduce it modulo _PyHASH_BITS */
     if e >= 0:
-        e = e % _PyHASH_BITS
+        e = np.int32(e % _PyHASH_BITS) # TODO: 4494 should this work w/o explicit cast?
     else:
-        e = _PyHASH_BITS - 1 - ((-1 - e) % _PyHASH_BITS)
+        e = np.int32(_PyHASH_BITS - 1 - ((-1 - e) % _PyHASH_BITS))
 
     x = ((x << e) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - e)
 
-    x = x * sign
+    x = np.uint64(x * sign)
     return process_return(x)
 
 

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -166,7 +166,7 @@ def unichr_usecase(x):
     return unichr(x)
 
 def zip_usecase():
-    result = 0
+    result = 0.     # TODO: 4494 getting picky about literal types
     for i, j in zip((1, 2, 3), (4.5, 6.7)):
         result += i * j
     return result
@@ -185,7 +185,7 @@ def zip_1_usecase():
 
 
 def zip_3_usecase():
-    result = 0
+    result = 0.     # TODO: 4494 getting picky about literal types
     for i, j, k in zip((1, 2), (3, 4, 5), (6.7, 8.9)):
         result += i * j * k
     return result
@@ -965,7 +965,10 @@ class TestBuiltins(TestCase):
             cres = compile_isolated(pow_op_usecase, (typeof(x), typeof(y)),
                                     flags=no_pyobj_flags)
             r = cres.entry_point(x, y)
-            self.assertPreciseEqual(r, pow_op_usecase(x, y))
+            # TODO: 4494 before making casts explicit Numba was closer to
+            #  Python's behaviour, ie pow(2, 3) -> int, pow(2, -3) -> float. Now, (int, int) -> float
+            #  only (int, uint) -> int but that requires explicit casting
+            self.assertEqual(r, pow_op_usecase(x, y))
 
     @tag('important')
     def test_pow_usecase(self):
@@ -980,7 +983,10 @@ class TestBuiltins(TestCase):
             cres = compile_isolated(pow_usecase, (typeof(x), typeof(y)),
                                     flags=no_pyobj_flags)
             r = cres.entry_point(x, y)
-            self.assertPreciseEqual(r, pow_usecase(x, y))
+            # TODO: 4494 before making casts explicit Numba was closer to
+            #  Python's behaviour, ie pow(2, 3) -> int, pow(2, -3) -> float. Now, (int, int) -> float
+            #  only (int, uint) -> int but that requires explicit casting
+            self.assertEqual(r, pow_usecase(x, y))
 
     def _check_min_max(self, pyfunc):
         cfunc = njit()(pyfunc)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -18,7 +18,7 @@ from numba import dictobject, typeof
 from numba.typed import Dict
 from numba.typedobjectutils import _sentry_safe_cast
 from numba.utils import IS_PY3
-from numba.errors import TypingError
+from numba.errors import TypingError, LoweringError
 from .support import TestCase, MemoryLeakMixin, unittest
 
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
@@ -1314,10 +1314,12 @@ class TestDictInferred(TestCase):
             return d
 
         k, v, w = 123, 321, 32.1
-        with self.assertRaises(TypingError) as raises:
+        with self.assertRaises(LoweringError) as raises:
             foo(k, v, w)
+        # TODO: 4494 this error message is a little more confusing than it used to be and
+        #  currently only detected during lowering
         self.assertIn(
-            'cannot safely cast float64 to {}'.format(typeof(v)),
+            'Cannot cast DictType[int64,{}] to DictType[int64,{}]'.format(typeof(v), typeof(w)),
             str(raises.exception),
         )
 
@@ -1330,10 +1332,12 @@ class TestDictInferred(TestCase):
             return d
 
         k, h, v = 123, 123.1, 321
-        with self.assertRaises(TypingError) as raises:
+        with self.assertRaises(LoweringError) as raises:
             foo(k, h, v)
+        # TODO: 4494 this error message is a little more confusing than it used to be and
+        #  currently only detected during lowering
         self.assertIn(
-            'cannot safely cast float64 to {}'.format(typeof(v)),
+            'Cannot cast DictType[{},int64] to DictType[{},int64]'.format(typeof(k), typeof(h)),
             str(raises.exception),
         )
 

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -406,11 +406,11 @@ class TestOperators(TestCase):
                 x_expected = copy.copy(x)
                 got = cfunc(x_got, y)
                 expected = pyfunc(x_expected, y)
-                self.assertPreciseEqual(
+                self.assertEqual(
                     got, expected,
                     msg="mismatch for (%r, %r) with types %s: %r != %r"
                         % (x, y, arg_types, got, expected))
-                self.assertPreciseEqual(
+                self.assertEqual(
                     x_got, x_expected,
                     msg="mismatch for (%r, %r) with types %s: %r != %r"
                         % (x, y, arg_types, x_got, x_expected))

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -179,10 +179,10 @@ def literal_iter_usecase():
 
 
 def enumerated_iter_usecase(x):
-    buf = ""
+    buf = [""]
     scan = 0
     for i, s in enumerate(x):
-        buf += s
+        buf.append(s)
         scan += 1
     return buf, scan
 

--- a/numba/typeconv/rules.py
+++ b/numba/typeconv/rules.py
@@ -34,7 +34,8 @@ def _init_casting_rules(tm):
     tcr.safe_unsafe(types.int16, types.float32)
     tcr.safe_unsafe(types.int32, types.float64)
 
-    tcr.unsafe_unsafe(types.int32, types.float32)
+    # TODO: 4494 trying to get int32 -> float32, same inconsistency as below
+    tcr.safe_unsafe(types.int32, types.float32)
     # XXX this is inconsistent with the above; but we want to prefer
     # float64 over int64 when typing a heterogeneous operation,
     # e.g. `float64 + int64`.  Perhaps we need more granularity in the

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -235,6 +235,9 @@ class Number(Hashable):
         """
         from .. import numpy_support
         if isinstance(other, Number):
+            if isinstance(other, Literal) and not isinstance(self, Literal):
+                # TODO: 4494 if other is literal rely on other's unify method
+                return other.unify(typingctx, self)
             # XXX: this can produce unsafe conversions,
             # e.g. would unify {int64, uint64} to float64
             a = numpy_support.as_dtype(self)

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -585,6 +585,11 @@ class DictType(IterableType):
         if isinstance(other, DictType):
             if not other.is_precise():
                 return self
+            else:
+                unified_kty = typingctx.unify_pairs(self.key_type, other.key_type)
+                unified_vty = typingctx.unify_pairs(self.value_type, other.value_type)
+                if unified_kty and unified_vty:
+                    return DictType(unified_kty, unified_vty)
 
 
 class DictItemsIterableType(SimpleIterableType):

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -221,6 +221,10 @@ class BoundFunction(Callable, Opaque):
         is_param = hasattr(self.template, 'generic')
         return sigs, is_param
 
+    def is_precise(self):
+        return self.this.is_precise()
+
+
 class MakeFunctionLiteral(Literal, Opaque):
     pass
 

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -40,8 +40,12 @@ class RawPointer(Opaque):
 
 
 class StringLiteral(Literal, Dummy):
-    pass
-
+    # TODO: 4494 any reason this was not available?
+    def can_convert_to(self, typingctx, other):
+        # TODO: 4494 any reason casting to unicode is not allowed?
+        conv = typingctx.can_convert(self.literal_type, other)
+        if conv is not None:
+            return max(conv, Conversion.promote)
 
 Literal.ctor_map[str] = StringLiteral
 
@@ -89,6 +93,12 @@ class Omitted(Opaque):
     @property
     def key(self):
         return type(self.value), id(self.value)
+
+    def unify(self, typingctx, other):
+        # TODO: 4494 make Omitted behave like a literal of self.value
+        default_as_literal = literal(self.value)
+        if typingctx.can_convert(default_as_literal, other):
+            return other
 
 
 class VarArg(Type):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -821,10 +821,16 @@ def bound_function(template_key):
             class MethodTemplate(AbstractTemplate):
                 key = template_key
 
-                def generic(_, args, kws):
-                    sig = method_resolver(self, ty, args, kws)
+                @property
+                def this(self):
+                    return self.this
+
+                def generic(_, args, kws):  # TODO: 4494 _/self is a little confusing, right?
+                    # pass the actual type along, bound method might have been defined for an
+                    # abstract type like List
+                    sig = method_resolver(self, _.this, args, kws)
                     if sig is not None and sig.recvr is None:
-                        sig.recvr = ty
+                        sig.recvr = _.this
                     return sig
 
             return types.BoundFunction(MethodTemplate, ty)


### PR DESCRIPTION
This is an attempt at making casts explicit in Numba IR as per [discussion](https://github.com/numba/numba/issues/4494#issuecomment-529674586) following #4494. The idea is to insert explicit casts in the IR in `interpreter.py` for all implict casts that are currently done in `lowering.py`.

This turns-out to be fairly tricky as there are much more casts required than one would expect due to lack of SSA of current Numba IR (for example incoming function arguments). Currently, most rewrites are in shambles (parfors, comprehensions, stencils, jitclasses do not work). Apart from that most tests marked important pass. 

However, there are still some conceptual issues:

1. Literals need to be casted or we need to be super picky about the literal type (ie writing 1 or 1. 
      matters). The former requires changes to many current rewrites the latter will very anoying to the 
      user.
2. There are intrinsics that will no longer work (example `unsafe.getrefcount`). Making the cast of 
      the argument explicit alters the refcount even if the type does not change. Maybe an additional 
     pass removing identity casts should be added.
3. Making casts explicit uncovers a bunch of sublties with number conversions especially with
      `float32` and unsigned integers. 

Overall, I am a little sceptic this can work w/o the IR being SSA. SSA would dramatically reduce the required casts (I'd hope only literals, calls, and phis) and hence the number of corner cases. I do not expect much progress until #4445 has landed.