### PR TITLE
loop canonicalisation and type aware tuple unroller/loop body versioning passes

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -75,6 +75,11 @@ These variables influence what is printed out during compilation of
 
    *Default value:* ``no_color``. The type of the value is ``string``.
 
+.. envvar:: NUMBA_HIGHLIGHT_DUMPS
+
+   If set to non-zero and ``pygments`` is installed, syntax highlighting is
+   applied to Numba IR, LLVM IR and assembly dumps. Default is zero.
+
 .. envvar:: NUMBA_DISABLE_PERFORMANCE_WARNINGS
 
    If set to non-zero the issuing of performance warnings is disabled. Default

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -215,15 +215,126 @@ likely never be supported.
 tuple
 -----
 
-The following operations are supported:
+Tuple support is categorised into two categories based on the contents of a
+tuple. The first category is homogeneous tuples, these are tuples where the type
+of all the values in the tuple are the same, the second is heterogeneous tuples,
+these are tuples where the types of the values are different.
 
-* tuple construction
-* tuple unpacking
-* comparison between tuples
-* iteration and indexing over homogeneous tuples
-* addition (concatenation) between tuples
-* slicing tuples with a constant slice
-* the index method on tuples
+.. note::
+
+    The ``tuple()`` constructor itself is NOT supported.
+
+homogeneous tuples
+------------------
+
+An example of a homogeneous tuple:
+
+.. code-block:: python
+
+    homogeneous_tuple = (1, 2, 3, 4)
+
+The following operations are supported on homogeneous tuples:
+
+* Tuple construction.
+* Tuple unpacking.
+* Comparison between tuples.
+* Iteration and indexing.
+* Addition (concatenation) between tuples.
+* Slicing tuples with a constant slice.
+* The index method on tuples.
+
+heterogeneous tuples
+--------------------
+
+An example of a heterogeneous tuple:
+
+.. code-block:: python
+
+    heterogeneous_tuple = (1, 2j, 3.0, "a")
+
+The following operations are supported on heterogeneous tuples:
+
+* Comparison between tuples.
+* Indexing using an index value that is a compile time constant
+  e.g. ``mytuple[7]``, where ``7`` is evidently a constant.
+* Iteration over a tuple (requires experimental :func:`literal_unroll` feature,
+  see below).
+
+.. warning::
+   The following feature (:func:`literal_unroll`) is experimental and was added
+   in version 0.47.
+
+To permit iteration over a heterogeneous tuple the special function
+:func:`numba.literal_unroll` must be used. This function has no effect other
+than to act as a token to permit the use of this feature. Example use:
+
+.. code-block:: python
+
+    from numba import njit, literal_unroll
+
+    @njit
+    def foo()
+        heterogeneous_tuple = (1, 2j, 3.0, "a")
+        for i in literal_unroll(heterogeneous_tuple):
+            print(i)
+
+.. warning::
+    The following restrictions apply to the use of :func:`literal_unroll`:
+
+    * This feature is only available for Python versions >= 3.6.
+    * :func:`literal_unroll` can only be used on tuples and constant lists of
+      compile time constants, e.g. ``[1, 2j, 3, "a"]`` and the list not being
+      mutated.
+    * The only supported use pattern for :func:`literal_unroll` is loop
+      iteration.
+    * Only one :func:`literal_unroll` call is permitted per loop nest (i.e.
+      nested heterogeneous tuple iteration loops are forbidden).
+    * The usual type inference/stability rules still apply.
+
+A more involved use of :func:`literal_unroll` might be type specific dispatch,
+recall that string and integer literal values are considered their own type,
+for example:
+
+.. code-block:: python
+
+    from numba import njit, types, literal_unroll
+    from numba.extending import overload
+
+    def dt(x):
+        # dummy function to overload
+        pass
+
+    @overload(dt, inline='always')
+    def ol_dt(li):
+        if isinstance(li, types.StringLiteral):
+            value = li.literal_value
+            if value == "apple":
+                def impl(li):
+                    return 1
+            elif value == "orange":
+                def impl(li):
+                    return 2
+            elif value == "banana":
+                def impl(li):
+                    return 3
+            return impl
+        elif isinstance(li, types.IntegerLiteral):
+            value = li.literal_value
+            if value == 0xca11ab1e:
+                def impl(li):
+                    # capture the dispatcher literal value
+                    return 0x5ca1ab1e + value
+                return impl
+
+    @njit
+    def foo():
+        acc = 0
+        for t in literal_unroll(('apple', 'orange', 'banana', 3390155550)):
+            acc += dt(t)
+        return acc
+
+    print(foo())
+
 
 list
 ----

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -17,7 +17,7 @@ from . import config, errors, _runtests as runtests, types
 # Re-export typeof
 from .special import (
     typeof, prange, pndindex, gdb, gdb_breakpoint, gdb_init,
-    literally
+    literally, literal_unroll
 )
 
 # Re-export error classes
@@ -70,6 +70,7 @@ __all__ = """
     stencil
     vectorize
     objmode
+    literal_unroll
     """.split() + types.__all__ + errors.__all__
 
 

--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1498,7 +1498,19 @@ class ArrayAnalysis(object):
         return self._analyze_broadcast(scope, equiv_set, expr.loc, expr.list_vars())
 
     def _analyze_op_build_tuple(self, scope, equiv_set, expr):
+        consts = []
+        for var in expr.items:
+            x = guard(find_const, self.func_ir, var)
+            if x is not None:
+                consts.append(x)
+            else:
+                break
+        else:
+            out = tuple([ir.Const(x, expr.loc) for x in consts])
+            return out, [], ir.Const(tuple(consts), expr.loc)
+        # default return for non-const
         return tuple(expr.items), []
+
 
     def _analyze_op_call(self, scope, equiv_set, expr):
         from numba.stencil import StencilFunc

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -350,7 +350,10 @@ class CompilerBase(object):
         pms = self.define_pipelines()
         for pm in pms:
             pipeline_name = pm.pipeline_name
-            event("Pipeline: %s" % pipeline_name)
+            func_name = "%s.%s" % (self.state.func_id.modname,
+                                   self.state.func_id.func_qualname)
+
+            event("Pipeline: %s for %s" % (pipeline_name, func_name))
             self.state.metadata['pipeline_times'] = {pipeline_name:
                                                      pm.exec_times}
             is_final_pipeline = pm == pms[-1]

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -19,7 +19,8 @@ from .untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
                              IRProcessing, DeadBranchPrune,
                              RewriteSemanticConstants, InlineClosureLikes,
                              GenericRewrites, WithLifting, InlineInlinables,
-                             FindLiterallyCalls, MakeFunctionToJitFunction)
+                             FindLiterallyCalls, MakeFunctionToJitFunction,
+                             LiteralUnroll)
 
 from .typed_passes import (NopythonTypeInference, AnnotateTypes,
                            NopythonRewrites, PreParforPass, ParforPass,
@@ -133,7 +134,7 @@ class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
                  lifted=lifted,
                  typing_error=None,
                  call_helper=None,
-                 metadata=None, # Do not store, arbitrary and potentially large!
+                 metadata=None,  # Do not store, arbitrary & potentially large!
                  reload_init=reload_init,
                  )
         return cr
@@ -440,14 +441,14 @@ class DefaultPassBuilder(object):
             pm.add_pass(GenericRewrites, "nopython rewrites")
             pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
             pm.add_pass(DeadBranchPrune, "dead branch pruning")
+
         pm.add_pass(InlineClosureLikes,
                     "inline calls to locally defined closures")
-
         # convert any remaining closures into functions
         pm.add_pass(MakeFunctionToJitFunction,
                     "convert make_function into JIT functions")
         # inline functions that have been determined as inlinable and rerun
-        # branch pruning this needs to be run after closures are inlined as
+        # branch pruning, this needs to be run after closures are inlined as
         # the IR repr of a closure masks call sites if an inlinable is called
         # inside a closure
         pm.add_pass(InlineInlinables, "inline inlinable functions")
@@ -455,6 +456,7 @@ class DefaultPassBuilder(object):
             pm.add_pass(DeadBranchPrune, "dead branch pruning")
 
         pm.add_pass(FindLiterallyCalls, "find literally calls")
+        pm.add_pass(LiteralUnroll, "handles literal_unroll")
 
         # typing
         pm.add_pass(NopythonTypeInference, "nopython frontend")

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -179,8 +179,9 @@ class PassManager(object):
         self.pipeline_name = pipeline_name
 
     def _validate_pass(self, pass_cls):
-        if (not (isinstance(pass_cls, str) or (inspect.isclass(pass_cls) and
-                 issubclass(pass_cls, CompilerPass)))):
+        if (not (isinstance(pass_cls, str) or
+                 (inspect.isclass(pass_cls) and
+                  issubclass(pass_cls, CompilerPass)))):
             msg = ("Pass must be referenced by name or be a subclass of a "
                    "CompilerPass. Have %s" % pass_cls)
             raise TypeError(msg)
@@ -218,17 +219,22 @@ class PassManager(object):
 
     def _debug_init(self):
         # determine after which passes IR dumps should take place
-        print_passes = []
-        if config.DEBUG_PRINT_AFTER != "none":
-            if config.DEBUG_PRINT_AFTER == "all":
-                print_passes = [x.name() for (x, _) in self.passes]
-            else:
-                # we don't validate whether the named passes exist in this
-                # pipeline the compiler may be used reentrantly and different
-                # pipelines may contain different passes
-                splitted = config.DEBUG_PRINT_AFTER.split(',')
-                print_passes = [x.strip() for x in splitted]
-        return print_passes
+        def parse(conf_item):
+            print_passes = []
+            if conf_item != "none":
+                if conf_item == "all":
+                    print_passes = [x.name() for (x, _) in self.passes]
+                else:
+                    # we don't validate whether the named passes exist in this
+                    # pipeline the compiler may be used reentrantly and
+                    # different pipelines may contain different passes
+                    splitted = conf_item.split(',')
+                    print_passes = [x.strip() for x in splitted]
+            return print_passes
+        ret = (parse(config.DEBUG_PRINT_AFTER),
+               parse(config.DEBUG_PRINT_BEFORE),
+               parse(config.DEBUG_PRINT_WRAP),)
+        return ret
 
     def finalize(self):
         """
@@ -236,7 +242,8 @@ class PassManager(object):
         without re-finalization.
         """
         self._analysis = self.dependency_analysis()
-        self._print_after = self._debug_init()
+        self._print_after, self._print_before, self._print_wrap = \
+            self._debug_init()
         self._finalized = True
 
     @property
@@ -272,6 +279,20 @@ class PassManager(object):
                 raise ValueError(msg % pss.name())
             return mangled
 
+        def debug_print(pass_name, print_condition, printable_condition):
+            if pass_name in print_condition:
+                fid = internal_state.func_id
+                args = (fid.modname, fid.func_qualname, self.pipeline_name,
+                        printable_condition, pass_name)
+                print(("%s.%s: %s: %s %s" % args).center(120, '-'))
+                if internal_state.func_ir is not None:
+                    internal_state.func_ir.dump()
+                else:
+                    print("func_ir is None")
+
+        # debug print before this pass?
+        debug_print(pss.name(), self._print_before + self._print_wrap, "BEFORE")
+
         # wire in the analysis info so it's accessible
         pss.analysis = self._analysis
 
@@ -286,9 +307,9 @@ class PassManager(object):
             # TODO: Add in self consistency enforcement for
             # `func_ir._definitions` etc
             if _pass_registry.get(pss.__class__).mutates_CFG:
-                if mutated: # block level changes, rebuild all
+                if mutated:  # block level changes, rebuild all
                     PostProcessor(internal_state.func_ir).run()
-                else: # CFG level changes rebuild CFG
+                else:  # CFG level changes rebuild CFG
                     internal_state.func_ir.blocks = transforms.canonicalize_cfg(
                         internal_state.func_ir.blocks)
 
@@ -298,12 +319,7 @@ class PassManager(object):
         self.exec_times["%s_%s" % (index, pss.name())] = pt
 
         # debug print after this pass?
-        if pss.name() in self._print_after:
-            fid = internal_state.func_id
-            args = (fid.modname, fid.func_qualname, self.pipeline_name,
-                    pss.name())
-            print(("%s.%s: %s: %s" % args).center(80, '-'))
-            internal_state.func_ir.dump()
+        debug_print(pss.name(), self._print_after + self._print_wrap, "AFTER")
 
     def run(self, state):
         """

--- a/numba/config.py
+++ b/numba/config.py
@@ -150,6 +150,15 @@ class _EnvReloader(object):
         # DEBUG print IR after pass names
         DEBUG_PRINT_AFTER = _readenv("NUMBA_DEBUG_PRINT_AFTER", str, "none")
 
+        # DEBUG print IR before pass names
+        DEBUG_PRINT_BEFORE = _readenv("NUMBA_DEBUG_PRINT_BEFORE", str, "none")
+
+        # DEBUG print IR before and after pass names
+        DEBUG_PRINT_WRAP = _readenv("NUMBA_DEBUG_PRINT_WRAP", str, "none")
+
+        # Highlighting in intermediate dumps
+        HIGHLIGHT_DUMPS = _readenv("NUMBA_HIGHLIGHT_DUMPS", int, 0)
+
         # JIT Debug flag to trigger IR instruction print
         DEBUG_JIT = _readenv("NUMBA_DEBUG_JIT", int, 0)
 

--- a/numba/controlflow.py
+++ b/numba/controlflow.py
@@ -82,8 +82,12 @@ class CFGraph(object):
         If such an edge already exists, it is replaced (duplicate edges
         are not possible).
         """
-        assert src in self._nodes
-        assert dest in self._nodes
+        if src not in self._nodes:
+            raise ValueError("Cannot add edge as src node %s not in nodes %s" %
+                             (src, self._nodes))
+        if dest not in self._nodes:
+            raise ValueError("Cannot add edge as dest node %s not in nodes %s" %
+                             (dest, self._nodes))
         self._add_edge(src, dest, data)
 
     def successors(self, src):
@@ -596,6 +600,23 @@ class CFGraph(object):
                          for src, dests in self._succs.items())
         import pprint
         pprint.pprint(adj_lists, stream=file)
+
+    def __eq__(self, other):
+        if not isinstance(other, CFGraph):
+            raise NotImplementedError
+
+        # A few derived items are checked to makes sure process() has been
+        # invoked equally.
+        for x in ['_nodes', '_edge_data', '_entry_point', '_preds', '_succs',
+                  '_doms', '_back_edges']:
+            this = getattr(self, x, None)
+            that = getattr(other, x, None)
+            if this != that:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class ControlFlowAnalysis(object):

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -726,6 +726,18 @@ class TupleModel(StructModel):
         super(TupleModel, self).__init__(dmm, fe_type, members)
 
 
+@register_default(types.UnionType)
+class UnionModel(StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('tag', types.uintp),
+            # XXX: it should really be a MemInfoPointer(types.voidptr)
+            ('payload', types.Tuple.from_types(fe_type.types)),
+        ]
+        super(UnionModel, self).__init__(dmm, fe_type, members)
+
+
+
 @register_default(types.Pair)
 class PairModel(StructModel):
     def __init__(self, dmm, fe_type):

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -460,11 +460,12 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
                 args = args + defaults_list
             elif (isinstance(callee_defaults, ir.Var)
                     or isinstance(callee_defaults, str)):
