### PR TITLE
NBEP 7: External Memory Management Plugin Interface

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -110,6 +110,9 @@ profiling, see the `NVidia Profiler User's Guide
 .. autofunction:: numba.cuda.profile_stop
 .. autofunction:: numba.cuda.profiling
 
+
+.. _events:
+
 Events
 ~~~~~~
 
@@ -129,6 +132,9 @@ Events are instances of the :class:`numba.cuda.cudadrv.driver.Event` class:
 
 .. autoclass:: numba.cuda.cudadrv.driver.Event
    :members: query, record, synchronize, wait
+
+
+.. _streams:
 
 Stream Management
 -----------------

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -152,6 +152,7 @@ The following Python libraries have adopted the CUDA Array Interface:
 - `ArrayViews <https://github.com/xnd-project/arrayviews>`_
 - `JAX <https://jax.readthedocs.io/en/latest/index.html>`_
 - The RAPIDS stack:
+
     - `cuDF <https://rapidsai.github.io/projects/cudf/en/0.11.0/10min-cudf-cupy.html>`_
     - `cuML <https://docs.rapids.ai/api/cuml/nightly/>`_
     - `cuSignal <https://github.com/rapidsai/cusignal>`_

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -1,0 +1,34 @@
+===========================================
+External Memory Management plugin interface
+===========================================
+
+.. _cuda-emm-plugin:
+
+By default, Numba allocates memory on CUDA devices by interacting with the CUDA
+driver API to call functions such as ``cuMemAlloc`` and ``cuMemFree``. This is
+suitable for many use cases. When Numba is used in conjunction with other
+CUDA-aware libraries that also allocate memory,
+
+Plugin interface
+================
+
+.. autoclass:: numba.cuda.BaseCUDAMemoryManager
+   :members: __init__, memalloc, memhostalloc, mempin, initialize,
+             get_ipc_handle, get_memory_info, reset, defer_cleanup,
+             interface_version
+
+.. autoclass:: numba.cuda.cudadrv.driver.MemoryInfo
+
+Memory pointers
+===============
+
+.. autoclass:: numba.cuda.MemoryPointer
+
+.. autoclass:: numba.cuda.MappedMemory
+
+.. autoclass:: numba.cuda.PinnedMemory
+
+IPC
+===
+
+.. autoclass:: numba.cuda.cudadrv.driver.IpcHandle

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -69,9 +69,10 @@ Management of other objects
 ---------------------------
 
 In addition to memory, Numba manages the allocation and deallocation of
-:ref:`events <events>`, :ref:`streams <streams>`, and modules (modules are a
-compiled objects, which is generated for CUDA kernels). The management of
-events, streams, and modules is unchanged by the use of an EMM Plugin.
+:ref:`events <events>`, :ref:`streams <streams>`, and modules (a module is a
+compiled object, which is generated from ``@cuda.jit``\ -ted functions). The
+management of events, streams, and modules is unchanged by the use of an EMM
+Plugin.
 
 
 Asynchronous allocation and deallocation

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -114,7 +114,7 @@ implementation follows:
   interface (rather than being handled within Numba) because the base address of
   the allocation is only known by the underlying library. Closing an IPC handle
   is handled internally within Numba.
-- It is optional provide memory info from the ``get_memory_info`` method, which
+- It is optional to provide memory info from the ``get_memory_info`` method, which
   provides a count of the total and free memory on the device for the context.
   It is preferrable to implement the method, but this may not be practical for
   all allocators. If memory info is not provided, this method should raise a

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -31,7 +31,7 @@ Overview of External Memory Management
 ======================================
 
 When an EMM Plugin is in use (see :ref:`setting-emm-plugin`), Numba will make
-does allocation and deallocation through the Plugin. It will never directly call
+allocation and deallocation through the Plugin. It will never directly call
 functions such as ``cuMemAlloc``, ``cuMemFree``, etc.
 
 EMM Plugins always take responsibility for the management of device memory.

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -1,34 +1,280 @@
-===========================================
-External Memory Management plugin interface
-===========================================
-
 .. _cuda-emm-plugin:
 
-By default, Numba allocates memory on CUDA devices by interacting with the CUDA
-driver API to call functions such as ``cuMemAlloc`` and ``cuMemFree``. This is
-suitable for many use cases. When Numba is used in conjunction with other
-CUDA-aware libraries that also allocate memory,
+=================================================
+External Memory Management (EMM) Plugin interface
+=================================================
 
