### PR TITLE
Initial attempt to support tuples to parfors.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include MANIFEST.in
-include README.rst setup.py runtests.py versioneer.py CHANGE_LOG AUTHORS LICENSE
+include README.rst setup.py runtests.py versioneer.py CHANGE_LOG LICENSE
 
 recursive-include numba *.c *.cpp *.h *.hpp *.inc
 recursive-include docs *.ipynb *.txt *.py Makefile *.rst

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: xcode9-macos10.13
+    vmImage: macOS-10.14
     matrix:
       py38_np117:
         PYTHON: '3.8'

--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -347,6 +347,21 @@ def dead_branch_prune(func_ir, called_args):
         taken = do_prune(take_truebr, blk)
         return True, taken
 
+    def prune_by_predicate(branch, pred, blk):
+        try:
+            # Just to prevent accidents, whilst already guarded, ensure this
+            # is an ir.Const
+            if not isinstance(pred, (ir.Const, ir.FreeVar, ir.Global)):
+                raise TypeError('Expected constant Numba IR node')
+            take_truebr = bool(pred.value)
+        except TypeError:
+            return False, None
+        if DEBUG > 0:
+            kill = branch.falsebr if take_truebr else branch.truebr
+            print("Pruning %s" % kill, branch, pred)
+        taken = do_prune(take_truebr, blk)
+        return True, taken
+
     class Unknown(object):
         pass
 
@@ -383,6 +398,7 @@ def dead_branch_prune(func_ir, called_args):
     # if the condition is met it will replace the branch with a jump
     branch_info = find_branches(func_ir)
     nullified_conditions = [] # stores conditions that have no impact post prune
+
     for branch, condition, blk in branch_info:
         const_conds = []
         if isinstance(condition, ir.Expr) and condition.op == 'binop':
@@ -411,6 +427,21 @@ def dead_branch_prune(func_ir, called_args):
             if len(const_conds) == 2:
                 # prune the branch, switch the branch for an unconditional jump
                 prune_stat, taken = prune(branch, condition, blk, *const_conds)
+                if(prune_stat):
+                    # add the condition to the list of nullified conditions
+                    nullified_conditions.append((condition, taken))
+        else:
+            # see if this is a branch on a constant value predicate
+            resolved_const = Unknown()
+            try:
+                resolved_const = find_const(func_ir, branch.cond)
+                if resolved_const is None:
+                    resolved_const = types.NoneType('none')
+            except GuardException:
+                pass
+
+            if not isinstance(resolved_const, Unknown):
+                prune_stat, taken = prune_by_predicate(branch, condition, blk)
                 if(prune_stat):
                     # add the condition to the list of nullified conditions
                     nullified_conditions.append((condition, taken))

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -173,8 +173,10 @@ class _EnvReloader(object):
         # of external references
         FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 128)
 
-        # Maximum tuple size that parfors will unpack and pass to internal gufunc.
-        PARFOR_MAX_TUPLE_SIZE = _readenv("NUMBA_PARFOR_MAX_TUPLE_SIZE", int, 100)
+        # Maximum tuple size that parfors will unpack and pass to
+        # internal gufunc.
+        PARFOR_MAX_TUPLE_SIZE = _readenv("NUMBA_PARFOR_MAX_TUPLE_SIZE",
+                                         int, 100)
 
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -173,6 +173,9 @@ class _EnvReloader(object):
         # of external references
         FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 128)
 
+        # Maximum tuple size that parfors will unpack and pass to internal gufunc.
+        PARFOR_MAX_TUPLE_SIZE = _readenv("NUMBA_PARFOR_MAX_TUPLE_SIZE", int, 100)
+
         # Enable logging of cache operation
         DEBUG_CACHE = _readenv("NUMBA_DEBUG_CACHE", int, DEBUG)
 

--- a/numba/core/types/iterators.py
+++ b/numba/core/types/iterators.py
@@ -1,4 +1,5 @@
 from .common import SimpleIterableType, SimpleIteratorType
+from ..errors import TypingError
 
 
 class RangeType(SimpleIterableType):
@@ -96,7 +97,9 @@ class ArrayIterator(SimpleIteratorType):
         self.array_type = array_type
         name = "iter(%s)" % (self.array_type,)
         nd = array_type.ndim
-        if nd == 0 or nd == 1:
+        if nd == 0:
+            raise TypingError("iteration over a 0-d array")
+        elif nd == 1:
             yield_type = array_type.dtype
         else:
             yield_type = array_type.copy(ndim=array_type.ndim - 1)

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -99,16 +99,7 @@ class GetIter(AbstractTemplate):
         assert not kws
         [obj] = args
         if isinstance(obj, types.IterableType):
-            # Raise this here to provide a very specific message about this
-            # common issue, delaying the error until later leads to something
-            # less specific being noted as the problem (e.g. no support for
-            # getiter on array(<>, 2, 'C')).
-            if isinstance(obj, types.Array) and obj.ndim > 1:
-                msg = ("Direct iteration is not supported for arrays with "
-                       "dimension > 1. Try using indexing instead.")
-                raise errors.TypingError(msg)
-            else:
-                return signature(obj.iterator_type, obj)
+            return signature(obj.iterator_type, obj)
 
 
 @infer

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -632,7 +632,7 @@ class CUDAKernel(CUDAKernelBase):
                     locinfo = ''
                 else:
                     sym, filepath, lineno = loc
