### PR TITLE
fix refining list by using extend on an iterator

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -905,9 +905,11 @@ def impl_extend(l, iterable):
             ty = iterable.dtype
         elif hasattr(iterable, "item_type"):  # lists
             ty = iterable.item_type
+        elif hasattr(iterable, "yield_type"):  # iterators and generators
+            ty = iterable.yield_type
         else:
             raise TypingError("unable to extend list, iterable is missing "
-                              "either *dtype* or *item_type*")
+                              "either *dtype*, *item_type* or *yield_type*.")
         l = l.refine(ty)
         # Create the signature that we wanted this impl to have
         sig = typing.signature(types.void, l, iterable)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -685,6 +685,19 @@ class TestListInferred(TestCase):
         self.assertEqual(list(got), [0, 1, 2])
         self.assertEqual(typeof(got).item_type, typeof(1))
 
+    def test_refine_list_extend_iter(self):
+        @njit
+        def foo():
+            l = List()
+            d = Dict()
+            d[0] = 0
+            # d.keys() provides a DictKeysIterableType
+            l.extend(d.keys())
+            return l
+
+        got = foo()
+        self.assertEqual(0, got[0])
+
 
 class TestListRefctTypes(MemoryLeakMixin, TestCase):
 


### PR DESCRIPTION
The interface for refining on extend for the typed list is a bit
'wobbly'. The type of the underlying thing to extend from, may be
encoded in three different ways. Specifically, certain kinds of
generators or iterators will expose the type of their items using the
`yield_type` attribute. So, we add a test to expose that missing
functionality via a test and add reading the attribute on extend to
enable this functionality.