### PR TITLE
Don't warn for numba.experimental.jitclass

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -44,6 +44,9 @@ from numba.np.numpy_support import carray, farray, from_dtype
 # Re-export experimental
 from numba import experimental
 
+# Re-export experimental.jitclass as jitclass, this is deprecated
+from numba.experimental.jitclass.decorators import _warning_jitclass as jitclass
+
 # Initialize withcontexts
 import numba.core.withcontexts
 from numba.core.withcontexts import objmode_context as objmode
@@ -53,25 +56,6 @@ import numba.cpython.charseq
 
 # Keep this for backward compatibility.
 test = runtests.main
-
-
-def jitclass(spec):
-    """
-    Re-export of numba.experimental.jitclass with a warning.
-    This endpoint is deprecated.
-    """
-    url = ("http://numba.pydata.org/numba-doc/latest/reference/"
-           "deprecation.html#change-of-jitclass-location")
-
-    msg = ("The 'numba.jitclass' decorator has moved to "
-           "'numba.experimental.jitclass' to better reflect the experimental "
-           "nature of the functionality. Please update your imports to "
-           "accommodate this change and see {} for the time frame.".format(url))
-
-    warnings.warn(msg, category=errors.NumbaDeprecationWarning,
-                  stacklevel=2)
-
-    return numba.experimental.jitclass(spec)
 
 
 __all__ = """

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -44,9 +44,6 @@ from numba.np.numpy_support import carray, farray, from_dtype
 # Re-export experimental
 from numba import experimental
 
-# Re-export experimental.jitclass as jitclass, this is deprecated
-from numba.experimental import jitclass
-
 # Initialize withcontexts
 import numba.core.withcontexts
 from numba.core.withcontexts import objmode_context as objmode
@@ -56,6 +53,25 @@ import numba.cpython.charseq
 
 # Keep this for backward compatibility.
 test = runtests.main
+
+
+def jitclass(spec):
+    """
+    Re-export of numba.experimental.jitclass with a warning.
+    This endpoint is deprecated.
+    """
+    url = ("http://numba.pydata.org/numba-doc/latest/reference/"
+           "deprecation.html#change-of-jitclass-location")
+
+    msg = ("The 'numba.jitclass' decorator has moved to "
+           "'numba.experimental.jitclass' to better reflect the experimental "
+           "nature of the functionality. Please update your imports to "
+           "accommodate this change and see {} for the time frame.".format(url))
+
+    warnings.warn(msg, category=errors.NumbaDeprecationWarning,
+                  stacklevel=2)
+
+    return numba.experimental.jitclass(spec)
 
 
 __all__ = """

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -1,7 +1,5 @@
 from numba.core import types, config
-from numba.core import errors
 from numba.experimental.jitclass.base import register_class_type, ClassBuilder
-import warnings
 
 
 def jitclass(spec):

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -20,16 +20,6 @@ def jitclass(spec):
 
     A callable that takes a class object, which will be compiled.
     """
-    url = ("http://numba.pydata.org/numba-doc/latest/reference/"
-           "deprecation.html#change-of-jitclass-location")
-
-    msg = ("The 'numba.jitclass' decorator has moved to "
-           "'numba.experimental.jitclass' to better reflect the experimental "
-           "nature of the functionality. Please update your imports to "
-           "accommodate this change and see {} for the time frame.".format(url))
-
-    warnings.warn(msg, category=errors.NumbaDeprecationWarning,
-                  stacklevel=2)
 
     def wrap(cls):
         if config.DISABLE_JIT:

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -1,4 +1,6 @@
-from numba.core import types, config
+import warnings
+
+from numba.core import types, config, errors
 from numba.experimental.jitclass.base import register_class_type, ClassBuilder
 
 
@@ -26,3 +28,23 @@ def jitclass(spec):
             return register_class_type(cls, spec, types.ClassType, ClassBuilder)
 
     return wrap
+
+
+def _warning_jitclass(spec):
+    """
+    Re-export of numba.experimental.jitclass with a warning.
+    To be used in numba/__init__.py.
+    This endpoint is deprecated.
+    """
+    url = ("http://numba.pydata.org/numba-doc/latest/reference/"
+           "deprecation.html#change-of-jitclass-location")
+
+    msg = ("The 'numba.jitclass' decorator has moved to "
+           "'numba.experimental.jitclass' to better reflect the experimental "
+           "nature of the functionality. Please update your imports to "
+           "accommodate this change and see {} for the time frame.".format(url))
+
+    warnings.warn(msg, category=errors.NumbaDeprecationWarning,
+                  stacklevel=2)
+
+    return jitclass(spec)


### PR DESCRIPTION
Only issue a `NumbaDeprecationWarning` if the deprecated endpoint `numba.jitclass` is used.
