### PR TITLE
Implement minmax support for Boolean type

### DIFF
--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -441,7 +441,6 @@ class Literal(Type):
         return self._literal_type_cache
 
 
-
 class TypeRef(Dummy):
     """Reference to a type.
 
@@ -451,3 +450,19 @@ class TypeRef(Dummy):
         self.instance_type = instance_type
         super(TypeRef, self).__init__('typeref[{}]'.format(self.instance_type))
 
+
+class Bounded(Type):
+    """
+    For types that have minimal and maximal values
+    """
+    @abstractproperty
+    def minval(self):
+        """
+        The minimal value representable by this type.
+        """
+    
+    @abstractproperty
+    def maxval(self):
+        """
+        The maximum value representable by this type.
+        """

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -453,7 +453,7 @@ class TypeRef(Dummy):
 
 class Bounded(Type):
     """
-    For types that have minimal and maximal values
+    For types that have minimal and maximal values.
     """
     @abstractproperty
     def minval(self):

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -16,6 +16,7 @@ class Boolean(Hashable, Bounded):
 
     def cast_python_value(self, value):
         return bool(value)
+
     @property
     def maxval(self):
         """

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -9,7 +9,6 @@ from numba.core.typeconv import Conversion
 from numba.np import npdatetime_helpers
 
 
-@total_ordering
 class Boolean(Hashable, Bounded):    
     def __init__(self, name):
         super(Boolean, self).__init__(name)
@@ -17,12 +16,6 @@ class Boolean(Hashable, Bounded):
 
     def cast_python_value(self, value):
         return bool(value)
