### PR TITLE
Return zero array from np.dot when the arguments are empty.

### DIFF
--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -392,8 +392,6 @@ def call_xxgemv(context, builder, do_trans,
                             builder.bitcast(v_data, ll_void_p),
                             builder.bitcast(beta, ll_void_p),
                             builder.bitcast(out_data, ll_void_p)))
-    # if lda == 0:
-    #     cgutils.memset(builder, res.data, builder.mul(res.itemsize, res.nitems), 0)
     check_blas_return(context, builder, res)
 
 
@@ -444,8 +442,6 @@ def call_xxgemm(context, builder,
                             builder.bitcast(alpha, ll_void_p), data_a, lda,
                             data_b, ldb, builder.bitcast(beta, ll_void_p),
                             data_c, ldc))
-    # if k == 0:
-    #     cgutils.memset(builder, res.data, builder.mul(res.itemsize, res.nitems), 0)
     check_blas_return(context, builder, res)
 
 
@@ -685,7 +681,7 @@ def dot_3_mm(context, builder, sig, args):
             cgutils.memset(builder, out.data,
                            builder.mul(out.itemsize, out.nitems), 0)
         with nonempty:
-            # Check whether any of the operands is really a 1-d vector represented
+            # Check if any of the operands is really a 1-d vector represented
             # as a (1, k) or (k, 1) 2-d array.  In those cases, it is pessimal
             # to call the generic matrix * matrix product BLAS function.
             one = ir.Constant(intp_t, 1)

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -609,7 +609,7 @@ def dot_3_vm(context, builder, sig, args):
         mty = xty
         m_shapes = x_shapes
         v_shape = y_shapes[0]
-        lda = m_shapes[1]
+        lda = m_shapes[0]
         do_trans = xty.layout == 'C'
         m_data, v_data = x.data, y.data
         check_args = dot_3_mv_check_args

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -618,7 +618,7 @@ def dot_3_vm(context, builder, sig, args):
     for val in m_shapes:
         check_c_int(context, builder, val)
 
-    zero = ir.Constant(intp_t, 0)
+    zero = context.get_constant(types.intp, 0)
     is_empty = builder.icmp_signed('==', v_shape, zero)
     with builder.if_else(is_empty, likely=False) as (empty, nonempty):
         with empty:
@@ -674,7 +674,7 @@ def dot_3_mm(context, builder, sig, args):
     out_data = out.data
 
     # If eliminated dimension is zero, set all entries to zero and return
-    zero = ir.Constant(intp_t, 0)
+    zero = context.get_constant(types.intp, 0)
     is_empty = builder.icmp_signed('==', k, zero)
     with builder.if_else(is_empty, likely=False) as (empty, nonempty):
         with empty:
@@ -684,7 +684,7 @@ def dot_3_mm(context, builder, sig, args):
             # Check if any of the operands is really a 1-d vector represented
             # as a (1, k) or (k, 1) 2-d array.  In those cases, it is pessimal
             # to call the generic matrix * matrix product BLAS function.
-            one = ir.Constant(intp_t, 1)
+            one = context.get_constant(types.intp, 1)
             is_left_vec = builder.icmp_signed('==', m, one)
             is_right_vec = builder.icmp_signed('==', n, one)
 

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -392,6 +392,8 @@ def call_xxgemv(context, builder, do_trans,
                             builder.bitcast(v_data, ll_void_p),
                             builder.bitcast(beta, ll_void_p),
                             builder.bitcast(out_data, ll_void_p)))
+    # if lda == 0:
+    #     cgutils.memset(builder, res.data, builder.mul(res.itemsize, res.nitems), 0)
     check_blas_return(context, builder, res)
 
 
@@ -442,6 +444,8 @@ def call_xxgemm(context, builder,
                             builder.bitcast(alpha, ll_void_p), data_a, lda,
                             data_b, ldb, builder.bitcast(beta, ll_void_p),
                             data_c, ldc))
+    # if k == 0:
+    #     cgutils.memset(builder, res.data, builder.mul(res.itemsize, res.nitems), 0)
     check_blas_return(context, builder, res)
 
 
@@ -577,6 +581,7 @@ def dot_3_mv_check_args(a, b, out):
         raise ValueError("incompatible output array size for "
                          "np.dot(a, b, out) (matrix * vector)")
 
