### PR TITLE
Replace NativeValue.is_error with NativeValue.error_blk

### DIFF
--- a/numba/core/callwrapper.py
+++ b/numba/core/callwrapper.py
@@ -31,8 +31,9 @@ class _ArgManager(object):
 
         # If an error occurred, go to the cleanup block for
         # the previous argument
-        with cgutils.if_unlikely(self.builder, native.is_error):
-            self.builder.branch(self.nextblk)
+        if native.error_blk is not None:
+            with self.builder.goto_block(native.error_blk):
+                self.builder.branch(self.nextblk)
 
         # Define the cleanup function for the argument
         def cleanup_arg():

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -95,9 +95,9 @@ class NativeValue(object):
     recording whether the conversion was successful and how to cleanup.
     """
 
-    def __init__(self, value, is_error=None, cleanup=None):
+    def __init__(self, value, error_blk=None, cleanup=None):
         self.value = value
-        self.is_error = is_error if is_error is not None else cgutils.false_bit
+        self.error_blk = error_blk
         self.cleanup = cleanup
 
 


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Done as an experiment to fix problems in #5417. Likely has typos for now.


The idea here is to use an exception-like model for propagating errors from unboxing, rather than using an error-code model. This means that for `native = unbox`, `native.error_blk` now points to an unterminated block that will be jumped to if an error occurs (or `None` if the unboxing cannot fail).

As a bonus, I suspect this now makes it a compilation error to not attempt to handle unboxing errors, as it would result in `native.error_blk` being unterminated.