### PR TITLE
State that CUDA Toolkit 8.0 required in docs

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -51,6 +51,8 @@ requirements:
     - tbb >=2018.0.5           # [not ((armv6l or armv7l or aarch64) or (win and py27))]
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
+    # CUDA 8.0 or later is required for CUDA support
+    - cudatoolkit >= 8.0
 test:
   requires:
     - jinja2

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     # CUDA 8.0 or later is required for CUDA support
-    - cudatoolkit >= 8.0
+    - cudatoolkit >=8.0
 test:
   requires:
     - jinja2

--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -43,8 +43,8 @@ up-to-data Nvidia driver.
 Software
 --------
 
-You will need the CUDA toolkit installed.  If you are using Conda, just
-type::
+You will need the CUDA toolkit version 8.0 or later installed.  If you are
+using Conda, just type::
 
    $ conda install cudatoolkit
 


### PR DESCRIPTION
As per title - the required version did not seem to be stated explicitly anywhere in the documentation.