-                    filepath = os.path.relpath(filepath)
+                    filepath = os.path.abspath(filepath)
                     locinfo = 'In function %r, file %s, line %s, ' % (
                         sym, filepath, lineno,
                         )

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -8,7 +8,7 @@ class MyError(Exception):
 
 
 regex_pattern = (
-    r'In function [\'"]test_exc[\'"], file [\.\/\\\-a-zA-Z_0-9]+, line \d+'
+    r'In function [\'"]test_exc[\'"], file [\:\.\/\\\-a-zA-Z_0-9]+, line \d+'
 )
 
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -632,7 +632,8 @@ class Parfor(ir.Expr, ir.Stmt):
                 msg = ("Use of a tuple (%s) in a parallel region is not "
                        "supported due to a limitation of the Generalized "
                        "Universal Functions that back parallel regions.")
-                raise errors.UnsupportedError(msg % p, self.loc)
+                raise errors.UnsupportedParforsError(msg % p, self.loc)
+
 
 def _analyze_parfor(parfor, equiv_set, typemap, array_analysis):
     """Recursive array analysis for parfor nodes.

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1523,6 +1523,165 @@ class ParforPassStates:
         ir_utils._max_label = max(func_ir.blocks.keys())
         self.flags = flags
 
+    def run(self):
+        """run parfor conversion pass: replace Numpy calls
+        with Parfors when possible and optimize the IR."""
+        # run array analysis, a pre-requisite for parfor translation
+        remove_dels(self.func_ir.blocks)
+        self.array_analysis.run(self.func_ir.blocks)
+        # run stencil translation to parfor
+        if self.options.stencil:
+            stencil_pass = StencilPass(self.func_ir, self.typemap, self.calltypes,
+                                            self.array_analysis, self.typingctx, self.flags)
+            stencil_pass.run()
+        if self.options.setitem:
+            self._convert_setitem(self.func_ir.blocks)
+        if self.options.numpy:
+            self._convert_numpy(self.func_ir.blocks)
+        if self.options.reduction:
+            self._convert_reduce(self.func_ir.blocks)
+        if self.options.prange:
+           self._convert_loop(self.func_ir.blocks)
+
+        # setup diagnostics now parfors are found
+        self.diagnostics.setup(self.func_ir, self.options.fusion)
+
+        dprint_func_ir(self.func_ir, "after parfor pass")
+
+        # simplify CFG of parfor body loops since nested parfors with extra
+        # jumps can be created with prange conversion
+        simplify_parfor_body_CFG(self.func_ir.blocks)
+        # simplify before fusion
+        simplify(self.func_ir, self.typemap, self.calltypes)
+        # need two rounds of copy propagation to enable fusion of long sequences
+        # of parfors like test_fuse_argmin (some PYTHONHASHSEED values since
+        # apply_copies_parfor depends on set order for creating dummy assigns)
+        simplify(self.func_ir, self.typemap, self.calltypes)
+
+        if self.options.fusion:
+            self.func_ir._definitions = build_definitions(self.func_ir.blocks)
+            self.array_analysis.equiv_sets = dict()
+            self.array_analysis.run(self.func_ir.blocks)
+            # reorder statements to maximize fusion
+            # push non-parfors down
+            maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap,
+                                                            up_direction=False)
+            dprint_func_ir(self.func_ir, "after maximize fusion down")
+            self.fuse_parfors(self.array_analysis, self.func_ir.blocks)
+            # push non-parfors up
+            maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap)
+            dprint_func_ir(self.func_ir, "after maximize fusion up")
+            # try fuse again after maximize
+            self.fuse_parfors(self.array_analysis, self.func_ir.blocks)
+            dprint_func_ir(self.func_ir, "after fusion")
+        # simplify again
+        simplify(self.func_ir, self.typemap, self.calltypes)
+        # push function call variables inside parfors so gufunc function
+        # wouldn't need function variables as argument
+        push_call_vars(self.func_ir.blocks, {}, {}, self.typemap)
+        dprint_func_ir(self.func_ir, "after push call vars")
+        # simplify again
+        simplify(self.func_ir, self.typemap, self.calltypes)
+        dprint_func_ir(self.func_ir, "after optimization")
+        if config.DEBUG_ARRAY_OPT >= 1:
+            print("variable types: ", sorted(self.typemap.items()))
+            print("call types: ", self.calltypes)
+
+        if config.DEBUG_ARRAY_OPT >= 3:
+            for(block_label, block) in self.func_ir.blocks.items():
+                new_block = []
+                scope = block.scope
+                for stmt in block.body:
+                    new_block.append(stmt)
+                    if isinstance(stmt, ir.Assign):
+                        loc = stmt.loc
+                        lhs = stmt.target
+                        rhs = stmt.value
+                        lhs_typ = self.typemap[lhs.name]
+                        print("Adding print for assignment to ", lhs.name, lhs_typ, type(lhs_typ))
+                        if lhs_typ in types.number_domain or isinstance(lhs_typ, types.Literal):
+                            str_var = ir.Var(scope, mk_unique_var("str_var"), loc)
+                            self.typemap[str_var.name] = types.StringLiteral(lhs.name)
+                            lhs_const = ir.Const(lhs.name, loc)
+                            str_assign = ir.Assign(lhs_const, str_var, loc)
+                            new_block.append(str_assign)
+                            str_print = ir.Print([str_var], None, loc)
+                            self.calltypes[str_print] = signature(types.none, self.typemap[str_var.name])
+                            new_block.append(str_print)
+                            ir_print = ir.Print([lhs], None, loc)
+                            self.calltypes[ir_print] = signature(types.none, lhs_typ)
+                            new_block.append(ir_print)
+                block.body = new_block
+
+        # run post processor again to generate Del nodes
+        post_proc = postproc.PostProcessor(self.func_ir)
+        post_proc.run()
+        if self.func_ir.is_generator:
+            fix_generator_types(self.func_ir.generator_info, self.return_type,
+                                self.typemap)
+        if sequential_parfor_lowering:
+            lower_parfor_sequential(
+                self.typingctx, self.func_ir, self.typemap, self.calltypes)
+        else:
+            # prepare for parallel lowering
+            # add parfor params to parfors here since lowering is destructive
+            # changing the IR after this is not allowed
+            parfor_ids, parfors = get_parfor_params(self.func_ir.blocks,
+                                                    self.options.fusion,
+                                                    self.nested_fusion_info)
+
+            # Validate reduction in parfors.
+            for p in parfors:
+                get_parfor_reductions(self.func_ir, p, p.params, self.calltypes)
+
+            # Validate parameters:
+            for p in parfors:
+                p.validate_params(self.typemap)
+
+            if config.DEBUG_ARRAY_OPT_STATS:
+                name = self.func_ir.func_id.func_qualname
+                n_parfors = len(parfor_ids)
+                if n_parfors > 0:
+                    after_fusion = ("After fusion" if self.options.fusion
+                                    else "With fusion disabled")
+                    print(('{}, function {} has '
+                           '{} parallel for-loop(s) #{}.').format(
+                           after_fusion, name, n_parfors, parfor_ids))
+                else:
+                    print('Function {} has no Parfor.'.format(name))
+
+        return
+
+    def _convert_numpy(self, blocks):
+        """
+        Convert supported Numpy functions, as well as arrayexpr nodes, to
+        parfor nodes.
+        """
+        topo_order = find_topo_order(blocks)
+        # variables available in the program so far (used for finding map
+        # functions in array_expr lowering)
+        avail_vars = []
+        for label in topo_order:
+            block = blocks[label]
+            new_body = []
+            equiv_set = self.array_analysis.get_equiv_set(label)
+            for instr in block.body:
+                if isinstance(instr, ir.Assign):
+                    expr = instr.value
+                    lhs = instr.target
+                    if self._is_C_order(lhs.name):
+                        # only translate C order since we can't allocate F
+                        if guard(self._is_supported_npycall, expr):
+                            instr = self._numpy_to_parfor(equiv_set, lhs, expr)
+                            if isinstance(instr, tuple):
+                                pre_stmts, instr = instr
+                                new_body.extend(pre_stmts)
+                        elif isinstance(expr, ir.Expr) and expr.op == 'arrayexpr':
+                            instr = self._arrayexpr_to_parfor(
+                                equiv_set, lhs, expr, avail_vars)
+                    avail_vars.append(lhs.name)
+                new_body.append(instr)
+            block.body = new_body
 
 class ConvertSetItemPass:
     """Parfor subpass to convert setitem on Arrays
