### PR TITLE
Don't launch ForAll kernels with 0 elements (Fixes #5017)

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -254,6 +254,9 @@ class ExternFunction(object):
 
 class ForAll(object):
     def __init__(self, kernel, ntasks, tpb, stream, sharedmem):
+        if ntasks < 0:
+            raise ValueError("Can't create ForAll with negative task count: %s"
+                             % ntasks)
         self.kernel = kernel
         self.ntasks = ntasks
         self.thread_per_block = tpb

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -261,6 +261,9 @@ class ForAll(object):
         self.sharedmem = sharedmem
 
     def __call__(self, *args):
+        if self.ntasks == 0:
+            return
+
         if isinstance(self.kernel, AutoJitCUDAKernel):
             kernel = self.kernel.specialize(*args)
         else:

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -188,6 +188,7 @@ def check_array_compatibility(ary1, ary2):
 
 
 def to_device(ary, stream=0, copy=True, to=None):
+    ary = np.array(ary, copy=False, subok=True)
     sentry_contiguous(ary)
     if to is None:
         buffer_dtype = np.int64 if ary.dtype.char in 'Mm' else ary.dtype

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -115,6 +115,9 @@ class FakeCUDAKernel(object):
         return self
 
     def forall(self, ntasks, tpb=0, stream=0, sharedmem=0):
+        if ntasks < 0:
+            raise ValueError("Can't create ForAll with negative task count: %s"
+                             % ntasks)
         return self[ntasks, 1, stream, sharedmem]
 
     @property

--- a/numba/cuda/tests/cudapy/test_forall.py
+++ b/numba/cuda/tests/cudapy/test_forall.py
@@ -34,6 +34,19 @@ class TestForAll(SerialMixin, unittest.TestCase):
         bar.forall(y.size)(a, x, y)
         np.testing.assert_array_almost_equal(y, a * x + oldy, decimal=3)
 
+    def test_forall_no_work(self):
+        # Ensure that forall doesn't launch a kernel with no blocks when called
+        # with 0 elements. See Issue #5017.
+
+        @cuda.jit
+        def foo(x):
+            i = cuda.grid(1)
+            if i < x.size:
+                x[i] += 1
+
+        arr = np.arange(11)
+        foo.forall(0)(arr)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_slicing.py
+++ b/numba/cuda/tests/cudapy/test_slicing.py
@@ -25,6 +25,13 @@ class TestCudaSlicing(SerialMixin, unittest.TestCase):
 
         cucopy[1, 10](inp, out)
 
+    def test_assign_empty_slice(self):
+        # Issue #5017. Assigning to an empty slice should not result in a
+        # CudaAPIError.
+        N = 0
+        a = range(N)
+        arr = cuda.device_array(len(a))
+        arr[:] = cuda.to_device(a)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When created with 0 elements, a `ForAll` would configure a kernel with 0 blocks and then cause a `CudaAPIError` when attempting to launch. This commit fixes this issue by returning early from `ForAll.__call__` when the `ForAll` was constructed with 0 elements.

Tests are added for the original issue reported, where assigning a zero-length slice would trigger the error, and also for directly constructing a `ForAll` with 0 elements.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
