### PR TITLE
Fix more spelling typos

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -10,7 +10,7 @@ package: numba
 
 #===============================================================================
 # Build Matrix Options
-# Thes options may be a single item, a list or empty
+# These options may be a single item, a list or empty
 # The resulting number of builds is [platform * engine * env]
 #===============================================================================
 
@@ -37,7 +37,7 @@ engine:
 
 #===============================================================================
 # Scrip options
-# Thes options may be broken out into the before_script, script and after_script
+# These options may be broken out into the before_script, script and after_script
 # or not, that is up to you
 #===============================================================================
 

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -4,7 +4,7 @@
 CUDA Array Interface (Version 2)
 ================================
 
-The *cuda array inteface* is created for interoperability between different
+The *cuda array interface* is created for interoperability between different
 implementation of GPU array-like objects in various projects.  The idea is
 borrowed from the `numpy array interface`_.
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -80,7 +80,7 @@ Glossary
       The process by which Numba determines the specialized types of all
       values within a function being compiled.  Type inference can fail
       if arguments or globals have Python types unknown to Numba, or if
-      functions are used that are not recognized by Numba.  Sucessful
+      functions are used that are not recognized by Numba.  Successful
       type inference is a prerequisite for compilation in
       :term:`nopython mode`.
 

--- a/docs/source/proposals/type-inference.rst
+++ b/docs/source/proposals/type-inference.rst
@@ -62,7 +62,7 @@ presented with the argument types ``(int32, int32)``, because demoting either
 argument to ``int16`` is equally "fit".  Fortunately, numba can usually resolve
 such ambiguity by compiling a new version with the exact signature
 ``(int32, int32)``.  When compilation is disabled and there are multiple
-signatures with equal fit, an execption is raised.
+signatures with equal fit, an exception is raised.
 
 Type Inference
 ==============

--- a/docs/source/reference/pysemantics.rst
+++ b/docs/source/reference/pysemantics.rst
@@ -21,7 +21,7 @@ functions get a fixed size through :term:`type inference` (usually,
 the size of a machine integer).  This means that arithmetic
 operations can wrapround or produce undefined results or overflow.
 
-Type inference can be overriden by an explicit type specification,
+Type inference can be overridden by an explicit type specification,
 if fine-grained control of integer width is desired.
 
 .. seealso::

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -288,7 +288,7 @@ likely never be supported.
     and ``find()``) and string creation (like ``.split()``).  Improving the
     string performance is an ongoing task, but the speed of CPython is
     unlikely to be surpassed for basic string operation in isolation.
-    Numba is most successfuly used for larger algorithms that happen to
+    Numba is most successfully used for larger algorithms that happen to
     involve strings, where basic string operations are not the bottleneck.
 
 

--- a/docs/source/user/cli.rst
+++ b/docs/source/user/cli.rst
@@ -22,7 +22,7 @@ and arguments like ``--help`` or ``-s``, as explained below.
 
 Sometimes it can happen that you get a "command not found" error when you type
 ``numba``, because your ``PATH`` isn't configured properly. In that case you can
-use the equivalent commmand ``python -m numba``. If that still gives "command
+use the equivalent command ``python -m numba``. If that still gives "command
 not found", try to ``import numba`` as suggested here:
 :ref:`numba-source-install-check`.
 

--- a/examples/stack.py
+++ b/examples/stack.py
@@ -64,7 +64,7 @@ data_type.define(intp)
 @njit
 def pushpop(size):
     """
-    Creates a list of decending numbers from size-1 to 0.
+    Creates a list of descending numbers from size-1 to 0.
     """
     stack = Stack()
 

--- a/numba/_dispatcher.c
+++ b/numba/_dispatcher.c
@@ -217,7 +217,7 @@ Dispatcher_Insert(DispatcherObject *self, PyObject *args)
     if (!self->fallbackdef && objectmode){
         self->fallbackdef = cfunc;
     }
-    /* Add interpeter fallback */
+    /* Add interpreter fallback */
     if (!self->interpdef && interpmode) {
         self->interpdef = cfunc;
     }

