### PR TITLE
Create typed-list from iterable

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -700,7 +700,8 @@ class Lower(BaseLower):
 
             def stararg_handler(index, param, vars):
                 stararg_ty = signature.args[index]
-                if not isinstance(stararg_ty, types.BaseTuple):
+                stararg_types = (types.StarArgTuple, types.StarArgUniTuple)
+                if not isinstance(stararg_ty, stararg_types):
                     stararg_ty = types.Tuple((stararg_ty,))
                 values = [self._cast_var(var, sigty)
                           for var, sigty in zip(vars, stararg_ty)]

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -700,7 +700,8 @@ class Lower(BaseLower):
 
             def stararg_handler(index, param, vars):
                 stararg_ty = signature.args[index]
-                assert isinstance(stararg_ty, types.BaseTuple), stararg_ty
+                if not isinstance(stararg_ty, types.BaseTuple):
+                    stararg_ty = types.Tuple((stararg_ty,))
                 values = [self._cast_var(var, sigty)
                           for var, sigty in zip(vars, stararg_ty)]
                 return cgutils.make_anonymous_struct(self.builder, values)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -700,9 +700,7 @@ class Lower(BaseLower):
 
             def stararg_handler(index, param, vars):
                 stararg_ty = signature.args[index]
-                stararg_types = (types.StarArgTuple, types.StarArgUniTuple)
-                if not isinstance(stararg_ty, stararg_types):
-                    stararg_ty = types.Tuple((stararg_ty,))
+                assert isinstance(stararg_ty, types.BaseTuple), stararg_ty
                 values = [self._cast_var(var, sigty)
                           for var, sigty in zip(vars, stararg_ty)]
                 return cgutils.make_anonymous_struct(self.builder, values)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -138,9 +138,17 @@ class BaseTuple(ConstSized, Hashable):
             # non-named tuple
             homogeneous = is_homogeneous(*tys)
             if homogeneous:
-                return UniTuple(tys[0], len(tys))
+                return cls._make_homogeneous_tuple(tys[0], len(tys))
             else:
-                return Tuple(tys)
+                return cls._make_heterogeneous_tuple(tys)
+
+    @classmethod
+    def _make_homogeneous_tuple(cls, dtype, count):
+        return UniTuple(dtype, count)
+
+    @classmethod
+    def _make_heterogeneous_tuple(cls, tys):
+        return Tuple(tys)
 
 
 class BaseAnonymousTuple(BaseTuple):
@@ -303,7 +311,18 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
                 return Tuple(unified)
 
 
-class StarArgTuple(Tuple):
+class _StarArgTupleMixin:
+
+    @classmethod
+    def _make_homogeneous_tuple(cls, dtype, count):
+        return StarArgUniTuple(dtype, count)
+
+    @classmethod
+    def _make_heterogeneous_tuple(cls, tys):
+        return StarArgTuple(tys)
+
+
+class StarArgTuple(_StarArgTupleMixin, Tuple):
     """To distinguish from Tuple() used as argument to a `*args`.
     """
     def __new__(cls, types):
@@ -315,7 +334,7 @@ class StarArgTuple(Tuple):
             return object.__new__(StarArgTuple)
 
 
-class StarArgUniTuple(UniTuple):
+class StarArgUniTuple(_StarArgTupleMixin, UniTuple):
     """To distinguish from UniTuple() used as argument to a `*args`.
     """
 

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -782,9 +782,19 @@ class TypeRefAttribute(AttributeTemplate):
             # For example, see numba/typed/typeddict.py
             #   @type_callable(DictType)
             #   def typeddict_call(context):
-            def redirect(*args, **kwargs):
-                return self.context.resolve_function_type(ty, args, kwargs)
-            return types.Function(make_callable_template(key=ty, typer=redirect))
+            class Redirect(object):
+
+                def __init__(self, context):
+                    self.context =  context
+
+                def __call__(self, *args, **kwargs):
+                    result = self.context.resolve_function_type(ty, args, kwargs)
+                    if hasattr(result, "pysig"):
+                        self.pysig = result.pysig
+                    return result
+
+            return types.Function(make_callable_template(key=ty,
+                                                         typer=Redirect(self.context)))
 
 
 #------------------------------------------------------------------------------

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -280,7 +280,6 @@ def complex_impl(context, builder, sig, args):
 
 
 @lower_builtin(types.NumberClass, types.Any)
