### PR TITLE
CUDA: Only release primary ctx if retained

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -534,10 +534,11 @@ class Device(object):
 
     def release_primary_context(self):
         """
-        Release reference to primary context
+        Release reference to primary context if it has been retained.
         """
-        driver.cuDevicePrimaryCtxRelease(self.id)
-        self.primary_context = None
+        if self.primary_context:
+            driver.cuDevicePrimaryCtxRelease(self.id)
+            self.primary_context = None
 
     def reset(self):
         try:


### PR DESCRIPTION
Certain versions of the CUDA driver are picky about the use of `cuDevicePrimaryCtxRelease` - if the context has not been retained previously by a call to `cuDevicePrimaryCtxRetain` then it can fail with `CUDA_ERROR_INVALID_CONTEXT`. Note that in general, primary context retention uses a reference counting scheme, so it is valid to call `cuDevicePrimaryCtxRelease` as many times as `cuDevicePrimaryCtxRetain` has been called.

This commit changes the `numba.cuda.cudadrv.driver.Device` class so that it will only release the primary context if it has already been retained. We don't need to count calls to `cuDevicePrimaryCtxRetain` because it is only called once from the `Device` class until the primary
context is released (`get_primary_context()` returns early if `self.primary_context` already holds a context).
