### PR TITLE
Fix #5408: test_set_registers_57 fails on Maxwell

### DIFF
--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -86,17 +86,26 @@ class TestLinker(CUDATestCase):
         self.assertTrue(A[0] == 123 + 2 * 321)
 
     @require_context
+    def test_set_registers_no_max(self):
+        """Ensure that the jitted kernel used in the test_set_registers_* tests
+        uses more than 57 registers - this ensures that test_set_registers_*
+        are really checking that they reduced the number of registers used from
+        something greater than the maximum."""
+        compiled = cuda.jit(function_with_lots_of_registers)
+        compiled = compiled.specialize(np.empty(32), *range(6))
+        self.assertGreater(compiled._func.get().attrs.regs, 57)
+
+    @require_context
     def test_set_registers_57(self):
         compiled = cuda.jit(max_registers=57)(function_with_lots_of_registers)
         compiled = compiled.specialize(np.empty(32), *range(6))
-        self.assertEquals(57, compiled._func.get().attrs.regs)
+        self.assertLessEqual(compiled._func.get().attrs.regs, 57)
 
     @require_context
     def test_set_registers_38(self):
         compiled = cuda.jit(max_registers=38)(function_with_lots_of_registers)
         compiled = compiled.specialize(np.empty(32), *range(6))
-        self.assertEquals(38, compiled._func.get().attrs.regs)
-
+        self.assertLessEqual(compiled._func.get().attrs.regs, 38)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The test_set_registers_* tests were a little too strict in what they checked - the max_registers option should limit the number of registers used, but does not guarantee that as many registers as the limit are used. When linking for some devices, fewer than the maximum are used.

To remedy this, the tests now check that there are less than or equal to the max registers used. An additional test is added, to ensure that the maximum register count would otherwise have been exceeded.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
