### PR TITLE
regex needs to accept singular form of "argument"

### DIFF
--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -117,7 +117,7 @@ class TestSlices(MemoryLeakMixin, TestCase):
                 n_args = len(args)
                 self.assertRegexpMatches(
                     str(py_type_e),
-                    r"slice expected at (most|least) (3|1) arguments, got {}"
+                    r"slice expected at (most|least) (3|1) arguments?, got {}"
                     .format(n_args)
                 )
                 with self.assertRaises(TypingError) as numba_e:


### PR DESCRIPTION
In Python 3.8, this message is coming back with a singular word "argument", which was not accepted by the regex.