### PR TITLE
Fix the is operator on Ellipsis

### DIFF
--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -57,6 +57,22 @@ def generic_is(context, builder, sig, args):
         return cgutils.false_bit
 
 
+@lower_builtin(operator.is_, types.Opaque, types.Opaque)
+def opaque_is(context, builder, sig, args):
+    """
+    Implementation for `x is y` for Opaque types.
+    """
+    lhs_type, rhs_type = sig.args
+    # the lhs and rhs have the same type
+    if lhs_type == rhs_type:
+        lhs_ptr = builder.ptrtoint(args[0], cgutils.intp_t)
+        rhs_ptr = builder.ptrtoint(args[1], cgutils.intp_t)
+
+        return builder.icmp_unsigned('==', lhs_ptr, rhs_ptr)
+    else:
+        return cgutils.false_bit
+
+
 @lower_builtin(operator.eq, types.Literal, types.Literal)
 @lower_builtin(operator.eq, types.IntegerLiteral, types.IntegerLiteral)
 def const_eq_impl(context, builder, sig, args):

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -504,6 +504,19 @@ class TestOperators(TestCase):
         cfunc = cres.entry_point
         self.assertTrue(cfunc(Ellipsis, Ellipsis))
 
+    def test_is_void_ptr(self):
+        # can't call this directly from python, as void cannot be unboxed
+        cfunc_void = jit(
+            (types.voidptr, types.voidptr), nopython=True
+        )(self.op.is_usecase)
+
+        # this wrapper performs the casts from int to voidptr for us
+        @jit(nopython=True)
+        def cfunc(x, y):
+            return cfunc_void(x, y)
+
+        self.assertTrue(cfunc(1, 1))
+        self.assertFalse(cfunc(1, 2))
 
     #
     # Arithmetic operators

--- a/numba/tests/test_operators.py
+++ b/numba/tests/test_operators.py
@@ -193,6 +193,10 @@ class LiteralOperatorImpl(object):
     def not_in_usecase(x, y):
         return x not in y
 
+    @staticmethod
+    def is_usecase(x, y):
+        return x is y
+
 
 class FunctionalOperatorImpl(object):
 
@@ -352,6 +356,10 @@ class FunctionalOperatorImpl(object):
     def not_in_usecase(x, y):
         return not operator.contains(y, x)
 
+    @staticmethod
+    def is_usecase(x, y):
+        return operator.is_(x, y)
+
 
 class TestOperators(TestCase):
     """
@@ -490,6 +498,11 @@ class TestOperators(TestCase):
 
     def test_ne_scalar_npm(self):
         self.test_ne_scalar(flags=Noflags)
+
+    def test_is_ellipsis(self):
+        cres = compile_isolated(self.op.is_usecase, (types.ellipsis, types.ellipsis))
+        cfunc = cres.entry_point
+        self.assertTrue(cfunc(Ellipsis, Ellipsis))
 
 
     #


### PR DESCRIPTION
This implements `a is b` on all opaque pointer types as `ptr_of(a) == ptr_of(b)`, which is exactly the meaning used by python anyway.

This implementation is copied from #3640.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
