### PR TITLE
Update `np.arange` implementation with `@overload`

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3800,12 +3800,21 @@ def np_arange(start, stop=None, step=None, dtype=None):
     use_complex = any([isinstance(x, types.Complex)
                        for x in (start, stop, step)])
 
+    start_value = getattr(start, "literal_value", None)
+    stop_value = getattr(stop, "literal_value", None)
+    step_value = getattr(step, "literal_value", None)
+
     def impl(start, stop=None, step=None, dtype=None):
-        _step = step if step is not None else 1
-        if stop is None:
-            _start, _stop = 0, start
+        # Allow for improved performance if given literal arguments.
+        lit_start = start_value if start_value is not None else start
+        lit_stop = stop_value if stop_value is not None else stop
+        lit_step = step_value if step_value is not None else step
+
+        _step = lit_step if lit_step is not None else 1
+        if lit_stop is None:
+            _start, _stop = 0, lit_start
         else:
-            _start, _stop = start, stop
+            _start, _stop = lit_start, lit_stop
 
         nitems_c = (_stop - _start) / _step
         nitems_r = int(math.ceil(nitems_c.real))

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3818,7 +3818,9 @@ def np_arange(start, stop=None, step=None, dtype=None):
 
         nitems_c = (_stop - _start) / _step
         nitems_r = int(math.ceil(nitems_c.real))
-        if use_complex == True:
+
+        # Binary operator needed for compiler branch pruning.
+        if use_complex == True: # noqa 712
             nitems_i = int(math.ceil(nitems_c.imag))
             nitems = max(min(nitems_i, nitems_r), 0)
         else:

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -312,7 +312,7 @@ def iternext_array(context, builder, sig, args, result):
         builder.store(nindex, iterobj.index)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Basic indexing (with integers and slices only)
 
 def basic_indexing(context, builder, aryty, ary, index_types, indices):
@@ -535,7 +535,7 @@ def array_itemset(context, builder, sig, args):
     return context.get_dummy_value()
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Advanced / fancy indexing
 
 
@@ -1404,7 +1404,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     return context.get_dummy_value()
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Shape / layout altering
 
 def vararg_to_tuple(context, builder, sig, args):
