### PR TITLE
implement None-typed typed-list

### DIFF
--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -905,6 +905,8 @@ def impl_extend(l, iterable):
     if not isinstance(iterable, types.IterableType):
         raise TypingError("extend argument must be iterable")
 
+    _check_for_none_typed(l, 'insert')
+
     def select_impl():
         if isinstance(iterable, types.ListType):
             def impl(l, iterable):

--- a/numba/listobject.py
+++ b/numba/listobject.py
@@ -26,6 +26,7 @@ from numba.types import (
     ListTypeIterableType,
     ListTypeIteratorType,
     Type,
+    NoneType,
 )
 from numba.targets.imputils import impl_ret_borrowed, RefType
 from numba.errors import TypingError
@@ -92,6 +93,12 @@ def _raise_if_error(context, builder, status, msg):
     with builder.if_then(builder.icmp_signed('!=', status, ok_status),
                          likely=True):
         context.call_conv.return_user_exc(builder, RuntimeError, (msg,))
+
+
+def _check_for_none_typed(lst, method):
+    if isinstance(lst.dtype, NoneType):
+        raise TypingError("method support for List[None] is limited, "
+                          "not supported: '{}'.".format(method))
 
 
 @intrinsic
@@ -560,14 +567,18 @@ def _list_pop(typingctx, l, index):
 def _list_getitem_pop_helper(typingctx, l, index, op):
     """Wrap numba_list_getitem and numba_list_pop
 
-    Returns 2-tuple of (intp, ?item_type)
+    Returns 2-tuple of (int32, ?item_type)
 
     This is a helper that is parametrized on the type of operation, which can
     be either 'pop' or 'getitem'. This is because, signature wise, getitem and
     pop and are the same.
     """
     assert(op in ("pop", "getitem"))
-    resty = types.Tuple([types.int32, types.Optional(l.item_type)])
+    IS_NOT_NONE = not isinstance(l.item_type, types.NoneType)
+    resty = types.Tuple([types.int32,
+                         types.Optional(l.item_type
+                                        if IS_NOT_NONE
+                                        else types.int64)])
     sig = resty(l, index)
 
     def codegen(context, builder, sig, args):
@@ -596,15 +607,19 @@ def _list_getitem_pop_helper(typingctx, l, index, op):
         # Load item if output is available
         found = builder.icmp_signed('>=', status,
                                     status.type(int(ListStatus.LIST_OK)))
-
-        out = context.make_optional_none(builder, tl.item_type)
+        out = context.make_optional_none(builder,
+                                         tl.item_type
+                                         if IS_NOT_NONE
+                                         else types.int64)
         pout = cgutils.alloca_once_value(builder, out)
 
         with builder.if_then(found):
-            item = dm_item.load_from_data_pointer(builder, ptr_item)
-            context.nrt.incref(builder, tl.item_type, item)
-            loaded = context.make_optional_value(builder, tl.item_type, item)
-            builder.store(loaded, pout)
+            if IS_NOT_NONE:
+                item = dm_item.load_from_data_pointer(builder, ptr_item)
+                context.nrt.incref(builder, tl.item_type, item)
+                loaded = context.make_optional_value(
+                    builder, tl.item_type, item)
+                builder.store(loaded, pout)
 
         out = builder.load(pout)
         return context.make_tuple(builder, resty, [status, out])
@@ -619,18 +634,24 @@ def impl_getitem(l, index):
 
     indexty = INDEXTY
     itemty = l.item_type
+    IS_NOT_NONE = not isinstance(l.item_type, types.NoneType)
 
     if index in index_types:
-        def integer_impl(l, index):
-            index = handle_index(l, index)
-            castedindex = _cast(index, indexty)
-            status, item = _list_getitem(l, castedindex)
-            if status == ListStatus.LIST_OK:
-                return _nonoptional(item)
-            else:
-                raise AssertionError("internal list error during getitem")
-
-        return integer_impl
+        if IS_NOT_NONE:
+            def integer_non_none_impl(l, index):
+                index = handle_index(l, index)
+                castedindex = _cast(index, indexty)
+                status, item = _list_getitem(l, castedindex)
+                if status == ListStatus.LIST_OK:
+                    return _nonoptional(item)
+                else:
+                    raise AssertionError("internal list error during getitem")
+            return integer_non_none_impl
+        else:
+            def integer_none_impl(l, index):
+                index = handle_index(l, index)
+                return None
+            return integer_none_impl
 
     elif isinstance(index, types.SliceType):
         def slice_impl(l, index):
@@ -759,6 +780,8 @@ def impl_pop(l, index=-1):
     if not isinstance(l, types.ListType):
         return
 
