### PR TITLE
Fix 5665 Block jit(nopython=True, forceobj=True) and suppress njit(forceobj=True)

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -144,7 +144,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
     if 'restype' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
     if options.get('nopython', False) and options.get('forceobj', False):
-        raise ValueError("Only either 'nopython' or 'forcobj' can be True.")
+        raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
 
     options['boundscheck'] = boundscheck
 

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -143,6 +143,8 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
+    if options.get('nopython', False) and options.get('forceobj', False):
+        raise ValueError("Only either 'nopython' or 'forcobj' can be True.")
 
     options['boundscheck'] = boundscheck
 
@@ -232,6 +234,7 @@ def njit(*args, **kws):
         warnings.warn('nopython is set for njit and is ignored', RuntimeWarning)
     if 'forceobj' in kws:
         warnings.warn('forceobj is set for njit and is ignored', RuntimeWarning)
+        del kws['forceobj']
     kws.update({'nopython': True})
     return jit(*args, **kws)
 

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -42,11 +42,13 @@ class TestJitDecorator(TestCase):
 
         jit_func = jit(nopython=True)(py_func)
         jit_func(1)
-        self.assertTrue(jit_func.nopython_signatures)
+        # Check length of nopython_signatures to check
+        # which mode the function was compiled in
+        self.assertTrue(len(jit_func.nopython_signatures) == 1)
 
         jit_func = jit(forceobj=True)(py_func)
         jit_func(1)
-        self.assertFalse(jit_func.nopython_signatures)
+        self.assertTrue(len(jit_func.nopython_signatures) == 0)
 
     def test_njit_nopython_forceobj(self):
         with self.assertWarns(RuntimeWarning):
@@ -60,11 +62,12 @@ class TestJitDecorator(TestCase):
 
         jit_func = njit(nopython=True)(py_func)
         jit_func(1)
-        self.assertTrue(jit_func.nopython_signatures)
+        self.assertTrue(len(jit_func.nopython_signatures) == 1)
 
         jit_func = njit(forceobj=True)(py_func)
         jit_func(1)
-        self.assertTrue(jit_func.nopython_signatures)
+        # Since forceobj is ignored this has to compile in nopython mode
+        self.assertTrue(len(jit_func.nopython_signatures) == 1)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -48,8 +48,6 @@ class TestJitDecorator(TestCase):
         jit_func(1)
         self.assertFalse(jit_func.nopython_signatures)
 
-
-
     def test_njit_nopython_forceobj(self):
         with self.assertWarns(RuntimeWarning):
             njit(forceobj=True)

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -44,11 +44,11 @@ class TestJitDecorator(TestCase):
         jit_func(1)
         # Check length of nopython_signatures to check
         # which mode the function was compiled in
-        self.assertTrue(len(jit_func.nopython_signatures) == 1)
+        self.assertEqual(len(jit_func.nopython_signatures), 1)
 
         jit_func = jit(forceobj=True)(py_func)
         jit_func(1)
-        self.assertTrue(len(jit_func.nopython_signatures) == 0)
+        self.assertEqual(len(jit_func.nopython_signatures), 0)
 
     def test_njit_nopython_forceobj(self):
         with self.assertWarns(RuntimeWarning):
@@ -62,12 +62,12 @@ class TestJitDecorator(TestCase):
 
         jit_func = njit(nopython=True)(py_func)
         jit_func(1)
-        self.assertTrue(len(jit_func.nopython_signatures) == 1)
+        self.assertEqual(len(jit_func.nopython_signatures), 1)
 
         jit_func = njit(forceobj=True)(py_func)
         jit_func(1)
         # Since forceobj is ignored this has to compile in nopython mode
-        self.assertTrue(len(jit_func.nopython_signatures) == 1)
+        self.assertEqual(len(jit_func.nopython_signatures), 1)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -1,4 +1,5 @@
 import numba
+from numba import jit, njit
 
 from numba.tests.support import TestCase
 import unittest
@@ -26,6 +27,46 @@ class TestNumbaModule(TestCase):
         self.check_member("int32")
         # misc
         numba.__version__  # not in __all__
+
+
+class TestJitDecorator(TestCase):
+    """
+    Test the jit and njit decorators
+    """
+    def test_jit_nopython_forceobj(self):
+        with self.assertRaises(ValueError):
+            jit(nopython=True, forceobj=True)
+
+        def py_func(x):
+            return(x)
+
+        jit_func = jit(nopython=True)(py_func)
+        jit_func(1)
+        self.assertTrue(jit_func.nopython_signatures)
+
+        jit_func = jit(forceobj=True)(py_func)
+        jit_func(1)
+        self.assertFalse(jit_func.nopython_signatures)
+
+
+
+    def test_njit_nopython_forceobj(self):
+        with self.assertWarns(RuntimeWarning):
+            njit(forceobj=True)
+
+        with self.assertWarns(RuntimeWarning):
+            njit(nopython=True)
+
+        def py_func(x):
+            return(x)
+
+        jit_func = njit(nopython=True)(py_func)
+        jit_func(1)
+        self.assertTrue(jit_func.nopython_signatures)
+
+        jit_func = njit(forceobj=True)(py_func)
+        jit_func(1)
+        self.assertTrue(jit_func.nopython_signatures)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #5665

Currently it is possible to decorate a function with `jit(nopython=True, forceobj=True)`, this fix will raise an error if this happens. Further, `njit` claims to ignore `forceobj=True`, but currently passes it on to `jit`. This fix deletes `forceobj` from the passed `njit` kwargs.

I am happy to include some small test cases, if somebody can point me as to which file I should best put them into. :)

