### PR TITLE
A fix for cases where SSA looks like a reduction variable.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3316,7 +3316,7 @@ def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=
             param_nodes[param].reverse()
             reduce_nodes = get_reduce_nodes(param, param_nodes[param], func_ir)
             # SSA can make things look like reductions except that they don't
-            # reduction operators.  If we get to this point but don't find a
+            # have reduction operators.  If we get to this point but don't find a
             # reduction operator then assume it is SSA.
             if reduce_nodes is not None:
                 reduce_varnames.append(param_name)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3315,9 +3315,12 @@ def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=
         if param_name in used_vars and param_name not in reduce_varnames:
             param_nodes[param].reverse()
             reduce_nodes = get_reduce_nodes(param, param_nodes[param], func_ir)
-            # SSA can make things look like reductions except that they don't
-            # have reduction operators.  If we get to this point but don't find a
-            # reduction operator then assume it is SSA.
+            # Certain kinds of ill-formed Python (like potentially undefined
+            # variables) in combination with SSA can make things look like
+            # reductions except that they don't have reduction operators.
+            # If we get to this point but don't find a reduction operator
+            # then assume it is this situation and just don't treat this
+            # variable as a reduction.
             if reduce_nodes is not None:
                 reduce_varnames.append(param_name)
                 check_conflicting_reduction_operators(param, reduce_nodes)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3313,17 +3313,21 @@ def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=
         # param already
         param_name = param.name
         if param_name in used_vars and param_name not in reduce_varnames:
-            reduce_varnames.append(param_name)
             param_nodes[param].reverse()
             reduce_nodes = get_reduce_nodes(param, param_nodes[param], func_ir)
-            check_conflicting_reduction_operators(param, reduce_nodes)
-            gri_out = guard(get_reduction_init, reduce_nodes)
-            if gri_out is not None:
-                init_val, redop = gri_out
-            else:
-                init_val = None
-                redop = None
-            reductions[param_name] = (init_val, reduce_nodes, redop)
+            # SSA can make things look like reductions except that they don't
+            # reduction operators.  If we get to this point but don't find a
+            # reduction operator then assume it is SSA.
+            if reduce_nodes is not None:
+                reduce_varnames.append(param_name)
+                check_conflicting_reduction_operators(param, reduce_nodes)
+                gri_out = guard(get_reduction_init, reduce_nodes)
+                if gri_out is not None:
+                    init_val, redop = gri_out
+                else:
+                    init_val = None
+                    redop = None
+                reductions[param_name] = (init_val, reduce_nodes, redop)
 
     return reduce_varnames, reductions
 
@@ -3421,7 +3425,6 @@ def get_reduce_nodes(reduction_node, nodes, func_ir):
                 replace_vars_inner(rhs, replace_dict)
                 reduce_nodes = nodes[i:]
                 break;
-    assert reduce_nodes, "Invalid reduction format"
     return reduce_nodes
 
 def get_expr_args(expr):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2502,17 +2502,19 @@ class TestPrange(TestPrangeBase):
         # reduction variable except that it lacks an associated
         # reduction operator.  Test here that h is excluded as a
         # reduction variable.
-        def test_impl(image, a):
+        def test_impl(image, a, b):
             empty = np.zeros(image.shape)
             for i in range(image.shape[0]):
                 r = image[i][0] / 255.0
                 if a == 0:
                     h = 0
+                if b == 0:
+                    h = 0
                 empty[i] = [h, h, h]
             return empty
 
         image = np.zeros((3, 3), dtype=np.int32)
-        self.prange_tester(test_impl, image, 0)
+        self.prange_tester(test_impl, image, 0, 0)
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2506,6 +2506,7 @@ class TestPrange(TestPrangeBase):
             empty = np.zeros(image.shape)
             for i in range(image.shape[0]):
                 r = image[i][0] / 255.0
+                h = 1
                 if b == 0:
                     h = 0
                 if a == r and b != 0:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2502,20 +2502,17 @@ class TestPrange(TestPrangeBase):
         # reduction variable except that it lacks an associated
         # reduction operator.  Test here that h is excluded as a
         # reduction variable.
-        def test_impl(image, a, b):
+        def test_impl(image, a):
             empty = np.zeros(image.shape)
             for i in range(image.shape[0]):
                 r = image[i][0] / 255.0
-                h = 1
-                if b == 0:
-                    h = 0
-                if a == r and b != 0:
+                if a == 0:
                     h = 0
                 empty[i] = [h, h, h]
             return empty
 
         image = np.zeros((3, 3), dtype=np.int32)
-        self.prange_tester(test_impl, image, 0, 0)
+        self.prange_tester(test_impl, image, 0)
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2495,6 +2495,28 @@ class TestPrange(TestPrangeBase):
         x = [np.array([1,2,3], dtype=int),np.array([1,2], dtype=int)]
         self.prange_tester(test_impl, x)
 
+    @skip_parfors_unsupported
+    def test_ssa_false_reduction(self):
+        # issue5698
+        # SSA for h creates assignments to h that make it look like a
+        # reduction variable except that it lacks an associated
+        # reduction operator.  Test here that h is excluded as a
+        # reduction variable.
+        def test_impl(image, a, b):
+            empty = np.zeros(image.shape)
+            for i in range(image.shape[0]):
+                r = image[i][0] / 255.0
+                if b == 0:
+                    h = 0
+                if a == r and b != 0:
+                    h = 0
+                empty[i] = [h, h, h]
+            return empty
+
+        image = np.zeros((3, 3), dtype=np.int32)
+        self.prange_tester(test_impl, image, 0, 0)
+
+
 @skip_parfors_unsupported
 @x86_only
 class TestParforsVectorizer(TestPrangeBase):


### PR DESCRIPTION
Resolves #5698 

I tried several approaches here.  I tried making this reduction code work with vars instead of strings so that I could check if all the nodes in the reduction dependency graphs were variation on a single SSA variable.  However, if there are multiple if's where the variable can be defined then those versions of the variable inside the "if" aren't considered the same as the variable outside the if.

This PR just says that if there is no reduction operator then there is no reduction which resolves this particular issue.  However, if the loops starts with "h=0" but also contains "h=h+1" then we'd see a reduction operator in the chain so maybe this solution isn't right.