### PR TITLE
Fix namedtuple mistreated by dispatcher as simple tuple

### DIFF
--- a/numba/_typeof.c
+++ b/numba/_typeof.c
@@ -256,7 +256,7 @@ compute_fingerprint(string_writer_t *w, PyObject *val)
         return string_writer_put_char(w, OP_FLOAT);
     if (PyComplex_CheckExact(val))
         return string_writer_put_char(w, OP_COMPLEX);
-    if (PyTuple_Check(val)) {
+    if (PyTuple_CheckExact(val)) {
         Py_ssize_t i, n;
         n = PyTuple_GET_SIZE(val);
         TRY(string_writer_put_char, w, OP_START_TUPLE);

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -4,7 +4,7 @@ import itertools
 import numpy as np
 
 from numba.core.compiler import compile_isolated
-from numba import njit, jit
+from numba import njit, jit, typeof
 from numba.core import types, errors, utils
 from numba.tests.support import TestCase, MemoryLeakMixin, tag
 import unittest
@@ -534,7 +534,10 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
         out2 = foo(in2)
         self.assertEqual(in2, out2)
 
+        # Check the signatures
         self.assertEqual(len(foo.nopython_signatures), 2)
+        self.assertEqual(foo.nopython_signatures[0].args[0], typeof(in1))
+        self.assertEqual(foo.nopython_signatures[1].args[0], typeof(in2))
 
 
 class TestTupleNRT(TestCase, MemoryLeakMixin):

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -520,6 +520,22 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
         r = foo()
         self.assertEqual(r, Rect(width=10, height='somestring'))
 
+    def test_dispatcher_mistreat(self):
+        # Test for issue #5215 that mistreat namedtuple as tuples
+        @jit(nopython=True)
+        def foo(x):
+            return x
+
+        in1 = (1, 2,  3)
+        out1 = foo(in1)
+        self.assertEqual(in1, out1)
+
+        in2 = Point(1, 2, 3)
+        out2 = foo(in2)
+        self.assertEqual(in2, out2)
+
+        self.assertEqual(len(foo.nopython_signatures), 2)
+
 
 class TestTupleNRT(TestCase, MemoryLeakMixin):
     def test_tuple_add(self):

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -14,6 +14,8 @@ Rect = collections.namedtuple('Rect', ('width', 'height'))
 
 Point = collections.namedtuple('Point', ('x', 'y', 'z'))
 
+Point2 = collections.namedtuple('Point2', ('x', 'y', 'z'))
+
 Empty = collections.namedtuple('Empty', ())
 
 def tuple_return_usecase(a, b):
@@ -538,6 +540,13 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
         self.assertEqual(len(foo.nopython_signatures), 2)
         self.assertEqual(foo.nopython_signatures[0].args[0], typeof(in1))
         self.assertEqual(foo.nopython_signatures[1].args[0], typeof(in2))
+
+        # Differently named
+        in3 = Point2(1, 2, 3)
+        out3 = foo(in3)
+        self.assertEqual(in3, out3)
+        self.assertEqual(len(foo.nopython_signatures), 3)
+        self.assertEqual(foo.nopython_signatures[2].args[0], typeof(in3))
 
 
 class TestTupleNRT(TestCase, MemoryLeakMixin):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Dispatcher should use match exactly to the `tuple` type.