### PR TITLE
Fix `.strip()` to strip all whitespace characters

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -1388,7 +1388,7 @@ def unicode_zfill(string, width):
 # ------------------------------------------------------------------------------
 @register_jitable
 def unicode_strip_left_bound(string, chars):
-    chars = ' ' if chars is None else chars
+    chars = ' \t\n\r\x0b\x0c' if chars is None else chars
     str_len = len(string)
 
     for i in range(str_len):
@@ -1399,7 +1399,7 @@ def unicode_strip_left_bound(string, chars):
 
 @register_jitable
 def unicode_strip_right_bound(string, chars):
-    chars = ' ' if chars is None else chars
+    chars = ' \t\n\r\x0b\x0c' if chars is None else chars
     str_len = len(string)
 
     for i in range(str_len - 1, -1, -1):

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -1388,24 +1388,35 @@ def unicode_zfill(string, width):
 # ------------------------------------------------------------------------------
 @register_jitable
 def unicode_strip_left_bound(string, chars):
-    chars = ' \t\n\r\x0b\x0c' if chars is None else chars
     str_len = len(string)
 
-    for i in range(str_len):
-        if string[i] not in chars:
-            return i
+    if chars is not None:
+        for i in range(str_len):
+            if string[i] not in chars:
+                return i
+    else:
+        for i in range(str_len):
+            if not _PyUnicode_IsSpace(string[i]):
+                return i
+
     return str_len
 
 
 @register_jitable
 def unicode_strip_right_bound(string, chars):
-    chars = ' \t\n\r\x0b\x0c' if chars is None else chars
     str_len = len(string)
 
-    for i in range(str_len - 1, -1, -1):
-        if string[i] not in chars:
-            i += 1
-            break
+    if chars is not None:
+        for i in range(str_len - 1, -1, -1):
+            if string[i] not in chars:
+                i += 1
+                break
+    else:
+        for i in range(str_len - 1, -1, -1):
+            if not _PyUnicode_IsSpace(string[i]):
+                i += 1
+                break
+
     return i
 
 

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -1701,7 +1701,12 @@ class TestUnicode(BaseTest):
             ('  tú quién te crees?   ', None),
             ('大处 着眼，小处着手。大大大处', '大处'),
             (' 大处大处  ', ''),
-            (' 大处大处  ', None)
+            (' 大处大处  ', None),
+            ('\t abcd \t', None),
+            ('\n abcd \n', None),
+            ('\r abcd \r', None),
+            ('\x0b abcd \x0b', None),
+            ('\x0c abcd \x0c', None)
         ]
 
         # form with no parameter

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -1701,12 +1701,15 @@ class TestUnicode(BaseTest):
             ('  tú quién te crees?   ', None),
             ('大处 着眼，小处着手。大大大处', '大处'),
             (' 大处大处  ', ''),
+            ('\t\nabcd\t', '\ta'),
             (' 大处大处  ', None),
             ('\t abcd \t', None),
             ('\n abcd \n', None),
             ('\r abcd \r', None),
             ('\x0b abcd \x0b', None),
-            ('\x0c abcd \x0c', None)
+            ('\x0c abcd \x0c', None),
+            ('\u2029abcd\u205F', None),
+            ('\u0085abcd\u2009', None)
         ]
 
         # form with no parameter


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

fixes #4188
(also fixes #4731)

Changes:
- Replaced `' '` with `' \t\n\r\x0b\x0c'` to check for all whitespace characters
- I have added tests as well

To see it working -
```python
from numba import njit
@njit 
def foo(s):
   return s.strip()

print(foo('\t abcd \t'))
```
