### PR TITLE
IR node aliasing check

### DIFF
--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -10,6 +10,7 @@ from numba import errors
 from . import config, utils, transforms, six
 from .tracing import event
 from .postproc import PostProcessor
+from .ir_utils import check_for_aliasing
 
 # terminal color markup
 _termcolor = errors.termcolor()
@@ -312,6 +313,9 @@ class PassManager(object):
                 else:  # CFG level changes rebuild CFG
                     internal_state.func_ir.blocks = transforms.canonicalize_cfg(
                         internal_state.func_ir.blocks)
+            alias_result = check_for_aliasing(internal_state.func_ir.blocks)
+            if len(alias_result) > 0:
+                print(pss.name(), "pass result has aliases in the IR.", alias_result)
 
         # inject runtimes
         pt = pass_timings(init_time.elapsed, pass_time.elapsed,

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -315,7 +315,9 @@ class PassManager(object):
                         internal_state.func_ir.blocks)
             alias_result = check_for_aliasing(internal_state.func_ir.blocks)
             if len(alias_result) > 0:
-                print(pss.name(), "pass result has aliases in the IR.", alias_result)
+                fid = internal_state.func_id
+                args = (pss.name(), alias_result, fid.modname, fid.func_qualname, self.pipeline_name)
+                print("%s has aliases in IR. %s %s.%s: %s" % args)
 
         # inject runtimes
         pt = pass_timings(init_time.elapsed, pass_time.elapsed,


### PR DESCRIPTION
This PR adds code to detect re-use (aliasing) of nodes in the IR.  Typically we don't want such aliasing because if some pass changes one spot in the IR, it will assume that that is the only spot changed.  If something that is aliased were changed, that wouldn't be the case.

Some aliasing is okay.  There is lots of Loc and Scope aliasing.  Those are filtered out and not reported.