### PR TITLE
Argsort improvement

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1193,7 +1193,7 @@ def simplify_CFG(blocks):
 
 
 arr_math = ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-            'cumsum', 'cumprod', 'argmin', 'argmax', # 'argsort',
+            'cumsum', 'cumprod', 'argmin', 'argmax',
             'nonzero', 'ravel']
 
 
@@ -2019,4 +2019,3 @@ def check_and_legalize_ir(func_ir):
     if not func_ir.equal_ir(orig_ir):
         msg +=  func_ir.diff_str(orig_ir)
         warnings.warn(NumbaWarning(msg, loc=func_ir.loc))
-

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1193,7 +1193,7 @@ def simplify_CFG(blocks):
 
 
 arr_math = ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-            'cumsum', 'cumprod', 'argmin', 'argmax', 'argsort',
+            'cumsum', 'cumprod', 'argmin', 'argmax', # 'argsort',
             'nonzero', 'ravel']
 
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -4994,54 +4994,54 @@ def np_argsort(a, axis=-1, kind="quicksort"):
         axis_value = 0
         axis_is_const = False
 
-        # Optimized implementation for 1D arrays
-        if arytype.ndim == 1:
-            def array_argsort_impl(a, axis=-1, kind="quicksort"):
-                axis_val = axis_value if axis_is_const else axis
-                assert axis_val in (-1, 0)
-                return sort_func(a)
-        else:
-            def gen_fill_loop(axis_val):
-                @register_jitable
-                def impl(arr):
-                    max_idx = 1
-                    for i, v in enumerate(arr.shape):
-                        if i != axis_val:
-                            max_idx *= v
+    # Optimized implementation for 1D arrays
+    if arytype.ndim == 1:
+        def array_argsort_impl(a, axis=-1, kind="quicksort"):
+            axis_val = axis_value if axis_is_const else axis
+            assert axis_val in (-1, 0)
+            return sort_func(a)
+    else:
+        def gen_fill_loop(axis_val):
+            @register_jitable
+            def impl(arr):
+                max_idx = 1
+                for i, v in enumerate(arr.shape):
+                    if i != axis_val:
+                        max_idx *= v
 
-                    result = np.empty(arr.shape, types.intp)
-                    for idx in range(max_idx):
-                        slice_tuple = _gen_slice_tuple(arr.shape, idx, axis_val)
-                        result[slice_tuple] = sort_func(arr[slice_tuple])
-                    return result
-                return impl
+                result = np.empty(arr.shape, types.intp)
+                for idx in range(max_idx):
+                    slice_tuple = _gen_slice_tuple(arr.shape, idx, axis_val)
+                    result[slice_tuple] = sort_func(arr[slice_tuple])
+                return result
+            return impl
 
-            fill_loop_const = gen_fill_loop(axis_value)
-            fill_loop_0 = gen_fill_loop(0)
-            fill_loop_1 = gen_fill_loop(1)
-            fill_loop_2 = gen_fill_loop(2)
-            fill_loop_3 = gen_fill_loop(3)
-            fill_loop_n1 = gen_fill_loop(-1)
+        fill_loop_const = gen_fill_loop(axis_value)
+        fill_loop_0 = gen_fill_loop(0)
+        fill_loop_1 = gen_fill_loop(1)
+        fill_loop_2 = gen_fill_loop(2)
+        fill_loop_3 = gen_fill_loop(3)
+        fill_loop_n1 = gen_fill_loop(-1)
 
-            def array_argsort_impl(a, axis=-1, kind="quicksort"):
-                if axis_is_const:
-                    return fill_loop_const(a)
-                elif axis == 0:
-                    return fill_loop_0(a)
-                elif axis == 1:
-                    return fill_loop_1(a)
-                elif axis == 2:
-                    return fill_loop_2(a)
-                elif axis == 3:
-                    return fill_loop_3(a)
-                elif axis == -1:
-                    return fill_loop_n1(a)
-                else:
-                    raise ValueError("Numba does not support argsort with "
-                                     "non-constant axis parameter outside the "
-                                     "range -1 to 3.")
+        def array_argsort_impl(a, axis=-1, kind="quicksort"):
+            if axis_is_const:
+                return fill_loop_const(a)
+            elif axis == 0:
+                return fill_loop_0(a)
+            elif axis == 1:
+                return fill_loop_1(a)
+            elif axis == 2:
+                return fill_loop_2(a)
+            elif axis == 3:
+                return fill_loop_3(a)
+            elif axis == -1:
+                return fill_loop_n1(a)
+            else:
+                raise ValueError("Numba does not support argsort with "
+                                    "non-constant axis parameter outside the "
+                                    "range -1 to 3.")
 