-Plugin interface
-================
+The :ref:`CUDA Array Interface <cuda-array-interface>` enables sharing of data
+between different Python libraries that access CUDA devices. However, each
+library manages its own memory distinctly from the others. For example:
+
+- By default, Numba allocates memory on CUDA devices by interacting with the
+  CUDA driver API to call functions such as ``cuMemAlloc`` and ``cuMemFree``,
+  which is suitable for many use cases.
+- The RAPIDS libraries (cuDF, cuML, etc.) use the `RAPIDS Memory Manager (RMM)
+  <https://github.com/rapidsai/rmm>`_ for allocating device memory.
+- `CuPy <https://cupy.chainer.org/>`_ includes a `memory pool implementation
+  <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_ for both
+  device and pinned memory.
+
+When multiple CUDA-aware libraries are used together, it may be preferable for
+Numba to defer to another library for memory management. The EMM Plugin
+interface facilitates this, by enabling Numba to use another CUDA-aware library
+for all allocations and deallocations.
+
+An EMM Plugin is used to facilitate the use of an external library for memory
+management. An EMM Plugin can be a part of an external library, or could be
+implemented as a separate library.
+
+
+Overview of External Memory Management
+======================================
+
+When an EMM Plugin is in use (see :ref:`setting-emm-plugin`), Numba will make
+does allocation and deallocation through the Plugin. It will never directly call
+functions such as ``cuMemAlloc``, ``cuMemFree``, etc.
+
+EMM Plugins always take responsibility for the management of device memory.
+However, not all CUDA-aware libraries also support managing host memory, so a
+facility for Numba to continue the management of host memory whilst ceding
+control of device memory to the EMM is provided (see
+:ref:`host-only-cuda-memory-manager`).
+
+
+Effects on Deallocation Strategies
+----------------------------------
+
+Numba's internal :ref:`deallocation-behavior` is designed to increase efficiency
+by deferring deallocations until a significant quantity are pending. It also
+provides a mechanism for preventing deallocations entirely during critical
+sections, using the :func:`~numba.cuda.defer_cleanup` context manager.
+
+When an EMM Plugin is in use, the deallocation strategy is implemented by the
+EMM, and Numba's internal deallocation mechanism is not used. The EMM
+Plugin could implement:
+  
+- A similar strategy to the Numba deallocation behaviour, or
+- Something more appropriate to the plugin - for example, deallocated memory
+  might immediately be returned to a memory pool.
+
+The ``defer_cleanup`` context manager may behave differently with an EMM Plugin
+- an EMM Plugin should be accompanied by documentation of the behaviour of the
+``defer_cleanup`` context manager when it is in use. For example, a pool
+allocator could always immediately return memory to a pool even when the
+context manager is in use, but could choose not to free empty pools until
+``defer_cleanup`` is not in use.
+
+
+Management of other objects
+---------------------------
+
+In addition to memory, Numba manages the allocation and deallocation of
+:ref:`events <events>`, :ref:`streams <streams>`, and modules (modules are a
+compiled objects, which is generated for CUDA kernels). The management of
+events, streams, and modules is unchanged by the use of an EMM Plugin.
+
+
+Asynchronous allocation and deallocation
+----------------------------------------
+
+The present EMM Plugin interface does not provide support for asynchronous
+allocation and deallocation. This may be added to a future version of the
+interface.
+
+
+Implementing an EMM Plugin
+==========================
+
+An EMM Plugin is implemented by deriving from
+:class:`~numba.cuda.BaseCUDAMemoryManager`. A summary of considerations for the
+implementation follows:
+
+- Numba instantiates one instance of the EMM Plugin class per context. The
+  context that owns an EMM Plugin object is accessible through ``self.context``,
+  if required.
+- The EMM Plugin is transparent to any code that uses Numba - all its methods
+  are invoked by Numba, and never need to be called by code that uses Numba.
+- The allocation methods ``memalloc``, ``memhostalloc``, and ``mempin``, should
+  use the underlying library to allocate and/or pin device or host memory, and
+  construct an instance of a :ref:`memory pointer <memory-pointers>`
+  representing the memory to return back to Numba. These methods are always
+  called when the current CUDA context is the context that owns the EMM Plugin
+  instance.
+- The ``initialize`` method is called by Numba prior to the first use of the EMM
+  Plugin object for a context. This method should do anything required to
+  prepare the underlying library for allocations in the current context. This
+  method may be called multiple times, and must not invalidate previous state
+  when it is called.
+- The ``reset`` method is called when all allocations in the context are to be
+  cleaned up. It may be called even prior to ``initialize``, and an EMM Plugin
+  implementation needs to guard against this.
+- To support inter-GPU communication, the ``get_ipc_handle`` method should
+  provide an :class:`~numba.cuda.IpcHandle` for a given
+  :class:`~numba.cuda.MemoryPointer` instance. This method is part of the EMM
+  interface (rather than being handled within Numba) because the base address of
+  the allocation is only known by the underlying library. Closing an IPC handle
+  is handled internally within Numba.
+- It is optional provide memory info from the ``get_memory_info`` method, which
+  provides a count of the total and free memory on the device for the context.
+  It is preferrable to implement the method, but this may not be practical for
+  all allocators. If memory info is not provided, this method should raise a
+  :class:`RuntimeError`.
+- The ``defer_cleanup`` method should return a context manager that ensures that
+  expensive cleanup operations are avoided whilst it is active. The nuances of
+  this will vary between plugins, so the plugin documentation should include an
+  explanation of how deferring cleanup affects deallocations, and performance in
+  general.
+- The ``interface_version`` property is used to ensure that the plugin version
+  matches the interface provided by the version of Numba. At present, this
+  should always be 1.
+
+Full documentation for the base class follows:
 
 .. autoclass:: numba.cuda.BaseCUDAMemoryManager
-   :members: __init__, memalloc, memhostalloc, mempin, initialize,
-             get_ipc_handle, get_memory_info, reset, defer_cleanup,
-             interface_version
+   :members: memalloc, memhostalloc, mempin, initialize, get_ipc_handle,
+             get_memory_info, reset, defer_cleanup, interface_version
+   :member-order: bysource
 
-.. autoclass:: numba.cuda.cudadrv.driver.MemoryInfo
 
-Memory pointers
-===============
+.. _host-only-cuda-memory-manager:
+
+The Host-Only CUDA Memory Manager
+---------------------------------
+
+Some external memory managers will support management of on-device memory but
+not host memory. For implementing EMM Plugins using one of these memory
+managers, a partial implementation of a plugin that implements host-side
+allocation and pinning is provided. To use it, derive from
+:class:`~numba.cuda.HostOnlyCUDAMemoryManager` instead of
+:class:`~numba.cuda.BaseCUDAMemoryManager`. Guidelines for using this class
+are:
+
+- The host-only memory manager implements ``memhostalloc`` and ``mempin`` - the
+  EMM Plugin should still implement ``memalloc``.
+- If ``reset`` is overridden, it must also call ``super().reset()`` to allow the
+  host allocations to be cleaned up.
+- If ``defer_cleanup`` is overridden, it must hold an active context manager
+  from ``super().defer_cleanup()`` to ensure that host-side cleanup is also
+  deferred.
+
+Documentation for the methods of :class:`~numba.cuda.HostOnlyCUDAMemoryManager`
+follows:
+
+.. autoclass:: numba.cuda.HostOnlyCUDAMemoryManager
+   :members: memhostalloc, mempin, reset, defer_cleanup
+   :member-order: bysource
+
+
+Classes and structures of returned objects
+==========================================
+
+This section provides an overview of the classes and structures that need to be
+constructed by an EMM Plugin.
+
+.. _memory-pointers:
+
+Memory Pointers
+---------------
+
+EMM Plugins should construct memory pointer instances that represent their
+allocations, for return to Numba. The appopriate memory pointer class to use in
+each method is:
+
+- :class:`~numba.cuda.MemoryPointer`: returned from ``memalloc``
+- :class:`~numba.cuda.MappedMemory`: returned from ``memhostalloc`` or
+  ``mempin`` when the host memory is mapped into the device memory space.
+- :class:`~numba.cuda.PinnedMemory`: return from ``memhostalloc`` or ``mempin``
+  when the host memory is not mapped into the device memory space.
+
+Memory pointers can take a finalizer, which is a function that is called when
+the buffer is no longer needed. Usually the finalizer will make a call to the
+memory management library (either internal to Numba, or external if allocated
+by an EMM Plugin) to inform it that the memory is no longer required, and that
+it could potentially be freed and/or unpinned. The memory manager may choose to
+defer actually cleaning up the memory to any later time after the finalizer
+runs - it is not required to free the buffer immediately.
+
+Documentation for the memory pointer classes follows.
 
 .. autoclass:: numba.cuda.MemoryPointer
+
+The ``AutoFreePointer`` class need not be used directly, but is documented here
+as it is subclassed by :class:`numba.cuda.MappedMemory`:
+
+.. autoclass:: numba.cuda.cudadrv.driver.AutoFreePointer
 
 .. autoclass:: numba.cuda.MappedMemory
 
 .. autoclass:: numba.cuda.PinnedMemory
 
-IPC
-===
 
-.. autoclass:: numba.cuda.cudadrv.driver.IpcHandle
+Memory Info
+-----------
+
+If an implementation of
+:meth:`~numba.cuda.BaseCUDAMemoryManager.get_memory_info` is to provide a
+result, then it should return an instance of the ``MemoryInfo`` named tuple:
+
+.. autoclass:: numba.cuda.MemoryInfo
+
+
+IPC
+---
+
+An instance of ``IpcHandle`` is required to be returned from an implementation
+of :meth:`~numba.cuda.BaseCUDAMemoryManager.get_ipc_handle`:
+
+.. autoclass:: numba.cuda.IpcHandle
+
+Guidance for constructing an IPC handle in the context of implementing an EMM
+Plugin:
+
+- The ``memory`` parameter to ``get_ipc_handle`` can be passed as the ``base``
+  parameter.
+- A suitable type for the ``handle`` can be constructed as ``ctypes.c_byte *
+  64``. The data for ``handle`` must be populated using a method for obtaining a
+  CUDA IPC handle appropriate to the underlying library.
+- ``size`` should match the size of the original allocation, which can be
+  obtained with ``memory.size`` in ``get_ipc_handle``.
+- An appropriate value for ``source_info`` can be created by calling
+  ``self.context.device.get_device_identity()``.
+- If the underlying memory does not point to the base of an allocation returned
+  by the CUDA driver or runtime API (e.g. if a pool allocator is in use) then
+  the ``offset`` from the base must be provided.
+
+
+.. _setting-emm-plugin:
+
+Setting the EMM Plugin
+======================
+
+By default, Numba uses its internal memory management - if an EMM Plugin is to
+be used, it must be configured. There are two mechanisms for configuring the use
+of an EMM Plugin: an environment variable, and a function.
+
+
+Environment variable
+--------------------
+
+A module name can be provided in the environment variable,
+``NUMBA_CUDA_MEMORY_MANAGER``. If this environment variable is set, Numba will
+attempt to import the module, and and use its ``_numba_memory_manager`` global
+variable as the memory manager class. This is primarily useful for running the
+Numba test suite with an EMM Plugin, e.g.:
+
+.. code::
+
+   $ NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
+
+
+Function
+--------
+
+The :func:`~numba.cuda.set_memory_manager` function can be used to set the
+memory manager at runtime. This must be called prior to the initialization of
+any contexts, and EMM Plugin instances are instantiated along with contexts.
+
+It is recommended that the memory manager is set once prior to using any CUDA
+functionality, and left unchanged for the remainder of execution.
+
+.. autofunction:: numba.cuda.set_memory_manager

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -229,8 +229,8 @@ of :meth:`~numba.cuda.BaseCUDAMemoryManager.get_ipc_handle`:
 Guidance for constructing an IPC handle in the context of implementing an EMM
 Plugin:
 
-- The ``memory`` parameter to ``get_ipc_handle`` can be passed as the ``base``
-  parameter.
+- The ``memory`` parameter passed to the ``get_ipc_handle`` method of an EMM
+  Plugin can be passed as the ``base`` parameter.
 - A suitable type for the ``handle`` can be constructed as ``ctypes.c_byte *
   64``. The data for ``handle`` must be populated using a method for obtaining a
   CUDA IPC handle appropriate to the underlying library.

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -177,7 +177,7 @@ Memory Pointers
 ---------------
 
 EMM Plugins should construct memory pointer instances that represent their
-allocations, for return to Numba. The appopriate memory pointer class to use in
+allocations, for return to Numba. The appropriate memory pointer class to use in
 each method is:
 
 - :class:`~numba.cuda.MemoryPointer`: returned from ``memalloc``

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -31,7 +31,7 @@ Overview of External Memory Management
 ======================================
 
 When an EMM Plugin is in use (see :ref:`setting-emm-plugin`), Numba will make
-allocation and deallocation through the Plugin. It will never directly call
+memory allocations and deallocations through the Plugin. It will never directly call
 functions such as ``cuMemAlloc``, ``cuMemFree``, etc.
 
 EMM Plugins always take responsibility for the management of device memory.

--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -9,6 +9,7 @@ Numba for CUDA GPUs
    overview.rst
    kernels.rst
    memory.rst
+   external-memory.rst
    device-functions.rst
    cudapysupported.rst
    intrinsics.rst

--- a/docs/source/cuda/index.rst
+++ b/docs/source/cuda/index.rst
@@ -9,7 +9,6 @@ Numba for CUDA GPUs
    overview.rst
    kernels.rst
    memory.rst
-   external-memory.rst
    device-functions.rst
    cudapysupported.rst
    intrinsics.rst
@@ -21,4 +20,5 @@ Numba for CUDA GPUs
    ufunc.rst
    ipc.rst
    cuda_array_interface.rst
+   external-memory.rst
    faq.rst

--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -150,8 +150,16 @@ creating an array in constant memory is through the use of:
    Allocate and make accessible an array in constant memory based on array-like
    *arr*.
 
+
+.. _deallocation-behavior:
+
 Deallocation Behavior
 =====================
+
+This section describes the deallocation behaviour of Numba's internal memory
+management. If an External Memory Management Plugin is in use (see
+:ref:`cuda-emm-plugin`), then deallocation behaviour may differ; you may refer to the
+documentation for the EMM Plugin to understand its deallocation behaviour.
 
 Deallocation of all CUDA resources are tracked on a per-context basis.
 When the last reference to a device memory is dropped, the underlying memory

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -646,7 +646,6 @@ allocations and deallocations:
 
 These are used to track allocations and deallocations of:
 
-
 * Device memory
 * Pinned memory
 * Mapped memory

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -138,7 +138,7 @@ New classes and functions will be added to ``numba.cuda.cudadrv.driver``:
 * ``set_memory_manager``: a method for registering an external memory manager with
   Numba.
 
-These will be exposed through the public API, in the `numba.cuda` module.
+These will be exposed through the public API, in the ``numba.cuda`` module.
 Additionally, some classes that are already part of the `driver` module will be
 exposed as part of the public API:
 

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -484,7 +484,7 @@ Example implementation - A RAPIDS Memory Manager (RMM) Plugin
 -------------------------------------------------------------
 
 An implementation of an EMM plugin within the `Rapids Memory Manager
-(RMM) <https://github.com:rapidsai/rmm>`_ is sketched out in this section. This is
+(RMM) <https://github.com/rapidsai/rmm>`_ is sketched out in this section. This is
 intended to show an overview of the implementation in order to support the
 descriptions above and to illustrate how the plugin interface can be used -
 different choices may be made for a production-ready implementation.

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -859,7 +859,7 @@ Numba CUDA Unit tests
 ^^^^^^^^^^^^^^^^^^^^^
 
 As well as providing correct execution of a simple example, all relevant Numba
-CUDA unit tests also pass with the prototype branch. for the internal memory
+CUDA unit tests also pass with the prototype branch, for both the internal memory
 manager and the RMM EMM Plugin.
 
 RMM

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -48,7 +48,7 @@ If an EMM is to be used, it will entirely replace Numba's internal memory
 management for the duration of program execution. An interface for setting the
 memory manager will be provided.
 
-Device v.s. Host memory
+Device vs. Host memory
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 An EMM will always take responsibility for the management of device memory.
@@ -915,4 +915,3 @@ The 8 errors are due to a lack of implementation of ``get_ipc_handle`` in the
 CuPy EMM Plugin implementation. It is expected that this implementation will be
 re-visited and completed so that CuPy can be used stably as an allocator for
 Numba in the future.
