### PR TITLE
Add support for multi-output ufuncs

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -608,6 +608,7 @@ Math operations
  remainder           Yes          Yes
  mod                 Yes          Yes
  fmod                Yes          Yes
+ divmod (*)          ???          Yes
  abs                 Yes          Yes
  absolute            Yes          Yes
  fabs                Yes          Yes
@@ -629,6 +630,7 @@ Math operations
  lcm                 Yes          Yes
 ==============  =============  ===============
 
+(\*) not supported on timedelta types
 
 Trigonometric functions
 -----------------------

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -608,7 +608,7 @@ Math operations
  remainder           Yes          Yes
  mod                 Yes          Yes
  fmod                Yes          Yes
- divmod (*)          ???          Yes
+ divmod (*)          Yes          Yes
  abs                 Yes          Yes
  absolute            Yes          Yes
  fabs                Yes          Yes

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -10,7 +10,7 @@ from numba.core.typing.templates import (AttributeTemplate, AbstractTemplate,
 from numba.np.numpy_support import (ufunc_find_matching_loop,
                              supported_ufunc_loop, as_dtype,
                              from_dtype, as_dtype, resolve_output_type,
-                             carray, farray)
+                             carray, farray, _ufunc_loop_sig)
 from numba.core.errors import TypingError, NumbaPerformanceWarning
 from numba import pndindex
 
@@ -38,10 +38,6 @@ class Numpy_rules_ufunc(AbstractTemplate):
 
         # preconditions
         assert nargs == nin + nout
-
-        if nout > 1:
-            msg = "ufunc '{0}': not supported in this mode (more than 1 output)"
-            raise TypingError(msg=msg.format(ufunc.__name__))
 
         if len(args) < nin:
             msg = "ufunc '{0}': not enough arguments ({1} found, {2} required)"
@@ -136,11 +132,7 @@ class Numpy_rules_ufunc(AbstractTemplate):
                            for ret_ty in ret_tys]
             out.extend(ret_tys)
 
-        # note: although the previous code should support multiple return values, only one
-        #       is supported as of now (signature may not support more than one).
-        #       there is an check enforcing only one output
-        out.extend(args)
-        return signature(*out)
+        return _ufunc_loop_sig(out, args)
 
 
 class NumpyRulesArrayOperator(Numpy_rules_ufunc):