+    _check_for_none_typed(l, 'pop')
+
     indexty = INDEXTY
 
     # FIXME: this type check works, but it isn't clear why and if it optimal
@@ -843,6 +866,7 @@ def impl_contains(l, item):
         return
 
     itemty = l.item_type
+    _check_for_none_typed(l, "__contains__")
 
     def impl(l, item):
         casteditem = _cast(item, itemty)
@@ -858,6 +882,8 @@ def impl_contains(l, item):
 def impl_count(l, item):
     if not isinstance(l, types.ListType):
         return
+
+    _check_for_none_typed(l, 'count')
 
     itemty = l.item_type
 
@@ -922,6 +948,11 @@ def impl_insert(l, index, item):
     if not isinstance(l, types.ListType):
         return
 
+    _check_for_none_typed(l, 'insert')
+    # insert can refine
+    if isinstance(item, NoneType):
+        raise TypingError("method support for List[None] is limited")
+
     if index in index_types:
         def impl(l, index, item):
             # If the index is larger than the size of the list or if the list is
@@ -964,6 +995,8 @@ def impl_remove(l, item):
     if not isinstance(l, types.ListType):
         return
 
+    _check_for_none_typed(l, 'remove')
+
     itemty = l.item_type
 
     def impl(l, item):
@@ -995,6 +1028,8 @@ def impl_reverse(l):
     if not isinstance(l, types.ListType):
         return
 
+    _check_for_none_typed(l, 'reverse')
+
     def impl(l):
         front = 0
         back = len(l) - 1
@@ -1008,7 +1043,11 @@ def impl_reverse(l):
 
 @overload_method(types.ListType, 'copy')
 def impl_copy(l):
+
+    _check_for_none_typed(l, 'copy')
+
     itemty = l.item_type
+
     if isinstance(l, types.ListType):
         def impl(l):
             newl = new_list(itemty, len(l))
@@ -1023,6 +1062,9 @@ def impl_copy(l):
 def impl_index(l, item, start=None, end=None):
     if not isinstance(l, types.ListType):
         return
+
+    _check_for_none_typed(l, 'index')
+
     itemty = l.item_type
 
     def check_arg(arg, name):
@@ -1091,17 +1133,29 @@ def _equals_helper(this, other, OP):
     if not isinstance(other, types.ListType):
         return lambda this, other: False
 
-    def impl(this, other):
-        def equals(this, other):
-            if len(this) != len(other):
-                return False
-            for i in range(len(this)):
-                if this[i] != other[i]:
+    this_is_none = isinstance(this.dtype, types.NoneType)
+    other_is_none = isinstance(other.dtype, types.NoneType)
+
+    if this_is_none or other_is_none:
+        def impl_some_none(this, other):
+            def equals(this, other):
+                # Equal if both none-typed and have equal length
+                return bool(this_is_none == other_is_none
+                            and len(this) == len(other))
+            return OP(equals(this, other))
+        return impl_some_none
+    else:
+        def impl_not_none(this, other):
+            def equals(this, other):
+                if len(this) != len(other):
                     return False
-            else:
-                return True
-        return OP(equals(this, other))
-    return impl
+                for i in range(len(this)):
+                    if this[i] != other[i]:
+                        return False
+                else:
+                    return True
+            return OP(equals(this, other))
+        return impl_not_none
 
 
 @overload(operator.eq)
@@ -1115,7 +1169,7 @@ def impl_not_equals(this, other):
 
 
 @register_jitable
-def compare(this, other):
+def compare_not_none(this, other):
     """Oldschool (python 2.x) cmp.
 
        if this < other return -1
@@ -1132,14 +1186,39 @@ def compare(this, other):
         return 0
 
 
+@register_jitable
+def compare_some_none(this, other, this_is_none, other_is_none):
+    """Oldschool (python 2.x) cmp for None typed lists.
+
+       if this < other return -1
+       if this = other return 0
+       if this > other return 1
+    """
+    if len(this) != len(other):
+        return -1 if len(this) < len(other) else 1
+    if this_is_none and other_is_none: # both none
+        return 0
+    # to get here there is precisely one none, and if the first is none, by
+    # induction, the second cannot be
+    return -1 if this_is_none else 1
+
+
 def compare_helper(this, other, accepted):
     if not isinstance(this, types.ListType):
         return
     if not isinstance(other, types.ListType):
         return lambda this, other: False
 
-    def impl(this, other):
-        return compare(this, other) in accepted
+    this_is_none = isinstance(this.dtype, types.NoneType)
+    other_is_none = isinstance(other.dtype, types.NoneType)
+
+    if this_is_none or other_is_none:
+        def impl(this, other):
+            return compare_some_none(
+                this, other, this_is_none, other_is_none) in accepted
+    else:
+        def impl(this, other):
+            return compare_not_none(this, other) in accepted
     return impl
 
 

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -8,8 +8,7 @@ from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.errors import TypingError
-from numba.utils import exec_
-from .support import (TestCase, MemoryLeakMixin, override_config,
+from .support import (TestCase, MemoryLeakMixin, unittest, override_config,
                       forbid_codegen, skip_parfors_unsupported)
 
 from numba.unsafe.refcount import get_refcount
@@ -586,7 +585,7 @@ class TestNoneType(MemoryLeakMixin, TestCase):
         """ Test that unsupported operations on List[None] raise. """
         def generate_function(line1, line2):
             context = {}
-            exec_(dedent("""
+            exec(dedent("""
                 from numba.typed import List
                 def bar():
                     lst = List()

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -591,7 +591,9 @@ class TestNoneType(MemoryLeakMixin, TestCase):
                     {}
                     {}
                 """.format(line1, line2)), context)