-

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -1,0 +1,918 @@
+.. _nbep-7:
+
+===========================================
+NBEP 7: External Memory Management Plugins
+===========================================
+
+:Author: Graham Markall, NVIDIA
+:Contributors: Thomson Comer, Peter Entschev, Leo Fang, John Kirkham, Keith Kraus
+:Date: March 2020
+:Status: Final
+
+Background and goals
+--------------------
+
+The :ref:`CUDA Array Interface <cuda-array-interface>` enables sharing of data
+between different Python libraries that access CUDA devices. However, each
+library manages its own memory distinctly from the others. For example:
+
+
+* `Numba <https://numba.pydata.org/>`_ internally manages memory for the creation
+  of device and mapped host arrays.
+* `The RAPIDS libraries <https://rapids.ai/>`_ (cuDF, cuML, etc.) use the `Rapids
+  Memory Manager (RMM) <https://github.com/rapidsai/rmm>`_ for allocating device
+  memory.
+* `CuPy <https://cupy.chainer.org/>`_ includes a `memory pool
+  implementation <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_
+  for both device and pinned memory.
+
+The goal of this NBEP is to describe a plugin interface that enables Numba's
+internal memory management to be replaced with an external memory manager by the
+user. When the plugin interface is in use, Numba no longer directly allocates or
+frees any memory when creating arrays, but instead requests allocations and
+frees through the external manager.
+
+Requirements
+------------
+
+Provide an *External Memory Manager (EMM)* interface in Numba.
+
+
+* When the EMM is in use, Numba will make all memory allocation using the EMM.
+  It will never directly call functions such as ``CuMemAlloc``\ , ``cuMemFree``\ , etc.
+* When not using an *External Memory Manager (EMM)*\ , Numba's present behaviour
+  is unchanged (at the time of writing, the current version is the 0.48
+  release).
+
+If an EMM is to be used, it will entirely replace Numba's internal memory
+management for the duration of program execution. An interface for setting the
+memory manager will be provided.
+
+Device v.s. Host memory
+^^^^^^^^^^^^^^^^^^^^^^^
+
+An EMM will always take responsibility for the management of device memory.
+However, not all CUDA memory management libraries also support managing host
+memory, so a facility for Numba to continue the management of host memory 
+whilst ceding control of device memory to the EMM will be provided.
+
+Deallocation strategies
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Numba's internal memory management uses a :ref:`deallocation strategy
+<deallocation-behavior>` designed to increase efficiency by deferring
+deallocations until a significant quantity are pending. It also provides a
+mechanism for preventing deallocations entirely during critical sections, using
+the :func:`~numba.cuda.defer_cleanup` context manager.
+
+
+* When the EMM is not in use, the deallocation strategy and operation of
+  ``defer_cleanup`` remain unchanged.
+* When the EMM is in use, the deallocation strategy is implemented by the EMM,
+  and Numba's internal deallocation mechanism is not used. For example:
+
+  * A similar strategy to Numba's could be implemented by the EMM, or
+  * Deallocated memory might immediately be returned to a memory pool.
+
+* The ``defer_cleanup`` context manager may behave differently with an EMM - an
+  EMM should be accompanied by documentation of the behaviour of the
+  ``defer_cleanup`` context manager when it is in use.
+
+  * For example, a pool allocator could always immediately return memory to a
+    pool even when the context manager is in use, but could choose
+    not to free empty pools until ``defer_cleanup`` is not in use.
+
+Management of other objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to memory, Numba manages the allocation and deallocation of
+:ref:`events <events>`, :ref:`streams <streams>`, and modules (a module is a
+compiled object, which is generated from ``@cuda.jit``\ -ted functions). The
+management of streams, events, and modules should be unchanged by the presence
+or absence of an EMM.
+
+Asynchronous allocation / deallocation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An asynchronous memory manager might provide the facility for an allocation or
+free to take a CUDA stream and execute asynchronously. For freeing this is
+unlikely to cause issues since it operates at a layer beneath Python, but for
+allocations this could be problematic if the user tries to then launch a kernel
+on the default stream from this asynchronous memory allocation.
+
+The interface described in this proposal will not be required to support
+asynchronous allocation and deallocation, and as such these use cases will not
+be considered further. However, nothing in this proposal should preclude the
+straightforward addition of asynchronous operations in future versions of the
+interface.
+
+Non-requirements
+^^^^^^^^^^^^^^^^
+
+In order to minimise complexity and constrain this proposal to a reasonable
+scope, the following will not be supported:
+
+
+* Using different memory manager implementations for different contexts. All
+  contexts will use the same memory manager implementation - either the Numba
+  internal implementation or an external implementation.
+* Changing the memory manager once execution has begun. It is not practical to
+  change the memory manager and retain all allocations. Cleaning up the entire
+  state and then changing to a different memory allocator (rather than starting
+  a new process) appears to be a rather niche use case.
+* Any changes to the ``__cuda_array_interface__`` to further define its semantics,
+  e.g. for acquiring / releasing memory as discussed in `Numba Issue
+  #4886 <https://github.com/numba/numba/issues/4886>`_ - these are independent,
+  and can be addressed as part of separate proposals.
+* Managed memory / UVM is not supported. At present Numba does not support UVM -
+  see `Numba Issue #4362 <https://github.com/numba/numba/issues/4362>`_ for
+  discussion of support.
+
+Interface for Plugin developers
+-------------------------------
+
+New classes and functions will be added to ``numba.cuda.cudadrv.driver``:
+
+* ``BaseCUDAMemoryManager`` and ``HostOnlyCUDAMemoryManager``\ : base classes for
+  EMM plugin implementations.
+* ``set_memory_manager``: a method for registering an external memory manager with
+  Numba.
+
+These will be exposed through the public API, in the `numba.cuda` module.
+Additionally, some classes that are already part of the `driver` module will be
+exposed as part of the public API:
+
+* ``MemoryPointer``: used to encapsulate information about a pointer to device
+  memory.
+* ``MappedMemory``: used to hold information about host memory that is mapped into
+  the device address space (a subclass of ``MemoryPointer``\ ).
+* ``PinnedMemory``: used to hold information about host memory that is pinned (a
+  subclass of ``mviewbuf.MemAlloc``\ , a class internal to Numba).
+
+As an alternative to calling the ``set_memory_manager`` function, an environment
+variable can be used to set the memory manager. The value of the environment
+variable should be the name of the module containing the memory manager in its
+global scope, named ``_numba_memory_manager``\ :
+
+.. code-block::
+
+   export NUMBA_CUDA_MEMORY_MANAGER="<module>"
+
+When this variable is set, Numba will automatically use the memory manager from
+the specified module. Calls to ``set_memory_manager`` will issue a warning, but
+otherwise be ignored.
+
+Plugin Base Classes
+^^^^^^^^^^^^^^^^^^^
+
+An EMM plugin is implemented by inheriting from the ``BaseCUDAMemoryManager``
+class, which is defined as:
+
+.. code-block:: python
+
+   class BaseCUDAMemoryManager(object, metaclass=ABCMeta):
+       @abstractmethod
+       def memalloc(self, size):
+           """
+           Allocate on-device memory in the current context. Arguments:
+
+           - `size`: Size of allocation in bytes
+
+           Returns: a `MemoryPointer` to the allocated memory.
+           """
+
+       @abstractmethod
+       def memhostalloc(self, size, mapped, portable, wc):
+           """
+           Allocate pinned host memory. Arguments:
+
+           - `size`: Size of the allocation in bytes
+           - `mapped`: Whether the allocated memory should be mapped into the CUDA
+                       address space.
+           - `portable`: Whether the memory will be considered pinned by all
+                         contexts, and not just the calling context.
+           - `wc`: Whether to allocate the memory as write-combined.
+
+           Returns a `MappedMemory` or `PinnedMemory` instance that owns the
+           allocated memory, depending on whether the region was mapped into
+           device memory.
+           """
+
+       @abstractmethod
+       def mempin(self, owner, pointer, size, mapped):
+           """
+           Pin a region of host memory that is already allocated. Arguments:
+
+           - `owner`: An object owning the memory - e.g. a `DeviceNDArray`.
+           - `pointer`: The pointer to the beginning of the region to pin.
+           - `size`: The size of the region to pin.
+           - `mapped`: Whether the region should also be mapped into device memory.
+
+           Returns a `MappedMemory` or `PinnedMemory` instance that refers to the
+           allocated memory, depending on whether the region was mapped into device
+           memory.
+           """
+
+       @abstractmethod
+       def initialize(self):
+           """
+           Perform any initialization required for the EMM plugin to be ready to
+           use.
+           """
+
+       @abstractmethod
+       def get_memory_info(self):
+           """
+           Returns (free, total) memory in bytes in the context
+           """
+
+       @abstractmethod
+       def get_ipc_handle(self, memory):
+           """
+           Return an `IpcHandle` from a GPU allocation. Arguments:
+
+           - `memory`: A `MemoryPointer` for which the IPC handle should be created.
+           """
+
+       @abstractmethod
+       def reset(self):
+           """
+           Clear up all memory allocated in this context.
+           """
+
+       @abstractmethod
+       def defer_cleanup(self):
+           """
+           Returns a context manager that ensures the implementation of deferred
+           cleanup whilst it is active.
+           """
+
+       @property
+       @abstractmethod
+       def interface_version(self):
+           """
+           Returns an integer specifying the version of the EMM Plugin interface
+           supported by the plugin implementation. Should always return 1 for
+           implementations described in this proposal.
+           """
+
+All of the methods of an EMM plugin are called from within Numba - they never
+need to be invoked directly by a Numba user.
+
+The ``initialize`` method is called by Numba prior to any memory allocations
+being requested. This gives the EMM an opportunity to initialize any data
+structures, etc., that it needs for its normal operations. The method may be
+called multiple times during the lifetime of the program - subsequent calls
+should not invalidate or reset the state of the EMM.
+
+The ``memalloc``\ , ``memhostalloc``\ , and ``mempin`` methods are called when Numba
+requires an allocation of device or host memory, or pinning of host memory.
+Device memory should always be allocated in the current context.
+
+``get_ipc_handle`` is called when an IPC handle for an array is required. Note
+that there is no method for closing an IPC handle - this is because the
+``IpcHandle`` object constructed by ``get_ipc_handle`` contains a ``close()`` method
+as part of its definition in Numba, which closes the handle by calling
+``cuIpcCloseMemHandle``. It is expected that this is sufficient for general use
+cases, so no facility for customising the closing of IPC handles is provided by
+the EMM Plugin interface.
+
+``get_memory_info`` may be called at any time after ``initialize``.
+
+``reset`` is called as part of resetting a context. Numba does not normally call
+reset spontaneously, but it may be called at the behest of the user. Calls to
+``reset`` may even occur before ``initialize`` is called, so the plugin should be
+robust against this occurrence.
+
+``defer_cleanup`` is called when the ``numba.cuda.defer_cleanup`` context manager
+is used from user code.
+
+``interface_version`` is called by Numba when the memory manager is set, to
+ensure that the version of the interface implemented by the plugin is
+compatible with the version of Numba in use.
+
+Representing pointers
+^^^^^^^^^^^^^^^^^^^^^
+
+Device Memory
+~~~~~~~~~~~~~
+
+The ``MemoryPointer`` class is used to represent a pointer to memory. Whilst there
+are various details of its implementation, the only aspect relevant to EMM
+plugin development is its initialization. The ``__init__`` method has the
+following interface:
+
+.. code-block:: python
+
+   class MemoryPointer:
+       def __init__(self, context, pointer, size, owner=None, finalizer=None):
+
+
+* ``context``\ : The context in which the pointer was allocated.
+* ``pointer``\ : A ``ctypes`` pointer (e.g. ``ctypes.c_uint64``\ ) holding the address of
+  the memory.
+* ``size``\ : The size of the allocation in bytes.
+* ``owner``\ : The owner is sometimes set by the internals of the class, or used for
+  Numba's internal memory management, but need not be provided by the writer of
+  an EMM plugin - the default of ``None`` should always suffice.
+* ``finalizer``\ : A method that is called when the last reference to the
+  ``MemoryPointer`` object is released. Usually this will make a call to the
+  external memory management library to inform it that the memory is no longer
+  required, and that it could potentially be freed (though the EMM is not
+  required to free it immediately).
+
+Host Memory
+~~~~~~~~~~~
+
+Memory mapped into the CUDA address space (which is created when the
+``memhostalloc`` or ``mempin`` methods are called with ``mapped=True``\ ) is managed
+using the ``MappedMemory`` class:
+
+.. code-block:: python
+
+   class MappedMemory(AutoFreePointer):
+       def __init__(self, context, pointer, size, owner, finalizer=None):
+
+
+* ``context``\ : The context in which the pointer was allocated.
+* ``pointer``\ : A ``ctypes`` pointer (e.g. ``ctypes.c_void_p``\ ) holding the address of
+  the allocated memory.
+* ``size``\ : The size of the allocated memory in bytes.
+* ``owner``\ : A Python object that owns the memory, e.g. a ``DeviceNDArray``
+  instance.
+* ``finalizer``\ : A method that is called when the last reference to the
+  ``MappedMemory`` object is released. For example, this method could call
+  ``cuMemFreeHost`` on the pointer to deallocate the memory immediately.
+
+Note that the inheritance from ``AutoFreePointer`` is an implementation detail and
+need not concern the developer of an EMM plugin - ``MemoryPointer`` is higher in
+the MRO of ``MappedMemory``.
+
+Memory that is only in the host address space and has been pinned is represented
+with the ``PinnedMemory`` class:
+
+.. code-block:: python
+
+   class PinnedMemory(mviewbuf.MemAlloc):
+       def __init__(self, context, pointer, size, owner, finalizer=None):
+
+
+* ``context``\ : The context in which the pointer was allocated.
+* ``pointer``\ : A ``ctypes`` pointer (e.g. ``ctypes.c_void_p``\ ) holding the address of
+  the pinned memory.
+* ``size``\ : The size of the pinned region in bytes.
+* ``owner``\ : A Python object that owns the memory, e.g. a ``DeviceNDArray``
+  instance.
+* ``finalizer``\ : A method that is called when the last reference to the
+  ``PinnedMemory`` object is released. This method could e.g. call
+  ``cuMemHostUnregister`` on the pointer to unpin the memory immediately.
+
+Providing device memory management only
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some external memory managers will support management of on-device memory but
+not host memory. To make it easy to implement an EMM plugin using one of these
+managers, Numba will provide a memory manager class with implementations of the
+``memhostalloc`` and ``mempin`` methods. An abridged definition of this class
+follows:
+
+.. code-block:: python
+
+   class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
+       # Unimplemented methods:
+       #
+       # - memalloc
+       # - get_memory_info
+
+       def memhostalloc(self, size, mapped, portable, wc):
+           # Implemented.
+
+       def mempin(self, owner, pointer, size, mapped):
+           # Implemented.
+
+       def initialize(self):
+           # Implemented.
+           #
+           # Must be called by any subclass when its initialize() method is
+           # called.
+
+       def reset(self):
+           # Implemented.
+           #
+           # Must be called by any subclass when its reset() method is
+           # called.
+
+       def defer_cleanup(self):
+           # Implemented.
+           #
+           # Must be called by any subclass when its defer_cleanup() method is
+           # called.
+
+A class can subclass the ``HostOnlyCUDAMemoryManager`` and then it only needs to
+add implementations of methods for on-device memory. Any subclass must observe
+the following rules:
+
+
+* If the subclass implements ``__init__``\ , then it must also call
+  ``HostOnlyCUDAMemoryManager.__init__``\ , as this is used to initialize some of
+  its data structures (\ ``self.allocations`` and ``self.deallocations``\ ).
+* The subclass must implement ``memalloc`` and ``get_memory_info``.
+* The ``initialize`` and ``reset`` methods perform initialisation of structures
+  used by the ``HostOnlyCUDAMemoryManager``.
+
+  * If the subclass has nothing to do on initialisation (possibly) or reset
+    (unlikely) then it need not implement these methods. 
+  * However, if it does implement these methods then it must also call the
+    methods from ``HostOnlyCUDAMemoryManager`` in its own implementations.
+
+* Similarly if ``defer_cleanup`` is implemented, it should enter the context
+  provided by ``HostOnlyCUDAManager.defer_cleanup()`` prior to ``yield``\ ing (or in
+  the ``__enter__`` method) and release it prior to exiting (or in the ``__exit__``
+  method).
+
+Import order
+^^^^^^^^^^^^
+
+The order in which Numba and the library implementing an EMM Plugin should not
+matter. For example, if ``rmm`` were to implement and register an EMM Plugin,
+then:
+
+.. code-block:: python
+
+   from numba import cuda
+   import rmm
+
+and
+
+.. code-block:: python
+
+   import rmm
+   from numba import cuda
+
+are equivalent - this is because Numba does not initialize CUDA or allocate any
+memory until the first call to a CUDA function - neither instantiating and
+registering an EMM plugin, nor importing ``numba.cuda`` causes a call to a CUDA
+function.
+
+Numba as a Dependency
+^^^^^^^^^^^^^^^^^^^^^
+
+Adding the implementation of an EMM Plugin to a library naturally makes Numba a
+dependency of the library where it may not have been previously. In order to
+make the dependency optional, if this is desired, one might conditionally
+instantiate and register the EMM Plugin like:
+
+.. code-block:: python
+
+   try:
+       import numba
+       from mylib.numba_utils import MyNumbaMemoryManager
+       numba.cuda.cudadrv.driver.set_memory_manager(MyNumbaMemoryManager)
+   except:
+       print("Numba not importable - not registering EMM Plugin")
+
+so that ``mylib.numba_utils``\ , which contains the implementation of the EMM
+Plugin, is only imported if Numba is already present. If Numba is not available,
+then ``mylib.numba_utils`` (which necessarily imports ``numba``\ ), will never be
+imported.
+
+It is recommended that any library with an EMM Plugin includes at least some
+environments with Numba for testing with the EMM Plugin in use, as well as some
+environments without Numba, to avoid introducing an accidental Numba dependency.
+
+Example implementation - A RAPIDS Memory Manager (RMM) Plugin
+-------------------------------------------------------------
+
+An implementation of an EMM plugin within the `Rapids Memory Manager
+(RMM) <https://github.com:rapidsai/rmm>`_ is sketched out in this section. This is
+intended to show an overview of the implementation in order to support the
+descriptions above and to illustrate how the plugin interface can be used -
+different choices may be made for a production-ready implementation.
+
+The plugin implementation consists of additions to ``python/rmm/rmm.py``\ :
+
+.. code-block:: python
+
+   # New imports:
+   from contextlib import context_manager
+   from numba.cuda import HostOnlyCUDAMemoryManager, MemoryPointer, IpcHandle
+
+
+   # New class implementing the EMM Plugin:
+   class RMMNumbaManager(HostOnlyCUDAMemoryManager):
+       def memalloc(self, size):
+           # Allocates device memory using RMM functions. The finalizer for the
+           # allocated memory calls back to RMM to free the memory.
+           addr = librmm.rmm_alloc(bytesize, 0)
+           ctx = cuda.current_context()
+           ptr = ctypes.c_uint64(int(addr))
+           finalizer = _make_finalizer(addr, stream)
+           return MemoryPointer(ctx, ptr, bytesize, finalizer=finalizer)
+
+      def get_ipc_handle(self, memory):
+           """ 
+           Get an IPC handle for the memory with offset modified by the RMM memory
+           pool.
+           """
+           # This implementation provides a functional implementation and illustrates
+           # what get_ipc_handle needs to do, but it is not a very "clean"
+           # implementation, and it relies on borrowing bits of Numba internals to
+           # initialise ipchandle. 
+           #
+           # A more polished implementation might make use of additional functions in
+           # the RMM C++ layer for initialising IPC handles, and not use any Numba
+           # internals.
+           ipchandle = (ctypes.c_byte * 64)()  # IPC handle is 64 bytes
+           cuda.cudadrv.memory.driver_funcs.cuIpcGetMemHandle(
+               ctypes.byref(ipchandle),
+               memory.owner.handle,
+           )
+           source_info = cuda.current_context().device.get_device_identity()
+           ptr = memory.device_ctypes_pointer.value
+           offset = librmm.rmm_getallocationoffset(ptr, 0)
+           return IpcHandle(memory, ipchandle, memory.size, source_info,
+                            offset=offset)
+
+       def get_memory_info(self):
+           # Returns a tuple of (free, total) using RMM functionality.
+           return get_memory_info()
+
+       def initialize(self):
+           # Nothing required to initialize RMM here, but this method is added
+           # to illustrate that the super() method should also be called.
+           super().initialize()
+
+       @contextmanager
+       def defer_cleanup(self):
+           # Does nothing to defer cleanup - a full implementation may choose to
+           # implement a different policy.
+           with super().defer_cleanup():
+               yield
+
+       @property
+       def interface_version(self):
+           # As required by the specification
+           return 1
+
+   # The existing _make_finalizer function is used by RMMNumbaManager:
+   def _make_finalizer(handle, stream):
+       """
+       Factory to make the finalizer function.
+       We need to bind *handle* and *stream* into the actual finalizer, which
+       takes no args.
+       """
+
+       def finalizer():
+           """
+           Invoked when the MemoryPointer is freed
+           """
+           librmm.rmm_free(handle, stream)
+
+       return finalizer
+
+   # Utility function register `RMMNumbaManager` as an EMM:
+   def use_rmm_for_numba():
+       cuda.set_memory_manager(RMMNumbaManager)
+
+   # To support `NUMBA_CUDA_MEMORY_MANAGER=rmm`:
+   _numba_memory_manager = RMMNumbaManager
+
+Example usage
+^^^^^^^^^^^^^
+
+A simple example that configures Numba to use RMM for memory management and
+creates a device array is as follows:
+
+.. code-block:: python
+
+   # example.py
+   import rmm 
+   import numpy as np
+
+   from numba import cuda
+
+   rmm.use_rmm_for_numba()
+
+   a = np.zeros(10)
+   d_a = cuda.to_device(a)
+   del(d_a)
+   print(rmm.csv_log())
+
+Running this should result in output similar to the following:
+
+.. code-block::
+
+   Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,Location
+   Alloc,0,0x7fae06600000,0,80,0,0,1,1.10549,1.1074,0.00191666,/home/nfs/gmarkall/numbadev/numba/numba/cuda/cudadrv/driver.py:683
+   Free,0,0x7fae06600000,0,0,0,0,0,1.10798,1.10921,0.00122238,/home/nfs/gmarkall/numbadev/numba/numba/utils.py:678
+
+Note that there is some scope for improvement in RMM for detecting the line
+number at which the allocation / free occurred, but this is outside the scope of
+the example in this proposal.
+
+Setting the memory manager through the environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rather than calling ``rmm.use_rmm_for_numba()`` in the example above, the memory
+manager could also be set to use RMM globally with an environment variable, so
+the Python interpreter is invoked to run the example as:
+
+.. code-block::
+
+   NUMBA_CUDA_MEMORY_MANAGER="rmm.RMMNumbaManager" python example.py
+
+Numba internal changes
+----------------------
+
+This section is intended primarily for Numba developers - those with an interest
+in the external interface for implementing EMM plugins may choose to skip over
+this section.
+
+Current model / implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+At present, memory management is implemented in the
+:class:`~numba.cuda.cudadrv.driver.Context` class. It maintains lists of
+allocations and deallocations:
+
+* ``allocations`` is a ``numba.utils.UniqueDict``, created at context creation time.
+* ``deallocations`` is an instance of the ``_PendingDeallocs`` class, and is created
+  when ``Context.prepare_for_use()`` is called.
+
+These are used to track allocations and deallocations of:
+
+
+* Device memory
+* Pinned memory
+* Mapped memory
+* Streams
+* Events
+* Modules
+
+The ``_PendingDeallocs`` class implements the deferred deallocation strategy -
+cleanup functions (such as ``cuMemFree``\ ) for the items above are added to its
+list of pending deallocations by the finalizers of objects representing
+allocations. These finalizers are run when the objects owning them are
+garbage-collected by the Python interpreter. When the addition of a new
+cleanup function to the deallocation list causes the number or size of pending
+deallocations to exceed a configured ratio, the ``_PendingDeallocs`` object runs
+deallocators for all items it knows about and then clears its internal pending
+list.
+
+See :ref:`deallocation-behavior` for more details of this implementation.
+
+Proposed changes
+^^^^^^^^^^^^^^^^
+
+This section outlines the major changes that will be made to support the EMM
+plugin interface - there will be various small changes to other parts of Numba
+that will be required in order to adapt to these changes; an exhaustive list of
+these is not provided.
+
+Context changes
+~~~~~~~~~~~~~~~
+
+The ``numba.cuda.cudadrv.driver.Context`` class will no longer directly allocate
+and free memory. Instead, the context will hold a reference to a memory manager
+instance, and its memory allocation methods will call into the memory manager,
+e.g.:
+
+.. code-block:: python
+
+       def memalloc(self, size):
+           return self.memory_manager.memalloc(size)
+
+       def memhostalloc(self, size, mapped=False, portable=False, wc=False):
+           return self.memory_manager.memhostalloc(size, mapped, portable, wc)
+
+       def mempin(self, owner, pointer, size, mapped=False):
+           if mapped and not self.device.CAN_MAP_HOST_MEMORY:
+               raise CudaDriverError("%s cannot map host memory" % self.device)
+           return self.memory_manager.mempin(owner, pointer, size, mapped)
+
+       def prepare_for_use(self):
+           self.memory_manager.initialize()
+
+       def get_memory_info(self):
+           self.memory_manager.get_memory_info()
+
+       def get_ipc_handle(self, memory):
+           return self.memory_manager.get_ipc_handle(memory)
+
+       def reset(self):
+           # ... Already-extant reset logic, plus:
+           self._memory_manager.reset()
+
+The ``memory_manager`` member is initialised when the context is created.
+
+The ``memunpin`` method (not shown above but currently exists in the ``Context``
+class) has never been implemented - it presently raises a ``NotImplementedError``.
+This method arguably un-needed - pinned memory is immediately unpinned by its
+finalizer, and unpinning before a finalizer runs would invalidate the state of
+``PinnedMemory`` objects for which references are still held. It is proposed that
+this is removed when making the other changes to the ``Context`` class.
+
+The ``Context`` class will still instantiate ``self.allocations`` and
+``self.deallocations`` as before - these will still be used by the context to
+manage the allocations and deallocations of events, streams, and modules, which
+are not handled by the EMM plugin.
+
+New components of the ``driver`` module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+* ``BaseCUDAMemoryManager``\ : An abstract class, as defined in the plugin interface
+  above.
+* ``HostOnlyCUDAMemoryManager``\ : A subclass of ``BaseCUDAMemoryManager``\ , with the
+  logic from ``Context.memhostalloc`` and ``Context.mempin`` moved into it. This
+  class will also create its own ``allocations`` and ``deallocations`` members,
+  similarly to how the ``Context`` class creates them. These are used to manage
+  the allocations and deallocations of pinned and mapped host memory.
+* ``NumbaCUDAMemoryManager``\ : A subclass of ``HostOnlyCUDAMemoryManager``\ , which
+  also contains an implementation of ``memalloc`` based on that presently existing
+  in the ``Context`` class. This is the default memory manager, and its use
+  preserves the behaviour of Numba prior to the addition of the EMM plugin
+  interface - that is, all memory allocation and deallocation for Numba arrays
+  is handled within Numba.
+
+  * This class shares the ``allocations`` and ``deallocations`` members with its
+    parent class ``HostOnlyCUDAMemoryManager``\ , and it uses these for the
+    management of device memory that it allocates.
+
+* The ``set_memory_manager`` function, which sets a global pointing to the memory
+  manager class. This global initially holds ``NumbaCUDAMemoryManager`` (the
+  default).
+
+Staged IPC
+~~~~~~~~~~
+
+Staged IPC should not take ownership of the memory that it allocates. When the
+default internal memory manager is in use, the memory allocated for the staging
+array is already owned. When an EMM plugin is in use, it is not legitimate to
+take ownership of the memory.
+
+This change can be made by applying the following small patch, which has been
+tested to have no effect on the CUDA test suite:
+
+.. code-block:: diff
+
+   diff --git a/numba/cuda/cudadrv/driver.py b/numba/cuda/cudadrv/driver.py
+   index 7832955..f2c1352 100644
+   --- a/numba/cuda/cudadrv/driver.py
+   +++ b/numba/cuda/cudadrv/driver.py
+   @@ -922,7 +922,11 @@ class _StagedIpcImpl(object):
+            with cuda.gpus[srcdev.id]:
+                impl.close()
+
+   -        return newmem.own()
+   +        return newmem
+
+Testing
+~~~~~~~
+
+Alongside the addition of appropriate tests for new functionality, there will be
+some refactoring of existing tests required, but these changes are not
+substantial. Tests of the deallocation strategy (e.g. ``TestDeallocation``\ ,
+``TestDeferCleanup``\ ) will need to be modified to ensure that they are
+examining the correct set of deallocations. When an EMM plugin is in use, they
+will need to be skipped.
+
+Prototyping / experimental implementation
+-----------------------------------------
+
+Some prototype / experimental implementations have been produced to guide the
+designs presented in this document. The current implementations can be found in:
+
+
+* Numba branch: https://github.com/gmarkall/numba/tree/grm-numba-nbep-7.
+* RMM branch: https://github.com/gmarkall/rmm/tree/grm-numba-nbep-7.
+* CuPy implementation: `nbep7/cupy_mempool.py <nbep7/cupy_mempool.py>`_ - uses an
+  unmodified CuPy.
+
+  * See `CuPy memory management
+    docs <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_.
+
+Current implementation status
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+RMM Plugin
+~~~~~~~~~~
+
+For a minimal example, a simple allocation and free using RMM works as expected.
+For the example code (similar to the RMM example above):
+
+.. code-block:: python
+
+   import rmm
+   import numpy as np
+
+   from numba import cuda
+
+   rmm.use_rmm_for_numba()
+
+   a = np.zeros(10)
+   d_a = cuda.to_device(a)
+   del(d_a)
+   print(rmm.csv_log())
+
+We see the following output:
+
+.. code-block::
+
+   Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,Location
+   Alloc,0,0x7f96c7400000,0,80,0,0,1,1.13396,1.13576,0.00180059,/home/nfs/gmarkall/numbadev/numba/numba/cuda/cudadrv/driver.py:686
+   Free,0,0x7f96c7400000,0,0,0,0,0,1.13628,1.13723,0.000956004,/home/nfs/gmarkall/numbadev/numba/numba/utils.py:678
+
+This output is similar to the expected output from the example usage presented
+above (though note that the pointer addresses and timestamps vary compared to
+the example), and provides some validation of the example use case.
+
+CuPy Plugin
+~~~~~~~~~~~
+
+.. code-block:: python
+
+   from nbep7.cupy_mempool import use_cupy_mm_for_numba
+   import numpy as np
+
+   from numba import cuda
+
+   use_cupy_mm_for_numba()
+
+   a = np.zeros(10)
+   d_a = cuda.to_device(a)
+   del(d_a)
+
+The prototype CuPy plugin has somewhat primitive logging, so we see the output:
+
+.. code-block::
+
+   Allocated 80 bytes at 7f004d400000
+   Freeing 80 bytes at 7f004d400000
+
+Numba CUDA Unit tests
+^^^^^^^^^^^^^^^^^^^^^
+
+As well as providing correct execution of a simple example, all relevant Numba
+CUDA unit tests also pass with the prototype branch. for the internal memory
+manager and the RMM EMM Plugin.
+
+RMM
+~~~
+
+The unit test suite can be run with the RMM EMM Plugin with:
+
+.. code-block::
+
+   NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
+
+A summary of the unit test suite output is:
+
+.. code-block::
+
+   Ran 564 tests in 142.211s
+
+   OK (skipped=11)
+
+When running with the built-in Numba memory management, the output is:
+
+.. code-block::
+
+   Ran 564 tests in 133.396s
+
+   OK (skipped=5)
+
+i.e. the changes for using an external memory manager do not break the built-in
+Numba memory management. There are an additional 6 skipped tests, from:
+
+
+* ``TestDeallocation``\ : skipped as it specifically tests Numba's internal
+  deallocation strategy.
+* ``TestDeferCleanup``\ : skipped as it specifically tests Numba's implementation of
+  deferred cleanup.
+* ``TestCudaArrayInterface.test_ownership``\ : skipped as Numba does not own memory
+  when an EMM Plugin is used, but ownership is assumed by this test case.
+
+CuPy
+~~~~
+
+The test suite can be run with the CuPy plugin using:
+
+.. code-block::
+
+   NUMBA_CUDA_MEMORY_MANAGER=nbep7. python -m numba.runtests numba.cuda.tests
+
+This plugin implementation is presently more primitive than the RMM
+implementation, and results in some errors with the unit test suite:
+
+.. code-block::
+
+   Ran 564 tests in 111.699s
+
+   FAILED (errors=8, skipped=11)
+
+The 8 errors are due to a lack of implementation of ``get_ipc_handle`` in the
+CuPy EMM Plugin implementation. It is expected that this implementation will be
+re-visited and completed so that CuPy can be used stably as an allocator for
+Numba in the future.
+

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -790,8 +790,9 @@ designs presented in this document. The current implementations can be found in:
 
 * Numba branch: https://github.com/gmarkall/numba/tree/grm-numba-nbep-7.
 * RMM branch: https://github.com/gmarkall/rmm/tree/grm-numba-nbep-7.
-* CuPy implementation: `nbep7/cupy_mempool.py <nbep7/cupy_mempool.py>`_ - uses an
-  unmodified CuPy.
+* CuPy implementation:
+  https://github.com/gmarkall/nbep-7/blob/master/nbep7/cupy_mempool.py - uses
+  an unmodified CuPy.
 
   * See `CuPy memory management
     docs <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_.

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -639,7 +639,8 @@ At present, memory management is implemented in the
 :class:`~numba.cuda.cudadrv.driver.Context` class. It maintains lists of
 allocations and deallocations:
 
