### PR TITLE
fix spelling in now-failing tests

### DIFF
--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1255,7 +1255,7 @@ class TestDictForbiddenTypes(TestCase):
         self.assertIn(expect, msg)
 
     def assert_disallow_key(self, ty):
-        msg = '{} as key is forbidded'.format(ty)
+        msg = '{} as key is forbidden'.format(ty)
         self.assert_disallow(msg, lambda: Dict.empty(ty, types.intp))
 
         @njit
@@ -1264,7 +1264,7 @@ class TestDictForbiddenTypes(TestCase):
         self.assert_disallow(msg, foo)
 
     def assert_disallow_value(self, ty):
-        msg = '{} as value is forbidded'.format(ty)
+        msg = '{} as value is forbidden'.format(ty)
         self.assert_disallow(msg, lambda: Dict.empty(types.intp, ty))
 
         @njit


### PR DESCRIPTION
previously merged PR accidentally fixed the spelling of some error messages without updating the corresponding tests
