### PR TITLE
Prevent some parfor aliasing.  Rename copied function var to prevent recursive type locking.

### DIFF
--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -3967,28 +3967,35 @@ def push_call_vars(blocks, saved_globals, saved_getattrs, typemap, nested=False)
 
 
 def _get_saved_call_nodes(fname, saved_globals, saved_getattrs, block_defs, rename_dict):
+    """ Implement the copying of globals or getattrs for the purposes noted in
+        push_call_vars.  We make a new var and assign to it a copy of the
+        global or getattr.  We remember this new assignment node and add an
+        entry in the renaming dictionary so that for this block the original
+        var name is replaced by the new var name we created.
+    """
     nodes = []
     while (fname not in block_defs and (fname in saved_globals
                                         or fname in saved_getattrs)):
-        if fname in saved_globals:
-            assert(isinstance(saved_globals[fname], ir.Assign))
-            saved_global = saved_globals[fname]
-            renamed_var = ir.Var(saved_global.target.scope, mk_unique_var("$push_global_to_block"), saved_global.target.loc)
-            renamed_assign = ir.Assign(copy.deepcopy(saved_global.value), renamed_var, saved_global.loc)
+        def rename_global_or_getattr(obj, var_base, nodes, block_defs, rename_dict):
+            assert(isinstance(obj, ir.Assign))
+            renamed_var = ir.Var(obj.target.scope,
+                                 mk_unique_var(var_base),
+                                 obj.target.loc)
+            renamed_assign = ir.Assign(copy.deepcopy(obj.value),
+                                       renamed_var,
+                                       obj.loc)
             nodes.append(renamed_assign)
-            block_defs.add(saved_global.target.name)
-            rename_dict[saved_global.target.name] = renamed_assign.target.name
+            block_defs.add(obj.target.name)
+            rename_dict[obj.target.name] = renamed_assign.target.name
+
+        if fname in saved_globals:
+            rename_global_or_getattr(saved_globals[fname], "$push_global_to_block",
+                                     nodes, block_defs, rename_dict)
             fname = '_PA_DONE'
         elif fname in saved_getattrs:
-            assert(isinstance(saved_getattrs[fname], ir.Assign))
-            up_name = saved_getattrs[fname].value.value.name
-            saved_getattr = saved_getattrs[fname]
-            renamed_var = ir.Var(saved_getattr.target.scope, mk_unique_var("$push_getattr_to_block"), saved_getattr.target.loc)
-            renamed_assign = ir.Assign(copy.deepcopy(saved_getattr.value), renamed_var, saved_getattr.loc)
-            nodes.append(renamed_assign)
-            block_defs.add(saved_getattr.target.name)
-            rename_dict[saved_getattr.target.name] = renamed_assign.target.name
-            fname = up_name
+            rename_global_or_getattr(saved_getattrs[fname], "$push_getattr_to_block",
+                                     nodes, block_defs, rename_dict)
+            fname = saved_getattrs[fname].value.value.name
     nodes.reverse()
     return nodes
 

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -3957,7 +3957,7 @@ def push_call_vars(blocks, saved_globals, saved_getattrs, typemap, nested=False)
         # If there is anything to rename then apply the renaming here.
         if len(rename_dict) > 0:
             # Fix-up the typing for the renamed vars.
-            for k,v in rename_dict.items():
+            for k, v in rename_dict.items():
                 typemap[v] = typemap[k]
             # This is only to call replace_var_names which takes a dict.
             temp_blocks = {0: block}

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -3960,7 +3960,7 @@ def push_call_vars(blocks, saved_globals, saved_getattrs, typemap, nested=False)
             for k,v in rename_dict.items():
                 typemap[v] = typemap[k]
             # This is only to call replace_var_names which takes a dict.
-            temp_blocks = {0:block}
+            temp_blocks = {0: block}
             replace_var_names(temp_blocks, rename_dict)
 
     return

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -77,7 +77,8 @@ from numba.ir_utils import (
     is_get_setitem,
     index_var_of_get_setitem,
     set_index_var_of_get_setitem,
-    find_potential_aliases)
+    find_potential_aliases,
+    replace_var_names)
 
 from numba.analysis import (compute_use_defs, compute_live_map,
                             compute_dead_maps, compute_cfg_from_blocks)
@@ -1547,7 +1548,7 @@ class ParforPass(object):
         simplify(self.func_ir, self.typemap, self.calltypes)
         # push function call variables inside parfors so gufunc function
         # wouldn't need function variables as argument
-        push_call_vars(self.func_ir.blocks, {}, {})
+        push_call_vars(self.func_ir.blocks, {}, {}, self.typemap)
         # simplify again
         simplify(self.func_ir, self.typemap, self.calltypes)
         dprint_func_ir(self.func_ir, "after optimization")