@@ -2658,6 +2817,8 @@ class ParforPass(ParforPassStates):
             parfor_ids, parfors = get_parfor_params(self.func_ir.blocks,
                                                     self.options.fusion,
                                                     self.nested_fusion_info)
+
+            # Validate reduction in parfors.
             for p in parfors:
                 get_parfor_reductions(self.func_ir, p, p.params, self.calltypes)
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -614,6 +614,26 @@ class Parfor(ir.Expr, ir.Stmt):
             block.dump(file)
         print(("end parfor {}".format(self.id)).center(20, '-'), file=file)
 
+    def validate_params(self, typemap):
+        """
+        Check that Parfors params are of valid types.
+        """
+        if self.params is None:
+            msg = ("Cannot run parameter validation on a Parfor with params"
+                   "not set")
+            raise ValueError(msg)
+        for p in self.params:
+            ty = typemap.get(p)
+            if ty is None:
+                msg = ("Cannot validate parameter %s, there is no type "
+                       "information available")
+                raise ValueError(msg)
+            if isinstance(ty, types.BaseTuple):
+                msg = ("Use of a tuple (%s) in a parallel region is not "
+                       "supported due to a limitation of the Generalized "
+                       "Universal Functions that back parallel regions.")
+                raise errors.UnsupportedError(msg % p, self.loc)
+
 def _analyze_parfor(parfor, equiv_set, typemap, array_analysis):
     """Recursive array analysis for parfor nodes.
     """
@@ -2639,6 +2659,11 @@ class ParforPass(ParforPassStates):
                                                     self.nested_fusion_info)
             for p in parfors:
                 get_parfor_reductions(self.func_ir, p, p.params, self.calltypes)
+
+            # Validate parameters:
+            for p in parfors:
+                p.validate_params(self.typemap)
+
             if config.DEBUG_ARRAY_OPT_STATS:
                 name = self.func_ir.func_id.func_qualname
                 n_parfors = len(parfor_ids)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -629,10 +629,19 @@ class Parfor(ir.Expr, ir.Stmt):
                        "information available")
                 raise ValueError(msg)
             if isinstance(ty, types.BaseTuple):
