### PR TITLE
Fix #5429: Exception using `.get_ipc_handle(...)` on array from `as_cuda_array(...)

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -834,13 +834,11 @@ class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
         return MemoryInfo(free=free.value, total=total.value)
 
     def get_ipc_handle(self, memory):
+        base, end = device_extents(memory)
         ipchandle = drvapi.cu_ipc_mem_handle()
-        driver.cuIpcGetMemHandle(
-            byref(ipchandle),
-            memory.owner.handle,
-        )
+        driver.cuIpcGetMemHandle(byref(ipchandle), base)
         source_info = self.context.device.get_device_identity()
-        offset = memory.handle.value - memory.owner.handle.value
+        offset = memory.handle.value - base
 
         return IpcHandle(memory, ipchandle, memory.size, source_info,
                          offset=offset)
@@ -2075,7 +2073,7 @@ def get_devptr_for_active_ctx(ptr):
     """Query the device pointer usable in the current context from an arbitrary
     pointer.
     """
-    devptr = c_void_p(0)
+    devptr = drvapi.cu_device_ptr()
     if ptr != 0:
         attr = enums.CU_POINTER_ATTRIBUTE_DEVICE_POINTER
         driver.cuPointerGetAttribute(byref(devptr), attr, ptr)

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -91,3 +91,15 @@ def captured_cuda_stdout():
         with redirect_c_stdout() as stream:
             yield CUDATextCapture(stream)
             cuda.synchronize()
+
+
+class ForeignArray(object):
+    """
+    Class for emulating an array coming from another library through the CUDA
+    Array interface. This just hides a DeviceNDArray so that it doesn't look
+    like a DeviceNDArray.
+    """
+
+    def __init__(self, arr):
+        self._arr = arr
+        self.__cuda_array_interface__ = arr.__cuda_array_interface__

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -1,5 +1,6 @@
 import sys
 import multiprocessing as mp
+import itertools
 import traceback
 import pickle
 
@@ -7,7 +8,8 @@ import numpy as np
 
 from numba import cuda
 from numba.cuda.cudadrv import drvapi, devicearray
-from numba.cuda.testing import skip_on_cudasim, ContextResettingTestCase
+from numba.cuda.testing import (skip_on_cudasim, ContextResettingTestCase,
+                                ForeignArray)
 from numba.tests.support import linux_only
 import unittest
 
@@ -109,12 +111,22 @@ class TestIpcMemory(ContextResettingTestCase):
             np.testing.assert_equal(arr, out)
         proc.join(3)
 
-    def check_ipc_handle_serialization(self, index_arg=None):
+    def variants(self):
+        # Test with no slicing and various different slices
+        indices = (None, slice(3, None), slice(3, 8), slice(None, 8))
+        # Test with a Numba DeviceNDArray, or an array from elsewhere through
+        # the CUDA Array Interface
+        foreigns = (False, True)
+        return itertools.product(indices, foreigns)
+
+    def check_ipc_handle_serialization(self, index_arg=None, foreign=False):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
         devarr = cuda.to_device(arr)
         if index_arg is not None:
             devarr = devarr[index_arg]
+        if foreign:
+            devarr = cuda.as_cuda_array(ForeignArray(devarr))
         expect = devarr.copy_to_host()
 
         # create IPC handle
@@ -142,20 +154,19 @@ class TestIpcMemory(ContextResettingTestCase):
         proc.join(3)
 
     def test_ipc_handle_serialization(self):
-        # test no slicing
-        self.check_ipc_handle_serialization()
-        # slicing tests
-        self.check_ipc_handle_serialization(slice(3, None))
-        self.check_ipc_handle_serialization(slice(3, 8))
-        self.check_ipc_handle_serialization(slice(None, 8))
+        for index, foreign, in self.variants():
+            with self.subTest(index=index, foreign=foreign):
+                self.check_ipc_handle_serialization(index, foreign)
 
-    def check_ipc_array(self, index_arg=None):
+    def check_ipc_array(self, index_arg=None, foreign=False):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
         devarr = cuda.to_device(arr)
         # Slice
         if index_arg is not None:
             devarr = devarr[index_arg]
+        if foreign:
+            devarr = cuda.as_cuda_array(ForeignArray(devarr))
         expect = devarr.copy_to_host()
         ipch = devarr.get_ipc_handle()
 
@@ -173,12 +184,10 @@ class TestIpcMemory(ContextResettingTestCase):
         proc.join(3)
 
     def test_ipc_array(self):
-        # test no slicing
-        self.check_ipc_array()
-        # slicing tests
-        self.check_ipc_array(slice(3, None))
-        self.check_ipc_array(slice(3, 8))
-        self.check_ipc_array(slice(None, 8))
+        for index, foreign, in self.variants():
+            with self.subTest(index=index, foreign=foreign):
+                self.check_ipc_array(index, foreign)
+
 
 @unittest.skipIf(linux, 'Only on OS other than Linux')
 @skip_on_cudasim('Ipc not available in CUDASIM')
@@ -196,8 +205,6 @@ def staged_ipc_handle_test(handle, device_num, result_queue):
     def the_work():
         with cuda.gpus[device_num]:
             this_ctx = cuda.devices.get_context()
-            can_access = handle.can_access_peer(this_ctx)
-            print('can_access_peer {} {}'.format(this_ctx, can_access))
             deviceptr = handle.open_staged(this_ctx)
             arrsize = handle.size // np.dtype(np.intp).itemsize
             hostarray = np.zeros(arrsize, dtype=np.intp)
@@ -214,7 +221,6 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
     try:
         with cuda.gpus[device_num]:
             this_ctx = cuda.devices.get_context()
-            print(this_ctx.device)
             with ipcarr as darr:
                 arr = darr.copy_to_host()
                 try:


### PR DESCRIPTION
In the implementation of `get_ipc_handle`, the owner of a MemoryPointer is assumed to be another MemoryPointer instance (and therefore has a `handle` attribute which points to the start of the allocation in which the MemoryPointer's value points to). This was always true when MemoryPointers were only created by slicing DeviceNDArrays - however, MemoryPointers can also now have owners that are objects coming in through the CUDA array interface (e.g. via `cuda.as_cuda_array()`).

This commit removes the assumption that the owner of a MemoryPointer is another MemoryPointer, and instead gets the start of the allocation with `cuMemGetAddressRange` (via the already-extant `device_extents` function).

`get_devptr_for_active_ctx()` also returned the wrong type for passing to any driver functions - it is now fixed to return a `cu_device_ptr`.

Tests are added to test_ipc that emulate an array from another library being used via the CUDA Array Interface. The mechanism for this test is common to test_ipc and test_cuda_array_interface, so the `MyArray` class from test_cuda_array_interface is moved to `numba.cuda.testing` as `ForeignArray`.

A couple of superfluous print calls are also removed from test_ipc, in the interests of tidiness.

With this commit, the original reproducer:

```python
import cupy
import numba.cuda

a = cupy.arange(5)
a2 = numba.cuda.as_cuda_array(a)

a2.get_ipc_handle()
```

runs to completion without error.

cc @jakirkham for comment / testing :-)
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
