### PR TITLE
Fix various issues in CUDA library search (Fixes #4979)

### DIFF
--- a/numba/cuda/cuda_paths.py
+++ b/numba/cuda/cuda_paths.py
@@ -30,7 +30,7 @@ def _get_libdevice_path_decision():
         ('Conda environment', get_conda_ctk()),
         ('CUDA_HOME', get_cuda_home('nvvm', 'libdevice')),
         ('System', get_system_ctk('nvvm', 'libdevice')),
-        ('Debian package', '/usr/lib/nvidia-cuda-toolkit/libdevice'),
+        ('Debian package', get_debian_pkg_libdevice()),
     ]
     by, libdir = _find_valid_path(options)
     return by, libdir
@@ -168,3 +168,14 @@ def get_cuda_paths():
         # Cache result
         get_cuda_paths._cached_result = d
         return d
+
+
+def get_debian_pkg_libdevice():
+    """
+    Return the Debian NVIDIA Maintainers-packaged libdevice location, if it
+    exists.
+    """
+    pkg_libdevice_location = '/usr/lib/nvidia-cuda-toolkit/libdevice'
+    if not os.path.exists(pkg_libdevice_location):
+        return None
+    return pkg_libdevice_location

--- a/numba/cuda/cuda_paths.py
+++ b/numba/cuda/cuda_paths.py
@@ -14,13 +14,13 @@ _env_path_tuple = namedtuple('_env_path_tuple', ['by', 'info'])
 def _find_valid_path(options):
     """Find valid path from *options*, which is a list of 2-tuple of
     (name, path).  Return first pair where *path* is not None.
-    If no valid path is found, return ('<unavailable>', None)
+    If no valid path is found, return ('<unknown>', None)
     """
     for by, data in options:
         if data is not None:
             return by, data
     else:
-        return '<unavailable>', None
+        return '<unknown>', None
 
 
 def _get_libdevice_path_decision():
@@ -30,6 +30,7 @@ def _get_libdevice_path_decision():
         ('Conda environment', get_conda_ctk()),
         ('CUDA_HOME', get_cuda_home('nvvm', 'libdevice')),
         ('System', get_system_ctk('nvvm', 'libdevice')),
+        ('Debian package', '/usr/lib/nvidia-cuda-toolkit/libdevice'),
     ]
     by, libdir = _find_valid_path(options)
     return by, libdir

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -1,8 +1,14 @@
 """Cudatoolkit libraries lookup utilities.
 
-Cudatoolkit libraries can be available via the `cudatoolkit` conda package or a
-user supplied location from CUDA_HOME or a system wide location.
+Cudatoolkit libraries can be available via either:
+
+- the `cudatoolkit` conda package,
+- a user supplied location from CUDA_HOME,
+- a system wide location,
+- package-specific locations (e.g. the Debian NVIDIA packages),
+- or can be discovered by the system loader.
 """
+
 from __future__ import print_function
 import os
 import sys
@@ -13,11 +19,11 @@ from numba.findlib import find_lib
 from numba.cuda.cuda_paths import get_cuda_paths
 
 if sys.platform == 'win32':
-    _dllopener = ctypes.WinDLL
+    _dllnamepattern = 'lib%s.dll'
 elif sys.platform == 'darwin':
-    _dllopener = ctypes.CDLL
+    _dllnamepattern = 'lib%s.dylib'
 else:
-    _dllopener = ctypes.CDLL
+    _dllnamepattern = 'lib%s.so'
 
 
 def get_libdevice(arch):
@@ -32,22 +38,27 @@ def open_libdevice(arch):
 
 
 def get_cudalib(lib, platform=None):
+    """
+    Find the path of a CUDA library based on a search of known locations. If
+    the search fails, return a generic filename for the library (e.g.
+    'libnvvm.so' for 'nvvm') so that we may attempt to load it using the system
+    loader's search mechanism.
+    """
     if lib == 'nvvm':
-        return get_cuda_paths()['nvvm'].info
+        return get_cuda_paths()['nvvm'].info or _dllnamepattern % 'nvvm'
     else:
         libdir = get_cuda_paths()['cudalib_dir'].info
 
     candidates = find_lib(lib, libdir, platform)
-    return max(candidates) if candidates else None
+    return max(candidates) if candidates else _dllnamepattern % lib
 
 
-def open_cudalib(lib, ccc=False):
+def open_cudalib(lib):
     path = get_cudalib(lib)
