### PR TITLE
Fix cuda spoof

### DIFF
--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -72,7 +72,7 @@ class FakeCUDAArray(object):
     __cuda_ndarray__ = True  # There must be gpu_data attribute
 
     def __init__(self, ary, stream=0):
-        if ary.ndim == 0:
+        if ary.ndim == 0:  # needed for TestCudaNDArray.test_device_array_interface
             self._ary = ary.reshape(1)
             self._ary_access = self._ary[0]
         else:

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -47,7 +47,7 @@ class FakeKernelCUDAArray(object):
 
     def __getattr__(self, attrname):
         if attrname in dir(self.__dict__['_item']._ary):  # For, eg, array size.
-            return getattr(self.__dict__['_item']._ary, attrname)
+            return self.__wrap_if_fake(getattr(self.__dict__['_item']._ary, attrname))
         else:
             return self.__wrap_if_fake(self._item.__getitem__(attrname))
 

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -46,8 +46,8 @@ class FakeKernelCUDAArray(object):
         return FakeKernelCUDAArray(item) if isinstance(item, FakeCUDAArray) else item
 
     def __getattr__(self, attrname):
-        if attrname in dir(self.__dict__['_item']._ary):  # For, eg, array size.
-            return self.__wrap_if_fake(getattr(self.__dict__['_item']._ary, attrname))
+        if attrname in dir(self._item._ary):  # For, eg, array size.
+            return self.__wrap_if_fake(getattr(self._item._ary, attrname))
         else:
             return self.__wrap_if_fake(self._item.__getitem__(attrname))
 
@@ -61,7 +61,7 @@ class FakeKernelCUDAArray(object):
         self._item.__setitem__(idx, val)
 
     def __len__(self):
-        return len(self.__dict__['_item'])
+        return len(self._item)
 
 class FakeCUDAArray(object):
     '''

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -47,14 +47,14 @@ class FakeKernelCUDAArray(object):
     def __getattr__(self, attrname):
         return self.__wrap_if_fake(self._item.__getitem__(attrname))
 
+    def __setattr__(self, nm, val):
+        self._item.__setitem__(nm, val)
+
     def __getitem__(self, idx):
         return self.__wrap_if_fake(self._item.__getitem__(idx))
 
     def __setitem__(self, idx, val):
         self._item.__setitem__(idx, val)
-
-    def __setattr__(self, nm, val):
-        self.__setattr__(nm, val)
 
 
 

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -109,7 +109,7 @@ class FakeCUDAArray(object):
 
     def __getitem__(self, idx):
         ret = self._ary_access.__getitem__(idx)
-        if np.issubdtype(type(ret), np.number) or np.issubdtype(type(ret), np.bool_):
+        if np.issubdtype(type(ret), np.number) or np.issubdtype(type(ret), np.bool_) or np.issubdtype(type(ret), np.record):
             return ret
         else:
             return FakeCUDAArray(ret, stream=self.stream)

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -39,9 +39,10 @@ class FakeShape(tuple):
 
 class FakeWithinKernelCUDAArray(object):
     '''
-    Created to emulate the behavior of arrays within kernels, where either array.item or array['item'] is valid.
-    This behaviour does not follow the semantics of Python and NumPy with
-    non-jitted code, and will be deprecated and removed.
+    Created to emulate the behavior of arrays within kernels, where either
+    array.item or array['item'] is valid. This behaviour does not follow
+    the semantics of Python and NumPy with non-jitted code, and will be
+    deprecated and removed.
     '''
 
     def __init__(self, item):
@@ -49,7 +50,10 @@ class FakeWithinKernelCUDAArray(object):
         self.__dict__['_item'] = item
 
     def __wrap_if_fake(self, item):
-        return FakeWithinKernelCUDAArray(item) if isinstance(item, FakeCUDAArray) else item
+        if isinstance(item, FakeCUDAArray):
+            return FakeWithinKernelCUDAArray(item)
+        else:
+            return item
 
     def __getattr__(self, attrname):
         if attrname in dir(self._item._ary):  # For e.g. array size.
@@ -69,6 +73,7 @@ class FakeWithinKernelCUDAArray(object):
     def __len__(self):
         return len(self._item)
 
+
 class FakeCUDAArray(object):
     '''
     Implements the interface of a DeviceArray/DeviceRecord, but mostly just
@@ -78,7 +83,8 @@ class FakeCUDAArray(object):
     __cuda_ndarray__ = True  # There must be gpu_data attribute
 
     def __init__(self, ary, stream=0):
-        if ary.ndim == 0:  # needed for TestCudaNDArray.test_device_array_interface
+        # ary/ary_access needed for TestCudaNDArray.test_device_array_interface
+        if ary.ndim == 0:
             self._ary = ary.reshape(1)
             self._ary_access = self._ary[0]
         else:

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -109,7 +109,7 @@ class FakeCUDAArray(object):
 
     def __getitem__(self, idx):
         ret = self._ary_access.__getitem__(idx)
