### PR TITLE
Eliminate all dangerous default values found by pylint

### DIFF
--- a/numba/_version.py
+++ b/numba/_version.py
@@ -218,7 +218,7 @@ def get_versions(default=None, verbose=False):
     # py2exe/bbfreeze/non-CPython implementations don't do __file__, in which
     # case we can only use expanded keywords.
 
-    default = default if default else {"version": "0+unknown", "full": ""}
+    default = default if default is not None else {"version": "0+unknown", "full": ""}
     keywords = {"refnames": git_refnames, "full": git_full}
     ver = git_versions_from_keywords(keywords, tag_prefix, verbose)
     if ver:

--- a/numba/_version.py
+++ b/numba/_version.py
@@ -212,12 +212,13 @@ def git_versions_from_vcs(tag_prefix, root, verbose=False):
     return {"version": version, "full": full}
 
 
-def get_versions(default={"version": "0+unknown", "full": ""}, verbose=False):
+def get_versions(default=None, verbose=False):
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some
     # py2exe/bbfreeze/non-CPython implementations don't do __file__, in which
     # case we can only use expanded keywords.
 
+    default = default if default else {"version": "0+unknown", "full": ""}
     keywords = {"refnames": git_refnames, "full": git_full}
     ver = git_versions_from_keywords(keywords, tag_prefix, verbose)
     if ver:

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -826,7 +826,7 @@ class BaseContext(object):
 
         Note this context's flags are not inherited.
         """
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         # Compile
         from numba.core import compiler
 
@@ -857,7 +857,7 @@ class BaseContext(object):
         If *caching* evaluates True, the function keeps the compiled function
         for reuse in *.cached_internal_func*.
         """
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         cache_key = (impl.__code__, sig, type(self.error_model))
         if not caching:
             cached = None
@@ -883,7 +883,7 @@ class BaseContext(object):
         Like compile_subroutine(), but also call the function with the given
         *args*.
         """
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         cres = self.compile_subroutine(builder, impl, sig, locals)
         return self.call_internal(builder, cres.fndesc, sig, args)
 

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -817,7 +817,7 @@ class BaseContext(object):
     def get_dummy_type(self):
         return GENERIC_POINTER
 
-    def _compile_subroutine_no_cache(self, builder, impl, sig, locals={},
+    def _compile_subroutine_no_cache(self, builder, impl, sig, locals=None,
                                      flags=None):
         """
         Invoke the compiler to compile a function to be used inside a
@@ -826,6 +826,7 @@ class BaseContext(object):
 
         Note this context's flags are not inherited.
         """
+        locals = locals if locals else {}
         # Compile
         from numba.core import compiler
 
@@ -847,7 +848,7 @@ class BaseContext(object):
             self.active_code_library.add_linking_library(cres.library)
             return cres
 
-    def compile_subroutine(self, builder, impl, sig, locals={}, flags=None,
+    def compile_subroutine(self, builder, impl, sig, locals=None, flags=None,
                            caching=True):
         """
         Compile the function *impl* for the given *sig* (in nopython mode).
@@ -856,6 +857,7 @@ class BaseContext(object):
         If *caching* evaluates True, the function keeps the compiled function
         for reuse in *.cached_internal_func*.
         """
+        locals = locals if locals else {}
         cache_key = (impl.__code__, sig, type(self.error_model))
         if not caching:
             cached = None
@@ -876,11 +878,12 @@ class BaseContext(object):
         self.active_code_library.add_linking_library(cres.library)
         return cres
 
-    def compile_internal(self, builder, impl, sig, args, locals={}):
+    def compile_internal(self, builder, impl, sig, args, locals=None):
         """
         Like compile_subroutine(), but also call the function with the given
         *args*.
         """
+        locals = locals if locals else {}
         cres = self.compile_subroutine(builder, impl, sig, locals)
         return self.call_internal(builder, cres.fndesc, sig, args)
 

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1,4 +1,5 @@
 from collections import namedtuple, defaultdict
+from types import MappingProxyType
 import copy
 import os
 import sys
@@ -826,7 +827,7 @@ class BaseContext(object):
 
         Note this context's flags are not inherited.
         """
-        locals = locals if locals is not None else {}
+        locals = MappingProxyType({} if locals is None else locals)
         # Compile
         from numba.core import compiler
 
@@ -857,7 +858,7 @@ class BaseContext(object):
         If *caching* evaluates True, the function keeps the compiled function
         for reuse in *.cached_internal_func*.
         """
-        locals = locals if locals is not None else {}
+        locals = MappingProxyType({} if locals is None else locals)
         cache_key = (impl.__code__, sig, type(self.error_model))
         if not caching:
             cached = None
@@ -883,7 +884,7 @@ class BaseContext(object):
         Like compile_subroutine(), but also call the function with the given
         *args*.
         """
-        locals = locals if locals is not None else {}
+        locals = MappingProxyType({} if locals is None else locals)
         cres = self.compile_subroutine(builder, impl, sig, locals)
         return self.call_internal(builder, cres.fndesc, sig, args)
 

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -76,7 +76,7 @@ def copy_struct(dst, src, repl=None):
     """
     Copy structure from *src* to *dst* with replacement from *repl*.
     """
-    repl = repl.copy() if repl else {}
+    repl = repl.copy() if repl is not None else {}
     # copy data from src or use those in repl
     for k in src._datamodel._fields:
         v = repl.pop(k, getattr(src, k))

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -72,11 +72,11 @@ def create_struct_proxy(fe_type, kind='value'):
     return res
 
 
-def copy_struct(dst, src, repl={}):
+def copy_struct(dst, src, repl=None):
     """
     Copy structure from *src* to *dst* with replacement from *repl*.
     """
