### PR TITLE
Add stub of str.format()

### DIFF
--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -807,6 +807,14 @@ class TestUnicode(BaseTest):
         self.assertIn('Invalid use of Function(<built-in function mul>)',
                       str(raises.exception))
 
+    def test_format(self):
+        def pyfunc():
+            return '{} {}'.format('hello', 'world')
+
+        cfunc = njit(pyfunc)
+
+        self.assertEqual(pyfunc(), cfunc())
+
     def test_split_exception_empty_sep(self):
         self.disable_leak_check()
 

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -675,6 +675,16 @@ def unicode_endswith(a, b):
         return endswith_impl
 
 
+# https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L14938-L15019    # noqa: E501
+@overload_method(types.UnicodeType, 'format')
+def unicode_format(s, *args):
+    """Implements str.format()"""
+    def format_impl(s, *args):
+        pass
+
+    return format_impl
+
+
 @overload_method(types.UnicodeType, 'split')
 def unicode_split(a, sep=None, maxsplit=-1):
     if not (maxsplit == -1 or


### PR DESCRIPTION
When I tried to implement `str.format()` got an issue with position arguments. Could you please give advice how to work with position arguments in particular in my case?