### PR TITLE
[DISCUSS] Run CUDA tests on CUDA hardware with gpuCI

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -17,10 +17,12 @@ function hasArg {
     (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
 }
 
-# Set path and build parallel level
+# Set path
 export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
-export PARALLEL_LEVEL=4
 export CUDA_REL=${CUDA_VERSION%.*}
+
+# Set python version
+export PY_VER=`python --version | awk '{print $2}'`
 
 # Set home to the job's workspace
 export HOME=$WORKSPACE
@@ -41,9 +43,9 @@ logger "Check GPU usage..."
 nvidia-smi
 
 logger "Activate conda env..."
-source activate gdf
 conda config --add channels numba
-conda install "llvmlite" "numpy" "scipy" "jinja2" "cffi" "cudatoolkit=$CUDA_REL"
+conda create -n numbatest python=$PY_VER "llvmlite" "numpy" "scipy" "jinja2" "cffi" "cudatoolkit=$CUDA_REL"
+source activate numbatest
 
 logger "Check versions..."
 python --version

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -61,6 +61,9 @@ logger "Build Numba..."
 python setup.py build_ext --inplace
 python setup.py develop
 
+# Dump system information from Numba
+python -m numba -s
+
 ################################################################################
 # TEST - Run CUDA tests
 ################################################################################

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION.
+##########################################
+# Numba GPU build and test script for CI #
+##########################################
+set -e
+NUMARGS=$#
+ARGS=$*
+
+# Logger function for build status output
+function logger() {
+  echo -e "\n>>>> $@\n"
+}
+
+# Arg parsing function
+function hasArg {
+    (( ${NUMARGS} != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")
+}
+
+# Set path and build parallel level
+export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
+export PARALLEL_LEVEL=4
+export CUDA_REL=${CUDA_VERSION%.*}
+
+# Set home to the job's workspace
+export HOME=$WORKSPACE
+
+# Parse git describe
+cd $WORKSPACE
+export GIT_DESCRIBE_TAG=`git describe --tags`
+export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
+
+################################################################################
+# SETUP - Check environment
+################################################################################
+
+logger "Check environment..."
+env
+
+logger "Check GPU usage..."
+nvidia-smi
+
+logger "Activate conda env..."
+source activate gdf
+conda config --add channels numba
+conda install "llvmlite" "numpy" "scipy" "jinja2" "cffi" "cudatoolkit=$CUDA_REL"
+
+logger "Check versions..."
+python --version
+$CC --version
+$CXX --version
+conda list
+
+################################################################################
+# BUILD - Build C extensions and link into environment
+################################################################################
+
+logger "Build Numba..."
+python setup.py build_ext --inplace
+python setup.py develop
+
+################################################################################
+# TEST - Run CUDA tests
+################################################################################
+
+if hasArg --skip-tests; then
+    logger "Skipping Tests..."
+else
+    logger "Check GPU usage..."
+    nvidia-smi
+
+    logger "Run tests in numba.cuda.tests..."
+    python -m numba.runtests numba.cuda.tests -m
+fi


### PR DESCRIPTION
(cc @mike-wendt)

This is a first draft of a gpuCI test script, for running CUDA tests with a device on [gpuCI](https://gpuci.gpuopenanalytics.com/) (as opposed to the simulator testing that's done presently). For reference, the gpuCI documentation is:

- [User documentation](https://docs.rapids.ai/gpuci) - for those making / checking / reviewing PRs.
- [Maintainer documentation](https://docs.rapids.ai/maintainers/gpuci/) - for those writing / editing scripts and configuration for testing on gpuCI.

The script is inspired by that in the cuDF repository: https://github.com/rapidsai/cudf/blob/branch-0.12/ci/gpu/build.sh

One or two discussion points for now are:

- It seem the docker image that gpuCI uses already has Numba installed, so creating a separate environment for installing `llvmlite` from the Numba channel and testing Numba in would probably be prudent - I'll add a commit to do this shortly.
- There is no style check here, which is probably not necessary on gpuCI as its already done in the Azure testing for Numba. Does a dummy style check need to be added?
- If I understand correctly from the documentation, the default will be to build with Python 3.6 and 3.7, and CUDA toolkit 9.2 and 10.0. Assuming this is correct, how does this suit everybody?
