### PR TITLE
Better error message if __init__ returns value

### DIFF
--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -246,6 +246,11 @@ class ConstructorTemplate(templates.AbstractTemplate):
         boundargs = (instance_type.get_reference_type(),) + args
         disp_type = types.Dispatcher(ctor)
         sig = disp_type.get_call_type(self.context, boundargs, kws)
+
+        if not isinstance(sig.return_type, types.NoneType):
+            raise TypeError(
+                f"__init__() should return None, not '{sig.return_type}'")
+
         # Actual constructor returns an instance value (not None)
         out = templates.signature(instance_type, *sig.args[1:])
         return out

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -87,6 +87,19 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(str(raises.exception),
                          "spec keys should be strings, got 1")
 
+    def test_init_errors(self):
+
+        @jitclass([])
+        class Test:
+            def __init__(self):
+                return 7
+
+        with self.assertRaises(errors.TypingError) as raises:
+            Test()
+
+        self.assertIn("__init__() should return None, not",
+                      str(raises.exception))
+
     def _make_Float2AndArray(self):
         spec = OrderedDict()
         spec['x'] = float32


### PR DESCRIPTION
Mirrors the behavior of normal Python.
Addresses https://github.com/numba/numba/issues/4985

```
>>> import numba
>>> class Test:
...     def __init__(self):
...             return 7
...
>>> Test()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() should return None, not 'int'
>>> jitTest = numba.experimental.jitclass([])(Test)
__main__:1: NumbaDeprecationWarning: The 'numba.jitclass' decorator has moved to 'numba.experimental.jitclass' to better reflect the experimental nature of the functionality. Please update your imports to accommodate this change and see http://numba.pydata.org/numba-doc/latest/reference/deprecation.html#change-of-jitclass-location for the time frame.
>>> jitTest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ethanpronovost/Documents/Projects/numba/numba/numba/experimental/jitclass/base.py", line 122, in __call__
    return cls._ctor(*bind.args[1:], **bind.kwargs)
  File "/Users/ethanpronovost/Documents/Projects/numba/numba/numba/core/dispatcher.py", line 401, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/Users/ethanpronovost/Documents/Projects/numba/numba/numba/core/dispatcher.py", line 344, in error_rewrite
    reraise(type(e), e, None)
  File "/Users/ethanpronovost/Documents/Projects/numba/numba/numba/core/utils.py", line 79, in reraise
    raise value.with_traceback(tb)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Internal error at <numba.core.typeinfer.CallConstraint object at 0x61ed59cf8>.
__init__() should return None, not 'Literal[int](7)'
[1] During: resolving callee type: jitclass.Test#11daf76d8<>
[2] During: typing of call at <string> (3)

Enable logging at debug level for details.

File "<string>", line 3:
<source missing, REPL/exec in use?>
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
