### PR TITLE
Add `is_internal` property to all Type classes.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -323,7 +323,6 @@ exclude =
     numba/tests/test_sets.py
     numba/tests/test_dyn_array.py
     numba/tests/test_objects.py
-    numba/tests/test_types.py
     numba/tests/test_random.py
     numba/tests/test_nan.py
     numba/tests/pycc_distutils_usecase/source_module.py

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -39,6 +39,15 @@ class _TypeMetaclass(ABCMeta):
     and hashing), then looking it up in the _typecache registry.
     """
 
+    def __init__(cls, name, bases, orig_vars):
+        # __init__ is hooked to mark whether a Type class being defined is a
+        # Numba internal type (one which is defined somewhere under the `numba`
+        # module) or an external type (one which is defined elsewhere, for
+        # example a user defined type).
+        super(_TypeMetaclass, cls).__init__(name, bases, orig_vars)
+        root = (cls.__module__.split('.'))[0]
+        cls._is_internal = root == "numba"
+
     def _intern(cls, inst):
         # Try to intern the created instance
         wr = weakref.ref(inst, _on_type_disposal)
@@ -206,6 +215,12 @@ class Type(object):
     def cast_python_value(self, args):
         raise NotImplementedError
 
+
+    @property
+    def is_internal(self):
+        """ Returns True if this class is an internally defined Numba type by
+        virtue of the module in which it is instantiated, False else."""
+        return self._is_internal
 
 # XXX we should distinguish between Dummy (no meaningful
 # representation, e.g. None or a builtin function) and Opaque (has a

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -425,6 +425,8 @@ def unicode_len(s):
 
 @overload(operator.eq)
 def unicode_eq(a, b):
+    if not (a.is_internal and b.is_internal):
+        return
     accept = (types.UnicodeType, types.StringLiteral, types.UnicodeCharSeq)
     a_unicode = isinstance(a, accept)
     b_unicode = isinstance(b, accept)
@@ -443,6 +445,8 @@ def unicode_eq(a, b):
 
 @overload(operator.ne)
 def unicode_ne(a, b):
+    if not (a.is_internal and b.is_internal):
+        return
     accept = (types.UnicodeType, types.StringLiteral, types.UnicodeCharSeq)
     a_unicode = isinstance(a, accept)
     b_unicode = isinstance(b, accept)


### PR DESCRIPTION
This is to make it possible to have all-internal-type consuming
overloads and have these not interfer with user defined extension
types. Also adds tests.

Fixes #4970

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
