### PR TITLE
fix test discovery for unittest

### DIFF
--- a/numba/tests/npyufunc/test_caching.py
+++ b/numba/tests/npyufunc/test_caching.py
@@ -5,8 +5,8 @@ import subprocess
 
 import numpy as np
 
-from ..support import capture_cache_log
-from ..test_dispatcher import BaseCacheTest
+from numba.tests.support import capture_cache_log
+from numba.tests.test_dispatcher import BaseCacheTest
 from numba.core import config
 import unittest
 

--- a/numba/tests/npyufunc/test_dufunc.py
+++ b/numba/tests/npyufunc/test_dufunc.py
@@ -3,7 +3,7 @@ import pickle
 import numpy as np
 
 from numba import njit, vectorize
-from ..support import MemoryLeakMixin
+from numba.tests.support import MemoryLeakMixin
 import unittest
 from numba.np.ufunc import dufunc
 

--- a/numba/tests/npyufunc/test_errors.py
+++ b/numba/tests/npyufunc/test_errors.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from numba import vectorize, guvectorize
 
-from ..support import TestCase, CheckWarningsMixin
+from numba.tests.support import TestCase, CheckWarningsMixin
 import unittest
 
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -3,7 +3,7 @@ import numpy.core.umath_tests as ut
 
 from numba import void, float32, jit, guvectorize
 from numba.np.ufunc import GUVectorize
-from ..support import tag, TestCase
+from numba.tests.support import tag, TestCase
 import unittest
 
 

--- a/numba/tests/npyufunc/test_ufunc.py
+++ b/numba/tests/npyufunc/test_ufunc.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import float32, jit
 from numba.np.ufunc import Vectorize
 from numba.core.errors import TypingError
-from ..support import TestCase
+from numba.tests.support import TestCase
 import unittest
 
 

--- a/numba/tests/npyufunc/test_ufuncbuilding.py
+++ b/numba/tests/npyufunc/test_ufuncbuilding.py
@@ -6,7 +6,7 @@ from numba.np.ufunc.ufuncbuilder import GUFuncBuilder
 from numba import vectorize, guvectorize
 from numba.np.ufunc import PyUFunc_One
 from numba.np.ufunc.dufunc import DUFunc as UFuncBuilder
-from ..support import tag, TestCase
+from numba.tests.support import tag, TestCase
 from numba.core import config
 import unittest
 

--- a/numba/tests/npyufunc/test_vectorize_decor.py
+++ b/numba/tests/npyufunc/test_vectorize_decor.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 
 from numba import int32, uint32, float32, float64, jit, vectorize
-from ..support import tag, CheckWarningsMixin
+from numba.tests.support import tag, CheckWarningsMixin
 import unittest
 
 


### PR DESCRIPTION
This fixes test discovery for `unittest` in VSCode.

The changes to the import statements are in line with the use of absolute import paths in other parts of the project.