### PR TITLE
[WIP] Allow cffi value as function arguments

### DIFF
--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -65,6 +65,12 @@ def load_ool_module():
     void vdSin(int n, double* x, double* y);
     void vector_real(numba_complex *c, double *real, int n);
     void vector_imag(numba_complex *c, double *imag, int n);
+
+    void* make_voidptr(void);
+    void use_voidptr(void *ptr);
+
+    int* make_intptr(void);
+    void use_intptr(int*);
     """
 
     source = numba_complex + bool_define + """
@@ -101,6 +107,16 @@ def load_ool_module():
         for (i = 0; i < n; i++)
             imag[i] = c[i].imag;
     }
+
+    void* make_voidptr(void) {
+        return NULL;
+    }
+    void use_voidptr(void *ptr) { }
+
+    int* make_intptr(void) {
+        return NULL;
+    }
+    void use_intptr(int*) { }
     """
 
     ffi = FFI()
@@ -197,3 +213,12 @@ def vector_extract_real(x, y):
 
 def vector_extract_imag(x, y):
     vector_imag(ffi.from_buffer(x), ffi.from_buffer(y), len(x))
+
+
+# For testing unboxing of cffi CData objets
+def make_pointers():
+    return make_voidptr(), make_intptr()
+
+def use_pointers(voidptr, intptr):
+    use_voidptr()
+    use_intptr()

--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -70,7 +70,7 @@ def load_ool_module():
     void use_voidptr(void *ptr);
 
     int* make_intptr(void);
-    void use_intptr(int*);
+    void use_intptr(int *ptr);
     """
 
     source = numba_complex + bool_define + """
@@ -116,7 +116,7 @@ def load_ool_module():
     int* make_intptr(void) {
         return NULL;
     }
-    void use_intptr(int*) { }
+    void use_intptr(int *ptr) { }
     """
 
     ffi = FFI()

--- a/numba/tests/test_cffi.py
+++ b/numba/tests/test_cffi.py
@@ -194,6 +194,10 @@ class TestCFFI(TestCase):
         x = 1.123
         self.assertEqual(foo(x), my_sin(x) + my_sin(x + 1))
 
+    def test_unbox_cdata(self):
+        voidptr, intptr = mod.make_pointers()
+        jit(nopython=True)(mod.use_pointers)(voidptr, intptr)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/types/common.py
+++ b/numba/types/common.py
@@ -10,6 +10,13 @@ class Opaque(Dummy):
     """
     A type that is a opaque pointer.
     """
+    def __init__(self, name, get_pointer=None):
+        self.get_pointer = get_pointer
+        super(Opaque, self).__init__(name)
+
+    @property
+    def key(self):
+        return self.name, self.get_pointer
 
 
 class SimpleIterableType(IterableType):

--- a/numba/types/misc.py
+++ b/numba/types/misc.py
@@ -153,14 +153,15 @@ class CPointer(Type):
     """
     mutable = True
 
-    def __init__(self, dtype):
+    def __init__(self, dtype, get_pointer=None):
         self.dtype = dtype
         name = "%s*" % dtype
+        self.get_pointer = get_pointer
         super(CPointer, self).__init__(name)
 
     @property
     def key(self):
-        return self.dtype
+        return self.dtype, self.get_pointer
 
 
 class EphemeralPointer(CPointer):

--- a/numba/typing/cffi_utils.py
+++ b/numba/typing/cffi_utils.py
@@ -47,6 +47,11 @@ def is_cffi_func(obj):
         except:
             return False
 
+
+def is_cffi_value(obj):
+    return isinstance(obj, cffi.FFI.CData)
+
+
 def get_pointer(cffi_func):
     """
     Get a pointer to the underlying function for a CFFI function as an
@@ -120,9 +125,10 @@ def map_type(cffi_type, use_record_dtype=False):
     elif kind == 'pointer':
         pointee = cffi_type.item
         if pointee.kind == 'void':
-            return types.voidptr
+            return types.RawPointer('void*', get_pointer=get_pointer)
         else:
-            return types.CPointer(primed_map_type(pointee))
+            pointee = primed_map_type(pointee)
+            return types.CPointer(pointee, get_pointer=get_pointer)
     elif kind == 'array':
         dtype = primed_map_type(cffi_type.item)
         nelem = cffi_type.length
@@ -134,6 +140,13 @@ def map_type(cffi_type, use_record_dtype=False):
         if result is None:
             raise TypeError(cffi_type)
         return result
+
+
+def map_typeof(value, use_record_dtype=False):
+    return map_type(
+        ffi.typeof(value),
+        use_record_dtype=use_record_dtype,
+    )
 
 
 def map_struct_to_record_dtype(cffi_type):

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -52,6 +52,8 @@ def typeof_impl(val, c):
             return cffi_utils.make_function_type(val)
         if cffi_utils.is_ffi_instance(val):
             return types.ffi
+        if cffi_utils.is_cffi_value(val):
+            return cffi_utils.map_typeof(val)
 
     return getattr(val, "_numba_type_", None)
 


### PR DESCRIPTION
numba can compile functions that take cffi pointers as arguments, but it can not unbox those values when they are given as cffi CData. This PR fixes this. This is eg useful in libraries that expect a `void* user_data` in some functions.

```python
import numba
import numba.cffi_support
import numpy as np
import cffi

builder = cffi.FFI()

builder.cdef("""
    void* make_foo(void);
    void use_foo(void*);
""")

builder.set_source("_foo_cffi", """
void* make_foo(void) {
    return NULL;
}
void use_foo(void* val) { }
""")
builder.compile()

import _foo_cffi

ffi, lib = _foo_cffi.ffi, _foo_cffi.lib
numba.cffi_support.register_module(_foo_cffi)
make_foo = lib.make_foo
use_foo = lib.use_foo

# This works just fine with the current numba version
@numba.njit
def use_funcs():
    val = make_foo()
    use_foo(val)

# Create pointer a cffi.FFI.CData object
val = make_foo()

# A CPointer or RawPointer
val_type = numba.cffi_support.map_type(ffi.typeof(val))

@numba.njit(numba.void(val_type))
def use_val(val):
    use_foo(val)

# This fails because it can't unbox val.
use_val(val)
```

This PR adds `get_pointer` methods to `CPointer` and `Opaque`, just as currently done in `ExternalFunctionPointer`. This is called when unboxing the values.
Also, we need to extend `typeof`, so that it works for CData objects.