### PR TITLE
Permit ravel('A') for contig device arrays in CUDA target

### DIFF
--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -8,6 +8,7 @@ from numba.tests.support import (
     captured_stdout,
     SerialMixin,
     redirect_c_stdout,
+    TestCase
 )
 from numba.cuda.cuda_paths import get_conda_ctk
 

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -8,7 +8,6 @@ from numba.tests.support import (
     captured_stdout,
     SerialMixin,
     redirect_c_stdout,
-    TestCase
 )
 from numba.cuda.cuda_paths import get_conda_ctk
 

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, TestCase, SerialMixin
+from numba.cuda.testing import unittest, SerialMixin
+from numba.tests.support import TestCase
 
 
 class TestArrayAttr(SerialMixin, TestCase):

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, TestCase, SerialMixin
 
 
-class TestArrayAttr(SerialMixin, unittest.TestCase):
+class TestArrayAttr(SerialMixin, TestCase):
     def test_contigous_2d(self):
         ary = np.arange(10)
         cary = ary.reshape(2, 5)
@@ -48,8 +48,8 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
         dary = cuda.to_device(reshaped)
         dflat = dary.ravel()
         flat = dflat.copy_to_host()
-        self.assertTrue(flat.ndim == 1)
-        self.assertTrue(np.all(expect == flat))
+        self.assertEqual(flat.ndim, 1)
+        self.assertPreciseEqual(expect, flat)
 
         # explicit order kwarg
         for order in 'CA':
@@ -57,8 +57,8 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
             dary = cuda.to_device(reshaped)
             dflat = dary.ravel(order=order)
             flat = dflat.copy_to_host()
-            self.assertTrue(flat.ndim == 1)
-            self.assertTrue(np.all(expect == flat))
+            self.assertEqual(flat.ndim, 1)
+            self.assertPreciseEqual(expect, flat)
 
     def test_ravel_f(self):
         ary = np.arange(60)
@@ -68,8 +68,8 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
             dary = cuda.to_device(reshaped)
             dflat = dary.ravel(order=order)
             flat = dflat.copy_to_host()
-            self.assertTrue(flat.ndim == 1)
-            self.assertTrue(np.all(expect == flat))
+            self.assertEqual(flat.ndim, 1)
+            self.assertPreciseEqual(expect, flat)
 
     def test_reshape_c(self):
         ary = np.arange(10)
@@ -77,7 +77,7 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
         dary = cuda.to_device(ary)
         dary_reshaped = dary.reshape(2, 5)
         got = dary_reshaped.copy_to_host()
-        self.assertTrue(np.all(expect == got))
+        self.assertPreciseEqual(expect, got)
 
     def test_reshape_f(self):
         ary = np.arange(10)
@@ -85,7 +85,7 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
         dary = cuda.to_device(ary)
         dary_reshaped = dary.reshape(2, 5, order='F')
         got = dary_reshaped.copy_to_host()
-        self.assertTrue(np.all(expect == got))
+        self.assertPreciseEqual(expect, got)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -43,6 +43,7 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
     def test_ravel_c(self):
         ary = np.arange(60)
         reshaped = ary.reshape(2, 5, 2, 3)
+
         expect = reshaped.ravel(order='C')
         dary = cuda.to_device(reshaped)
         dflat = dary.ravel()
@@ -50,15 +51,25 @@ class TestArrayAttr(SerialMixin, unittest.TestCase):
         self.assertTrue(flat.ndim == 1)
         self.assertTrue(np.all(expect == flat))
 
+        # explicit order kwarg
+        for order in 'CA':
+            expect = reshaped.ravel(order=order)
+            dary = cuda.to_device(reshaped)
+            dflat = dary.ravel(order=order)
+            flat = dflat.copy_to_host()
+            self.assertTrue(flat.ndim == 1)
+            self.assertTrue(np.all(expect == flat))
+
     def test_ravel_f(self):
         ary = np.arange(60)
         reshaped = np.asfortranarray(ary.reshape(2, 5, 2, 3))
-        expect = reshaped.ravel(order='F')
-        dary = cuda.to_device(reshaped)
-        dflat = dary.ravel(order='F')
-        flat = dflat.copy_to_host()
-        self.assertTrue(flat.ndim == 1)
-        self.assertTrue(np.all(expect == flat))
+        for order in 'FA':
+            expect = reshaped.ravel(order=order)
+            dary = cuda.to_device(reshaped)
+            dflat = dary.ravel(order=order)
+            flat = dflat.copy_to_host()
+            self.assertTrue(flat.ndim == 1)
+            self.assertTrue(np.all(expect == flat))
 
     def test_reshape_c(self):
         ary = np.arange(10)

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -350,8 +350,8 @@ class Array(object):
         if self.ndim <= 1:
             return self
 
-        elif (order == 'C' and self.is_c_contig or
-                          order == 'F' and self.is_f_contig):
+        elif (order in 'CA' and self.is_c_contig or
+                          order in 'FA' and self.is_f_contig):
             newshape = (self.size,)
             newstrides = (self.itemsize,)
             arr = self.from_desc(self.extent.begin, newshape, newstrides,


### PR DESCRIPTION
As title.

Fixes #4827

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
