### PR TITLE
Initialize process lock lazily to prevent multiprocessing issue

### DIFF
--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -287,28 +287,33 @@ class _nop(object):
         pass
 
 
-try:
-    # Force the use of an RLock in the case a fork was used to start the
-    # process and thereby the init sequence, some of the threading backend
-    # init sequences are not fork safe. Also, windows global mp locks seem
-    # to be fine.
-    if "fork" in multiprocessing.get_start_method() or _windows:
-        _backend_init_process_lock = multiprocessing.get_context().RLock()
-    else:
+_backend_init_process_lock = None
+
+
+def _set_init_process_lock():
+    global _backend_init_process_lock
+    try:
+        # Force the use of an RLock in the case a fork was used to start the
+        # process and thereby the init sequence, some of the threading backend
+        # init sequences are not fork safe. Also, windows global mp locks seem
+        # to be fine.
+        if "fork" in multiprocessing.get_start_method() or _windows:
+            _backend_init_process_lock = multiprocessing.get_context().RLock()
+        else:
+            _backend_init_process_lock = _nop()
+    
+    except OSError as e:
+    
+        # probably lack of /dev/shm for semaphore writes, warn the user
+        msg = ("Could not obtain multiprocessing lock due to OS level error: %s\n"
+               "A likely cause of this problem is '/dev/shm' is missing or"
+               "read-only such that necessary semaphores cannot be written.\n"
+               "*** The responsibility of ensuring multiprocessing safe access to "
+               "this initialization sequence/module import is deferred to the "
+               "user! ***\n")
+        warnings.warn(msg % str(e))
+    
         _backend_init_process_lock = _nop()
-
-except OSError as e:
-
-    # probably lack of /dev/shm for semaphore writes, warn the user
-    msg = ("Could not obtain multiprocessing lock due to OS level error: %s\n"
-           "A likely cause of this problem is '/dev/shm' is missing or"
-           "read-only such that necessary semaphores cannot be written.\n"
-           "*** The responsibility of ensuring multiprocessing safe access to "
-           "this initialization sequence/module import is deferred to the "
-           "user! ***\n")
-    warnings.warn(msg % str(e))
-
-    _backend_init_process_lock = _nop()
 
 _is_initialized = False
 
@@ -361,6 +366,9 @@ def _check_tbb_version_compatible():
 
 
 def _launch_threads():
+    if not _backend_init_process_lock:
+        _set_init_process_lock()
+
     with _backend_init_process_lock:
         with _backend_init_thread_lock:
             global _is_initialized

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -301,19 +301,22 @@ def _set_init_process_lock():
             _backend_init_process_lock = multiprocessing.get_context().RLock()
         else:
             _backend_init_process_lock = _nop()
-    
+
     except OSError as e:
-    
+
         # probably lack of /dev/shm for semaphore writes, warn the user
-        msg = ("Could not obtain multiprocessing lock due to OS level error: %s\n"
-               "A likely cause of this problem is '/dev/shm' is missing or"
-               "read-only such that necessary semaphores cannot be written.\n"
-               "*** The responsibility of ensuring multiprocessing safe access to "
-               "this initialization sequence/module import is deferred to the "
-               "user! ***\n")
+        msg = (
+            "Could not obtain multiprocessing lock due to OS level error: %s\n"
+            "A likely cause of this problem is '/dev/shm' is missing or"
+            "read-only such that necessary semaphores cannot be written.\n"
+            "*** The responsibility of ensuring multiprocessing safe access to "
+            "this initialization sequence/module import is deferred to the "
+            "user! ***\n"
+        )
         warnings.warn(msg % str(e))
-    
+
         _backend_init_process_lock = _nop()
+
 
 _is_initialized = False
 

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -862,33 +862,33 @@ class TestInitSafetyIssues(TestCase):
 
     _DEBUG = False
 
+    def run_cmd(self, cmdline):
+        popen = subprocess.Popen(cmdline,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,)
+        # finish in _TEST_TIMEOUT seconds or kill it
+        timeout = threading.Timer(_TEST_TIMEOUT, popen.kill)
+        try:
+            timeout.start()
+            out, err = popen.communicate()
+            if popen.returncode != 0:
+                raise AssertionError(
+                    "process failed with code %s: stderr follows\n%s\n" %
+                    (popen.returncode, err.decode()))
+        finally:
+            timeout.cancel()
+        return out.decode(), err.decode()
+
+
     @linux_only # only linux can leak semaphores
     def test_orphaned_semaphore(self):
         # sys path injection and separate usecase module to make sure everything
         # is importable by children of multiprocessing
 
-        def run_cmd(cmdline):
-            popen = subprocess.Popen(cmdline,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE,)
-            # finish in _TEST_TIMEOUT seconds or kill it
-            timeout = threading.Timer(_TEST_TIMEOUT, popen.kill)
-            try:
-                timeout.start()
-                out, err = popen.communicate()
-                if popen.returncode != 0:
-                    raise AssertionError(
-                        "process failed with code %s: stderr follows\n%s\n" %
-                        (popen.returncode, err.decode()))
-            finally:
-                timeout.cancel()
-            return out.decode(), err.decode()
-
         test_file = os.path.join(os.path.dirname(__file__),
                                  "orphaned_semaphore_usecase.py")