--- a/numba/_lapack.c
+++ b/numba/_lapack.c
@@ -46,7 +46,7 @@ EMIT_GET_CBLAS_FUNC(dznrm2)
 /*
  * NOTE: On return value convention.
  * For LAPACK wrapper development the following conventions are followed:
- * Publically exposed wrapper functions must return:-
+ * Publicly exposed wrapper functions must return:-
  * STATUS_ERROR  : For an unrecoverable error e.g. caught by xerbla, this is so
  *                 a Py_FatalError can be raised.
  * STATUS_SUCCESS: For successful execution

--- a/numba/annotations/type_annotations.py
+++ b/numba/annotations/type_annotations.py
@@ -230,7 +230,7 @@ class TypeAnnotation(object):
                         # was successfully compiled in nopython mode.
                         func_data['python_tags'][self.lifted_from[0]] = 'object_tag'
 
-            # We're done with this lifted loop, so decrement lfited loop counter.
+            # We're done with this lifted loop, so decrement lifted loop counter.
             # When lifted loop counter hits zero, that means we're ready to write
             # out annotations to html file.
             self.lifted_from[1]['num_lifted_loops'] -= 1

--- a/numba/appdirs.py
+++ b/numba/appdirs.py
@@ -190,7 +190,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
         Win *:                  same as user_data_dir
 
     For Unix, we follow the XDG spec and support $XDG_CONFIG_HOME.
-    That means, by deafult "~/.config/<AppName>".
+    That means, by default "~/.config/<AppName>".
     """
     if system in ["win32", "darwin"]:
         path = user_data_dir(appname, appauthor, None, roaming)

--- a/numba/caching.py
+++ b/numba/caching.py
@@ -431,7 +431,7 @@ class CodeLibraryCacheImpl(_CacheImpl):
     Implements the logic to cache CodeLibrary objects.
     """
 
-    _filename_prefix = None  # must be overriden
+    _filename_prefix = None  # must be overridden
 
     def reduce(self, codelib):
         """
@@ -606,7 +606,7 @@ class Cache(_Cache):
     by a subclass of ``_CacheImpl`` specified as *_impl_class* in the subclass.
     """
 
-    # The following class variables must be overriden by subclass.
+    # The following class variables must be overridden by subclass.
     _impl_class = None
 
     def __init__(self, py_func):

--- a/numba/cext/dictobject.h
+++ b/numba/cext/dictobject.h
@@ -82,7 +82,7 @@ Parameters
 - NB_Dict **out
     Output for the new dictionary.
 - Py_ssize_t size
-    Hashtable size. Must be powe of two.
+    Hashtable size. Must be power of two.
 - Py_ssize_t key_size
     Size of a key entry.
 - Py_ssize_t val_size

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -778,7 +778,7 @@ def is_scalar_zero(builder, value):
 
 def is_not_scalar_zero(builder, value):
     """
-    Return a predicate representin whether a *value* is not equal to zero.
+    Return a predicate representing whether a *value* is not equal to zero.
     (not exactly "not is_scalar_zero" because of nans)
     """
     return _scalar_pred_against_zero(

--- a/numba/config.py
+++ b/numba/config.py
@@ -218,7 +218,7 @@ class _EnvReloader(object):
         # print stats about parallel for-loops
         DEBUG_ARRAY_OPT_STATS = _readenv("NUMBA_DEBUG_ARRAY_OPT_STATS", int, 0)
 
-        # prints user friendly information about parllel
+        # prints user friendly information about parallel
         PARALLEL_DIAGNOSTICS = _readenv("NUMBA_PARALLEL_DIAGNOSTICS", int, 0)
 
         # print debug info of inline closure pass

--- a/numba/cuda/cudadrv/autotune.py
+++ b/numba/cuda/cudadrv/autotune.py
@@ -1,6 +1,6 @@
 """
 - Parse jit compile info
-- Compute warp occupany histogram
+- Compute warp occupancy histogram
 """
 from __future__ import division, absolute_import, print_function
 import math

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1192,7 +1192,7 @@ class IpcHandle(object):
 
     def open_array(self, context, shape, dtype, strides=None):
         """
-        Simliar to `.open()` but returns an device array.
+        Similar to `.open()` but returns an device array.
         """
         from . import devicearray
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -23,7 +23,7 @@ ADDRSPACE_SHARED = 3
 ADDRSPACE_CONSTANT = 4
 ADDRSPACE_LOCAL = 5
 
-# Opaque handle for comilation unit
+# Opaque handle for compilation unit
 nvvm_program = c_void_p
 
 # Result code
@@ -164,7 +164,7 @@ class CompilationUnit(object):
         self.driver.check_error(err, 'Failed to add module')
 
     def compile(self, **options):
-        """Perform Compliation
+        """Perform Compilation
 
         The valid compiler options are
 

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -39,7 +39,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
     :param debug: If True, check for exceptions thrown when executing the
        kernel. Since this degrades performance, this should only be used for
        debugging purposes.  Defaults to False.  (The default value can be
-       overriden by setting environment variable ``NUMBA_CUDA_DEBUGINFO=1``.)
+       overridden by setting environment variable ``NUMBA_CUDA_DEBUGINFO=1``.)
     :param fastmath: If true, enables flush-to-zero and fused-multiply-add,
        disables precise division and square root. This parameter has no effect
        on device function, whose fastmath setting depends on the kernel function

--- a/numba/cuda/kernels/reduction.py
+++ b/numba/cuda/kernels/reduction.py
@@ -143,7 +143,7 @@ def _gpu_reduce_factory(fn, nbtype):
 
         Launch config:
 
-        Blocksize must be mutiple of warpsize and it is limited to 4 warps.
+        Blocksize must be multiple of warpsize and it is limited to 4 warps.
         """
         tid = cuda.threadIdx.x
 

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -234,7 +234,7 @@ def init_xoroshiro128p_states_cpu(states, seed, subsequence_start):
 def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
     '''Initialize RNG states on the GPU for parallel generators.
 
-    This intializes the RNG states so that each state in the array corresponds
+    This initializes the RNG states so that each state in the array corresponds
     subsequences in the separated by 2**64 steps from each other in the main
     sequence.  Therefore, as long no CUDA thread requests more than 2**64
     random numbers, all of the RNG states produced by this function are
@@ -259,7 +259,7 @@ def init_xoroshiro128p_states(states, seed, subsequence_start=0, stream=0):
 def create_xoroshiro128p_states(n, seed, subsequence_start=0, stream=0):
     '''Returns a new device array initialized for n random number generators.
 
-    This intializes the RNG states so that each state in the array corresponds
+    This initializes the RNG states so that each state in the array corresponds
     subsequences in the separated by 2**64 steps from each other in the main
     sequence.  Therefore, as long no CUDA thread requests more than 2**64
     random numbers, all of the RNG states produced by this function are

--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -16,7 +16,7 @@ class TestGUFuncScalar(SerialMixin, TestCase):
     def test_gufunc_scalar_output(self):
         #    function type:
         #        - has no void return type
-        #        - array argument is one dimenion fewer than the source array
+        #        - array argument is one dimension fewer than the source array
         #        - scalar output is passed as a 1-element array.
         #
         #    signature: (n)->()

--- a/numba/debuginfo.py
+++ b/numba/debuginfo.py
@@ -169,7 +169,7 @@ class DIBuilder(AbstractDIBuilder):
             mflags.add(debuginfo_version)
 
     def _add_subprogram(self, name, linkagename, line):
-        """Emit subprogram metdata
+        """Emit subprogram metadata
         """
         subp = self._di_subprogram(name, linkagename, line)
         self.subprograms.append(subp)

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -363,7 +363,7 @@ class Array(object):
 
 
 def iter_strides_f_contig(arr, shape=None):
-    """yields the f-contigous strides
+    """yields the f-contiguous strides
     """
     shape = arr.shape if shape is None else shape
     itemsize = arr.itemsize
@@ -375,7 +375,7 @@ def iter_strides_f_contig(arr, shape=None):
 
 
 def iter_strides_c_contig(arr, shape=None):
-    """yields the c-contigous strides
+    """yields the c-contiguous strides
     """
     shape = arr.shape if shape is None else shape
     itemsize = arr.itemsize

--- a/numba/help/inspector.py
+++ b/numba/help/inspector.py
@@ -42,7 +42,7 @@ def inspect_function(function, target=None):
         - "numba_type": str or None
             The numba type object of the function if supported.
         - "explained": str
-            A textual descrption of the support.
+            A textual description of the support.
         - "source_infos": dict
             A dictionary containing the source location of each definition.
     """

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -800,7 +800,7 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     array_var = ir.Var(scope, mk_unique_var("array"), loc)
     empty_func = ir.Var(scope, mk_unique_var("empty_func"), loc)
     if dtype_def and dtype_mod_def:
-        # when dtype is present, we'll call emtpy with dtype
+        # when dtype is present, we'll call empty with dtype
         dtype_mod_var = ir.Var(scope, mk_unique_var("dtype_mod"), loc)
         dtype_var = ir.Var(scope, mk_unique_var("dtype"), loc)
         stmts.append(_new_definition(func_ir, dtype_mod_var, dtype_mod_def, loc))

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1943,7 +1943,7 @@ def raise_on_unsupported_feature(func_ir, typemap):
                             (use, expr)
                     raise UnsupportedError(msg, stmt.value.loc)
 
-            # this checks for gdb initilization calls, only one is permitted
+            # this checks for gdb initialization calls, only one is permitted
             if isinstance(stmt.value, (ir.Global, ir.FreeVar)):
                 val = stmt.value
                 val = getattr(val, 'value', None)

--- a/numba/jitclass/base.py
+++ b/numba/jitclass/base.py
@@ -302,7 +302,7 @@ class ClassBuilder(object):
         """
         for meth in instance_type.jitmethods:
 
-            # There's no way to retrive the particular method name
+            # There's no way to retrieve the particular method name
             # inside the implementation function, so we have to register a
             # specific closure for each different name
             if meth not in self.implemented_methods:

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -104,7 +104,7 @@ class BaseLower(object):
 
         # Specializes the target context as seen inside the Lowerer
         # This adds:
-        #  - environment: the python exceution environment
+        #  - environment: the python execution environment
         self.context = context.subtarget(environment=self.env,
                                          fndesc=self.fndesc)
 

--- a/numba/npyufunc/gufunc_scheduler.cpp
+++ b/numba/npyufunc/gufunc_scheduler.cpp
@@ -311,7 +311,7 @@ std::vector<RangeActual> create_schedule(const RangeActual &full_space, uintp nu
         std::sort(dims.begin(), dims.end(), dimlength_by_length_reverse());
         std::vector<RangeActual> assignments(num_sched, RangeActual((intp)1,(intp)0));
         std::vector<isf_range> build;
-        // Compute the division of work across dimensinos and threads.
+        // Compute the division of work across dimensions and threads.
         divide_work(full_space, assignments, build, 0, num_sched-1, dims, 0);
         return assignments;
     }

--- a/numba/roc/compiler.py
+++ b/numba/roc/compiler.py
@@ -329,7 +329,7 @@ class HSAKernel(HSAKernelBase):
         # Insert kernel arguments
         base = 0
         for av in expanded_values:
-            # Adjust for alignemnt
+            # Adjust for alignment
             align = ctypes.sizeof(av)
             pad = _calc_padding_for_alignment(align, base)
             base += pad

--- a/numba/roc/hsadrv/driver.py
+++ b/numba/roc/hsadrv/driver.py
@@ -862,7 +862,7 @@ class Queue(object):
 
         # synchronous if no signal was provided
         if signal is None:
-            _logger.info('wait for sychronous kernel to complete')
+            _logger.info('wait for synchronous kernel to complete')
             timeout = 10
             if not s.wait_until_ne_one(timeout=timeout):
                 msg = "Kernel timed out after {timeout} second"

--- a/numba/roc/mathimpl.py
+++ b/numba/roc/mathimpl.py
@@ -64,7 +64,7 @@ function_descriptors = {
 
 
 # some functions may be named differently by the underlying math
-# library as oposed to the Python name.
+# library as opposed to the Python name.
 _lib_counterpart = {
     'gamma': 'tgamma'
 }

--- a/numba/roc/tests/hsadrv/test_driver.py
+++ b/numba/roc/tests/hsadrv/test_driver.py
@@ -304,7 +304,7 @@ class TestMemory(_TestBase):
         self.assertNotEqual(sym.kernel_object, 0)
         self.assertGreater(sym.kernarg_segment_size, 0)
 
-        # attempt kernel excution
+        # attempt kernel execution
         import ctypes
         import numpy as np
 

--- a/numba/roc/tests/hsapy/test_scan.py
+++ b/numba/roc/tests/hsapy/test_scan.py
@@ -119,7 +119,7 @@ def device_scan(tid, data, temp, inclusive):
     warp_scan_res = warp_scan(tid, temp, inclusive)
     roc.barrier(roc.CLK_GLOBAL_MEM_FENCE)
 
-    # Get parital result
+    # Get partial result
     if lane == (_WARPSIZE - 1):
         temp[warpid] = temp[tid]
     roc.barrier(roc.CLK_GLOBAL_MEM_FENCE)
@@ -129,7 +129,7 @@ def device_scan(tid, data, temp, inclusive):
         warp_scan(tid, temp, True)
     roc.barrier(roc.CLK_GLOBAL_MEM_FENCE)
 
-    # Accumlate scanned partial results
+    # Accumulate scanned partial results
     if warpid > 0:
         warp_scan_res += temp[warpid - 1]
     roc.barrier(roc.CLK_GLOBAL_MEM_FENCE)

--- a/numba/stencil.py
+++ b/numba/stencil.py
@@ -654,7 +654,7 @@ class StencilFunc(object):
 
         stencil_stub_last_label = max(stencil_ir.blocks.keys()) + 1
 
-        # Shift lables in the kernel copy so they are guaranteed unique
+        # Shift labels in the kernel copy so they are guaranteed unique
         # and don't conflict with any labels in the stencil_ir.
         kernel_copy.blocks = ir_utils.add_offset_to_labels(
                                 kernel_copy.blocks, stencil_stub_last_label)

--- a/numba/targets/base.py
+++ b/numba/targets/base.py
@@ -285,7 +285,7 @@ class BaseContext(object):
 
     def load_additional_registries(self):
         """
-        Load target-specific registries.  Can be overriden by subclasses.
+        Load target-specific registries.  Can be overridden by subclasses.
         """
 
     def mangler(self, name, types):

--- a/numba/targets/externals.py
+++ b/numba/targets/externals.py
@@ -183,7 +183,7 @@ def set_fnclex(context, c_helpers):
 
 def compile_fnclex(context):
     """
-    Compile a function that calls fnclex to workround
+    Compile a function that calls fnclex to workaround
     https://support.microsoft.com/en-us/kb/982107
     """
     codegen = context.codegen()

--- a/numba/targets/iterators.py
+++ b/numba/targets/iterators.py
@@ -61,7 +61,7 @@ def iternext_enumerate(context, builder, sig, args, result):
 
     with builder.if_then(is_valid):
         srcval = srcres.yielded_value()
-        # As a iternext_impl function, this will incref the yieled value.
+        # As a iternext_impl function, this will incref the yielded value.
         # We need to release the new reference from call_iternext.
         if context.enable_nrt:
             context.nrt.decref(builder, enumty.yield_type[1], srcval)

--- a/numba/targets/linalg.py
+++ b/numba/targets/linalg.py
@@ -1798,7 +1798,7 @@ def pinv_impl(a, rcond=1.e-15):
         # gain a few % performance increase:
         # * A is destroyed by the SVD algorithm from LAPACK so a copy is
         #   required, this memory is exactly the right size in which to return
-        #   the pseudo-inverse and so can be resued for this purpose.
+        #   the pseudo-inverse and so can be reused for this purpose.
         # * The pseudo-inverse of S can be applied to either V or U^H, this
         #   then leaves a GEMM operation to compute the inverse via either:
         #   A^+ = (V*(S^+))*U^H

--- a/numba/testing/__init__.py
+++ b/numba/testing/__init__.py
@@ -36,7 +36,7 @@ def load_testsuite(loader, dir):
 
 
 def allow_interpreter_mode(fn):
-    """Temporarily re-enable intepreter mode
+    """Temporarily re-enable interpreter mode
     """
     @functools.wraps(fn)
     def _core(*args, **kws):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -400,7 +400,7 @@ class TestDispatcher(BaseTest):
 
         self.assertIs(foo, foo_rebuilt)
 
-        # do we get the same object even if we delete all the explict
+        # do we get the same object even if we delete all the explicit
         # references?
         id_orig = id(foo_rebuilt)
         del foo

--- a/numba/tests/test_listimpl.py
+++ b/numba/tests/test_listimpl.py
@@ -125,7 +125,7 @@ class List(object):
                                                      i.stop,
                                                      i.step)
             self.tc.assertEqual(status, LIST_OK)
-        # must be an intger, deferr to pop
+        # must be an integer, defer to pop
         else:
             self.list_pop(i)
 
@@ -383,7 +383,7 @@ class TestListImpl(TestCase):
         self.assertEqual(len(l), 8)
 
         # delete every second item
-        # no slice default normalization here, be explict about start anb stop
+        # no slice default normalization here, be explicit about start anb stop
         del l[0:8:2]
         self.assertEqual(len(l), 4)
         self.assertEqual(list(l), values[1:8:2])

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -488,7 +488,7 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         """
         https://github.com/numba/numba/issues/2179
 
-        Looplifting transformation is using the wrong verion of variable `h`.
+        Looplifting transformation is using the wrong version of variable `h`.
         """
         from numba import jit
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3027,7 +3027,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             def check(a, repeats):
                 self.assertPreciseEqual(pyfunc(a, repeats), nbfunc(a, repeats))
 
-            # test array argumens
+            # test array arguments
             target_numpy_values = [
                 np.ones(1),
                 np.arange(1000),

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -243,7 +243,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         def setup(start=10, stop=20):
             # initialize regular list
             rl_ = list(range(start, stop))
-            # intialize typed list
+            # initialize typed list
             tl_ = List.empty_list(int32)
             # populate typed list
             for i in range(start, stop):
@@ -380,7 +380,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
         def setup(start=10, stop=20):
             # initialize regular list
             rl_ = list(range(start, stop))
-            # intialize typed list
+            # initialize typed list
             tl_ = List.empty_list(int32)
             # populate typed list
             for i in range(start, stop):

--- a/numba/types/abstract.py
+++ b/numba/types/abstract.py
@@ -99,7 +99,7 @@ class Type(object):
     @property
     def key(self):
         """
-        A property used for __eq__, __ne__ and __hash__.  Can be overriden
+        A property used for __eq__, __ne__ and __hash__.  Can be overridden
         in subclasses.
         """
         return self.name
@@ -365,7 +365,7 @@ class ArrayCompatible(Type):
     exposing an __array__ method).
     Derived classes should implement the *as_array* attribute.
     """
-    # If overriden by a subclass, it should also implement typing
+    # If overridden by a subclass, it should also implement typing
     # for '__array_wrap__' with arguments (input, formal result).
     array_priority = 0.0
 

--- a/numba/types/functions.py
+++ b/numba/types/functions.py
@@ -376,7 +376,7 @@ class NamedTupleClass(Callable, Opaque):
         super(NamedTupleClass, self).__init__(name)
 
     def get_call_type(self, context, args, kws):
-        # Overriden by the __call__ constructor resolution in typing.collections
+        # Overridden by the __call__ constructor resolution in typing.collections
         return None
 
     def get_call_signatures(self):
@@ -398,7 +398,7 @@ class NumberClass(Callable, DTypeSpec, Opaque):
         super(NumberClass, self).__init__(name)
 
     def get_call_type(self, context, args, kws):
-        # Overriden by the __call__ constructor resolution in typing.builtins
+        # Overridden by the __call__ constructor resolution in typing.builtins
         return None
 
     def get_call_signatures(self):

--- a/numba/typing/context.py
+++ b/numba/typing/context.py
@@ -147,7 +147,7 @@ class BaseContext(object):
 
     def init(self):
         """
-        Initialize the typing context.  Can be overriden by subclasses.
+        Initialize the typing context.  Can be overridden by subclasses.
         """
 
     def refresh(self):
@@ -404,7 +404,7 @@ class BaseContext(object):
 
     def load_additional_registries(self):
         """
-        Load target-specific registries.  Can be overriden by subclasses.
+        Load target-specific registries.  Can be overridden by subclasses.
         """
 
     def install_registry(self, registry):

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -695,7 +695,7 @@ class AttributeTemplate(object):
     @classmethod
     def do_class_init(cls):
         """
-        Class-wide initialization.  Can be overriden by subclasses to
+        Class-wide initialization.  Can be overridden by subclasses to
         register permanent typing or target hooks.
         """
 

--- a/numba/withcontexts.py
+++ b/numba/withcontexts.py
@@ -24,7 +24,7 @@ class WithContext(object):
         func_ir : FunctionIR
         blocks : dict[ir.Block]
         blk_start, blk_end : int
-            labels of the starting and ending block of the context-maanger.
+            labels of the starting and ending block of the context-manager.
         body_block: sequence[int]
             A sequence of int's representing labels of the with-body
         dispatcher_factory : callable


### PR DESCRIPTION
Like https://github.com/numba/numba/pull/4909 , should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos. Uses a new script (https://github.com/bwignall/typochecker) to help automate the finding.

This time, I have verified upfront that `flake8 numba` returns clean.