### PR TITLE
Implement np.split and np.array_split

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -355,6 +355,7 @@ The following top-level functions are supported:
 * :func:`numpy.argwhere`
 * :func:`numpy.array` (only the 2 first arguments)
 * :func:`numpy.array_equal`
+* :func:`numpy.array_split`
 * :func:`numpy.asarray` (only the 2 first arguments)
 * :func:`numpy.asfortranarray` (only the first argument)
 * :func:`numpy.atleast_1d`
@@ -426,6 +427,7 @@ The following top-level functions are supported:
 * :func:`numpy.shape`
 * :func:`numpy.sinc`
 * :func:`numpy.sort` (no optional arguments)
+* :func:`numpy.split`
 * :func:`numpy.stack`
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.transpose`

--- a/numba/cpython/unsafe/tuple.py
+++ b/numba/cpython/unsafe/tuple.py
@@ -3,6 +3,7 @@ This file provides internal compiler utilities that support certain special
 operations with tuple and workarounds for limitations enforced in userland.
 """
 
+from numba.core import types, typing
 from numba.core.cgutils import alloca_once
 from numba.core.extending import intrinsic
 
@@ -29,4 +30,43 @@ def tuple_setitem(typingctx, tup, idx, val):
         return builder.load(stack)
 
     sig = tup(tup, idx, tup.dtype)
+    return sig, codegen
+
+
+@intrinsic
+def build_full_slice_tuple(tyctx, sz):
+    """Creates a sz-tuple of full slices.
+
+    Usage
+    -----
+
+    To slice an array of n-dimensions at dim n - 1:
+
+    >>> @jit
+    ... def penultimate_slice(a, idx):
+    ...     n = a.ndim
+    ...     t = build_full_slice_tuple(n)
+    ...     return a[tuple_setitem(t, n-1, idx)]
+    """
+    size = int(sz.literal_value)
+    tuple_type = types.UniTuple(dtype=types.slice2_type, count=size)
+    sig = tuple_type(sz)
+
+    def codegen(context, builder, signature, args):
+        def impl(length, empty_tuple):
+            out = empty_tuple
+            for i in range(length):
+                out = tuple_setitem(out, i, slice(None, None))
+            return out
+
+        inner_argtypes = [types.intp, tuple_type]
+        inner_sig = typing.signature(tuple_type, *inner_argtypes)
+        ll_idx_type = context.get_value_type(types.intp)
+        # Allocate an empty tuple
+        empty_tuple = context.get_constant_undef(tuple_type)
+        inner_args = [ll_idx_type(size), empty_tuple]
+
+        res = context.compile_internal(builder, impl, inner_sig, inner_args)
+        return res
+
     return sig, codegen

--- a/numba/cpython/unsafe/tuple.py
+++ b/numba/cpython/unsafe/tuple.py
@@ -35,19 +35,7 @@ def tuple_setitem(typingctx, tup, idx, val):
 
 @intrinsic
 def build_full_slice_tuple(tyctx, sz):
-    """Creates a sz-tuple of full slices.
-
-    Usage
-    -----
-
-    To slice an array of n-dimensions at dim n - 1:
-
-    >>> @jit
-    ... def penultimate_slice(a, idx):
-    ...     n = a.ndim
-    ...     t = build_full_slice_tuple(n)
-    ...     return a[tuple_setitem(t, n-1, idx)]
-    """
+    """Creates a sz-tuple of full slices."""
     size = int(sz.literal_value)
     tuple_type = types.UniTuple(dtype=types.slice2_type, count=size)
     sig = tuple_type(sz)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5007,7 +5007,7 @@ def np_split(a, indices, axis=0):
             l, rem = divmod(a.shape[axis], indices)
             if rem != 0:
                 raise ValueError("array split does not result in an equal division")
-            return np.split(a, list(range(l, len(a), l)), axis=axis)
+            return np.split(a, np.arange(l, len(a), l), axis=axis)
 
     else:
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5006,7 +5006,7 @@ def np_split(a, indices, axis=0):
         def impl(a, indices, axis=0):
             l, rem = divmod(a.shape[axis], indices)
             if rem != 0:
-                raise ValueError()
+                raise ValueError("array split does not result in an equal division")
             return np.split(a, list(range(l, len(a), l)), axis=axis)
 
     else:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4966,6 +4966,16 @@ def np_flip(a):
 
 @overload(np.array_split)
 def np_array_split(ary, indices_or_sections, axis=0):
+    if isinstance(ary, (types.UniTuple, types.ListType, types.List)):
+        def impl(ary, indices_or_sections, axis=0):
+            return np.array_split(
+                np.asarray(ary),
+                indices_or_sections,
+                axis=axis
+            )
+
+        return impl
+
     if isinstance(indices_or_sections, types.Integer):
         def impl(ary, indices_or_sections, axis=0):
             l, rem = divmod(ary.shape[axis], indices_or_sections)
@@ -5019,6 +5029,12 @@ def np_array_split(ary, indices_or_sections, axis=0):
 def np_split(ary, indices_or_sections, axis=0):
     # This is just a wrapper of array_split, but with an extra error if
     # indices is an int.
+    if isinstance(ary, (types.UniTuple, types.ListType, types.List)):
+        def impl(ary, indices_or_sections, axis=0):
+            return np.split(np.asarray(ary), indices_or_sections, axis=axis)
+
+        return impl
+
     if isinstance(indices_or_sections, types.Integer):
         def impl(ary, indices_or_sections, axis=0):
             l, rem = divmod(ary.shape[axis], indices_or_sections)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5037,17 +5037,13 @@ def np_split(ary, indices_or_sections, axis=0):
 
     if isinstance(indices_or_sections, types.Integer):
         def impl(ary, indices_or_sections, axis=0):
-            l, rem = divmod(ary.shape[axis], indices_or_sections)
+            _, rem = divmod(ary.shape[axis], indices_or_sections)
             if rem != 0:
                 raise ValueError(
                     "array split does not result in an equal division"
                 )
-            indices = np.cumsum(np.array(
-                [l + 1] * rem +
-                [l] * (indices_or_sections - rem - 1)
-            ))
             return np.array_split(
-                ary, indices, axis=axis
+                ary, indices_or_sections, axis=axis
             )
 
         return impl

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5025,12 +5025,15 @@ def np_array_split(a, indices, axis=0):
 
 @overload(np.split)
 def np_split(a, indices, axis=0):
-    # This is just a wrapper of array_split, but with an extra error if indices is an int.
+    # This is just a wrapper of array_split, but with an extra error if
+    # indices is an int.
     if isinstance(indices, types.Integer):
         def impl(a, indices, axis=0):
             l, rem = divmod(a.shape[axis], indices)
             if rem != 0:
-                raise ValueError("array split does not result in an equal division")
+                raise ValueError(
+                    "array split does not result in an equal division"
+                )
             return np.array_split(a, np.arange(l, len(a), l), axis=axis)
     else:
         def impl(a, indices, axis=0):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4979,7 +4979,10 @@ def np_array_split(ary, indices_or_sections, axis=0):
 
     elif (
         isinstance(indices_or_sections, types.IterableType)
-        and isinstance(indices_or_sections.iterator_type.yield_type, types.Integer)
+        and isinstance(
+            indices_or_sections.iterator_type.yield_type,
+            types.Integer
+        )
     ):
         def impl(ary, indices_or_sections, axis=0):
             slice_tup = build_full_slice_tuple(ary.ndim)
@@ -4994,7 +4997,7 @@ def np_array_split(ary, indices_or_sections, axis=0):
 
         return impl
 
-    elif  (
+    elif (
         isinstance(indices_or_sections, types.Tuple)
         and all(isinstance(t, types.Integer) for t in indices_or_sections.types)
     ):
@@ -5031,7 +5034,6 @@ def np_split(ary, indices_or_sections, axis=0):
 
     else:
         return np_array_split(ary, indices_or_sections, axis=axis)
-
 
 
 # -----------------------------------------------------------------------------

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5042,8 +5042,12 @@ def np_split(ary, indices_or_sections, axis=0):
                 raise ValueError(
                     "array split does not result in an equal division"
                 )
+            indices = np.cumsum(np.array(
+                [l + 1] * rem +
+                [l] * (indices_or_sections - rem - 1)
+            ))
             return np.array_split(
-                ary, np.arange(l, ary.shape[axis], l), axis=axis
+                ary, indices, axis=axis
             )
 
         return impl

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -14,7 +14,7 @@ from llvmlite.llvmpy.core import Constant
 
 import numpy as np
 
-from numba import pndindex, typeof
+from numba import pndindex
 from numba.core import types, utils, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, carray, farray, is_contiguous,
                                     is_fortran)
@@ -4967,13 +4967,6 @@ def np_flip(a):
 @overload(np.array_split)
 def np_array_split(ary, indices_or_sections, axis=0):
     # If this statement is put at the top of the file, numba fails to import
-    from numba.typed import List
-
-    if ary.ndim > 1:
-        a_type = types.Array(ary.dtype, ary.ndim, "A")
-    else:
-        a_type = typeof(ary)
-
     if isinstance(indices_or_sections, types.Integer):
 
         def impl(ary, indices_or_sections, axis=0):
@@ -4986,7 +4979,7 @@ def np_array_split(ary, indices_or_sections, axis=0):
 
         def impl(ary, indices_or_sections, axis=0):
             slice_tup = build_full_slice_tuple(ary.ndim)
-            out = List.empty_list(a_type, len(indices_or_sections) + 1)
+            out = list()
             prev = 0
             for cur in indices_or_sections:
                 idx = tuple_setitem(slice_tup, axis, slice(prev, cur))

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4969,9 +4969,11 @@ def np_array_split(ary, indices_or_sections, axis=0):
     if isinstance(indices_or_sections, types.Integer):
         def impl(ary, indices_or_sections, axis=0):
             l, rem = divmod(ary.shape[axis], indices_or_sections)
-            return np.array_split(
-                ary, np.arange(l + rem, ary.shape[axis], l), axis=axis
-            )
+            indices = np.cumsum(np.array(
+                [l + 1] * rem +
+                [l] * (indices_or_sections - rem - 1)
+            ))
+            return np.array_split(ary, indices, axis=axis)
 
         return impl
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2219,6 +2219,18 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, (1,)
             yield a, (np.int32(4), 10)
 
+            a = np.array([])
+            yield a, 1
+            yield a, 2
+            yield a, (2, 3), 0
+            yield a, 1, 0
+
+            a = np.array([[]])
+            yield a, 1
+            yield a, (2, 3), 1
+            yield a, 1, 0
+            yield a, 1, 1
+
         for args in args_variations():
             expected = pyfunc(*args)
             got = cfunc(*args)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2193,7 +2193,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, 2
             yield a, 2, 0
             yield a, [1, 4, 72]
+            yield list(a), [1, 4, 72]
+            yield tuple(a), [1, 4, 72]
             yield a, [1, 4, 72], 0
+            yield list(a), [1, 4, 72], 0
+            yield tuple(a), [1, 4, 72], 0
 
             a = np.arange(64).reshape(4, 4, 4)
             yield a, 2
@@ -2228,6 +2232,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         def args_variations():
             yield np.arange(8), 3
+            yield list(np.arange(8)), 3
+            yield tuple(np.arange(8)), 3
             yield np.arange(24).reshape(12, 2), 5
 
         for args in args_variations():

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2208,6 +2208,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             np.testing.assert_equal(expected, list(got))
             # self.assertTrue(np.array_equal(expected, got))
 
+        with self.assertRaises(ValueError) as raises:
+            cfunc(np.ones(5), 2)
+
+        self.assertIn("array split does not result in an equal division", str(raises.exception))
+
     def test_roll_basic(self):
         pyfunc = roll
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -122,11 +122,11 @@ def flip(a):
 
 
 def array_split(a, indices, axis=0):
-    return np.array_split(a, indices, axis=0)
+    return np.array_split(a, indices, axis=axis)
 
 
 def split(a, indices, axis=0):
-    return np.split(a, indices, axis=0)
+    return np.split(a, indices, axis=axis)
 
 
 def correlate(a, v):
@@ -2206,12 +2206,18 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, [1, 3], 1
             yield a, [1, 3], 2
 
+            a = np.arange(100).reshape(2, -1)
+            yield a, 1
+            yield a, 1, 0
+            yield a, [1], 0
+            yield a, 50, 1
+            yield a, np.arange(10, 50, 10), 1
+
         for args in args_variations():
             expected = pyfunc(*args)
             got = cfunc(*args)
 
             np.testing.assert_equal(expected, list(got))
-            # self.assertTrue(np.array_equal(expected, got))
 
     def test_array_split_basic(self):
         self._check_array_split(array_split)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2222,7 +2222,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         self.disable_leak_check()  # The exception leaks
         with self.assertRaises(ValueError) as raises:
             njit(split)(np.ones(5), 2)
-        self.assertIn("array split does not result in an equal division", str(raises.exception))
+        self.assertIn(
+            "array split does not result in an equal division",
+            str(raises.exception)
+        )
 
     def test_roll_basic(self):
         pyfunc = roll

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2212,6 +2212,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, [1], 0
             yield a, 50, 1
             yield a, np.arange(10, 50, 10), 1
+            yield a, (1,)
+            yield a, (np.int32(4), 10)
 
         for args in args_variations():
             expected = pyfunc(*args)

--- a/numba/tests/test_unsafe_intrinsics.py
+++ b/numba/tests/test_unsafe_intrinsics.py
@@ -2,9 +2,9 @@ import random
 import numpy as np
 
 from numba.tests.support import TestCase, captured_stdout
-from numba import njit
+from numba import njit, literally
 from numba.core import types
-from numba.cpython.unsafe.tuple import tuple_setitem
+from numba.cpython.unsafe.tuple import tuple_setitem, build_full_slice_tuple
 from numba.np.unsafe.ndarray import to_fixed_tuple, empty_inferred
 from numba.core.unsafe.bytes import memcpy_region
 from numba.core.unsafe.refcount import dump_refcount
@@ -41,6 +41,20 @@ class TestTupleIntrinsic(TestCase):
             # Check
             self.assertEqual(got_tup, expect_tup)
             self.assertEqual(got_out, tuple(expect_out))
+
+    def test_slice_tuple(self):
+        @njit
+        def full_slice_array(a, n):
+            # Since numba slices can't be boxed at the moment
+            return a[build_full_slice_tuple(literally(n))]
+
+        for n in range(1, 3):
+            a = np.random.random(np.arange(n) + 1)
+            for i in range(1, n + 1):
+                np.testing.assert_array_equal(a, full_slice_array(a, i))
+            with self.assertRaises(TypingError):
+                # numpy would throw an IndexError here
+                full_slice_array(a, n + 1)
 
 
 class TestNdarrayIntrinsic(TestCase):


### PR DESCRIPTION
This PR implements `np.split` and `np.array_split`, and would help towards closing #2102. I think this is ready for review.

Questions: 

*  For testing, I'm not sure what assertion method I should use in place of `np.testing.assert_equal`, since the result is a list of arrays. Any suggestions?
* For implementations of numpy functions, what naming convention should be used for the arguments? I've tried to follow other functions in the file, but I was wondering if I should use the same arguments names as numpy.