-                msg = ("Use of a tuple (%s) in a parallel region is not "
-                       "supported due to a limitation of the Generalized "
-                       "Universal Functions that back parallel regions.")
-                raise errors.UnsupportedParforsError(msg % p, self.loc)
+                if ty.count > config.PARFOR_MAX_TUPLE_SIZE:
+                    msg = ("Use of a tuple (%s) in a parallel region having "
+                           "%d elements.  Since Generalized Universal Functions "
+                           "(GUFUNCs) back parallel regions and GUFUNCs don't "
+                           "support tuples, Numba will unpack tuples up to a "
+                           "certain size threshold in order to pass them to "
+                           "the GUFUNC.  This threshold is currently "
+                           "configured to be %d. This threshold can be "
+                           "changed by setting the Numba environment variable "
+                           "NUMBA_PARFOR_MAX_TUPLE_SIZE.")
+                    raise errors.UnsupportedParforsError(msg %
+                              (p, ty.count, config.PARFOR_MAX_TUPLE_SIZE),
+                              self.loc)
 
 
 def _analyze_parfor(parfor, equiv_set, typemap, array_analysis):
@@ -1523,165 +1532,6 @@ class ParforPassStates:
         ir_utils._max_label = max(func_ir.blocks.keys())
         self.flags = flags
 
