### PR TITLE
Fix #4954, and some other small CUDA testsuite fixes

### DIFF
--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -8,10 +8,20 @@ from numba.tests.support import (
 )
 from numba.cuda.cuda_paths import get_conda_ctk
 from numba.core import config
+from numba.tests.support import TestCase
 import unittest
 
 
-class ContextResettingTestCase(SerialMixin, unittest.TestCase):
+class CUDATestCase(SerialMixin, TestCase):
+    """
+    For tests that use a CUDA device. Test methods in a CUDATest case must not
+    be run out of module order, because the ContextResettingTestCase may reset
+    the context and destroy resources used by a normal CUDATestCase if any of
+    its tests are run between tests from a CUDATestCase.
+    """
+
+
+class ContextResettingTestCase(CUDATestCase):
     """
     For tests where the context needs to be reset after each test. Typically
     these inspect or modify parts of the context that would usually be expected

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -14,7 +14,7 @@ import unittest
 
 class CUDATestCase(SerialMixin, TestCase):
     """
-    For tests that use a CUDA device. Test methods in a CUDATest case must not
+    For tests that use a CUDA device. Test methods in a CUDATestCase must not
     be run out of module order, because the ContextResettingTestCase may reset
     the context and destroy resources used by a normal CUDATestCase if any of
     its tests are run between tests from a CUDATestCase.

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -11,10 +11,16 @@ from numba.core import config
 import unittest
 
 
-class CUDATestCase(SerialMixin, unittest.TestCase):
+class ContextResettingTestCase(SerialMixin, unittest.TestCase):
+    """
+    For tests where the context needs to be reset after each test. Typically
+    these inspect or modify parts of the context that would usually be expected
+    to be internal implementation details (such as the state of allocations and
+    deallocations, etc.).
+    """
+
     def tearDown(self):
         from numba.cuda.cudadrv.devices import reset
-
         reset()
 
 

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -1,10 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
-from numba.tests.support import TestCase
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestArrayAttr(SerialMixin, TestCase):
+class TestArrayAttr(CUDATestCase):
     def test_contigous_2d(self):
         ary = np.arange(10)
         cary = ary.reshape(2, 5)

--- a/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -3,11 +3,11 @@ from ctypes import byref
 import weakref
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.cuda.cudadrv import driver
 
 
-class TestContextStack(SerialMixin, unittest.TestCase):
+class TestContextStack(CUDATestCase):
     def setUp(self):
         # Reset before testing
         cuda.close()
@@ -25,7 +25,7 @@ class TestContextStack(SerialMixin, unittest.TestCase):
         self.assertGreater(len(gpulist), 0)
 
 
-class TestContextAPI(SerialMixin, unittest.TestCase):
+class TestContextAPI(CUDATestCase):
 
     def tearDown(self):
         cuda.close()
@@ -68,7 +68,7 @@ class TestContextAPI(SerialMixin, unittest.TestCase):
 
 
 @skip_on_cudasim('CUDA HW required')
-class Test3rdPartyContext(SerialMixin, unittest.TestCase):
+class Test3rdPartyContext(CUDATestCase):
     def tearDown(self):
         cuda.close()
 

--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -3,10 +3,10 @@ from itertools import product
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class CudaArrayIndexing(SerialMixin, unittest.TestCase):
+class CudaArrayIndexing(CUDATestCase):
     def test_index_1d(self):
         arr = np.arange(10)
         darr = cuda.to_device(arr)
@@ -56,7 +56,7 @@ class CudaArrayIndexing(SerialMixin, unittest.TestCase):
             darr[0, 0, z]
 
 
-class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):
+class CudaArrayStridedSlice(CUDATestCase):
 
     def test_strided_index_1d(self):
         arr = np.arange(10)
@@ -85,7 +85,7 @@ class CudaArrayStridedSlice(SerialMixin, unittest.TestCase):
                         darr[i::2, j::2, k::2].copy_to_host())
 
 
-class CudaArraySlicing(SerialMixin, unittest.TestCase):
+class CudaArraySlicing(CUDATestCase):
     def test_prefix_1d(self):
         arr = np.arange(5)
         darr = cuda.to_device(arr)
@@ -205,7 +205,7 @@ class CudaArraySlicing(SerialMixin, unittest.TestCase):
                                       arr[:0][-1:])
 
 
-class CudaArraySetting(SerialMixin, unittest.TestCase):
+class CudaArraySetting(CUDATestCase):
     """
     Most of the slicing logic is tested in the cases above, so these
     tests focus on the setting logic.

--- a/numba/cuda/tests/cudadrv/test_cuda_auto_context.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_auto_context.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaAutoContext(SerialMixin, unittest.TestCase):
+class TestCudaAutoContext(CUDATestCase):
     def test_auto_context(self):
         """A problem was revealed by a customer that the use cuda.to_device
         does not create a CUDA context.

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -3,13 +3,13 @@ import ctypes
 from numba.cuda.cudadrv.devicearray import (DeviceRecord, from_record_like,
                                             auto_device)
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 import numpy as np
 from numba.np import numpy_support
 
 @skip_on_cudasim('Device Record API unsupported in the simulator')
-class TestCudaDeviceRecord(SerialMixin, unittest.TestCase):
+class TestCudaDeviceRecord(CUDATestCase):
     """
     Tests the DeviceRecord class with np.void host types.
     """

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -1,7 +1,7 @@
 from ctypes import c_int, sizeof
 from numba.cuda.cudadrv.driver import host_to_device, device_to_host
 from numba.cuda.cudadrv import devices
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 ptx1 = '''
@@ -58,7 +58,7 @@ ptx2 = '''
 
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
-class TestCudaDriver(SerialMixin, unittest.TestCase):
+class TestCudaDriver(CUDATestCase):
     def setUp(self):
         self.assertTrue(len(devices.gpus) > 0)
         self.context = devices.get_context()

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -3,12 +3,12 @@ import ctypes
 import numpy as np
 
 from numba.cuda.cudadrv import driver, drvapi, devices
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('CUDA Memory API unsupported in the simulator')
-class TestCudaMemory(CUDATestCase):
+class TestCudaMemory(ContextResettingTestCase):
     def setUp(self):
         self.context = devices.get_context()
 
@@ -92,7 +92,7 @@ class TestCudaMemory(CUDATestCase):
 
 
 @skip_on_cudasim('CUDA Memory API unsupported in the simulator')
-class TestCudaMemoryFunctions(CUDATestCase):
+class TestCudaMemoryFunctions(ContextResettingTestCase):
     def setUp(self):
         self.context = devices.get_context()
 
@@ -137,7 +137,7 @@ class TestCudaMemoryFunctions(CUDATestCase):
 
 
 @skip_on_cudasim('CUDA Memory API unsupported in the simulator')
-class TestMVExtent(CUDATestCase):
+class TestMVExtent(ContextResettingTestCase):
     def test_c_contiguous_array(self):
         ary = np.arange(100)
         arysz = ary.dtype.itemsize * ary.size

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -1,11 +1,11 @@
 import numpy as np
 from numba.cuda.cudadrv import devicearray
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
-class TestCudaNDArray(SerialMixin, unittest.TestCase):
+class TestCudaNDArray(CUDATestCase):
     def test_device_array_interface(self):
         dary = cuda.device_array(shape=100)
         devicearray.verify_cuda_ndarray_interface(dary)
