### PR TITLE
Add implmentation for int types for isnan and isinf for CUDA

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -468,6 +468,12 @@ def ptx_round(context, builder, sig, args):
     ])
 
 
+@lower(math.isinf, types.Integer)
+@lower(math.isnan, types.Integer)
+def math_isinf_isnan_int(context, builder, sig, args):
+    return lc.Constant.int(lc.Type.int(1), 0)
+
+
 def gen_deg_rad(const):
     def impl(context, builder, sig, args):
         argty, = sig.args

--- a/numba/cuda/libdevice.py
+++ b/numba/cuda/libdevice.py
@@ -105,14 +105,10 @@ binarys += [('__nv_hypot', '__nv_hypotf', math.hypot)]
 
 
 for name64, name32, key in booleans:
-    implf64 = bool_implement(name64, types.float64)
-    lower(key, types.float64)(implf64)
-    implf32 = bool_implement(name32, types.float32)
-    lower(key, types.float32)(implf32)
-    impli64 = bool_implement(name64, types.int64)
-    lower(key, types.int64)(impli64)
-    impli32 = bool_implement(name32, types.int32)
-    lower(key, types.int32)(impli32)
+    impl64 = bool_implement(name64, types.float64)
+    lower(key, types.float64)(impl64)
+    impl32 = bool_implement(name32, types.float32)
+    lower(key, types.float32)(impl32)
 
 
 for name64, name32, key in unarys:

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -1,7 +1,7 @@
 import sys
 import numpy as np
 from numba.cuda.testing import unittest, CUDATestCase
-from numba import cuda, float32, float64, int32
+from numba import cuda, float32, float64, int32, int64
 import math
 
 
@@ -198,12 +198,22 @@ class TestCudaMath(CUDATestCase):
         cfunc[1, nelem](A, B)
         self.assertTrue(np.allclose(npfunc(A), B))
 
+
     def unary_bool_template_float32(self, func, npfunc, start=0, stop=1):
         self.unary_template(func, npfunc, np.float32, float32, start, stop)
 
 
     def unary_bool_template_float64(self, func, npfunc, start=0, stop=1):
         self.unary_template(func, npfunc, np.float64, float64, start, stop)
+
+
+    def unary_bool_template_int32(self, func, npfunc, start=0, stop=49):
+        self.unary_template(func, npfunc, np.int32, int32, start, stop)
+
+
+    def unary_bool_template_int64(self, func, npfunc, start=0, stop=49):
+        self.unary_template(func, npfunc, np.int64, int64, start, stop)
+
 
     def unary_bool_template(self, func, npfunc, npdtype, npmtype, start, stop):
         nelem = 50
@@ -555,6 +565,8 @@ class TestCudaMath(CUDATestCase):
     def test_math_isnan(self):
         self.unary_bool_template_float32(math_isnan, np.isnan)
         self.unary_bool_template_float64(math_isnan, np.isnan)
+        self.unary_bool_template_int32(math_isnan, np.isnan)
+        self.unary_bool_template_int64(math_isnan, np.isnan)
 
     #------------------------------------------------------------------------------
     # test_math_isinf
@@ -563,6 +575,8 @@ class TestCudaMath(CUDATestCase):
     def test_math_isinf(self):
         self.unary_bool_template_float32(math_isinf, np.isinf)
         self.unary_bool_template_float64(math_isinf, np.isinf)
+        self.unary_bool_template_int32(math_isinf, np.isnan)
+        self.unary_bool_template_int64(math_isinf, np.isnan)
 
     #------------------------------------------------------------------------------
     # test_math_degrees


### PR DESCRIPTION
fixes #3789 
I have currently added a small change that fixes the issue. However as mentioned in the issue, it may be possible to return False whenever insnan and isinf. I would like some guidance as to how to add that. 