### PR TITLE
Fix #5537 Removed reference to `platform.linux_distribution`

### DIFF
--- a/numba/misc/numba_entry.py
+++ b/numba/misc/numba_entry.py
@@ -95,7 +95,7 @@ def get_sys_info():
         print(fmt % ("Version", platform.version()))
         try:
             if system_name == 'Linux':
-                info = platform.linux_distribution()
+                info = ()
             elif system_name == 'Windows':
                 info = platform.win32_ver()
             elif system_name == 'Darwin':


### PR DESCRIPTION
Removed reference to `platform.linux_distribution` in `numba/misc/numba_entry.py`.