### PR TITLE
Add support for CUDA 11 and Ampere / CC 8.0

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -202,3 +202,15 @@ stream, and the stream must remain valid whilst the Numba ``Stream`` object is
 in use.
 
 .. autofunction:: numba.cuda.external_stream
+
+
+Runtime
+-------
+
+Numba generally uses the Driver API, but it provides a simple wrapper to the
+Runtime API so that the version of the runtime in use can be queried. This is
+accessed through ``cuda.runtime``, which is an instance of the
+:class:`numba.cuda.cudadrv.runtime.Runtime` class:
+
+.. autoclass:: numba.cuda.cudadrv.runtime.Runtime
+   :members: get_version

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -44,7 +44,7 @@ MIN_REQUIRED_CC = (2, 0)
 SUPPORTS_IPC = sys.platform.startswith('linux')
 
 
-def _make_logger():
+def make_logger():
     logger = logging.getLogger(__name__)
     # is logging configured?
     if not logger.hasHandlers():
@@ -224,7 +224,7 @@ class Driver(object):
     def initialize(self):
         # lazily initialize logger
         global _logger
-        _logger = _make_logger()
+        _logger = make_logger()
 
         self.is_initialized = True
         try:

--- a/numba/cuda/cudadrv/error.py
+++ b/numba/cuda/cudadrv/error.py
@@ -2,6 +2,10 @@ class CudaDriverError(Exception):
     pass
 
 
+class CudaRuntimeError(Exception):
+    pass
+
+
 class CudaSupportError(ImportError):
     pass
 

--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -69,7 +69,7 @@ def test(_platform=None, print_paths=True):
     """Test library lookup.  Path info is printed to stdout.
     """
     failed = False
-    libs = 'cublas cusparse cufft curand nvvm'.split()
+    libs = 'cublas cusparse cufft curand nvvm cudart'.split()
     for lib in libs:
         path = get_cudalib(lib, _platform)
         print('Finding {} from {}'.format(lib, _get_source_variable(lib)))

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -274,21 +274,27 @@ default_data_layout = data_layout[tuple.__itemsize__ * 8]
 
 
 try:
-    NVVM_VERSION = NVVM().get_version()
+    from numba.cuda.cudadrv.runtime import runtime
+    cudart_version_major = runtime.get_version()[0]
 except:
-    # the CUDA driver may not be present
-    NVVM_VERSION = (0, 0)
+    # The CUDA Runtime may not be present
+    cudart_version_major = 0
 
 # List of supported compute capability in sorted order
-if NVVM_VERSION < (1, 4):
-    # CUDA 8.0
+if cudart_version_major == 0:
+    SUPPORTED_CC = (),
+elif cudart_version_major < 9:
+    # CUDA 8.x
     SUPPORTED_CC = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2)
-elif NVVM_VERSION < (1, 5):
-    # CUDA 9.0 and later
+elif cudart_version_major < 10:
+    # CUDA 9.x
     SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0)
-else:
-    # CUDA 10.0 and later
+elif cudart_version_major < 11:
+    # CUDA 10.x
     SUPPORTED_CC = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0), (7, 2), (7, 5)
+else:
+    # CUDA 11.0 and later
+    SUPPORTED_CC = (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0), (7, 2), (7, 5), (8, 0)
 
 
 def find_closest_arch(mycc):

