### PR TITLE
arange returns max of bounds types

### DIFF
--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3765,7 +3765,7 @@ def _arange_dtype(*args):
     elif any(isinstance(a, types.Float) for a in bounds):
         dtype = types.float64
     else:
-        dtype = types.intp
+        dtype = types.intc
 
     return dtype
 

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -3765,7 +3765,7 @@ def _arange_dtype(*args):
     elif any(isinstance(a, types.Float) for a in bounds):
         dtype = types.float64
     else:
-        dtype = types.intc
+        dtype = max(bounds)
 
     return dtype
 


### PR DESCRIPTION
PR #4770 seems to have introduced arange test failures on windows 64-bit.