### PR TITLE
Fix missing null initializer for variable after phi strip

### DIFF
--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -150,7 +150,9 @@ class _EnvReloader(object):
         # Whether to always warn about potential uninitialized variables
         # because static controlflow analysis cannot find a definition
         # in one or more of the incoming paths.
-        ALWAYS_WARN_UNINIT_VAR = _readenv("ALWAYS_WARN_UNINIT_VAR", int, 0)
+        ALWAYS_WARN_UNINIT_VAR = _readenv(
+            "NUMBA_ALWAYS_WARN_UNINIT_VAR", int, 0,
+        )
 
         # Debug flag to control compiler debug print
         DEBUG = _readenv("NUMBA_DEBUG", int, 0)

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -543,6 +543,17 @@ class Expr(Inst):
         op = 'make_function'
         return cls(op=op, name=name, code=code, closure=closure, defaults=defaults, loc=loc)
 
+    @classmethod
+    def null(cls, loc):
+        """
+        A node for null value.
+
+        This node is not handled by type inference. It is only added by
+        post-typing passing.
+        """
+        op = 'null'
+        return cls(op=op, loc=loc)
+
     def __repr__(self):
         if self.op == 'call':
             args = ', '.join(str(a) for a in self.args)

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -549,7 +549,7 @@ class Expr(Inst):
         A node for null value.
 
         This node is not handled by type inference. It is only added by
-        post-typing passing.
+        post-typing passes.
         """
         op = 'null'
         return cls(op=op, loc=loc)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1251,6 +1251,9 @@ class Lower(BaseLower):
         elif expr.op == "phi":
             raise LoweringError("PHI not stripped")
 
+        elif expr.op == 'null':
+            return self.context.get_constant_null(resty)
+
         elif expr.op in self.context.special_ops:
             res = self.context.special_ops[expr.op](self, expr)
             return res

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -401,6 +401,10 @@ class PyLower(BaseLower):
         elif expr.op == 'phi':
             raise LoweringError("PHI not stripped")
 
+        elif expr.op == 'null':
+            # TODO
+            raise LoweringError("Expr.null not stripped")
+
         else:
             raise NotImplementedError(expr)
 

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -402,8 +402,8 @@ class PyLower(BaseLower):
             raise LoweringError("PHI not stripped")
 
         elif expr.op == 'null':
-            # TODO
-            raise LoweringError("Expr.null not stripped")
+            # Make null value
+            return cgutils.get_null_value(self.pyapi.pyobj)
 
         else:
             raise NotImplementedError(expr)

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -74,12 +74,44 @@ def _fix_ssa_vars(blocks, varname, defmap):
     states['cfg'] = cfg = compute_cfg_from_blocks(blocks)
     states['df+'] = _iterated_domfronts(cfg)
     newblocks = _run_block_rewrite(blocks, states, _FixSSAVars())
+    # check for unneeded phi nodes
+    _remove_unneeded_phis(phimap)
     # insert phi nodes
     for label, philist in phimap.items():
         curblk = newblocks[label]
         # Prepend PHI nodes to the block
         curblk.body = philist + curblk.body
     return newblocks
+
+
+def _remove_unneeded_phis(phimap):
+    """Remove unneeded PHis from the phimap
+    """
+    all_phis = []
+    for philist in phimap.values():
+        all_phis.extend(philist)
+    unneeded_phis = set()
+    # Find unneeded PHIs.
+    for phi in all_phis:
+        ivs = phi.value.incoming_values
+        # It's unneeded if the incomings are either undefined or
+        # the PHI node it self
+        if all(iv is ir.UNDEFINED or iv == phi.target for iv in ivs):
+            unneeded_phis.add(phi)
+    # Fix up references to unneeded PHIs
+    for phi in all_phis:
+        for unneed in unneeded_phis:
+            if unneed is not phi:
+                # If the unneeded PHI is in the current phi's incoming values
+                if unneed.target in phi.value.incoming_values:
+                    # Replace the unneeded PHI with a UNDEFINED
+                    idx = phi.value.incoming_values.index(unneed.target)
+                    phi.value.incoming_values[idx] = ir.UNDEFINED
+    # Remove unneeded phis
+    for philist in phimap.values():
+        for unneeded in unneeded_phis:
+            if unneeded in philist:
+                philist.remove(unneeded)
 
 
 def _iterated_domfronts(cfg):

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -85,7 +85,7 @@ def _fix_ssa_vars(blocks, varname, defmap):
 
 
 def _remove_unneeded_phis(phimap):
-    """Remove unneeded PHis from the phimap
+    """Remove unneeded PHIs from the phimap
     """
     all_phis = []
     for philist in phimap.values():
@@ -95,7 +95,7 @@ def _remove_unneeded_phis(phimap):
     for phi in all_phis:
         ivs = phi.value.incoming_values
         # It's unneeded if the incomings are either undefined or
-        # the PHI node it self
+        # the PHI node target is itself
         if all(iv is ir.UNDEFINED or iv == phi.target for iv in ivs):
             unneeded_phis.add(phi)
     # Fix up references to unneeded PHIs
@@ -104,7 +104,7 @@ def _remove_unneeded_phis(phimap):
             if unneed is not phi:
                 # If the unneeded PHI is in the current phi's incoming values
                 if unneed.target in phi.value.incoming_values:
