### PR TITLE
Document lifetime semantics of CUDA Array Interface

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -76,6 +76,43 @@ The following are optional entries:
             and will raise a ``NotImplementedError`` exception if one is passed
             to a GPU function.
 
+
+Lifetime management
+-------------------
+
+Obtaining the value of the ``__cuda_array_interface__`` property of any object
+has no effect on the lifetime of the object from which it was created. In
+particular, note that the interface has no slot for the owner of the data.
+
+It is therefore imperative for a consumer to retain a reference to the object
+owning the data for as long as they make use of the data.
+
+
+Lifetime management in Numba
+----------------------------
+
+Numba provides two mechanisms for creating device arrays. Which to use depends
+on whether the created device array should maintain the life of the object from
+which it is created:
+
+- ``as_cuda_array``: This creates a device array that holds a reference to the
+  owning object. As long as a reference to the device array is held, its
+  underlying data will also be kept alive, even if all other references to the
+  original owning object have been dropped.
+- ``from_cuda_array_interface``: This creates a device array with no reference
+  to the owning object by default. The owning object, or some other object to
+  be considered the owner can be passed in the ``owner`` parameter.
+
+The interfaces of these functions are:
+
+.. automethod:: numba.cuda.as_cuda_array
+
+.. automethod:: numba.cuda.from_cuda_array_interface
+
+
+Pointer Attributes
+------------------
+
 Additional information about the data pointer can be retrieved using
 ``cuPointerGetAttribute`` or ``cudaPointerGetAttributes``.  Such information
 include:


### PR DESCRIPTION
This documents the lifetime of objects in relation to the CUDA Array Interface - the content is taken from #5162 with some editing for clarity, as this is the uncontentious part of the PR.

The wording only clarifies and makes explicit what is already required of the user of the interface - it does not specify any semantic changes.

This also resolves #5164 (document `from_cuda_array_interface`).
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