-@lower_builtin(types.TypeRef, types.Any)
 def number_constructor(context, builder, sig, args):
     """
     Call a number class, e.g. np.int32(...)
@@ -540,7 +539,7 @@ def iterable_max(iterable):
     return min_max_impl(iterable, greater_than)
 
 
-@lower_builtin(types.TypeRef)
+@lower_builtin(types.TypeRef, types.VarArg(types.Any))
 def redirect_type_ctor(context, builder, sig, args):
     """Redirect constructor implementation to `numba_typeref_ctor(cls, *args)`,
     which should be overloaded by type implementator.
@@ -562,9 +561,12 @@ def redirect_type_ctor(context, builder, sig, args):
     ctor_args = types.Tuple.from_types(sig.args)
     # Make signature T(TypeRef[T], *args) where T is cls
     sig = typing.signature(cls, types.TypeRef(cls), ctor_args)
-
-    args = (context.get_dummy_value(),   # Type object has no runtime repr.
-            context.make_tuple(builder, sig.args[1], args))
+    if len(ctor_args) > 0:
+        args = (context.get_dummy_value(),   # Type object has no runtime repr.
+                *args)
+    else:
+        args = (context.get_dummy_value(),   # Type object has no runtime repr.
+                context.make_tuple(builder, ctor_args, ()))
 
     return context.compile_internal(builder, call_ctor, sig, args)
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -563,7 +563,7 @@ def redirect_type_ctor(context, builder, sig, args):
     sig = typing.signature(cls, types.TypeRef(cls), ctor_args)
     if len(ctor_args) > 0:
         args = (context.get_dummy_value(),   # Type object has no runtime repr.
-                *args)
+                context.make_tuple(builder, ctor_args, args))
     else:
         args = (context.get_dummy_value(),   # Type object has no runtime repr.
                 context.make_tuple(builder, ctor_args, ()))

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2873,7 +2873,7 @@ class ArrayAnalysis(object):
         argtyps = tuple([msg_typ] + [self.typemap[x.name] for x in args])
 
         # assert_equiv takes vararg, which requires a tuple as argument type
-        tup_typ = types.BaseTuple.from_types(argtyps)
+        tup_typ = types.StarArgTuple.from_types(argtyps)
 
         # prepare function variable whose type may vary since it takes vararg
         assert_var = ir.Var(scope, mk_unique_var("assert"), loc)

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -132,7 +132,7 @@ def assert_equiv(typingctx, *val):
         # Make sure argument is a single tuple type. Note that this only
         # happens when IR containing assert_equiv call is being compiled
         # (and going through type inference) again.
-        val = (types.Tuple(val),)
+        val = (types.StarArgTuple(val),)
 
     assert len(val[0]) > 1
     # Arguments must be either array, tuple, or integer

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1338,3 +1338,54 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             foo, expected = generate_function(line), generate_expected(values)
             for func in (foo, foo.py_func):
                 self.assertEqual(func(), expected)
+
+    def test_exception_on_non_iterable_types(self):
+        @njit
+        def foo():
+            l = List(23)
+            return l
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "List() argument must be iterable",
+            str(raises.exception),
+        )
+
+    def test_exception_on_too_many_args(self):
+        @njit
+        def foo():
+            l = List((0, 1, 2), (3, 4, 5))
+            return l
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "List() expected at most 1 argument, got 2",
+            str(raises.exception),
+        )
+
+        @njit
+        def foo():
+            l = List((0, 1, 2), (3, 4, 5), (6, 7, 8))
+            return l
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "List() expected at most 1 argument, got 3",
+            str(raises.exception),
+        )
+
+    def test_exception_on_kwargs(self):
+        @njit
+        def foo():
+            l = List(iterable=(0, 1, 2))
+            return l
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "List() takes no keyword arguments",
+            str(raises.exception),
+        )

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1339,10 +1339,23 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             for func in (foo, foo.py_func):
                 self.assertEqual(func(), expected)
 