@@ -407,7 +407,7 @@ class TestCudaNDArray(SerialMixin, unittest.TestCase):
         self.assertEqual(d._numba_type_.layout, 'A')
 
 
-class TestRecarray(SerialMixin, unittest.TestCase):
+class TestRecarray(CUDATestCase):
     def test_recarray(self):
         # From issue #4111
         a = np.recarray((16,), dtype=[
@@ -434,7 +434,7 @@ class TestRecarray(SerialMixin, unittest.TestCase):
         np.testing.assert_array_equal(expect2, got2)
 
 
-class TestCoreContiguous(SerialMixin, unittest.TestCase):
+class TestCoreContiguous(CUDATestCase):
     def _test_against_array_core(self, view):
         self.assertEqual(
             devicearray.is_contiguous(view),

--- a/numba/cuda/tests/cudadrv/test_deallocations.py
+++ b/numba/cuda/tests/cudadrv/test_deallocations.py
@@ -4,14 +4,14 @@ import numpy as np
 
 from numba import cuda
 from numba.cuda.testing import (unittest, skip_on_cudasim,
-                                skip_if_external_memmgr, SerialMixin)
+                                skip_if_external_memmgr, CUDATestCase)
 from numba.tests.support import captured_stderr
 from numba.core import config
 
 
 @skip_on_cudasim('not supported on CUDASIM')
 @skip_if_external_memmgr('Deallocation specific to Numba memory management')
-class TestDeallocation(SerialMixin, unittest.TestCase):
+class TestDeallocation(CUDATestCase):
     def test_max_pending_count(self):
         # get deallocation manager and flush it
         deallocs = cuda.current_context().memory_manager.deallocations
@@ -63,7 +63,7 @@ class TestDeallocation(SerialMixin, unittest.TestCase):
 
 @skip_on_cudasim("defer_cleanup has no effect in CUDASIM")
 @skip_if_external_memmgr('Deallocation specific to Numba memory management')
-class TestDeferCleanup(SerialMixin, unittest.TestCase):
+class TestDeferCleanup(CUDATestCase):
     def test_basic(self):
         harr = np.arange(5)
         darr1 = cuda.to_device(harr)
@@ -129,7 +129,7 @@ class TestDeferCleanup(SerialMixin, unittest.TestCase):
         self.assertEqual(len(deallocs), 0)
 
 
-class TestDeferCleanupAvail(SerialMixin, unittest.TestCase):
+class TestDeferCleanupAvail(CUDATestCase):
     def test_context_manager(self):
         # just make sure the API is available
         with cuda.defer_cleanup():
@@ -137,7 +137,7 @@ class TestDeferCleanupAvail(SerialMixin, unittest.TestCase):
 
 
 @skip_on_cudasim('not supported on CUDASIM')
-class TestDel(SerialMixin, unittest.TestCase):
+class TestDel(CUDATestCase):
     """
     Ensure resources are deleted properly without ignored exception.
     """

--- a/numba/cuda/tests/cudadrv/test_detect.py
+++ b/numba/cuda/tests/cudadrv/test_detect.py
@@ -3,11 +3,11 @@ import sys
 import subprocess
 import threading
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.tests.support import captured_stdout
 
 
-class TestCudaDetect(SerialMixin, unittest.TestCase):
+class TestCudaDetect(CUDATestCase):
     def test_cuda_detect(self):
         # exercise the code path
         with captured_stdout() as out:
@@ -17,7 +17,7 @@ class TestCudaDetect(SerialMixin, unittest.TestCase):
         self.assertIn('CUDA devices', output)
 
 
-class TestCUDAFindLibs(SerialMixin, unittest.TestCase):
+class TestCUDAFindLibs(CUDATestCase):
 
     def run_cmd(self, cmdline, env):
         popen = subprocess.Popen(cmdline,

--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -4,7 +4,7 @@ import weakref
 
 from numba import cuda
 from numba.core import config
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.tests.support import linux_only
 
 if not config.ENABLE_CUDASIM:
@@ -98,7 +98,7 @@ if not config.ENABLE_CUDASIM:
 
 
 @skip_on_cudasim('EMM Plugins not supported on CUDA simulator')
-class TestDeviceOnlyEMMPlugin(unittest.TestCase, SerialMixin):
+class TestDeviceOnlyEMMPlugin(CUDATestCase):
     """
     Tests that the API of an EMM Plugin that implements device allocations
     only is used correctly by Numba.
@@ -175,7 +175,7 @@ class TestDeviceOnlyEMMPlugin(unittest.TestCase, SerialMixin):
 
 
 @skip_on_cudasim('EMM Plugins not supported on CUDA simulator')
-class TestBadEMMPluginVersion(unittest.TestCase, SerialMixin):
+class TestBadEMMPluginVersion(CUDATestCase):
     """
     Ensure that Numba rejects EMM Plugins with incompatible version
     numbers.
@@ -185,3 +185,7 @@ class TestBadEMMPluginVersion(unittest.TestCase, SerialMixin):
         with self.assertRaises(RuntimeError) as raises:
             cuda.set_memory_manager(BadVersionEMMPlugin)
         self.assertIn('version 1 required', str(raises.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudadrv/test_events.py
+++ b/numba/cuda/tests/cudadrv/test_events.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaEvent(SerialMixin, unittest.TestCase):
+class TestCudaEvent(CUDATestCase):
     def test_event_elapsed(self):
         N = 32
         dary = cuda.device_array(N, dtype=np.double)

--- a/numba/cuda/tests/cudadrv/test_host_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_host_alloc.py
@@ -1,12 +1,12 @@
 import numpy as np
 from numba.cuda.cudadrv import driver
 from numba import cuda
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
-class TestHostAlloc(CUDATestCase):
+class TestHostAlloc(ContextResettingTestCase):
     def test_host_alloc_driver(self):
         n = 32
         mem = cuda.current_context().memhostalloc(n, mapped=True)

--- a/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -2,12 +2,12 @@ from llvmlite.llvmpy.core import Module, Type, Builder, InlineAsm
 from llvmlite import binding as ll
 
 from numba.cuda.cudadrv import nvvm
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('Inline PTX cannot be used in the simulator')
-class TestCudaInlineAsm(CUDATestCase):
+class TestCudaInlineAsm(ContextResettingTestCase):
     def test_inline_rsqrt(self):
         mod = Module(__name__)
         fnty = Type.function(Type.void(), [Type.pointer(Type.float())])

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -2,7 +2,7 @@ import os.path
 import numpy as np
 from numba.cuda.testing import unittest
 from numba.cuda.testing import skip_on_cudasim
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 from numba.cuda.cudadrv.driver import Linker
 from numba.cuda import require_context
 from numba import cuda
@@ -57,7 +57,7 @@ def function_with_lots_of_registers(x, a, b, c, d, e, f):
 
 
 @skip_on_cudasim('Linking unsupported in the simulator')
-class TestLinker(SerialMixin, unittest.TestCase):
+class TestLinker(CUDATestCase):
 
     @require_context
     def test_linker_basic(self):

--- a/numba/cuda/tests/cudadrv/test_pinned.py
+++ b/numba/cuda/tests/cudadrv/test_pinned.py
@@ -1,13 +1,13 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 
 
 REPEAT = 25
 
 
-class TestPinned(CUDATestCase):
+class TestPinned(ContextResettingTestCase):
 
     def _run_copies(self, A):
         A0 = np.copy(A)

--- a/numba/cuda/tests/cudadrv/test_profiler.py
+++ b/numba/cuda/tests/cudadrv/test_profiler.py
@@ -1,11 +1,11 @@
 import unittest
-from numba.cuda.testing import CUDATestCase
+from numba.cuda.testing import ContextResettingTestCase
 from numba import cuda
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('CUDA Profiler unsupported in the simulator')
-class TestProfiler(CUDATestCase):
+class TestProfiler(ContextResettingTestCase):
     def test_profiling(self):
         with cuda.profiling():
             a = cuda.device_array(10)

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -2,11 +2,7 @@ import threading
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
 from numba.cuda.testing import unittest, ContextResettingTestCase
-
-try:
-    from Queue import Queue  # Python 2
-except:
-    from queue import Queue  # Python 3
+from queue import Queue
 
 
 class TestResetDevice(ContextResettingTestCase):

--- a/numba/cuda/tests/cudadrv/test_reset_device.py
+++ b/numba/cuda/tests/cudadrv/test_reset_device.py
@@ -1,7 +1,7 @@
 import threading
 from numba import cuda
 from numba.cuda.cudadrv.driver import driver
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 
 try:
     from Queue import Queue  # Python 2
@@ -9,7 +9,7 @@ except:
     from queue import Queue  # Python 3
 
 
-class TestResetDevice(CUDATestCase):
+class TestResetDevice(ContextResettingTestCase):
     def test_reset_device(self):
 
         def newthread(exception_queue):

--- a/numba/cuda/tests/cudadrv/test_select_device.py
+++ b/numba/cuda/tests/cudadrv/test_select_device.py
@@ -9,7 +9,7 @@ except:
 
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 
 
 def newthread(exception_queue):
@@ -26,7 +26,7 @@ def newthread(exception_queue):
         exception_queue.put(e)
 
 
-class TestSelectDevice(CUDATestCase):
+class TestSelectDevice(ContextResettingTestCase):
     def test_select_device(self):
         exception_queue = Queue()
         for i in range(10):

--- a/numba/cuda/tests/cudadrv/test_select_device.py
+++ b/numba/cuda/tests/cudadrv/test_select_device.py
@@ -2,10 +2,7 @@
 # Test does not work on some cards.
 #
 import threading
-try:
-    from Queue import Queue  # Python 2
-except:
-    from queue import Queue  # Python 3
+from queue import Queue
 
 import numpy as np
 from numba import cuda

--- a/numba/cuda/tests/cudapy/test_alignment.py
+++ b/numba/cuda/tests/cudapy/test_alignment.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import from_dtype, cuda
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
-class TestAlignment(SerialMixin, unittest.TestCase):
+class TestAlignment(CUDATestCase):
     def test_record_alignment(self):
         rec_dtype = np.dtype([('a', 'int32'), ('b', 'float64')], align=True)
         rec = from_dtype(rec_dtype)

--- a/numba/cuda/tests/cudapy/test_array.py
+++ b/numba/cuda/tests/cudapy/test_array.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim, skip_unless_cudasim
 from numba import cuda
 
 
-class TestCudaArray(SerialMixin, unittest.TestCase):
+class TestCudaArray(CUDATestCase):
     def test_gpu_array_zero_length(self):
         x = np.arange(0)
         dx = cuda.to_device(x)

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaArrayArg(SerialMixin, unittest.TestCase):
+class TestCudaArrayArg(CUDATestCase):
     def test_array_ary(self):
 
         @cuda.jit('double(double[:],int64)', device=True, inline=True)

--- a/numba/cuda/tests/cudapy/test_array_methods.py
+++ b/numba/cuda/tests/cudapy/test_array_methods.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
@@ -10,7 +10,7 @@ def reinterpret_array_type(byte_arr, start, stop, output):
     output[0] = val
 
 
-class TestCudaArrayMethods(SerialMixin, unittest.TestCase):
+class TestCudaArrayMethods(CUDATestCase):
     def test_reinterpret_array_type(self):
         """
         Reinterpret byte array as int32 in the GPU.

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -2,7 +2,7 @@ import random
 import numpy as np
 
 from numba import cuda, uint32, uint64, float32, float64
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core import config
 
 
@@ -181,7 +181,7 @@ def atomic_compare_and_swap(res, old, ary):
         old[gid] = out
 
 
-class TestCudaAtomics(SerialMixin, unittest.TestCase):
+class TestCudaAtomics(CUDATestCase):
     def test_atomic_add(self):
         ary = np.random.randint(0, 32, size=32).astype(np.uint32)
         orig = ary.copy()

--- a/numba/cuda/tests/cudapy/test_autojit.py
+++ b/numba/cuda/tests/cudapy/test_autojit.py
@@ -1,11 +1,11 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('Simulator does not have definitions attribute')
-class TestCudaAutoJit(SerialMixin, unittest.TestCase):
+class TestCudaAutoJit(CUDATestCase):
     def test_autojit(self):
         @cuda.autojit
         def what(a, b, c):

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -2,7 +2,7 @@ import numpy as np
 import math
 import time
 from numba import cuda, double
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 RISKFREE = 0.02
@@ -45,7 +45,7 @@ def randfloat(rand_var, low, high):
     return (1.0 - rand_var) * low + rand_var * high
 
 
-class TestBlackScholes(SerialMixin, unittest.TestCase):
+class TestBlackScholes(CUDATestCase):
     def test_blackscholes(self):
         OPT_N = 400
         iterations = 2

--- a/numba/cuda/tests/cudapy/test_boolean.py
+++ b/numba/cuda/tests/cudapy/test_boolean.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba import cuda
 
 
@@ -10,7 +10,7 @@ def boolean_func(A, vertial):
         A[0] = 321
 
 
-class TestCudaBoolean(SerialMixin, unittest.TestCase):
+class TestCudaBoolean(CUDATestCase):
     def test_boolean(self):
         func = cuda.jit('void(float64[:], bool_)')(boolean_func)
         A = np.array([0], dtype='float64')

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from numba import cuda
 from numba.core import types
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
@@ -23,7 +23,7 @@ def float_to_complex(x):
     return np.complex128(x)
 
 
-class TestCasting(SerialMixin, unittest.TestCase):
+class TestCasting(CUDATestCase):
     def _create_wrapped(self, pyfunc, intype, outtype):
         wrapped_func = cuda.jit(device=True)(pyfunc)
 

--- a/numba/cuda/tests/cudapy/test_complex.py
+++ b/numba/cuda/tests/cudapy/test_complex.py
@@ -7,10 +7,9 @@ import textwrap
 
 import numpy as np
 
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core import types, utils
 from numba import cuda
-from numba.tests.support import TestCase, compile_function
 from numba.tests.complex_usecases import *
 from numba.np import numpy_support
 
@@ -53,7 +52,7 @@ def compile_scalar_func(pyfunc, argtypes, restype):
     return kernel_wrapper
 
 
-class BaseComplexTest(SerialMixin):
+class BaseComplexTest(CUDATestCase):
 
     def basic_values(self):
         reals = [-0.0, +0.0, 1, -1, +1.5, -3.5,
@@ -104,7 +103,7 @@ class BaseComplexTest(SerialMixin):
     run_binary = run_func
 
 
-class TestComplex(BaseComplexTest, TestCase):
+class TestComplex(BaseComplexTest):
 
     def check_real_image(self, pyfunc):
         values = self.basic_values()
@@ -127,7 +126,7 @@ class TestComplex(BaseComplexTest, TestCase):
                        values)
 
 
-class TestCMath(BaseComplexTest, TestCase):
+class TestCMath(BaseComplexTest):
     """
     Tests for cmath module support.
     """

--- a/numba/cuda/tests/cudapy/test_complex_kernel.py
+++ b/numba/cuda/tests/cudapy/test_complex_kernel.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaComplex(SerialMixin, unittest.TestCase):
+class TestCudaComplex(CUDATestCase):
     def test_cuda_complex_arg(self):
         @cuda.jit('void(complex128[:], complex128)')
         def foo(a, b):

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core.config import ENABLE_CUDASIM
 
 CONST_EMPTY = np.array([])
@@ -89,7 +89,7 @@ def cuconstAlign(z):
     z[i] = a[i] + b[i]
 
 
-class TestCudaConstantMemory(SerialMixin, unittest.TestCase):
+class TestCudaConstantMemory(CUDATestCase):
     def test_const_array(self):
         jcuconst = cuda.jit('void(float64[:])')(cuconst)
         A = np.zeros_like(CONST1D)

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import vectorize, guvectorize
 from numba import cuda
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, ContextResettingTestCase
 from numba.cuda.testing import skip_on_cudasim, skip_if_external_memmgr
 
 
@@ -13,7 +13,7 @@ class MyArray(object):
 
 
 @skip_on_cudasim('CUDA Array Interface is not supported in the simulator')
-class TestCudaArrayInterface(CUDATestCase):
+class TestCudaArrayInterface(ContextResettingTestCase):
     def test_as_cuda_array(self):
         h_arr = np.arange(10)
         self.assertFalse(cuda.is_cuda_array(h_arr))

--- a/numba/cuda/tests/cudapy/test_cuda_autojit.py
+++ b/numba/cuda/tests/cudapy/test_cuda_autojit.py
@@ -1,10 +1,10 @@
 from numba import cuda
 import numpy as np
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
-class TestCudaAutojit(SerialMixin, unittest.TestCase):
+class TestCudaAutojit(CUDATestCase):
     def test_device_array(self):
         @cuda.autojit
         def foo(x, y):

--- a/numba/cuda/tests/cudapy/test_datetime.py
+++ b/numba/cuda/tests/cudapy/test_datetime.py
@@ -2,12 +2,11 @@ import numpy as np
 
 from numba import cuda, vectorize, guvectorize
 from numba.np.numpy_support import from_dtype
-from numba.tests.support import TestCase
-from numba.cuda.testing import SerialMixin, skip_on_cudasim
+from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 import unittest
 
 
-class TestCudaDateTime(SerialMixin, TestCase):
+class TestCudaDateTime(CUDATestCase):
     def test_basic_datetime_kernel(self):
         @cuda.jit
         def foo(start, end, delta):

--- a/numba/cuda/tests/cudapy/test_debug.py
+++ b/numba/cuda/tests/cudapy/test_debug.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 from numba.tests.support import (override_config, captured_stderr,
                                  captured_stdout)
 from numba import cuda, float64
@@ -13,7 +13,7 @@ def simple_cuda(A, B):
 
 
 @skip_on_cudasim('Simulator does not produce debug dumps')
-class TestDebugOutput(SerialMixin, unittest.TestCase):
+class TestDebugOutput(CUDATestCase):
 
     def compile_simple_cuda(self):
         with captured_stderr() as err:

--- a/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -1,13 +1,13 @@
-from numba.tests.support import override_config, TestCase
+from numba.tests.support import override_config
 from numba.cuda.testing import skip_on_cudasim
 from numba import cuda
 from numba.core import types
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('Simulator does not produce debug dumps')
-class TestCudaDebugInfo(SerialMixin, TestCase):
+class TestCudaDebugInfo(CUDATestCase):
     """
     These tests only checks the compiled PTX for debuginfo section
     """

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -3,12 +3,12 @@ import types
 
 import numpy as np
 
-from numba.cuda.testing import unittest, skip_on_cudasim, SerialMixin
+from numba.cuda.testing import unittest, skip_on_cudasim, CUDATestCase
 from numba import cuda, jit, int32
 from numba.core.errors import TypingError
 
 
-class TestDeviceFunc(SerialMixin, unittest.TestCase):
+class TestDeviceFunc(CUDATestCase):
 
     def test_use_add2f(self):
 

--- a/numba/cuda/tests/cudapy/test_errors.py
+++ b/numba/cuda/tests/cudapy/test_errors.py
@@ -1,14 +1,14 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def noop(x):
     pass
 
 
-class TestJitErrors(SerialMixin, unittest.TestCase):
+class TestJitErrors(CUDATestCase):
     """
     Test compile-time errors with @jit.
     """

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from numba import cuda, jit
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.core import config
 
-class TestException(SerialMixin, unittest.TestCase):
+class TestException(CUDATestCase):
     def test_exception(self):
         def foo(ary):
             x = cuda.threadIdx.x

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -1,11 +1,11 @@
 import numpy as np
 
 from numba import cuda, float32
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
-class TestFastMathOption(SerialMixin, unittest.TestCase):
+class TestFastMathOption(CUDATestCase):
     def test_kernel(self):
 
         def foo(arr, val):

--- a/numba/cuda/tests/cudapy/test_forall.py
+++ b/numba/cuda/tests/cudapy/test_forall.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import cuda
 import unittest
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 
 
 @cuda.jit
@@ -12,7 +12,7 @@ def foo(x):
         x[i] += 1
 
 
-class TestForAll(SerialMixin, unittest.TestCase):
+class TestForAll(CUDATestCase):
     def test_forall_1(self):
         arr = np.arange(11)
         orig = arr.copy()

--- a/numba/cuda/tests/cudapy/test_freevar.py
+++ b/numba/cuda/tests/cudapy/test_freevar.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestFreeVar(SerialMixin, unittest.TestCase):
+class TestFreeVar(CUDATestCase):
     def test_freevar(self):
         """Make sure we can compile the following kernel with freevar reference
         in macros

--- a/numba/cuda/tests/cudapy/test_globals.py
+++ b/numba/cuda/tests/cudapy/test_globals.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 N = 100
 
@@ -27,7 +27,7 @@ def coop_smem2d(ary):
     ary[i, j] = sm[i, j]
 
 
-class TestCudaTestGlobal(SerialMixin, unittest.TestCase):
+class TestCudaTestGlobal(CUDATestCase):
     def test_global_int_const(self):
         """Test simple_smem
         """

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -4,12 +4,12 @@ import numpy.core.umath_tests as ut
 from numba import void, float32, float64
 from numba import guvectorize
 from numba import cuda
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAGufunc(SerialMixin, unittest.TestCase):
+class TestCUDAGufunc(CUDATestCase):
 
     def test_gufunc_small(self):
 

--- a/numba/cuda/tests/cudapy/test_gufunc_scalar.py
+++ b/numba/cuda/tests/cudapy/test_gufunc_scalar.py
@@ -5,13 +5,12 @@ See Numpy documentation for detail about gufunc:
 """
 import numpy as np
 from numba import guvectorize, cuda
-from numba.tests.support import TestCase
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestGUFuncScalar(SerialMixin, TestCase):
+class TestGUFuncScalar(CUDATestCase):
     def test_gufunc_scalar_output(self):
         #    function type:
         #        - has no void return type

--- a/numba/cuda/tests/cudapy/test_idiv.py
+++ b/numba/cuda/tests/cudapy/test_idiv.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda, float32, float64, int32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaIDiv(SerialMixin, unittest.TestCase):
+class TestCudaIDiv(CUDATestCase):
     def test_inplace_div(self):
 
         @cuda.jit(argtypes=[float32[:, :], int32, int32])

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -1,11 +1,11 @@
 from io import StringIO
 from numba import cuda, float64, intp
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('Simulator does not generate code to be inspected')
-class TestInspect(SerialMixin, unittest.TestCase):
+class TestInspect(CUDATestCase):
     @property
     def cc(self):
         return cuda.current_context().device.compute_capability

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import re
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 
 
 def simple_threadidx(ary):
@@ -110,7 +110,7 @@ def simple_warpsize(ary):
     ary[0] = cuda.warpsize
 
 
-class TestCudaIntrinsic(SerialMixin, unittest.TestCase):
+class TestCudaIntrinsic(CUDATestCase):
     def test_simple_threadidx(self):
         compiled = cuda.jit("void(int32[:])")(simple_threadidx)
         ary = np.ones(1, dtype=np.int32)

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from numba import cuda
 from numba.cuda.cudadrv import drvapi, devicearray
-from numba.cuda.testing import skip_on_cudasim, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim, ContextResettingTestCase
 from numba.tests.support import linux_only
 import unittest
 
@@ -82,7 +82,7 @@ def ipc_array_test(ipcarr, result_queue):
 @linux_only
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
-class TestIpcMemory(CUDATestCase):
+class TestIpcMemory(ContextResettingTestCase):
     def test_ipc_handle(self):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
@@ -182,7 +182,7 @@ class TestIpcMemory(CUDATestCase):
 
 @unittest.skipIf(linux, 'Only on OS other than Linux')
 @skip_on_cudasim('Ipc not available in CUDASIM')
-class TestIpcNotSupported(CUDATestCase):
+class TestIpcNotSupported(ContextResettingTestCase):
     def test_unsupported(self):
         arr = np.arange(10, dtype=np.intp)
         devarr = cuda.to_device(arr)
@@ -240,7 +240,7 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
 @linux_only
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
-class TestIpcStaged(CUDATestCase):
+class TestIpcStaged(ContextResettingTestCase):
     def test_staged(self):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)

--- a/numba/cuda/tests/cudapy/test_lang.py
+++ b/numba/cuda/tests/cudapy/test_lang.py
@@ -5,10 +5,10 @@ Test basic language features
 
 import numpy as np
 from numba import cuda, float64
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestLang(SerialMixin, unittest.TestCase):
+class TestLang(CUDATestCase):
     def test_enumerate(self):
         tup = (1., 2.5, 3.)
 

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -1,7 +1,7 @@
 import numpy as np
 import time
 from numba import cuda, float64, void
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core import config
 
 # NOTE: CUDA kernel does not return any value
@@ -12,7 +12,7 @@ else:
     tpb = 16
 SM_SIZE = tpb, tpb
 
-class TestCudaLaplace(SerialMixin, unittest.TestCase):
+class TestCudaLaplace(CUDATestCase):
     def test_laplace_small(self):
 
         @cuda.jit(float64(float64, float64), device=True, inline=True)

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numba import cuda, int32, complex128
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def culocal(A, B):
@@ -28,7 +28,7 @@ def culocal1tuple(A, B):
         B[i] = C[i]
 
 
-class TestCudaLocalMem(SerialMixin, unittest.TestCase):
+class TestCudaLocalMem(CUDATestCase):
     def test_local_array(self):
         jculocal = cuda.jit('void(int32[:], int32[:])')(culocal)
         self.assertTrue('.local' in jculocal.ptx)

--- a/numba/cuda/tests/cudapy/test_macro.py
+++ b/numba/cuda/tests/cudapy/test_macro.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numba import cuda, float32
 from numba.core.errors import MacroError
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
 GLOBAL_CONSTANT = 5
@@ -47,7 +47,7 @@ def udt_invalid_2(A):
     A[i, j] = sa[i, j]
 
 
-class TestMacro(SerialMixin, unittest.TestCase):
+class TestMacro(CUDATestCase):
     def getarg(self):
         return np.array(100, dtype=np.float32, ndmin=1)
 

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -1,6 +1,6 @@
 import sys
 import numpy as np
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba import cuda, float32, float64, int32
 import math
 
@@ -180,7 +180,7 @@ def math_mod_binop(A, B, C):
     C[i] = A[i] % B[i]
 
 
-class TestCudaMath(SerialMixin, unittest.TestCase):
+class TestCudaMath(CUDATestCase):
     def unary_template_float32(self, func, npfunc, start=0, stop=1):
         self.unary_template(func, npfunc, np.float32, float32, start, stop)
 

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numba import cuda, float32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core import config
 
 # Ensure the test takes a reasonable amount of time in the simulator
@@ -14,7 +14,7 @@ n = bpg * tpb
 SM_SIZE = (tpb, tpb)
 
 
-class TestCudaMatMul(SerialMixin, unittest.TestCase):
+class TestCudaMatMul(CUDATestCase):
 
     def test_func(self):
 

--- a/numba/cuda/tests/cudapy/test_minmax.py
+++ b/numba/cuda/tests/cudapy/test_minmax.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numba import cuda, float64
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 
 
 def builtin_max(A, B, C):
@@ -23,7 +23,7 @@ def builtin_min(A, B, C):
 
 
 @skip_on_cudasim('Tests PTX emission')
-class TestCudaMinMax(SerialMixin, unittest.TestCase):
+class TestCudaMinMax(CUDATestCase):
     def _run(
             self,
             kernel,

--- a/numba/cuda/tests/cudapy/test_montecarlo.py
+++ b/numba/cuda/tests/cudapy/test_montecarlo.py
@@ -1,9 +1,9 @@
 import math
 from numba import cuda
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaMonteCarlo(SerialMixin, unittest.TestCase):
+class TestCudaMonteCarlo(CUDATestCase):
     def test_montecarlo(self):
         """Just make sure we can compile this
         """

--- a/numba/cuda/tests/cudapy/test_multigpu.py
+++ b/numba/cuda/tests/cudapy/test_multigpu.py
@@ -1,11 +1,11 @@
 from numba import cuda
 import numpy as np
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import threading
 import unittest
 
 
-class TestMultiGPUContext(SerialMixin, unittest.TestCase):
+class TestMultiGPUContext(CUDATestCase):
     @unittest.skipIf(len(cuda.gpus) < 2, "need more than 1 gpus")
     def test_multigpu_context(self):
         @cuda.jit("void(float64[:], float64[:])")

--- a/numba/cuda/tests/cudapy/test_multiprocessing.py
+++ b/numba/cuda/tests/cudapy/test_multiprocessing.py
@@ -4,7 +4,7 @@ import multiprocessing as mp
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 has_mp_get_context = hasattr(mp, 'get_context')
@@ -22,7 +22,7 @@ def fork_test(q):
 
 
 @skip_on_cudasim('disabled for cudasim')
-class TestMultiprocessing(SerialMixin, unittest.TestCase):
+class TestMultiprocessing(CUDATestCase):
     @unittest.skipUnless(has_mp_get_context, 'requires mp.get_context')
     @unittest.skipUnless(is_unix, 'requires Unix')
     def test_fork(self):

--- a/numba/cuda/tests/cudapy/test_multithreads.py
+++ b/numba/cuda/tests/cudapy/test_multithreads.py
@@ -3,7 +3,7 @@ import threading
 import multiprocessing
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 try:
@@ -45,7 +45,7 @@ def spawn_process_entry(q):
 
 
 @skip_on_cudasim('disabled for cudasim')
-class TestMultiThreadCompiling(SerialMixin, unittest.TestCase):
+class TestMultiThreadCompiling(CUDATestCase):
 
     @unittest.skipIf(not has_concurrent_futures, "no concurrent.futures")
     def test_concurrent_compiling(self):

--- a/numba/cuda/tests/cudapy/test_nondet.py
+++ b/numba/cuda/tests/cudapy/test_nondet.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda, float32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def generate_input(n):
@@ -9,7 +9,7 @@ def generate_input(n):
     return A, B
 
 
-class TestCudaNonDet(SerialMixin, unittest.TestCase):
+class TestCudaNonDet(CUDATestCase):
     def test_for_pre(self):
         """Test issue with loop not running due to bad sign-extension at the for loop
         precondition.

--- a/numba/cuda/tests/cudapy/test_operator.py
+++ b/numba/cuda/tests/cudapy/test_operator.py
@@ -1,10 +1,10 @@
 import numpy as np
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba import cuda
 import operator
 
 
-class TestOperatorModule(SerialMixin, unittest.TestCase):
+class TestOperatorModule(CUDATestCase):
     """
     Test if operator module is supported by the CUDA target.
     """

--- a/numba/cuda/tests/cudapy/test_powi.py
+++ b/numba/cuda/tests/cudapy/test_powi.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
 from numba import cuda, float64, int8, int32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def cu_mat_power(A, power, power_A):
@@ -24,7 +24,7 @@ def cu_mat_power_binop(A, power, power_A):
     power_A[y, x] = A[y, x] ** power
 
 
-class TestCudaPowi(SerialMixin, unittest.TestCase):
+class TestCudaPowi(CUDATestCase):
     def test_powi(self):
         dec = cuda.jit(argtypes=[float64[:, :], int8, float64[:, :]])
         kernel = dec(cu_mat_power)

--- a/numba/cuda/tests/cudapy/test_print.py
+++ b/numba/cuda/tests/cudapy/test_print.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import captured_cuda_stdout, SerialMixin
+from numba.cuda.testing import captured_cuda_stdout, CUDATestCase
 import unittest
 
 
@@ -25,7 +25,7 @@ def printempty():
     print()
 
 
-class TestPrint(SerialMixin, unittest.TestCase):
+class TestPrint(CUDATestCase):
 
     def test_cuhello(self):
         jcuhello = cuda.jit('void()', debug=False)(cuhello)

--- a/numba/cuda/tests/cudapy/test_py2_div_issue.py
+++ b/numba/cuda/tests/cudapy/test_py2_div_issue.py
@@ -1,9 +1,9 @@
 import numpy as np
 from numba import cuda, float32, int32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
-class TestCudaPy2Div(SerialMixin, unittest.TestCase):
+class TestCudaPy2Div(CUDATestCase):
     def test_py2_div_issue(self):
         @cuda.jit(argtypes=[float32[:], float32[:], float32[:], int32])
         def preCalc(y, yA, yB, numDataPoints):

--- a/numba/cuda/tests/cudapy/test_random.py
+++ b/numba/cuda/tests/cudapy/test_random.py
@@ -5,7 +5,7 @@ import numpy as np
 from numba import cuda, float32
 from numba.cuda.testing import unittest
 import numba.cuda.random
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 
 from numba.cuda.random import \
     xoroshiro128p_uniform_float32, xoroshiro128p_normal_float32, \
@@ -40,7 +40,7 @@ def rng_kernel_float64(states, out, count, distribution):
             out[thread_id * count + i] = xoroshiro128p_normal_float64(states, thread_id)
 
 
-class TestCudaRandomXoroshiro128p(SerialMixin, unittest.TestCase):
+class TestCudaRandomXoroshiro128p(CUDATestCase):
     def test_create(self):
         states = cuda.random.create_xoroshiro128p_states(10, seed=1)
         s = states.copy_to_host()

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 from numba import cuda
 from numba.core import types
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 from numba.np import numpy_support
 
@@ -100,7 +100,7 @@ recordwith2darray = np.dtype([('i', np.int32),
                               ('j', np.float32, (3, 2))])
 
 
-class TestRecordDtype(SerialMixin, unittest.TestCase):
+class TestRecordDtype(CUDATestCase):
 
     def _createSampleArrays(self):
         self.sample1d = np.recarray(3, dtype=recordtype)

--- a/numba/cuda/tests/cudapy/test_reduction.py
+++ b/numba/cuda/tests/cudapy/test_reduction.py
@@ -1,14 +1,14 @@
 import numpy as np
 from numba import cuda
 from numba.core.config import ENABLE_CUDASIM
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 # Avoid recompilation of the sum_reduce function by keeping it at global scope
 sum_reduce = cuda.Reduce(lambda a, b: a + b)
 
 
-class TestReduction(SerialMixin, unittest.TestCase):
+class TestReduction(CUDATestCase):
     def _sum_reduce(self, n):
         A = (np.arange(n, dtype=np.float64) + 1)
         expect = A.sum()

--- a/numba/cuda/tests/cudapy/test_retrieve_autoconverted_arrays.py
+++ b/numba/cuda/tests/cudapy/test_retrieve_autoconverted_arrays.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from numba import cuda
 from numba.cuda.args import wrap_arg
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 import unittest
 
 
@@ -30,7 +30,7 @@ recordtype = np.dtype(
 )
 
 
-class TestRetrieveAutoconvertedArrays(SerialMixin, unittest.TestCase):
+class TestRetrieveAutoconvertedArrays(CUDATestCase):
     def setUp(self):
         self.set_array_to_three = cuda.jit(set_array_to_three)
         self.set_array_to_three_nocopy = nocopy(cuda.jit(set_array_to_three))

--- a/numba/cuda/tests/cudapy/test_serialize.py
+++ b/numba/cuda/tests/cudapy/test_serialize.py
@@ -2,13 +2,13 @@ import pickle
 import numpy as np
 from numba import cuda, vectorize
 from numba.core import types
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 from numba.np import numpy_support
 
 
 @skip_on_cudasim('pickling not supported in CUDASIM')
-class TestPickle(SerialMixin, unittest.TestCase):
+class TestPickle(CUDATestCase):
 
     def check_call(self, callee):
         arr = np.array([100])

--- a/numba/cuda/tests/cudapy/test_slicing.py
+++ b/numba/cuda/tests/cudapy/test_slicing.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda, float32, int32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 
 def foo(inp, out):
@@ -13,7 +13,7 @@ def copy(inp, out):
     cufoo(inp[i, :], out[i, :])
 
 
-class TestCudaSlicing(SerialMixin, unittest.TestCase):
+class TestCudaSlicing(CUDATestCase):
     def test_slice_as_arg(self):
         global cufoo
         cufoo = cuda.jit("void(int32[:], int32[:])", device=True)(foo)

--- a/numba/cuda/tests/cudapy/test_sm.py
+++ b/numba/cuda/tests/cudapy/test_sm.py
@@ -1,6 +1,6 @@
 from numba import cuda, int32, float64
 
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 
 import numpy as np
 from numba.np import numpy_support as nps
@@ -10,7 +10,7 @@ recordwith2darray = np.dtype([('i', np.int32),
                               ('j', np.float32, (3, 2))])
 
 
-class TestSharedMemoryIssue(SerialMixin, unittest.TestCase):
+class TestSharedMemoryIssue(CUDATestCase):
     def test_issue_953_sm_linkage_conflict(self):
         @cuda.jit(device=True)
         def inner():
@@ -74,7 +74,7 @@ class TestSharedMemoryIssue(SerialMixin, unittest.TestCase):
         cuda.synchronize()
 
 
-class TestSharedMemory(SerialMixin, unittest.TestCase):
+class TestSharedMemory(CUDATestCase):
     def _test_shared(self, arr):
         # Use a kernel that copies via shared memory to check loading and
         # storing different dtypes with shared memory. All threads in a block

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda, int32, float32
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, CUDATestCase
 from numba.core.config import ENABLE_CUDASIM
 
 
@@ -71,7 +71,7 @@ def use_syncthreads_or(ary_in, ary_out):
 
 
 
-class TestCudaSync(SerialMixin, unittest.TestCase):
+class TestCudaSync(CUDATestCase):
     def test_useless_sync(self):
         compiled = cuda.jit("void(int32[::1])")(useless_sync)
         nelem = 10

--- a/numba/cuda/tests/cudapy/test_transpose.py
+++ b/numba/cuda/tests/cudapy/test_transpose.py
@@ -2,7 +2,7 @@ import numpy as np
 from numba import cuda
 from numba.cuda.kernels.transpose import transpose
 from numba.cuda.testing import unittest
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 
 
 recordwith2darray = np.dtype([('i', np.int32),
@@ -10,7 +10,7 @@ recordwith2darray = np.dtype([('i', np.int32),
 
 
 @skip_on_cudasim('Device Array API unsupported in the simulator')
-class Test(SerialMixin, unittest.TestCase):
+class Test(CUDATestCase):
 
     def test_transpose(self):
         variants = ((5, 6, np.float64),

--- a/numba/cuda/tests/cudapy/test_userexc.py
+++ b/numba/cuda/tests/cudapy/test_userexc.py
@@ -1,4 +1,4 @@
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba import cuda
 from numba.core import config
 
@@ -12,7 +12,7 @@ regex_pattern = (
 )
 
 
-class TestUserExc(SerialMixin, unittest.TestCase):
+class TestUserExc(CUDATestCase):
 
     def test_user_exception(self):
         @cuda.jit("void(int32)", debug=True)

--- a/numba/cuda/tests/cudapy/test_vectorize.py
+++ b/numba/cuda/tests/cudapy/test_vectorize.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import vectorize
 from numba import cuda, int32, float32, float64
 from numba.cuda.testing import skip_on_cudasim
-from numba.cuda.testing import CUDATestCase
+from numba.cuda.testing import SerialMixin
 from numba.core import config
 import unittest
 
@@ -21,7 +21,7 @@ test_dtypes = np.float32, np.int32
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAVectorize(CUDATestCase):
+class TestCUDAVectorize(SerialMixin, unittest.TestCase):
     N = 1000001
 
     def test_scalar(self):

--- a/numba/cuda/tests/cudapy/test_vectorize.py
+++ b/numba/cuda/tests/cudapy/test_vectorize.py
@@ -3,7 +3,7 @@ import numpy as np
 from numba import vectorize
 from numba import cuda, int32, float32, float64
 from numba.cuda.testing import skip_on_cudasim
-from numba.cuda.testing import SerialMixin
+from numba.cuda.testing import CUDATestCase
 from numba.core import config
 import unittest
 
@@ -21,7 +21,7 @@ test_dtypes = np.float32, np.int32
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAVectorize(SerialMixin, unittest.TestCase):
+class TestCUDAVectorize(CUDATestCase):
     N = 1000001
 
     def test_scalar(self):

--- a/numba/cuda/tests/cudapy/test_vectorize_complex.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_complex.py
@@ -1,11 +1,11 @@
 import numpy as np
 from numba import vectorize
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeComplex(SerialMixin, unittest.TestCase):
+class TestVectorizeComplex(CUDATestCase):
     def test_vectorize_complex(self):
         @vectorize(['complex128(complex128)'], target='cuda')
         def vcomp(a):

--- a/numba/cuda/tests/cudapy/test_vectorize_decor.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_decor.py
@@ -9,14 +9,10 @@ import unittest
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
 class TestVectorizeDecor(CUDATestCase, BaseVectorizeDecor):
-    def test_gpu_1(self):
-        self._test_template_1('cuda')
-
-    def test_gpu_2(self):
-        self._test_template_2('cuda')
-
-    def test_gpu_3(self):
-        self._test_template_3('cuda')
+    """
+    Runs the tests from BaseVectorizeDecor with the CUDA target.
+    """
+    target = 'cuda'
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')

--- a/numba/cuda/tests/cudapy/test_vectorize_decor.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_decor.py
@@ -3,12 +3,12 @@ import numpy as np
 from numba import vectorize, cuda
 from numba.tests.npyufunc.test_vectorize_decor import BaseVectorizeDecor, \
     BaseVectorizeNopythonArg, BaseVectorizeUnrecognizedArg
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeDecor(SerialMixin, BaseVectorizeDecor):
+class TestVectorizeDecor(CUDATestCase, BaseVectorizeDecor):
     def test_gpu_1(self):
         self._test_template_1('cuda')
 
@@ -20,7 +20,7 @@ class TestVectorizeDecor(SerialMixin, BaseVectorizeDecor):
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestGPUVectorizeBroadcast(SerialMixin, unittest.TestCase):
+class TestGPUVectorizeBroadcast(CUDATestCase):
     def test_broadcast_bug_90(self):
         """
         https://github.com/ContinuumIO/numbapro/issues/90
@@ -61,14 +61,14 @@ class TestGPUVectorizeBroadcast(SerialMixin, unittest.TestCase):
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeNopythonArg(BaseVectorizeNopythonArg, SerialMixin):
+class TestVectorizeNopythonArg(BaseVectorizeNopythonArg, CUDATestCase):
     def test_target_cuda_nopython(self):
         warnings = ["nopython kwarg for cuda target is redundant"]
         self._test_target_nopython('cuda', warnings)
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestVectorizeUnrecognizedArg(BaseVectorizeUnrecognizedArg, SerialMixin):
+class TestVectorizeUnrecognizedArg(BaseVectorizeUnrecognizedArg, CUDATestCase):
     def test_target_cuda_unrecognized_arg(self):
         self._test_target_unrecognized_arg('cuda')
 

--- a/numba/cuda/tests/cudapy/test_vectorize_device.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_device.py
@@ -1,12 +1,12 @@
 from numba import vectorize
 from numba import cuda, float32
 import numpy as np
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCudaVectorizeDeviceCall(SerialMixin, unittest.TestCase):
+class TestCudaVectorizeDeviceCall(CUDATestCase):
     def test_cuda_vectorize_device_call(self):
 
         @cuda.jit(float32(float32, float32, float32), device=True)

--- a/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_scalar_arg.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numba import vectorize
 from numba import cuda, float64
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 from numba.core import config
 import unittest
 
@@ -14,7 +14,7 @@ if config.ENABLE_CUDASIM:
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
-class TestCUDAVectorizeScalarArg(SerialMixin, unittest.TestCase):
+class TestCUDAVectorizeScalarArg(CUDATestCase):
 
     def test_vectorize_scalar_arg(self):
         @vectorize(sig, target=target)

--- a/numba/cuda/tests/cudapy/test_warp_ops.py
+++ b/numba/cuda/tests/cudapy/test_warp_ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda, int32, int64, float32, float64
-from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.core import config
 
 
@@ -108,7 +108,7 @@ def _safe_cc_check(cc):
 @unittest.skipUnless(_safe_skip(),
                      "Warp Operations require at least CUDA 9"
                      "and are not yet implemented for the CudaSim")
-class TestCudaWarpOperations(SerialMixin, unittest.TestCase):
+class TestCudaWarpOperations(CUDATestCase):
     def test_useful_syncwarp(self):
         compiled = cuda.jit("void(int32[:])")(useful_syncwarp)
         nelem = 32

--- a/numba/cuda/tests/cudasim/test_cudasim_issues.py
+++ b/numba/cuda/tests/cudasim/test_cudasim_issues.py
@@ -4,13 +4,12 @@ import numpy as np
 
 import numba as nb
 from numba import cuda
-from numba.cuda.testing import SerialMixin, skip_unless_cudasim
+from numba.cuda.testing import CUDATestCase, skip_unless_cudasim
 import numba.cuda.simulator as simulator
 import unittest
 
 
-
-class TestCudaSimIssues(SerialMixin, unittest.TestCase):
+class TestCudaSimIssues(CUDATestCase):
 
 
     def test_record_access(self):

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -53,10 +53,6 @@ def make_tag_decorator(known_tags):
     return tag
 
 
-def test_mtime(x):
-    return str(os.path.getmtime(inspect.getfile(x.__class__))) + str(x)
-
-
 def parse_slice(useslice):
     """Parses the argument string "useslice" as the arguments to the `slice()`
     constructor and returns a slice object that's been instantiated with those
@@ -81,7 +77,6 @@ class TestLister(object):
         result = runner.TextTestResult(sys.stderr, descriptions=True, verbosity=1)
         self._test_list = _flatten_suite(test)
         masked_list = self._test_list[self.useslice]
-        self._test_list.sort(key=test_mtime)
         for t in masked_list:
             print(t.id())
         print('%d tests found. %s selected' % (len(self._test_list), len(masked_list)))
@@ -115,7 +110,6 @@ class BasicTestRunner(runner.TextTestRunner):
 
     def run(self, test):
         run = _flatten_suite(test)[self.useslice]
-        run.sort(key=test_mtime)
         wrapped = unittest.TestSuite(run)
         return super(BasicTestRunner, self).run(wrapped)
 
@@ -737,7 +731,6 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     def _run_parallel_tests(self, result, pool, child_runner, tests):
         remaining_ids = set(t.id() for t in tests)
-        tests.sort(key=test_mtime)
         it = pool.imap_unordered(child_runner, tests)
         while True:
             try:

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -61,8 +61,8 @@ def cuda_sensitive_mtime(x):
     CUDA tests the key prioritises the test module and class ahead of the
     mtime.
     """
-    key = str(os.path.getmtime(inspect.getfile(x.__class__))) + str(x)
     cls = x.__class__
+    key = str(os.path.getmtime(inspect.getfile(cls))) + str(x)
 
     from numba.cuda.testing import CUDATestCase
     if CUDATestCase in cls.mro():

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -53,6 +53,23 @@ def make_tag_decorator(known_tags):
     return tag
 
 
+def cuda_sensitive_mtime(x):
+    """
+    Return a key for sorting tests bases on mtime and test name. For CUDA
+    tests, interleaving tests from different classes is dangerous as the CUDA
+    context might get reset unexpectedly between methods of a class, so for
+    CUDA tests the key prioritises the test module and class ahead of the
+    mtime.
+    """
+    key = str(os.path.getmtime(inspect.getfile(x.__class__))) + str(x)
+    cls = x.__class__
+
+    from numba.cuda.testing import CUDATestCase
+    if CUDATestCase in cls.mro():
+        key = "%s.%s %s" % (str(cls.__module__), str(cls.__name__), key)
+
+    return key
+
 def parse_slice(useslice):
     """Parses the argument string "useslice" as the arguments to the `slice()`
     constructor and returns a slice object that's been instantiated with those
@@ -77,6 +94,7 @@ class TestLister(object):
         result = runner.TextTestResult(sys.stderr, descriptions=True, verbosity=1)
         self._test_list = _flatten_suite(test)
         masked_list = self._test_list[self.useslice]
+        self._test_list.sort(key=cuda_sensitive_mtime)
         for t in masked_list:
             print(t.id())
         print('%d tests found. %s selected' % (len(self._test_list), len(masked_list)))
@@ -110,6 +128,7 @@ class BasicTestRunner(runner.TextTestRunner):
 
     def run(self, test):
         run = _flatten_suite(test)[self.useslice]
+        run.sort(key=cuda_sensitive_mtime)
         wrapped = unittest.TestSuite(run)
         return super(BasicTestRunner, self).run(wrapped)
 
@@ -731,6 +750,7 @@ class ParallelTestRunner(runner.TextTestRunner):
 
     def _run_parallel_tests(self, result, pool, child_runner, tests):
         remaining_ids = set(t.id() for t in tests)
+        tests.sort(key=cuda_sensitive_mtime)
         it = pool.imap_unordered(child_runner, tests)
         while True:
             try:


### PR DESCRIPTION
This PR aims to fix #4954. Factors that come together to cause the issue are:

- The interleaving of CUDA test methods from different classes during execution.
- Some of the CUDA test classes having teardowns that reset the context after every method.
- Other CUDA test classes expect various CUDA objects (allocations, modules, streams, etc.) to persist between methods

So, some methods for class A would run, class B would then have a few methods run and reset the context, then another method from class A runs and causes unexpected behaviour (various CUDA errors, a segfault, etc.) because objects it expected to persist no longer exist in the context.

The main fix of this PR is to ensure that CUDA test classes have all their test methods executed concurrently, and not interleaved with other classes. However, there are also some other fixes / tidy-ups to the CUDA tests:

- Rename `CUDATestCase` to `ContextResettingTestCase`, so that it's clear what the class is for and what the subclasses will do.
- Put all tests that use a CUDA device under a common superclass, `CUDATestCase`, so that they can be identified easily (e.g. for the purpose of sorting correctly, as in this PR) or their behaviour modified as a set without editing lots of individual test classes (for possible future changes, e.g. parallelising the CUDA test suite). This is a subclass of `numba.testing.support.TestCase` because some of the CUDA test cases need `self.assertPreciseEqual`, etc.
- Fix the `TestVectorizeDecor` CUDA test - there's no way this could have worked before, and in previous test runs it doesn't appear in the results. I think some set of circumstances conspired to hide the errors from the results completely - now that the class is fixed and seems to be getting picked up, I get 588 CUDA tests run instead of 584 prior to this PR.