### PR TITLE
fix version spec for llvmlite

### DIFF
--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -11,4 +11,5 @@ python setup.py build_ext -q --inplace
 #  during distutils-dependent tests -- e.g. test_pycc)
 
 # Install numba locally for use in `numba -s` sys info tool at test time
-python -m pip install -e .
+# `-iNOWHERE` make a fake index to avoid auto downloading dependency
+python -m pip install -iNOWHERE -e .

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ packages = find_packages(include=["numba", "numba.*"])
 
 build_requires = [f'numpy >={min_numpy_build_version}']
 install_requires = [
-    f'llvmlite >={min_llvmlite_version},<{max_llvmlite_version}',
+    f'llvmlite >={min_llvmlite_version},<={max_llvmlite_version}',
     f'numpy >={min_numpy_run_version}',
     'setuptools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ import versioneer
 min_python_version = "3.6"
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.15"
-min_llvmlite_version = "0.31.0dev0"
-max_llvmlite_version = "0.32.0"
+min_llvmlite_version = "0.31.0.dev0"
+max_llvmlite_version = "0.32.0.dev0"
 
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython


### PR DESCRIPTION
This fixes being able to use Numba 0.49.0.dev0.*  with llvmlite
0.32.0dev0.*.

I usually install the dependenices for Numba using:

```
conda install  -c numba/label/dev llvmlite
conda install numpy pyyaml colorama scipy jinja2 cffi ipython
conda install clang_osx-64 clangxx_osx-64
```

Currently, this will install `llvmlite-0.32.0dev0` as it is the latest
dev release available from the Numba channel on anaconda.org with the
`dev` label.

When I then compile Numba using:

```
python setup.py build_ext -i && python setup.py develop
```

I see the following version of llvmlite being installed (as a wheel
using `pip`...)

```
Installed /Users/vhaenel/git/numba
Processing dependencies for numba==0.49.0.dev0+136.gf8367ce4a4
Searching for llvmlite<0.32.0,>=0.31.0dev0
Reading https://pypi.org/simple/llvmlite/
Downloading https://files.pythonhosted.org/packages/b9/c3/f5a53c8352a6a1576097904feae12d12f8081ba653962a15b126426a47f1/llvmlite-0.31.0-cp38-cp38-macosx_10_9_x86_64.whl#sha256=5593acefd5f01765ee403ea4b0288a59aff2276eb8f5241deb2e52018219a66a
Best match: llvmlite 0.31.0
Processing llvmlite-0.31.0-cp38-cp38-macosx_10_9_x86_64.whl
Installing llvmlite-0.31.0-cp38-cp38-macosx_10_9_x86_64.whl to /Users/vhaenel/miniconda3/envs/numba_3.7/lib/python3.8/site-packages
Adding llvmlite 0.31.0 to easy-install.pth file
```

This is because the setup.py clamps the llvmlite version to be strictly
less than 0.32.0, not less than or equal to and so `pip` tries to 'fix'
this.