### PR TITLE
Implement np.gcd and math.gcd

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -604,6 +604,7 @@ Math operations
  square              Yes          Yes
  reciprocal          Yes          Yes
  conjugate           Yes          Yes
+ gcd                 Yes          Yes
 ==============  =============  ===============
 
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -671,6 +671,7 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.floor`
 * :func:`math.frexp`
 * :func:`math.gamma`
+* :func:`math.gcd`
 * :func:`math.hypot`
 * :func:`math.isfinite`
 * :func:`math.isinf`

--- a/numba/targets/mathimpl.py
+++ b/numba/targets/mathimpl.py
@@ -433,14 +433,9 @@ def _unsigned(T):
 def _unsigned_impl(T):
     if T in types.unsigned_domain:
         return lambda T: T
-    elif T is types.int8:
-        return lambda T: types.uint8(T)
-    elif T is types.int16:
-        return lambda T: types.uint16(T)
-    elif T is types.int32:
-        return lambda T: types.uint32(T)
-    elif T is types.int64:
-        return lambda T: types.uint64(T)
+    elif T in types.signed_domain:
+        newT = getattr(types, 'uint{}'.format(T.bitwidth))
+        return lambda T: newT(T)
 
 
 def gcd_impl(context, builder, sig, args):

--- a/numba/targets/npyfuncs.py
+++ b/numba/targets/npyfuncs.py
@@ -462,6 +462,14 @@ def np_complex_power_impl(context, builder, sig, args):
 
 
 ########################################################################
+# numpy greatest common denominator
+
+def np_gcd_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 2)
+    return mathimpl.gcd_impl(context, builder, sig, args)
+
+
+########################################################################
 # Numpy style complex sign
 
 def np_complex_sign_impl(context, builder, sig, args):

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -272,16 +272,19 @@ def _fill_ufunc_db(ufunc_db):
         'DD->D': npyfuncs.np_complex_power_impl,
     }
 
-    ufunc_db[np.gcd] = {
-        'bb->b': npyfuncs.np_gcd_impl,
-        'BB->B': npyfuncs.np_gcd_impl,
-        'hh->h': npyfuncs.np_gcd_impl,
-        'HH->H': npyfuncs.np_gcd_impl,
-        'ii->i': npyfuncs.np_gcd_impl,
-        'II->I': npyfuncs.np_gcd_impl,
-        'll->l': npyfuncs.np_gcd_impl,
-        'LL->L': npyfuncs.np_gcd_impl,
-    }
+    if v >= (1, 15):
+        ufunc_db[np.gcd] = {
+            'bb->b': npyfuncs.np_gcd_impl,
+            'BB->B': npyfuncs.np_gcd_impl,
+            'hh->h': npyfuncs.np_gcd_impl,
+            'HH->H': npyfuncs.np_gcd_impl,
+            'ii->i': npyfuncs.np_gcd_impl,
+            'II->I': npyfuncs.np_gcd_impl,
+            'll->l': npyfuncs.np_gcd_impl,
+            'LL->L': npyfuncs.np_gcd_impl,
+            'qq->q': npyfuncs.np_gcd_impl,
+            'QQ->Q': npyfuncs.np_gcd_impl,
+        }
 
     ufunc_db[np.rint] = {
         'f->f': npyfuncs.np_real_rint_impl,

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -272,6 +272,17 @@ def _fill_ufunc_db(ufunc_db):
         'DD->D': npyfuncs.np_complex_power_impl,
     }
 
+    ufunc_db[np.gcd] = {
+        'bb->b': npyfuncs.np_gcd_impl,
+        'BB->B': npyfuncs.np_gcd_impl,
+        'hh->h': npyfuncs.np_gcd_impl,
+        'HH->H': npyfuncs.np_gcd_impl,
+        'ii->i': npyfuncs.np_gcd_impl,
+        'II->I': npyfuncs.np_gcd_impl,
+        'll->l': npyfuncs.np_gcd_impl,
+        'LL->L': npyfuncs.np_gcd_impl,
+    }
+
     ufunc_db[np.rint] = {
         'f->f': npyfuncs.np_real_rint_impl,
         'd->d': npyfuncs.np_real_rint_impl,

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -243,6 +243,13 @@ class TestBuiltins(TestCase):
         for x in complex_values:
             self.assertPreciseEqual(cfunc(x), pyfunc(x))
 
+        for unsigned_type in types.unsigned_domain:
+            unsigned_values = [0, 10, 2, 2 ** unsigned_type.bitwidth - 1]
+            cr = compile_isolated(pyfunc, (unsigned_type,), flags=flags)
+            cfunc = cr.entry_point
+            for x in unsigned_values:
+                self.assertPreciseEqual(cfunc(x), pyfunc(x))
+
     @tag('important')
     def test_abs_npm(self):
         self.test_abs(flags=no_pyobj_flags)

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -627,22 +627,15 @@ class TestMathLib(TestCase):
 
     @unittest.skipIf(utils.PYVERSION < (3, 5), "gcd added in Python 3.5")
     def test_gcd(self, flags=enable_pyobj_flags):
+        from itertools import product, repeat, chain
         pyfunc = gcd
-        x_values, y_values = zip(
-            *itertools.product([-2, -1, 0, 1, 2, 7, 10], repeat=2)
+        signed_args = product(
+            sorted(types.signed_domain), *repeat((-2, -1, 0, 1, 2, 7, 10), 2)
         )
-        x_types = [t for _, t in zip(
-            range(len(x_values)), itertools.cycle(types.signed_domain)
-        )]
-        x_uvalues, y_uvalues = zip(
-            *itertools.product([0, 1, 2, 7, 10], repeat=2)
+        unsigned_args = product(
+            sorted(types.unsigned_domain), *repeat((0, 1, 2, 7, 9, 16), 2)
         )
-        x_utypes = [t for _, t in zip(
-            range(len(x_uvalues)), itertools.cycle(types.unsigned_domain)
-        )]
-        x_values += x_uvalues
-        y_values += y_uvalues
-        x_types += x_utypes
+        x_types, x_values, y_values = zip(*chain(signed_args, unsigned_args))
         self.run_binary(pyfunc, x_types, x_values, y_values, flags)
 
     @unittest.skipIf(utils.PYVERSION < (3, 5), "gcd added in Python 3.5")

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -625,6 +625,7 @@ class TestMathLib(TestCase):
         y_values = [x * 2 for x in x_values]
         self.run_binary(pyfunc, x_types, x_values, y_values, flags)
 
+    @unittest.skipIf(utils.PYVERSION < (3, 5), "gcd added in Python 3.5")
     def test_gcd(self, flags=enable_pyobj_flags):
         pyfunc = gcd
         x_values, y_values = zip(
@@ -644,6 +645,7 @@ class TestMathLib(TestCase):
         x_types += x_utypes
         self.run_binary(pyfunc, x_types, x_values, y_values, flags)
 
+    @unittest.skipIf(utils.PYVERSION < (3, 5), "gcd added in Python 3.5")
     def test_gcd_npm(self):
         self.test_gcd(flags=no_pyobj_flags)
 

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -154,6 +154,8 @@ def lgamma(x):
 def pow(x, y):
     return math.pow(x, y)
 
+def gcd(x, y):
+    return math.gcd(x, y)
 
 def copysign(x, y):
     return math.copysign(x, y)
@@ -622,6 +624,28 @@ class TestMathLib(TestCase):
         x_values = [-2, -1, -2, 2, 1, 2, .1, .2]
         y_values = [x * 2 for x in x_values]
         self.run_binary(pyfunc, x_types, x_values, y_values, flags)
+
+    def test_gcd(self, flags=enable_pyobj_flags):
+        pyfunc = gcd
+        x_values, y_values = zip(
+            *itertools.product([-2, -1, 0, 1, 2, 7, 10], repeat=2)
+        )
+        x_types = [t for _, t in zip(
+            range(len(x_values)), itertools.cycle(types.signed_domain)
+        )]
+        x_uvalues, y_uvalues = zip(
+            *itertools.product([0, 1, 2, 7, 10], repeat=2)
+        )
+        x_utypes = [t for _, t in zip(
+            range(len(x_uvalues)), itertools.cycle(types.unsigned_domain)
+        )]
+        x_values += x_uvalues
+        y_values += y_uvalues
+        x_types += x_utypes
+        self.run_binary(pyfunc, x_types, x_values, y_values, flags)
+
+    def test_gcd_npm(self):
+        self.test_gcd(flags=no_pyobj_flags)
 
     @tag('important')
     def test_pow_npm(self):

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -375,7 +375,8 @@ class TestUFuncs(BaseUFuncTest, TestCase):
                                positive_only=after_numpy_112)
 
     def test_gcd_ufunc(self, flags=no_pyobj_flags):
-        self.binary_ufunc_test(np.gcd, flags=flags, kinds="iu")
+        if numpy_support.version >= (1, 15):
+            self.binary_ufunc_test(np.gcd, flags=flags, kinds="iu")
 
     @tag('important')
     def test_remainder_ufunc(self, flags=no_pyobj_flags):

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -374,6 +374,9 @@ class TestUFuncs(BaseUFuncTest, TestCase):
         self.binary_ufunc_test(np.power, flags=flags,
                                positive_only=after_numpy_112)
 
+    def test_gcd_ufunc(self, flags=no_pyobj_flags):
+        self.binary_ufunc_test(np.gcd, flags=flags, kinds="iu")
+
     @tag('important')
     def test_remainder_ufunc(self, flags=no_pyobj_flags):
         self.binary_ufunc_test(np.remainder, flags=flags)

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -163,24 +163,24 @@ class TestZeroCounts(TestCase):
         evens = [2, 42, 126, 128]
 
         for T in types.unsigned_domain:
-            assert tz(T(0)) == lz(T(0)) == T.bitwidth
+            self.assertTrue(tz(T(0)) == lz(T(0)) == T.bitwidth)
             for i in range(T.bitwidth):
                 val = T(2 ** i)
-                assert lz(val) + tz(val) + 1 == T.bitwidth
+                self.assertEqual(lz(val) + tz(val) + 1, T.bitwidth)
             for n in evens:
-                assert tz(T(n)) > 0
-                assert tz(T(n + 1)) == 0
+                self.assertGreater(tz(T(n)), 0)
+                self.assertEqual(tz(T(n + 1)), 0)
 
         for T in types.signed_domain:
-            assert tz(T(0)) == lz(T(0)) == T.bitwidth
+            self.assertTrue(tz(T(0)) == lz(T(0)) == T.bitwidth)
             for i in range(T.bitwidth - 1):
                 val = T(2 ** i)
-                assert lz(val) + tz(val) + 1 == T.bitwidth
-                assert lz(-val) == 0
-                assert tz(val) == tz(-val)
+                self.assertEqual(lz(val) + tz(val) + 1, T.bitwidth)
+                self.assertEqual(lz(-val), 0)
+                self.assertEqual(tz(val), tz(-val))
             for n in evens:
-                assert tz(T(n)) > 0
-                assert tz(T(n + 1)) == 0
+                self.assertGreater(tz(T(n)), 0)
+                self.assertEqual(tz(T(n + 1)), 0)
 
     def check_error_msg(self, func):
         cfunc = njit(lambda *x: func(*x))

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -160,11 +160,11 @@ class TestZeroCounts(TestCase):
         lz = njit(lambda x: leading_zeros(x))
         tz = njit(lambda x: trailing_zeros(x))
 
-        evens = np.array([2, 42, 126, 128])
+        evens = [2, 42, 126, 128]
 
         for T in types.unsigned_domain:
             assert tz(T(0)) == lz(T(0)) == T.bitwidth
-            for i in np.arange(T.bitwidth):
+            for i in range(T.bitwidth):
                 val = T(2 ** i)
                 assert lz(val) + tz(val) + 1 == T.bitwidth
             for n in evens:
@@ -173,7 +173,7 @@ class TestZeroCounts(TestCase):
 
         for T in types.signed_domain:
             assert tz(T(0)) == lz(T(0)) == T.bitwidth
-            for i in np.arange(T.bitwidth - 1):
+            for i in range(T.bitwidth - 1):
                 val = T(2 ** i)
                 assert lz(val) + tz(val) + 1 == T.bitwidth
                 assert lz(-val) == 0

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -163,6 +163,7 @@ class TestZeroCounts(TestCase):
         evens = np.array([2, 42, 126, 128])
 
         for T in types.unsigned_domain:
+            assert tz(T(0)) == lz(T(0)) == T.bitwidth
             for i in np.arange(T.bitwidth):
                 val = T(2 ** i)
                 assert lz(val) + tz(val) + 1 == T.bitwidth
@@ -171,6 +172,7 @@ class TestZeroCounts(TestCase):
                 assert tz(T(n + 1)) == 0
 
         for T in types.signed_domain:
+            assert tz(T(0)) == lz(T(0)) == T.bitwidth
             for i in np.arange(T.bitwidth - 1):
                 val = T(2 ** i)
                 assert lz(val) + tz(val) + 1 == T.bitwidth

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -37,10 +37,11 @@ class PrintItem(AbstractTemplate):
 @infer_global(abs)
 class Abs(ConcreteTemplate):
     int_cases = [signature(ty, ty) for ty in sorted(types.signed_domain)]
+    uint_cases = [signature(ty, ty) for ty in sorted(types.unsigned_domain)]
     real_cases = [signature(ty, ty) for ty in sorted(types.real_domain)]
     complex_cases = [signature(ty.underlying_float, ty)
                      for ty in sorted(types.complex_domain)]
-    cases = int_cases + real_cases + complex_cases
+    cases = int_cases + uint_cases +  real_cases + complex_cases
 
 
 @infer_global(slice)

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -118,18 +118,19 @@ class Math_pow(ConcreteTemplate):
     ]
 
 
-@infer_global(math.gcd)
-class Math_gcd(ConcreteTemplate):
-    cases = [
-        signature(types.int64, types.int64, types.int64),
-        signature(types.int32, types.int32, types.int32),
-        signature(types.int16, types.int16, types.int16),
-        signature(types.int8, types.int8, types.int8),
-        signature(types.uint64, types.uint64, types.uint64),
-        signature(types.uint32, types.uint32, types.uint32),
-        signature(types.uint16, types.uint16, types.uint16),
-        signature(types.uint8, types.uint8, types.uint8),
-    ]
+if utils.PYVERSION >= (3, 5):
+    @infer_global(math.gcd)
+    class Math_gcd(ConcreteTemplate):
+        cases = [
+            signature(types.int64, types.int64, types.int64),
+            signature(types.int32, types.int32, types.int32),
+            signature(types.int16, types.int16, types.int16),
+            signature(types.int8, types.int8, types.int8),
+            signature(types.uint64, types.uint64, types.uint64),
+            signature(types.uint32, types.uint32, types.uint32),
+            signature(types.uint16, types.uint16, types.uint16),
+            signature(types.uint8, types.uint8, types.uint8),
+        ]
 
 
 @infer_global(math.frexp)

--- a/numba/typing/mathdecl.py
+++ b/numba/typing/mathdecl.py
@@ -117,6 +117,21 @@ class Math_pow(ConcreteTemplate):
         signature(types.float64, types.float64, types.float64),
     ]
 
+
+@infer_global(math.gcd)
+class Math_gcd(ConcreteTemplate):
+    cases = [
+        signature(types.int64, types.int64, types.int64),
+        signature(types.int32, types.int32, types.int32),
+        signature(types.int16, types.int16, types.int16),
+        signature(types.int8, types.int8, types.int8),
+        signature(types.uint64, types.uint64, types.uint64),
+        signature(types.uint32, types.uint32, types.uint32),
+        signature(types.uint16, types.uint16, types.uint16),
+        signature(types.uint8, types.uint8, types.uint8),
+    ]
+
+
 @infer_global(math.frexp)
 class Math_frexp(ConcreteTemplate):
     cases = [

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -278,7 +278,7 @@ class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
 
 _math_operations = [ "add", "subtract", "multiply",
                      "logaddexp", "logaddexp2", "true_divide",
-                     "floor_divide", "negative", "power",
+                     "floor_divide", "negative", "power", "gcd",
                      "remainder", "fmod", "absolute",
                      "rint", "sign", "conjugate", "exp", "exp2",
                      "log", "log2", "log10", "expm1", "log1p",

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -278,12 +278,15 @@ class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
 
 _math_operations = [ "add", "subtract", "multiply",
                      "logaddexp", "logaddexp2", "true_divide",
-                     "floor_divide", "negative", "power", "gcd",
+                     "floor_divide", "negative", "power",
                      "remainder", "fmod", "absolute",
                      "rint", "sign", "conjugate", "exp", "exp2",
                      "log", "log2", "log10", "expm1", "log1p",
                      "sqrt", "square", "reciprocal",
                      "divide", "mod", "abs", "fabs" ]
+
+if numpy_version >= (1, 15):
+    _math_operations.append("gcd")
 
 _trigonometric_functions = [ "sin", "cos", "tan", "arcsin",
                              "arccos", "arctan", "arctan2",

--- a/numba/unsafe/numbers.py
+++ b/numba/unsafe/numbers.py
@@ -27,6 +27,7 @@ def viewer(tyctx, val, viewty):
 
 @intrinsic
 def trailing_zeros(typeingctx, src):
+    """Counts trailing zeros in the binary representation of an integer."""
     assert isinstance(src, types.Integer)
 
     def codegen(context, builder, signature, args):
@@ -37,6 +38,7 @@ def trailing_zeros(typeingctx, src):
 
 @intrinsic
 def leading_zeros(typeingctx, src):
+    """Counts leading zeros in the binary representation of an integer."""
     assert isinstance(src, types.Integer)
 
     def codegen(context, builder, signature, args):

--- a/numba/unsafe/numbers.py
+++ b/numba/unsafe/numbers.py
@@ -28,7 +28,11 @@ def viewer(tyctx, val, viewty):
 @intrinsic
 def trailing_zeros(typeingctx, src):
     """Counts trailing zeros in the binary representation of an integer."""
-    assert isinstance(src, types.Integer)
+    if not isinstance(src, types.Integer):
+        raise TypeError(
+            "trailing_zeros is only defined for integers, but passed value was"
+            " '{}'.".format(src)
+        )
 
     def codegen(context, builder, signature, args):
         [src] = args
@@ -39,7 +43,11 @@ def trailing_zeros(typeingctx, src):
 @intrinsic
 def leading_zeros(typeingctx, src):
     """Counts leading zeros in the binary representation of an integer."""
-    assert isinstance(src, types.Integer)
+    if not isinstance(src, types.Integer):
+        raise TypeError(
+            "leading_zeros is only defined for integers, but passed value was "
+            "'{}'.".format(src)
+        )
 
     def codegen(context, builder, signature, args):
         [src] = args

--- a/numba/unsafe/numbers.py
+++ b/numba/unsafe/numbers.py
@@ -23,3 +23,23 @@ def viewer(tyctx, val, viewty):
     retty = viewty.dtype
     sig = retty(val, viewty)
     return sig, codegen
+
+
+@intrinsic
+def trailing_zeros(typeingctx, src):
+    assert isinstance(src, types.Integer)
+
+    def codegen(context, builder, signature, args):
+        [src] = args
+        return builder.cttz(src, ir.Constant(ir.IntType(1), 0))
+    return src(src), codegen
+
+
+@intrinsic
+def leading_zeros(typeingctx, src):
+    assert isinstance(src, types.Integer)
+
+    def codegen(context, builder, signature, args):
+        [src] = args
+        return builder.ctlz(src, ir.Constant(ir.IntType(1), 0))
+    return src(src), codegen


### PR DESCRIPTION
This PR adds implementations for `math.gcd` and `np.gcd`. I've implemented a binary GCD algorithm heavily cribbing from [Julia's implementation](https://github.com/JuliaLang/julia/blob/3efdda65d4046a4825353dddc090a6235764fa8f/base/intfuncs.jl#L28-L49). As pointed out [on gitter](https://gitter.im/numba/numba?at=5db1a4d87477946badc0d480), this is different from how [numpy implements gcd](https://github.com/numpy/numpy/blob/master/numpy/core/src/npymath/npy_math_internal.h.src#L688-L697), but is faster:

```python
import numpy as np
from numba import njit

gcd = lambda x, y, out: np.gcd(x, y, out)
cgcd = njit(gcd)

a = np.random.randint(0, 100000, 10000)
b = np.random.randint(0, 100000, 10000)

out_numpy = np.empty_like(a)
out_numba = np.empty_like(a)

# warmup
cgcd(a, b, out_numba)

%timeit gcd(a, b, out_numpy)
# 957 µs ± 3.65 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

%timeit cgcd(a, b, out_numba)
# 351 µs ± 1.11 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

np.all(out_numba == out_numpy)
# True
```

The speed advantage decreases for smaller width values, especially unsigned ones. I think a bit of the issue here is that values are being upcast to `uintp`. I'd like this to be more generic, but I'm unsure if there's an elegant way to cast signed values to unsigned values of equivalent width.

I'm a little unsure of what more I have to do to get this working with CUDA and ROC, and would definitely like some advice on that.

I think this is pretty close to ready for review, I'd just like to see that the tests pass before taking off the WIP label.