### PR TITLE
Wip/deprecate jitclass location

### DIFF
--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -9,7 +9,7 @@ set -v -e
 if [ "$BUILD_DOC" == "yes" ]; then rstcheck README.rst; fi
 # Ensure that the documentation builds without warnings
 pushd docs
-if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi
+if [ "$BUILD_DOC" == "yes" ]; then make clean html; fi
 popd
 # Run system info tool
 pushd bin

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -221,3 +221,36 @@ benefit to having the ``@jit`` decorator present consider removing it! If there
 is benefit to having the ``@jit`` decorator present, then to be future proof
 supply the keyword argument ``forceobj=True`` to ensure the function is always
 compiled in :term:`object mode`.
+
+
+Change of jitclass location
+===========================
+Between versions 0.48 and 0.49 Numba underwent a large amount of refactoring.
+One of the decisions made by the core developers as part of this refactoring was
+to move ``numba.jitclass`` to a new location ``numba.experimental.jitclass``.
+This is to help reinforce expectations over the behaviour and support for
+certain features by deliberately placing them in an ``experimental`` submodule.
+
+
+Example(s) of the impact
+------------------------
+The ``jitclass`` decorator has historically been available via
+``from numba import jitclass``, any code using this import location will in
+future need to be updated to ``from numba.experimental import jitclass``.
+
+
+Recommendations
+---------------
+Simply update imports as follows:
+
+* Change ``from numba import jitclass`` to
+  ``from numba.experimental import jitclass``
+
+
+Schedule
+--------
+This feature will be moved with respect to this schedule:
+
+* Deprecation warnings will be issued in version 0.49.0
+* Support for importing from ``numba.jitclass`` will be removed in version
+  0.51.0.

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -44,6 +44,9 @@ from numba.np.numpy_support import carray, farray, from_dtype
 # Re-export experimental
 from numba import experimental
 
+# Re-export experimental.jitclass as jitclass, this is deprecated
+from numba.experimental import jitclass
+
 # Initialize withcontexts
 import numba.core.withcontexts
 from numba.core.withcontexts import objmode_context as objmode
@@ -64,6 +67,7 @@ __all__ = """
     njit
     stencil
     jit_module
+    jitclass
     typeof
     prange
     gdb

--- a/numba/analysis.py
+++ b/numba/analysis.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.analysis"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.analysis import *  # noqa: F403, F401
+    from numba.core.analysis import _use_defs_result  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/array_analysis.py
+++ b/numba/array_analysis.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.parfors.array_analysis"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.parfors.array_analysis import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/cgutils.py
+++ b/numba/cgutils.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.cgutils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.cgutils import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/compiler.py
+++ b/numba/compiler.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.compiler"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.compiler import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/compiler_machinery.py
+++ b/numba/compiler_machinery.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.compiler_machinery"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.compiler_machinery import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from numba.core.utils import add_metaclass, reraise, chain_exception
 from functools import wraps
 from abc import abstractmethod
+from importlib import import_module
 
 # Filled at the end
 __all__ = []
@@ -390,6 +391,48 @@ def deprecated(arg):
         return decorator(arg)
     else:
         return decorator
+
+
+_moved_msg1 = ("An import was requested from a module that has moved location."
+               "\nImport requested from: '{}', please update to use "
+               "'{}' or pin to Numba version 0.48.0. This alias will not be "
+               "present in Numba version 0.50.0.")
+
+
+_moved_msg2 = ("An import was requested from a module that has moved location"
+               ".\nImport of '{}' requested from: '{}', please update to use "
+               "'{}' or pin to Numba version 0.48.0. This alias will not be "
+               "present in Numba version 0.50.0.")
+
+
+_moved_no_replacement = ("No direct replacement available. Visit "
+                         "https://gitter.im/numba/numba-dev to request help. "
+                         "Thanks!")
+
+
+def deprecate_moved_module(old_module, new_module, stacklevel=3):
+    """Warn about a module level location move of some part of Numba's
+    internals. stacklevel is 3 by default as most warning locations are
+    from `numba.XYZ` shims.
+    """
+    if new_module is None:
+        msg = _moved_no_replacement
+    else:
+        msg = _moved_msg1.format(old_module, new_module)
+    warnings.warn(msg, category=NumbaDeprecationWarning, stacklevel=stacklevel)
+
+
+def deprecate_moved_module_getattr(old_module, new_module):
+    """For replacing module level __getattr__ to warn users above modules moving
+    locations
+    """
+    def wrapper(attr):
+        mod = import_module(new_module)
+        ret_attr = getattr(mod, attr)
+        msg = _moved_msg2.format(attr, old_module, new_module)
+        warnings.warn(msg, category=NumbaDeprecationWarning, stacklevel=2)
+        return ret_attr
+    return wrapper
 
 
 class WarningsFixer(object):

--- a/numba/datamodel/__init__.py
+++ b/numba/datamodel/__init__.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.datamodel"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.datamodel import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/datamodel/models.py
+++ b/numba/datamodel/models.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.datamodel.models"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.datamodel.models import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/decorators.py
+++ b/numba/decorators.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.decorators"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.decorators import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/dictobject.py
+++ b/numba/dictobject.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.typed.dictobject"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.typed.dictobject import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/dispatcher.py
+++ b/numba/dispatcher.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.dispatcher"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.dispatcher import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/errors.py
+++ b/numba/errors.py
@@ -1,0 +1,17 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.errors"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    # wildcard import fails, import explicit
+    from numba.core.errors import (  # noqa: F401
+        WarningsFixer,
+        TypingError,
+        NumbaWarning,
+        ForceLiteralArg,
+    )
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -1,5 +1,7 @@
 from numba.core import types, config
+from numba.core import errors
 from numba.experimental.jitclass.base import register_class_type, ClassBuilder
+import warnings
 
 
 def jitclass(spec):
@@ -18,6 +20,17 @@ def jitclass(spec):
 
     A callable that takes a class object, which will be compiled.
     """
