### PR TITLE
Add support for tuple concatenation to array analysis.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,7 +47,6 @@ exclude =
     numba/core/annotations/pretty_annotate.py
     numba/misc/dummyarray.py
     numba/core/dataflow.py
-    numba/runtests.py
     numba/core/pythonapi.py
     numba/core/decorators.py
     numba/core/typeconv/typeconv.py

--- a/.flake8
+++ b/.flake8
@@ -99,7 +99,6 @@ exclude =
     numba/cuda/printimpl.py
     numba/cuda/libdevice.py
     numba/cuda/device_init.py
-    numba/cuda/compiler.py
     numba/cuda/initialize.py
     numba/cuda/simulator_init.py
     numba/cuda/random.py

--- a/.flake8
+++ b/.flake8
@@ -305,7 +305,6 @@ exclude =
     numba/tests/test_nested_calls.py
     numba/tests/test_chained_assign.py
     numba/tests/test_withlifting.py
-    numba/tests/test_errorhandling.py
     numba/tests/test_parfors.py
     numba/tests/test_sets.py
     numba/tests/test_dyn_array.py

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,10 +11,6 @@ efficiently, please first ensure that there is no other issue present that
 already describes the issue you have
 (search at https://github.com/numba/numba/issues?&q=is%3Aissue).
 
-For more general "how do I do X?" type questions, please speak to us in real
-time on https://gitter.im/numba/numba or post to the Numba mailing list
-https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.
-
 -->
 
 ## Reporting a bug
@@ -25,8 +21,8 @@ Before submitting a bug report please ensure that you can check off these boxes:
 
 -->
 
-- [ ] I am using the latest released version of Numba (most recent is visible in
- the change log (https://github.com/numba/numba/blob/master/CHANGE_LOG).
+- [ ] I have tried using the latest released version of Numba (most recent is
+ visible in the change log (https://github.com/numba/numba/blob/master/CHANGE_LOG).
 - [ ] I have included below a minimal working reproducer (if you are unsure how
  to write one see http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports).
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for Numba
+about: Tell us about something in the Python language/NumPy you'd like Numba to support.
 
 ---
 
@@ -11,10 +11,6 @@ efficiently, please first ensure that there is no other issue present that
 already describes the issue you have
 (search at https://github.com/numba/numba/issues?&q=is%3Aissue).
 
-For more general "how do I do X?" type questions, please speak to us in real
-time on https://gitter.im/numba/numba or post to the Numba mailing list
-https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.
-
 -->
 
 ## Feature request
@@ -22,6 +18,6 @@ https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.
 <!--
 
 Please include details of the feature you would like to see, why you would
-like to see it/the use case
+like to see it/the use case.
 
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Question
+    url: https://numba.discourse.group/c/numba/community-support/
+    about: "If you have a question like *How do I speed up X?* then please ask on Numba's discourse instance."
+  - name: Quick Question/Just want to say Hi!
+    url: https://gitter.im/numba/numba
+    about: "If you have a quick question or want chat to users/developers in real time then please use gitter.im/numba/numba"
+  - name: Discuss an involved feature
+    url: https://numba.discourse.group/c/numba/development/
+    about: "If you would like to suggest a more involved feature like *Can a new compiler pass be added to do X* then please start a discussion on Numba's discourse instance."

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt
+    - method: setuptools
+      path: .

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -11,13 +11,17 @@ This is a bugfix release for 0.50.0, it fixes a critical bug in error reporting
 and a number of other smaller issues:
 
 * PR #5861: Added except for possible Windows get_terminal_size exception
+* PR #5876: Improve undefined variable error message
 * PR #5884: Update the deprecation notices for 0.50.1
 * PR #5889: Fixes literally not forcing re-dispatch for inline='always'
 * PR #5912: Fix bad attr access on certain typing templates breaking exceptions.
+* PR #5918: Fix cuda test due to #5876
 
 Authors:
 
 * ``@pepping_dore``
+* Lucio Fernandez-Arjona
+* Siu Kwan Lam (core dev)
 * Stuart Archibald (core dev)
 
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,9 @@
+Version 0.51.0
+--------------
+
+In development
+
+
 Version 0.50.0 (Jun 10, 2020)
 -----------------------------
 
@@ -300,7 +306,7 @@ Enhancements from user contributed PRs (with thanks!):
 
 General Enhancements:
 
-* PR #4615: Allow masking threads out at runtime 
+* PR #4615: Allow masking threads out at runtime
 * PR #4798: Add branch pruning based on raw predicates.
 * PR #5115: Add support for iterating over 2D arrays
 * PR #5117: Implement ord()/chr()

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -4,6 +4,23 @@ Version 0.51.0
 In development
 
 
+Version 0.50.1 (Jun 24, 2020)
+-----------------------------
+
+This is a bugfix release for 0.50.0, it fixes a critical bug in error reporting
+and a number of other smaller issues:
+
+* PR #5861: Added except for possible Windows get_terminal_size exception
+* PR #5884: Update the deprecation notices for 0.50.1
+* PR #5889: Fixes literally not forcing re-dispatch for inline='always'
+* PR #5912: Fix bad attr access on certain typing templates breaking exceptions.
+
+Authors:
+
+* ``@pepping_dore``
+* Stuart Archibald (core dev)
+
+
 Version 0.50.0 (Jun 10, 2020)
 -----------------------------
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -69,6 +69,10 @@ Fixes:
 * PR #5791: Fix up no cgroups problem
 * PR #5795: Restore refct removal pass and make it strict
 * PR #5807: Skip failing test on POWER8 due to PPC CTR Loop problem.
+* PR #5812: Fix side issue from #5792, @overload inliner cached IR being
+  mutated.
+* PR #5815: Pin llvmlite to 0.33
+* PR #5833: Fixes the source location appearing incorrectly in error messages.
 
 CUDA Enhancements/Fixes:
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,7 +1,155 @@
-Version 0.50.0
---------------
+Version 0.50.0 (Jun 10, 2020)
+-----------------------------
 
-In development
+This is a more usual release in comparison to the others that have been made in
+the last six months. It comprises the result of a number of maintenance tasks
+along with some new features and a lot of bug fixes.
+
+Highlights of core feature changes include:
+
+* The compilation chain is now based on LLVM 9.
+* The error handling and reporting system has been improved to reduce the size
+  of error messages, and also improve quality and specificity.
+* The CUDA target has more stream constructors available and a new function for
+  compiling to PTX without linking and loading the code to a device. Further,
+  the macro-based system for describing CUDA threads and blocks has been
+  replaced with standard typing and lowering implementations, for improved
+  debugging and extensibility.
+
+IMPORTANT: The backwards compatibility shim, that was present in 0.49.x to
+accommodate the refactoring of Numba's internals, has been removed. If a module
+is imported from a moved location an ``ImportError`` will occur.
+
+General Enhancements:
+
+* PR #5060: Enables np.sum for timedelta64
+* PR #5225: Adjust interpreter to make conditionals predicates via bool() call.
+* PR #5506: Jitclass static methods
+* PR #5580: Revert shim
+* PR #5591: Fix #5525 Add figure for total memory to ``numba -s`` output.
+* PR #5616: Simplify the ufunc kernel registration
+* PR #5617: Remove /examples from the Numba repo.
+* PR #5673: Fix inliners to run all passes on IR and clean up correctly.
+* PR #5700: Make it easier to understand type inference: add SSA dump, use for
+  ``DEBUG_TYPEINFER``
+* PR #5702: Fixes for LLVM 9
+* PR #5722: Improve error messages.
+* PR #5758: Support NumPy 1.18
+
+Fixes:
+
+* PR #5390: add error handling for lookup_module
+* PR #5464: Jitclass drops annotations to avoid error
+* PR #5478: Fix #5471. Issue with omitted type not recognized as literal value.
+* PR #5517: Fix numba.typed.List extend for singleton and empty iterable
+* PR #5549: Check type getitem
+* PR #5568: Add skip to entrypoint test on windows
+* PR #5581: Revert #5568
+* PR #5602: Fix segfault caused by pop from numba.typed.List
+* PR #5645: Fix SSA redundant CFG computation
+* PR #5686: Fix issue with SSA not minimal
+* PR #5689: Fix bug in unified_function_type (issue 5685)
+* PR #5694: Skip part of slice array analysis if any part is not analyzable.
+* PR #5697: Fix usedef issue with parfor loopnest variables.
+* PR #5705: A fix for cases where SSA looks like a reduction variable.
+* PR #5714: Fix bug in test
+* PR #5717: Initialise Numba extensions ahead of any compilation starting.
+* PR #5721: Fix array iterator layout.
+* PR #5738: Unbreak master on buildfarm
+* PR #5757: Force LLVM to use ZMM registers for vectorization.
+* PR #5764: fix flake8 errors
+* PR #5768: Interval example: fix import
+* PR #5781: Moving record array examples to a test module
+* PR #5791: Fix up no cgroups problem
+* PR #5795: Restore refct removal pass and make it strict
+* PR #5807: Skip failing test on POWER8 due to PPC CTR Loop problem.
+
+CUDA Enhancements/Fixes:
+
+* PR #5347: CUDA: Provide more stream constructors
+* PR #5388: CUDA: Fix OOB write in test_round{f4,f8}
+* PR #5437: Fix #5429: Exception using ``.get_ipc_handle(...)`` on array from
+  ``as_cuda_array(...)``
+* PR #5481: CUDA: Replace macros with typing and lowering implementations
+* PR #5556: CUDA: Make atomic semantics match Python / NumPy, and fix #5458
+* PR #5558: CUDA: Only release primary ctx if retained
+* PR #5561: CUDA: Add function for compiling to PTX (+ other small fixes)
+* PR #5573: CUDA: Skip tests under cuda-memcheck that hang it
+* PR #5578: Implement math.modf for CUDA target
+* PR #5704: CUDA Eager compilation: Fix max_registers kwarg
+* PR #5718: CUDA lib path tests: unset CUDA_PATH when CUDA_HOME unset
+* PR #5800: Fix LLVM 9 IR for NVVM
+* PR #5803: CUDA Update expected error messages to fix #5797
+
+Documentation Updates:
+
+* PR #5546: DOC: Add documentation about cost model to inlining notes.
+* PR #5653: Update doc with respect to try-finally case
+
+Enhancements from user contributed PRs (with thanks!):
+
+* Elias Kuthe fixed in issue with imports in the Interval example in #5768
+* Eric Wieser Simplified the ufunc kernel registration mechanism in #5616
+* Ethan Pronovost patched a problem with ``__annotations__`` in ``jitclass`` in
+  #5464, fixed a bug that lead to infinite loops in Numba's ``Type.__getitem__``
+  in #5549, fixed a bug in ``np.arange`` testing in #5714 and added support for
+  ``@staticmethod`` to ``jitclass`` in #5506.
+* Gabriele Gemmi implemented ``math.modf`` for the CUDA target in #5578
+* Graham Markall contributed many patches, largely to the CUDA target, as
+  follows:
+
+  * #5347: CUDA: Provide more stream constructors
+  * #5388: CUDA: Fix OOB write in test_round{f4,f8}
+  * #5437: Fix #5429: Exception using ``.get_ipc_handle(...)`` on array from
+    ``as_cuda_array(...)``
+  * #5481: CUDA: Replace macros with typing and lowering implementations
+  * #5556: CUDA: Make atomic semantics match Python / NumPy, and fix #5458
+  * #5558: CUDA: Only release primary ctx if retained
+  * #5561: CUDA: Add function for compiling to PTX (+ other small fixes)
+  * #5573: CUDA: Skip tests under cuda-memcheck that hang it
+  * #5648: Unset the memory manager after EMM Plugin tests
+  * #5700: Make it easier to understand type inference: add SSA dump, use for
+    ``DEBUG_TYPEINFER``
+  * #5704: CUDA Eager compilation: Fix max_registers kwarg
+  * #5718: CUDA lib path tests: unset CUDA_PATH when CUDA_HOME unset
+  * #5800: Fix LLVM 9 IR for NVVM
+  * #5803: CUDA Update expected error messages to fix #5797
+
+* Guilherme Leobas updated the documentation surrounding try-finally in #5653
+* Hameer Abbasi added documentation about the cost model to the notes on
+  inlining in #5546
+* Jacques Gaudin rewrote ``numba -s`` to produce and consume a dictionary of
+  output about the current system in #5591
+* James Bourbeau Updated min/argmin and max/argmax to handle non-leading nans
+  (via #5758)
+* Lucio Fernandez-Arjona moved the record array examples to a test module in
+  #5781 and added ``np.timedelta64`` handling to ``np.sum`` in #5060
+* Pearu Peterson Fixed a bug in unified_function_type in #5689
+* Sergey Pokhodenko fixed an issue impacting LLVM 10 regarding vectorization
+  widths on Intel SkyLake processors in #5757
+* Shan Sikdar added error handling for ``lookup_module`` in #5390
+* @toddrme2178 add CI testing for NumPy 1.18 (via #5758)
+
+Authors:
+
+* Elias Kuthe
+* Eric Wieser
+* Ethan Pronovost
+* Gabriele Gemmi
+* Graham Markall
+* Guilherme Leobas
+* Hameer Abbasi
+* Jacques Gaudin
+* James Bourbeau
+* Lucio Fernandez-Arjona
+* Pearu Peterson
+* Sergey Pokhodenko
+* Shan Sikdar
+* Siu Kwan Lam (core dev)
+* Stuart Archibald (core dev)
+* Todd A. Anderson (core dev)
+* ``@toddrme2178``
+* Valentin Haenel (core dev)
 
 
 Version 0.49.1 (May 7, 2020)

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ Numba
    :target: https://gitter.im/numba/numba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
    :alt: Gitter
 
+.. image:: https://img.shields.io/badge/discuss-on%20discourse-blue
+   :target: https://numba.discourse.group/
+   :alt: Discourse
+
 A Just-In-Time Compiler for Numerical Functions in Python
 #########################################################
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Dependencies
 ============
 
 * Python versions: 3.6-3.8
-* llvmlite 0.32.*
+* llvmlite 0.33.*
 * NumPy >=1.15 (can build with 1.11 for ABI compatibility)
 
 Optionally:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 16
+  TEST_COUNT: 18
 
 jobs:
 # Mac and Linux use the same template with different matrixes
@@ -98,6 +98,16 @@ jobs:
         NUMPY: '1.17'
         CONDA_ENV: travisci
         TEST_START_INDEX: 13
+      py37_np118:
+        PYTHON: '3.7'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 14
+      py38_np118:
+        PYTHON: '3.8'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 15
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py38_np117:
+      py38_np118:
         PYTHON: '3.8'
-        NUMPY: '1.17'
+        NUMPY: '1.18'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 14
+        TEST_START_INDEX: 16
       py37_np115:
         PYTHON: '3.7'
         NUMPY: '1.15'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 15
+        TEST_START_INDEX: 17
 
   steps:
     - task: CondaEnvironment@1

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.31,<0.33
+    - llvmlite >=0.33.0dev0,<0.34
     # TBB devel version is to match TBB libs
     - tbb-devel >=2019.5       # [not (armv6l or armv7l or aarch64 or linux32)]
   run:
@@ -40,7 +40,7 @@ requirements:
     - numpy >=1.15
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.31,<0.33
+    - llvmlite >=0.33.0dev0,<0.34
   run_constrained:
     # If TBB is present it must be at least this version from Anaconda due to
     # build flag issues triggering UB

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+numpydoc

--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -91,6 +91,34 @@ the functionality of the selected device:
       Delete the context for the device. This will destroy all memory
       allocations, events, and streams created within the context.
 
+
+Compilation
+-----------
+
+Numba provides an entry point for compiling a Python function to PTX without
+invoking any of the driver API. This can be useful for:
+
+- Generating PTX that is to be inlined into other PTX code (e.g. from outside
+  the Numba / Python ecosystem).
+- Generating code when there is no device present.
+- Generating code prior to a fork without initializing CUDA.
+
+.. note:: It is the user's responsibility to manage any ABI issues arising from
+   the use of compilation to PTX.
+
+.. autofunction:: numba.cuda.compile_ptx
+
+
+The environment variable ``NUMBA_CUDA_DEFAULT_PTX_CC`` can be set to control
+the default compute capability targeted by ``compile_ptx`` - see
+:ref:`numba-envvars-gpu-support`. If PTX for the compute capability of the
+current device is required, the ``compile_ptx_for_current_device`` function can
+be used:
+
+.. autofunction:: numba.cuda.compile_ptx_for_current_device
+
+
+
 Measurement
 -----------
 

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -9,13 +9,16 @@ The ``@cuda.jit`` decorator is used to create a CUDA kernel:
 .. autofunction:: numba.cuda.jit
 
 .. autoclass:: numba.cuda.compiler.AutoJitCUDAKernel
-   :members: inspect_asm, inspect_llvm, inspect_types, specialize, extensions
+   :members: inspect_asm, inspect_llvm, inspect_types, specialize, extensions,
+             forall
 
 Individual specialized kernels are instances of
 :class:`numba.cuda.compiler.CUDAKernel`:
 
 .. autoclass:: numba.cuda.compiler.CUDAKernel
-   :members: bind, ptx, device, inspect_llvm, inspect_asm, inspect_types
+   :members: bind, ptx, device, inspect_llvm, inspect_asm, inspect_types,
+             forall
+
 
 Intrinsic Attributes and Functions
 ----------------------------------

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -272,10 +272,36 @@ Function
 --------
 
 The :func:`~numba.cuda.set_memory_manager` function can be used to set the
-memory manager at runtime. This must be called prior to the initialization of
-any contexts, and EMM Plugin instances are instantiated along with contexts.
-
-It is recommended that the memory manager is set once prior to using any CUDA
-functionality, and left unchanged for the remainder of execution.
+memory manager at runtime. This should be called prior to the initialization of
+any contexts, as EMM Plugin instances are instantiated along with contexts.
 
 .. autofunction:: numba.cuda.set_memory_manager
+
+
+Resetting the memory manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is recommended that the memory manager is set once prior to using any CUDA
+functionality, and left unchanged for the remainder of execution. It is possible
+to set the memory manager multiple times, noting the following:
+
+* At the time of their creation, contexts are bound to an instance of a memory
+  manager for their lifetime.
+* Changing the memory manager will have no effect on existing contexts - only
+  contexts created after the memory manager was updated will use instances of
+  the new memory manager.
+* :func:`numba.cuda.close` can be used to destroy contexts after setting the
+  memory manager so that they get re-created with the new memory manager.
+
+  - This will invalidate any arrays, streams, events, and modules owned by the
+    context.
+  - Attempting to use invalid arrays, streams, or events will likely fail with
+    an exception being raised due to a ``CUDA_ERROR_INVALID_CONTEXT`` or
+    ``CUDA_ERROR_CONTEXT_IS_DESTROYED`` return code from a Driver API function.
+  - Attempting to use an invalid module will result in similar, or in some
+    cases a segmentation fault / access violation.
+
+.. note:: The invalidation of modules means that all functions compiled with
+          ``@cuda.jit`` prior to context destruction will need to be
+          redefined, as the code underlying them will also have been unloaded
+          from the GPU.

--- a/docs/source/cuda/reduction.rst
+++ b/docs/source/cuda/reduction.rst
@@ -3,12 +3,7 @@ GPU Reduction
 
 Writing a reduction algorithm for CUDA GPU can be tricky.  Numba provides a
 ``@reduce`` decorator for converting a simple binary operation into a reduction
-kernel.
-
-``@reduce``
-------------
-
-Example::
+kernel. An example follows::
 
     import numpy
     from numba import cuda
@@ -26,12 +21,13 @@ Lambda functions can also be used here::
 
     sum_reduce = cuda.reduce(lambda a, b: a + b)
 
-class Reduce
--------------
+The Reduce class
+----------------
 
 The ``reduce`` decorator creates an instance of the ``Reduce`` class.
-(Currently, ``reduce`` is an alias to ``Reduce``, but this behavior is not
-guaranteed.)
+Currently, ``reduce`` is an alias to ``Reduce``, but this behavior is not
+guaranteed.
 
 .. autoclass:: numba.cuda.Reduce
    :members: __init__, __call__
+   :member-order: bysource

--- a/docs/source/developer/caching.rst
+++ b/docs/source/developer/caching.rst
@@ -17,7 +17,8 @@ overhead because no compilation is needed. The cached data is saved under the
 cache directory (see :envvar:`NUMBA_CACHE_DIR`). The index of the cache is
 stored in a ``.nbi`` file, with one index per function, and it lists all the
 overloaded signatures compiled for the function. The *object code* is stored in
-files with an ``.nbc`` extension, one file per overload.
+files with an ``.nbc`` extension, one file per overload. The data in both files
+is serialized with :mod:`pickle`.
 
 
 Requirements for Cacheability

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -393,6 +393,8 @@ typing and implementation to be specified together.
   needed to link generated code
 - :ghfile:`numba/core/fastmathpass.py` - Rewrite pass to add fastmath
   attributes to function call sites and binary operations
+- :ghfile:`numba/core/removerefctpass.py` - Rewrite pass to remove
+  unnecessary incref/decref pairs
 - :ghfile:`numba/core/descriptors.py` - empty base class for all target
   descriptors (is this needed?)
 - :ghfile:`numba/cpython/builtins.py` - Python builtin functions and

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -5,11 +5,6 @@ The Numba repository is quite large, and due to age has functionality spread
 around many locations.  To help orient developers, this document will try to
 summarize where different categories of functionality can be found.
 
-.. note::
-    It is likely that the organization of the code base will change in the
-    future to improve organization.  Follow `issue #3807 <https://github.com/numba/numba/issues/3807>`_
-    for more details.
-
 
 Support Files
 -------------
@@ -25,6 +20,7 @@ Build and Packaging
 - :ghfile:`.flake8` - Preferences for code formatting.  Files should be
   fixed and removed from the exception list as time allows.
 - :ghfile:`.pre-commit-config.yaml` - Configuration file for pre-commit hooks.
+- :ghfile:`.readthedocs.yml` - Configuration file for Read the Docs.
 - :ghfile:`buildscripts/condarecipe.local` - Conda build recipe
 - :ghfile:`buildscripts/condarecipe_clone_icc_rt` - Recipe to build a
   standalone icc_rt package.
@@ -61,6 +57,8 @@ Documentation
 - :ghfile:`docs/gh-pages.py` - Utility script to update Numba docs (stored
   as gh-pages)
 - :ghfile:`docs/make.bat` - Not used (remove?)
+- :ghfile:`docs/requirements.txt` - Pip package requirements for building docs
+  with Read the Docs.
 - :ghfile:`numba/scripts/generate_lower_listing.py` - Dump all registered
   implementations decorated with ``@lower*`` for reference
   documentation.  Currently misses implementations from the higher

--- a/docs/source/extending/interval-example.rst
+++ b/docs/source/extending/interval-example.rst
@@ -191,7 +191,7 @@ Implementing the constructor
 Now we want to implement the two-argument ``Interval`` constructor::
 
    from numba.extending import lower_builtin
-   from numba import cgutils
+   from numba.core import cgutils
 
    @lower_builtin(Interval, types.Float, types.Float)
    def impl_interval(context, builder, sig, args):

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -100,8 +100,8 @@ Schedule
 This feature will be removed with respect to this schedule:
 
 * Pending-deprecation warnings will be issued in version 0.44.0
-* Deprecation warnings and replacements will be issued in version 0.50.0
-* Support will be removed in version 0.51.0
+* Deprecation warnings and replacements will be issued in version 0.52.0
+* Support will be removed in version 0.53.0
 
 Recommendations
 ---------------
@@ -205,7 +205,7 @@ Schedule
 This feature will be removed with respect to this schedule:
 
 * Deprecation warnings will be issued in version 0.44.0
-* Support will be removed in version 0.50.0
+* Support will be removed in version 0.54.0
 
 Recommendations
 ---------------
@@ -253,4 +253,4 @@ This feature will be moved with respect to this schedule:
 
 * Deprecation warnings will be issued in version 0.49.0
 * Support for importing from ``numba.jitclass`` will be removed in version
-  0.51.0.
+  0.52.0.

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -341,6 +341,7 @@ Options for the compilation cache.
     :ref:`docs on cache clearing <cache-clearing>`
 
 
+.. _numba-envvars-gpu-support:
 
 GPU support
 -----------
@@ -353,6 +354,13 @@ GPU support
 
    If set, force the CUDA compute capability to the given version (a
    string of the type ``major.minor``), regardless of attached devices.
+
+.. envvar:: NUMBA_CUDA_DEFAULT_PTX_CC
+
+   The default compute capability (a string of the type ``major.minor``) to
+   target when compiling to PTX using ``cuda.compile_ptx``. The default is
+   5.2, which is the lowest non-deprecated compute capability in the most
+   recent version of the CUDA toolkit supported (10.2 at present).
 
 .. envvar:: NUMBA_ENABLE_CUDASIM
 

--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -386,7 +386,7 @@ Vectorized functions (ufuncs and DUFuncs)
    arrays as inputs (for example, if a cast is required).
 
    .. seealso::
-      Specification of the `layout string <http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html#details-of-signature>`_
+      Specification of the `layout string <https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html#details-of-signature>`_
       as supported by Numpy.  Note that Numpy uses the term "signature",
       which we unfortunately use for something else.
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -99,40 +99,22 @@ Structured scalars support attribute getting and setting, as well as
 member lookup using constant strings. Strings stored in a local or global tuple
 are considered constant strings and can be used for member lookup.
 
-.. code:: pycon
 
 
-
-    >>> import numpy as np
-    >>> from numba import njit
-    >>> arr = np.array([1, 2], dtype=[('a1', 'f8'), ('a2', 'f8')])
-    >>> fields_gl = ('a1', 'a2')
-    >>> @njit
-    ... def get_field_sum(rec):
-    ...     fields_lc = ('a1', 'a2')
-    ...     field_name1 = fields_lc[0]
-    ...     field_name2 = fields_gl[1]
-    ...     return rec[field_name1] + rec[field_name2]
-    ...
-    >>> get_field_sum(arr[0])
-    3
+.. literalinclude:: ../../../numba/tests/doc_examples/test_rec_array.py
+   :language: python
+   :start-after: magictoken.ex_rec_arr_const_index.begin
+   :end-before: magictoken.ex_rec_arr_const_index.end
+   :dedent: 8
 
 It is also possible to use local or global tuples together with ``literal_unroll``:
 
+.. literalinclude:: ../../../numba/tests/doc_examples/test_rec_array.py
+   :language: python
+   :start-after: magictoken.ex_rec_arr_lit_unroll_index.begin
+   :end-before: magictoken.ex_rec_arr_lit_unroll_index.end
+   :dedent: 8
 
-    >>> import numpy as np
-    >>> from numba import njit
-    >>> arr = np.array([1, 2], dtype=[('a1', 'f8'), ('a2', 'f8')])
-    >>> fields_gl = ('a1', 'a2')
-    >>> @njit
-    ... def get_field_sum(rec):
-    ...     out = 0
-    ...     for f in literal_unroll(fields_gl):
-    ...        out += rec[f]
-    ...     return out
-    ...
-    >>> get_field_sum(arr[0])
-    3
 
 .. seealso::
    `Numpy scalars <http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html>`_

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -343,7 +343,7 @@ The following top-level functions are supported:
 * :func:`numpy.atleast_2d`
 * :func:`numpy.atleast_3d`
 * :func:`numpy.bartlett`
-* :func:`numpy.bincount` (only the 2 first arguments)
+* :func:`numpy.bincount`
 * :func:`numpy.blackman`
 * :func:`numpy.column_stack`
 * :func:`numpy.concatenate`

--- a/docs/source/user/jitclass.rst
+++ b/docs/source/user/jitclass.rst
@@ -22,34 +22,13 @@ to the underlying data, bypassing the interpreter.
 Basic usage
 ===========
 
-Here's an example of a jitclass::
+Here's an example of a jitclass:
 
-  import numpy as np
-  from numba import jitclass          # import the decorator
-  from numba import int32, float32    # import the types
-
-  spec = [
-      ('value', int32),               # a simple scalar field
-      ('array', float32[:]),          # an array field
-  ]
-
-  @jitclass(spec)
-  class Bag(object):
-      def __init__(self, value):
-          self.value = value
-          self.array = np.zeros(value, dtype=np.float32)
-
-      @property
-      def size(self):
-          return self.array.size
-
-      def increment(self, val):
-          for i in range(self.size):
-              self.array[i] = val
-          return self.array
-
-
-(see full example at `examples/jitclass.py` from the source tree)
+.. literalinclude:: ../../../numba/tests/doc_examples/test_jitclass.py
+   :language: python
+   :start-after: magictoken.ex_jitclass.begin
+   :end-before: magictoken.ex_jitclass.end
+   :dedent: 8
 
 In the above example, a ``spec`` is provided as a list of 2-tuples.  The tuples
 contain the name of the field and the Numba type of the field.  Alternatively,
@@ -152,6 +131,8 @@ compiled functions:
   (e.g. ``mybag = Bag(123)``);
 * read/write access to attributes and properties (e.g. ``mybag.value``);
 * calling methods (e.g. ``mybag.increment(3)``);
+* calling static methods as instance attributes (e.g. ``mybag.add(1, 1)``);
+* calling static methods as class attributes (e.g. ``Bag.add(1, 2)``);
 
 Using jitclasses in Numba compiled function is more efficient.
 Short methods can be inlined (at the discretion of LLVM inliner).
@@ -162,6 +143,9 @@ must be unboxed or boxed between Python objects and native representation.
 Values encapsulated by a jitclass does not get boxed into Python object when
 the jitclass instance is handed to the interpreter.  It is during attribute
 access to the field values that they are boxed.
+Calling static methods as class attributes is only supported outside of the
+class definition (i.e. you can't call ``Bag.add()`` from within another method
+of ``Bag``).
 
 
 Limitations

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -81,8 +81,8 @@ __all__ = """
     """.split() + types.__all__ + errors.__all__
 
 
-_min_llvmlite_version = (0, 31, 0)
-_min_llvm_version = (7, 0, 0)
+_min_llvmlite_version = (0, 33, 0)
+_min_llvm_version = (9, 0, 0)
 
 def _ensure_llvm():
     """

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -16,8 +16,7 @@ from numba.np import numpy_support
 
 @box(types.Boolean)
 def box_bool(typ, val, c):
-    longval = c.builder.zext(val, c.pyapi.long)
-    return c.pyapi.bool_from_long(longval)
+    return c.pyapi.bool_from_bool(val)
 
 @unbox(types.Boolean)
 def unbox_boolean(typ, obj, c):

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -678,7 +678,7 @@ def do_boundscheck(context, builder, ind, dimlen, axis=None):
                        "for axis {} with size %d\n".format(axis), ind, dimlen)
             else:
                 printf(builder, "debug: IndexError: index %d is out of bounds "
-                       "for axis %d with size %d\n".format(axis), ind, axis,
+                       "for axis %d with size %d\n", ind, axis,
                        dimlen)
         else:
             printf(builder,

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -829,6 +829,8 @@ class JITCPUCodegen(BaseCPUCodegen):
         arch = ll.Target.from_default_triple().name
         if arch.startswith('x86'): # one of x86 or x86_64
             reloc_model = 'static'
+        elif arch.startswith('ppc'):
+            reloc_model = 'pic'
         else:
             reloc_model = 'default'
         options['reloc'] = reloc_model
@@ -838,8 +840,11 @@ class JITCPUCodegen(BaseCPUCodegen):
         # This overrides default feature selection by CPU model above
         options['features'] = self._tm_features
 
-        # Enable JIT debug
-        options['jitdebug'] = True
+        # Deal with optional argument to ll.Target.create_target_machine
+        sig = utils.pysignature(ll.Target.create_target_machine)
+        if 'jit' in sig.parameters:
+            # Mark that this is making a JIT engine
+            options['jit'] = True
 
     def _customize_tm_features(self):
         # For JIT target, we will use LLVM to get the feature map

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -35,7 +35,7 @@ def _parse_cc(text):
     else:
         m = re.match(r'(\d+)\.(\d+)', text)
         if not m:
-            raise ValueError("NUMBA_FORCE_CUDA_CC must be specified as a "
+            raise ValueError("Compute capability must be specified as a "
                              "string of \"major.minor\" where major "
                              "and minor are decimals")
         grp = m.groups()
@@ -306,6 +306,10 @@ class _EnvReloader(object):
 
         # Force CUDA compute capability to a specific version
         FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _parse_cc, None)
+
+        # The default compute capability to target when compiling to PTX.
+        CUDA_DEFAULT_PTX_CC = _readenv("NUMBA_CUDA_DEFAULT_PTX_CC", _parse_cc,
+                                       (5, 2))
 
         # Disable CUDA support
         DISABLE_CUDA = _readenv("NUMBA_DISABLE_CUDA",

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -143,6 +143,8 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
+    if options.get('nopython', False) and options.get('forceobj', False):
+        raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
 
     options['boundscheck'] = boundscheck
 
@@ -232,6 +234,7 @@ def njit(*args, **kws):
         warnings.warn('nopython is set for njit and is ignored', RuntimeWarning)
     if 'forceobj' in kws:
         warnings.warn('forceobj is set for njit and is ignored', RuntimeWarning)
+        del kws['forceobj']
     kws.update({'nopython': True})
     return jit(*args, **kws)
 

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -10,7 +10,7 @@ import logging
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
-from numba.core import config, sigutils, registry
+from numba.core import config, extending, sigutils, registry
 
 
 _logger = logging.getLogger(__name__)
@@ -181,6 +181,19 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
     dispatcher = registry.dispatcher_registry[target]
 
     def wrapper(func):
+        if extending.is_jitted(func):
+            raise TypeError(
+                "A jit decorator was called on an already jitted function "
+                f"{func}.  If trying to access the original python "
+                f"function, use the {func}.py_func attribute."
+            )
+
+        if not inspect.isfunction(func):
+            raise TypeError(
+                "The decorated object is not a function (got type "
+                f"{type(func)})."
+            )
+
         if config.ENABLE_CUDASIM and target == 'cuda':
             from numba import cuda
             return cuda.jit(func)

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -138,6 +138,7 @@ def register_jitable(*args, **kwargs):
     def wrap(fn):
         # It is just a wrapper for @overload
         inline = kwargs.pop('inline', 'never')
+
         @overload(fn, jit_options=kwargs, inline=inline, strict=False)
         def ov_wrap(*args, **kwargs):
             return fn

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -122,6 +122,13 @@ class InlineClosureCallPass(object):
                 _fix_nested_array(self.func_ir)
 
         if modified:
+            # clean up now dead/unreachable blocks, e.g. unconditionally raising
+            # an exception in an inlined function would render some parts of the
+            # inliner unreachable
+            cfg = compute_cfg_from_blocks(self.func_ir.blocks)
+            for dead in cfg.dead_nodes():
+                del self.func_ir.blocks[dead]
+
             # run dead code elimination
             dead_code_elimination(self.func_ir)
             # do label renaming
@@ -260,6 +267,247 @@ def check_reduce_func(func_ir, func_var):
     if not f_code.co_argcount == 2:
         raise TypeError("Reduction function should take 2 arguments")
     return reduce_func
+
+
+class InlineWorker(object):
+    """ A worker class for inlining, this is a more advanced version of
+    `inline_closure_call` in that it permits inlining from function type, Numba
+    IR and code object. It also, runs the entire untyped compiler pipeline on
+    the inlinee to ensure that it is transformed as though it were compiled
+    directly.
+    """
+
+    def __init__(self,
+                 typingctx=None,
+                 targetctx=None,
+                 locals=None,
+                 pipeline=None,
+                 flags=None,
+                 validator=callee_ir_validator,
+                 typemap=None,
+                 calltypes=None):
+        """
+        Instantiate a new InlineWorker, all arguments are optional though some
+        must be supplied together for certain use cases. The methods will refuse
+        to run if the object isn't configured in the manner needed. Args are the
+        same as those in a numba.core.Compiler.state, except the validator which
+        is a function taking Numba IR and validating it for use when inlining
+        (this is optional and really to just provide better error messages about
+        things which the inliner cannot handle like yield in closure).
+        """
+        def check(arg, name):
+            if arg is None:
+                raise TypeError("{} must not be None".format(name))
+
+        from numba.core.compiler import DefaultPassBuilder
+
+        # check the stuff needed to run the more advanced compilation pipeline
+        # is valid if any of it is provided
+        compiler_args = (targetctx, locals, pipeline, flags)
+        compiler_group = [x is not None for x in compiler_args]
+        if any(compiler_group) and not all(compiler_group):
+            check(targetctx, 'targetctx')
+            check(locals, 'locals')
+            check(pipeline, 'pipeline')
+            check(flags, 'flags')
+        elif all(compiler_group):
+            check(typingctx, 'typingctx')
+
+        self._compiler_pipeline = DefaultPassBuilder.define_untyped_pipeline
+
+        self.typingctx = typingctx
+        self.targetctx = targetctx
+        self.locals = locals
+        self.pipeline = pipeline
+        self.flags = flags
+        self.validator = validator
+        self.debug_print = _make_debug_print("InlineWorker")
+
+        # check whether this inliner can also support typemap and calltypes
+        # update and if what's provided is valid
+        pair = (typemap, calltypes)
+        pair_is_none = [x is None for x in pair]
+        if any(pair_is_none) and not all(pair_is_none):
+            msg = ("typemap and calltypes must both be either None or have a "
+                   "value, got: %s, %s")
+            raise TypeError(msg % pair)
+        self._permit_update_type_and_call_maps = not all(pair_is_none)
+        self.typemap = typemap
+        self.calltypes = calltypes
+
+
+    def inline_ir(self, caller_ir, block, i, callee_ir, callee_freevars,
+                  arg_typs=None):
+        """ Inlines the callee_ir in the caller_ir at statement index i of block
+        `block`, callee_freevars are the free variables for the callee_ir. If
+        the callee_ir is derived from a function `func` then this is
+        `func.__code__.co_freevars`. If `arg_typs` is given and the InlineWorker
+        instance was initialized with a typemap and calltypes then they will be
+        appropriately updated based on the arg_typs.
+        """
+        # check that the contents of the callee IR is something that can be
+        # inlined if a validator is present
+        if self.validator is not None:
+            self.validator(callee_ir)
+
+        # save an unmutated copy of the callee_ir to return
+        callee_ir_original = callee_ir.copy()
+        scope = block.scope
+        instr = block.body[i]
+        call_expr = instr.value
+        callee_blocks = callee_ir.blocks
+
+        # 1. relabel callee_ir by adding an offset
+        max_label = max(ir_utils._max_label, max(caller_ir.blocks.keys()))
+        callee_blocks = add_offset_to_labels(callee_blocks, max_label + 1)
+        callee_blocks = simplify_CFG(callee_blocks)
+        callee_ir.blocks = callee_blocks
+        min_label = min(callee_blocks.keys())
+        max_label = max(callee_blocks.keys())
+        #    reset globals in ir_utils before we use it
+        ir_utils._max_label = max_label
+        self.debug_print("After relabel")
+        _debug_dump(callee_ir)
+
+        # 2. rename all local variables in callee_ir with new locals created in
+        # caller_ir
+        callee_scopes = _get_all_scopes(callee_blocks)
+        self.debug_print("callee_scopes = ", callee_scopes)
+        #    one function should only have one local scope
+        assert(len(callee_scopes) == 1)
+        callee_scope = callee_scopes[0]
+        var_dict = {}
+        for var in callee_scope.localvars._con.values():
+            if not (var.name in callee_freevars):
+                new_var = scope.redefine(mk_unique_var(var.name), loc=var.loc)
+                var_dict[var.name] = new_var
+        self.debug_print("var_dict = ", var_dict)
+        replace_vars(callee_blocks, var_dict)
+        self.debug_print("After local var rename")
+        _debug_dump(callee_ir)
+
+        # 3. replace formal parameters with actual arguments
+        callee_func = callee_ir.func_id.func
+        args = _get_callee_args(call_expr, callee_func, block.body[i].loc,
+                                caller_ir)
+
+        # 4. Update typemap
+        if self._permit_update_type_and_call_maps:
+            if arg_typs is None:
+                raise TypeError('arg_typs should have a value not None')
+            self.update_type_and_call_maps(callee_ir, arg_typs)
+
+        self.debug_print("After arguments rename: ")
+        _debug_dump(callee_ir)
+
+        _replace_args_with(callee_blocks, args)
+        # 5. split caller blocks into two
+        new_blocks = []
+        new_block = ir.Block(scope, block.loc)
+        new_block.body = block.body[i + 1:]
+        new_label = next_label()
+        caller_ir.blocks[new_label] = new_block
+        new_blocks.append((new_label, new_block))
+        block.body = block.body[:i]
+        block.body.append(ir.Jump(min_label, instr.loc))
+
+        # 6. replace Return with assignment to LHS
+        topo_order = find_topo_order(callee_blocks)
+        _replace_returns(callee_blocks, instr.target, new_label)
+
+        # remove the old definition of instr.target too
+        if (instr.target.name in caller_ir._definitions
+                and call_expr in caller_ir._definitions[instr.target.name]):
+            # NOTE: target can have multiple definitions due to control flow
+            caller_ir._definitions[instr.target.name].remove(call_expr)
+
+        # 7. insert all new blocks, and add back definitions
+        for label in topo_order:
+            # block scope must point to parent's
+            block = callee_blocks[label]
+            block.scope = scope
+            _add_definitions(caller_ir, block)
+            caller_ir.blocks[label] = block
+            new_blocks.append((label, block))
+        self.debug_print("After merge in")
+        _debug_dump(caller_ir)
+
+        return callee_ir_original, callee_blocks, var_dict, new_blocks
+
+    def inline_function(self, caller_ir, block, i, function, arg_typs=None):
+        """ Inlines the function in the caller_ir at statement index i of block
+        `block`. If `arg_typs` is given and the InlineWorker instance was
+        initialized with a typemap and calltypes then they will be appropriately
+        updated based on the arg_typs.
+        """
+        callee_ir = self.run_untyped_passes(function)
+        freevars = function.__code__.co_freevars
+        return self.inline_ir(caller_ir, block, i, callee_ir, freevars,
+                              arg_typs=arg_typs)
+
+    def run_untyped_passes(self, func):
+        """
+        Run the compiler frontend's untyped passes over the given Python
+        function, and return the function's canonical Numba IR.
+        """
+        from numba.core.compiler import StateDict, _CompileStatus
+        from numba.core.untyped_passes import ExtractByteCode, WithLifting
+        from numba.core import bytecode
+        from numba.parfors.parfor import ParforDiagnostics
+        state = StateDict()
+        state.func_ir = None
+        state.typingctx = self.typingctx
+        state.targetctx = self.targetctx
+        state.locals = self.locals
+        state.pipeline = self.pipeline
+        state.flags = self.flags
+
+        # Disable SSA transformation, the call site won't be in SSA form and
+        # self.inline_ir depends on this being the case.
+        state.flags.enable_ssa = False
+
+        state.func_id = bytecode.FunctionIdentity.from_function(func)
+
+        state.typemap = None
+        state.calltypes = None
+        state.type_annotation = None
+        state.status = _CompileStatus(False, False)
+        state.return_type = None
+        state.parfor_diagnostics = ParforDiagnostics()
+        state.metadata = {}
+
+        ExtractByteCode().run_pass(state)
+        # This is a lie, just need *some* args for the case where an obj mode
+        # with lift is needed
+        state.args = len(state.bc.func_id.pysig.parameters) * (types.pyobject,)
+
+        pm = self._compiler_pipeline(state)
+
+        pm.finalize()
+        pm.run(state)
+        return state.func_ir
+
+    def update_type_and_call_maps(self, callee_ir, arg_typs):
+        """ Updates the type and call maps based on calling callee_ir with arguments
+        from arg_typs"""
+        if not self._permit_update_type_and_call_maps:
+            msg = ("InlineWorker instance not configured correctly, typemap or "
+                   "calltypes missing in initialization.")
+            raise ValueError(msg)
+        from numba.core import typed_passes
+        # call branch pruning to simplify IR and avoid inference errors
+        callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
+        numba.core.analysis.dead_branch_prune(callee_ir, arg_typs)
+        f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
+                self.typingctx, callee_ir, arg_typs, None)
+        canonicalize_array_math(callee_ir, f_typemap,
+                                f_calltypes, self.typingctx)
+        # remove argument entries like arg.a from typemap
+        arg_names = [vname for vname in f_typemap if vname.startswith("arg.")]
+        for a in arg_names:
+            f_typemap.pop(a)
+        self.typemap.update(f_typemap)
+        self.calltypes.update(f_calltypes)
 
 
 def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -725,11 +725,11 @@ class StaticRaise(Terminator):
 
     def __str__(self):
         if self.exc_class is None:
-            return "raise"
+            return "<static> raise"
         elif self.exc_args is None:
-            return "raise %s" % (self.exc_class,)
+            return "<static> raise %s" % (self.exc_class,)
         else:
-            return "raise %s(%s)" % (self.exc_class,
+            return "<static> raise %s(%s)" % (self.exc_class,
                                      ", ".join(map(repr, self.exc_args)))
 
     def get_targets(self):

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -7,7 +7,7 @@ from llvmlite.llvmpy.core import Constant, Type, Builder
 
 from numba import _dynfunc
 from numba.core import (typing, utils, types, ir, debuginfo, funcdesc,
-                        generators, config, ir_utils, cgutils)
+                        generators, config, ir_utils, cgutils, removerefctpass)
 from numba.core.errors import (LoweringError, new_error_context, TypingError,
                                LiteralTypingError, UnsupportedError)
 from numba.core.funcdesc import default_mangler
@@ -203,6 +203,12 @@ class BaseLower(object):
             else:
                 print(self.module)
             print('=' * 80)
+
+        # Special optimization to remove NRT on functions that do not need it.
+        if self.context.enable_nrt and self.generator_info is None:
+            removerefctpass.remove_unnecessary_nrt_usage(self.function,
+                                                         context=self.context,
+                                                         fndesc=self.fndesc)
 
         # Run target specific post lowering transformation
         self.context.post_lowering(self.module, self.library)

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -259,9 +259,7 @@ class PyLower(BaseLower):
             elif expr.fn == operator.not_:
                 res = self.pyapi.object_not(value)
                 self.check_int_status(res)
-
-                longval = self.builder.zext(res, self.pyapi.long)
-                res = self.pyapi.bool_from_long(longval)
+                res = self.pyapi.bool_from_bool(res)
             elif expr.fn == operator.invert:
                 res = self.pyapi.number_invert(value)
             else:

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -950,10 +950,10 @@ class PythonAPI(object):
             return self.builder.call(fn, (lhs, rhs, lopid))
         elif opstr == 'is':
             bitflag = self.builder.icmp(lc.ICMP_EQ, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr == 'is not':
             bitflag = self.builder.icmp(lc.ICMP_NE, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr in ('in', 'not in'):
             fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
             fn = self._get_function(fnty, name="PySequence_Contains")

--- a/numba/core/removerefctpass.py
+++ b/numba/core/removerefctpass.py
@@ -1,0 +1,121 @@
+"""
+Implement a rewrite pass on a LLVM module to remove unnecessary 
+refcount operations.
+"""
+
+from llvmlite.ir.transforms import CallVisitor
+
+from numba.core import types
+
+
+class _MarkNrtCallVisitor(CallVisitor):
+    """
+    A pass to mark all NRT_incref and NRT_decref.
+    """
+    def __init__(self):
+        self.marked = set()
+
+    def visit_Call(self, instr):
+        if getattr(instr.callee, 'name', '') in _accepted_nrtfns:
+            self.marked.add(instr)
+
+
+def _rewrite_function(function):
+    # Mark NRT usage
+    markpass = _MarkNrtCallVisitor()
+    markpass.visit_Function(function)
+    # Remove NRT usage
+    for bb in function.basic_blocks:
+        for inst in list(bb.instructions):
+            if inst in markpass.marked:
+                bb.instructions.remove(inst)
+
+
+_accepted_nrtfns = 'NRT_incref', 'NRT_decref'
+
+
+def _legalize(module, dmm, fndesc):
+    """
+    Legalize the code in the module.
+    Returns True if the module is legal for the rewrite pass that removes
+    unnecessary refcounts.
+    """
+
+    def valid_output(ty):
+        """
+        Valid output are any type that does not need refcount
+        """
+        model = dmm[ty]
+        return not model.contains_nrt_meminfo()
+
+    def valid_input(ty):
+        """
+        Valid input are any type that does not need refcount except Array.
+        """
+        return valid_output(ty) or isinstance(ty, types.Array)
+
+
+    # Ensure no reference to function marked as
+    # "numba_args_may_always_need_nrt"
+    try:
+        nmd = module.get_named_metadata("numba_args_may_always_need_nrt")
+    except KeyError:
+        # Nothing marked
+        pass
+    else:
+        # Has functions marked as "numba_args_may_always_need_nrt"
+        if len(nmd.operands) > 0:
+            # The pass is illegal for this compilation unit.
+            return False
+
+    # More legalization base on function type
+    argtypes = fndesc.argtypes
+    restype = fndesc.restype
+    calltypes = fndesc.calltypes
+
+    # Legalize function arguments
+    for argty in argtypes:
+        if not valid_input(argty):
+            return False
+
+    # Legalize function return
+    if not valid_output(restype):
+        return False
+
+    # Legalize all called functions
+    for callty in calltypes.values():
+        if callty is not None and not valid_output(callty.return_type):
+            return False
+
+    # Ensure no allocation
+    for fn in module.functions:
+        if fn.name.startswith("NRT_"):
+            if fn.name not in _accepted_nrtfns:
+                return False
+
+    return True
+
+
+def remove_unnecessary_nrt_usage(function, context, fndesc):
+    """
+    Remove unnecessary NRT incref/decref in the given LLVM function.
+    It uses highlevel type info to determine if the function does not need NRT.
+    Such a function does not:
+
+    - return array object(s);
+    - take arguments that need refcounting except array;
+    - call function(s) that return refcounted object.
+
+    In effect, the function will not capture or create references that extend
+    the lifetime of any refcounted objects beyound the lifetime of the
+    function.
+
+    The rewrite is performed in place.
+    If rewrite has happened, this function returns True, otherwise, it returns False.
+    """
+    dmm = context.data_model_manager
+    if _legalize(function.module, dmm, fndesc):
+        _rewrite_function(function)
+        return True
+    else:
+        return False

--- a/numba/core/rewrites/static_getitem.py
+++ b/numba/core/rewrites/static_getitem.py
@@ -75,8 +75,7 @@ class RewriteStringLiteralGetitems(Rewrite):
         Rewrite all matching getitems as static_getitems where the index
         is the literal value of the string.
         """
-        new_block = self.block.copy()
-        new_block.clear()
+        new_block = ir.Block(self.block.scope, self.block.loc)
         for inst in self.block.body:
             if isinstance(inst, ir.Assign):
                 expr = inst.value
@@ -89,6 +88,50 @@ class RewriteStringLiteralGetitems(Rewrite):
                     self.calltypes[new_expr] = self.calltypes[expr]
                     inst = ir.Assign(value=new_expr, target=inst.target,
                                      loc=inst.loc)
+            new_block.append(inst)
+        return new_block
+
+
+@register_rewrite('after-inference')
+class RewriteStringLiteralSetitems(Rewrite):
+    """
+    Rewrite IR expressions of the kind `setitem(value=arr, index=$XX, value=)`
+    where `$XX` is a StringLiteral value as
+    `static_setitem(value=arr, index=<literal value>, value=)`.
+    """
+
+    def match(self, func_ir, block, typemap, calltypes):
+        """
+        Detect all setitem expressions and find which ones have
+        string literal indexes
+        """
+        self.setitems = setitems = {}
+        self.block = block
+        self.calltypes = calltypes
+        for inst in block.find_insts(ir.SetItem):
+            index_ty = typemap[inst.index.name]
+            if isinstance(index_ty, types.StringLiteral):
+                setitems[inst] = (inst.index, index_ty.literal_value)
+
+        return len(setitems) > 0
+
+    def apply(self):
+        """
+        Rewrite all matching setitems as static_setitems where the index
+        is the literal value of the string.
+        """
+        new_block = ir.Block(self.block.scope, self.block.loc)
+        for inst in self.block.body:
+            if isinstance(inst, ir.SetItem):
+                if inst in self.setitems:
+                    const, lit_val = self.setitems[inst]
+                    new_inst = ir.StaticSetItem(target=inst.target,
+                                                index=lit_val,
+                                                index_var=inst.index,
+                                                value=inst.value,
+                                                loc=inst.loc)
+                    self.calltypes[new_inst] = self.calltypes[inst]
+                    inst = new_inst
             new_block.append(inst)
         return new_block
 

--- a/numba/core/runtime/nrtopt.py
+++ b/numba/core/runtime/nrtopt.py
@@ -9,7 +9,17 @@ from numba.core import cgutils
 _regex_incref = re.compile(r'\s*(?:tail)?\s*call void @NRT_incref\((.*)\)')
 _regex_decref = re.compile(r'\s*(?:tail)?\s*call void @NRT_decref\((.*)\)')
 _regex_bb = re.compile(
-    r'([\'"]?[-a-zA-Z$._][-a-zA-Z$._0-9]*[\'"]?:)|^define|^;\s*<label>')
+    r'|'.join([
+        # unamed BB is just a plain number
+        r'[0-9]+:',
+        # with a proper identifer (see llvm langref)
+        r'[\'"]?[-a-zA-Z$._0-9][-a-zA-Z$._0-9]*[\'"]?:',
+        # is a start of a function definition
+        r'^define',
+        # no name
+        r'^;\s*<label>',
+    ])
+)
 
 
 def _remove_redundant_nrt_refct(llvmir):

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -66,7 +66,7 @@ def _reduce_function(func, globs):
         cells = [cell.cell_contents for cell in func.__closure__]
     else:
         cells = None
-    return _reduce_code(func.__code__), globs, func.__name__, cells
+    return _reduce_code(func.__code__), globs, func.__name__, cells, func.__defaults__
 
 def _reduce_code(code):
     """
@@ -80,7 +80,7 @@ def _dummy_closure(x):
     """
     return lambda: x
 
-def _rebuild_function(code_reduced, globals, name, cell_values):
+def _rebuild_function(code_reduced, globals, name, cell_values, defaults):
     """
     Rebuild a function from its _reduce_function() results.
     """
@@ -96,7 +96,7 @@ def _rebuild_function(code_reduced, globals, name, cell_values):
         # If the module can't be found, avoid passing it (it would produce
         # errors when lowering).
         del globals['__name__']
-    return FunctionType(code, globals, name, (), cells)
+    return FunctionType(code, globals, name, defaults, cells)
 
 def _rebuild_code(marshal_version, bytecode_magic, marshalled):
     """

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -17,7 +17,7 @@ from numba.core.ir_utils import (raise_on_unsupported_feature, warn_deprecated,
                                  check_and_legalize_ir, guard,
                                  dead_code_elimination, simplify_CFG,
                                  get_definition, remove_dels,
-                                 build_definitions)
+                                 build_definitions, compute_cfg_from_blocks)
 from numba.core import postproc
 
 
@@ -487,8 +487,20 @@ class InlineOverloads(FunctionPass):
         """
         if self._DEBUG:
             print('before overload inline'.center(80, '-'))
+            print(state.func_id.unique_name)
             print(state.func_ir.dump())
             print(''.center(80, '-'))
+        from numba.core.inline_closurecall import (InlineWorker,
+                                                   callee_ir_validator)
+        inline_worker = InlineWorker(state.typingctx,
+                                     state.targetctx,
+                                     state.locals,
+                                     state.pipeline,
+                                     state.flags,
+                                     callee_ir_validator,
+                                     state.typemap,
+                                     state.calltypes,
+                                     )
         modified = False
         work_list = list(state.func_ir.blocks.items())
         # use a work list, look for call sites via `ir.Expr.op == call` and
@@ -506,16 +518,22 @@ class InlineOverloads(FunctionPass):
                         else:
                             continue
 
-                        if guard(workfn, state, work_list, block, i, expr):
+                        if guard(workfn, state, work_list, block, i, expr,
+                                 inline_worker):
                             modified = True
                             break  # because block structure changed
 
         if self._DEBUG:
             print('after overload inline'.center(80, '-'))
+            print(state.func_id.unique_name)
             print(state.func_ir.dump())
             print(''.center(80, '-'))
 
         if modified:
+            # Remove dead blocks, this is safe as it relies on the CFG only.
+            cfg = compute_cfg_from_blocks(state.func_ir.blocks)
+            for dead in cfg.dead_nodes():
+                del state.func_ir.blocks[dead]
             # clean up blocks
             dead_code_elimination(state.func_ir,
                                   typemap=state.type_annotation.typemap)
@@ -525,12 +543,12 @@ class InlineOverloads(FunctionPass):
 
         if self._DEBUG:
             print('after overload inline DCE'.center(80, '-'))
+            print(state.func_id.unique_name)
             print(state.func_ir.dump())
             print(''.center(80, '-'))
-
         return True
 
-    def _do_work_getattr(self, state, work_list, block, i, expr):
+    def _do_work_getattr(self, state, work_list, block, i, expr, inline_worker):
         recv_type = state.type_annotation.typemap[expr.value.name]
         recv_type = types.unliteral(recv_type)
         matched = state.typingctx.find_matching_getattr_template(
@@ -564,10 +582,10 @@ class InlineOverloads(FunctionPass):
         is_method = False
         return self._run_inliner(
             state, inline_type, sig, template, arg_typs, expr, i, impl, block,
-            work_list, is_method,
+            work_list, is_method, inline_worker,
         )
 
-    def _do_work_call(self, state, work_list, block, i, expr):
+    def _do_work_call(self, state, work_list, block, i, expr, inline_worker):
         # try and get a definition for the call, this isn't always possible as
         # it might be a eval(str)/part generated awaiting update etc. (parfors)
         to_inline = None
@@ -627,15 +645,13 @@ class InlineOverloads(FunctionPass):
         # definitely something that could be inlined.
         return self._run_inliner(
             state, inline_type, sig, template, arg_typs, expr, i, impl, block,
-            work_list, is_method,
+            work_list, is_method, inline_worker,
         )
 
     def _run_inliner(
         self, state, inline_type, sig, template, arg_typs, expr, i, impl, block,
-        work_list, is_method,
+        work_list, is_method, inline_worker,
     ):
-        from numba.core.inline_closurecall import (inline_closure_call,
-                                                   callee_ir_validator)
 
         do_inline = True
         if not inline_type.is_always_inline:
@@ -657,15 +673,17 @@ class InlineOverloads(FunctionPass):
                 if not self._add_method_self_arg(state, expr):
                     return False
             arg_typs = template._inline_overloads[arg_typs]['folded_args']
-            # pass is typed so use the callee globals
-            inline_closure_call(state.func_ir, impl.__globals__,
-                                block, i, impl, typingctx=state.typingctx,
-                                arg_typs=arg_typs,
-                                typemap=state.type_annotation.typemap,
-                                calltypes=state.type_annotation.calltypes,
-                                work_list=work_list,
-                                replace_freevars=False,
-                                callee_validator=callee_ir_validator)
+            iinfo = template._inline_overloads[arg_typs]['iinfo']
+            freevars = iinfo.func_ir.func_id.func.__code__.co_freevars
+            _, _, _, new_blocks = inline_worker.inline_ir(state.func_ir,
+                                                          block,
+                                                          i,
+                                                          iinfo.func_ir,
+                                                          freevars,
+                                                          arg_typs=arg_typs)
+            if work_list is not None:
+                for blk in new_blocks:
+                    work_list.append(blk)
             return True
         else:
             return False

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -1475,7 +1475,8 @@ http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-u
                 func_glbls = self.func_id.func.__globals__
                 if (nm not in func_glbls.keys() and
                         nm not in special.__all__ and
-                        nm not in __builtins__.keys()):
+                        nm not in __builtins__.keys() and
+                        nm not in self.func_id.code.co_freevars):
                     errstr = "NameError: name '%s' is not defined"
                     msg = _termcolor.errmsg(errstr % nm)
                     e.patch_message(msg)

--- a/numba/core/types/function_type.py
+++ b/numba/core/types/function_type.py
@@ -52,7 +52,7 @@ class FunctionType(Type):
             # first-class function may not use the same argument names
             # that the caller assumes. [numba/issues/5540].
             raise errors.UnsupportedError(
-                f'first-class function call cannot use keyword arguments')
+                'first-class function call cannot use keyword arguments')
 
         if len(args) != self.nargs:
             raise ValueError(

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -145,6 +145,8 @@ class _ResolutionFailures(object):
             elif (is_external_fn_ptr and
                   isinstance(source_fn, numba.core.typing.templates.Signature)):
                 source_fn = template.__class__
+            elif hasattr(template, '_overload_func'):
+                source_fn = template._overload_func
             source_file, source_line = self._get_source_info(source_fn)
             largstr = argstr if err.literal else nolitargstr
             msgbuf.append(_termcolor.errmsg(

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -1,27 +1,78 @@
 import traceback
+from collections import namedtuple, defaultdict
+import inspect
+import itertools
+import logging
+import textwrap
+from os import path, get_terminal_size
 
 from .abstract import Callable, DTypeSpec, Dummy, Literal, Type, weakref
 from .common import Opaque
 from .misc import unliteral
-from numba.core import errors, utils, types
+from numba.core import errors, utils, types, config
+import numba
+
+_logger = logging.getLogger(__name__)
 
 # terminal color markup
 _termcolor = errors.termcolor()
 
+_FAILURE = namedtuple('_FAILURE', 'template matched error literal')
+
+try:
+    _termwidth = get_terminal_size()[0]
+except OSError: # lack of active console
+    _termwidth = 120
+
+# pull out the lead line as unit tests often use this
+_header_lead = "No implementation of function"
+_header_template = (_header_lead + " {the_function} found for signature:\n \n "
+                    ">>> {fname}({signature})\n \nThere are {ncandidates} "
+                    "candidate implementations:")
+
+_reason_template = """
+" - Of which {nmatches} did not match due to:\n
+"""
+
+def _wrapper(tmp, indent=0):
+    return textwrap.indent(tmp, ' ' * indent,  lambda line: True)
+
+_overload_template = ("- Of which {nduplicates} did not match due to:\n"
+                      "Overload in function '{function}': File: {file}: "
+                      "Line {line}.\n  With argument(s): '({args})':")
+
+_err_reasons = {}
+_err_reasons['specific_error'] = ("Rejected as the implementation raised a "
+                                  "specific error:\n{}")
+
+def _bt_as_lines(bt):
+    """
+    Converts a backtrace into a list of lines, squashes it a bit on the way.
+    """
+    return [y for y in itertools.chain(*[x.split('\n') for x in bt]) if y]
+
+def argsnkwargs_to_str(args, kwargs):
+    buf = [str(a) for a in tuple(args)]
+    buf.extend(["{}={}".format(k, v) for k, v in kwargs.items()])
+    return ', '.join(buf)
+
 class _ResolutionFailures(object):
     """Collect and format function resolution failures.
     """
-    def __init__(self, context, function_type, args, kwargs):
+    def __init__(self, context, function_type, args, kwargs, depth=0):
         self._context = context
         self._function_type = function_type
         self._args = args
         self._kwargs = kwargs
-        self._failures = []
+        self._failures = defaultdict(list)
+        self._depth = depth
+        self._max_depth = 5
+        self._scale = 2
 
     def __len__(self):
         return len(self._failures)
 
-    def add_error(self, calltemplate, error):
+    def add_error(self, calltemplate, matched, error, literal):
         """
         Args
         ----
@@ -29,30 +80,105 @@ class _ResolutionFailures(object):
         error : Exception or str
             Error message
         """
-        self._failures.append((calltemplate, error))
+        isexc = isinstance(error, Exception)
+        errclazz = '%s: ' % type(error).__name__ if isexc else ''
+
+        key = "{}{}".format(errclazz, str(error))
+        self._failures[key].append(_FAILURE(calltemplate, matched, error,
+                                            literal))
+
+    def _get_source_info(self, source_fn):
+        source_line = "<N/A>"
+        if 'builtin_function' in str(type(source_fn)):
+            source_file = "<built-in>"
+        else:
+            try:
+                source_file = path.abspath(inspect.getsourcefile(source_fn))
+                source_line = inspect.getsourcelines(source_fn)[1]
+                here = path.abspath(__file__)
+                common = path.commonpath([here, source_file])
+                source_file = source_file.replace(common, 'numba')
+            except:
+                source_file = "Unknown"
+        return source_file, source_line
 
     def format(self):
         """Return a formatted error message from all the gathered errors.
         """
-        indent = ' ' * 4
-        args = [str(a) for a in self._args]
-        args += ["%s=%s" % (k, v) for k, v in sorted(self._kwargs.items())]
-        headtmp = 'Invalid use of {} with argument(s) of type(s): ({})'
-        msgbuf = [headtmp.format(self._function_type, ', '.join(args))]
-        explain = self._context.explain_function_type(self._function_type)
-        msgbuf.append(explain)
-        for i, (temp, error) in enumerate(self._failures):
-            msgbuf.append(_termcolor.errmsg("In definition {}:".format(i)))
-            msgbuf.append(_termcolor.highlight('{}{}'.format(
-                indent, self.format_error(error))))
-            loc = self.get_loc(temp, error)
+        indent = ' ' * self._scale
+        argstr = argsnkwargs_to_str(self._args, self._kwargs)
+        ncandidates = sum([len(x) for x in self._failures.values()])
+
+        # sort out a display name for the function
+        tykey = self._function_type.typing_key
+        # most things have __name__
+        fname = getattr(tykey, '__name__', None)
+        is_external_fn_ptr = isinstance(self._function_type,
+                                        ExternalFunctionPointer)
+        if fname is None:
+            if is_external_fn_ptr:
+                fname = "ExternalFunctionPointer"
+            else:
+                fname = "<unknown function>"
+
+        msgbuf = [_header_template.format(the_function=self._function_type,
+                                          fname=fname,
+                                          signature=argstr,
+                                          ncandidates=ncandidates)]
+        nolitargs = tuple([unliteral(a) for a in self._args])
+        nolitkwargs = {k: unliteral(v) for k, v in self._kwargs.items()}
+        nolitargstr = argsnkwargs_to_str(nolitargs, nolitkwargs)
+
+        key = self._function_type.key[0]
+        fn_name = getattr(key, '__name__', str(key))
+
+        # depth could potentially get massive, so limit it.
+        ldepth = min(max(self._depth, 0), self._max_depth)
+
+        for i, (k, err_list) in enumerate(self._failures.items()):
+            err = err_list[0]
+            nduplicates = len(err_list)
+            template, error = err.template, err.error
+            source_fn = template.key
+            if isinstance(source_fn, numba.core.extending._Intrinsic):
+                source_fn = template.key._defn
+            elif (is_external_fn_ptr and
+                  isinstance(source_fn, numba.core.typing.templates.Signature)):
+                source_fn = template.__class__
+            source_file, source_line = self._get_source_info(source_fn)
+            largstr = argstr if err.literal else nolitargstr
+            msgbuf.append(_termcolor.errmsg(
+                _wrapper(_overload_template.format(nduplicates=nduplicates,
+                                                  function=source_fn.__name__,
+                                                  file=source_file,
+                                                  line=source_line,
+                                                  args=largstr),
+                ldepth + 1)))
+
+            if isinstance(error, BaseException):
+                reason = indent + self.format_error(error)
+                errstr = _err_reasons['specific_error'].format(reason)
+            else:
+                errstr = error
+            # if you are a developer, show the back traces
+            if config.DEVELOPER_MODE:
+                if isinstance(error, BaseException):
+                    # if the error is an actual exception instance, trace it
+                    bt = traceback.format_exception(type(error), error,
+                                                    error.__traceback__)
+                else:
+                    bt = [""]
+                bt_as_lines = _bt_as_lines(bt)
+                nd2indent = '\n{}'.format(2 * indent)
+                errstr += _termcolor.reset(nd2indent +
+                                            nd2indent.join(bt_as_lines))
+            msgbuf.append(_termcolor.highlight(_wrapper(errstr, ldepth + 2)))
+            loc = self.get_loc(template, error)
             if loc:
                 msgbuf.append('{}raised from {}'.format(indent, loc))
 
-        likely_cause = ("This error is usually caused by passing an argument "
-                        "of a type that is unsupported by the named function.")
-        msgbuf.append(_termcolor.errmsg(likely_cause))
-        return '\n'.join(msgbuf)
+        # the commented bit rewraps each block, may not be helpful?!
+        return _wrapper('\n'.join(msgbuf) + '\n') # , self._scale * ldepth)
 
     def format_error(self, error):
         """Format error message or exception
@@ -71,9 +197,10 @@ class _ResolutionFailures(object):
             return "{}:{}".format(frame[0], frame[1])
 
     def raise_error(self):
-        for _tempcls, e in self._failures:
-            if isinstance(e, errors.ForceLiteralArg):
-                raise e
+        for faillist in self._failures.values():
+            for fail in faillist:
+                if isinstance(fail.error, errors.ForceLiteralArg):
+                    raise fail.error
         raise errors.TypingError(self.format())
 
 
@@ -96,6 +223,7 @@ class BaseFunction(Callable):
             self.typing_key = template.key
         self._impl_keys = {}
         name = "%s(%s)" % (self.__class__.__name__, self.typing_key)
+        self._depth = 0
         super(BaseFunction, self).__init__(name)
 
     @property
@@ -118,7 +246,9 @@ class BaseFunction(Callable):
         return self._impl_keys[sig.args]
 
     def get_call_type(self, context, args, kws):
-        failures = _ResolutionFailures(context, self, args, kws)
+        failures = _ResolutionFailures(context, self, args, kws,
+                                       depth=self._depth)
+        self._depth += 1
         for temp_cls in self.templates:
             temp = temp_cls(context)
             for uselit in [True, False]:
@@ -131,15 +261,21 @@ class BaseFunction(Callable):
                         sig = temp.apply(nolitargs, nolitkws)
                 except Exception as e:
                     sig = None
-                    failures.add_error(temp_cls, e)
+                    failures.add_error(temp, False, e, uselit)
                 else:
                     if sig is not None:
                         self._impl_keys[sig.args] = temp.get_impl_key(sig)
+                        self._depth -= 1
                         return sig
                     else:
-                        haslit= '' if uselit else 'out'
-                        msg = "All templates rejected with%s literals." % haslit
-                        failures.add_error(temp_cls, msg)
+                        registered_sigs = getattr(temp, 'cases', None)
+                        if registered_sigs is not None:
+                            msg = "No match for registered cases:\n%s"
+                            msg = msg % '\n'.join(" * {}".format(x) for x in
+                                                  registered_sigs)
+                        else:
+                            msg = 'No match.'
+                        failures.add_error(temp, True, msg, uselit)
 
         if len(failures) == 0:
             raise AssertionError("Internal Error. "
@@ -202,20 +338,65 @@ class BoundFunction(Callable, Opaque):
 
     def get_call_type(self, context, args, kws):
         template = self.template(context)
-        e = None
+        literal_e = None
+        nonliteral_e = None
+
+
         # Try with Literal
         try:
             out = template.apply(args, kws)
-        except Exception:
+        except Exception as exc:
+            if isinstance(exc, errors.ForceLiteralArg):
+                raise exc
+            literal_e = exc
             out = None
-        # If that doesn't work, remove literals
-        if out is None:
-            args = [unliteral(a) for a in args]
-            kws = {k: unliteral(v) for k, v in kws.items()}
-            out = template.apply(args, kws)
-        if out is None and e is not None:
-            raise e
+
+        # if the unliteral_args and unliteral_kws are the same as the literal
+        # ones, set up to not bother retrying
+        unliteral_args = tuple([unliteral(a) for a in args])
+        unliteral_kws = {k: unliteral(v) for k, v in kws.items()}
+        skip = unliteral_args == args and kws == unliteral_kws
+
+        # If the above template application failed and the non-literal args are
+        # different to the literal ones, try again with literals rewritten as
+        # non-literals
+        if not skip and out is None:
+            try:
+                out = template.apply(unliteral_args, unliteral_kws)
+            except Exception as exc:
+                if isinstance(exc, errors.ForceLiteralArg):
+                    raise exc
+                nonliteral_e = exc
+
+        if out is None and (nonliteral_e is not None or literal_e is not None):
+            header = "- Resolution failure for {} arguments:\n{}\n"
+            tmplt = _termcolor.highlight(header)
+            if config.DEVELOPER_MODE:
+                indent = ' ' * 4
+                def add_bt(error):
+                    if isinstance(error, BaseException):
+                        # if the error is an actual exception instance, trace it
+                        bt = traceback.format_exception(type(error), error,
+                                                        error.__traceback__)
+                    else:
+                        bt = [""]
+                    nd2indent = '\n{}'.format(2 * indent)
+                    errstr += _termcolor.reset(nd2indent +
+                                               nd2indent.join(bt_as_lines))
+                    return _termcolor.reset(errstr)
+            else:
+                add_bt = lambda X: ''
+
+            def nested_msg(literalness, e):
+                estr = str(e)
+                estr = estr if estr else (str(repr(e)) + add_bt(e))
+                new_e = errors.TypingError(textwrap.dedent(estr))
+                return tmplt.format(literalness, str(new_e))
+
+            raise errors.TypingError(nested_msg('literal', literal_e) +
+                                     nested_msg('non-literal', nonliteral_e))
         return out
+
 
     def get_call_signatures(self):
         sigs = getattr(self.template, 'cases', [])

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -401,8 +401,8 @@ class BoundFunction(Callable, Opaque):
                     else:
                         bt = [""]
                     nd2indent = '\n{}'.format(2 * indent)
-                    errstr += _termcolor.reset(nd2indent +
-                                               nd2indent.join(bt_as_lines))
+                    errstr = _termcolor.reset(nd2indent +
+                                               nd2indent.join(_bt_as_lines(bt)))
                     return _termcolor.reset(errstr)
             else:
                 add_bt = lambda X: ''

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -432,6 +432,7 @@ class WeakType(Type):
         if type(self) is type(other):
             obj = self._wr()
             return obj is not None and obj is other._wr()
+        return NotImplemented
 
     def __hash__(self):
         return Type.__hash__(self)

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -4,7 +4,8 @@ import inspect
 import itertools
 import logging
 import textwrap
-from os import path, get_terminal_size
+from os import path
+from shutil import get_terminal_size
 
 from .abstract import Callable, DTypeSpec, Dummy, Literal, Type, weakref
 from .common import Opaque
@@ -19,10 +20,8 @@ _termcolor = errors.termcolor()
 
 _FAILURE = namedtuple('_FAILURE', 'template matched error literal')
 
-try:
-    _termwidth = get_terminal_size()[0]
-except OSError: # lack of active console
-    _termwidth = 120
+_termwidth = get_terminal_size().columns
+
 
 # pull out the lead line as unit tests often use this
 _header_lead = "No implementation of function"

--- a/numba/core/types/iterators.py
+++ b/numba/core/types/iterators.py
@@ -103,5 +103,6 @@ class ArrayIterator(SimpleIteratorType):
         elif nd == 1:
             yield_type = array_type.dtype
         else:
-            yield_type = array_type.copy(ndim=array_type.ndim - 1)
+            # iteration semantics leads to A order layout
+            yield_type = array_type.copy(ndim=array_type.ndim - 1, layout='A')
         super(ArrayIterator, self).__init__(name, yield_type)

--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -182,9 +182,6 @@ class BaseContext(object):
             for sig in defns:
                 desc.append(' * {0}'.format(sig))
 
-        if param:
-            desc.append(' * parameterized')
-
         return '\n'.join(desc)
 
     def resolve_function_type(self, func, args, kws):

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -143,22 +143,6 @@ class Numpy_rules_ufunc(AbstractTemplate):
         return signature(*out)
 
 
-@infer_global(operator.pos)
-class UnaryPositiveArray(AbstractTemplate):
-    '''Typing template class for +(array) expressions.  This operator is
-    special because there is no Numpy ufunc associated with it; we
-    include typing for it here (numba.typing.npydecl) because this is
-    where the remaining array operators are defined.
-    '''
-    key = operator.pos
-
-    def generic(self, args, kws):
-        assert not kws
-        if len(args) == 1 and isinstance(args[0], types.ArrayCompatible):
-            arg_ty = args[0]
-            return arg_ty.copy()(arg_ty)
-
-
 class NumpyRulesArrayOperator(Numpy_rules_ufunc):
     _op_map = {
         operator.add: "add",
@@ -252,9 +236,7 @@ class NumpyRulesInplaceArrayOperator(NumpyRulesArrayOperator):
 
 class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
     _op_map = {
-        # Positive is a special case since there is no Numpy ufunc
-        # corresponding to it (it's essentially an identity operator).
-        # See UnaryPositiveArray, above.
+        operator.pos: "positive",
         operator.neg: "negative",
         operator.invert: "invert",
     }
@@ -269,7 +251,7 @@ class NumpyRulesUnaryArrayOperator(NumpyRulesArrayOperator):
 
 _math_operations = [ "add", "subtract", "multiply",
                      "logaddexp", "logaddexp2", "true_divide",
-                     "floor_divide", "negative", "power",
+                     "floor_divide", "negative", "positive", "power",
                      "remainder", "fmod", "absolute",
                      "rint", "sign", "conjugate", "exp", "exp2",
                      "log", "log2", "log10", "expm1", "log1p",

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -2,6 +2,7 @@
 Define typing templates
 """
 
+from abc import ABC, abstractmethod
 import functools
 import sys
 import inspect
@@ -246,7 +247,7 @@ def fold_arguments(pysig, args, kws, normal_handler, default_handler,
     return args
 
 
-class FunctionTemplate(object):
+class FunctionTemplate(ABC):
     # Set to true to disable unsafe cast.
     # subclass overide-able
     unsafe_casting = True
@@ -276,6 +277,24 @@ class FunctionTemplate(object):
             assert key.im_self is None
             key = key.im_func
         return key
+
+    @abstractmethod
+    def get_template_info(self):
+        """
+        Returns a dictionary with information specific to the template that will
+        govern how error messages are displayed to users. The dictionary must
+        be of the form:
+        info = {
+            'kind': "unknown", # str: The kind of template, e.g. "Overload"
+            'name': "unknown", # str: The name of the source function
+            'sig': "unknown",  # str: The signature(s) of the source function
+            'filename': "unknown", # str: The filename of the source function
+            'lines': ("start", "end"), # tuple(int, int): The start and
+                                         end line of the source function.
+            'docstring': "unknown" # str: The docstring of the source function
+        }
+        """
+        pass
 
 
 class AbstractTemplate(FunctionTemplate):
@@ -309,6 +328,22 @@ class AbstractTemplate(FunctionTemplate):
             sig = generic(args, kws)
 
         return sig
+
+    def get_template_info(self):
+        impl = getattr(self, "generic")
+        basepath = os.path.dirname(os.path.dirname(numba.__file__))
+        code, firstlineno = inspect.getsourcelines(impl)
+        path = inspect.getsourcefile(impl)
+        sig = str(utils.pysignature(impl))
+        info = {
+            'kind': "overload",
+            'name': getattr(impl, '__qualname__', impl.__name__),
+            'sig': sig,
+            'filename': os.path.relpath(path, start=basepath),
+            'lines': (firstlineno, firstlineno + len(code) - 1),
+            'docstring': impl.__doc__
+        }
+        return info
 
 
 class CallableTemplate(FunctionTemplate):
@@ -369,6 +404,23 @@ class CallableTemplate(FunctionTemplate):
         cases = [sig]
         return self._select(cases, bound.args, bound.kwargs)
 
+    def get_template_info(self):
+        impl = getattr(self, "generic")
+        basepath = os.path.dirname(os.path.dirname(numba.__file__))
+        code, firstlineno = inspect.getsourcelines(impl)
+        path = inspect.getsourcefile(impl)
+        sig = str(utils.pysignature(impl))
+        info = {
+            'kind': "overload",
+            'name': getattr(self.key, '__name__',
+                            getattr(impl, '__qualname__', impl.__name__),),
+            'sig': sig,
+            'filename': os.path.relpath(path, start=basepath),
+            'lines': (firstlineno, firstlineno + len(code) - 1),
+            'docstring': impl.__doc__
+        }
+        return info
+
 
 class ConcreteTemplate(FunctionTemplate):
     """
@@ -379,6 +431,25 @@ class ConcreteTemplate(FunctionTemplate):
     def apply(self, args, kws):
         cases = getattr(self, 'cases')
         return self._select(cases, args, kws)
+
+    def get_template_info(self):
+        import operator
+        name = getattr(self.key, '__name__', "unknown")
+        op_func = getattr(operator, name, None)
+
+        kind = "Type restricted function"
+        if op_func is not None:
+            if self.key is op_func:
+                kind = "operator overload"
+        info = {
+            'kind': kind,
+            'name': name,
+            'sig': "unknown",
+            'filename': "unknown",
+            'lines': ("unknown", "unknown"),
+            'docstring': "unknown"
+        }
+        return info
 
 
 class _EmptyImplementationEntry(InternalError):
@@ -667,6 +738,22 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         }
         return info
 
+    def get_template_info(self):
+        basepath = os.path.dirname(os.path.dirname(numba.__file__))
+        impl = self._overload_func
+        code, firstlineno = inspect.getsourcelines(impl)
+        path = inspect.getsourcefile(impl)
+        sig = str(utils.pysignature(impl))
+        info = {
+            'kind': "overload",
+            'name': getattr(impl, '__qualname__', impl.__name__),
+            'sig': sig,
+            'filename': os.path.relpath(path, start=basepath),
+            'lines': (firstlineno, firstlineno + len(code) - 1),
+            'docstring': impl.__doc__
+        }
+        return info
+
 
 def make_overload_template(func, overload_func, jit_options, strict,
                            inline):
@@ -719,6 +806,22 @@ class _IntrinsicTemplate(AbstractTemplate):
         signature on the target context.
         """
         return self._overload_cache[sig.args]
+
+    def get_template_info(self):
+        basepath = os.path.dirname(os.path.dirname(numba.__file__))
+        impl = self._definition_func
+        code, firstlineno = inspect.getsourcelines(impl)
+        path = inspect.getsourcefile(impl)
+        sig = str(utils.pysignature(impl))
+        info = {
+            'kind': "intrinsic",
+            'name': getattr(impl, '__qualname__', impl.__name__),
+            'sig': sig,
+            'filename': os.path.relpath(path, start=basepath),
+            'lines': (firstlineno, firstlineno + len(code) - 1),
+            'docstring': impl.__doc__
+        }
+        return info
 
 
 def make_intrinsic_template(handle, defn, name):
@@ -877,7 +980,7 @@ def make_overload_attribute_template(typ, attr, overload_func, inline,
     *overload_func*.
     """
     assert isinstance(typ, types.Type) or issubclass(typ, types.Type)
-    name = "OverloadTemplate_%s_%s" % (typ, attr)
+    name = "OverloadAttributeTemplate_%s_%s" % (typ, attr)
     # Note the implementation cache is subclass-specific
     dct = dict(key=typ, _attr=attr, _impl_cache={},
                _inline=staticmethod(InlineOptions(inline)),

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -203,6 +203,7 @@ class InlineClosureLikes(FunctionPass):
             state.parfor_diagnostics.replaced_fns,
             typed_pass)
         inline_pass.run()
+
         # Remove all Dels, and re-run postproc
         post_proc = postproc.PostProcessor(state.func_ir)
         post_proc.run()
@@ -288,6 +289,16 @@ class InlineInlinables(FunctionPass):
             print('before inline'.center(80, '-'))
             print(state.func_ir.dump())
             print(''.center(80, '-'))
+
+        from numba.core.inline_closurecall import (InlineWorker,
+                                                   callee_ir_validator)
+        inline_worker = InlineWorker(state.typingctx,
+                                     state.targetctx,
+                                     state.locals,
+                                     state.pipeline,
+                                     state.flags,
+                                     validator=callee_ir_validator)
+
         modified = False
         # use a work list, look for call sites via `ir.Expr.op == call` and
         # then pass these to `self._do_work` to make decisions about inlining.
@@ -299,13 +310,18 @@ class InlineInlinables(FunctionPass):
                     expr = instr.value
                     if isinstance(expr, ir.Expr) and expr.op == 'call':
                         if guard(self._do_work, state, work_list, block, i,
-                                 expr):
+                                 expr, inline_worker):
                             modified = True
                             break  # because block structure changed
 
         if modified:
             # clean up unconditional branches that appear due to inlined
             # functions introducing blocks
+            cfg = compute_cfg_from_blocks(state.func_ir.blocks)
+            for dead in cfg.dead_nodes():
+                del state.func_ir.blocks[dead]
+            post_proc = postproc.PostProcessor(state.func_ir)
+            post_proc.run()
             state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
 
         if self._DEBUG:
@@ -314,9 +330,7 @@ class InlineInlinables(FunctionPass):
             print(''.center(80, '-'))
         return True
 
-    def _do_work(self, state, work_list, block, i, expr):
-        from numba.core.inline_closurecall import (inline_closure_call,
-                                                   callee_ir_validator)
+    def _do_work(self, state, work_list, block, i, expr, inline_worker):
         from numba.core.compiler import run_frontend
         from numba.core.cpu import InlineOptions
 
@@ -373,12 +387,12 @@ class InlineInlinables(FunctionPass):
                                                     py_func_ir)
                         # if do_inline is True then inline!
                         if do_inline:
-                            inline_closure_call(
-                                state.func_ir,
-                                pyfunc.__globals__,
-                                block, i, pyfunc,
-                                work_list=work_list,
-                                callee_validator=callee_ir_validator)
+                            _, _, _, new_blocks = \
+                                inline_worker.inline_function(state.func_ir,
+                                                              block, i, pyfunc,)
+                            if work_list is not None:
+                                for blk in new_blocks:
+                                    work_list.append(blk)
                             return True
         return False
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -415,24 +415,14 @@ def bool_none(x):
 
 def get_type_max_value(typ):
     if isinstance(typ, types.Float):
-        bw = typ.bitwidth
-        if bw == 32:
-            return np.finfo(np.float32).max
-        if bw == 64:
-            return np.finfo(np.float64).max
-        raise NotImplementedError("Unsupported floating point type")
+        return np.inf
     if isinstance(typ, types.Integer):
         return typ.maxval
     raise NotImplementedError("Unsupported type")
 
 def get_type_min_value(typ):
     if isinstance(typ, types.Float):
-        bw = typ.bitwidth
-        if bw == 32:
-            return np.finfo(np.float32).min
-        if bw == 64:
-            return np.finfo(np.float64).min
-        raise NotImplementedError("Unsupported floating point type")
+        return -np.inf
     if isinstance(typ, types.Integer):
         return typ.minval
     raise NotImplementedError("Unsupported type")
@@ -455,7 +445,7 @@ def lower_get_type_min_value(context, builder, sig, args):
         else:
             raise NotImplementedError("llvmlite only supports 32 and 64 bit floats")
         npty = getattr(np, 'float{}'.format(bw))
-        res = ir.Constant(lty, np.finfo(npty).min)
+        res = ir.Constant(lty, -np.inf)
     return impl_ret_untracked(context, builder, lty, res)
 
 @lower_builtin(get_type_max_value, types.NumberClass)
@@ -476,7 +466,7 @@ def lower_get_type_max_value(context, builder, sig, args):
         else:
             raise NotImplementedError("llvmlite only supports 32 and 64 bit floats")
         npty = getattr(np, 'float{}'.format(bw))
-        res = ir.Constant(lty, np.finfo(npty).max)
+        res = ir.Constant(lty, np.inf)
     return impl_ret_untracked(context, builder, lty, res)
 
 # -----------------------------------------------------------------------------

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -251,6 +251,7 @@ if _py38_or_later:
         _PyHASH_XXPRIME_1 = _Py_uhash_t(11400714785074694791)
         _PyHASH_XXPRIME_2 = _Py_uhash_t(14029467366897019727)
         _PyHASH_XXPRIME_5 = _Py_uhash_t(2870177450012600261)
+
         @register_jitable(locals={'x': types.uint64})
         def _PyHASH_XXROTATE(x):
             # Rotate left 31 bits
@@ -259,6 +260,7 @@ if _py38_or_later:
         _PyHASH_XXPRIME_1 = _Py_uhash_t(2654435761)
         _PyHASH_XXPRIME_2 = _Py_uhash_t(2246822519)
         _PyHASH_XXPRIME_5 = _Py_uhash_t(374761393)
+
         @register_jitable(locals={'x': types.uint64})
         def _PyHASH_XXROTATE(x):
             # Rotate left 13 bits

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -665,6 +665,7 @@ def unicode_rindex(s, sub, start=None, end=None):
 
     return rindex_impl
 
+
 # https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L11692-L11718    # noqa: E501
 @overload_method(types.UnicodeType, 'index')
 def unicode_index(s, sub, start=None, end=None):

--- a/numba/cpython/unicode_support.py
+++ b/numba/cpython/unicode_support.py
@@ -322,6 +322,7 @@ def _PyUnicode_ToFoldedFull(ch, res):
         return n
     return _PyUnicode_ToLowerFull(ch, res)
 
+
 # From: https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodectype.c#L274-L279    # noqa: E501
 @register_jitable
 def _PyUnicode_IsCased(ch):

--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -1,4 +1,4 @@
-import numba.testing
+from numba import runtests
 from numba.core import config
 
 if config.ENABLE_CUDASIM:
@@ -13,4 +13,4 @@ def test(*args, **kwargs):
     if not is_available():
         raise cuda_error()
 
-    return numba.testing.test("numba.cuda.tests", *args, **kwargs)
+    return runtests.main("numba.cuda.tests", *args, **kwargs)

--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -7,6 +7,7 @@ else:
     from .device_init import *
     from .device_init import _auto_device
 
+from numba.cuda.compiler import compile_ptx, compile_ptx_for_current_device
 
 def test(*args, **kwargs):
     if not is_available():

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -386,12 +386,24 @@ class CUDAKernelBase(object):
         return self.configure(*args)
 
     def forall(self, ntasks, tpb=0, stream=0, sharedmem=0):
-        """Returns a configured kernel for 1D kernel of given number of tasks
+        """Returns a 1D-configured kernel for a given number of tasks
         ``ntasks``.
 
         This assumes that:
-        - the kernel 1-to-1 maps global thread id ``cuda.grid(1)`` to tasks.
-        - the kernel must check if the thread id is valid."""
+
+        - the kernel maps the Global Thread ID ``cuda.grid(1)`` to tasks on a
+          1-1 basis.
+        - the kernel checks that the Global Thread ID is upper-bounded by
+          ``ntasks``, and does nothing if it is not.
+
+        :param ntasks: The number of tasks.
+        :param tpb: The size of a block. An appropriate value is chosen if this
+                    parameter is not supplied.
+        :param stream: The stream on which the configured kernel will be
+                       launched.
+        :param sharedmem: The number of bytes of dynamic shared memory required
+                          by the kernel.
+        :return: A configured kernel, ready to launch on a set of arguments."""
 
         return ForAll(self, ntasks, tpb=tpb, stream=stream, sharedmem=sharedmem)
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,26 +1,23 @@
 import ctypes
 import os
-from functools import reduce, wraps
-import operator
 import sys
-import threading
-import warnings
 
 import numpy as np
 
 from numba.core.typing.templates import AbstractTemplate, ConcreteTemplate
-from numba.core import types, typing, utils, funcdesc, serialize, config, compiler, sigutils
+from numba.core import (types, typing, utils, funcdesc, serialize, config,
+                        compiler, sigutils)
 from numba.core.compiler_lock import global_compiler_lock
 
 from .cudadrv.devices import get_context
-from .cudadrv import nvvm, devicearray, driver
+from .cudadrv import nvvm, driver
 from .errors import normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
 
 
 @global_compiler_lock
-def compile_cuda(pyfunc, return_type, args, debug, inline):
+def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
     # First compilation will trigger the initialization of the CUDA backend.
     from .descriptor import CUDATargetDesc
 
@@ -72,6 +69,64 @@ def compile_kernel(pyfunc, args, link, debug=False, inline=False,
                         extensions=extensions,
                         max_registers=max_registers)
     return cukern
+
+
+@global_compiler_lock
+def compile_ptx(pyfunc, args, debug=False, device=False, fastmath=False,
+                cc=None, opt=True):
+    """Compile a Python function to PTX for a given set of argument types.
+
+    :param pyfunc: The Python function to compile.
+    :param args: A tuple of argument types to compile for.
+    :param debug: Whether to include debug info in the generated PTX.
+    :type debug: bool
+    :param device: Whether to compile a device function. Defaults to ``False``,
+                   to compile global kernel functions.
+    :type device: bool
+    :param fastmath: Whether to enable fast math flags (ftz=1, prec_sqrt=0,
+                     prec_div=, and fma=1)
+    :type fastmath: bool
+    :param cc: Compute capability to compile for, as a tuple ``(MAJOR, MINOR)``.
+               Defaults to ``(5, 2)``.
+    :type cc: tuple
+    :param opt: Enable optimizations. Defaults to ``True``.
+    :type opt: bool
+    :return: (ptx, resty): The PTX code and inferred return type
+    :rtype: tuple
+    """
+    cres = compile_cuda(pyfunc, None, args, debug=debug)
+    resty = cres.signature.return_type
+    if device:
+        llvm_module = cres.library._final_module
+        nvvm.fix_data_layout(llvm_module)
+    else:
+        fname = cres.fndesc.llvm_func_name
+        tgt = cres.target_context
+        lib, kernel = tgt.prepare_cuda_kernel(cres.library, fname,
+                                              cres.signature.args, debug=debug)
+        llvm_module = lib._final_module
+
+    options = {
+        'debug': debug,
+        'fastmath': fastmath,
+    }
+
+    cc = cc or config.CUDA_DEFAULT_PTX_CC
+    opt = 3 if opt else 0
+    arch = nvvm.get_arch_option(*cc)
+    llvmir = str(llvm_module)
+    ptx = nvvm.llvm_to_ptx(llvmir, opt=opt, arch=arch, **options)
+    return ptx.decode('utf-8'), resty
+
+
+def compile_ptx_for_current_device(pyfunc, args, debug=False, device=False,
+                                   fastmath=False, opt=True):
+    """Compile a Python function to PTX for a given set of argument types for
+    the current device's compute capabilility. This calls :func:`compile_ptx`
+    with an appropriate ``cc`` value for the current device."""
+    cc = get_current_device().compute_capability
+    return compile_ptx(pyfunc, args, debug=-debug, device=device,
+                       fastmath=fastmath, cc=cc, opt=True)
 
 
 class DeviceFunctionTemplate(object):
@@ -215,7 +270,7 @@ class DeviceFunction(object):
         cres = compile_cuda(self.py_func, self.return_type, self.args,
                             debug=self.debug, inline=self.inline)
         self.cres = cres
-        # Register
+
         class device_function_template(ConcreteTemplate):
             key = self
             cases = [cres.signature]
@@ -438,7 +493,8 @@ class CachedCUFunction(object):
             msg = ('cannot pickle CUDA kernel function with additional '
                    'libraries to link against')
             raise RuntimeError(msg)
-        args = (self.__class__, self.entry_name, self.ptx, self.linking, self.max_registers)
+        args = (self.__class__, self.entry_name, self.ptx, self.linking,
+                self.max_registers)
         return (serialize._rebuild_reduction, args)
 
     @classmethod
@@ -460,12 +516,10 @@ class CUDAKernel(CUDAKernelBase):
                  extensions=[], max_registers=None):
         super(CUDAKernel, self).__init__()
         # initialize CUfunction
-        options = {'debug': debug}
-        if fastmath:
-            options.update(dict(ftz=True,
-                                prec_sqrt=False,
-                                prec_div=False,
-                                fma=True))
+        options = {
+            'debug': debug,
+            'fastmath': fastmath
+        }
 
         ptx = CachedPTX(pretty_name, str(llvm_module), options=options)
         cufunc = CachedCUFunction(name, ptx, link, max_registers)
@@ -480,7 +534,8 @@ class CUDAKernel(CUDAKernelBase):
         self.extensions = list(extensions)
 
     @classmethod
-    def _rebuild(cls, name, argtypes, cufunc, link, debug, call_helper, extensions, config):
+    def _rebuild(cls, name, argtypes, cufunc, link, debug, call_helper,
+                 extensions, config):
         """
         Rebuild an instance.
         """
@@ -516,7 +571,8 @@ class CUDAKernel(CUDAKernelBase):
 
     def __call__(self, *args, **kwargs):
         assert not kwargs
-        griddim, blockdim = normalize_kernel_dimensions(self.griddim, self.blockdim)
+        griddim, blockdim = normalize_kernel_dimensions(self.griddim,
+                                                        self.blockdim)
         self._kernel_call(args=args,
                           griddim=griddim,
                           blockdim=blockdim,
@@ -619,13 +675,14 @@ class CUDAKernel(CUDAKernelBase):
                 else:
                     sym, filepath, lineno = loc
                     filepath = os.path.abspath(filepath)
-                    locinfo = 'In function %r, file %s, line %s, ' % (
-                        sym, filepath, lineno,
-                        )
+                    locinfo = 'In function %r, file %s, line %s, ' % (sym,
+                                                                      filepath,
+                                                                      lineno,)
                 # Prefix the exception message with the thread position
                 prefix = "%stid=%s ctaid=%s" % (locinfo, tid, ctaid)
                 if exc_args:
-                    exc_args = ("%s: %s" % (prefix, exc_args[0]),) + exc_args[1:]
+                    exc_args = ("%s: %s" % (prefix, exc_args[0]),) + \
+                        exc_args[1:]
                 else:
                     exc_args = prefix,
                 raise exccls(*exc_args)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -283,12 +283,22 @@ except:
 if NVVM_VERSION < (1, 4):
     # CUDA 8.0
     SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2)
-else:
+elif NVVM_VERSION < (1, 5):
     # CUDA 9.0 and later
     SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0)
+else:
+    # CUDA 10.0 and later
+    SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0), (7, 2), (7, 5)
 
 
-def _find_arch(mycc):
+def find_closest_arch(mycc):
+    """
+    Given a compute capability, return the closest compute capability supported
+    by the CUDA toolkit.
+
+    :param mycc: Compute capability as a tuple ``(MAJOR, MINOR)``
+    :return: Closest supported CC as a tuple ``(MAJOR, MINOR)``
+    """
     for i, cc in enumerate(SUPPORTED_CC):
         if cc == mycc:
             # Matches
@@ -313,7 +323,7 @@ def get_arch_option(major, minor):
     if config.FORCE_CUDA_CC:
         arch = config.FORCE_CUDA_CC
     else:
-        arch = _find_arch((major, minor))
+        arch = find_closest_arch((major, minor))
     return 'compute_%d%d' % arch
 
 
@@ -465,6 +475,14 @@ def _replace_datalayout(llvmir):
 
 
 def llvm_to_ptx(llvmir, **opts):
+    if opts.pop('fastmath', False):
+        opts.update({
+            'ftz': True,
+            'fma': True,
+            'prec_div': False,
+            'prec_sqrt': False,
+        })
+
     cu = CompilationUnit()
     libdevice = LibDevice(arch=opts.get('arch', 'compute_20'))
     # New LLVM generate a shorthand for datalayout that NVVM does not know

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -502,6 +502,7 @@ def llvm_to_ptx(llvmir, **opts):
          ir_numba_atomic_min.format(T='float', Ti='i32')),
         ('declare double @___numba_atomic_double_min(double*, double)',
          ir_numba_atomic_min.format(T='double', Ti='i64')),
+        ('immarg', '')
     ]
 
     for decl, fn in replacements:

--- a/numba/cuda/kernels/reduction.py
+++ b/numba/cuda/kernels/reduction.py
@@ -160,17 +160,18 @@ def _gpu_reduce_factory(fn, nbtype):
 
 
 class Reduce(object):
+    """Create a reduction object that reduces values using a given binary
+    function. The binary function is compiled once and cached inside this
+    object. Keeping this object alive will prevent re-compilation.
+    """
+
     _cache = {}
 
     def __init__(self, functor):
-        """Create a reduction object that reduces values using a given binary
-        function. The binary function is compiled once and cached inside this
-        object. Keeping this object alive will prevent re-compilation.
-
-        :param binop: A function to be compiled as a CUDA device function that
-                    will be used as the binary operation for reduction on a
-                    CUDA device. Internally, it is compiled using
-                    ``cuda.jit(device=True)``.
+        """
+        :param functor: A function implementing a binary operation for
+                        reduction. It will be compiled as a CUDA device
+                        function using ``cuda.jit(device=True)``.
         """
         self._functor = functor
 
@@ -186,10 +187,7 @@ class Reduce(object):
     def __call__(self, arr, size=None, res=None, init=0, stream=0):
         """Performs a full reduction.
 
-        :param arr: A host or device array. If a device array is given, the
-                    reduction is performed inplace and the values in the array
-                    are overwritten. If a host array is given, it is copied to
-                    the device automatically.
+        :param arr: A host or device array.
         :param size: Optional integer specifying the number of elements in
                     ``arr`` to reduce. If this parameter is not specified, the
                     entire array is reduced.

--- a/numba/cuda/simulator/compiler.py
+++ b/numba/cuda/simulator/compiler.py
@@ -4,3 +4,6 @@ to allow tests to import successfully.
 '''
 
 compile_kernel = None
+
+compile_ptx = None
+compile_ptx_for_current_device = None

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -1,0 +1,85 @@
+from math import sqrt
+from numba import cuda, float32, void
+from numba.cuda import compile_ptx, compile_ptx_for_current_device
+
+from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
+
+
+@skip_on_cudasim('Compilation unsupported in the simulator')
+class TestCompileToPTX(unittest.TestCase):
+    def test_global_kernel(self):
+        def f(r, x, y):
+            i = cuda.grid(1)
+            if i < len(r):
+                r[i] = x[i] + y[i]
+
+        args = (float32[:], float32[:], float32[:])
+        ptx, resty = compile_ptx(f, args)
+
+        # Kernels should not have a func_retval parameter
+        self.assertNotIn('func_retval', ptx)
+        # .visible .func is used to denote a device function
+        self.assertNotIn('.visible .func', ptx)
+        # .visible .entry would denote the presence of a global function
+        self.assertIn('.visible .entry', ptx)
+        # Return type for kernels should always be void
+        self.assertEqual(resty, void)
+
+    def test_device_function(self):
+        def add(x, y):
+            return x + y
+
+        args = (float32, float32)
+        ptx, resty = compile_ptx(add, args, device=True)
+
+        # Device functions take a func_retval parameter for storing the
+        # returned value in by reference
+        self.assertIn('func_retval', ptx)
+        # .visible .func is used to denote a device function
+        self.assertIn('.visible .func', ptx)
+        # .visible .entry would denote the presence of a global function
+        self.assertNotIn('.visible .entry', ptx)
+        # Inferred return type as expected?
+        self.assertEqual(resty, float32)
+
+    def test_fastmath(self):
+        def f(x, y, z, d):
+            return sqrt((x * y + z) / d)
+
+        args = (float32, float32, float32, float32)
+        ptx, resty = compile_ptx(f, args, device=True)
+
+        # Without fastmath, fma contraction is enabled by default, but ftz and
+        # approximate div / sqrt is not.
+        self.assertIn('fma.rn.f32', ptx)
+        self.assertIn('div.rn.f32', ptx)
+        self.assertIn('sqrt.rn.f32', ptx)
+
+        ptx, resty = compile_ptx(f, args, device=True, fastmath=True)
+
+        # With fastmath, ftz and approximate div / sqrt are enabled
+        self.assertIn('fma.rn.ftz.f32', ptx)
+        # "full" refers to a full-range approximate divide
+        self.assertIn('div.full.ftz.f32', ptx)
+        self.assertIn('sqrt.approx.ftz.f32', ptx)
+
+
+@skip_on_cudasim('Compilation unsupported in the simulator')
+class TestCompileToPTXForCurrentDevice(CUDATestCase):
+    def test_compile_ptx_for_current_device(self):
+        def add(x, y):
+            return x + y
+
+        args = (float32, float32)
+        ptx, resty = compile_ptx_for_current_device(add, args, device=True)
+
+        # Check we target the current device's compute capability, or the
+        # closest compute capability supported by the current toolkit.
+        device_cc = cuda.get_current_device().compute_capability
+        cc = cuda.cudadrv.nvvm.find_closest_arch(device_cc)
+        target = f'.target sm_{cc[0]}{cc[1]}'
+        self.assertIn(target, ptx)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_sm_creation.py
+++ b/numba/cuda/tests/cudapy/test_sm_creation.py
@@ -73,10 +73,11 @@ class TestSharedMemoryCreation(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             cuda.jit((float32[:, :],))(udt_global_build_list)
 
-        self.assertIn("Invalid use of Function(<function shared.array",
+        self.assertIn("No implementation of function "
+                      "Function(<function shared.array",
                       str(raises.exception))
-        self.assertIn("with argument(s) of type(s): "
-                      "(dtype=class(float32), shape=list(int64)",
+        self.assertIn("found for signature:\n \n "
+                      ">>> array(shape=list(int64), dtype=class(float32)",
                       str(raises.exception))
 
     def test_global_constant_tuple(self):
@@ -89,10 +90,11 @@ class TestSharedMemoryCreation(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             cuda.jit((float32[:],))(udt_invalid_1)
 
-        self.assertIn("Invalid use of Function(<function shared.array",
+        self.assertIn("No implementation of function "
+                      "Function(<function shared.array",
                       str(raises.exception))
-        self.assertIn("with argument(s) of type(s): "
-                      "(dtype=class(float32), shape=float32)",
+        self.assertIn("found for signature:\n \n "
+                      ">>> array(shape=float32, dtype=class(float32))",
                       str(raises.exception))
 
     @skip_on_cudasim("Can't check for constants in simulator")
@@ -101,10 +103,12 @@ class TestSharedMemoryCreation(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             cuda.jit((float32[:, :],))(udt_invalid_2)
 
-        self.assertIn("Invalid use of Function(<function shared.array",
+        self.assertIn("No implementation of function "
+                      "Function(<function shared.array",
                       str(raises.exception))
-        self.assertIn("with argument(s) of type(s): (dtype=class(float32), "
-                      "shape=Tuple(Literal[int](1), array(float32, 1d, A)))",
+        self.assertIn("found for signature:\n \n "
+                      ">>> array(shape=Tuple(Literal[int](1), "
+                      "array(float32, 1d, A)), dtype=class(float32))",
                       str(raises.exception))
 
     @skip_on_cudasim("Can't check for constants in simulator")
@@ -113,10 +117,11 @@ class TestSharedMemoryCreation(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             cuda.jit((int32[:],))(udt_invalid_1)
 
-        self.assertIn("Invalid use of Function(<function shared.array",
+        self.assertIn("No implementation of function "
+                      "Function(<function shared.array",
                       str(raises.exception))
-        self.assertIn("with argument(s) of type(s): "
-                      "(dtype=class(float32), shape=int32)",
+        self.assertIn("found for signature:\n \n "
+                      ">>> array(shape=int32, dtype=class(float32))",
                       str(raises.exception))
 
     @skip_on_cudasim("Can't check for constants in simulator")
@@ -125,10 +130,12 @@ class TestSharedMemoryCreation(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             cuda.jit((int32[:],))(udt_invalid_3)
 
-        self.assertIn("Invalid use of Function(<function shared.array",
+        self.assertIn("No implementation of function "
+                      "Function(<function shared.array",
                       str(raises.exception))
-        self.assertIn("with argument(s) of type(s): (dtype=class(float32), "
-                      "shape=Tuple(Literal[int](1), int32))",
+        self.assertIn("found for signature:\n \n "
+                      ">>> array(shape=Tuple(Literal[int](1), int32), "
+                      "dtype=class(float32))",
                       str(raises.exception))
 
 

--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -179,16 +179,19 @@ def register_class_type(cls, spec, class_ctor, builder):
     for basecls in reversed(inspect.getmro(cls)):
         clsdct.update(basecls.__dict__)
 
-    methods = dict((k, v) for k, v in clsdct.items()
-                   if isinstance(v, pytypes.FunctionType))
-    props = dict((k, v) for k, v in clsdct.items()
-                 if isinstance(v, property))
-
-    others = dict((k, v) for k, v in clsdct.items()
-                  if k not in methods and k not in props)
+    methods, props, static_methods, others = {}, {}, {}, {}
+    for k, v in clsdct.items():
+        if isinstance(v, pytypes.FunctionType):
+            methods[k] = v
+        elif isinstance(v, property):
+            props[k] = v
+        elif isinstance(v, staticmethod):
+            static_methods[k] = v
+        else:
+            others[k] = v
 
     # Check for name shadowing
-    shadowed = (set(methods) | set(props)) & set(spec)
+    shadowed = (set(methods) | set(props) | set(static_methods)) & set(spec)
     if shadowed:
         raise NameError("name shadowing: {0}".format(', '.join(shadowed)))
 
@@ -203,25 +206,32 @@ def register_class_type(cls, spec, class_ctor, builder):
         if v.fdel is not None:
             raise TypeError("deleter is not supported: {0}".format(k))
 
-    jitmethods = {}
-    for k, v in methods.items():
-        jitmethods[k] = njit(v)
+    jit_methods = {k: njit(v) for k, v in methods.items()}
 
-    jitprops = {}
+    jit_props = {}
     for k, v in props.items():
         dct = {}
         if v.fget:
             dct['get'] = njit(v.fget)
         if v.fset:
             dct['set'] = njit(v.fset)
-        jitprops[k] = dct
+        jit_props[k] = dct
+
+    jit_static_methods = {
+        k: njit(v.__func__) for k, v in static_methods.items()}
 
     # Instantiate class type
-    class_type = class_ctor(cls, ConstructorTemplate, spec, jitmethods,
-                            jitprops)
+    class_type = class_ctor(
+        cls,
+        ConstructorTemplate,
+        spec,
+        jit_methods,
+        jit_props,
+        jit_static_methods)
 
-    cls = JitClassType(cls.__name__, (cls,), dict(class_type=class_type,
-                                                  __doc__=docstring))
+    jit_class_dct = dict(class_type=class_type, __doc__=docstring)
+    jit_class_dct.update(jit_static_methods)
+    cls = JitClassType(cls.__name__, (cls,), jit_class_dct)
 
     # Register resolution of the class object
     typingctx = cpu_target.typing_context
@@ -229,7 +239,7 @@ def register_class_type(cls, spec, class_ctor, builder):
 
     # Register class
     targetctx = cpu_target.target_context
-    builder(class_type, methods, typingctx, targetctx).register()
+    builder(class_type, typingctx, targetctx).register()
 
     return cls
 
@@ -242,7 +252,7 @@ class ConstructorTemplate(templates.AbstractTemplate):
     def generic(self, args, kws):
         # Redirect resolution to __init__
         instance_type = self.key.instance_type
-        ctor = instance_type.jitmethods['__init__']
+        ctor = instance_type.jit_methods['__init__']
         boundargs = (instance_type.get_reference_type(),) + args
         disp_type = types.Dispatcher(ctor)
         sig = disp_type.get_call_type(self.context, boundargs, kws)
@@ -284,9 +294,8 @@ class ClassBuilder(object):
     class_impl_registry = imputils.Registry()
     implemented_methods = set()
 
-    def __init__(self, class_type, methods, typingctx, targetctx):
+    def __init__(self, class_type, typingctx, targetctx):
         self.class_type = class_type
-        self.methods = methods
         self.typingctx = typingctx
         self.targetctx = targetctx
 
@@ -303,9 +312,14 @@ class ClassBuilder(object):
 
     def _register_methods(self, registry, instance_type):
         """
-        Register method implementations for the given instance type.
+        Register method implementations.
+        This simply registers that the method names are valid methods.  Inside
+        of imp() below we retrieve the actual method to run from the type of
+        the reciever argument (i.e. self).
         """
-        for meth in instance_type.jitmethods:
+        to_register = list(instance_type.jit_methods) + \
+            list(instance_type.jit_static_methods)
+        for meth in to_register:
 
             # There's no way to retrieve the particular method name
             # inside the implementation function, so we have to register a
@@ -319,7 +333,16 @@ class ClassBuilder(object):
         def get_imp():
             def imp(context, builder, sig, args):
                 instance_type = sig.args[0]
-                method = instance_type.jitmethods[attr]
+
+                if attr in instance_type.jit_methods:
+                    method = instance_type.jit_methods[attr]
+                elif attr in instance_type.jit_static_methods:
+                    method = instance_type.jit_static_methods[attr]
+                    # imp gets called as a method, where the first argument is
+                    # self.  We drop this for a static method.
+                    sig = sig.replace(args=sig.args[1:])
+                    args = args[1:]
+
                 disp_type = types.Dispatcher(method)
                 call = context.get_function(disp_type, sig)
                 out = call(builder, args)
@@ -337,8 +360,8 @@ class ClassBuilder(object):
                 def generic(self, args, kws):
                     instance = args[0]
                     if isinstance(instance, types.ClassInstanceType) and \
-                            _dunder_meth in instance.jitmethods:
-                        meth = instance.jitmethods[_dunder_meth]
+                            _dunder_meth in instance.jit_methods:
+                        meth = instance.jit_methods[_dunder_meth]
                         disp_type = types.Dispatcher(meth)
                         sig = disp_type.get_call_type(self.context, args, kws)
                         return sig
@@ -370,9 +393,9 @@ class ClassAttribute(templates.AttributeTemplate):
             # It's a struct field => the type is well-known
             return instance.struct[attr]
 
-        elif attr in instance.jitmethods:
+        elif attr in instance.jit_methods:
             # It's a jitted method => typeinfer it
-            meth = instance.jitmethods[attr]
+            meth = instance.jit_methods[attr]
             disp_type = types.Dispatcher(meth)
 
             class MethodTemplate(templates.AbstractTemplate):
@@ -385,9 +408,29 @@ class ClassAttribute(templates.AttributeTemplate):
 
             return types.BoundFunction(MethodTemplate, instance)
 
-        elif attr in instance.jitprops:
+        elif attr in instance.jit_static_methods:
+            # It's a jitted method => typeinfer it
+            meth = instance.jit_static_methods[attr]
+            disp_type = types.Dispatcher(meth)
+
+            class StaticMethodTemplate(templates.AbstractTemplate):
+                key = (self.key, attr)
+
+                def generic(self, args, kws):
+                    # Don't add instance as the first argument for a static
+                    # method.
+                    sig = disp_type.get_call_type(self.context, args, kws)
+                    # sig itself does not include ClassInstanceType as it's
+                    # first argument, so instead of calling sig.as_method()
+                    # we insert the recvr. This is equivalent to
+                    # sig.replace(args=(instance,) + sig.args).as_method().
+                    return sig.replace(recvr=instance)
+
+            return types.BoundFunction(StaticMethodTemplate, instance)
+
+        elif attr in instance.jit_props:
             # It's a jitted property => typeinfer its getter
-            impdct = instance.jitprops[attr]
+            impdct = instance.jit_props[attr]
             getter = impdct['get']
             disp_type = types.Dispatcher(getter)
             sig = disp_type.get_call_type(self.context, (instance,), {})
@@ -408,9 +451,9 @@ def get_attr_impl(context, builder, typ, value, attr):
         return imputils.impl_ret_borrowed(context, builder,
                                           typ.struct[attr],
                                           getattr(data, _mangle_attr(attr)))
-    elif attr in typ.jitprops:
+    elif attr in typ.jit_props:
         # It's a jitted property
-        getter = typ.jitprops[attr]['get']
+        getter = typ.jit_props[attr]['get']
         sig = templates.signature(None, typ)
         dispatcher = types.Dispatcher(getter)
         sig = dispatcher.get_call_type(context.typing_context, [typ], {})
@@ -448,9 +491,9 @@ def set_attr_impl(context, builder, sig, args, attr):
         # Delete old value
         context.nrt.decref(builder, attr_type, oldvalue)
 
-    elif attr in typ.jitprops:
+    elif attr in typ.jit_props:
         # It's a jitted property
-        setter = typ.jitprops[attr]['set']
+        setter = typ.jit_props[attr]['set']
         disp_type = types.Dispatcher(setter)
         sig = disp_type.get_call_type(context.typing_context,
                                       (typ, valty), {})
@@ -520,7 +563,7 @@ def ctor_impl(context, builder, sig, args):
     # TODO: extract the following into a common util
     init_sig = (sig.return_type,) + sig.args
 
-    init = inst_typ.jitmethods['__init__']
+    init = inst_typ.jit_methods['__init__']
     disp_type = types.Dispatcher(init)
     call = context.get_function(disp_type, types.void(*init_sig))
     _add_linking_libs(context, call)

--- a/numba/experimental/jitclass/boxing.py
+++ b/numba/experimental/jitclass/boxing.py
@@ -84,7 +84,7 @@ def _specialize_box(typ):
         setter = _generate_setter(field)
         dct[field] = property(getter, setter)
     # Inject properties as class properties
-    for field, impdct in typ.jitprops.items():
+    for field, impdct in typ.jit_props.items():
         getter = None
         setter = None
         if 'get' in impdct:
@@ -101,6 +101,11 @@ def _specialize_box(typ):
                 (not (name.startswith('__') and name.endswith('__'))):
 
             dct[name] = _generate_method(name, func)
+
+    # Inject static methods as class members
+    for name, func in typ.static_methods.items():
+        dct[name] = _generate_method(name, func)
+
     # Create subclass
     subcls = type(typ.classname, (_box.Box,), dct)
     # Store to cache

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -403,12 +403,12 @@ def get_sysinfo():
         sys_info[_hsa_agents_count] = len(hsa.agents)
         agents = []
         for i, agent in enumerate(hsa.agents):
-            agents += {
+            agents.append({
                 'Agent id': i,
                 'Vendor': decode(agent.vendor_name),
                 'Name': decode(agent.name),
                 'Type': agent.device,
-            }
+            })
         sys_info[_hsa_agents] = agents
 
         _dgpus = []

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3443,10 +3443,13 @@ def validate_1d_array_like(func_name, seq):
 
 
 @overload(np.bincount)
-def np_bincount(a, weights=None):
+def np_bincount(a, weights=None, minlength=0):
     validate_1d_array_like("bincount", a)
+
     if not isinstance(a.dtype, types.Integer):
         return
+
+    _check_is_integer(minlength, 'minlength')
 
     if weights not in (None, types.none):
         validate_1d_array_like("bincount", weights)
@@ -3455,7 +3458,7 @@ def np_bincount(a, weights=None):
         out_dtype = np.float64
 
         @register_jitable
-        def validate_inputs(a, weights):
+        def validate_inputs(a, weights, minlength):
             if len(a) != len(weights):
                 raise ValueError("bincount(): weights and list don't have "
                                  "the same length")
@@ -3468,17 +3471,19 @@ def np_bincount(a, weights=None):
         out_dtype = types.intp
 
         @register_jitable
-        def validate_inputs(a, weights):
+        def validate_inputs(a, weights, minlength):
             pass
 
         @register_jitable
         def count_item(out, idx, val, weights):
             out[val] += 1
 
-    def bincount_impl(a, weights=None):
-        validate_inputs(a, weights)
-        n = len(a)
+    def bincount_impl(a, weights=None, minlength=0):
+        validate_inputs(a, weights, minlength)
+        if minlength < 0:
+            raise ValueError("'minlength' must not be negative")
 
+        n = len(a)
         a_max = a[0] if n > 0 else -1
         for i in range(1, n):
             if a[i] < 0:
@@ -3486,7 +3491,8 @@ def np_bincount(a, weights=None):
                                  "non-negative")
             a_max = max(a_max, a[i])
 
-        out = np.zeros(a_max + 1, out_dtype)
+        out_length = max(a_max + 1, minlength)
+        out = np.zeros(out_length, out_dtype)
         for i in range(n):
             count_item(out, i, a[i], weights)
         return out

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -450,6 +450,19 @@ def zero_dim_msg(fn_name):
     return msg
 
 
+def _is_nat(x):
+    pass
+
+
+@overload(_is_nat)
+def ol_is_nat(x):
+    if numpy_version >= (1, 18):
+        return lambda x: np.isnat(x)
+    else:
+        nat = x('NaT')
+        return lambda x: x == nat
+
+
 @lower_builtin(np.min, types.Array)
 @lower_builtin("array.min", types.Array)
 def array_min(context, builder, sig, args):
@@ -457,25 +470,26 @@ def array_min(context, builder, sig, args):
     MSG = zero_dim_msg('minimum')
 
     if isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
-        # NaT is smaller than every other value, but it is
+        # NP < 1.18: NaT is smaller than every other value, but it is
         # ignored as far as min() is concerned.
-        nat = ty('NaT')
-
+        # NP >= 1.18: NaT dominates like NaN
         def array_min_impl(arry):
             if arry.size == 0:
                 raise ValueError(MSG)
 
-            min_value = nat
             it = np.nditer(arry)
-            for view in it:
-                v = view.item()
-                if v != nat:
-                    min_value = v
-                    break
+            min_value = next(it).take(0)
+            if _is_nat(min_value):
+                return min_value
 
             for view in it:
                 v = view.item()
-                if v != nat and v < min_value:
+                if _is_nat(v):
+                    if numpy_version >= (1, 18):
+                        return v
+                    else:
+                        continue
+                if v < min_value:
                     min_value = v
             return min_value
 
@@ -494,6 +508,24 @@ def array_min(context, builder, sig, args):
                 elif v.real == min_value.real:
                     if v.imag < min_value.imag:
                         min_value = v
+            return min_value
+
+    elif isinstance(ty, types.Float):
+        def array_min_impl(arry):
+            if arry.size == 0:
+                raise ValueError(MSG)
+
+            it = np.nditer(arry)
+            min_value = next(it).take(0)
+            if np.isnan(min_value):
+                return min_value
+
+            for view in it:
+                v = view.item()
+                if np.isnan(v):
+                    return v
+                if v < min_value:
+                    min_value = v
             return min_value
 
     else:
@@ -520,7 +552,31 @@ def array_max(context, builder, sig, args):
     ty = sig.args[0].dtype
     MSG = zero_dim_msg('maximum')
 
-    if isinstance(ty, types.Complex):
+    if isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
+        # NP < 1.18: NaT is smaller than every other value, but it is
+        # ignored as far as min() is concerned.
+        # NP >= 1.18: NaT dominates like NaN
+        def array_max_impl(arry):
+            if arry.size == 0:
+                raise ValueError(MSG)
+
+            it = np.nditer(arry)
+            max_value = next(it).take(0)
+            if _is_nat(max_value):
+                return max_value
+
+            for view in it:
+                v = view.item()
+                if _is_nat(v):
+                    if numpy_version >= (1, 18):
+                        return v
+                    else:
+                        continue
+                if v > max_value:
+                    max_value = v
+            return max_value
+
+    elif isinstance(ty, types.Complex):
         def array_max_impl(arry):
             if arry.size == 0:
                 raise ValueError(MSG)
@@ -536,6 +592,25 @@ def array_max(context, builder, sig, args):
                     if v.imag > max_value.imag:
                         max_value = v
             return max_value
+
+    elif isinstance(ty, types.Float):
+        def array_max_impl(arry):
+            if arry.size == 0:
+                raise ValueError(MSG)
+
+            it = np.nditer(arry)
+            max_value = next(it).take(0)
+            if np.isnan(max_value):
+                return max_value
+
+            for view in it:
+                v = view.item()
+                if np.isnan(v):
+                    return v
+                if v > max_value:
+                    max_value = v
+            return max_value
+
     else:
         def array_max_impl(arry):
             if arry.size == 0:
@@ -560,27 +635,46 @@ def array_argmin(context, builder, sig, args):
     ty = sig.args[0].dtype
 
     if (isinstance(ty, (types.NPDatetime, types.NPTimedelta))):
-        # NaT is smaller than every other value, but it is
-        # ignored as far as argmin() is concerned.
-        nat = ty('NaT')
-
         def array_argmin_impl(arry):
             if arry.size == 0:
                 raise ValueError("attempt to get argmin of an empty sequence")
-            min_value = nat
+            it = np.nditer(arry)
+            min_value = next(it).take(0)
             min_idx = 0
-            it = arry.flat
-            idx = 0
-            for v in it:
-                if v != nat:
+            if _is_nat(min_value):
+                return min_idx
+
+            idx = 1
+            for view in it:
+                v = view.item()
+                if _is_nat(v):
+                    if numpy_version >= (1, 18):
+                        return idx
+                    else:
+                        idx += 1
+                        continue
+                if v < min_value:
                     min_value = v
                     min_idx = idx
-                    idx += 1
-                    break
                 idx += 1
+            return min_idx
 
-            for v in it:
-                if v != nat and v < min_value:
+    elif isinstance(ty, types.Float):
+        def array_argmin_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmin of an empty sequence")
+            for v in arry.flat:
+                min_value = v
+                min_idx = 0
+                break
+            if np.isnan(min_value):
+                return min_idx
+
+            idx = 0
+            for v in arry.flat:
+                if np.isnan(v):
+                    return idx
+                if v < min_value:
                     min_value = v
                     min_idx = idx
                 idx += 1
@@ -611,23 +705,70 @@ def array_argmin(context, builder, sig, args):
 @lower_builtin(np.argmax, types.Array)
 @lower_builtin("array.argmax", types.Array)
 def array_argmax(context, builder, sig, args):
-    def array_argmax_impl(arry):
-        if arry.size == 0:
-            raise ValueError("attempt to get argmax of an empty sequence")
-        for v in arry.flat:
-            max_value = v
-            max_idx = 0
-            break
-        else:
-            raise RuntimeError('unreachable')
+    ty = sig.args[0].dtype
 
-        idx = 0
-        for v in arry.flat:
-            if v > max_value:
+    if (isinstance(ty, (types.NPDatetime, types.NPTimedelta))):
+        def array_argmax_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmax of an empty sequence")
+            it = np.nditer(arry)
+            max_value = next(it).take(0)
+            max_idx = 0
+            if _is_nat(max_value):
+                return max_idx
+
+            idx = 1
+            for view in it:
+                v = view.item()
+                if _is_nat(v):
+                    if numpy_version >= (1, 18):
+                        return idx
+                    else:
+                        idx += 1
+                        continue
+                if v > max_value:
+                    max_value = v
+                    max_idx = idx
+                idx += 1
+            return max_idx
+
+    elif isinstance(ty, types.Float):
+        def array_argmax_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmax of an empty sequence")
+            for v in arry.flat:
                 max_value = v
-                max_idx = idx
-            idx += 1
-        return max_idx
+                max_idx = 0
+                break
+            if np.isnan(max_value):
+                return max_idx
+
+            idx = 0
+            for v in arry.flat:
+                if np.isnan(v):
+                    return idx
+                if v > max_value:
+                    max_value = v
+                    max_idx = idx
+                idx += 1
+            return max_idx
+
+    else:
+        def array_argmax_impl(arry):
+            if arry.size == 0:
+                raise ValueError("attempt to get argmax of an empty sequence")
+            for v in arry.flat:
+                max_value = v
+                max_idx = 0
+                break
+
+            idx = 0
+            for v in arry.flat:
+                if v > max_value:
+                    max_value = v
+                    max_idx = idx
+                idx += 1
+            return max_idx
     res = context.compile_internal(builder, array_argmax_impl, sig, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
@@ -2644,19 +2785,38 @@ def np_corrcoef(x, y=None, rowvar=True):
 #----------------------------------------------------------------------------
 # Element-wise computations
 
+
 @overload(np.argwhere)
 def np_argwhere(a):
+    # needs to be much more array-like for the array impl to work, Numba bug
+    # in one of the underlying function calls?
 
-    if type_can_asarray(a):
+    use_scalar = (numpy_version >= (1, 18) and
+                  isinstance(a, (types.Number, types.Boolean)))
+    if type_can_asarray(a) and not use_scalar:
+        if numpy_version < (1, 18):
+            check = register_jitable(lambda x: not np.any(x))
+        else:
+            check = register_jitable(lambda x: True)
+
         def impl(a):
             arr = np.asarray(a)
+            if arr.shape == () and check(arr):
+                return np.zeros((0, 1), dtype=types.intp)
             return np.transpose(np.vstack(np.nonzero(arr)))
     else:
+        if numpy_version < (1, 18):
+            falseish = (0, 1)
+            trueish = (1, 1)
+        else:
+            falseish = (0, 0)
+            trueish = (1, 0)
+
         def impl(a):
             if a is not None and bool(a):
-                return np.zeros((1, 1), dtype=types.intp)
+                return np.zeros(trueish, dtype=types.intp)
             else:
-                return np.zeros((0, 1), dtype=types.intp)
+                return np.zeros(falseish, dtype=types.intp)
 
     return impl
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -122,13 +122,14 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
 
 def np_int_sdiv_impl(context, builder, sig, args):
     # based on the actual code in NumPy loops.c.src for signed integer types
-    num, den = args
-    lltype = num.type
-    assert all(i.type==lltype for i in args), "must have homogeneous types"
+    _check_arity_and_homogeneity(sig, args, 2)
 
-    ZERO = lc.Constant.int(lltype, 0)
-    MINUS_ONE = lc.Constant.int(lltype, -1)
-    MIN_INT = lc.Constant.int(lltype, 1 << (den.type.width-1))
+    num, den = args
+    ty = sig.args[0]  # any arg type will do, homogeneous
+
+    ZERO = context.get_constant(ty, 0)
+    MINUS_ONE = context.get_constant(ty, -1)
+    MIN_INT = context.get_constant(ty, 1 << (den.type.width-1))
     den_is_zero = builder.icmp(lc.ICMP_EQ, ZERO, den)
     den_is_minus_one = builder.icmp(lc.ICMP_EQ, MINUS_ONE, den)
     num_is_min_int = builder.icmp(lc.ICMP_EQ, MIN_INT, num)
@@ -149,7 +150,7 @@ def np_int_sdiv_impl(context, builder, sig, args):
             fix_value = builder.select(needs_fixing, MINUS_ONE, ZERO)
             result_otherwise = builder.add(div, fix_value)
 
-    result = builder.phi(lltype)
+    result = builder.phi(ZERO.type)
     result.add_incoming(ZERO, bb_then)
     result.add_incoming(result_otherwise, bb_otherwise)
 
@@ -161,8 +162,7 @@ def np_int_srem_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     num, den = args
-    ty = sig.args[0] # any arg type will do, homogeneous
-    lty = num.type
+    ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
     den_not_zero = builder.icmp(lc.ICMP_NE, ZERO, den)
@@ -178,7 +178,7 @@ def np_int_srem_impl(context, builder, sig, args):
         fix_value = builder.select(needs_fixing, den, ZERO)
         final_mod = builder.add(fix_value, mod)
 
-    result = builder.phi(lty)
+    result = builder.phi(ZERO.type)
     result.add_incoming(ZERO, bb_no_if)
     result.add_incoming(final_mod, bb_if)
 
@@ -186,11 +186,12 @@ def np_int_srem_impl(context, builder, sig, args):
 
 
 def np_int_udiv_impl(context, builder, sig, args):
-    num, den = args
-    lltype = num.type
-    assert all(i.type==lltype for i in args), "must have homogeneous types"
+    _check_arity_and_homogeneity(sig, args, 2)
 
-    ZERO = lc.Constant.int(lltype, 0)
+    num, den = args
+    ty = sig.args[0]  # any arg type will do, homogeneous
+
+    ZERO = context.get_constant(ty, 0)
     div_by_zero = builder.icmp(lc.ICMP_EQ, ZERO, den)
     with builder.if_else(div_by_zero, likely=False) as (then, otherwise):
         with then:
@@ -201,7 +202,7 @@ def np_int_udiv_impl(context, builder, sig, args):
             div = builder.udiv(num, den)
             bb_otherwise = builder.basic_block
 
-    result = builder.phi(lltype)
+    result = builder.phi(ZERO.type)
     result.add_incoming(ZERO, bb_then)
     result.add_incoming(div, bb_otherwise)
     return result
@@ -212,8 +213,7 @@ def np_int_urem_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     num, den = args
-    ty = sig.args[0] # any arg type will do, homogeneous
-    lty = num.type
+    ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
     den_not_zero = builder.icmp(lc.ICMP_NE, ZERO, den)
@@ -222,7 +222,7 @@ def np_int_urem_impl(context, builder, sig, args):
         bb_if = builder.basic_block
         mod = builder.urem(num,den)
 
-    result = builder.phi(lty)
+    result = builder.phi(ZERO.type)
     result.add_incoming(ZERO, bb_no_if)
     result.add_incoming(mod, bb_if)
 

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -176,10 +176,11 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where='input operand'):
         return _ArrayHelper(ctxt, bld, shape, strides, ary.data,
                             tyinp.layout, tyinp.dtype, tyinp.ndim, inp)
     elif (types.unliteral(tyinp) in types.number_domain | {types.boolean}
-          or isinstance(tyinp, types.NPTimedelta)):
+          or isinstance(tyinp, types.scalars._NPDatetimeBase)):
         return _ScalarHelper(ctxt, bld, inp, tyinp)
     else:
-        raise NotImplementedError('unsupported type for {0}: {1}'.format(where, str(tyinp)))
+        raise NotImplementedError('unsupported type for {0}: {1}'.format(where,
+                                  str(tyinp)))
 
 
 _broadcast_onto_sig = types.intp(types.intp, types.CPointer(types.intp),

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -382,7 +382,7 @@ def ufunc_find_matching_loop(ufunc, arg_types):
                   for letter in ufunc_letters[len(numba_types):]]
         return types
 
-    def set_output_dt_units(inputs, outputs):
+    def set_output_dt_units(inputs, outputs, ufunc_inputs):
         """
         Sets the output unit of a datetime type based on the input units
 
@@ -391,25 +391,46 @@ def ufunc_find_matching_loop(ufunc, arg_types):
         leads to an output of timedelta output. However, for those that do,
         the unit of output must be inferred based on the units of the inputs.
 
-        At the moment this function takes care of the case where all
-        inputs have the same unit, and therefore the output unit has the same.
-        If in the future this should be extended to a case with mixed units,
+        At the moment this function takes care of two cases:
+        a) where all inputs are timedelta with the same unit (mm), and
+        therefore the output has the same unit.
+        This case is used for arr.sum, and for arr1+arr2 where all arrays
+        are timedeltas.
+        If in the future this needs to be extended to a case with mixed units,
         the rules should be implemented in `npdatetime_helpers` and called
         from this function to set the correct output unit.
+        b) where left operand is a timedelta, i.e. the "m?" case. This case
+        is used for division, eg timedelta / int.
+
+        At the time of writing, Numba does not support addition of timedelta
+        and other types, so this function does not consider the case "?m",
+        i.e. where timedelta is the right operand to a non-timedelta left
+        operand. To extend it in the future, just add another elif clause.
         """
-        if all(inp.unit == inputs[0].unit for inp in inputs):
-            # Case with operation on same units. Operations on different units
-            # not adjusted for now but might need to be added in the future
-            unit = inputs[0].unit
+        def make_specific(outputs, unit):
             new_outputs = []
             for out in outputs:
                 if isinstance(out, types.NPTimedelta) and out.unit == "":
                     new_outputs.append(types.NPTimedelta(unit))
                 else:
                     new_outputs.append(out)
-        else:
-            return outputs
-        return new_outputs
+            return new_outputs
+
+        if ufunc_inputs == 'mm':
+            if all(inp.unit == inputs[0].unit for inp in inputs):
+                # Case with operation on same units. Operations on different
+                # units not adjusted for now but might need to be
+                # added in the future
+                unit = inputs[0].unit
+                new_outputs = make_specific(outputs, unit)
+            else:
+                return outputs
+            return new_outputs
+        elif ufunc_inputs[0] == 'm':
+            # case where the left operand has timedelta type
+            unit = inputs[0].unit
+            new_outputs = make_specific(outputs, unit)
+            return new_outputs
 
     # In NumPy, the loops are evaluated from first to last. The first one
     # that is viable is the one used. One loop is viable if it is possible
@@ -452,8 +473,10 @@ def ufunc_find_matching_loop(ufunc, arg_types):
             try:
                 inputs = choose_types(input_types, ufunc_inputs)
                 outputs = choose_types(output_types, ufunc_outputs)
-                if ufunc_inputs == 'mm':
-                    outputs = set_output_dt_units(inputs, outputs)
+                # if the left operand or both are timedeltas, then the output
+                # units need to be determined.
+                if ufunc_inputs[0] == 'm':
+                    outputs = set_output_dt_units(inputs, outputs, ufunc_inputs)
 
             except NotImplementedError:
                 # One of the selected dtypes isn't supported by Numba

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -832,6 +832,12 @@ def _fill_ufunc_db(ufunc_db):
         '?->?': npyfuncs.np_int_isnan_impl,
     }
 
+    if numpy_version >= (1, 18):
+        ufunc_db[np.isnan].update({
+            'm->?': npyfuncs.np_datetime_isnat_impl,
+            'M->?': npyfuncs.np_datetime_isnat_impl,
+        })
+
     ufunc_db[np.isinf] = {
         'f->?': npyfuncs.np_real_isinf_impl,
         'd->?': npyfuncs.np_real_isinf_impl,
@@ -855,6 +861,12 @@ def _fill_ufunc_db(ufunc_db):
         # boolean
         '?->?': npyfuncs.np_int_isinf_impl,
     }
+
+    if numpy_version >= (1, 18):
+        ufunc_db[np.isinf].update({
+            'm->?': npyfuncs.np_int_isinf_impl,
+            'M->?': npyfuncs.np_int_isinf_impl,
+        })
 
     ufunc_db[np.isfinite] = {
         'f->?': npyfuncs.np_real_isfinite_impl,
@@ -1066,22 +1078,22 @@ def _fill_ufunc_db(ufunc_db):
         'mm->?': npdatetime.timedelta_ge_timedelta_impl,
     })
     ufunc_db[np.maximum].update({
-        'MM->M': npdatetime.datetime_max_impl,
-        'mm->m': npdatetime.timedelta_max_impl,
+        'MM->M': npdatetime.datetime_maximum_impl,
+        'mm->m': npdatetime.timedelta_maximum_impl,
     })
     ufunc_db[np.minimum].update({
-        'MM->M': npdatetime.datetime_min_impl,
-        'mm->m': npdatetime.timedelta_min_impl,
+        'MM->M': npdatetime.datetime_minimum_impl,
+        'mm->m': npdatetime.timedelta_minimum_impl,
     })
     # there is no difference for datetime/timedelta in maximum/fmax
     # and minimum/fmin
     ufunc_db[np.fmax].update({
-        'MM->M': npdatetime.datetime_max_impl,
-        'mm->m': npdatetime.timedelta_max_impl,
+        'MM->M': npdatetime.datetime_fmax_impl,
+        'mm->m': npdatetime.timedelta_fmax_impl,
     })
     ufunc_db[np.fmin].update({
-        'MM->M': npdatetime.datetime_min_impl,
-        'mm->m': npdatetime.timedelta_min_impl,
+        'MM->M': npdatetime.datetime_fmin_impl,
+        'mm->m': npdatetime.timedelta_fmin_impl,
     })
 
     if numpy_version >= (1, 16):

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -75,6 +75,24 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': numbers.complex_negate_impl,
     }
 
+    ufunc_db[np.positive] = {
+        '?->?': numbers.int_positive_impl,
+        'b->b': numbers.int_positive_impl,
+        'B->B': numbers.int_positive_impl,
+        'h->h': numbers.int_positive_impl,
+        'H->H': numbers.int_positive_impl,
+        'i->i': numbers.int_positive_impl,
+        'I->I': numbers.int_positive_impl,
+        'l->l': numbers.int_positive_impl,
+        'L->L': numbers.int_positive_impl,
+        'q->q': numbers.int_positive_impl,
+        'Q->Q': numbers.int_positive_impl,
+        'f->f': numbers.real_positive_impl,
+        'd->d': numbers.real_positive_impl,
+        'F->F': numbers.complex_positive_impl,
+        'D->D': numbers.complex_positive_impl,
+    }
+
     ufunc_db[np.absolute] = {
         '?->?': numbers.int_abs_impl,
         'b->b': numbers.int_abs_impl,
@@ -1009,6 +1027,9 @@ def _fill_ufunc_db(ufunc_db):
     from numba.np import npdatetime
     ufunc_db[np.negative].update({
         'm->m': npdatetime.timedelta_neg_impl,
+    })
+    ufunc_db[np.positive].update({
+        'm->m': npdatetime.timedelta_pos_impl,
     })
     ufunc_db[np.absolute].update({
         'm->m': npdatetime.timedelta_abs_impl,

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2807,8 +2807,19 @@ class ArrayAnalysis(object):
         tups = list(filter(lambda a: self._istuple(a.name), args))
         # Here we have a tuple concatenation.
         if len(tups) == 2 and fn.__name__ == 'add':
+            # If either of the tuples is empty then the resulting shape
+            # is just the other tuple.
+            tup0typ = self.typemap[tups[0].name]
+            tup1typ = self.typemap[tups[1].name]
+            if tup0typ.count == 0:
+                return (equiv_set.get_shape(tups[1]), [])
+            if tup1typ.count == 0:
+                return (equiv_set.get_shape(tups[0]), [])
+
             try:
                 shapes = [equiv_set.get_shape(x) for x in tups]
+                if None in shapes:
+                    return None
                 concat_shapes = sum(shapes, ())
                 return (concat_shapes, [])
             except GuardException:
@@ -2822,7 +2833,7 @@ class ArrayAnalysis(object):
         require(max_dim > 0)
         try:
             shapes = [equiv_set.get_shape(x) for x in arrs]
-        except errors.GuardException:
+        except GuardException:
             return (
                 arrs[0],
                 self._call_assert_equiv(scope, loc, equiv_set, arrs),

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2028,8 +2028,12 @@ class ArrayAnalysis(object):
                 expr.index_var = result[0]
             return result[1]
         shape = equiv_set._get_shape(var)
-        require(isinstance(expr.index, int) and expr.index < len(shape))
-        return shape[expr.index], []
+        if isinstance(expr.index, int):
+            require(expr.index < len(shape))
+            return shape[expr.index], []
+        elif isinstance(expr.index, slice):
+            return shape[expr.index], []
+        require(False)
 
     def _analyze_op_unary(self, scope, equiv_set, expr):
         require(expr.fn in UNARY_MAP_OP)
@@ -3000,7 +3004,7 @@ class ArrayAnalysis(object):
 
     def _istuple(self, varname):
         typ = self.typemap[varname]
-        return isinstance(typ, types.UniTuple)
+        return isinstance(typ, types.BaseTuple)
 
     def _sum_size(self, equiv_set, sizes):
         """Return the sum of the given list of sizes if they are all equivalent

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2042,18 +2042,18 @@ class ArrayAnalysis(object):
     def _analyze_op_binop(self, scope, equiv_set, expr):
         require(expr.fn in BINARY_MAP_OP)
         return self._analyze_broadcast(
-            scope, equiv_set, expr.loc, [expr.lhs, expr.rhs]
+            scope, equiv_set, expr.loc, [expr.lhs, expr.rhs], expr.fn
         )
 
     def _analyze_op_inplace_binop(self, scope, equiv_set, expr):
         require(expr.fn in INPLACE_BINARY_MAP_OP)
         return self._analyze_broadcast(
-            scope, equiv_set, expr.loc, [expr.lhs, expr.rhs]
+            scope, equiv_set, expr.loc, [expr.lhs, expr.rhs], expr.fn
         )
 
     def _analyze_op_arrayexpr(self, scope, equiv_set, expr):
         return self._analyze_broadcast(
-            scope, equiv_set, expr.loc, expr.list_vars()
+            scope, equiv_set, expr.loc, expr.list_vars(), expr.fn
         )
 
     def _analyze_op_build_tuple(self, scope, equiv_set, expr):
@@ -2110,7 +2110,7 @@ class ArrayAnalysis(object):
             ".", "_"
         )
         if fname in UFUNC_MAP_OP:  # known numpy ufuncs
-            return self._analyze_broadcast(scope, equiv_set, expr.loc, args)
+            return self._analyze_broadcast(scope, equiv_set, expr.loc, args, None)
         else:
             try:
                 fn = getattr(self, fname)
@@ -2793,11 +2793,21 @@ class ArrayAnalysis(object):
         require(len(args) >= 1)
         return equiv_set._get_shape(args[0]), []
 
-    def _analyze_broadcast(self, scope, equiv_set, loc, args):
+    def _analyze_broadcast(self, scope, equiv_set, loc, args, fn):
         """Infer shape equivalence of arguments based on Numpy broadcast rules
         and return shape of output
         https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html
         """
+        tups = list(filter(lambda a: self._istuple(a.name), args))
+        # Here we have a tuple concatenation.
+        if len(tups) == 2 and fn.__name__ == 'add':
+            try:
+                shapes = [equiv_set.get_shape(x) for x in tups]
+                concat_shapes = sum(shapes, ())
+                return (concat_shapes, [])
+            except errors.GuardException:
+                return None
+
         arrs = list(filter(lambda a: self._isarray(a.name), args))
         require(len(arrs) > 0)
         names = [x.name for x in arrs]
@@ -2986,6 +2996,10 @@ class ArrayAnalysis(object):
     def _isarray(self, varname):
         typ = self.typemap[varname]
         return isinstance(typ, types.npytypes.Array) and typ.ndim > 0
+
+    def _istuple(self, varname):
+        typ = self.typemap[varname]
+        return isinstance(typ, types.UniTuple)
 
     def _sum_size(self, equiv_set, sizes):
         """Return the sum of the given list of sizes if they are all equivalent

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -19,6 +19,7 @@ from numba.core.ir_utils import (
     find_const,
     is_namedtuple_class,
     build_definitions,
+    GuardException,
 )
 from numba.core.analysis import compute_cfg_from_blocks
 from numba.core.typing import npydecl, signature
@@ -2810,7 +2811,7 @@ class ArrayAnalysis(object):
                 shapes = [equiv_set.get_shape(x) for x in tups]
                 concat_shapes = sum(shapes, ())
                 return (concat_shapes, [])
-            except errors.GuardException:
+            except GuardException:
                 return None
 
         arrs = list(filter(lambda a: self._isarray(a.name), args))

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2110,7 +2110,8 @@ class ArrayAnalysis(object):
             ".", "_"
         )
         if fname in UFUNC_MAP_OP:  # known numpy ufuncs
-            return self._analyze_broadcast(scope, equiv_set, expr.loc, args, None)
+            return self._analyze_broadcast(scope, equiv_set,
+                                           expr.loc, args, None)
         else:
             try:
                 fn = getattr(self, fname)

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2053,7 +2053,7 @@ class ArrayAnalysis(object):
 
     def _analyze_op_arrayexpr(self, scope, equiv_set, expr):
         return self._analyze_broadcast(
-            scope, equiv_set, expr.loc, expr.list_vars(), expr.fn
+            scope, equiv_set, expr.loc, expr.list_vars(), None
         )
 
     def _analyze_op_build_tuple(self, scope, equiv_set, expr):

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1767,12 +1767,13 @@ class ConvertNumpyPass:
                         # only translate C order since we can't allocate F
                         if guard(self._is_supported_npycall, expr):
                             new_instr = self._numpy_to_parfor(equiv_set, lhs, expr)
-                            self.rewritten.append(dict(
-                                old=instr,
-                                new=new_instr,
-                                reason='numpy_allocator',
-                            ))
-                            instr = new_instr
+                            if new_instr is not None:
+                                self.rewritten.append(dict(
+                                    old=instr,
+                                    new=new_instr,
+                                    reason='numpy_allocator',
+                                ))
+                                instr = new_instr
                         elif isinstance(expr, ir.Expr) and expr.op == 'arrayexpr':
                             new_instr = self._arrayexpr_to_parfor(
                                 equiv_set, lhs, expr, avail_vars)
@@ -1881,6 +1882,11 @@ class ConvertNumpyPass:
 
         # generate loopnests and size variables from lhs correlations
         size_vars = equiv_set.get_shape(lhs)
+        if size_vars is None:
+            if config.DEBUG_ARRAY_OPT >= 1:
+                print("Could not convert numpy map to parfor, unknown size")
+            return None
+
         index_vars, loopnests = _mk_parfor_loops(pass_states.typemap, size_vars, scope, loc)
 
         # generate init block and body
@@ -1910,7 +1916,7 @@ class ConvertNumpyPass:
                 typing.Context(), new_arg_typs, new_kw_types)
             value = expr
         else:
-            NotImplementedError(
+            raise NotImplementedError(
                 "Map of numpy.{} to parfor is not implemented".format(call_name))
 
         value_assign = ir.Assign(value, expr_out_var, loc)
@@ -1992,6 +1998,9 @@ class ConvertReducePass:
 
         init_val = args[2]
         size_vars = equiv_set.get_shape(in_arr if mask_indices is None else mask_var)
+        if size_vars is None:
+            return None
+
         index_vars, loopnests = _mk_parfor_loops(pass_states.typemap, size_vars, scope, loc)
         mask_index = index_vars
         if mask_indices:

--- a/numba/runtests.py
+++ b/numba/runtests.py
@@ -1,4 +1,4 @@
-from numba.testing._runtests import _main, main
+from numba.testing._runtests import _main
 
 
 if __name__ == '__main__':

--- a/numba/tests/doc_examples/test_jitclass.py
+++ b/numba/tests/doc_examples/test_jitclass.py
@@ -1,0 +1,57 @@
+# Contents in this file are referenced from the sphinx-generated docs.
+# "magictoken" is used for markers as beginning and ending of example text.
+
+import unittest
+from numba.tests.support import TestCase
+
+
+class DocsJitclassUsageTest(TestCase):
+
+    def test_ex_jitclass(self):
+        # magictoken.ex_jitclass.begin
+        import numpy as np
+        from numba import int32, float32    # import the types
+        from numba.experimental import jitclass
+
+        spec = [
+            ('value', int32),               # a simple scalar field
+            ('array', float32[:]),          # an array field
+        ]
+
+        @jitclass(spec)
+        class Bag(object):
+            def __init__(self, value):
+                self.value = value
+                self.array = np.zeros(value, dtype=np.float32)
+
+            @property
+            def size(self):
+                return self.array.size
+
+            def increment(self, val):
+                for i in range(self.size):
+                    self.array[i] += val
+                return self.array
+
+            @staticmethod
+            def add(x, y):
+                return x + y
+
+        n = 21
+        mybag = Bag(n)
+        # magictoken.ex_jitclass.end
+
+        self.assertTrue(isinstance(mybag, Bag))
+        self.assertPreciseEqual(mybag.value, n)
+        np.testing.assert_allclose(mybag.array, np.zeros(n, dtype=np.float32))
+        self.assertPreciseEqual(mybag.size, n)
+        np.testing.assert_allclose(mybag.increment(3),
+                                   3 * np.ones(n, dtype=np.float32))
+        np.testing.assert_allclose(mybag.increment(6),
+                                   9 * np.ones(n, dtype=np.float32))
+        self.assertPreciseEqual(mybag.add(1, 1), 2)
+        self.assertPreciseEqual(Bag.add(1, 2), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/doc_examples/test_rec_array.py
+++ b/numba/tests/doc_examples/test_rec_array.py
@@ -1,0 +1,46 @@
+import unittest
+
+
+class TestExample(unittest.TestCase):
+
+    def test_documentation_example1(self):
+        # magictoken.ex_rec_arr_const_index.begin
+        import numpy as np
+        from numba import njit
+
+        arr = np.array([(1, 2)], dtype=[('a1', 'f8'), ('a2', 'f8')])
+        fields_gl = ('a1', 'a2')
+
+        @njit
+        def get_field_sum(rec):
+            fields_lc = ('a1', 'a2')
+            field_name1 = fields_lc[0]
+            field_name2 = fields_gl[1]
+            return rec[field_name1] + rec[field_name2]
+
+        get_field_sum(arr[0])  # returns 3
+        # magictoken.ex_rec_arr_const_index.end
+        self.assertEqual(get_field_sum(arr[0]), 3)
+
+    def test_documentation_example2(self):
+        # magictoken.ex_rec_arr_lit_unroll_index.begin
+        import numpy as np
+        from numba import njit, literal_unroll
+
+        arr = np.array([(1, 2)], dtype=[('a1', 'f8'), ('a2', 'f8')])
+        fields_gl = ('a1', 'a2')
+
+        @njit
+        def get_field_sum(rec):
+            out = 0
+            for f in literal_unroll(fields_gl):
+                out += rec[f]
+            return out
+
+        get_field_sum(arr[0])   # returns 3
+        # magictoken.ex_rec_arr_lit_unroll_index.end
+        self.assertEqual(get_field_sum(arr[0]), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/error_usecases.py
+++ b/numba/tests/error_usecases.py
@@ -1,4 +1,6 @@
 import numba as nb
+
+
 @nb.jit(nopython=True, parallel=True)
 def foo():
     pass

--- a/numba/tests/inlining_usecases.py
+++ b/numba/tests/inlining_usecases.py
@@ -12,6 +12,7 @@ def bar():
 
 def baz_factory(a):
     b = 17 + a
+
     @njit(inline='always')
     def baz():
         return _GLOBAL1 + a - b

--- a/numba/tests/npyufunc/test_dufunc.py
+++ b/numba/tests/npyufunc/test_dufunc.py
@@ -33,6 +33,7 @@ class TestDUFunc(MemoryLeakMixin, unittest.TestCase):
 
     def test_npm_call(self):
         duadd = self.nopython_dufunc(pyuadd)
+
         @njit
         def npmadd(a0, a1, o0):
             duadd(a0, a1, o0)
@@ -54,6 +55,7 @@ class TestDUFunc(MemoryLeakMixin, unittest.TestCase):
 
     def test_npm_call_implicit_output(self):
         duadd = self.nopython_dufunc(pyuadd)
+
         @njit
         def npmadd(a0, a1):
             return duadd(a0, a1)

--- a/numba/tests/pycc_distutils_usecase/nested/source_module.py
+++ b/numba/tests/pycc_distutils_usecase/nested/source_module.py
@@ -7,10 +7,12 @@ cc = CC('pycc_compiled_module')
 
 _const = 42
 
+
 # This ones references a global variable at compile time
 @cc.export('get_const', 'i8()')
 def get_const():
     return _const
+
 
 # This one needs NRT and an environment
 @cc.export('ones', 'f8[:](i4)')

--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -531,7 +531,6 @@ class TestOptionals(MemoryLeakMixin, unittest.TestCase):
         self.assertTrue(isinstance(oty, types.Optional))
         self.assertTrue(isinstance(oty.type, types.Float))
 
-
     def test_optional_array_type(self):
 
         @njit

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -1003,7 +1003,6 @@ class TestArrayReductionsExceptions(MemoryLeakMixin, TestCase):
         with self.assertRaises(ValueError) as e:
             cfunc(self.zero_size)
         self.assertIn(msg, str(e.exception))
-        self.disable_leak_check()
 
     @classmethod
     def install(cls):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -209,6 +209,8 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         check(arr)
         arr = np.float64(['nan', -1.5, 2.5, 'nan', 'inf', '-inf', 3.0])
         check(arr)
+        arr = np.float64([5.0, 'nan', -1.5, 'nan'])
+        check(arr)
         # Only NaNs
         arr = np.float64(['nan', 'nan'])
         check(arr)
@@ -665,6 +667,15 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # Test with a NaT
         arr[arr.size // 2] = 'NaT'
         self.assertPreciseEqual(cfunc(arr), pyfunc(arr))
+        if 'median' not in pyfunc.__name__:
+            # Test with (val, NaT)^N (and with the random NaT from above)
+            # use a loop, there's some weird thing/bug with arr[1::2] = 'NaT'
+
+            # Further Numba has bug(s) relating to NaN/NaT handling in anything
+            # using a partition such as np.median
+            for x in range(1, len(arr), 2):
+                arr[x] = 'NaT'
+            self.assertPreciseEqual(cfunc(arr), pyfunc(arr))
         # Test with all NaTs
         arr.fill(arrty.dtype('NaT'))
         self.assertPreciseEqual(cfunc(arr), pyfunc(arr))

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -10,6 +10,7 @@ from numba.core.compiler import compile_isolated
 from numba import jit
 from numba.core import types, utils
 from numba.core.errors import TypingError, LoweringError
+from numba.core.types.functions import _header_lead
 from numba.tests.support import tag, _32bit, captured_stdout
 
 
@@ -347,7 +348,7 @@ class TestArrayComprehension(unittest.TestCase):
         # test is expected to fail
         with self.assertRaises(TypingError) as raises:
             self.check(comp_nest_with_dependency, 5)
-        self.assertIn('Invalid use of Function', str(raises.exception))
+        self.assertIn(_header_lead, str(raises.exception))
         self.assertIn('array(undefined,', str(raises.exception))
 
     def test_no_array_comp(self):
@@ -432,7 +433,7 @@ class TestArrayComprehension(unittest.TestCase):
             cfunc = jit(nopython=True)(array_comp)
             cfunc(10, 2.3j)
         self.assertIn(
-            "Invalid use of Function({})".format(operator.setitem),
+            _header_lead + " Function({})".format(operator.setitem),
             str(raises.exception),
         )
         self.assertIn(

--- a/numba/tests/test_conditions_as_predicates.py
+++ b/numba/tests/test_conditions_as_predicates.py
@@ -13,6 +13,7 @@ class TestConditionsAsPredicates(TestCase):
         for dt in dts:
             for c in 1, 0:
                 x = dt(c)
+
                 @njit
                 def foo():
                     if x:
@@ -21,6 +22,7 @@ class TestConditionsAsPredicates(TestCase):
                         return 20
                 self.assertEqual(foo(), foo.py_func())
                 self.assertEqual(foo(), 10 if c == 1 or dt is str else 20)
+
         # empty string
         @njit
         def foo(x):
@@ -164,7 +166,6 @@ class TestConditionsAsPredicates(TestCase):
         z = np.array(0)
         self.assertEqual(foo(z), foo.py_func(z))
         self.assertEqual(foo.py_func(z), 20)
-
         # non-empty nd True
         z = np.array([[[1]]])
         self.assertEqual(foo(z), foo.py_func(z))

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -220,7 +220,8 @@ class TestCTypesUseCases(MemoryLeakMixin, TestCase):
         # Non-compatible pointers are not accepted (here float32* vs. float64*)
         with self.assertRaises(errors.TypingError) as raises:
             cfunc(np.float32([0.0]))
-        self.assertIn("Invalid use of ExternalFunctionPointer",
+
+        self.assertIn("No implementation of function ExternalFunctionPointer",
                       str(raises.exception))
 
     def test_storing_voidptr_to_int_array(self):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -15,7 +15,7 @@ from io import StringIO
 
 import numpy as np
 
-from numba import jit, generated_jit, typeof
+from numba import njit, jit, generated_jit, typeof
 from numba.core import types, errors, codegen
 from numba import _dispatcher
 from numba.core.compiler import compile_isolated
@@ -26,7 +26,8 @@ from numba.tests.support import (TestCase, temp_directory, import_dynamic,
 from numba.np.numpy_support import as_dtype
 from numba.core.caching import _UserWideCacheLocator
 from numba.core.dispatcher import Dispatcher
-from numba.tests.support import skip_parfors_unsupported, needs_lapack
+from numba.tests.support import (skip_parfors_unsupported, needs_lapack,
+                                 SerialMixin)
 
 import llvmlite.binding as ll
 import unittest
@@ -1963,6 +1964,47 @@ class TestNoRetryFailedSignature(unittest.TestCase):
         # compilation.
         self.assertEqual(ct_ok, 1)
         self.assertEqual(ct_bad, 1)
+
+
+class TestMultiprocessingDefaultParameters(SerialMixin, unittest.TestCase):
+    def run_fc_multiproc(self, fc):
+        try:
+            ctx = multiprocessing.get_context('spawn')
+        except AttributeError:
+            ctx = multiprocessing
+        with ctx.Pool(1) as p:
+            self.assertEqual(p.map(fc, [1, 2, 3]), list(map(fc, [1, 2, 3])))
+
+    def test_int_def_param(self):
+        """ Tests issue #4888"""
+
+        @njit
+        def add(x, y=1):
+            return x + y
+
+        self.run_fc_multiproc(add)
+
+    def test_none_def_param(self):
+        """ Tests None as a default parameter"""
+
+        @njit
+        def add(x, y=None):
+            return x + (1 if y else 2)
+
+        self.run_fc_multiproc(add)
+
+    def test_function_def_param(self):
+        """ Tests a function as a default parameter"""
+
+        @njit
+        def mult(x, y):
+            return x * y
+
+        @njit
+        def add(x, func=mult):
+            return x + func(x, x)
+
+        self.run_fc_multiproc(add)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -594,6 +594,27 @@ class TestDispatcher(BaseTest):
         expected_sigs = [(types.complex128,)]
         self.assertEqual(jitfoo.signatures, expected_sigs)
 
+    def test_dispatcher_raises_for_invalid_decoration(self):
+        # For context see https://github.com/numba/numba/issues/4750.
+
+        @jit(nopython=True)
+        def foo(x):
+            return x
+
+        with self.assertRaises(TypeError) as raises:
+            jit(foo)
+        err_msg = str(raises.exception)
+        self.assertIn(
+            "A jit decorator was called on an already jitted function", err_msg)
+        self.assertIn("foo", err_msg)
+        self.assertIn(".py_func", err_msg)
+
+        with self.assertRaises(TypeError) as raises:
+            jit(BaseTest)
+        err_msg = str(raises.exception)
+        self.assertIn("The decorated object is not a function", err_msg)
+        self.assertIn(f"{type(BaseTest)}", err_msg)
+
 
 class TestSignatureHandling(BaseTest):
     """

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -154,6 +154,22 @@ skip_bad_access = unittest.skipUnless(_access_preventable, _access_msg)
 
 class TestDispatcher(BaseTest):
 
+    def test_equality(self):
+        @jit
+        def foo(x):
+            return x
+
+        @jit
+        def bar(x):
+            return x
+
+        # Written this way to verify `==` returns a bool (gh-5838). Using
+        # `assertTrue(foo == foo)` or `assertEqual(foo, foo)` would defeat the
+        # purpose of this test.
+        self.assertEqual(foo == foo, True)
+        self.assertEqual(foo == bar, False)
+        self.assertEqual(foo == None, False)  # noqa: E711
+
     def test_dyn_pyfunc(self):
         @jit
         def foo(x):

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -171,6 +171,16 @@ class TestMiscErrorHandling(unittest.TestCase):
                 dec(foo)()
             self.assertIn(expected, str(raises.exception))
 
+    def test_handling_undefined_variable(self):
+        @njit
+        def foo():
+            return a
+
+        expected = "NameError: name 'a' is not defined"
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+        self.assertIn(expected, str(raises.exception))
 
 class TestConstantInferenceErrorHandling(unittest.TestCase):
 

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -2,21 +2,20 @@
 Unspecified error handling tests
 """
 
-import os
-from numba import jit, njit, typed, int64, intp, types
-from numba.core import errors, utils
-from numba.extending import overload, intrinsic
 import numpy as np
+import os
 
-
-from numba.core.untyped_passes import (ExtractByteCode, TranslateByteCode, FixupArgs,
+from numba import jit, njit, typed, int64, types
+from numba.core import errors
+import numba.core.typing.cffi_utils as cffi_support
+from numba.extending import (overload, intrinsic, overload_method,
+                             overload_attribute)
+from numba.core.compiler import CompilerBase
+from numba.core.untyped_passes import (TranslateByteCode, FixupArgs,
                                        IRProcessing,)
-
 from numba.core.typed_passes import (NopythonTypeInference, DeadCodeElimination,
-                                     NativeLowering, IRLegalization,
                                      NoPythonBackend)
-
-from numba.core.compiler_machinery import FunctionPass, PassManager, register_pass
+from numba.core.compiler_machinery import PassManager
 from numba.core.types.functions import _err_reasons as error_reasons
 
 from numba.tests.support import skip_parfors_unsupported
@@ -25,6 +24,7 @@ import unittest
 # used in TestMiscErrorHandling::test_handling_of_write_to_*_global
 _global_list = [1, 2, 3, 4]
 _global_dict = typed.Dict.empty(int64, int64)
+
 
 class TestErrorHandlingBeforeLowering(unittest.TestCase):
 
@@ -96,7 +96,6 @@ class TestMiscErrorHandling(unittest.TestCase):
 
     def test_use_of_ir_unknown_loc(self):
         # for context see # 3390
-        from numba.core.compiler import CompilerBase
         class TestPipeline(CompilerBase):
             def define_pipelines(self):
                 name = 'bad_DCE_pipeline'
@@ -104,8 +103,8 @@ class TestMiscErrorHandling(unittest.TestCase):
                 pm.add_pass(TranslateByteCode, "analyzing bytecode")
                 pm.add_pass(FixupArgs, "fix up args")
                 pm.add_pass(IRProcessing, "processing IR")
-                # remove dead before type inference so that the Arg node is removed
-                # and the location of the arg cannot be found
+                # remove dead before type inference so that the Arg node is
+                # removed and the location of the arg cannot be found
                 pm.add_pass(DeadCodeElimination, "DCE")
                 # typing
                 pm.add_pass(NopythonTypeInference, "nopython frontend")
@@ -131,7 +130,6 @@ class TestMiscErrorHandling(unittest.TestCase):
         for ex in expected:
             self.assertIn(ex, str(raises.exception))
 
-
     def test_handling_of_write_to_reflected_global(self):
         @njit
         def foo():
@@ -150,7 +148,7 @@ class TestMiscErrorHandling(unittest.TestCase):
     def test_handling_forgotten_numba_internal_import(self):
         @njit(parallel=True)
         def foo():
-            for i in prange(10): # prange is not imported
+            for i in prange(10): # noqa: F821 prange is not imported
                 pass
 
         with self.assertRaises(errors.TypingError) as raises:
@@ -162,7 +160,7 @@ class TestMiscErrorHandling(unittest.TestCase):
 
     def test_handling_unsupported_generator_expression(self):
         def foo():
-            y = (x for x in range(10))
+            (x for x in range(10))
 
         expected = "The use of yield in a closure is unsupported."
 
@@ -174,13 +172,14 @@ class TestMiscErrorHandling(unittest.TestCase):
     def test_handling_undefined_variable(self):
         @njit
         def foo():
-            return a
+            return a # noqa: F821
 
         expected = "NameError: name 'a' is not defined"
 
         with self.assertRaises(errors.TypingError) as raises:
             foo()
         self.assertIn(expected, str(raises.exception))
+
 
 class TestConstantInferenceErrorHandling(unittest.TestCase):
 
@@ -244,8 +243,91 @@ class TestErrorMessages(unittest.TestCase):
         excstr = str(raises.exception)
         self.assertIn("No match", excstr)
 
-    def test_error_in_intrinsic(self):
+    def test_error_function_source_is_correct(self):
+        """ Checks that the reported source location for an overload is the
+        overload implementation source, not the actual function source from the
+        target library."""
 
+        @njit
+        def foo():
+            np.linalg.svd("chars")
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn(error_reasons['specific_error'].splitlines()[0], excstr)
+        expected_file = os.path.join("numba", "np", "linalg.py")
+        expected = f"Overload in function 'svd_impl': File: {expected_file}:"
+        self.assertIn(expected.format(expected_file), excstr)
+
+    def test_concrete_template_source(self):
+        # hits ConcreteTemplate
+        @njit
+        def foo():
+            return 'a' + 1
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+
+        self.assertIn("Operator Overload in function 'add'", excstr)
+        # there'll be numerous matched templates that don't work
+        self.assertIn("<numerous>", excstr)
+
+    def test_abstract_template_source(self):
+        # hits AbstractTemplate
+        @njit
+        def foo():
+            return len(1)
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn("Overload of function 'len'", excstr)
+
+    def test_callable_template_source(self):
+        # hits CallableTemplate
+        @njit
+        def foo():
+            return np.angle(1)
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn("Overload of function 'angle'", excstr)
+
+    def test_overloadfunction_template_source(self):
+        # hits _OverloadFunctionTemplate
+        def bar(x):
+            pass
+
+        @overload(bar)
+        def ol_bar(x):
+            pass
+
+        @njit
+        def foo():
+            return bar(1)
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        # there will not be "numerous" matched templates, there's just one,
+        # the one above, so assert it is reported
+        self.assertNotIn("<numerous>", excstr)
+        expected_file = os.path.join("numba", "tests",
+                                     "test_errorhandling.py")
+        expected_ol = f"Overload of function 'bar': File: {expected_file}:"
+        self.assertIn(expected_ol.format(expected_file), excstr)
+        self.assertIn("No match.", excstr)
+
+    def test_intrinsic_template_source(self):
+        # hits _IntrinsicTemplate
         given_reason1 = "x must be literal"
         given_reason2 = "array.ndim must be 1"
 
@@ -275,24 +357,70 @@ class TestErrorMessages(unittest.TestCase):
         self.assertIn(error_reasons['specific_error'].splitlines()[0], excstr)
         self.assertIn(given_reason1, excstr)
         self.assertIn(given_reason2, excstr)
+        self.assertIn("Intrinsic in function", excstr)
 
-    def test_error_function_source_is_correct(self):
-        """ Checks that the reported source location for an overload is the
-        overload implementation source, not the actual function source from the
-        target library."""
+    def test_overloadmethod_template_source(self):
+        # doesn't hit _OverloadMethodTemplate for source as it's a nested
+        # exception
+        @overload_method(types.UnicodeType, 'isnonsense')
+        def ol_unicode_isnonsense(self):
+            pass
 
         @njit
         def foo():
-            np.linalg.svd("chars")
+            "abc".isnonsense()
 
         with self.assertRaises(errors.TypingError) as raises:
             foo()
 
         excstr = str(raises.exception)
-        self.assertIn(error_reasons['specific_error'].splitlines()[0], excstr)
-        expected_file = os.path.join("numba", "np", "linalg.py")
-        expected = f"Overload in function 'svd_impl': File: {expected_file}:"
-        self.assertIn(expected.format(expected_file), excstr)
+        self.assertIn("Overload of function 'ol_unicode_isnonsense'", excstr)
+
+    def test_overloadattribute_template_source(self):
+        # doesn't hit _OverloadMethodTemplate for source as it's a nested
+        # exception
+        @overload_attribute(types.UnicodeType, 'isnonsense')
+        def ol_unicode_isnonsense(self):
+            pass
+
+        @njit
+        def foo():
+            "abc".isnonsense
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn("Overload of function 'ol_unicode_isnonsense'", excstr)
+
+    def test_external_function_pointer_template_source(self):
+        from numba.tests.ctypes_usecases import c_cos
+
+        @njit
+        def foo():
+            c_cos('a')
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn("Type Restricted Function in function 'unknown'", excstr)
+
+    @unittest.skipUnless(cffi_support.SUPPORTED, "CFFI not supported")
+    def test_cffi_function_pointer_template_source(self):
+        from numba.tests import cffi_usecases as mod
+        mod.init()
+        func = mod.cffi_cos
+
+        @njit
+        def foo():
+            func('a')
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn("Type Restricted Function in function 'unknown'", excstr)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -2,6 +2,7 @@
 Unspecified error handling tests
 """
 
+import os
 from numba import jit, njit, typed, int64, intp, types
 from numba.core import errors, utils
 from numba.extending import overload, intrinsic
@@ -264,6 +265,24 @@ class TestErrorMessages(unittest.TestCase):
         self.assertIn(error_reasons['specific_error'].splitlines()[0], excstr)
         self.assertIn(given_reason1, excstr)
         self.assertIn(given_reason2, excstr)
+
+    def test_error_function_source_is_correct(self):
+        """ Checks that the reported source location for an overload is the
+        overload implementation source, not the actual function source from the
+        target library."""
+
+        @njit
+        def foo():
+            np.linalg.svd("chars")
+
+        with self.assertRaises(errors.TypingError) as raises:
+            foo()
+
+        excstr = str(raises.exception)
+        self.assertIn(error_reasons['specific_error'].splitlines()[0], excstr)
+        expected_file = os.path.join("numba", "np", "linalg.py")
+        expected = f"Overload in function 'svd_impl': File: {expected_file}:"
+        self.assertIn(expected.format(expected_file), excstr)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -1071,5 +1071,65 @@ class TestInlineOptions(TestCase):
         self.assertIs(model.value, cost_model)
 
 
+class TestInlineMiscIssues(TestCase):
+
+    def test_issue4691(self):
+        def output_factory(array, dtype):
+            pass
+
+        @overload(output_factory, inline='always')
+        def ol_output_factory(array, dtype):
+            if isinstance(array, types.npytypes.Array):
+                def impl(array, dtype):
+                    shape = array.shape[3:]
+                    return np.zeros(shape, dtype=dtype)
+
+                return impl
+
+        @njit(nogil=True)
+        def fn(array):
+            out = output_factory(array, array.dtype)
+            return out
+
+        @njit(nogil=True)
+        def fn2(array):
+            return np.zeros(array.shape[3:], dtype=array.dtype)
+
+        fn(np.ones((10, 20, 30, 40, 50)))
+        fn2(np.ones((10, 20, 30, 40, 50)))
+
+    def test_issue4693(self):
+
+        @njit(inline='always')
+        def inlining(array):
+            if array.ndim != 1:
+                raise ValueError("Invalid number of dimensions")
+
+            return array
+
+        @njit
+        def fn(array):
+            return inlining(array)
+
+        fn(np.zeros(10))
+
+    def test_issue5476(self):
+        # Actual issue has the ValueError passed as an arg to `inlining` so is
+        # a constant inference error
+        @njit(inline='always')
+        def inlining():
+            msg = 'Something happened'
+            raise ValueError(msg)
+
+        @njit
+        def fn():
+            return inlining()
+
+        with self.assertRaises(ValueError) as raises:
+            fn()
+
+        self.assertIn("Something happened", str(raises.exception))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -3,11 +3,11 @@ This tests the inline kwarg to @jit and @overload etc, it has nothing to do with
 LLVM or low level inlining.
 """
 
-
+from itertools import product
 import numpy as np
 
 from numba import njit, typeof
-from numba.core import types, ir, ir_utils
+from numba.core import types, ir, ir_utils, cgutils
 from numba.core.extending import (
     overload,
     overload_method,
@@ -16,14 +16,17 @@ from numba.core.extending import (
     typeof_impl,
     unbox,
     NativeValue,
+    models,
+    make_attribute_wrapper,
+    intrinsic,
     register_jitable,
 )
 from numba.core.datamodel.models import OpaqueModel
 from numba.core.cpu import InlineOptions
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
-from numba.core.typed_passes import IRLegalization
+from numba.core.typed_passes import IRLegalization, InlineOverloads
 from numba.core.untyped_passes import PreserveIR
-from itertools import product
+from numba.core.typing import signature
 from numba.tests.support import (TestCase, unittest, skip_py38_or_later,
                                  MemoryLeakMixin)
 
@@ -1129,6 +1132,105 @@ class TestInlineMiscIssues(TestCase):
             fn()
 
         self.assertIn("Something happened", str(raises.exception))
+
+    def test_issue5792(self):
+        # Issue is that overloads cache their IR and closure inliner was
+        # manipulating the cached IR in a way that broke repeated inlines.
+
+        class Dummy:
+            def __init__(self, data):
+                self.data = data
+
+            def div(self, other):
+                return data / other.data
+
+        class DummyType(types.Type):
+            def __init__(self, data):
+                self.data = data
+                super().__init__(name=f'Dummy({self.data})')
+
+        @register_model(DummyType)
+        class DummyTypeModel(models.StructModel):
+            def __init__(self, dmm, fe_type):
+                members = [
+                    ('data', fe_type.data),
+                ]
+                super().__init__(dmm, fe_type, members)
+
+        make_attribute_wrapper(DummyType, 'data', '_data')
+
+        @intrinsic
+        def init_dummy(typingctx, data):
+            def codegen(context, builder, sig, args):
+                typ = sig.return_type
+                data, = args
+                dummy = cgutils.create_struct_proxy(typ)(context, builder)
+                dummy.data = data
+
+                if context.enable_nrt:
+                    context.nrt.incref(builder, sig.args[0], data)
+
+                return dummy._getvalue()
+
+            ret_typ = DummyType(data)
+            sig = signature(ret_typ, data)
+
+            return sig, codegen
+
+        @overload(Dummy, inline='always')
+        def dummy_overload(data):
+            def ctor(data):
+                return init_dummy(data)
+
+            return ctor
+
+        @overload_method(DummyType, 'div', inline='always')
+        def div_overload(self, other):
+            def impl(self, other):
+                return self._data / other._data
+
+            return impl
+
+        @njit
+        def test_impl(data, other_data):
+            dummy = Dummy(data) # ctor inlined once
+            other = Dummy(other_data)  # ctor inlined again
+
+            return dummy.div(other)
+
+        data = 1.
+        other_data = 2.
+        res = test_impl(data, other_data)
+        self.assertEqual(res, data / other_data)
+
+    def test_issue5824(self):
+        """ Similar to the above test_issue5792, checks mutation of the inlinee
+        IR is local only"""
+
+        class CustomCompiler(CompilerBase):
+
+            def define_pipelines(self):
+                pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
+                # Run the inliner twice!
+                pm.add_pass_after(InlineOverloads, InlineOverloads)
+                pm.finalize()
+                return [pm]
+
+        def bar(x):
+            ...
+
+        @overload(bar, inline='always')
+        def ol_bar(x):
+            if isinstance(x, types.Integer):
+                def impl(x):
+                    return x + 1.3
+                return impl
+
+        @njit(pipeline_class=CustomCompiler)
+        def foo(z):
+            return bar(z), bar(z)
+
+        self.assertEqual(foo(10), (11.3, 11.3))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -244,6 +244,7 @@ class TestFunctionInlining(MemoryLeakMixin, InliningBase):
 
         def factory(inline, x, y):
             z = x + 12
+
             @njit(inline=inline)
             def func():
                 return (x, y + 3, z)
@@ -311,6 +312,7 @@ class TestFunctionInlining(MemoryLeakMixin, InliningBase):
 
         def factory():
             from .inlining_usecases import bar
+
             @njit(inline='always')
             def tmp():
                 return bar()
@@ -616,6 +618,7 @@ class TestOverloadInlining(MemoryLeakMixin, InliningBase):
 
             def factory(target, x, y, inline=None):
                 z = x + 12
+
                 @overload(target, inline=inline)
                 def func():
                     def impl():
@@ -675,6 +678,7 @@ class TestOverloadInlining(MemoryLeakMixin, InliningBase):
 
         def factory():
             from .inlining_usecases import baz
+
             @njit(inline='always')
             def tmp():
                 return baz()

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -6,7 +6,7 @@ LLVM or low level inlining.
 from itertools import product
 import numpy as np
 
-from numba import njit, typeof
+from numba import njit, typeof, literally
 from numba.core import types, ir, ir_utils, cgutils
 from numba.core.extending import (
     overload,
@@ -815,6 +815,48 @@ class TestOverloadInlining(MemoryLeakMixin, InliningBase):
                   if isinstance(getattr(x, 'value', None), ir.Const)]
         for val in consts:
             self.assertNotEqual(val.value, 1234)
+
+    def test_overload_inline_always_with_literally_in_inlinee(self):
+        # See issue #5887
+
+        def foo_ovld(dtype):
+
+            if not isinstance(dtype, types.StringLiteral):
+                def foo_noop(dtype):
+                    return literally(dtype)
+                return foo_noop
+
+            if dtype.literal_value == 'str':
+                def foo_as_str_impl(dtype):
+                    return 10
+                return foo_as_str_impl
+
+            if dtype.literal_value in ('int64', 'float64'):
+                def foo_as_num_impl(dtype):
+                    return 20
+                return foo_as_num_impl
+
+        # define foo for literal str 'str'
+        def foo(dtype):
+            return 10
+
+        overload(foo, inline='always')(foo_ovld)
+
+        def test_impl(dtype):
+            return foo(dtype)
+
+        # check literal dispatch on 'str'
+        dtype = 'str'
+        self.check(test_impl, dtype, inline_expect={'foo': True})
+
+        # redefine foo to be correct for literal str 'int64'
+        def foo(dtype):
+            return 20
+        overload(foo, inline='always')(foo_ovld)
+
+        # check literal dispatch on 'int64'
+        dtype = 'int64'
+        self.check(test_impl, dtype, inline_expect={'foo': True})
 
 
 class TestOverloadMethsAttrsInlining(InliningBase):

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -11,11 +11,12 @@ from numba import (float32, float64, int16, int32, boolean, deferred_type,
                    optional)
 from numba import njit, typeof
 from numba.core import types, errors
-from numba.tests.support import TestCase, MemoryLeakMixin
-from numba.experimental.jitclass import _box
-from numba.core.runtime.nrt import MemInfo
+from numba.core.dispatcher import Dispatcher
 from numba.core.errors import LoweringError
+from numba.core.runtime.nrt import MemInfo
 from numba.experimental import jitclass
+from numba.experimental.jitclass import _box
+from numba.tests.support import TestCase, MemoryLeakMixin
 import unittest
 
 
@@ -629,6 +630,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         @jitclass([])
         class Apple(object):
             "Class docstring"
+
             def __init__(self):
                 "init docstring"
 
@@ -941,6 +943,89 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertIsInstance(ty, types.ClassInstanceType)
         pickled = pickle.dumps(ty)
         self.assertIs(pickle.loads(pickled), ty)
+
+    def test_static_methods(self):
+        @jitclass([("x", int32)])
+        class Test1:
+            def __init__(self, x):
+                self.x = x
+
+            def increase(self, y):
+                self.x = self.add(self.x, y)
+                return self.x
+
+            @staticmethod
+            def add(a, b):
+                return a + b
+
+            @staticmethod
+            def sub(a, b):
+                return a - b
+
+        @jitclass([("x", int32)])
+        class Test2:
+            def __init__(self, x):
+                self.x = x
+
+            def increase(self, y):
+                self.x = self.add(self.x, y)
+                return self.x
+
+            @staticmethod
+            def add(a, b):
+                return a - b
+
+        self.assertIsInstance(Test1.add, Dispatcher)
+        self.assertIsInstance(Test1.sub, Dispatcher)
+        self.assertIsInstance(Test2.add, Dispatcher)
+        self.assertNotEqual(Test1.add, Test2.add)
+
+        self.assertEqual(3, Test1.add(1, 2))
+        self.assertEqual(-1, Test2.add(1, 2))
+        self.assertEqual(4, Test1.sub(6, 2))
+
+        t1 = Test1(0)
+        t2 = Test2(0)
+        self.assertEqual(1, t1.increase(1))
+        self.assertEqual(-1, t2.increase(1))
+        self.assertEqual(2, t1.add(1, 1))
+        self.assertEqual(0, t1.sub(1, 1))
+        self.assertEqual(0, t2.add(1, 1))
+        self.assertEqual(2j, t1.add(1j, 1j))
+        self.assertEqual(1j, t1.sub(2j, 1j))
+        self.assertEqual("foobar", t1.add("foo", "bar"))
+
+        with self.assertRaises(AttributeError) as raises:
+            Test2.sub(3, 1)
+        self.assertIn("has no attribute 'sub'",
+                      str(raises.exception))
+
+        with self.assertRaises(TypeError) as raises:
+            Test1.add(3)
+        self.assertIn("not enough arguments: expected 2, got 1",
+                      str(raises.exception))
+
+        # Check error message for calling a static method as a class attr from
+        # another method (currently unsupported).
+
+        @jitclass([])
+        class Test3:
+            def __init__(self):
+                pass
+
+            @staticmethod
+            def a_static_method(a, b):
+                pass
+
+            def call_static(self):
+                return Test3.a_static_method(1, 2)
+
+        invalid = Test3()
+        with self.assertRaises(errors.TypingError) as raises:
+            invalid.call_static()
+
+        self.assertIn("Unknown attribute 'a_static_method'",
+                      str(raises.exception))
 
     def test_import_warnings(self):
         class Test:

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -153,7 +153,6 @@ class TestProduct(TestCase):
         self.check_dot_vv(vdot, "np.vdot()")
 
     def check_dot_vm(self, pyfunc2, pyfunc3, func_name):
-        m, n = 2, 3
 
         def samples(m, n):
             for order in 'CF':
@@ -170,16 +169,22 @@ class TestProduct(TestCase):
         cfunc2 = jit(nopython=True)(pyfunc2)
         if pyfunc3 is not None:
             cfunc3 = jit(nopython=True)(pyfunc3)
-        for a, b in samples(m, n):
-            self.check_func(pyfunc2, cfunc2, (a, b))
-            self.check_func(pyfunc2, cfunc2, (b, a.T))
-        if pyfunc3 is not None:
+
+        for m, n in [(2, 3),
+                     (3, 0),
+                     (0, 3)
+                     ]:
             for a, b in samples(m, n):
-                out = np.empty(m, dtype=a.dtype)
-                self.check_func_out(pyfunc3, cfunc3, (a, b), out)
-                self.check_func_out(pyfunc3, cfunc3, (b, a.T), out)
+                self.check_func(pyfunc2, cfunc2, (a, b))
+                self.check_func(pyfunc2, cfunc2, (b, a.T))
+            if pyfunc3 is not None:
+                for a, b in samples(m, n):
+                    out = np.empty(m, dtype=a.dtype)
+                    self.check_func_out(pyfunc3, cfunc3, (a, b), out)
+                    self.check_func_out(pyfunc3, cfunc3, (b, a.T), out)
 
         # Mismatching sizes
+        m, n = 2, 3
         a = self.sample_matrix(m, n - 1, np.float64)
         b = self.sample_vector(n, np.float64)
         self.assert_mismatching_sizes(cfunc2, (a, b))
@@ -230,10 +235,15 @@ class TestProduct(TestCase):
 
         # Test generic matrix * matrix as well as "degenerate" cases
         # where one of the outer dimensions is 1 (i.e. really represents
-        # a vector, which may select a different implementation)
+        # a vector, which may select a different implementation),
+        # one of the matrices is empty, or both matrices are empty.
         for m, n, k in [(2, 3, 4),  # Generic matrix * matrix
                         (1, 3, 4),  # 2d vector * matrix
                         (1, 1, 4),  # 2d vector * 2d vector
+                        (0, 3, 2),  # Empty matrix * matrix, empty output
+                        (3, 0, 2),  # Matrix * empty matrix, empty output
+                        (0, 0, 3),  # Both arguments empty, empty output
+                        (3, 2, 0),  # Both arguments empty, nonempty output
                         ]:
             for a, b in samples(m, n, k):
                 self.check_func(pyfunc2, cfunc2, (a, b))

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from numba import jit
 from numba.core import errors
-from numba.tests.support import TestCase, tag, needs_lapack, needs_blas, _is_armv7l
+from numba.tests.support import (TestCase, tag, needs_lapack, needs_blas,
+                                 _is_armv7l, skip_ppc64le_issue4026)
 from .matmul_usecase import matmul_usecase
 import unittest
 
@@ -762,6 +763,7 @@ class TestLinalgInv(TestLinalgBase):
         self.assert_raise_on_singular(cfunc, (np.zeros((2, 2)),))
 
 
+@skip_ppc64le_issue4026
 class TestLinalgCholesky(TestLinalgBase):
     """
     Tests for np.linalg.cholesky.

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -443,6 +443,7 @@ class TestGetitemSlice(MemoryLeakMixin, TestCase):
 
     def test_list_getitem_multiple_slice_zero_step_index_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -654,6 +655,7 @@ class TestPop(MemoryLeakMixin, TestCase):
 
     def test_list_pop_empty_index_error_with_index(self):
         self.disable_leak_check()
+
         @njit
         def foo(i):
             l = listobject.new_list(int32)
@@ -682,6 +684,7 @@ class TestPop(MemoryLeakMixin, TestCase):
 
     def test_list_pop_mutiple_index_error_with_index(self):
         self.disable_leak_check()
+
         @njit
         def foo(i):
             l = listobject.new_list(int32)
@@ -923,6 +926,7 @@ class TestExtend(MemoryLeakMixin, TestCase):
 
     def test_list_extend_typing_error_non_iterable(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1003,6 +1007,7 @@ class TestInsert(MemoryLeakMixin, TestCase):
 
     def test_list_insert_typing_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1021,6 +1026,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_empty(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1041,6 +1047,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_singleton_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1064,6 +1071,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_multiple_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1220,6 +1228,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_singleton_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1235,6 +1244,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1251,6 +1261,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error_start(self):
         self.disable_leak_check()
+
         @njit
         def foo(start):
             l = listobject.new_list(int32)
@@ -1269,6 +1280,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error_end(self):
         self.disable_leak_check()
+
         @njit
         def foo(end):
             l = listobject.new_list(int32)
@@ -1287,6 +1299,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_typing_error_start(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1302,6 +1315,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_typing_error_end(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1553,6 +1567,7 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
     def test_append_fails(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = make_test_list()

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -17,6 +17,7 @@ from numba.core.untyped_passes import (FixupArgs, TranslateByteCode,
 from numba.core.typed_passes import (NopythonTypeInference, IRLegalization,
                                      NoPythonBackend, PartialTypeInference)
 from numba.core.ir_utils import (compute_cfg_from_blocks, flatten_labels)
+from numba.core.types.functions import _header_lead
 
 _X_GLOBAL = (10, 11)
 
@@ -648,7 +649,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
         with self.assertRaises(errors.TypingError) as raises:
             foo(tup1, tup2)
 
-        self.assertIn("Invalid use", str(raises.exception))
+        self.assertIn(_header_lead, str(raises.exception))
 
     def test_10(self):
         # dispatch on literals triggering @overload resolution
@@ -1166,7 +1167,7 @@ class TestMixedTupleUnroll(MemoryLeakMixin, TestCase):
         with self.assertRaises(errors.TypingError) as raises:
             foo()
 
-        self.assertIn("Invalid use of", str(raises.exception))
+        self.assertIn(_header_lead, str(raises.exception))
         self.assertIn("zip", str(raises.exception))
 
     def test_32(self):

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1890,6 +1890,7 @@ class TestLiteralUnrollPassTriggering(TestCase):
 
     def test_literal_unroll_is_invoked_via_alias(self):
         alias = literal_unroll
+
         @njit(pipeline_class=CapturingCompiler)
         def foo():
             acc = 0

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1583,6 +1583,7 @@ class TestMore(TestCase):
         # literal_unroll
         bar()
 
+    @unittest.skip("inlining of foo doesn't have const prop so y isn't const")
     def test_inlined_unroll_list(self):
         @njit(inline='always')
         def foo(y):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -69,6 +69,10 @@ def bincount2(a, w):
     return np.bincount(a, weights=w)
 
 
+def bincount3(a, w=None, minlength=0):
+    return np.bincount(a, w, minlength)
+
+
 def searchsorted(a, v):
     return np.searchsorted(a, v)
 
@@ -747,6 +751,37 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(ValueError) as raises:
             cfunc([2, -1], [0])
         self.assertIn("weights and list don't have the same length",
+                      str(raises.exception))
+
+    def test_bincount3(self):
+        pyfunc = bincount3
+        cfunc = jit(nopython=True)(pyfunc)
+        for seq in self.bincount_sequences():
+            a_max = max(seq)
+            # Length should be a_max in the first case, minlength in the second
+            for minlength in (a_max, a_max + 2):
+                expected = pyfunc(seq, None, minlength)
+                got = cfunc(seq, None, minlength)
+                self.assertEqual(len(expected), len(got))
+                self.assertPreciseEqual(expected, got)
+
+    def test_bincount3_exceptions(self):
+        pyfunc = bincount3
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        # Negative input
+        with self.assertRaises(ValueError) as raises:
+            cfunc([2, -1], [0, 0])
+        self.assertIn("first argument must be non-negative",
+                      str(raises.exception))
+
+        # Negative minlength
+        with self.assertRaises(ValueError) as raises:
+            cfunc([17, 38], None, -1)
+        self.assertIn("'minlength' must not be negative",
                       str(raises.exception))
 
     def test_searchsorted(self):

--- a/numba/tests/test_num_threads.py
+++ b/numba/tests/test_num_threads.py
@@ -526,6 +526,7 @@ class TestNumThreads(TestCase):
     @unittest.skipIf(not sys.platform.startswith('linux'), "Linux only")
     def _test_threadmask_across_fork(self):
         forkctx = multiprocessing.get_context('fork')
+
         @njit
         def foo():
             return get_num_threads()

--- a/numba/tests/test_numbers.py
+++ b/numba/tests/test_numbers.py
@@ -61,6 +61,7 @@ class TestViewIntFloat(TestCase):
 
     def test_python_scalar_exception(self):
         intty = getattr(np, 'int{}'.format(types.intp.bitwidth))
+
         @njit
         def myview():
             a = 1

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -10,6 +10,7 @@ import unittest
 from numba.core.compiler import compile_isolated, Flags
 from numba import jit
 from numba.core import types, utils, errors, typeinfer
+from numba.core.types.functions import _header_lead
 from numba.tests.support import TestCase, tag, needs_blas
 from numba.tests.matmul_usecase import (matmul_usecase, imatmul_usecase,
                                         DumbMatrix,)
@@ -979,7 +980,7 @@ class TestOperators(TestCase):
             with self.assertRaises(errors.TypingError, msg=msg) as raises:
                 compile_isolated(pyfunc, argtypes)
             # check error message
-            fmt = 'Invalid use of {}'
+            fmt = _header_lead + ' {}'
             expecting = fmt.format(opname
                                    if isinstance(opname, str)
                                    else 'Function({})'.format(opname))

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1568,6 +1568,22 @@ class TestParfors(TestParforsBase):
                                      types.Array(types.float64, 1, 'C'))) == 1)
 
     @skip_parfors_unsupported
+    def test_tuple_concat(self):
+        # issue5383
+        def test_impl(a):
+            n = len(a)
+            array_shape = n, n
+            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
+            k_list = indices[0, :]
+
+            for i, g in enumerate(a):
+                k_list[i, i] = i
+            return k_list
+
+        x = np.array([1, 1])
+        self.check(test_impl, x)
+
+    @skip_parfors_unsupported
     def test_tuple1(self):
         def test_impl(a):
             atup = (3, 4)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1014,12 +1014,15 @@ class TestParfors(TestParforsBase):
         A = np.random.ranf(n)
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([np.inf, np.inf])
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
+        self.check(test_impl1, D)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = ("zero-size array to reduction operation "
@@ -1042,12 +1045,15 @@ class TestParfors(TestParforsBase):
         A = np.random.ranf(n)
         B = np.random.randint(10, size=n).astype(np.int32)
         C = np.random.ranf((n, n))  # test multi-dimensional array
+        D = np.array([-np.inf, -np.inf])
         self.check(test_impl1, A)
         self.check(test_impl1, B)
         self.check(test_impl1, C)
+        self.check(test_impl1, D)
         self.check(test_impl2, A)
         self.check(test_impl2, B)
         self.check(test_impl2, C)
+        self.check(test_impl2, D)
 
         # checks that 0d array input raises
         msg = ("zero-size array to reduction operation "

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2547,9 +2547,12 @@ class TestParforsVectorizer(TestPrangeBase):
         fastmath = kwargs.pop('fastmath', False)
         cpu_name = kwargs.pop('cpu_name', 'skylake-avx512')
         assertions = kwargs.pop('assertions', True)
+        # force LLVM to use zmm registers for vectorization
+        # https://reviews.llvm.org/D67259
+        cpu_features = kwargs.pop('cpu_features', '-prefer-256-bit')
 
         env_opts = {'NUMBA_CPU_NAME': cpu_name,
-                    'NUMBA_CPU_FEATURES': '',
+                    'NUMBA_CPU_FEATURES': cpu_features,
                     }
 
         overrides = []

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1628,6 +1628,21 @@ class TestParfors(TestParforsBase):
         x = np.arange(10)
         self.check(test_impl, x)
 
+    @skip_parfors_unsupported
+    def test_tuple_concat(self):
+        def test_impl(a):
+            n = len(a)
+            array_shape = n, n
+            indices = np.zeros((1,) + array_shape, dtype=np.uint64)
+            k_list = indices[0, :]
+
+            for i, g in enumerate(a):
+                k_list[i, i] = i
+            return k_list
+
+        x = np.array([1, 1])
+        self.check(test_impl, x)
+
 
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):
     def check(self, pyfunc, *args, **kwargs):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1630,10 +1630,11 @@ class TestParfors(TestParforsBase):
 
     @skip_parfors_unsupported
     def test_tuple_concat(self):
+        # issue5383
         def test_impl(a):
             n = len(a)
             array_shape = n, n
-            indices = np.zeros((1,) + array_shape, dtype=np.uint64)
+            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
             k_list = indices[0, :]
 
             for i, g in enumerate(a):

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -8,6 +8,7 @@ import numpy as np
 from numba import jit, typeof, TypingError
 from numba.core import utils
 from numba.tests.support import TestCase, MemoryLeakMixin
+from numba.core.types.functions import _header_lead
 import unittest
 
 
@@ -122,7 +123,7 @@ class TestSlices(MemoryLeakMixin, TestCase):
                 with self.assertRaises(TypingError) as numba_e:
                     cfunc(args, array)
                 self.assertIn(
-                    "Invalid use of Function",
+                    _header_lead,
                     str(numba_e.exception)
                 )
                 self.assertIn(

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1473,21 +1473,27 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
     def test_ndarray_twod(self):
 
         @njit
-        def foo():
-            return List(np.array([[1,2],[3,4]]))
+        def foo(x):
+            return List(x)
 
-        expected = List()
-        expected.append(np.array([1,2]))
-        expected.append(np.array([3,4]))
-        received = foo()
+        carr = np.array([[1, 2], [3, 4]])
+        farr = np.asfortranarray(carr)
+        aarr = np.arange(8).reshape((2, 4))[:, ::2]
 
-        np.testing.assert_equal(expected[0], received[0])
-        np.testing.assert_equal(expected[1], received[1])
+        for layout, arr in zip('CFA', (carr, farr, aarr)):
+            self.assertEqual(typeof(arr).layout, layout)
+            expected = List()
+            expected.append(arr[0, :])
+            expected.append(arr[1, :])
+            received = foo(arr)
 
-        pyreceived = foo.py_func()
+            np.testing.assert_equal(expected[0], received[0])
+            np.testing.assert_equal(expected[1], received[1])
 
-        np.testing.assert_equal(expected[0], pyreceived[0])
-        np.testing.assert_equal(expected[1], pyreceived[1])
+            pyreceived = foo.py_func(arr)
+
+            np.testing.assert_equal(expected[0], pyreceived[0])
+            np.testing.assert_equal(expected[1], pyreceived[1])
 
     def test_exception_on_plain_int(self):
         @njit

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1016,6 +1016,7 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     def test_list_as_item_in_list(self):
         nested_type = types.ListType(types.int32)
+
         @njit
         def foo():
             la = List.empty_list(nested_type)
@@ -1030,6 +1031,7 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     def test_array_as_item_in_list(self):
         nested_type = types.Array(types.float64, 1, 'C')
+
         @njit
         def foo():
             l = List.empty_list(nested_type)
@@ -1321,6 +1323,7 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
     def test_append_fails(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = List()

--- a/numba/tests/test_types.py
+++ b/numba/tests/test_types.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from numba.core import types, typing, errors, sigutils
 from numba.core.types.abstract import _typecache
+from numba.core.types.functions import _header_lead
 from numba.core.typing.templates import make_overload_template
 from numba import jit, njit, typeof
 from numba.core.extending import (overload, register_model, models, unbox,
@@ -754,7 +755,7 @@ class FooType(types.Type):
             with self.assertRaises(errors.TypingError) as raises:
                 call_false_if_not_array_closed_system(Foo())
             estr = str(raises.exception)
-            self.assertIn("Invalid use of Function", estr)
+            self.assertIn(_header_lead, estr)
             self.assertIn("false_if_not_array_closed_system", estr)
             self.assertIn("(Foo)", estr)
 

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -10,6 +10,7 @@ from numba.core.compiler import compile_isolated
 from numba import jit
 from numba.core import types
 from numba.core.errors import TypingError
+from numba.core.types.functions import _header_lead
 from numba.tests.support import TestCase
 
 
@@ -92,11 +93,11 @@ class TestTypingError(unittest.TestCase):
         with self.assertRaises(TypingError) as raises:
             compile_isolated(issue_868, (types.Array(types.int32, 1, 'C'),))
 
-        expected = (
-            "Invalid use of Function(<built-in function mul>) with argument(s) of type(s): (UniTuple({0} x 1), {1})"
+        expected = ((_header_lead + " Function(<built-in function mul>) found "
+                     "for signature:\n \n >>> mul(UniTuple({} x 1), {})")
             .format(str(types.intp), types.IntegerLiteral(2)))
         self.assertIn(expected, str(raises.exception))
-        self.assertIn("[1] During: typing of", str(raises.exception))
+        self.assertIn("During: typing of", str(raises.exception))
 
     def test_return_type_unification(self):
         with self.assertRaises(TypingError) as raises:
@@ -115,11 +116,11 @@ class TestTypingError(unittest.TestCase):
         self.assertIn(" * (float64, float64) -> float64", errmsg)
 
         # find the context lines
-        ctx_lines = [x for x in errmsg.splitlines() if "] During" in x ]
+        ctx_lines = [x for x in errmsg.splitlines() if "During:" in x ]
 
         # Check contextual msg
-        self.assertTrue(re.search(r'\[1\] During: resolving callee type: Function.*hypot', ctx_lines[0]))
-        self.assertTrue(re.search(r'\[2\] During: typing of call .*test_typingerror.py', ctx_lines[1]))
+        self.assertTrue(re.search(r'.*During: resolving callee type: Function.*hypot', ctx_lines[0]))
+        self.assertTrue(re.search(r'.*During: typing of call .*test_typingerror.py', ctx_lines[1]))
 
 
     def test_imprecise_list(self):
@@ -154,7 +155,7 @@ class TestTypingError(unittest.TestCase):
 
         errmsg = str(raises.exception)
         self.assertIn(
-            "Invalid use of Function({})".format(operator.setitem),
+            _header_lead + " Function({})".format(operator.setitem),
             errmsg,
         )
         self.assertIn(
@@ -174,13 +175,12 @@ class TestTypingError(unittest.TestCase):
         with self.assertRaises(TypingError) as raises:
             foo()
         errmsg = str(raises.exception)
-        expected = "All templates rejected with%s literals."
-        for x in ['', 'out']:
-            self.assertIn(expected % x, errmsg)
+        expected = "No match."
+        self.assertIn(expected, errmsg)
 
-        ctx_lines = [x for x in errmsg.splitlines() if "] During" in x ]
-        search = [r'\[1\] During: resolving callee type: Function.*enumerate',
-                  r'\[2\] During: typing of call .*test_typingerror.py']
+        ctx_lines = [x for x in errmsg.splitlines() if "During:" in x ]
+        search = [r'.*During: resolving callee type: Function.*enumerate',
+                  r'.*During: typing of call .*test_typingerror.py']
         for i, x in enumerate(search):
             self.assertTrue(re.search(x, ctx_lines[i]))
 

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -82,7 +82,7 @@ class TestTypingError(unittest.TestCase):
         # This used to print "'object' object has no attribute 'int32'"
         with self.assertRaises(TypingError) as raises:
             compile_isolated(unknown_module, ())
-        self.assertIn("Untyped global name 'numpyz'", str(raises.exception))
+        self.assertIn("name 'numpyz' is not defined", str(raises.exception))
 
     def test_issue_868(self):
         '''

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -303,6 +303,9 @@ class TestUFuncs(BaseUFuncTest, TestCase):
                               skip_inputs=[types.Array(types.uint32, 1, 'C'), types.uint32],
                               flags=flags)
 
+    def test_positive_ufunc(self, flags=no_pyobj_flags):
+        self.basic_ufunc_test(np.positive, flags=flags)
+
     def test_power_ufunc(self, flags=no_pyobj_flags):
         self.basic_ufunc_test(np.power, flags=flags,
                                positive_only=True)

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -8,6 +8,7 @@ import unittest
 from numba.tests.support import (TestCase, no_pyobj_flags, MemoryLeakMixin)
 from numba.core.errors import TypingError
 from numba.cpython.unicode import _MAX_UNICODE
+from numba.core.types.functions import _header_lead
 
 
 _py37_or_later = utils.PYVERSION >= (3, 7)
@@ -1297,7 +1298,7 @@ class TestUnicode(BaseTest):
         cfunc = njit(repeat_usecase)
         with self.assertRaises(TypingError) as raises:
             cfunc('hi', 2.5)
-        self.assertIn('Invalid use of Function(<built-in function mul>)',
+        self.assertIn(_header_lead + ' Function(<built-in function mul>)',
                       str(raises.exception))
 
     def test_split_exception_empty_sep(self):
@@ -2434,7 +2435,7 @@ class TestUnicodeAuxillary(BaseTest):
         # wrong type
         with self.assertRaises(TypingError) as raises:
             cfunc(1.23)
-        self.assertIn('Invalid use of Function', str(raises.exception))
+        self.assertIn(_header_lead, str(raises.exception))
 
     def test_chr(self):
         pyfunc = chr_usecase
@@ -2461,7 +2462,7 @@ class TestUnicodeAuxillary(BaseTest):
         # wrong type
         with self.assertRaises(TypingError) as raises:
             cfunc('abc')
-        self.assertIn('Invalid use of Function', str(raises.exception))
+        self.assertIn(_header_lead, str(raises.exception))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -188,7 +188,7 @@ class TestZeroCounts(TestCase):
         unsupported_types = filter(
             lambda x: not isinstance(x, types.Integer), types.number_domain
         )
-        for typ in unsupported_types:
+        for typ in sorted(unsupported_types, key=str):
             with self.assertRaises(TypingError) as e:
                 cfunc(typ(2))
             self.assertIn(
@@ -197,15 +197,17 @@ class TestZeroCounts(TestCase):
                 str(e.exception),
             )
 
-        # Testing w/ too many arguments
-        arg_cases = [(1, 2), ()]
-        for args in arg_cases:
+        # Testing w/ too many/few arguments
+        def check(args, string):
             with self.assertRaises(TypingError) as e:
                 cfunc(*args)
             self.assertIn(
-                "Invalid use of Function({})".format(str(func)),
+                "{}() ".format(func_name),
                 str(e.exception)
             )
+
+        check((1, 2), "takes 2 positional arguments but 3 were given")
+        check((), "missing 1 required positional argument")
 
     def test_trailing_zeros_error(self):
         self.check_error_msg(trailing_zeros)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -482,7 +482,7 @@ def _guess_dtype(iterable):
             "List() argument must be iterable")
     # Special case for nested NumPy arrays.
     elif isinstance(iterable, types.Array) and iterable.ndim > 1:
-        return iterable.copy(ndim=iterable.ndim - 1)
+        return iterable.copy(ndim=iterable.ndim - 1, layout='A')
     elif hasattr(iterable, "dtype"):
         return iterable.dtype
     elif hasattr(iterable, "yield_type"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
 numpy>=1.10
-llvmlite>=0.31,<0.33
+llvmlite>=0.33.0dev0,<0.34
 argparse

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 min_python_version = "3.6"
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.15"
-min_llvmlite_version = "0.31.0.dev0"
+min_llvmlite_version = "0.33.0.dev0"
 max_llvmlite_version = "0.34"
 
 if sys.platform.startswith('linux'):


### PR DESCRIPTION
Resolves #5383 

Adds support for tuple concatenation to array analysis.  Fixed a couple of places where equiv_set get_shape could fail and in those cases we do not create a parfor.  There are other spots and there probably needs to be a comprehensive review of those cases.