### PR TITLE
CUDA: Add function to get SASS for kernels

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -57,8 +57,8 @@ Dispatcher objects also provide several utility methods for inspection and
 creating a specialized instance:
 
 .. autoclass:: numba.cuda.compiler.Dispatcher
-   :members: inspect_asm, inspect_llvm, inspect_types, specialize, specialized,
-             extensions
+   :members: inspect_asm, inspect_llvm, inspect_sass, inspect_types,
+             specialize, specialized, extensions
 
 
 Intrinsic Attributes and Functions

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,6 +1,8 @@
 import ctypes
 import os
+import subprocess
 import sys
+import tempfile
 
 import numpy as np
 
@@ -127,6 +129,34 @@ def compile_ptx_for_current_device(pyfunc, args, debug=False, device=False,
     cc = get_current_device().compute_capability
     return compile_ptx(pyfunc, args, debug=-debug, device=device,
                        fastmath=fastmath, cc=cc, opt=True)
+
+
+def disassemble_cubin(cubin):
+    # nvdisasm only accepts input from a file, so we need to write out to a
+    # temp file and clean up afterwards.
+    fd = None
+    fname = None
+    try:
+        fd, fname = tempfile.mkstemp()
+        with open(fname, 'wb') as f:
+            f.write(cubin)
+
+        try:
+            cp = subprocess.run(['nvdisasm', fname], check=True,
+                                capture_output=True)
+        except FileNotFoundError as e:
+            if e.filename == 'nvdisasm':
+                msg = ("nvdisasm is required for SASS inspection, and has not "
+                       "been found.\n\nYou may need to install the CUDA "
+                       "toolkit and ensure that it is available on your "
+                       "PATH.\n")
+                raise RuntimeError(msg)
+        return cp.stdout.decode('utf-8')
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if fname is not None:
+            os.unlink(fname)
 
 
 class DeviceFunctionTemplate(object):
@@ -452,6 +482,7 @@ class CachedCUFunction(object):
         self.linking = linking
         self.cache = {}
         self.ccinfos = {}
+        self.cubins = {}
         self.max_registers = max_registers
 
     def get(self):
@@ -466,15 +497,26 @@ class CachedCUFunction(object):
             linker.add_ptx(ptx)
             for path in self.linking:
                 linker.add_file_guess_ext(path)
-            cubin, _size = linker.complete()
+            cubin, size = linker.complete()
             compile_info = linker.info_log
             module = cuctx.create_module_image(cubin)
 
             # Load
             cufunc = module.get_function(self.entry_name)
+
+            # Populate caches
             self.cache[device.id] = cufunc
             self.ccinfos[device.id] = compile_info
+            # We take a copy of the cubin because it's owned by the linker
+            cubin_ptr = ctypes.cast(cubin, ctypes.POINTER(ctypes.c_char))
+            cubin_data = np.ctypeslib.as_array(cubin_ptr, shape=(size,)).copy()
+            self.cubins[device.id] = cubin_data
         return cufunc
+
+    def get_sass(self):
+        self.get()  # trigger compilation
+        device = get_context().device
+        return disassemble_cubin(self.cubins[device.id])
 
     def get_info(self):
         self.get()   # trigger compilation
@@ -610,6 +652,14 @@ class CUDAKernel(CUDAKernelBase):
         Returns the PTX code for this kernel.
         '''
         return self._func.ptx.get().decode('ascii')
+
+    def inspect_sass(self):
+        '''
+        Returns the SASS code for this kernel.
+
+        Requires nvdisasm to be available on the PATH.
+        '''
+        return self._func.get_sass()
 
     def inspect_types(self, file=None):
         '''
@@ -859,15 +909,30 @@ class AutoJitCUDAKernel(CUDAKernelBase):
 
     def inspect_asm(self, signature=None, compute_capability=None):
         '''
-        Return the generated assembly code for all signatures encountered thus
-        far, or the LLVM IR for a specific signature and compute_capability
-        if given.
+        Return the generated PTX assembly code for all signatures encountered
+        thus far, or the PTX assembly code for a specific signature and
+        compute_capability if given.
         '''
         cc = compute_capability or get_current_device().compute_capability
         if signature is not None:
             return self.definitions[(cc, signature)].inspect_asm()
         else:
             return dict((sig, defn.inspect_asm())
+                        for sig, defn in self.definitions.items())
+
+    def inspect_sass(self, signature=None, compute_capability=None):
+        '''
+        Return the generated SASS code for all signatures encountered thus
+        far, or the SASS code for a specific signature and compute_capability
+        if given.
+
+        Requires nvdisasm to be available on the PATH.
+        '''
+        cc = compute_capability or get_current_device().compute_capability
+        if signature is not None:
+            return self.definitions[(cc, signature)].inspect_sass()
+        else:
+            return dict((sig, defn.inspect_sass())
                         for sig, defn in self.definitions.items())
 
     def inspect_types(self, file=None):

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -144,7 +144,8 @@ def disassemble_cubin(cubin):
 
         try:
             cp = subprocess.run(['nvdisasm', fname], check=True,
-                                capture_output=True)
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
         except FileNotFoundError as e:
             if e.filename == 'nvdisasm':
                 msg = ("nvdisasm is required for SASS inspection, and has not "

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import shutil
 import sys
 
 from numba.tests.support import (
@@ -57,6 +58,16 @@ def skip_if_external_memmgr(reason):
 
 def skip_under_cuda_memcheck(reason):
     return unittest.skipIf(os.environ.get('CUDA_MEMCHECK') is not None, reason)
+
+
+def skip_without_nvdisasm(reason):
+    nvdisasm_path = shutil.which('nvdisasm')
+    return unittest.skipIf(nvdisasm_path is None, reason)
+
+
+def skip_with_nvdisasm(reason):
+    nvdisasm_path = shutil.which('nvdisasm')
+    return unittest.skipIf(nvdisasm_path is not None, reason)
 
 
 class CUDATextCapture(object):


### PR DESCRIPTION
This enables calling a function `inspect_sass()` on kernels, similarly to how `inspect_asm()` provides the PTX code. It is not yet implemented for device functions, because device functions don't appear in the SASS when compiled alone without Relocatable Device Code (RDC) on, which is not presently supported by Numba.

The SASS disassembly is created by calling out to `nvdisasm`, which is required to be on the PATH.