-    if path is None:
-        raise OSError('library %s not found' % lib)
-    if ccc:
+    try:
         return ctypes.CDLL(path)
-    return _dllopener(path)
+    except:
+        raise OSError('library %s not found' % lib)
 
 
 def _get_source_variable(lib):
@@ -67,24 +78,19 @@ def test(_platform=None, print_paths=True):
     for lib in libs:
         path = get_cudalib(lib, _platform)
         print('Finding {} from {}'.format(lib, _get_source_variable(lib)))
-        if path:
-            if print_paths:
-                print('\tlocated at', path)
-            else:
-                print('\tnamed ', os.path.basename(path))
+        if print_paths:
+            print('\tlocated at', path)
         else:
-            print('\tERROR: can\'t locate lib')
-            failed = True
+            print('\tnamed ', os.path.basename(path))
 
-        if not failed and _platform in (None, sys.platform):
+        if _platform in (None, sys.platform):
             try:
                 print('\ttrying to open library', end='...')
-                open_cudalib(lib, ccc=True)
+                open_cudalib(lib)
                 print('\tok')
             except OSError as e:
                 print('\tERROR: failed to open %s:\n%s' % (lib, e))
-                # NOTE: ignore failure of dlopen on cuBlas on OSX 10.5
-                failed = True if not _if_osx_10_5() else False
+                failed = True
 
     archs = 'compute_20', 'compute_30', 'compute_35', 'compute_50'
     where = _get_source_variable('libdevice')
@@ -98,11 +104,3 @@ def test(_platform=None, print_paths=True):
             print('\tERROR: can\'t open libdevice for %s' % arch)
             failed = True
     return not failed
-
-
-def _if_osx_10_5():
-    if sys.platform == 'darwin':
-        vers = tuple(map(int, platform.mac_ver()[0].split('.')))
-        if vers < (10, 6):
-            return True
-    return False

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 import os
 import sys
 import ctypes
-import platform
 
 from numba.findlib import find_lib
 from numba.cuda.cuda_paths import get_cuda_paths
@@ -55,10 +54,7 @@ def get_cudalib(lib, platform=None):
 
 def open_cudalib(lib):
     path = get_cudalib(lib)
-    try:
-        return ctypes.CDLL(path)
-    except:
-        raise OSError('library %s not found' % lib)
+    return ctypes.CDLL(path)
 
 
 def _get_source_variable(lib):

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -18,7 +18,7 @@ from numba.findlib import find_lib
 from numba.cuda.cuda_paths import get_cuda_paths
 
 if sys.platform == 'win32':
-    _dllnamepattern = 'lib%s.dll'
+    _dllnamepattern = '%s.dll'
 elif sys.platform == 'darwin':
     _dllnamepattern = 'lib%s.dylib'
 else:

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -108,7 +108,7 @@ class NVVM(object):
             if cls.__INSTANCE is None:
                 cls.__INSTANCE = inst = object.__new__(cls)
                 try:
