### PR TITLE
Unbreak master on buildfarm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ min_python_version = "3.6"
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.15"
 min_llvmlite_version = "0.31.0.dev0"
-max_llvmlite_version = "0.33.0.dev0"
+max_llvmlite_version = "0.34"
 
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython
@@ -304,7 +304,7 @@ packages = find_packages(include=["numba", "numba.*"])
 
 build_requires = [f'numpy >={min_numpy_build_version}']
 install_requires = [
-    f'llvmlite >={min_llvmlite_version},<={max_llvmlite_version}',
+    f'llvmlite >={min_llvmlite_version},<{max_llvmlite_version}',
     f'numpy >={min_numpy_run_version}',
     'setuptools',
 ]


### PR DESCRIPTION
buildfarm is broken because of checks on llvmlite version is failing during loading of entrypoints. 

for example, buildfarm is creating llvmlite version:

```python
>>> import llvmlite
>>> llvmlite.__version__
'0.33.0dev0+17.gc4f5a08'
```

The version spec comparison thinks the above is greater than `0.33.0dev0` and fails.

To replicate the problem, get a llvmlite from buildfarm and just run 

```
$ python -m numba.runtests numba.tests.test_entrypoints.TestEntrypoints.test_entrypoint_tolerance
```