### PR TITLE
Allow array construction with mixed type shape tuples

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3337,8 +3337,13 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
 
     # compute array length
     arrlen = context.get_constant(types.intp, 1)
+    overflow = ir.Constant(ir.IntType(1), 0)
     for s in shapes:
-        arrlen = builder.mul(arrlen, s)
+        arrlen_mult = builder.smul_with_overflow(arrlen, s)
+        arrlen = builder.extract_value(arrlen_mult, 0)
+        overflow = builder.or_(
+            overflow, builder.extract_value(arrlen_mult, 1)
+        )
 
     if arrtype.ndim == 0:
         strides = ()
@@ -3357,7 +3362,20 @@ def _empty_nd_impl(context, builder, arrtype, shapes):
             "Don't know how to allocate array with layout '{0}'.".format(
                 arrtype.layout))
 
-    allocsize = builder.mul(itemsize, arrlen)
+    # Check overflow, numpy also does this after checking order
+    allocsize_mult = builder.smul_with_overflow(arrlen, itemsize)
+    allocsize = builder.extract_value(allocsize_mult, 0)
+    overflow = builder.or_(overflow, builder.extract_value(allocsize_mult, 1))
+
+    with builder.if_then(overflow, likely=False):
+        # Raise same error as numpy, see:
+        # https://github.com/numpy/numpy/blob/2a488fe76a0f732dc418d03b452caace161673da/numpy/core/src/multiarray/ctors.c#L1095-L1101    # noqa: E501
+        context.call_conv.return_user_exc(
+            builder, ValueError,
+            ("array is too big; `arr.size * arr.dtype.itemsize` is larger than"
+             " the maximum possible size.",)
+        )
+
     align = context.get_preferred_array_alignment(arrtype.dtype)
     meminfo = context.nrt.meminfo_alloc_aligned(builder, size=allocsize,
                                                 align=align)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3396,8 +3396,8 @@ def _parse_shape(context, builder, ty, val):
         assert isinstance(ty, types.BaseTuple)
         ndim = ty.count
         intp_t = context.get_value_type(types.intp)
-        shapes = [builder.sext(dims, intp_t) for dims in
-                  cgutils.unpack_tuple(builder, val, count=ndim)]
+        shapes = [builder.sext(d, intp_t) if d.type.width < intp_t.width else d
+                  for d in cgutils.unpack_tuple(builder, val, count=ndim)]
 
     zero = context.get_constant_generic(builder, types.intp, 0)
     for dim in range(ndim):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3395,7 +3395,9 @@ def _parse_shape(context, builder, ty, val):
     else:
         assert isinstance(ty, types.BaseTuple)
         ndim = ty.count
-        shapes = cgutils.unpack_tuple(builder, val, count=ndim)
+        intp_t = context.get_value_type(types.intp)
+        shapes = [builder.sext(dims, intp_t) for dims in
+                  cgutils.unpack_tuple(builder, val, count=ndim)]
 
     zero = context.get_constant_generic(builder, types.intp, 0)
     for dim in range(ndim):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3398,9 +3398,10 @@ def _parse_shape(context, builder, ty, val):
         passed_shapes = cgutils.unpack_tuple(builder, val, count=ndim)
 
     shapes = []
-    maxval = 1 << (context.address_size - 1)
     intp_t = context.get_value_type(types.intp)
+    maxval = 1 << (intp_t.width - 1) - 1
     for s in passed_shapes:
+        cgutils.printf(builder, "%d ", s)
         width = s.type.width
         if width < intp_t.width:
             shapes.append(builder.sext(s, intp_t))
@@ -3411,7 +3412,7 @@ def _parse_shape(context, builder, ty, val):
             is_larger = builder.icmp_signed(">", s, maxval_ir)
             with builder.if_then(is_larger, likely=False):
                 context.call_conv.return_user_exc(
-                    builder, OverflowError,
+                    builder, ValueError,
                     ("Passed array shape is greater than intp typemax for this"
                      " {}-bit system.".format(context.address_size),)
                 )

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3412,7 +3412,7 @@ def _parse_shape(context, builder, ty, val):
         intp_t = context.get_value_type(types.intp)
         intp_width = intp_t.width
         intp_ir = ir.IntType(intp_width)
