### PR TITLE
Add prange variant to has_no_side_effect.

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -593,6 +593,8 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
             stmt = f(stmt, lives, lives_n_aliases, arg_aliases, alias_map, func_ir,
                      typemap)
             if stmt is None:
+                if config.DEBUG_ARRAY_OPT >= 2:
+                    print("Statement was removed.")
                 removed = True
                 continue
 
@@ -602,21 +604,29 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
             rhs = stmt.value
             if lhs.name not in lives and has_no_side_effect(
                     rhs, lives_n_aliases, call_table):
+                if config.DEBUG_ARRAY_OPT >= 2:
+                    print("Statement was removed.")
                 removed = True
                 continue
             if isinstance(rhs, ir.Var) and lhs.name == rhs.name:
+                if config.DEBUG_ARRAY_OPT >= 2:
+                    print("Statement was removed.")
                 removed = True
                 continue
             # TODO: remove other nodes like SetItem etc.
 
         if isinstance(stmt, ir.Del):
             if stmt.value not in lives:
+                if config.DEBUG_ARRAY_OPT >= 2:
+                    print("Statement was removed.")
                 removed = True
                 continue
 
         if isinstance(stmt, ir.SetItem):
             name = stmt.target.name
             if name not in lives_n_aliases:
+                if config.DEBUG_ARRAY_OPT >= 2:
+                    print("Statement was removed.")
                 continue
 
         if type(stmt) in analysis.ir_extension_usedefs:
@@ -662,6 +672,7 @@ def has_no_side_effect(rhs, lives, call_table):
             call_list == ['dtype', numpy] or
             call_list == [array_analysis.wrap_index] or
             call_list == [prange] or
+            call_list == ['prange', numba] or
             call_list == [parfor.internal_prange]):
             return True
         elif (isinstance(call_list[0], _Intrinsic) and

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1554,7 +1554,9 @@ class TestParfors(TestParforsBase):
         y = np.arange(10 ** 2, dtype=float)
 
         self.check(test_impl, x, y)
-        self.assertTrue(countParfors(test_impl, (types.Array(types.float64, 1, 'C'), types.Array(types.float64, 1, 'C'))) == 1)
+        self.assertTrue(countParfors(test_impl,
+                                    (types.Array(types.float64, 1, 'C'),
+                                     types.Array(types.float64, 1, 'C'))) == 1)
 
 
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1539,6 +1539,23 @@ class TestParfors(TestParforsBase):
         x = np.ones(20)
         self.check(test_impl, x, True, check_scheduling=False)
 
+    @skip_parfors_unsupported
+    def test_prange_side_effects(self):
+        def test_impl(a, b):
+            data = np.empty(len(a), dtype=np.float64)
+            size = len(data)
+            for i in numba.prange(size):
+                data[i] = a[i]
+            for i in numba.prange(size):
+                data[i] = data[i] + b[i]
+            return data
+
+        x = np.arange(10 ** 2, dtype=float)
+        y = np.arange(10 ** 2, dtype=float)
+
+        self.check(test_impl, x, y)
+        self.assertTrue(countParfors(test_impl, (types.Array(types.float64, 1, 'C'), types.Array(types.float64, 1, 'C'))) == 1)
+
 
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):
     def check(self, pyfunc, *args, **kwargs):


### PR DESCRIPTION
In an internal benchmark, we were seeing some parfors not fusing due to a dead prange call remaining between them.  For some reason, this prange was going through the has_no_side_effect function and the call_list had prange in quotes with the Numba module instead of the other already supported variants.  So, I just added this particular variant.