-        return array_argsort_impl
+    return array_argsort_impl
 
 
 # -----------------------------------------------------------------------------

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -4943,11 +4943,20 @@ def _gen_slice_tuple(tyctx, shape_tuple, value, axis):
 @overload_method(types.Array, "argsort")
 @overload(np.argsort)
 def np_argsort(a, axis=-1, kind="quicksort"):
-    if axis == -1:
-        axis = types.IntegerLiteral(axis)
-    if kind == "quicksort":
-        kind = types.StringLiteral(kind)
+    # Unpack TypeRef
+    axis = getattr(axis, "instance_type", axis)
+    kind = getattr(kind, "instance_type", kind)
 
+    # Unpack Omitted
+    axis = getattr(axis, "value", axis)
+    kind = getattr(kind, "value", kind)
+
+    # Wrap python types
+    if isinstance(axis, int):
+        axis = types.IntegerLiteral(axis)
+    if isinstance(kind, str):
+        kind = types.StringLiteral(kind)
+    
     if (not isinstance(a, types.Array) or
         not isinstance(axis, types.IntegerLiteral) or
         not isinstance(kind, types.StringLiteral)):

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -5038,8 +5038,8 @@ def np_argsort(a, axis=-1, kind="quicksort"):
                 return fill_loop_n1(a)
             else:
                 raise ValueError("Numba does not support argsort with "
-                                    "non-constant axis parameter outside the "
-                                    "range -1 to 3.")
+                                 "non-constant axis parameter outside the "
+                                 "range -1 to 3.")
 
     return array_argsort_impl
 

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -51,6 +51,15 @@ def argsort_kind_usecase(val, is_stable=False):
     else:
         return val.argsort(kind='quicksort')
 
+def get_argsort_axis_usecase(axis, use_keyword=False):
+    if use_keyword:
+        def argsort_axis_usecase(val):
+            return val.argsort(axis=axis)
+    else:
+        def argsort_axis_usecase(val):
+            return val.argsort(axis)
+    return argsort_axis_usecase
+
 def sorted_usecase(val):
     return sorted(val)
 
@@ -68,6 +77,15 @@ def np_argsort_kind_usecase(val, is_stable=False):
         return np.argsort(val, kind='mergesort')
     else:
         return np.argsort(val, kind='quicksort')
+    
+def get_np_argsort_axis_usecase(axis, use_keyword=False):
+    if use_keyword:
+        def np_argsort_axis_usecase(val):
+            return np.argsort(val, axis=axis)
+    else:
+        def np_argsort_axis_usecase(val):
+            return np.argsort(val, axis)
+    return np_argsort_axis_usecase
 
 def list_sort_usecase(n):
     np.random.seed(42)
@@ -828,6 +846,32 @@ class TestNumpySort(TestCase):
         check(argsort_kind_usecase, is_stable=False)
         check(np_argsort_kind_usecase, is_stable=False)
 
+    def test_argsort_axis_int(self):
+        sizes = [
+            (5,),
+            (5, 5),
+            (3, 4, 5),
+            (6, 5, 4, 5)
+        ]
+
+        def check(get_pyfunc, axis, use_keyword):
+            pyfunc = get_pyfunc(axis, use_keyword=use_keyword)
+            cfunc = jit(nopython=True)(pyfunc)
+            for s in sizes:
+                if len(s) <= abs(axis):
+                    continue
+                val = np.random.randint(99, size=s)
+                expected = pyfunc(val)
+                got = cfunc(val)
+                self.assertPreciseEqual(expected, got)
+        
+        func = [get_np_argsort_axis_usecase, get_argsort_axis_usecase]
+        axis = [0, 1, 2, 3, -1, -2]
+        use_keyword = [True, False]
+
+        for t in itertools.product(func, axis, use_keyword):
+            check(*t)
+                
     @tag('important')
     def test_argsort_float(self):
         def check(pyfunc):

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -60,6 +60,19 @@ def get_argsort_axis_usecase(axis, use_keyword=False):
             return val.argsort(axis)
     return argsort_axis_usecase
 