@@ -256,7 +248,7 @@ _math_operations = [ "add", "subtract", "multiply",
                      "rint", "sign", "conjugate", "exp", "exp2",
                      "log", "log2", "log10", "expm1", "log1p",
                      "sqrt", "square", "reciprocal",
-                     "divide", "mod", "abs", "fabs" , "gcd", "lcm"]
+                     "divide", "mod", "divmod", "abs", "fabs" , "gcd", "lcm"]
 
 _trigonometric_functions = [ "sin", "cos", "tan", "arcsin",
                              "arccos", "arctan", "arctan2",
@@ -289,8 +281,8 @@ _logic_functions = [ "isnat" ]
 # implemented.
 #
 # It also works as a nice TODO list for ufunc support :)
-_unsupported = set([ 'frexp', # this one is tricky, as it has 2 returns
-                     'modf',  # this one also has 2 returns
+_unsupported = set([ 'frexp',
+                     'modf',
                  ])
 
 # A list of ufuncs that are in fact aliases of other ufuncs. They need to insert the

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -185,6 +185,12 @@ def np_int_srem_impl(context, builder, sig, args):
     return result
 
 
+def np_int_sdivrem_impl(context, builder, sig, args):
+    div = np_int_sdiv_impl(context, builder, sig.return_type[0](*sig.args), args)
+    rem = np_int_srem_impl(context, builder, sig.return_type[1](*sig.args), args)
+    return context.make_tuple(builder, sig.return_type, [div, rem])
+
+
 def np_int_udiv_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
@@ -227,6 +233,12 @@ def np_int_urem_impl(context, builder, sig, args):
     result.add_incoming(mod, bb_if)
 
     return result
+
+
+def np_int_udivrem_impl(context, builder, sig, args):
+    div = np_int_udiv_impl(context, builder, sig.return_type[0](*sig.args), args)
+    rem = np_int_urem_impl(context, builder, sig.return_type[1](*sig.args), args)
+    return context.make_tuple(builder, sig.return_type, [div, rem])
 
 
 # implementation of int_fmod is in fact the same as the unsigned remainder,
@@ -400,6 +412,12 @@ def np_real_floor_div_impl(context, builder, sig, args):
     res = np_real_div_impl(context, builder, sig, args)
     s = typing.signature(sig.return_type, sig.return_type)
     return np_real_floor_impl(context, builder, s, (res,))
+
+
+def np_real_divmod_impl(context, builder, sig, args):
+    div = np_real_floor_div_impl(context, builder, sig.return_type[0](*sig.args), args)
+    rem = np_real_mod_impl(context, builder, sig.return_type[1](*sig.args), args)
+    return context.make_tuple(builder, sig.return_type, [div, rem])
 
 
 def np_complex_floor_div_impl(context, builder, sig, args):

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -479,7 +479,7 @@ def register_ufunc_kernel(ufunc, kernel):
     _any = types.Any
     in_args = (_any,) * ufunc.nin
 
-    # Add an overload for each out argument being missing.
+    # Add a lowering for each out argument that is missing.
     for n_explicit_out in range(ufunc.nout + 1):
         out_args = (types.Array,) * n_explicit_out
         lower(ufunc, *in_args, *out_args)(do_ufunc)

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -16,7 +16,9 @@ import operator
 from numba.np import arrayobj, ufunc_db, numpy_support
 from numba.core.imputils import Registry, impl_ret_new_ref, force_error_model
 from numba.core import typing, types, utils, cgutils, callconv
-from numba.np.numpy_support import ufunc_find_matching_loop, select_array_wrapper, from_dtype, _ufunc_loop_sig
+from numba.np.numpy_support import (
+    ufunc_find_matching_loop, select_array_wrapper, from_dtype, _ufunc_loop_sig
+)
 from numba.core.typing import npydecl
 from numba.core.extending import overload, intrinsic
 
@@ -374,7 +376,7 @@ def numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel_class):
 
     indices = [inp.create_iter_indices() for inp in inputs]
 
-    # assume outputs are all the same size
+    # assume outputs are all the same size, which numpy requires
 
     loopshape = outputs[0].shape
     with cgutils.loop_nest(builder, loopshape, intp=intpty) as loop_indices:

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -16,7 +16,7 @@ import operator
 from numba.np import arrayobj, ufunc_db, numpy_support
 from numba.core.imputils import Registry, impl_ret_new_ref, force_error_model
 from numba.core import typing, types, utils, cgutils, callconv
-from numba.np.numpy_support import ufunc_find_matching_loop, select_array_wrapper, from_dtype
+from numba.np.numpy_support import ufunc_find_matching_loop, select_array_wrapper, from_dtype, _ufunc_loop_sig
 from numba.core.typing import npydecl
 from numba.core.extending import overload, intrinsic
 
@@ -304,9 +304,30 @@ def _build_array(context, builder, array_ty, input_types, inputs):
                         array_ty.layout, array_ty.dtype, ndim,
                         out_val)
 
+# ufuncs either return a single result when nout == 1, else a tuple of results
 
-def numpy_ufunc_kernel(context, builder, sig, args, kernel_class,
-                       explicit_output=True):
+def _unpack_output_types(ufunc, sig):
+    if ufunc.nout == 1:
+        return [sig.return_type]
+    else:
+        return list(sig.return_type)
+
+
+def _unpack_output_values(ufunc, builder, values):
+    if ufunc.nout == 1:
+        return [values]
+    else:
+        return cgutils.unpack_tuple(builder, values)
+
+
+def _pack_output_values(ufunc, context, builder, typ, values):
+    if ufunc.nout == 1:
+        return values[0]
+    else:
+        return context.make_tuple(builder, typ, values)
+
+
+def numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel_class):
     # This is the code generator that builds all the looping needed
     # to execute a numpy functions over several dimensions (including
     # scalar cases).
