### PR TITLE
Fix numba.typed.List extend for singleton and empty iterable

### DIFF
--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -740,6 +740,14 @@ class TestExtend(MemoryLeakMixin, TestCase):
         got = impl()
         self.assertEqual(expected, got)
 
+    def test_extend_empty(self):
+        # Extending an untyped list with an empty iterable doesn't work in a
+        # jit compiled function as the list remains untyped.
+        l = List()
+        l.extend(tuple())
+        self.assertEqual(len(l), 0)
+        self.assertFalse(l._typed)
+
 
 @njit
 def cmp(a, b):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -729,6 +729,17 @@ class TestExtend(MemoryLeakMixin, TestCase):
         got = impl()
         self.assertEqual(expected, got)
 
+    def test_extend_singleton(self):
+        @njit
+        def impl():
+            l = List()
+            l.extend((100,))
+            return l
+
+        expected = impl.py_func()
+        got = impl()
+        self.assertEqual(expected, got)
+
 
 @njit
 def cmp(a, b):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -740,13 +740,21 @@ class TestExtend(MemoryLeakMixin, TestCase):
         got = impl()
         self.assertEqual(expected, got)
 
-    def test_extend_empty(self):
-        # Extending an untyped list with an empty iterable doesn't work in a
+    def test_extend_empty_unrefined(self):
+        # Extending an unrefined list with an empty iterable doesn't work in a
         # jit compiled function as the list remains untyped.
         l = List()
         l.extend(tuple())
         self.assertEqual(len(l), 0)
         self.assertFalse(l._typed)
+
+    def test_extend_empty_refiend(self):
+        # Extending a refined list with an empty iterable doesn't work in a
+        # jit compiled function as the (empty) argument can't be typed
+        l = List((1,))
+        l.extend(tuple())
+        self.assertEqual(len(l), 1)
+        self.assertTrue(l._typed)
 
 
 @njit

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -729,7 +729,7 @@ class TestExtend(MemoryLeakMixin, TestCase):
         got = impl()
         self.assertEqual(expected, got)
 
-    def test_extend_singleton(self):
+    def test_extend_single_value_container(self):
         @njit
         def impl():
             l = List()

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -356,12 +356,17 @@ class List(MutableSequence):
 
     def extend(self, iterable):
         if not self._typed:
+            iterable_length = len(iterable)
+            # Empty iterable, do nothing
+            if iterable_length == 0:
+                return self
             # Need to get the first element of the iterable to initialise the
             # type of the list. FIXME: this may be a problem if the iterable
             # can not be sliced.
             self._initialise_list(iterable[0])
             self.append(iterable[0])
-            if len(iterable) > 1:
+            # Iterable has more values to extend from
+            if iterable_length > 1:
                 return _extend(self, iterable[1:])
             else:
                 return self

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -370,7 +370,10 @@ class List(MutableSequence):
                 return _extend(self, iterable[1:])
             else:
                 return self
-        return _extend(self, iterable)
+        elif len(iterable) == 0:
+            return self
+        else:
+            return _extend(self, iterable)
 
     def remove(self, item):
         return _remove(self, item)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -361,7 +361,10 @@ class List(MutableSequence):
             # can not be sliced.
             self._initialise_list(iterable[0])
             self.append(iterable[0])
-            return _extend(self, iterable[1:])
+            if len(iterable) > 1:
+                return _extend(self, iterable[1:])
+            else:
+                return self
         return _extend(self, iterable)
 
     def remove(self, item):

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -355,25 +355,15 @@ class List(MutableSequence):
         return _pop(self, i)
 
     def extend(self, iterable):
+        # Empty iterable, do nothing
+        if len(iterable) == 0:
+            return self
         if not self._typed:
-            iterable_length = len(iterable)
-            # Empty iterable, do nothing
-            if iterable_length == 0:
-                return self
             # Need to get the first element of the iterable to initialise the
             # type of the list. FIXME: this may be a problem if the iterable
             # can not be sliced.
             self._initialise_list(iterable[0])
-            self.append(iterable[0])
-            # Iterable has more values to extend from
-            if iterable_length > 1:
-                return _extend(self, iterable[1:])
-            else:
-                return self
-        elif len(iterable) == 0:
-            return self
-        else:
-            return _extend(self, iterable)
+        return _extend(self, iterable)
 
     def remove(self, item):
         return _remove(self, item)


### PR DESCRIPTION
Fixes #5152

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->