+    url = ("http://numba.pydata.org/numba-doc/latest/reference/"
+           "deprecation.html#change-of-jitclass-location")
+
+    msg = ("The 'numba.jitclass' decorator has moved to "
+           "'numba.experimental.jitclass' to better reflect the experimental "
+           "nature of the functionality. Please update your imports to "
+           "accommodate this change and see {} for the time frame.".format(url))
+
+    warnings.warn(msg, category=errors.NumbaDeprecationWarning,
+                  stacklevel=2)
+
     def wrap(cls):
         if config.DISABLE_JIT:
             return cls

--- a/numba/inline_closurecall.py
+++ b/numba/inline_closurecall.py
@@ -1,0 +1,14 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.inline_closurecall"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.inline_closurecall import *  # noqa: F403, F401
+    from numba.core.inline_closurecall import _replace_returns  # noqa: F401
+    from numba.core.inline_closurecall import _replace_freevars  # noqa: F401
+    from numba.core.inline_closurecall import _add_definitions  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/ir.py
+++ b/numba/ir.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.ir"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.ir import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1,0 +1,13 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.ir_utils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.ir_utils import *  # noqa: F403, F401
+    from numba.core.ir_utils import _max_label  # noqa: F401
+    from numba.core.ir_utils import _add_alias  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/lowering.py
+++ b/numba/lowering.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.lowering"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.lowering import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/npdatetime.py
+++ b/numba/npdatetime.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.npdatetime_helpers"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.npdatetime_helpers import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/numpy_support.py
+++ b/numba/numpy_support.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.numpy_support"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.numpy_support import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.parfors.parfor"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.parfors.parfor import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/pythonapi.py
+++ b/numba/pythonapi.py
@@ -1,0 +1,13 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.pythonapi"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.pythonapi import *  # noqa: F403, F401
+    from numba.core.pythonapi import _BoxContext  # noqa: F401
+    from numba.core.pythonapi import _UnboxContext  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/rewrites/__init__.py
+++ b/numba/rewrites/__init__.py
@@ -1,0 +1,15 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.rewrites"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.rewrites.registry import (
+        register_rewrite,  # noqa: F401
+        rewrite_registry,  # noqa: F401
+        Rewrite,
+    )  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/runtime/__init__.py
+++ b/numba/runtime/__init__.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.runtime"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.runtime import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/runtime/nrt.py
+++ b/numba/runtime/nrt.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.runtime.nrt"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.runtime.nrt import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/stencil.py
+++ b/numba/stencil.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.stencils.stencil"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.stencils.stencil import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.stencils.stencilparfor"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.stencils.stencilparfor import *  # noqa: F403, F401
+    from numba.stencils.stencilparfor import _compute_last_ind  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/__init__.py
+++ b/numba/targets/__init__.py
@@ -1,0 +1,9 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = None
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/arraymath.py
+++ b/numba/targets/arraymath.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.arraymath"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.arraymath import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.arrayobj"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.arrayobj import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/boxing.py
+++ b/numba/targets/boxing.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.boxing"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.boxing import *  # noqa: F403, F401
+    from numba.core.boxing import _NumbaTypeHelper  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.builtins"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.builtins import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/callconv.py
+++ b/numba/targets/callconv.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.callconv"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.callconv import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/cpu.py
+++ b/numba/targets/cpu.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.cpu"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.cpu import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/hashing.py
+++ b/numba/targets/hashing.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.hashing"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.hashing import *  # noqa: F403, F401
+    from numba.cpython.hashing import _Py_hash_t  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/imputils.py
+++ b/numba/targets/imputils.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.imputils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.imputils import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/listobj.py
+++ b/numba/targets/listobj.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.listobj"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.listobj import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/npdatetime.py
+++ b/numba/targets/npdatetime.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.npdatetime"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.npdatetime import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/options.py
+++ b/numba/targets/options.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.options"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.options import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/registry.py
+++ b/numba/targets/registry.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.registry"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.registry import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/setobj.py
+++ b/numba/targets/setobj.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.setobj"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.setobj import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/slicing.py
+++ b/numba/targets/slicing.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.slicing"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.slicing import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/targets/ufunc_db.py
+++ b/numba/targets/ufunc_db.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.ufunc_db"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.ufunc_db import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/tests/test_refactor_moves.py
+++ b/numba/tests/test_refactor_moves.py
@@ -875,6 +875,27 @@ class TestAPIMoves_Q1_2020(TestCase):
             with checker(fn):
                 getattr(numba.decorators, fn)
 