@@ -315,47 +336,58 @@ def numpy_ufunc_kernel(context, builder, sig, args, kernel_class,
     # builder - the code emitter
     # sig - signature of the ufunc
     # args - the args to the ufunc
+    # ufunc - the ufunc itself
     # kernel_class -  a code generating subclass of _Kernel that provides
-    # explicit_output - if the output was explicit in the call
-    #                   (ie: np.add(x,y,r))
 
     arguments = [_prepare_argument(context, builder, arg, tyarg)
                  for arg, tyarg in zip(args, sig.args)]
-    if not explicit_output:
-        ret_ty = sig.return_type
-        if isinstance(ret_ty, types.ArrayCompatible):
-            output = _build_array(context, builder, ret_ty, sig.args, arguments)
-        else:
-            output = _prepare_argument(
-                context, builder,
-                lc.Constant.null(context.get_value_type(ret_ty)), ret_ty)
-        arguments.append(output)
-    elif context.enable_nrt:
-        # Incref the output
-        context.nrt.incref(builder, sig.return_type, args[-1])
 
-    inputs = arguments[0:-1]
-    output = arguments[-1]
+    if len(arguments) < ufunc.nin:
+        raise RuntimeError(
+            "Not enough inputs to {}, expected {} got {}"
+            .format(ufunc.__name__, ufunc.nin, len(arguments)))
 
-    outer_sig = [a.base_type for a in arguments]
-    #signature expects return type first, while we have it last:
-    outer_sig = outer_sig[-1:] + outer_sig[:-1]
-    outer_sig = typing.signature(*outer_sig)
+    for out_i, ret_ty in enumerate(_unpack_output_types(ufunc, sig)):
+        if ufunc.nin + out_i >= len(arguments):
+            # this out argument is not provided
+            if isinstance(ret_ty, types.ArrayCompatible):
+                output = _build_array(context, builder, ret_ty, sig.args, arguments)
+            else:
+                output = _prepare_argument(
+                    context, builder,
+                    lc.Constant.null(context.get_value_type(ret_ty)), ret_ty)
+            arguments.append(output)
+        elif context.enable_nrt:
+            # Incref the output
+            context.nrt.incref(builder, ret_ty, args[ufunc.nin + out_i])
+
+    inputs = arguments[:ufunc.nin]
+    outputs = arguments[ufunc.nin:]
+    assert len(outputs) == ufunc.nout
+
+    outer_sig = _ufunc_loop_sig(
+        [a.base_type for a in outputs],
+        [a.base_type for a in inputs]
+    )
     kernel = kernel_class(context, builder, outer_sig)
     intpty = context.get_value_type(types.intp)
 
     indices = [inp.create_iter_indices() for inp in inputs]
 
-    loopshape = output.shape
+    # assume outputs are all the same size
+
+    loopshape = outputs[0].shape
     with cgutils.loop_nest(builder, loopshape, intp=intpty) as loop_indices:
         vals_in = []
         for i, (index, arg) in enumerate(zip(indices, inputs)):
             index.update_indices(loop_indices, i)
             vals_in.append(arg.load_data(index.as_values()))
 
-        val_out = kernel.generate(*vals_in)
-        output.store_data(loop_indices, val_out)
-    out = arguments[-1].return_val
+        vals_out = _unpack_output_values(ufunc, builder, kernel.generate(*vals_in))
+        for val_out, output in zip(vals_out, outputs):
+            output.store_data(loop_indices, val_out)
+
+    out = _pack_output_values(ufunc, context, builder, sig.return_type, [o.return_val for o in outputs])
     return impl_ret_new_ref(context, builder, sig.return_type, out)
 
 
@@ -413,10 +445,9 @@ def _ufunc_db_function(ufunc):
         def __init__(self, context, builder, outer_sig):
             super(_KernelImpl, self).__init__(context, builder, outer_sig)
             loop = ufunc_find_matching_loop(
-                ufunc, outer_sig.args + (outer_sig.return_type,))
+                ufunc, outer_sig.args + tuple(_unpack_output_types(ufunc, outer_sig)))
             self.fn = ufunc_db.get_ufunc_info(ufunc).get(loop.ufunc_sig)
-            self.inner_sig = typing.signature(
-                *(loop.outputs + loop.inputs))
+            self.inner_sig = _ufunc_loop_sig(loop.outputs, loop.inputs)
 
             if self.fn is None:
                 msg = "Don't know how to lower ufunc '{0}' for loop '{1}'"
@@ -443,36 +474,30 @@ def _ufunc_db_function(ufunc):
 
 def register_ufunc_kernel(ufunc, kernel):
     def do_ufunc(context, builder, sig, args):
-        return numpy_ufunc_kernel(context, builder, sig, args, kernel)
-
-    def do_ufunc_no_explicit_output(context, builder, sig, args):
-        return numpy_ufunc_kernel(context, builder, sig, args, kernel,
-                                  explicit_output=False)
+        return numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel)
 
     _any = types.Any
     in_args = (_any,) * ufunc.nin
 
