### PR TITLE
implement repr for untyped lists

### DIFF
--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -522,7 +522,7 @@ class TestTypedList(MemoryLeakMixin, TestCase):
 
     def test_repr(self):
         l = List()
-        expected = "ListType[UNTYPED]([])"
+        expected = "ListType[Undefined]([])"
         self.assertEqual(expected, repr(l))
 
         l = List([int32(i) for i in (1, 2, 3)])

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -520,6 +520,15 @@ class TestTypedList(MemoryLeakMixin, TestCase):
             str(raises.exception),
         )
 
+    def test_repr(self):
+        l = List()
+        expected = "ListType[UNTYPED]([])"
+        self.assertEqual(expected, repr(l))
+
+        l = List([int32(i) for i in (1, 2, 3)])
+        expected = "ListType[int32]([1, 2, 3])"
+        self.assertEqual(expected, repr(l))
+
 
 class TestNoneType(MemoryLeakMixin, TestCase):
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -397,7 +397,7 @@ class List(MutableSequence):
 
     def __repr__(self):
         body = str(self)
-        prefix = str(self._list_type) if self._typed else "ListType[UNTYPED]"
+        prefix = str(self._list_type) if self._typed else "ListType[Undefined]"
         return "{prefix}({body})".format(prefix=prefix, body=body)
 
 

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -397,7 +397,7 @@ class List(MutableSequence):
 
     def __repr__(self):
         body = str(self)
-        prefix = str(self._list_type)
+        prefix = str(self._list_type) if self._typed else "ListType[UNTYPED]"
         return "{prefix}({body})".format(prefix=prefix, body=body)
 
 


### PR DESCRIPTION
This implemes a proper `__repr__` for untyped numba.typed.List and
tests.