### PR TITLE
Remove xfail for test which has since had underlying issue fixed.

### DIFF
--- a/numba/tests/test_try_except.py
+++ b/numba/tests/test_try_except.py
@@ -768,9 +768,8 @@ class TestTryExceptOtherControlFlow(TestCase):
 @skip_tryexcept_unsupported
 @skip_parfors_unsupported
 class TestTryExceptParfors(TestCase):
-    @unittest.expectedFailure
+
     def test_try_in_prange_reduction(self):
-        # Related issue https://github.com/numba/numba/issues/4922
         # The try-except is transformed basically into chains of if-else
         def udt(n):
             c = 0
@@ -787,7 +786,6 @@ class TestTryExceptParfors(TestCase):
         self.assertEqual(njit(parallel=True)(udt)(*args), expect)
 
     def test_try_outside_prange_reduction(self):
-        # Related issue https://github.com/numba/numba/issues/4922
         # The try-except is transformed basically into chains of if-else
         def udt(n):
             c = 0


### PR DESCRIPTION
As title. #4922 was fixed by #4935.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