-* ``allocations`` is a ``numba.utils.UniqueDict``, created at context creation time.
+* ``allocations`` is a ``numba.core.utils.UniqueDict``, created at context
+  creation time.
 * ``deallocations`` is an instance of the ``_PendingDeallocs`` class, and is created
   when ``Context.prepare_for_use()`` is called.
 

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -95,7 +95,7 @@ Asynchronous allocation / deallocation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 An asynchronous memory manager might provide the facility for an allocation or
-free to take a CUDA stream and execute asynchronously. For freeing this is
+free to take a CUDA stream and execute asynchronously. For freeing, this is
 unlikely to cause issues since it operates at a layer beneath Python, but for
 allocations this could be problematic if the user tries to then launch a kernel
 on the default stream from this asynchronous memory allocation.

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -538,7 +538,7 @@ The plugin implementation consists of additions to `python/rmm/rmm.py
 
        def get_memory_info(self):
            # Returns a tuple of (free, total) using RMM functionality.
-           return get_memory_info()
+           return get_info() # Function defined in rmm.py
 
        def initialize(self):
            # Nothing required to initialize RMM here, but this method is added

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -20,7 +20,7 @@ library manages its own memory distinctly from the others. For example:
 * `Numba <https://numba.pydata.org/>`_ internally manages memory for the creation
   of device and mapped host arrays.
 * `The RAPIDS libraries <https://rapids.ai/>`_ (cuDF, cuML, etc.) use the `Rapids
-  Memory Manager (RMM) <https://github.com/rapidsai/rmm>`_ for allocating device
+  Memory Manager <https://github.com/rapidsai/rmm>`_ for allocating device
   memory.
 * `CuPy <https://cupy.chainer.org/>`_ includes a `memory pool
   implementation <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -607,8 +607,8 @@ Running this should result in output similar to the following:
 .. code-block::
 
    Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,Location
-   Alloc,0,0x7fae06600000,0,80,0,0,1,1.10549,1.1074,0.00191666,/home/nfs/gmarkall/numbadev/numba/numba/cuda/cudadrv/driver.py:683
-   Free,0,0x7fae06600000,0,0,0,0,0,1.10798,1.10921,0.00122238,/home/nfs/gmarkall/numbadev/numba/numba/utils.py:678
+   Alloc,0,0x7fae06600000,0,80,0,0,1,1.10549,1.1074,0.00191666,<path>/numba/numba/cuda/cudadrv/driver.py:683
+   Free,0,0x7fae06600000,0,0,0,0,0,1.10798,1.10921,0.00122238,<path>/numba/numba/utils.py:678
 
 Note that there is some scope for improvement in RMM for detecting the line
 number at which the allocation / free occurred, but this is outside the scope of
@@ -825,8 +825,8 @@ We see the following output:
 .. code-block::
 
    Event Type,Device ID,Address,Stream,Size (bytes),Free Memory,Total Memory,Current Allocs,Start,End,Elapsed,Location
-   Alloc,0,0x7f96c7400000,0,80,0,0,1,1.13396,1.13576,0.00180059,/home/nfs/gmarkall/numbadev/numba/numba/cuda/cudadrv/driver.py:686
-   Free,0,0x7f96c7400000,0,0,0,0,0,1.13628,1.13723,0.000956004,/home/nfs/gmarkall/numbadev/numba/numba/utils.py:678
+   Alloc,0,0x7f96c7400000,0,80,0,0,1,1.13396,1.13576,0.00180059,<path>/numba/numba/cuda/cudadrv/driver.py:686
+   Free,0,0x7f96c7400000,0,0,0,0,0,1.13628,1.13723,0.000956004,<path>/numba/numba/utils.py:678
 
 This output is similar to the expected output from the example usage presented
 above (though note that the pointer addresses and timestamps vary compared to

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -498,7 +498,8 @@ The plugin implementation consists of additions to `python/rmm/rmm.py
    from contextlib import context_manager
    # RMM already has Numba as a dependency, so these imports need not be guarded
    # by a check for the presence of numba.
