### PR TITLE
Fix overload_method problem with stararg

### DIFF
--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -419,6 +419,7 @@ class ExternalFuncPointerModel(PrimitiveModel):
 
 @register_default(types.UniTuple)
 @register_default(types.NamedUniTuple)
+@register_default(types.StarArgUniTuple)
 class UniTupleModel(DataModel):
     def __init__(self, dmm, fe_type):
         super(UniTupleModel, self).__init__(dmm, fe_type)
@@ -720,6 +721,7 @@ class ComplexModel(StructModel):
 
 @register_default(types.Tuple)
 @register_default(types.NamedTuple)
+@register_default(types.StarArgTuple)
 class TupleModel(StructModel):
     def __init__(self, dmm, fe_type):
         members = [('f' + str(i), t) for i, t in enumerate(fe_type)]

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -64,7 +64,7 @@ class _FunctionCompiler(object):
         def default_handler(index, param, default):
             return types.Omitted(default)
         def stararg_handler(index, param, values):
-            return types.Tuple(values)
+            return types.StarArgTuple(values)
         # For now, we take argument values from the @jit function, even
         # in the case of generated jit.
         args = fold_arguments(self.pysig, args, kws,

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1022,6 +1022,13 @@ class TestHighLevelExtending(TestCase):
             ),
         )
 
+        # Expected failure
+        with self.assertRaises(errors.LoweringError) as raises:
+            foo(obj, 1, 2, (3,))
+        self.assertIn("Cannot cast UniTuple(int64 x 1) to int64",
+                      str(raises.exception))
+
+
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):
     hit = cfunc._cache_hits[cfunc.signatures[0]]

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1025,8 +1025,10 @@ class TestHighLevelExtending(TestCase):
         # Expected failure
         with self.assertRaises(errors.LoweringError) as raises:
             foo(obj, 1, 2, (3,))
-        self.assertIn("Cannot cast UniTuple(int64 x 1) to int64",
-                      str(raises.exception))
+        self.assertRegexpMatches(
+            str(raises.exception),
+            r"Cannot cast UniTuple\(int(64|32) x 1\) to int(64|32)",
+        )
 
 
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1022,14 +1022,20 @@ class TestHighLevelExtending(TestCase):
             ),
         )
 
-        # Expected failure
-        with self.assertRaises(errors.LoweringError) as raises:
-            foo(obj, 1, 2, (3,))
-        self.assertRegexpMatches(
-            str(raises.exception),
-            r"Cannot cast UniTuple\(int(64|32) x 1\) to int(64|32)",
+        # Check cases that put tuple type into stararg
+        # NOTE: the expected result has an extra tuple because of stararg.
+        self.assertEqual(
+            foo(obj, 1, 2, (3,)),
+            (1, 2, ((3,),)),
         )
-
+        self.assertEqual(
+            foo(obj, 1, 2, (3, 4)),
+            (1, 2, ((3, 4),)),
+        )
+        self.assertEqual(
+            foo(obj, 1, 2, (3, (4, 5))),
+            (1, 2, ((3, (4, 5)),)),
+        )
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -986,6 +986,42 @@ class TestHighLevelExtending(TestCase):
 
         self.assertEqual(test(), 0xdeadbeef)
 
+    def test_overload_method_stararg(self):
+        @overload_method(MyDummyType, "method_stararg")
+        def _ov_method_stararg(obj, val, val2, *args):
+            def get(obj, val, val2, *args):
+                return (val, val2, args)
+
+            return get
+
+        @njit
+        def foo(obj, *args):
+            # Test with expanding stararg
+            return obj.method_stararg(*args)
+
+        obj = MyDummy()
+        self.assertEqual(foo(obj, 1, 2), (1, 2, ()))
+        self.assertEqual(foo(obj, 1, 2, 3), (1, 2, (3,)))
+        self.assertEqual(foo(obj, 1, 2, 3, 4), (1, 2, (3, 4)))
+
+        @njit
+        def bar(obj):
+            # Test with explicit argument
+            return (
+                obj.method_stararg(1, 2),
+                obj.method_stararg(1, 2, 3),
+                obj.method_stararg(1, 2, 3, 4),
+            )
+
+        self.assertEqual(
+            bar(obj),
+            (
+                (1, 2, ()),
+                (1, 2, (3,)),
+                (1, 2, (3, 4))
+            ),
+        )
+
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):
     hit = cfunc._cache_hits[cfunc.signatures[0]]

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -300,6 +300,23 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
                 return Tuple(unified)
 
 
+class StarArgTuple(Tuple):
+    """To distinguish from Tuple() used as argument to a `*args`.
+    """
+    def __new__(cls, types):
+        _HeterogeneousTuple.is_types_iterable(types)
+
+        if types and all(t == types[0] for t in types[1:]):
+            return StarArgUniTuple(dtype=types[0], count=len(types))
+        else:
+            return object.__new__(StarArgTuple)
+
+
+class StarArgUniTuple(UniTuple):
+    """To distinguish from UniTuple() used as argument to a `*args`.
+    """
+
+
 class BaseNamedTuple(BaseTuple):
     pass
 

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -202,7 +202,9 @@ class UniTuple(BaseAnonymousTuple, _HomogeneousTuple, Sequence):
     def __init__(self, dtype, count):
         self.dtype = dtype
         self.count = count
