### PR TITLE
boundscheck fix

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -51,7 +51,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')
 
-    if 'boundscheck' in kws:
+    if kws.get('boundscheck') == True:
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
     fastmath = kws.get('fastmath', False)

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -76,7 +76,7 @@ def jit(func_or_sig=None, device=False, debug=False, argtypes=None,
         boundscheck=None,
         ):
     # Here for API compatibility
-    if boundscheck is not None:
+    if boundscheck == True:
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
     if link is not None:

--- a/numba/tests/test_boundscheck.py
+++ b/numba/tests/test_boundscheck.py
@@ -121,7 +121,7 @@ class TestNoCudaBoundsCheck(SerialMixin, unittest.TestCase):
                 pass
 
         @cuda.jit(boundscheck=False)
-        def func():
+        def func3():
             pass
 
         with override_env_config('NUMBA_BOUNDSCHECK', '1'):

--- a/numba/tests/test_boundscheck.py
+++ b/numba/tests/test_boundscheck.py
@@ -120,6 +120,10 @@ class TestNoCudaBoundsCheck(SerialMixin, unittest.TestCase):
             def func():
                 pass
 
+        @cuda.jit(boundscheck=False)
+        def func():
+            pass
+
         with override_env_config('NUMBA_BOUNDSCHECK', '1'):
             @cuda.jit
             def func2(x, a):

--- a/numba/tests/test_boundscheck.py
+++ b/numba/tests/test_boundscheck.py
@@ -120,6 +120,8 @@ class TestNoCudaBoundsCheck(SerialMixin, unittest.TestCase):
             def func():
                 pass
 
+        # Make sure we aren't raising "not supported" error if we aren't
+        # requesting bounds checking anyway. Related pull request: #5257
         @cuda.jit(boundscheck=False)
         def func3():
             pass


### PR DESCRIPTION
Without this, even if it is set to False, the error will be raised. That can't possibly be the intended behaviour, right?