-    def test_exception_on_non_iterable_types(self):
+    def test_exception_on_plain_int(self):
         @njit
         def foo():
             l = List(23)
+            return l
+
+        with self.assertRaises(TypingError) as raises:
+            foo()
+        self.assertIn(
+            "List() argument must be iterable",
+            str(raises.exception),
+        )
+
+    def test_exception_on_inhomogeneous_tuple(self):
+        @njit
+        def foo():
+            l = List((1, 1.0))
             return l
 
         with self.assertRaises(TypingError) as raises:

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1293,3 +1293,15 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             for result in (cf_received, py_received):
                 for i in range(3):
                     self.assertEqual(i, result[i])
+
+    def test_unicode(self):
+        """Test that a List can be created from a unicode string."""
+        @njit
+        def foo():
+            l = List("abc")
+            return l
+        expected = List()
+        for i in ("a", "b", "c"):
+            expected.append(i)
+        self.assertEqual(foo.py_func(), expected)
+        self.assertEqual(foo(), expected)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1352,6 +1352,13 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
+        with self.assertRaises(TypeError) as raises:
+            List(23)
+        self.assertIn(
+            "List() argument must be iterable",
+            str(raises.exception),
+        )
+
     def test_exception_on_inhomogeneous_tuple(self):
         @njit
         def foo():
@@ -1365,6 +1372,11 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
+        with self.assertRaises(TypingError) as raises:
+            List((1, 1.0))
+        # FIXME this bails with a length casting error when we attempt to
+        # append 1.0 to an int typed list.
+
     def test_exception_on_too_many_args(self):
         @njit
         def foo():
@@ -1373,6 +1385,13 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
 
         with self.assertRaises(TypingError) as raises:
             foo()