+def get_argsort_axis_kind_usecase(axis, kind, num_keywords=2):
+    if num_keywords == 0:
+        def argsort_axis_kind_usecase(val):
+            return val.argsort(axis, kind)
+    elif num_keywords == 1:
+        def argsort_axis_kind_usecase(val):
+            return val.argsort(axis, kind=kind)
+    elif num_keywords == 2:
+        def argsort_axis_kind_usecase(val):
+            return val.argsort(axis=axis, kind=kind)
+    
+    return argsort_axis_kind_usecase
+    
 def sorted_usecase(val):
     return sorted(val)
 
@@ -86,6 +99,19 @@ def get_np_argsort_axis_usecase(axis, use_keyword=False):
         def np_argsort_axis_usecase(val):
             return np.argsort(val, axis)
     return np_argsort_axis_usecase
+
+def get_np_argsort_axis_kind_usecase(axis, kind, num_keywords=2):
+    if num_keywords == 0:
+        def np_argsort_axis_kind_usecase(val):
+            return np.argsort(val, axis, kind)
+    elif num_keywords == 1:
+        def np_argsort_axis_kind_usecase(val):
+            return np.argsort(val, axis, kind=kind)
+    elif num_keywords == 2:
+        def np_argsort_axis_kind_usecase(val):
+            return np.argsort(val, axis=axis, kind=kind)
+    
+    return np_argsort_axis_kind_usecase
 
 def list_sort_usecase(n):
     np.random.seed(42)
@@ -870,6 +896,33 @@ class TestNumpySort(TestCase):
         use_keyword = [True, False]
 
         for t in itertools.product(func, axis, use_keyword):
+            check(*t)
+                
+    def test_argsort_axis_kind_int(self):
+        sizes = [
+            (5,),
+            (5, 5),
+            (3, 4, 5),
+            (6, 5, 4, 5)
+        ]
+
+        def check(get_pyfunc, axis, kind, num_keywords):
+            pyfunc = get_pyfunc(axis, kind, num_keywords=num_keywords)
+            cfunc = jit(nopython=True)(pyfunc)
+            for s in sizes:
+                if len(s) <= abs(axis):
+                    continue
+                val = np.random.randint(99, size=s)
+                expected = pyfunc(val)
+                got = cfunc(val)
+                self.assertPreciseEqual(expected, got)
+        
+        func = [get_np_argsort_axis_kind_usecase, get_argsort_axis_kind_usecase]
+        axis = [0, 1, 2, 3, -1, -2]
+        kind = ["quicksort", "mergesort"]
+        num_keywords = [0, 1, 2]
+
+        for t in itertools.product(func, axis, kind, num_keywords):
             check(*t)
                 
     @tag('important')

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -51,49 +51,59 @@ def argsort_kind_usecase(val, is_stable=False):
     else:
         return val.argsort(kind='quicksort')
 
-def get_argsort_axis_usecase(use_keyword=False):
-    if use_keyword:
-        def argsort_axis_usecase(val, axis):
-            return val.argsort(axis=axis)
-    else:
-        def argsort_axis_usecase(val, axis):
-            return val.argsort(axis)
-    return argsort_axis_usecase
+def argsort_axis_usecase(val, axis):
+    return val.argsort(axis)
 
-def get_argsort_axis_lit_usecase(axis, use_keyword=False):
-    if use_keyword:
-        def argsort_axis_usecase(val):
-            return val.argsort(axis=axis)
-    else:
-        def argsort_axis_usecase(val):
-            return val.argsort(axis)
-    return argsort_axis_usecase
+def argsort_axis_kwd_usecase(val, axis):
+    return val.argsort(axis=axis)
 
-def get_argsort_axis_kind_usecase(kind, num_keywords=2):
-    if num_keywords == 0:
-        def argsort_axis_kind_usecase(val, axis):
-            return val.argsort(axis, kind)
-    elif num_keywords == 1:
-        def argsort_axis_kind_usecase(val, axis):
-            return val.argsort(axis, kind=kind)
-    elif num_keywords == 2:
-        def argsort_axis_kind_usecase(val, axis):
-            return val.argsort(axis=axis, kind=kind)
+def argsort_axis_const_usecase(val):
+    a = val.argsort(0)
+    b = val.argsort(axis=-1)
+    c = val.argsort(None)
+    if val.ndim == 1:
+        return a, b, c
+    d = val.argsort(axis=1)
+    if val.ndim == 2:
+        return a, b, c, d
+    e = val.argsort(2)
+    f = val.argsort(axis=-2)
+    if val.ndim == 3:
+        return a, b, c, d, e, f
+    g = val.argsort(3)
+    if val.ndim == 4:
+        return a, b, c, d, e, f, g
+    h = val.argsort(axis=4)
+    return a, b, c, d, e, f, g, h
 
