### PR TITLE
[Experiment] Using env_manager.read_const(env_manager.add_const(...)) in boxers

### DIFF
--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -482,7 +482,8 @@ class _GufuncObjectWrapper(_GufuncWrapper):
         innercall, error = _prepare_call_to_object_mode(self.context,
                                                         builder, pyapi, func,
                                                         self.signature,
-                                                        args, self.envptr, self.env)
+                                                        args,
+                                                        self.envptr, self.env)
         return innercall, error
 
     def gen_prologue(self, builder, pyapi):
@@ -490,9 +491,8 @@ class _GufuncObjectWrapper(_GufuncWrapper):
         self.gil = pyapi.gil_ensure()
 
         # prepare the env
-        envname = self.context.get_env_name(self.cres.fndesc)
-        self.env = self.cres.environment
-        self.envptr = builder.load(self.context.declare_env_global(builder.module, envname))
+        self.envptr = builder.load(
+            self.context.declare_env_global(builder.module, self.env.env_name))
 
     def gen_epilogue(self, builder, pyapi):
         # Release GIL

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -991,10 +991,12 @@ class PythonAPI(object):
             return self.builder.call(fn, (lhs, rhs, lopid))
         elif opstr == 'is':
             bitflag = self.builder.icmp(lc.ICMP_EQ, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            # return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr == 'is not':
             bitflag = self.builder.icmp(lc.ICMP_NE, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            # return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr in ('in', 'not in'):
             fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
             fn = self._get_function(fnty, name="PySequence_Contains")
@@ -1431,7 +1433,7 @@ class PythonAPI(object):
         out = self.from_native_value(typ, val, env_manager)
         return out
 
-    def from_native_value(self, typ, val, env_manager=None):
+    def from_native_value(self, typ, val, env_manager):
         """
         Box the native value of the given Numba type.  A Python object
         pointer is returned (NULL if an error occurred).

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -165,7 +165,8 @@ def box_enum(typ, val, c):
     """
     valobj = c.box(typ.dtype, val)
     # Call the enum class with the value object
-    cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    # cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    cls_obj = c.env_manager.read_const(c.env_manager.add_const(typ.instance_class))
     return c.pyapi.call_function_objargs(cls_obj, (valobj,))
 
 
@@ -502,10 +503,11 @@ def box_namedtuple(typ, val, c):
     """
     Convert native array or structure *val* to a namedtuple object.
     """
-    cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    # cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+    cls_obj = c.env_manager.read_const(c.env_manager.add_const(typ.instance_class))
     tuple_obj = box_tuple(typ, val, c)
     obj = c.pyapi.call(cls_obj, tuple_obj)
-    c.pyapi.decref(cls_obj)
+    # c.pyapi.decref(cls_obj)   # read_const gives borrowed ref
     c.pyapi.decref(tuple_obj)
     return obj
 
@@ -987,7 +989,10 @@ def unbox_generator(typ, obj, c):
 @box(types.DType)
 def box_dtype(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
-    return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
+    # return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
+    obj = c.env_manager.read_const(c.env_manager.add_const(np_dtype))
+    c.pyapi.incref(obj)
+    return obj
 
 @unbox(types.DType)
 def unbox_dtype(typ, val, c):
@@ -997,7 +1002,10 @@ def unbox_dtype(typ, val, c):
 @box(types.NumberClass)
 def box_number_class(typ, val, c):
     np_dtype = numpy_support.as_dtype(typ.dtype)
-    return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
+    # return c.pyapi.unserialize(c.pyapi.serialize_object(np_dtype))
+    obj = c.env_manager.read_const(c.env_manager.add_const(np_dtype))
+    c.pyapi.incref(obj)
+    return obj
 
 @unbox(types.NumberClass)
 def unbox_number_class(typ, val, c):
@@ -1082,7 +1090,10 @@ def box_literal(typ, val, c):
     # which we can directly return.
     retval = typ.literal_value
     # Serialize the value into the IR
-    return c.pyapi.unserialize(c.pyapi.serialize_object(retval))
+    # return c.pyapi.unserialize(c.pyapi.serialize_object(retval))
+    obj = c.env_manager.read_const(c.env_manager.add_const(retval))
+    c.pyapi.incref(obj)
+    return obj
 
 
 @box(types.MemInfoPointer)

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -227,7 +227,8 @@ def box_dicttype(typ, val, c):
     typeddict_mod = c.pyapi.import_module_noblock(modname)
     fmp_fn = c.pyapi.object_getattr_string(typeddict_mod, '_from_meminfo_ptr')
 
-    dicttype_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
+    # dicttype_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
+    dicttype_obj = c.env_manager.read_const(c.env_manager.add_const(typ))
 
     res = c.pyapi.call_function_objargs(fmp_fn, (boxed_meminfo, dicttype_obj))
     c.pyapi.decref(fmp_fn)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -323,7 +323,8 @@ def box_lsttype(typ, val, c):
     typedlist_mod = c.pyapi.import_module_noblock(modname)
     fmp_fn = c.pyapi.object_getattr_string(typedlist_mod, '_from_meminfo_ptr')
 
-    lsttype_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
+    # lsttype_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
+    lsttype_obj = c.env_manager.read_const(c.env_manager.add_const(typ))
 
     res = c.pyapi.call_function_objargs(fmp_fn, (boxed_meminfo, lsttype_obj))
     c.pyapi.decref(fmp_fn)


### PR DESCRIPTION
Currently most boxers use `pyapi.unserialize(pyapi.serialize_object(MyClass))` to get the class object for boxing. Ths PR is using `env_manager.read_const(env_manager.add_const(MyClass)` instead. The benefit is to avoid unpickleing the class object which might help boxing performance.

The impact on memory is not fully understood, yet. On the one hand using `env_manager` will reduce 
the size of the resulting code as the string constant with the pickled object is avoided, on the other hand the class object might be kept alive for longer (but that should only be relevant for dynamically created classes).

One breaking API change is required: `env_manager` now is a mandatory argument to `pyapi.from_native_value` (was optional before).
