### PR TITLE
More explicit llvmlite requirement in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 numpy>=1.10
-llvmlite>=0.31
+llvmlite==0.31.*
 argparse
 funcsigs ; python_version < '3.4'
 singledispatch ; python_version < '3.4'


### PR DESCRIPTION
Requirements.txt specifies an endless bound, but the setup.py has an explicit requirement for llvmlite. This caused some confusion recently, so this brings the requirements.txt requirement inline with the setup.py one.