### PR TITLE
fix Python 2.7 on MacOSX build issue (second attempt)

### DIFF
--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -6,10 +6,9 @@ source activate $CONDA_ENV
 set -v -e
 
 # Check if we are on MACOSX and Python 2.7 and reset -isysroot if so
-UNAME=$(uname -a)
+UNAME=$(uname -s)
 PYVERSION=$(python -V 2>&1 | grep -o "Python \d")
-echo $UNAME
-echo $PYVERSION
+echo $UNAME $PYVERSION
 if [ "$UNAME"  = "Darwin" ] && [ "$PYVERSION" = "Python 2" ]; then
     echo "Will try to fix CFLAGS..."
     export CFLAGS="${CFLAGS} -isysroot /"

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -5,9 +5,10 @@ source activate $CONDA_ENV
 # Make sure any error below is reported as such
 set -v -e
 
-# Check if we are on MACOSX and Python 2.7 and reset -isysroot if so.
-if  [ "$(uname -a)" == "Darwin" ] and \
-    [ "$(python -V 2>&1 | grep -o \"Python \\d\")" == "Python 2" ]; then
+# Check if we are on MACOSX and Python 2.7 and reset -isysroot if so
+UNAME=$(uname -a)
+PYVERSION=$(python -V 2>&1 | grep -o "Python \d")
+if [ "$UNAME"  = "Darwin" ] && [ "$PYVERSION" = "Python 2" ]; then
     export CFLAGS="${CFLAGS} -isysroot /"
 fi
 

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -5,6 +5,12 @@ source activate $CONDA_ENV
 # Make sure any error below is reported as such
 set -v -e
 
+# Check if we are on MACOSX and Python 2.7 and reset -isysroot if so.
+if  [ "$(uname -a)" == "Darwin" ] and \
+    [ "$(python -V 2>&1 | grep -o \"Python \\d\")" == "Python 2" ]; then
+    export CFLAGS="${CFLAGS} -isysroot /"
+fi
+
 # Build numba extensions without silencing compile errors
 python setup.py build_ext -q --inplace
 # (note we don't install to avoid problems with extra long Windows paths

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -8,7 +8,10 @@ set -v -e
 # Check if we are on MACOSX and Python 2.7 and reset -isysroot if so
 UNAME=$(uname -a)
 PYVERSION=$(python -V 2>&1 | grep -o "Python \d")
+echo $UNAME
+echo $PYVERSION
 if [ "$UNAME"  = "Darwin" ] && [ "$PYVERSION" = "Python 2" ]; then
+    echo "Will try to fix CFLAGS..."
     export CFLAGS="${CFLAGS} -isysroot /"
 fi
 


### PR DESCRIPTION
At some point in October 2019 the Python 2.7 Builds on MacOSX started
failing with the following error:

```
/Users/runner/miniconda3/envs/travisci/include/python2.7/Python.h:33:10: fatal error: 'stdio.h' file not found
         ^~~~~~~~~
1 error generated.
```

While it isn't clear where the root cause of this issue lies --- either
with the Anaconda based c-compilers  or with the Microsoft build image
--- this patch

It is to be suspected that the following backport may be involved:

python/cpython#12349

This also means that future releases of Python may actually suffer from
the same issue, so we will have to keep an eye on these.

Hopfully, this patch will no longer be required when Python 2.7 is EOL
in 2020.