+        self.assertIn(
+            "List() expected at most 1 argument, got 2",
+            str(raises.exception),
+        )
+
+        with self.assertRaises(TypeError) as raises:
+            List((0, 1, 2), (3, 4, 5))
         self.assertIn(
             "List() expected at most 1 argument, got 2",
             str(raises.exception),
@@ -1390,6 +1409,13 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
+        with self.assertRaises(TypeError) as raises:
+            List((0, 1, 2), (3, 4, 5), (6, 7, 8))
+        self.assertIn(
+            "List() expected at most 1 argument, got 3",
+            str(raises.exception),
+        )
+
     def test_exception_on_kwargs(self):
         @njit
         def foo():
@@ -1398,6 +1424,13 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
 
         with self.assertRaises(TypingError) as raises:
             foo()
+        self.assertIn(
+            "List() takes no keyword arguments",
+            str(raises.exception),
+        )
+
+        with self.assertRaises(TypeError) as raises:
+            List(iterable=(0, 1, 2))
         self.assertIn(
             "List() takes no keyword arguments",
             str(raises.exception),

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1270,8 +1270,8 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
 class TestListFromIter(MemoryLeakMixin, TestCase):
 
-    def test_types(self):
-        """Test all types that a List can be constructed from."""
+    def test_simple_iterable_types(self):
+        """Test all simple iterables that a List can be constructed from."""
 
         def generate_function(line):
             context = {}
@@ -1287,6 +1287,7 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
                      "l = List(range(3))",
                      "l = List(List([0, 1, 2]))",
                      "l = List((0, 1, 2))",
+                     "l = List(set([0, 1, 2]))",
                      ):
             foo = generate_function(line)
             cf_received, py_received = foo(), foo.py_func()

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1271,19 +1271,22 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 class TestListFromIter(MemoryLeakMixin, TestCase):
 
     def test_types(self):
-        """Test all types that a List can be constructe from."""
+        """Test all types that a List can be constructed from."""
 
         def generate_function(line):
             context = {}
-            exec(dedent("""
+            code = dedent("""
                 from numba.typed import List
                 def bar():
                     {}
                     return l
-                """.format(line)), context)
+                """).format(line)
+            exec(code, context)
             return njit(context["bar"])
         for line in ("l = List([0, 1, 2])",
                      "l = List(range(3))",
+                     "l = List(List([0, 1, 2]))",
+                     "l = List((0, 1, 2))",
                      ):
             foo = generate_function(line)
             cf_received, py_received = foo(), foo.py_func()

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1339,6 +1339,50 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             for func in (foo, foo.py_func):
                 self.assertEqual(func(), expected)
 
+    def test_ndarray_scalar(self):
+
+        @njit
+        def foo():
+            return List(np.ones(3))
+
+        expected = List()
+        for i in range(3):
+            expected.append(1)
+
+        self.assertEqual(expected, foo())
+        self.assertEqual(expected, foo.py_func())
+
+    def test_ndarray_oned(self):
+
+        @njit
+        def foo():
+            return List(np.array(1))
+
+        expected = List()
+        expected.append(1)
+
+        self.assertEqual(expected, foo())
+        self.assertEqual(expected, foo.py_func())
+
+    def test_ndarray_twod(self):
+
+        @njit
+        def foo():
+            return List(np.array([[1,2],[3,4]]))
+
+        expected = List()
+        expected.append(np.array([1,2]))
+        expected.append(np.array([3,4]))
+        received = foo()
+
+        np.testing.assert_equal(expected[0], received[0])
+        np.testing.assert_equal(expected[1], received[1])
+
+        pyreceived = foo.py_func()
+
+        np.testing.assert_equal(expected[0], pyreceived[0])
+        np.testing.assert_equal(expected[1], pyreceived[1])
+
     def test_exception_on_plain_int(self):
         @njit
         def foo():

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1266,3 +1266,10 @@ class TestImmutable(MemoryLeakMixin, TestCase):
                     "list is immutable",
                     str(raises.exception),
                 )
+
+
+class TestListFromIter(MemoryLeakMixin, TestCase):
+
+    def test_basic(self):
+        l = List((1,2,3))
+        print(l)

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1270,14 +1270,22 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
 class TestListFromIter(MemoryLeakMixin, TestCase):
 
-    def test_basic(self):
+    def test_from_list(self):
         @njit
         def foo():
-            l = List([1, 2, 3])
+            l = List([0, 1, 2])
             return l
-        cf_received = foo()
-        py_received = foo.py_func()
+        cf_received, py_received = foo(), foo.py_func()
         for r in (cf_received, py_received):
-            self.assertEqual(1, r[0])
-            self.assertEqual(2, r[1])
-            self.assertEqual(3, r[2])
+            for i in range(3):
+                self.assertEqual(i, r[i])
+
+    def test_from_range(self):
+        @njit
+        def foo():
+            l = List(range(3))
+            return l
+        cf_received, py_received = foo(), foo.py_func()
+        for r in (cf_received, py_received):
+            for i in range(3):
+                self.assertEqual(i, r[i])

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1271,5 +1271,13 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 class TestListFromIter(MemoryLeakMixin, TestCase):
 
     def test_basic(self):
-        l = List((1,2,3))
-        print(l)
+        @njit
+        def foo():
+            l = List([1, 2, 3])
+            return l
+        cf_received = foo()
+        py_received = foo.py_func()
+        for r in (cf_received, py_received):
+            self.assertEqual(1, r[0])
+            self.assertEqual(2, r[1])
+            self.assertEqual(3, r[2])

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1270,22 +1270,23 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
 class TestListFromIter(MemoryLeakMixin, TestCase):
 
-    def test_from_list(self):
-        @njit
-        def foo():
-            l = List([0, 1, 2])
-            return l
-        cf_received, py_received = foo(), foo.py_func()
-        for r in (cf_received, py_received):
-            for i in range(3):
-                self.assertEqual(i, r[i])
+    def test_types(self):
+        """Test all types that a List can be constructe from."""
 
-    def test_from_range(self):
-        @njit
-        def foo():
-            l = List(range(3))
-            return l
-        cf_received, py_received = foo(), foo.py_func()
-        for r in (cf_received, py_received):
-            for i in range(3):
-                self.assertEqual(i, r[i])
+        def generate_function(line):
+            context = {}
+            exec(dedent("""
+                from numba.typed import List
+                def bar():
+                    {}
+                    return l
+                """.format(line)), context)
+            return njit(context["bar"])
+        for line in ("l = List([0, 1, 2])",
+                     "l = List(range(3))",
+                     ):
+            foo = generate_function(line)
+            cf_received, py_received = foo(), foo.py_func()
+            for result in (cf_received, py_received):
+                for i in range(3):
+                    self.assertEqual(i, result[i])

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -196,13 +196,15 @@ class List(MutableSequence):
         else:
             return cls(lsttype=ListType(item_type), allocated=allocated)
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         For users, the constructor does not take any parameters.
         The keyword arguments are for internal use only.
 
         Parameters
         ----------
+        args: iterable
+            The iterable to intialize the list from
         lsttype : numba.core.types.ListType; keyword-only
             Used internally for the list type.
         meminfo : MemInfo; keyword-only
@@ -210,10 +212,15 @@ class List(MutableSequence):
         allocated: int; keyword-only
             Used internally to pre-allocate space for items
         """
+        if args and kwargs:
+            raise ValueError
         if kwargs:
             self._list_type, self._opaque = self._parse_arg(**kwargs)
         else:
             self._list_type = None
+        if args:
+            for i in args[0]:
+                self.append(i)
 
     def _parse_arg(self, lsttype, meminfo=None, allocated=DEFAULT_ALLOCATED):
         if not isinstance(lsttype, ListType):

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -462,7 +462,7 @@ def typedlist_call(context):
 
 
 @overload(numba_typeref_ctor)
-def impl_numba_typeref_ctor(cls):
+def impl_numba_typeref_ctor(cls, *args):
     """
     Defines ``List()``, the type-inferred version of the list ctor.
 
@@ -483,9 +483,15 @@ def impl_numba_typeref_ctor(cls):
         raise errors.LoweringError(msg)
 
     item_type = types.TypeRef(list_ty.item_type)
-
-    def impl(cls):
-        # Simply call .empty_list with the item types from *cls*
-        return List.empty_list(item_type)
+    if args:
+        def impl(cls, *args):
+            r = List.empty_list(item_type)
+            for i in args[0]:
+                r.append(i)
+            return r
+    else:
+        def impl(cls, *args):
+            # Simply call .empty_list with the item types from *cls*
+            return List.empty_list(item_type)
 
     return impl

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -448,9 +448,27 @@ def unbox_listtype(typ, val, c):
 
 @type_callable(ListType)
 def typedlist_call(context):
-    """
-    Defines typing logic for ``List()``.
-    Produces List[undefined]
+    """Defines typing logic for ``List()`` and ``List(iterable)``.
+
+    If no argument is given, the returned typer types a new typed-list with an
+    undefined item type. If a single argument is given it must be iterable with
+    a guessable 'dtype'. In this case, the typer types a new typed-list with
+    the type set to the 'dtype' of the iterable arg.
+
+    Parameters
+    ----------
+    arg : single iterable (optional)
+        The single optional argument.
+
+    Returns
+    -------
+    typer : function
+        A typer suitable to type constructor calls.
+
+    Raises
+    ------
+    The returned typer raises a TypingError in case of unsuitable arguments.
+
     """
     def typer(*args, **kwargs):
         if kwargs:
@@ -464,6 +482,7 @@ def typedlist_call(context):
                     .format(len(args))
                 )
             iterable = args[0]
+            # 'guess' the correct dtype or reject
             if not isinstance(iterable, types.IterableType):
                 raise TypingError(
                     "List() argument must be iterable")

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -453,11 +453,20 @@ def typedlist_call(context):
     Produces List[undefined]
     """
     def typer(*args, **kwargs):
-        if args:
+        if kwargs:
+            raise TypingError(
+                "List() takes no keyword arguments"
+            )
+        elif args:
+            if not 0 <= len(args) <= 1:
+                raise TypingError(
+                    "List() expected at most 1 argument, got {}"
+                    .format(len(args))
+                )
             iterable = args[0]
             if not isinstance(iterable, types.IterableType):
                 raise TypingError(
-                    "argument for List constructor must be iterable")
+                    "List() argument must be iterable")
             elif hasattr(iterable, "dtype"):
                 item_type = iterable.dtype
             elif hasattr(iterable, "yield_type"):