-    def run(self):
-        """run parfor conversion pass: replace Numpy calls
-        with Parfors when possible and optimize the IR."""
-        # run array analysis, a pre-requisite for parfor translation
-        remove_dels(self.func_ir.blocks)
-        self.array_analysis.run(self.func_ir.blocks)
-        # run stencil translation to parfor
-        if self.options.stencil:
-            stencil_pass = StencilPass(self.func_ir, self.typemap, self.calltypes,
-                                            self.array_analysis, self.typingctx, self.flags)
-            stencil_pass.run()
-        if self.options.setitem:
-            self._convert_setitem(self.func_ir.blocks)
-        if self.options.numpy:
-            self._convert_numpy(self.func_ir.blocks)
-        if self.options.reduction:
-            self._convert_reduce(self.func_ir.blocks)
-        if self.options.prange:
-           self._convert_loop(self.func_ir.blocks)
-
-        # setup diagnostics now parfors are found
-        self.diagnostics.setup(self.func_ir, self.options.fusion)
-
-        dprint_func_ir(self.func_ir, "after parfor pass")
-
-        # simplify CFG of parfor body loops since nested parfors with extra
-        # jumps can be created with prange conversion
-        simplify_parfor_body_CFG(self.func_ir.blocks)
-        # simplify before fusion
-        simplify(self.func_ir, self.typemap, self.calltypes)
-        # need two rounds of copy propagation to enable fusion of long sequences
-        # of parfors like test_fuse_argmin (some PYTHONHASHSEED values since
-        # apply_copies_parfor depends on set order for creating dummy assigns)
-        simplify(self.func_ir, self.typemap, self.calltypes)
-
-        if self.options.fusion:
-            self.func_ir._definitions = build_definitions(self.func_ir.blocks)
-            self.array_analysis.equiv_sets = dict()
-            self.array_analysis.run(self.func_ir.blocks)
-            # reorder statements to maximize fusion
-            # push non-parfors down
-            maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap,
-                                                            up_direction=False)
-            dprint_func_ir(self.func_ir, "after maximize fusion down")
-            self.fuse_parfors(self.array_analysis, self.func_ir.blocks)
-            # push non-parfors up
-            maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap)
-            dprint_func_ir(self.func_ir, "after maximize fusion up")
-            # try fuse again after maximize
-            self.fuse_parfors(self.array_analysis, self.func_ir.blocks)
-            dprint_func_ir(self.func_ir, "after fusion")
-        # simplify again
-        simplify(self.func_ir, self.typemap, self.calltypes)
-        # push function call variables inside parfors so gufunc function
-        # wouldn't need function variables as argument
-        push_call_vars(self.func_ir.blocks, {}, {}, self.typemap)
-        dprint_func_ir(self.func_ir, "after push call vars")
-        # simplify again
-        simplify(self.func_ir, self.typemap, self.calltypes)
-        dprint_func_ir(self.func_ir, "after optimization")
-        if config.DEBUG_ARRAY_OPT >= 1:
-            print("variable types: ", sorted(self.typemap.items()))
-            print("call types: ", self.calltypes)
-
-        if config.DEBUG_ARRAY_OPT >= 3:
-            for(block_label, block) in self.func_ir.blocks.items():
-                new_block = []
-                scope = block.scope
-                for stmt in block.body:
-                    new_block.append(stmt)
-                    if isinstance(stmt, ir.Assign):
-                        loc = stmt.loc
-                        lhs = stmt.target
-                        rhs = stmt.value
-                        lhs_typ = self.typemap[lhs.name]
-                        print("Adding print for assignment to ", lhs.name, lhs_typ, type(lhs_typ))
-                        if lhs_typ in types.number_domain or isinstance(lhs_typ, types.Literal):
-                            str_var = ir.Var(scope, mk_unique_var("str_var"), loc)
-                            self.typemap[str_var.name] = types.StringLiteral(lhs.name)
-                            lhs_const = ir.Const(lhs.name, loc)
-                            str_assign = ir.Assign(lhs_const, str_var, loc)
-                            new_block.append(str_assign)
-                            str_print = ir.Print([str_var], None, loc)
-                            self.calltypes[str_print] = signature(types.none, self.typemap[str_var.name])
-                            new_block.append(str_print)
-                            ir_print = ir.Print([lhs], None, loc)
-                            self.calltypes[ir_print] = signature(types.none, lhs_typ)
-                            new_block.append(ir_print)
-                block.body = new_block
-
-        # run post processor again to generate Del nodes
-        post_proc = postproc.PostProcessor(self.func_ir)
-        post_proc.run()
-        if self.func_ir.is_generator:
-            fix_generator_types(self.func_ir.generator_info, self.return_type,
-                                self.typemap)
-        if sequential_parfor_lowering:
-            lower_parfor_sequential(
-                self.typingctx, self.func_ir, self.typemap, self.calltypes)
-        else:
-            # prepare for parallel lowering
-            # add parfor params to parfors here since lowering is destructive
-            # changing the IR after this is not allowed
-            parfor_ids, parfors = get_parfor_params(self.func_ir.blocks,
-                                                    self.options.fusion,
-                                                    self.nested_fusion_info)
-
-            # Validate reduction in parfors.
-            for p in parfors:
-                get_parfor_reductions(self.func_ir, p, p.params, self.calltypes)
-
-            # Validate parameters:
-            for p in parfors:
-                p.validate_params(self.typemap)
-
-            if config.DEBUG_ARRAY_OPT_STATS:
-                name = self.func_ir.func_id.func_qualname
-                n_parfors = len(parfor_ids)
-                if n_parfors > 0:
-                    after_fusion = ("After fusion" if self.options.fusion
-                                    else "With fusion disabled")
-                    print(('{}, function {} has '
-                           '{} parallel for-loop(s) #{}.').format(
-                           after_fusion, name, n_parfors, parfor_ids))
-                else:
-                    print('Function {} has no Parfor.'.format(name))
-
-        return
-
-    def _convert_numpy(self, blocks):
-        """
-        Convert supported Numpy functions, as well as arrayexpr nodes, to
-        parfor nodes.
-        """
-        topo_order = find_topo_order(blocks)
-        # variables available in the program so far (used for finding map
-        # functions in array_expr lowering)
-        avail_vars = []
-        for label in topo_order:
-            block = blocks[label]
-            new_body = []
-            equiv_set = self.array_analysis.get_equiv_set(label)
-            for instr in block.body:
-                if isinstance(instr, ir.Assign):
-                    expr = instr.value
-                    lhs = instr.target
-                    if self._is_C_order(lhs.name):
-                        # only translate C order since we can't allocate F
-                        if guard(self._is_supported_npycall, expr):
-                            instr = self._numpy_to_parfor(equiv_set, lhs, expr)
-                            if isinstance(instr, tuple):
-                                pre_stmts, instr = instr
-                                new_body.extend(pre_stmts)
-                        elif isinstance(expr, ir.Expr) and expr.op == 'arrayexpr':
-                            instr = self._arrayexpr_to_parfor(
-                                equiv_set, lhs, expr, avail_vars)
-                    avail_vars.append(lhs.name)
-                new_body.append(instr)
-            block.body = new_body
 
 class ConvertSetItemPass:
     """Parfor subpass to convert setitem on Arrays

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -796,8 +796,6 @@ def _create_gufunc_for_parfor_body(
     if config.DEBUG_ARRAY_OPT >= 1:
         print("starting _create_gufunc_for_parfor_body")
 
-    call_table = get_call_table(lowerer.func_ir.blocks)
-
     loc = parfor.init_block.loc
 
     # The parfor body and the main function body share ir.Var nodes.

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -845,8 +845,8 @@ def _create_gufunc_for_parfor_body(
             # Get the size and dtype of the tuple.
             tuple_count = pi_type.count
             tuple_dtype = pi_type.dtype
-            # Only do tuples up to 10 length.
-            if tuple_count < 10:
+            # Only do tuples up to config.PARFOR_MAX_TUPLE_SIZE length.
+            if tuple_count <= config.PARFOR_MAX_TUPLE_SIZE:
                 this_var_expansion = []
                 for i in range(tuple_count):
                     # Generate a new name for the individual part of the tuple var.
@@ -872,7 +872,8 @@ def _create_gufunc_for_parfor_body(
             # pi_type.types[offset].
             tuple_count = pi_type.count
             tuple_types = pi_type.types
-            if tuple_count < 10:
+            # Only do tuples up to config.PARFOR_MAX_TUPLE_SIZE length.
+            if tuple_count <= config.PARFOR_MAX_TUPLE_SIZE:
                 this_var_expansion = []
                 for i in range(tuple_count):
                     expanded_name = "expanded_tuple_var_" + str(next_expanded_tuple_var)

--- a/numba/tests/test_analysis.py
+++ b/numba/tests/test_analysis.py
@@ -1,10 +1,11 @@
 # Tests numba.analysis functions
 import collections
+import types as pytypes
 
 import numpy as np
 from numba.core.compiler import compile_isolated, run_frontend, Flags, StateDict
 from numba import jit, njit
-from numba.core import types, errors, ir, rewrites, ir_utils
+from numba.core import types, errors, ir, rewrites, ir_utils, utils
 from numba.tests.support import TestCase, MemoryLeakMixin, SerialMixin
 
 from numba.core.analysis import dead_branch_prune, rewrite_semantic_constants
@@ -561,6 +562,238 @@ class TestBranchPrune(TestBranchPruneBase, SerialMixin):
                            types.float64, types.NoneType('none')),
                           [None, None],
                           np.zeros((2, 3)), 1.2, None)
+
+
+class TestBranchPrunePredicates(TestBranchPruneBase, SerialMixin):
+    # Really important thing to remember... the branch on predicates end up as
+    # POP_JUMP_IF_<bool> and the targets are backwards compared to normal, i.e.
+    # the true condition is far jump and the false the near i.e. `if x` would
+    # end up in Numba IR as e.g. `branch x 10, 6`.
+
+    _TRUTHY = (1, "String", True, 7.4, 3j)
+    _FALSEY = (0, "", False, 0.0, 0j, None)
+
+    def _literal_const_sample_generator(self, pyfunc, consts):
+        """
+        This takes a python function, pyfunc, and manipulates its co_const
+        __code__ member to create a new function with different co_consts as
+        supplied in argument consts.
+
+        consts is a dict {index: value} of co_const tuple index to constant
+        value used to update a pyfunc clone's co_const.
+        """
+        pyfunc_code = pyfunc.__code__
+
+        # translate consts spec to update the constants
+        co_consts = {k: v for k, v in enumerate(pyfunc_code.co_consts)}
+        for k, v in consts.items():
+            co_consts[k] = v
+        new_consts = tuple([v for _, v in sorted(co_consts.items())])
+
+        # create new code parts
+        co_args = [pyfunc_code.co_argcount]
+
+        if utils.PYVERSION >= (3, 8):
+            co_args.append(pyfunc_code.co_posonlyargcount)
+        co_args.append(pyfunc_code.co_kwonlyargcount)
+        co_args.extend([pyfunc_code.co_nlocals,
+                        pyfunc_code.co_stacksize,
+                        pyfunc_code.co_flags,
+                        pyfunc_code.co_code,
+                        new_consts,
+                        pyfunc_code.co_names,
+                        pyfunc_code.co_varnames,
+                        pyfunc_code.co_filename,
+                        pyfunc_code.co_name,
+                        pyfunc_code.co_firstlineno,
+                        pyfunc_code.co_lnotab,
+                        pyfunc_code.co_freevars,
+                        pyfunc_code.co_cellvars
+                        ])
+
+        # create code object with mutation
+        new_code = pytypes.CodeType(*co_args)
+
+        # get function
+        return pytypes.FunctionType(new_code, globals())
+
+    def test_literal_const_code_gen(self):
+        def impl(x):
+            _CONST1 = "PLACEHOLDER1"
+            if _CONST1:
+                return 3.14159
+            else:
+                _CONST2 = "PLACEHOLDER2"
+            return _CONST2 + 4
+
+        new = self._literal_const_sample_generator(impl, {1:0, 3:20})
+        iconst = impl.__code__.co_consts
+        nconst = new.__code__.co_consts
+        self.assertEqual(iconst, (None, "PLACEHOLDER1", 3.14159,
+                                  "PLACEHOLDER2", 4))
+        self.assertEqual(nconst, (None, 0, 3.14159,  20, 4))
+        self.assertEqual(impl(None), 3.14159)
+        self.assertEqual(new(None), 24)
+
+    def test_single_if_const(self):
+
+        def impl(x):
+            _CONST1 = "PLACEHOLDER1"
+            if _CONST1:
+                return 3.14159
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+                func = self._literal_const_sample_generator(impl, {1: const})
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_negate_const(self):
+
+        def impl(x):
+            _CONST1 = "PLACEHOLDER1"
+            if not _CONST1:
+                return 3.14159
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+                func = self._literal_const_sample_generator(impl, {1: const})
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_const(self):
+
+        def impl(x):
+            _CONST1 = "PLACEHOLDER1"
+            if _CONST1:
+                return 3.14159
+            else:
+                return 1.61803
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+                func = self._literal_const_sample_generator(impl, {1: const})
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_negate_const(self):
+
+        def impl(x):
+            _CONST1 = "PLACEHOLDER1"
+            if not _CONST1:
+                return 3.14159
+            else:
+                return 1.61803
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+                func = self._literal_const_sample_generator(impl, {1: const})
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_freevar(self):
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+
+                def func(x):
+                    if const:
+                        return 3.14159
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_negate_freevar(self):
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+
+                def func(x):
+                    if not const:
+                        return 3.14159
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_freevar(self):
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+
+                def func(x):
+                    if const:
+                        return 3.14159
+                    else:
+                        return 1.61803
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_negate_freevar(self):
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for const in c_inp:
+
+                def func(x):
+                    if not const:
+                        return 3.14159
+                    else:
+                        return 1.61803
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    # globals in this section have absurd names after their test usecase names
+    # so as to prevent collisions and permit tests to run in parallel
+    def test_single_if_global(self):
+        global c_test_single_if_global
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for c in c_inp:
+                c_test_single_if_global = c
+
+                def func(x):
+                    if c_test_single_if_global:
+                        return 3.14159
+
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_negate_global(self):
+        global c_test_single_if_negate_global
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for c in c_inp:
+                c_test_single_if_negate_global = c
+
+                def func(x):
+                    if c_test_single_if_negate_global:
+                        return 3.14159
+
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_global(self):
+        global c_test_single_if_else_global
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for c in c_inp:
+                c_test_single_if_else_global = c
+
+                def func(x):
+                    if c_test_single_if_else_global:
+                        return 3.14159
+                    else:
+                        return 1.61803
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
+
+    def test_single_if_else_negate_global(self):
+        global c_test_single_if_else_negate_global
+
+        for c_inp, prune in (self._TRUTHY, False), (self._FALSEY, True):
+            for c in c_inp:
+                c_test_single_if_else_negate_global = c
+
+                def func(x):
+                    if not c_test_single_if_else_negate_global:
+                        return 3.14159
+                    else:
+                        return 1.61803
+                self.assert_prune(func, (types.NoneType('none'),), [prune],
+                                  None)
 
 
 class TestBranchPrunePostSemanticConstRewrites(TestBranchPruneBase):

--- a/numba/tests/test_array_iterators.py
+++ b/numba/tests/test_array_iterators.py
@@ -15,6 +15,9 @@ def array_iter(arr):
         total += i * v
     return total
 
+def array_iter_items(arr):
+    return list(iter(arr))
+
 def array_view_iter(arr, idx):
     total = 0
     for i, v in enumerate(arr[idx]):
@@ -124,8 +127,15 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
         super(TestArrayIterators, self).setUp()
         self.ccache = CompilationCache()
 
-    def check_array_iter(self, arr):
+    def check_array_iter_1d(self, arr):
         pyfunc = array_iter
+        cres = compile_isolated(pyfunc, [typeof(arr)])
+        cfunc = cres.entry_point
+        expected = pyfunc(arr)
+        self.assertPreciseEqual(cfunc(arr), expected)
+
+    def check_array_iter_items(self, arr):
+        pyfunc = array_iter_items
         cres = compile_isolated(pyfunc, [typeof(arr)])
         cfunc = cres.entry_point
         expected = pyfunc(arr)
@@ -166,13 +176,19 @@ class TestArrayIterators(MemoryLeakMixin, TestCase):
     def test_array_iter(self):
         # Test iterating over a 1d array
         arr = np.arange(6)
-        self.check_array_iter(arr)
+        self.check_array_iter_1d(arr)
+        self.check_array_iter_items(arr)
         arr = arr[::2]
         self.assertFalse(arr.flags.c_contiguous)
         self.assertFalse(arr.flags.f_contiguous)
-        self.check_array_iter(arr)
+        self.check_array_iter_1d(arr)
+        self.check_array_iter_items(arr)
         arr = np.bool_([1, 0, 0, 1])
-        self.check_array_iter(arr)
+        self.check_array_iter_1d(arr)
+        self.check_array_iter_items(arr)
+        arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        self.check_array_iter_items(arr)
+        self.check_array_iter_items(arr.T)
 
     def test_array_view_iter(self):
         # Test iterating over a 1d view over a 2d array

--- a/numba/tests/test_iteration.py
+++ b/numba/tests/test_iteration.py
@@ -188,23 +188,18 @@ class IterationTest(MemoryLeakMixin, TestCase):
     def test_array_1d_record_mutate(self):
         self.test_array_1d_record_mutate_npm(flags=force_pyobj_flags)
 
-    def test_array_2d_raises(self):
+    def test_array_0d_raises(self):
 
         def foo(x):
             for i in x:
                 pass
 
-        # 1D is fine
-        aryty = types.Array(types.int32, 1, 'C')
-        compile_isolated(foo, (aryty,))
-
-        # 2d is typing error
+        # 0d is typing error
         with self.assertRaises(errors.TypingError) as raises:
-            aryty = types.Array(types.int32, 2, 'C')
+            aryty = types.Array(types.int32, 0, 'C')
             compile_isolated(foo, (aryty,))
 
-        self.assertIn("Direct iteration is not supported",
-                      str(raises.exception))
+        self.assertIn("0-d array", str(raises.exception))
 
     def test_tuple_iter_issue1504(self):
         # The issue is due to `row` being typed as heterogeneous tuple.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -16,7 +16,7 @@ from functools import reduce
 import numpy as np
 from numpy.random import randn
 import operator
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 
 import numba.parfors.parfor
 from numba import njit, prange, set_num_threads, get_num_threads
@@ -47,6 +47,8 @@ x86_only = unittest.skipIf(platform.machine() not in ('i386', 'x86_64'), 'x86 on
 
 _GLOBAL_INT_FOR_TESTING1 = 17
 _GLOBAL_INT_FOR_TESTING2 = 5
+
+TestNamedTuple = namedtuple('TestNamedTuple', ('part0', 'part1'))
 
 class TestParforsBase(TestCase):
     """
