### PR TITLE
Fix IndexError when accessing the "-1" element of dummyarray 

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -24,7 +24,7 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
         arr = np.arange(3 * 4).reshape(3, 4)
         darr = cuda.to_device(arr)
         x, y = arr.shape
-        for i in range(-x, y):
+        for i in range(-x, x):
             for j in range(-y, y):
                 self.assertEqual(arr[i, j], darr[i, j])
         with self.assertRaises(IndexError):

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -15,9 +15,9 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
         for i in range(-10, 10):
             self.assertEqual(arr[i], darr[i])
         with self.assertRaises(IndexError):
-            a = darr[-11]
+            darr[-11]
         with self.assertRaises(IndexError):
-            a = darr[10]
+            darr[10]
 
     def test_index_2d(self):
         arr = np.arange(3 * 4).reshape(3, 4)
@@ -27,13 +27,13 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
             for j in range(-4, 4):
                 self.assertEqual(arr[i, j], darr[i, j])
         with self.assertRaises(IndexError):
-            a = darr[-4, 0]
+            darr[-4, 0]
         with self.assertRaises(IndexError):
-            a = darr[3, 0]
+            darr[3, 0]
         with self.assertRaises(IndexError):
-            a = darr[0, -5]
+            darr[0, -5]
         with self.assertRaises(IndexError):
-            a = darr[0, 4]
+            darr[0, 4]
 
     def test_index_3d(self):
         arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
@@ -44,17 +44,17 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
                 for k in range(-5, 5):
                     self.assertEqual(arr[i, j, k], darr[i, j, k])
         with self.assertRaises(IndexError):
-            a = darr[-4, 0, 0]
+            darr[-4, 0, 0]
         with self.assertRaises(IndexError):
-            a = darr[3, 0, 0]
+            darr[3, 0, 0]
         with self.assertRaises(IndexError):
-            a = darr[0, -5, 0]
+            darr[0, -5, 0]
         with self.assertRaises(IndexError):
-            a = darr[0, 4, 0]
+            darr[0, 4, 0]
         with self.assertRaises(IndexError):
-            a = darr[0, 0, -6]
+            darr[0, 0, -6]
         with self.assertRaises(IndexError):
-            a = darr[0, 0, 5]
+            darr[0, 0, 5]
 
 
 class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -12,25 +12,49 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
     def test_index_1d(self):
         arr = np.arange(10)
         darr = cuda.to_device(arr)
-        for i in range(arr.size):
+        for i in range(-10, 10):
             self.assertEqual(arr[i], darr[i])
+        with self.assertRaises(IndexError):
+            a = darr[-11]
+        with self.assertRaises(IndexError):
+            a = darr[10]
 
     def test_index_2d(self):
         arr = np.arange(3 * 4).reshape(3, 4)
         darr = cuda.to_device(arr)
 
-        for i in range(arr.shape[0]):
-            for j in range(arr.shape[1]):
+        for i in range(-3, 3):
+            for j in range(-4, 4):
                 self.assertEqual(arr[i, j], darr[i, j])
+        with self.assertRaises(IndexError):
+            a = darr[-4, 0]
+        with self.assertRaises(IndexError):
+            a = darr[3, 0]
+        with self.assertRaises(IndexError):
+            a = darr[0, -5]
+        with self.assertRaises(IndexError):
+            a = darr[0, 4]
 
     def test_index_3d(self):
         arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
         darr = cuda.to_device(arr)
 
-        for i in range(arr.shape[0]):
-            for j in range(arr.shape[1]):
-                for k in range(arr.shape[2]):
+        for i in range(-3, 3):
+            for j in range(-4, 4):
+                for k in range(-5, 5):
                     self.assertEqual(arr[i, j, k], darr[i, j, k])
+        with self.assertRaises(IndexError):
+            a = darr[-4, 0, 0]
+        with self.assertRaises(IndexError):
+            a = darr[3, 0, 0]
+        with self.assertRaises(IndexError):
+            a = darr[0, -5, 0]
+        with self.assertRaises(IndexError):
+            a = darr[0, 4, 0]
+        with self.assertRaises(IndexError):
+            a = darr[0, 0, -6]
+        with self.assertRaises(IndexError):
+            a = darr[0, 0, 5]
 
 
 class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -12,49 +12,50 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
     def test_index_1d(self):
         arr = np.arange(10)
         darr = cuda.to_device(arr)
-        for i in range(-10, 10):
+        x, = arr.shape
+        for i in range(-x, x):
             self.assertEqual(arr[i], darr[i])
         with self.assertRaises(IndexError):
-            darr[-11]
+            darr[-x - 1]
         with self.assertRaises(IndexError):