@@ -467,9 +476,10 @@ def typedlist_call(context):
             elif isinstance(iterable, types.DictType):
                 item_type = iterable.key_type
             else:
+                # This should never happen, since the 'dtype' of any iterable
+                # should have determined above.
                 raise TypingError(
-                    "unable to determine a suitable dtype for the argument of "
-                    "List constructor")
+                    "List() argument does not have a suitable dtype")
         else:
             item_type = types.undefined
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -460,8 +460,12 @@ def typedlist_call(context):
                     "argument for List constructor must be iterable")
             elif hasattr(iterable, "dtype"):
                 item_type = iterable.dtype
+            elif hasattr(iterable, "yield_type"):
+                item_type = iterable.yield_type
             elif isinstance(iterable, types.UnicodeType):
                 item_type = iterable
+            elif isinstance(iterable, types.DictType):
+                item_type = iterable.key_type
             else:
                 raise TypingError(
                     "unable to determine a suitable dtype for the argument of "

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -13,7 +13,7 @@ from collections.abc import MutableSequence
 from numba.core.types import ListType, TypeRef
 from numba.core.imputils import numba_typeref_ctor
 from numba.core.dispatcher import Dispatcher
-from numba.core import types, errors, config, cgutils
+from numba.core import types, config, cgutils
 from numba import njit, typeof
 from numba.core.extending import (
     overload_method,
@@ -24,7 +24,7 @@ from numba.core.extending import (
     type_callable,
 )
 from numba.typed import listobject
-from numba.core.errors import TypingError
+from numba.core.errors import TypingError, LoweringError
 
 DEFAULT_ALLOCATED = listobject.DEFAULT_ALLOCATED
 
@@ -529,12 +529,11 @@ def impl_numba_typeref_ctor(cls, *args):
     """
     list_ty = cls.instance_type
     if not isinstance(list_ty, types.ListType):
-        msg = "expecting a ListType but got {}".format(list_ty)
         return  # reject
     # Ensure the list is precisely typed.
     if not list_ty.is_precise():
         msg = "expecting a precise ListType but got {}".format(list_ty)
-        raise errors.LoweringError(msg)
+        raise LoweringError(msg)
 
     item_type = types.TypeRef(list_ty.item_type)
     if args:

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -451,8 +451,13 @@ def typedlist_call(context):
     Defines typing logic for ``List()``.
     Produces List[undefined]
     """
-    def typer():
-        return types.ListType(types.undefined)
+    def typer(*args, **kwargs):
+        if args:
+            item_type = args[0].dtype
+        else:
+            item_type = types.undefined
+
+        return types.ListType(item_type)
     return typer
 
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -508,13 +508,22 @@ def typedlist_call(context):
 
 @overload(numba_typeref_ctor)
 def impl_numba_typeref_ctor(cls, *args):
-    """
-    Defines ``List()``, the type-inferred version of the list ctor.
+    """Defines lowering for ``List()`` and ``List(iterable)``.
+
+    This defines the lowering logic to instantiate either an empty typed-list
+    or a typed-list initialised with values from a single iterable argument.
 
     Parameters
     ----------
     cls : TypeRef
         Expecting a TypeRef of a precise ListType.
+    args: tuple
+        A tuple that contains a single iterable (optional)
+
+    Returns
+    -------
+    impl : function
+        An implementation suitable for lowering the constructor call.
 
     See also: `redirect_type_ctor` in numba/cpython/bulitins.py
     """
@@ -530,13 +539,15 @@ def impl_numba_typeref_ctor(cls, *args):
     item_type = types.TypeRef(list_ty.item_type)
     if args:
         def impl(cls, *args):
+            # Instatiate an empty list and populate it with values from the
+            # iterable.
             r = List.empty_list(item_type)
             for i in args[0]:
                 r.append(i)
             return r
     else:
         def impl(cls, *args):
-            # Simply call .empty_list with the item types from *cls*
+            # Simply call .empty_list with the item type from *cls*
             return List.empty_list(item_type)
 
     return impl

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -177,7 +177,11 @@ class List(MutableSequence):
 
     _legal_kwargs = ["lsttype", "meminfo", "allocated"]
 
-    def __new__(cls, lsttype=None, meminfo=None, allocated=DEFAULT_ALLOCATED):
+    def __new__(cls,
+                lsttype=None,
+                meminfo=None,
+                allocated=DEFAULT_ALLOCATED,
+                **kwargs):
         if config.DISABLE_JIT:
             return list.__new__(list)
         else:

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -175,6 +175,8 @@ class List(MutableSequence):
     Implements the MutableSequence interface.
     """
 
+    _legal_kwargs = ["lsttype", "meminfo", "allocated"]
+
     def __new__(cls, lsttype=None, meminfo=None, allocated=DEFAULT_ALLOCATED):
         if config.DISABLE_JIT:
             return list.__new__(list)
@@ -213,15 +215,26 @@ class List(MutableSequence):
         allocated: int; keyword-only
             Used internally to pre-allocate space for items
         """
-        if args and kwargs:
-            raise ValueError
+        illegal_kwargs = any((kw not in self._legal_kwargs for kw in kwargs))
+        if illegal_kwargs or args and kwargs:
+            raise TypeError("List() takes no keyword arguments")
         if kwargs:
             self._list_type, self._opaque = self._parse_arg(**kwargs)
         else:
             self._list_type = None
-        if args:
-            for i in args[0]:
-                self.append(i)
+            if args:
+                if not 0 <= len(args) <= 1:
+                    raise TypeError(
+                        "List() expected at most 1 argument, got {}"
+                        .format(len(args))
+                    )
+                iterable = args[0]
+                try:
+                    iter(iterable)
+                except TypeError:
+                    raise TypeError("List() argument must be iterable")
+                for i in args[0]:
+                    self.append(i)
 
     def _parse_arg(self, lsttype, meminfo=None, allocated=DEFAULT_ALLOCATED):
         if not isinstance(lsttype, ListType):

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -24,6 +24,7 @@ from numba.core.extending import (
     type_callable,
 )
 from numba.typed import listobject
+from numba.core.errors import TypingError
 
 DEFAULT_ALLOCATED = listobject.DEFAULT_ALLOCATED
 
@@ -453,7 +454,11 @@ def typedlist_call(context):
     """
     def typer(*args, **kwargs):
         if args:
-            item_type = args[0].dtype
+            iterable = args[0]
+            if not isinstance(iterable, types.IterableType):
+                raise TypingError(
+                    "argument for List constructor must be iterable")
+            item_type = iterable.dtype
         else:
             item_type = types.undefined
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -458,7 +458,14 @@ def typedlist_call(context):
             if not isinstance(iterable, types.IterableType):
                 raise TypingError(
                     "argument for List constructor must be iterable")
-            item_type = iterable.dtype
+            elif hasattr(iterable, "dtype"):
+                item_type = iterable.dtype
+            elif isinstance(iterable, types.UnicodeType):
+                item_type = iterable
+            else:
+                raise TypingError(
+                    "unable to determine a suitable dtype for the argument of "
+                    "List constructor")
         else:
             item_type = types.undefined
 


### PR DESCRIPTION
This implements the code to run: `l = List((1, 2, 3))` within `@njit` compiled
functions and within the interpreter.

Things to note:

* Props go out to @sklam for the fix at 800f6c08.
* There is still something fishy going on at b7319f0 and e099552 - presumably
  the code to compute the signature is wobbly.
* The error messages are the same for most tested exceptions, the one exception
  being the inhomogeneous tuple, which will be reject outright during type
  inference but will only crash at the first inhomogeneously typed element in
  the interpreter.
* The API of `List` in the interpreter still seems a bit rough and isn't yet
  too well understood.
* We can now probably remove `empty_list`, but we would need an alternative for
  initialising a typed-list from a suitable Numba type. It appears as though
  not everyone in the community will be satisfied with refinement.