-        maxval = ir.Constant(intp_ir, ((1 << intp_width- 1) - 1))
+        maxval = ir.Constant(intp_ir, ((1 << intp_width - 1) - 1))
         if src_t.width < intp_width:
             res = builder.sext(src, intp_ir)
         elif src_t.width >= intp_width:

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -621,7 +621,7 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
         # Test for issue #4575
         pyfunc = self.pyfunc
         def func(m, n):
-            return pyfunc((np.int16(m), np.int64(n)))
+            return pyfunc((np.int16(m), np.int32(n)))
         self.check_2d(func)
 
     @tag('important')
@@ -696,7 +696,7 @@ class TestNdFull(ConstructorBaseTest, TestCase):
     def test_2d_shape_dtypes(self):
         # Test for issue #4575
         def func(m, n):
-            return np.full((np.int16(m), np.int64(n)), 4.5)
+            return np.full((np.int16(m), np.int32(n)), 4.5)
         self.check_2d(func)
 
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -575,9 +575,6 @@ class ConstructorBaseTest(NrtRefCtTest):
         with self.assertRaises(ValueError) as cm:
             cfunc(2, -1)
         self.assertEqual(str(cm.exception), "negative dimensions not allowed")
-        if config.IS_32BITS:
-            with self.assertRaises(ValueError):
-                cfunc(1 << (32 - 1), 1)
 
 
 class TestNdZeros(ConstructorBaseTest, TestCase):
@@ -631,6 +628,11 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
         def func2(m, n):
             return pyfunc((np.int64(m), np.int8(n)))
         self.check_2d(func2)
+        # Make sure an error is thrown if we can't downcast safely
+        if config.IS_32BITS:
+            cfunc = nrtjit(lambda m, n: pyfunc((m, n)))
+            with self.assertRaises(ValueError):
+                cfunc(np.int64(1 << (32 - 1)), 1)
 
     @tag('important')
     def test_2d_dtype_kwarg(self):
@@ -710,6 +712,11 @@ class TestNdFull(ConstructorBaseTest, TestCase):
         def func2(m, n):
             return np.full((np.int64(m), np.int8(n)), 4.5)
         self.check_2d(func2)
+        # Make sure an error is thrown if we can't downcast safely
+        if config.IS_32BITS:
+            cfunc = nrtjit(lambda m, n: np.full((m, n), 4.5))
+            with self.assertRaises(ValueError):
+                cfunc(np.int64(1 << (32 - 1)), 1)
 
 
 class ConstructorLikeBaseTest(object):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -617,6 +617,13 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
             return pyfunc((m, n))
         self.check_2d(func)
 
+    def test_2d_shape_dtypes(self):
+        # Test for issue #4575
+        pyfunc = self.pyfunc
+        def func(m, n):
+            return pyfunc((np.int16(m), np.int64(n)))
+        self.check_2d(func)
+
     @tag('important')
     def test_2d_dtype_kwarg(self):
         pyfunc = self.pyfunc
@@ -684,6 +691,12 @@ class TestNdFull(ConstructorBaseTest, TestCase):
         # and that if a dtype is specified, this influences the return type
         def func(m, n):
             return np.full((m, n), 1, dtype=np.int8)
+        self.check_2d(func)
+
+    def test_2d_shape_dtypes(self):
+        # Test for issue #4575
+        def func(m, n):
+            return np.full((np.int16(m), np.int64(n)), 4.5)
         self.check_2d(func)
 
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -576,7 +576,7 @@ class ConstructorBaseTest(NrtRefCtTest):
             cfunc(2, -1)
         self.assertEqual(str(cm.exception), "negative dimensions not allowed")
         if config.IS_32BITS:
-            with self.assertRaises(OverflowError):
+            with self.assertRaises(ValueError):
                 cfunc(1 << (32 - 1), 1)
 
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR allows array constructor functions to accept shape tuples with heterogenous integer types.

I've done this by converting the contents of the shape tuple to integers of `types.intp` width, since that's what's expected downstream by `_empty_nd_impl` here:

https://github.com/numba/numba/blob/ad3303c25133d57127abf8be1cd72d6048f45813/numba/targets/arrayobj.py#L3339-L3341

Fixes #4575, and fixes #4529.

*Update* 

I've modified the original test to not include using a 64 bit integer in the shape tuple. This was due to errors in the 32 bit builds. They (of course) wouldn't allow extending a 64 bit integer to a 32 bit integer.

An alternative approach would be to see if we can safely downcast a value of greater than system width to system width. It might be good to check what numpy does if you've got an 32 bit system, and pass a shape tuple with 64 bit integers.