### PR TITLE
fix exception during locale detection

### DIFF
--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -306,7 +306,10 @@ def get_sysinfo():
     # Python locale
     # On MacOSX, getdefaultlocale can raise. Check again if Py > 3.7.5
     try:
-        sys_info[_python_locale] = '.'.join(locale.getdefaultlocale())
+        # If $LANG is unset, getdefaultlocale() can return (None, None), make
+        # sure we can encode this as strings by casting explicitly.
+        sys_info[_python_locale] = '.'.join([str(i) for i in
+                                             locale.getdefaultlocale()])
     except Exception as e:
         _error_log.append(f'Error (locale): {e}')
 


### PR DESCRIPTION
Under certain circumstances for example if `$LANG` is unset in the
environment, `getdefaultlocale` can return the tuple `(None, None)`.
This in turn would cause an `Exception` to be raised by `join` at least
in Python 3.6, as it expects the iterable to contain `str`s. The result
was the following error message:

```
Error (locale): sequence item 0: expected str instance, NoneType found
```

Unfortunately the tests for the system info detection would then crash
making the test-suite fail. To mitigate this, we now cast everything
returned by `getdefaultlocale` to `str` to make sure that the call to
`join` will succeed. The output will then be `None.None` which is fine
as it indicates that no default locale was detected.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
