### PR TITLE
fix flake8 errors

### DIFF
--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -678,7 +678,7 @@ def do_boundscheck(context, builder, ind, dimlen, axis=None):
                        "for axis {} with size %d\n".format(axis), ind, dimlen)
             else:
                 printf(builder, "debug: IndexError: index %d is out of bounds "
-                       "for axis %d with size %d\n".format(axis), ind, axis,
+                       "for axis %d with size %d\n", ind, axis,
                        dimlen)
         else:
             printf(builder,

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -138,6 +138,7 @@ def register_jitable(*args, **kwargs):
     def wrap(fn):
         # It is just a wrapper for @overload
         inline = kwargs.pop('inline', 'never')
+
         @overload(fn, jit_options=kwargs, inline=inline, strict=False)
         def ov_wrap(*args, **kwargs):
             return fn

--- a/numba/core/types/function_type.py
+++ b/numba/core/types/function_type.py
@@ -52,7 +52,7 @@ class FunctionType(Type):
             # first-class function may not use the same argument names
             # that the caller assumes. [numba/issues/5540].
             raise errors.UnsupportedError(
-                f'first-class function call cannot use keyword arguments')
+                'first-class function call cannot use keyword arguments')
 
         if len(args) != self.nargs:
             raise ValueError(

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -251,6 +251,7 @@ if _py38_or_later:
         _PyHASH_XXPRIME_1 = _Py_uhash_t(11400714785074694791)
         _PyHASH_XXPRIME_2 = _Py_uhash_t(14029467366897019727)
         _PyHASH_XXPRIME_5 = _Py_uhash_t(2870177450012600261)
+
         @register_jitable(locals={'x': types.uint64})
         def _PyHASH_XXROTATE(x):
             # Rotate left 31 bits
@@ -259,6 +260,7 @@ if _py38_or_later:
         _PyHASH_XXPRIME_1 = _Py_uhash_t(2654435761)
         _PyHASH_XXPRIME_2 = _Py_uhash_t(2246822519)
         _PyHASH_XXPRIME_5 = _Py_uhash_t(374761393)
+
         @register_jitable(locals={'x': types.uint64})
         def _PyHASH_XXROTATE(x):
             # Rotate left 13 bits

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -665,6 +665,7 @@ def unicode_rindex(s, sub, start=None, end=None):
 
     return rindex_impl
 
+
 # https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L11692-L11718    # noqa: E501
 @overload_method(types.UnicodeType, 'index')
 def unicode_index(s, sub, start=None, end=None):

--- a/numba/cpython/unicode_support.py
+++ b/numba/cpython/unicode_support.py
@@ -322,6 +322,7 @@ def _PyUnicode_ToFoldedFull(ch, res):
         return n
     return _PyUnicode_ToLowerFull(ch, res)
 
+
 # From: https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodectype.c#L274-L279    # noqa: E501
 @register_jitable
 def _PyUnicode_IsCased(ch):

--- a/numba/tests/error_usecases.py
+++ b/numba/tests/error_usecases.py
@@ -1,4 +1,6 @@
 import numba as nb
+
+
 @nb.jit(nopython=True, parallel=True)
 def foo():
     pass

--- a/numba/tests/inlining_usecases.py
+++ b/numba/tests/inlining_usecases.py
@@ -12,6 +12,7 @@ def bar():
 
 def baz_factory(a):
     b = 17 + a
+
     @njit(inline='always')
     def baz():
         return _GLOBAL1 + a - b

--- a/numba/tests/npyufunc/test_dufunc.py
+++ b/numba/tests/npyufunc/test_dufunc.py
@@ -33,6 +33,7 @@ class TestDUFunc(MemoryLeakMixin, unittest.TestCase):
 
     def test_npm_call(self):
         duadd = self.nopython_dufunc(pyuadd)
+
         @njit
         def npmadd(a0, a1, o0):
             duadd(a0, a1, o0)
@@ -54,6 +55,7 @@ class TestDUFunc(MemoryLeakMixin, unittest.TestCase):
 
     def test_npm_call_implicit_output(self):
         duadd = self.nopython_dufunc(pyuadd)
+
         @njit
         def npmadd(a0, a1):
             return duadd(a0, a1)

--- a/numba/tests/pycc_distutils_usecase/nested/source_module.py
+++ b/numba/tests/pycc_distutils_usecase/nested/source_module.py
@@ -7,10 +7,12 @@ cc = CC('pycc_compiled_module')
 
 _const = 42
 
+
 # This ones references a global variable at compile time
 @cc.export('get_const', 'i8()')
 def get_const():
     return _const
+
 
 # This one needs NRT and an environment
 @cc.export('ones', 'f8[:](i4)')

--- a/numba/tests/test_conditions_as_predicates.py
+++ b/numba/tests/test_conditions_as_predicates.py
@@ -13,6 +13,7 @@ class TestConditionsAsPredicates(TestCase):
         for dt in dts:
             for c in 1, 0:
                 x = dt(c)
+
                 @njit
                 def foo():
                     if x:
@@ -21,6 +22,7 @@ class TestConditionsAsPredicates(TestCase):
                         return 20
                 self.assertEqual(foo(), foo.py_func())
                 self.assertEqual(foo(), 10 if c == 1 or dt is str else 20)
+
         # empty string
         @njit
         def foo(x):
@@ -164,7 +166,6 @@ class TestConditionsAsPredicates(TestCase):
         z = np.array(0)
         self.assertEqual(foo(z), foo.py_func(z))
         self.assertEqual(foo.py_func(z), 20)
-
         # non-empty nd True
         z = np.array([[[1]]])
         self.assertEqual(foo(z), foo.py_func(z))

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -244,6 +244,7 @@ class TestFunctionInlining(MemoryLeakMixin, InliningBase):
 
         def factory(inline, x, y):
             z = x + 12
+
             @njit(inline=inline)
             def func():
                 return (x, y + 3, z)
@@ -311,6 +312,7 @@ class TestFunctionInlining(MemoryLeakMixin, InliningBase):
 
         def factory():
             from .inlining_usecases import bar
+
             @njit(inline='always')
             def tmp():
                 return bar()
@@ -616,6 +618,7 @@ class TestOverloadInlining(MemoryLeakMixin, InliningBase):
 
             def factory(target, x, y, inline=None):
                 z = x + 12
+
                 @overload(target, inline=inline)
                 def func():
                     def impl():
@@ -675,6 +678,7 @@ class TestOverloadInlining(MemoryLeakMixin, InliningBase):
 
         def factory():
             from .inlining_usecases import baz
+
             @njit(inline='always')
             def tmp():
                 return baz()

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -443,6 +443,7 @@ class TestGetitemSlice(MemoryLeakMixin, TestCase):
 
     def test_list_getitem_multiple_slice_zero_step_index_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -654,6 +655,7 @@ class TestPop(MemoryLeakMixin, TestCase):
 
     def test_list_pop_empty_index_error_with_index(self):
         self.disable_leak_check()
+
         @njit
         def foo(i):
             l = listobject.new_list(int32)
@@ -682,6 +684,7 @@ class TestPop(MemoryLeakMixin, TestCase):
 
     def test_list_pop_mutiple_index_error_with_index(self):
         self.disable_leak_check()
+
         @njit
         def foo(i):
             l = listobject.new_list(int32)
@@ -923,6 +926,7 @@ class TestExtend(MemoryLeakMixin, TestCase):
 
     def test_list_extend_typing_error_non_iterable(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1003,6 +1007,7 @@ class TestInsert(MemoryLeakMixin, TestCase):
 
     def test_list_insert_typing_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1021,6 +1026,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_empty(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1041,6 +1047,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_singleton_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1064,6 +1071,7 @@ class TestRemove(MemoryLeakMixin, TestCase):
 
     def test_list_remove_multiple_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1220,6 +1228,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_singleton_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1235,6 +1244,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1251,6 +1261,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error_start(self):
         self.disable_leak_check()
+
         @njit
         def foo(start):
             l = listobject.new_list(int32)
@@ -1269,6 +1280,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_multiple_value_error_end(self):
         self.disable_leak_check()
+
         @njit
         def foo(end):
             l = listobject.new_list(int32)
@@ -1287,6 +1299,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_typing_error_start(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1302,6 +1315,7 @@ class TestIndex(MemoryLeakMixin, TestCase):
 
     def test_index_typing_error_end(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = listobject.new_list(int32)
@@ -1553,6 +1567,7 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
     def test_append_fails(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = make_test_list()

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1890,6 +1890,7 @@ class TestLiteralUnrollPassTriggering(TestCase):
 
     def test_literal_unroll_is_invoked_via_alias(self):
         alias = literal_unroll
+
         @njit(pipeline_class=CapturingCompiler)
         def foo():
             acc = 0

--- a/numba/tests/test_num_threads.py
+++ b/numba/tests/test_num_threads.py
@@ -526,6 +526,7 @@ class TestNumThreads(TestCase):
     @unittest.skipIf(not sys.platform.startswith('linux'), "Linux only")
     def _test_threadmask_across_fork(self):
         forkctx = multiprocessing.get_context('fork')
+
         @njit
         def foo():
             return get_num_threads()

--- a/numba/tests/test_numbers.py
+++ b/numba/tests/test_numbers.py
@@ -61,6 +61,7 @@ class TestViewIntFloat(TestCase):
 
     def test_python_scalar_exception(self):
         intty = getattr(np, 'int{}'.format(types.intp.bitwidth))
+
         @njit
         def myview():
             a = 1

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -1016,6 +1016,7 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     def test_list_as_item_in_list(self):
         nested_type = types.ListType(types.int32)
+
         @njit
         def foo():
             la = List.empty_list(nested_type)
@@ -1030,6 +1031,7 @@ class TestListRefctTypes(MemoryLeakMixin, TestCase):
 
     def test_array_as_item_in_list(self):
         nested_type = types.Array(types.float64, 1, 'C')
+
         @njit
         def foo():
             l = List.empty_list(nested_type)
@@ -1321,6 +1323,7 @@ class TestImmutable(MemoryLeakMixin, TestCase):
 
     def test_append_fails(self):
         self.disable_leak_check()
+
         @njit
         def foo():
             l = List()


### PR DESCRIPTION
As of flake8 version 3.8.2 (mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes:
2.2.0) -- some additional errors are being reported. This PR fixes those
errors.