### PR TITLE
fix error messages in test_array_reductions

### DIFF
--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -962,7 +962,7 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
                             # some architectures (power, 32bit) for complex input
                             ulps = 3
                         npr, nbr = run_comparative(redFunc, testArray)
-                        self.assertPreciseEqual(npr, nbr, msg=test_name,
+                        self.assertPreciseEqual(npr, nbr, msg=testName,
                                                 prec="single", ulps=ulps)
 
                     # Install it into the class


### PR DESCRIPTION
On the current master, some error messages in `test_array_reductions.py` show an incorrect test name.

This is the result of mistakenly referencing a closure variable rather than a function argument.