### PR TITLE
Update typeconv error message to ask for sys.executable.

### DIFF
--- a/numba/typeconv/typeconv.py
+++ b/numba/typeconv/typeconv.py
@@ -13,10 +13,8 @@ except ImportError as e:
            "are undertaking Numba development work, you may need to re-run:\n\n"
            "python setup.py build_ext --inplace\n\n(Also, please check the "
            "development set up guide %s.)\n\nIf you are not working on Numba "
-           "development:\n%s\nThe original error was: '%s'\n" + dashes + "\nIt "
-           "is not compulsory, but it is incredibly helpful if the following "
-           "is included\nin your error report along with the traceback "
-           "(thanks!):\n\n"
+           "development:\n%s\nThe original error was: '%s'\n" + dashes + "\nIf "
+           "possible please include the following in your error report:\n\n"
            "sys.executable: %s\n")
     raise ImportError(msg % (url, reportme, str(e), sys.executable))
 

--- a/numba/typeconv/typeconv.py
+++ b/numba/typeconv/typeconv.py
@@ -6,14 +6,19 @@ try:
     from . import _typeconv
 except ImportError as e:
     from ..errors import feedback_details as reportme
+    import sys
     url = "http://numba.pydata.org/numba-doc/latest/developer/contributing.html"
+    dashes = '-' * 80
     msg = ("Numba could not be imported.\nIf you are seeing this message and "
            "are undertaking Numba development work, you may need to re-run:\n\n"
            "python setup.py build_ext --inplace\n\n(Also, please check the "
            "development set up guide %s.)\n\nIf you are not working on Numba "
-           "development:\n%s\nThe original error was: '%s'") % \
-           (url, reportme, str(e))
-    raise ImportError(msg)
+           "development:\n%s\nThe original error was: '%s'\n" + dashes + "\nIt "
+           "is not compulsory, but it is incredibly helpful if the following "
+           "is included\nin your error report along with the traceback "
+           "(thanks!):\n\n"
+           "sys.executable: %s\n")
+    raise ImportError(msg % (url, reportme, str(e), sys.executable))
 
 from . import castgraph, Conversion
 from .. import types


### PR DESCRIPTION
Users sometimes report problems importing Numba which are often
caught in the import of `_typeconv`. The root cause is often a
mismatch between the installed Python and the Numba installation,
this patch adds a line to report the system executable such that,
along with the traceback, this situation can be spotted.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
