### PR TITLE
Skip part of slice array analysis if any part is not analyzable.

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -1869,7 +1869,7 @@ class ArrayAnalysis(object):
 
         # We can only replace the slice and record some information about the slice
         # size if both parts of the slice were analyzable.
-        if def_res1 and def_res1:
+        if def_res1 and def_res2:
             post_wrap_size_var = ir.Var(
                 scope, mk_unique_var("post_wrap_slice_size"), loc
             )

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -858,8 +858,8 @@ class SymbolicEquivSet(ShapeEquivSet):
                         # If wrap_index for a slice works on a variable
                         # that is not analyzable (e.g., multiple definitions)
                         # then we have to return None here since we can't know
-                        # how that size will compare to others if we can't analyze
-                        # some part of the slice.
+                        # how that size will compare to others if we can't
+                        # analyze some part of the slice.
                         if -1 in index:
                             return None
                         names = self.ext_shapes.get(index, [])
@@ -1867,13 +1867,16 @@ class ArrayAnalysis(object):
         if value2 is not None:
             stmts.append(ir.Assign(value=value2, target=var2, loc=loc))
 
-        # We can only replace the slice and record some information about the slice
-        # size if both parts of the slice were analyzable.
+        # We can only replace the slice and record some information about
+        # the slice size if both parts of the slice were analyzable.
         if def_res1 and def_res2:
             post_wrap_size_var = ir.Var(
                 scope, mk_unique_var("post_wrap_slice_size"), loc
             )
-            post_wrap_size_val = ir.Expr.binop(operator.sub, var2, var1, loc=loc)
+            post_wrap_size_val = ir.Expr.binop(operator.sub,
+                                               var2,
+                                               var1,
+                                               loc=loc)
             self.calltypes[post_wrap_size_val] = signature(
                 slice_typ, var2_typ, var1_typ
             )

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2983,6 +2983,25 @@ class TestParforsSlice(TestParforsBase):
 
         self.check(test_impl, np.arange(4))
 
+    @skip_parfors_unsupported
+    def test_parfor_slice27(self):
+        # issue5601: tests array analysis of the slice with
+        # n_valid_vals of unknown size.
+        def test_impl(a):
+            n_valid_vals = 0
+
+            for i in prange(a.shape[0]):
+                if a[i] != 0:
+                    n_valid_vals += 1
+
+                if n_valid_vals:
+                    unused = a[:n_valid_vals]
+
+            return 0
+
+        self.check(test_impl, np.arange(3))
+
+
 class TestParforsOptions(TestParforsBase):
 
     def check(self, pyfunc, *args, **kwargs):


### PR DESCRIPTION
Resolves #5601 

Some variables are not present in array analysis.  One common case of that is, like this issue, where a variable is multiply defined.  If such a variable occurs in a slice then likewise the slice becomes not analyzable.  This PR implements this propagation of a slice part being unanalyzable to the whole of the slice.