### PR TITLE
Change get_call_table to support intermediate Vars.

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1088,6 +1088,13 @@ def get_call_table(blocks, call_table=None, reverse_call_table=None, topological
                     if lhs in reverse_call_table:
                         call_var = reverse_call_table[lhs]
                         call_table[call_var].append(rhs.value)
+                if isinstance(rhs, ir.Var):
+                    if lhs in call_table:
+                        call_table[lhs].append(rhs.name)
+                        reverse_call_table[rhs.name] = lhs
+                    if lhs in reverse_call_table:
+                        call_var = reverse_call_table[lhs]
+                        call_table[call_var].append(rhs.name)
             for T, f in call_table_extensions.items():
                 if isinstance(inst, T):
                     f(inst, call_table, reverse_call_table)

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -48,10 +48,11 @@ class StencilPass(object):
         stencil_calls = []
         stencil_dict = {}
         for call_varname, call_list in call_table.items():
-            if len(call_list)==1 and isinstance(call_list[0], StencilFunc):
-                # Remember all calls to StencilFuncs.
-                stencil_calls.append(call_varname)
-                stencil_dict[call_varname] = call_list[0]
+            for one_call in call_list:
+                if isinstance(one_call, StencilFunc):
+                    # Remember all calls to StencilFuncs.
+                    stencil_calls.append(call_varname)
+                    stencil_dict[call_varname] = one_call
         if not stencil_calls:
             return  # return early if no stencil calls found
 

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -523,6 +523,28 @@ class TestStencil(TestStencilBase):
         self.assertNotIn('@do_scheduling', cpfunc.library.get_llvm_str())
 
     @skip_unsupported
+    def test_stencil_nested1(self):
+        """Tests whether nested stencil decorator works.
+        """
+        @njit(parallel=True)
+        def test_impl(n):
+            @stencil
+            def fun(a):
+                c = 2
+                return a[-c+1]
+            B = fun(n)
+            return B
+
+        def test_impl_seq(n):
+            B = np.zeros(len(n), dtype=int)
+            for i in range(1, len(n)):
+                B[i] = n[i-1]
+            return B
+
+        n = np.arange(10)
+        np.testing.assert_equal(test_impl(n), test_impl_seq(n))
+
+    @skip_unsupported
     def test_out_kwarg_w_cval(self):
         """ Issue #3518, out kwarg did not work with cval."""
         # test const value that matches the arg dtype, and one that can be cast


### PR DESCRIPTION
Resolves #4696 

What I did is if there is one intermediate function variable then we put that in the call list.  Then, the stencil code checks if anything in the call list is a StencilFunc.

We should consider the case for multiple intermediate function variables because I don't think this PR would support that.