### PR TITLE
Add support for parfors creating 'F'ortran layout Numpy arrays.

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -57,7 +57,7 @@ def next_label():
     return _max_label
 
 
-def mk_alloc(typemap, calltypes, lhs, size_var, dtype, scope, loc):
+def mk_alloc(typemap, calltypes, lhs, size_var, dtype, scope, loc, lhs_typ):
     """generate an array allocation with np.empty() and return list of nodes.
     size_var can be an int variable or tuple of int variables.
     """
@@ -113,9 +113,34 @@ def mk_alloc(typemap, calltypes, lhs, size_var, dtype, scope, loc):
     # signature(
     #    types.npytypes.Array(dtype, ndims, 'C'), size_typ,
     #    types.functions.NumberClass(dtype))
-    alloc_assign = ir.Assign(alloc_call, lhs, loc)
 
-    out.extend([g_np_assign, attr_assign, typ_var_assign, alloc_assign])
+    if lhs_typ.layout == 'F':
+        empty_c_typ = lhs_typ.copy(layout='C')
+        empty_c_var = ir.Var(scope, mk_unique_var("$empty_c_var"), loc)
+        if typemap:
+            typemap[empty_c_var.name] = lhs_typ.copy(layout='C')
+        empty_c_assign = ir.Assign(alloc_call, empty_c_var, loc)
+
+        # attr call: asfortranarray = getattr(g_np_var, asfortranarray)
+        asfortranarray_attr_call = ir.Expr.getattr(g_np_var, "asfortranarray", loc)
+        afa_attr_var = ir.Var(scope, mk_unique_var("$asfortran_array_attr"), loc)
+        if typemap:
+            typemap[afa_attr_var.name] = get_np_ufunc_typ(numpy.asfortranarray)
+        afa_attr_assign = ir.Assign(asfortranarray_attr_call, afa_attr_var, loc)
+        # call asfortranarray
+        asfortranarray_call = ir.Expr.call(afa_attr_var, [empty_c_var], (), loc)
+        if calltypes:
+            calltypes[asfortranarray_call] = typemap[afa_attr_var.name].get_call_type(
+                typing.Context(), [empty_c_typ], {})
+
+        asfortranarray_assign = ir.Assign(asfortranarray_call, lhs, loc)
+
+        out.extend([g_np_assign, attr_assign, typ_var_assign, empty_c_assign,
+                    afa_attr_assign, asfortranarray_assign])
+    else:
+        alloc_assign = ir.Assign(alloc_call, lhs, loc)
+        out.extend([g_np_assign, attr_assign, typ_var_assign, alloc_assign])
+
     return out
 
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1907,7 +1907,7 @@ class ConvertNumpyPass:
         init_block = ir.Block(scope, loc)
         init_block.body = mk_alloc(pass_states.typemap, pass_states.calltypes, lhs,
                                    tuple(size_vars), el_typ, scope, loc,
-                                   self.typemap[lhs.name])
+                                   pass_states.typemap[lhs.name])
         body_label = next_label()
         body_block = ir.Block(scope, loc)
         expr_out_var = ir.Var(scope, mk_unique_var("$expr_out_var"), loc)


### PR DESCRIPTION
Resolves #5625 

If the target of an arrayexpr is a Fortran layout array then we allocate an empty C layout array in the parfor init block and then call numpy.asfortranarray to convert that empty array to Fortran layout.

Also, please note that this is a correctness-only fix.  Multi-dimensional access to Fortran arrays would still use the C loop structure and would therefore be inefficient from a cache perspective.  If all the arrays are F then we could invert the loop structure but if the arrays are mixed then more thought would need to go into optimizing performance.