### PR TITLE
Correctly restore numba.parfor.sequential_parfor_lowering in case of …

### DIFF
--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -223,11 +223,14 @@ def _lower_parfor_parallel(lowerer, parfor):
     # index variables should have the same type, check rest of indices
     for l in parfor.loop_nests[1:]:
         assert typemap[l.index_variable.name] == index_var_typ
+
     numba.parfors.parfor.sequential_parfor_lowering = True
-    func, func_args, func_sig, redargstartdim, func_arg_types = _create_gufunc_for_parfor_body(
-        lowerer, parfor, typemap, typingctx, targetctx, flags, {},
-        bool(alias_map), index_var_typ, parfor.races)
-    numba.parfors.parfor.sequential_parfor_lowering = False
+    try:
+        func, func_args, func_sig, redargstartdim, func_arg_types = _create_gufunc_for_parfor_body(
+            lowerer, parfor, typemap, typingctx, targetctx, flags, {},
+            bool(alias_map), index_var_typ, parfor.races)
+    finally:
+        numba.parfors.parfor.sequential_parfor_lowering = False
 
     # get the shape signature
     func_args = ['sched'] + func_args


### PR DESCRIPTION
…exception

Partial fix for https://github.com/numba/numba/issues/5098

Not sure how to write test for this (need to deliberately throw exception from `_create_gufunc_for_parfor_body`)

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
