### PR TITLE
pass 'inline' explicitly to overload

### DIFF
--- a/numba/extending.py
+++ b/numba/extending.py
@@ -137,7 +137,8 @@ def register_jitable(*args, **kwargs):
     """
     def wrap(fn):
         # It is just a wrapper for @overload
-        @overload(fn, jit_options=kwargs, strict=False)
+        inline = kwargs.pop('inline', 'never')
+        @overload(fn, jit_options=kwargs, inline=inline, strict=False)
         def ov_wrap(*args, **kwargs):
             return fn
         return fn

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -44,7 +44,7 @@ class InlineTestPipeline(numba.compiler.CompilerBase):
         return [pipeline]
 
 
-# this global has the same name as the the global in inlining_usecases.py, it
+# this global has the same name as the global in inlining_usecases.py, it
 # is here to check that inlined functions bind to their own globals
 _GLOBAL1 = -50
 

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -16,6 +16,7 @@ from numba.extending import (
     typeof_impl,
     unbox,
     NativeValue,
+    register_jitable,
 )
 from numba.datamodel.models import OpaqueModel
 from numba.targets.cpu import InlineOptions
@@ -454,6 +455,20 @@ class TestFunctionInlining(InliningBase):
 
         self.check(impl, inline_expect={'foo': True, 'boz': True,
                                         'fortran': True}, block_count=37)
+
+
+class TestRegisterJitableInlining(InliningBase):
+
+    def test_register_jitable_inlines(self):
+
+        @register_jitable(inline='always')
+        def foo():
+            return 1
+
+        def impl():
+            foo()
+
+        self.check(impl, inline_expect={'foo': True})
 
 
 class TestOverloadInlining(InliningBase):


### PR DESCRIPTION
Since `@register_jitable` doesn't have 'inline' as an explicit keyword,
but `@overload` does, we need to pop the keword argument from `kwargs`
and hand it over explicity.

Closes: #5142