### PR TITLE
Test numpy 1.18

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 16
+  TEST_COUNT: 18
 
 jobs:
 # Mac and Linux use the same template with different matrixes
@@ -98,6 +98,16 @@ jobs:
         NUMPY: '1.17'
         CONDA_ENV: travisci
         TEST_START_INDEX: 13
+      py37_np118:
+        PYTHON: '3.7'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 14
+      py38_np118:
+        PYTHON: '3.8'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 15
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:


### PR DESCRIPTION
Numpy 1.18 is out now.  Run unit tests on it, also.