-    return argsort_axis_kind_usecase
+def get_argsort_axis_kind_usecase(kind):
+    def impl(val, axis):
+        a = val.argsort(axis, kind)
+        b = val.argsort(axis, kind=kind)
+        c = val.argsort(axis=axis, kind=kind)
+        return a, b, c
+    return impl
 
-def get_argsort_axis_lit_kind_usecase(axis, kind, num_keywords=2):
-    if num_keywords == 0:
-        def argsort_axis_kind_usecase(val):
-            return val.argsort(axis, kind)
-    elif num_keywords == 1:
-        def argsort_axis_kind_usecase(val):
-            return val.argsort(axis, kind=kind)
-    elif num_keywords == 2:
-        def argsort_axis_kind_usecase(val):
-            return val.argsort(axis=axis, kind=kind)
-
-    return argsort_axis_kind_usecase
+def get_argsort_axis_const_kind_usecase(kind):
+    def impl(val):
+        a = val.argsort(0, kind)
+        b = val.argsort(-1, kind=kind)
+        c = val.argsort(axis=None, kind=kind)
+        if val.ndim == 1:
+            return a, b, c
+        d = val.argsort(1, kind)
+        if val.ndim == 2:
+            return a, b, c, d
+        e = val.argsort(2, kind=kind)
+        f = val.argsort(axis=-2, kind=kind)
+        if val.ndim == 3:
+            return a, b, c, d, e, f
+        g = val.argsort(3, kind)
+        if val.ndim == 4:
+            return a, b, c, d, e, f, g
+        h = val.argsort(4, kind=kind)
+        return a, b, c, d, e, f, g, h
+    return impl
 
 def sorted_usecase(val):
     return sorted(val)
@@ -113,14 +123,30 @@ def np_argsort_kind_usecase(val, is_stable=False):
     else:
         return np.argsort(val, kind='quicksort')
 
-def get_np_argsort_axis_usecase(use_keyword=False):
-    if use_keyword:
-        def np_argsort_axis_usecase(val, axis):
-            return np.argsort(val, axis=axis)
-    else:
-        def np_argsort_axis_usecase(val, axis):
-            return np.argsort(val, axis)
-    return np_argsort_axis_usecase
+def np_argsort_axis_kwd_usecase(val, axis):
+    return np.argsort(val, axis=axis)
+
+def np_argsort_axis_usecase(val, axis):
+    return np.argsort(val, axis)
+
+def np_argsort_axis_const_usecase(val):
+    a = np.argsort(val, 0)
+    b = np.argsort(val, axis=-1)
+    c = np.argsort(val, None)
+    if val.ndim == 1:
+        return a, b, c
+    d = np.argsort(val, axis=1)
+    if val.ndim == 2:
+        return a, b, c, d
+    e = np.argsort(val, 2)
+    f = np.argsort(val, axis=-2)
+    if val.ndim == 3:
+        return a, b, c, d, e, f
+    g = np.argsort(val, 3)
+    if val.ndim == 4:
+        return a, b, c, d, e, f, g
+    h = np.argsort(val, axis=4)
+    return a, b, c, d, e, f, g, h
 
 def get_np_argsort_axis_lit_usecase(axis, use_keyword=False):
     if use_keyword:
@@ -131,18 +157,34 @@ def get_np_argsort_axis_lit_usecase(axis, use_keyword=False):
             return np.argsort(val, axis)
     return np_argsort_axis_usecase
 
-def get_np_argsort_axis_kind_usecase(kind, num_keywords=2):
-    if num_keywords == 0:
-        def np_argsort_axis_kind_usecase(val, axis):
-            return np.argsort(val, axis, kind)
-    elif num_keywords == 1:
-        def np_argsort_axis_kind_usecase(val, axis):
-            return np.argsort(val, axis, kind=kind)
-    elif num_keywords == 2:
-        def np_argsort_axis_kind_usecase(val, axis):
-            return np.argsort(val, axis=axis, kind=kind)
+def get_np_argsort_axis_const_kind_usecase(kind):
+    def impl(val):
+        a = np.argsort(val, 0, kind)
+        b = np.argsort(val, -1, kind=kind)
+        c = np.argsort(val, axis=None, kind=kind)
+        if val.ndim == 1:
+            return a, b, c
+        d = np.argsort(val, 1, kind)
+        if val.ndim == 2:
+            return a, b, c, d
+        e = np.argsort(val, 2, kind=kind)
+        f = np.argsort(val, axis=-2, kind=kind)
+        if val.ndim == 3:
+            return a, b, c, d, e, f
+        g = np.argsort(val, 3, kind)
+        if val.ndim == 4:
+            return a, b, c, d, e, f, g
+        h = np.argsort(val, 4, kind=kind)
+        return a, b, c, d, e, f, g, h
+    return impl
 
