### PR TITLE
Update docs to include disable_reflected_list switch

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -124,6 +124,12 @@ are:
   formats are largely avoided.
 * Numba's ``typed.Dict`` will be able to use these containers as values.
 
+As of Numba 0.47.0 a feature switch, `disable_reflected_list` has been
+introduced that allows library authors and users to opt-in to the
+``typed.List`` for all use-cases. As of 0.47.0, is the recommended way to
+replace any use of the reflected ``list``.  For more information, please see:
+feature-disable-reflected-list_.
+
 
 Deprecation of :term:`object mode` `fall-back` behaviour when using ``@jit``
 ============================================================================

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -124,9 +124,9 @@ are:
   formats are largely avoided.
 * Numba's ``typed.Dict`` will be able to use these containers as values.
 
-As of Numba 0.47.0 a feature switch, `disable_reflected_list` has been
+As of Numba 0.47.0 a feature switch, ``disable_reflected_list`` has been
 introduced that allows library authors and users to opt-in to the
-``typed.List`` for all use-cases. As of 0.47.0, is the recommended way to
+``typed.List`` for all use-cases. Using this switch is the recommended way to
 replace any use of the reflected ``list``.  For more information, please see:
 :ref:`feature-disable-reflected-list`.
 
@@ -253,4 +253,3 @@ Projects that need/rely on the deprecated behaviour should pin their dependency
 on Numba to a version prior to removal of this behaviour. The recommended method
 for accommodating the deprecation of ``numba.autojit`` is to simply replace it
 with the semantically and functionally equivalent ``numba.jit`` decorator.
-

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -128,7 +128,7 @@ As of Numba 0.47.0 a feature switch, `disable_reflected_list` has been
 introduced that allows library authors and users to opt-in to the
 ``typed.List`` for all use-cases. As of 0.47.0, is the recommended way to
 replace any use of the reflected ``list``.  For more information, please see:
-feature-disable-reflected-list_.
+:ref:`feature-disable-reflected-list`.
 
 
 Deprecation of :term:`object mode` `fall-back` behaviour when using ``@jit``

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -99,9 +99,17 @@ Schedule
 --------
 This feature will be removed with respect to this schedule:
 
-* Pending-deprecation warnings will be issued in version 0.44.0
-* Deprecation warnings and replacements will be issued in version 0.47.0
-* Support will be removed in version 0.48.0
+* For ``list``:
+
+  * Pending-deprecation warnings will be issued in version 0.44.0
+  * Deprecation warnings and replacements will be issued in version 0.47.0
+  * Support will be removed in version 0.48.0
+
+* For ``set``:
+
+  * Pending-deprecation warnings will be issued in version 0.44.0
+  * Deprecation warnings and replacements will be issued in version 0.48.0
+  * Support will be removed in version 0.49.0
 
 Recommendations
 ---------------

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -560,7 +560,7 @@ Finally, here's an example of using a nested `List()`:
 
 
 Disabling Reflected Lists
-''''''''''''''''''''''
+''''''''''''''''''''''''''
 
 As of Numba 0.47.0 a switch, ``disable_reflected_list``, has been introduced
 to the ``numba.future`` module. Using this switch will disable the

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -564,11 +564,12 @@ Disabling Reflected Lists
 ''''''''''''''''''''''''''
 
 As of Numba 0.47.0 a switch, ``disable_reflected_list``, has been introduced to
-the ``numba.future`` module. Using this switch will disable the
-*reflected-list* fully across the Numba code-base. This means that the built-in
-constructors ``list()`` and ``[]`` will result in a *typed-list*. This also
-means that any Python list that is passed into a Numba compiled function will
-be converted into an *immutable typed-list*.
+the ``numba.future`` module. Referencing ``disable_reflected_list`` in a module
+will disable *reflected-list* fully in all Numba-compiled code inside that
+module. This means that the built-in constructors ``list()`` and ``[]`` will
+result in a *typed-list*. This also means that any Python list that is passed
+into a Numba compiled function will be converted into an *immutable
+typed-list*.
 
 In order to use the switch add the following statement at the module level:
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -518,7 +518,7 @@ explicitly from the `numba.typed` module::
 
 
 .. note::
-    The typed-list is considered stable with Numba version 0.47.0. Using
+    The typed-list is considered stable in Numba version 0.47.0. Using
     the ``disable_reflected_list`` switch from the ``numba.future`` module will
     mean that the constructors ``[]`` and ``list()`` will create a typed-list
     instead of a reflected one.

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -562,12 +562,12 @@ Finally, here's an example of using a nested `List()`:
 Disabling Reflected Lists
 ''''''''''''''''''''''''''
 
-As of Numba 0.47.0 a switch, ``disable_reflected_list``, has been introduced
-to the ``numba.future`` module. Using this switch will disable the
-*reflected-list* fully across the Numba code-base. This means that the
-built-in constructors ``list()`` and ``[]`` will result in a *typed-list*. Also,
-this means that any Python list that is passed into a Numba compiled function
-will be converted into an *immutable typed-list*.
+As of Numba 0.47.0 a switch, ``disable_reflected_list``, has been introduced to
+the ``numba.future`` module. Using this switch will disable the
+*reflected-list* fully across the Numba code-base. This means that the built-in
+constructors ``list()`` and ``[]`` will result in a *typed-list*. This also
+means that any Python list that is passed into a Numba compiled function will
+be converted into an *immutable typed-list*.
 
 In order to use the switch add the following statement at the module level:
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -565,7 +565,7 @@ Disable Reflected List
 As of Numba 0.47.0 a new switch, ``disable_reflected_list`` has been introduced
 to the ``numba.future`` module. Using this switch will disable the
 *reflected-list* fully across the Numba code-base. This means, that the
-built-in constructors ``list()`` and ``[]`` will result in a *typed-list* Also,
+built-in constructors ``list()`` and ``[]`` will result in a *typed-list*. Also,
 this means that any Python list that is passed into a Numba compiled function
 will be converted into an *immutable typed-list*.
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -520,7 +520,7 @@ explicitly from the `numba.typed` module::
 .. note::
     The typed-list is considered stable with Numba version 0.47.0. Using
     the ``disable_reflected_list`` switch from the ``numba.future`` module will
-    mean that the constructors `[]` and `list()` will create a typed-list
+    mean that the constructors ``[]`` and ``list()`` will create a typed-list
     instead of a reflected one.
 
 
@@ -617,7 +617,8 @@ as arguments and have them converted to *immutable typed-lists*:
     total = foo(z)
 
 Immutability in this case, means that the contents of the *typed-list* cannot
-be modified, for example, by using methods such as `append`, `pop` or `clear`.
+be modified, for example, by using methods such as ``append``, ``pop`` or
+``clear``.
 
 .. code-block:: python
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -517,7 +517,7 @@ explicitly from the `numba.typed` module::
 
 
 .. note::
-    The typed-list is beginning to stabilize with Numba version 0.47.0. Using
+    The typed-list is considered stable with Numba version 0.47.0. Using
     the ``disable_reflected_list`` switch from the ``numba.future`` module will
     mean that the constructors `[]` and `list()` will create a typed-list
     instead of a reflected one.

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -427,10 +427,10 @@ list
     However, it was scheduled for deprecation from version 0.44.0 onwards due
     to its limitations. As of version 0.45.0 a new implementation, the
     so-called *typed-list* (see below), is available as an experimental
-    feature. As of version 0.47.0 a new switch, ``disable_reflected_list`` is
+    feature. As of version 0.47.0 a switch, ``disable_reflected_list`` is
     available from the ``numba.future`` module that can be used to opt-in to
     fully disable the reflected list for all use-cases (see below).
-    For more information, please see: :ref:`deprecation`.
+    For more information about the deprecation schedule, please see: :ref:`deprecation`.
 
 Creating and returning lists from JIT-compiled functions is supported,
 as well as all methods and operations.  Lists must be strictly homogeneous:
@@ -559,12 +559,12 @@ Finally, here's an example of using a nested `List()`:
 .. _feature-disable-reflected-list:
 
 
-Disable Reflected List
+Disabling Reflected Lists
 ''''''''''''''''''''''
 