@@ -1576,6 +1578,18 @@ class TestParfors(TestParforsBase):
             b = 7
             for i in numba.prange(len(a)):
                 a[i] += atup[0] + b
+            return a
+
+        x = np.arange(10)
+        self.check(test_impl, x)
+
+    @skip_parfors_unsupported
+    def test_namedtuple1(self):
+        def test_impl(a):
+            antup = TestNamedTuple(part0=3, part1=4)
+            b = 7
+            for i in numba.prange(len(a)):
+                a[i] += antup.part0 + antup.part1 + b
             return a
 
         x = np.arange(10)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3261,18 +3261,20 @@ class TestParforsMisc(TestParforsBase):
             # original state
             numba.parfors.parfor.sequential_parfor_lowering = save_state
 
-    def test_tuple_as_arg_to_kernel(self):
-
+    def test_oversized_tuple_as_arg_to_kernel(self):
         @njit(parallel=True)
-        def tuple_bug():
-            t = (10,)
+        def oversize_tuple():
+            big_tup = (1,2,3,4)
             z = 0
             for x in prange(10):
-                z += t[0]
+                z += big_tup[0]
             return z
 
+        save_max = config.PARFOR_MAX_TUPLE_SIZE
+        config.PARFOR_MAX_TUPLE_SIZE = 3
         with self.assertRaises(errors.UnsupportedParforsError) as raises:
