### PR TITLE
fix creating dict with JIT disabled

### DIFF
--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -82,7 +82,7 @@ def new_dict(key, value):
         Key type and value type of the new dict.
     """
     # With JIT disabled, ignore all arguments and return a Python dict.
-    return {}
+    return dict()
 
 
 @register_model(DictType)

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -74,14 +74,15 @@ class Status(IntEnum):
 
 
 def new_dict(key, value):
-    """Construct a new dict. (Not implemented in the interpreter yet)
+    """Construct a new dict.
 
     Parameters
     ----------
     key, value : TypeRef
         Key type and value type of the new dict.
     """
-    raise NotImplementedError
+    # With JIT disabled, ignore all arguments and return a Python dict.
+    return {}
 
 
 @register_model(DictType)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -19,7 +19,8 @@ from numba.typed import Dict
 from numba.typedobjectutils import _sentry_safe_cast
 from numba.utils import IS_PY3
 from numba.errors import TypingError
-from .support import TestCase, MemoryLeakMixin, unittest
+from .support import (TestCase, MemoryLeakMixin, unittest, override_config,
+                      forbid_codegen)
 
 skip_py2 = unittest.skipUnless(IS_PY3, reason='not supported in py2')
 
@@ -64,13 +65,6 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(n=2), 2)
         # Insert 100 entries
         self.assertEqual(foo(n=100), 100)
-
-    def test_dict_create_no_jit(self):
-        """
-        Exercise dictionary creation with JIT disabled.
-        """
-        d = dictobject.new_dict(int32, float32)
-        self.assertTrue(isinstance(d, dict))
 
     def test_dict_get(self):
         """
@@ -1592,3 +1586,26 @@ class TestDictWithJitclass(TestCase):
         d = foo(Bag(a=100))
         self.assertEqual(d[0].a, 100)
         self.assertEqual(d[1].a, 101)
+
+
+class TestNoJit(TestCase):
+    """Exercise dictionary creation with JIT disabled. """
+
+    def test_dict_create_no_jit_using_new_dict(self):
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                d = dictobject.new_dict(int32, float32)
+                self.assertEqual(type(d), dict)
+
+    @unittest.expectedFailure
+    def test_dict_create_no_jit_using_Dict(self):
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                d = Dict()
+                self.assertEqual(type(d), dict)
+
+    def test_dict_create_no_jit_using_empty(self):
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                d = Dict.empty(types.int32, types.float32)
+                self.assertEqual(type(d), dict)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1597,7 +1597,6 @@ class TestNoJit(TestCase):
                 d = dictobject.new_dict(int32, float32)
                 self.assertEqual(type(d), dict)
 
-    @unittest.expectedFailure
     def test_dict_create_no_jit_using_Dict(self):
         with override_config('DISABLE_JIT', True):
             with forbid_codegen():

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -45,6 +45,13 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         # Insert 100 entries
         self.assertEqual(foo(n=100), 100)
 
+    def test_dict_create_no_jit(self):
+        """
+        Exercise dictionary creation with JIT disabled.
+        """
+        d = dictobject.new_dict(int32, float32)
+        self.assertTrue(isinstance(d, dict))
+
     def test_dict_get(self):
         """
         Exercise dictionary creation, insertion and get

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -1,6 +1,7 @@
 """
 Python wrapper that connects CPython interpreter to the numba dictobject.
 """
+from numba import config
 from numba.six import MutableMapping
 from numba.types import DictType, TypeRef
 from numba.targets.imputils import numba_typeref_ctor
@@ -85,7 +86,10 @@ class Dict(MutableMapping):
         """Create a new empty Dict with *key_type* and *value_type*
         as the types for the keys and values of the dictionary respectively.
         """
-        return cls(dcttype=DictType(key_type, value_type))
+        if config.DISABLE_JIT:
+            return dict()
+        else:
+            return cls(dcttype=DictType(key_type, value_type))
 
     def __init__(self, **kwargs):
         """

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -81,6 +81,13 @@ class Dict(MutableMapping):
 
     Implements the MutableMapping interface.
     """
+
+    def __new__(cls, dcttype=None, meminfo=None):
+        if config.DISABLE_JIT:
+            return dict.__new__(dict)
+        else:
+            return object.__new__(cls)
+
     @classmethod
     def empty(cls, key_type, value_type):
         """Create a new empty Dict with *key_type* and *value_type*


### PR DESCRIPTION
When using `NUMBA_DISABLE_JIT=1` we still want `dictobject.new_dict` to
work, for example to measure coverage and such things.