### PR TITLE
CUDA: Enable asynchronous operations on the default stream

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -141,9 +141,13 @@ transfers and kernel execution. For further details on streams, see the `CUDA C
 Programming Guide Streams section
 <http://docs.nvidia.com/cuda/cuda-c-programming-guide/#streams>`_.
 
-To create a stream:
+To create a new stream:
 
 .. autofunction:: numba.cuda.stream
+
+To get the default stream:
+
+.. autofunction:: numba.cuda.default_stream
 
 Streams are instances of :class:`numba.cuda.cudadrv.driver.Stream`:
 

--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -56,7 +56,14 @@ Pinned memory
 Streams
 =======
 
+Streams can be passed to functions that accept them (e.g. copies between the
+host and device) and into kernel launch configurations so that the operations
+are executed asynchronously.
+
 .. autofunction:: numba.cuda.stream
+   :noindex:
+
+.. autofunction:: numba.cuda.default_stream
    :noindex:
 
 CUDA streams have the following methods:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -270,6 +270,14 @@ def stream():
     """
     return current_context().create_stream()
 
+@require_context
+def default_stream():
+    """default_stream()
+
+    Get the default CUDA stream.
+    """
+    return current_context().get_default_stream()
+
 # Page lock
 @require_context
 @contextlib.contextmanager

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -118,6 +118,9 @@ class TestCudaDriver(SerialMixin, unittest.TestCase):
         ds = self.context.get_default_stream()
         self.assertIn("Default CUDA stream", repr(ds))
         self.assertEqual(0, int(ds))
+        # bool(stream) is the check that is done in memcpy to decide if async
+        # version should be used. So the default (0) stream should be true-ish
+        # even though 0 is usually false-ish in Python.
         self.assertTrue(ds)
 
     def test_cuda_driver_stream(self):

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -93,7 +93,7 @@ class TestCudaDriver(SerialMixin, unittest.TestCase):
 
         module.unload()
 
-    def test_cuda_driver_stream(self):
+    def test_cuda_driver_stream_operations(self):
         module = self.context.create_module_ptx(self.ptx)
         function = module.get_function('_Z10helloworldPi')
 
@@ -112,6 +112,21 @@ class TestCudaDriver(SerialMixin, unittest.TestCase):
 
         for i, v in enumerate(array):
             self.assertEqual(i, v)
+
+    def test_cuda_driver_default_stream(self):
+        # Test properties of the default stream
+        ds = self.context.get_default_stream()
+        self.assertIn("Default CUDA stream", repr(ds))
+        self.assertEqual(0, int(ds))
+        self.assertTrue(ds)
+
+    def test_cuda_driver_stream(self):
+        # Test properties of non-default streams
+        s = self.context.create_stream()
+        self.assertIn("CUDA stream", repr(s))
+        self.assertNotIn("Default", repr(s))
+        self.assertNotEqual(0, int(s))
+        self.assertTrue(s)
 
     def test_cuda_driver_occupancy(self):
         module = self.context.create_module_ptx(self.ptx)


### PR DESCRIPTION
Asynchronous operations can be executed on the default stream in CUDA C++ by passing `0` as the stream parameter to functions that accept them. The literal `0` for a stream parameter is interpreted by Numba as no stream being passed in a lot of places, so Numba chooses to use synchronous operations when this is done.

This PR adds a way to get a `Stream` object for the default stream, which can be used to execute asynchronous transfers on the default stream. For example:

```python
a = cuda.pinned_array(10)
a[:] = 0
# Asynchronous copy to device on default stream:
d_a = cuda.to_device(a, stream=cuda.default_stream())
```

CUDA test results for this branch locally are:

```
$ python -m numba.runtests numba.cuda.tests
.........s......................................................................./home/nfs/gmarkall/numbadev/numba/numba/cuda/decorators.py:116: UserWarning: autojit is deprecated and will be removed in a future release. Use jit instead.
  warn('autojit is deprecated and will be removed in a future release. Use jit instead.')
.................................................................................................s................<CUDA device 0 'b'Tesla V100-SXM2-16GB''>
<CUDA device 1 'b'Tesla V100-SXM2-16GB''>
...can_access_peer <CUDA context c_void_p(94731122708896) of device 0> True
can_access_peer <CUDA context c_void_p(94439286740544) of device 1> True
.s...............................................................s...............................................................s............................/home/nfs/gmarkall/numbadev/numba/numba/cuda/decorators.py:116: UserWarning: autojit is deprecated and will be removed in a future release. Use jit instead.
  warn('autojit is deprecated and will be removed in a future release. Use jit instead.')
...............................................................................................................................................................................................active blocks: 16
grid size: 1280 , block size: 128
...
----------------------------------------------------------------------
Ran 550 tests in 137.149s

OK (skipped=5)
```