### PR TITLE
[WIP] Add support for numpy insert

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -363,6 +363,7 @@ The following top-level functions are supported:
 * :func:`numpy.histogram` (only the 3 first arguments)
 * :func:`numpy.hstack`
 * :func:`numpy.identity`
+* :func:`numpy.insert` (only `obj` of type `int` or `slice`)
 * :func:`numpy.kaiser`
 * :func:`numpy.interp` (only the 3 first arguments; requires NumPy >= 1.10)
 * :func:`numpy.linspace` (only the 3-argument form)

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -601,3 +601,16 @@ def type_can_asarray(arr):
     """
     ok = (types.Array, types.Sequence, types.Tuple, types.Number, types.Boolean)
     return isinstance(arr, ok)
+
+
+def obj_is_int_slice_or_sequence_of_ints(obj):
+    """
+    Returns `True` if `obj` is either an integer, a slice or a sequence of
+    integers.
+
+    TODO: Implement a check whether all sequence elements are `types.Integer`.
+          Until then, only parts of the functionality will be supported.
+    """
+    ok = (types.Integer, slice)
+
+    return isinstance(obj, ok)


### PR DESCRIPTION
Adds support for `numpy.insert`, including tests.

Intended to close:
#3878