-        name = "UniTuple(%s x %d)" % (dtype, count)
+        name = "%s(%s x %d)" % (
+            self.__class__.__name__, dtype, count,
+        )
         super(UniTuple, self).__init__(name)
 
     @property
@@ -276,7 +278,10 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
         self.types = tuple(types)
         self.count = len(self.types)
         self.dtype = UnionType(types)
-        name = "Tuple(%s)" % ', '.join(str(i) for i in self.types)
+        name = "%s(%s)" % (
+            self.__class__.__name__,
+            ', '.join(str(i) for i in self.types),
+        )
         super(Tuple, self).__init__(name)
 
     @property

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -177,8 +177,11 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
             # is simply the empty tuple
             if name in ba.arguments:
                 argval = ba.arguments[name]
-                # FIXME: avoid wrapping the tuple type for stararg in another
-                #        tuple
+                # NOTE: avoid wrapping the tuple type for stararg in another
+                #       tuple.
+                # FIXME: known problem. cannot distinguish between a tuple
+                #        given for stararg vs an implicit tuple created
+                #        internally for stararg.
                 if len(argval) == 1 and isinstance(argval[0], types.BaseTuple):
                     argval = tuple(argval[0])
             else:

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -175,8 +175,17 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
         if param.kind == param.VAR_POSITIONAL:
             # stararg may be omitted, in which case its "default" value
             # is simply the empty tuple
-            ba.arguments[name] = stararg_handler(i, param,
-                                                 ba.arguments.get(name, ()))
+            if name in ba.arguments:
+                argval = ba.arguments[name]
+                # FIXME: avoid wrapping the tuple type for stararg in another
+                #        tuple
+                if len(argval) == 1 and isinstance(argval[0], types.BaseTuple):
+                    argval = tuple(argval[0])
+            else:
+                argval = ()
+            out = stararg_handler(i, param, argval)
+
+            ba.arguments[name] = out
         elif name in ba.arguments:
             # Non-stararg, present
             ba.arguments[name] = normal_handler(i, param, ba.arguments[name])
@@ -523,6 +532,29 @@ class _OverloadFunctionTemplate(AbstractTemplate):
 
         """
         from numba import jit
+
+        def normalize_args(pyfunc, args, kws):
+            pysig = utils.pysignature(pyfunc)
+            ba = pysig.bind(*args, **kws)
+            starargs = None
+            for i, (k, parm) in enumerate(pysig.parameters.items()):
+                if parm.kind == parm.VAR_POSITIONAL and k in ba.arguments:
+                    starargs = ba.arguments[k]
+                    del ba.arguments[k]
+
+            new_args = ba.args
+            if starargs is not None:
+                if (len(starargs) and isinstance(starargs[0], types.Tuple) and
+                        len(starargs[0]) == 0):
+                    # empty tuple means no starargs
+                    pass
+                else:
+                    new_args += starargs
+
+            new_kws = ba.kwargs
+            return new_args, new_kws
+
+        # args, kws = normalize_args(self._overload_func, args, kws)
 
         # Get the overload implementation for the given types
         ovf_result = self._overload_func(*args, **kws)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -536,29 +536,6 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         """
         from numba import jit
 
-        def normalize_args(pyfunc, args, kws):
-            pysig = utils.pysignature(pyfunc)
-            ba = pysig.bind(*args, **kws)
-            starargs = None
-            for i, (k, parm) in enumerate(pysig.parameters.items()):
-                if parm.kind == parm.VAR_POSITIONAL and k in ba.arguments:
-                    starargs = ba.arguments[k]
-                    del ba.arguments[k]
-
-            new_args = ba.args
-            if starargs is not None:
-                if (len(starargs) and isinstance(starargs[0], types.Tuple) and
-                        len(starargs[0]) == 0):
-                    # empty tuple means no starargs
-                    pass
-                else:
-                    new_args += starargs
-
-            new_kws = ba.kwargs
-            return new_args, new_kws
-
-        # args, kws = normalize_args(self._overload_func, args, kws)
-
         # Get the overload implementation for the given types
         ovf_result = self._overload_func(*args, **kws)
         if ovf_result is None:

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -179,10 +179,9 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
                 argval = ba.arguments[name]
                 # NOTE: avoid wrapping the tuple type for stararg in another
                 #       tuple.
-                # FIXME: known problem. cannot distinguish between a tuple
-                #        given for stararg vs an implicit tuple created
-                #        internally for stararg.
-                if len(argval) == 1 and isinstance(argval[0], types.BaseTuple):
+                if (len(argval) == 1 and
+                        isinstance(argval[0], (types.StarArgTuple,
+                                               types.StarArgUniTuple))):
                     argval = tuple(argval[0])
             else:
                 argval = ()


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Fix #4944

- Fixes creating extra tuple that contains the `*args` tuple
- Adds StarArgTuple to tell from tuple in `*args` versus tuple created by it.