-
-    def __lt__(self, other):
-        if self.__class__ is not other.__class__:
-            return NotImplemented
-        return self
-
     @property
     def maxval(self):
         """

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -10,9 +10,6 @@ from numba.np import npdatetime_helpers
 
 
 class Boolean(Hashable, Bounded):    
-    def __init__(self, name):
-        super(Boolean, self).__init__(name)
-
     def cast_python_value(self, value):
         return bool(value)
 

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -2,18 +2,40 @@ import enum
 
 import numpy as np
 
-from .abstract import Dummy, Hashable, Literal, Number, Type
+from .abstract import Dummy, Hashable, Literal, Number, Type, Bounded
 from functools import total_ordering
 from numba.core import utils
 from numba.core.typeconv import Conversion
 from numba.np import npdatetime_helpers
 
 
-class Boolean(Hashable):
+@total_ordering
+class Boolean(Hashable, Bounded):    
+    def __init__(self, name):
+        super(Boolean, self).__init__(name)
+        self.bitwidth = 1
 
     def cast_python_value(self, value):
         return bool(value)
 
+    def __lt__(self, other):
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        return self
+
+    @property
+    def maxval(self):
+        """
+        The maximum value representable by this type.
+        """
+        return 1
+
+    @property
+    def minval(self):
+        """
+        The minimal value representable by this type.
+        """
+        return 0
 
 def parse_integer_bitwidth(name):
     for prefix in ('int', 'uint'):
@@ -28,7 +50,7 @@ def parse_integer_signed(name):
 
 
 @total_ordering
-class Integer(Number):
+class Integer(Number, Bounded):
     def __init__(self, name, bitwidth=None, signed=None):
         super(Integer, self).__init__(name)
         if bitwidth is None:

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -12,7 +12,6 @@ from numba.np import npdatetime_helpers
 class Boolean(Hashable, Bounded):    
     def __init__(self, name):
         super(Boolean, self).__init__(name)
-        self.bitwidth = 1
 
     def cast_python_value(self, value):
         return bool(value)

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -803,7 +803,7 @@ class MinMaxBase(AbstractTemplate):
 
     def _unify_minmax(self, tys):
         for ty in tys:
-            if not isinstance(ty, types.Number):
+            if not isinstance(ty, (types.Boolean, types.Number)):
                 return
         return self.context.unify_types(*tys)
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -417,7 +417,7 @@ def get_type_max_value(typ):
         if bw == 64:
             return np.finfo(np.float64).max
         raise NotImplementedError("Unsupported floating point type")
-    if isinstance(typ, types.Integer):
+    if isinstance(typ, types.Bounded):
         return typ.maxval
     raise NotImplementedError("Unsupported type")
 
@@ -429,7 +429,7 @@ def get_type_min_value(typ):
         if bw == 64:
             return np.finfo(np.float64).min
         raise NotImplementedError("Unsupported floating point type")
-    if isinstance(typ, types.Integer):
+    if isinstance(typ, types.Bounded):
         return typ.minval
     raise NotImplementedError("Unsupported type")
 
@@ -438,11 +438,10 @@ def get_type_min_value(typ):
 def lower_get_type_min_value(context, builder, sig, args):
     typ = sig.args[0].dtype
     bw = typ.bitwidth
-
-    if isinstance(typ, types.Integer):
+    
+    if isinstance(typ, types.Bounded):
         lty = ir.IntType(bw)
-        val = typ.minval
-        res = ir.Constant(lty, val)
+        res = ir.Constant(lty, typ.minval)
     elif isinstance(typ, types.Float):
         if bw == 32:
             lty = ir.FloatType()
@@ -460,10 +459,9 @@ def lower_get_type_max_value(context, builder, sig, args):
     typ = sig.args[0].dtype
     bw = typ.bitwidth
 
-    if isinstance(typ, types.Integer):
+    if isinstance(typ, types.Bounded):
         lty = ir.IntType(bw)
-        val = typ.maxval
-        res = ir.Constant(lty, val)
+        res = ir.Constant(lty, typ.maxval)
     elif isinstance(typ, types.Float):
         if bw == 32:
             lty = ir.FloatType()

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -437,12 +437,15 @@ def get_type_min_value(typ):
 @lower_builtin(get_type_min_value, types.DType)
 def lower_get_type_min_value(context, builder, sig, args):
     typ = sig.args[0].dtype
-    bw = typ.bitwidth
-    
-    if isinstance(typ, types.Bounded):
-        lty = ir.IntType(bw)
+
+    if isinstance(typ, types.Boolean):
+        lty = ir.IntType(1)
+        res = ir.Constant(lty, typ.minval)
+    elif isinstance(typ, types.Bounded):
+        lty = ir.IntType(typ.bitwidth)
         res = ir.Constant(lty, typ.minval)
     elif isinstance(typ, types.Float):
+        bw = typ.bitwidth
         if bw == 32:
             lty = ir.FloatType()
         elif bw == 64:
@@ -457,12 +460,15 @@ def lower_get_type_min_value(context, builder, sig, args):
 @lower_builtin(get_type_max_value, types.DType)
 def lower_get_type_max_value(context, builder, sig, args):
     typ = sig.args[0].dtype
-    bw = typ.bitwidth
-
-    if isinstance(typ, types.Bounded):
-        lty = ir.IntType(bw)
+    
+    if isinstance(typ, types.Boolean):
+        lty = ir.IntType(1)
+        res = ir.Constant(lty, typ.maxval)
+    elif isinstance(typ, types.Bounded):
+        lty = ir.IntType(typ.bitwidth)
         res = ir.Constant(lty, typ.maxval)
     elif isinstance(typ, types.Float):
+        bw = typ.bitwidth
         if bw == 32:
             lty = ir.FloatType()
         elif bw == 64:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -139,8 +139,9 @@ class TestParforsBase(TestCase):
 
         # parfor result
         parfor_output = cpfunc.entry_point(*copy_args(*args))
-
-        if py_expected.dtype == np.bool_:
+        
+        # check to avoid TypeError when subtracting arrays
+        if isinstance(py_expected, np.ndarray) and py_expected.dtype == np.bool_:
             np.testing.assert_equal(njit_output, py_expected, **kwargs)
             np.testing.assert_equal(parfor_output, py_expected, **kwargs)
         else:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1005,12 +1005,15 @@ class TestParfors(TestParforsBase):
         A = np.random.ranf(n)
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([[1, 0], [0, 0]], dtype=np.bool_) # issue #5632
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl1, D)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = ("zero-size array to reduction operation "
@@ -1033,12 +1036,15 @@ class TestParfors(TestParforsBase):
         A = np.random.ranf(n)
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([[1, 0], [0, 0]], dtype=np.bool_) # issue #5632
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl1, D)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = ("zero-size array to reduction operation "
@@ -1075,12 +1081,15 @@ class TestParfors(TestParforsBase):
         A = np.array([1., 0., 2., 0., 3.])
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([[1, 0], [0, 0]], dtype=np.bool_) # issue #5263
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl1, D)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = 'attempt to get argmin of an empty sequence'
@@ -1102,12 +1111,15 @@ class TestParfors(TestParforsBase):
         A = np.array([1., 0., 3., 2., 3.])
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([[1, 0], [0, 0]], dtype=np.bool_) # issue #5632
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl1, D)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = 'attempt to get argmax of an empty sequence'

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -140,8 +140,12 @@ class TestParforsBase(TestCase):
         # parfor result
         parfor_output = cpfunc.entry_point(*copy_args(*args))
 
-        np.testing.assert_almost_equal(njit_output, py_expected, **kwargs)
-        np.testing.assert_almost_equal(parfor_output, py_expected, **kwargs)
+        if py_expected.dtype == np.bool_:
+            np.testing.assert_equal(njit_output, py_expected, **kwargs)
+            np.testing.assert_equal(parfor_output, py_expected, **kwargs)
+        else:
+            np.testing.assert_almost_equal(njit_output, py_expected, **kwargs)
+            np.testing.assert_almost_equal(parfor_output, py_expected, **kwargs)
 
         self.assertEqual(type(njit_output), type(parfor_output))
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -141,7 +141,7 @@ class TestParforsBase(TestCase):
         parfor_output = cpfunc.entry_point(*copy_args(*args))
         
         # check to avoid TypeError when subtracting arrays
-        if isinstance(py_expected, np.ndarray) and py_expected.dtype == np.bool_:
+        if isinstance(py_expected, (np.ndarray, np.generic)) and py_expected.dtype == np.bool_:
             np.testing.assert_equal(njit_output, py_expected, **kwargs)
             np.testing.assert_equal(parfor_output, py_expected, **kwargs)
         else:

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -252,9 +252,8 @@ class TestNumbers(TestCase):
 
     def test_bitwidth(self):
         """
