### PR TITLE
Fix transpose output array layout

### DIFF
--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -76,8 +76,18 @@ def numpy_transpose_array(a):
 def numpy_transpose_array_axes_kwarg(arr, axes):
     return np.transpose(arr, axes=axes)
 
+
+def numpy_transpose_array_axes_kwarg_copy(arr, axes):
+    return np.transpose(arr, axes=axes).copy()
+
+
 def array_transpose_axes(arr, axes):
     return arr.transpose(axes)
+
+
+def array_transpose_axes_copy(arr, axes):
+    return arr.transpose(axes).copy()
+
 
 def squeeze_array(a):
     return a.squeeze()
@@ -266,7 +276,9 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
     def test_array_transpose_axes(self):
         pyfuncs_to_use = [numpy_transpose_array_axes_kwarg,
-                          array_transpose_axes]
+                          numpy_transpose_array_axes_kwarg_copy,
+                          array_transpose_axes,
+                          array_transpose_axes_copy]
 
         def run(pyfunc, arr, axes):
             cres = self.ccache.compile(pyfunc, (typeof(arr), typeof(axes)))

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -317,14 +317,14 @@ class ArrayAttribute(AttributeTemplate):
                 return
 
             assert ary.ndim == shape.count
-            return signature(self.resolve_T(ary), shape)
+            return signature(self.resolve_T(ary).copy(layout="A"), shape)
 
         else:
             if any(not sentry_shape_scalar(a) for a in args):
                 raise TypeError("transpose({0}) is not supported".format(
                     ', '.join(args)))
             assert ary.ndim == len(args)
-            return signature(self.resolve_T(ary), *args)
+            return signature(self.resolve_T(ary).copy(layout="A"), *args)
 
     @bound_function("array.copy")
     def resolve_copy(self, ary, args, kws):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
When transpose called layout always changed from `'F'` to `'C'` and from `'C'` to `'F'`. But in some cases it is wrong behavior, e.g. when call `.transpose(0, 1)` on 2d array.
This PR set `'A'` layout when transposition with custom `axes` arg performed. 

_Note_: In some cases layout can differ from numpy result. To match numpy behavior we need to resolve layout on runtime, not compile-time.
  
Ref #4708 #4764