### PR TITLE
Adds support for viewing the CFG of the ELF disassembly.

### DIFF
--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -215,6 +215,60 @@ Dispatcher objects
         # opens the CFG in system default application
         foo.inspect_cfg(foo.signatures[0]).display(view=True)
 
+
+   .. method:: inspect_disasm_cfg(signature=None)
+
+      Return a dictionary keying compiled function signatures to the
+      control-flow graph of the disassembly of the underlying compiled ``ELF``
+      object.  If the signature keyword is specified a control-flow graph
+      corresponding to that individual signature is returned. This function is
+      execution environment aware and will produce SVG output in Jupyter
+      notebooks and ASCII in terminals.
+
+      Example::
+
+        @njit
+        def foo(x):
+            if x < 3:
+                return x + 1
+            return x + 2
+
+        foo(10)
+
+        print(foo.inspect_disasm_cfg(signature=foo.signatures[0]))
+
+      Gives::
+
+        [0x08000040]>  # method.__main__.foo_241_long_long (int64_t arg1, int64_t arg3);
+         ─────────────────────────────────────────────────────────────────────┐
+        │  0x8000040                                                          │
+        │ ; arg3 ; [02] -r-x section size 279 named .text                     │
+        │   ;-- section..text:                                                │
+        │   ;-- .text:                                                        │
+        │   ;-- __main__::foo$241(long long):                                 │
+        │   ;-- rip:                                                          │
+        │ 25: method.__main__.foo_241_long_long (int64_t arg1, int64_t arg3); │
+        │ ; arg int64_t arg1 @ rdi                                            │
+        │ ; arg int64_t arg3 @ rdx                                            │
+        │ ; 2                                                                 │
+        │ cmp rdx, 2                                                          │
+        │ jg 0x800004f                                                        │
+        └─────────────────────────────────────────────────────────────────────┘
+                f t
+                │ │
+                │ └──────────────────────────────┐
+                └──┐                             │
+                   │                             │
+            ┌─────────────────────────┐   ┌─────────────────────────┐
+            │  0x8000046              │   │  0x800004f              │
+            │ ; arg3                  │   │ ; arg3                  │
+            │ inc rdx                 │   │ add rdx, 2              │
+            │ ; arg3                  │   │ ; arg3                  │
+            │ mov qword [rdi], rdx    │   │ mov qword [rdi], rdx    │
+            │ xor eax, eax            │   │ xor eax, eax            │
+            │ ret                     │   │ ret                     │
+            └─────────────────────────┘   └─────────────────────────┘
+
    .. method:: recompile()
 
       Recompile all existing signatures.  This can be useful for example if

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -224,6 +224,11 @@ vary with target operating system and hardware. The following lists them all
     support
   * Compiler toolchain mentioned above, if you would like to use ``pycc`` for
     Ahead-of-Time (AOT) compilation
+  * ``r2pipe`` - required for assembly CFG inspection.
+  * ``radare2`` as an executable on the ``$PATH`` - required for assembly CFG
+    inspection. `See here <https://github.com/radareorg/radare2>`_ for
+    information on obtaining and installing.
+  * ``graphviz`` - for some CFG inspection functionality.
 
 * To build the documentation:
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -537,6 +537,14 @@ class _DispatcherBase(_dispatcher.Dispatcher):
     def inspect_disasm_cfg(self, signature=None):
         """
         For inspecting the CFG of the disassembly of the function.
+
+        Requires python package: r2pipe
+        Requires radare2 binary on $PATH.
+        Notebook rendering requires python package: graphviz
+
+        signature : tuple of Numba types, optional
+            Print/return the disassembly CFG for only the given signatures.
+            If None, the IR is printed for all available signatures.
         """
         if signature is not None:
             cres = self.overloads[signature]

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -516,7 +516,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         """
         For inspecting the CFG of the function.
 
-        By default the CFG of the user function is showed.  The *show_wrapper*
+        By default the CFG of the user function is shown.  The *show_wrapper*
         option can be set to "python" or "cfunc" to show the python wrapper
         function or the *cfunc* wrapper function, respectively.
         """
