### PR TITLE
Fix #3955. Allow `with objmode` to be cached

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -22,7 +22,6 @@ exclude =
     __init__.py
     # Grandfather in existing failing files.  This list should shrink over time
     numba/core/dispatcher.py
-    numba/core/serialize.py
     numba/core/funcdesc.py
     numba/core/postproc.py
     numba/stencils/stencil.py
@@ -223,7 +222,6 @@ exclude =
     numba/tests/test_wrapper.py
     numba/tests/test_obj_lifetime.py
     numba/tests/test_intwidth.py
-    numba/tests/test_extending.py
     numba/tests/test_remove_dead.py
     numba/tests/serialize_usecases.py
     numba/tests/test_del.py

--- a/LICENSES.third-party
+++ b/LICENSES.third-party
@@ -481,3 +481,41 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 --------------------------------------------------------------------
+
+
+cloudpickle
+-----------
+
+This module was extracted from the `cloud` package, developed by
+PiCloud, Inc.
+
+Copyright (c) 2015, Cloudpickle contributors.
+Copyright (c) 2012, Regents of the University of California.
+Copyright (c) 2009 PiCloud, Inc. http://www.picloud.com.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the University of California, Berkeley nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+© 2020 GitHub, Inc.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,11 +34,12 @@ jobs:
         CONDA_ENV: travisci
         TEST_THREADING: 'tbb'
         TEST_START_INDEX: 2
-      py37_np117:
+      py37_np117_pickle5:
         PYTHON: '3.7'
         NUMPY: '1.17'
         CONDA_ENV: travisci
         TEST_START_INDEX: 3
+        TEST_PICKLE5: yes
       py36_np115_cov:
         PYTHON: '3.6'
         NUMPY: '1.15'

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -86,6 +86,8 @@ if [ "$RUN_COVERAGE" == "yes" ]; then $PIP_INSTALL codecov; fi
 if [ "$TEST_SVML" == "yes" ]; then $CONDA_INSTALL -c numba icc_rt; fi
 # Install Intel TBB parallel backend
 if [ "$TEST_THREADING" == "tbb" ]; then $CONDA_INSTALL tbb tbb-devel; fi
+# Install pickle5
+if [ "$TEST_PICKLE5" == "yes" ]; then $PIP_INSTALL pickle5; fi
 
 # environment dump for debug
 echo "DEBUG ENV:"

--- a/docs/source/developer/caching.rst
+++ b/docs/source/developer/caching.rst
@@ -20,6 +20,10 @@ overloaded signatures compiled for the function. The *object code* is stored in
 files with an ``.nbc`` extension, one file per overload. The data in both files
 is serialized with :mod:`pickle`.
 
+.. note:: On Python <=3.7, Numba extends ``pickle`` using the pure-Python
+          pickler. To use the faster C Pickler, install ``pickle5``
+          from ``pip``. ``pickle5`` backports Python 3.8 pickler features.
+
 
 Requirements for Cacheability
 -----------------------------

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -146,6 +146,7 @@ Compiler Pipeline
   variable lifetime, inserts del operations, and handles generators
 - :ghfile:`numba/core/lowering.py` - General implementation of lowering Numba IR
   to LLVM
+  :ghfile:`numba/core/environment.py` - Runtime environment object
 - :ghfile:`numba/core/withcontexts.py` - General scaffolding for implementing
   context managers in nopython mode, and the objectmode context
   manager

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -197,6 +197,8 @@ vary with target operating system and hardware. The following lists them all
     threading backend.
   * ``tbb-devel`` - provides TBB headers/libraries for compiling TBB support
     into Numba's threading backend
+  * ``pickle5`` - provides Python 3.8 pickling features for faster pickling in
+    Python 3.6 and 3.7.
 
 * Required run time:
 

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -9,7 +9,7 @@ import inspect
 import itertools
 from types import CodeType, ModuleType
 
-from numba.core import errors, utils
+from numba.core import errors, utils, serialize
 
 
 opcode_info = namedtuple('opcode_info', ['argsize'])
@@ -288,7 +288,7 @@ class ByteCode(object):
                                           self.co_consts, self.co_names)
 
 
-class FunctionIdentity(object):
+class FunctionIdentity(serialize.ReduceMixin):
     """
     A function's identity and metadata.
 
@@ -343,3 +343,16 @@ class FunctionIdentity(object):
         """Copy the object and increment the unique counter.
         """
         return self.from_function(self.func)
+
+    def _reduce_states(self):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return dict(pyfunc=self.func)
+
+    @classmethod
+    def _rebuild(cls, pyfunc):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return cls.from_function(pyfunc)

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -411,8 +411,8 @@ class CompileResultCacheImpl(_CacheImpl):
         cannot_cache = None
         if self._is_closure:
             cannot_cache = "as it uses outer variables in a closure"
-        elif cres.lifted:
-            cannot_cache = "as it uses lifted loops"
+        elif any(not x.can_cache for x in cres.lifted):
+            cannot_cache = "as it uses lifted code"
         elif cres.library.has_dynamic_globals:
             cannot_cache = ("as it uses dynamic globals "
                             "(such as ctypes pointers and large global arrays)")

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -153,6 +153,23 @@ class _CacheLocator(object):
         """
         raise NotImplementedError
 
+    @classmethod
+    def get_suitable_cache_subpath(cls, py_file):
+        """Given the Python file path, compute a suitable path inside the
+        cache directory.
+
+        This will reduce file path that are too long, which can be a problem
+        on some operating system (i.e. Windows 7).
+        """
+        path = os.path.abspath(py_file)
+        subpath = os.path.dirname(path)
+        parentdir = os.path.split(subpath)[-1]
+        # Use SHA1 to reduce path length.
+        # Note: windows doesn't like long path.
+        hashed = hashlib.sha1(subpath.encode()).hexdigest()
+        # Retain parent directory name for easier debugging
+        return '_'.join([parentdir, hashed])
+
 
 class _SourceFileBackedLocatorMixin(object):
     """
@@ -194,9 +211,8 @@ class _UserProvidedCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
     def __init__(self, py_func, py_file):
         self._py_file = py_file
         self._lineno = py_func.__code__.co_firstlineno
-        drive, path = os.path.splitdrive(os.path.abspath(self._py_file))
-        subpath = os.path.dirname(path).lstrip(os.path.sep)
-        self._cache_path = os.path.join(config.CACHE_DIR, subpath)
+        cache_subpath = self.get_suitable_cache_subpath(py_file)
+        self._cache_path = os.path.join(config.CACHE_DIR, cache_subpath)
 
     def get_cache_path(self):
         return self._cache_path
@@ -235,15 +251,7 @@ class _UserWideCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
         self._lineno = py_func.__code__.co_firstlineno
         appdirs = AppDirs(appname="numba", appauthor=False)
         cache_dir = appdirs.user_cache_dir
-        cache_subpath = os.path.dirname(py_file)
-        if not (os.name == "nt" or getattr(sys, 'frozen', False)):
-            # On non-Windows, further disambiguate by appending the entire
-            # absolute source path to the cache dir, e.g.
-            # "$HOME/.cache/numba/usr/lib/.../mypkg/mysubpkg"
-            # On Windows, this is undesirable because of path length limitations
-            # For frozen applications, there is no existing "full path"
-            # directory, and depends on a relocatable executable.
-            cache_subpath = os.path.abspath(cache_subpath).lstrip(os.path.sep)
+        cache_subpath = self.get_suitable_cache_subpath(py_file)
         self._cache_path = os.path.join(cache_dir, cache_subpath)
 
     def get_cache_path(self):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -330,7 +330,6 @@ class _CacheImpl(object):
                         _IPythonCacheLocator]
 
     def __init__(self, py_func):
-        self._is_closure = bool(py_func.__closure__)
         self._lineno = py_func.__code__.co_firstlineno
         # Get qualname
         try:
@@ -409,9 +408,7 @@ class CompileResultCacheImpl(_CacheImpl):
         Check cachability of the given compile result.
         """
         cannot_cache = None
-        if self._is_closure:
-            cannot_cache = "as it uses outer variables in a closure"
-        elif any(not x.can_cache for x in cres.lifted):
+        if any(not x.can_cache for x in cres.lifted):
             cannot_cache = "as it uses lifted code"
         elif cres.library.has_dynamic_globals:
             cannot_cache = ("as it uses dynamic globals "
@@ -448,7 +445,7 @@ class CodeLibraryCacheImpl(_CacheImpl):
         """
         Check cachability of the given CodeLibrary.
         """
-        return not self._is_closure
+        return not codelib.has_dynamic_globals
 
     def get_filename_base(self, fullname, abiflags):
         parent = super(CodeLibraryCacheImpl, self)

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -158,7 +158,7 @@ class _CacheLocator(object):
         """Given the Python file path, compute a suitable path inside the
         cache directory.
 
-        This will reduce file path that are too long, which can be a problem
+        This will reduce a file path that is too long, which can be a problem
         on some operating system (i.e. Windows 7).
         """
         path = os.path.abspath(py_file)
@@ -732,5 +732,4 @@ def make_library_cache(prefix):
         _impl_class = CustomCodeLibraryCacheImpl
 
     return LibraryCache
-
 

--- a/numba/core/callwrapper.py
+++ b/numba/core/callwrapper.py
@@ -190,7 +190,8 @@ class PyCallWrapper(object):
 
         env_body = self.context.get_env_body(builder, envptr)
 
-        api.emit_environment_sentry(envptr, return_pyobject=True)
+        api.emit_environment_sentry(envptr, return_pyobject=True,
+                                    debug_msg=self.fndesc.env_name)
         env_manager = api.get_env_manager(self.env, env_body, envptr)
         return env_manager
 

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -106,7 +106,9 @@ class CPUContext(BaseContext):
                                         self.get_env_name(self.fndesc))
         envarg = builder.load(envgv)
         pyapi = self.get_python_api(builder)
-        pyapi.emit_environment_sentry(envarg)
+        pyapi.emit_environment_sentry(
+            envarg, debug_msg=self.fndesc.env_name,
+        )
         env_body = self.get_env_body(builder, envarg)
         return pyapi.get_env_manager(self.environment, env_body, envarg)
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -658,7 +658,7 @@ class _MemoMixin:
         An instance-specific UUID, to avoid multiple deserializations of
         a given instance.
 
-        Note this is lazily-generated, for performance reasons.
+        Note: this is lazily-generated, for performance reasons.
         """
         u = self.__uuid
         if u is None:

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -644,7 +644,36 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         return tp
 
 
-class Dispatcher(_DispatcherBase):
+class _MemoMixin:
+    __uuid = None
+    # A {uuid -> instance} mapping, for deserialization
+    _memo = weakref.WeakValueDictionary()
+    # hold refs to last N functions deserialized, retaining them in _memo
+    # regardless of whether there is another reference
+    _recent = collections.deque(maxlen=config.FUNCTION_CACHE_SIZE)
+
+    @property
+    def _uuid(self):
+        """
+        An instance-specific UUID, to avoid multiple deserializations of
+        a given instance.
+
+        Note this is lazily-generated, for performance reasons.
+        """
+        u = self.__uuid
+        if u is None:
+            u = str(uuid.uuid1())
+            self._set_uuid(u)
+        return u
+
+    def _set_uuid(self, u):
+        assert self.__uuid is None
+        self.__uuid = u
+        self._memo[u] = self
+        self._recent.append(self)
+
+
+class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
     """
     Implementation of user-facing dispatcher objects (i.e. created using
     the @jit decorator).
