### PR TITLE
Add setuptools as a dependency

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -39,6 +39,7 @@ requirements:
   run:
     - python
     - numpy x.x
+    - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite 0.30.*
     - funcsigs                 # [py27]

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -201,6 +201,7 @@ vary with target operating system and hardware. The following lists them all
 
 * Required run time:
 
+  * ``setuptools``
   * ``numpy``
   * ``llvmlite``
   * ``funcsigs`` (Python 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 numpy>=1.10
 llvmlite>=0.30
 argparse

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ packages = find_packages("numba", "numba")
 
 build_requires = ['numpy']
 
-install_requires = ['llvmlite>=0.30.0dev0', 'numpy']
+install_requires = ['llvmlite>=0.30.0dev0', 'numpy', 'setuptools']
 install_requires.extend(['enum34; python_version < "3.4"'])
 install_requires.extend(['singledispatch; python_version < "3.4"'])
 install_requires.extend(['funcsigs; python_version < "3.3"'])


### PR DESCRIPTION
Currently we use the `pkg_resources` module (which is [distributed with `setuptools`](https://setuptools.readthedocs.io/en/latest/pkg_resources.html)) in `numba/entrypoints.py`

https://github.com/numba/numba/blob/3e1d89cb500e84c26fec3810164fbaf07003f991/numba/entrypoints.py#L3

but don't explicitly list `setuptools` as a dependency. This PR adds `setuptools` as a dependency. 

Closes #4763