-    # (array or scalar, out=array)
-    lower(ufunc, *in_args, types.Array)(do_ufunc)
-    # (array or scalar)
-    lower(ufunc, *in_args)(do_ufunc_no_explicit_output)
+    # Add an overload for each out argument being missing.
+    for n_explicit_out in range(ufunc.nout + 1):
+        out_args = (types.Array,) * n_explicit_out
+        lower(ufunc, *in_args, *out_args)(do_ufunc)
 
     return kernel
 
 
-def register_unary_operator_kernel(operator, kernel, inplace=False):
+def register_unary_operator_kernel(operator, ufunc, kernel, inplace=False):
     assert not inplace  # are there any inplace unary operators?
     def lower_unary_operator(context, builder, sig, args):
-        return numpy_ufunc_kernel(context, builder, sig, args, kernel,
-                                  explicit_output=False)
+        return numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel)
     _arr_kind = types.Array
     lower(operator, _arr_kind)(lower_unary_operator)
 
 
-def register_binary_operator_kernel(op, kernel, inplace=False):
+def register_binary_operator_kernel(op, ufunc, kernel, inplace=False):
     def lower_binary_operator(context, builder, sig, args):
-        return numpy_ufunc_kernel(context, builder, sig, args, kernel,
-                                  explicit_output=False)
+        return numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel)
 
     def lower_inplace_operator(context, builder, sig, args):
         # The visible signature is (A, B) -> A
@@ -480,8 +505,7 @@ def register_binary_operator_kernel(op, kernel, inplace=False):
         # is (A, B, A) -> A
         args = tuple(args) + (args[0],)
         sig = typing.signature(sig.return_type, *sig.args + (sig.args[0],))
-        return numpy_ufunc_kernel(context, builder, sig, args, kernel,
-                                  explicit_output=True)
+        return numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel)
 
     _any = types.Any
     _arr_kind = types.Array
@@ -507,8 +531,8 @@ def array_positive_impl(context, builder, sig, args):
             [val] = args
             return val
 
-    return numpy_ufunc_kernel(context, builder, sig, args,
-                              _UnaryPositiveKernel, explicit_output=False)
+    return numpy_ufunc_kernel(context, builder, sig, args, np.positive,
+                              _UnaryPositiveKernel)
 
 
 def _register_ufuncs():
@@ -524,9 +548,9 @@ def _register_ufuncs():
             ufunc = getattr(np, ufunc_name)
             kernel = kernels[ufunc]
             if ufunc.nin == 1:
-                register_unary_operator_kernel(operator, kernel)
+                register_unary_operator_kernel(operator, ufunc, kernel)
             elif ufunc.nin == 2:
-                register_binary_operator_kernel(operator, kernel)
+                register_binary_operator_kernel(operator, ufunc, kernel)
             else:
                 raise RuntimeError("There shouldn't be any non-unary or binary operators")
 
@@ -536,9 +560,9 @@ def _register_ufuncs():
             ufunc = getattr(np, ufunc_name)
             kernel = kernels[ufunc]
             if ufunc.nin == 1:
-                register_unary_operator_kernel(operator, kernel, inplace=True)
+                register_unary_operator_kernel(operator, ufunc, kernel, inplace=True)
             elif ufunc.nin == 2:
-                register_binary_operator_kernel(operator, kernel, inplace=True)
+                register_binary_operator_kernel(operator, ufunc, kernel, inplace=True)
             else:
                 raise RuntimeError("There shouldn't be any non-unary or binary operators")
 

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -5,6 +5,7 @@ import re
 import numpy as np
 
 from numba.core import errors, types, utils
+from numba.core.typing.templates import signature
 
 
 # re-export
