### PR TITLE
Fix fails in TestCudaWarpOperations

### DIFF
--- a/numba/cuda/tests/cudapy/test_warp_ops.py
+++ b/numba/cuda/tests/cudapy/test_warp_ops.py
@@ -214,7 +214,7 @@ class TestCudaWarpOperations(SerialMixin, unittest.TestCase):
         nelem = 10
         ary_in = np.arange(nelem, dtype=np.int32) % 2
         ary_out = np.empty(nelem, dtype=np.int32)
-        exp = np.tile((0b1010101010, 0b0101010101), 5)
+        exp = np.tile((0b0101010101, 0b1010101010), 5)
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == exp))
 
@@ -234,11 +234,11 @@ class TestCudaWarpOperations(SerialMixin, unittest.TestCase):
     @unittest.skipUnless(_safe_cc_check((7, 0)),
                          "Independent scheduling requires at least Volta Architecture")
     def test_independent_scheduling(self):
-        compiled = cuda.jit("void(int32[:])")(use_independent_scheduling)
-        arr = np.empty(32, dtype=np.int32)
+        compiled = cuda.jit("void(uint32[:])")(use_independent_scheduling)
+        arr = np.empty(32, dtype=np.uint32)
         exp = np.tile((0x11111111, 0x22222222, 0x44444444, 0x88888888), 8)
         compiled[1, 32](arr)
-        self.assertTrue(np.all(ary_out == exp))
+        self.assertTrue(np.all(arr == exp))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are two failures in `TestCudaWarpOperations`:

```
======================================================================
ERROR: test_independent_scheduling (numba.cuda.tests.cudapy.test_warp_ops.TestCudaWarpOperations)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nfs/gmarkall/numbadev/numba/numba/cuda/tests/cudapy/test_warp_ops.py", line 241, in test_independent_scheduling
    self.assertTrue(np.all(ary_out == exp))
NameError: name 'ary_out' is not defined

======================================================================
FAIL: test_match_any_sync (numba.cuda.tests.cudapy.test_warp_ops.TestCudaWarpOperations)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nfs/gmarkall/numbadev/numba/numba/cuda/tests/cudapy/test_warp_ops.py", line 219, in test_match_any_sync
    self.assertTrue(np.all(ary_out == exp))
AssertionError: False is not true

----------------------------------------------------------------------
```

This commit fixes them with these changes:

- `test_independent_scheduling` overflows an `int32` with its output, so its argument types are changed to `uint32`. There is also a copy/paste error (probably), where `ary_out` (which doesn't exist) is compared against `exp` - this commit changes it to `arr`.
- `test_match_any_sync` has the values in the expected data transposed. This commit switches them round to fix the test. I have also checked that the Numba implementation of the intrinsic is correct by comparing the output against a similar CUDA C program.

This is tested on a Tesla V100-SXM2-16GB; the tests now pass with this commit.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
