### PR TITLE
Fix and enable idle tests from test_array_manipulation

### DIFF
--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -37,7 +37,7 @@ def from_generic(pyfuncs_to_use):
     """
     def decorator(func):
         def result(*args, **kwargs):
-            return (func(pyfunc, *args, **kwargs) for pyfunc in pyfuncs_to_use)
+            return [func(pyfunc, *args, **kwargs) for pyfunc in pyfuncs_to_use]
         return result
     return decorator
 

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -312,6 +312,9 @@ class ArrayAttribute(AttributeTemplate):
                 assert ary.ndim == 1
                 return signature(ary, *args)
 
+            if isinstance(shape, types.NoneType):
+                return signature(self.resolve_T(ary))
+
             shape = normalize_shape(shape)
             if shape is None:
                 return


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Function `from_generic` in test_array_manipulation returns generator that don't consumed in some tests. Thus, such test don't actually run.
After enabling it, one test fails and it requires small fix in
`resolve_transpose` from `numba/typing/arraydecl.py`