### PR TITLE
allow the implementation of contexts which can type uncompiled dispatchers

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -387,7 +387,11 @@ class BaseContext(object):
         for impl, sig in defns:
             self._get_constants.append(impl, sig)
 
-    def insert_user_function(self, func, fndesc, libs=()):
+    def insert_user_function(self, func, fndesc, libs=(), uncompiled=False):
+        if uncompiled:
+            # uncompiled functions are not supported but this allows custom
+            # subclasses that implement support for uncompiled functions
+            return
         impl = user_function(fndesc, libs)
         self._defns[func].append(impl, impl.signature)
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -316,6 +316,13 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         args, return_type = sigutils.normalize_signature(sig)
         return self.overloads[tuple(args)].entry_point
 
+    def get_impl_key(self, sig):
+        """
+        Get the implementation key (used by the target context) for the
+        given signature.
+        """
+        return self.get_overload(sig)
+
     @property
     def is_compiling(self):
         """

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -390,6 +390,11 @@ class NativeLowering(LoweringPass):
 
             from numba.core.compiler import _LowerResult  # TODO: move this
             if flags.no_compile:
+                # Insert function for use by other jitted-functions.
+                # (BaseContext does not support uncompiled functions but this
+                # enables implementing custom contexts that do.)
+                targetctx.insert_user_function(None, fndesc, [library],
+                                               uncompiled=True)
                 state['cr'] = _LowerResult(fndesc, call_helper,
                                            cfunc=None, env=env)
             else:

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -301,7 +301,7 @@ class Dispatcher(WeakType, Callable, Dummy):
         """
         Get the implementation key for the given signature.
         """
-        return self.get_overload(sig)
+        return self.dispatcher.get_impl_key(sig.args)
 
     def unify(self, context, other):
         return utils.unified_function_type((self, other))


### PR DESCRIPTION
At present uncompiled dispatchers cannot be typed. For some applications however it is desirable to allow typing of uncompiled dispatchers.

This PR refactors existing code to allow clean subclassing of contexts and dispatchers to enable typing of uncompiled dispatchers. No functionality is changed or added.