### PR TITLE
Improve errors / warnings for cuda vectorize decorator

### DIFF
--- a/numba/cuda/tests/cudapy/test_vectorize_decor.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_decor.py
@@ -4,12 +4,13 @@ import numpy as np
 
 from numba import unittest_support as unittest
 from numba import vectorize, cuda
-from numba.tests.npyufunc import test_vectorize_decor
+from numba.tests.npyufunc.test_vectorize_decor import BaseVectorizeDecor, \
+    BaseVectorizeNopythonArg, BaseVectorizeUnrecognizedArg
 from numba.cuda.testing import skip_on_cudasim, SerialMixin
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeDecor(SerialMixin, test_vectorize_decor.BaseVectorizeDecor):
+class TestVectorizeDecor(SerialMixin, BaseVectorizeDecor):
     def test_gpu_1(self):
         self._test_template_1('cuda')
 
@@ -59,6 +60,19 @@ class TestGPUVectorizeBroadcast(SerialMixin, unittest.TestCase):
         expect = fn(a, b)
         got = fngpu(cuda.to_device(a), cuda.to_device(b))
         np.testing.assert_almost_equal(expect, got.copy_to_host())
+
+
+@skip_on_cudasim('ufunc API unsupported in the simulator')
+class TestVectorizeNopythonArg(BaseVectorizeNopythonArg, SerialMixin):
+    def test_target_cuda_nopython(self):
+        warnings = ["nopython kwarg for cuda target is redundant"]
+        self._test_target_nopython('cuda', warnings)
+
+
+@skip_on_cudasim('ufunc API unsupported in the simulator')
+class TestVectorizeUnrecognizedArg(BaseVectorizeUnrecognizedArg, SerialMixin):
+    def test_target_cuda_unrecognized_arg(self):
+        self._test_target_unrecognized_arg('cuda')
 
 
 if __name__ == '__main__':

--- a/numba/npyufunc/deviceufunc.py
+++ b/numba/npyufunc/deviceufunc.py
@@ -364,7 +364,13 @@ class DeviceVectorize(_BaseUFuncBuilder):
     def __init__(self, func, identity=None, cache=False, targetoptions={}):
         if cache:
             raise TypeError("caching is not supported")
-        assert not targetoptions
+        for opt in targetoptions:
+            if opt == 'nopython':
+                warnings.warn("nopython kwarg for cuda target is redundant",
+                              RuntimeWarning)
+            else:
+                fmt = "cuda vectorize target does not support option: '%s'"
+                raise KeyError(fmt % opt)
         self.py_func = func
         self.identity = parse_identity(identity)
         # { arg_dtype: (return_dtype), cudakernel }

--- a/numba/tests/npyufunc/test_errors.py
+++ b/numba/tests/npyufunc/test_errors.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, print_function, division
 
 import contextlib
 import sys
-import warnings
 
 import numpy as np
 
@@ -10,7 +9,7 @@ from numba import unittest_support as unittest
 from numba import vectorize, guvectorize
 from numba.numpy_support import version as np_version
 
-from ..support import TestCase
+from ..support import TestCase, CheckWarningsMixin
 
 
 def sqrt(val):
@@ -80,27 +79,12 @@ class TestExceptions(TestCase):
     def test_gufunc_raise_objmode(self):
         self.check_gufunc_raise(forceobj=True)
 
-
-class TestFloatingPointExceptions(TestCase):
+class TestFloatingPointExceptions(TestCase, CheckWarningsMixin):
     """
     Test floating-point exceptions inside ufuncs.
 
     Note the warnings emitted by Numpy reflect IEEE-754 semantics.
     """
-
-    @contextlib.contextmanager
-    def check_warnings(self, messages, category=RuntimeWarning):
-        with warnings.catch_warnings(record=True) as catch:
-            warnings.simplefilter("always")
-            yield
-        # Check warnings for 1/0 and 0/0
-        found = 0
-        for w in catch:
-            for m in messages:
-                if m in str(w.message):
-                    self.assertEqual(w.category, category)
-                    found += 1
-        self.assertEqual(found, len(messages))
 
     @skipIfFPStatusBug
     def check_truediv_real(self, dtype):


### PR DESCRIPTION
The CUDA vectorize decorator provides harsh feedback to users who provide it with unexpected arguments - an assertion failure with no further information. This commit changes the decorator in the following ways:

1. The `nopython` kwarg is now accepted, albeit with a warning that it is redundant on CUDA. The cpu and parallel targets do also accept this kwarg.
2. Provide a `KeyError` for other unsupported kwargs, consistent with the CPU and parallel targets.

The additional tests check the expected behaviour for all targets. For ths CPU target the decorator is tested with and without a signature, in order to check for normal ufuncs and dynamic ufuncs.

Minor changes:
- The `check_warnings` context manager is made available for tests by inheriting from `CheckWarningsMixin`, which contains an implementation from `tests/npyufunc/test_errors.py`.
- A small whitespace error in `test_vectorize_decor.py` is also corrected.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