@@ -656,12 +685,7 @@ class Dispatcher(_DispatcherBase):
         'direct': _FunctionCompiler,
         'generated': _GeneratedFunctionCompiler,
         }
-    # A {uuid -> instance} mapping, for deserialization
-    _memo = weakref.WeakValueDictionary()
-    # hold refs to last N functions deserialized, retaining them in _memo
-    # regardless of whether there is another reference
-    _recent = collections.deque(maxlen=config.FUNCTION_CACHE_SIZE)
-    __uuid = None
+
     __numba__ = 'py_func'
 
     def __init__(self, py_func, locals={}, targetoptions={},
@@ -725,34 +749,41 @@ class Dispatcher(_DispatcherBase):
         else:  # Bound method
             return pytypes.MethodType(self, obj)
 
-    def __reduce__(self):
+    def _reduce_states(self):
         """
         Reduce the instance for pickling.  This will serialize
         the original function as well the compilation options and
         compiled signatures, but not the compiled code itself.
+
+        NOTE: part of ReduceMixin protocol
         """
         if self._can_compile:
             sigs = []
         else:
             sigs = [cr.signature for cr in self.overloads.values()]
-        globs = self._compiler.get_globals_for_reduction()
-        return (serialize._rebuild_reduction,
-                (self.__class__, str(self._uuid),
-                 serialize._reduce_function(self.py_func, globs),
-                 self.locals, self.targetoptions, self._impl_kind,
-                 self._can_compile, sigs))
+
+        return dict(
+            uuid=str(self._uuid),
+            py_func=self.py_func,
+            locals=self.locals,
+            targetoptions=self.targetoptions,
+            impl_kind=self._impl_kind,
+            can_compile=self._can_compile,
+            sigs=sigs,
+        )
 
     @classmethod
-    def _rebuild(cls, uuid, func_reduced, locals, targetoptions, impl_kind,
+    def _rebuild(cls, uuid, py_func, locals, targetoptions, impl_kind,
                  can_compile, sigs):
         """
         Rebuild an Dispatcher instance after it was __reduce__'d.
+
+        NOTE: part of ReduceMixin protocol
         """
         try:
             return cls._memo[uuid]
         except KeyError:
             pass
-        py_func = serialize._rebuild_function(*func_reduced)
         self = cls(py_func, locals, targetoptions, impl_kind)
         # Make sure this deserialization will be merged with subsequent ones
         self._set_uuid(uuid)
@@ -760,26 +791,6 @@ class Dispatcher(_DispatcherBase):
             self.compile(sig)
         self._can_compile = can_compile
         return self
-
-    @property
-    def _uuid(self):
-        """
-        An instance-specific UUID, to avoid multiple deserializations of
-        a given instance.
-
-        Note this is lazily-generated, for performance reasons.
-        """
-        u = self.__uuid
-        if u is None:
-            u = str(uuid.uuid1())
-            self._set_uuid(u)
-        return u
-
-    def _set_uuid(self, u):
-        assert self.__uuid is None
-        self.__uuid = u
-        self._memo[u] = self
-        self._recent.append(self)
 
     @global_compiler_lock
     def compile(self, sig):
@@ -889,12 +900,13 @@ class Dispatcher(_DispatcherBase):
             return types.FunctionType(cres.signature)
 
 
-class LiftedCode(_DispatcherBase):
+class LiftedCode(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
     """
     Implementation of the hidden dispatcher objects used for lifted code
     (a lifted loop is really compiled as a separate function).
     """
     _fold_args = False
+    can_cache = False
 
     def __init__(self, func_ir, typingctx, targetctx, flags, locals):
         self.func_ir = func_ir
@@ -910,6 +922,49 @@ class LiftedCode(_DispatcherBase):
                                  self.func_ir.func_id.pysig,
                                  can_fallback=True,
                                  exact_match_required=False)
+
+    def _reduce_states(self):
+        """
+        Reduce the instance for pickling.  This will serialize
+        the original function as well the compilation options and
+        compiled signatures, but not the compiled code itself.
+
+        NOTE: part of ReduceMixin protocol
+        """
+        return dict(
+            uuid=self._uuid, func_ir=self.func_ir, flags=self.flags,
+            locals=self.locals, extras=self._reduce_extras(),
+        )
+
+    def _reduce_extras(self):
+        """
+        NOTE: sub-class can override to add extra states
+        """
+        return {}
+
+    @classmethod
+    def _rebuild(cls, uuid, func_ir, flags, locals, extras):
+        """
+        Rebuild an Dispatcher instance after it was __reduce__'d.
+
+        NOTE: part of ReduceMixin protocol
+        """
+        try:
+            return cls._memo[uuid]
+        except KeyError:
+            pass
+
+        # NOTE: We are assuming that this is must be cpu_target, which is true
+        #       for now.
+        # TODO: refactor this to not assume on `cpu_target`
+
+        from numba.core import registry
+        typingctx = registry.cpu_target.typing_context
+        targetctx = registry.cpu_target.target_context
+
+        self = cls(func_ir, typingctx, targetctx, flags, locals, **extras)
+        self._set_uuid(uuid)
+        return self
 
     def get_source_location(self):
         """Return the starting line number of the loop.
@@ -961,6 +1016,13 @@ class LiftedLoop(LiftedCode):
 
 
 class LiftedWith(LiftedCode):
+
+    can_cache = True
+
+
+    def _reduce_extras(self):
+        return dict(output_types=self.output_types)
+
     @property
     def _numba_type_(self):
         return types.Dispatcher(self)

--- a/numba/core/environment.py
+++ b/numba/core/environment.py
@@ -1,0 +1,64 @@
+import weakref
+
+from numba import _dynfunc
+from numba.core import serialize
+
+
+class Environment(_dynfunc.Environment):
+    """Stores globals and constant pyobjects for runtime.
+
+    It is often needed to convert b/w nopython objects and pyobjects.
+    """
+    __slots__ = ('env_name', '__weakref__')
+    # A weak-value dictionary to store live environment with env_name as the
+    # key.
+    _memo = weakref.WeakValueDictionary()
+
+    @classmethod
+    def from_fndesc(cls, fndesc):
+        try:
+            # Avoid creating new Env
+            return cls._memo[fndesc.env_name]
+        except KeyError:
+            inst = cls(fndesc.lookup_globals())
+            inst.env_name = fndesc.env_name
+            cls._memo[fndesc.env_name] = inst
+            return inst
+
+    def can_cache(self):
+        is_dyn = '__name__' not in self.globals
+        return not is_dyn
+
+    def __reduce__(self):
+        return _rebuild_env, (
+            self.globals.get('__name__'),
+            self.consts,
+            self.env_name,
+        )
+
+    def __del__(self):
+        return
+
+    def __repr__(self):
+        return f"<Environment {self.env_name!r} >"
+
+
+def _rebuild_env(modname, consts, env_name):
+    env = lookup_environment(env_name)
+    if env is not None:
+        return env
+
+    mod = serialize._rebuild_module(modname)
+    env = Environment(mod.__dict__)
+    env.consts[:] = consts
+    env.env_name = env_name
+    # Cache loaded object
+    Environment._memo[env_name] = env
+    return env
+
+
+def lookup_environment(env_name):
+    """Returns the Environment object for the given name;
+    or None if not found
+    """
+    return Environment._memo.get(env_name)

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -16,6 +16,7 @@ from numba.core.datamodel import models   # noqa: F401
 from numba.core.datamodel import register_default as register_model  # noqa: F401, E501
 from numba.core.pythonapi import box, unbox, reflect, NativeValue  # noqa: F401
 from numba._helperlib import _import_cython_function  # noqa: F401
+from numba.core.serialize import ReduceMixin
 
 
 def type_callable(func):
@@ -256,7 +257,7 @@ def make_attribute_wrapper(typeclass, struct_attr, python_attr):
         return impl_ret_borrowed(context, builder, attrty, attrval)
 
 
-class _Intrinsic(object):
+class _Intrinsic(ReduceMixin):
     """
     Dummy callable for intrinsic
     """
@@ -309,26 +310,25 @@ class _Intrinsic(object):
     def __repr__(self):
         return "<intrinsic {0}>".format(self._name)
 
-    def __reduce__(self):
-        from numba.core import serialize
+    def __deepcopy__(self, memo):
+        # NOTE: Intrinsic are immutable and we don't need to copy.
+        #       This is triggered from deepcopy of statements.
+        return self
 
-        def reduce_func(fn):
-            gs = serialize._get_function_globals_for_reduction(fn)
-            return serialize._reduce_function(fn, gs)
-
-        return (serialize._rebuild_reduction,
-                (self.__class__, str(self._uuid), self._name,
-                 reduce_func(self._defn)))
+    def _reduce_states(self):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return dict(uuid=self._uuid, name=self._name, defn=self._defn)
 
     @classmethod
-    def _rebuild(cls, uuid, name, defn_reduced):
-        from numba.core import serialize
-
+    def _rebuild(cls, uuid, name, defn):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
         try:
             return cls._memo[uuid]
         except KeyError:
-            defn = serialize._rebuild_function(*defn_reduced)
-
             llc = cls(name=name, defn=defn)
             llc._register()
             llc._set_uuid(uuid)

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -935,6 +935,13 @@ class Const(EqualityCheckMixin, AbstractRHS):
     def infer_constant(self):
         return self.value
 
+    def __deepcopy__(self, memo):
+        # Override to not copy constant values in code
+        return Const(
+            value=self.value, loc=self.loc,
+            use_literal_type=self.use_literal_type,
+        )
+
 
 class Global(EqualityCheckMixin, AbstractRHS):
     def __init__(self, name, value, loc):
@@ -978,6 +985,12 @@ class FreeVar(EqualityCheckMixin, AbstractRHS):
 
     def infer_constant(self):
         return self.value
+
+    def __deepcopy__(self, memo):
+        # Override to not copy constant values in code
+        return FreeVar(index=self.index, name=self.name, value=self.value,
+                       loc=self.loc)
+
 
 
 class Var(EqualityCheckMixin, AbstractRHS):

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -8,8 +8,9 @@ import llvmlite.llvmpy.core as lc
 
 import ctypes
 from numba import _helperlib
-from numba.core import types, utils, config, lowering, cgutils, imputils
-
+from numba.core import (
+    types, utils, config, lowering, cgutils, imputils, serialize,
+)
 
 PY_UNICODE_1BYTE_KIND = _helperlib.py_unicode_1byte_kind
 PY_UNICODE_2BYTE_KIND = _helperlib.py_unicode_2byte_kind
@@ -181,7 +182,8 @@ class PythonAPI(object):
     def get_env_manager(self, env, env_body, env_ptr):
         return EnvironmentManager(self, env, env_body, env_ptr)
 
-    def emit_environment_sentry(self, envptr, return_pyobject=False):
+    def emit_environment_sentry(self, envptr, return_pyobject=False,
+                                debug_msg=''):
         """Emits LLVM code to ensure the `envptr` is not NULL
         """
         is_null = cgutils.is_null(self.builder, envptr)
@@ -189,13 +191,15 @@ class PythonAPI(object):
             if return_pyobject:
                 fnty = self.builder.function.type.pointee
                 assert fnty.return_type == self.pyobj
-                self.err_set_string("PyExc_RuntimeError",
-                                    "missing Environment")
+                self.err_set_string(
+                    "PyExc_RuntimeError", f"missing Environment: {debug_msg}",
+                )
                 self.builder.ret(self.get_null_object())
             else:
-                self.context.call_conv.return_user_exc(self.builder,
-                                                       RuntimeError,
-                                                       ("missing Environment",))
+                self.context.call_conv.return_user_exc(
+                    self.builder, RuntimeError,
+                    (f"missing Environment: {debug_msg}",),
+                )
 
     # ------ Python API -----
 
@@ -1306,7 +1310,7 @@ class PythonAPI(object):
         simply return a literal {i8* data, i32 length} structure.
         """
         # First make the array constant
-        data = pickle.dumps(obj, protocol=-1)
+        data = serialize.dumps(obj)
         assert len(data) < 2**31
         name = ".const.pickledata.%s" % (id(obj) if config.DIFF_IR == 0 else "DIFF_IR")
         bdata = cgutils.make_bytearray(data)
@@ -1567,3 +1571,55 @@ class PythonAPI(object):
         res = builder.load(res_ptr)
         return is_error, res
 
+
+class ObjModeUtils:
+    def __init__(self, pyapi):
+        self.pyapi = pyapi
+
+    def load_dispatcher(self, fnty, argtypes):
+        builder = self.pyapi.builder
+        tyctx = self.pyapi.context
+        m = builder.module
+
+        # Add a global variable to cache the objmode dispatcher
+        gv = ir.GlobalVariable(
+            m, self.pyapi.pyobj,
+            name=m.get_unique_name("cached_objmode_dispatcher"),
+        )
+        gv.initializer = gv.type.pointee(None)
+        gv.linkage = 'internal'
+
+        cached = builder.load(gv)
+        with builder.if_then(cgutils.is_null(builder, cached)):
+            if serialize.check(fnty.dispatcher):
+                cls = type(self)
+                compiler = self.pyapi.unserialize(
+                    self.pyapi.serialize_object(cls._call_objmode_dispatcher)
+                )
+                serialized_dispatcher = self.pyapi.serialize_object(
+                    (fnty.dispatcher, tuple(argtypes)),
+                )
+                compile_args = self.pyapi.unserialize(serialized_dispatcher)
+                callee = self.pyapi.call_function_objargs(
+                    compiler, [compile_args],
+                )
+                # Clean up
+                self.pyapi.decref(compiler)
+                self.pyapi.decref(compile_args)
+            else:
+                entry_pt = fnty.dispatcher.compile(tuple(argtypes))
+                callee = tyctx.add_dynamic_addr(
+                    builder, id(entry_pt), info="with_objectmode",
+                )
+            # Incref the dispatcher and cache it
+            self.pyapi.incref(callee)
+            builder.store(callee, gv)
+
+        callee = builder.load(gv)
+        return callee
+
+    @staticmethod
+    def _call_objmode_dispatcher(compile_args):
+        dispatcher, argtypes = compile_args
+        entrypt = dispatcher.compile(argtypes)
+        return entrypt

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1593,7 +1593,7 @@ class ObjModeUtils:
 
         cached = builder.load(gv)
         with builder.if_then(cgutils.is_null(builder, cached)):
-            if serialize.check(fnty.dispatcher):
+            if serialize.is_serialiable(fnty.dispatcher):
                 cls = type(self)
                 compiler = self.pyapi.unserialize(
                     self.pyapi.serialize_object(cls._call_objmode_dispatcher)

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1573,6 +1573,8 @@ class PythonAPI(object):
 
 
 class ObjModeUtils:
+    """Internal utils for calling objmode dispatcher from within NPM code.
+    """
     def __init__(self, pyapi):
         self.pyapi = pyapi
 

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -198,8 +198,8 @@ copyreg.pickle(_CustomPickled, _pickle__CustomPickled)
 def custom_reduce(cls, states):
     """For customizing object serialization in `__reduce__`.
 
-    Object states provided here are used as keyword arguments to the `._rebuild()`
-    class method.
+    Object states provided here are used as keyword arguments to the
+    `._rebuild()` class method.
 
     Parameters
     ----------

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -2,9 +2,9 @@
 Serialization support for compiled functions.
 """
 
-
 from importlib.util import MAGIC_NUMBER as bc_magic
 
+import abc
 import io
 import marshal
 import sys
@@ -365,20 +365,21 @@ class FastNumbaPickler(pickle.Pickler):
 NumbaPickler = FastNumbaPickler if pickle38 else SlowNumbaPickler
 
 
-class ReduceMixin:
+class ReduceMixin(abc.ABC):
     """A mixin class for objects that should be reduced by the NumbaPickler instead
     of the standard pickler.
     """
     # Subclass MUST override the below methods
 
+    @abc.abstractmethod
     def _reduce_states(self):
         raise NotImplementedError
 
-    @classmethod
+    @abc.abstractclassmethod
     def _rebuild(cls, **kwargs):
         raise NotImplementedError
 
-    # Subclass should override the below methods
+    # Subclass can override the below methods
 
     def _reduce_class(self):
         return self.__class__

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -5,11 +5,28 @@ Serialization support for compiled functions.
 
 from importlib.util import MAGIC_NUMBER as bc_magic
 
+import io
 import marshal
 import sys
-from types import FunctionType, ModuleType
+import copyreg
+from types import FunctionType, ModuleType, CodeType
 
-from numba.core import bytecode, compiler
+from numba.core.utils import PYVERSION
+
+
+if PYVERSION >= (3, 8):
+    from types import CellType
+
+    import pickle
+    pickle38 = pickle
+else:
+    try:
+        import pickle5 as pickle38
+    except ImportError:
+        pickle38 = None
+        import pickle
+    else:
+        pickle = pickle38
 
 
 #
@@ -44,17 +61,16 @@ def _get_function_globals_for_reduction(func):
     Analyse *func* and return a dictionary of global values suitable for
     reduction.
     """
+    from numba.core import bytecode   # needed here to avoid cyclic import
+
     func_id = bytecode.FunctionIdentity.from_function(func)
     bc = bytecode.ByteCode(func_id)
     globs = bc.get_used_globals()
-    for k, v in globs.items():
-        # Make modules picklable by name
-        if isinstance(v, ModuleType):
-            globs[k] = _ModuleRef(v.__name__)
     # Remember the module name so that the function gets a proper __module__
     # when rebuilding.  This is used to recreate the environment.
     globs['__name__'] = func.__module__
     return globs
+
 
 def _reduce_function(func, globs):
     """
@@ -68,24 +84,28 @@ def _reduce_function(func, globs):
         cells = None
     return _reduce_code(func.__code__), globs, func.__name__, cells
 
+
 def _reduce_code(code):
     """
     Reduce a code object to picklable components.
     """
     return marshal.version, bc_magic, marshal.dumps(code)
 
-def _dummy_closure(x):
+
+def _make_cell(x):
     """
-    A dummy function allowing us to build cell objects.
+    A dummy function allowing us to build cell objects because
+    types.CellType doesn't exist until Python3.8.
     """
-    return lambda: x
+    return (lambda: x).__closure__[0]
+
 
 def _rebuild_function(code_reduced, globals, name, cell_values):
     """
     Rebuild a function from its _reduce_function() results.
     """
     if cell_values:
-        cells = tuple(_dummy_closure(v).__closure__[0] for v in cell_values)
+        cells = tuple(_make_cell(v) for v in cell_values)
     else:
         cells = ()
     code = _rebuild_code(*code_reduced)
@@ -97,6 +117,7 @@ def _rebuild_function(code_reduced, globals, name, cell_values):
         # errors when lowering).
         del globals['__name__']
     return FunctionType(code, globals, name, (), cells)
+
 
 def _rebuild_code(marshal_version, bytecode_magic, marshalled):
     """
@@ -110,3 +131,375 @@ def _rebuild_code(marshal_version, bytecode_magic, marshalled):
         raise RuntimeError("incompatible bytecode version")
     return marshal.loads(marshalled)
 
+
+def dumps(obj):
+    """Similar to `pickle.dumps()`. Returns the serialized object in bytes.
+    """
+    pickler = NumbaPickler
+    with io.BytesIO() as buf:
+        p = pickler(buf)
+        p.dump(obj)
+        pickled = buf.getvalue()
+
+    return pickled
+
+
+# Alias to pickle.loads to allow `serialize.loads()`
+loads = pickle.loads
+
+
+class _CustomPickled:
+    """Wrapper for objects that must be pickled with `NumbaPickler`.
+
+    Standard `pickle` will pickup the implementation registered via `copyreg`.
+    This will spawn a `NumbaPickler` instance to serialize the data.
+
+    `NumbaPickler` override the handling of this type so not to spawn a
+    new pickler for the object when it is already being pickled by a
+    `NumbaPickler`.
+    """
+
+    __slots__ = 'ctor', 'states'
+
+    def __init__(self, ctor, states):
+        self.ctor = ctor
+        self.states = states
+
+    def _reduce(self):
+        return _CustomPickled._rebuild, (self.ctor, self.states)
+
+    @classmethod
+    def _rebuild(cls, ctor, states):
+        return cls(ctor, states)
+
+
+def _unpickle__CustomPickled(serialized):
+    """standard unpickling for `_CustomPickled`.
+
+    Uses `NumbaPickler` to load.
+    """
+    ctor, states = loads(serialized)
+    return _CustomPickled(ctor, states)
+
+
+def _pickle__CustomPickled(cp):
+    """standard pickling for `_CustomPickled`.
+
+    Uses `NumbaPickler` to dump.
+    """
+    serialized = dumps((cp.ctor, cp.states))
+    return _unpickle__CustomPickled, (serialized,)
+
+
+# Register custom pickling for the standard pickler.
+copyreg.pickle(_CustomPickled, _pickle__CustomPickled)
+
+
+def custom_reduce(cls, states):
+    """For customizing object serialization in `__reduce__`.
+
+    Object states provided here is used as keyword arguments to `._rebuild()`
+    class method.
+
+    Parameters
+    ----------
+    states : dict
+        Dictionary of object states to be serialized.
+
+    Returns
+    -------
+    result : tuple
+        This tuple conforms to the return type requirement for `__reduce__`.
+    """
+    return custom_rebuild, (_CustomPickled(cls, states),)
+
+
+def custom_rebuild(custom_pickled):
+    """Customized object deserialization.
+
+    This function is referenced internally by `custom_reduce()`.
+    """
+    cls, states = custom_pickled.ctor, custom_pickled.states
+    return cls._rebuild(**states)
+
+
+def check(obj):
+    """Check if *obj* can be serialized.
+
+    Parameters
+    ----------
+    obj : object
+
+    Returns
+    --------
+    can_serialize : bool
+    """
+    with io.BytesIO() as fout:
+        pickler = NumbaPickler(fout)
+        try:
+            pickler.dump(obj)
+        except pickle.PicklingError:
+            return False
+        else:
+            return True
+
+
+class _TracedPicklingError(pickle.PicklingError):
+    """A custom pickling error used internally in NumbaPickler.
+    """
+    pass
+
+
+class SlowNumbaPickler(pickle._Pickler):
+    """Extends the pure-python Pickler to support the pickling need in Numba.
+
+    Note: this is used on Python < 3.8 unless `pickle5` is installed.
+
+    Note: This is good for debugging because the C-pickler hides the traceback
+    """
+
+    dispatch = pickle._Pickler.dispatch.copy()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__trace = []
+        self.__memo = {}
+
+    def save(self, obj):
+        """
+        Overrides parent's `.save()` to provide better error messages.
+        """
+        self.__trace.append(f"{type(obj)}: {id(obj)}" )
+        try:
+            return super().save(obj)
+        except _TracedPicklingError:
+            raise
+        except Exception as e:
+            def perline(items):
+                return '\n'.join(f" [{depth}]: {it}"
+                                 for depth, it in enumerate(items))
+            m = (f"Failed to pickle because of\n  {type(e).__name__}: {e}"
+                 f"\ntracing... \n{perline(self.__trace)}")
+            raise _TracedPicklingError(m)
+        finally:
+            self.__trace.pop()
+
+    def _save_function(self, func):
+        """
+        Override how functions are saved by serializing the bytecode and
+        corresponding globals.
+        """
+        if _is_importable(func):
+            return self.save_global(func)
+        if id(func) in self.__memo:
+            # Detect recursive pickling; i.e. functions references itself.
+            # NOTE: this is not ideal, but we prefer the fast pickler which
+            #       does this properly.
+            msg = f"Recursive function reference on {func}"
+            raise pickle.PicklingError(msg)
+        self.__memo[id(func)] = func
+        try:
+            gls = _get_function_globals_for_reduction(func)
+            args = _reduce_function(func, gls)
+            self.save_reduce(_rebuild_function, args, obj=func)
+        finally:
+            self.__memo.pop(id(func))
+
+    # Override the dispatch table for functions
+    dispatch[FunctionType] = _save_function
+
+    def _save_module(self, mod):
+        return self.save_reduce(_rebuild_module, (mod.__name__,))
+
+    # Override the dispatch table for modules
+    dispatch[ModuleType] = _save_module
+
+    def _save_custom_pickled(self, cp):
+        return self.save_reduce(*cp._reduce())
+
+    # Override the dispatch table for _CustomPickled
+    # thus override the copyreg registry
+    dispatch[_CustomPickled] = _save_custom_pickled
+
+
+class FastNumbaPickler(pickle.Pickler):
+    """Faster version of NumbaPickler by using Python3.8+ features from
+    the C Pickler or install `pickle5` for older Python versions.
+    """
+    def reducer_override(self, obj):
+        if isinstance(obj, FunctionType):
+            return self._custom_reduce_func(obj)
+        elif isinstance(obj, ModuleType):
+            return self._custom_reduce_module(obj)
+        elif isinstance(obj, CodeType):
+            return self._custom_reduce_code(obj)
+        elif isinstance(obj, _CustomPickled):
+            return self._custom_reduce__custompickled(obj)
+        return NotImplemented
+
+    def _custom_reduce_func(self, func):
+        if not _is_importable(func):
+            gls = _get_function_globals_for_reduction(func)
+            args, cells = _reduce_function_no_cells(func, gls)
+            states = {'cells': cells}
+            return (_rebuild_function, args, states, None, None,
+                    _function_setstate)
+        else:
+            return NotImplemented
+
+    def _custom_reduce_module(self, mod):
+        return _rebuild_module, (mod.__name__,)
+
+    def _custom_reduce_code(self, code):
+        return _reduce_code(code)
+
+    def _custom_reduce__custompickled(self, cp):
+        return cp._reduce()
+
+
+# Pick our preferred pickler
+NumbaPickler = FastNumbaPickler if pickle38 else SlowNumbaPickler
+
+
+class ReduceMixin:
+    """A mixin class for objects should be reduced by the NumbaPickler instead
+    of the standard pickler.
+    """
+    # Subclass MUST override the below methods
+
+    def _reduce_states(self):
+        raise NotImplementedError
+
+    @classmethod
+    def _rebuild(cls, **kwargs):
+        raise NotImplementedError
+
+    # Subclass should override the below methods
+
+    def _reduce_class(self):
+        return self.__class__
+
+    # Private methods
+
+    def __reduce__(self):
+        return custom_reduce(self._reduce_class(), self._reduce_states())
+
+
+# ----------------------------------------------------------------------------
+# The following code are adapted from cloudpickle.
+# commit: 9518ae3cc71b7a6c14478a6881c0db41d73812b8
+# Please see LICENSE.third-party file for full copyright information.
+
+def _is_importable(obj):
+    """Check if an object is importable.
+
+    Parameters
+    ----------
+    obj :
+        Must define `__module__` and `__qualname__`.
+    """
+    if obj.__module__ in sys.modules:
+        ptr = sys.modules[obj.__module__]
+        # Walk through the attributes
+        parts = obj.__qualname__.split('.')
+        if len(parts) > 1:
+            # can't deal with function insides classes yet
+            return False
+        for p in parts:
+            try:
+                ptr = getattr(ptr, p)
+            except AttributeError:
+                return False
+        return obj is ptr
+    return False
+
+
+def _function_setstate(obj, states):
+    """The setstate function is executed after
+    """
+    cells = states.pop('cells')
+    for i, v in enumerate(cells):
+        _cell_set(obj.__closure__[i], v)
+    return obj
+
+
+def _reduce_function_no_cells(func, globs):
+    """_reduce_function() but return empty cells instead.
+
+    """
+    if func.__closure__:
+        oldcells = [cell.cell_contents for cell in func.__closure__]
+        cells = [None for _ in range(len(oldcells))] # idea from cloudpickle
+    else:
+        oldcells = ()
+        cells = None
+    return (_reduce_code(func.__code__), globs, func.__name__, cells), oldcells
+
+
+def _cell_rebuild(contents):
+    if contents is None:
+        return CellType()
+    else:
+        return CellType(contents)
+
+
+def _cell_reduce(obj):
+    try:
+        # .cell_contents attr lookup raises the wrong exception?
+        obj.cell_contents
+    except ValueError:
+        # empty cell
+        return _cell_rebuild, (None,)
+    else:
+        # non-empty cell
+        return _cell_rebuild, (obj.cell_contents,)
+
+
+def _cell_set(cell, value):
+    """Set *value* into *cell* because `.cell_contents` is not writable
+    before python 3.7.
+
+    See cloudpickle/cloudpickle.py#L298
+    commit: 9518ae3cc71b7a6c14478a6881c0db41d73812b8
+    """
+    if PYVERSION >= (3, 7):  # pragma: no branch
+        cell.cell_contents = value
+    else:
+        _cell_set = FunctionType(
+            _cell_set_template_code, {}, '_cell_set', (), (cell,),)
+        _cell_set(value)
+
+
+def _make_cell_set_template_code():
+    """See _cell_set"""
+    def _cell_set_factory(value):
+        lambda: cell
+        cell = value
+
+    co = _cell_set_factory.__code__
+
+    _cell_set_template_code = CodeType(
+        co.co_argcount,
+        co.co_kwonlyargcount,   # Python 3 only argument
+        co.co_nlocals,
+        co.co_stacksize,
+        co.co_flags,
+        co.co_code,
+        co.co_consts,
+        co.co_names,
+        co.co_varnames,
+        co.co_filename,
+        co.co_name,
+        co.co_firstlineno,
+        co.co_lnotab,
+        co.co_cellvars,  # co_freevars is initialized with co_cellvars
+        (),  # co_cellvars is made empty
+    )
+    return _cell_set_template_code
+
+
+if PYVERSION < (3, 7):
+    _cell_set_template_code = _make_cell_set_template_code()
+
+# End adapting from cloudpickle
+# ----------------------------------------------------------------------------

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -223,7 +223,7 @@ def custom_rebuild(custom_pickled):
     return cls._rebuild(**states)
 
 
-def check(obj):
+def is_serialiable(obj):
     """Check if *obj* can be serialized.
 
     Parameters

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -82,7 +82,8 @@ def _reduce_function(func, globs):
         cells = [cell.cell_contents for cell in func.__closure__]
     else:
         cells = None
-    return _reduce_code(func.__code__), globs, func.__name__, cells, func.__defaults__
+    return (_reduce_code(func.__code__), globs, func.__name__, cells,
+            func.__defaults__)
 
 
 def _reduce_code(code):
@@ -439,7 +440,9 @@ def _reduce_function_no_cells(func, globs):
     else:
         oldcells = ()
         cells = None
-    return (_reduce_code(func.__code__), globs, func.__name__, cells), oldcells
+    rebuild_args = (_reduce_code(func.__code__), globs, func.__name__, cells,
+                    func.__defaults__)
+    return rebuild_args, oldcells
 
 
 def _cell_rebuild(contents):

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -149,12 +149,12 @@ loads = pickle.loads
 
 
 class _CustomPickled:
-    """Wrapper for objects that must be pickled with `NumbaPickler`.
+    """A wrapper for objects that must be pickled with `NumbaPickler`.
 
-    Standard `pickle` will pickup the implementation registered via `copyreg`.
+    Standard `pickle` will pick up the implementation registered via `copyreg`.
     This will spawn a `NumbaPickler` instance to serialize the data.
 
-    `NumbaPickler` override the handling of this type so not to spawn a
+    `NumbaPickler` overrides the handling of this type so as not to spawn a
     new pickler for the object when it is already being pickled by a
     `NumbaPickler`.
     """
@@ -198,7 +198,7 @@ copyreg.pickle(_CustomPickled, _pickle__CustomPickled)
 def custom_reduce(cls, states):
     """For customizing object serialization in `__reduce__`.
 
-    Object states provided here is used as keyword arguments to `._rebuild()`
+    Object states provided here are used as keyword arguments to the `._rebuild()`
     class method.
 
     Parameters
@@ -292,7 +292,7 @@ class SlowNumbaPickler(pickle._Pickler):
         if _is_importable(func):
             return self.save_global(func)
         if id(func) in self.__memo:
-            # Detect recursive pickling; i.e. functions references itself.
+            # Detect recursive pickling; i.e. function references itself.
             # NOTE: this is not ideal, but we prefer the fast pickler which
             #       does this properly.
             msg = f"Recursive function reference on {func}"
@@ -323,8 +323,8 @@ class SlowNumbaPickler(pickle._Pickler):
 
 
 class FastNumbaPickler(pickle.Pickler):
-    """Faster version of NumbaPickler by using Python3.8+ features from
-    the C Pickler or install `pickle5` for older Python versions.
+    """Faster version of the NumbaPickler through use of Python3.8+ features from
+    the C Pickler, install `pickle5` for similar on older Python versions.
     """
     def reducer_override(self, obj):
         if isinstance(obj, FunctionType):
@@ -362,7 +362,7 @@ NumbaPickler = FastNumbaPickler if pickle38 else SlowNumbaPickler
 
 
 class ReduceMixin:
-    """A mixin class for objects should be reduced by the NumbaPickler instead
+    """A mixin class for objects that should be reduced by the NumbaPickler instead
     of the standard pickler.
     """
     # Subclass MUST override the below methods
@@ -386,7 +386,7 @@ class ReduceMixin:
 
 
 # ----------------------------------------------------------------------------
-# The following code are adapted from cloudpickle.
+# The following code is adapted from cloudpickle.
 # commit: 9518ae3cc71b7a6c14478a6881c0db41d73812b8
 # Please see LICENSE.third-party file for full copyright information.
 
@@ -480,7 +480,7 @@ def _make_cell_set_template_code():
 
     _cell_set_template_code = CodeType(
         co.co_argcount,
-        co.co_kwonlyargcount,   # Python 3 only argument
+        co.co_kwonlyargcount,
         co.co_nlocals,
         co.co_stacksize,
         co.co_flags,

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -66,7 +66,7 @@ class DUFuncLowerer(object):
                                           explicit_output=explicit_output)
 
 
-class DUFunc(_internal._DUFunc):
+class DUFunc(serialize.ReduceMixin, _internal._DUFunc):
     """
     Dynamic universal function (DUFunc) intended to act like a normal
     Numpy ufunc, but capable of call-time (just-in-time) compilation
@@ -95,14 +95,23 @@ class DUFunc(_internal._DUFunc):
         self.__name__ = dispatcher.py_func.__name__
         self.__doc__ = dispatcher.py_func.__doc__
 
-    def __reduce__(self):
+    def _reduce_states(self):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
         siglist = list(self._dispatcher.overloads.keys())
-        return (serialize._rebuild_reduction,
-                (self.__class__, self._dispatcher, self.identity,
-                 self._frozen, siglist))
+        return dict(
+            dispatcher=self._dispatcher,
+            identity=self.identity,
+            frozen=self._frozen,
+            siglist=siglist,
+        )
 
     @classmethod
     def _rebuild(cls, dispatcher, identity, frozen, siglist):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
         self = _internal._DUFunc.__new__(cls)
         self._initialize(dispatcher, identity)
         # Re-add signatures

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -41,7 +41,7 @@ class UFuncTarget(TargetDescriptor):
 ufunc_target = UFuncTarget()
 
 
-class UFuncDispatcher(object):
+class UFuncDispatcher(serialize.ReduceMixin):
     """
     An object handling compilation of various signatures for a ufunc.
     """
@@ -54,21 +54,22 @@ class UFuncDispatcher(object):
         self.locals = locals
         self.cache = NullCache()
 
-    def __reduce__(self):
-        globs = serialize._get_function_globals_for_reduction(self.py_func)
-        return (
-            serialize._rebuild_reduction,
-            (
-                self.__class__,
-                serialize._reduce_function(self.py_func, globs),
-                self.locals, self.targetoptions,
-            ),
+    def _reduce_states(self):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return dict(
+            pyfunc=self.py_func,
+            locals=self.locals,
+            targetoptions=self.targetoptions,
         )
 
     @classmethod
-    def _rebuild(cls, redfun, locals, targetoptions):
-        return cls(serialize._rebuild_function(*redfun),
-                   locals, targetoptions)
+    def _rebuild(cls, pyfunc, locals, targetoptions):
+        """
+        NOTE: part of ReduceMixin protocol
+        """
+        return cls(py_func=pyfunc, locals=locals, targetoptions=targetoptions)
 
     def enable_caching(self):
         self.cache = FunctionCache(self.py_func)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1077,9 +1077,12 @@ class BaseCacheUsecasesTest(BaseCacheTest):
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = popen.communicate()
         if popen.returncode != 0:
-            raise AssertionError("process failed with code %s: "
-                                 "stderr follows\n%s\n"
-                                 % (popen.returncode, err.decode()))
+            raise AssertionError(
+                "process failed with code %s: \n"
+                "stdout follows\n%s\n"
+                "stderr follows\n%s\n"
+                % (popen.returncode, out.decode(), err.decode()),
+            )
 
     def check_module(self, mod):
         self.check_pycache(0)
@@ -1208,7 +1211,7 @@ class TestCache(BaseCacheUsecasesTest):
 
         self.assertEqual(len(w), 1)
         self.assertIn('Cannot cache compiled function "looplifted" '
-                      'as it uses lifted loops', str(w[0].message))
+                      'as it uses lifted code', str(w[0].message))
 
     def test_big_array(self):
         # Code references big array globals cannot be cached
@@ -1757,14 +1760,16 @@ def function2(x):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()
-        self.assertEqual(popen.returncode, 0)
+        msg = f"stdout:\n{out.decode()}\n\nstderr:\n{err.decode()}"
+        self.assertEqual(popen.returncode, 0, msg=msg)
 
         # Execute file2.py
         popen = subprocess.Popen([sys.executable, self.file2],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()
-        self.assertEqual(popen.returncode, 0)
+        msg = f"stdout:\n{out.decode()}\n\nstderr:\n{err.decode()}"
+        self.assertEqual(popen.returncode, 0, msg)
 
 
 class TestDispatcherFunctionBoundaries(TestCase):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1248,19 +1248,14 @@ class TestCache(BaseCacheUsecasesTest):
     def test_closure(self):
         mod = self.import_module()
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', NumbaWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', NumbaWarning)
 
             f = mod.closure1
             self.assertPreciseEqual(f(3), 6)
             f = mod.closure2
-            self.assertPreciseEqual(f(3), 8)
-            self.check_pycache(0)
-
-        self.assertEqual(len(w), 2)
-        for item in w:
-            self.assertIn('Cannot cache compiled function "closure"',
-                          str(item.message))
+            self.assertPreciseEqual(f(3), 6)
+            self.check_pycache(2)
 
     def test_cache_reuse(self):
         mod = self.import_module()

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1696,6 +1696,12 @@ class TestBoxingCallingJIT(TestCase):
         )
 
 
+def with_objmode_cache_ov_example(x):
+    # This is the function stub for overloading inside
+    # TestCachingOverloadObjmode.test_caching_overload_objmode
+    pass
+
+
 class TestCachingOverloadObjmode(TestCase):
     """Test caching of the use of overload implementation that uses
     `with objmode`
@@ -1747,12 +1753,6 @@ class TestCachingOverloadObjmode(TestCase):
             self.assertEqual(
                 testcase_cached._cache_misses[testcase.signatures[0]], 0,
             )
-
-
-def with_objmode_cache_ov_example(x):
-    # This is the function stub for overloading inside
-    # TestCachingOverloadObjmode.test_caching_overload_objmode
-    pass
 
 
 class TestMisc(TestCase):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -4,35 +4,52 @@ import sys
 import pickle
 import multiprocessing
 import ctypes
+import warnings
 from distutils.version import LooseVersion
 import re
 
 import numpy as np
 
-from numba import njit, jit, vectorize, guvectorize
+from numba import njit, jit, vectorize, guvectorize, objmode
 from numba.core import types, errors, typing, compiler, cgutils
 from numba.core.typed_passes import type_inference_stage
 from numba.core.registry import cpu_target
 from numba.core.compiler import compile_isolated
-from numba.tests.support import (TestCase, captured_stdout, tag, temp_directory,
-                      override_config)
+from numba.tests.support import (
+    TestCase,
+    captured_stdout,
+    temp_directory,
+    override_config,
+)
 from numba.core.errors import LoweringError
 import unittest
 
-from numba.extending import (typeof_impl, type_callable,
-                             lower_builtin, lower_cast,
-                             overload, overload_attribute,
-                             overload_method,
-                             models, register_model,
-                             box, unbox, NativeValue,
-                             make_attribute_wrapper,
-                             intrinsic, _Intrinsic,
-                             register_jitable,
-                             get_cython_function_address,
-                             is_jitted,
-                             )
+from numba.extending import (
+    typeof_impl,
+    type_callable,
+    lower_builtin,
+    lower_cast,
+    overload,
+    overload_attribute,
+    overload_method,
+    models,
+    register_model,
+    box,
+    unbox,
+    NativeValue,
+    intrinsic,
+    _Intrinsic,
+    register_jitable,
+    get_cython_function_address,
+    is_jitted,
+)
 from numba.core.typing.templates import (
-    ConcreteTemplate, signature, infer, infer_global, AbstractTemplate)
+    ConcreteTemplate,
+    signature,
+    infer,
+    infer_global,
+    AbstractTemplate,
+)
 
 
 # Pandas-like API implementation
@@ -41,7 +58,8 @@ from .pdlike_usecase import Index, Series
 
 try:
     import scipy
-    if LooseVersion(scipy.__version__) < '0.19':
+
+    if LooseVersion(scipy.__version__) < "0.19":
         sc = None
     else:
         import scipy.special.cython_special as sc
@@ -52,21 +70,27 @@ except ImportError:
 # -----------------------------------------------------------------------
 # Define a custom type and an implicit cast on it
 
+
 class MyDummy(object):
     pass
+
 
 class MyDummyType(types.Opaque):
     def can_convert_to(self, context, toty):
         if isinstance(toty, types.Number):
             from numba.core.typeconv import Conversion
+
             return Conversion.safe
 
-mydummy_type = MyDummyType('mydummy')
+
+mydummy_type = MyDummyType("mydummy")
 mydummy = MyDummy()
+
 
 @typeof_impl.register(MyDummy)
 def typeof_mydummy(val, c):
     return mydummy_type
+
 
 @lower_cast(MyDummyType, types.Number)
 def mydummy_to_number(context, builder, fromty, toty, val):
@@ -75,10 +99,13 @@ def mydummy_to_number(context, builder, fromty, toty, val):
     """
     return context.get_constant(toty, 42)
 
+
 def get_dummy():
     return mydummy
 
+
 register_model(MyDummyType)(models.OpaqueModel)
+
 
 @unbox(MyDummyType)
 def unbox_index(typ, obj, c):
@@ -87,6 +114,7 @@ def unbox_index(typ, obj, c):
 
 # -----------------------------------------------------------------------
 # Define a second custom type but w/o implicit cast to Number
+
 
 def base_dummy_type_factory(name):
     class DynType(object):
@@ -105,11 +133,11 @@ def base_dummy_type_factory(name):
     return DynTypeType, DynType, dyn_type_type
 
 
-MyDummyType2, MyDummy2, mydummy_type_2 = base_dummy_type_factory('mydummy2')
+MyDummyType2, MyDummy2, mydummy_type_2 = base_dummy_type_factory("mydummy2")
 
 
 @unbox(MyDummyType2)
-def unbox_index(typ, obj, c):
+def unbox_index2(typ, obj, c):
     return NativeValue(c.context.get_dummy_value())
 
 
@@ -117,8 +145,10 @@ def unbox_index(typ, obj, c):
 # Define a function's typing and implementation using the classical
 # two-step API
 
+
 def func1(x=None):
     raise NotImplementedError
+
 
 def type_func1_(context):
     def typer(x=None):
@@ -140,19 +170,24 @@ type_func1 = type_callable(func1)(type_func1_)
 def func1_nullary(context, builder, sig, args):
     return context.get_constant(sig.return_type, 42)
 
+
 @lower_builtin(func1, types.Float)
 def func1_unary(context, builder, sig, args):
     def func1_impl(x):
         return math.sqrt(2 * x)
+
     return context.compile_internal(builder, func1_impl, sig, args)
+
 
 # We can do the same for a known internal operation, here "print_item"
 # which we extend to support MyDummyType.
+
 
 @infer
 class PrintDummy(ConcreteTemplate):
     key = "print_item"
     cases = [signature(types.none, mydummy_type)]
+
 
 @lower_builtin("print_item", MyDummyType)
 def print_dummy(context, builder, sig, args):
@@ -167,14 +202,17 @@ def print_dummy(context, builder, sig, args):
 # -----------------------------------------------------------------------
 # Define an overloaded function (combined API)
 
+
 def where(cond, x, y):
     raise NotImplementedError
+
 
 def np_where(cond, x, y):
     """
     Wrap np.where() to allow for keyword arguments
     """
     return np.where(cond, x, y)
+
 
 def call_where(cond, x, y):
     return where(cond, y=y, x=x)
@@ -191,7 +229,8 @@ def overload_where_arrays(cond, x, y):
             raise errors.TypingError("x and y should have the same dtype")
 
         # Array where() => return an array of the same shape
-        if all(ty.layout == 'C' for ty in (cond, x, y)):
+        if all(ty.layout == "C" for ty in (cond, x, y)):
+
             def where_impl(cond, x, y):
                 """
                 Fast implementation for C-contiguous arrays
@@ -207,7 +246,9 @@ def overload_where_arrays(cond, x, y):
                 for i in range(cond.size):
                     rf[i] = xf[i] if cf[i] else yf[i]
                 return res
+
         else:
+
             def where_impl(cond, x, y):
                 """
                 Generic implementation for other arrays
@@ -222,8 +263,10 @@ def overload_where_arrays(cond, x, y):
 
         return where_impl
 
+
 # We can define another overload function for the same function, they
 # will be tried in turn until one succeeds.
+
 
 @overload(where)
 def overload_where_scalars(cond, x, y):
@@ -246,12 +289,15 @@ def overload_where_scalars(cond, x, y):
 
         return where_impl
 
+
 # -----------------------------------------------------------------------
 # Overload an already defined built-in function, extending it for new types.
+
 
 @overload(len)
 def overload_len_dummy(arg):
     if isinstance(arg, MyDummyType):
+
         def len_impl(arg):
             return 13
 
@@ -260,7 +306,10 @@ def overload_len_dummy(arg):
 
 @overload(operator.add)
 def overload_add_dummy(arg1, arg2):
-    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(arg2, (MyDummyType, MyDummyType2)):
+    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
+        arg2, (MyDummyType, MyDummyType2)
+    ):
+
         def dummy_add_impl(arg1, arg2):
             return 42
 
@@ -270,28 +319,36 @@ def overload_add_dummy(arg1, arg2):
 @overload(operator.delitem)
 def overload_dummy_delitem(obj, idx):
     if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+
         def dummy_delitem_impl(obj, idx):
-            print('del', obj, idx)
+            print("del", obj, idx)
+
         return dummy_delitem_impl
 
 
 @overload(operator.getitem)
 def overload_dummy_getitem(obj, idx):
     if isinstance(obj, MyDummyType) and isinstance(idx, types.Integer):
+
         def dummy_getitem_impl(obj, idx):
             return idx + 123
+
         return dummy_getitem_impl
 
 
 @overload(operator.setitem)
 def overload_dummy_setitem(obj, idx, val):
-    if all([
-        isinstance(obj, MyDummyType),
-        isinstance(idx, types.Integer),
-        isinstance(val, types.Integer)
-    ]):
+    if all(
+        [
+            isinstance(obj, MyDummyType),
+            isinstance(idx, types.Integer),
+            isinstance(val, types.Integer),
+        ]
+    ):
+
         def dummy_setitem_impl(obj, idx, val):
             print(idx, val)
+
         return dummy_setitem_impl
 
 
@@ -305,7 +362,10 @@ def call_add_binop(arg1, arg2):
 
 @overload(operator.iadd)
 def overload_iadd_dummy(arg1, arg2):
-    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(arg2, (MyDummyType, MyDummyType2)):
+    if isinstance(arg1, (MyDummyType, MyDummyType2)) and isinstance(
+        arg2, (MyDummyType, MyDummyType2)
+    ):
+
         def dummy_iadd_impl(arg1, arg2):
             return 42
 
@@ -334,10 +394,11 @@ def call_setitem(obj, idx, val):
     obj[idx] = val
 
 
-@overload_method(MyDummyType, 'length')
+@overload_method(MyDummyType, "length")
 def overload_method_length(arg):
     def imp(arg):
         return len(arg)
+
     return imp
 
 
@@ -348,38 +409,49 @@ def cache_overload_method_usecase(x):
 def call_func1_nullary():
     return func1()
 
+
 def call_func1_unary(x):
     return func1(x)
+
 
 def len_usecase(x):
     return len(x)
 
+
 def print_usecase(x):
     print(x)
+
 
 def getitem_usecase(x, key):
     return x[key]
 
+
 def npyufunc_usecase(x):
     return np.cos(np.sin(x))
+
 
 def get_data_usecase(x):
     return x._data
 
+
 def get_index_usecase(x):
     return x._index
+
 
 def is_monotonic_usecase(x):
     return x.is_monotonic_increasing
 
+
 def make_series_usecase(data, index):
     return Series(data, index)
+
 
 def clip_usecase(x, lo, hi):
     return x.clip(lo, hi)
 
 
 # -----------------------------------------------------------------------
+
 
 def return_non_boxable():
     return np
@@ -389,6 +461,7 @@ def return_non_boxable():
 def overload_return_non_boxable():
     def imp():
         return np
+
     return imp
 
 
@@ -422,9 +495,11 @@ def mk_func_test_impl():
 @overload(np.exp)
 def overload_np_exp(obj):
     if isinstance(obj, MyDummyType):
+
         def imp(obj):
             # Returns a constant if a MyDummyType is seen
-            return 0xdeadbeef
+            return 0xDEADBEEF
+
         return imp
 
 
@@ -468,10 +543,13 @@ class TestLowLevelExtending(TestCase):
         test_ir = compiler.run_frontend(mk_func_test_impl)
         typingctx = cpu_target.typing_context
         typingctx.refresh()
-        typemap, _, _ = type_inference_stage(
-            typingctx, test_ir, (), None)
-        self.assertTrue(any(isinstance(a, types.MakeFunctionLiteral)
-                            for a in typemap.values()))
+        typemap, _, _ = type_inference_stage(typingctx, test_ir, (), None)
+        self.assertTrue(
+            any(
+                isinstance(a, types.MakeFunctionLiteral)
+                for a in typemap.values()
+            )
+        )
 
 
 class TestPandasLike(TestCase):
@@ -514,9 +592,11 @@ class TestPandasLike(TestCase):
         # The is_monotonic_increasing attribute is exposed with
         # overload_attribute()
         cfunc = jit(nopython=True)(is_monotonic_usecase)
-        for values, expected in [([8, 42, 5], False),
-                                 ([5, 8, 42], True),
-                                 ([], True)]:
+        for values, expected in [
+            ([8, 42, 5], False),
+            ([5, 8, 42], True),
+            ([], True),
+        ]:
             i = Index(np.int32(values))
             got = cfunc(i)
             self.assertEqual(got, expected)
@@ -584,18 +664,22 @@ class TestHighLevelExtending(TestCase):
         def check(*args, **kwargs):
             expected = np_where(*args, **kwargs)
             got = cfunc(*args, **kwargs)
-            self.assertPreciseEqual
+            self.assertPreciseEqual(expected, got)
 
         check(x=3, cond=True, y=8)
         check(True, 3, 8)
-        check(np.bool_([True, False, True]), np.int32([1, 2, 3]),
-              np.int32([4, 5, 5]))
+        check(
+            np.bool_([True, False, True]),
+            np.int32([1, 2, 3]),
+            np.int32([4, 5, 5]),
+        )
 
         # The typing error is propagated
         with self.assertRaises(errors.TypingError) as raises:
             cfunc(np.bool_([]), np.int32([]), np.int64([]))
-        self.assertIn("x and y should have the same dtype",
-                      str(raises.exception))
+        self.assertIn(
+            "x and y should have the same dtype", str(raises.exception)
+        )
 
     def test_len(self):
         """
@@ -624,7 +708,8 @@ class TestHighLevelExtending(TestCase):
         self.assertPreciseEqual(cfunc(1, 2), 3)
         self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
 
-        # this will call add(Number, Number) as MyDummy implicitly casts to Number
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
 
     def test_add_binop(self):
@@ -637,7 +722,8 @@ class TestHighLevelExtending(TestCase):
         self.assertPreciseEqual(cfunc(1, 2), 3)
         self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
 
-        # this will call add(Number, Number) as MyDummy implicitly casts to Number
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
 
     def test_iadd_operator(self):
@@ -650,7 +736,8 @@ class TestHighLevelExtending(TestCase):
         self.assertPreciseEqual(cfunc(1, 2), 3)
         self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
 
-        # this will call add(Number, Number) as MyDummy implicitly casts to Number
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
 
     def test_iadd_binop(self):
@@ -663,7 +750,8 @@ class TestHighLevelExtending(TestCase):
         self.assertPreciseEqual(cfunc(1, 2), 3)
         self.assertPreciseEqual(cfunc(MyDummy2(), MyDummy2()), 42)
 
-        # this will call add(Number, Number) as MyDummy implicitly casts to Number
+        # this will call add(Number, Number) as MyDummy implicitly casts to
+        # Number
         self.assertPreciseEqual(cfunc(MyDummy(), MyDummy()), 84)
 
     def test_delitem(self):
@@ -680,7 +768,7 @@ class TestHighLevelExtending(TestCase):
 
         if e is not None:
             raise e
-        self.assertEqual(out.getvalue(), 'del hello! 321\n')
+        self.assertEqual(out.getvalue(), "del hello! 321\n")
 
     def test_getitem(self):
         pyfunc = call_getitem
@@ -701,7 +789,7 @@ class TestHighLevelExtending(TestCase):
 
         if e is not None:
             raise e
-        self.assertEqual(out.getvalue(), '321 123\n')
+        self.assertEqual(out.getvalue(), "321 123\n")
 
     def test_no_cpython_wrapper(self):
         """
@@ -727,8 +815,8 @@ class TestHighLevelExtending(TestCase):
         Tests that an overload which has a differing typing and implementing
         signature raises an exception.
         """
-        def gen_ol(impl=None):
 
+        def gen_ol(impl=None):
             def myoverload(a, b, c, kw=None):
                 pass
 
@@ -776,7 +864,7 @@ class TestHighLevelExtending(TestCase):
 
         # arg name is different
         def impl3(z, b, c, kw=None):
-            if a > 10:
+            if a > 10:      # noqa: F821
                 return 1
             else:
                 return -1
@@ -791,6 +879,7 @@ class TestHighLevelExtending(TestCase):
         self.assertIn('<Parameter "z">', msg)
 
         from .overload_usecases import impl4, impl5
+
         with self.assertRaises(errors.TypingError) as e:
             gen_ol(impl4)(1, 2, 3, 4)
         msg = str(e.exception)
@@ -872,12 +961,13 @@ class TestHighLevelExtending(TestCase):
         Tests that an overload which has a differing typing and implementing
         signature raises an exception and uses VAR_POSITIONAL (*args) in typing
         """
+
         def myoverload(a, kw=None):
             pass
 
         from .overload_usecases import var_positional_impl
-        overload(myoverload)(var_positional_impl)
 
+        overload(myoverload)(var_positional_impl)
 
         @jit(nopython=True)
         def foo(a, b):
@@ -895,7 +985,6 @@ class TestHighLevelExtending(TestCase):
         """
 
         def gen_ol(impl, strict=True):
-
             def myoverload(a, kw=None):
                 pass
 
@@ -911,9 +1000,10 @@ class TestHighLevelExtending(TestCase):
         def ol1(a, **kws):
             def impl(a, kw=10):
                 return a
+
             return impl
 
-        gen_ol(ol1, False)(1, 2) # no error if strictness not enforced
+        gen_ol(ol1, False)(1, 2)  # no error if strictness not enforced
         with self.assertRaises(errors.TypingError) as e:
             gen_ol(ol1)(1, 2)
         msg = str(e.exception)
@@ -924,6 +1014,7 @@ class TestHighLevelExtending(TestCase):
         def ol2(a, kw=0):
             def impl(a, **kws):
                 return a
+
             return impl
 
         with self.assertRaises(errors.TypingError) as e:
@@ -934,10 +1025,11 @@ class TestHighLevelExtending(TestCase):
 
     def test_overload_method_kwargs(self):
         # Issue #3489
-        @overload_method(types.Array, 'foo')
+        @overload_method(types.Array, "foo")
         def fooimpl(arr, a_kwarg=10):
             def impl(arr, a_kwarg=10):
                 return a_kwarg
+
             return impl
 
         @njit
@@ -950,23 +1042,25 @@ class TestHighLevelExtending(TestCase):
 
     def test_overload_method_literal_unpack(self):
         # Issue #3683
-        @overload_method(types.Array, 'litfoo')
+        @overload_method(types.Array, "litfoo")
         def litfoo(arr, val):
             # Must be an integer
             if isinstance(val, types.Integer):
                 # Must not be literal
                 if not isinstance(val, types.Literal):
+
                     def impl(arr, val):
                         return val
+
                     return impl
 
         @njit
         def bar(A):
-            return A.litfoo(0xcafe)
+            return A.litfoo(0xCAFE)
 
         A = np.zeros(1)
         bar(A)
-        self.assertEqual(bar(A), 0xcafe)
+        self.assertEqual(bar(A), 0xCAFE)
 
     def test_overload_ufunc(self):
         # Issue #4133.
@@ -976,7 +1070,7 @@ class TestHighLevelExtending(TestCase):
         def test():
             return np.exp(mydummy)
 
-        self.assertEqual(test(), 0xdeadbeef)
+        self.assertEqual(test(), 0xDEADBEEF)
 
     def test_overload_method_stararg(self):
         @overload_method(MyDummyType, "method_stararg")
@@ -1006,37 +1100,29 @@ class TestHighLevelExtending(TestCase):
             )
 
         self.assertEqual(
-            bar(obj),
-            (
-                (1, 2, ()),
-                (1, 2, (3,)),
-                (1, 2, (3, 4))
-            ),
+            bar(obj), ((1, 2, ()), (1, 2, (3,)), (1, 2, (3, 4))),
         )
 
         # Check cases that put tuple type into stararg
         # NOTE: the expected result has an extra tuple because of stararg.
         self.assertEqual(
-            foo(obj, 1, 2, (3,)),
-            (1, 2, ((3,),)),
+            foo(obj, 1, 2, (3,)), (1, 2, ((3,),)),
         )
         self.assertEqual(
-            foo(obj, 1, 2, (3, 4)),
-            (1, 2, ((3, 4),)),
+            foo(obj, 1, 2, (3, 4)), (1, 2, ((3, 4),)),
         )
         self.assertEqual(
-            foo(obj, 1, 2, (3, (4, 5))),
-            (1, 2, ((3, (4, 5)),)),
+            foo(obj, 1, 2, (3, (4, 5))), (1, 2, ((3, (4, 5)),)),
         )
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):
     hit = cfunc._cache_hits[cfunc.signatures[0]]
     if hit != expect_hit:
