### PR TITLE
5081 typed.dict

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -624,6 +624,7 @@ class DictItemsIterableType(SimpleIterableType):
         self.parent = parent
         self.yield_type = self.parent.keyvalue_type
         name = "items[{}]".format(self.parent.name)
+        self.name = name
         iterator_type = DictIteratorType(self)
         super(DictItemsIterableType, self).__init__(name, iterator_type)
 
@@ -636,6 +637,7 @@ class DictKeysIterableType(SimpleIterableType):
         self.parent = parent
         self.yield_type = self.parent.key_type
         name = "keys[{}]".format(self.parent.name)
+        self.name = name
         iterator_type = DictIteratorType(self)
         super(DictKeysIterableType, self).__init__(name, iterator_type)
 
@@ -648,6 +650,7 @@ class DictValuesIterableType(SimpleIterableType):
         self.parent = parent
         self.yield_type = self.parent.value_type
         name = "values[{}]".format(self.parent.name)
+        self.name = name
         iterator_type = DictIteratorType(self)
         super(DictValuesIterableType, self).__init__(name, iterator_type)
 
@@ -657,5 +660,11 @@ class DictIteratorType(SimpleIteratorType):
         self.parent = iterable.parent
         self.iterable = iterable
         yield_type = iterable.yield_type
-        name = "iter[{}->{}]".format(iterable.parent, yield_type)
+        name = "iter[{}->{}],{}".format(iterable.parent, yield_type,
+                                        iterable.name)
+        # name = "iter[{}->{}]".format(iterable.parent, yield_type)
         super(DictIteratorType, self).__init__(name, yield_type)
+
+    # @property
+    # def key(self):
+    #     return self.name + self.iterable.name

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -662,9 +662,4 @@ class DictIteratorType(SimpleIteratorType):
         yield_type = iterable.yield_type
         name = "iter[{}->{}],{}".format(iterable.parent, yield_type,
                                         iterable.name)
-        # name = "iter[{}->{}]".format(iterable.parent, yield_type)
         super(DictIteratorType, self).__init__(name, yield_type)
-
-    # @property
-    # def key(self):
-    #     return self.name + self.iterable.name

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1599,3 +1599,41 @@ class TestNoJit(TestCase):
             with forbid_codegen():
                 d = Dict.empty(types.int32, types.float32)
                 self.assertEqual(type(d), dict)
+
+
+class TestDictIterator(TestCase):
+    def test_dict_iterator(self):
+        @njit
+        def fun1():
+            dd = Dict.empty(key_type=types.intp,
+                            value_type=types.intp)
+            dd[0] = 10
+            dd[1] = 20
+            dd[2] = 30
+
+            for v in dd.values():
+                print(v)
+            for k in dd.keys():
+                print(k)
+            return list(dd.keys()), list(dd.values())
+
+        @njit
+        def fun2():
+            dd = Dict.empty(key_type=types.intp,
+                            value_type=types.intp)
+            dd[4] = 77
+            dd[5] = 88
+            dd[6] = 99
+
+            for k in dd.keys():
+                print(k)
+            for v in dd.values():
+                print(v)
+            return list(dd.keys()), list(dd.values())
+        res1 = fun1()
+        res2 = fun2()
+
+        self.assertEqual([0,1,2], res1[0])
+        self.assertEqual([10,20,30], res1[1])
+        self.assertEqual([4,5,6], res2[0])
+        self.assertEqual([77,88,99], res2[1])

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1611,10 +1611,6 @@ class TestDictIterator(TestCase):
             dd[1] = 20
             dd[2] = 30
 
-            for v in dd.values():
-                print(v)
-            for k in dd.keys():
-                print(k)
             return list(dd.keys()), list(dd.values())
 
         @njit
@@ -1625,10 +1621,6 @@ class TestDictIterator(TestCase):
             dd[5] = 88
             dd[6] = 99
 
-            for k in dd.keys():
-                print(k)
-            for v in dd.values():
-                print(v)
             return list(dd.keys()), list(dd.values())
         res1 = fun1()
         res2 = fun2()


### PR DESCRIPTION
Fixes #5081 (at least all provided reproducers are Ok).

### Briefly

`_typecache` has same `hash` for `DictIteratorType` no matter what type of Iterable type DictIteratorType contains: `DictKeysIterableType` or `DictItemsIterableType` or `DictValuesIterableType`. So you will constantly get __first__ invoked(created/cached) iterable

### Not briefly

From provided (in #5081) reproducers not very clear, but __first__ invocation of _keys or values_ iterator defines what you will get on next invocation. In other words: if first expression was `keys()` then all further calls to `keys()` __and__ `values()` will return __keys__, if first expression was `values()` then all further calls to `keys()` __and__ `values()` will return __values__.

Reproducer (included as unit test):

```python
    from numba import njit
    from numba import types
    from numba.typed import Dict


    @njit
    def fun1():
        dd = Dict.empty(key_type=types.intp,
                        value_type=types.intp)
        dd[0] = 10
        dd[1] = 20
        dd[2] = 30


        for v in dd.values():
            print(v)
        for k in dd.keys():
            print(k)
        return list(dd.keys()), list(dd.values())


    @njit
    def fun2():
        dd = Dict.empty(key_type=types.intp,
                        value_type=types.intp)
        dd[4] = 77
        dd[5] = 88
        dd[6] = 99


        for k in dd.keys():
            print(k)
        for v in dd.values():
            print(v)
        return list(dd.keys()), list(dd.values())
    res1 = fun1()
    res2 = fun2()
```
Will print dict values each time:
```    
	10
	20
	30
	10
	20
	30
	77
	88
	99
	77
	88
	99
```

It happens, because on call to `DictIteratorType` construtor
https://github.com/numba/numba/blob/0aaf62d830e7a9d1dc5ffbf710a7cd38caa52d1a/numba/core/types/containers.py#L638-L640
it calls `_intern`
https://github.com/numba/numba/blob/0aaf62d830e7a9d1dc5ffbf710a7cd38caa52d1a/numba/core/types/abstract.py#L60-L67
which caches `DictIteratorType` instance 
https://github.com/numba/numba/blob/0aaf62d830e7a9d1dc5ffbf710a7cd38caa52d1a/numba/core/types/abstract.py#L51
by `key` which is `name` of `DictIteratorType`, which is the same despite of iterable type it contains
https://github.com/numba/numba/blob/0aaf62d830e7a9d1dc5ffbf710a7cd38caa52d1a/numba/core/types/abstract.py#L102

So to fix that bug we need 
 1. Provide `iterable` with `name` before call to `DictIteratorType` constructor 
 2. Change `name` of `DictIteratorType` so that it will be different for different iterable types OR (if for some reason we don't want to change the `name`) we may change `key` property (which actually are used for hash) - to activate that solution uncomment it please. 




<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
