### PR TITLE
Support NumPy 1.18

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 16
+  TEST_COUNT: 18
 
 jobs:
 # Mac and Linux use the same template with different matrixes
@@ -98,6 +98,16 @@ jobs:
         NUMPY: '1.17'
         CONDA_ENV: travisci
         TEST_START_INDEX: 13
+      py37_np118:
+        PYTHON: '3.7'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 14
+      py38_np118:
+        PYTHON: '3.8'
+        NUMPY: '1.18'
+        CONDA_ENV: travisci
+        TEST_START_INDEX: 15
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      py38_np117:
+      py38_np118:
         PYTHON: '3.8'
-        NUMPY: '1.17'
+        NUMPY: '1.18'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 14
+        TEST_START_INDEX: 16
       py37_np115:
         PYTHON: '3.7'
         NUMPY: '1.15'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 15
+        TEST_START_INDEX: 17
 
   steps:
     - task: CondaEnvironment@1

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -503,6 +503,8 @@ def array_min(context, builder, sig, args):
 
             it = np.nditer(arry)
             min_value = next(it).take(0)
+            if np.isnan(min_value):
+                return min_value
 
             for view in it:
                 v = view.item()
@@ -543,6 +545,8 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
+            if np.isnan(max_value):
+                return max_value
 
             for view in it:
                 v = view.item()
@@ -627,6 +631,8 @@ def array_argmin(context, builder, sig, args):
                 min_value = v
                 min_idx = 0
                 break
+            if np.isnan(min_value):
+                return min_idx
 
             idx = 0
             for v in arry.flat:
@@ -673,6 +679,8 @@ def array_argmax(context, builder, sig, args):
                 max_value = v
                 max_idx = 0
                 break
+            if np.isnan(max_value):
+                return max_idx
 
             idx = 0
             for v in arry.flat:

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -453,6 +453,7 @@ def zero_dim_msg(fn_name):
 def _is_nat(x):
     pass
 
+
 @overload(_is_nat)
 def ol_is_nat(x):
     if numpy_version >= (1, 18):
@@ -460,6 +461,7 @@ def ol_is_nat(x):
     else:
         nat = x('NaT')
         return lambda x: x == nat
+
 
 @lower_builtin(np.min, types.Array)
 @lower_builtin("array.min", types.Array)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -483,7 +483,10 @@ def array_min(context, builder, sig, args):
             for view in it:
                 v = view.item()
                 if _is_nat(v):
-                    return v
+                    if numpy_version >= (1, 18):
+                        return v
+                    else:
+                        continue
                 if v < min_value:
                     min_value = v
             return min_value
@@ -563,7 +566,10 @@ def array_max(context, builder, sig, args):
             for view in it:
                 v = view.item()
                 if _is_nat(v):
-                    return v
+                    if numpy_version >= (1, 18):
+                        return v
+                    else:
+                        continue
                 if v > max_value:
                     max_value = v
             return max_value
@@ -640,7 +646,11 @@ def array_argmin(context, builder, sig, args):
             for view in it:
                 v = view.item()
                 if _is_nat(v):
-                    return idx
+                    if numpy_version >= (1, 18):
+                        return idx
+                    else:
+                        idx += 1
+                        continue
                 if v < min_value:
                     min_value = v
                     min_idx = idx
@@ -709,7 +719,11 @@ def array_argmax(context, builder, sig, args):
             for view in it:
                 v = view.item()
                 if _is_nat(v):
-                    return idx
+                    if numpy_version >= (1, 18):
+                        return idx
+                    else:
+                        idx += 1
+                        continue
                 if v > max_value:
                     max_value = v
                     max_idx = idx

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -545,8 +545,6 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
-            if np.isnan(max_value):
-                return max_value
 
             for view in it:
                 v = view.item()
@@ -564,6 +562,8 @@ def array_max(context, builder, sig, args):
 
             it = np.nditer(arry)
             max_value = next(it).take(0)
+            if np.isnan(max_value):
+                return max_value
 
             for view in it:
                 v = view.item()

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -176,10 +176,11 @@ def _prepare_argument(ctxt, bld, inp, tyinp, where='input operand'):
         return _ArrayHelper(ctxt, bld, shape, strides, ary.data,
                             tyinp.layout, tyinp.dtype, tyinp.ndim, inp)
     elif (types.unliteral(tyinp) in types.number_domain | {types.boolean}
-          or isinstance(tyinp, types.NPTimedelta)):
+          or isinstance(tyinp, types.scalars._NPDatetimeBase)):
         return _ScalarHelper(ctxt, bld, inp, tyinp)
     else:
-        raise NotImplementedError('unsupported type for {0}: {1}'.format(where, str(tyinp)))
+        raise NotImplementedError('unsupported type for {0}: {1}'.format(where,
+                                  str(tyinp)))
 
 
 _broadcast_onto_sig = types.intp(types.intp, types.CPointer(types.intp),

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -868,7 +868,6 @@ def _fill_ufunc_db(ufunc_db):
             'M->?': npyfuncs.np_int_isinf_impl,
         })
 