-                defaults = func_ir.get_definition(callee_defaults)
-                assert(isinstance(defaults, ir.Const))
-                loc = defaults.loc
-                args = args + [ir.Const(value=v, loc=loc)
-                            for v in defaults.value]
+                default_tuple = func_ir.get_definition(callee_defaults)
+                assert(isinstance(default_tuple, ir.Expr))
+                assert(default_tuple.op == "build_tuple")
+                const_vals = [func_ir.get_definition(x) for
+                              x in default_tuple.items]
+                args = args + const_vals
             else:
                 raise NotImplementedError(
                     "Unsupported defaults to make_function: {}".format(

--- a/numba/interpreter.py
+++ b/numba/interpreter.py
@@ -277,7 +277,7 @@ class Interpreter(object):
     def store(self, value, name, redefine=False):
         """
         Store *value* (a Expr or Var instance) into the variable named *name*
-        (a str object).
+        (a str object). Returns the target variable.
         """
         if redefine or self.current_block_offset in self.cfa.backbone:
             rename = not (name in self.code_cellvars)
@@ -289,6 +289,7 @@ class Interpreter(object):
         stmt = ir.Assign(value=value, target=target, loc=self.loc)
         self.current_block.append(stmt)
         self.definitions[target.name].append(value)
+        return target
 
     def get(self, name):
         """
@@ -606,7 +607,16 @@ class Interpreter(object):
 
     def op_LOAD_CONST(self, inst, res):
         value = self.code_consts[inst.arg]
-        const = ir.Const(value, loc=self.loc)
+        if isinstance(value, tuple):
+            st = []
+            for x in value:
+                nm = '$const_%s' % str(x)
+                val_const = ir.Const(x, loc=self.loc)
+                target = self.store(val_const, name=nm, redefine=True)
+                st.append(target)
+            const = ir.Expr.build_tuple(st, loc=self.loc)
+        else:
+            const = ir.Const(value, loc=self.loc)
         self.store(const, res)
 
     def op_LOAD_GLOBAL(self, inst, res):
@@ -710,7 +720,16 @@ class Interpreter(object):
             for inst in self.current_block.body:
                 if isinstance(inst, ir.Assign) and inst.target is names:
                     self.current_block.remove(inst)
-                    keys = inst.value.value
+                    # scan up the block looking for the values, remove them
+                    # and find their name strings
+                    named_items = []
+                    for x in inst.value.items:
+                        for y in self.current_block.body[::-1]:
+                            if x == y.target:
+                                self.current_block.remove(y)
+                                named_items.append(y.value.value)
+                                break
+                    keys = named_items
                     break
 
             nkeys = len(keys)
@@ -750,7 +769,16 @@ class Interpreter(object):
         for inst in self.current_block.body:
             if isinstance(inst, ir.Assign) and inst.target is keyvar:
                 self.current_block.remove(inst)
-                keytup = inst.value.value
+                # scan up the block looking for the values, remove them
+                # and find their name strings
+                named_items = []
+                for x in inst.value.items:
+                    for y in self.current_block.body[::-1]:
+                        if x == y.target:
+                            self.current_block.remove(y)
+                            named_items.append(y.value.value)
+                            break
+                keytup = named_items
                 break
         assert len(keytup) == len(values)
         keyconsts = [ir.Const(value=x, loc=self.loc) for x in keytup]

--- a/numba/special.py
+++ b/numba/special.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
+import sys
+
+from numba.extending import overload
 import numpy as np
 
 from .typing.typeof import typeof
@@ -88,6 +91,24 @@ def literally(obj):
     return obj
 
 
+def literal_unroll(container):
+    from numba.errors import UnsupportedError
+    if sys.version_info[:2] < (3, 6):
+        raise UnsupportedError("literal_unroll is only support in Python > 3.5")
+    return container
+
+
+@overload(literal_unroll)
+def literal_unroll_impl(container):
+    from numba.errors import UnsupportedError
+    if sys.version_info[:2] < (3, 6):
+        raise UnsupportedError("literal_unroll is only support in Python > 3.5")
+
+    def impl(container):
+        return container
+    return impl
+
+
 __all__ = [
     'typeof',
     'prange',
@@ -96,4 +117,5 @@ __all__ = [
     'gdb_breakpoint',
     'gdb_init',
     'literally',
+    'literal_unroll',
 ]

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -707,7 +707,8 @@ class BaseContext(object):
         cav = self.cast(builder, av, at, ty)
         cbv = self.cast(builder, bv, bt, ty)
         fnty = self.typing_context.resolve_value_type(key)
-        cmpsig = fnty.get_call_type(self.typing_context, argtypes, {})
+        # the sig is homogeneous in the unified casted type
+        cmpsig = fnty.get_call_type(self.typing_context, (ty, ty), {})
         cmpfunc = self.get_function(fnty, cmpsig)
         self.add_linking_libs(getattr(cmpfunc, 'libs', ()))
         return cmpfunc(builder, (cav, cbv))
@@ -1124,7 +1125,8 @@ class _wrap_impl(object):
     """
 
     def __init__(self, imp, context, sig):
-        self._imp = _wrap_missing_loc(imp)
+        self._callable = _wrap_missing_loc(imp)
+        self._imp = self._callable()
         self._context = context
         self._sig = sig
 
@@ -1137,8 +1139,7 @@ class _wrap_impl(object):
         return getattr(self._imp, item)
 
     def __repr__(self):
-        return "<wrapped %s>" % self._imp
-
+        return "<wrapped %s>" % repr(self._callable)
 
 def _has_loc(fn):
     """Does function *fn* take ``loc`` argument?
@@ -1147,27 +1148,36 @@ def _has_loc(fn):
     return 'loc' in sig.parameters
 
 
-def _wrap_missing_loc(fn):
-    """Wrap function for missing ``loc`` keyword argument.
-    Otherwise, return the original *fn*.
-    """
-    if not _has_loc(fn):
-        def wrapper(*args, **kwargs):
-            kwargs.pop('loc')     # drop unused loc
-            return fn(*args, **kwargs)
+class _wrap_missing_loc(object):
 
-        # Copy the following attributes from the wrapped.
-        # Following similar implementation as functools.wraps but
-        # ignore attributes if not available (i.e fix py2.7)
-        attrs = '__name__', 'libs'
-        for attr in attrs:
-            try:
-                val = getattr(fn, attr)
-            except AttributeError:
-                pass
-            else:
-                setattr(wrapper, attr, val)
+    def __init__(self, fn):
+        self.func = fn # store this to help with debug
 
-        return wrapper
-    else:
-        return fn
+    def __call__(self):
+        """Wrap function for missing ``loc`` keyword argument.
+        Otherwise, return the original *fn*.
+        """
+        fn = self.func
+        if not _has_loc(fn):
+            def wrapper(*args, **kwargs):
+                kwargs.pop('loc')     # drop unused loc
+                return fn(*args, **kwargs)
+
+            # Copy the following attributes from the wrapped.
+            # Following similar implementation as functools.wraps but
+            # ignore attributes if not available (i.e fix py2.7)
+            attrs = '__name__', 'libs'
+            for attr in attrs:
+                try:
+                    val = getattr(fn, attr)
+                except AttributeError:
+                    pass
+                else:
+                    setattr(wrapper, attr, val)
+
+            return wrapper
+        else:
+            return fn
+
+    def __repr__(self):
+        return "<wrapped %s>" % self.func

--- a/numba/targets/codegen.py
+++ b/numba/targets/codegen.py
@@ -26,8 +26,24 @@ def _is_x86(triple):
 
 
 def dump(header, body):
+    if config.HIGHLIGHT_DUMPS:
+        try:
+            import pygments
+        except ImportError:
+            msg = "Please install pygments to see highlighted dumps"
+            raise ValueError(msg)
+        else:
+            from pygments import highlight
+            from pygments.lexers import GasLexer as lexer
+            from pygments.formatters import Terminal256Formatter
+            def printer(arg):
+                print(highlight(arg, lexer(),
+                      Terminal256Formatter(style='solarized-light')))
+    else:
+        printer = print
+    print('=' * 80)
     print(header.center(80, '-'))
-    print(body)
+    printer(body)
     print('=' * 80)
 
 

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 from numba import unittest_support as unittest
 from numba import (njit, typeof, types, typing, typeof, ir, utils, bytecode,
-    jitclass, prange)
+    jitclass, prange, postproc)
 from .support import TestCase, tag
 from numba.array_analysis import EquivSet, ArrayAnalysis
 from numba.compiler import Compiler, Flags, PassManager
@@ -94,6 +94,8 @@ class ArrayAnalysisPass(FunctionPass):
                                              state.type_annotation.typemap,
                                              state.type_annotation.calltypes)
         state.array_analysis.run(state.func_ir.blocks)
+        post_proc = postproc.PostProcessor(state.func_ir)
+        post_proc.run()
         state.func_ir_copies.append(state.func_ir.copy())
         if state.test_idempotence and len(state.func_ir_copies) > 1:
             state.test_idempotence(state.func_ir_copies)

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -372,10 +372,8 @@ class TestArrayComprehension(unittest.TestCase):
         # test is expected to fail
         with self.assertRaises(TypingError) as raises:
             self.check(comp_nest_with_dependency, 5)
-        self.assertIn(
-            'Invalid use of Function({})'.format(operator.setitem),
-            str(raises.exception),
-        )
+        self.assertIn('Invalid use of Function', str(raises.exception))
+        self.assertIn('array(undefined,', str(raises.exception))
 
     @tag('important')
     def test_no_array_comp(self):

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1371,8 +1371,8 @@ class TestDictInferred(TestCase):
             d, dk2 = foo(k1, v1, k2)
         self.assertEqual(len(w), 1)
         # Make sure the warning is about unsafe cast
-        self.assertIn('unsafe cast from tuple(int32 x 2) to tuple(int8 x 2)',
-                      str(w[0]))
+        msg = 'unsafe cast from UniTuple(int32 x 2) to UniTuple(int8 x 2)'
+        self.assertIn(msg, str(w[0]))
 
         keys = list(d.keys())
         self.assertEqual(keys[0], (1, 2))

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -1137,12 +1137,12 @@ class TestNpArray(MemoryLeakMixin, BaseTest):
                            'homogeneous sequence')):
             cfunc(np.array([1.]))
 
-        with check_raises(('type (int64, reflected list(int64)) does '
+        with check_raises(('type Tuple(int64, reflected list(int64)) does '
                           'not have a regular shape')):
             cfunc((np.int64(1), [np.int64(2)]))
 
         with check_raises(
-                "cannot convert (int64, Record(a[type=int32;offset=0],"
+                "cannot convert Tuple(int64, Record(a[type=int32;offset=0],"
                 "b[type=float32;offset=4];8;False)) to a homogeneous type",
             ):
             st = np.dtype([('a', 'i4'), ('b', 'f4')])

--- a/numba/tests/test_flow_control.py
+++ b/numba/tests/test_flow_control.py
@@ -980,6 +980,48 @@ class TestCFGraph(TestCase):
         for node in [7, 10, 23]:
             self.assertEqual(g.in_loops(node), [loop])
 
+    def test_equals(self):
+
+        def get_new():
+            g = self.from_adj_list({0: [18, 12], 12: [21], 18: [21], 21: []})
+            g.set_entry_point(0)
+            g.process()
+            return g
+
+        x = get_new()
+        y = get_new()
+
+        # identical
+        self.assertEqual(x, y)
+
+        # identical but defined in a different order
+        g = self.from_adj_list({0: [12, 18], 18: [21], 21: [], 12: [21]})
+        g.set_entry_point(0)
+        g.process()
+        self.assertEqual(x, g)
+
+        # different entry point
+        z = get_new()
+        z.set_entry_point(18)
+        z.process()
+        self.assertNotEqual(x, z)
+
+        # extra node/edge, same entry point
+        z = self.from_adj_list({0: [18, 12], 12: [21], 18: [21], 21: [22],
+                                22: []})
+        z.set_entry_point(0)
+        z.process()
+        self.assertNotEqual(x, z)
+
+        # same nodes, different edges
+        a = self.from_adj_list({0: [18, 12], 12: [0], 18: []})
+        a.set_entry_point(0)
+        a.process()
+        z = self.from_adj_list({0: [18, 12], 12: [18], 18: []})
+        z.set_entry_point(0)
+        z.process()
+        self.assertNotEqual(a, z)
+
 
 class TestRealCodeDomFront(TestCase):
     """Test IDOM and DOMFRONT computation on real python bytecode.

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -832,7 +832,7 @@ class TestUnboxing(MemoryLeakMixin, TestCase):
             cfunc(lst)
         if utils.IS_PY3:
             msg = ("can't unbox heterogeneous list: "
-                   "tuple({0} x 1) != tuple({0} x 2)")
+                   "UniTuple({0} x 1) != UniTuple({0} x 2)")
             self.assertEqual(str(raises.exception), msg.format(types.intp))
         else:
             self.assertEqual(

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1535,6 +1535,7 @@ class TestLiteralUnrollPy2(TestCase):
                       str(raises.exception))
 
 
+@skip_lt_py36
 class TestMore(TestCase):
     def test_invalid_use_of_unroller(self):
         @njit
@@ -1735,6 +1736,7 @@ class CapturingCompiler(CompilerBase):
         return [pm]
 
 
+@skip_lt_py36
 class TestLiteralUnrollPassTriggering(TestCase):
 
     def test_literal_unroll_not_invoked(self):

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1,0 +1,1539 @@
+from __future__ import print_function, absolute_import, division
+
+import sys
+import numpy as np
+
+from numba.tests.support import (TestCase, MemoryLeakMixin,
+                                 skip_parfors_unsupported)
+from numba import njit, types, typed, ir, errors, literal_unroll, prange
+from numba.testing import unittest
+from numba.extending import overload
+from numba.compiler_machinery import PassManager, register_pass, FunctionPass
+from numba.compiler import CompilerBase
+from numba.untyped_passes import (TranslateByteCode, IRProcessing,
+                                  InlineClosureLikes, SimplifyCFG,
+                                  IterLoopCanonicalization)
+from numba.typed_passes import (NopythonTypeInference, IRLegalization,
+                                NoPythonBackend, PartialTypeInference)
+from numba.ir_utils import (compute_cfg_from_blocks, flatten_labels)
+
+_lt_py_36 = sys.version_info[:2] < (3, 6)
+skip_lt_py36 = unittest.skipIf(_lt_py_36, "Unsupported on < Python 3.6")
+
+
+@skip_lt_py36
+class TestLiteralTupleInterpretation(MemoryLeakMixin, TestCase):
+
+    def check(self, func, var):
+        cres = func.overloads[func.signatures[0]]
+        ty = cres.fndesc.typemap[var]
+        self.assertTrue(isinstance(ty, types.Tuple))
+        for subty in ty:
+            self.assertTrue(isinstance(subty, types.Literal), "non literal")
+
+    def test_homogeneous_literal(self):
+        @njit
+        def foo():
+            x = (1, 2, 3)
+            return x[1]
+
+        self.assertEqual(foo(), foo.py_func())
+        self.check(foo, 'x')
+
+    def test_heterogeneous_literal(self):
+        @njit
+        def foo():
+            x = (1, 2, 3, 'a')
+            return x[3]
+
+        self.assertEqual(foo(), foo.py_func())
+        self.check(foo, 'x')
+
+    def test_non_literal(self):
+        @njit
+        def foo():
+            x = (1, 2, 3, 'a', 1j)
+            return x[4]
+
+        self.assertEqual(foo(), foo.py_func())
+        with self.assertRaises(AssertionError) as e:
+            self.check(foo, 'x')
+
+        self.assertIn("non literal", str(e.exception))
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class PreserveIR(FunctionPass):
+    _name = "preserve_ir"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state.metadata['func_ir'] = state.func_ir
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=False)
+class ResetTypeInfo(FunctionPass):
+    _name = "reset_the_type_information"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state.typemap = None
+        state.return_type = None
+        state.calltypes = None
+        return True
+
+
+@skip_lt_py36
+class TestLoopCanonicalisation(MemoryLeakMixin, TestCase):
+
+    def get_pipeline(use_canonicaliser, use_partial_typing=False):
+        class NewCompiler(CompilerBase):
+
+            def define_pipelines(self):
+                pm = PassManager("custom_pipeline")
+
+                # untyped
+                pm.add_pass(TranslateByteCode, "analyzing bytecode")
+                pm.add_pass(IRProcessing, "processing IR")
+                pm.add_pass(InlineClosureLikes,
+                            "inline calls to locally defined closures")
+                if use_partial_typing:
+                    pm.add_pass(PartialTypeInference, "do partial typing")
+                if use_canonicaliser:
+                    pm.add_pass(IterLoopCanonicalization, "Canonicalise loops")
+                pm.add_pass(SimplifyCFG, "Simplify the CFG")
+
+                # typed
+                if use_partial_typing:
+                    pm.add_pass(ResetTypeInfo, "resets the type info state")
+
+                pm.add_pass(NopythonTypeInference, "nopython frontend")
+
+                # legalise
+                pm.add_pass(IRLegalization, "ensure IR is legal")
+
+                # preserve
+                pm.add_pass(PreserveIR, "save IR for later inspection")
+
+                # lower
+                pm.add_pass(NoPythonBackend, "nopython mode backend")
+
+                # finalise the contents
+                pm.finalize()
+
+                return [pm]
+        return NewCompiler
+
+    # generate variants
+    LoopIgnoringCompiler = get_pipeline(False)
+    LoopCanonicalisingCompiler = get_pipeline(True)
+    TypedLoopCanonicalisingCompiler = get_pipeline(True, True)
+
+    def test_simple_loop_in_depth(self):
+        """ This heavily checks a simple loop transform """
+
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo(tup):
+                acc = 0
+                for i in tup:
+                    acc += i
+                return acc
+
+            x = (1, 2, 3)
+            self.assertEqual(foo(x), foo.py_func(x))
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.LoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's three more call types in the canonicalised one:
+        # len(tuple arg)
+        # range(of the len() above)
+        # getitem(tuple arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 3,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+        def find_getX(fd, op):
+            return [x for x in fd.calltypes.keys()
+                    if isinstance(x, ir.Expr) and x.op == op]
+
+        il_getiters = find_getX(ignore_loops_fndesc, "getiter")
+        self.assertEqual(len(il_getiters), 1)  # tuple iterator
+
+        cl_getiters = find_getX(canonicalise_loops_fndesc, "getiter")
+        self.assertEqual(len(cl_getiters), 1)  # loop range iterator
+
+        cl_getitems = find_getX(canonicalise_loops_fndesc, "getitem")
+        self.assertEqual(len(cl_getitems), 1)  # tuple getitem induced by loop
+
+        # check the value of the untransformed IR getiter is now the value of
+        # the transformed getitem
+        self.assertEqual(il_getiters[0].value.name, cl_getitems[0].value.name)
+
+        # check the type of the transformed IR getiter is a range iter
+        range_inst = canonicalise_loops_fndesc.calltypes[cl_getiters[0]].args[0]
+        self.assertTrue(isinstance(range_inst, types.RangeType))
+
+    def test_transform_scope(self):
+        """ This checks the transform, when there's no typemap, will happily
+        transform a loop on something that's not tuple-like
+        """
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo():
+                acc = 0
+                for i in [1, 2, 3]:
+                    acc += i
+                return acc
+
+            self.assertEqual(foo(), foo.py_func())
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.LoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's three more call types in the canonicalised one:
+        # len(literal list)
+        # range(of the len() above)
+        # getitem(literal list arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 3,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+        def find_getX(fd, op):
+            return [x for x in fd.calltypes.keys()
+                    if isinstance(x, ir.Expr) and x.op == op]
+
+        il_getiters = find_getX(ignore_loops_fndesc, "getiter")
+        self.assertEqual(len(il_getiters), 1)  # list iterator
+
+        cl_getiters = find_getX(canonicalise_loops_fndesc, "getiter")
+        self.assertEqual(len(cl_getiters), 1)  # loop range iterator
+
+        cl_getitems = find_getX(canonicalise_loops_fndesc, "getitem")
+        self.assertEqual(len(cl_getitems), 1)  # list getitem induced by loop
+
+        # check the value of the untransformed IR getiter is now the value of
+        # the transformed getitem
+        self.assertEqual(il_getiters[0].value.name, cl_getitems[0].value.name)
+
+        # check the type of the transformed IR getiter is a range iter
+        range_inst = canonicalise_loops_fndesc.calltypes[cl_getiters[0]].args[0]
+        self.assertTrue(isinstance(range_inst, types.RangeType))
+
+    @unittest.skip("Waiting for pass to be enabled for all tuples")
+    def test_influence_of_typed_transform(self):
+        """ This heavily checks a typed transformation only impacts tuple
+        induced loops"""
+
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo(tup):
+                acc = 0
+                for i in range(4):
+                    for y in tup:
+                        for j in range(3):
+                            acc += 1
+                return acc
+
+            x = (1, 2, 3)
+            self.assertEqual(foo(x), foo.py_func(x))
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.TypedLoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's three more call types in the canonicalised one:
+        # len(tuple arg)
+        # range(of the len() above)
+        # getitem(tuple arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 3,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+        def find_getX(fd, op):
+            return [x for x in fd.calltypes.keys()
+                    if isinstance(x, ir.Expr) and x.op == op]
+
+        il_getiters = find_getX(ignore_loops_fndesc, "getiter")
+        self.assertEqual(len(il_getiters), 3)  # 1 * tuple + 2 * loop range
+
+        cl_getiters = find_getX(canonicalise_loops_fndesc, "getiter")
+        self.assertEqual(len(cl_getiters), 3)  # 3 * loop range iterator
+
+        cl_getitems = find_getX(canonicalise_loops_fndesc, "getitem")
+        self.assertEqual(len(cl_getitems), 1)  # tuple getitem induced by loop
+
+        # check the value of the untransformed IR getiter is now the value of
+        # the transformed getitem
+        self.assertEqual(il_getiters[1].value.name, cl_getitems[0].value.name)
+
+        # check the type of the transformed IR getiter's are all range iter
+        for x in cl_getiters:
+            range_inst = canonicalise_loops_fndesc.calltypes[x].args[0]
+            self.assertTrue(isinstance(range_inst, types.RangeType))
+
+    def test_influence_of_typed_transform_literal_unroll(self):
+        """ This heavily checks a typed transformation only impacts loops with
+        literal_unroll marker"""
+
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo(tup):
+                acc = 0
+                for i in range(4):
+                    for y in literal_unroll(tup):
+                        for j in range(3):
+                            acc += 1
+                return acc
+
+            x = (1, 2, 3)
+            self.assertEqual(foo(x), foo.py_func(x))
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.TypedLoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's three more call types in the canonicalised one:
+        # len(tuple arg)
+        # range(of the len() above)
+        # getitem(tuple arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 3,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+        def find_getX(fd, op):
+            return [x for x in fd.calltypes.keys()
+                    if isinstance(x, ir.Expr) and x.op == op]
+
+        il_getiters = find_getX(ignore_loops_fndesc, "getiter")
+        self.assertEqual(len(il_getiters), 3)  # 1 * tuple + 2 * loop range
+
+        cl_getiters = find_getX(canonicalise_loops_fndesc, "getiter")
+        self.assertEqual(len(cl_getiters), 3)  # 3 * loop range iterator
+
+        cl_getitems = find_getX(canonicalise_loops_fndesc, "getitem")
+        self.assertEqual(len(cl_getitems), 1)  # tuple getitem induced by loop
+
+        # check the value of the untransformed IR getiter is now the value of
+        # the transformed getitem
+        self.assertEqual(il_getiters[1].value.name, cl_getitems[0].value.name)
+
+        # check the type of the transformed IR getiter's are all range iter
+        for x in cl_getiters:
+            range_inst = canonicalise_loops_fndesc.calltypes[x].args[0]
+            self.assertTrue(isinstance(range_inst, types.RangeType))
+
+    @unittest.skip("Waiting for pass to be enabled for all tuples")
+    def test_lots_of_loops(self):
+        """ This heavily checks a simple loop transform """
+
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo(tup):
+                acc = 0
+                for i in tup:
+                    acc += i
+                    for j in tup + (4, 5, 6):
+                        acc += 1 - j
+                        if j > 5:
+                            break
+                    else:
+                        acc -= 2
+                for i in tup:
+                    acc -= i % 2
+
+                return acc
+
+            x = (1, 2, 3)
+            self.assertEqual(foo(x), foo.py_func(x))
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.LoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's three * N more call types in the canonicalised one:
+        # len(tuple arg)
+        # range(of the len() above)
+        # getitem(tuple arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 3 * 3,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+    def test_inlined_loops(self):
+        """ Checks a loop appearing from a closure """
+
+        def get_info(pipeline):
+            @njit(pipeline_class=pipeline)
+            def foo(tup):
+                def bar(n):
+                    acc = 0
+                    for i in range(n):
+                        acc += 1
+                    return acc
+
+                acc = 0
+                for i in tup:
+                    acc += i
+                    acc += bar(i)
+
+                return acc
+
+            x = (1, 2, 3)
+            self.assertEqual(foo(x), foo.py_func(x))
+            cres = foo.overloads[foo.signatures[0]]
+            func_ir = cres.metadata['func_ir']
+            return func_ir, cres.fndesc
+
+        ignore_loops_ir, ignore_loops_fndesc = \
+            get_info(self.LoopIgnoringCompiler)
+        canonicalise_loops_ir, canonicalise_loops_fndesc = \
+            get_info(self.LoopCanonicalisingCompiler)
+
+        # check CFG is the same
+        def compare_cfg(a, b):
+            a_cfg = compute_cfg_from_blocks(flatten_labels(a.blocks))
+            b_cfg = compute_cfg_from_blocks(flatten_labels(b.blocks))
+            self.assertEqual(a_cfg, b_cfg)
+
+        compare_cfg(ignore_loops_ir, canonicalise_loops_ir)
+
+        # check there's 2 * N - 1 more call types in the canonicalised one:
+        # The -1 comes from the closure being inlined and and the call removed.
+        # len(tuple arg)
+        # range(of the len() above)
+        # getitem(tuple arg, index)
+        self.assertEqual(len(ignore_loops_fndesc.calltypes) + 5,
+                         len(canonicalise_loops_fndesc.calltypes))
+
+
+@skip_lt_py36
+class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
+
+    def test_01(self):
+        # test a case which is already in loop canonical form
+        @njit
+        def foo(idx, z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for i in range(len(literal_unroll(a))):
+                acc += a[i]
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    break
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(2, k), foo.py_func(2, k))
+
+    def test_02(self):
+        # same as test_1 but without the explicit loop canonicalisation
+
+        @njit
+        def foo(idx, z):
+            x = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    break
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(2, k), foo.py_func(2, k))
+
+    def test_03(self):
+        # two unrolls
+        @njit
+        def foo(idx, z):
+            x = (12, 12.7, 3j, 4, z, 2 * z)
+            y = ('foo', z, 2 * z)
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for t in literal_unroll(y):
+                        acc += t is False
+                    break
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(2, k), foo.py_func(2, k))
+
+    def test_04(self):
+        # mixed ref counted types
+        @njit
+        def foo(tup):
+            acc = 0
+            for a in literal_unroll(tup):
+                acc += a.sum()
+            return acc
+
+        n = 10
+        tup = (np.ones((n,)), np.ones((n, n)), np.ones((n, n, n)))
+        self.assertEqual(foo(tup), foo.py_func(tup))
+
+    def test_05(self):
+        # mix unroll and static_getitem
+        @njit
+        def foo(tup1, tup2):
+            acc = 0
+            for a in literal_unroll(tup1):
+                if a == 'a':
+                    acc += tup2[0].sum()
+                elif a == 'b':
+                    acc += tup2[1].sum()
+                elif a == 'c':
+                    acc += tup2[2].sum()
+                elif a == 12:
+                    acc += tup2[3].sum()
+                elif a == 3j:
+                    acc += tup2[4].sum()
+                else:
+                    raise RuntimeError("Unreachable")
+            return acc
+
+        n = 10
+        tup1 = ('a', 'b', 'c', 12, 3j,)
+        tup2 = (np.ones((n,)), np.ones((n, n)), np.ones((n, n, n)),
+                np.ones((n, n, n, n)), np.ones((n, n, n, n, n)))
+        self.assertEqual(foo(tup1, tup2), foo.py_func(tup1, tup2))
+
+    @unittest.skip("needs more clever branch prune")
+    def test_06(self):
+        # This wont work because both sides of the branch need typing as neither
+        # can be pruned by the current pruner
+        @njit
+        def foo(tup):
+            acc = 0
+            str_buf = typed.List.empty_list(types.unicode_type)
+            for a in literal_unroll(tup):
+                if a == 'a':
+                    str_buf.append(a)
+                else:
+                    acc += a
+            return acc
+
+        tup = ('a', 12)
+        self.assertEqual(foo(tup), foo.py_func(tup))
+
+    def test_07(self):
+        # A mix bag of stuff as an arg to a function that unifies as `intp`.
+        @njit
+        def foo(tup):
+            acc = 0
+            for a in literal_unroll(tup):
+                acc += len(a)
+            return acc
+
+        n = 10
+        tup = (np.ones((n,)), np.ones((n, n)), "ABCDEFGHJI", (1, 2, 3),
+               (1, 'foo', 2, 'bar'), {3, 4, 5, 6, 7})
+        self.assertEqual(foo(tup), foo.py_func(tup))
+
+    def test_08(self):
+        # dispatch to functions
+
+        @njit
+        def foo(tup1, tup2):
+            acc = 0
+            for a in literal_unroll(tup1):
+                if a == 'a':
+                    acc += tup2[0]()
+                elif a == 'b':
+                    acc += tup2[1]()
+                elif a == 'c':
+                    acc += tup2[2]()
+            return acc
+
+        def gen(x):
+            def impl():
+                return x
+            return njit(impl)
+
+        tup1 = ('a', 'b', 'c', 12, 3j, ('f',))
+        tup2 = (gen(1), gen(2), gen(3))
+        self.assertEqual(foo(tup1, tup2), foo.py_func(tup1, tup2))
+
+    def test_09(self):
+        # illegal RHS, has a mixed tuple being index dynamically
+
+        @njit
+        def foo(tup1, tup2):
+            acc = 0
+            idx = 0
+            for a in literal_unroll(tup1):
+                if a == 'a':
+                    acc += tup2[idx]
+                elif a == 'b':
+                    acc += tup2[idx]
+                elif a == 'c':
+                    acc += tup2[idx]
+                idx += 1
+            return idx, acc
+
+        @njit
+        def func1():
+            return 1
+
+        @njit
+        def func2():
+            return 2
+
+        @njit
+        def func3():
+            return 3
+
+        tup1 = ('a', 'b', 'c')
+        tup2 = (1j, 1, 2)
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo(tup1, tup2)
+
+        self.assertIn("Invalid use", str(raises.exception))
+
+    def test_10(self):
+        # dispatch on literals triggering @overload resolution
+
+        def dt(value):
+            if value == "apple":
+                return 1
+            elif value == "orange":
+                return 2
+            elif value == "banana":
+                return 3
+            elif value == 0xca11ab1e:
+                return 0x5ca1ab1e + value
+
+        @overload(dt, inline='always')
+        def ol_dt(li):
+            if isinstance(li, types.StringLiteral):
+                value = li.literal_value
+                if value == "apple":
+                    def impl(li):
+                        return 1
+                elif value == "orange":
+                    def impl(li):
+                        return 2
+                elif value == "banana":
+                    def impl(li):
+                        return 3
+                return impl
+            elif isinstance(li, types.IntegerLiteral):
+                value = li.literal_value
+                if value == 0xca11ab1e:
+                    def impl(li):
+                        # close over the dispatcher :)
+                        return 0x5ca1ab1e + value
+                    return impl
+
+        @njit
+        def foo():
+            acc = 0
+            for t in literal_unroll(('apple', 'orange', 'banana', 3390155550)):
+                acc += dt(t)
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_11(self):
+
+        @njit
+        def foo():
+            x = []
+            z = ('apple', 'orange', 'banana')
+            for i in range(len(literal_unroll(z))):
+                t = z[i]
+                if t == "apple":
+                    x.append("0")
+                elif t == "orange":
+                    x.append(t)
+                elif t == "banana":
+                    x.append("2.0")
+            return x
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_11a(self):
+
+        @njit
+        def foo():
+            x = typed.List()
+            z = ('apple', 'orange', 'banana')
+            for i in range(len(literal_unroll(z))):
+                t = z[i]
+                if t == "apple":
+                    x.append("0")
+                elif t == "orange":
+                    x.append(t)
+                elif t == "banana":
+                    x.append("2.0")
+            return x
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_12(self):
+        # unroll the same target twice
+        @njit
+        def foo(idx, z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for i in literal_unroll(a):
+                acc += i
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for x in literal_unroll(a):
+                        acc += x
+                    break
+            if a[0] < 23:
+                acc += 2
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(2, k), foo.py_func(2, k))
+
+    def test_13(self):
+        # nesting unrolls is illegal
+        @njit
+        def foo(idx, z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for i in literal_unroll(a):
+                acc += i
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for x in literal_unroll(a):
+                        for j in literal_unroll(a):
+                            acc += j
+                        acc += x
+                for x in literal_unroll(a):
+                    acc += x
+            for x in literal_unroll(a):
+                acc += x
+            if a[0] < 23:
+                acc += 2
+            return acc
+
+        f = 9
+        k = f
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo(2, k)
+
+        self.assertIn("Nesting of literal_unroll is unsupported",
+                      str(raises.exception))
+
+    def test_14(self):
+        # unituple unroll can return derivative of the induction var
+
+        @njit
+        def foo():
+            x = (1, 2, 3, 4)
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+            return a
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_15(self):
+        # mixed tuple unroll cannot return derivative of the induction var
+
+        @njit
+        def foo(x):
+            acc = 0
+            for a in literal_unroll(x):
+                acc += len(a)
+            return a
+
+        n = 5
+        tup = (np.ones((n,)), np.ones((n, n)), "ABCDEFGHJI", (1, 2, 3),
+               (1, 'foo', 2, 'bar'), {3, 4, 5, 6, 7})
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo(tup)
+
+        self.assertIn("Cannot unify", str(raises.exception))
+
+    def test_16(self):
+        # unituple slice and unroll is ok
+
+        def dt(value):
+            if value == 1000:
+                return "a"
+            elif value == 2000:
+                return "b"
+            elif value == 3000:
+                return "c"
+            elif value == 4000:
+                return "d"
+
+        @overload(dt, inline='always')
+        def ol_dt(li):
+            if isinstance(li, types.IntegerLiteral):
+                value = li.literal_value
+                if value == 1000:
+                    def impl(li):
+                        return "a"
+                elif value == 2000:
+                    def impl(li):
+                        return "b"
+                elif value == 3000:
+                    def impl(li):
+                        return "c"
+                elif value == 4000:
+                    def impl(li):
+                        return "d"
+                return impl
+
+        @njit
+        def foo():
+            x = (1000, 2000, 3000, 4000)
+            acc = ""
+            for a in literal_unroll(x[:2]):
+                acc += dt(a)
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_17(self):
+        # mixed tuple slice and unroll is ok
+
+        def dt(value):
+            if value == 1000:
+                return "a"
+            elif value == 2000:
+                return "b"
+            elif value == 3000:
+                return "c"
+            elif value == 4000:
+                return "d"
+            elif value == 'f':
+                return "EFF"
+
+        @overload(dt, inline='always')
+        def ol_dt(li):
+            if isinstance(li, types.IntegerLiteral):
+                value = li.literal_value
+                if value == 1000:
+                    def impl(li):
+                        return "a"
+                elif value == 2000:
+                    def impl(li):
+                        return "b"
+                elif value == 3000:
+                    def impl(li):
+                        return "c"
+                elif value == 4000:
+                    def impl(li):
+                        return "d"
+                return impl
+            elif isinstance(li, types.StringLiteral):
+                value = li.literal_value
+                if value == 'f':
+                    def impl(li):
+                        return "EFF"
+                    return impl
+
+        @njit
+        def foo():
+            x = (1000, 2000, 3000, 'f')
+            acc = ""
+            for a in literal_unroll(x[1:]):
+                acc += dt(a)
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_18(self):
+        # unituple backwards slice
+        @njit
+        def foo():
+            x = (1000, 2000, 3000, 4000, 5000, 6000)
+            count = 0
+            for a in literal_unroll(x[::-1]):
+                count += 1
+                if a < 3000:
+                    break
+            return count
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_19(self):
+        # mixed bag of refcounted
+        @njit
+        def foo():
+            acc = 0
+            l1 = [1, 2, 3, 4]
+            l2 = [10, 20]
+            tup = (l1, l2)
+            a1 = np.arange(20)
+            a2 = np.ones(5, dtype=np.complex128)
+            tup = (l1, a1, l2, a2)
+            for t in literal_unroll(tup):
+                acc += len(t)
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_20(self):
+        # testing partial type inference survives as the list append in the
+        # unrolled version is full inferable
+        @njit
+        def foo():
+            l = []
+            a1 = np.arange(20)
+            a2 = np.ones(5, dtype=np.complex128)
+            tup = (a1, a2)
+            for t in literal_unroll(tup):
+                l.append(t.sum())
+            return l
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_21(self):
+        # unroll in closure that gets inlined
+        @njit
+        def foo(z):
+            b = (23, 23.9, 6j, 8)
+
+            def bar():
+                acc = 0
+                for j in literal_unroll(b):
+                    acc += j
+                return acc
+            outer_acc = 0
+            for x in (1, 2, 3, 4):
+                outer_acc += bar() + x
+
+            return outer_acc
+
+        f = 9
+        k = f
+        self.assertEqual(foo(k), foo.py_func(k))
+
+    def test_22(self):
+        @njit
+        def foo(z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            b = (23, 23.9, 6j, 8)
+
+            def bar():
+                acc = 0
+                for j in literal_unroll(b):
+                    acc += j
+                return acc
+            acc = 0
+            # this loop is induced in `x` but `x` is not used, there is a nest
+            # here by virtue of inlining
+            for x in literal_unroll(a):
+                acc += bar()
+
+            return acc
+
+        f = 9
+        k = f
+        self.assertEqual(foo(k), foo.py_func(k))
+
+    def test_23(self):
+        # unroll from closure that ends up banned as it leads to nesting
+        @njit
+        def foo(z):
+            b = (23, 23.9, 6j, 8)
+
+            def bar():
+                acc = 0
+                for j in literal_unroll(b):
+                    acc += j
+                return acc
+            outer_acc = 0
+            # this drives an inlined literal_unroll loop but also has access to
+            # the induction variable, this is a nested literal_unroll so is
+            # banned
+            for x in literal_unroll(b):
+                outer_acc += bar() + x
+
+            return outer_acc
+
+        f = 9
+        k = f
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo(k)
+
+        self.assertIn("Nesting of literal_unroll is unsupported",
+                      str(raises.exception))
+
+    def test_24(self):
+        # unroll something unsupported
+        @njit
+        def foo():
+            for x in literal_unroll("ABCDE"):
+                print(x)
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo()
+
+        msg = "argument should be a tuple or a list of constant values"
+        self.assertIn(msg, str(raises.exception))
+
+    def test_25(self):
+        # use unroll by reference/alias
+        @njit
+        def foo():
+            val = literal_unroll(((1, 2, 3), (2j, 3j), [1, 2], "xyz"))
+            alias1 = val
+            alias2 = alias1
+            lens = []
+            for x in alias2:
+                lens.append(len(x))
+            return lens
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_26(self):
+        # var defined in unrolled body escapes
+        # untouched variable is untouched
+        # read only variable is only read
+        # mutated is muted correctly
+        @njit
+        def foo(z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            count = 0
+            untouched = 54
+            read_only = 17
+            mutated = np.empty((len(a),), dtype=np.complex128)
+            for x in literal_unroll(a):
+                acc += x
+                mutated[count] = x
+                count += 1
+                escape = count + read_only
+            return escape, acc, untouched, read_only, mutated
+
+        f = 9
+        k = f
+
+        self.assertPreciseEqual(foo(k), foo.py_func(k))
+
+    @skip_parfors_unsupported
+    def test_27(self):
+        # parfors loop in unrolled loop
+        @njit(parallel=True)
+        def foo(z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for x in literal_unroll(a):
+                for k in prange(10):
+                    acc += 1
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(k), foo.py_func(k))
+
+    @skip_parfors_unsupported
+    def test_28(self):
+        # parfors reducing on the unrolled induction var
+        @njit(parallel=True)
+        def foo(z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for x in literal_unroll(a):
+                for k in prange(10):
+                    acc += x
+            return acc
+
+        f = 9
+        k = f
+
+        # summation is unstable
+        np.testing.assert_allclose(foo(k), foo.py_func(k))
+
+    @skip_parfors_unsupported
+    def test_29(self):
+        # This "works" but parfors is not producing a parallel loop
+        # TODO: fix
+        @njit(parallel=True)
+        def foo(z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            acc = 0
+            for k in prange(10):
+                for x in literal_unroll(a):
+                    acc += x
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(k), foo.py_func(k))
+
+    def test_30(self):
+        # function escaping containing an unroll
+        @njit
+        def foo():
+            const = 1234
+
+            def bar(t):
+                acc = 0
+                a = (12, 12.7, 3j, 4)
+                for x in literal_unroll(a):
+                    acc += x + const
+                return acc, t
+            return [x for x in map(bar, (1, 2))]
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_31(self):
+        # this is testing that generators can survive partial typing
+        # invalid function escaping, map uses zip which can't handle the mixed
+        # tuple
+        @njit
+        def foo():
+            const = 1234
+
+            def bar(t):
+                acc = 0
+                a = (12, 12.7, 3j, 4)
+                for x in literal_unroll(a):
+                    acc += x + const
+                return acc, t
+            return [x for x in map(bar, (1, 2j))]
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        self.assertIn("Invalid use of", str(raises.exception))
+        self.assertIn("zip", str(raises.exception))
+
+    def test_32(self):
+        # test yielding from an unroll
+        @njit
+        def gen(a):
+            for x in literal_unroll(a):
+                yield x
+
+        @njit
+        def foo():
+            return [x for x in gen((1, 2.3, 4j,))]
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_33(self):
+        # test yielding from unroll in escaping function that is consumed and
+        # yields
+
+        @njit
+        def consumer(func, arg):
+            yield func(arg)
+
+        def get(cons):
+            @njit
+            def foo():
+                def gen(a):
+                    for x in literal_unroll(a):
+                        yield x
+                return [next(x) for x in cons(gen, (1, 2.3, 4j,))]
+            return foo
+
+        cfunc = get(consumer)
+        pyfunc = get(consumer.py_func).py_func
+
+        self.assertEqual(cfunc(), pyfunc())
+
+
+@skip_lt_py36
+class TestConstListUnroll(MemoryLeakMixin, TestCase):
+
+    def test_01(self):
+
+        @njit
+        def foo():
+            a = [12, 12.7, 3j, 4]
+            acc = 0
+            for i in range(len(literal_unroll(a))):
+                acc += a[i]
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    break
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_02(self):
+        # same as test_1 but without the explicit loop canonicalisation
+
+        @njit
+        def foo():
+            x = [12, 12.7, 3j, 4]
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    break
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_03(self):
+        # two unrolls
+        @njit
+        def foo():
+            x = [12, 12.7, 3j, 4]
+            y = ['foo', 8]
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for t in literal_unroll(y):
+                        acc += t is False
+                    break
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_04(self):
+        # two unrolls, one is a const list, one is a tuple
+        @njit
+        def foo():
+            x = [12, 12.7, 3j, 4]
+            y = ('foo', 8)
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for t in literal_unroll(y):
+                        acc += t is False
+                    break
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_05(self):
+        # illegal, list has to be const
+        @njit
+        def foo(tup1, tup2):
+            acc = 0
+            for a in literal_unroll(tup1):
+                if a[0] > 1:
+                    acc += tup2[0].sum()
+            return acc
+
+        n = 10
+        tup1 = [np.zeros(10), np.zeros(10)]
+        tup2 = (np.ones((n,)), np.ones((n, n)), np.ones((n, n, n)),
+                np.ones((n, n, n, n)), np.ones((n, n, n, n, n)))
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo(tup1, tup2)
+
+        msg = "Invalid use of literal_unroll with a function argument"
+        self.assertIn(msg, str(raises.exception))
+
+    def test_06(self):
+        # illegal: list containing non const
+        @njit
+        def foo():
+            n = 10
+            tup = [np.ones((n,)), np.ones((n, n)), "ABCDEFGHJI", (1, 2, 3),
+                   (1, 'foo', 2, 'bar'), {3, 4, 5, 6, 7}]
+            acc = 0
+            for a in literal_unroll(tup):
+                acc += len(a)
+            return acc
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo()
+
+        self.assertIn("Found non-constant value at position 0",
+                      str(raises.exception))
+
+    def test_7(self):
+        # dispatch on literals triggering @overload resolution
+
+        def dt(value):
+            if value == "apple":
+                return 1
+            elif value == "orange":
+                return 2
+            elif value == "banana":
+                return 3
+            elif value == 0xca11ab1e:
+                return 0x5ca1ab1e + value
+
+        @overload(dt, inline='always')
+        def ol_dt(li):
+            if isinstance(li, types.StringLiteral):
+                value = li.literal_value
+                if value == "apple":
+                    def impl(li):
+                        return 1
+                elif value == "orange":
+                    def impl(li):
+                        return 2
+                elif value == "banana":
+                    def impl(li):
+                        return 3
+                return impl
+            elif isinstance(li, types.IntegerLiteral):
+                value = li.literal_value
+                if value == 0xca11ab1e:
+                    def impl(li):
+                        # close over the dispatcher :)
+                        return 0x5ca1ab1e + value
+                    return impl
+
+        @njit
+        def foo():
+            acc = 0
+            for t in literal_unroll(['apple', 'orange', 'banana', 3390155550]):
+                acc += dt(t)
+            return acc
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_8(self):
+
+        @njit
+        def foo():
+            x = []
+            z = ['apple', 'orange', 'banana']
+            for i in range(len(literal_unroll(z))):
+                t = z[i]
+                if t == "apple":
+                    x.append("0")
+                elif t == "orange":
+                    x.append(t)
+                elif t == "banana":
+                    x.append("2.0")
+            return x
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_9(self):
+        # unroll the same target twice
+        @njit
+        def foo(idx, z):
+            a = [12, 12.7, 3j, 4]
+            acc = 0
+            for i in literal_unroll(a):
+                acc += i
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for x in literal_unroll(a):
+                        acc += x
+                    break
+            if a[0] < 23:
+                acc += 2
+            return acc
+
+        f = 9
+        k = f
+
+        self.assertEqual(foo(2, k), foo.py_func(2, k))
+
+    def test_10(self):
+        # nesting unrolls is illegal
+        @njit
+        def foo(idx, z):
+            a = (12, 12.7, 3j, 4, z, 2 * z)
+            b = [12, 12.7, 3j, 4]
+            acc = 0
+            for i in literal_unroll(a):
+                acc += i
+                if acc.real < 26:
+                    acc -= 1
+                else:
+                    for x in literal_unroll(a):
+                        for j in literal_unroll(b):
+                            acc += j
+                        acc += x
+                for x in literal_unroll(a):
+                    acc += x
+            for x in literal_unroll(a):
+                acc += x
+            if a[0] < 23:
+                acc += 2
+            return acc
+
+        f = 9
+        k = f
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo(2, k)
+
+        self.assertIn("Nesting of literal_unroll is unsupported",
+                      str(raises.exception))
+
+    def test_11(self):
+        # homogeneous const list unroll can return derivative of the induction
+        # var
+
+        @njit
+        def foo():
+            x = [1, 2, 3, 4]
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+            return a
+
+        self.assertEqual(foo(), foo.py_func())
+
+    def test_12(self):
+        # mixed unroll cannot return derivative of the induction var
+        @njit
+        def foo():
+            acc = 0
+            x = [1, 2, 'a']
+            for a in literal_unroll(x):
+                acc += bool(a)
+            return a
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        self.assertIn("Cannot unify", str(raises.exception))
+
+    def test_13(self):
+        # list slice is illegal
+
+        @njit
+        def foo():
+            x = [1000, 2000, 3000, 4000]
+            acc = 0
+            for a in literal_unroll(x[:2]):
+                acc += a
+            return acc
+
+        with self.assertRaises(errors.UnsupportedError) as raises:
+            foo()
+
+        self.assertIn("Invalid use of literal_unroll", str(raises.exception))
+
+    def test_14(self):
+        # list mutate is illegal
+
+        @njit
+        def foo():
+            x = [1000, 2000, 3000, 4000]
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+            x.append(10)
+            return acc
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        self.assertIn("Unknown attribute 'append' of type Tuple",
+                      str(raises.exception))
+
+
+@unittest.skipIf(not _lt_py_36, "Python < 3.6 only test")
+class TestLiteralUnrollPy2(TestCase):
+
+    def test_py_lt_36_not_supported(self):
+
+        @njit
+        def foo():
+            x = (1000, 2000, 3000, 4000)
+            acc = 0
+            for a in literal_unroll(x):
+                acc += a
+            return acc
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        self.assertIn("literal_unroll is only support in Python > 3.5",
+                      str(raises.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1569,6 +1569,7 @@ class TestMore(TestCase):
             str(raises.exception)
         )
 
+    @unittest.skip("numba.literally not supported yet")
     def test_literally_constant_list(self):
         # FAIL. May need to consider it in a future PR
         from numba import literally
@@ -1581,7 +1582,9 @@ class TestMore(TestCase):
                 r += a
             return r
 
-        foo(12)  # Found non-constant value at position 1 in a list argument to literal_unroll
+        # Found non-constant value at position 1 in a list argument to
+        # literal_unroll
+        foo(12)
 
         @njit
         def bar():
@@ -1641,7 +1644,7 @@ class TestMore(TestCase):
         self.assertEqual(foo(), foo.py_func())
 
     def test_unroll_tuple_nested(self):
-        # FAIL
+
         @njit
         def foo():
             x = ((10, 1.2), (1j, 3.))
@@ -1651,9 +1654,12 @@ class TestMore(TestCase):
                     out += j
             return out
 
-        # Can literal_unroll give a better error message?
-        # errmsg: Invalid use of getiter with parameters (Tuple(int64, float64))
-        foo()
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        self.assertIn("getiter", str(raises.exception))
+        re = r".*Tuple\(int[0-9][0-9], float64\).*"
+        self.assertRegexpMatches(str(raises.exception), re)
 
     def test_unroll_tuple_of_dict(self):
         from numba.tests.support import captured_stdout
@@ -1677,7 +1683,6 @@ class TestMore(TestCase):
             lines,
             ['a 1', 'b 2', '3 c', '4 d'],
         )
-
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3560,3 +3560,7 @@ def foo():
         with self.assertTypingError():
             cfunc = jit(nopython=True)(iinfo)
             cfunc(np.float64(7))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -592,7 +592,7 @@ class TestConversions(TestCase):
 
         with self.assertRaises(errors.TypingError) as raises:
             check(fromty, types.Tuple((types.float32,)), (4, 5))
-        msg = "No conversion from tuple(int32 x 2) to tuple(float32 x 1)"
+        msg = "No conversion from UniTuple(int32 x 2) to UniTuple(float32 x 1)"
         self.assertIn(msg, str(raises.exception))
 
 

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -94,7 +94,7 @@ class TestTypingError(unittest.TestCase):
             compile_isolated(issue_868, (types.Array(types.int32, 1, 'C'),))
 
         expected = (
-            "Invalid use of Function(<built-in function mul>) with argument(s) of type(s): (tuple({0} x 1), {1})"
+            "Invalid use of Function(<built-in function mul>) with argument(s) of type(s): (UniTuple({0} x 1), {1})"
             .format(str(types.intp), types.IntegerLiteral(2)))
         self.assertIn(expected, str(raises.exception))
         self.assertIn("[1] During: typing of", str(raises.exception))
@@ -102,8 +102,9 @@ class TestTypingError(unittest.TestCase):
     def test_return_type_unification(self):
         with self.assertRaises(TypingError) as raises:
             compile_isolated(impossible_return_type, (types.int32,))
-        self.assertIn("Can't unify return type from the following types: (), complex128",
-                      str(raises.exception))
+        msg = ("Can't unify return type from the following types: Tuple(), "
+               "complex128")
+        self.assertIn(msg, str(raises.exception))
 
     def test_bad_hypot_usage(self):
         with self.assertRaises(TypingError) as raises:
@@ -146,9 +147,7 @@ class TestTypingError(unittest.TestCase):
             compile_isolated(using_imprecise_list, ())
 
         errmsg = str(raises.exception)
-        self.assertRegexpMatches(
-            errmsg, r"Undecided type \$[^\s]+ := <undecided>",
-        )
+        self.assertIn("Undecided type", errmsg)
 
     def test_array_setitem_invalid_cast(self):
         with self.assertRaises(TypingError) as raises:

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -368,6 +368,11 @@ class TestUnicode(BaseTest):
             for b in reversed(UNICODE_EXAMPLES):
                 self.assertEqual(pyfunc(a, b),
                                  cfunc(a, b), '%s, %s' % (a, b))
+                # comparing against something that's not unicode
+                self.assertEqual(pyfunc(a, 1),
+                                 cfunc(a, 1), '%s, %s' % (a, 1))
+                self.assertEqual(pyfunc(1, b),
+                                 cfunc(1, b), '%s, %s' % (1, b))
 
     def _check_ordering_op(self, usecase):
         pyfunc = usecase

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -981,7 +981,7 @@ class TypeInferer(object):
         if source_constraint is not None:
             source_constraint.refine(self, updated_type)
 
-    def unify(self):
+    def unify(self, raise_errors=True):
         """
         Run the final unification pass over all inferred types, and
         catch imprecise types.
@@ -1046,12 +1046,16 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
         def check_var(name):
             tv = self.typevars[name]
             if not tv.defined:
-                offender = find_offender(name)
-                val = getattr(offender, 'value', 'unknown operation')
-                loc = getattr(offender, 'loc', ir.unknown_loc)
-                msg = ("Type of variable '%s' cannot be determined, operation:"
-                       " %s, location: %s")
-                raise TypingError(msg % (var, val, loc), loc)
+                if raise_errors:
+                    offender = find_offender(name)
+                    val = getattr(offender, 'value', 'unknown operation')
+                    loc = getattr(offender, 'loc', ir.unknown_loc)
+                    msg = ("Type of variable '%s' cannot be determined, "
+                           "operation: %s, location: %s")
+                    raise TypingError(msg % (var, val, loc), loc)
+                else:
+                    typdict[var] = types.unknown
+                    return
             tp = tv.getone()
             if not tp.is_precise():
                 offender = find_offender(name, exhaustive=True)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -392,6 +392,27 @@ class StaticGetItemConstraint(object):
         return self.fallback and self.fallback.get_call_signature()
 
 
+class TypedGetItemConstraint(object):
+    def __init__(self, target, value, dtype, index, loc):
+        self.target = target
+        self.value = value
+        self.dtype = dtype
+        self.index = index
+        self.loc = loc
+
+    def __call__(self, typeinfer):
+        with new_error_context("typing of typed-get-item at {0}", self.loc):
+            typevars = typeinfer.typevars
+            idx_ty = typevars[self.index.name].get()
+            ty = typevars[self.value.name].get()
+            from numba.typing.templates import Signature
+            self.signature = Signature(self.dtype, ty + idx_ty, None)
+            typeinfer.add_type(self.target, self.dtype, loc=self.loc)
+
+    def get_call_signature(self):
+        return self.signature
+
+
 def fold_arg_vars(typevars, args, vararg, kws):
     """
     Fold and resolve the argument variables of a function call.
@@ -617,6 +638,7 @@ class SetItemRefinement(object):
     """A mixin class to provide the common refinement logic in setitem
     and static setitem.
     """
+
     def _refine_target_type(self, typeinfer, targetty, idxty, valty, sig):
         """Refine the target-type given the known index type and value type.
         """
@@ -998,7 +1020,7 @@ class TypeInferer(object):
                 if offender is not None:
                     if not exhaustive:
                         break
-                    try: # simple assignment
+                    try:  # simple assignment
                         hasattr(offender.value, 'name')
                         offender_value = offender.value.name
                     except (AttributeError, KeyError):
@@ -1032,7 +1054,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                             return list_msg
                         # or might be `foo = list()`
                         elif offender.value.op == 'call':
-                            try: # assignment involving a call
+                            try:  # assignment involving a call
                                 call_name = offender.value.func.name
                                 # find the offender based on the call name
                                 offender = find_offender(call_name)
@@ -1041,7 +1063,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                                         return list_msg
                             except (AttributeError, KeyError):
                                 pass
-            return "" # no help possible
+            return ""  # no help possible
 
         def check_var(name):
             tv = self.typevars[name]
@@ -1065,8 +1087,12 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                 loc = getattr(offender, 'loc', ir.unknown_loc)
                 # is this an untyped list? try and provide help
                 extra_msg = diagnose_imprecision(offender)
-                raise TypingError(msg % (var, istmp, tp, extra_msg), loc)
-            else: # type is precise, hold it
+                if raise_errors:
+                    raise TypingError(msg % (var, istmp, tp, extra_msg), loc)
+                else:
+                    typdict[var] = types.unknown
+                    return
+            else:  # type is precise, hold it
                 typdict[var] = tp
 
         # For better error display, check first user-visible vars, then
@@ -1078,26 +1104,68 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
         for var in sorted(temps):
             check_var(var)
 
-        retty = self.get_return_type(typdict)
-        fntys = self.get_function_types(typdict)
+        try:
+            retty = self.get_return_type(typdict)
+        except Exception as e:
+            # partial type inference may raise e.g. attribute error if a
+            # constraint has no computable signature, ignore this as needed
+            if raise_errors:
+                raise e
+            else:
+                retty = None
+
+        try:
+            fntys = self.get_function_types(typdict)
+        except Exception as e:
+            # partial type inference may raise e.g. attribute error if a
+            # constraint has no computable signature, ignore this as needed
+            if raise_errors:
+                raise e
+            else:
+                fntys = None
+
         if self.generator_info:
-            retty = self.get_generator_type(typdict, retty)
+            retty = self.get_generator_type(typdict, retty,
+                                            raise_errors=raise_errors)
 
         self.debug.unify_finished(typdict, retty, fntys)
 
         return typdict, retty, fntys
 
-    def get_generator_type(self, typdict, retty):
+    def get_generator_type(self, typdict, retty, raise_errors=True):
         gi = self.generator_info
         arg_types = [None] * len(self.arg_names)
         for index, name in self.arg_names.items():
             arg_types[index] = typdict[name]
-        state_types = [typdict[var_name] for var_name in gi.state_vars]
-        yield_types = [typdict[y.inst.value.name]
-                       for y in gi.get_yield_points()]
+
+        state_types = None
+        try:
+            state_types = [typdict[var_name] for var_name in gi.state_vars]
+        except KeyError:
+            msg = "Cannot type generator: state variable types cannot be found"
+            if raise_errors:
+                raise TypingError(msg)
+            state_types = [types.unknown for _ in gi.state_vars]
+
+        yield_types = None
+        try:
+            yield_types = [typdict[y.inst.value.name]
+                           for y in gi.get_yield_points()]
+        except KeyError:
+            msg = "Cannot type generator: yield type cannot be found"
+            if raise_errors:
+                raise TypingError(msg)
         if not yield_types:
             msg = "Cannot type generator: it does not yield any value"
-            raise TypingError(msg)
+            if raise_errors:
+                raise TypingError(msg)
+            yield_types = [types.unknown for _ in gi.get_yield_points()]
+
+        if not yield_types or all(yield_types) == types.unknown:
+            # unknown yield, probably partial type inference, escape
+            return types.Generator(self.func_id.func, types.unknown, arg_types,
+                                   state_types, has_finalizer=True)
+
         yield_type = self.context.unify_types(*yield_types)
         if yield_type is None or isinstance(yield_type, types.Optional):
             msg = "Cannot type generator: cannot unify yielded types %s"
@@ -1116,10 +1184,11 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                     explain_ty.add(types.NoneType('none'))
                 else:
                     explain_ty.add(ty)
-            raise TypingError("Can't unify yield type from the "
-                              "following types: %s"
-                              % ", ".join(sorted(map(str, explain_ty))) +
-                              "\n\n" + "\n".join(yp_highlights))
+            if raise_errors:
+                raise TypingError("Can't unify yield type from the "
+                                  "following types: %s"
+                                  % ", ".join(sorted(map(str, explain_ty))) +
+                                  "\n\n" + "\n".join(yp_highlights))
 
         return types.Generator(self.func_id.func, yield_type, arg_types,
                                state_types, has_finalizer=True)
@@ -1156,6 +1225,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                                     returns[x] = instr
                                     break
 
+                    interped = ""
                     for name, offender in returns.items():
                         loc = getattr(offender, 'loc', ir.unknown_loc)
                         msg = ("Return of: IR name '%s', type '%s', "
@@ -1370,7 +1440,7 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
             else:
                 nm = gvar.name
                 msg = _termcolor.errmsg("Untyped global name '%s':" % nm)
-                msg += " %s" # interps the actual error
+                msg += " %s"  # interps the actual error
 
                 # if the untyped global is a numba internal function then add
                 # to the error message asking if it's been imported.
@@ -1446,6 +1516,14 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
         elif expr.op == 'getitem':
             self.typeof_intrinsic_call(inst, target, operator.getitem,
                                        expr.value, expr.index,)
+        elif expr.op == 'typed_getitem':
+            constraint = TypedGetItemConstraint(target.name, value=expr.value,
+                                                dtype=expr.dtype,
+                                                index=expr.index,
+                                                loc=expr.loc)
+            self.constraints.append(constraint)
+            self.calls.append((inst.value, constraint))
+
         elif expr.op == 'getattr':
             constraint = GetAttrConstraint(target.name, attr=expr.attr,
                                            value=expr.value, loc=inst.loc,

--- a/numba/types/__init__.py
+++ b/numba/types/__init__.py
@@ -26,6 +26,7 @@ undefined = Undefined('undefined')
 py2_string_type = Opaque('str')
 unicode_type = UnicodeType('unicode_type')
 string = unicode_type if utils.PY3 else py2_string_type
+unknown = Dummy('unknown')
 
 code_type = Opaque('code')
 pyfunc_type = Opaque('pyfunc')

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -202,7 +202,7 @@ class UniTuple(BaseAnonymousTuple, _HomogeneousTuple, Sequence):
     def __init__(self, dtype, count):
         self.dtype = dtype
         self.count = count
-        name = "tuple(%s x %d)" % (dtype, count)
+        name = "UniTuple(%s x %d)" % (dtype, count)
         super(UniTuple, self).__init__(name)
 
     @property
@@ -276,7 +276,7 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
         self.types = tuple(types)
         self.count = len(self.types)
         self.dtype = UnionType(types)
-        name = "(%s)" % ', '.join(str(i) for i in self.types)
+        name = "Tuple(%s)" % ', '.join(str(i) for i in self.types)
         super(Tuple, self).__init__(name)
 
     @property

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -252,6 +252,16 @@ class _HeterogeneousTuple(BaseTuple):
             raise TypingError("Argument 'types' is not iterable")
 
 
+class UnionType(Type):
+    def __init__(self, types):
+        self.types = tuple(sorted(set(types), key=lambda x:x.name))
+        name = 'Union[{}]'.format(','.join(map(str, self.types)))
+        super(UnionType, self).__init__(name=name)
+
+    def get_type_tag(self, typ):
+        return self.types.index(typ)
+
+
 class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
 
     def __new__(cls, types):
@@ -265,6 +275,7 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
     def __init__(self, types):
         self.types = tuple(types)
         self.count = len(self.types)
+        self.dtype = UnionType(types)
         name = "(%s)" % ', '.join(str(i) for i in self.types)
         super(Tuple, self).__init__(name)
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -93,6 +93,11 @@ class GetIter(AbstractTemplate):
     def generic(self, args, kws):
         assert not kws
         [obj] = args
+        if isinstance(obj, types.Tuple):
+            return self.generic(args=[types.UniTuple(
+                types.UnionType(obj.types),
+                count=len(obj),
+            )], kws={})
         if isinstance(obj, types.IterableType):
             # Raise this here to provide a very specific message about this
             # common issue, delaying the error until later leads to something

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -93,11 +93,6 @@ class GetIter(AbstractTemplate):
     def generic(self, args, kws):
         assert not kws
         [obj] = args
-        if isinstance(obj, types.Tuple):
-            return self.generic(args=[types.UniTuple(
-                types.UnionType(obj.types),
-                count=len(obj),
-            )], kws={})
         if isinstance(obj, types.IterableType):
             # Raise this here to provide a very specific message about this
             # common issue, delaying the error until later leads to something

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -423,25 +423,43 @@ def unicode_len(s):
 
 @overload(operator.eq)
 def unicode_eq(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    accept = (types.UnicodeType, types.StringLiteral, types.UnicodeCharSeq)
+    a_unicode = isinstance(a, accept)
+    b_unicode = isinstance(b, accept)
+    if a_unicode and b_unicode:
         def eq_impl(a, b):
             if len(a) != len(b):
                 return False
             return _cmp_region(a, 0, b, 0, len(a)) == 0
         return eq_impl
+    elif a_unicode ^ b_unicode:
+        # one of the things is unicode, everything compares False
+        def eq_impl(a, b):
+            return False
+        return eq_impl
 
 
 @overload(operator.ne)
 def unicode_ne(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    accept = (types.UnicodeType, types.StringLiteral, types.UnicodeCharSeq)
+    a_unicode = isinstance(a, accept)
+    b_unicode = isinstance(b, accept)
+    if a_unicode and b_unicode:
         def ne_impl(a, b):
             return not (a == b)
         return ne_impl
+    elif a_unicode ^ b_unicode:
+        # one of the things is unicode, everything compares True
+        def eq_impl(a, b):
+            return True
+        return eq_impl
 
 
 @overload(operator.lt)
 def unicode_lt(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    a_unicode = isinstance(a, (types.UnicodeType, types.StringLiteral))
+    b_unicode = isinstance(b, (types.UnicodeType, types.StringLiteral))
+    if a_unicode and b_unicode:
         def lt_impl(a, b):
             minlen = min(len(a), len(b))
             eqcode = _cmp_region(a, 0, b, 0, minlen)
@@ -455,7 +473,9 @@ def unicode_lt(a, b):
 
 @overload(operator.gt)
 def unicode_gt(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    a_unicode = isinstance(a, (types.UnicodeType, types.StringLiteral))
+    b_unicode = isinstance(b, (types.UnicodeType, types.StringLiteral))
+    if a_unicode and b_unicode:
         def gt_impl(a, b):
             minlen = min(len(a), len(b))
             eqcode = _cmp_region(a, 0, b, 0, minlen)
@@ -469,7 +489,9 @@ def unicode_gt(a, b):
 
 @overload(operator.le)
 def unicode_le(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    a_unicode = isinstance(a, (types.UnicodeType, types.StringLiteral))
+    b_unicode = isinstance(b, (types.UnicodeType, types.StringLiteral))
+    if a_unicode and b_unicode:
         def le_impl(a, b):
             return not (a > b)
         return le_impl
@@ -477,7 +499,9 @@ def unicode_le(a, b):
 
 @overload(operator.ge)
 def unicode_ge(a, b):
-    if isinstance(a, types.UnicodeType) and isinstance(b, types.UnicodeType):
+    a_unicode = isinstance(a, (types.UnicodeType, types.StringLiteral))
+    b_unicode = isinstance(b, (types.UnicodeType, types.StringLiteral))
+    if a_unicode and b_unicode:
         def ge_impl(a, b):
             return not (a < b)
         return ge_impl

--- a/numba/untyped_passes.py
+++ b/numba/untyped_passes.py
@@ -1330,6 +1330,21 @@ class LiteralUnroll(FunctionPass):
         FunctionPass.__init__(self)
 
     def run_pass(self, state):
+        # Determine whether to even attempt this pass... if there's no
+        # `literal_unroll as a global or as a freevar then just skip.
+        found = False
+        func_ir = state.func_ir
+        for blk in func_ir.blocks.values():
+            for asgn in blk.find_insts(ir.Assign):
+                if isinstance(asgn.value, (ir.Global, ir.FreeVar)):
+                    if asgn.value.value is literal_unroll:
+                        found = True
+                        break
+            if found:
+                break
+        if not found:
+            return False
+
         # run as subpipeline
         from numba.compiler_machinery import PassManager
         from numba.typed_passes import PartialTypeInference

--- a/numba/untyped_passes.py
+++ b/numba/untyped_passes.py
@@ -1,17 +1,26 @@
 from __future__ import print_function, division, absolute_import
+from collections import defaultdict, namedtuple
+from copy import deepcopy, copy
+
 from .compiler_machinery import FunctionPass, register_pass
 from . import (config, bytecode, interpreter, postproc, errors, types, rewrites,
                transforms, ir, utils)
+from .special import literal_unroll
 import warnings
 from .analysis import (
     dead_branch_prune,
     rewrite_semantic_constants,
     find_literally_calls,
+    compute_cfg_from_blocks,
+    compute_use_defs,
 )
 from contextlib import contextmanager
-from .inline_closurecall import InlineClosureCallPass
+from .inline_closurecall import InlineClosureCallPass, inline_closure_call
 from .ir_utils import (guard, resolve_func_from_module, simplify_CFG,
-                       GuardException, convert_code_obj_to_function)
+                       GuardException,  convert_code_obj_to_function,
+                       mk_unique_var, build_definitions,
+                       replace_var_names, get_name_var_table,
+                       compile_to_numba_ir, get_definition)
 
 
 @contextmanager
@@ -141,10 +150,6 @@ class RewriteSemanticConstants(FunctionPass):
         with fallback_context(state, msg):
             rewrite_semantic_constants(state.func_ir, state.args)
 
-        if config.DEBUG or config.DUMP_IR:
-            print('branch_pruned_ir'.center(80, '-'))
-            print(state.func_ir.dump())
-            print('end branch_pruned_ir'.center(80, '-'))
         return True
 
 
@@ -171,11 +176,6 @@ class DeadBranchPrune(FunctionPass):
                'function "%s"' % (state.func_id.func_name,))
         with fallback_context(state, msg):
             dead_branch_prune(state.func_ir, state.args)
-
-        if config.DEBUG or config.DUMP_IR:
-            print('branch_pruned_ir'.center(80, '-'))
-            print(state.func_ir.dump())
-            print('end branch_pruned_ir'.center(80, '-'))
 
         return True
 
@@ -285,7 +285,7 @@ class InlineInlinables(FunctionPass):
     def run_pass(self, state):
         """Run inlining of inlinables
         """
-        if config.DEBUG or self._DEBUG:
+        if self._DEBUG:
             print('before inline'.center(80, '-'))
             print(state.func_ir.dump())
             print(''.center(80, '-'))
@@ -309,7 +309,7 @@ class InlineInlinables(FunctionPass):
             # functions introducing blocks
             state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
 
-        if config.DEBUG or self._DEBUG:
+        if self._DEBUG:
             print('after inline'.center(80, '-'))
             print(state.func_ir.dump())
             print(''.center(80, '-'))
@@ -446,8 +446,13 @@ class MakeFunctionToJitFunction(FunctionPass):
                             elif isinstance(kw_default, tuple):
                                 ok = all([isinstance(getdef(x), ir.Const)
                                           for x in kw_default])
-
+                            elif isinstance(kw_default, ir.Expr):
+                                if kw_default.op != "build_tuple":
+                                    continue
+                                ok = all([isinstance(getdef(x), ir.Const)
+                                          for x in kw_default.items])
                             if not ok:
+                                print("NOT OK")
                                 continue
 
                             pyfunc = convert_code_obj_to_function(node, func_ir)
@@ -462,4 +467,903 @@ class MakeFunctionToJitFunction(FunctionPass):
             post_proc = postproc.PostProcessor(func_ir)
             post_proc.run()
 
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class TransformLiteralUnrollConstListToTuple(FunctionPass):
+    """ This pass spots a `literal_unroll([<constant values>])` and rewrites it
+    as a `literal_unroll(tuple(<constant values>))`.
+    """
+    _name = "transform_literal_unroll_const_list_to_tuple"
+
+    _accepted_types = (types.Tuple, types.UniTuple)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        mutated = False
+        func_ir = state.func_ir
+        for label, blk in func_ir.blocks.items():
+            calls = [_ for _ in blk.find_exprs('call')]
+            for call in calls:
+                glbl = guard(get_definition, func_ir, call.func)
+                if glbl and isinstance(glbl, ir.Global):
+                    # find a literal_unroll
+                    if glbl.value is literal_unroll:
+                        if len(call.args) > 1:
+                            msg = "literal_unroll takes one argument, found %s"
+                            raise errors.UnsupportedError(msg % len(call.args),
+                                                          call.loc)
+                        # get the arg, make sure its a build_list
+                        unroll_var = call.args[0]
+                        to_unroll = guard(get_definition, func_ir, unroll_var)
+                        if (isinstance(to_unroll, ir.Expr) and
+                                to_unroll.op == "build_list"):
+                            # make sure they are all const items in the list
+                            for i, item in enumerate(to_unroll.items):
+                                val = guard(get_definition, func_ir, item)
+                                if not val:
+                                    msg = ("multiple definitions for variable "
+                                           "%s, cannot resolve constant")
+                                    raise errors.UnsupportedError(msg % item,
+                                                                  to_unroll.loc)
+                                if not isinstance(val, ir.Const):
+                                    msg = ("Found non-constant value at "
+                                           "position %s in a list argument to "
+                                           "literal_unroll" % i)
+                                    raise errors.UnsupportedError(msg,
+                                                                  to_unroll.loc)
+                            # The above appears ok, now swap the build_list for
+                            # a built tuple.
+
+                            # find the assignment for the unroll target
+                            to_unroll_lhs = guard(get_definition, func_ir,
+                                                  unroll_var, lhs_only=True)
+
+                            if to_unroll_lhs is None:
+                                msg = ("multiple definitions for variable "
+                                       "%s, cannot resolve constant")
+                                raise errors.UnsupportedError(msg % unroll_var,
+                                                              to_unroll.loc)
+                            # scan all blocks looking for the LHS
+                            for b in func_ir.blocks.values():
+                                asgn = b.find_variable_assignment(
+                                    to_unroll_lhs.name)
+                                if asgn is not None:
+                                    break
+                            else:
+                                msg = ("Cannot find assignment for known "
+                                       "variable %s") % to_unroll_lhs.name
+                                raise errors.CompilerError(msg, to_unroll.loc)
+
+                            # Create a tuple with the list items as contents
+                            tup = ir.Expr.build_tuple(to_unroll.items,
+                                                      to_unroll.loc)
+
+                            # swap the list for the tuple
+                            asgn.value = tup
+                            mutated = True
+                        elif (isinstance(to_unroll, ir.Expr) and
+                              to_unroll.op == "build_tuple"):
+                            # this is fine, do nothing
+                            pass
+                        elif isinstance(to_unroll, ir.Arg):
+                            # this is only fine if the arg is a tuple
+                            ty = state.typemap[to_unroll.name]
+                            if not isinstance(ty, self._accepted_types):
+                                msg = ("Invalid use of literal_unroll with a "
+                                       "function argument, only tuples are "
+                                       "supported as function arguments, found "
+                                       "%s") % ty
+                                raise errors.UnsupportedError(msg,
+                                                              to_unroll.loc)
+                        else:
+                            extra = None
+                            if isinstance(to_unroll, ir.Expr):
+                                # probably a slice
+                                if to_unroll.op == "getitem":
+                                    ty = state.typemap[to_unroll.value.name]
+                                    # check if this is a tuple slice
+                                    if not isinstance(ty, self._accepted_types):
+                                        extra = "operation %s" % to_unroll.op
+                            elif isinstance(to_unroll, ir.Arg):
+                                extra = "non-const argument %s" % to_unroll.name
+                            else:
+                                extra = "unknown problem"
+                            if extra:
+                                msg = ("Invalid use of literal_unroll, "
+                                       "argument should be a tuple or a list "
+                                       "of constant values, found %s" % extra)
+                                raise errors.UnsupportedError(msg,
+                                                              to_unroll.loc)
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class MixedContainerUnroller(FunctionPass):
+    _name = "mixed_container_unroller"
+
+    _DEBUG = False
+
+    _accepted_types = (types.Tuple, types.UniTuple)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def analyse_tuple(self, tup):
+        """
+        Returns a map of type->list(indexes) for a typed tuple
+        """
+        d = defaultdict(list)
+        for i, ty in enumerate(tup):
+            d[ty].append(i)
+        return d
+
+    def add_offset_to_labels_w_ignore(self, blocks, offset, ignore=None):
+        """add an offset to all block labels and jump/branch targets
+        don't add an offset to anything in the ignore list
+        """
+        if ignore is None:
+            ignore = set()
+
+        new_blocks = {}
+        for l, b in blocks.items():
+            # some parfor last blocks might be empty
+            term = None
+            if b.body:
+                term = b.body[-1]
+            if isinstance(term, ir.Jump):
+                if term.target not in ignore:
+                    b.body[-1] = ir.Jump(term.target + offset, term.loc)
+            if isinstance(term, ir.Branch):
+                if term.truebr not in ignore:
+                    new_true = term.truebr + offset
+                else:
+                    new_true = term.truebr
+
+                if term.falsebr not in ignore:
+                    new_false = term.falsebr + offset
+                else:
+                    new_false = term.falsebr
+                b.body[-1] = ir.Branch(term.cond, new_true, new_false, term.loc)
+            new_blocks[l + offset] = b
+        return new_blocks
+
+    def inject_loop_body(self, switch_ir, loop_ir, caller_max_label,
+                         dont_replace, switch_data):
+        """
+        Injects the "loop body" held in `loop_ir` into `switch_ir` where ever
+        there is a statement of the form `SENTINEL.<int> = RHS`. It also:
+        * Finds and then deliberately does not relabel non-local jumps so as to
+          make the switch table suitable for injection into the IR from which
+          the loop body was derived.
+        * Looks for `typed_getitem` and wires them up to loop body version
+          specific variables or, if possible, directly writes in their constant
+          value at their use site.
+
+        Args:
+        - switch_ir, the switch table with SENTINELS as generated by
+          self.gen_switch
+        - loop_ir, the IR of the loop blocks (derived from the original func_ir)
+        - caller_max_label, the maximum label in the func_ir caller
+        - dont_replace, variables that should not be renamed (to handle
+          references to variables that are incoming at the loop head/escaping at
+          the loop exit.
+        - switch_data, the switch table data used to generated the switch_ir,
+          can be generated by self.analyse_tuple.
+
+        Returns:
+        - A type specific switch table with each case containing a versioned
+          loop body suitable for injection as a replacement for the loop_ir.
+        """
+        # Find the sentinels and validate the form
+        sentinel_exits = set()
+        sentinel_blocks = []
+        for lbl, blk in switch_ir.blocks.items():
+            for i, stmt in enumerate(blk.body):
+                if isinstance(stmt, ir.Assign):
+                    if "SENTINEL" in stmt.target.name:
+                        sentinel_blocks.append(lbl)
+                        sentinel_exits.add(blk.body[-1].target)
+                        break
+
+        assert len(sentinel_exits) == 1  # should only be 1 exit
+        switch_ir.blocks.pop(sentinel_exits.pop())  # kill the exit, it's dead
+
+        # find jumps that are non-local, we won't relabel these
+        ignore_set = set()
+        local_lbl = [x for x in loop_ir.blocks.keys()]
+        for lbl, blk in loop_ir.blocks.items():
+            for i, stmt in enumerate(blk.body):
+                if isinstance(stmt, ir.Jump):
+                    if stmt.target not in local_lbl:
+                        ignore_set.add(stmt.target)
+                if isinstance(stmt, ir.Branch):
+                    if stmt.truebr not in local_lbl:
+                        ignore_set.add(stmt.truebr)
+                    if stmt.falsebr not in local_lbl:
+                        ignore_set.add(stmt.falsebr)
+
+        # make sure the generated switch table matches the switch data
+        assert len(sentinel_blocks) == len(switch_data)
+
+        # replace the sentinel_blocks with the loop body
+        for lbl, branch_ty in zip(sentinel_blocks, switch_data.keys()):
+            loop_blocks = deepcopy(loop_ir.blocks)
+            # relabel blocks
+            max_label = max(switch_ir.blocks.keys())
+            loop_blocks = self.add_offset_to_labels_w_ignore(
+                loop_blocks, max_label + 1, ignore_set)
+
+            # start label
+            loop_start_lbl = min(loop_blocks.keys())
+
+            # fix the typed_getitem locations in the loop blocks
+            for blk in loop_blocks.values():
+                new_body = []
+                for stmt in blk.body:
+                    if isinstance(stmt, ir.Assign):
+                        if (isinstance(stmt.value, ir.Expr) and
+                                stmt.value.op == "typed_getitem"):
+                            if isinstance(branch_ty, types.Literal):
+                                new_const_name = mk_unique_var("branch_const")
+                                new_const_var = ir.Var(
+                                    blk.scope, new_const_name, stmt.loc)
+                                new_const_val = ir.Const(
+                                    branch_ty.literal_value, stmt.loc)
+                                const_assign = ir.Assign(
+                                    new_const_val, new_const_var, stmt.loc)
+                                new_assign = ir.Assign(
+                                    new_const_var, stmt.target, stmt.loc)
+                                new_body.append(const_assign)
+                                new_body.append(new_assign)
+                                dont_replace.append(new_const_name)
+                            else:
+                                orig = stmt.value
+                                new_typed_getitem = ir.Expr.typed_getitem(
+                                    value=orig.value, dtype=branch_ty,
+                                    index=orig.index, loc=orig.loc)
+                                new_assign = ir.Assign(
+                                    new_typed_getitem, stmt.target, stmt.loc)
+                                new_body.append(new_assign)
+                        else:
+                            new_body.append(stmt)
+                    else:
+                        new_body.append(stmt)
+                blk.body = new_body
+
+            # rename
+            var_table = get_name_var_table(loop_blocks)
+            drop_keys = []
+            for k, v in var_table.items():
+                if v.name in dont_replace:
+                    drop_keys.append(k)
+            for k in drop_keys:
+                var_table.pop(k)
+
+            new_var_dict = {}
+            for name, var in var_table.items():
+                new_var_dict[name] = mk_unique_var(name)
+            replace_var_names(loop_blocks, new_var_dict)
+
+            # clobber the sentinel body and then stuff in the rest
+            switch_ir.blocks[lbl] = deepcopy(loop_blocks[loop_start_lbl])
+            remaining_keys = [y for y in loop_blocks.keys()]
+            remaining_keys.remove(loop_start_lbl)
+            for k in remaining_keys:
+                switch_ir.blocks[k] = deepcopy(loop_blocks[k])
+
+        # now relabel the switch_ir WRT the caller max label
+        switch_ir.blocks = self.add_offset_to_labels_w_ignore(
+            switch_ir.blocks, caller_max_label + 1, ignore_set)
+
+        if self._DEBUG:
+            print("-" * 80 + "EXIT STUFFER")
+            switch_ir.dump()
+            print("-" * 80)
+
+        return switch_ir
+
+    def gen_switch(self, data, index):
+        """
+        Generates a function with a switch table like
+        def foo():
+            if PLACEHOLDER_INDEX in (<integers>):
+                SENTINEL = None
+            elif PLACEHOLDER_INDEX in (<integers>):
+                SENTINEL = None
+            ...
+            else:
+                raise RuntimeError
+
+        The data is a map of (type : indexes) for example:
+        (int64, int64, float64)
+        might give:
+        {int64: [0, 1], float64: [2]}
+
+        The index is the index variable for the driving range loop over the
+        mixed tuple.
+        """
+        elif_tplt = "\n\telif PLACEHOLDER_INDEX in (%s,):\n\t\tSENTINEL = None"
+
+        b = ('def foo():\n\tif PLACEHOLDER_INDEX in (%s,):\n\t\t'
+             'SENTINEL = None\n%s\n\telse:\n\t\t'
+             'raise RuntimeError("Unreachable")')
+        keys = [k for k in data.keys()]
+
+        elifs = []
+        for i in range(1, len(keys)):
+            elifs.append(elif_tplt % ','.join(map(str, data[keys[i]])))
+        src = b % (','.join(map(str, data[keys[0]])), ''.join(elifs))
+        wstr = src
+        l = {}
+        exec(wstr, {}, l)
+        bfunc = l['foo']
+        branches = compile_to_numba_ir(bfunc, {})
+        for lbl, blk in branches.blocks.items():
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if isinstance(stmt.value, ir.Global):
+                        if stmt.value.name == "PLACEHOLDER_INDEX":
+                            stmt.value = index
+        return branches
+
+    def apply_transform(self, state):
+        # compute new CFG
+        func_ir = state.func_ir
+        cfg = compute_cfg_from_blocks(func_ir.blocks)
+        # find loops
+        loops = cfg.loops()
+
+        # 0. Find the loops containing literal_unroll and store this
+        #    information
+        literal_unroll_info = dict()
+        unroll_info = namedtuple(
+            "unroll_info", [
+                "loop", "call", "arg", "getitem"])
+
+        def get_call_args(init_arg, want):
+            # Chases the assignment of a called value back through a specific
+            # call to a global function "want" and returns the arguments
+            # supplied to that function's call
+            some_call = get_definition(func_ir, init_arg)
+            if not isinstance(some_call, ir.Expr):
+                raise GuardException
+            if not some_call.op == "call":
+                raise GuardException
+            the_global = get_definition(func_ir, some_call.func)
+            if not isinstance(the_global, ir.Global):
+                raise GuardException
+            if the_global.value is not want:
+                raise GuardException
+            return some_call
+
+        for lbl, loop in loops.items():
+            # TODO: check the loop head has literal_unroll, if it does but
+            # does not conform to the following then raise
+
+            # scan loop header
+            iternexts = [_ for _ in
+                         func_ir.blocks[loop.header].find_exprs('iternext')]
+            if len(iternexts) != 1:
+                return False
+            for iternext in iternexts:
+                # Walk the canonicalised loop structure and check it
+                # Check loop form range(literal_unroll(container)))
+                phi = guard(get_definition, func_ir,  iternext.value)
+                if phi is None:
+                    continue
+
+                # check call global "range"
+                range_call = guard(get_call_args, phi.value, range)
+                if range_call is None:
+                    continue
+                range_arg = range_call.args[0]
+
+                # check call global "len"
+                len_call = guard(get_call_args, range_arg, len)
+                if len_call is None:
+                    continue
+                len_arg = len_call.args[0]
+
+                # check literal_unroll
+                literal_unroll_call = guard(get_definition, func_ir, len_arg)
+                if literal_unroll_call is None:
+                    continue
+                if not isinstance(literal_unroll_call, ir.Expr):
+                    continue
+                if literal_unroll_call.op != "call":
+                    continue
+                literal_func = getattr(literal_unroll_call, 'func', None)
+                if not literal_func:
+                    continue
+                call_func = guard(get_definition, func_ir,
+                                  literal_unroll_call.func)
+                if call_func is None:
+                    continue
+                call_func = call_func.value
+
+                if call_func is literal_unroll:
+                    assert len(literal_unroll_call.args) == 1
+                    arg = literal_unroll_call.args[0]
+                    typemap = state.typemap
+                    resolved_arg = guard(get_definition, func_ir, arg,
+                                         lhs_only=True)
+                    ty = typemap[resolved_arg.name]
+                    assert isinstance(ty, self._accepted_types)
+                    # loop header is spelled ok, now make sure the body
+                    # actually contains a getitem
+
+                    # find a "getitem"
+                    tuple_getitem = None
+                    for lbl in loop.body:
+                        blk = func_ir.blocks[lbl]
+                        for stmt in blk.body:
+                            if isinstance(stmt, ir.Assign):
+                                if (isinstance(stmt.value, ir.Expr) and
+                                        stmt.value.op == "getitem"):
+                                    # check for something like a[i]
+                                    if stmt.value.value != arg:
+                                        # that failed, so check for the
+                                        # definition
+                                        dfn = guard(get_definition, func_ir,
+                                                    stmt.value.value)
+                                        if dfn is None:
+                                            continue
+                                        args = getattr(dfn, 'args', False)
+                                        if not args:
+                                            continue
+                                        if not args[0] == arg:
+                                            continue
+                                    target_ty = state.typemap[arg.name]
+                                    if not isinstance(target_ty,
+                                                      self._accepted_types):
+                                        continue
+                                    tuple_getitem = stmt
+                                    break
+                        if tuple_getitem:
+                            break
+                    else:
+                        continue  # no getitem in this loop
+
+                    ui = unroll_info(loop, literal_unroll_call, arg,
+                                     tuple_getitem)
+                    literal_unroll_info[lbl] = ui
+
+        if not literal_unroll_info:
+            return False
+
+        # 1. Validate loops, must not have any calls to literal_unroll
+        for test_lbl, test_loop in literal_unroll_info.items():
+            for ref_lbl, ref_loop in literal_unroll_info.items():
+                if test_lbl == ref_lbl:  # comparing to self! skip
+                    continue
+                if test_loop.loop.header in ref_loop.loop.body:
+                    msg = ("Nesting of literal_unroll is unsupported")
+                    loc = func_ir.blocks[test_loop.loop.header].loc
+                    raise errors.UnsupportedError(msg, loc)
+
+        # 2. Do the unroll, get a loop and process it!
+        lbl, info = literal_unroll_info.popitem()
+        self.unroll_loop(state, info)
+
+        # 3. Rebuild the state, the IR has taken a hammering
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+        if self._DEBUG:
+            print('-' * 80 + "END OF PASS, SIMPLIFY DONE")
+            func_ir.dump()
+        func_ir._definitions = build_definitions(func_ir.blocks)
+        return True
+
+    def unroll_loop(self, state, loop_info):
+        # The general idea here is to:
+        # 1. Find *a* getitem that conforms to the literal_unroll semantic,
+        #    i.e. one that is targeting a tuple with a loop induced index
+        # 2. Compute a structure from the tuple that describes which
+        #    iterations of a loop will have which type
+        # 3. Generate a switch table in IR form for the structure in 2
+        # 4. Switch out getitems for the tuple for a `typed_getitem`
+        # 5. Inject switch table as replacement loop body
+        # 6. Patch up
+        func_ir = state.func_ir
+        getitem_target = loop_info.arg
+        target_ty = state.typemap[getitem_target.name]
+        assert isinstance(target_ty, self._accepted_types)
+
+        # 1. find a "getitem" that conforms
+        tuple_getitem = []
+        for lbl in loop_info.loop.body:
+            blk = func_ir.blocks[lbl]
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if isinstance(stmt.value,
+                                  ir.Expr) and stmt.value.op == "getitem":
+                        # try a couple of spellings... a[i] and ref(a)[i]
+                        if stmt.value.value != getitem_target:
+                            dfn = func_ir.get_definition(stmt.value.value)
+                            args = getattr(dfn, 'args', False)
+                            if not args:
+                                continue
+                            if not args[0] == getitem_target:
+                                continue
+                        target_ty = state.typemap[getitem_target.name]
+                        if not isinstance(target_ty, self._accepted_types):
+                            continue
+                        tuple_getitem.append(stmt)
+
+        if not tuple_getitem:
+            msg = ("Loop unrolling analysis has failed, there's no getitem "
+                   "in loop body that conforms to literal_unroll "
+                   "requirements.")
+            LOC = func_ir.blocks[loop_info.loop.header].loc
+            raise errors.CompilerError(msg, LOC)
+
+        # 2. get switch data
+        switch_data = self.analyse_tuple(target_ty)
+
+        # 3. generate switch IR
+        index = func_ir._definitions[tuple_getitem[0].value.index.name][0]
+        branches = self.gen_switch(switch_data, index)
+
+        # 4. swap getitems for a typed_getitem, these are actually just
+        # placeholders at this point. When the loop is duplicated they can
+        # be swapped for a typed_getitem of the correct type or if the item
+        # is literal it can be shoved straight into the duplicated loop body
+        for item in tuple_getitem:
+            old = item.value
+            new = ir.Expr.typed_getitem(
+                old.value, types.void, old.index, old.loc)
+            item.value = new
+
+        # 5. Inject switch table
+
+        # Find the actual loop without the header (that won't get replaced)
+        # and derive some new IR for this set of blocks
+        this_loop = loop_info.loop
+        this_loop_body = this_loop.body - \
+            set([this_loop.header])
+        loop_blocks = {
+            x: func_ir.blocks[x] for x in this_loop_body}
+        new_ir = func_ir.derive(loop_blocks)
+
+        # Work out what is live on entry and exit so as to prevent
+        # replacement (defined vars can escape, used vars live at the header
+        # need to remain as-is so their references are correct, they can
+        # also escape).
+
+        usedefs = compute_use_defs(func_ir.blocks)
+        idx = this_loop.header
+        keep = set()
+        keep |= usedefs.usemap[idx] | usedefs.defmap[idx]
+        keep |= func_ir.variable_lifetime.livemap[idx]
+        dont_replace = [x for x in (keep)]
+
+        # compute the unrolled body
+        unrolled_body = self.inject_loop_body(
+            branches, new_ir, max(func_ir.blocks.keys()),
+            dont_replace, switch_data)
+
+        # 6. Patch in the unrolled body and fix up
+        blks = state.func_ir.blocks
+        orig_lbl = tuple(this_loop_body)
+        data = unrolled_body, this_loop.header
+        # python 2 can't star unpack
+        replace, delete = orig_lbl[0], orig_lbl[1:]
+        unroll, header_block = data
+        unroll_lbl = [x for x in sorted(unroll.blocks.keys())]
+        blks[replace] = unroll.blocks[unroll_lbl[0]]
+        [blks.pop(d) for d in delete]
+        for k in unroll_lbl[1:]:
+            blks[k] = unroll.blocks[k]
+        # stitch up the loop predicate true -> new loop body jump
+        blks[header_block].body[-1].truebr = replace
+
+    def run_pass(self, state):
+        mutated = False
+        func_ir = state.func_ir
+        # first limit the work by squashing the CFG if possible
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+
+        if self._DEBUG:
+            print("-" * 80 + "PASS ENTRY")
+            func_ir.dump()
+            print("-" * 80)
+
+        # limitations:
+        # 1. No nested unrolls
+        # 2. Opt in via `numba.literal_unroll`
+        # 3. No multiple mix-tuple use
+
+        # TODO: Add the following in so that loop nests are walked in reverse
+        # nesting order and as a result nested transforms become valid.
+        def true_body(loop):
+            # computes blocks reachable from a loop head
+            return loop.body - {loop.header} - loop.exits
+
+        def get_loop_nest(structure):
+            all_children = []
+            for x in structure.values():
+                all_children.extend(x)
+
+            # BFS order
+            def BFS(root):
+                acc = []
+
+                def walk(node):
+                    for x in structure[node]:
+                        acc.append(x)
+                    for x in structure[node]:
+                        walk(x)
+                walk(root)
+                return acc
+
+            nest = {}
+            for x in structure.keys():
+                if x not in all_children:
+                    nest[x] = BFS(x)
+            return nest
+
+        def compute_loop_structure(loops):
+            """
+            Return BFS ordered list of loop nests
+            """
+            # a loop can only have one loop parent, but a loop parent may have
+            # many children
+            children = defaultdict(list)
+            for loop in loops.values():
+                for test_loop in loops.values():
+                    if loop.header in true_body(test_loop):
+                        # loop is a child of test_loop
+                        children[test_loop.header].append(loop.header)
+                else:
+                    # loop is inner most
+                    children[test_loop.header] = []
+            # any loop which has children which also have children themselves
+            # needs fixing up as children!=grandchildren
+            ck = [x for x in children.keys()]
+            for k in ck:
+                for child in children[k][:]:
+                    grandchildren = children[child]
+                    for grandchild in grandchildren:
+                        if grandchild in children[k]:
+                            children[k].remove(grandchild)
+
+            loop_nest = get_loop_nest(children)
+            # any loops with that are not in children's keys are parents without
+            # children
+            for loop in loops.values():
+                if loop.header not in children:
+                    loop_nest[loop.header] = []
+
+        # keep running the transform loop until it reports no more changes
+        while(True):
+            stat = self.apply_transform(state)
+            mutated |= stat
+            if not stat:
+                break
+
+        # reset type inference now we are done with the partial results
+        state.typemap = {}
+        state.calltypes = None
+
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class IterLoopCanonicalization(FunctionPass):
+    """ Transforms loops that are induced by `getiter` into range() driven loops
+    If the typemap is available this will only impact Tuple and UniTuple, if it
+    is not available it will impact all matching loops.
+    """
+    _name = "iter_loop_canonicalisation"
+
+    _DEBUG = False
+
+    # if partial typing info is available it will only look at these types
+    _accepted_types = (types.Tuple, types.UniTuple)
+    _accepted_calls = (literal_unroll,)
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def assess_loop(self, loop, func_ir, partial_typemap=None):
+        # it's a iter loop if:
+        # - loop header is driven by an iternext
+        # - the iternext value is a phi derived from getiter()
+
+        # check header
+        iternexts = [_ for _ in
+                     func_ir.blocks[loop.header].find_exprs('iternext')]
+        if len(iternexts) != 1:
+            return False
+        for iternext in iternexts:
+            phi = guard(get_definition, func_ir,  iternext.value)
+            if phi is None:
+                return False
+            if getattr(phi, 'op', False) == 'getiter':
+                if partial_typemap:
+                    # check that the call site is accepted, until we're
+                    # confident that tuple unrolling is behaving require opt-in
+                    # guard of `literal_unroll`, remove this later!
+                    phi_val_defn = guard(get_definition, func_ir,  phi.value)
+                    if not isinstance(phi_val_defn, ir.Expr):
+                        return False
+                    if not phi_val_defn.op == "call":
+                        return False
+                    call = guard(get_definition, func_ir,  phi_val_defn)
+                    if call is None or len(call.args) != 1:
+                        return False
+                    func_var = guard(get_definition, func_ir,  call.func)
+                    func = guard(get_definition, func_ir,  func_var)
+                    if func is None or not isinstance(func, ir.Global):
+                        return False
+                    if (func.value is None or
+                            func.value not in self._accepted_calls):
+                        return False
+
+                    # now check the type is supported
+                    ty = partial_typemap.get(call.args[0].name, None)
+                    if ty and isinstance(ty, self._accepted_types):
+                        return len(loop.entries) == 1
+                else:
+                    return len(loop.entries) == 1
+
+    def transform(self, loop, func_ir, cfg):
+        def get_range(a):
+            return range(len(a))
+
+        def tokenise(x):
+            return mk_unique_var("CANONICALISER_%s" % x)
+
+        iternext = [_ for _ in
+                    func_ir.blocks[loop.header].find_exprs('iternext')][0]
+        LOC = func_ir.blocks[loop.header].loc
+        get_range_var = ir.Var(func_ir.blocks[loop.header].scope,
+                               tokenise('get_range_gbl'), LOC)
+        get_range_global = ir.Global('get_range', get_range, LOC)
+        assgn = ir.Assign(get_range_global, get_range_var, LOC)
+
+        loop_entry = tuple(loop.entries)[0]
+        entry_block = func_ir.blocks[loop_entry]
+        entry_block.body.insert(0, assgn)
+
+        iterarg = guard(get_definition, func_ir,  iternext.value)
+        if iterarg is not None:
+            iterarg = iterarg.value
+
+        # look for iternext
+        idx = 0
+        for stmt in entry_block.body:
+            if isinstance(stmt, ir.Assign):
+                if isinstance(stmt.value,
+                              ir.Expr) and stmt.value.op == 'getiter':
+                    break
+            idx += 1
+        else:
+            raise ValueError("problem")
+
+        # create a range(len(tup)) and inject it
+        call_get_range_var = ir.Var(entry_block.scope,
+                                    tokenise('call_get_range'), LOC)
+        make_call = ir.Expr.call(get_range_var, (stmt.value.value,), (), LOC)
+        assgn_call = ir.Assign(make_call, call_get_range_var, LOC)
+        entry_block.body.insert(idx, assgn_call)
+        entry_block.body[idx + 1].value.value = call_get_range_var
+
+        glbls = copy(func_ir.func_id.func.__globals__)
+        inline_closure_call(func_ir, glbls, entry_block, idx, get_range,)
+        kill = entry_block.body.index(assgn)
+        entry_block.body.pop(kill)
+
+        # find the induction variable + references in the loop header
+        # fixed point iter to do this, it's a bit clunky
+        induction_vars = set()
+        header_block = func_ir.blocks[loop.header]
+
+        # find induction var
+        ind = [x for x in header_block.find_exprs('pair_first')]
+        for x in ind:
+            induction_vars.add(func_ir.get_assignee(x, loop.header))
+        # find aliases of the induction var
+        tmp = set()
+        for x in induction_vars:
+            try:  # there's not always an alias, e.g. loop from inlined closure
+                tmp.add(func_ir.get_assignee(x, loop.header))
+            except ValueError:
+                pass
+        induction_vars |= tmp
+        induction_var_names = set([x.name for x in induction_vars])
+
+        # Find the downstream blocks that might reference the induction var
+        succ = set()
+        for lbl in loop.exits:
+            succ |= set([x[0] for x in cfg.successors(lbl)])
+        check_blocks = (loop.body | loop.exits | succ) ^ {loop.header}
+
+        # replace RHS use of induction var with getitem
+        for lbl in check_blocks:
+            for stmt in func_ir.blocks[lbl].body:
+                if isinstance(stmt, ir.Assign):
+                    # check for aliases
+                    try:
+                        lookup = getattr(stmt.value, 'name', None)
+                    except KeyError:
+                        continue
+                    if lookup and lookup in induction_var_names:
+                        stmt.value = ir.Expr.getitem(
+                            iterarg, stmt.value, stmt.loc)
+
+        post_proc = postproc.PostProcessor(func_ir)
+        post_proc.run()
+
+    def run_pass(self, state):
+        func_ir = state.func_ir
+        cfg = compute_cfg_from_blocks(func_ir.blocks)
+        loops = cfg.loops()
+
+        mutated = False
+        for header, loop in loops.items():
+            stat = self.assess_loop(loop, func_ir, state.typemap)
+            if stat:
+                if self._DEBUG:
+                    print("Canonicalising loop", loop)
+                self.transform(loop, func_ir, cfg)
+                mutated = True
+            else:
+                if self._DEBUG:
+                    print("NOT Canonicalising loop", loop)
+
+        func_ir.blocks = simplify_CFG(func_ir.blocks)
+        return mutated
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class LiteralUnroll(FunctionPass):
+    """Implement the literal_unroll semantics"""
+    _name = "literal_unroll"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        # run as subpipeline
+        from numba.compiler_machinery import PassManager
+        from numba.typed_passes import PartialTypeInference
+        pm = PassManager("literal_unroll_subpipeline")
+        # get types where possible to help with list->tuple change
+        pm.add_pass(PartialTypeInference, "performs partial type inference")
+        # make const lists tuples
+        pm.add_pass(TransformLiteralUnrollConstListToTuple,
+                    "switch const list for tuples")
+        # recompute partial typemap following IR change
+        pm.add_pass(PartialTypeInference, "performs partial type inference")
+        # canonicalise loops
+        pm.add_pass(IterLoopCanonicalization,
+                    "switch iter loops for range driven loops")
+        # rewrite consts
+        pm.add_pass(RewriteSemanticConstants, "rewrite semantic constants")
+        # do the unroll
+        pm.add_pass(MixedContainerUnroller, "performs mixed container unroll")
+        pm.finalize()
+        pm.run(state)
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class SimplifyCFG(FunctionPass):
+    """Perform CFG simplification"""
+    _name = "simplify_cfg"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        blks = state.func_ir.blocks
+        new_blks = simplify_CFG(blks)
+        state.func_ir.blocks = new_blks
+        mutated = blks != new_blks
         return mutated


### PR DESCRIPTION
This PR adds:
 * A pass to canonicalise `getiter()` driven loops into the form `for i in range(len(iterable))`.
 * A special marker function `numba.literal_unroll` to indicate that iterating over the argument tuple should be done so with literal typing.
 * A pass that consumes canonicalised loops looking for those which are iterating over tuples marked with `literal_unroll` and transforms this iteration using partial typing and versioned loop bodies such that literal dispatch will work. Example:

```python
@njit
def foo(idx, z):
    a = (12, 12.7, 3j, 4, z, 2 * z)
    acc = 0
    for x in literal_unroll(a):
        acc += x
        if acc.real < 26:
            acc -= 1
        else:
            break
    return acc
```
will effectively be transformed into
```python
@njit
def foo(idx, z):
    a = (12, 12.7, 3j, 4, z, 2 * z)
    acc = 0
    for i in range(len(a)):
        if i in (0,): # specialised on IntegerLiteral[12]
            acc += 12 # integer literal replacement as const
            if acc.real < 26:
                acc -= 1
            else:
                break
        elif i in (1,): # generic float64 case
            acc += a[i]
            if acc.real < 26:
                acc -= 1
            else:
                break
        elif i in (2,): # generic complex128 case
            acc += a[i]
            if acc.real < 26:
                acc -= 1
            else:
                break
        elif i in (3,): # specialised on IntegerLiteral[4]
            acc += 4 # integer literal replacement as const
            if acc.real < 26:
                acc -= 1
            else:
                break
        elif i in (4, 5,): # generic int64 case, note two cases into one branch
            acc += a[i]
            if acc.real < 26:
                acc -= 1
            else:
                break
    return acc
```

Other things added:
 * More debug tooling to the compiler, including:
   - A env var for print before, after and both sides of any compiler pass.
   - Syntax highlighting of IR/LLVM IR/ASM dumps.
 * Utility to flatten labels for a given `FunctionIR`.
 * The CFG class now supports comparison.

Things left to do:
 * [x] Clean up
 * [x] More testing
 * [x] Documentation
 * [x] Docstrings
 * [x] Almost certainly fixes for Python 3.8 and probably other Python/Platform problems.
 * [x] Flake8 etc.