--- a/numba/cuda/cudadrv/rtapi.py
+++ b/numba/cuda/cudadrv/rtapi.py
@@ -1,0 +1,10 @@
+"""
+Declarations of the Runtime API functions.
+"""
+
+from ctypes import c_int, POINTER
+
+API_PROTOTYPES = {
+    # cudaError_t cudaRuntimeGetVersion ( int* runtimeVersion )
+    'cudaRuntimeGetVersion': (c_int, POINTER(c_int)),
+}

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -1,0 +1,123 @@
+"""
+CUDA Runtime wrapper.
+
+This provides a very minimal set of bindings, since the Runtime API is not
+really used in Numba except for querying the Runtime version.
+"""
+
+import ctypes
+import functools
+
+from numba.core import config
+from numba.cuda.cudadrv.driver import ERROR_MAP, make_logger
+from numba.cuda.cudadrv.error import CudaSupportError, CudaRuntimeError
+from numba.cuda.cudadrv.libs import open_cudalib
+from numba.cuda.cudadrv.rtapi import API_PROTOTYPES
+from numba.cuda.cudadrv import enums
+
+
+class CudaRuntimeAPIError(CudaRuntimeError):
+    """
+    Raised when there is an error accessing a C API from the CUDA Runtime.
+    """
+    def __init__(self, code, msg):
+        self.code = code
+        self.msg = msg
+        super().__init__(code, msg)
+
+    def __str__(self):
+        return "[%s] %s" % (self.code, self.msg)
+
+
+class Runtime:
+    """
+    Runtime object that lazily binds runtime API functions.
+    """
+
+    def __init__(self):
+        self.is_initialized = False
+        try:
+            if config.DISABLE_CUDA:
+                msg = ("CUDA is disabled due to setting NUMBA_DISABLE_CUDA=1 "
+                       "in the environment, or because CUDA is unsupported on "
+                       "32-bit systems.")
+                raise CudaSupportError(msg)
+            self.lib = open_cudalib('cudart')
+            self.load_error = None
+        except CudaSupportError as e:
+            self.load_error = e
+
+    def _initialize(self):
+        # lazily initialize logger
+        global _logger
+        _logger = make_logger()
+        self.is_initialized = True
+
+    def __getattr__(self, fname):
+        # First request of a runtime API function
+        try:
+            proto = API_PROTOTYPES[fname]
+        except KeyError:
+            raise AttributeError(fname)
+        restype = proto[0]
+        argtypes = proto[1:]
+
+        if not self.is_initialized:
+            self._initialize()
+
+        if self.load_error is not None:
+            raise CudaSupportError("Error at runtime load: \n%s:" %
+                                   self.load_error)
+
+        # Find function in runtime library
+        libfn = self._find_api(fname)
+        libfn.restype = restype
+        libfn.argtypes = argtypes
+
+        safe_call = self._wrap_api_call(fname, libfn)
+        setattr(self, fname, safe_call)
+        return safe_call
+
+    def _wrap_api_call(self, fname, libfn):
+        @functools.wraps(libfn)
+        def safe_cuda_api_call(*args):
+            _logger.debug('call runtime api: %s', libfn.__name__)
+            retcode = libfn(*args)
+            self._check_error(fname, retcode)
+        return safe_cuda_api_call
+
+    def _check_error(self, fname, retcode):
+        if retcode != enums.CUDA_SUCCESS:
+            errname = ERROR_MAP.get(retcode, "cudaErrorUnknown")
+            msg = "Call to %s results in %s" % (fname, errname)
+            _logger.error(msg)
+            raise CudaRuntimeAPIError(retcode, msg)
+
+    def _find_api(self, fname):
+        try:
+            return getattr(self.lib, fname)
+        except AttributeError:
+            pass
+
+        # Not found.
+        # Delay missing function error to use
+        def absent_function(*args, **kws):
+            msg = "runtime missing function: %s."
+            raise CudaRuntimeError(msg % fname)
+
+        setattr(self, fname, absent_function)
+        return absent_function
+
+    def get_version(self):
+        """
+        Returns the CUDA Runtime version as a tuple (major, minor).
+        """
+        rtver = ctypes.c_int()
+        self.cudaRuntimeGetVersion(ctypes.byref(rtver))
+        # The version is encoded as (1000 * major) + (10 * minor)
+        major = rtver.value // 1000
+        minor = (rtver.value - (major * 1000)) // 10
+        return (major, minor)
+
+
+runtime = Runtime()

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -36,21 +36,19 @@ class Runtime:
 
     def __init__(self):
         self.is_initialized = False
-        try:
-            if config.DISABLE_CUDA:
-                msg = ("CUDA is disabled due to setting NUMBA_DISABLE_CUDA=1 "
-                       "in the environment, or because CUDA is unsupported on "
-                       "32-bit systems.")
-                raise CudaSupportError(msg)
-            self.lib = open_cudalib('cudart')
-            self.load_error = None
-        except CudaSupportError as e:
-            self.load_error = e
 
     def _initialize(self):
         # lazily initialize logger
         global _logger
         _logger = make_logger()
+
+        if config.DISABLE_CUDA:
+            msg = ("CUDA is disabled due to setting NUMBA_DISABLE_CUDA=1 "
+                   "in the environment, or because CUDA is unsupported on "
+                   "32-bit systems.")
+            raise CudaSupportError(msg)
+        self.lib = open_cudalib('cudart')
+
         self.is_initialized = True
 
     def __getattr__(self, fname):
@@ -64,10 +62,6 @@ class Runtime:
 
         if not self.is_initialized:
             self._initialize()
-
-        if self.load_error is not None:
-            raise CudaSupportError("Error at runtime load: \n%s:" %
-                                   self.load_error)
 
         # Find function in runtime library
         libfn = self._find_api(fname)

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -12,6 +12,7 @@ from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        MemoryPointer, MappedMemory,
                                        PinnedMemory, MemoryInfo,
                                        IpcHandle, set_memory_manager)
+from numba.cuda.cudadrv.runtime import runtime
 from .cudadrv import nvvm
 from numba.cuda import initialize
 from .errors import KernelRuntimeError

