### PR TITLE
Fix readability issues in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,7 +127,8 @@ html_theme = 'bootstrap'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  'bootswatch_theme': "paper",
+    'bootswatch_theme': "paper",
+    'navbar_fixed_top': False,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
https://github.com/numba/numba/issues/5074

I fixed the sidebar issue with the latest version of sphinx_bootstrap_theme.

Maybe someone who is better at CSS can help with the see also links. It seems that the css for `a`, which specifies background color transparent overrides the `literal` background color of white. I can't figure out what to put in the custom css to make it work. 