### PR TITLE
Normalize kws going into fold_arguments.

### DIFF
--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -6,6 +6,7 @@ import numpy as np
 from numba import unittest_support as unittest
 from numba.compiler import compile_isolated
 from numba import types, typeinfer, typing, jit, errors
+from numba import utils
 from numba.typeconv import Conversion
 
 from .support import TestCase, tag
@@ -676,6 +677,61 @@ class TestMiscIssues(TestCase):
         for v in (0, 1, 2):
             res = cfunc(v)
             self.assertEqual(res, pyfunc(v))
+
+
+class TestFoldArguments(unittest.TestCase):
+    def check_fold_arguments_list_inputs(self, func, args, kws):
+        def make_tuple(*args):
+            return args
+
+        unused_handler = None
+
+        pysig = utils.pysignature(func)
+        names = list(pysig.parameters)
+
+        with self.subTest(kind='dict'):
+            folded_dict = typing.fold_arguments(
+                pysig, args, kws, make_tuple, unused_handler, unused_handler,
+            )
+            # correct ordering
+            for i, (j, k) in enumerate(zip(folded_dict, names)):
+                (got_index, got_param, got_name) = j
+                self.assertEqual(got_index, i)
+                self.assertEqual(got_name, f'arg.{k}')
+
+        kws = list(kws.items())
+        with self.subTest(kind='list'):
+            folded_list = typing.fold_arguments(
+                pysig, args, kws, make_tuple, unused_handler, unused_handler,
+            )
+            self.assertEqual(folded_list, folded_dict)
+
+    def test_fold_arguments_list_inputs(self):
+        cases = [
+            dict(
+                func=lambda a, b, c, d: None,
+                args=['arg.a', 'arg.b'],
+                kws=dict(c='arg.c', d='arg.d')
+            ),
+            dict(
+                func=lambda: None,
+                args=[],
+                kws=dict(),
+            ),
+            dict(
+                func=lambda a: None,
+                args=['arg.a'],
+                kws={},
+            ),
+            dict(
+                func=lambda a: None,
+                args=[],
+                kws=dict(a='arg.a'),
+            ),
+        ]
+        for case in cases:
+            with self.subTest(**case):
+                self.check_fold_arguments_list_inputs(**case)
 
 
 if __name__ == '__main__':

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -7,6 +7,7 @@ import sys
 import inspect
 import os.path
 from collections import namedtuple
+from collections.abc import Sequence
 from types import MethodType, FunctionType
 
 import numba
@@ -147,6 +148,9 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
     - default_handler(index, param, default) is called for omitted arguments
     - stararg_handler(index, param, values) is called for a "*args" argument
     """
+    if isinstance(kws, Sequence):
+        # Normalize dict kws
+        kws = dict(kws)
 
     # deal with kwonly args
     params = pysig.parameters


### PR DESCRIPTION
Fixes #5079

CallConstrain may be passing list of 2-tuple for the dictionary

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
