### PR TITLE
Enable dispatcher instances as 1st class function types when used in argument tuples

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -120,7 +120,7 @@ class BaseTuple(ConstSized, Hashable):
     """
 
     @classmethod
-    def from_types(cls, tys, pyclass=None):
+    def from_types(cls, tys, pyclass=None, typeofctx=None):
         """
         Instantiate the right tuple type for the given element types.
         """
@@ -135,7 +135,7 @@ class BaseTuple(ConstSized, Hashable):
                 else:
                     return NamedTuple(tys, pyclass)
         else:
-            dtype = utils.unified_function_type(tys)
+            dtype = utils.unified_function_type(tys, typeofctx=typeofctx)
             if dtype is not None:
                 return UniTuple(dtype, len(tys))
             # non-named tuple

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -157,7 +157,7 @@ def _typeof_tuple(val, c):
     tys = [typeof_impl(v, c) for v in val]
     if any(ty is None for ty in tys):
         return
-    return types.BaseTuple.from_types(tys, type(val))
+    return types.BaseTuple.from_types(tys, type(val), typeofctx=c)
 
 @typeof_impl.register(list)
 def _typeof_list(val, c):

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -473,7 +473,8 @@ def unify_function_types(numba_types):
     return (dtype,) * len(numba_types)
 
 
-def unified_function_type(numba_types, require_precise=True):
+def unified_function_type(numba_types, require_precise=True,
+                          typeofctx=None):
     """Returns a unified Numba function type if possible.
 
     Parameters
@@ -544,6 +545,10 @@ def unified_function_type(numba_types, require_precise=True):
                     assert function == t
         else:
             return
+    if typeofctx is not None:
+        from .typing.typeof import Purpose
+        if typeofctx.purpose == Purpose.argument:
+            require_precise = False
     if require_precise and (function is None or undefined_function is not None):
         return
     if function is not None:

--- a/numba/tests/test_function_type.py
+++ b/numba/tests/test_function_type.py
@@ -490,7 +490,7 @@ class TestFunctionType(TestCase):
         sig = int64(int64)
 
         for decor in [mk_cfunc_func(sig), mk_wap_func(sig),
-                      mk_njit_with_sig_func(sig)]:
+                      mk_njit_with_sig_func(sig), njit_func]:
             for jit_opts in [dict(nopython=True), dict(forceobj=True)]:
                 jit_ = jit(**jit_opts)
                 with self.subTest(decor=decor.__name__):
@@ -521,7 +521,7 @@ class TestFunctionType(TestCase):
         sig = int64(int64)
 
         for decor in [mk_cfunc_func(sig), mk_wap_func(sig),
-                      mk_njit_with_sig_func(sig)]:
+                      mk_njit_with_sig_func(sig), njit_func]:
             for jit_opts in [dict(nopython=True), dict(forceobj=True)]:
                 jit_ = jit(**jit_opts)
                 with self.subTest(decor=decor.__name__):


### PR DESCRIPTION
Tackles issue #5641 .

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