+    def test_numba_jitclass(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", NumbaDeprecationWarning)
+            from numba import jitclass # SHOULD NOT WARN
+        for x in w:
+            if "numba.jitclass" in str(x.message):
+                raise ValueError("Unexpected warning encountered")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", NumbaDeprecationWarning)
+            @jitclass(spec=[])
+            class foo:
+                def __init__(self):
+                    pass
+            foo()
+        for x in w:
+            if "has moved to 'numba.experimental.jitclass'" in str(x.message):
+                break
+        else:
+            raise ValueError("Expected warning not found")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/numba/tests/test_refactor_moves.py
+++ b/numba/tests/test_refactor_moves.py
@@ -1,0 +1,880 @@
+import unittest
+import warnings
+from importlib import import_module
+from contextlib import contextmanager
+
+from numba.core.errors import NumbaDeprecationWarning
+from numba.tests.support import TestCase
+from numba.core.utils import PYVERSION
+
+
+class TestAPIMoves_Q1_2020(TestCase):
+    """ Checks API moves made in Q1 2020, this roughly corresponds to 0.48->0.49
+    """
+
+    def check_warning(self, from_mod, to_mod):
+        """
+        Returns a context manager to check that a NumbaDeprecationWarning is
+        raised in the context managed block and that the warning contains
+        information that from_mod has moved to to_mod
+        """
+        # make sure the `to_mod` location actually exists (None indicates no
+        # replacement"
+        if to_mod is not None:
+            import_module(to_mod)
+
+        @contextmanager
+        def checker(fn=None):
+            """
+            If fn is not None and Python version is >= 3.7 then a check will be
+            made to ensure the module level `__getattr__`
+            """
+            if fn is not None and PYVERSION < (3, 7):
+                # nothing to check , there's no module __getattr__ to intercept
+                # in Python < 3.7
+                yield
+            else:
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always", NumbaDeprecationWarning)
+                    yield
+                self.assertTrue(len(w) > 0)
+                _require = "requested from a module that has moved location"
+                for x in w:
+                    if to_mod is not None:
+                        c1 = _require in str(x.message)
+                        c2 = from_mod in str(x.message)
+                        c3 = to_mod in str(x.message)
+                    else:  # check for help link
+                        c1 = True
+                        c2 = True
+                        c3 = "gitter.im" in str(x.message)
+                    if fn is not None:
+                        c4 = "Import of '{}' requested".format(fn) in str(
+                            x.message
+                        )
+                    else:
+                        c4 = True
+                    if c1 and c2 and c3 and c4:
+                        break
+                else:
+                    raise ValueError("No valid warning message found")
+
+        return checker
+
+    def test_nonexistant_moved_raises_not_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", NumbaDeprecationWarning)
+            with self.assertRaises(ImportError) as raises:
+                from numba import nonexistant_thing  # noqa: F401
+            self.assertIn("cannot import name", str(raises.exception))
+            self.assertIn("nonexistant_thing", str(raises.exception))
+        self.assertEqual(len(w), 0)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", NumbaDeprecationWarning)
+            with self.assertRaises(ImportError) as raises:
+                import numba.nonexistant_thing  # noqa: F401
+            self.assertIn("No module named", str(raises.exception))
+            self.assertIn("nonexistant_thing", str(raises.exception))
+        self.assertEqual(len(w), 0)
+
+    def test_numba_utils(self):
+        checker = self.check_warning("numba.utils", "numba.core.utils")
+        with checker():
+            import numba.utils
+
+        for fn in ("pysignature", "OPERATORS_TO_BUILTINS"):
+            with checker(fn):
+                getattr(numba.utils, fn)
+
+    def test_numba_untyped_passes(self):
+        checker = self.check_warning(
+            "numba.untyped_passes", "numba.core.untyped_passes"
+        )
+        with checker():
+            import numba.untyped_passes
+
+        fn = "InlineClosureLikes"
+        with checker(fn):
+            getattr(numba.untyped_passes, fn)
+
+    def test_numba_unsafe(self):
+        # this is a bit dubious, unsafe was largely split up and moved.
+        # numba.unsafe.refcount is in use in external packages and is now in
+        # core
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always", NumbaDeprecationWarning)
+            fn = "refcount"
+            import numba.unsafe
+
+            getattr(numba.unsafe, fn)
+        for x in w:
+            if "No direct replacement available" in str(x.message):
+                break
+        else:
+            raise ValueError("Could not find expected warning message")
+
+    def test_numba_unsafe_ndarray(self):
+        checker = self.check_warning(
+            "numba.unsafe.ndarray", "numba.np.unsafe.ndarray"
+        )
+        with checker():
+            import numba.unsafe.ndarray
+
+        fn = "empty_inferred"
+        with checker(fn):
+            getattr(numba.unsafe.ndarray, fn)
+
+    def test_numba_unicode(self):
+        checker = self.check_warning("numba.unicode", "numba.cpython.unicode")
+        with checker():
+            import numba.unicode
+
+        for fn in (
+            "unbox_unicode_str",
+            "make_string_from_constant",
+            "_slice_span",
+            "_normalize_slice",
+            "_empty_string",
+            "PY_UNICODE_1BYTE_KIND",
+            "PY_UNICODE_2BYTE_KIND",
+            "PY_UNICODE_4BYTE_KIND",
+            "PY_UNICODE_WCHAR_KIND",
+        ):
+            with checker(fn):
+                getattr(numba.unicode, fn)
+
+    def test_aaaaa_numba_typing(self):
+        # silly 'aaaaa' name to game test ordering, warnings only get triggered
+        # once and the `TestAPIMoves_Q1_2020` hits numba.typing.* so this needs
+        # to run first
+        checker = self.check_warning("numba.typing", "numba.core.typing")
+        with checker():
+            import numba.typing
+
+        for fn in (
+            "signature",
+            "make_concrete_template",
+            "Signature",
+            "fold_arguments",
+        ):
+            with checker(fn):
+                getattr(numba.typing, fn)
+
+    def test_numba_typing_typeof(self):
+        checker = self.check_warning(
+            "numba.typing.typeof", "numba.core.typing.typeof"
+        )
+        with checker():
+            import numba.typing.typeof
+
+        for fn in ("typeof_impl", "_typeof_ndarray"):
+            with checker(fn):
+                getattr(numba.typing.typeof, fn)
+
+    def test_numba_typing_templates(self):
+        checker = self.check_warning(
+            "numba.typing.templates", "numba.core.typing.templates"
+        )
+        with checker():
+            import numba.typing.templates
+
+        for fn in (
+            "signature",
+            "infer_global",
+            "infer_getattr",
+            "infer",
+            "bound_function",
+            "AttributeTemplate",
+            "AbstractTemplate",
+        ):
+            with checker(fn):
+                getattr(numba.typing.templates, fn)
+
+    def test_numba_typing_npydecl(self):
+        checker = self.check_warning(
+            "numba.typing.npydecl", "numba.core.typing.npydecl"
+        )
+        with checker():
+            import numba.typing.npydecl
+
+        for fn in (
+            "supported_ufuncs",
+            "NumpyRulesInplaceArrayOperator",
+            "NumpyRulesArrayOperator",
+            "NdConcatenate",
+        ):
+            with checker(fn):
+                getattr(numba.typing.npydecl, fn)
+
+    def test_numba_typing_ctypes_utils(self):
+        checker = self.check_warning(
+            "numba.typing.ctypes_utils", "numba.core.typing.ctypes_utils"
+        )
+        with checker():
+            import numba.typing.ctypes_utils
+
+        fn = "make_function_type"
+        with checker(fn):
+            getattr(numba.typing.ctypes_utils, fn)
+
+    def test_numba_typing_collections(self):
+        checker = self.check_warning(
+            "numba.typing.collections", "numba.core.typing.collections"
+        )
+        with checker():
+            import numba.typing.collections
+
+        fn = "GetItemSequence"
+        with checker(fn):
+            getattr(numba.typing.collections, fn)
+
+    def test_numba_typing_builtins(self):
+        checker = self.check_warning(
+            "numba.typing.builtins", "numba.core.typing.builtins"
+        )
+        with checker():
+            import numba.typing.builtins
+
+        for fn in (
+            "MinMaxBase",
+            "IndexValueType",
+        ):
+            with checker(fn):
+                getattr(numba.typing.builtins, fn)
+
+    def test_numba_typing_arraydecl(self):
+        checker = self.check_warning(
+            "numba.typing.arraydecl", "numba.core.typing.arraydecl"
+        )
+        with checker():
+            import numba.typing.arraydecl
+
+        for fn in (
+            "get_array_index_type",
+            "ArrayAttribute",
+        ):
+            with checker(fn):
+                getattr(numba.typing.arraydecl, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.typing.arraydecl import ArrayAttribute
+
+            ArrayAttribute.resolve_var
+            ArrayAttribute.resolve_sum
+            ArrayAttribute.resolve_prod
+
+    def test_numba_typeinfer(self):
+        checker = self.check_warning("numba.typeinfer", "numba.core.typeinfer")
+        with checker():
+            import numba.typeinfer
+
+        fn = "IntrinsicCallConstraint"
+        with checker(fn):
+            getattr(numba.typeinfer, fn)
+
+    def test_numba_typedobjectutils(self):
+        checker = self.check_warning(
+            "numba.typedobjectutils", "numba.typed.typedobjectutils"
+        )
+        with checker():
+            import numba.typedobjectutils
+
+        fn = "_cast"
+        with checker(fn):
+            getattr(numba.typedobjectutils, fn)
+
+    def test_numba_typed_passes(self):
+        checker = self.check_warning(
+            "numba.typed_passes", "numba.core.typed_passes"
+        )
+        with checker():
+            import numba.typed_passes
+
+        for fn in ("type_inference_stage", "AnnotateTypes"):
+            with checker(fn):
+                getattr(numba.typed_passes, fn)
+
+    def test_numba_typed(self):
+        # no refactoring was done to `numba.typed`.
+        import numba.typed  # noqa: F401
+        from numba.typed import List
+
+        List.empty_list
+        from numba.typed import Dict
+
+        Dict.empty
+
+    def test_numba_typeconv(self):
+        checker = self.check_warning("numba.typeconv", "numba.core.typeconv")
+        with checker():
+            import numba.typeconv
+
+        fn = "Conversion"
+        with checker(fn):
+            getattr(numba.typeconv, fn)
+
+    def test_numba_types(self):
+        checker = self.check_warning("numba.types", "numba.core.types")
+        with checker():
+            import numba.types
+
+        for fn in ("int64", "float64"):
+            with checker(fn):
+                getattr(numba.types, fn)
+
+    def test_aaaaa_numba_targets(self):
+        # silly 'aaaaa' name to game test ordering, warnings only get triggered
+        # once and the `TestAPIMoves_Q1_2020` hits numba.targets.* so this needs
+        # to run first
+        checker = self.check_warning("numba.targets", None)
+        with checker():
+            import numba.targets  # noqa: F401
+
+    def test_numba_targets_boxing(self):
+        checker = self.check_warning(
+            "numba.targets.boxing", "numba.core.boxing"
+        )
+        with checker():
+            import numba.targets.boxing
+
+        for fn in ("box_array", "_NumbaTypeHelper"):
+            with checker(fn):
+                getattr(numba.targets.boxing, fn)
+
+    def test_numba_targets_callconv(self):
+        checker = self.check_warning(
+            "numba.targets.callconv", "numba.core.callconv"
+        )
+        with checker():
+            import numba.targets.callconv
+
+        fn = "RETCODE_USEREXC"
+        with checker(fn):
+            getattr(numba.targets.callconv, fn)
+
+    def test_numba_targets_hashing(self):
+        checker = self.check_warning(
+            "numba.targets.hashing", "numba.cpython.hashing"
+        )
+        with checker():
+            import numba.targets.hashing
+
+        # some codebases claim to use these, but they are not present in 0.48:
+        # '_Py_HashSecret_siphash_k0', '_Py_HashSecret_siphash_k1',
+        # '_Py_HashSecret_djbx33a_suffix'
+        fn = "_Py_hash_t"
+        with checker(fn):
+            getattr(numba.targets.hashing, fn)
+
+    def test_numba_targets_ufunc_db(self):
+        checker = self.check_warning(
+            "numba.targets.ufunc_db", "numba.np.ufunc_db"
+        )
+        with checker():
+            import numba.targets.ufunc_db
+
+        fn = "get_ufuncs"
+        with checker(fn):
+            getattr(numba.targets.ufunc_db, fn)
+
+    def test_numba_targets_slicing(self):
+        checker = self.check_warning(
+            "numba.targets.slicing", "numba.cpython.slicing"
+        )
+        with checker():
+            import numba.targets.slicing
+
+        for fn in ("guard_invalid_slice", "get_slice_length", "fix_slice"):
+            with checker(fn):
+                getattr(numba.targets.slicing, fn)
+
+    def test_numba_targets_setobj(self):
+        checker = self.check_warning(
+            "numba.targets.setobj", "numba.cpython.setobj"
+        )
+        with checker():
+            import numba.targets.setobj
+
+        fn = "set_empty_constructor"
+        with checker(fn):
+            getattr(numba.targets.setobj, fn)
+
+    def test_numba_targets_registry(self):
+        checker = self.check_warning(
+            "numba.targets.registry", "numba.core.registry"
+        )
+        with checker():
+            import numba.targets.registry
+
+        for fn in ("dispatcher_registry", "cpu_target"):
+            with checker(fn):
+                getattr(numba.targets.registry, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.targets.registry import cpu_target
+
+            typing_context = cpu_target.typing_context
+            typing_context.resolve_value_type
+
+    def test_numba_targets_options(self):
+        checker = self.check_warning(
+            "numba.targets.options", "numba.core.options"
+        )
+        with checker():
+            import numba.targets.options
+
+        fn = "TargetOptions"
+        with checker(fn):
+            getattr(numba.targets.options, fn)
+
+    def test_numba_targets_listobj(self):
+        checker = self.check_warning(
+            "numba.targets.listobj", "numba.cpython.listobj"
+        )
+        with checker():
+            import numba.targets.listobj
+
+        fn = "ListInstance"
+        with checker(fn):
+            getattr(numba.targets.listobj, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.targets.listobj import ListInstance
+
+            ListInstance.allocate
+
+    def test_numba_targets_imputils(self):
+        checker = self.check_warning(
+            "numba.targets.imputils", "numba.core.imputils"
+        )
+        with checker():
+            import numba.targets.imputils
+
+        for fn in (
+            "lower_cast",
+            "iternext_impl",
+            "impl_ret_new_ref",
+            "RefType",
+        ):
+            with checker(fn):
+                getattr(numba.targets.imputils, fn)
+
+    def test_numba_targets_cpu(self):
+        checker = self.check_warning("numba.targets.cpu", "numba.core.cpu")
+        with checker():
+            import numba.targets.cpu
+
+        for fn in ("ParallelOptions", "CPUTargetOptions", "CPUContext"):
+            with checker(fn):
+                getattr(numba.targets.cpu, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.targets.cpu import CPUTargetOptions
+
+            CPUTargetOptions.OPTIONS
+
+    def test_numba_targets_builtins(self):
+        checker = self.check_warning(
+            "numba.targets.builtins", "numba.cpython.builtins"
+        )
+        with checker():
+            import numba.targets.builtins
+
+        for fn in ("get_type_min_value", "get_type_max_value"):
+            with checker(fn):
+                getattr(numba.targets.builtins, fn)
+
+    def test_numba_targets_arrayobj(self):
+        checker = self.check_warning(
+            "numba.targets.arrayobj", "numba.np.arrayobj"
+        )
+        with checker():
+            import numba.targets.arrayobj
+
+        for fn in (
+            "store_item",
+            "setitem_array",
+            "populate_array",
+            "numpy_empty_nd",
+            "make_array",
+            "getiter_array",
+            "getitem_arraynd_intp",
+            "getitem_array_tuple",
+            "fancy_getitem_array",
+            "array_reshape",
+            "array_ravel",
+            "array_len",
+            "array_flatten",
+        ):
+            with checker(fn):
+                getattr(numba.targets.arrayobj, fn)
+
+    def test_numba_targets_arraymath(self):
+        checker = self.check_warning(
+            "numba.targets.arraymath", "numba.np.arraymath"
+        )
+        with checker():
+            import numba.targets.arraymath
+
+        fn = "get_isnan"
+        with checker(fn):
+            getattr(numba.targets.arraymath, fn)
+
+    def test_numba_stencilparfor(self):
+        checker = self.check_warning(
+            "numba.stencilparfor", "numba.stencils.stencilparfor"
+        )
+        with checker():
+            import numba.stencilparfor
+
+        fn = "_compute_last_ind"
+        with checker(fn):
+            getattr(numba.stencilparfor, fn)
+
+    def test_numba_stencil(self):
+        checker = self.check_warning("numba.stencil", "numba.stencils.stencil")
+        with checker():
+            import numba.stencil
+
+        fn = "StencilFunc"
+        with checker(fn):
+            getattr(numba.stencil, fn)
+
+    def test_numba_runtime_nrt(self):
+        checker = self.check_warning(
+            "numba.runtime.nrt", "numba.core.runtime.nrt"
+        )
+        with checker():
+            import numba.runtime.nrt
+
+        fn = "rtsys"
+        with checker(fn):
+            getattr(numba.runtime.nrt, fn)
+
+    def test_numba_runtime(self):
+        checker = self.check_warning("numba.runtime", "numba.core.runtime")
+        with checker():
+            import numba.runtime
+
+        fn = "nrt"
+        with checker(fn):
+            getattr(numba.runtime, fn)
+
+    def test_numba_rewrites(self):
+        checker = self.check_warning("numba.rewrites", "numba.core.rewrites")
+        with checker():
+            import numba.rewrites
+
+        fn = "rewrite_registry"
+        with checker(fn):
+            getattr(numba.rewrites, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.rewrites import rewrite_registry
+
+            rewrite_registry.apply
+
+    def test_numba_pythonapi(self):
+        checker = self.check_warning("numba.pythonapi", "numba.core.pythonapi")
+        with checker():
+            import numba.pythonapi
+
+        for fn in (
+            "_UnboxContext",
+            "_BoxContext",
+        ):
+            with checker(fn):
+                getattr(numba.pythonapi, fn)
+
+    def test_numba_parfor(self):
+        checker = self.check_warning("numba.parfor", "numba.parfors.parfor")
+        with checker():
+            import numba.parfor
+
+        for fn in (
+            "replace_functions_map",
+            "min_checker",
+            "maximize_fusion",
+            "max_checker",
+            "lower_parfor_sequential",
+            "internal_prange",
+            "init_prange",
+            "argmin_checker",
+            "argmax_checker",
+            "PreParforPass",
+            "ParforPass",
+            "Parfor",
+        ):
+            with checker(fn):
+                getattr(numba.parfor, fn)
+
+    def test_numba_numpy_support(self):
+        checker = self.check_warning(
+            "numba.numpy_support", "numba.np.numpy_support"
+        )
+        with checker():
+            import numba.numpy_support
+
+        for fn in ("map_layout", "from_dtype", "as_dtype"):
+            with checker(fn):
+                getattr(numba.numpy_support, fn)
+
+    def test_numba_targets_npdatetime(self):
+        checker = self.check_warning(
+            "numba.targets.npdatetime", "numba.np.npdatetime"
+        )
+        with checker():
+            import numba.targets.npdatetime
+
+        for fn in ("convert_datetime_for_arith",):
+            with checker(fn):
+                getattr(numba.targets.npdatetime, fn)
+
+    def test_numba_npdatetime(self):
+        #  the <= 0.48  numba.npdatetime module provides the datetime helper
+        # functions, this got moved in location and name
+        checker = self.check_warning(
+            "numba.npdatetime", "numba.np.npdatetime_helpers"
+        )
+        with checker():
+            import numba.npdatetime
+
+        for fn in ("DATETIME_UNITS",):
+            with checker(fn):
+                getattr(numba.npdatetime, fn)
+
+    def test_numba_lowering(self):
+        checker = self.check_warning("numba.lowering", "numba.core.lowering")
+        with checker():
+            import numba.lowering  # noqa: F401
+
+    def test_numba_ir_utils(self):
+        checker = self.check_warning("numba.ir_utils", "numba.core.ir_utils")
+        with checker():
+            import numba.ir_utils
+
+        for fn in (
+            "simplify_CFG",
+            "replace_vars_stmt",
+            "replace_arg_nodes",
+            "remove_dead",
+            "remove_call_handlers",
+            "next_label",
+            "mk_unique_var",
+            "get_ir_of_code",
+            "get_definition",
+            "find_const",
+            "dprint_func_ir",
+            "compute_cfg_from_blocks",
+            "compile_to_numba_ir",
+            "build_definitions",
+            "alias_func_extensions",
+            "_max_label",
+            "_add_alias",
+            "GuardException",
+        ):
+            with checker(fn):
+                getattr(numba.ir_utils, fn)
+
+    def test_numba_ir(self):
+        checker = self.check_warning("numba.ir", "numba.core.ir")
+        with checker():
+            import numba.ir
+
+        for fn in ("Assign", "Const", "Expr", "Var"):
+            with checker(fn):
+                getattr(numba.ir, fn)
+
+    def test_numba_inline_closurecall(self):
+        checker = self.check_warning(
+            "numba.inline_closurecall", "numba.core.inline_closurecall"
+        )
+        with checker():
+            import numba.inline_closurecall
+
+        for fn in (
+            "inline_closure_call",
+            "_replace_returns",
+            "_replace_freevars",
+            "_add_definitions",
+        ):
+            with checker(fn):
+                getattr(numba.inline_closurecall, fn)
+
+    def test_numba_errors(self):
+        checker = self.check_warning("numba.errors", "numba.core.errors")
+        with checker():
+            import numba.errors
+
+        for fn in (
+            "WarningsFixer",
+            "TypingError",
+            "NumbaWarning",
+            "ForceLiteralArg",
+        ):
+            with checker(fn):
+                getattr(numba.errors, fn)
+
+    def test_numba_dispatcher(self):
+        checker = self.check_warning(
+            "numba.dispatcher", "numba.core.dispatcher"
+        )
+        with checker():
+            import numba.dispatcher
+
+        for fn in (
+            "ObjModeLiftedWith",
+            "Dispatcher",
+        ):
+            with checker(fn):
+                getattr(numba.dispatcher, fn)
+
+    def test_numba_dictobject(self):
+        checker = self.check_warning(
+            "numba.dictobject", "numba.typed.dictobject"
+        )
+        with checker():
+            import numba.dictobject
+
+        fn = "DictModel"
+        with checker(fn):
+            getattr(numba.dictobject, fn)
+
+    def test_numba_datamodel(self):
+        checker = self.check_warning("numba.datamodel", "numba.core.datamodel")
+        with checker():
+            import numba.datamodel
+
+        for fn in (
+            "registry",
+            "register_default",
+        ):
+            with checker(fn):
+                getattr(numba.datamodel, fn)
+
+        checker = self.check_warning(
+            "numba.datamodel.models", "numba.core.datamodel.models"
+        )
+        with checker():
+            import numba.datamodel.models
+
+        for fn in ("StructModel", "PointerModel", "BooleanModel"):
+            with checker(fn):
+                getattr(numba.datamodel.models, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.datamodel import registry
+
+            registry.register_default
+
+    def test_numba_compiler_machinery(self):
+        checker = self.check_warning(
+            "numba.compiler_machinery", "numba.core.compiler_machinery"
+        )
+        with checker():
+            import numba.compiler_machinery  # noqa: F401
+
+    def test_numba_compiler(self):
+        checker = self.check_warning("numba.compiler", "numba.core.compiler")
+        with checker():
+            import numba.compiler
+
+        for fn in (
+            "run_frontend",
+            "StateDict",
+            "Flags",
+            "DefaultPassBuilder",
+            "CompilerBase",
+        ):
+            with checker(fn):
+                getattr(numba.compiler, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.compiler import DefaultPassBuilder, Flags
+
+            DefaultPassBuilder.define_nopython_pipeline
+            Flags.OPTIONS
+
+    def test_numba_cgutils(self):
+        checker = self.check_warning("numba.cgutils", "numba.core.cgutils")
+        with checker():
+            import numba.cgutils
+        for fn in (
+            "unpack_tuple",
+            "true_bit",
+            "is_not_null",
+            "increment_index",
+            "get_null_value",
+            "false_bit",
+            "create_struct_proxy",
+            "alloca_once_value",
+            "alloca_once",
+        ):
+            with checker(fn):
+                getattr(numba.cgutils, fn)
+
+    def test_numba_array_analysis(self):
+        checker = self.check_warning(
+            "numba.array_analysis", "numba.parfors.array_analysis"
+        )
+        with checker():
+            import numba.array_analysis
+
+        for fn in ("ArrayAnalysis", "array_analysis_extensions"):
+            with checker(fn):
+                getattr(numba.array_analysis, fn)
+
+        # want to check this works, not that it warns
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumbaDeprecationWarning)
+            from numba.array_analysis import ArrayAnalysis
+
+            args = (None,) * 4
+            ArrayAnalysis(*args)._analyze_op_static_getitem
+            ArrayAnalysis(*args)._analyze_broadcast
+
+    def test_numba_analysis(self):
+        checker = self.check_warning("numba.analysis", "numba.core.analysis")
+        with checker():
+            import numba.analysis
+        for fn in (
+            "ir_extension_usedefs",
+            "compute_use_defs",
+            "compute_cfg_from_blocks",
+            "_use_defs_result",
+        ):
+            with checker(fn):
+                getattr(numba.analysis, fn)
+
+    def test_numba_decorators(self):
+        checker = self.check_warning(
+            "numba.decorators", "numba.core.decorators"
+        )
+        with checker():
+            import numba.decorators
+        for fn in (
+            "njit",
+            "jit",
+            "generated_jit",
+        ):
+            with checker(fn):
+                getattr(numba.decorators, fn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/numba/typeconv.py
+++ b/numba/typeconv.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typeconv"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typeconv import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typed_passes.py
+++ b/numba/typed_passes.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typed_passes"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typed_passes import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typedobjectutils.py
+++ b/numba/typedobjectutils.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.typed.typedobjectutils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.typed.typedobjectutils import *  # noqa: F403, F401
+    from numba.typed.typedobjectutils import _cast  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typeinfer"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typeinfer import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/types/__init__.py
+++ b/numba/types/__init__.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.types"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.types import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/__init__.py
+++ b/numba/typing/__init__.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/arraydecl.py
+++ b/numba/typing/arraydecl.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.arraydecl"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.arraydecl import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.builtins"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.builtins import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/collections.py
+++ b/numba/typing/collections.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.collections"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.collections import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/ctypes_utils.py
+++ b/numba/typing/ctypes_utils.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.ctypes_utils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.ctypes_utils import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.npydecl"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.npydecl import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/templates.py
+++ b/numba/typing/templates.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.templates"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.templates import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/typing/typeof.py
+++ b/numba/typing/typeof.py
@@ -1,0 +1,12 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.typing.typeof"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.typing.typeof import *  # noqa: F403, F401
+    from numba.core.typing.typeof import _typeof_ndarray  # noqa: F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/unicode.py
+++ b/numba/unicode.py
@@ -1,0 +1,22 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.cpython.unicode"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.cpython.unicode import *  # noqa: F403, F401
+    from numba.cpython.unicode import (  # noqa: F401
+        _slice_span,
+        _normalize_slice,
+        _empty_string,
+    )
+    from numba.cpython.unicode import (  # noqa: F401
+        PY_UNICODE_1BYTE_KIND,
+        PY_UNICODE_2BYTE_KIND,
+        PY_UNICODE_4BYTE_KIND,
+        PY_UNICODE_WCHAR_KIND,
+    )
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/unsafe/__init__.py
+++ b/numba/unsafe/__init__.py
@@ -1,0 +1,8 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+# What was numba.unsafe.refcount got renamed to numba.core.unsafe
+from numba.core import unsafe as refcount  # noqa: F401
+
+_moved_mod = None
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/unsafe/ndarray.py
+++ b/numba/unsafe/ndarray.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.np.unsafe.ndarray"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.np.unsafe.ndarray import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/untyped_passes.py
+++ b/numba/untyped_passes.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.untyped_passes"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.untyped_passes import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)

--- a/numba/utils.py
+++ b/numba/utils.py
@@ -1,0 +1,11 @@
+import numba.core.errors as _errors
+from numba.core.utils import PYVERSION as _PYVERSION
+
+_moved_mod = "numba.core.utils"
+
+if _PYVERSION >= (3, 7):
+    __getattr__ = _errors.deprecate_moved_module_getattr(__name__, _moved_mod)
+else:
+    from numba.core.utils import *  # noqa: F403, F401
+
+_errors.deprecate_moved_module(__name__, _moved_mod)


### PR DESCRIPTION
Based on https://github.com/numba/numba/pull/5352 adds deprecation behaviours for `numba.jitclass` moving to `numba.experimental.jitclass`.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
