### PR TITLE
Make user facing error string use abs path not rel.

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -632,7 +632,7 @@ class CUDAKernel(CUDAKernelBase):
                     locinfo = ''
                 else:
                     sym, filepath, lineno = loc
-                    filepath = os.path.relpath(filepath)
+                    filepath = os.path.abspath(filepath)
                     locinfo = 'In function %r, file %s, line %s, ' % (
                         sym, filepath, lineno,
                         )

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -8,7 +8,7 @@ class MyError(Exception):
 
 
 regex_pattern = (
-    r'In function [\'"]test_exc[\'"], file [\.\/\\\-a-zA-Z_0-9]+, line \d+'
+    r'In function [\'"]test_exc[\'"], file [\:\.\/\\\-a-zA-Z_0-9]+, line \d+'
 )
 
 


### PR DESCRIPTION
This fixes a bug that appeared on windows where the installation
and CWD were on different drives and as a result `os.path.relpath`
raises a ValueError. `os.path.abspath` will produce a longer but
more OS situation tolerant string.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
