### PR TITLE
skip the xfail test for now.  Py3.8 CFG refactor seems to have changed the test case

### DIFF
--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -91,6 +91,7 @@ class TestException(SerialMixin, unittest.TestCase):
         """
         self.case_raise_causing_warp_diverge(with_debug_mode=False)
 
+    @unittest.skip("python 3.8 CFG refactor makes this test pass")
     @skip_on_cudasim("failing case doesn't happen in CUDASIM")
     @unittest.expectedFailure
     def test_raise_causing_warp_diverge_failing(self):


### PR DESCRIPTION
Not removing the test until we're sure it is no longer relevant, but this test seems to no longer test what was intended since the Python 3.8-inspired CFG refactoring was merged.