-        raise AssertionError('cache not used')
+        raise AssertionError("cache not used")
     miss = cfunc._cache_misses[cfunc.signatures[0]]
     if miss != expect_misses:
-        raise AssertionError('cache not used')
+        raise AssertionError("cache not used")
 
 
 class TestOverloadMethodCaching(TestCase):
@@ -1046,7 +1132,7 @@ class TestOverloadMethodCaching(TestCase):
 
     def test_caching_overload_method(self):
         self._cache_dir = temp_directory(self.__class__.__name__)
-        with override_config('CACHE_DIR', self._cache_dir):
+        with override_config("CACHE_DIR", self._cache_dir):
             self.run_caching_overload_method()
 
     def run_caching_overload_method(self):
@@ -1055,17 +1141,21 @@ class TestOverloadMethodCaching(TestCase):
         _assert_cache_stats(cfunc, 0, 1)
         llvmir = cfunc.inspect_llvm((mydummy_type,))
         # Ensure the inner method is not a declaration
-        decls = [ln for ln in llvmir.splitlines()
-                 if ln.startswith('declare') and 'overload_method_length' in ln]
+        decls = [
+            ln
+            for ln in llvmir.splitlines()
+            if ln.startswith("declare") and "overload_method_length" in ln
+        ]
         self.assertEqual(len(decls), 0)
         # Test in a separate process
         try:
