### PR TITLE
CUDA: Make atomic semantics match Python / NumPy, and fix #5458

### DIFF
--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -105,15 +105,21 @@ caslock = threading.Lock()
 class FakeCUDAAtomic(object):
     def add(self, array, index, val):
         with addlock:
+            old = array[index]
             array[index] += val
+        return old
 
     def max(self, array, index, val):
         with maxlock:
-            array[index] = max(array[index], val)
+            old = array[index]
+            array[index] = max(old, val)
+        return old
 
     def min(self, array, index, val):
         with minlock:
-            array[index] = min(array[index], val)
+            old = array[index]
+            array[index] = min(old, val)
+        return old
 
     def compare_and_swap(self, array, old, val):
         with caslock:

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -109,24 +109,10 @@ class FakeCUDAAtomic(object):
 
     def max(self, array, index, val):
         with maxlock:
-            # CUDA Python's semantics for max differ from Numpy's Python's,
-            # so we have special handling here (CUDA Python treats NaN as
-            # missing data).
-            if np.isnan(array[index]):
-                array[index] = val
-            elif np.isnan(val):
-                return
             array[index] = max(array[index], val)
 
     def min(self, array, index, val):
         with minlock:
-            # CUDA Python's semantics for min differ from Numpy's Python's,
-            # so we have special handling here (CUDA Python treats NaN as
-            # missing data).
-            if np.isnan(array[index]):
-                array[index] = val
-            elif np.isnan(val):
-                return
             array[index] = min(array[index], val)
 
     def compare_and_swap(self, array, old, val):

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -450,10 +450,7 @@ class atomic(Stub):
     class max(Stub):
         """max(ary, idx, val)
 
-        Perform atomic ary[idx] = max(ary[idx], val). NaN is treated as a
-        missing value, so max(NaN, n) == max(n, NaN) == n. Note that this
-        differs from Python and Numpy behaviour, where max(a, b) is always
-        a when either a or b is a NaN.
+        Perform atomic ary[idx] = max(ary[idx], val).
 
         Supported on int32, int64, uint32, uint64, float32, float64 operands only.
 
@@ -464,12 +461,12 @@ class atomic(Stub):
     class min(Stub):
         """min(ary, idx, val)
 
-        Perform atomic ary[idx] = min(ary[idx], val). NaN is treated as a
-        missing value, so min(NaN, n) == min(n, NaN) == n. Note that this
-        differs from Python and Numpy behaviour, where min(a, b) is always
-        a when either a or b is a NaN.
+        Perform atomic ary[idx] = min(ary[idx], val).
 
         Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
         """
 
     class compare_and_swap(Stub):

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -467,6 +467,69 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_array_equal(expect_res, res)
         np.testing.assert_array_equal(expect_out, out)
 
+    # Tests that the atomic add, min, and max operations return the old value -
+    # in the simulator, they did not (see Issue #5458). The max and min have
+    # special handling for NaN values, so we explicitly test with a NaN in the
+    # array being modified and the value provided.
+
+    def _test_atomic_returns_old(self, kernel, initial):
+        x = np.zeros(2, dtype=np.float32)
+        x[0] = initial
+        kernel[1, 1](x)
+        if np.isnan(initial):
+            self.assertTrue(np.isnan(x[1]))
+        else:
+            self.assertEqual(x[1], initial)
+
+    def test_atomic_add_returns_old(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.add(x, 0, 1)
+
+        self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_max_returns_old(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.max(x, 0, 1)
+
+        self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_max_returns_old_nan_in_array(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.max(x, 0, 1)
+
+        self._test_atomic_returns_old(kernel, np.nan)
+
+    def test_atomic_max_returns_old_nan_val(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.max(x, 0, np.nan)
+
+        self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_min_returns_old(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.min(x, 0, 11)
+
+        self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_min_returns_old_nan_in_array(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.min(x, 0, 11)
+
+        self._test_atomic_returns_old(kernel, np.nan)
+
+    def test_atomic_min_returns_old_nan_val(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.min(x, 0, 11)
+
+        self._test_atomic_returns_old(kernel, np.nan)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The main aim for this PR is to fix #5458 by ensuring that the simulator's atomic implementations return the old value. It also includes a change in the semantics of `cuda.atomic.min` and `cuda.atomic.max` such that they now match the semantics of `min` and `max` in Python and NumPy.

There doesn't appear to be a good reason for the semantics of `cuda.atomic.min` and `max` deviating from NumPy - the original PR which added it (#979) makes no comment about it. Treating NaN values as missing data also makes it more difficult to fix Issue #5458 in a manner that is consistent between the simulator and the hardware target.

The first commit in this PR changes the CUDA atomic `min` and `max` functions to match the semantics of Python and NumPy - that is, `{min,max}(a, b)` always returns `a` if either is a NaN. In practice, for:

```python
cuda.atomic.{min,max}(ary, idx, val)
````

the stored result is always `ary[idx]` when either of `ary[idx]` or `val` is a NaN.

The second commit then fixes Issue #5458.
