### PR TITLE
CUDA Docs: document `forall` method of kernels

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -9,13 +9,16 @@ The ``@cuda.jit`` decorator is used to create a CUDA kernel:
 .. autofunction:: numba.cuda.jit
 
 .. autoclass:: numba.cuda.compiler.AutoJitCUDAKernel
-   :members: inspect_asm, inspect_llvm, inspect_types, specialize, extensions
+   :members: inspect_asm, inspect_llvm, inspect_types, specialize, extensions,
+             forall
 
 Individual specialized kernels are instances of
 :class:`numba.cuda.compiler.CUDAKernel`:
 
 .. autoclass:: numba.cuda.compiler.CUDAKernel
-   :members: bind, ptx, device, inspect_llvm, inspect_asm, inspect_types
+   :members: bind, ptx, device, inspect_llvm, inspect_asm, inspect_types,
+             forall
+
 
 Intrinsic Attributes and Functions
 ----------------------------------

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -331,12 +331,24 @@ class CUDAKernelBase(object):
         return self.configure(*args)
 
     def forall(self, ntasks, tpb=0, stream=0, sharedmem=0):
-        """Returns a configured kernel for 1D kernel of given number of tasks
+        """Returns a 1D-configured kernel for a given number of tasks
         ``ntasks``.
 
         This assumes that:
-        - the kernel 1-to-1 maps global thread id ``cuda.grid(1)`` to tasks.
-        - the kernel must check if the thread id is valid."""
+
+        - the kernel maps the Global Thread ID ``cuda.grid(1)`` to tasks on a
+          1-1 basis.
+        - the kernel checks that the Global Thread ID is upper-bounded by
+          ``ntasks``, and does nothing if it is not.
+
+        :param ntasks: The number of tasks.
+        :param tpb: The size of a block. An appropriate value is chosen if this
+                    parameter is not supplied.
+        :param stream: The stream on which the configured kernel will be
+                       launched.
+        :param sharedmem: The number of bytes of dynamic shared memory required
+                          by the kernel.
+        :return: A configured kernel, ready to launch on a set of arguments."""
 
         return ForAll(self, ntasks, tpb=tpb, stream=stream, sharedmem=sharedmem)
 


### PR DESCRIPTION
I noticed there seems not to be any mention of `forall` in the docs - as this is intended to be a public API, this PR adds them to the documentation.