--- a/numba/cuda/simulator/__init__.py
+++ b/numba/cuda/simulator/__init__.py
@@ -5,6 +5,7 @@ from .cudadrv.devicearray import (device_array, device_array_like, pinned,
 from .cudadrv import devicearray
 from .cudadrv.devices import require_context, gpus
 from .cudadrv.devices import get_context as current_context
+from .cudadrv.runtime import runtime
 from numba.core import config
 reduce = Reduce
 
@@ -17,6 +18,7 @@ if config.ENABLE_CUDASIM:
     sys.modules['numba.cuda.cudadrv.devicearray'] = cudadrv.devicearray
     sys.modules['numba.cuda.cudadrv.devices'] = cudadrv.devices
     sys.modules['numba.cuda.cudadrv.driver'] = cudadrv.driver
+    sys.modules['numba.cuda.cudadrv.runtime'] = cudadrv.runtime
     sys.modules['numba.cuda.cudadrv.drvapi'] = cudadrv.drvapi
     sys.modules['numba.cuda.cudadrv.nvvm'] = cudadrv.nvvm
 

--- a/numba/cuda/simulator/cudadrv/runtime.py
+++ b/numba/cuda/simulator/cudadrv/runtime.py
@@ -1,0 +1,12 @@
+'''
+The runtime API is unsupported in the simulator, but some stubs are
+provided to allow tests to import correctly.
+'''
+
+
+class FakeRuntime(object):
+    def get_version(self):
+        return (-1, -1)
+
+
+runtime = FakeRuntime()

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -76,9 +76,9 @@ class TestNvvmDriver(unittest.TestCase):
 class TestArchOption(unittest.TestCase):
     def test_get_arch_option(self):
         # Test returning the nearest lowest arch.
-        self.assertEqual(get_arch_option(3, 0), 'compute_30')
-        self.assertEqual(get_arch_option(3, 3), 'compute_30')
-        self.assertEqual(get_arch_option(3, 4), 'compute_30')
+        self.assertEqual(get_arch_option(5, 0), 'compute_50')
+        self.assertEqual(get_arch_option(5, 1), 'compute_50')
+        self.assertEqual(get_arch_option(3, 7), 'compute_35')
         # Test known arch.
         for arch in SUPPORTED_CC:
             self.assertEqual(get_arch_option(*arch), 'compute_%d%d' % arch)

--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -1,0 +1,17 @@
+from numba.core import config
+from numba.cuda.cudadrv.runtime import runtime
+from numba.cuda.testing import unittest
+
+
+class TestRuntime(unittest.TestCase):
+    def test_get_version(self):
+        if config.ENABLE_CUDASIM:
+            supported_versions = (-1, -1),
+        else:
+            supported_versions = ((8, 0), (9, 0), (9, 1), (9, 2), (10, 0),
+                                  (10, 1), (10, 2), (11, 0))
+        self.assertIn(runtime.get_version(), supported_versions)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -179,10 +179,18 @@ class TestCudaConstantMemory(CUDATestCase):
         jcuconst = cuda.jit(cuconstRecAlign).specialize(A, B, C, D, E)
 
         if not ENABLE_CUDASIM:
+            # Code generation differs slightly in 10.2 onwards
+            if cuda.runtime.get_version() >= (10, 2):
+                first_bytes = 'ld.const.v2.u8'
+                first_bytes_msg = 'load the first two bytes as a vector'
+            else:
+                first_bytes = 'ld.const.v4.u8'
+                first_bytes_msg = 'load the first three bytes as a vector'
+
             self.assertIn(
-                'ld.const.v4.u8',
+                first_bytes,
                 jcuconst.ptx,
-                'load the first three bytes as a vector')
+                first_bytes_msg)
 
             self.assertIn(
                 'ld.const.u32',

--- a/numba/cuda/tests/cudapy/test_warp_ops.py
+++ b/numba/cuda/tests/cudapy/test_warp_ops.py
@@ -95,7 +95,7 @@ def _safe_skip():
     if config.ENABLE_CUDASIM:
         return False
     else:
-        return cuda.cudadrv.nvvm.NVVM_VERSION >= (1, 4)
+        return cuda.runtime.get_version() >= (9, 0)
 
 
 def _safe_cc_check(cc):


### PR DESCRIPTION
With CUDA 11, we need to switch to determining the supported compute capabilities using the runtime version, because:

- CC 8.0 is supported by CUDA 11.0, and not 10.2.
- The NVVM version and its IR version, as well as the soversion, are all  constant between CUDA 10.2 and 11.0.

Therefore, the existing mechanism that looks at the IR version was not sufficient to determine if CC 8.0 is supported (and also 3.0 and 3.2 unsupported, as in CUDA 11.0). It is expected that the cudart version will always be consistent with the NVVM version in the environment in which Numba is used, so the runtime version is queried instead.

This PR adds a small wrapper over the Runtime API to allow the version to be queried. It also changes the determination of the supported compute capabilities to be based on the Runtime API version rather than the NVVM IR version.

Having the Runtime API version query makes it easy to fix #5804 in a way that is precise and works for all supported toolkits, so this PR also includes a fix for that issue.

A little more detail can be found in the individual commit messages.