### PR TITLE
Move overload of literal_unroll to avoid circular dependency that breaks Python 2.7

### DIFF
--- a/numba/special.py
+++ b/numba/special.py
@@ -2,7 +2,6 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 
-from numba.extending import overload
 import numpy as np
 
 from .typing.typeof import typeof
@@ -96,17 +95,6 @@ def literal_unroll(container):
     if sys.version_info[:2] < (3, 6):
         raise UnsupportedError("literal_unroll is only support in Python > 3.5")
     return container
-
-
-@overload(literal_unroll)
-def literal_unroll_impl(container):
-    from numba.errors import UnsupportedError
-    if sys.version_info[:2] < (3, 6):
-        raise UnsupportedError("literal_unroll is only support in Python > 3.5")
-
-    def impl(container):
-        return container
-    return impl
 
 
 __all__ = [

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -262,7 +262,7 @@ class BaseContext(object):
         # Populate built-in registry
         from . import (arraymath, enumimpl, iterators, linalg, numbers,
                        optional, polynomial, rangeobj, slicing, tupleobj,
-                       gdb_hook, hashing, heapq, literal_dispatch)
+                       gdb_hook, hashing, heapq, literal)
         try:
             from . import npdatetime
         except NotImplementedError:

--- a/numba/targets/literal.py
+++ b/numba/targets/literal.py
@@ -1,6 +1,8 @@
+import sys
+
 from numba.extending import overload
 from numba import types
-from numba.special import literally
+from numba.special import literally, literal_unroll
 from numba.errors import TypingError
 
 
@@ -12,3 +14,14 @@ def _ov_literally(obj):
     else:
         m = "Invalid use of non-Literal type in literally({})".format(obj)
         raise TypingError(m)
+
+
+@overload(literal_unroll)
+def literal_unroll_impl(container):
+    from numba.errors import UnsupportedError
+    if sys.version_info[:2] < (3, 6):
+        raise UnsupportedError("literal_unroll is only support in Python > 3.5")
+
+    def impl(container):
+        return container
+    return impl


### PR DESCRIPTION
Python 3 doesn't seem to mind, but Python 2.7 can't resolve this dependency.  Moved the overload of `literal_unroll` to the same location and `literally` and renamed the file to be more generic.