### PR TITLE
Make it easier to understand type inference: add SSA dump, use for DEBUG_TYPEINFER

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -158,6 +158,12 @@ These variables influence what is printed out during compilation of
    If set to non-zero, print out the Numba Intermediate Representation
    of compiled functions.
 
+
+.. envvar:: NUMBA_DUMP_SSA
+
+   If set to non-zero, print out the Numba Intermediate Representation of
+   compiled functions after conversion to Static Single Assignment (SSA) form.
+
 .. envvar:: NUMBA_DEBUG_PRINT_AFTER
 
    Dump the Numba IR after declared pass(es). This is useful for debugging IR

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -216,7 +216,11 @@ class _EnvReloader(object):
 
         # Force dump of Numba IR
         DUMP_IR = _readenv("NUMBA_DUMP_IR", int,
-                           DEBUG_FRONTEND or DEBUG_TYPEINFER)
+                           DEBUG_FRONTEND)
+
+        # Force dump of Numba IR in SSA form
+        DUMP_SSA = _readenv("NUMBA_DUMP_SSA", int,
+                            DEBUG_FRONTEND or DEBUG_TYPEINFER)
 
         # print debug info of analysis and optimization on array operations
         DEBUG_ARRAY_OPT = _readenv("NUMBA_DEBUG_ARRAY_OPT", int, 0)

--- a/numba/core/ssa.py
+++ b/numba/core/ssa.py
@@ -28,15 +28,8 @@ def reconstruct_ssa(func_ir):
 
     Produces minimal SSA using Choi et al algorithm.
     """
-    _logger.debug("BEFORE SSA".center(80, "-"))
-    _logger.debug(func_ir.dump_to_string())
-    _logger.debug("=" * 80)
-
     func_ir.blocks = _run_ssa(func_ir.blocks)
 
-    _logger.debug("AFTER SSA".center(80, "-"))
-    _logger.debug(func_ir.dump_to_string())
-    _logger.debug("=" * 80)
     return func_ir
 
 

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -1493,6 +1493,12 @@ class ReconstructSSA(FunctionPass):
         # example generator_info
         post_proc = postproc.PostProcessor(state.func_ir)
         post_proc.run(emit_dels=False)
+
+        if config.DEBUG or config.DUMP_SSA:
+            name = state.func_ir.func_id.func_qualname
+            print(f"SSA IR DUMP: {name}".center(80, "-"))
+            state.func_ir.dump()
+
         return True      # XXX detect if it actually got changed
 
     def _patch_locals(self, state):


### PR DESCRIPTION
Type inference happens on the IR after conversion to SSA form, and refers to variables with their  SSA names (e.g. `ret`, `ret.1`, `ret.2`, etc.). This PR adds dumping of the IR in SSA form, and dumps it instead of the non-SSA IR when `DEBUG_TYPEINFER` is `True`.

Prior to this PR, running:

```python
from numba import njit

@njit
def select(a, b, c):
    if c:
        ret = a
    else:
        ret = b
    return ret

select(1, 3, False)
select((1, 2), 3, False)
```

with `NUMBA_DEBUG_TYPEINFER=1` produces:

```
--------------------------------IR DUMP: select---------------------------------
label 0:
    a = arg(0, name=a)                       ['a']
    b = arg(1, name=b)                       ['b']
    c = arg(2, name=c)                       ['c']
    branch c, 6, 12                          ['c']
label 6:
    ret = a                                  ['a', 'ret']
    jump 16                                  []
label 12:
    ret = b                                  ['b', 'ret']
    jump 16                                  []
label 16:
    $18return_value.1 = cast(value=ret)      ['$18return_value.1', 'ret']
    return $18return_value.1                 ['$18return_value.1']

--------------------------------IR DUMP: select---------------------------------
label 0:
    a = arg(0, name=a)                       ['a']
    b = arg(1, name=b)                       ['b']
    c = arg(2, name=c)                       ['c']
    branch c, 6, 12                          ['c']
label 6:
    ret = a                                  ['a', 'ret']
    jump 16                                  []
label 12:
    ret = b                                  ['b', 'ret']
    jump 16                                  []
label 16:
    $18return_value.1 = cast(value=ret)      ['$18return_value.1', 'ret']
    return $18return_value.1                 ['$18return_value.1']

-----------------------------------propagate------------------------------------
---- type variables ----
[$18return_value.1 := int64,
 a := int64,
 arg.a := int64,
 arg.b := int64,
 arg.c := bool,
 b := int64,
 c := bool,
 ret := int64,
 ret.1 := int64,
 ret.2 := int64]
...
```

The IR dump is produced twice, presumably once from `IRProcessing` and once from `InlineClosureLikes`, and the type inference appears to refer to names that don't appear in the IR - e.g. `ret.1`. With this PR, running the same gives:

```
------------------------------SSA IR DUMP: select-------------------------------
label 0:
    a = arg(0, name=a)                       ['a']
    b = arg(1, name=b)                       ['b']
    c = arg(2, name=c)                       ['c']
    branch c, 6, 12                          ['c']
label 6:
    ret = a                                  ['a', 'ret']
    jump 16                                  []
label 12:
    ret.1 = b                                ['b', 'ret.1']
    jump 16                                  []
label 16:
    ret.2 = phi(incoming_values=[Var(ret.1, debug_typeinfer.py:8), Var(ret, debug_typeinfer.py:6)], incoming_blocks=[12, 6]) ['ret', 'ret.1', 'ret.2']
    $18return_value.1 = cast(value=ret.2)    ['$18return_value.1', 'ret.2']
    return $18return_value.1                 ['$18return_value.1']

-----------------------------------propagate------------------------------------
---- type variables ----
[$18return_value.1 := int64,
 a := int64,
 arg.a := int64,
 arg.b := int64,
 arg.c := bool,
 b := int64,
 c := bool,
 ret := int64,
 ret.1 := int64,
 ret.2 := int64]
...
```

The IR dump only appears once, and the versioned names are given in the IR, so it's easier to relate the outcome of each propagation step back to the IR.

I've also removed the logging of all before-and-after-SSA IR dumps, as it seems redundant with the addition of this option.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