@@ -318,6 +319,13 @@ class UFuncLoopSpec(collections.namedtuple('_UFuncLoopSpec',
     @property
     def numpy_outputs(self):
         return [as_dtype(x) for x in self.outputs]
+
+
+def _ufunc_loop_sig(out_tys, in_tys):
+    if len(out_tys) == 1:
+        return signature(out_tys[0], *in_tys)
+    else:
+        return signature(types.Tuple(out_tys), *in_tys)
 
 
 def ufunc_can_cast(from_, to, has_mixed_inputs, casting='safe'):

--- a/numba/np/ufunc/array_exprs.py
+++ b/numba/np/ufunc/array_exprs.py
@@ -2,6 +2,7 @@ import ast
 from collections import defaultdict, OrderedDict
 import contextlib
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import operator
@@ -392,6 +393,10 @@ def _lower_array_expr(lowerer, expr):
             return self.cast(result, inner_sig.return_type,
                              self.outer_sig.return_type)
 
+    # create a fake ufunc object which is enough to trick numpy_ufunc_kernel
+    ufunc = SimpleNamespace(nin=len(expr_args), nout=1, __name__=expr_name)
+    ufunc.nargs = ufunc.nin + ufunc.nout
+
     args = [lowerer.loadvar(name) for name in expr_args]
     return npyimpl.numpy_ufunc_kernel(
-        context, builder, outer_sig, args, ExprKernel, explicit_output=False)
+        context, builder, outer_sig, args, ufunc, ExprKernel)

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -60,10 +60,9 @@ class DUFuncLowerer(object):
 
     def __call__(self, context, builder, sig, args):
         from numba.np import npyimpl
-        explicit_output = len(args) > self.kernel.dufunc.ufunc.nin
         return npyimpl.numpy_ufunc_kernel(context, builder, sig, args,
-                                          self.kernel,
-                                          explicit_output=explicit_output)
+                                          self.kernel.dufunc.ufunc,
+                                          self.kernel)
 
 
 class DUFunc(_internal._DUFunc):

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -249,6 +249,21 @@ def _fill_ufunc_db(ufunc_db):
         'dd->d': npyfuncs.np_real_mod_impl,
     }
 
+    ufunc_db[np.divmod] = {
+        'bb->bb': npyfuncs.np_int_sdivrem_impl,
+        'BB->BB': npyfuncs.np_int_udivrem_impl,
+        'hh->hh': npyfuncs.np_int_sdivrem_impl,
+        'HH->HH': npyfuncs.np_int_udivrem_impl,
+        'ii->ii': npyfuncs.np_int_sdivrem_impl,
+        'II->II': npyfuncs.np_int_udivrem_impl,
+        'll->ll': npyfuncs.np_int_sdivrem_impl,
+        'LL->LL': npyfuncs.np_int_udivrem_impl,
+        'qq->qq': npyfuncs.np_int_sdivrem_impl,
+        'QQ->QQ': npyfuncs.np_int_udivrem_impl,
+        'ff->ff': npyfuncs.np_real_divmod_impl,
+        'dd->dd': npyfuncs.np_real_divmod_impl,
+    }
+
     ufunc_db[np.fmod] = {
         'bb->b': npyfuncs.np_int_fmod_impl,
         'BB->B': npyfuncs.np_int_fmod_impl,

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1569,7 +1569,7 @@ TestLoopTypesIntRightShiftNoPython.autogenerate()
 
 class TestLoopTypesFloorDivideNoPython(_LoopTypesTester):
     _compile_flags = no_pyobj_flags
-    _ufuncs = [np.floor_divide, np.remainder]
+    _ufuncs = [np.floor_divide, np.remainder, np.divmod]
     _required_types = 'bBhHiIlLqQfdFD'
     _skip_types = 'mMO' + _LoopTypesTester._skip_types
 
@@ -1593,6 +1593,7 @@ class TestLoopTypesFloatNoPython(_LoopTypesTester):
         _ufuncs.remove(np.signbit) # TODO: fix issue #758
     _ufuncs.remove(np.floor_divide) # has its own test class
     _ufuncs.remove(np.remainder) # has its own test class
+    _ufuncs.remove(np.divmod) # has its own test class
     _ufuncs.remove(np.mod) # same as np.remainder
     _required_types = 'fd'
     _skip_types = 'FDmMO' + _LoopTypesTester._skip_types
@@ -1615,6 +1616,8 @@ TestLoopTypesComplexNoPython.autogenerate()
 class TestLoopTypesDatetimeNoPython(_LoopTypesTester):
     _compile_flags = no_pyobj_flags
     _ufuncs = supported_ufuncs[:]
+
+    _ufuncs.remove(np.divmod)  # not implemented yet
 
     # NOTE: the full list of ufuncs supporting datetime64 and timedelta64
     # types in Numpy is:


### PR DESCRIPTION
This adds a simple implementation of `divmod` for the integer types to prove the multi-output feature works.

Adding support for remaining multi-output ufuncs is out of scope for this patch.