### PR TITLE
Update choosing the "CUDA_PATH" for windows

### DIFF
--- a/numba/cuda/cuda_paths.py
+++ b/numba/cuda/cuda_paths.py
@@ -129,6 +129,8 @@ def get_cuda_home(*subdirs):
     path.
     """
     cuda_home = os.environ.get('CUDA_HOME')
+    if cuda_home is None:
+        cuda_home = os.environ.get('CUDA_PATH')  # Try Windows CUDA installation without Anaconda
     if cuda_home is not None:
         return os.path.join(cuda_home, *subdirs)
 

--- a/numba/cuda/cuda_paths.py
+++ b/numba/cuda/cuda_paths.py
@@ -130,7 +130,8 @@ def get_cuda_home(*subdirs):
     """
     cuda_home = os.environ.get('CUDA_HOME')
     if cuda_home is None:
-        cuda_home = os.environ.get('CUDA_PATH')  # Try Windows CUDA installation without Anaconda
+        # Try Windows CUDA installation without Anaconda
+        cuda_home = os.environ.get('CUDA_PATH')
     if cuda_home is not None:
         return os.path.join(cuda_home, *subdirs)
 


### PR DESCRIPTION
In Windows, when the CUDA Toolkit is installed, the path in which it is installed is saved as the env variable "CUDA_PATH", which is not recognized in the file. So I made the program to look also in that environmental variable. Now it is working.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