-   from numba.cuda import HostOnlyCUDAMemoryManager, MemoryPointer, IpcHandle
+   from numba.cuda import (HostOnlyCUDAMemoryManager, MemoryPointer, IpcHandle,
+                           set_memory_manager)
 
 
    # New class implementing the EMM Plugin:
@@ -575,7 +576,7 @@ The plugin implementation consists of additions to `python/rmm/rmm.py
 
    # Utility function register `RMMNumbaManager` as an EMM:
    def use_rmm_for_numba():
-       cuda.set_memory_manager(RMMNumbaManager)
+       set_memory_manager(RMMNumbaManager)
 
    # To support `NUMBA_CUDA_MEMORY_MANAGER=rmm`:
    _numba_memory_manager = RMMNumbaManager

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -508,7 +508,7 @@ The plugin implementation consists of additions to `python/rmm/rmm.py
            ctx = cuda.current_context()
            ptr = ctypes.c_uint64(int(addr))
            finalizer = _make_finalizer(addr, stream)
-           return MemoryPointer(ctx, ptr, bytesize, finalizer=finalizer)
+           return MemoryPointer(ctx, ptr, size, finalizer=finalizer)
 
       def get_ipc_handle(self, memory):
            """ 

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -1,8 +1,8 @@
 .. _nbep-7:
 
-===========================================
-NBEP 7: External Memory Management Plugins
-===========================================
+===============================================
+NBEP 7: CUDA External Memory Management Plugins
+===============================================
 
 :Author: Graham Markall, NVIDIA
 :Contributors: Thomson Comer, Peter Entschev, Leo Fang, John Kirkham, Keith Kraus

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -496,6 +496,8 @@ The plugin implementation consists of additions to `python/rmm/rmm.py
 
    # New imports:
    from contextlib import context_manager
+   # RMM already has Numba as a dependency, so these imports need not be guarded
+   # by a check for the presence of numba.
    from numba.cuda import HostOnlyCUDAMemoryManager, MemoryPointer, IpcHandle
 
 

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -489,7 +489,8 @@ intended to show an overview of the implementation in order to support the
 descriptions above and to illustrate how the plugin interface can be used -
 different choices may be made for a production-ready implementation.
 
-The plugin implementation consists of additions to ``python/rmm/rmm.py``\ :
+The plugin implementation consists of additions to `python/rmm/rmm.py
+<https://github.com/rapidsai/rmm/blob/d5831ac5ebb5408ee83f63b7c7d03d8870ecb361/python/rmm/rmm.py>`_:
 
 .. code-block:: python
 

--- a/docs/source/proposals/external-memory-management.rst
+++ b/docs/source/proposals/external-memory-management.rst
@@ -905,7 +905,7 @@ The test suite can be run with the CuPy plugin using:
 
 .. code-block::
 
-   NUMBA_CUDA_MEMORY_MANAGER=nbep7. python -m numba.runtests numba.cuda.tests
+   NUMBA_CUDA_MEMORY_MANAGER=nbep7.cupy_mempool python -m numba.runtests numba.cuda.tests
 
 This plugin implementation is presently more primitive than the RMM
 implementation, and results in some errors with the unit test suite:

--- a/docs/source/proposals/index.rst
+++ b/docs/source/proposals/index.rst
@@ -19,7 +19,7 @@ Implemented proposals
    :maxdepth: 1
 
    integer-typing.rst
-
+   external-memory-management.rst
 
 Other proposals
 ---------------

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -357,6 +357,9 @@ class _EnvReloader(object):
         # gdb binary location
         GDB_BINARY = _readenv("NUMBA_GDB_BINARY", str, '/usr/bin/gdb')
 
+        # CUDA Memory management
+        CUDA_MEMORY_MANAGER = _readenv("NUMBA_CUDA_MEMORY_MANAGER", str, '')
+
         # Inject the configuration values into the module globals
         for name, value in locals().copy().items():
             if name.isupper():

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -358,7 +358,8 @@ class _EnvReloader(object):
         GDB_BINARY = _readenv("NUMBA_GDB_BINARY", str, '/usr/bin/gdb')
 
         # CUDA Memory management
-        CUDA_MEMORY_MANAGER = _readenv("NUMBA_CUDA_MEMORY_MANAGER", str, '')
+        CUDA_MEMORY_MANAGER = _readenv("NUMBA_CUDA_MEMORY_MANAGER", str,
+                                       'default')
 
         # Inject the configuration values into the module globals
         for name, value in locals().copy().items():

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -421,21 +421,6 @@ def benchmark(func, maxsec=1):
 RANGE_ITER_OBJECTS = (builtins.range,)
 
 
-def logger_hasHandlers(logger):
-    # Backport from python3.5 logging implementation of `.hasHandlers()`
-    c = logger
-    rv = False
-    while c:
-        if c.handlers:
-            rv = True
-            break
-        if not c.propagate:
-            break
-        else:
-            c = c.parent
-    return rv
-
-
 # A dummy module for dynamically-generated functions
 _dynamic_modname = '<dynamic>'
 _dynamic_module = ModuleType(_dynamic_modname)

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -412,8 +412,7 @@ def defer_cleanup():
 
     Note: this context manager can be nested.
     """