-            ctx = multiprocessing.get_context('spawn')
+            ctx = multiprocessing.get_context("spawn")
         except AttributeError:
             ctx = multiprocessing
         q = ctx.Queue()
-        p = ctx.Process(target=run_caching_overload_method,
-                        args=(q, self._cache_dir))
+        p = ctx.Process(
+            target=run_caching_overload_method, args=(q, self._cache_dir)
+        )
         p.start()
         q.put(MyDummy())
         p.join()
@@ -1079,13 +1169,14 @@ def run_caching_overload_method(q, cache_dir):
     """
     Used by TestOverloadMethodCaching.test_caching_overload_method
     """
-    with override_config('CACHE_DIR', cache_dir):
+    with override_config("CACHE_DIR", cache_dir):
         arg = q.get()
         cfunc = jit(nopython=True, cache=True)(cache_overload_method_usecase)
         res = cfunc(arg)
         q.put(res)
         # Check cache stat
         _assert_cache_stats(cfunc, 1, 0)
+
 
 class TestIntrinsic(TestCase):
     def test_void_return(self):
@@ -1097,17 +1188,20 @@ class TestIntrinsic(TestCase):
         @intrinsic
         def void_func(typingctx, a):
             sig = types.void(types.int32)
+
             def codegen(context, builder, signature, args):
                 pass  # do nothing, return None, should be turned into
