### PR TITLE
Fix #5421: Add notes on printing in CUDA kernels

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -36,6 +36,14 @@ The following Python constructs are not supported:
 The ``raise`` and ``assert`` statements are supported.
 See :ref:`nopython language support <pysupported-language>`.
 
+Printing of strings and integers is supported (see :ref:`nopython builtin
+support <pysupported-builtin-functions>`), but printing is an asynchronous
+operation - in order to ensure that all output is printed after a kernel
+launch, it is necessary to call :func:`numba.cuda.synchronize`. Eliding the
+call to ``synchronize`` is acceptable, but output from a kernel may appear
+during other later driver operations (e.g. subsequent kernel launches, memory
+transfers, etc.), or fail to appear before the program execution completes.
+
 Built-in types
 ===============
 

--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -36,11 +36,10 @@ The following Python constructs are not supported:
 The ``raise`` and ``assert`` statements are supported.
 See :ref:`nopython language support <pysupported-language>`.
 
-Printing of strings and numbers is supported (see :ref:`nopython builtin
-support <pysupported-builtin-functions>`), but printing is an asynchronous
-operation - in order to ensure that all output is printed after a kernel
-launch, it is necessary to call :func:`numba.cuda.synchronize`. Eliding the
-call to ``synchronize`` is acceptable, but output from a kernel may appear
+Printing of strings, integers, and floats is supported, but printing is an
+asynchronous operation - in order to ensure that all output is printed after a
+kernel launch, it is necessary to call :func:`numba.cuda.synchronize`. Eliding
+the call to ``synchronize`` is acceptable, but output from a kernel may appear
 during other later driver operations (e.g. subsequent kernel launches, memory
 transfers, etc.), or fail to appear before the program execution completes.
 

--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -36,7 +36,7 @@ The following Python constructs are not supported:
 The ``raise`` and ``assert`` statements are supported.
 See :ref:`nopython language support <pysupported-language>`.
 
-Printing of strings and integers is supported (see :ref:`nopython builtin
+Printing of strings and numbers is supported (see :ref:`nopython builtin
 support <pysupported-builtin-functions>`), but printing is an asynchronous
 operation - in order to ensure that all output is printed after a kernel
 launch, it is necessary to call :func:`numba.cuda.synchronize`. Eliding the

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -736,6 +736,8 @@ retrieving the len(), and also the following attributes:
 * :attr:`~memoryview.strides`
 
 
+.. _pysupported-builtin-functions:
+
 Built-in functions
 ==================
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -736,8 +736,6 @@ retrieving the len(), and also the following attributes:
 * :attr:`~memoryview.strides`
 
 
-.. _pysupported-builtin-functions:
-
 Built-in functions
 ==================
 


### PR DESCRIPTION
As I may not be the only one who gets caught out by #5421, this PR attempts to improve the documentation surrounding it :-)

It may not be obvious that printing in CUDA kernels is an asynchronous operation, so this commit adds some notes to the manual describing the behaviour and the requirement for synchronization in order to avoid print output from a kernel only appearing during later driver operations.