-    deallocs = current_context().deallocations
-    with deallocs.disable():
+    with current_context().defer_cleanup():
         yield
 
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -695,7 +695,7 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
 
     def _attempt_allocation(self, allocator):
         """
-        Attempt allocation by calling *allocator*.  If a out-of-memory error
+        Attempt allocation by calling *allocator*.  If an out-of-memory error
         is raised, the pending deallocations are flushed and the allocation
         is retried.  If it fails in the second attempt, the error is reraised.
         """

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -795,7 +795,7 @@ class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
 
         finalizer = _alloc_finalizer(self, ptr, bytesize)
         ctx = weakref.proxy(self._context)
-        mem = AutoFreePointer(ctx, ptr, bytesize, finalizer)
+        mem = AutoFreePointer(ctx, ptr, bytesize, finalizer=finalizer)
         self.allocations[ptr.value] = mem
         return mem.own()
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -679,7 +679,7 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
     :class:`numba.cuda.BaseCUDAMemoryManager`) for its own internal state
     management. If an EMM Plugin based on this class also implements these
     methods, then its implementations of these must also call the method from
-    ``super()`` to give ``HostOnlyCUDAMemoryManager`` an opportunity  to do the
+    ``super()`` to give ``HostOnlyCUDAMemoryManager`` an opportunity to do the
     necessary work for the host allocations it is managing.
 
     This class does not implement ``interface_version``, as it will always be

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -560,7 +560,7 @@ class BaseCUDAMemoryManager(object, metaclass=ABCMeta):
         """The __init__ method sets the """
         if 'context' not in kwargs:
             raise RuntimeError("Memory manager requires a context")
-        self._context = kwargs.pop('context')
+        self.context = kwargs.pop('context')
 
     @abstractmethod
     def memalloc(self, nbytes, stream=0):
@@ -719,7 +719,7 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
         owner = None
 
         finalizer = _hostalloc_finalizer(self, pointer, bytesize, mapped)
-        ctx = weakref.proxy(self._context)
+        ctx = weakref.proxy(self.context)
 
         if mapped:
 
@@ -753,7 +753,7 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
             allocator()
 
         finalizer = _pin_finalizer(self, pointer, mapped)
-        ctx = weakref.proxy(self._context)
+        ctx = weakref.proxy(self.context)
 
         if mapped:
             mem = MappedMemory(ctx, owner, pointer, size,
@@ -794,7 +794,7 @@ class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
         self._attempt_allocation(allocator)
 
         finalizer = _alloc_finalizer(self, ptr, bytesize)
-        ctx = weakref.proxy(self._context)
+        ctx = weakref.proxy(self.context)
         mem = AutoFreePointer(ctx, ptr, bytesize, finalizer=finalizer)
         self.allocations[ptr.value] = mem
         return mem.own()
@@ -811,7 +811,7 @@ class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
             byref(ipchandle),
             memory.owner.handle,
         )
