### PR TITLE
Fixes Parfor nested-loop transformation with Python 3.8 

### DIFF
--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -465,6 +465,8 @@ class DefaultPassBuilder(object):
         # optimisation
         pm.add_pass(InlineOverloads, "inline overloaded functions")
         if state.flags.auto_parallel.enabled:
+            if utils.PYVERSION > (3, 7):
+                pm.add_pass(CanonicalizeLoopExit, "canonicalize loop exit")
             pm.add_pass(PreParforPass, "Preprocessing for parfors")
         if not state.flags.no_rewrites:
             pm.add_pass(NopythonRewrites, "nopython rewrites")

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -465,8 +465,6 @@ class DefaultPassBuilder(object):
         # optimisation
         pm.add_pass(InlineOverloads, "inline overloaded functions")
         if state.flags.auto_parallel.enabled:
-            if utils.PYVERSION > (3, 7):
-                pm.add_pass(CanonicalizeLoopExit, "canonicalize loop exit")
             pm.add_pass(PreParforPass, "Preprocessing for parfors")
         if not state.flags.no_rewrites:
             pm.add_pass(NopythonRewrites, "nopython rewrites")

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2126,6 +2126,24 @@ class TestPrange(TestPrangeBase):
                'operators.')
         self.assertIn(msg, str(raises.exception))
 
+    @skip_parfors_unsupported
+    def test_prange_py38_loop_exit_sharing(self):
+        # Issue #5156.
+        # A problem with py3.8. The exit point of the inner loop is sharing
+        # with the loop entry of the outer loop. Parfor transformation is
+        # incorrectly removing the blocks assuming such sharing is impossible.
+        @njit(parallel=True)
+        def foo():
+            c = 0
+            for _ in prange(10):
+                n = 1
+                while n > 0:
+                    n -= 1
+                    c += 1
+            return c
+
+        self.assertEqual(foo(), foo.py_func())
+
 #    @skip_parfors_unsupported
     @test_disabled
     def test_check_error_model(self):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fixes #5156.

Python 3.8 can produce bytecode where the loop-exit of the inner loop is the loop-header of the outer. Parfor transformation has assumed that such sharing of loop-blocks is not possible. The fix is to canonicalize the loops to avoid such sharing of blocks.