+
 def dot_3_vm(context, builder, sig, args):
     """
     np.dot(vector, matrix, out)
@@ -597,16 +602,16 @@ def dot_3_vm(context, builder, sig, args):
         # Asked for x * y, we will compute y.T * x
         mty = yty
         m_shapes = y_shapes
+        v_shape = x_shapes[0]
         do_trans = yty.layout == 'F'
         m_data, v_data = y.data, x.data
         check_args = dot_3_vm_check_args
-
-
     else:
         # Matrix * vector
         # We will compute x * y
         mty = xty
         m_shapes = x_shapes
+        v_shape = y_shapes[0]
         do_trans = xty.layout == 'C'
         m_data, v_data = x.data, y.data
         check_args = dot_3_mv_check_args
@@ -617,8 +622,15 @@ def dot_3_vm(context, builder, sig, args):
     for val in m_shapes:
         check_c_int(context, builder, val)
 
-    call_xxgemv(context, builder, do_trans, mty, m_shapes, m_data,
-                v_data, out.data)
+    zero = ir.Constant(intp_t, 0)
+    is_empty = builder.icmp_signed('==', v_shape, zero)
+    with builder.if_else(is_empty, likely=False) as (empty, nonempty):
+        with empty:
+            cgutils.memset(builder, out.data,
+                           builder.mul(out.itemsize, out.nitems), 0)
+        with nonempty:
+            call_xxgemv(context, builder, do_trans, mty, m_shapes, m_data,
+                        v_data, out.data)
 
     return impl_ret_borrowed(context, builder, sig.return_type,
                              out._getvalue())
@@ -656,6 +668,7 @@ def dot_3_mm(context, builder, sig, args):
 
     context.compile_internal(builder, check_args,
                              signature(types.none, *sig.args), args)
+
     check_c_int(context, builder, m)
     check_c_int(context, builder, k)
     check_c_int(context, builder, n)
@@ -664,38 +677,46 @@ def dot_3_mm(context, builder, sig, args):
     y_data = y.data
     out_data = out.data
 
-    # Check whether any of the operands is really a 1-d vector represented
-    # as a (1, k) or (k, 1) 2-d array.  In those cases, it is pessimal
-    # to call the generic matrix * matrix product BLAS function.
-    one = ir.Constant(intp_t, 1)
-    is_left_vec = builder.icmp_signed('==', m, one)
-    is_right_vec = builder.icmp_signed('==', n, one)
+    # If eliminated dimension is zero, set all entries to zero and return
+    zero = ir.Constant(intp_t, 0)
+    is_empty = builder.icmp_signed('==', k, zero)
+    with builder.if_else(is_empty, likely=False) as (empty, nonempty):
+        with empty:
+            cgutils.memset(builder, out.data,
+                           builder.mul(out.itemsize, out.nitems), 0)
+        with nonempty:
+            # Check whether any of the operands is really a 1-d vector represented
+            # as a (1, k) or (k, 1) 2-d array.  In those cases, it is pessimal
+            # to call the generic matrix * matrix product BLAS function.
+            one = ir.Constant(intp_t, 1)
+            is_left_vec = builder.icmp_signed('==', m, one)
+            is_right_vec = builder.icmp_signed('==', n, one)
 
-    with builder.if_else(is_right_vec) as (r_vec, r_mat):
-        with r_vec:
-            with builder.if_else(is_left_vec) as (v_v, m_v):
-                with v_v:
-                    # V * V
-                    call_xxdot(context, builder, False, dtype,
-                               k, x_data, y_data, out_data)
-                with m_v:
-                    # M * V
-                    do_trans = xty.layout == outty.layout
-                    call_xxgemv(context, builder, do_trans,
-                                xty, x_shapes, x_data, y_data, out_data)
-        with r_mat:
-            with builder.if_else(is_left_vec) as (v_m, m_m):
-                with v_m:
-                    # V * M
-                    do_trans = yty.layout != outty.layout
-                    call_xxgemv(context, builder, do_trans,
-                                yty, y_shapes, y_data, x_data, out_data)
-                with m_m:
-                    # M * M
-                    call_xxgemm(context, builder,
-                                xty, x_shapes, x_data,
-                                yty, y_shapes, y_data,
-                                outty, out_shapes, out_data)
+            with builder.if_else(is_right_vec) as (r_vec, r_mat):
+                with r_vec:
+                    with builder.if_else(is_left_vec) as (v_v, m_v):
+                        with v_v:
+                            # V * V
+                            call_xxdot(context, builder, False, dtype,
+                                       k, x_data, y_data, out_data)
+                        with m_v:
+                            # M * V
+                            do_trans = xty.layout == outty.layout
+                            call_xxgemv(context, builder, do_trans,
+                                        xty, x_shapes, x_data, y_data, out_data)
+                with r_mat:
+                    with builder.if_else(is_left_vec) as (v_m, m_m):
+                        with v_m:
+                            # V * M
+                            do_trans = yty.layout != outty.layout
+                            call_xxgemv(context, builder, do_trans,
+                                        yty, y_shapes, y_data, x_data, out_data)
+                        with m_m:
+                            # M * M
+                            call_xxgemm(context, builder,
+                                        xty, x_shapes, x_data,
+                                        yty, y_shapes, y_data,
+                                        outty, out_shapes, out_data)
 
     return impl_ret_borrowed(context, builder, sig.return_type,
                              out._getvalue())

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -452,6 +452,8 @@ def dot_2_mm(context, builder, sig, args):
     def dot_impl(a, b):
         m, k = a.shape
         _k, n = b.shape
+        if k == 0:
+            return np.zeros((m, n), a.dtype)
         out = np.empty((m, n), a.dtype)
         return np.dot(a, b, out)
 
@@ -466,6 +468,8 @@ def dot_2_vm(context, builder, sig, args):
     def dot_impl(a, b):
         m, = a.shape
         _m, n = b.shape
+        if m == 0:
+            return np.zeros((n, ), a.dtype)
         out = np.empty((n, ), a.dtype)
         return np.dot(a, b, out)
 
@@ -480,6 +484,8 @@ def dot_2_mv(context, builder, sig, args):
     def dot_impl(a, b):
         m, n = a.shape
         _n, = b.shape
+        if n == 0:
+            return np.zeros((m, ), a.dtype)
         out = np.empty((m, ), a.dtype)
         return np.dot(a, b, out)
 

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -182,6 +182,7 @@ class TestProduct(TestCase):
                     self.check_func_out(pyfunc3, cfunc3, (b, a.T), out)
 
         # Mismatching sizes
+        m, n = 2, 3
         a = self.sample_matrix(m, n - 1, np.float64)
         b = self.sample_vector(n, np.float64)
         self.assert_mismatching_sizes(cfunc2, (a, b))

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -170,7 +170,8 @@ class TestProduct(TestCase):
             cfunc3 = jit(nopython=True)(pyfunc3)
 
         for m, n in [(2, 3),
-                     (3, 0)
+                     (3, 0),
+                     (0, 3)
                      ]:
             for a, b in samples(m, n):
                 self.check_func(pyfunc2, cfunc2, (a, b))
@@ -234,11 +235,14 @@ class TestProduct(TestCase):
         # Test generic matrix * matrix as well as "degenerate" cases
         # where one of the outer dimensions is 1 (i.e. really represents
         # a vector, which may select a different implementation),
-        # or both matrices are empty but their product is not.
+        # one of the matrices is empty, or both matrices are empty.
         for m, n, k in [(2, 3, 4),  # Generic matrix * matrix
                         (1, 3, 4),  # 2d vector * matrix
                         (1, 1, 4),  # 2d vector * 2d vector
-                        (3, 2, 0)   # Empty matrix * empty matrix
+                        (0, 3, 2),  # Empty matrix * matrix, empty output
+                        (3, 0, 2),  # Matrix * empty matrix, empty output
+                        (0, 0, 3),  # Both arguments empty, empty output
+                        (3, 2, 0),  # Both arguments empty, nonempty output
                         ]:
             for a, b in samples(m, n, k):
                 self.check_func(pyfunc2, cfunc2, (a, b))


### PR DESCRIPTION
When np.dot(a, b) is called with empty argments, the result can be non-empty if the zero dimension is eliminated (e.g. a is m x 0 and b is 0 x n). In these cases, we should return an array of zeros. Previously, the result was initialized with np.empty, so the it contained garbage values.

Fixes #5539

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