-        source_info = self._context.device.get_device_identity()
+        source_info = self.context.device.get_device_identity()
         offset = memory.handle.value - memory.owner.handle.value
 
         from numba.cuda.cudadrv.driver import IpcHandle

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -666,7 +666,7 @@ class BaseCUDAMemoryManager(object, metaclass=ABCMeta):
         """
         Returns an integer specifying the version of the EMM Plugin interface
         supported by the plugin implementation. Should always return 1 for
-        implementations described in this proposal.
+        implementations of this version of the specification.
         """
 
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -646,7 +646,7 @@ class BaseCUDAMemoryManager(object, metaclass=ABCMeta):
     @abstractmethod
     def reset(self):
         """
-        Clear up all memory allocated in this context.
+        Clears up all memory allocated in this context.
 
         :return: None
         """

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -7,6 +7,10 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     threadfence_block, threadfence_system,
                     threadfence, selp, popc, brev, clz, ffs, fma)
 from .cudadrv.error import CudaSupportError
+from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
+                                       HostOnlyCUDAMemoryManager,
+                                       MemoryPointer, MappedMemory,
+                                       PinnedMemory, set_memory_manager)
 from .cudadrv import nvvm
 from numba.cuda import initialize
 from .errors import KernelRuntimeError

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -10,7 +10,8 @@ from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,
                                        MemoryPointer, MappedMemory,
-                                       PinnedMemory, set_memory_manager)
+                                       PinnedMemory, MemoryInfo,
+                                       IpcHandle, set_memory_manager)
 from .cudadrv import nvvm
 from numba.cuda import initialize
 from .errors import KernelRuntimeError

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -30,6 +30,10 @@ def skip_unless_conda_cudatoolkit(reason):
     return unittest.skipUnless(get_conda_ctk() is not None, reason)
 
 
+def skip_with_external_memmgr(reason):
+    return unittest.skipIf(config.CUDA_MEMORY_MANAGER, reason)
+
+
 class CUDATextCapture(object):
 
     def __init__(self, stream):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -19,19 +19,23 @@ class CUDATestCase(SerialMixin, unittest.TestCase):
 
 
 def skip_on_cudasim(reason):
+    """Skip this test if running on the CUDA simulator"""
     return unittest.skipIf(config.ENABLE_CUDASIM, reason)
 
 
 def skip_unless_cudasim(reason):
+    """Skip this test if running on CUDA hardware"""
     return unittest.skipUnless(config.ENABLE_CUDASIM, reason)
 
 
 def skip_unless_conda_cudatoolkit(reason):
+    """Skip test if the CUDA toolkit was not installed by Conda"""
     return unittest.skipUnless(get_conda_ctk() is not None, reason)
 
 
-def skip_with_external_memmgr(reason):
-    return unittest.skipIf(config.CUDA_MEMORY_MANAGER, reason)
+def skip_if_external_memmgr(reason):
+    """Skip test if an EMM Plugin is in use"""
+    return unittest.skipIf(config.CUDA_MEMORY_MANAGER != 'default', reason)
 
 
 class CUDATextCapture(object):

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -4,13 +4,13 @@ import numpy as np
 
 from numba import cuda
 from numba.cuda.testing import (unittest, skip_on_cudasim,
-                                skip_with_external_memmgr, SerialMixin)
+                                skip_if_external_memmgr, SerialMixin)
 from numba.tests.support import captured_stderr
 from numba.core import config
 
 
 @skip_on_cudasim('not supported on CUDASIM')
-@skip_with_external_memmgr('Deallocation specific to Numba memory management')
+@skip_if_external_memmgr('Deallocation specific to Numba memory management')
 class TestDeallocation(SerialMixin, unittest.TestCase):
     def test_max_pending_count(self):
         # get deallocation manager and flush it
@@ -62,7 +62,7 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
 
 
 @skip_on_cudasim("defer_cleanup has no effect in CUDASIM")
-@skip_with_external_memmgr('Deallocation specific to Numba memory management')
+@skip_if_external_memmgr('Deallocation specific to Numba memory management')
 class TestDeferCleanup(SerialMixin, unittest.TestCase):
     def test_basic(self):
         harr = np.arange(5)

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -3,16 +3,18 @@ from contextlib import contextmanager
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, skip_on_cudasim, SerialMixin
+from numba.cuda.testing import (unittest, skip_on_cudasim,
+                                skip_with_external_memmgr, SerialMixin)
 from numba.tests.support import captured_stderr
 from numba.core import config
 
 
 @skip_on_cudasim('not supported on CUDASIM')
+@skip_with_external_memmgr('Deallocation specific to Numba memory management')
 class TestDeallocation(SerialMixin, unittest.TestCase):
     def test_max_pending_count(self):
         # get deallocation manager and flush it
-        deallocs = cuda.current_context().deallocations
+        deallocs = cuda.current_context().memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
         # deallocate to maximum count
@@ -26,7 +28,7 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
     def test_max_pending_bytes(self):
         # get deallocation manager and flush it
         ctx = cuda.current_context()
-        deallocs = ctx.deallocations
+        deallocs = ctx.memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
 
@@ -60,11 +62,12 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
 
 
 @skip_on_cudasim("defer_cleanup has no effect in CUDASIM")
+@skip_with_external_memmgr('Deallocation specific to Numba memory management')
 class TestDeferCleanup(SerialMixin, unittest.TestCase):
     def test_basic(self):
         harr = np.arange(5)
         darr1 = cuda.to_device(harr)
-        deallocs = cuda.current_context().deallocations
+        deallocs = cuda.current_context().memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
         with cuda.defer_cleanup():
@@ -82,7 +85,7 @@ class TestDeferCleanup(SerialMixin, unittest.TestCase):
     def test_nested(self):
         harr = np.arange(5)
         darr1 = cuda.to_device(harr)
-        deallocs = cuda.current_context().deallocations
+        deallocs = cuda.current_context().memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
         with cuda.defer_cleanup():
@@ -103,7 +106,7 @@ class TestDeferCleanup(SerialMixin, unittest.TestCase):
     def test_exception(self):
         harr = np.arange(5)
         darr1 = cuda.to_device(harr)
-        deallocs = cuda.current_context().deallocations
+        deallocs = cuda.current_context().memory_manager.deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)
 

--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -5,8 +5,7 @@ import weakref
 
 from numba import cuda
 from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
-
-not_linux = not sys.platform.startswith('linux')
+from numba.tests.support import linux_only
 
 
 class DeviceOnlyEMMPlugin(cuda.HostOnlyCUDAMemoryManager):
@@ -162,7 +161,7 @@ class TestDeviceOnlyEMMPlugin(unittest.TestCase, SerialMixin):
         self.assertEqual(meminfo.free, 32)
         self.assertEqual(meminfo.total, 64)
 
-    @unittest.skipIf(not_linux, "IPC only supported on Linux")
+    @linux_only
     def test_get_ipc_handle(self):
         # We don't attempt to close the IPC handle in this test because Numba
         # will be expecting a real IpcHandle object to have been returned from