-            return njit(context["bar"], _disable_reflected_list=True)
+            # FIXME: when _disable_reflected_list becomes available
+            # return njit(context["bar"], _disable_reflected_list=True)
+            return njit(context["bar"])
         for line1, line2 in (
                 ("lst.append(None)", "lst.pop()"),
                 ("lst.append(None)", "lst.count(None)"),

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -556,6 +556,7 @@ class TestNoneType(MemoryLeakMixin, TestCase):
 
         self.assertEqual(impl.py_func(), impl())
 
+    @unittest.skip("Works only with _disable_reflected_list")
     def test_square_bracket_builtin_with_None(self):
         @njit(_disable_reflected_list=True)
         def foo():
@@ -568,6 +569,7 @@ class TestNoneType(MemoryLeakMixin, TestCase):
         received = foo()
         self.assertEqual(expected, received)
 
+    @unittest.skip("Works only with _disable_reflected_list")
     def test_list_comprehension_with_none(self):
         @njit(_disable_reflected_list=True)
         def foo():

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -8,7 +8,7 @@ from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.errors import TypingError
-from .support import (TestCase, MemoryLeakMixin, unittest, override_config,
+from .support import (TestCase, MemoryLeakMixin, override_config,
                       forbid_codegen, skip_parfors_unsupported)
 
 from numba.unsafe.refcount import get_refcount
@@ -554,32 +554,6 @@ class TestNoneType(MemoryLeakMixin, TestCase):
             return count
 
         self.assertEqual(impl.py_func(), impl())
-
-    @unittest.skip("Works only with _disable_reflected_list")
-    def test_square_bracket_builtin_with_None(self):
-        @njit(_disable_reflected_list=True)
-        def foo():
-            l = [None, None, None]
-            return l
-        expected = List()
-        expected.append(None)
-        expected.append(None)
-        expected.append(None)
-        received = foo()
-        self.assertEqual(expected, received)
-
-    @unittest.skip("Works only with _disable_reflected_list")
-    def test_list_comprehension_with_none(self):
-        @njit(_disable_reflected_list=True)
-        def foo():
-            l = List()
-            # the following construct results in a List[None] that is discarded
-            [l.append(i) for i in (1, 3, 3)]
-            return l
-        expected = List()
-        [expected.append(i) for i in (1, 3, 3)]
-        received = foo()
-        self.assertEqual(expected, received)
 
     def test_none_typed_method_fails(self):
         """ Test that unsupported operations on List[None] raise. """

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -566,8 +566,6 @@ class TestNoneType(MemoryLeakMixin, TestCase):
                     {}
                     {}
                 """.format(line1, line2)), context)
-            # FIXME: when _disable_reflected_list becomes available
-            # return njit(context["bar"], _disable_reflected_list=True)
             return njit(context["bar"])
         for line1, line2 in (
                 ("lst.append(None)", "lst.pop()"),

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1,4 +1,5 @@
 from itertools import product
+from textwrap import dedent
 
 import numpy as np
 
@@ -7,6 +8,7 @@ from numba import int32, float32, types, prange
 from numba import jitclass, typeof
 from numba.typed import List, Dict
 from numba.errors import TypingError
+from numba.utils import exec_
 from .support import (TestCase, MemoryLeakMixin, override_config,
                       forbid_codegen, skip_parfors_unsupported)
 
@@ -477,6 +479,140 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             expected_message,
             str(raises.exception),
         )
+
+
+class TestNoneType(MemoryLeakMixin, TestCase):
+
+    def test_append_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            return l
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_len_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            return len(l)
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_getitem_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            return l[0]
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_setitem_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            l[0] = None
+            return l
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_equals_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            m = List()
+            m.append(None)
+            return l == m, l != m, l < m, l <= m, l > m, l >= m
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_not_equals_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            m = List()
+            m.append(1)
+            return l == m, l != m, l < m, l <= m, l > m, l >= m
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_iter_none(self):
+        @njit
+        def impl():
+            l = List()
+            l.append(None)
+            l.append(None)
+            l.append(None)
+            count = 0
+            for i in l:
+                count += 1
+            return count
+
+        self.assertEqual(impl.py_func(), impl())
+
+    def test_square_bracket_builtin_with_None(self):
+        @njit(_disable_reflected_list=True)
+        def foo():
+            l = [None, None, None]
+            return l
+        expected = List()
+        expected.append(None)
+        expected.append(None)
+        expected.append(None)
+        received = foo()
+        self.assertEqual(expected, received)
+
+    def test_list_comprehension_with_none(self):
+        @njit(_disable_reflected_list=True)
+        def foo():
+            l = List()
+            # the following construct results in a List[None] that is discarded
+            [l.append(i) for i in (1, 3, 3)]
+            return l
+        expected = List()
+        [expected.append(i) for i in (1, 3, 3)]
+        received = foo()
+        self.assertEqual(expected, received)
+
+    def test_none_typed_method_fails(self):
+        """ Test that unsupported operations on List[None] raise. """
+        def generate_function(line1, line2):
+            context = {}
+            exec_(dedent("""
+                from numba.typed import List
+                def bar():
+                    lst = List()
+                    {}
+                    {}
+                """.format(line1, line2)), context)
+            return njit(context["bar"], _disable_reflected_list=True)
+        for line1, line2 in (
+                ("lst.append(None)", "lst.pop()"),
+                ("lst.append(None)", "lst.count(None)"),
+                ("lst.append(None)", "lst.index(None)"),
+                ("lst.append(None)", "lst.insert(0, None)"),
+                (""                , "lst.insert(0, None)"),
+                ("lst.append(None)", "lst.clear()"),
+                ("lst.append(None)", "lst.copy()"),
+                ("lst.append(None)", "lst.extend([None])"),
+                ("",                 "lst.extend([None])"),
+                ("lst.append(None)", "lst.remove(None)"),
+                ("lst.append(None)", "lst.reverse()"),
+                ("lst.append(None)", "None in lst"),
+        ):
+            with self.assertRaises(TypingError) as raises:
+                foo = generate_function(line1, line2)
+                foo()
+            self.assertIn(
+                "method support for List[None] is limited",
+                str(raises.exception),
+            )
 
 
 class TestAllocation(MemoryLeakMixin, TestCase):

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -502,6 +502,7 @@ class ListType(IterableType):
             raise TypingError(fmt.format(itemty))
         # FIXME: _sentry_forbidden_types(itemty)
         self.item_type = itemty
+        self.dtype = itemty
         name = '{}[{}]'.format(
             self.__class__.__name__,
             itemty,

--- a/numba/types/containers.py
+++ b/numba/types/containers.py
@@ -497,7 +497,7 @@ class ListType(IterableType):
     def __init__(self, itemty):
         assert not isinstance(itemty, TypeRef)
         itemty = unliteral(itemty)
-        if isinstance(itemty, (Optional, NoneType)):
+        if isinstance(itemty, Optional):
             fmt = 'List.item_type cannot be of type {}'
             raise TypingError(fmt.format(itemty))
         # FIXME: _sentry_forbidden_types(itemty)


### PR DESCRIPTION
This is the code for the None-typed typed-list as extracted from:

https://github.com/numba/numba/pull/4883/files

The support is very limited and was designed only for a single, very
limited use-case: populating a typed-list with a list comprehension.

Let's imagine you want to do the following:

```python

from numba import njit, typed

@njit
def foo():
    l = typed.List()
    [l.append(i) for i in range(10)]

```

While it is true, that this is fairly uncommon way to initialize a list,
it was and is used to populate a typed-list since that doesn't (at the
time of writing this) have a way to be initialised from an iterable or
similar. And so the list comprehension approach is one line shorter than
a for-loop construct.

As a by product of this idiom, is that a None-typed list is generated
and discarded as a result. If the list comprehension is to generate a
Numba typed-list, rather than a reflected list, in future, then it must
support a None-typed variant

A mentioned, the implementation here is as minimal as it can be and
doesn't have an optimizations. Most of the method are not supported and
will be guarded against. An optimized variant may not need to allocate
any memory at all, for example, since a None value will always be
returned when accessing it and we only need a count of the number of
Nones stored

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
