### PR TITLE
implement allocated parameter in njit

### DIFF
--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -616,6 +616,25 @@ class TestAllocation(MemoryLeakMixin, TestCase):
             tl = List.empty_list(types.int32, i)
             self.assertEqual(tl._allocated(), i)
 
+    def test_allocation_njit(self):
+        # kwarg version
+        @njit
+        def foo(i):
+            tl = List.empty_list(types.int32, allocated=i)
+            return tl._allocated()
+
+        for j in range(16):
+            self.assertEqual(foo(j), j)
+
+        # posarg version
+        @njit
+        def foo(i):
+            tl = List.empty_list(types.int32, i)
+            return tl._allocated()
+
+        for j in range(16):
+            self.assertEqual(foo(j), j)
+
     def test_growth_and_shrinkage(self):
         tl = List.empty_list(types.int32)
         growth_before = {0: 0, 4:4, 8:8, 16:16}

--- a/numba/typed/listobject.py
+++ b/numba/typed/listobject.py
@@ -50,6 +50,8 @@ INDEXTY = types.intp
 
 index_types = types.integer_domain
 
+DEFAULT_ALLOCATED = 0
+
 
 @register_model(ListType)
 class ListModel(models.StructModel):
@@ -258,7 +260,7 @@ def _imp_dtor(context, module):
     return fn
 
 
-def new_list(item, allocated=0):
+def new_list(item, allocated=DEFAULT_ALLOCATED):
     """Construct a new list. (Not implemented in the interpreter yet)
 
     Parameters
@@ -369,7 +371,7 @@ def _list_new(typingctx, itemty, allocated):
 
 
 @overload(new_list)
-def impl_new_list(item, allocated=0):
+def impl_new_list(item, allocated=DEFAULT_ALLOCATED):
     """Creates a new list.
 
     Parameters
@@ -385,7 +387,7 @@ def impl_new_list(item, allocated=0):
 
     itemty = item
 
-    def imp(item, allocated=0):
+    def imp(item, allocated=DEFAULT_ALLOCATED):
         if allocated < 0:
             raise RuntimeError("expecting *allocated* to be >= 0")
         lp = _list_new(itemty, allocated)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -25,9 +25,11 @@ from numba.core.extending import (
 )
 from numba.typed import listobject
 
+DEFAULT_ALLOCATED = listobject.DEFAULT_ALLOCATED
+
 
 @njit
-def _make_list(itemty, allocated=0):
+def _make_list(itemty, allocated=DEFAULT_ALLOCATED):
     return listobject._as_meminfo(listobject.new_list(itemty,
                                                       allocated=allocated))
 
@@ -172,14 +174,14 @@ class List(MutableSequence):
     Implements the MutableSequence interface.
     """
 
-    def __new__(cls, lsttype=None, meminfo=None, allocated=None):
+    def __new__(cls, lsttype=None, meminfo=None, allocated=DEFAULT_ALLOCATED):
         if config.DISABLE_JIT:
             return list.__new__(list)
         else:
             return object.__new__(cls)
 
     @classmethod
-    def empty_list(cls, item_type, allocated=0):
+    def empty_list(cls, item_type, allocated=DEFAULT_ALLOCATED):
         """Create a new empty List.
 
         Parameters
@@ -213,7 +215,7 @@ class List(MutableSequence):
         else:
             self._list_type = None
 
-    def _parse_arg(self, lsttype, meminfo=None, allocated=0):
+    def _parse_arg(self, lsttype, meminfo=None, allocated=DEFAULT_ALLOCATED):
         if not isinstance(lsttype, ListType):
             raise TypeError('*lsttype* must be a ListType')
 
@@ -247,7 +249,7 @@ class List(MutableSequence):
 
     def _allocated(self):
         if not self._typed:
-            return 0
+            return DEFAULT_ALLOCATED
         else:
             return _allocated(self)
 
@@ -364,12 +366,12 @@ class List(MutableSequence):
 
 # XXX: should we have a better way to classmethod
 @overload_method(TypeRef, 'empty_list')
-def typedlist_empty(cls, item_type):
+def typedlist_empty(cls, item_type, allocated=DEFAULT_ALLOCATED):
     if cls.instance_type is not ListType:
         return
 
-    def impl(cls, item_type):
-        return listobject.new_list(item_type)
+    def impl(cls, item_type, allocated=DEFAULT_ALLOCATED):
+        return listobject.new_list(item_type, allocated=allocated)
 
     return impl
 


### PR DESCRIPTION
Fixes #5355

This implements access to the `allocated` keyword argument when calling
`List.empty_list`. Also, this unfies the default value for `allocated`
in a central place. Tests included.