-            tuple_bug()
+            oversize_tuple()
+        config.PARFOR_MAX_TUPLE_SIZE = save_max
 
         errstr = str(raises.exception)
         self.assertIn("Use of a tuple", errstr)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3068,6 +3068,8 @@ class TestParforsBitMask(TestParforsBase):
             self.check(test_impl, a, b, c)
         self.assertIn("\'@do_scheduling\' not found", str(raises.exception))
 
+
+@skip_parfors_unsupported
 class TestParforsMisc(TestParforsBase):
     """
     Tests miscellaneous parts of ParallelAccelerator use.
@@ -3078,7 +3080,6 @@ class TestParforsMisc(TestParforsBase):
         cfunc, cpfunc = self.compile_all(pyfunc, *args)
         self.check_parfors_vs_others(pyfunc, cfunc, cpfunc, *args, **kwargs)
 
-    @skip_parfors_unsupported
     def test_no_warn_if_cache_set(self):
 
         def pyfunc():
@@ -3100,7 +3101,6 @@ class TestParforsMisc(TestParforsBase):
                                for cres in cfunc.overloads.values()]
         self.assertEqual(has_dynamic_globals, [False])
 
-    @skip_parfors_unsupported
     def test_statement_reordering_respects_aliasing(self):
         def impl():
             a = np.zeros(10)
@@ -3115,7 +3115,6 @@ class TestParforsMisc(TestParforsBase):
         for line in stdout.getvalue().splitlines():
             self.assertEqual('a[3]: 2.0', line)
 
-    @skip_parfors_unsupported
     def test_parfor_ufunc_typing(self):
         def test_impl(A):
             return np.isinf(A)
@@ -3131,7 +3130,6 @@ class TestParforsMisc(TestParforsBase):
             # recover global state
             numba.parfors.parfor.sequential_parfor_lowering = old_seq_flag
 
-    @skip_parfors_unsupported
     def test_init_block_dce(self):
         # issue4690
         def test_impl():
@@ -3145,7 +3143,6 @@ class TestParforsMisc(TestParforsBase):
 
         self.assertTrue(get_init_block_size(test_impl, ()) == 0)
 
-    @skip_parfors_unsupported
     def test_alias_analysis_for_parfor1(self):
         def test_impl():
             acc = 0
@@ -3157,7 +3154,6 @@ class TestParforsMisc(TestParforsBase):
 
         self.check(test_impl)
 
-    @skip_parfors_unsupported
     def test_no_state_change_in_gufunc_lowering_on_error(self):
         # tests #5098, if there's an exception arising in gufunc lowering the
         # sequential_parfor_lowering global variable should remain as False on
@@ -3212,7 +3208,6 @@ class TestParforsMisc(TestParforsBase):
         # assert state has not changed
         self.assertFalse(numba.parfors.parfor.sequential_parfor_lowering)
 
-    @skip_parfors_unsupported
     def test_issue_5098(self):
         class DummyType(types.Opaque):
             pass
@@ -3265,6 +3260,23 @@ class TestParforsMisc(TestParforsBase):
             # always set the sequential_parfor_lowering state back to the
             # original state
             numba.parfors.parfor.sequential_parfor_lowering = save_state
+
+    def test_tuple_as_arg_to_kernel(self):
+
+        @njit(parallel=True)
+        def tuple_bug():
+            t = (10,)
+            z = 0
+            for x in prange(10):
+                z += t[0]
+            return z
+
+        with self.assertRaises(errors.UnsupportedParforsError) as raises:
+            tuple_bug()
+
+        errstr = str(raises.exception)
+        self.assertIn("Use of a tuple", errstr)
+        self.assertIn("in a parallel region", errstr)
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1557,6 +1557,30 @@ class TestParfors(TestParforsBase):
                                     (types.Array(types.float64, 1, 'C'),
                                      types.Array(types.float64, 1, 'C'))) == 1)
 
+    @skip_parfors_unsupported
+    def test_tuple1(self):
+        def test_impl(a):
+            atup = (3,4)
+            b = 7
+            for i in numba.prange(len(a)):
+                a[i] += atup[0] + atup[1] + b
+            return a
+
+        x = np.arange(10)
+        self.check(test_impl, x)
+
+    @skip_parfors_unsupported
+    def test_tuple2(self):
+        def test_impl(a):
+            atup = a.shape
+            b = 7
+            for i in numba.prange(len(a)):
+                a[i] += atup[0] + b
+            return a
+
+        x = np.arange(10)
+        self.check(test_impl, x)
+
 
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):
     def check(self, pyfunc, *args, **kwargs):


### PR DESCRIPTION
Partially resolves #5282 This is to get the discussion going.  This patch convert tuples of size less than 10 to individual parameters.  Are the cases we know about with really large counts UniTuples?  If so then maybe conversion to an array would be better?  

We can try to generate a better error message in this area where I check types but it is still in lowering.  I can add something to check it before lowering as well.  Thoughts?