-                      # dummy value
+                # dummy value
 
             return sig, codegen
 
         @intrinsic
         def non_void_func(typingctx, a):
             sig = types.int32(types.int32)
+
             def codegen(context, builder, signature, args):
-                pass # oops, should be returning a value here, raise exception
+                pass  # oops, should be returning a value here, raise exception
+
             return sig, codegen
 
         @jit(nopython=True)
@@ -1125,7 +1219,7 @@ class TestIntrinsic(TestCase):
         # not void function should raise exception
         with self.assertRaises(LoweringError) as e:
             call_non_void_func()
-        self.assertIn('non-void function returns None', e.exception.msg)
+        self.assertIn("non-void function returns None", e.exception.msg)
 
     def test_ll_pointer_cast(self):
         """
@@ -1166,6 +1260,7 @@ class TestIntrinsic(TestCase):
 
                 def array_impl(arr):
                     return unsafe_cast(src=arr.ctypes.data)
+
                 return array_impl
 
         # the ctype wrapped function for use in nopython mode
@@ -1242,6 +1337,7 @@ class TestIntrinsic(TestCase):
         """
         Test deserialization of intrinsic
         """
+
         def defn(context, x):
             def codegen(context, builder, signature, args):
                 return args[0]
@@ -1252,7 +1348,7 @@ class TestIntrinsic(TestCase):
         memo_size = len(memo)
         # invoke _Intrinsic indirectly to avoid registration which keeps an
         # internal reference inside the compiler
-        original = _Intrinsic('foo', defn)
+        original = _Intrinsic("foo", defn)
         self.assertIs(original._defn, defn)
         pickled = pickle.dumps(original)
         # by pickling, a new memo entry is created
@@ -1306,14 +1402,19 @@ class TestRegisterJitable(unittest.TestCase):
         cbar = jit(nopython=True)(bar)
         with self.assertRaises(errors.TypingError) as raises:
             cbar(2)
-        msg = "Only accept returning of array passed into the function as argument"
+        msg = (
+            "Only accept returning of array passed into the function as "
+            "argument"
+        )
         self.assertIn(msg, str(raises.exception))
 
 
 class TestImportCythonFunction(unittest.TestCase):
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
     def test_getting_function(self):
-        addr = get_cython_function_address("scipy.special.cython_special", "j0")
+        addr = get_cython_function_address(
+            "scipy.special.cython_special", "j0"
+        )
         functype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
         _j0 = functype(addr)
         j0 = jit(nopython=True)(lambda x: _j0(x))
@@ -1321,7 +1422,7 @@ class TestImportCythonFunction(unittest.TestCase):
 
     def test_missing_module(self):
         with self.assertRaises(ImportError) as raises:
-            addr = get_cython_function_address("fakemodule", "fakefunction")
+            get_cython_function_address("fakemodule", "fakefunction")
         # The quotes are not there in Python 2
         msg = "No module named '?fakemodule'?"
         match = re.match(msg, str(raises.exception))
@@ -1330,41 +1431,53 @@ class TestImportCythonFunction(unittest.TestCase):
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
     def test_missing_function(self):
         with self.assertRaises(ValueError) as raises:
-            addr = get_cython_function_address("scipy.special.cython_special", "foo")
-        msg = "No function 'foo' found in __pyx_capi__ of 'scipy.special.cython_special'"
+            get_cython_function_address(
+                "scipy.special.cython_special", "foo"
+            )
+        msg = (
+            "No function 'foo' found in __pyx_capi__ of "
+            "'scipy.special.cython_special'"
+        )
         self.assertEqual(msg, str(raises.exception))
 
 
-@overload_method(MyDummyType, 'method_jit_option_check_nrt',
-                 jit_options={'_nrt': True})
+@overload_method(
+    MyDummyType, "method_jit_option_check_nrt", jit_options={"_nrt": True}
+)
 def ov_method_jit_option_check_nrt(obj):
     def imp(obj):
         return np.arange(10)
+
     return imp
 
 
-@overload_method(MyDummyType, 'method_jit_option_check_no_nrt',
-                 jit_options={'_nrt': False})
+@overload_method(
+    MyDummyType, "method_jit_option_check_no_nrt", jit_options={"_nrt": False}
+)
 def ov_method_jit_option_check_no_nrt(obj):
     def imp(obj):
         return np.arange(10)
+
     return imp
 
 
-
-@overload_attribute(MyDummyType, 'attr_jit_option_check_nrt',
-                    jit_options={'_nrt': True})
+@overload_attribute(
+    MyDummyType, "attr_jit_option_check_nrt", jit_options={"_nrt": True}
+)
 def ov_attr_jit_option_check_nrt(obj):
     def imp(obj):
         return np.arange(10)
+
     return imp
 
 
-@overload_attribute(MyDummyType, 'attr_jit_option_check_no_nrt',
-                    jit_options={'_nrt': False})
+@overload_attribute(
+    MyDummyType, "attr_jit_option_check_no_nrt", jit_options={"_nrt": False}
+)
 def ov_attr_jit_option_check_no_nrt(obj):
     def imp(obj):
         return np.arange(10)
+
     return imp
 
 
@@ -1373,8 +1486,10 @@ class TestJitOptionsNoNRT(TestCase):
 
     def check_error_no_nrt(self, func, *args, **kwargs):
         # Check that the compilation fails with a complaint about dynamic array
-        msg = ("Only accept returning of array passed into "
-               "the function as argument")
+        msg = (
+            "Only accept returning of array passed into "
+            "the function as argument"
+        )
         with self.assertRaises(errors.TypingError) as raises:
             func(*args, **kwargs)
         self.assertIn(msg, str(raises.exception))
@@ -1383,10 +1498,11 @@ class TestJitOptionsNoNRT(TestCase):
         def dummy():
             return np.arange(10)
 
-        @overload(dummy, jit_options={'_nrt': flag})
+        @overload(dummy, jit_options={"_nrt": flag})
         def ov_dummy():
             def dummy():
                 return np.arange(10)
+
             return dummy
 
         @njit
@@ -1432,14 +1548,14 @@ class TestJitOptionsNoNRT(TestCase):
 class TestBoxingCallingJIT(TestCase):
     def setUp(self):
         super().setUp()
-        many = base_dummy_type_factory('mydummy2')
+        many = base_dummy_type_factory("mydummy2")
         self.DynTypeType, self.DynType, self.dyn_type_type = many
         self.dyn_type = self.DynType()
 
     def test_unboxer_basic(self):
         # Implements an unboxer on DynType that calls an intrinsic into the
         # unboxer code.
-        magic_token = 0xcafe
+        magic_token = 0xCAFE
         magic_offset = 123
 
         @intrinsic
@@ -1448,9 +1564,9 @@ class TestBoxingCallingJIT(TestCase):
             def impl(context, builder, sig, args):
                 [val] = args
                 return builder.add(val, val.type(magic_offset))
+
             sig = signature(val, val)
             return sig, impl
-
 
         @unbox(self.DynTypeType)
         def unboxer(typ, obj, c):
@@ -1485,7 +1601,7 @@ class TestBoxingCallingJIT(TestCase):
             # The unboxer that calls some jitcode
             def bridge(x):
                 if x > 0:
-                    raise ValueError('cannot be x > 0')
+                    raise ValueError("cannot be x > 0")
                 return x
 
             args = [c.context.get_constant(types.intp, 1)]
@@ -1504,15 +1620,14 @@ class TestBoxingCallingJIT(TestCase):
             return x
 
         with self.assertRaises(ValueError) as raises:
-            out = passthru(self.dyn_type)
+            passthru(self.dyn_type)
         self.assertIn(
-            "cannot be x > 0",
-            str(raises.exception),
+            "cannot be x > 0", str(raises.exception),
         )
 
     def test_boxer(self):
         # Call jitcode inside the boxer
-        magic_token = 0xcafe
+        magic_token = 0xCAFE
         magic_offset = 312
 
         @intrinsic
@@ -1521,6 +1636,7 @@ class TestBoxingCallingJIT(TestCase):
             def impl(context, builder, sig, args):
                 [val] = args
                 return builder.add(val, val.type(magic_offset))
+
             sig = signature(val, val)
             return sig, impl
 
@@ -1576,13 +1692,70 @@ class TestBoxingCallingJIT(TestCase):
         with self.assertRaises(ValueError) as raises:
             passthru(self.dyn_type)
         self.assertIn(
-            "cannot do x > 0",
-            str(raises.exception),
+            "cannot do x > 0", str(raises.exception),
         )
 
 
-class TestMisc(TestCase):
+class TestCachingOverloadObjmode(TestCase):
+    """Test caching of the use of overload implementation that uses
+    `with objmode`
+    """
 
+    def setUp(self):
+        warnings.simplefilter("error", errors.NumbaWarning)
+
+    def tearDown(self):
+        warnings.resetwarnings()
+
+    def test_caching_overload_objmode(self):
+        cache_dir = temp_directory(self.__class__.__name__)
+        with override_config("CACHE_DIR", cache_dir):
+
+            def realwork(x):
+                # uses numpy code
+                arr = np.arange(x) / x
+                return np.linalg.norm(arr)
+
+            def python_code(x):
+                # create indirections
+                return realwork(x)
+
+            @overload(with_objmode_cache_ov_example)
+            def _ov_with_objmode_cache_ov_example(x):
+                def impl(x):
+                    with objmode(y="float64"):
+                        y = python_code(x)
+                    return y
+
+                return impl
+
+            @njit(cache=True)
+            def testcase(x):
+                return with_objmode_cache_ov_example(x)
+
+            expect = realwork(123)
+            got = testcase(123)
+            self.assertEqual(got, expect)
+
+            testcase_cached = njit(cache=True)(testcase.py_func)
+            got = testcase_cached(123)
+            self.assertEqual(got, expect)
+
+            self.assertEqual(
+                testcase_cached._cache_hits[testcase.signatures[0]], 1,
+            )
+            self.assertEqual(
+                testcase_cached._cache_misses[testcase.signatures[0]], 0,
+            )
+
+
+def with_objmode_cache_ov_example(x):
+    # This is the function stub for overloading inside
+    # TestCachingOverloadObjmode.test_caching_overload_objmode
+    pass
+
+
+class TestMisc(TestCase):
     def test_is_jitted(self):
         def foo(x):
             pass
@@ -1591,8 +1764,10 @@ class TestMisc(TestCase):
         self.assertTrue(is_jitted(njit(foo)))
         self.assertFalse(is_jitted(vectorize(foo)))
         self.assertFalse(is_jitted(vectorize(parallel=True)(foo)))
-        self.assertFalse(is_jitted(guvectorize('void(float64[:])', '(m)')(foo)))
+        self.assertFalse(
+            is_jitted(guvectorize("void(float64[:])", "(m)")(foo))
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1703,7 +1703,7 @@ def with_objmode_cache_ov_example(x):
 
 
 class TestCachingOverloadObjmode(TestCase):
-    """Test caching of the use of overload implementation that uses
+    """Test caching of the use of overload implementations that use
     `with objmode`
     """
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1706,6 +1706,7 @@ class TestCachingOverloadObjmode(TestCase):
     """Test caching of the use of overload implementations that use
     `with objmode`
     """
