### PR TITLE
Unset the memory manager after EMM Plugin tests

### DIFF
--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -110,10 +110,9 @@ class TestDeviceOnlyEMMPlugin(CUDATestCase):
         cuda.set_memory_manager(DeviceOnlyEMMPlugin)
 
     def tearDown(self):
-        # Set the memory manager back to the Numba internal one for subsequent
-        # tests.
+        # Unset the memory manager for subsequent tests
         cuda.close()
-        cuda.set_memory_manager(cuda.cudadrv.driver.NumbaCUDAMemoryManager)
+        cuda.cudadrv.driver._memory_manager = None
 
     def test_memalloc(self):
         mgr = cuda.current_context().memory_manager


### PR DESCRIPTION
Setting the EMM plugin to the internal memory manager is incorrect when the tests are being run with an external memory manager, e.g. with:

```
NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
```

After the EMM plugin tests execute, testing would continue with the internal memory manager instead of the specified external memory manager. The correct behaviour is to un-set it, so that when the new context is created, it is set to the chosen memory manager (either the internal one or an external one).

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