@@ -532,6 +532,18 @@ class _DispatcherBase(_dispatcher.Dispatcher):
             return lib.get_function_cfg(fname)
 
         return dict((sig, self.inspect_cfg(sig, show_wrapper=show_wrapper))
+                    for sig in self.signatures)
+
+    def inspect_disasm_cfg(self, signature=None):
+        """
+        For inspecting the CFG of the disassembly of the function.
+        """
+        if signature is not None:
+            cres = self.overloads[signature]
+            lib = cres.library
+            return lib.get_disasm_cfg()
+
+        return dict((sig, self.inspect_disasm_cfg(sig))
                     for sig in self.signatures)
 
     def get_annotation_info(self, signature=None):

--- a/numba/misc/inspection.py
+++ b/numba/misc/inspection.py
@@ -1,5 +1,6 @@
 """Miscellaneous inspection tools
 """
+from tempfile import NamedTemporaryFile
 
 
 def disassemble_elf_to_cfg(elf):
@@ -16,7 +17,6 @@ def disassemble_elf_to_cfg(elf):
         if cmd is None:
             raise ValueError("No command given")
 
-        from tempfile import NamedTemporaryFile
         with NamedTemporaryFile(delete=False) as f:
             f.write(elf)
             f.flush()  # force write, radare2 needs a binary blob on disk

--- a/numba/misc/inspection.py
+++ b/numba/misc/inspection.py
@@ -1,0 +1,60 @@
+"""Miscellaneous inspection tools
+"""
+
+
+def disassemble_elf_to_cfg(elf):
+    """
+    Gets the CFG of the disassembly of an ELF object, elf, and renders it
+    appropriately depending on the execution environment (terminal/notebook).
+    """
+    try:
+        import r2pipe
+    except ImportError:
+        raise RuntimeError("r2pipe package needed for disasm CFG")
+
+    def get_rendering(cmd=None):
+        if cmd is None:
+            raise ValueError("No command given")
+
+        from tempfile import NamedTemporaryFile
+        with NamedTemporaryFile(delete=False) as f:
+            f.write(elf)
+            f.flush()  # force write, radare2 needs a binary blob on disk
+
+            # catch if r2pipe can actually talk to radare2
+            try:
+                flags = ['-e io.cache=true',  # fix relocations in disassembly
+                         '-e scr.color=1',  # 16 bit ANSI colour terminal
+                         ]
+                r = r2pipe.open(f.name, flags=flags)
+                data = r.cmd('af;%s' % cmd)
+                r.quit()
+            except Exception as e:
+                if "radare2 in PATH" in str(e):
+                    msg = ("This feature requires 'radare2' to be "
+                           "installed and available on the system see: "
+                           "https://github.com/radareorg/radare2. "
+                           "Cannot find 'radare2' in $PATH.")
+                    raise RuntimeError(msg)
+                else:
+                    raise e
+        return data
+
+    class DisasmCFG(object):
+
+        def _repr_svg_(self):
+            try:
+                import graphviz
+            except ImportError:
+                raise RuntimeError("graphviz package needed for disasm CFG")
+            jupyter_rendering = get_rendering(cmd='agfd')
+            # this just makes it read slightly better in jupyter notebooks
+            jupyter_rendering.replace('fontname="Courier",',
+                                      'fontname="Courier",fontsize=6,')
+            src = graphviz.Source(jupyter_rendering)
+            return src.pipe('svg').decode('UTF-8')
+
+        def __repr__(self):
+            return get_rendering(cmd='agf')
+
+    return DisasmCFG()


### PR DESCRIPTION
As title. Requires `radare2` to be installed on the system and
the prescence of the `r2pipe2` package. In jupyter-notebooks the
`graphviz` package is needed to get a SVG via dot format. On the
terminal nothing further is required.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
