### PR TITLE
[WIP] Add np.asarray(string) and str() impl

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -2341,6 +2341,22 @@ def ol_chr(i):
             return _PyUnicode_FromOrdinal(i)
         return impl
 
+
+@overload(str)
+def str_overload(n):
+    impl = None
+    if isinstance(n, types.Integer):
+        def impl(n):
+            s = ''
+            while n > 0:
+                c = chr(ord('0') + (n % 10))
+                n = n // 10
+                s = c + s
+            return s
+    if isinstance(n, (types.UnicodeType, types.UnicodeCharSeq, types.CharSeq)):
+        def impl(n):
+            return n
+    return impl
 # ------------------------------------------------------------------------------
 # iteration
 # ------------------------------------------------------------------------------

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3895,6 +3895,10 @@ def np_asarray(a, dtype=None):
             for i, v in enumerate(a):
                 ret[i] = v
             return ret
+    elif isinstance(a, types.UnicodeType):
+        def impl(a, dtype=None):
+            dt = 'U' + str(len(a))
+            return np.array(a, dtype=np.dtype('U10'))
 
     return impl
 

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -95,7 +95,6 @@ def from_dtype(dtype):
         return FROM_DTYPE[dtype]
     except KeyError:
         char = dtype.char
-
         if char in 'SU':
             return _from_str_dtype(dtype)
         if char in 'mM':
@@ -112,6 +111,7 @@ _as_dtype_letters = {
     types.NPTimedelta: 'm8',
     types.CharSeq: 'S',
     types.UnicodeCharSeq: 'U',
+    types.UnicodeType: 'U',
 }
 
 
@@ -134,6 +134,11 @@ def as_dtype(nbtype):
     if isinstance(nbtype, (types.CharSeq, types.UnicodeCharSeq)):
         letter = _as_dtype_letters[type(nbtype)]
         return np.dtype('%s%d' % (letter, nbtype.count))
+    if isinstance(nbtype, types.UnicodeType):
+        # XXX: fix this! The dtype should be 'U#len(str)'
+        # print('nbtype', nbtype)
+        letter = _as_dtype_letters[type(nbtype)]
+        return np.dtype('%s%d' % (letter, 0))
     if isinstance(nbtype, types.Record):
         return as_struct_dtype(nbtype)
     if isinstance(nbtype, types.EnumMember):
@@ -600,7 +605,7 @@ def type_can_asarray(arr):
     implementation, False otherwise.
     """
 
-    ok = (types.Array, types.Sequence, types.Tuple,
+    ok = (types.Array, types.Sequence, types.Tuple, types.UnicodeType,
           types.Number, types.Boolean, types.containers.ListType)
 
     return isinstance(arr, ok)


### PR DESCRIPTION
Following up on #4610, this PR implements `np.asarray('string')` and the `str` builtin for integers.

This still needs some polishing.