### PR TITLE
First-class function call cannot use keyword arguments

### DIFF
--- a/numba/core/types/function_type.py
+++ b/numba/core/types/function_type.py
@@ -4,7 +4,7 @@ __all__ = ['FunctionType', 'UndefinedFunctionType', 'FunctionPrototype',
 
 from abc import ABC, abstractmethod
 from .abstract import Type
-from .. import types
+from .. import types, errors
 
 
 class FunctionType(Type):
@@ -42,6 +42,17 @@ class FunctionType(Type):
 
     def get_call_type(self, context, args, kws):
         from numba.core import typing
+
+        if kws:
+            # First-class functions carry only the type signature
+            # information and function address value. So, it is not
+            # possible to determine the positional arguments
+            # corresponding to the keyword arguments in the call
+            # expression. For instance, the definition of the
+            # first-class function may not use the same argument names
+            # that the caller assumes. [numba/issues/5540].
+            raise errors.UnsupportedError(
+                f'first-class function call cannot use keyword arguments')
 
         if len(args) != self.nargs:
             raise ValueError(


### PR DESCRIPTION
The PR implements a proper error message as in the description.

Fixes #5540 

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
