### PR TITLE
Fix usedef issue with parfor loopnest variables.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3517,7 +3517,7 @@ def parfor_defs(parfor, use_set=None, def_set=None):
     loop_vars |= {
         l.step.name for l in parfor.loop_nests if isinstance(
             l.step, ir.Var)}
-    use_set.update(loop_vars)
+    use_set.update(loop_vars - def_set)
     use_set |= get_parfor_pattern_vars(parfor)
 
     return analysis._use_defs_result(usemap=use_set, defmap=def_set)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2188,6 +2188,24 @@ class TestPrange(TestPrangeBase):
                            check_fastmath=True, check_fastmath_result=True)
 
     @skip_parfors_unsupported
+    def test_prange27(self):
+        # issue5597: usedef error in parfor
+        def test_impl(a, b, c):
+            for j in range(b[0]-1):
+                for k in range(2):
+                    z = np.abs(a[c-1:c+1])
+            return 0
+
+        # patch inner loop to 'prange'
+        self.prange_tester(test_impl,
+                           np.arange(20),
+                           np.asarray([4,4,4,4,4,4,4,4,4,4]),
+                           0,
+                           patch_instance=[1],
+                           scheduler_type='unsigned',
+                           check_fastmath=True)
+
+    @skip_parfors_unsupported
     def test_prange_two_instances_same_reduction_var(self):
         # issue4922 - multiple uses of same reduction variable
         def test_impl(n):


### PR DESCRIPTION
Resolves #5597

The parfor callback for usedef analysis was slightly wrong when it came to handling variables used in the loopnests. They were added to the enclosing use set regardless but this is wrong. If those variables are present in the enclosing def set then this PR makes sure that they aren't added to the use set. The bug manifested as one of the slice variables being detected as a race, when it isn't, and then the pre-existing parfor code to handle this situation kicked in which was not expecting this situation and so something asserted.