### PR TITLE
[WIP] Creation of record array from list of lists/tuples

### DIFF
--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -495,20 +495,23 @@ class NpArray(CallableTemplate):
     def generic(self):
         def typer(object, dtype=None):
             ndim, seq_dtype = _parse_nested_sequence(self.context, object)
-            if isinstance(dtype.dtype, types.Record):
-                # a nested sequence should be interpreted as ndim=1 array,
-                # with the other dimension being part of the Record
-                if ndim == 2:
-                    ndim = 1
-                else:
-                    raise ValueError("Only two levels of nested sequences "
-                                     "allowed for Record arrays")
             if dtype is None:
                 dtype = seq_dtype
             else:
                 dtype = _parse_dtype(dtype)
                 if dtype is None:
                     return
+            if isinstance(dtype, types.Record):
+                # a nested sequence should be interpreted as ndim=1 array,
+                # with the other dimension being part of the Record
+                if ndim == 1:
+                    raise ValueError("Creation of Record array requires "
+                                     "a nested sequence")
+                elif ndim == 2:
+                    ndim = 1
+                else:
+                    raise ValueError("Only two levels of nested sequences "
+                                     "allowed for Record arrays")
             return types.Array(dtype, ndim, 'C')
 
         return typer

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -495,6 +495,14 @@ class NpArray(CallableTemplate):
     def generic(self):
         def typer(object, dtype=None):
             ndim, seq_dtype = _parse_nested_sequence(self.context, object)
+            if isinstance(dtype.dtype, types.Record):
+                # a nested sequence should be interpreted as ndim=1 array,
+                # with the other dimension being part of the Record
+                if ndim == 2:
+                    ndim = 1
+                else:
+                    raise ValueError("Only two levels of nested sequences "
+                                     "allowed for Record arrays")
             if dtype is None:
                 dtype = seq_dtype
             else:

--- a/numba/tests/test_recarray_usecases.py
+++ b/numba/tests/test_recarray_usecases.py
@@ -2,6 +2,7 @@ import sys
 
 import numpy as np
 
+from numba import njit
 from numba.core import types
 from numba.core.compiler import compile_isolated
 from numba.tests.support import captured_stdout, tag, TestCase
@@ -142,6 +143,19 @@ class TestRecordUsecase(TestCase):
     def test_usecase5(self):
         self._test_usecase2to5(usecase5, self.unaligned_dtype)
         self._test_usecase2to5(usecase5, self.aligned_dtype)
+
+
+class TestRecArrayCreation(unittest.TestCase):
+    def test_creation_from_tuple_list(self):
+        a_b_type = np.dtype([('a', 'i8'), ('b', 'f8')], align=True)
+        x = np.array([(1, 2.), (3, 4.)], a_b_type)
+
+        @njit
+        def create():
+            new = np.array([(1., 2.), (3., 4.)], a_b_type)
+            return new
+
+        self.assertTrue(np.array_equal(create(), x))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds support for creating a record array from a list of tuples

```python
a_b_type = np.dtype([('a', 'i8'), ('b', 'f8')], align=True)

@njit
def create():
    new = np.array([(1., 2.), (3., 4.)], a_b_type)
    return new
```
