### PR TITLE
Disable test failing due to removed pass.

### DIFF
--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -482,6 +482,7 @@ br i1 %.294, label %B42, label %B160
         # no other lines
         self.assertEqual(len(list(pruned_lines.splitlines())), len(combined))
 
+    @unittest.skip("Pass removed as it was buggy. Re-enable when fixed.")
     def test_refct_pruning_with_branches(self):
         '''testcase from #2350'''
         @njit


### PR DESCRIPTION
The test "test_refct_pruning_with_branches" now fails as #5338
removed the pass that made it work as it was discovered the
pass itself was buggy.

This patch adds a skip on the failing test but does not remove
it as it is anticipated that in the future the functionality
required for the test to pass will be implemented.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
