### PR TITLE
Provide `numba.extending.is_jitted`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -51,7 +51,6 @@ exclude =
     numba/core/dataflow.py
     numba/runtests.py
     numba/core/pythonapi.py
-    numba/extending.py
     numba/core/decorators.py
     numba/core/typeconv/typeconv.py
     numba/core/typeconv/rules.py

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -511,3 +511,16 @@ class BoundLiteralArgs(collections.namedtuple(
             args,
             kwargs,
         )
+
+
+def is_jitted(function):
+    """Returns True if a function is wrapped by one of the Numba @jit
+    decorators, for example: numba.jit, numba.njit
+
+    The purpose of this function is to provide a means to check if a function is
+    already JIT decorated.
+    """
+
+    # don't want to export this so import locally
+    from numba.core.dispatcher import Dispatcher
+    return isinstance(function, Dispatcher)

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -1,4 +1,3 @@
 # Re-export symbols
 from numba.core.extending import *  # noqa: F403, F401
 from numba.core.extending import _Intrinsic  # noqa: F401
-

--- a/numba/extending.py
+++ b/numba/extending.py
@@ -1,3 +1,4 @@
 # Re-export symbols
-from numba.core.extending import *
-from numba.core.extending import _Intrinsic
+from numba.core.extending import *  # noqa: F403, F401
+from numba.core.extending import _Intrinsic  # noqa: F401
+

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -9,7 +9,7 @@ import re
 
 import numpy as np
 
-from numba import njit, jit
+from numba import njit, jit, vectorize, guvectorize
 from numba.core import types, errors, typing, compiler, cgutils
 from numba.core.typed_passes import type_inference_stage
 from numba.core.registry import cpu_target
@@ -28,7 +28,8 @@ from numba.extending import (typeof_impl, type_callable,
                              make_attribute_wrapper,
                              intrinsic, _Intrinsic,
                              register_jitable,
-                             get_cython_function_address
+                             get_cython_function_address,
+                             is_jitted,
                              )
 from numba.core.typing.templates import (
     ConcreteTemplate, signature, infer, infer_global, AbstractTemplate)
@@ -1578,6 +1579,19 @@ class TestBoxingCallingJIT(TestCase):
             "cannot do x > 0",
             str(raises.exception),
         )
+
+
+class TestMisc(TestCase):
+
+    def test_is_jitted(self):
+        def foo(x):
+            pass
+
+        self.assertFalse(is_jitted(foo))
+        self.assertTrue(is_jitted(njit(foo)))
+        self.assertFalse(is_jitted(vectorize(foo)))
+        self.assertFalse(is_jitted(vectorize(parallel=True)(foo)))
+        self.assertFalse(is_jitted(guvectorize('void(float64[:])', '(m)')(foo)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Provides `numba.extending.is_jitted` as a means to query
whether a function is JIT wrapped.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
