### PR TITLE
add error handling for lookup_module

### DIFF
--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -92,7 +92,9 @@ class FunctionDescriptor(object):
             try:
                 return sys.modules[self.modname]
             except:
-                raise ModuleNotFoundError(f"can't compile {self.qualname}: import of module {self.modname} failed")
+                raise ModuleNotFoundError(
+                    f"can't compile {self.qualname}: "
+                    f"import of module {self.modname} failed")
 
     def lookup_function(self):
         """

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -78,18 +78,22 @@ class FunctionDescriptor(object):
         It may not match the Module's globals if the function is created
         dynamically (i.e. exec)
         """
+        print(self.lookup_module())
         return self.global_dict or self.lookup_module().__dict__
 
     def lookup_module(self):
         """
         Return the module in which this function is supposed to exist.
         This may be a dummy module if the function was dynamically
-        generated.
+        generated. Raise exception if the module can't be found.
         """
         if self.modname == _dynamic_modname:
             return _dynamic_module
         else:
-            return sys.modules[self.modname]
+            try:
+                return sys.modules[self.modname]
+            except:
+                raise ModuleNotFoundError(f"can't compile {self.qualname}: import of module {self.modname} failed")
 
     def lookup_function(self):
         """

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -78,7 +78,6 @@ class FunctionDescriptor(object):
         It may not match the Module's globals if the function is created
         dynamically (i.e. exec)
         """
-        print(self.lookup_module())
         return self.global_dict or self.lookup_module().__dict__
 
     def lookup_module(self):

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -12,16 +12,17 @@ class TestModule(unittest.TestCase):
         filename = 'test.py'
         name = 'mypackage'
         code = """
-        def f(x):
-            return x
-        """
+def f(x):
+    return x
+"""
 
         objs = dict(__file__=filename, __name__=name)
         compiled = compile(code, filename, 'exec')
         exec(compiled, objs)
 
         compiled_f = njit(objs['f'])
-        self.assertRaises(ModuleNotFoundError, compiled_f(0))
+        with self.assertRaises(ModuleNotFoundError):
+            compiled_f(0)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -21,8 +21,10 @@ def f(x):
         exec(compiled, objs)
 
         compiled_f = njit(objs['f'])
-        with self.assertRaises(ModuleNotFoundError):
+        with self.assertRaises(ModuleNotFoundError) as raises:
             compiled_f(0)
+        msg = "can't compile f: import of module mypackage failed"
+        self.assertIn(msg, str(raises.exception))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -1,0 +1,28 @@
+
+import unittest
+from numba import njit
+
+
+class TestModule(unittest.TestCase):
+    def test_module_not_in_namespace(self):
+        """ Test of trying to run a compiled function
+        where the module which the function is being compiled
+        doesn't exist in the namespace.
+        """
+        filename = 'test.py'
+        name = 'mypackage'
+        code = """
+        def f(x):
+            return x
+        """
+
+        objs = dict(__file__=filename, __name__=name)
+        compiled = compile(code, filename, 'exec')
+        exec(compiled, objs)
+
+        compiled_f = njit(objs['f'])
+        self.assertRaises(ModuleNotFoundError, compiled_f(0))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description
Closes #4914 . Adds error handling for when `self.modname` cannot be found in `sys.modules`. 

# Testing 

Added a unit test `test_funcdesc.py` with the example case from the issue. 
```
$ python -m numba.runtests  numba.tests.test_funcdesc
.
----------------------------------------------------------------------
Ran 1 test in 0.224s
```

Also by testing in the shell:
```
>>> filename = 'test.py'
>>> name = 'mypackage'
>>> code = """
... def f(x):
...     return x
... """
>>> 
>>> objs = dict(__file__=filename, __name__=name)
>>> compiled = compile(code, filename, 'exec')
>>> exec(compiled, objs)
>>> 
>>> from numba import njit
>>> compiled_f = njit(objs['f'])
>>> print(compiled_f(0))
Traceback (most recent call last):
  File "/Users/ssikdar1/numba/numba/core/lowering.py", line 30, in from_fndesc
    return cls._memo[fndesc.env_name]
  File "/Users/ssikdar1/anaconda3/envs/numbaenv/lib/python3.6/weakref.py", line 137, in __getitem__
    o = self.data[key]()
KeyError: '_ZN08NumbaEnv9mypackage5f$241Ex'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ssikdar1/numba/numba/core/funcdesc.py", line 94, in lookup_module
    return sys.modules[self.modname]
KeyError: 'mypackage'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ssikdar1/numba/numba/core/dispatcher.py", line 420, in _compile_for_args
    raise e
...
  File "/Users/ssikdar1/numba/numba/core/funcdesc.py", line 96, in lookup_module
    raise ModuleNotFoundError(f"can't compile {self.qualname}: import of module {self.modname} failed")
ModuleNotFoundError: can't compile f: import of module mypackage failed
>>> 
```