### PR TITLE
test_consuming_strides: Keep dev array alive

### DIFF
--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -247,7 +247,8 @@ class TestCudaArrayInterface(CUDATestCase):
 
     def test_consuming_strides(self):
         hostarray = np.arange(10).reshape(2, 5)
-        face = cuda.to_device(hostarray).__cuda_array_interface__
+        devarray = cuda.to_device(hostarray)
+        face = devarray.__cuda_array_interface__
         self.assertIsNone(face['strides'])
         got = cuda.from_cuda_array_interface(face).copy_to_host()
         np.testing.assert_array_equal(got, hostarray)


### PR DESCRIPTION
The `__cuda_array_interface__` doesn't hold a reference to the object underlying it, so a reference to the object must be kept (see discussion in Issue #4886).

This test did not keep a reference to the array it used, so if there were sufficient pending deallocations, the array underlying `face` in this test would be deleted. This commit adds a local variable holding the underlying array in order to prevent its premature deletion.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