-        if np.issubdtype(type(ret), np.number) or np.issubdtype(type(ret), np.bool_) or np.issubdtype(type(ret), np.record):
+        if type(ret) not in [np.ndarray, np.void]:
             return ret
         else:
             return FakeCUDAArray(ret, stream=self.stream)

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -40,7 +40,8 @@ class FakeShape(tuple):
 class FakeWithinKernelCUDAArray(object):
     '''
     Created to emulate the behavior of arrays within kernels, where either
-    array.item or array['item'] is valid. This behaviour does not follow
+    array.item or array['item'] is valid (that is, give all structured
+    arrays `numpy.recarray`-like semantics). This behaviour does not follow
     the semantics of Python and NumPy with non-jitted code, and will be
     deprecated and removed.
     '''

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -40,7 +40,8 @@ class FakeShape(tuple):
 class FakeWithinKernelCUDAArray(object):
     '''
     Created to emulate the behavior of arrays within kernels, where either array.item or array['item'] is valid.
-    This is weird behavior and should eventually be removed.
+    This behaviour does not follow the semantics of Python and NumPy with
+    non-jitted code, and will be deprecated and removed.
     '''
 
     def __init__(self, item):

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -60,6 +60,8 @@ class FakeKernelCUDAArray(object):
     def __setitem__(self, idx, val):
         self._item.__setitem__(idx, val)
 
