### PR TITLE
Docs: Add example usage of List.empty_list

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -574,13 +574,24 @@ function:
    :dedent: 4
    :linenos:
 
-Finally, here's an example of using a nested `List()`:
+Here's an example of using a nested ``List()``:
 
 .. literalinclude:: ../../../examples/typed_list_usage.py
    :language: python
    :caption: from ``ex_nested_list`` of ``examples/typed_list_usage.py``
    :start-after: magictoken.ex_nested_list.begin
    :end-before: magictoken.ex_nested_list.end
+   :dedent: 4
+   :linenos:
+
+If you don't want the list type to be inferred, you can use
+``List.empty_list()`` to create a list with explicit type. For example:
+
+.. literalinclude:: ../../../examples/typed_list_usage.py
+   :language: python
+   :caption: from ``ex_empty_list`` of ``examples/typed_list_usage.py``
+   :start-after: magictoken.ex_empty_list.begin
+   :end-before: magictoken.ex_empty_list.end
    :dedent: 4
    :linenos:
 

--- a/examples/typed_list_usage.py
+++ b/examples/typed_list_usage.py
@@ -11,7 +11,8 @@ def ex_inferred_list_jit():
     def foo():
         # Instantiate a typed-list
         l = List()
-        # Append a value to it, this will set the type to int32/int64 (depending on platform)
+        # Append a value to it, this will set the type to int32/int64
+        # (depending on platform)
         l.append(42)
         # The usual list operations, getitem, pop and length are supported
         print(l[0])   # 42
@@ -25,6 +26,9 @@ def ex_inferred_list_jit():
     mylist = foo()
 
     # magictoken.ex_inferred_list_jit.end
+
+    # Return mylist outside the example to avoid flake8 error
+    return mylist
 
 
 def ex_inferred_list():
@@ -40,7 +44,8 @@ def ex_inferred_list():
 
     # Instantiate a typed-list, outside of a jit context
     l = List()
-    # Append a value to it, this will set the type to int32/int64 (depending on platform)
+    # Append a value to it, this will set the type to int32/int64
+    # (depending on platform)
     l.append(42)
     # The usual list operations, getitem, pop and length are supported
     print(l[0])   # 42
@@ -73,3 +78,22 @@ def ex_nested_list():
     print(mylist)
 
     # magictoken.ex_nested_list.end
+
+
+def ex_empty_list():
+    # magictoken.ex_empty_list.begin
+    from numba.typed import List
+    from numba import types, njit
+
+    @njit
+    def main(n):
+        l = List()
+        for _ in range(n):
+            sublist = List.empty_list(types.int64)
+            l.append(sublist)
+        return l
+
+    # Produces a list of five empty typed lists of int64 type
+    print(main(5))
+
+    # magictoken.ex_empty_list.end


### PR DESCRIPTION
Also some minor edits to examples/typed_list_usage.py to fix flake8 errors, that prevent committing when a pre-commit hook is used.

This came up in https://gitter.im/numba/numba?at=5ec146b50e8a3131e4c8722e, and I noticed that `empty_list` doesn't seem to be documented anywhere.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
