### PR TITLE
fix creating list with JIT disabled

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -254,7 +254,8 @@ def new_list(item, allocated=0):
         number of items to pre-allocate
 
     """
-    raise NotImplementedError
+    # With JIT disabled, ignore all arguments and return a Python list.
+    return list()
 
 
 @intrinsic

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -36,6 +36,10 @@ class TestCreateAppendLength(MemoryLeakMixin, TestCase):
         for i in (0, 1, 2, 100):
             self.assertEqual(foo(i), i)
 
+    def test_list_create_no_jit(self):
+        l = listobject.new_list(int32)
+        self.assertTrue(isinstance(l, list))
+
 
 class TestAllocation(MemoryLeakMixin, TestCase):
 

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -17,7 +17,8 @@ from numba import int32, types
 from numba.errors import TypingError
 from numba import listobject
 from numba.utils import IS_PY3
-from .support import TestCase, MemoryLeakMixin, unittest
+from .support import (TestCase, MemoryLeakMixin, unittest, override_config,
+                      forbid_codegen)
 
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
 
@@ -37,8 +38,10 @@ class TestCreateAppendLength(MemoryLeakMixin, TestCase):
             self.assertEqual(foo(i), i)
 
     def test_list_create_no_jit(self):
-        l = listobject.new_list(int32)
-        self.assertTrue(isinstance(l, list))
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                l = listobject.new_list(int32)
+                self.assertEqual(type(l), list)
 
 
 class TestBool(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -9,7 +9,8 @@ from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.utils import IS_PY3
-from .support import TestCase, MemoryLeakMixin, unittest
+from .support import (TestCase, MemoryLeakMixin, unittest, override_config,
+                      forbid_codegen)
 
 from numba.unsafe.refcount import get_refcount
 
@@ -445,6 +446,12 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             del rl[sa:so:se]
             del tl[sa:so:se]
             self.assertEqual(rl, list(tl))
+
+    def test_list_create_no_jit(self):
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                l = List.empty_list(types.int32)
+                self.assertEqual(type(l), list)
 
 
 class TestAllocation(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -447,10 +447,16 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             del tl[sa:so:se]
             self.assertEqual(rl, list(tl))
 
-    def test_list_create_no_jit(self):
+    def test_list_create_no_jit_using_empty_list(self):
         with override_config('DISABLE_JIT', True):
             with forbid_codegen():
                 l = List.empty_list(types.int32)
+                self.assertEqual(type(l), list)
+
+    def test_list_create_no_jit_using_List(self):
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                l = List()
                 self.assertEqual(type(l), list)
 
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -150,6 +150,13 @@ class List(MutableSequence):
 
     Implements the MutableSequence interface.
     """
+
+    def __new__(cls, lsttype=None, meminfo=None, allocated=None):
+        if config.DISABLE_JIT:
+            return list.__new__(list)
+        else:
+            return object.__new__(cls)
+
     @classmethod
     def empty_list(cls, item_type, allocated=0):
         """Create a new empty List.

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -13,6 +13,7 @@ from numba.six import MutableSequence
 from numba.types import ListType, TypeRef
 from numba.targets.imputils import numba_typeref_ctor
 from numba import listobject
+from numba import config
 from numba import njit, types, cgutils, errors, typeof
 from numba.extending import (
     overload_method,
@@ -160,7 +161,10 @@ class List(MutableSequence):
         allocated: int
             number of items to pre-allocate
         """
-        return cls(lsttype=ListType(item_type), allocated=allocated)
+        if config.DISABLE_JIT:
+            return []
+        else:
+            return cls(lsttype=ListType(item_type), allocated=allocated)
 
     def __init__(self, **kwargs):
         """

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -162,7 +162,7 @@ class List(MutableSequence):
             number of items to pre-allocate
         """
         if config.DISABLE_JIT:
-            return []
+            return list()
         else:
             return cls(lsttype=ListType(item_type), allocated=allocated)
 


### PR DESCRIPTION
When using NUMBA_DISABLE_JIT=1 we still want `listobject.new_list` to
work, for example to measure coverage and such things.

Fixes https://github.com/numba/numba/issues/4905