### PR TITLE
windowing test should check equality only up to double precision errors

### DIFF
--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3236,7 +3236,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             for M in [0, 1, 5, 12]:
                 expected = np_pyfunc(M)
                 got = np_nbfunc(M)
-                self.assertPreciseEqual(expected, got)
+                self.assertPreciseEqual(expected, got, prec='double')
 
             for M in ['a', 1.1, 1j]:
                 with self.assertRaises(TypingError) as raises:


### PR DESCRIPTION
exact comparison causes fails on macOS + SVML because macOS libm returns slighly different result.  (No such problem on Linux.)