--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -1,0 +1,188 @@
+import ctypes
+import numpy as np
+import sys
+import weakref
+
+from numba import cuda
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+
+not_linux = not sys.platform.startswith('linux')
+
+
+class DeviceOnlyEMMPlugin(cuda.HostOnlyCUDAMemoryManager):
+    """
+    Dummy EMM Plugin implementation for testing. It memorises which
+    plugin API methods have been called so that the tests can check that Numba
+    called into the plugin as expected.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # For tracking our dummy allocations
+        self.allocations = {}
+        self.count = 0
+
+        # For tracking which methods have been called
+        self.initialized = False
+        self.memalloc_called = False
+        self.reset_called = False
+        self.get_memory_info_called = False
+        self.get_ipc_handle_called = False
+
+    def memalloc(self, size):
+        # We maintain a list of allocations and keep track of them, so that we
+        # can test that the finalizers of objects returned by memalloc get
+        # called.
+
+        # Numba should have initialized the memory manager when preparing the
+        # context for use, prior to any memalloc call.
+        if not self.initialized:
+            raise RuntimeError("memalloc called before initialize")
+        self.memalloc_called = True
+
+        # Create an allocation and record it
+        self.count += 1
+        alloc_count = self.count
+        self.allocations[alloc_count] = size
+
+        # The finalizer deletes the record from our internal dict of
+        # allocations.
+        finalizer_allocs = self.allocations
+
+        def finalizer():
+            del finalizer_allocs[alloc_count]
+
+        # We use an AutoFreePointer so that the finalizer will be run when the
+        # reference count drops to zero.
+        ctx = weakref.proxy(self.context)
+        ptr = ctypes.c_void_p(alloc_count)
+        return cuda.cudadrv.driver.AutoFreePointer(ctx, ptr, size,
+                                                   finalizer=finalizer)
+
+    def initialize(self):
+        # No special initialization needed.
+        self.initialized = True
+
+    def reset(self):
+        # We remove all allocations on reset, just as a real EMM Plugin would
+        # do. Note that our finalizers in memalloc don't check whether the
+        # allocations are still alive, so running them after reset will detect
+        # any allocations that are floating around at exit time; however, the
+        # atexit finalizer for weakref will only print a traceback, not
+        # terminate the interpreter abnormally.
+        self.reset_called = True
+
+    def get_memory_info(self):
+        # Return some dummy memory information
+        self.get_memory_info_called = True
+        return cuda.MemoryInfo(free=32, total=64)
+
+    def get_ipc_handle(self, memory):
+        # The dummy IPC handle is only a string, so it is important that the
+        # tests don't try to do too much with it (e.g. open / close it).
+        self.get_ipc_handle_called = True
+        return "Dummy IPC handle for alloc %s" % memory.device_pointer.value
+
+    @property
+    def interface_version(self):
+        # The expected version for an EMM Plugin.
+        return 1
+
+
+class BadVersionEMMPlugin(DeviceOnlyEMMPlugin):
+    """A plugin that claims to implement a different interface version"""
+
+    @property
+    def interface_version(self):
+        return 2
+
+
+@skip_on_cudasim('EMM Plugins not supported on CUDA simulator')
+class TestDeviceOnlyEMMPlugin(unittest.TestCase, SerialMixin):
+    """
+    Tests that the API of an EMM Plugin that implements device allocations
+    only is used correctly by Numba.
+    """
+
+    def setUp(self):
+        # Always start afresh with a new context and memory manager
+        cuda.close()
+        cuda.set_memory_manager(DeviceOnlyEMMPlugin)
+
+    def tearDown(self):
+        # Set the memory manager back to the Numba internal one for subsequent
+        # tests.
+        cuda.close()
+        cuda.set_memory_manager(cuda.cudadrv.driver.NumbaCUDAMemoryManager)
+
+    def test_memalloc(self):
+        mgr = cuda.current_context().memory_manager
+
+        # Allocate an array and check that memalloc was called with the correct
+        # size.
+        arr_1 = np.arange(10)
+        d_arr_1 = cuda.device_array_like(arr_1)
+        self.assertTrue(mgr.memalloc_called)
+        self.assertEqual(mgr.count, 1)
+        self.assertEqual(mgr.allocations[1], arr_1.nbytes)
+
+        # Allocate again, with a different size, and check that it is also
+        # correct.
+        arr_2 = np.arange(5)
+        d_arr_2 = cuda.device_array_like(arr_2)
+        self.assertEqual(mgr.count, 2)
+        self.assertEqual(mgr.allocations[2], arr_2.nbytes)
+
+        # Remove the first array, and check that our finalizer was called for
+        # the first array only.
+        del d_arr_1
+        self.assertNotIn(1, mgr.allocations)
+        self.assertIn(2, mgr.allocations)
+
+        # Remove the second array and check that its finalizer was also
+        # called.
+        del d_arr_2
+        self.assertNotIn(2, mgr.allocations)
+
+    def test_initialized_in_context(self):
+        # If we have a CUDA context, it should already have initialized its
+        # memory manager.
+        self.assertTrue(cuda.current_context().memory_manager.initialized)
+
+    def test_reset(self):
+        ctx = cuda.current_context()
+        ctx.reset()
+        self.assertTrue(ctx.memory_manager.reset_called)
+
+    def test_get_memory_info(self):
+        ctx = cuda.current_context()
+        meminfo = ctx.get_memory_info()
+        self.assertTrue(ctx.memory_manager.get_memory_info_called)
+        self.assertEqual(meminfo.free, 32)
+        self.assertEqual(meminfo.total, 64)
+
+    @unittest.skipIf(not_linux, "IPC only supported on Linux")
+    def test_get_ipc_handle(self):
+        # We don't attempt to close the IPC handle in this test because Numba
+        # will be expecting a real IpcHandle object to have been returned from
+        # get_ipc_handle, and it would cause problems to do so.
+        arr = np.arange(2)
+        d_arr = cuda.device_array_like(arr)
+        ipch = d_arr.get_ipc_handle()
+        ctx = cuda.current_context()
+        self.assertTrue(ctx.memory_manager.get_ipc_handle_called)
+        self.assertIn("Dummy IPC handle for alloc 1", ipch._ipc_handle)
+
+
+@skip_on_cudasim('EMM Plugins not supported on CUDA simulator')
+class TestBadEMMPluginVersion(unittest.TestCase, SerialMixin):
+    """
+    Ensure that Numba rejects EMM Plugins with incompatible version
+    numbers.
+    """
+
+    def test_bad_plugin_version(self):
+        with self.assertRaises(RuntimeError) as raises:
+            cuda.set_memory_manager(BadVersionEMMPlugin)
+        self.assertIn('version 1 required', str(raises.exception))

--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -1,6 +1,5 @@
 import ctypes
 import numpy as np
-import sys
 import weakref
 
 from numba import cuda
@@ -89,7 +88,6 @@ if not config.ENABLE_CUDASIM:
         def interface_version(self):
             # The expected version for an EMM Plugin.
             return 1
-
 
     class BadVersionEMMPlugin(DeviceOnlyEMMPlugin):
         """A plugin that claims to implement a different interface version"""

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import vectorize, guvectorize
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, skip_with_external_memmgr
 
 
 class MyArray(object):
@@ -30,10 +30,11 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(wrapped.device_ctypes_pointer.value,
                          d_arr.device_ctypes_pointer.value)
 
+    @skip_with_external_memmgr('Ownership not relevant with external memmgr')
     def test_ownership(self):
         # Get the deallocation queue
         ctx = cuda.current_context()
-        deallocs = ctx.deallocations
+        deallocs = ctx.memory_manager.deallocations
         # Flush all deallocations
         deallocs.clear()
         self.assertEqual(len(deallocs), 0)

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import vectorize, guvectorize
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
-from numba.cuda.testing import skip_on_cudasim, skip_with_external_memmgr
+from numba.cuda.testing import skip_on_cudasim, skip_if_external_memmgr
 
 
 class MyArray(object):
@@ -30,7 +30,7 @@ class TestCudaArrayInterface(CUDATestCase):
         self.assertEqual(wrapped.device_ctypes_pointer.value,
                          d_arr.device_ctypes_pointer.value)
 
-    @skip_with_external_memmgr('Ownership not relevant with external memmgr')
+    @skip_if_external_memmgr('Ownership not relevant with external memmgr')
     def test_ownership(self):
         # Get the deallocation queue
         ctx = cuda.current_context()

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -11,7 +11,7 @@ from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 from numba.tests.support import linux_only
 import unittest
 
-
+not_linux = not sys.platform.startswith('linux')
 has_mp_get_context = hasattr(mp, 'get_context')
 
 
@@ -180,7 +180,7 @@ class TestIpcMemory(CUDATestCase):
         self.check_ipc_array(slice(3, 8))
         self.check_ipc_array(slice(None, 8))
 
-@linux_only
+@unittest.skipUnless(not_linux, 'Only on OS other than Linux')
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcNotSupported(CUDATestCase):
     def test_unsupported(self):

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -11,7 +11,7 @@ from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 from numba.tests.support import linux_only
 import unittest
 
-not_linux = not sys.platform.startswith('linux')
+linux = sys.platform.startswith('linux')
 has_mp_get_context = hasattr(mp, 'get_context')
 
 
@@ -180,7 +180,7 @@ class TestIpcMemory(CUDATestCase):
         self.check_ipc_array(slice(3, 8))
         self.check_ipc_array(slice(None, 8))
 
-@unittest.skipUnless(not_linux, 'Only on OS other than Linux')
+@unittest.skipIf(linux, 'Only on OS other than Linux')
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcNotSupported(CUDATestCase):
     def test_unsupported(self):

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -8,10 +8,10 @@ import numpy as np
 from numba import cuda
 from numba.cuda.cudadrv import drvapi, devicearray
 from numba.cuda.testing import skip_on_cudasim, CUDATestCase
+from numba.tests.support import linux_only
 import unittest
 
 
-not_linux = not sys.platform.startswith('linux')
 has_mp_get_context = hasattr(mp, 'get_context')
 
 
@@ -79,7 +79,7 @@ def ipc_array_test(ipcarr, result_queue):
     result_queue.put((succ, out))
 
 
-@unittest.skipIf(not_linux, "IPC only supported on Linux")
+@linux_only
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcMemory(CUDATestCase):
@@ -180,7 +180,7 @@ class TestIpcMemory(CUDATestCase):
         self.check_ipc_array(slice(3, 8))
         self.check_ipc_array(slice(None, 8))
 
-@unittest.skipUnless(not_linux, "Only on OS other than Linux")
+@linux_only
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcNotSupported(CUDATestCase):
     def test_unsupported(self):
@@ -237,7 +237,7 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
     result_queue.put((succ, out))
 
 
-@unittest.skipIf(not_linux, "IPC only supported on Linux")
+@linux_only
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcStaged(CUDATestCase):


### PR DESCRIPTION
As described in [NBEP 7](https://gmarkall.github.io/numba-nbep7-docs/proposals/external-memory-management.html) and [the EMM documentation](https://gmarkall.github.io/numba-nbep7-docs/cuda/external-memory.html). This implements support for External Memory Management (EMM) Plugins - when an EMM Plugin is in use, Numba does all memory allocation and deallocation through the plugin. The NBEP linked above describes the motivations for doing this in more detail, but the main aim is to enable the use of pool allocators such as those provided by the RAPIDS Memory Manager or CuPy.

The implementation is currently passing all tests with the internal memory management on my system:

```
$ python -m numba.runtests numba.cuda.tests
...
Ran 564 tests in 133.396s

OK (skipped=5)
```

There is a PR to the RAPIDS Memory Manager that implements an EMM Plugin: https://github.com/rapidsai/rmm/pull/317 - the CI is failing on that PR, but this is because the RMM PR tester tests with a release version of Numba (instead of with this branch, which would presently be required). This implementation passes all tests on my system when it is used for memory management:

```
$ NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
...
Ran 564 tests in 142.211s

OK (skipped=11)
```

I have also partially implemented a plugin that enables the use of CuPy allocators: https://github.com/gmarkall/nbep-7/blob/master/nbep7/cupy_mempool.py - this is currently a bit of a "draft", and doesn't support IPC, but demonstrates that the concept functions for more than one memory allocation library. Results with it are:

```
$ NUMBA_CUDA_MEMORY_MANAGER=nbep7.cupy_mempool python -m numba.runtests numba.cuda.tests
...
Ran 564 tests in 111.699s

FAILED (errors=8, skipped=11)
```

The errors are due to the lack of implementation of `get_ipc_handle`. I plan to complete this implementation at some point in the future.

Adding functional tests specifically for the plugin interface is a little bit catch-22 - since testing the interface requires an external library capable of managing CUDA memory, I would expect to add functional tests once an EMM plugin is available in a release version of a memory management library, when it can easily be installed as a dependency for test purposes (possibly to be added when gpuCI testing is up and running, since it will allow CI with CUDA hardware).

For the changes that touched internal memory management (the creation of the `BaseCUDAMemoryManager`, `HostOnlyCUDAMemoryManager`, and `NumbaCUDAMemoryManager` classes, and the related `Context` changes), running of the CUDA test suite in general is exercising these changes.



The NBEP 7 document discusses the code changes and their motivations in general, but a summary of the changes made in this PR, in the order they appear on the diff, for the purposes of aiding reviewers follows:

- Add documentation for the interface and the NBEP 7 document.
- A small fix to the markup in `cuda_array_interface.rst` - I accidentally committed this, but left it in as it fixes a nested list.
- Add a new environment variable, `NUMBA_CUDA_MEMORY_MANAGER`.
- Remove `utils.logger_hasHandlers` - this was a backport from Python 3.5 that is no longer required.
- Change `cuda.defer_cleanup()` so it uses the context's `defer_cleanup()` method, instead of directly disabling deallocations for the context, which would be incorrect when an EMM Plugin is in use.
- Add classes and functions to `driver.py`: `BaseCUDAMemoryManager`, `HostOnlyCUDAMemoryManager`, `NumbaCUDAMemoryManager`, `set_memory_manager`, and `_ensure_memory_manager`. All but the last are described in the NBEP 7 document - the last is called by a context on initialization to set the memory manager class if it has not already been set.
- Make `_SizeNotSet` behave more like an int - the previous implementation defined `__int__` to enable it to be used in arithmetic, but this failed for binary ops with floats, which might be used in EMM plugin implementations.
- Change `_PendingDeallocs` so that it can start out with an unknown capacity, then have the capacity set later. This is because the `HostOnlyCUDAMemoryManager` needs to create an object to hold pending deallocations for the host-side objects, and it may only be later that an EMM plugin subclass can provide the memory capacity.
- Make `_MemoryInfo` public, as it is expected to be instantiated by EMM Plugins.
- The `Context` class now creates an instance of the memory manager (either the internal one or an EMM Plugin depending on settings) and uses it for all allocations and deallocations (`memalloc` etc.) instead of managing memory directly.
- The `Context` no longer has to lazily initialize `self.deallocations`, because it does not need to know the memory capacity for the objects it does manage the lifetime of (events, streams, and modules).
- `defer_cleanup` is added to the `Context` class, which is provided for the purpose of calling into the memory manager's `defer_cleanup` function.
- Various finalizer functions have the `context` variable renamed to `memory_manager`, in order to reflect the type of the object accurately.
- `_StagedIpcImpl.own()` no longer calls `own()` on the memory it returns - this is unnecessary when internal memory management is used, and incorrect when an EMM Plugin is used (discussed in NBEP 7 document).
- Adjust argument list of `__init__` methods for `MemoryPointer`, `MappedMemory`, and `PinnedMemory` to be consistent with each other. 
- Add docstrings in various places throughout `driver.py`, for classes and methods that are part of the public API or referred to in the documentation.
- Add all classes and functions related to EMM Plugins to the public API in the `numba.cuda` module (through `device_init.py`).
- Add a new test skip method to avoid running tests that only apply to internal memory management when an EMM Plugin is in use, and decorate appropriate tests.
- Modify tests that inspected the context to inspect the memory manager instead, where appropriate.