-                    # Replace the unneeded PHI with a UNDEFINED
+                    # Replace the unneeded PHI with an UNDEFINED
                     idx = phi.value.incoming_values.index(unneed.target)
                     phi.value.incoming_values[idx] = ir.UNDEFINED
     # Remove unneeded phis

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -763,22 +763,25 @@ class PreLowerStripPhis(FunctionPass):
 
             # insert exporters
             for target, rhs in exporters[label]:
-                if rhs is not ir.UNDEFINED:
-                    assign = ir.Assign(
-                        target=target,
-                        value=rhs,
-                        loc=target.loc
-                    )
-                    # Insert at the earliest possible location; i.e. after the
-                    # last assignment to rhs
-                    assignments = [stmt
-                                   for stmt in newblk.find_insts(ir.Assign)
-                                   if stmt.target == rhs]
-                    if assignments:
-                        last_assignment = assignments[-1]
-                        newblk.insert_after(assign, last_assignment)
-                    else:
-                        newblk.prepend(assign)
+                # If RHS is undefined
+                if rhs is ir.UNDEFINED:
+                    # Put in a NULL initializer
+                    rhs = ir.Expr.null(loc=target.loc)
+
+                assign = ir.Assign(
+                    target=target,
+                    value=rhs,
+                    loc=target.loc
+                )
+                # Insert at the earliest possible location; i.e. after the
+                # last assignment to rhs
+                assignments = [stmt for stmt in newblk.find_insts(ir.Assign)
+                               if stmt.target == rhs]
+                if assignments:
+                    last_assignment = assignments[-1]
+                    newblk.insert_after(assign, last_assignment)
+                else:
+                    newblk.prepend(assign)
 
         func_ir.blocks = newblocks
         return func_ir

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -340,7 +340,6 @@ class TestReportedSSAIssues(SSABaseTest):
         A = np.ones(1)
         B = np.ones((1,1))
 
-        @njit
         def foo(m, n, data):
             if len(data) == 1:
                 v0 = data[0]
@@ -366,4 +365,8 @@ class TestReportedSSAIssues(SSABaseTest):
                             problematic = problematic + t
             return problematic
 
-        foo(10, 10, data)
+        expect = foo(10, 10, data)
+        res1 = njit(foo)(10, 10, data)
+        res2 = jit(forceobj=True, looplift=False)(foo)(10, 10, data)
+        np.testing.assert_array_equal(expect, res1)
+        np.testing.assert_array_equal(expect, res2)

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -282,7 +282,9 @@ class TestReportedSSAIssues(SSABaseTest):
 
         self.check_func(foo, np.zeros((2, 2)))
 
-    def test_issue5482(self):
+    def test_issue5482_missing_variable_init(self):
+        # Test error that lowering fails because variable is missing
+        # a definition before use.
         @njit("(intp, intp, intp)")
         def foo(x, v, n):
             for i in range(n):
@@ -299,6 +301,8 @@ class TestReportedSSAIssues(SSABaseTest):
             return problematic
 
     def test_issue5493_unneeded_phi(self):
+        # Test error that unneeded phi is inserted because variable does not
+        # have a dominance definition.
         data = (np.ones(2), np.ones(2))
         A = np.ones(1)
         B = np.ones((1,1))
@@ -309,7 +313,7 @@ class TestReportedSSAIssues(SSABaseTest):
                 v0 = data[0]
             else:
                 v0 = data[0]
-                # Unneeded PHI node here would be inserted here
+                # Unneeded PHI node for `problematic` would be placed here
                 for _ in range(1, len(data)):
                     v0 += A
 

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -297,3 +297,36 @@ class TestReportedSSAIssues(SSABaseTest):
                     else:
                         problematic = problematic + v
             return problematic
+
+    def test_issue5493_unneeded_phi(self):
+        data = (np.ones(2), np.ones(2))
+        A = np.ones(1)
+        B = np.ones((1,1))
+
+        @njit
+        def foo(m, n, data):
+            if len(data) == 1:
+                v0 = data[0]
+            else:
+                v0 = data[0]
+                # Unneeded PHI node here would be inserted here
+                for _ in range(1, len(data)):
+                    v0 += A
+
+            for t in range(1, m):
+                for idx in range(n):
+                    t = B
+
+                    if idx == 0:
+                        if idx == n - 1:
+                            pass
+                        else:
+                            problematic = t
+                    else:
+                        if idx == n - 1:
+                            pass
+                        else:
+                            problematic = problematic + t
+            return problematic
+
+        foo(10, 10, data)

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -281,3 +281,19 @@ class TestReportedSSAIssues(SSABaseTest):
             return lin[0]
 
         self.check_func(foo, np.zeros((2, 2)))
+
+    def test_issue5482(self):
+        @njit("(intp, intp, intp)")
+        def foo(x, v, n):
+            for i in range(n):
+                if i == 0:
+                    if i == x:
+                        pass
+                    else:
+                        problematic = v
+                else:
+                    if i == x:
+                        pass
+                    else:
+                        problematic = problematic + v
+            return problematic


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Closes #5482
Phi stripping pass needs to insert a definition in the "uninitialize" path so that there is a dominating definition during lowering.

Closes #5493 
Remove unneeded PHIs which were added because variables do not have a dominance definition, which violates the classic SSA algorithm. Unneeded PHIs have incoming values that are itself or undefined incoming values.