-    repl = repl.copy()
+    repl = repl.copy() if repl else {}
     # copy data from src or use those in repl
     for k in src._datamodel._fields:
         v = repl.pop(k, getattr(src, k))

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from types import MappingProxyType
 import copy
 import warnings
 from numba.core.tracing import event
@@ -181,7 +182,7 @@ def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
     context).
     Good for testing.
     """
-    locals = locals if locals is not None else {}
+    locals = MappingProxyType({} if locals is None else locals)
     from numba.core.registry import cpu_target
     typingctx = typing.Context()
     targetctx = cpu.CPUContext(typingctx)

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -175,12 +175,13 @@ def compile_result(**kws):
 
 
 def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
-                     locals={}):
+                     locals=None):
     """
     Compile the function in an isolated environment (typing and target
     context).
     Good for testing.
     """
+    locals = locals if locals else {}
     from numba.core.registry import cpu_target
     typingctx = typing.Context()
     targetctx = cpu.CPUContext(typingctx)

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -181,7 +181,7 @@ def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,
     context).
     Good for testing.
     """
-    locals = locals if locals else {}
+    locals = locals if locals is not None else {}
     from numba.core.registry import cpu_target
     typingctx = typing.Context()
     targetctx = cpu.CPUContext(typingctx)

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 import inspect
 import logging