@@ -1889,7 +1889,7 @@ def np_shape(a):
         return np.asarray(a).shape
     return impl
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 @overload(np.unique)
@@ -2001,7 +2001,7 @@ def array_view(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Array attributes
 
 @lower_getattr(types.Array, "dtype")
@@ -2182,7 +2182,7 @@ def array_flags_f_contiguous(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # .real / .imag
 
 @lower_getattr(types.Array, "real")
@@ -2271,7 +2271,7 @@ def array_complex_attr(context, builder, typ, value, attr):
     return impl_ret_borrowed(context, builder, resultty, result._getvalue())
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # DType attribute
 
 def dtype_type(context, builder, dtypety, dtypeval):
@@ -2283,7 +2283,7 @@ lower_getattr(types.DType, 'type')(dtype_type)
 lower_getattr(types.DType, 'kind')(dtype_type)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Structured / record lookup
 
 @lower_getattr_generic(types.Array)
@@ -2417,7 +2417,7 @@ def record_setitem(context, builder, sig, args):
     return impl(builder, (rec, val))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Constant arrays and records
 
 
@@ -2447,7 +2447,7 @@ def constant_bytes(context, builder, ty, pyval):
     buf = np.array(bytearray(pyval), dtype=np.uint8)
     return context.make_constant_array(builder, ty, buf)
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Comparisons
 
 
@@ -2465,7 +2465,7 @@ def array_is(context, builder, sig, args):
     return context.compile_internal(builder, array_is_impl, sig, args)
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # builtin `np.flat` implementation
 
 def make_array_flat_cls(flatiterty):
@@ -3671,7 +3671,7 @@ def numpy_diag_kwarg(context, builder, sig, args):
     elif arg.ndim == 2:
         # matrix context
         def diag_impl(arr, k=0):
-            #Will return arr.diagonal(v, k) when axis args are supported
+            # Will return arr.diagonal(v, k) when axis args are supported
             rows, cols = arr.shape
             if k < 0:
                 rows = rows + k
@@ -3687,7 +3687,7 @@ def numpy_diag_kwarg(context, builder, sig, args):
                     ret[i] = arr[i - k, i]
             return ret
     else:
-        #invalid input
+        # invalid input
         raise ValueError("Input must be 1- or 2-d.")
 
     res = context.compile_internal(builder, diag_impl, sig, args)
@@ -3716,7 +3716,7 @@ def numpy_take_2(context, builder, sig, args):
     def take_impl(a, indices):
         ret = np.empty(indices.size, dtype=a.dtype)
         if F_order:
-            walker = indices.copy() # get C order
+            walker = indices.copy()  # get C order
         else:
             walker = indices
         it = np.nditer(walker)
@@ -3765,7 +3765,7 @@ def _arange_dtype(*args):
         dtype = types.float64
     else:
         dtype = max(bounds)
-    
+
     return dtype
 
 
@@ -3826,7 +3826,7 @@ def np_arange(start, stop=None, step=None, dtype=None):
     if (not isinstance(start, types.Number) or
         not isinstance(stop, (types.NoneType, types.Number)) or
         not isinstance(step, (types.NoneType, types.Number)) or
-        not isinstance(dtype, (types.NoneType, types.DTypeSpec))):
+            not isinstance(dtype, (types.NoneType, types.DTypeSpec))):
 
         return
 
@@ -3835,7 +3835,8 @@ def np_arange(start, stop=None, step=None, dtype=None):
     else:
         true_dtype = dtype.dtype
 
-    use_complex = any([isinstance(x, types.Complex) for x in (start, stop, step)]) 
+    use_complex = any([isinstance(x, types.Complex)
+                       for x in (start, stop, step)])
     if use_complex:
         def impl(start, stop=None, step=None, dtype=None):
             return _arange_impl_complex(start, stop, step, true_dtype)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3778,8 +3778,8 @@ def _arange_impl_complex(_start, _stop, _step, dtype):
         start, stop = _start, _stop
 
     nitems_c = (stop - start) / step
-    nitems_r = math.ceil(nitems_c.real)
-    nitems_i = math.ceil(nitems_c.imag)
+    nitems_r = int(math.ceil(nitems_c.real))
+    nitems_i = int(math.ceil(nitems_c.imag))
     nitems = max(min(nitems_i, nitems_r), 0)
     arr = np.empty(nitems, dtype)
     val = start
@@ -3797,7 +3797,7 @@ def _arange_impl_real(_start, _stop, _step, dtype):
     else:
         start, stop = _start, _stop
 
-    nitems_r = math.ceil((stop - start) / step)
+    nitems_r = int(math.ceil((stop - start) / step))
     nitems = max(nitems_r, 0)
     arr = np.empty(nitems, dtype)
     val = start

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -312,7 +312,7 @@ def iternext_array(context, builder, sig, args, result):
         builder.store(nindex, iterobj.index)
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Basic indexing (with integers and slices only)
 
 def basic_indexing(context, builder, aryty, ary, index_types, indices):
@@ -535,7 +535,7 @@ def array_itemset(context, builder, sig, args):
     return context.get_dummy_value()
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Advanced / fancy indexing
 
 
@@ -1404,7 +1404,7 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
     return context.get_dummy_value()
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Shape / layout altering
 
 def vararg_to_tuple(context, builder, sig, args):
@@ -1889,7 +1889,7 @@ def np_shape(a):
         return np.asarray(a).shape
     return impl
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 
 @overload(np.unique)
@@ -2001,7 +2001,7 @@ def array_view(context, builder, sig, args):
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Array attributes
 
 @lower_getattr(types.Array, "dtype")
@@ -2182,7 +2182,7 @@ def array_flags_f_contiguous(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # .real / .imag
 
 @lower_getattr(types.Array, "real")
@@ -2271,7 +2271,7 @@ def array_complex_attr(context, builder, typ, value, attr):
     return impl_ret_borrowed(context, builder, resultty, result._getvalue())
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # DType attribute
 
 def dtype_type(context, builder, dtypety, dtypeval):
@@ -2283,7 +2283,7 @@ lower_getattr(types.DType, 'type')(dtype_type)
 lower_getattr(types.DType, 'kind')(dtype_type)
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Structured / record lookup
 
 @lower_getattr_generic(types.Array)
@@ -2417,7 +2417,7 @@ def record_setitem(context, builder, sig, args):
     return impl(builder, (rec, val))
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Constant arrays and records
 
 
@@ -2447,7 +2447,7 @@ def constant_bytes(context, builder, ty, pyval):
     buf = np.array(bytearray(pyval), dtype=np.uint8)
     return context.make_constant_array(builder, ty, buf)
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Comparisons
 
 
@@ -2465,7 +2465,7 @@ def array_is(context, builder, sig, args):
     return context.compile_internal(builder, array_is_impl, sig, args)
 
 
-# -------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # builtin `np.flat` implementation
 
 def make_array_flat_cls(flatiterty):
@@ -3320,7 +3320,7 @@ def iternext_numpy_nditer2(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, result)
 
 
-# -----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Numpy array constructors
 
 def _empty_nd_impl(context, builder, arrtype, shapes):
@@ -3764,7 +3764,7 @@ def _arange_dtype(*args):
     elif any(isinstance(a, types.Float) for a in bounds):
         dtype = types.float64
     else:
-        dtype = max(bounds)
+        dtype = types.intp
 
     return dtype
 
@@ -3820,7 +3820,6 @@ def np_arange(start, stop=None, step=None, dtype=None):
             arr[i] = val
             val += _step
         return arr
-
 
     return impl
 
@@ -4803,7 +4802,7 @@ def array_dot(arr, other):
     return dot_impl
 
 
-# -----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Sorting
 
 _sorts = {}
@@ -4876,7 +4875,7 @@ def array_argsort(context, builder, sig, args):
                                     innersig, innerargs)
 
 
-# -----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Implicit cast
 
 @lower_cast(types.Array, types.Array)
@@ -4886,7 +4885,7 @@ def array_to_array(context, builder, fromty, toty, val):
     return val
 
 
-# -----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Stride tricks
 
 def reshape_unchecked(a, shape, strides):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3820,7 +3820,7 @@ def np_arange(start, stop=None, step=None, dtype=None):
         nitems_r = int(math.ceil(nitems_c.real))
 
         # Binary operator needed for compiler branch pruning.
-        if use_complex == True: # noqa 712
+        if use_complex is True:
             nitems_i = int(math.ceil(nitems_c.imag))
             nitems = max(min(nitems_i, nitems_r), 0)
         else:

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -765,6 +765,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         def check_ok(arg0):
             expected = pyfunc(arg0)
             got = cfunc(arg0)
+            self.assertEqual(got.dtype, expected.dtype)
             self.assertPreciseEqual(got, expected, prec="double")
         
         check_ok(0)
@@ -778,6 +779,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         def check_ok(arg0, arg1, pyfunc, cfunc):
             expected = pyfunc(arg0, arg1)
             got = cfunc(arg0, arg1)
+            self.assertEqual(got.dtype, expected.dtype)
             self.assertPreciseEqual(got, expected, prec="double")
 
         for pyfunc in (np_arange_2, np_arange_start_stop, np_arange_1_stop, np_arange_1_step):
@@ -804,6 +806,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         def check_ok(arg0, arg1, arg2, pyfunc, cfunc):
             expected = pyfunc(arg0, arg1, arg2)
             got = cfunc(arg0, arg1, arg2)
+            self.assertEqual(got.dtype, expected.dtype)
             self.assertPreciseEqual(got, expected, prec="double")
         
         for pyfunc in (np_arange_3, np_arange_2_step, np_arange_start_stop_step):
@@ -834,6 +837,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             def check_ok(arg0, arg1, arg2, arg3):
                 expected = pyfunc(arg0, arg1, arg2, arg3)
                 got = cfunc(arg0, arg1, arg2, arg3)
+                self.assertEqual(got.dtype, expected.dtype)
                 self.assertPreciseEqual(got, expected, prec="double")
             
             check_ok(0, 5, 1, np.float64)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -86,6 +86,42 @@ def array_take(arr, indices):
 def array_take_kws(arr, indices, axis):
     return arr.take(indices, axis=axis)
 
+def np_arange_1(arg0):
+    return np.arange(arg0)
+
+def np_arange_2(arg0, arg1):
+    return np.arange(arg0, arg1)
+
+def np_arange_3(arg0, arg1, arg2):
+    return np.arange(arg0, arg1, arg2)
+
+def np_arange_4(arg0, arg1, arg2, arg3):
+    return np.arange(arg0, arg1, arg2, arg3)
+
+def np_arange_1_stop(arg0, stop):
+    return np.arange(arg0, stop=stop)
+
+def np_arange_1_step(arg0, step):
+    return np.arange(arg0, step=step)
+
+def np_arange_1_dtype(arg0, dtype):
+    return np.arange(arg0, dtype=dtype)
+
+def np_arange_2_step(arg0, arg1, step):
+    return np.arange(arg0, arg1, step=step)
+
+def np_arange_2_dtype(arg0, arg1, dtype):
+    return np.arange(arg0, arg1, dtype=dtype)
+
+def np_arange_start_stop(start, stop):
+    return np.arange(start=start, stop=stop)
+
+def np_arange_start_stop_step(start, stop, step):
+    return np.arange(start=start, stop=stop, step=step)
+
+def np_arange_start_stop_step_dtype(start, stop, step, dtype):
+    return np.arange(start=start, stop=stop, step=step, dtype=dtype)
+    
 def array_fill(arr, val):
     return arr.fill(val)
 
@@ -721,6 +757,120 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                 condition = x > x_mean
                 params = (condition, x, y)
                 check_ok(params)
+
+    def test_arange_1_arg(self):
+        pyfunc = np_arange_1
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check_ok(arg0):
+            expected = pyfunc(arg0)
+            got = cfunc(arg0)
+            self.assertPreciseEqual(got, expected, prec="double")
+        
+        check_ok(0)
+        check_ok(1)
+        check_ok(4)
+        check_ok(5.5)
+        check_ok(-3)
+        check_ok(np.complex(4, 4))
+    
+    def test_arange_2_arg(self):
+        def check_ok(arg0, arg1, pyfunc, cfunc):
+            expected = pyfunc(arg0, arg1)
+            got = cfunc(arg0, arg1)
+            self.assertPreciseEqual(got, expected, prec="double")
+
+        for pyfunc in (np_arange_2, np_arange_start_stop, np_arange_1_stop, np_arange_1_step):
+            cfunc = jit(nopython=True)(pyfunc)
+            
+            check_ok(0, 5, pyfunc, cfunc)
+            check_ok(-8, -1, pyfunc, cfunc)
+            check_ok(4, 0.5, pyfunc, cfunc)
+            check_ok(0.5, 4, pyfunc, cfunc)
+            check_ok(np.complex(1, 1), np.complex(4, 4), pyfunc, cfunc)
+            check_ok(np.complex(4, 4), np.complex(1, 1), pyfunc, cfunc)
+            check_ok(3, None, pyfunc, cfunc)
+        
+        pyfunc = np_arange_1_dtype
+        cfunc = jit(nopython=True)(pyfunc)
+
+        check_ok(5, np.float32, pyfunc, cfunc)
+        check_ok(2.0, np.int32, pyfunc, cfunc)
+        check_ok(10, np.complex128, pyfunc, cfunc)                        
+        check_ok(np.complex64(10), np.complex128, pyfunc, cfunc)                        
+        check_ok(7, None, pyfunc, cfunc)                        
+
+    def test_arange_3_arg(self):
+        def check_ok(arg0, arg1, arg2, pyfunc, cfunc):
+            expected = pyfunc(arg0, arg1, arg2)
+            got = cfunc(arg0, arg1, arg2)
+            self.assertPreciseEqual(got, expected, prec="double")
+        
+        for pyfunc in (np_arange_3, np_arange_2_step, np_arange_start_stop_step):
+            cfunc = jit(nopython=True)(pyfunc)
+
+            check_ok(0, 5, 1, pyfunc, cfunc)
+            check_ok(-8, -1, 3, pyfunc, cfunc)
+            check_ok(0, -10, -2, pyfunc, cfunc)
+            check_ok(0.5, 4, 2, pyfunc, cfunc)
+            check_ok(0, 1, 0.1, pyfunc, cfunc)
+            check_ok(0, np.complex(4, 4), np.complex(1, 1), pyfunc, cfunc)
+            check_ok(3, 6, None, pyfunc, cfunc)
+            check_ok(3, None, None, pyfunc, cfunc)
+
+        pyfunc = np_arange_2_dtype
+        cfunc = jit(nopython=True)(pyfunc)
+
+        check_ok(1, 5, np.float32, pyfunc, cfunc)
+        check_ok(2.0, 8, np.int32, pyfunc, cfunc)
+        check_ok(-2, 10, np.complex128, pyfunc, cfunc)                        
+        check_ok(3, np.complex64(10), np.complex128, pyfunc, cfunc)                        
+        check_ok(1, 7, None, pyfunc, cfunc)                        
+
+    def test_arange_4_arg(self):
+        for pyfunc in (np_arange_4, np_arange_start_stop_step_dtype):
+            cfunc = jit(nopython=True)(pyfunc)
+
+            def check_ok(arg0, arg1, arg2, arg3):
+                expected = pyfunc(arg0, arg1, arg2, arg3)
+                got = cfunc(arg0, arg1, arg2, arg3)
+                self.assertPreciseEqual(got, expected, prec="double")
+            
+            check_ok(0, 5, 1, np.float64)
+            check_ok(-8, -1, 3, np.int32)
+            check_ok(0, -10, -2, np.float32)
+            check_ok(0.5, 4, 2, None)
+            check_ok(0, 1, 0.1, np.complex128)
+            check_ok(0, np.complex(4, 4), np.complex(1, 1), np.complex128)
+            check_ok(3, 6, None, None)
+            check_ok(3, None, None, None)
+
+    def test_arange_throws(self):
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        bad_funcs_1 = [
+            lambda x: np.arange(stop=x),
+            lambda x: np.arange(step=x),
+            lambda x: np.arange(dtype=x),
+        ]
+        bad_funcs_2 = [
+            lambda x, y: np.arange(stop=x, step=y),
+            lambda x, y: np.arange(stop=x, dtype=y),
+        ]
+
+        for pyfunc in bad_funcs_1:
+            with self.assertRaises(TypingError) as raises:
+                cfunc = jit(nopython=True)(pyfunc)
+                cfunc(2)
+            for keyword in ["missing", "argument", "start"]:
+                self.assertIn(keyword, str(raises.exception))
+        for pyfunc in bad_funcs_2:
+            with self.assertRaises(TypingError) as raises:
+                cfunc = jit(nopython=True)(pyfunc)
+                cfunc(2, 6)
+            for keyword in ["missing", "argument", "start"]:
+                self.assertIn(keyword, str(raises.exception))
 
     def test_item(self):
         pyfunc = array_item

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -863,14 +863,10 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
             with self.assertRaises(TypingError) as raises:
                 cfunc = jit(nopython=True)(pyfunc)
                 cfunc(2)
-            for keyword in ["missing", "argument", "start"]:
-                self.assertIn(keyword, str(raises.exception))
         for pyfunc in bad_funcs_2:
             with self.assertRaises(TypingError) as raises:
                 cfunc = jit(nopython=True)(pyfunc)
                 cfunc(2, 6)
-            for keyword in ["missing", "argument", "start"]:
-                self.assertIn(keyword, str(raises.exception))
 
     def test_item(self):
         pyfunc = array_item

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -37,6 +37,7 @@ def lift2(x):
 
 def lift3(x):
     # Output variable from the loop
+    _ = object()
     a = np.arange(5, dtype=np.int64)
     c = 0
     for i in range(a.shape[0]):
@@ -45,6 +46,7 @@ def lift3(x):
 
 def lift4(x):
     # Output two variables from the loop
+    _ = object()
     a = np.arange(5, dtype=np.int64)
     c = 0
     d = 0
@@ -54,6 +56,7 @@ def lift4(x):
     return c + d
 
 def lift5(x):
+    _ = object()
     a = np.arange(4)
     for i in range(a.shape[0]):
         # Inner has a break statement
@@ -86,13 +89,14 @@ def reject1(x):
 
 
 def reject_gen1(x):
+    _ = object()
     a = np.arange(4)
     for i in range(a.shape[0]):
         # Inner is a generator => cannot loop-lift
         yield a[i]
 
 def reject_gen2(x):
-    # Outer needs object mode because of np.empty()
+    _ = object()
     a = np.arange(3)
     for i in range(a.size):
         # Middle has a yield => cannot loop-lift
@@ -106,8 +110,8 @@ def reject_gen2(x):
 def reject_npm1(x):
     a = np.empty(3, dtype=np.int32)
     for i in range(a.size):
-        # Inner uses np.arange() => cannot loop-lift unless
-        # enable_pyobject_looplift is enabled.
+        # Inner uses object() => cannot loop-lift
+        _ = object()
         a[i] = np.arange(i + 1)[i]
 
     return a

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -633,28 +633,6 @@ def _infer_dtype_from_inputs(inputs):
     return dtype
 
 
-@infer_global(np.arange)
-class NdArange(AbstractTemplate):
-
-    def generic(self, args, kws):
-        assert not kws
-        if len(args) >= 4:
-            dtype = _parse_dtype(args[3])
-            bounds = args[:3]
-        else:
-            bounds = args
-            if any(isinstance(arg, types.Complex) for arg in bounds):
-                dtype = types.complex128
-            elif any(isinstance(arg, types.Float) for arg in bounds):
-                dtype = types.float64
-            else:
-                dtype = max(bounds)
-        if not all(isinstance(arg, types.Number) for arg in bounds):
-            return
-        return_type = types.Array(ndim=1, dtype=dtype, layout='C')
-        return signature(return_type, *args)
-
-
 @infer_global(np.linspace)
 class NdLinspace(AbstractTemplate):
 


### PR DESCRIPTION
This lets us more easily handle a wider range of use cases,
such as `np.arange(5, dtype=np.float32)`.

Addresses https://github.com/numba/numba/issues/4659
