### PR TITLE
CUDA Eager compilation: Fix max_registers kwarg

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -91,9 +91,12 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
         if restype and not device and restype != types.void:
             raise TypeError("CUDA kernel must have void return type.")
 
+        max_registers = kws.get('max_registers', None)
+
         def kernel_jit(func):
             kernel = compile_kernel(func, argtypes, link=link, debug=debug,
-                                    inline=inline, fastmath=fastmath)
+                                    inline=inline, fastmath=fastmath,
+                                    max_registers=max_registers)
 
             # Force compilation for the current context
             if bind:

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -5,7 +5,7 @@ from numba.cuda.testing import skip_on_cudasim
 from numba.cuda.testing import CUDATestCase
 from numba.cuda.cudadrv.driver import Linker
 from numba.cuda import require_context
-from numba import cuda
+from numba import cuda, void, float64, int64
 
 
 def function_with_lots_of_registers(x, a, b, c, d, e, f):
@@ -105,6 +105,12 @@ class TestLinker(CUDATestCase):
     def test_set_registers_38(self):
         compiled = cuda.jit(max_registers=38)(function_with_lots_of_registers)
         compiled = compiled.specialize(np.empty(32), *range(6))
+        self.assertLessEqual(compiled._func.get().attrs.regs, 38)
+
+    @require_context
+    def test_set_registers_eager(self):
+        sig = void(float64[::1], int64, int64, int64, int64, int64, int64)
+        compiled = cuda.jit(sig, max_registers=38)(function_with_lots_of_registers)
         self.assertLessEqual(compiled._func.get().attrs.regs, 38)
 
 


### PR DESCRIPTION
The `max_registers` kwarg to `@cuda.jit` was getting dropped for eager compilation. This PR fixes it by passing the `max_registers` kwarg, if present, to `compile_kernel` when eagerly compiling.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