@@ -2676,7 +2677,7 @@ def _arrayexpr_tree_to_ir(
                 func_var_name = _find_func_var(typemap, op, avail_vars)
                 func_var = ir.Var(scope, mk_unique_var(func_var_name), loc)
                 typemap[func_var.name] = typemap[func_var_name]
-                func_var_def = func_ir.get_definition(func_var_name)
+                func_var_def = copy.deepcopy(func_ir.get_definition(func_var_name))
                 if isinstance(func_var_def, ir.Expr) and func_var_def.op == 'getattr' and func_var_def.attr == 'sqrt':
                      g_math_var = ir.Var(scope, mk_unique_var("$math_g_var"), loc)
                      typemap[g_math_var.name] = types.misc.Module(math)
@@ -3909,7 +3910,7 @@ def apply_copies_parfor(parfor, var_dict, name_var_table,
 ir_utils.apply_copy_propagate_extensions[Parfor] = apply_copies_parfor
 
 
-def push_call_vars(blocks, saved_globals, saved_getattrs, nested=False):
+def push_call_vars(blocks, saved_globals, saved_getattrs, typemap, nested=False):
     """push call variables to right before their call site.
     assuming one global/getattr is created for each call site and control flow
     doesn't change it.
@@ -3919,6 +3920,12 @@ def push_call_vars(blocks, saved_globals, saved_getattrs, nested=False):
         # global/attr variables that are defined in this block already,
         #   no need to reassign them
         block_defs = set()
+        # Some definitions are copied right before the call but then we
+        # need to rename that symbol in that block so that typing won't
+        # generate an error trying to lock the save var twice.
+        # In rename_dict, we collect the symbols that must be renamed in
+        # this block.  We collect them then apply the renaming at the end.
+        rename_dict = {}
         for stmt in block.body:
             def process_assign(stmt):
                 if isinstance(stmt, ir.Assign):
@@ -3937,32 +3944,50 @@ def push_call_vars(blocks, saved_globals, saved_getattrs, nested=False):
                 for s in stmt.init_block.body:
                     process_assign(s)
                 pblocks = stmt.loop_body.copy()
-                push_call_vars(pblocks, saved_globals, saved_getattrs, nested=True)
+                push_call_vars(pblocks, saved_globals, saved_getattrs, typemap, nested=True)
                 new_body.append(stmt)
                 continue
             else:
                 process_assign(stmt)
             for v in stmt.list_vars():
                 new_body += _get_saved_call_nodes(v.name, saved_globals,
-                                                  saved_getattrs, block_defs)
+                                                  saved_getattrs, block_defs, rename_dict)
             new_body.append(stmt)
         block.body = new_body
+        # If there is anything to rename then apply the renaming here.
+        if len(rename_dict) > 0:
+            # Fix-up the typing for the renamed vars.
+            for k,v in rename_dict.items():
+                typemap[v] = typemap[k]
+            # This is only to call replace_var_names which takes a dict.
+            temp_blocks = {0:block}
+            replace_var_names(temp_blocks, rename_dict)
 
     return
 
 
-def _get_saved_call_nodes(fname, saved_globals, saved_getattrs, block_defs):
+def _get_saved_call_nodes(fname, saved_globals, saved_getattrs, block_defs, rename_dict):
     nodes = []
     while (fname not in block_defs and (fname in saved_globals
                                         or fname in saved_getattrs)):
         if fname in saved_globals:
-            nodes.append(saved_globals[fname])
-            block_defs.add(saved_globals[fname].target.name)
+            assert(isinstance(saved_globals[fname], ir.Assign))
+            saved_global = saved_globals[fname]
+            renamed_var = ir.Var(saved_global.target.scope, mk_unique_var("$push_global_to_block"), saved_global.target.loc)
+            renamed_assign = ir.Assign(copy.deepcopy(saved_global.value), renamed_var, saved_global.loc)
+            nodes.append(renamed_assign)
+            block_defs.add(saved_global.target.name)
+            rename_dict[saved_global.target.name] = renamed_assign.target.name
             fname = '_PA_DONE'
         elif fname in saved_getattrs:
+            assert(isinstance(saved_getattrs[fname], ir.Assign))
             up_name = saved_getattrs[fname].value.value.name
-            nodes.append(saved_getattrs[fname])
-            block_defs.add(saved_getattrs[fname].target.name)
+            saved_getattr = saved_getattrs[fname]
+            renamed_var = ir.Var(saved_getattr.target.scope, mk_unique_var("$push_getattr_to_block"), saved_getattr.target.loc)
+            renamed_assign = ir.Assign(copy.deepcopy(saved_getattr.value), renamed_var, saved_getattr.loc)
+            nodes.append(renamed_assign)
+            block_defs.add(saved_getattr.target.name)
+            rename_dict[saved_getattr.target.name] = renamed_assign.target.name
             fname = up_name
     nodes.reverse()
     return nodes

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2321,6 +2321,30 @@ class TestPrange(TestPrangeBase):
         self.prange_tester(test_impl)
 
     @skip_unsupported
+    def test_copy_global_for_parfor(self):
+        """ issue4903: a global is copied next to a parfor so that
+            it can be inlined into the parfor and thus not have to be
+            passed to the parfor (i.e., an unsupported function type).
+            This global needs to be renamed in the block into which
+            it is copied.
+        """
+        def test_impl(zz, tc):
+            lh = np.zeros(len(tc))
+            lc = np.zeros(len(tc))
+            for i in range(1):
+                nt = tc[i]
+                for t in range(nt):
+                    lh += np.exp(zz[i, t])
+                for t in range(nt):
+                    lc += np.exp(zz[i, t])
+            return lh, lc
+
+        m = 2
+        zz = np.ones((m, m, m))
+        tc = np.ones(m, dtype=np.int_)
+        self.prange_tester(test_impl, zz, tc, patch_instance=[0])
+
+    @skip_unsupported
     def test_multiple_call_getattr_object(self):
         def test_impl(n):
             B = 0


### PR DESCRIPTION
Resolves #4903