### PR TITLE
Add: highlight Numba IR dump

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -34,9 +34,10 @@ def dump(header, body):
             from pygments import highlight
             from pygments.lexers import GasLexer as lexer
             from pygments.formatters import Terminal256Formatter
+            from numba.misc.dump_style import by_colorscheme
             def printer(arg):
                 print(highlight(arg, lexer(),
-                      Terminal256Formatter(style='solarized-light')))
+                      Terminal256Formatter(style=by_colorscheme())))
     else:
         printer = print
     print('=' * 80)

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -1462,8 +1462,8 @@ class FunctionIR(object):
                     raise ValueError(msg)
                 else:
                     from pygments import highlight
-                    from numba.misc.dump_style \
-                        import NumbaIRLexer as lexer, by_colorscheme
+                    from numba.misc.dump_style import NumbaIRLexer as lexer
+                    from numba.misc.dump_style import by_colorscheme
                     from pygments.formatters import Terminal256Formatter
                     print(highlight(text, lexer(), Terminal256Formatter(
                         style=by_colorscheme())))

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -1462,9 +1462,11 @@ class FunctionIR(object):
                     raise ValueError(msg)
                 else:
                     from pygments import highlight
-                    from .ir_lexer import NumbaIRLexer as lexer
+                    from numba.misc.dump_style \
+                        import NumbaIRLexer as lexer, by_colorscheme
                     from pygments.formatters import Terminal256Formatter
-                    print(highlight(text, lexer(), Terminal256Formatter()))
+                    print(highlight(text, lexer(), Terminal256Formatter(
+                        style=by_colorscheme())))
             else:
                 print(text)
 

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -1462,7 +1462,7 @@ class FunctionIR(object):
                     raise ValueError(msg)
                 else:
                     from pygments import highlight
-                    from pygments.lexers import DelphiLexer as lexer
+                    from .ir_lexer import NumbaIRLexer as lexer
                     from pygments.formatters import Terminal256Formatter
                     print(highlight(text, lexer(), Terminal256Formatter()))
             else:

--- a/numba/core/ir_lexer.py
+++ b/numba/core/ir_lexer.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from pygments.lexer import RegexLexer, include, bygroups, words
+from pygments.token import Text, Name, String,  Punctuation, Keyword, Operator
+
+
+class NumbaIRLexer(RegexLexer):
+    """
+    For Numba IR code.
+    """
+    name = 'Numba_IR'
+    aliases = ['numba_ir']
+    filenames = ['*.numba_ir']
+
+    identifier = r'\$[a-zA-Z0-9._]+'
+    fun_or_var = r'([a-zA-Z_]+[a-zA-Z0-9]*)'
+
+    tokens = {
+        'root' : [
+            (r'(label)(\ [0-9]+)(:)$',
+                bygroups(Keyword, Name.Label, Punctuation)),
+
+            (r' = ', Operator),
+            include('whitespace'),
+            include('keyword'),
+
+            (identifier, Name.Variable),
+            (fun_or_var + r'(\()',
+                bygroups(Name.Function, Punctuation)),
+            (fun_or_var + r'(\=)',
+                bygroups(Name.Attribute, Punctuation)),
+            (fun_or_var, Name.Constant),
+
+            # <built-in function some>
+            (r'<.*>', String),
+
+            (r'[=<>{}\[\]()*.,!]|x\b', Punctuation)
+        ],
+
+        'keyword':[
+            (words((
+                'del', 'jump', 'call', 'branch',
+            ), suffix=' '), Keyword),
+        ],
+
+        'whitespace': [
+            (r'(\n|\s)', Text),
+        ],
+    }

--- a/numba/core/ir_lexer.py
+++ b/numba/core/ir_lexer.py
@@ -32,7 +32,7 @@ class NumbaIRLexer(RegexLexer):
             (fun_or_var, Name.Constant),
 
             # <built-in function some>
-            (r'<.*>', String),
+            (r'<[^>]*>', String),
 
             (r'[=<>{}\[\]()*.,!]|x\b', Punctuation)
         ],

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -192,9 +192,10 @@ class BaseLower(object):
                     from pygments import highlight
                     from pygments.lexers import LlvmLexer as lexer
                     from pygments.formatters import Terminal256Formatter
+                    from numba.misc.dump_style import by_colorscheme
                     print(highlight(self.module.__repr__(), lexer(),
                                     Terminal256Formatter(
-                                        style='solarized-light')))
+                                        style=by_colorscheme())))
                 except ImportError:
                     msg = "Please install pygments to see highlighted dumps"
                     raise ValueError(msg)

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -45,7 +45,7 @@ class NumbaIRLexer(RegexLexer):
             (r'[0-9]+', Number),
 
             # <built-in function some>
-            (r'<[^>]*>', String),
+            (r'<[^>\n]*>', String),
 
             (r'[=<>{}\[\]()*.,!\':]|x\b', Punctuation)
         ],

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -1,6 +1,10 @@
+try:
+    from pygments.styles.default import DefaultStyle
+except ImportError:
+    msg = "Please install pygments to see highlighted dumps"
+    raise ImportError(msg)
 
 import numba.core.config
