### PR TITLE
implement hoistable getitem for typed-list

### DIFF
--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -151,6 +151,7 @@ build_c_helpers_dict(void)
     declmethod(list_free);
     declmethod(list_length);
     declmethod(list_allocated);
+    declmethod(list_base_ptr);
     declmethod(list_is_mutable);
     declmethod(list_set_is_mutable);
     declmethod(list_setitem);

--- a/numba/cext/listobject.c
+++ b/numba/cext/listobject.c
@@ -234,6 +234,16 @@ numba_list_allocated(NB_List *lp) {
     return lp->allocated;
 }
 
+/* Return the base pointer of the list items
+ *
+ * lp: a list
+ */
+char *
+numba_list_base_ptr(NB_List *lp)
+{
+    return lp->items;
+}
+
 /* Return the mutability status of the list
  *
  * lp: a list
@@ -253,6 +263,7 @@ numba_list_is_mutable(NB_List *lp){
 void
 numba_list_set_is_mutable(NB_List *lp, int is_mutable){
     lp->is_mutable = is_mutable;
+
 }
 
 /* Set an item in a list.

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -88,6 +88,9 @@ numba_list_length(NB_List *lp);
 NUMBA_EXPORT_FUNC(Py_ssize_t)
 numba_list_allocated(NB_List *lp);
 
+NUMBA_EXPORT_FUNC(char *)
+numba_list_base_ptr(NB_List *lp);
+
 NUMBA_EXPORT_FUNC(int)
 numba_list_is_mutable(NB_List *lp);
 


### PR DESCRIPTION
This implements exporting the base pointer of the typed-list `items`
array  and then implements `getitem` in builder code. This has the
advantage, that the `getitem` can in principle be hoisted / loop lifted.