-            darr[10]
+            darr[x]
 
     def test_index_2d(self):
         arr = np.arange(3 * 4).reshape(3, 4)
         darr = cuda.to_device(arr)
-
-        for i in range(-3, 3):
-            for j in range(-4, 4):
+        x, y = arr.shape
+        for i in range(-x, y):
+            for j in range(-y, y):
                 self.assertEqual(arr[i, j], darr[i, j])
         with self.assertRaises(IndexError):
-            darr[-4, 0]
+            darr[-x - 1, 0]
         with self.assertRaises(IndexError):
-            darr[3, 0]
+            darr[x, 0]
         with self.assertRaises(IndexError):
-            darr[0, -5]
+            darr[0, -y - 1]
         with self.assertRaises(IndexError):
-            darr[0, 4]
+            darr[0, y]
 
     def test_index_3d(self):
         arr = np.arange(3 * 4 * 5).reshape(3, 4, 5)
         darr = cuda.to_device(arr)
-
-        for i in range(-3, 3):
-            for j in range(-4, 4):
-                for k in range(-5, 5):
+        x, y, z = arr.shape
+        for i in range(-x, x):
+            for j in range(-y, y):
+                for k in range(-z, z):
                     self.assertEqual(arr[i, j, k], darr[i, j, k])
         with self.assertRaises(IndexError):
-            darr[-4, 0, 0]
+            darr[-x - 1, 0, 0]
         with self.assertRaises(IndexError):
-            darr[3, 0, 0]
+            darr[x, 0, 0]
         with self.assertRaises(IndexError):
-            darr[0, -5, 0]
+            darr[0, -y - 1, 0]
         with self.assertRaises(IndexError):
-            darr[0, 4, 0]
+            darr[0, y, 0]
         with self.assertRaises(IndexError):
-            darr[0, 0, -6]
+            darr[0, 0, -z - 1]
         with self.assertRaises(IndexError):
-            darr[0, 0, 5]
+            darr[0, 0, z]
 
 
 class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -214,6 +214,17 @@ class Array(object):
         if nitem > ndim:
             raise IndexError("%d extra indices given" % (nitem - ndim,))
 
+        for axis, idx in enumerate(item):
+            if np.isscalar(idx):
+                old_idx = idx
+                if idx < 0:
+                    idx += self.shape[axis]
+                    item[axis] = idx
+                if not (0 <= idx < self.shape[axis]):
+                    msg = 'Index %s is out of bounds for axis %s with '\
+                          'size %s' % (old_idx, axis, self.shape[axis])
+                    raise IndexError(msg)
+
         # Add empty slices for missing indices
         while len(item) < ndim:
             item.append(slice(None, None))

--- a/numba/dummyarray.py
+++ b/numba/dummyarray.py
@@ -69,7 +69,7 @@ class Dim(object):
             )
             return ret
         else:
-            sliced = self[item:item + 1]
+            sliced = self[item:item + 1] if item != -1 else self[-1:]
             if sliced.size != 1:
                 raise IndexError
             return Dim(
@@ -213,17 +213,6 @@ class Array(object):
         ndim = len(self.dims)
         if nitem > ndim:
             raise IndexError("%d extra indices given" % (nitem - ndim,))
-
-        for axis, idx in enumerate(item):
-            if np.isscalar(idx):
-                old_idx = idx
-                if idx < 0:
-                    idx += self.shape[axis]
-                    item[axis] = idx
-                if not (0 <= idx < self.shape[axis]):
-                    msg = 'Index %s is out of bounds for axis %s with '\
-                          'size %s' % (old_idx, axis, self.shape[axis])
-                    raise IndexError(msg)
 
         # Add empty slices for missing indices
         while len(item) < ndim:


### PR DESCRIPTION
This PR fixes the following error:
```python
>>> import numpy as np
>>> from numba import cuda
>>> ary = np.arange(10)
>>> d_ary = cuda.to_device(ary)
>>> d_ary[-1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/cuda/cudadrv/devices.py", line 225, in _require_cuda_context
    return fn(*args, **kws)
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/cuda/cudadrv/devicearray.py", line 497, in __getitem__
    return self._do_getitem(item)
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/cuda/cudadrv/devicearray.py", line 507, in _do_getitem
    arr = self._dummy.__getitem__(item)
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/dummyarray.py", line 225, in __getitem__
    dims = [dim.__getitem__(it) for dim, it in zip(self.dims, item)]
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/dummyarray.py", line 225, in <listcomp>
    dims = [dim.__getitem__(it) for dim, it in zip(self.dims, item)]
  File "/home/leofang/conda_envs/mpi4py_dev/lib/python3.6/site-packages/numba/dummyarray.py", line 76, in __getitem__
    raise IndexError
IndexError
```