### PR TITLE
Convert from arrays to names in define() and don't invalidate for multiple consistent defines.

### DIFF
--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1532,6 +1532,19 @@ class TestParfors(TestParforsBase):
             return np.sum(n) + np.prod(n) + np.min(n) + np.max(n) + np.var(n)
         self.check(test_impl, np.array(7), check_scheduling=False)
 
+    @skip_unsupported
+    def test_array_analysis_optional_def(self):
+        def test_impl(x, half):
+            size = len(x)
+            parr = x[0:size]
+
+            if half:
+                parr = x[0:size//2]
+
+            return parr.sum()
+        x = np.ones(20)
+        self.check(test_impl, x, True, check_scheduling=False)
+
 
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):
     def check(self, pyfunc, *args, **kwargs):


### PR DESCRIPTION
Resolves issue #5031

Arrays passed to define() were previously using their whole name which would not appear in the equivalence sets since they are stored there per dimension.  Calling _get_names() in define() converts array names to dimensional names.

This define() function will also invalidate (remove forever from any equivalence class) a variable that is multiply defined.  This is the previous behavior and is overly restrictive.  You need only invalidate on multiple definitions if they are not known to be equivalent.  So, the equivalence insertion functions now return True if some change was made and False otherwise.  If no change was made, then define() need not be called.  For no change to have been made, the variable must already be present.  If the new definition of the var has the case where lhs and rhs are in the same equivalence class then again, no change will be made and define() need not be called or the variable invalidated.