-As of Numba 0.47.0 a new switch, ``disable_reflected_list`` has been introduced
+As of Numba 0.47.0 a switch, ``disable_reflected_list``, has been introduced
 to the ``numba.future`` module. Using this switch will disable the
-*reflected-list* fully across the Numba code-base. This means, that the
+*reflected-list* fully across the Numba code-base. This means that the
 built-in constructors ``list()`` and ``[]`` will result in a *typed-list*. Also,
 this means that any Python list that is passed into a Numba compiled function
 will be converted into an *immutable typed-list*.
@@ -592,7 +592,7 @@ in a Numba compiled function:
         return a, b, c # return all three
 
 
-Additionally, it is possible to hand Python lists into Numba compiled functions
+Additionally, it is possible to pass Python lists into Numba compiled functions
 as arguments and have them converted to *immutable typed-lists*:
 
 .. code-block:: python
@@ -613,8 +613,8 @@ as arguments and have them converted to *immutable typed-lists*:
 
     total = foo(z)
 
-Immutability in this case, means that the contents of the *typed-list* can not
-be modified, for example using methods such as `append`, `pop` or `clear`.
+Immutability in this case, means that the contents of the *typed-list* cannot
+be modified, for example, by using methods such as `append`, `pop` or `clear`.
 
 .. code-block:: python
 
@@ -650,7 +650,7 @@ Numba compiled function, consider using a typed-list to begin with:
     append_three(l)
     # l now contains 1, 2, 3
 
-An important advantage over the previous behaviour of the reflected list, is
+An important advantage over the previous behaviour of the reflected list is
 that nested lists can now be used as arguments for Numba compiled functions:
 
 .. code-block:: python

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -587,7 +587,9 @@ in a Numba compiled function:
     @njit
     def foo():
         a = list()     # create an empty typed-list
+        a.append(1)
         b = []         # create another empty typed-list
+        b.append(2.0)
         c = [1, 2, 3]  # create typed-list containing 1, 2 and 3
         return a, b, c # return all three
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -430,7 +430,8 @@ list
     feature. As of version 0.47.0 a switch, ``disable_reflected_list`` is
     available from the ``numba.future`` module that can be used to opt-in to
     fully disable the reflected list for all use-cases (see below).
-    For more information about the deprecation schedule, please see: :ref:`deprecation`.
+    For more information about the deprecation schedule, please see:
+    :ref:`deprecation`.
 
 Creating and returning lists from JIT-compiled functions is supported,
 as well as all methods and operations.  Lists must be strictly homogeneous:
@@ -534,8 +535,8 @@ jit-compiled function and letting the compiler infer the item type:
    :dedent: 4
    :linenos:
 
-Here's an example of using ``List()`` to create a ``numba.typed.List`` outside of
-a jit-compiled function and then using it as an argument to a jit-compiled
+Here's an example of using ``List()`` to create a ``numba.typed.List`` outside
+of a jit-compiled function and then using it as an argument to a jit-compiled
 function:
 
 .. literalinclude:: ../../../examples/typed_list_usage.py


### PR DESCRIPTION
This add documentation for the `disable_reflected_list` switch to the reference
manual and the dperecation documentation.

Questions:

a) will this suffice or should we add some more info to deprecation docs.
b) do we want to switch from PendingDeprecationWarning to DeprecationWarning
already?