### PR TITLE
[DISCUSSION] Allow CUDA array interface to be a callable

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -20,8 +20,11 @@ Python Interface Specification
 
 .. note:: Experimental feature.  Specification may change.
 
-The ``__cuda_array_interface__`` attribute returns a dictionary (``dict``)
-that must contain the following entries:
+For providing a CUDA array interface, an object must contain either a
+``__cuda_array_interface__`` dictionary (``dict``) attribute or a method
+named ``__cuda_array_interface__`` that takes no arguments and returns
+a dictionary.
+The dictionary must contain the following entries:
 
 - **shape**: ``(integer, ...)``
 

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -29,6 +29,9 @@ def from_cuda_array_interface(desc, owner=None):
     The *owner* is the owner of the underlying memory.
     The resulting DeviceNDArray will acquire a reference from it.
     """
+    # Argument may be a description or callable description provider
+    desc = desc() if callable(desc) else desc
+
     version = desc.get('version')
     # Mask introduced in version 1
     if 1 <= version:

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,6 +1,7 @@
 import contextlib
 import os
 import sys
+import enum
 
 from numba.tests.support import (
     captured_stdout,
@@ -104,7 +105,14 @@ class ForeignArray(object):
     Array interface. This just hides a DeviceNDArray so that it doesn't look
     like a DeviceNDArray.
     """
+    class InterfaceType(enum.Enum):
+        Attribute = "Attribute"  #: Provide interface description as attribute
+        Callable = "Callable"  #: Provide interface description via callable
 
-    def __init__(self, arr):
+    def __init__(self, arr, iftype: InterfaceType = InterfaceType.Attribute):
         self._arr = arr
-        self.__cuda_array_interface__ = arr.__cuda_array_interface__
+        desc = arr.__cuda_array_interface__
+        desc = desc() if callable(desc) else desc
+        self.__cuda_array_interface__ = \
+            desc if iftype is ForeignArray.InterfaceType.Attribute \
+            else lambda: desc

--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -9,11 +9,15 @@ from numba.cuda.testing import skip_on_cudasim, skip_if_external_memmgr
 @skip_on_cudasim('CUDA Array Interface is not supported in the simulator')
 class TestCudaArrayInterface(ContextResettingTestCase):
     def test_as_cuda_array(self):
+        for iftype in ForeignArray.InterfaceType:
+            self._test_as_cuda_array(iftype)
+
+    def _test_as_cuda_array(self, iftype: ForeignArray.InterfaceType):
         h_arr = np.arange(10)
         self.assertFalse(cuda.is_cuda_array(h_arr))
         d_arr = cuda.to_device(h_arr)
         self.assertTrue(cuda.is_cuda_array(d_arr))
-        my_arr = ForeignArray(d_arr)
+        my_arr = ForeignArray(d_arr, iftype=iftype)
         self.assertTrue(cuda.is_cuda_array(my_arr))
         wrapped = cuda.as_cuda_array(my_arr)
         self.assertTrue(cuda.is_cuda_array(wrapped))


### PR DESCRIPTION
Spin-off discussion from #5162, concerning the topic of allowing `__cuda_array_interface__` to be a callable (possible realization included in PR).

**Current state**
Arguably, `__cuda_array_interface__` is always going to be a function call for gathering the required description information from an underlying array implementation. With CAI being specified as a `dict` attribute this effectively requires CAI to be a python `property`, which is a quite problematic abstraction for its purpose.

**Issues with `property`**
Providing a device array descriptor is a potentially non-trivial operation. An implementation may choose to (or be required to) execute additional steps for creating a valid descriptor (e.g. internal syncs, initialization, queries, etc.).

The `property` mechanic is almost a guarantee for making more calls to the CAI function than intended or desired:
```python
# CAI code invoked multiple times by what appears to be a simple attribute lookup
other_shape = obj.__cuda_array_interface__["shape"]
other_dtype = obj.__cuda_array_interface__["dtype"]

# CAI code invoked implicitly by `hasattr` check
has_cai = hasattr(obj, "__cuda_array_interface__")

# CAI code invoked as a side effect if the object is being inspected
members = inspect.getmembers(obj)
```

**Proposed solution**
Modify CAI specification for `__cuda_array_interface__` to be a `dict` or a `Callable[[], dict]`. Consumers can easily be adapted to work with both types in a backward compatible manner. CAI implementations are free to switch to the callable interface as they see fit.

Bonus: I can finally finish my CAI implementation for OpenCV, which doesn't support wrapping member functions as python properties ^^