### PR TITLE
Add BooleanLiteral type

### DIFF
--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -28,7 +28,8 @@ def unbox_boolean(typ, obj, c):
 
 
 @box(types.IntegerLiteral)
-def box_literal_integer(typ, val, c):
+@box(types.BooleanLiteral)
+def box_literal_scalar(typ, val, c):
     val = c.context.cast(c.builder, val, typ, typ.literal_type)
     return c.box(typ.literal_type, val)
 

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -163,6 +163,7 @@ class OmittedArgDataModel(DataModel):
 
 
 @register_default(types.Boolean)
+@register_default(types.BooleanLiteral)
 class BooleanModel(DataModel):
     _bit_type = ir.IntType(1)
     _byte_type = ir.IntType(8)

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -15,6 +15,21 @@ class Boolean(Hashable):
         return bool(value)
 
 
+class BooleanLiteral(Literal, Boolean):
+    def __init__(self, value):
+        self._literal_init(value)
+        self.name = 'Literal[bool]({})'.format(value)
+        self.basetype = self.literal_type
+
+    def can_convert_to(self, typingctx, other):
+        conv = typingctx.can_convert(self.literal_type, other)
+        if conv is not None:
+            return max(conv, Conversion.promote)
+
+
+Literal.ctor_map[bool] = BooleanLiteral
+
+
 def parse_integer_bitwidth(name):
     for prefix in ('int', 'uint'):
         if name.startswith(prefix):

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -68,16 +68,9 @@ def boolean_literal_cross_type_is(context, builder, sig, args):
     else:
         literal_sig_arg = arg1
         non_literal_arg = args[0]
-
-    
-    # QUESTION: how do I call the already defined casting instead?
-    #           This is just copy-paste from lower_cast
-    lit = context.get_constant_generic(
-        builder,
-        literal_sig_arg.literal_type,
-        literal_sig_arg.literal_value,
-        )
-    cast_literal = context.is_true(builder, literal_sig_arg.literal_type, lit)
+        
+    cast_literal = context.cast(builder, literal_sig_arg, 
+                                types.BooleanLiteral, types.Boolean)
 
     sig_new = typing.signature(types.boolean, types.boolean, types.boolean)
     eq_impl = context.get_function(operator.eq, sig_new)

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -59,6 +59,7 @@ def generic_is(context, builder, sig, args):
 
 @lower_builtin(operator.eq, types.Literal, types.Literal)
 @lower_builtin(operator.eq, types.IntegerLiteral, types.IntegerLiteral)
+@lower_builtin(operator.eq, types.BooleanLiteral, types.BooleanLiteral)
 def const_eq_impl(context, builder, sig, args):
     arg1, arg2 = sig.args
     val = 0

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -60,21 +60,16 @@ def generic_is(context, builder, sig, args):
 @lower_builtin(operator.is_, types.Boolean, types.BooleanLiteral)
 @lower_builtin(operator.is_, types.BooleanLiteral, types.Boolean)
 def boolean_literal_cross_type_is(context, builder, sig, args):
-    sig_arg0, arg1 = sig.args
+    literal_index = 0 if isinstance(sig.args[0], types.BooleanLiteral) else 1
+    non_literal_index = int(1 ^ literal_index)
 
-    if isinstance(sig_arg0, types.BooleanLiteral):
-        literal_sig_arg = sig_arg0
-        non_literal_arg = args[1]
-    else:
-        literal_sig_arg = arg1
-        non_literal_arg = args[0]
-        
-    cast_literal = context.cast(builder, literal_sig_arg, 
-                                types.BooleanLiteral, types.Boolean)
+    cast_literal = context.cast(builder, args[literal_index],
+                                sig.args[literal_index],
+                                sig.args[literal_index].literal_type)
 
     sig_new = typing.signature(types.boolean, types.boolean, types.boolean)
     eq_impl = context.get_function(operator.eq, sig_new)
-    return eq_impl(builder, (non_literal_arg, cast_literal))
+    return eq_impl(builder, (args[non_literal_index], cast_literal))
 
 
 @lower_builtin(operator.eq, types.Literal, types.Literal)

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -59,7 +59,7 @@ def generic_is(context, builder, sig, args):
 
 @lower_builtin(operator.is_, types.Boolean, types.BooleanLiteral)
 @lower_builtin(operator.is_, types.BooleanLiteral, types.Boolean)
-def const_eq_impl(context, builder, sig, args):
+def boolean_literal_cross_type_is(context, builder, sig, args):
     sig_arg0, arg1 = sig.args
 
     if isinstance(sig_arg0, types.BooleanLiteral):

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -1312,7 +1312,8 @@ def boolean_to_any(context, builder, fromty, toty, val):
 
 
 @lower_cast(types.IntegerLiteral, types.Boolean)
-def literal_int_to_boolean(context, builder, fromty, toty, val):
+@lower_cast(types.BooleanLiteral, types.Boolean)
+def literal_scalar_to_boolean(context, builder, fromty, toty, val):
     lit = context.get_constant_generic(
         builder,
         fromty.literal_type,


### PR DESCRIPTION
Adds a `BooleanLiteral` type.

PR contains no tests but it is successful in solving some type unification problems I had.

At present this PR leads to test failures in existing tests for string functions (e.g. `endswith`) that I do not understand. - Especially since these test do seem to pass on the majority of platforms.

If additional tests specifically for `BooleanLiteral` are required, I will need help. I cannot figure out how to write the tests in `TestBranchPrune`.  In particular what arguments I need to pass to `assert_prune` in what circumstances is a mystery to me. I can write tests that somehow test OK by fiddling with the arguments but I have no idea what I am doing. - Which is probably not the best approach to writing tests...

