### PR TITLE
Fix #4875: Make #2655 test with debug expect to pass

### DIFF
--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -95,6 +95,12 @@ class TestException(SerialMixin, unittest.TestCase):
     def test_raise_causing_warp_diverge_debug(self):
         """Test case for issue #2655 with debug mode.
         """
+        # This test case is a little sensitive to CFG layout, and currently
+        # passes. It is kept as it may signal changes in the CFG layout in
+        # future if it begins to fail again. See for background:
+        # https://github.com/numba/numba/pull/5144
+        # https://github.com/numba/numba/issues/4875
+        # https://github.com/numba/numba/issues/2655
         self.case_raise_causing_warp_diverge(with_debug_mode=True)
 
 

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -91,13 +91,9 @@ class TestException(SerialMixin, unittest.TestCase):
         """
         self.case_raise_causing_warp_diverge(with_debug_mode=False)
 
-    @unittest.skip("python 3.8 CFG refactor makes this test pass")
     @skip_on_cudasim("failing case doesn't happen in CUDASIM")
-    @unittest.expectedFailure
-    def test_raise_causing_warp_diverge_failing(self):
-        """Test case for issue #2655.
-
-        This test that the issue still exists in debug mode.
+    def test_raise_causing_warp_diverge_debug(self):
+        """Test case for issue #2655 with debug mode.
         """
         self.case_raise_causing_warp_diverge(with_debug_mode=True)
 

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -91,18 +91,6 @@ class TestException(SerialMixin, unittest.TestCase):
         """
         self.case_raise_causing_warp_diverge(with_debug_mode=False)
 
-    @skip_on_cudasim("failing case doesn't happen in CUDASIM")
-    def test_raise_causing_warp_diverge_debug(self):
-        """Test case for issue #2655 with debug mode.
-        """
-        # This test case is a little sensitive to CFG layout, and currently
-        # passes. It is kept as it may signal changes in the CFG layout in
-        # future if it begins to fail again. See for background:
-        # https://github.com/numba/numba/pull/5144
-        # https://github.com/numba/numba/issues/4875
-        # https://github.com/numba/numba/issues/2655
-        self.case_raise_causing_warp_diverge(with_debug_mode=True)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The test case `TestException.test_raise_causing_warp_diverge_failing` was originally added in PR #2706 which worked around unexpected warp divergence due to exception raising code (discussed in Issue #2655). Since the merge of the Python 3.8 CFG refactoring the test case has begun to pass again as it is sensitive to CFG layout.

The suggested resolution in #4875 is to remove the failing test. However, this commit instead makes the test an expected pass as there still seems to be some value in the test itself - this test could provide a canary for future changes (potentially elsewhere in the software stack) that affect scheduling or synchronisation - this test beginning to fail again suggests something to be aware of and understand / investigate.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
