### PR TITLE
Fix side issue from #5792, @overload inliner cached IR being mutated.

### DIFF
--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -3,11 +3,11 @@ This tests the inline kwarg to @jit and @overload etc, it has nothing to do with
 LLVM or low level inlining.
 """
 
-
+from itertools import product
 import numpy as np
 
 from numba import njit, typeof
-from numba.core import types, ir, ir_utils
+from numba.core import types, ir, ir_utils, cgutils
 from numba.core.extending import (
     overload,
     overload_method,
@@ -16,14 +16,17 @@ from numba.core.extending import (
     typeof_impl,
     unbox,
     NativeValue,
+    models,
+    make_attribute_wrapper,
+    intrinsic,
     register_jitable,
 )
 from numba.core.datamodel.models import OpaqueModel
 from numba.core.cpu import InlineOptions
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
-from numba.core.typed_passes import IRLegalization
+from numba.core.typed_passes import IRLegalization, InlineOverloads
 from numba.core.untyped_passes import PreserveIR
-from itertools import product
+from numba.core.typing import signature
 from numba.tests.support import (TestCase, unittest, skip_py38_or_later,
                                  MemoryLeakMixin)
 
@@ -1129,6 +1132,105 @@ class TestInlineMiscIssues(TestCase):
             fn()
 
         self.assertIn("Something happened", str(raises.exception))
+
+    def test_issue5792(self):
+        # Issue is that overloads cache their IR and closure inliner was
+        # manipulating the cached IR in a way that broke repeated inlines.
+
+        class Dummy:
+            def __init__(self, data):
+                self.data = data
+
+            def div(self, other):
+                return data / other.data
+
+        class DummyType(types.Type):
+            def __init__(self, data):
+                self.data = data
+                super().__init__(name=f'Dummy({self.data})')
+
+        @register_model(DummyType)
+        class DummyTypeModel(models.StructModel):
+            def __init__(self, dmm, fe_type):
+                members = [
+                    ('data', fe_type.data),
+                ]
+                super().__init__(dmm, fe_type, members)
+
+        make_attribute_wrapper(DummyType, 'data', '_data')
+
+        @intrinsic
+        def init_dummy(typingctx, data):
+            def codegen(context, builder, sig, args):
+                typ = sig.return_type
+                data, = args
+                dummy = cgutils.create_struct_proxy(typ)(context, builder)
+                dummy.data = data
+
+                if context.enable_nrt:
+                    context.nrt.incref(builder, sig.args[0], data)
+
+                return dummy._getvalue()
+
+            ret_typ = DummyType(data)
+            sig = signature(ret_typ, data)
+
+            return sig, codegen
+
+        @overload(Dummy, inline='always')
+        def dummy_overload(data):
+            def ctor(data):
+                return init_dummy(data)
+
+            return ctor
+
+        @overload_method(DummyType, 'div', inline='always')
+        def div_overload(self, other):
+            def impl(self, other):
+                return self._data / other._data
+
+            return impl
+
+        @njit
+        def test_impl(data, other_data):
+            dummy = Dummy(data) # ctor inlined once
+            other = Dummy(other_data)  # ctor inlined again
+
+            return dummy.div(other)
+
+        data = 1.
+        other_data = 2.
+        res = test_impl(data, other_data)
+        self.assertEqual(res, data / other_data)
+
+    def test_issue5824(self):
+        """ Similar to the above test_issue5792, checks mutation of the inlinee
+        IR is local only"""
+
+        class CustomCompiler(CompilerBase):
+
+            def define_pipelines(self):
+                pm = DefaultPassBuilder.define_nopython_pipeline(self.state)
+                # Run the inliner twice!
+                pm.add_pass_after(InlineOverloads, InlineOverloads)
+                pm.finalize()
+                return [pm]
+
+        def bar(x):
+            ...
+
+        @overload(bar, inline='always')
+        def ol_bar(x):
+            if isinstance(x, types.Integer):
+                def impl(x):
+                    return x + 1.3
+                return impl
+
+        @njit(pipeline_class=CustomCompiler)
+        def foo(z):
+            return bar(z), bar(z)
+
+        self.assertEqual(foo(10), (11.3, 11.3))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As title. This prevents dangerous mutation of the IR cache associated
with a given overload.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