+    def __len__(self):
+        return len(self.__dict__['_item'])
 
 class FakeCUDAArray(object):
     '''

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -86,7 +86,8 @@ class FakeCUDAArray(object):
             attr = getattr(self._ary, attrname)
             return attr
         except AttributeError as e:
-            six.raise_from(AttributeError("Wrapped array has no attribute '%s'" % attrname), e)
+            msg = "Wrapped array has no attribute '%s'" % attrname
+            raise AttributeError(msg) from e
 
     def bind(self, stream=0):
         return FakeCUDAArray(self._ary, stream)

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -52,7 +52,7 @@ class FakeWithinKernelCUDAArray(object):
         return FakeWithinKernelCUDAArray(item) if isinstance(item, FakeCUDAArray) else item
 
     def __getattr__(self, attrname):
-        if attrname in dir(self._item._ary):  # For, eg, array size.
+        if attrname in dir(self._item._ary):  # For e.g. array size.
             return self.__wrap_if_fake(getattr(self._item._ary, attrname))
         else:
             return self.__wrap_if_fake(self._item.__getitem__(attrname))

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -108,11 +108,11 @@ class FakeCUDAArray(object):
         return FakeCUDAArray(np.transpose(self._ary, axes=axes))
 
     def __getitem__(self, idx):
-        ret = self._ary.__getitem__(idx)
+        ret = self._ary_access.__getitem__(idx)
         if np.issubdtype(type(ret), np.number) or np.issubdtype(type(ret), np.bool_):
             return ret
         else:
-            return FakeCUDAArray(self._ary_access.__getitem__(idx), stream=self.stream)
+            return FakeCUDAArray(ret, stream=self.stream)
 
     def __setitem__(self, idx, val):
         return self._ary_access.__setitem__(idx, val)

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -37,13 +37,18 @@ class FakeShape(tuple):
         return super(FakeShape, self).__getitem__(k)
 
 
-class FakeKernelCUDAArray(object):
+class FakeWithinKernelCUDAArray(object):
+    '''
+    Created to emulate the behavior of arrays within kernels, where either array.item or array['item'] is valid.
+    This is weird behavior and should eventually be removed.
+    '''
+
     def __init__(self, item):
         assert isinstance(item, FakeCUDAArray)
         self.__dict__['_item'] = item
 
     def __wrap_if_fake(self, item):
-        return FakeKernelCUDAArray(item) if isinstance(item, FakeCUDAArray) else item
+        return FakeWithinKernelCUDAArray(item) if isinstance(item, FakeCUDAArray) else item
 
     def __getattr__(self, attrname):
         if attrname in dir(self._item._ary):  # For, eg, array size.

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -72,7 +72,12 @@ class FakeCUDAArray(object):
     __cuda_ndarray__ = True  # There must be gpu_data attribute
 
     def __init__(self, ary, stream=0):
-        self._ary = ary
+        if ary.ndim == 0:
+            self._ary = ary.reshape(1)
+            self._ary_access = self._ary[0]
+        else:
+            self._ary = ary
+            self._ary_access = self._ary
         self.stream = stream
 
     @property
@@ -107,10 +112,10 @@ class FakeCUDAArray(object):
         if np.issubdtype(type(ret), np.number) or np.issubdtype(type(ret), np.bool_):
             return ret
         else:
-            return FakeCUDAArray(self._ary.__getitem__(idx), stream=self.stream)
+            return FakeCUDAArray(self._ary_access.__getitem__(idx), stream=self.stream)
 
     def __setitem__(self, idx, val):
-        return self._ary.__setitem__(idx, val)
+        return self._ary_access.__setitem__(idx, val)
 
     def copy_to_host(self, ary=None, stream=0):
         if ary is None:

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -6,7 +6,7 @@ import threading
 import numpy as np
 
 from numba.core.utils import reraise
-from .cudadrv.devicearray import to_device, auto_device, FakeCUDAArray, FakeKernelCUDAArray
+from .cudadrv.devicearray import to_device, auto_device, FakeCUDAArray, FakeWithinKernelCUDAArray
 from .kernelapi import Dim3, FakeCUDAModule, swapped_cuda_module
 from ..errors import normalize_kernel_dimensions
 from ..args import wrap_arg, ArgHint
@@ -94,7 +94,7 @@ class FakeCUDAKernel(object):
                 else:
                     ret = arg
                 if isinstance(ret,FakeCUDAArray):
-                    return FakeKernelCUDAArray(ret)
+                    return FakeWithinKernelCUDAArray(ret)
                 return ret
 
             fake_args = [fake_arg(arg) for arg in args]

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -6,7 +6,8 @@ import threading
 import numpy as np
 
 from numba.core.utils import reraise
-from .cudadrv.devicearray import to_device, auto_device, FakeCUDAArray, FakeWithinKernelCUDAArray
+from .cudadrv.devicearray import to_device, auto_device, \
+    FakeCUDAArray, FakeWithinKernelCUDAArray
 from .kernelapi import Dim3, FakeCUDAModule, swapped_cuda_module
 from ..errors import normalize_kernel_dimensions
 from ..args import wrap_arg, ArgHint

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -6,7 +6,7 @@ import threading
 import numpy as np
 
 from numba.core.utils import reraise
-from .cudadrv.devicearray import to_device, auto_device
+from .cudadrv.devicearray import to_device, auto_device, FakeCUDAArray, FakeKernelCUDAArray
 from .kernelapi import Dim3, FakeCUDAModule, swapped_cuda_module
 from ..errors import normalize_kernel_dimensions
 from ..args import wrap_arg, ArgHint
@@ -86,11 +86,14 @@ class FakeCUDAKernel(object):
                 )
 
                 if isinstance(arg, np.ndarray) and arg.ndim > 0:
-                    return wrap_arg(arg).to_device(retr)
+                    ret = wrap_arg(arg).to_device(retr)
                 elif isinstance(arg, ArgHint):
-                    return arg.to_device(retr)
+                    ret = arg.to_device(retr)
                 else:
-                    return arg
+                    ret = arg
+                if isinstance(ret,FakeCUDAArray):
+                    return FakeKernelCUDAArray(ret)
+                return ret
 
             fake_args = [fake_arg(arg) for arg in args]
             with swapped_cuda_module(self.fn, fake_cuda_module):

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -93,7 +93,7 @@ class FakeCUDAKernel(object):
                     ret = FakeCUDAArray(arg)  # In case a np record comes in.
                 else:
                     ret = arg
-                if isinstance(ret,FakeCUDAArray):
+                if isinstance(ret, FakeCUDAArray):
                     return FakeWithinKernelCUDAArray(ret)
                 return ret
 

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -89,6 +89,8 @@ class FakeCUDAKernel(object):
                     ret = wrap_arg(arg).to_device(retr)
                 elif isinstance(arg, ArgHint):
                     ret = arg.to_device(retr)
+                elif isinstance(arg, np.void):
+                    ret = FakeCUDAArray(arg)  # In case a np record comes in.
                 else:
                     ret = arg
                 if isinstance(ret,FakeCUDAArray):

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -27,19 +27,14 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
 
         @cuda.jit
         def simple_kernel(f):
-            shr = cuda.shared.array(1, dtype=goose_nb_type)
-            shr[0] = f
             f.garden[0] = 45.0
-            shr[0].backyard.statue = 3.0
-            f.backyard.statue = shr[0].backyard.statue
             f.backyard.newspaper[3] = 2.0
             f.backyard.newspaper[3] = f.backyard.newspaper[3] + 3.0
 
         item = np.recarray(1, dtype=goose_np_type)
         simple_kernel[1, 1](item[0])
         np.testing.assert_equal(item[0]['garden'][0], 45)
-        np.testing.assert_equal(3, item[0]['backyard']['statue'])
-        np.testing.assert_equal(5, item[0]['backyard']['newspaper'][3])
+        np.testing.assert_equal(item[0]['backyard']['newspaper'], 3)
 
     def test_recarray_setting(self):
         recordwith2darray = np.dtype([('i', np.int32), ('j', np.float32, (3, 2))])

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -35,6 +35,16 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
         np.testing.assert_equal(3, item[0]['backyard']['statue'])
         np.testing.assert_equal(5, item[0]['backyard']['newspaper'][3])
 
+    def test_recarray_setting(self):
+        recordwith2darray = np.dtype([('i', np.int32), ('j', np.float32, (3, 2))])
+        rec = np.recarray(2, dtype=recordwith2darray)
+        rec[0]['i'] = 45
+        @cuda.jit
+        def simple_kernel(f):
+            f[1] = f[0]
+        simple_kernel[1, 1](rec)
+        np.testing.assert_equal(rec[0]['i'], rec[1]['i'])
+
     def test_cuda_module_in_device_function(self):
         """
         Discovered in https://github.com/numba/numba/issues/1837.

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -1,14 +1,39 @@
 import threading
 
 import numpy as np
+from numpy import float64
 
-from numba import cuda
+from numba import cuda, numba
 from numba.cuda.testing import SerialMixin, skip_unless_cudasim
 import numba.cuda.simulator as simulator
 import unittest
 
 
 class TestCudaSimIssues(SerialMixin, unittest.TestCase):
+    BACKYARD_TYPE = [('statue', float64),
+                     ('newspaper', float64, 6)]
+
+    GOOSE_TYPE = [('garden', float64, (12,)),
+                  ('town', float64, (42,)),
+                  ('backyard', BACKYARD_TYPE)]
+
+    GOOSE_NP_DTYPE = np.dtype(GOOSE_TYPE, align=True)
+
+    GOOSE_NB_DTYPE = numba.from_dtype(GOOSE_NP_DTYPE)
+
+    def test_record_access(self):
+        @cuda.jit
+        def simple_kernel(f):
+            f.garden[0] = 45.0
+            f.backyard.statue = 3.0
+            f.backyard.newspaper[3] = 2.0
+            f.backyard.newspaper[3] = f.backyard.newspaper[3] + 3.0
+
+        item = np.zeros(1, self.GOOSE_NP_DTYPE)
+        simple_kernel[1, 1](item[0])
+        np.testing.assert_equal(45, item[0]['garden'][0])
+        np.testing.assert_equal(item[0]['backyard']['statue'], 3)
+        np.testing.assert_equal(item[0]['backyard']['newspaper'][3], 5)
 
     def test_cuda_module_in_device_function(self):
         """

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -34,7 +34,7 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
         item = np.recarray(1, dtype=goose_np_type)
         simple_kernel[1, 1](item[0])
         np.testing.assert_equal(item[0]['garden'][0], 45)
-        np.testing.assert_equal(item[0]['backyard']['newspaper'], 3)
+        np.testing.assert_equal(item[0]['backyard']['newspaper'][3], 3)
 
     def test_recarray_setting(self):
         recordwith2darray = np.dtype([('i', np.int32), ('j', np.float32, (3, 2))])

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -34,7 +34,7 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
         item = np.recarray(1, dtype=goose_np_type)
         simple_kernel[1, 1](item[0])
         np.testing.assert_equal(item[0]['garden'][0], 45)
-        np.testing.assert_equal(item[0]['backyard']['newspaper'][3], 3)
+        np.testing.assert_equal(item[0]['backyard']['newspaper'][3], 5)
 
     def test_recarray_setting(self):
         recordwith2darray = np.dtype([('i', np.int32), ('j', np.float32, (3, 2))])

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -11,7 +11,7 @@ import unittest
 
 class TestCudaSimIssues(SerialMixin, unittest.TestCase):
     BACKYARD_TYPE = [('statue', float64),
-                     ('newspaper', float64, 6)]
+                     ('newspaper', float64, (6, ))]
 
     GOOSE_TYPE = [('garden', float64, (12,)),
                   ('town', float64, (42,)),
@@ -31,9 +31,9 @@ class TestCudaSimIssues(SerialMixin, unittest.TestCase):
 
         item = np.zeros(1, self.GOOSE_NP_DTYPE)
         simple_kernel[1, 1](item[0])
-        np.testing.assert_equal(45, item[0]['garden'][0])
-        np.testing.assert_equal(item[0]['backyard']['statue'], 3)
-        np.testing.assert_equal(item[0]['backyard']['newspaper'][3], 5)
+        np.testing.assert_equal(item[0]['garden'][0], 45)
+        np.testing.assert_equal(3, item[0]['backyard']['statue'])
+        np.testing.assert_equal(5, item[0]['backyard']['newspaper'][3])
 
     def test_cuda_module_in_device_function(self):
         """


### PR DESCRIPTION
Far better fidelity simulation of numpy records in cudasim mode. Essentially, just flips everything to __getitem__ if in kernels, unless a __getitem__ exists. A few little whitespace fixes too.