### PR TITLE
Fix compiler warnings due to missing (void)

### DIFF
--- a/numba/tests/cffi_usecases.py
+++ b/numba/tests/cffi_usecases.py
@@ -20,7 +20,7 @@ def load_inline_module():
     double _numba_test_sin(double x);
     double _numba_test_cos(double x);
     double _numba_test_funcptr(double (*func)(double));
-    bool _numba_test_boolean();
+    bool _numba_test_boolean(void);
     """
 
     ffi = FFI()
@@ -55,7 +55,7 @@ def load_ool_module():
     """
 
     defs = numba_complex + """
-    bool boolean();
+    bool boolean(void);
     double sin(double x);
     double cos(double x);
     int foo(int a, int b, int c);
@@ -66,7 +66,7 @@ def load_ool_module():
     """
 
     source = numba_complex + bool_define + """
-    static bool boolean()
+    static bool boolean(void)
     {
         return true;
     }


### PR DESCRIPTION
In C, `ret_type func()` is a function with unspecified arguments, not a function with no arguments.
`ret_type func(void)` is the correct spelling.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
