### PR TITLE
fix Azure test failure detection on windows

### DIFF
--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -58,10 +58,11 @@ jobs:
       displayName: 'Remove TBB'
       condition: ne(variables['PYTHON'], '2.7')
 
-    - script: |
-        call activate %CONDA_ENV%
-        numba.exe -s
-      displayName: 'Display numba system information'
+    # not working on windows?
+    #- script: |
+    #    call activate %CONDA_ENV%
+    #    numba.exe -s
+    #  displayName: 'Display numba system information'
 
     - script: |
         call activate %CONDA_ENV%

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -60,12 +60,20 @@ jobs:
 
     - script: |
         call activate %CONDA_ENV%
-        pushd bin
-        numba -s
-        popd
+        numba.exe -s
+      displayName: 'Display numba system information'
+
+    - script: |
+        call activate %CONDA_ENV%
         python -m numba.tests.test_runtests
-        # Now run tests based on the changes identified via git
+      displayName: 'Verify runtests'
+
+    - script: |
+        call activate %CONDA_ENV%
         python -m numba.runtests -b -v -g -m 2 -- numba.tests
-        # Now run the rest with slice
+      displayName: 'Test modified test files'
+
+    - script: |
+        call activate %CONDA_ENV%
         python runtests.py -m 2 -b -j "%TEST_START_INDEX%,None,%TEST_COUNT%"  --exclude-tags='long_running'  -- numba.tests
-      displayName: 'Test'
+      displayName: 'Test slice of test files'

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -17,9 +17,6 @@ class TestNumbaModule(TestCase):
 
     @tag('important')
     def test_numba_module(self):
-        # bogus line to force a test to fail
-        self.assertTrue(False)
-        
         # jit
         self.check_member("jit")
         self.check_member("vectorize")

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -17,6 +17,9 @@ class TestNumbaModule(TestCase):
 
     @tag('important')
     def test_numba_module(self):
+        # bogus line to force a test to fail
+        self.assertTrue(False)
+        
         # jit
         self.check_member("jit")
         self.check_member("vectorize")


### PR DESCRIPTION
It appears that Azure isn't catching test failures on Windows unless we run the test script as the last item.