### PR TITLE
Immutable typed-list

### DIFF
--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -151,6 +151,8 @@ build_c_helpers_dict(void)
     declmethod(list_free);
     declmethod(list_length);
     declmethod(list_allocated);
+    declmethod(list_is_mutable);
+    declmethod(list_set_is_mutable);
     declmethod(list_setitem);
     declmethod(list_getitem);
     declmethod(list_append);

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -41,6 +41,12 @@ typedef struct {
  *
  * Items must normally not be NULL, except during construction when
  * the list is not yet visible outside the function that builds it.
+ *
+ * Additionally, this list has boolean member 'is_mutable' that can be used to
+ * set a list as immutable. Two functions to query and set this member are
+ * provided. Any attempt to mutate an immutable list will result in a status
+ * of LIST_ERR_IMMUTABLE.
+ *
  */
 typedef struct {
     /* size of the list in items  */
@@ -49,6 +55,8 @@ typedef struct {
     Py_ssize_t      item_size;
     /* total allocated slots in items */
     Py_ssize_t allocated;
+    /* is the list mutable */
+    int is_mutable;
     /* method table for type-dependent operations */
     list_type_based_methods_table methods;
     /* array/pointer for items. Interpretation is governed by item_size */
@@ -79,6 +87,12 @@ numba_list_length(NB_List *lp);
 
 NUMBA_EXPORT_FUNC(Py_ssize_t)
 numba_list_allocated(NB_List *lp);
+
+NUMBA_EXPORT_FUNC(int)
+numba_list_is_mutable(NB_List *lp);
+
+NUMBA_EXPORT_FUNC(void)
+numba_list_set_is_mutable(NB_List *lp, int is_mutable);
 
 NUMBA_EXPORT_FUNC(int)
 numba_list_setitem(NB_List *lp, Py_ssize_t index, const char *item);

--- a/numba/tests/test_listimpl.py
+++ b/numba/tests/test_listimpl.py
@@ -14,6 +14,7 @@ LIST_ERR_INDEX = -1
 LIST_ERR_NO_MEMORY = -2
 LIST_ERR_MUTATED = -3
 LIST_ERR_ITER_EXHAUSTED = -4
+LIST_ERR_IMMUTABLE = -5
 
 
 class List(object):
@@ -58,6 +59,16 @@ class List(object):
     def allocated(self):
         return self.list_allocated()
 
+    @property
+    def is_mutable(self):
+        return self.list_is_mutable()
+
+    def set_mutable(self):
+        return self.list_set_is_mutable(1)
+
+    def set_immutable(self):
+        return self.list_set_is_mutable(0)
+
     def append(self, item):
         self.list_append(item)
 
@@ -80,10 +91,18 @@ class List(object):
     def list_allocated(self):
         return self.tc.numba_list_allocated(self.lp)
 
+    def list_is_mutable(self):
+        return self.tc.numba_list_is_mutable(self.lp)
+
+    def list_set_is_mutable(self, is_mutable):
+        return self.tc.numba_list_set_is_mutable(self.lp, is_mutable)
+
     def list_setitem(self, i, item):
         status = self.tc.numba_list_setitem(self.lp, i, item)
         if status == LIST_ERR_INDEX:
             raise IndexError("list index out of range")
+        elif status == LIST_ERR_IMMUTABLE:
+            raise ValueError("list is immutable")
         else:
             self.tc.assertEqual(status, LIST_OK)
 
@@ -98,6 +117,8 @@ class List(object):
 
     def list_append(self, item):
         status = self.tc.numba_list_append(self.lp, item)
+        if status == LIST_ERR_IMMUTABLE:
+            raise ValueError("list is immutable")
         self.tc.assertEqual(status, LIST_OK)
 
     def list_pop(self, i):
@@ -111,6 +132,8 @@ class List(object):
         status = self.tc.numba_list_pop(self.lp, i, item_out_buffer)
         if status == LIST_ERR_INDEX:
             raise IndexError("list index out of range")
+        elif status == LIST_ERR_IMMUTABLE:
+            raise ValueError("list is immutable")
         else:
             self.tc.assertEqual(status, LIST_OK)
             return item_out_buffer.raw
@@ -122,6 +145,8 @@ class List(object):
                                                      i.start,
                                                      i.stop,
                                                      i.step)
+            if status == LIST_ERR_IMMUTABLE:
+                raise ValueError("list is immutable")
             self.tc.assertEqual(status, LIST_OK)
         # must be an integer, defer to pop
         else:
@@ -204,6 +229,18 @@ class TestListImpl(TestCase):
             'list_allocated',
             ctypes.c_int,
             [list_t],
+        )
+        # numba_list_is_mutable(NB_List *lp)
+        self.numba_list_is_mutable = wrap(
+            'list_is_mutable',
+            ctypes.c_int,
+            [list_t],
+        )
+        # numba_list_set_is_mutable(NB_List *lp, int is_mutable)
+        self.numba_list_set_is_mutable = wrap(
+            'list_set_is_mutable',
+            None,
+            [list_t, ctypes.c_int],
         )
         # numba_list_setitem(NB_List *l, Py_ssize_t i, const char *item)
         self.numba_list_setitem = wrap(
@@ -421,3 +458,39 @@ class TestListImpl(TestCase):
         # Check different sizes of the key & value.
         for i in range(1, 16):
             self.check_sizing(item_size=i, nmax=2**i)
+
+    def test_mutability(self):
+        # setup and populate a singleton
+        l = List(self, 8, 1)
+        one = struct.pack("q", 1)
+        l.append(one)
+        self.assertTrue(l.is_mutable)
+        self.assertEqual(len(l), 1)
+        r = struct.unpack("q", l[0])[0]
+        self.assertEqual(r, 1)
+
+        # set to immutable and test guards
+        l.set_immutable()
+        self.assertFalse(l.is_mutable)
+        # append
+        with self.assertRaises(ValueError):
+            l.append(one)
+        # setitem
+        with self.assertRaises(ValueError):
+            l[0] = one
+        # pop
+        with self.assertRaises(ValueError):
+            l.pop()
+        # delitem with index
+        with self.assertRaises(ValueError):
+            del l[0]
+        # delitem with slice
+        with self.assertRaises(ValueError):
+            del l[0:1:1]
+        l.set_mutable()
+
+        # check that nothing has changed
+        self.assertTrue(l.is_mutable)
+        self.assertEqual(len(l), 1)
+        r = struct.unpack("q", l[0])[0]
+        self.assertEqual(r, 1)

--- a/numba/tests/test_listimpl.py
+++ b/numba/tests/test_listimpl.py
@@ -473,20 +473,25 @@ class TestListImpl(TestCase):
         l.set_immutable()
         self.assertFalse(l.is_mutable)
         # append
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             l.append(one)
+        self.assertIn("list is immutable", str(raises.exception))
         # setitem
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             l[0] = one
+        self.assertIn("list is immutable", str(raises.exception))
         # pop
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             l.pop()
+        self.assertIn("list is immutable", str(raises.exception))
         # delitem with index
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             del l[0]
+        self.assertIn("list is immutable", str(raises.exception))
         # delitem with slice
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             del l[0:1:1]
+        self.assertIn("list is immutable", str(raises.exception))
         l.set_mutable()
 
         # check that nothing has changed

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -11,8 +11,11 @@ assumes that they work.
 
 """
 
+from textwrap import dedent
+
 from numba import njit
 from numba import int32
+from numba.extending import register_jitable
 from numba.core import types
 from numba.core.errors import TypingError
 from numba.tests.support import (TestCase, MemoryLeakMixin, override_config,
@@ -1502,3 +1505,97 @@ class TestItemCasting(TestCase):
             'Cannot cast int32 to unicode_type',
             str(raises.exception),
         )
+
+
+@register_jitable
+def make_test_list():
+    l = listobject.new_list(int32)
+    l.append(int32(1))
+    return l
+
+
+class TestImmutable(MemoryLeakMixin, TestCase):
+
+    def test_is_immutable(self):
+        @njit
+        def foo():
+            l = make_test_list()
+            return l._is_mutable()
+        self.assertTrue(foo())
+
+    def test_make_immutable_is_immutable(self):
+        @njit
+        def foo():
+            l = make_test_list()
+            l._make_immutable()
+            return l._is_mutable()
+        self.assertFalse(foo())
+
+    def test_length_still_works_when_immutable(self):
+        @njit
+        def foo():
+            l = make_test_list()
+            l._make_immutable()
+            return len(l),l._is_mutable()
+        length, mutable = foo()
+        self.assertEqual(length, 1)
+        self.assertFalse(mutable)
+
+    def test_getitem_still_works_when_immutable(self):
+        @njit
+        def foo():
+            l = make_test_list()
+            l._make_immutable()
+            return l[0], l._is_mutable()
+        test_item, mutable = foo()
+        self.assertEqual(test_item, 1)
+        self.assertFalse(mutable)
+
+    def test_append_fails(self):
+        self.disable_leak_check()
+        @njit
+        def foo():
+            l = make_test_list()
+            l._make_immutable()
+            l.append(int32(1))
+        with self.assertRaises(ValueError) as raises:
+            foo()
+        self.assertIn(
+            'list is immutable',
+            str(raises.exception),
+        )
+
+    def test_mutation_fails(self):
+        """ Test that any attempt to mutate an immutable typed list fails. """
+        self.disable_leak_check()
+
+        def generate_function(line):
+            context = {}
+            exec(dedent("""
+                from numba.typed import listobject
+                from numba import int32
+                def bar():
+                    lst = listobject.new_list(int32)
+                    lst.append(int32(1))
+                    lst._make_immutable()
+                    zero = int32(0)
+                    {}
+                """.format(line)), context)
+            return njit(context["bar"])
+        for line in ("lst.append(zero)",
+                     "lst[0] = zero",
+                     "lst.pop()",
+                     "del lst[0]",
+                     "lst.extend((zero,))",
+                     "lst.insert(0, zero)",
+                     "lst.clear()",
+                     "lst.reverse()",
+                     "lst.sort()",
+                     ):
+            foo = generate_function(line)
+            with self.assertRaises(ValueError) as raises:
+                foo()
+            self.assertIn(
+                "list is immutable",
+                str(raises.exception),
+            )

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1141,3 +1141,98 @@ class TestListSort(MemoryLeakMixin, TestCase):
             list(foo(my_lists['nb'])),
             foo.py_func(my_lists['py']),
         )
+
+
+class TestImmutable(MemoryLeakMixin, TestCase):
+
+    def test_is_immutable(self):
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            return l._is_mutable()
+        self.assertTrue(foo())
+        self.assertTrue(foo.py_func())
+
+    def test_make_immutable_is_immutable(self):
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            l._make_immutable()
+            return l._is_mutable()
+        self.assertFalse(foo())
+        self.assertFalse(foo.py_func())
+
+    def test_length_still_works_when_immutable(self):
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            l._make_immutable()
+            return len(l),l._is_mutable()
+        length, mutable = foo()
+        self.assertEqual(length, 1)
+        self.assertFalse(mutable)
+
+    def test_getitem_still_works_when_immutable(self):
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            l._make_immutable()
+            return l[0], l._is_mutable()
+        test_item, mutable = foo()
+        self.assertEqual(test_item, 1)
+        self.assertFalse(mutable)
+
+    def test_append_fails(self):
+        self.disable_leak_check()
+        @njit
+        def foo():
+            l = List()
+            l.append(1)
+            l._make_immutable()
+            l.append(1)
+
+        for func in (foo, foo.py_func):
+            with self.assertRaises(ValueError) as raises:
+                func()
+            self.assertIn(
+                'list is immutable',
+                str(raises.exception),
+            )
+
+    def test_mutation_fails(self):
+        """ Test that any attempt to mutate an immutable typed list fails. """
+        self.disable_leak_check()
+
+        def generate_function(line):
+            context = {}
+            exec(dedent("""
+                from numba.typed import List
+                def bar():
+                    lst = List()
+                    lst.append(1)
+                    lst._make_immutable()
+                    {}
+                """.format(line)), context)
+            return njit(context["bar"])
+        for line in ("lst.append(0)",
+                     "lst[0] = 0",
+                     "lst.pop()",
+                     "del lst[0]",
+                     "lst.extend((0,))",
+                     "lst.insert(0, 0)",
+                     "lst.clear()",
+                     "lst.reverse()",
+                     "lst.sort()",
+                     ):
+            foo = generate_function(line)
+            for func in (foo, foo.py_func):
+                with self.assertRaises(ValueError) as raises:
+                    func()
+                self.assertIn(
+                    "list is immutable",
+                    str(raises.exception),
+                )

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -43,6 +43,21 @@ def _allocated(l):
 
 
 @njit
+def _is_mutable(l):
+    return l._is_mutable()
+
+
+@njit
+def _make_mutable(l):
+    return l._make_mutable()
+
+
+@njit
+def _make_immutable(l):
+    return l._make_immutable()
+
+
+@njit
 def _append(l, item):
     l.append(item)
 
@@ -235,6 +250,15 @@ class List(MutableSequence):
             return 0
         else:
             return _allocated(self)
+
+    def _is_mutable(self):
+        return _is_mutable(self)
+
+    def _make_mutable(self):
+        return _make_mutable(self)
+
+    def _make_immutable(self):
+        return _make_immutable(self)
 
     def __eq__(self, other):
         return _eq(self, other)


### PR DESCRIPTION
This is the runtime approach to the immutable typed-list. An additional member is added
to the underlying C-Struct and exposed to the compiler and Python levels above
as usual.