-
     ufunc_db[np.isfinite] = {
         'f->?': npyfuncs.np_real_isfinite_impl,
         'd->?': npyfuncs.np_real_isfinite_impl,

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -832,6 +832,12 @@ def _fill_ufunc_db(ufunc_db):
         '?->?': npyfuncs.np_int_isnan_impl,
     }
 
+    if numpy_version >= (1, 18):
+        ufunc_db[np.isnan].update({
+            'm->?': npyfuncs.np_datetime_isnat_impl,
+            'M->?': npyfuncs.np_datetime_isnat_impl,
+        })
+
     ufunc_db[np.isinf] = {
         'f->?': npyfuncs.np_real_isinf_impl,
         'd->?': npyfuncs.np_real_isinf_impl,
@@ -855,6 +861,13 @@ def _fill_ufunc_db(ufunc_db):
         # boolean
         '?->?': npyfuncs.np_int_isinf_impl,
     }
+
+    if numpy_version >= (1, 18):
+        ufunc_db[np.isinf].update({
+            'm->?': npyfuncs.np_int_isinf_impl,
+            'M->?': npyfuncs.np_int_isinf_impl,
+        })
+
 
     ufunc_db[np.isfinite] = {
         'f->?': npyfuncs.np_real_isfinite_impl,
@@ -1066,22 +1079,22 @@ def _fill_ufunc_db(ufunc_db):
         'mm->?': npdatetime.timedelta_ge_timedelta_impl,
     })
     ufunc_db[np.maximum].update({
-        'MM->M': npdatetime.datetime_max_impl,
-        'mm->m': npdatetime.timedelta_max_impl,
+        'MM->M': npdatetime.datetime_maximum_impl,
+        'mm->m': npdatetime.timedelta_maximum_impl,
     })
     ufunc_db[np.minimum].update({
-        'MM->M': npdatetime.datetime_min_impl,
-        'mm->m': npdatetime.timedelta_min_impl,
+        'MM->M': npdatetime.datetime_minimum_impl,
+        'mm->m': npdatetime.timedelta_minimum_impl,
     })
     # there is no difference for datetime/timedelta in maximum/fmax
     # and minimum/fmin
     ufunc_db[np.fmax].update({
-        'MM->M': npdatetime.datetime_max_impl,
-        'mm->m': npdatetime.timedelta_max_impl,
+        'MM->M': npdatetime.datetime_fmax_impl,
+        'mm->m': npdatetime.timedelta_fmax_impl,
     })
     ufunc_db[np.fmin].update({
-        'MM->M': npdatetime.datetime_min_impl,
-        'mm->m': npdatetime.timedelta_min_impl,
+        'MM->M': npdatetime.datetime_fmin_impl,
+        'mm->m': npdatetime.timedelta_fmin_impl,
     })
 
     if numpy_version >= (1, 16):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -209,9 +209,12 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         check(arr)
         arr = np.float64(['nan', -1.5, 2.5, 'nan', 'inf', '-inf', 3.0])
         check(arr)
-        # Only NaNs
-        arr = np.float64(['nan', 'nan'])
+        arr = np.float64([5.0, 'nan', -1.5, 'nan'])
         check(arr)
+        if all_nans:
+            # Only NaNs
+            arr = np.float64(['nan', 'nan'])
+            check(arr)
 
     def test_all_basic(self, pyfunc=array_all):
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -211,10 +211,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         check(arr)
         arr = np.float64([5.0, 'nan', -1.5, 'nan'])
         check(arr)
-        if all_nans:
-            # Only NaNs
-            arr = np.float64(['nan', 'nan'])
-            check(arr)
+        # Only NaNs
+        arr = np.float64(['nan', 'nan'])
+        check(arr)
 
     def test_all_basic(self, pyfunc=array_all):
         cfunc = jit(nopython=True)(pyfunc)
@@ -668,6 +667,15 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         # Test with a NaT
         arr[arr.size // 2] = 'NaT'
         self.assertPreciseEqual(cfunc(arr), pyfunc(arr))
+        if 'median' not in pyfunc.__name__:
+            # Test with (val, NaT)^N (and with the random NaT from above)
+            # use a loop, there's some weird thing/bug with arr[1::2] = 'NaT'
+
+            # Further Numba has bug(s) relating to NaN/NaT handling in anything
+            # using a partition such as np.median
+            for x in range(1, len(arr), 2):
+                arr[x] = 'NaT'
+            self.assertPreciseEqual(cfunc(arr), pyfunc(arr))
         # Test with all NaTs
         arr.fill(arrty.dtype('NaT'))
         self.assertPreciseEqual(cfunc(arr), pyfunc(arr))


### PR DESCRIPTION
Adds support for NumPy 1.18 and fixes a few bugs on the way.

This gets merged in:
Closes https://github.com/numba/numba/pull/5153

This also gets merged in:
Closes https://github.com/numba/numba/pull/4210

Also:

Closes https://github.com/numba/numba/issues/5752
Closes https://github.com/numba/numba/issues/5736
Closes https://github.com/numba/numba/issues/5178
Closes https://github.com/numba/numba/issues/4897
Closes https://github.com/numba/numba/issues/4125
Closes https://github.com/numba/numba/issues/5788