### PR TITLE
Add support for inferring the types of object arrays

### DIFF
--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -31,6 +31,8 @@ FROM_DTYPE = {
 
     np.dtype('complex64'): types.complex64,
     np.dtype('complex128'): types.complex128,
+
+    np.dtype(object): types.pyobject,
 }
 
 re_typestr = re.compile(r'[<>=\|]([a-z])(\d+)?$', re.I)
@@ -143,6 +145,8 @@ def as_dtype(nbtype):
     if isinstance(nbtype, types.NestedArray):
         spec = (as_dtype(nbtype.dtype), tuple(nbtype.shape))
         return np.dtype(spec)
+    if isinstance(nbtype, types.PyObject):
+        return np.dtype(object)
     raise NotImplementedError("%r cannot be represented as a Numpy dtype"
                               % (nbtype,))
 

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -193,10 +193,6 @@ def _check_struct_alignment(rec, fields):
                 raise ValueError(msg.format(npy_align, llvm_align, dt))
 
 
-def is_arrayscalar(val):
-    return np.dtype(type(val)) in FROM_DTYPE
-
-
 def map_arrayscalar_type(val):
     if isinstance(val, np.generic):
         # We can't blindly call np.dtype() as it loses information

--- a/numba/tests/test_numpy_support.py
+++ b/numba/tests/test_numpy_support.py
@@ -41,6 +41,8 @@ class TestFromDtype(TestCase):
         check('D', types.complex128)
         check('c16', types.complex128)
 
+        check('O', types.pyobject)
+
         check('b', types.int8)
         check('i1', types.int8)
         check('B', types.uint8)


### PR DESCRIPTION
This hopefully doesn't enable them to be used in any new jit contexts, but at least allows inspection of their type.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
