### PR TITLE
change Integer:use @property for bitwidth & signed

### DIFF
--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -38,10 +38,32 @@ class Integer(Number):
         self.bitwidth = bitwidth
         self.signed = signed
 
+    @property
+    def bitwidth(self):
+        return self.__bitwidth
+
+    @bitwidth.setter
+    def bitwidth(self, bitwidth):
+        if not hasattr(self, "_Integer__bitwidth"):
+            self.__bitwidth = bitwidth
+        else:
+            raise Exception("Cannot re-define bitwidth of integer")
+
+    @property
+    def signed(self):
+        return self.__signed
+
+    @signed.setter
+    def signed(self, signed):
+        if not hasattr(self, "_Integer__signed"):
+            self.__signed = signed
+        else:
+            raise Exception("Cannot re-define sign of integer")
+
     @classmethod
     def from_bitwidth(cls, bitwidth, signed=True):
         name = ('int%d' if signed else 'uint%d') % bitwidth
-        return cls(name)
+        return cls(name, bitwidth, signed)
 
     def cast_python_value(self, value):
         return getattr(np, self.name)(value)

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -272,6 +272,13 @@ class TestNumbers(TestCase):
         self.assertIs(f(32), types.int32)
         self.assertIs(f(8, signed=False), types.uint8)
 
+    def test_cant_modify_Integer(self):
+        int16 = types.Integer.from_bitwidth(16)
+        with self.assertRaises(Exception):
+            int16.bitwidth = 32
+        with self.assertRaises(Exception):
+            int16.signed = False
+
     def test_ordering(self):
         def check_order(values):
             for i in range(len(values)):


### PR DESCRIPTION
# Description
Issue #5246.
Makes `bitwidth` and `signed`  properties of the `Integer` class.

# Testing
Added a unit test to `numba/tests/test_types.py`

```
$ python -m numba.runtests  numba.tests.test_types
..............x......................
----------------------------------------------------------------------
Ran 37 tests in 0.817s

OK (expected failures=1)
```

Also showing behavior from the REPL:
```
$ python
Python 3.6.10 |Anaconda, Inc.| (default, Jan  7 2020, 15:01:53) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from numba.core import types
>>> int16 = types.Integer.from_bitwidth(16)
>>> int16.bitwidth # show getter
16
>>> int16.bitwidth = 32 # show error on setter
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ssikdar1/numba/numba/core/types/scalars.py", line 50, in bitwidth
    raise Exception("Cannot re-define bitwidth of integer")
Exception: Cannot re-define bitwidth of integer
>>> 
>>> int16.signed # show getter
True
>>> int16.signed = False # show error on setter
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ssikdar1/numba/numba/core/types/scalars.py", line 61, in signed
    raise Exception("Cannot re-define sign of integer")
Exception: Cannot re-define sign of integer
>>> 
```