-
         cmdline = [sys.executable, test_file]
-        out, err = run_cmd(cmdline)
+        out, err = self.run_cmd(cmdline)
 
         # assert no semaphore leaks reported on stderr
         self.assertNotIn("leaked semaphore", err)
@@ -896,6 +896,27 @@ class TestInitSafetyIssues(TestCase):
         if self._DEBUG:
             print("OUT:", out)
             print("ERR:", err)
+
+    def test_lazy_lock_init(self):
+        # checks based on https://github.com/numba/numba/pull/5724
+        # looking for "lazy" process lock initialisation so as to avoid setting
+        # a multiprocessing context as part of import.
+        for meth in ('fork', 'spawn', 'forkserver'):
+            # if a context is available on the host check it can be set as the
+            # start method in a separate process
+            try:
+                multiprocessing.get_context(meth)
+            except ValueError:
+                continue
+            cmd = ("import numba; import multiprocessing;"
+                   "multiprocessing.set_start_method('{}');"
+                   "print(multiprocessing.get_context().get_start_method())")
+            cmdline = [sys.executable, "-c", cmd.format(meth)]
+            out, err = self.run_cmd(cmdline)
+            self.assertIn(meth, out)
+            if self._DEBUG:
+                print("OUT:", out)
+                print("ERR:", err)
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -864,8 +864,8 @@ class TestInitSafetyIssues(TestCase):
 
     def run_cmd(self, cmdline):
         popen = subprocess.Popen(cmdline,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,)
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,)
         # finish in _TEST_TIMEOUT seconds or kill it
         timeout = threading.Timer(_TEST_TIMEOUT, popen.kill)
         try:
@@ -878,7 +878,6 @@ class TestInitSafetyIssues(TestCase):
         finally:
             timeout.cancel()
         return out.decode(), err.decode()
-
 
     @linux_only # only linux can leak semaphores
     def test_orphaned_semaphore(self):

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -912,10 +912,10 @@ class TestInitSafetyIssues(TestCase):
                    "print(multiprocessing.get_context().get_start_method())")
             cmdline = [sys.executable, "-c", cmd.format(meth)]
             out, err = self.run_cmd(cmdline)
-            self.assertIn(meth, out)
             if self._DEBUG:
                 print("OUT:", out)
                 print("ERR:", err)
+            self.assertIn(meth, out)
 
 
 @skip_parfors_unsupported


### PR DESCRIPTION
## Background and about this PR

Due to the side-effect made by `multiprocessing.get_context` which is called at numba import time [here](https://github.com/numba/numba/blob/f3ca34da03b03c62a27daacfbddf63f7d72e7cee/numba/np/ufunc/parallel.py#L296), some of operations like `multiprocessing.set_start_method` raise the following error.
```python
>>> import numba
>>> import multiprocessing
>>> multiprocessing.set_start_method('forkserver')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/xxxx/.pyenv/versions/miniconda3-4.7.12/lib/python3.7/multiprocessing/context.py", line 242, in set_start_method
    raise RuntimeError('context has already been set')
RuntimeError: context has already been set
```
This PR is the fix for this issue.

### Reason

There are 2 facts in background.
* (1) `multiprocessing` module requires to set process start method by `set_start_method` at most once during the master process lifetime.
* (2) Calling `multiprocessing.get_context` with the default argument globally sets the default one (`"fork"`) implicitly, if nothing has been set until then.
    * https://github.com/python/cpython/blob/3.7/Lib/multiprocessing/context.py#L232-L238

In the current Numba this runs at import time, which means that once we import numba the process start method is already set implicitly (Fact (2)). Therefore users can no longer change the process launch method of multiprocessing module anymore (Fact (1)), regardless of what mode the user actually wants to specify (either "fork", "forkserver" or "spawn").

Here is the minimum simulation of what is happening inside.
```python
>>> import multiprocessing
>>> cxt = multiprocessing.get_context()
>>> multiprocessing.set_start_method('forkserver')
...
RuntimeError: context has already been set

>>> multiprocessing.set_start_method('fork')
...
RuntimeError: context has already been set
```

### Workaround

We can prevent this error by making sure to call `set_start_method` _before_ importing numba.
This means that we always have to be very careful of import order (and possible violation of pep8/flake8) if there is a specific need of changing process start mode.

In this PR I tried to solve this by eliminating the side-effect in import time, by initializing `_backend_init_process_lock` lazily when it's necessary.


### Effect & Confirmation of this PR

You can reproduce and confirm the effect of this PR by checking if `set_start_method` raises the error.

```python
>>> import numba
>>> import multiprocessing
>>> multiprocessing.set_start_method('forkserver')
(No error will occur after this patch is applied)
```

## Testing concerns

I'm quite new to Numba so I am unfamiliar with where and how this should be tested.
I thought that this PR intends to exactly keep the current behavior so confirmation of existing test cases would work, but if there is some suggestions, I'm happy to make any further efforts.


<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
