### PR TITLE
Add tolerance to numba extension module entrypoints.

### DIFF
--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from pkg_resources import iter_entry_points
 
@@ -20,5 +21,11 @@ def init_all():
 
     for entry_point in iter_entry_points('numba_extensions', 'init'):
         logger.debug('Loading extension: %s', entry_point)
-        func = entry_point.load()
-        func()
+        try:
+            func = entry_point.load()
+            func()
+        except Exception as e:
+            msg = "Numba extension module '{}' failed to load due to '{}({})'."
+            warnings.warn(msg.format(entry_point.module_name, type(e).__name__,
+                                     str(e)), stacklevel=2)
+            logger.debug('Extension loading failed for: %s', entry_point)

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -1,5 +1,6 @@
 import sys
 import types
+import warnings
 
 import pkg_resources
 
@@ -54,6 +55,60 @@ class TestEntrypoints(TestCase):
             # ensure we do not initialize twice
             entrypoints.init_all()
             self.assertEqual(counters['init'], 1)
+        finally:
+            # remove fake module
+            if mod.__name__ in sys.modules:
+                del sys.modules[mod.__name__]
+
+    def test_entrypoint_tolerance(self):
+        # loosely based on Pandas test from:
+        #   https://github.com/pandas-dev/pandas/pull/27488
+
+        # FIXME: Python 2 workaround because nonlocal doesn't exist
+        counters = {'init': 0}
+
+        def init_function():
+            counters['init'] += 1
+            raise ValueError("broken")
+
+        mod = types.ModuleType("_test_numba_bad_extension")
+        mod.init_func = init_function
+
+        try:
+            # will remove this module at the end of the test
+            sys.modules[mod.__name__] = mod
+
+            # We are registering an entry point using the "numba" package
+            # ("distribution" in pkg_resources-speak) itself, though these are
+            # normally registered by other packages.
+            dist = "numba"
+            entrypoints = pkg_resources.get_entry_map(dist)
+            my_entrypoint = pkg_resources.EntryPoint(
+                "init", # name of entry point
+                mod.__name__, # module with entry point object
+                attrs=['init_func'], # name of entry point object
+                dist=pkg_resources.get_distribution(dist)
+            )
+            entrypoints.setdefault('numba_extensions',
+                                   {})['init'] = my_entrypoint
+
+            from numba.core import entrypoints
+            # Allow reinitialization
+            entrypoints._already_initialized = False
+
+            with warnings.catch_warnings(record=True) as w:
+                entrypoints.init_all()
+
+            bad_str = "Numba extension module '_test_numba_bad_extension'"
+            for x in w:
+                if bad_str in str(x):
+                    break
+            else:
+                raise ValueError("Expected warning message not found")
+
+            # was our init function called?
+            self.assertEqual(counters['init'], 1)
+
         finally:
             # remove fake module
             if mod.__name__ in sys.modules:


### PR DESCRIPTION
This makes it so that if there's a problem with an extension module
and loading it fails, that it doesn't prevent Numba from working.

Warnings are now issued. Tests added.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