-        All numeric and boolean types have bitwidth attribute.
+        All numeric types have bitwidth attribute.
         """
-        self.assertTrue(hasattr(types.boolean, "bitwidth"))
         for ty in types.number_domain:
             self.assertTrue(hasattr(ty, "bitwidth"))
 

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -252,7 +252,7 @@ class TestNumbers(TestCase):
 
     def test_bitwidth(self):
         """
-        All numeric types have bitwidth attribute
+        All numeric and boolean types have bitwidth attribute.
         """
         self.assertTrue(hasattr(types.boolean, "bitwidth"))
         for ty in types.number_domain:

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -254,10 +254,13 @@ class TestNumbers(TestCase):
         """
         All numeric types have bitwidth attribute
         """
+        self.assertTrue(hasattr(types.boolean, "bitwidth"))
         for ty in types.number_domain:
             self.assertTrue(hasattr(ty, "bitwidth"))
 
     def test_minval_maxval(self):
+        self.assertEqual(types.boolean.minval, 0)
+        self.assertEqual(types.boolean.maxval, 1)
         self.assertEqual(types.int8.maxval, 127)
         self.assertEqual(types.int8.minval, -128)
         self.assertEqual(types.uint8.maxval, 255)


### PR DESCRIPTION
Closes #5263.

- [x] Define `Bounded` type for types with minimal and maximal values.
- [x] Implement `Bounded` type for `Boolean` and `Integer` types.
- [x] Add tests for parfors with `min`/`max`/`argmin`/`argmax` on arrays with bool dtype
- [x] Make output equality checks in parfors tests not fail for boolean arrays