+from types import MappingProxyType
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
@@ -139,7 +140,7 @@ def jit(signature_or_function=None, locals=None, target='cpu', cache=False,
                 return x + y
 
     """
-    locals = locals if locals is not None else {}
+    locals = MappingProxyType({} if locals is None else locals)
     if 'argtypes' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
@@ -248,7 +249,7 @@ def cfunc(sig, locals=None, cache=False, **options):
             return a + b
 
     """
-    locals = locals if locals is not None else {}
+    locals = MappingProxyType({} if locals is None else locals)
     sig = sigutils.normalize_signature(sig)
 
     def wrapper(func):

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -139,7 +139,7 @@ def jit(signature_or_function=None, locals=None, target='cpu', cache=False,
                 return x + y
 
     """
-    locals = locals if locals else {}
+    locals = locals if locals is not None else {}
     if 'argtypes' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
@@ -248,7 +248,7 @@ def cfunc(sig, locals=None, cache=False, **options):
             return a + b
 
     """
-    locals = locals if locals else {}
+    locals = locals if locals is not None else {}
     sig = sigutils.normalize_signature(sig)
 
     def wrapper(func):

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -23,7 +23,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
 
-def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
+def jit(signature_or_function=None, locals=None, target='cpu', cache=False,
         pipeline_class=None, boundscheck=False, **options):
     """
     This decorator is used to compile a Python function into native code.
@@ -139,6 +139,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
                 return x + y
 
     """
+    locals = locals if locals else {}
     if 'argtypes' in options:
         raise DeprecationError(_msg_deprecated_signature_arg.format('argtypes'))
     if 'restype' in options:
@@ -236,7 +237,7 @@ def njit(*args, **kws):
     return jit(*args, **kws)
 
 
-def cfunc(sig, locals={}, cache=False, **options):
+def cfunc(sig, locals=None, cache=False, **options):
     """
     This decorator is used to compile a Python function into a C callback
     usable with foreign C libraries.
@@ -247,6 +248,7 @@ def cfunc(sig, locals={}, cache=False, **options):
             return a + b
 
     """
+    locals = locals if locals else {}
     sig = sigutils.normalize_signature(sig)
 
     def wrapper(func):

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -664,7 +664,7 @@ class Dispatcher(_DispatcherBase):
     __uuid = None
     __numba__ = 'py_func'
 
-    def __init__(self, py_func, locals={}, targetoptions={},
+    def __init__(self, py_func, locals=None, targetoptions=None,
                  impl_kind='direct', pipeline_class=compiler.Compiler):
         """
         Parameters
@@ -680,6 +680,8 @@ class Dispatcher(_DispatcherBase):
         pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type.
         """
+        locals = locals if locals else {}
+        targetoptions = targetoptions if targetoptions else {}
         self.typingctx = self.targetdescr.typing_context
         self.targetctx = self.targetdescr.target_context
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -10,6 +10,7 @@ import types as pytypes
 import uuid
 import weakref
 from copy import deepcopy
+from types import MappingProxyType
 
 from numba import _dispatcher
 from numba.core import utils, types, errors, typing, serialize, config, compiler, sigutils
@@ -680,8 +681,8 @@ class Dispatcher(_DispatcherBase):
         pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type.
         """
-        locals = locals if locals is not None else {}
-        targetoptions = targetoptions if targetoptions is not None else {}
+        locals = MappingProxyType({} if locals is None else locals)
+        targetoptions = MappingProxyType({} if targetoptions is None else targetoptions)
         self.typingctx = self.targetdescr.typing_context
         self.targetctx = self.targetdescr.target_context
 

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -680,8 +680,8 @@ class Dispatcher(_DispatcherBase):
         pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type.
         """
-        locals = locals if locals else {}
-        targetoptions = targetoptions if targetoptions else {}
+        locals = locals if locals is not None else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         self.typingctx = self.targetdescr.typing_context
         self.targetctx = self.targetdescr.target_context
 

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -54,7 +54,7 @@ def type_callable(func):
 _overload_default_jit_options = {'no_cpython_wrapper': True}
 
 
-def overload(func, jit_options={}, strict=True, inline='never'):
+def overload(func, jit_options=None, strict=True, inline='never'):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode.
@@ -101,6 +101,7 @@ def overload(func, jit_options={}, strict=True, inline='never'):
       to determine whether to inline, this essentially permitting custom
       inlining rules (typical use might be cost models).
     """
+    jit_options = jit_options if jit_options else {}
     from numba.core.typing.templates import make_overload_template, infer_global
 
     # set default options

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import weakref
 import collections
+from types import MappingProxyType
 
 import numba
 from numba.core import types, errors, utils, config
@@ -101,7 +102,7 @@ def overload(func, jit_options=None, strict=True, inline='never'):
       to determine whether to inline, this essentially permitting custom
       inlining rules (typical use might be cost models).
     """
-    jit_options = jit_options if jit_options is not None else {}
+    jit_options = MappingProxyType({} if jit_options is None else jit_options)
     from numba.core.typing.templates import make_overload_template, infer_global
 
     # set default options

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -101,7 +101,7 @@ def overload(func, jit_options=None, strict=True, inline='never'):
       to determine whether to inline, this essentially permitting custom
       inlining rules (typical use might be cost models).
     """
-    jit_options = jit_options if jit_options else {}
+    jit_options = jit_options if jit_options is not None else {}
     from numba.core.typing.templates import make_overload_template, infer_global
 
     # set default options

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -61,7 +61,7 @@ class InlineClosureCallPass(object):
     def __init__(self, func_ir, parallel_options, swapped=None, typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
-        self.swapped = swapped if swapped is not None else {}
+        self.swapped = {} if swapped is None else swapped
         self._processed_stencils = []
         self.typed = typed
 

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -61,7 +61,7 @@ class InlineClosureCallPass(object):
     def __init__(self, func_ir, parallel_options, swapped=None, typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
-        self.swapped = swapped if swapped else {}
+        self.swapped = swapped if swapped is not None else {}
         self._processed_stencils = []
         self.typed = typed
 

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -58,10 +58,10 @@ class InlineClosureCallPass(object):
     closures, and inlines the body of the closure function to the call site.
     """
 
-    def __init__(self, func_ir, parallel_options, swapped={}, typed=False):
+    def __init__(self, func_ir, parallel_options, swapped=None, typed=False):
         self.func_ir = func_ir
         self.parallel_options = parallel_options
-        self.swapped = swapped
+        self.swapped = swapped if swapped else {}
         self._processed_stencils = []
         self.typed = typed
 

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -47,8 +47,9 @@ def fallback_context(state, msg):
             raise
 
 
-def type_inference_stage(typingctx, interp, args, return_type, locals={},
+def type_inference_stage(typingctx, interp, args, return_type, locals=None,
                          raise_errors=True):
+    locals = locals if locals else {}
     if len(args) != interp.arg_count:
         raise TypeError("Mismatch number of argument types")
     warnings = errors.WarningsFixer(errors.NumbaWarning)

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -49,7 +49,7 @@ def fallback_context(state, msg):
 
 def type_inference_stage(typingctx, interp, args, return_type, locals=None,
                          raise_errors=True):
-    locals = locals if locals else {}
+    locals = locals if locals is not None else {}
     if len(args) != interp.arg_count:
         raise TypeError("Mismatch number of argument types")
     warnings = errors.WarningsFixer(errors.NumbaWarning)

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from collections import defaultdict
+from types import MappingProxyType
 from copy import copy
 import warnings
 
@@ -49,7 +50,7 @@ def fallback_context(state, msg):
 
 def type_inference_stage(typingctx, interp, args, return_type, locals=None,
                          raise_errors=True):
-    locals = locals if locals is not None else {}
+    locals = MappingProxyType({} if locals is None else locals)
     if len(args) != interp.arg_count:
         raise TypeError("Mismatch number of argument types")
     warnings = errors.WarningsFixer(errors.NumbaWarning)

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -50,7 +50,8 @@ def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
 
 @global_compiler_lock
 def compile_kernel(pyfunc, args, link, debug=False, inline=False,
-                   fastmath=False, extensions=[], max_registers=None):
+                   fastmath=False, extensions=None, max_registers=None):
+    extensions = extensions if extensions else []
     cres = compile_cuda(pyfunc, types.void, args, debug=debug, inline=inline)
     fname = cres.fndesc.llvm_func_name
     lib, kernel = cres.target_context.prepare_cuda_kernel(cres.library, fname,
@@ -192,7 +193,7 @@ class DeviceFunctionTemplate(object):
         mod = cres.library._final_module
         return str(mod)
 
-    def inspect_ptx(self, args, nvvm_options={}):
+    def inspect_ptx(self, args, nvvm_options=None):
         """Returns the PTX compiled for *args* for the currently active GPU
 
         Parameters
@@ -206,6 +207,7 @@ class DeviceFunctionTemplate(object):
         -------
         ptx : bytes
         """
+        nvvm_options = nvvm_options if nvvm_options else {}
         llvmir = self.inspect_llvm(args)
         # Make PTX
         cuctx = get_context()
@@ -513,7 +515,8 @@ class CUDAKernel(CUDAKernelBase):
     '''
     def __init__(self, llvm_module, name, pretty_name, argtypes, call_helper,
                  link=(), debug=False, fastmath=False, type_annotation=None,
-                 extensions=[], max_registers=None):
+                 extensions=None, max_registers=None):
+        extensions = extensions if extensions else []
         super(CUDAKernel, self).__init__()
         # initialize CUfunction
         options = {

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -51,7 +51,7 @@ def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
 @global_compiler_lock
 def compile_kernel(pyfunc, args, link, debug=False, inline=False,
                    fastmath=False, extensions=None, max_registers=None):
-    extensions = extensions if extensions else []
+    extensions = extensions if extensions is not None else []
     cres = compile_cuda(pyfunc, types.void, args, debug=debug, inline=inline)
     fname = cres.fndesc.llvm_func_name
     lib, kernel = cres.target_context.prepare_cuda_kernel(cres.library, fname,
@@ -207,7 +207,7 @@ class DeviceFunctionTemplate(object):
         -------
         ptx : bytes
         """
-        nvvm_options = nvvm_options if nvvm_options else {}
+        nvvm_options = nvvm_options if nvvm_options is not None else {}
         llvmir = self.inspect_llvm(args)
         # Make PTX
         cuctx = get_context()
@@ -516,7 +516,7 @@ class CUDAKernel(CUDAKernelBase):
     def __init__(self, llvm_module, name, pretty_name, argtypes, call_helper,
                  link=(), debug=False, fastmath=False, type_annotation=None,
                  extensions=None, max_registers=None):
-        extensions = extensions if extensions else []
+        extensions = extensions if extensions is not None else []
         super(CUDAKernel, self).__init__()
         # initialize CUfunction
         options = {

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -8,7 +8,7 @@ from .simulator.kernel import FakeCUDAKernel
 def jitdevice(func, link=None, debug=None, inline=False):
     """Wrapper for device-jit.
     """
-    link = link if link else []
+    link = link if link is not None else []
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     if link:
         raise ValueError("link keyword invalid for device function")
@@ -48,7 +48,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
        registers per thread. Useful for increasing occupancy.
     """
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
-    link = link if link else []
+    link = link if link is not None else []
 
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -5,9 +5,10 @@ from .compiler import (compile_kernel, compile_device, declare_device_function,
 from .simulator.kernel import FakeCUDAKernel
 
 
-def jitdevice(func, link=[], debug=None, inline=False):
+def jitdevice(func, link=None, debug=None, inline=False):
     """Wrapper for device-jit.
     """
+    link = link if link else []
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     if link:
         raise ValueError("link keyword invalid for device function")
@@ -15,7 +16,7 @@ def jitdevice(func, link=[], debug=None, inline=False):
 
 
 def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
-        link=[], debug=None, **kws):
+        link=None, debug=None, **kws):
     """
     JIT compile a python function conforming to the CUDA Python specification.
     If a signature is supplied, then a function is returned that takes a
@@ -47,6 +48,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
        registers per thread. Useful for increasing occupancy.
     """
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
+    link = link if link else []
 
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -14,15 +14,15 @@ class CUDADispatcher(object):
     targetdescr = CUDATargetDesc
 
     def __init__(self, py_func, locals=None, targetoptions=None):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         assert not locals
         self.py_func = py_func
-        self.targetoptions = targetoptions if targetoptions else {}
+        self.targetoptions = targetoptions if targetoptions is not None else {}
         self.doc = py_func.__doc__
         self._compiled = None
 
     def compile(self, sig, locals=None, **targetoptions):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         assert self._compiled is None
         assert not locals
         options = self.targetoptions.copy()

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -13,14 +13,16 @@ from numba.np.ufunc.deviceufunc import (UFuncMechanism, GenerializedUFunc,
 class CUDADispatcher(object):
     targetdescr = CUDATargetDesc
 
-    def __init__(self, py_func, locals={}, targetoptions={}):
+    def __init__(self, py_func, locals=None, targetoptions=None):
+        locals = locals if locals else {}
         assert not locals
         self.py_func = py_func
-        self.targetoptions = targetoptions
+        self.targetoptions = targetoptions if targetoptions else {}
         self.doc = py_func.__doc__
         self._compiled = None
 
-    def compile(self, sig, locals={}, **targetoptions):
+    def compile(self, sig, locals=None, **targetoptions):
+        locals = locals if locals else {}
         assert self._compiled is None
         assert not locals
         options = self.targetoptions.copy()

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -47,7 +47,8 @@ class FakeCUDAKernel(object):
     Wraps a @cuda.jit-ed function.
     '''
 
-    def __init__(self, fn, device, fastmath=False, extensions=[]):
+    def __init__(self, fn, device, fastmath=False, extensions=None):
+        extensions = extensions if extensions else []
         self.fn = fn
         self._device = device
         self._fastmath = fastmath

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -48,7 +48,7 @@ class FakeCUDAKernel(object):
     '''
 
     def __init__(self, fn, device, fastmath=False, extensions=None):
-        extensions = extensions if extensions else []
+        extensions = extensions if extensions is not None else []
         self.fn = fn
         self._device = device
         self._fastmath = fastmath

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -359,7 +359,7 @@ def to_dtype(ty):
 
 class DeviceVectorize(_BaseUFuncBuilder):
     def __init__(self, func, identity=None, cache=False, targetoptions=None):
-        targetoptions = targetoptions if targetoptions else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         if cache:
             raise TypeError("caching is not supported")
         for opt in targetoptions:
@@ -432,7 +432,7 @@ class DeviceVectorize(_BaseUFuncBuilder):
 
 class DeviceGUFuncVectorize(_BaseUFuncBuilder):
     def __init__(self, func, sig, identity=None, cache=False, targetoptions=None):
-        targetoptions = targetoptions if targetoptions else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         if cache:
             raise TypeError("caching is not supported")
         # Allow nopython flag to be set.

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -358,7 +358,8 @@ def to_dtype(ty):
 
 
 class DeviceVectorize(_BaseUFuncBuilder):
-    def __init__(self, func, identity=None, cache=False, targetoptions={}):
+    def __init__(self, func, identity=None, cache=False, targetoptions=None):
+        targetoptions = targetoptions if targetoptions else {}
         if cache:
             raise TypeError("caching is not supported")
         for opt in targetoptions:
@@ -430,7 +431,8 @@ class DeviceVectorize(_BaseUFuncBuilder):
 
 
 class DeviceGUFuncVectorize(_BaseUFuncBuilder):
-    def __init__(self, func, sig, identity=None, cache=False, targetoptions={}):
+    def __init__(self, func, sig, identity=None, cache=False, targetoptions=None):
+        targetoptions = targetoptions if targetoptions else {}
         if cache:
             raise TypeError("caching is not supported")
         # Allow nopython flag to be set.

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -76,7 +76,8 @@ class DUFunc(_internal._DUFunc):
     # _internal.c:dufunc_init()
     __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
-    def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
+    def __init__(self, py_func, identity=None, cache=False, targetoptions=None):
+        targetoptions = targetoptions if targetoptions else {}
         if isinstance(py_func, Dispatcher):
             py_func = py_func.py_func
         dispatcher = jit(target='npyufunc',

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -77,7 +77,7 @@ class DUFunc(_internal._DUFunc):
     __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
     def __init__(self, py_func, identity=None, cache=False, targetoptions=None):
-        targetoptions = targetoptions if targetoptions else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         if isinstance(py_func, Dispatcher):
             py_func = py_func.py_func
         dispatcher = jit(target='npyufunc',

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -206,8 +206,9 @@ def build_ufunc_wrapper(library, ctx, fname, signature, cres):
 
 class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
     def __init__(self, py_func, signature, identity=None, cache=False,
-                 targetoptions={}):
+                 targetoptions=None):
         # Force nopython mode
+        targetoptions = targetoptions if targetoptions else {}
         targetoptions.update(dict(nopython=True))
         super(
             ParallelGUFuncBuilder,

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -208,7 +208,7 @@ class ParallelGUFuncBuilder(ufuncbuilder.GUFuncBuilder):
     def __init__(self, py_func, signature, identity=None, cache=False,
                  targetoptions=None):
         # Force nopython mode
-        targetoptions = targetoptions if targetoptions else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         targetoptions.update(dict(nopython=True))
         super(
             ParallelGUFuncBuilder,

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -47,11 +47,11 @@ class UFuncDispatcher(object):
     """
     targetdescr = ufunc_target
 
-    def __init__(self, py_func, locals={}, targetoptions={}):
+    def __init__(self, py_func, locals=None, targetoptions=None):
         self.py_func = py_func
         self.overloads = utils.UniqueDict()
-        self.targetoptions = targetoptions
-        self.locals = locals
+        self.targetoptions = targetoptions if targetoptions else {}
+        self.locals = locals if locals else {}
         self.cache = NullCache()
 
     def __reduce__(self):
@@ -73,7 +73,8 @@ class UFuncDispatcher(object):
     def enable_caching(self):
         self.cache = FunctionCache(self.py_func)
 
-    def compile(self, sig, locals={}, **targetoptions):
+    def compile(self, sig, locals=None, **targetoptions):
+        locals = locals if locals else {}
         locs = self.locals.copy()
         locs.update(locals)
 
@@ -224,7 +225,8 @@ class _BaseUFuncBuilder(object):
 
 class UFuncBuilder(_BaseUFuncBuilder):
 
-    def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
+    def __init__(self, py_func, identity=None, cache=False, targetoptions=None):
+        targetoptions = targetoptions if targetoptions else {}
         self.py_func = py_func
         self.identity = parse_identity(identity)
         self.nb_func = jit(target='npyufunc',
@@ -289,13 +291,13 @@ class GUFuncBuilder(_BaseUFuncBuilder):
 
     # TODO handle scalar
     def __init__(self, py_func, signature, identity=None, cache=False,
-                 targetoptions={}):
+                 targetoptions=None):
         self.py_func = py_func
         self.identity = parse_identity(identity)
         self.nb_func = jit(target='npyufunc', cache=cache)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
-        self.targetoptions = targetoptions
+        self.targetoptions = targetoptions if targetoptions else {}
         self.cache = cache
         self._sigs = []
         self._cres = {}

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -50,8 +50,8 @@ class UFuncDispatcher(object):
     def __init__(self, py_func, locals=None, targetoptions=None):
         self.py_func = py_func
         self.overloads = utils.UniqueDict()
-        self.targetoptions = targetoptions if targetoptions else {}
-        self.locals = locals if locals else {}
+        self.targetoptions = targetoptions if targetoptions is not None else {}
+        self.locals = locals if locals is not None else {}
         self.cache = NullCache()
 
     def __reduce__(self):
@@ -74,7 +74,7 @@ class UFuncDispatcher(object):
         self.cache = FunctionCache(self.py_func)
 
     def compile(self, sig, locals=None, **targetoptions):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         locs = self.locals.copy()
         locs.update(locals)
 
@@ -226,7 +226,7 @@ class _BaseUFuncBuilder(object):
 class UFuncBuilder(_BaseUFuncBuilder):
 
     def __init__(self, py_func, identity=None, cache=False, targetoptions=None):
-        targetoptions = targetoptions if targetoptions else {}
+        targetoptions = targetoptions if targetoptions is not None else {}
         self.py_func = py_func
         self.identity = parse_identity(identity)
         self.nb_func = jit(target='npyufunc',
@@ -297,7 +297,7 @@ class GUFuncBuilder(_BaseUFuncBuilder):
         self.nb_func = jit(target='npyufunc', cache=cache)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
-        self.targetoptions = targetoptions if targetoptions else {}
+        self.targetoptions = targetoptions if targetoptions is not None else {}
         self.cache = cache
         self._sigs = []
         self._cres = {}

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1350,14 +1350,14 @@ class PreParforPass(object):
     implementations of numpy functions if available.
     """
     def __init__(self, func_ir, typemap, calltypes, typingctx, options,
-                 swapped=None):
+                 swapped={}):
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
         self.typingctx = typingctx
         self.options = options
         # diagnostics
-        self.swapped = swapped if swapped else {}
+        self.swapped = swapped
         self.stats = {
             'replaced_func': 0,
             'replaced_dtype': 0,

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -554,7 +554,7 @@ class Parfor(ir.Expr, ir.Stmt):
         # if True, this parfor shouldn't be lowered sequentially even with the
         # sequential lowering option
         self.no_sequential_lowering = no_sequential_lowering
-        self.races = races if races else set()
+        self.races = races if races is not None else set()
         if config.DEBUG_ARRAY_OPT_STATS:
             fmt = 'Parallel for-loop #{} is produced from pattern \'{}\' at {}'
             print(fmt.format(
@@ -1350,14 +1350,14 @@ class PreParforPass(object):
     implementations of numpy functions if available.
     """
     def __init__(self, func_ir, typemap, calltypes, typingctx, options,
-                 swapped={}):
+                 swapped=None):
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
         self.typingctx = typingctx
         self.options = options
         # diagnostics
-        self.swapped = swapped
+        self.swapped = swapped if swapped is not None else {}
         self.stats = {
             'replaced_func': 0,
             'replaced_dtype': 0,

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -529,7 +529,7 @@ class Parfor(ir.Expr, ir.Stmt):
             pattern,
             flags,
             no_sequential_lowering=False,
-            races=set()):
+            races=None):
         super(Parfor, self).__init__(
             op='parfor',
             loc=loc
@@ -554,7 +554,7 @@ class Parfor(ir.Expr, ir.Stmt):
         # if True, this parfor shouldn't be lowered sequentially even with the
         # sequential lowering option
         self.no_sequential_lowering = no_sequential_lowering
-        self.races = races
+        self.races = races if races else set()
         if config.DEBUG_ARRAY_OPT_STATS:
             fmt = 'Parallel for-loop #{} is produced from pattern \'{}\' at {}'
             print(fmt.format(
@@ -1350,14 +1350,14 @@ class PreParforPass(object):
     implementations of numpy functions if available.
     """
     def __init__(self, func_ir, typemap, calltypes, typingctx, options,
-                 swapped={}):
+                 swapped=None):
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
         self.typingctx = typingctx
         self.options = options
         # diagnostics
-        self.swapped = swapped
+        self.swapped = swapped if swapped else {}
         self.stats = {
             'replaced_func': 0,
             'replaced_dtype': 0,

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -32,7 +32,7 @@ class ParforLoweringBuilder:
     def _calltypes(self):
         return self._lowerer.fndesc.calltypes
 
-    def bind_global_function(self, fobj, ftype, args, kws={}):
+    def bind_global_function(self, fobj, ftype, args, kws=None):
         """Binds a global function to a variable.
 
         Parameters
@@ -47,6 +47,7 @@ class ParforLoweringBuilder:
         -------
         callable: _CallableNode
         """
+        kws = kws if kws else {}
         loc = self._loc
         varname = f"{fobj.__name__}_func"
         gvname = f"{fobj.__name__}"
@@ -144,7 +145,7 @@ class ParforLoweringBuilder:
         self._lowerer.lower_inst(assign)
         return var
 
-    def call(self, callable_node, args, kws={}) -> ir.Expr:
+    def call(self, callable_node, args, kws=None) -> ir.Expr:
         """Call a bound callable
 
         Parameters
@@ -159,6 +160,7 @@ class ParforLoweringBuilder:
         res : ir.Expr
             The expression node for the return value of the call
         """
+        kws = kws if kws else {}
         call = ir.Expr.call(callable_node.func, args, kws, loc=self._loc)
         self._calltypes[call] = callable_node.sig
         return call

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -47,7 +47,7 @@ class ParforLoweringBuilder:
         -------
         callable: _CallableNode
         """
-        kws = kws if kws else {}
+        kws = kws if kws is not None else {}
         loc = self._loc
         varname = f"{fobj.__name__}_func"
         gvname = f"{fobj.__name__}"
@@ -160,7 +160,7 @@ class ParforLoweringBuilder:
         res : ir.Expr
             The expression node for the return value of the call
         """
-        kws = kws if kws else {}
+        kws = kws if kws is not None else {}
         call = ir.Expr.call(callable_node.func, args, kws, loc=self._loc)
         self._calltypes[call] = callable_node.sig
         return call

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -108,7 +108,7 @@ class ArrayAnalysisTester(Compiler):
     @classmethod
     def mk_pipeline(cls, args, return_type=None, flags=None, locals=None,
                     library=None, typing_context=None, target_context=None):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         if not flags:
             flags = Flags()
         flags.nrt = True
@@ -180,8 +180,8 @@ class TestArrayAnalysis(TestCase):
         """
         Compile the given function and get its IR.
         """
-        asserts = asserts if asserts else []
-        equivs = equivs if equivs else []
+        asserts = asserts if asserts is not None else []
+        equivs = equivs if equivs is not None else []
         test_pipeline = ArrayAnalysisTester.mk_pipeline(arg_tys)
         test_idempotence = self.compare_ir if idempotent else lambda x:()
         analysis = test_pipeline.compile_to_ir(fn, test_idempotence)

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -106,8 +106,9 @@ class ArrayAnalysisPass(FunctionPass):
 class ArrayAnalysisTester(Compiler):
 
     @classmethod
-    def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
+    def mk_pipeline(cls, args, return_type=None, flags=None, locals=None,
                     library=None, typing_context=None, target_context=None):
+        locals = locals if locals else {}
         if not flags:
             flags = Flags()
         flags.nrt = True
@@ -175,10 +176,12 @@ class TestArrayAnalysis(TestCase):
             outputs.append(output.getvalue())
         self.assertTrue(len(set(outputs)) == 1)  # assert all outputs are equal
 
-    def _compile_and_test(self, fn, arg_tys, asserts=[], equivs=[], idempotent=True):
+    def _compile_and_test(self, fn, arg_tys, asserts=None, equivs=None, idempotent=True):
         """
         Compile the given function and get its IR.
         """
+        asserts = asserts if asserts else []
+        equivs = equivs if equivs else []
         test_pipeline = ArrayAnalysisTester.mk_pipeline(arg_tys)
         test_idempotence = self.compare_ir if idempotent else lambda x:()
         analysis = test_pipeline.compile_to_ir(fn, test_idempotence)

--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -78,7 +78,7 @@ class RewritesTester(Compiler):
     @classmethod
     def mk_pipeline(cls, args, return_type=None, flags=None, locals=None,
                     library=None, typing_context=None, target_context=None):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         if not flags:
             flags = Flags()
         flags.nrt = True
@@ -92,7 +92,7 @@ class RewritesTester(Compiler):
     @classmethod
     def mk_no_rw_pipeline(cls, args, return_type=None, flags=None, locals=None,
                           library=None, **kws):
-        locals = locals if locals else {}
+        locals = locals if locals is not None else {}
         if not flags:
             flags = Flags()
         flags.no_rewrites = True

--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -76,8 +76,9 @@ def distance_matrix(vectors):
 
 class RewritesTester(Compiler):
     @classmethod
-    def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
+    def mk_pipeline(cls, args, return_type=None, flags=None, locals=None,
                     library=None, typing_context=None, target_context=None):
+        locals = locals if locals else {}
         if not flags:
             flags = Flags()
         flags.nrt = True
@@ -89,8 +90,9 @@ class RewritesTester(Compiler):
                    flags, locals)
 
     @classmethod
-    def mk_no_rw_pipeline(cls, args, return_type=None, flags=None, locals={},
+    def mk_no_rw_pipeline(cls, args, return_type=None, flags=None, locals=None,
                           library=None, **kws):
+        locals = locals if locals else {}
         if not flags:
             flags = Flags()
         flags.no_rewrites = True

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -12,7 +12,8 @@ from numba.tests.support import TestCase
 import numba.misc.numba_sysinfo as nsi
 
 
-def run_cmd(cmdline, env=os.environ, timeout=60):
+def run_cmd(cmdline, env=None, timeout=60):
+    env = env if env else os.environ
     popen = subprocess.Popen(cmdline,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -13,7 +13,7 @@ import numba.misc.numba_sysinfo as nsi
 
 
 def run_cmd(cmdline, env=None, timeout=60):
-    env = env if env else os.environ
+    env = env if env is not None else os.environ
     popen = subprocess.Popen(cmdline,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,

--- a/numba/tests/test_ir.py
+++ b/numba/tests/test_ir.py
@@ -46,7 +46,9 @@ class CheckEquality(unittest.TestCase):
     loc2 = ir.Loc('mock', 2, 0)
     loc3 = ir.Loc('mock', 3, 0)
 
-    def check(self, base, same=[], different=[]):
+    def check(self, base, same=None, different=None):
+        same = same if same else []
+        different = different if different else []
         for s in same:
             self.assertTrue(base == s)
         for d in different:
@@ -391,7 +393,8 @@ class TestIRCompounds(CheckEquality):
 
         self.assertTrue(x_ir.equal_ir(y_ir))
 
-        def check_diffstr(string, pointing_at=[]):
+        def check_diffstr(string, pointing_at=None):
+            pointing_at = pointing_at if pointing_at else []
             lines = string.splitlines()
             for item in pointing_at:
                 for l in lines:

--- a/numba/tests/test_ir.py
+++ b/numba/tests/test_ir.py
@@ -47,8 +47,8 @@ class CheckEquality(unittest.TestCase):
     loc3 = ir.Loc('mock', 3, 0)
 
     def check(self, base, same=None, different=None):
-        same = same if same else []
-        different = different if different else []
+        same = same if same is not None else []
+        different = different if different is not None else []
         for s in same:
             self.assertTrue(base == s)
         for d in different:
@@ -394,7 +394,7 @@ class TestIRCompounds(CheckEquality):
         self.assertTrue(x_ir.equal_ir(y_ir))
 
         def check_diffstr(string, pointing_at=None):
-            pointing_at = pointing_at if pointing_at else []
+            pointing_at = pointing_at if pointing_at is not None else []
             lines = string.splitlines()
             for item in pointing_at:
                 for l in lines:

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -49,9 +49,10 @@ class TestIrUtils(TestCase):
         class Tester(CompilerBase):
 
             @classmethod
-            def mk_pipeline(cls, args, return_type=None, flags=None, locals={},
-                            library=None, typing_context=None,
+            def mk_pipeline(cls, args, return_type=None, flags=None,
+                            locals=None, library=None, typing_context=None,
                             target_context=None):
+                locals = locals if locals else {}
                 if not flags:
                     flags = Flags()
                 flags.nrt = True

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -52,7 +52,7 @@ class TestIrUtils(TestCase):
             def mk_pipeline(cls, args, return_type=None, flags=None,
                             locals=None, library=None, typing_context=None,
                             target_context=None):
-                locals = locals if locals else {}
+                locals = locals if locals is not None else {}
                 if not flags:
                     flags = Flags()
                 flags.nrt = True

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -517,11 +517,12 @@ class JITTimsortMixin(object):
     test_merge_at = None
     test_merge_force_collapse = None
 
-    def wrap_with_mergestate(self, timsort, func, _cache={}):
+    def wrap_with_mergestate(self, timsort, func, _cache=None):
         """
         Wrap *func* into another compiled function inserting a runtime-created
         mergestate as the first function argument.
         """
+        _cache = _cache if _cache else {}
         key = timsort, func
         if key in _cache:
             return _cache[key]
@@ -759,7 +760,8 @@ class TestNumpySort(TestCase):
         # The original wasn't mutated
         self.assertPreciseEqual(val, orig)
 
-    def check_argsort(self, pyfunc, cfunc, val, kwargs={}):
+    def check_argsort(self, pyfunc, cfunc, val, kwargs=None):
+        kwargs = kwargs if kwargs else {}
         orig = copy.copy(val)
         expected = pyfunc(val, **kwargs)
         got = cfunc(val, **kwargs)

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -522,7 +522,7 @@ class JITTimsortMixin(object):
         Wrap *func* into another compiled function inserting a runtime-created
         mergestate as the first function argument.
         """
-        _cache = _cache if _cache else {}
+        _cache = _cache if _cache is not None else {}
         key = timsort, func
         if key in _cache:
             return _cache[key]
@@ -761,7 +761,7 @@ class TestNumpySort(TestCase):
         self.assertPreciseEqual(val, orig)
 
     def check_argsort(self, pyfunc, cfunc, val, kwargs=None):
-        kwargs = kwargs if kwargs else {}
+        kwargs = kwargs if kwargs is not None else {}
         orig = copy.copy(val)
         expected = pyfunc(val, **kwargs)
         got = cfunc(val, **kwargs)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -161,12 +161,14 @@ class BaseUFuncTest(MemoryLeakMixin):
 class TestUFuncs(BaseUFuncTest, TestCase):
 
     def basic_ufunc_test(self, ufunc, flags=no_pyobj_flags,
-                         skip_inputs=[], additional_inputs=[],
+                         skip_inputs=None, additional_inputs=None,
                          int_output_type=None, float_output_type=None,
                          kinds='ifc', positive_only=False):
 
         # Necessary to avoid some Numpy warnings being silenced, despite
         # the simplefilter() call below.
+        skip_inputs = skip_inputs if skip_inputs else []
+        additional_inputs = additional_inputs if additional_inputs else []
         self.reset_module_warnings(__name__)
 
         pyfunc = _make_ufunc_usecase(ufunc)
@@ -854,8 +856,10 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
         np.testing.assert_array_almost_equal(expected, got)
 
     def unary_op_test(self, operator, flags=enable_nrt_flags,
-                      skip_inputs=[], additional_inputs=[],
+                      skip_inputs=None, additional_inputs=None,
                       int_output_type=None, float_output_type=None):
+        skip_inputs = skip_inputs if skip_inputs else []
+        additional_inputs = additional_inputs if additional_inputs else []
         operator_func = _make_unary_ufunc_op_usecase(operator)
         inputs = list(self.inputs)
         inputs.extend(additional_inputs)
@@ -875,9 +879,11 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
             self._check_results(expected, got)
 
     def binary_op_test(self, operator, flags=enable_nrt_flags,
-                       skip_inputs=[], additional_inputs=[],
+                       skip_inputs=None, additional_inputs=None,
                        int_output_type=None, float_output_type=None,
                        positive_rhs=False):
+        skip_inputs = skip_inputs if skip_inputs else []
+        additional_inputs = additional_inputs if additional_inputs else []
         operator_func = _make_binary_ufunc_op_usecase(operator)
         inputs = list(self.inputs)
         inputs.extend(additional_inputs)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -167,8 +167,8 @@ class TestUFuncs(BaseUFuncTest, TestCase):
 
         # Necessary to avoid some Numpy warnings being silenced, despite
         # the simplefilter() call below.
-        skip_inputs = skip_inputs if skip_inputs else []
-        additional_inputs = additional_inputs if additional_inputs else []
+        skip_inputs = skip_inputs if skip_inputs is not None else []
+        additional_inputs = additional_inputs if additional_inputs is not None else []
         self.reset_module_warnings(__name__)
 
         pyfunc = _make_ufunc_usecase(ufunc)
@@ -858,8 +858,8 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
     def unary_op_test(self, operator, flags=enable_nrt_flags,
                       skip_inputs=None, additional_inputs=None,
                       int_output_type=None, float_output_type=None):
-        skip_inputs = skip_inputs if skip_inputs else []
-        additional_inputs = additional_inputs if additional_inputs else []
+        skip_inputs = skip_inputs if skip_inputs is not None else []
+        additional_inputs = additional_inputs if additional_inputs is not None else []
         operator_func = _make_unary_ufunc_op_usecase(operator)
         inputs = list(self.inputs)
         inputs.extend(additional_inputs)
@@ -882,8 +882,8 @@ class TestArrayOperators(BaseUFuncTest, TestCase):
                        skip_inputs=None, additional_inputs=None,
                        int_output_type=None, float_output_type=None,
                        positive_rhs=False):
-        skip_inputs = skip_inputs if skip_inputs else []
-        additional_inputs = additional_inputs if additional_inputs else []
+        skip_inputs = skip_inputs if skip_inputs is not None else []
+        additional_inputs = additional_inputs if additional_inputs is not None else []
         operator_func = _make_binary_ufunc_op_usecase(operator)
         inputs = list(self.inputs)
         inputs.extend(additional_inputs)


### PR DESCRIPTION
Proposal to fix #5809

Eliminates dangerous default values in numba (as identified by pylint)

Some of these cases where not actually dangerous in the way they were used, but I simply tried to get rid of all occurrences I found to be consistent. If there are good arguments in favour of keeping them, this can of course be arranged. :)