+    _numba_parallel_test_ = False
 
     def setUp(self):
         warnings.simplefilter("error", errors.NumbaWarning)

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -796,6 +796,16 @@ class TestLiftObj(MemoryLeak, TestCase):
         return output
 
 
+def case_inner_pyfunc(x):
+    return x / 10
+
+
+def case_objmode_cache(x):
+    with objmode(output='float64'):
+        output = case_inner_pyfunc(x)
+    return output
+
+
 class TestLiftObjCaching(MemoryLeak, TestCase):
     # Warnings in this test class are converted to errors
 
@@ -835,15 +845,6 @@ class TestLiftObjCaching(MemoryLeak, TestCase):
 
     def test_objmode_caching_call_closure_good(self):
         self.check(case_objmode_cache)
-
-
-def case_inner_pyfunc(x):
-    return x / 10
-
-def case_objmode_cache(x):
-    with objmode(output='float64'):
-        output = case_inner_pyfunc(x)
-    return output
 
 
 class TestBogusContext(BaseTestWithLifting):

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -789,6 +789,66 @@ class TestLiftObj(MemoryLeak, TestCase):
 
         self.assertEqual(f(), 1 + 3)
 
+    @staticmethod
+    def case_objmode_cache(x):
+        with objmode(output='float64'):
+            output = x / 10
+        return output
+
+
+class TestLiftObjCaching(MemoryLeak, TestCase):
+    # Warnings in this testclass is converted to error
+    #
+
+    def setUp(self):
+        warnings.simplefilter("error", errors.NumbaWarning)
+
+    def tearDown(self):
+        warnings.resetwarnings()
+
+    def check(self, py_func):
+        first = njit(cache=True)(py_func)
+        self.assertEqual(first(123), 12.3)
+
+        second = njit(cache=True)(py_func)
+        self.assertFalse(second._cache_hits)
+        self.assertEqual(second(123), 12.3)
+        self.assertTrue(second._cache_hits)
+
+    def test_objmode_caching_basic(self):
+        def pyfunc(x):
+            with objmode(output='float64'):
+                output = x / 10
+            return output
+
+        self.check(pyfunc)
+
+    def test_objmode_caching_call_closure_bad(self):
+        def other_pyfunc(x):
+            return x / 10
+
+        def pyfunc(x):
+            with objmode(output='float64'):
+                output = other_pyfunc(x)
+            return output
+
+        # TODO: we can make closure work by disabling the check in caching.py
+        with self.assertRaises(errors.NumbaWarning) as raises:
+            self.check(pyfunc)
+        self.assertIn("Cannot cache", str(raises.exception))
+
+    def test_objmode_caching_call_closure_good(self):
+        self.check(case_objmode_cache)
+
+
+def case_inner_pyfunc(x):
+    return x / 10
+
+def case_objmode_cache(x):
+    with objmode(output='float64'):
+        output = case_inner_pyfunc(x)
+    return output
+
 
 class TestBogusContext(BaseTestWithLifting):
     def test_undefined_global(self):

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -832,10 +832,7 @@ class TestLiftObjCaching(MemoryLeak, TestCase):
                 output = other_pyfunc(x)
             return output
 