-from pygments.styles.default import DefaultStyle
 from pygments.styles.manni import ManniStyle
 from pygments.styles.monokai import MonokaiStyle
 from pygments.styles.native import NativeStyle
@@ -59,6 +63,10 @@ class NumbaIRLexer(RegexLexer):
 
 
 def by_colorscheme():
+    """
+    Get appropriate style for highlighting according to
+    NUMBA_COLOR_SCHEME setting
+    """
     styles = DefaultStyle.styles.copy()
     styles.update({
         Name.Variable:        "#888888",

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -14,7 +14,7 @@ from pygments.style import Style
 
 class NumbaIRLexer(RegexLexer):
     """
-    For Numba IR code.
+    Pygments style lexer for Numba IR (for use with highlighting etc).
     """
     name = 'Numba_IR'
     aliases = ['numba_ir']

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -1,14 +1,13 @@
 
 import numba.core.config
 from pygments.styles.default import DefaultStyle
-from pygments.styles.bw import BlackWhiteStyle
 from pygments.styles.manni import ManniStyle
 from pygments.styles.monokai import MonokaiStyle
 from pygments.styles.native import NativeStyle
 
 from pygments.lexer import RegexLexer, include, bygroups, words
 from pygments.token import Text, Name, String,  Punctuation, Keyword, \
-    Operator, Number, Comment, Error
+    Operator, Number
 
 from pygments.style import Style
 

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -8,7 +8,7 @@ from pygments.styles.native import NativeStyle
 
 from pygments.lexer import RegexLexer, include, bygroups, words
 from pygments.token import Text, Name, String,  Punctuation, Keyword, \
-    Operator, Number
+    Operator, Number, Comment, Error
 
 from pygments.style import Style
 
@@ -60,16 +60,14 @@ class NumbaIRLexer(RegexLexer):
 
 
 def by_colorscheme():
-    styles = BlackWhiteStyle.styles.copy()
+    styles = DefaultStyle.styles.copy()
     styles.update({
-        Name.Function:             "bold",
-        Name.Attribute:            "bold",
-        Name.Constant:             "bold",
+        Name.Variable:        "#888888",
     })
-    numba_bw = type('NumbaBwStyle', (Style, ), {'styles': styles})
+    custom_default = type('CustomDefaultStyle', (Style, ), {'styles': styles})
 
     style_map = {
-        'no_color' : numba_bw,
+        'no_color' : custom_default,
         'dark_bg' : MonokaiStyle,
         'light_bg' : ManniStyle,
         'blue_bg' : NativeStyle,

--- a/numba/misc/dump_style.py
+++ b/numba/misc/dump_style.py
@@ -1,7 +1,16 @@
-# -*- coding: utf-8 -*-
+
+import numba.core.config
+from pygments.styles.default import DefaultStyle
+from pygments.styles.bw import BlackWhiteStyle
+from pygments.styles.manni import ManniStyle
+from pygments.styles.monokai import MonokaiStyle
+from pygments.styles.native import NativeStyle
 
 from pygments.lexer import RegexLexer, include, bygroups, words
-from pygments.token import Text, Name, String,  Punctuation, Keyword, Operator
+from pygments.token import Text, Name, String,  Punctuation, Keyword, \
+    Operator, Number
+
+from pygments.style import Style
 
 
 class NumbaIRLexer(RegexLexer):
@@ -30,11 +39,12 @@ class NumbaIRLexer(RegexLexer):
             (fun_or_var + r'(\=)',
                 bygroups(Name.Attribute, Punctuation)),
             (fun_or_var, Name.Constant),
+            (r'[0-9]+', Number),
 
             # <built-in function some>
             (r'<[^>]*>', String),
 
-            (r'[=<>{}\[\]()*.,!]|x\b', Punctuation)
+            (r'[=<>{}\[\]()*.,!\':]|x\b', Punctuation)
         ],
 
         'keyword':[
@@ -47,3 +57,23 @@ class NumbaIRLexer(RegexLexer):
             (r'(\n|\s)', Text),
         ],
     }
+
+
+def by_colorscheme():
+    styles = BlackWhiteStyle.styles.copy()
+    styles.update({
+        Name.Function:             "bold",
+        Name.Attribute:            "bold",
+        Name.Constant:             "bold",
+    })
+    numba_bw = type('NumbaBwStyle', (Style, ), {'styles': styles})
+
+    style_map = {
+        'no_color' : numba_bw,
+        'dark_bg' : MonokaiStyle,
+        'light_bg' : ManniStyle,
+        'blue_bg' : NativeStyle,
+        'jupyter_nb' : DefaultStyle,
+    }
+
+    return style_map[numba.core.config.COLOR_SCHEME]


### PR DESCRIPTION
Closes #4657

Colors in ipython(white background) and Jupyter are ok. `Terminal256Formatter` doesn't recognize black background currently so colors a bit dark on black background.
Demo: 
![image](https://user-images.githubusercontent.com/1679388/75668002-a2cf7000-5c89-11ea-82de-8a4e36200874.png)

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
