### PR TITLE
CUDA lib path tests: unset CUDA_PATH when CUDA_HOME unset

### DIFF
--- a/numba/cuda/tests/nocuda/test_library_lookup.py
+++ b/numba/cuda/tests/nocuda/test_library_lookup.py
@@ -129,6 +129,7 @@ class TestLibDeviceLookUp(LibraryLookupBase):
     @staticmethod
     def do_clear_envs():
         remove_env('CUDA_HOME')
+        remove_env('CUDA_PATH')
         remove_env('NUMBAPRO_CUDALIB')
         remove_env('NUMBAPRO_LIBDEVICE')
         return True, _get_libdevice_path_decision()
@@ -194,6 +195,7 @@ class TestNvvmLookUp(LibraryLookupBase):
     @staticmethod
     def do_clear_envs():
         remove_env('CUDA_HOME')
+        remove_env('CUDA_PATH')
         remove_env('NUMBAPRO_CUDALIB')
         remove_env('NUMBAPRO_NVVM')
         return True, _get_nvvm_path_decision()
@@ -259,6 +261,7 @@ class TestCudaLibLookUp(LibraryLookupBase):
     @staticmethod
     def do_clear_envs():
         remove_env('CUDA_HOME')
+        remove_env('CUDA_PATH')
         remove_env('NUMBAPRO_CUDALIB')
         return True, _get_cudalib_dir_path_decision()
 


### PR DESCRIPTION
The library lookup mechanism in `numba.cuda.cuda_paths.get_cuda_home()` tries `CUDA_PATH` if `CUDA_HOME` is unset. This causes a problem for the test_library_lookup tests if `CUDA_PATH` is set, because it unsets `CUDA_HOME` then expects not to find the CUDA toolkit by the `CUDA_PATH` method.

The `CUDA_PATH` variable can sometimes be set on Windows, or on other platforms where the conda-forge CuPy package is installed - it adds an activation script to the conda environment that sets `CUDA_PATH` to point to the conda environment.

This PR rectifies the issue by changing the tests so that they also unset `CUDA_PATH` when `CUDA_HOME` is unset.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
