### PR TITLE
Help needed: test failures with overload

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -345,19 +345,15 @@ def array_sum_axis(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
-@lower_builtin(np.prod, types.Array)
-@lower_builtin("array.prod", types.Array)
-def array_prod(context, builder, sig, args):
-
+@overload(np.prod)
+@overload_method(types.Array, 'prod')
+def array_prod(arr):
     def array_prod_impl(arr):
         c = 1
         for v in np.nditer(arr):
             c *= v.item()
         return c
-
-    res = context.compile_internal(builder, array_prod_impl, sig, args,
-                                   locals=dict(c=sig.return_type))
-    return impl_ret_borrowed(context, builder, sig.return_type, res)
+    return array_prod_impl        
 
 
 @lower_builtin(np.cumsum, types.Array)


### PR DESCRIPTION
**Do not merge. For demonstration purposes only.**

I have been working on extending the capabilities of the array reduction routines.

I intended to "plug them in" by replacing the existing implementations that use `lower_builtin`. Unfortunately I get errors as if the implementation was completely missing. To demonstrate my problem, I did a trivial refactoring of `np.prod`:

```
numba.core.errors.LoweringError: Failed in nopython mode pipeline (step: nopython mode backend)
?[1m?[1mNo definition for lowering array.prod(array(bool, 1d, C),) -> int64
?[1m
File "numba\tests\test_array_reductions.py", line 48:?[0m
?[1mdef array_prod(arr):
?[1m    return arr.prod()
?[0m    ?[1m^?[0m?[0m
?[0m
?[0m?[1m[1] During: lowering "$6call_method.2 = call $4load_method.1(func=$4load_method.1, args=[], kws=(), vararg=None)" at C:\Users\My User\Documents\numba\numba\tests\test_array_reductions.py (48)?[0m
```

I really cannot see where the problem could be since `np.all` and `np.any` are implemented the same way already and work just fine.

I was hoping I could get some pointers on how to solve this.