### PR TITLE
put git hash into build string

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -7,6 +7,7 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER|int }}
+  string: np{{ NPY_VER }}py{{ PY_VER }}h{{ PKG_HASH }}_{{GIT_DESCRIBE_HASH}}_{{ GIT_DESCRIBE_NUMBER }}
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.numba_entry:main


### PR DESCRIPTION
It would be useful to see the git hash in the build string for development conda packages built and uploaded to the `numba` channel.

For example, this change will create package names like:

```
numba-0.46.0dev0-np1.11py2.7h0a44026_g3e1d89cb5_602.tar.bz2
```

I am assuming multiple underscores in the build string are fine.