### PR TITLE
CUDA: Fix OOB write in test_round{f4,f8}

### DIFF
--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -380,7 +380,7 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
 
     def test_round_f4(self):
         compiled = cuda.jit("void(int64[:], float32)")(simple_round)
-        ary = np.zeros(1, dtype=np.int32)
+        ary = np.zeros(1, dtype=np.int64)
 
         for i in [-3.0, -2.5, -2.25, -1.5, 1.5, 2.25, 2.5, 2.75]:
             compiled[1, 1](ary, i)
@@ -388,7 +388,7 @@ class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
 
     def test_round_f8(self):
         compiled = cuda.jit("void(int64[:], float64)")(simple_round)
-        ary = np.zeros(1, dtype=np.int32)
+        ary = np.zeros(1, dtype=np.int64)
 
         for i in [-3.0, -2.5, -2.25, -1.5, 1.5, 2.25, 2.5, 2.75]:
             compiled[1, 1](ary, i)


### PR DESCRIPTION
In these tests, the typing of the first parameter passed to the kernel (`int64[:]`)  vs. the type of the array that was passed in (`np.int32`) resulted in 8 bytes being written to a 4-byte allocation.

This was picked up with cuda-memcheck whilst looking into #4954 (but does not fix it - it is unrelated).