### PR TITLE
Fixes #5583 Remove references to cffi_support from docs and examples

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -41,7 +41,6 @@ exclude =
     numba/core/itanium_mangler.py
     numba/core/generators.py
     numba/misc/appdirs.py
-    numba/cffi_support.py
     numba/core/interpreter.py
     numba/core/caching.py
     numba/core/debuginfo.py

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1057,12 +1057,12 @@ type may be registered with Numba. This may include struct types, though it is
 only permitted to call functions that accept pointers to structs - passing a
 struct by value is unsupported. For registering a mapping, use:
 
-.. function:: numba.cffi_support.register_type(cffi_type, numba_type)
+.. function:: numba.core.typing.cffi_utils.register_type(cffi_type, numba_type)
 
 Out-of-line cffi modules must be registered with Numba prior to the use of any
 of their functions from within Numba-compiled functions:
 
-.. function:: numba.cffi_support.register_module(mod)
+.. function:: numba.core.typing.cffi_utils.register_module(mod)
 
    Register the cffi out-of-line module ``mod`` with Numba.
 

--- a/docs/source/user/cfunc.rst
+++ b/docs/source/user/cfunc.rst
@@ -126,14 +126,17 @@ With CFFI
 For applications that have a lot of state, it is useful to pass data in C
 structures.  To simplify the interoperability with C code, numba can convert
 a ``cffi`` type into a numba ``Record`` type using
-``numba.cffi_support.map_type``::
+``numba.core.typing.cffi_utils.map_type``::
 
-   from numba import cffi_support
+   from numba.core.typing import cffi_utils
 
-   nbtype = cffi_support.map_type(cffi_type, use_record_dtype=True)
+   nbtype = cffi_utils.map_type(cffi_type, use_record_dtype=True)
 
 .. note:: **use_record_dtype=True** is needed otherwise pointers to C
     structures are returned as void pointers.
+
+.. note:: From v0.49 the ``numba.cffi_support`` module has been phased out
+    in favour of ``numba.core.typing.cffi_utils``
 
 
 For example::
@@ -158,7 +161,7 @@ For example::
    ffi.cdef(src)
 
    # Get the function signature from *my_func*
-   sig = cffi_support.map_type(ffi.typeof('my_func'), use_record_dtype=True)
+   sig = cffi_utils.map_type(ffi.typeof('my_func'), use_record_dtype=True)
 
    # Make the cfunc
    from numba import cfunc, carray

--- a/examples/notebooks/Accessing C Struct Data.ipynb
+++ b/examples/notebooks/Accessing C Struct Data.ipynb
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using `numba.cffi_support.map_type` we can convert the `cffi` type into a Numba `Record` type."
+    "Using `numba.core.typing.cffi_utils.map_type` we can convert the `cffi` type into a Numba `Record` type."
    ]
   },
   {
@@ -95,9 +95,9 @@
     }
    ],
    "source": [
-    "from numba import cffi_support\n",
+    "from numba.core.typing import cffi_utils\n",
     "\n",
-    "cffi_support.map_type(ffi.typeof('my_struct'), use_record_dtype=True)"
+    "cffi_utils.map_type(ffi.typeof('my_struct'), use_record_dtype=True)"
    ]
   },
   {
@@ -124,7 +124,7 @@
     }
    ],
    "source": [
-    "sig = cffi_support.map_type(ffi.typeof('my_func'), use_record_dtype=True)\n",
+    "sig = cffi_utils.map_type(ffi.typeof('my_func'), use_record_dtype=True)\n",
     "sig"
    ]
   },
@@ -168,7 +168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "address of data: 0x7fb70a611b30\n"
+      "address of data: 0x563d9a74e7c0\n"
      ]
     },
     {
@@ -213,7 +213,7 @@
     {
      "data": {
       "text/plain": [
-       "Record(i1[type=int32;offset=0],f2[type=float32;offset=4],d3[type=float64;offset=8],af4[type=nestedarray(float32, (7,));offset=16];48;True)"
+       "Record(i1[type=int32;offset=0;alignment=4],f2[type=float32;offset=4;alignment=4],d3[type=float64;offset=8;alignment=8],af4[type=nestedarray(float32, (7,));offset=16;alignment=4];48;True)"
       ]
      },
      "execution_count": 7,
@@ -251,7 +251,7 @@
     {
      "data": {
       "text/plain": [
-       "Record(i1[type=int32;offset=0],pad0[type=int8;offset=4],f2[type=float32;offset=8],pad1[type=int8;offset=12],d3[type=float64;offset=16];24;True)"
+       "Record(i1[type=int32;offset=0;alignment=4],pad0[type=int8;offset=4;alignment=1],f2[type=float32;offset=8;alignment=4],pad1[type=int8;offset=12;alignment=1],d3[type=float64;offset=16;alignment=8];24;True)"
       ]
      },
      "execution_count": 8,
@@ -294,8 +294,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "signature: (Record(i1[type=int32;offset=0],f2[type=float32;offset=4],d3[type=float64;offset=8],af4[type=nestedarray(float32, (7,));offset=16];48;True)*, uint64) -> float64\n",
-      "signature matches: True\n"
+      "signature: (Record(i1[type=int32;offset=0;alignment=4],f2[type=float32;offset=4;alignment=4],d3[type=float64;offset=8;alignment=8],af4[type=nestedarray(float32, (7,));offset=16;alignment=4];48;True)*, uint64) -> float64\n",
+      "signature matches: False\n"
      ]
     }
    ],
@@ -311,7 +311,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "python3"
+   "name": "Python 3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -323,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #5583 

Removed the references to `cffi_support` (before deprecated, now completely removed) from the documentation to refer to `cffi_utils` instead. Added a note about the change. I've added a small example to `cffi_example.py` to show a non-trivial usage of `cffi_utils`.

Changed also the notebook example https://github.com/numba/numba/blob/master/examples/notebooks/Accessing%20C%20Struct%20Data.ipynb to use `cffi_utils`. But I have a problem here, the latest equality does not hold because the signature from `map_type` does not include the alignment. Not sure how to go around that.

Let me know if there are any issues.