### PR TITLE
Add Python 3.8 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -329,6 +329,7 @@ metadata = dict(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Compilers",
     ],
     package_data={


### PR DESCRIPTION
As title

Also, is it safe to remove Python 3.4 here too? It's not listed in the readme as a supported Python version