-    return np_argsort_axis_kind_usecase
+def get_np_argsort_axis_kind_usecase(kind):
+    def impl(val, axis):
+        a = np.argsort(val, axis, kind)
+        b = np.argsort(val, axis, kind=kind)
+        c = np.argsort(val, axis=axis, kind=kind)
+        return a, b, c
+    return impl
 
 def get_np_argsort_axis_lit_kind_usecase(axis, kind, num_keywords=2):
     if num_keywords == 0:
@@ -922,111 +964,57 @@ class TestNumpySort(TestCase):
         np.random.shuffle(arr)
         return arr.reshape(shape)
 
-    def test_argsort_axis_lit_int(self):
+    def _check_with_axis(self, pyfunc, axis_list=[]):
         sizes = [
-            (5,),
-            (5, 5),
-            (3, 4, 5),
-            (6, 5, 4, 5)
+            (3,),
+            (4, 3),
+            (3, 4, 3),
+            (4, 3, 4, 3)
         ]
-
-        def check(get_pyfunc, axis, use_keyword):
-            pyfunc = get_pyfunc(axis, use_keyword=use_keyword)
-            cfunc = jit(nopython=True)(pyfunc)
-            for s in sizes:
-                if isinstance(axis, int) and (axis >= len(s) or -len(s) > axis):
-                    continue
-                val = self._get_unique_int_array(s)
+        test_arrays = [self._get_unique_int_array(s) for s in sizes]
+        cfunc = jit(nopython=True)(pyfunc)
+        for val in test_arrays:
+            if axis_list:
+                axis = [a for a in axis_list
+                        if a is None or (a < val.ndim and a >= -val.ndim)]
+                expected = [pyfunc(val, a) for a in axis]
+                got = [cfunc(val, a) for a in axis]
+            else:
                 expected = pyfunc(val)
                 got = cfunc(val)
-                self.assertPreciseEqual(expected, got)
+            self.assertPreciseEqual(expected, got)
 
-        func = [get_np_argsort_axis_lit_usecase, get_argsort_axis_lit_usecase]
-        axis = [0, 1, 2, 3, -1, -2, None]
-        use_keyword = [True, False]
-
-        for t in itertools.product(func, axis, use_keyword):
-            check(*t)
+    def test_argsort_axis_const_int(self):
+        self._check_with_axis(argsort_axis_const_usecase)
+        self._check_with_axis(np_argsort_axis_const_usecase)
 
     def test_argsort_axis_int(self):
-        sizes = [
-            (5,),
-            (5, 5),
-            (3, 4, 5),
-            (6, 5, 4, 5)
-        ]
-
-        def check(get_pyfunc, axis, use_keyword):
-            pyfunc = get_pyfunc(use_keyword=use_keyword)
-            cfunc = jit(nopython=True)(pyfunc)
-            for s in sizes:
-                if isinstance(axis, int) and (axis >= len(s) or -len(s) > axis):
-                    continue
-                val = self._get_unique_int_array(s)
-                expected = pyfunc(val, axis)
-                got = cfunc(val, axis)
-                self.assertPreciseEqual(expected, got)
-
-        func = [get_np_argsort_axis_usecase, get_argsort_axis_usecase]
         axis = [0, 1, 2, 3, -1, None]
-        use_keyword = [True, False]
+        self._check_with_axis(argsort_axis_usecase, axis)
+        self._check_with_axis(np_argsort_axis_usecase, axis)
 