-        # TODO: we can make closure work by disabling the check in caching.py
-        with self.assertRaises(errors.NumbaWarning) as raises:
-            self.check(pyfunc)
-        self.assertIn("Cannot cache", str(raises.exception))
+        self.check(pyfunc)
 
     def test_objmode_caching_call_closure_good(self):
         self.check(case_objmode_cache)

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -797,8 +797,7 @@ class TestLiftObj(MemoryLeak, TestCase):
 
 
 class TestLiftObjCaching(MemoryLeak, TestCase):
-    # Warnings in this testclass is converted to error
-    #
+    # Warnings in this test class are converted to errors
 
     def setUp(self):
         warnings.simplefilter("error", errors.NumbaWarning)

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -436,11 +436,18 @@ def box_lsttype(typ, val, c):
 
     lsttype_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
 
-    res = c.pyapi.call_function_objargs(fmp_fn, (boxed_meminfo, lsttype_obj))
-    c.pyapi.decref(fmp_fn)
-    c.pyapi.decref(typedlist_mod)
-    c.pyapi.decref(boxed_meminfo)
-    return res
+    result_var = builder.alloca(c.pyapi.pyobj)
+    builder.store(cgutils.get_null_value(c.pyapi.pyobj), result_var)
+
+    with builder.if_then(cgutils.is_not_null(builder, lsttype_obj)):
+        res = c.pyapi.call_function_objargs(
+            fmp_fn, (boxed_meminfo, lsttype_obj),
+        )
+        c.pyapi.decref(fmp_fn)
+        c.pyapi.decref(typedlist_mod)
+        c.pyapi.decref(boxed_meminfo)
+        builder.store(res, result_var)
+    return builder.load(result_var)
 
 
 @unbox(types.ListType)


### PR DESCRIPTION
Fix #3955.

# Major changes

- Extends `pickle` to handle function and module differently from default. Adapted code from cloudpickle.
- When a `Dispatcher` is pickled, it uses the `NumbaPickler`. This is transparent to the user.
- `pickle5` is needed to use the C-Pickler in Python <= 3.7. 

## Why adapt code from `cloudpickle`?

I have chosen to adapt code from `cloudpickle` instead of using it as a dependency because we want to ensure that the same version of numba will always work with pickled data (cached) from the same version of numba. By using `cloudpickle` as a dependency, one can have the same version of numba but different version of cloudpickle, and it might be incompatible.