### PR TITLE
Implement math.modf for CUDA target 

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -149,6 +149,7 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.floor`
 * :func:`math.copysign`
 * :func:`math.fmod`
+* :func:`math.modf`
 * :func:`math.isnan`
 * :func:`math.isinf`
 

--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -94,3 +94,10 @@ class Math_isnan(ConcreteTemplate):
         signature(types.boolean, types.float32),
         signature(types.boolean, types.float64),
     ]
+
+@infer_global(math.modf)
+class Math_modf(ConcreteTemplate):
+    cases = [
+        signature(types.UniTuple(types.float64, 2), types.float64),
+        signature(types.UniTuple(types.float32, 2), types.float32)
+    ]

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -501,7 +501,7 @@ class TestCudaMath(CUDATestCase):
             B = np.zeros_like(A)
             C = np.zeros_like(A)
             cfunc = cuda.jit((arytype, arytype, arytype))(math_modf)
-            cfunc[1, nelem](A, B, C)
+            cfunc[1, len(A)](A, B, C)
             self.assertTrue(np.isnan(B))
             self.assertTrue(np.isnan(C))
 
@@ -510,7 +510,7 @@ class TestCudaMath(CUDATestCase):
             B = np.zeros_like(A)
             C = np.zeros_like(A)
             cfunc = cuda.jit((arytype, arytype, arytype))(math_modf)
-            cfunc[1, nelem](A, B, C)
+            cfunc[1, len(A)](A, B, C)
             D, E =np.modf(A)
             self.assertTrue(np.array_equal(B,D))
             self.assertTrue(np.array_equal(C,E))

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -517,14 +517,20 @@ class TestCudaMath(CUDATestCase):
 
         nelem = 50
         #32 bit float
-        modf_template_compare(np.linspace(0, 10, nelem), dtype=np.float32, arytype = float32[:])
-        modf_template_compare(np.array([np.inf, -np.inf]), dtype=np.float32, arytype = float32[:])
-        modf_template_nan(dtype=np.float32, arytype = float32[:])
+        with self.subTest("float32 modf on simple float"):
+            modf_template_compare(np.linspace(0, 10, nelem), dtype=np.float32, arytype = float32[:])
+        with self.subTest("float32 modf on +- infinity"):
+            modf_template_compare(np.array([np.inf, -np.inf]), dtype=np.float32, arytype = float32[:])
+        with self.subTest("float32 modf on nan"):
+            modf_template_nan(dtype=np.float32, arytype = float32[:])
 
         #64 bit float
-        modf_template_compare(np.linspace(0, 10, nelem), dtype=np.float64, arytype = float64[:])
-        modf_template_compare(np.array([np.inf, -np.inf]), dtype=np.float64, arytype = float64[:])
-        modf_template_nan(dtype=np.float64, arytype = float64[:])
+        with self.subTest("float64 modf on simple float"):
+            modf_template_compare(np.linspace(0, 10, nelem), dtype=np.float64, arytype = float64[:])
+        with self.subTest("float64 modf on +- infinity"):
+            modf_template_compare(np.array([np.inf, -np.inf]), dtype=np.float64, arytype = float64[:])
+        with self.subTest("float64 modf on nan"):
+            modf_template_nan(dtype=np.float64, arytype = float64[:])
 
     #------------------------------------------------------------------------------
     # test_math_fmod


### PR DESCRIPTION
As title. Request reference: https://gitter.im/numba/numba?at=5e8f92d83a85536c431d086f

After the basic implementation by @stuartarchibald, I implemented the tests for float32 and float64 and edited the docs. 
The tests cover a range of 50 floats between 0 and 10, infinity, minus infinity and nan.

see #5545 