### PR TITLE
Add warning if FNV hashing is found as the default for CPython.

### DIFF
--- a/numba/tests/test_hashing.py
+++ b/numba/tests/test_hashing.py
@@ -37,8 +37,6 @@ class TestHashingSetup(TestCase):
         # hash_info is a StructSequence, mock as a named tuple
         fields = ["width", "modulus", "inf", "nan", "imag", "algorithm",
                   "hash_bits", "seed_bits", "cutoff"]
-        if sys.version_info[:2] > (3, 7):
-            fields.append("memoryviews")
 
         hinfo = sys.hash_info
         FAKE_HASHINFO = namedtuple('FAKE_HASHINFO', fields)

--- a/numba/tests/test_hashing.py
+++ b/numba/tests/test_hashing.py
@@ -6,7 +6,9 @@ Test hashing of various supported types.
 import unittest
 
 import sys
+import subprocess
 from collections import defaultdict
+from textwrap import dedent
 
 import numpy as np
 
@@ -21,6 +23,49 @@ from numba.cpython import hashing
 
 def hash_usecase(x):
     return hash(x)
+
+
+class TestHashingSetup(TestCase):
+
+    def test_warn_on_fnv(self):
+        # FNV hash alg variant is not supported, check Numba warns
+        work = """
+        import sys
+        import warnings
+        from collections import namedtuple
+
+        # hash_info is a StructSequence, mock as a named tuple
+        fields = ["width", "modulus", "inf", "nan", "imag", "algorithm",
+                  "hash_bits", "seed_bits", "cutoff"]
+        if sys.version_info[:2] > (3, 7):
+            fields.append("memoryviews")
+
+        hinfo = sys.hash_info
+        FAKE_HASHINFO = namedtuple('FAKE_HASHINFO', fields)
+
+        fd = dict()
+        for f in fields:
+            fd[f] = getattr(hinfo, f)
+
+        fd['algorithm'] = 'fnv'
+
+        fake_hashinfo = FAKE_HASHINFO(**fd)
+
+        # replace the hashinfo with the fnv version
+        sys.hash_info = fake_hashinfo
+        with warnings.catch_warnings(record=True) as warns:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            import numba
+            assert len(warns) > 0
+            expect = "FNV hashing is not implemented in Numba. See PEP 456"
+            for w in warns:
+                if expect in str(w.message):
+                    break
+            else:
+                raise RuntimeError("Expected warning not found")
+        """
+        subprocess.check_call([sys.executable, '-c', dedent(work)])
 
 
 class BaseTest(TestCase):


### PR DESCRIPTION
As title. This basically raises a warning if the CPython importing
Numba uses FNV as a hashing alg. This doesn't stop Numba from
working, it just means that Numba and CPython hashes may not match.

Closes #5324

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