-                    inst.driver = open_cudalib('nvvm', ccc=True)
+                    inst.driver = open_cudalib('nvvm')
                 except OSError as e:
                     cls.__INSTANCE = None
                     errmsg = ("libNVVM cannot be found. Do `conda install "

--- a/numba/cuda/tests/nocuda/test_library_lookup.py
+++ b/numba/cuda/tests/nocuda/test_library_lookup.py
@@ -101,7 +101,7 @@ class TestLibDeviceLookUp(LibraryLookupBase):
         if has_cuda:
             self.assertEqual(by, 'Conda environment')
         else:
-            self.assertEqual(by, "<unavailable>")
+            self.assertEqual(by, "<unknown>")
             self.assertIsNone(info)
         self.assertFalse(warns)
         # Check that CUDA_HOME works by removing conda-env
@@ -119,7 +119,7 @@ class TestLibDeviceLookUp(LibraryLookupBase):
         if get_system_ctk() is None:
             # Fake remove conda environment so no cudatoolkit is available
             by, info, warns = self.remote_do(self.do_clear_envs)
-            self.assertEqual(by, '<unavailable>')
+            self.assertEqual(by, '<unknown>')
             self.assertIsNone(info)
             self.assertFalse(warns)
         else:
@@ -157,7 +157,7 @@ class TestNvvmLookUp(LibraryLookupBase):
         if has_cuda:
             self.assertEqual(by, 'Conda environment')
         else:
-            self.assertEqual(by, "<unavailable>")
+            self.assertEqual(by, "<unknown>")
             self.assertIsNone(info)
         self.assertFalse(warns)
         # Check that CUDA_HOME works by removing conda-env
@@ -184,7 +184,7 @@ class TestNvvmLookUp(LibraryLookupBase):
         if get_system_ctk() is None:
             # Fake remove conda environment so no cudatoolkit is available
             by, info, warns = self.remote_do(self.do_clear_envs)
-            self.assertEqual(by, '<unavailable>')
+            self.assertEqual(by, '<unknown>')
             self.assertIsNone(info)
             self.assertFalse(warns)
         else:
@@ -227,7 +227,7 @@ class TestCudaLibLookUp(LibraryLookupBase):
         if has_cuda:
             self.assertEqual(by, 'Conda environment')
         else:
-            self.assertEqual(by, "<unavailable>")
+            self.assertEqual(by, "<unknown>")
             self.assertIsNone(info)
         self.assertFalse(warns)
 
@@ -249,7 +249,7 @@ class TestCudaLibLookUp(LibraryLookupBase):
         if get_system_ctk() is None:
             # Fake remove conda environment so no cudatoolkit is available
             by, info, warns = self.remote_do(self.do_clear_envs)
-            self.assertEqual(by, "<unavailable>")
+            self.assertEqual(by, "<unknown>")
             self.assertIsNone(info)
             self.assertFalse(warns)
         else:


### PR DESCRIPTION
Since the removal of `NUMBAPRO_NVVM` and `NUMBAPRO_LIBDEVICE`, it has not been possible to load these libraries in systems where they are installed outside of locations known to Numba (Issue #4979).

This commit addresses this issue and some other minor issues with the following changes:

- `libs.get_cudalib` now returns either the full path to the library if it was found in a known location, or just the name of the library if it was not found (e.g. for `nvvm`, it will return `libnvvm.so`). The name of the library is then used to allow the system loader to search for the library.
- `libs.open_cudalib` always uses the C calling convention to load libraries - there is no instance where it was used with another calling convention, so providing alternatives seems superfluous.
- The failure to `dlopen` cuBLAS on OS X 10.5 is now no longer ignored as the earliest supported OS X version is 10.9.
- `cuda_paths._find_valid_path` states that paths to libraries that it does not find are `<unknown>` rather than `<unavailable>`, since they may be available in a location that Numba does not know about.
- `cuda_paths._get_libdevice_path_decision` now also includes the location of libdevice used by the Debian NVIDIA packages.

Prior to this PR, on my Ubuntu 18.04 system with the Debian NVIDIA Packages installed (not the ones from the NVIDIA CUDA download site), the output of `libs.test()` is:

```
$ python -c "from numba import cuda; cuda.cudadrv.libs.test()"
Finding cublas from <unavailable>
	ERROR: can't locate lib
Finding cusparse from <unavailable>
	ERROR: can't locate lib
Finding cufft from <unavailable>
	ERROR: can't locate lib
Finding curand from <unavailable>
	ERROR: can't locate lib
Finding nvvm from <unavailable>
	ERROR: can't locate lib
Finding libdevice from <unavailable>
	searching for compute_20...	ERROR: can't open libdevice for compute_20
	searching for compute_30...	ERROR: can't open libdevice for compute_30
	searching for compute_35...	ERROR: can't open libdevice for compute_35
	searching for compute_50...	ERROR: can't open libdevice for compute_50
```

With the commit in this PR, it is:

```
$ python -c "from numba import cuda; cuda.cudadrv.libs.test()"
Finding cublas from <unknown>
	located at libcublas.so
	trying to open library...	ok
Finding cusparse from <unknown>
	located at libcusparse.so
	trying to open library...	ok
Finding cufft from <unknown>
	located at libcufft.so
	trying to open library...	ok
Finding curand from <unknown>
	located at libcurand.so
	trying to open library...	ok
Finding nvvm from <unknown>
	located at libnvvm.so
	trying to open library...	ok
Finding libdevice from Debian package
	searching for compute_20...	ok
	searching for compute_30...	ok
	searching for compute_35...	ok
	searching for compute_50...	ok
```

The output running on a system with a Conda-installed CUDA toolkit or a systemwide install of the official NVIDIA packages appears to be unaffected on an Ubuntu 16.04 system I have access to.