### PR TITLE
Install optional dependencies for Python 3.8 tests

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -57,9 +57,7 @@ fi
 # Install optional packages into activated env
 if [ "${VANILLA_INSTALL}" != "yes" ]; then
     # Scipy, CFFI, jinja2, IPython and pygments are optional dependencies, but exercised in the test suite
-    if [ $PYTHON \< "3.8" ]; then
-        $CONDA_INSTALL ${EXTRA_CHANNELS} cffi scipy jinja2 ipython pygments
-    fi
+    $CONDA_INSTALL ${EXTRA_CHANNELS} cffi scipy jinja2 ipython pygments
 fi
 
 # Install the compiler toolchain

--- a/numba/tests/test_annotations.py
+++ b/numba/tests/test_annotations.py
@@ -52,6 +52,8 @@ class TestAnnotation(unittest.TestCase):
 
         def foo(x):
             h = 0.
+            for i in range(x): # py 38 needs two loops for one to lift?!
+                h = h + i
             for k in range(x):
                 h = h + k
             if x:

--- a/numba/tests/test_annotations.py
+++ b/numba/tests/test_annotations.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     pygments = None
 
+
 @unittest.skipIf(jinja2 is None, "please install the 'jinja2' package")
 class TestAnnotation(unittest.TestCase):
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

At https://github.com/conda-forge/numba-feedstock/pull/41 we noticed that the test
`numba.tests.test_annotations.TestAnnotation.test_exercise_code_path_with_lifted_loop`
failed for Python 3.8.
The test is not run if `jinja2` is not installed.

Additionally, I'm not sure whether the CI will run this test for Python 3.8 now since Git won't report `numba/tests/test_annotations.py` as changed. I might add a dummy change to that file in a second commit if that's the case.