-        for t in itertools.product(func, axis, use_keyword):
-            check(*t)
-
-    def test_argsort_axis_lit_kind_int(self):
-        sizes = [
-            (5,),
-            (5, 5),
-            (3, 4, 5),
-            (6, 5, 4, 5)
-        ]
-
-        def check(get_pyfunc, axis, kind, num_keywords):
-            pyfunc = get_pyfunc(axis, kind, num_keywords=num_keywords)
-            cfunc = jit(nopython=True)(pyfunc)
-            for s in sizes:
-                if isinstance(axis, int) and (axis >= len(s) or -len(s) > axis):
-                    continue
-                val = self._get_unique_int_array(s)
-                expected = pyfunc(val)
-                got = cfunc(val)
-                self.assertPreciseEqual(expected, got)
-
-        func = [get_np_argsort_axis_lit_kind_usecase, get_argsort_axis_lit_kind_usecase]
-        axis = [0, 1, 2, 3, -1, -2, None]
-        kind = ["quicksort", "mergesort"]
-        num_keywords = [0, 1, 2]
-
-        for t in itertools.product(func, axis, kind, num_keywords):
-            check(*t)
+    def test_argsort_axis_kwd_int(self):
+        axis = [0, 1, 2, 3, -1, None]
+        self._check_with_axis(argsort_axis_kwd_usecase, axis)
+        self._check_with_axis(np_argsort_axis_kwd_usecase, axis)
 
     def test_argsort_axis_kind_int(self):
-        sizes = [
-            (5,),
-            (5, 5),
-            (3, 4, 5),
-            (6, 5, 4, 5)
-        ]
-
-        def check(get_pyfunc, axis, kind, num_keywords):
-            pyfunc = get_pyfunc(kind, num_keywords=num_keywords)
-            cfunc = jit(nopython=True)(pyfunc)
-            for s in sizes:
-                if isinstance(axis, int) and (axis >= len(s) or -len(s) > axis):
-                    continue
-                val = self._get_unique_int_array(s)
-                expected = pyfunc(val, axis)
-                got = cfunc(val, axis)
-                self.assertPreciseEqual(expected, got)
-
-        func = [get_np_argsort_axis_kind_usecase, get_argsort_axis_kind_usecase]
-        axis = [0, 1, 2, 3, -1, None]
+        func = [get_argsort_axis_kind_usecase, get_np_argsort_axis_kind_usecase]
         kind = ["quicksort", "mergesort"]
-        num_keywords = [0, 1, 2]
 
-        for t in itertools.product(func, axis, kind, num_keywords):
-            check(*t)
+        pyfunc = [f(k) for f in func for k in kind]
+        axis = [0, 1, 2, 3, -1, None]
+        for p in pyfunc:
+            self._check_with_axis(p, axis)
+
+    def test_argsort_axis_const_kind_int(self):
+        func = [get_argsort_axis_const_kind_usecase,
+                get_np_argsort_axis_const_kind_usecase]
+        kind = ["quicksort", "mergesort"]
+
+        pyfunc = [f(k) for f in func for k in kind]
+        for p in pyfunc:
+            self._check_with_axis(p)
 
     @tag('important')
     def test_argsort_float(self):

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -413,20 +413,8 @@ class ArrayAttribute(AttributeTemplate):
         if ary.ndim == 1:
             return signature(types.none)
 
-    @bound_function("array.argsort")
-    def resolve_argsort(self, ary, args, kws):
-        assert not args
-        kwargs = dict(kws)
-        kind = kwargs.pop('kind', types.StringLiteral('quicksort'))
-        if kwargs:
-            msg = "Unsupported keywords: {!r}"
-            raise TypingError(msg.format([k for k in kwargs.keys()]))
-        if ary.ndim == 1:
-            def argsort_stub(kind='quicksort'):
-                pass
-            pysig = utils.pysignature(argsort_stub)
-            sig = signature(types.Array(types.intp, 1, 'C'), kind).replace(pysig=pysig)
-            return sig
+
+
 
     @bound_function("array.view")
     def resolve_view(self, ary, args, kws):

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -390,10 +390,6 @@ class Numpy_method_redirection(AbstractTemplate):
                     def sum_stub(arr, axis, dtype):
                         pass
                     pysig = utils.pysignature(sum_stub)
-            elif self.method_name == 'argsort':
-                def argsort_stub(arr, kind='quicksort'):
-                    pass
-                pysig = utils.pysignature(argsort_stub)
             else:
                 fmt = "numba doesn't support kwarg for {}"
                 raise TypingError(fmt.format(self.method_name))
@@ -415,7 +411,7 @@ def _numpy_redirect(fname):
     infer_global(numpy_function, types.Function(cls))
 
 for func in ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-             'cumsum', 'cumprod', 'argmin', 'argmax', 'argsort',
+             'cumsum', 'cumprod', 'argmin', 'argmax', #'argsort',
              'nonzero', 'ravel']:
     _numpy_redirect(func)
 


### PR DESCRIPTION
The code supports `axis` literal arguments, `None`, and select non-literal integers.  However, the performance is slower than `np.argsort`.