### PR TITLE
Ensure `Dispatcher.__eq__` always returns a bool

### DIFF
--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -430,6 +430,7 @@ class WeakType(Type):
         if type(self) is type(other):
             obj = self._wr()
             return obj is not None and obj is other._wr()
+        return NotImplemented
 
     def __hash__(self):
         return Type.__hash__(self)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -153,6 +153,22 @@ skip_bad_access = unittest.skipUnless(_access_preventable, _access_msg)
 
 
 class TestDispatcher(BaseTest):
+  
+    def test_equality(self):
+        @jit
+        def foo(x):
+            return x
+        
+        @jit
+        def bar(x):
+            return x
+        
+        # Written this way to verify `==` returns a bool (gh-5838). Using
+        # `assertTrue(foo == foo)` or `assertEqual(foo, foo)` would defeat the
+        # purpose of this test.
+        self.assertEqual(foo == foo, True)
+        self.assertEqual(foo == bar, False)
+        self.assertEqual(foo == None, False)
 
     def test_dyn_pyfunc(self):
         @jit

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -153,22 +153,22 @@ skip_bad_access = unittest.skipUnless(_access_preventable, _access_msg)
 
 
 class TestDispatcher(BaseTest):
-  
+
     def test_equality(self):
         @jit
         def foo(x):
             return x
-        
+
         @jit
         def bar(x):
             return x
-        
+
         # Written this way to verify `==` returns a bool (gh-5838). Using
         # `assertTrue(foo == foo)` or `assertEqual(foo, foo)` would defeat the
         # purpose of this test.
         self.assertEqual(foo == foo, True)
         self.assertEqual(foo == bar, False)
-        self.assertEqual(foo == None, False)
+        self.assertEqual(foo == None, False)  # noqa: E711
 
     def test_dyn_pyfunc(self):
         @jit


### PR DESCRIPTION
Previously `typeof(some_jit_func) == "nonsense"` would return `None` instead of `False`

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
