### PR TITLE
Better compiler error messages for improperly used reduction variables.

### DIFF
--- a/numba/npyufunc/parfor.py
+++ b/numba/npyufunc/parfor.py
@@ -96,7 +96,7 @@ def _lower_parfor_parallel(lowerer, parfor):
     parfor_output_arrays = numba.parfor.get_parfor_outputs(
         parfor, parfor.params)
     parfor_redvars, parfor_reddict = numba.parfor.get_parfor_reductions(
-        parfor, parfor.params, lowerer.fndesc.calltypes)
+        lowerer.func_ir, parfor, parfor.params, lowerer.fndesc.calltypes)
 
     # init reduction array allocation here.
     nredvars = len(parfor_redvars)
@@ -783,7 +783,7 @@ def _create_gufunc_for_parfor_body(
     # Get all parfor reduction vars, and operators.
     typemap = lowerer.fndesc.typemap
     parfor_redvars, parfor_reddict = numba.parfor.get_parfor_reductions(
-        parfor, parfor_params, lowerer.fndesc.calltypes)
+        lowerer.func_ir, parfor, parfor_params, lowerer.fndesc.calltypes)
     # Compute just the parfor inputs as a set difference.
     parfor_inputs = sorted(
         list(

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -3011,6 +3011,7 @@ def supported_reduction(x, func_ir):
         return True
     if x.op == 'call':
         callname = guard(find_callname, func_ir, x)
+        callname = tuple(i if i != '__builtin__' else 'builtins' for i in callname)
         if callname == ('max', 'builtins') or callname == ('min', 'builtins'):
             return True
     return False

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1517,7 +1517,14 @@ class ParforPass(object):
             # prepare for parallel lowering
             # add parfor params to parfors here since lowering is destructive
             # changing the IR after this is not allowed
-            parfor_ids = get_parfor_params(self.func_ir.blocks, self.options.fusion, self.nested_fusion_info)
+            parfor_ids, parfors = get_parfor_params(self.func_ir.blocks,
+                                                    self.options.fusion,
+                                                    self.nested_fusion_info)
+            for p in parfors:
+                numba.parfor.get_parfor_reductions(self.func_ir,
+                                                   p,
+                                                   p.params,
+                                                   self.calltypes)
             if config.DEBUG_ARRAY_OPT_STATS:
                 name = self.func_ir.func_id.func_qualname
                 n_parfors = len(parfor_ids)
@@ -2843,6 +2850,7 @@ def get_parfor_params(blocks, options_fusion, fusion_info):
     # that could be undefined before. So we only consider variables that are
     # actually defined before the parfor body in the program.
     parfor_ids = set()
+    parfors = []
     pre_defs = set()
     _, all_defs = compute_use_defs(blocks)
     topo_order = find_topo_order(blocks)
@@ -2856,9 +2864,10 @@ def get_parfor_params(blocks, options_fusion, fusion_info):
             pre_defs |= before_defs
             parfor.params = get_parfor_params_inner(parfor, pre_defs, options_fusion, fusion_info) | parfor.races
             parfor_ids.add(parfor.id)
+            parfors.append(parfor)
 
         pre_defs |= all_defs[label]
-    return parfor_ids
+    return parfor_ids, parfors
 
 
 def get_parfor_params_inner(parfor, pre_defs, options_fusion, fusion_info):
@@ -2867,7 +2876,7 @@ def get_parfor_params_inner(parfor, pre_defs, options_fusion, fusion_info):
     cfg = compute_cfg_from_blocks(blocks)
     usedefs = compute_use_defs(blocks)
     live_map = compute_live_map(cfg, blocks, usedefs.usemap, usedefs.defmap)
-    parfor_ids = get_parfor_params(blocks, options_fusion, fusion_info)
+    parfor_ids, _ = get_parfor_params(blocks, options_fusion, fusion_info)
     n_parfors = len(parfor_ids)
     if n_parfors > 0:
         if config.DEBUG_ARRAY_OPT_STATS:
@@ -2911,7 +2920,7 @@ def get_parfor_outputs(parfor, parfor_params):
     outputs = list(set(outputs) & set(parfor_params))
     return sorted(outputs)
 
-def get_parfor_reductions(parfor, parfor_params, calltypes, reductions=None,
+def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=None,
         reduce_varnames=None, param_uses=None, param_nodes=None,
         var_to_param=None):
     """find variables that are updated using their previous values and an array
@@ -2959,7 +2968,7 @@ def get_parfor_reductions(parfor, parfor_params, calltypes, reductions=None,
                 param_nodes[cur_param].append(stmt_cp)
             if isinstance(stmt, Parfor):
                 # recursive parfors can have reductions like test_prange8
-                get_parfor_reductions(stmt, parfor_params, calltypes,
+                get_parfor_reductions(func_ir, stmt, parfor_params, calltypes,
                     reductions, reduce_varnames, param_uses, param_nodes, var_to_param)
     for param, used_vars in param_uses.items():
         # a parameter is a reduction variable if its value is used to update it
@@ -2968,7 +2977,7 @@ def get_parfor_reductions(parfor, parfor_params, calltypes, reductions=None,
         if param in used_vars and param not in reduce_varnames:
             reduce_varnames.append(param)
             param_nodes[param].reverse()
-            reduce_nodes = get_reduce_nodes(param, param_nodes[param])
+            reduce_nodes = get_reduce_nodes(param, param_nodes[param], func_ir)
             gri_out = guard(get_reduction_init, reduce_nodes)
             if gri_out is not None:
                 init_val, redop = gri_out
@@ -2997,7 +3006,16 @@ def get_reduction_init(nodes):
         return 1, acc_expr.fn
     return None, None
 
-def get_reduce_nodes(name, nodes):
+def supported_reduction(x, func_ir):
+    if x.op == 'inplace_binop' or x.op == 'binop':
+        return True
+    if x.op == 'call':
+        callname = guard(find_callname, func_ir, x)
+        if callname == ('max', 'builtins') or callname == ('min', 'builtins'):
+            return True
+    return False
+
+def get_reduce_nodes(name, nodes, func_ir):
     """
     Get nodes that combine the reduction variable with a sentinel variable.
     Recognizes the first node that combines the reduction variable with another
@@ -3022,6 +3040,15 @@ def get_reduce_nodes(name, nodes):
         if isinstance(rhs, ir.Expr):
             in_vars = set(lookup(v, True).name for v in rhs.list_vars())
             if name in in_vars:
+                next_node = nodes[i+1]
+                if not (isinstance(next_node, ir.Assign) and next_node.target.name == name):
+                    raise ValueError(("Use of reduction variable " + name +
+                                      " other than in a supported reduction"
+                                      " function is not permitted."))
+
+                if not supported_reduction(rhs, func_ir):
+                    raise ValueError(("Use of reduction variable " + name +
+                                      " in an unsupported reduction function."))
                 args = [ (x.name, lookup(x, True)) for x in get_expr_args(rhs) ]
                 non_red_args = [ x for (x, y) in args if y.name != name ]
                 assert len(non_red_args) == 1

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -38,6 +38,7 @@ from numba.bytecode import ByteCodeIter
 from .support import tag, override_env_config, skip_parfors_unsupported
 from .matmul_usecase import needs_blas
 from .test_linalg import needs_lapack
+import cmath
 
 
 
@@ -1036,6 +1037,20 @@ class TestParfors(TestParforsBase):
             with self.assertRaises(ValueError) as e:
                 pcfunc.entry_point(np.array([], dtype=np.int64))
             self.assertIn(msg, str(e.exception))
+
+    @skip_unsupported
+    def test_use_of_reduction_var1(self):
+        def test_impl():
+            acc = 0
+            for i in prange(1):
+                acc = cmath.sqrt(acc)
+            return acc
+
+        # checks that invalid use of reduction variable is detected
+        msg = ("Use of reduction variable acc in an unsupported reduction function.")
+        with self.assertRaises(ValueError) as e:
+            pcfunc = self.compile_parallel(test_impl, ())
+        self.assertIn(msg, str(e.exception))
 
     @skip_unsupported
     def test_argmin(self):


### PR DESCRIPTION
Resolves #4738