### PR TITLE
fix typed list equals

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -1053,7 +1053,7 @@ def _equals_helper(this, other, op):
     if not isinstance(this, types.ListType):
         return
     if not isinstance(other, types.ListType):
-        raise TypingError("list can only be compared to list")
+        return lambda this, other: False
 
     if op == "equals":
         def impl(this, other):
@@ -1096,7 +1096,7 @@ def compare_helper(this, other, accepted):
     if not isinstance(this, types.ListType):
         return
     if not isinstance(other, types.ListType):
-        raise TypingError("list can only be compared to list")
+        return lambda this, other: False
 
     def impl(this, other):
         return compare(this, other) in accepted

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -1043,8 +1043,7 @@ def equals(this, other):
     if len(this) != len(other):
         return False
     for i in range(len(this)):
-        this_item, other_item = this[i], other[i]
-        if this_item != other_item:
+        if this[i] != other[i]:
             return False
     else:
         return True

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -1038,40 +1038,33 @@ def impl_index(l, item, start=None, end=None):
     return impl
 
 
-@register_jitable
-def equals(this, other):
-    if len(this) != len(other):
-        return False
-    for i in range(len(this)):
-        if this[i] != other[i]:
-            return False
-    else:
-        return True
-
-
-def _equals_helper(this, other, op):
+def _equals_helper(this, other, OP):
     if not isinstance(this, types.ListType):
         return
     if not isinstance(other, types.ListType):
         return lambda this, other: False
 
-    if op == "equals":
-        def impl(this, other):
-            return equals(this, other)
-    elif op == "not_equals":
-        def impl(this, other):
-            return not equals(this, other)
+    def impl(this, other):
+        def equals(this, other):
+            if len(this) != len(other):
+                return False
+            for i in range(len(this)):
+                if this[i] != other[i]:
+                    return False
+            else:
+                return True
+        return OP(equals(this, other))
     return impl
 
 
 @overload(operator.eq)
 def impl_equals(this, other):
-    return _equals_helper(this, other, "equals")
+    return _equals_helper(this, other, operator.truth)
 
 
 @overload(operator.ne)
 def impl_not_equals(this, other):
-    return _equals_helper(this, other, "not_equals")
+    return _equals_helper(this, other, operator.not_)
 
 
 @register_jitable

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -16,6 +16,15 @@ from .imputils import (lower_builtin, lower_getattr, lower_getattr_generic,
                        impl_ret_borrowed, impl_ret_untracked,
                        numba_typeref_ctor)
 from .. import typing, types, cgutils, utils
+from ..extending import overload
+
+
+@overload(operator.truth)
+def ol_truth(val):
+    if isinstance(val, types.Boolean):
+        def impl(val):
+            return val
+        return impl
 
 
 @lower_builtin(operator.is_not, types.Any, types.Any)

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import itertools
 import functools
 import sys
+import operator
 
 import numpy as np
 
@@ -161,6 +162,9 @@ def sum_usecase(x):
 
 def type_unary_usecase(a, b):
     return type(a)(b)
+
+def truth_usecase(p):
+    return operator.truth(p)
 
 def unichr_usecase(x):
     return unichr(x)
@@ -885,6 +889,13 @@ class TestBuiltins(TestCase):
     def test_sum_npm(self):
         with self.assertTypingError():
             self.test_sum(flags=no_pyobj_flags)
+
+    def test_truth(self):
+        pyfunc = truth_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        self.assertEqual(pyfunc(True), cfunc(True))
+        self.assertEqual(pyfunc(False), cfunc(False))
 
     def test_type_unary(self):
         # Test type(val) and type(val)(other_val)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -863,3 +863,22 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
         # test
         for i, x in enumerate(ref):
             self.assertEqual(lst[i], ref[i])
+
+    @skip_py2
+    def test_equals_on_list_with_dict(self):
+        # https://github.com/numba/numba/issues/4879
+        a = List()
+        b = Dict()
+        b["a"] = 1
+        a.append(b)
+
+        c = List()
+        d = Dict()
+        d["a"] = 1
+        c.append(d)
+
+        self.assertEqual(a, c)
+
+        d["a"] = 2
+
+        self.assertNotEqual(a, c)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -853,20 +853,42 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
             self.assertEqual(lst[i], ref[i])
 
     @skip_py2
-    def test_equals_on_list_with_dict(self):
+    def test_equals_on_list_with_dict_for_equal_lists(self):
         # https://github.com/numba/numba/issues/4879
-        a = List()
-        b = Dict()
+        a, b = List(), Dict()
         b["a"] = 1
         a.append(b)
 
-        c = List()
-        d = Dict()
+        c, d = List(), Dict()
         d["a"] = 1
         c.append(d)
 
         self.assertEqual(a, c)
 
+    @skip_py2
+    def test_equals_on_list_with_dict_for_unequal_dicts(self):
+        # https://github.com/numba/numba/issues/4879
+        a, b = List(), Dict()
+        b["a"] = 1
+        a.append(b)
+
+        c, d = List(), Dict()
         d["a"] = 2
+        c.append(d)
+
+        self.assertNotEqual(a, c)
+
+    @skip_py2
+    def test_equals_on_list_with_dict_for_unequal_lists(self):
+        # https://github.com/numba/numba/issues/4879
+        a, b = List(), Dict()
+        b["a"] = 1
+        a.append(b)
+
+        c, d, e = List(), Dict(), Dict()
+        d["a"] = 1
+        e["b"] = 2
+        c.append(d)
+        c.append(e)
 
         self.assertNotEqual(a, c)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -610,22 +610,10 @@ class TestComparisons(MemoryLeakMixin, TestCase):
         expected = False, False, False, True, True, True
         self._cmp_dance(expected, pa, pb, na, nb)
 
-    def test_typing_mimatch(self):
-        self.disable_leak_check()
+    def test_equals_non_list(self):
         l = to_tl([1, 2, 3])
-
-        with self.assertRaises(TypingError) as raises:
-            cmp.py_func(l, 1)
-        self.assertIn(
-            "list can only be compared to list",
-            str(raises.exception),
-        )
-        with self.assertRaises(TypingError) as raises:
-            cmp(l, 1)
-        self.assertIn(
-            "list can only be compared to list",
-            str(raises.exception),
-        )
+        self.assertFalse(any(cmp.py_func(l, 1)))
+        self.assertFalse(any(cmp(l, 1)))
 
 
 class TestListInferred(TestCase):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -9,7 +9,6 @@ from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.utils import IS_PY3
-from numba.errors import TypingError
 from .support import TestCase, MemoryLeakMixin, unittest
 
 from numba.unsafe.refcount import get_refcount


### PR DESCRIPTION
The previous implementation incorrectly assumed that when comparing
equality of lists, we can compare the list elements for order. However,
not all possible types can be compared for order, for example typed
dictionaries can be compared for equality but not for order and so the
previous  implementation failed during typing. This fixes that and the
new equals and not equals methods don't assume that the types can be
compared for order but for quality only.

