### PR TITLE
Typed Tuple

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -334,7 +334,6 @@ exclude =
     numba/core/typing/ctypes_utils.py
     numba/core/typing/enumdecl.py
     numba/core/typing/cffi_utils.py
-    numba/core/typing/typeof.py
     numba/core/typing/npdatetime.py
     numba/core/annotations/type_annotations.py
     numba/roc/mathdecl.py

--- a/docs/source/user/jitclass.rst
+++ b/docs/source/user/jitclass.rst
@@ -64,14 +64,16 @@ automatically compiled.
 Any type annotations on the class will be used to extend the spec if not already
 present.  For example, if we have the class
 
-  @jitclass([("x", int32)])
-  class Foo:
-      x: int
-      y: float
-      z: T
+.. code-block:: python
 
-      def __init__(self, x, y, z):
-          ...
+    @jitclass([("x", int32)])
+    class Foo:
+        x: int
+        y: float
+        z: T
+
+        def __init__(self, x, y, z):
+            ...
 
 then the full spec used for ``Foo`` will be:
 

--- a/docs/source/user/jitclass.rst
+++ b/docs/source/user/jitclass.rst
@@ -61,6 +61,24 @@ initializing each defined fields.  Uninitialized fields contains garbage data.
 Methods and properties (getters and setters only) can be defined.  They will be
 automatically compiled.
 
+Any type annotations on the class will be used to extend the spec if not already
+present.  For example, if we have the class
+
+  @jitclass([("x", int32)])
+  class Foo:
+      x: int
+      y: float
+      z: T
+
+      def __init__(self, x, y, z):
+          ...
+
+then the full spec used for ``Foo`` will be:
+
+* ``"x": int32`` (specified in the original `spec` passed to `jitclass`)
+* ``"y": float64`` (added from type annotation)
+* ``"z": numba.typeof(T)`` (added from type annotation)
+
 Specifying ``numba.typed`` containers as class members
 ======================================================
 It is often desirable to use a ``numba.typed.Dict`` or a ``numba.typed.List`` as

--- a/examples/jitclass.py
+++ b/examples/jitclass.py
@@ -5,36 +5,38 @@
 A simple jitclass example.
 """
 
+import typing
+
 import numpy as np
-from numba import int32, float32    # import the types
+from numba import float32
 from numba.experimental import jitclass
 
-spec = [
-    ('value', int32),               # a simple scalar field
-    ('array', float32[:]),          # an array field
-]
 
-
-@jitclass(spec)
+@jitclass([("array", float32[:])])
 class Bag(object):
-    def __init__(self, value):
+    # For simple scalar fields, we can infer the spec from type annotations.
+    value: int
+    # For numpy arrays, we need to specify type and rank in the spec explicitly.
+    array: np.ndarray
+
+    def __init__(self, value: int):
         self.value = value
         self.array = np.zeros(value, dtype=np.float32)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self.array.size
 
-    def increment(self, val):
+    def increment(self, val: typing.Union[int, float]) -> np.ndarray:
         for i in range(self.size):
             self.array[i] += val
         return self.array
 
 
-mybag = Bag(21)
+mybag = Bag(7)
 print('isinstance(mybag, Bag)', isinstance(mybag, Bag))
 print('mybag.value', mybag.value)
 print('mybag.array', mybag.array)
 print('mybag.size', mybag.size)
-print('mybag.increment(3)', mybag.increment(3))
-print('mybag.increment(6)', mybag.increment(6))
+print('mybag.increment(2)', mybag.increment(2)) # call with int
+print('mybag.increment(3.14)', mybag.increment(3.14)) # call with float

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -115,7 +115,8 @@ def _typeof_type(val, c):
             return typeof_impl(str("numba"), c)
 
 
-@typeof_impl.register(py_typing.GenericMeta)
+# type(py_typing.List) is different in Python 3.6 vs. 3.7+.
+@typeof_impl.register(type(py_typing.List))
 def _typeof_typing(val, c):
     if issubclass(val, py_typing.List):
         (element_py,) = val.__args__
@@ -150,7 +151,7 @@ def _typeof_typing(val, c):
         return types.BaseTuple.from_types(tys)
 
 
-@typeof_impl.register(type(py_typing.Union))
+@typeof_impl.register(type(py_typing.Optional))
 def _typeof_optional(val, c):
     (arg_1_py, arg_2_py) = val.__args__
     if arg_2_py is not type(None): # noqa: E721

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -103,11 +103,16 @@ def _typeof_type(val, c):
     if issubclass(val, List):
         return types.TypeRef(types.ListType)
 
-    if val in (int, float, complex):
-        return typeof_impl(val(0), c)
+    if c.purpose == Purpose.argument:
+        # We only return for argument contexts.
+        # For situations like x = int(y), we want typeof(int) to return None,
+        # so that Context.resolve_value_type calls Context._get_global_type.
 
-    if val is str:
-        return typeof_impl(str("numba"), c)
+        if val in (int, float, complex):
+            return typeof_impl(val(0), c)
+
+        if val is str:
+            return typeof_impl(str("numba"), c)
 
 
 @typeof_impl.register(py_typing.GenericMeta)

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -11,6 +11,7 @@ from numba.np import numpy_support
 # terminal color markup
 _termcolor = errors.termcolor()
 
+
 class Purpose(enum.Enum):
     # Value being typed is used as an argument
     argument = 1
@@ -19,6 +20,7 @@ class Purpose(enum.Enum):
 
 
 _TypeofContext = namedtuple("_TypeofContext", ("purpose",))
+
 
 def typeof(val, purpose=Purpose.argument):
     """
@@ -29,7 +31,7 @@ def typeof(val, purpose=Purpose.argument):
     ty = typeof_impl(val, c)
     if ty is None:
         msg = _termcolor.errmsg(
-            "cannot determine Numba type of %r") % (type(val),)
+            f"Cannot determine Numba type of {type(val)}")
         raise ValueError(msg)
     return ty
 
@@ -73,14 +75,14 @@ def _typeof_buffer(val, c):
 
 
 @typeof_impl.register(ctypes._CFuncPtr)
-def typeof_ctypes_function(val, c):
+def _typeof_ctypes_function(val, c):
     from .ctypes_utils import is_ctypes_funcptr, make_function_type
     if is_ctypes_funcptr(val):
         return make_function_type(val)
 
 
 @typeof_impl.register(type)
-def typeof_type(val, c):
+def _typeof_type(val, c):
     """
     Type various specific Python types.
     """
@@ -105,13 +107,16 @@ def typeof_type(val, c):
 def _typeof_bool(val, c):
     return types.boolean
 
+
 @typeof_impl.register(float)
-def _typeof_bool(val, c):
+def _typeof_float(val, c):
     return types.float64
 
+
 @typeof_impl.register(complex)
-def _typeof_bool(val, c):
+def _typeof_complex(val, c):
     return types.complex128
+
 
 def _typeof_int(val, c):
     # As in _typeof.c
@@ -126,8 +131,10 @@ def _typeof_int(val, c):
         raise ValueError("Int value is too large: %s" % val)
     return typ
 
+
 for cls in utils.INT_TYPES:
     typeof_impl.register(cls, _typeof_int)
+
 
 @typeof_impl.register(np.generic)
 def _typeof_numpy_scalar(val, c):
@@ -136,21 +143,26 @@ def _typeof_numpy_scalar(val, c):
     except NotImplementedError:
         pass
 
+
 @typeof_impl.register(str)
 def _typeof_str(val, c):
     return types.string
+
 
 @typeof_impl.register(type((lambda a: a).__code__))
 def _typeof_code(val, c):
     return types.code_type
 
+
 @typeof_impl.register(type(None))
 def _typeof_none(val, c):
     return types.none
 
+
 @typeof_impl.register(type(Ellipsis))
 def _typeof_ellipsis(val, c):
     return types.ellipsis
+
 
 @typeof_impl.register(tuple)
 def _typeof_tuple(val, c):
@@ -159,6 +171,7 @@ def _typeof_tuple(val, c):
         return
     return types.BaseTuple.from_types(tys, type(val))
 
+
 @typeof_impl.register(list)
 def _typeof_list(val, c):
     if len(val) == 0:
@@ -166,9 +179,9 @@ def _typeof_list(val, c):
     ty = typeof_impl(val[0], c)
     if ty is None:
         raise ValueError(
-            "Cannot type list element of {!r}".format(type(val[0])),
-            )
+            f"Cannot type list element type {type(val[0])}")
     return types.List(ty, reflected=True)
+
 
 @typeof_impl.register(set)
 def _typeof_set(val, c):
@@ -176,17 +189,23 @@ def _typeof_set(val, c):
         raise ValueError("Cannot type empty set")
     item = next(iter(val))
     ty = typeof_impl(item, c)
+    if ty is None:
+        raise ValueError(
+            f"Cannot type set element type {type(item)}")
     return types.Set(ty, reflected=True)
+
 
 @typeof_impl.register(slice)
 def _typeof_slice(val, c):
     return types.slice2_type if val.step in (None, 1) else types.slice3_type
+
 
 @typeof_impl.register(enum.Enum)
 @typeof_impl.register(enum.IntEnum)
 def _typeof_enum(val, c):
     clsty = typeof_impl(type(val), c)
     return clsty.member_type
+
 
 @typeof_impl.register(enum.EnumMeta)
 def _typeof_enum_class(val, c):
@@ -204,6 +223,7 @@ def _typeof_enum_class(val, c):
     else:
         typecls = types.EnumClass
     return typecls(cls, dtypes.pop())
+
 
 @typeof_impl.register(np.dtype)
 def _typeof_dtype(val, c):
@@ -223,22 +243,22 @@ def _typeof_ndarray(val, c):
 
 
 @typeof_impl.register(types.NumberClass)
-def typeof_number_class(val, c):
+def _typeof_number_class(val, c):
     return val
 
 
 @typeof_impl.register(types.Literal)
-def typeof_literal(val, c):
+def _typeof_literal(val, c):
     return val
 
 
 @typeof_impl.register(types.TypeRef)
-def typeof_typeref(val, c):
+def _typeof_typeref(val, c):
     return val
 
 
 @typeof_impl.register(types.Type)
-def typeof_typeref(val, c):
+def _typeof_nb_type(val, c):
     if isinstance(val, types.BaseFunction):
         return val
     elif isinstance(val, (types.Number, types.Boolean)):

--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -8,7 +8,7 @@ from llvmlite import ir as llvmir
 
 from numba.core import types, utils, errors, cgutils, imputils
 from numba.core.registry import cpu_target
-from numba import njit
+from numba import njit, typeof
 from numba.core.typing import templates
 from numba.core.datamodel import default_manager, models
 from numba.experimental.jitclass import _box
@@ -167,8 +167,17 @@ def register_class_type(cls, spec, class_ctor, builder):
     builder: the internal jitclass builder
     """
     # Normalize spec
-    if isinstance(spec, Sequence):
+    if spec is None:
+        spec = OrderedDict()
+    elif isinstance(spec, Sequence):
         spec = OrderedDict(spec)
+
+    # Extend spec with class annotations.
+    if hasattr(cls, "__annotations__"):
+        for attr, py_type in cls.__annotations__.items():
+            if attr not in spec:
+                spec[attr] = typeof(py_type)
+
     _validate_spec(spec)
 
     # Fix up private attribute names

--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -261,6 +261,10 @@ def _drop_ignored_attrs(dct):
     drop = set(['__weakref__',
                 '__module__',
                 '__dict__'])
+
+    if '__annotations__' in dct:
+        drop.add('__annotations__')
+
     for k, v in dct.items():
         if isinstance(v, (pytypes.BuiltinFunctionType,
                           pytypes.BuiltinMethodType)):

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -11,56 +11,54 @@ def jitclass(cls_or_spec=None, spec=None):
 
     Different use cases will cause different arguments to be set.
 
-    1) cls_or_spec = None, spec = None
+    If specified, ``spec`` gives the types of class fields.
+    It must be a dictionary or sequence.
+    With a dictionary, use collections.OrderedDict for stable ordering.
+    With a sequence, it must contain 2-tuples of (fieldname, fieldtype).
 
-        @jitclass()
-        class Foo:
-            ...
+    Any class annotations for field names not listed in spec will be added.
+    For class annotation `x: T` we will append `("x", numba.typeof(T))` to
+    spec if x is not already a key in spec.
 
-    2) cls_or_spec = None, spec = spec
 
-        @jitclass(spec=spec)
-        class Foo:
-            ...
+    Examples
+    --------
 
-    3) cls_or_spec = Foo, spec = None
+    1) ``cls_or_spec = None``, ``spec = None``
 
-        @jitclass
-        class Foo:
-            ...
+    >>> @jitclass()
+    ... class Foo:
+    ...     ...
 
-    4) cls_or_spec = spec, spec = None
+    2) ``cls_or_spec = None``, ``spec = spec``
 
-        @jitclass(spec)
-        class Foo:
-            ...
+    >>> @jitclass(spec=spec)
+    ... class Foo:
+    ...     ...
 
-        In this case we update `cls_or_spec, spec = None, cls_or_spec`.
+    3) ``cls_or_spec = Foo``, ``spec = None``
 
-    5) cls_or_spec = Foo, spec = spec
+    >>> @jitclass
+    ... class Foo:
+    ...     ...
 
-        JitFoo = jitclass(Foo, spec)
+    4) ``cls_or_spec = spec``, ``spec = None``
+    In this case we update ``cls_or_spec, spec = None, cls_or_spec``.
 
-    Args
-    ----
-    spec:
-        Specifies the types of class fields.
-        Must be a dictionary or sequence.
-        With a dictionary, use collections.OrderedDict for stable ordering.
-        With a sequence, it must contain 2-tuples of (fieldname, fieldtype).
+    >>> @jitclass(spec)
+    ... class Foo:
+    ...     ...
 
-        Any class annotations for field names not listed in spec will be added.
-        For class annotation
-            x: T
-        we will append
-            ("x", numba.typeof(T))
-        to spec if x is not already a key in spec.
+    5) ``cls_or_spec = Foo``, ``spec = spec``
+
+    >>> JitFoo = jitclass(Foo, spec)
 
     Returns
     -------
     If used as a decorator, returns a callable that takes a class object and
     returns a compiled version.
-    If used as a function, returns the compiled class.
+    If used as a function, returns the compiled class (an instance of
+    ``JitClassType``).
     """
 
     if (cls_or_spec is not None and

--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -4,22 +4,74 @@ from numba.core import types, config, errors
 from numba.experimental.jitclass.base import register_class_type, ClassBuilder
 
 
-def jitclass(spec):
+def jitclass(cls_or_spec=None, spec=None):
     """
-    A decorator for creating a jitclass.
+    A function for creating a jitclass.
+    Can be used as a decorator or function.
 
-    **arguments**:
+    Different use cases will cause different arguments to be set.
 
-    - spec:
-        Specifies the types of each field on this class.
-        Must be a dictionary or a sequence.
+    1) cls_or_spec = None, spec = None
+
+        @jitclass()
+        class Foo:
+            ...
+
+    2) cls_or_spec = None, spec = spec
+
+        @jitclass(spec=spec)
+        class Foo:
+            ...
+
+    3) cls_or_spec = Foo, spec = None
+
+        @jitclass
+        class Foo:
+            ...
+
+    4) cls_or_spec = spec, spec = None
+
+        @jitclass(spec)
+        class Foo:
+            ...
+
+        In this case we update `cls_or_spec, spec = None, cls_or_spec`.
+
+    5) cls_or_spec = Foo, spec = spec
+
+        JitFoo = jitclass(Foo, spec)
+
+    Args
+    ----
+    spec:
+        Specifies the types of class fields.
+        Must be a dictionary or sequence.
         With a dictionary, use collections.OrderedDict for stable ordering.
         With a sequence, it must contain 2-tuples of (fieldname, fieldtype).
 
-    **returns**:
+        Any class annotations for field names not listed in spec will be added.
+        For class annotation
+            x: T
+        we will append
+            ("x", numba.typeof(T))
+        to spec if x is not already a key in spec.
 
-    A callable that takes a class object, which will be compiled.
+    Returns
+    -------
+    If used as a decorator, returns a callable that takes a class object and
+    returns a compiled version.
+    If used as a function, returns the compiled class.
     """
+
+    if (cls_or_spec is not None and
+        spec is None and
+            not isinstance(cls_or_spec, type)):
+        # Used like
+        # @jitclass([("x", intp)])
+        # class Foo:
+        #     ...
+        spec = cls_or_spec
+        cls_or_spec = None
 
     def wrap(cls):
         if config.DISABLE_JIT:
@@ -27,7 +79,10 @@ def jitclass(spec):
         else:
             return register_class_type(cls, spec, types.ClassType, ClassBuilder)
 
-    return wrap
+    if cls_or_spec is None:
+        return wrap
+    else:
+        return wrap(cls_or_spec)
 
 
 def _warning_jitclass(spec):
@@ -47,4 +102,4 @@ def _warning_jitclass(spec):
     warnings.warn(msg, category=errors.NumbaDeprecationWarning,
                   stacklevel=2)
 
-    return jitclass(spec)
+    return jitclass(spec=spec)

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -45,20 +45,28 @@ def _get_meminfo(box):
 
 class TestJitClass(TestCase, MemoryLeakMixin):
 
-    def _check_spec(self, spec):
-        @jitclass(spec)
-        class Test(object):
+    def _check_spec(self, spec, test_cls=None):
+        if test_cls is None:
+            @jitclass(spec)
+            class Test(object):
 
-            def __init__(self):
-                pass
+                def __init__(self):
+                    pass
+            test_cls = Test
 
-        clsty = Test.class_type.instance_type
+        clsty = test_cls.class_type.instance_type
         names = list(clsty.struct.keys())
         values = list(clsty.struct.values())
-        self.assertEqual(names[0], 'x')
-        self.assertEqual(names[1], 'y')
-        self.assertEqual(values[0], int32)
-        self.assertEqual(values[1], float32)
+
+        if isinstance(spec, OrderedDict):
+            all_expected = spec.items()
+        else:
+            all_expected = spec
+
+        self.assertEqual(len(names), len(spec))
+        for got, expected in zip(zip(names, values), all_expected):
+            self.assertEqual(got[0], expected[0])
+            self.assertEqual(got[1], expected[1])
 
     def test_ordereddict_spec(self):
         spec = OrderedDict()
@@ -70,6 +78,18 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         spec = [('x', int32),
                 ('y', float32)]
         self._check_spec(spec)
+
+    def test_type_annotations(self):
+        spec = [('x', int32)]
+
+        @jitclass(spec)
+        class Test(object):
+            y: int
+
+            def __init__(self):
+                pass
+
+        self._check_spec(spec, Test)
 
     def test_spec_errors(self):
         spec1 = [('x', int), ('y', float32[:])]

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import ctypes
 import random
 import pickle
+import typing as py_typing
 import warnings
 
 import numba
@@ -13,6 +14,7 @@ from numba import njit, typeof
 from numba.core import types, errors
 from numba.tests.support import TestCase, MemoryLeakMixin
 from numba.experimental.jitclass import _box
+from numba.experimental.jitclass.base import JitClassType
 from numba.core.runtime.nrt import MemInfo
 from numba.core.errors import LoweringError
 from numba.experimental import jitclass
@@ -45,7 +47,7 @@ def _get_meminfo(box):
 
 class TestJitClass(TestCase, MemoryLeakMixin):
 
-    def _check_spec(self, spec, test_cls=None):
+    def _check_spec(self, spec, test_cls=None, all_expected=None):
         if test_cls is None:
             @jitclass(spec)
             class Test(object):
@@ -58,42 +60,44 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         names = list(clsty.struct.keys())
         values = list(clsty.struct.values())
 
-        if isinstance(spec, OrderedDict):
-            all_expected = spec.items()
-        else:
-            all_expected = spec
+        if all_expected is None:
+            if isinstance(spec, OrderedDict):
+                all_expected = spec.items()
+            else:
+                all_expected = spec
 
-        self.assertEqual(len(names), len(spec))
+        self.assertEqual(len(names), len(all_expected))
         for got, expected in zip(zip(names, values), all_expected):
             self.assertEqual(got[0], expected[0])
             self.assertEqual(got[1], expected[1])
 
     def test_ordereddict_spec(self):
         spec = OrderedDict()
-        spec['x'] = int32
-        spec['y'] = float32
+        spec["x"] = int32
+        spec["y"] = float32
         self._check_spec(spec)
 
     def test_list_spec(self):
-        spec = [('x', int32),
-                ('y', float32)]
+        spec = [("x", int32),
+                ("y", float32)]
         self._check_spec(spec)
 
     def test_type_annotations(self):
-        spec = [('x', int32)]
+        spec = [("x", int32)]
 
         @jitclass(spec)
-        class Test(object):
-            y: int
+        class Test1(object):
+            x: int
+            y: py_typing.List[float]
 
             def __init__(self):
                 pass
 
-        self._check_spec(spec, Test)
+        self._check_spec(spec, Test1, spec + [("y", types.List(float64))])
 
     def test_spec_errors(self):
-        spec1 = [('x', int), ('y', float32[:])]
-        spec2 = [(1, int32), ('y', float32[:])]
+        spec1 = [("x", int), ("y", float32[:])]
+        spec2 = [(1, int32), ("y", float32[:])]
 
         class Test(object):
 
@@ -101,11 +105,11 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 pass
 
         with self.assertRaises(TypeError) as raises:
-            jitclass(spec1)(Test)
+            jitclass(Test, spec1)
         self.assertIn("spec values should be Numba type instances",
                       str(raises.exception))
         with self.assertRaises(TypeError) as raises:
-            jitclass(spec2)(Test)
+            jitclass(Test, spec2)
         self.assertEqual(str(raises.exception),
                          "spec keys should be strings, got 1")
 
@@ -124,9 +128,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def _make_Float2AndArray(self):
         spec = OrderedDict()
-        spec['x'] = float32
-        spec['y'] = float32
-        spec['arr'] = float32[:]
+        spec["x"] = float32
+        spec["y"] = float32
+        spec["arr"] = float32[:]
 
         @jitclass(spec)
         class Float2AndArray(object):
@@ -145,8 +149,8 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def _make_Vector2(self):
         spec = OrderedDict()
-        spec['x'] = int32
-        spec['y'] = int32
+        spec["x"] = int32
+        spec["y"] = int32
 
         @jitclass(spec)
         class Vector2(object):
@@ -236,7 +240,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
     def test_jitclass_datalayout(self):
         spec = OrderedDict()
         # Boolean has different layout as value vs data
-        spec['val'] = boolean
+        spec["val"] = boolean
 
         @jitclass(spec)
         class Foo(object):
@@ -251,8 +255,8 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         node_type = deferred_type()
 
         spec = OrderedDict()
-        spec['data'] = float32
-        spec['next'] = optional(node_type)
+        spec["data"] = float32
+        spec["next"] = optional(node_type)
 
         @njit
         def get_data(node):
@@ -311,9 +315,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def test_c_structure(self):
         spec = OrderedDict()
-        spec['a'] = int32
-        spec['b'] = int16
-        spec['c'] = float64
+        spec["a"] = int32
+        spec["b"] = int16
+        spec["c"] = float64
 
         @jitclass(spec)
         class Struct(object):
@@ -327,9 +331,9 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
         class CStruct(ctypes.Structure):
             _fields_ = [
-                ('a', ctypes.c_int32),
-                ('b', ctypes.c_int16),
-                ('c', ctypes.c_double),
+                ("a", ctypes.c_int32),
+                ("b", ctypes.c_int16),
+                ("c", ctypes.c_double),
             ]
 
         ptr = ctypes.c_void_p(_box.box_get_dataptr(st))
@@ -349,7 +353,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         with self.assertRaises(LoweringError) as raises:
             # trigger compilation
             do_is(vec_a, vec_a)
-        self.assertIn('no default `is` implementation', str(raises.exception))
+        self.assertIn("no default `is` implementation", str(raises.exception))
 
     def test_isinstance(self):
         Vector2 = self._make_Vector2()
@@ -370,7 +374,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             def what(self):
                 return self.attr
 
-        @jitclass([('attr', int32)])
+        @jitclass([("attr", int32)])
         class Test(Base):
 
             def __init__(self, attr):
@@ -388,13 +392,13 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 pass
 
         with self.assertRaises(TypeError) as raises:
-            jitclass(())(Mine)
+            jitclass(Mine)
 
         self.assertEqual(str(raises.exception),
                          "class members are not yet supported: constant")
 
     def test_user_getter_setter(self):
-        @jitclass([('attr', int32)])
+        @jitclass([("attr", int32)])
         class Foo(object):
 
             def __init__(self, attr):
@@ -446,7 +450,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 pass
 
         with self.assertRaises(TypeError) as raises:
-            jitclass([])(Foo)
+            jitclass(Foo)
         self.assertEqual(str(raises.exception),
                          "deleter is not supported: value")
 
@@ -464,16 +468,16 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 pass
 
         with self.assertRaises(NameError) as raises:
-            jitclass([('my_property', int32)])(Foo)
-        self.assertEqual(str(raises.exception), 'name shadowing: my_property')
+            jitclass(Foo, [("my_property", int32)])
+        self.assertEqual(str(raises.exception), "name shadowing: my_property")
 
         with self.assertRaises(NameError) as raises:
-            jitclass([('my_method', int32)])(Foo)
-        self.assertEqual(str(raises.exception), 'name shadowing: my_method')
+            jitclass(Foo, [("my_method", int32)])
+        self.assertEqual(str(raises.exception), "name shadowing: my_method")
 
     def test_distinct_classes(self):
         # Different classes with the same names shouldn't confuse the compiler
-        @jitclass([('x', int32)])
+        @jitclass([("x", int32)])
         class Foo(object):
 
             def __init__(self, x):
@@ -484,7 +488,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
         FirstFoo = Foo
 
-        @jitclass([('x', int32)])
+        @jitclass([("x", int32)])
         class Foo(object):
 
             def __init__(self, x):
@@ -508,7 +512,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 self.value = value
 
         def create_my_class(value):
-            cls = jitclass([('value', typeof(value))])(MyClass)
+            cls = jitclass(MyClass, [("value", typeof(value))])
             return cls(value)
 
         a = create_my_class(123)
@@ -525,10 +529,10 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def test_protected_attrs(self):
         spec = {
-            'value': int32,
-            '_value': float32,
-            '__value': int32,
-            '__value__': int32,
+            "value": int32,
+            "_value": float32,
+            "__value": int32,
+            "__value__": int32,
         }
 
         @jitclass(spec)
@@ -604,12 +608,12 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         with self.assertRaises(errors.TypingError) as raises:
             access_dunder(inst)
         # It will appear as "_TestJitClass__value" because the `access_dunder`
-        # is under the scope of 'TestJitClass'.
-        self.assertIn('_TestJitClass__value', str(raises.exception))
+        # is under the scope of "TestJitClass".
+        self.assertIn("_TestJitClass__value", str(raises.exception))
 
         with self.assertRaises(AttributeError) as raises:
             access_dunder.py_func(inst)
-        self.assertIn('_TestJitClass__value', str(raises.exception))
+        self.assertIn("_TestJitClass__value", str(raises.exception))
 
     def test_annotations(self):
         """
@@ -617,8 +621,8 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         """
         from .annotation_usecases import AnnotatedClass
 
-        spec = {'x': int32}
-        cls = jitclass(spec)(AnnotatedClass)
+        spec = {"x": int32}
+        cls = jitclass(AnnotatedClass, spec)
 
         obj = cls(5)
         self.assertEqual(obj.x, 5)
@@ -626,9 +630,10 @@ class TestJitClass(TestCase, MemoryLeakMixin):
 
     def test_docstring(self):
 
-        @jitclass([])
+        @jitclass
         class Apple(object):
             "Class docstring"
+
             def __init__(self):
                 "init docstring"
 
@@ -639,14 +644,14 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             def aval(self):
                 "aval property docstring"
 
-        self.assertEqual(Apple.__doc__, 'Class docstring')
-        self.assertEqual(Apple.__init__.__doc__, 'init docstring')
-        self.assertEqual(Apple.foo.__doc__, 'foo method docstring')
-        self.assertEqual(Apple.aval.__doc__, 'aval property docstring')
+        self.assertEqual(Apple.__doc__, "Class docstring")
+        self.assertEqual(Apple.__init__.__doc__, "init docstring")
+        self.assertEqual(Apple.foo.__doc__, "foo method docstring")
+        self.assertEqual(Apple.aval.__doc__, "aval property docstring")
 
     def test_kwargs(self):
-        spec = [('a', int32),
-                ('b', float64)]
+        spec = [("a", int32),
+                ("b", float64)]
 
         @jitclass(spec)
         class TestClass(object):
@@ -657,15 +662,15 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         x = 2
         y = 2
         z = 1.1
-        kwargs = {'y': y, 'z': z}
+        kwargs = {"y": y, "z": z}
         tc = TestClass(x=2, **kwargs)
         self.assertEqual(tc.a, x * y)
         self.assertEqual(tc.b, z)
 
     def test_default_args(self):
-        spec = [('x', int32),
-                ('y', int32),
-                ('z', int32)]
+        spec = [("x", int32),
+                ("y", int32),
+                ("z", int32)]
 
         @jitclass(spec)
         class TestClass(object):
@@ -690,12 +695,12 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.z, 5)
 
     def test_default_args_keyonly(self):
-        spec = [('x', int32),
-                ('y', int32),
-                ('z', int32),
-                ('a', int32)]
+        spec = [("x", int32),
+                ("y", int32),
+                ("z", int32),
+                ("a", int32)]
 
-        TestClass = jitclass(spec)(TestClass1)
+        TestClass = jitclass(TestClass1, spec)
 
         tc = TestClass(2, 3)
         self.assertEqual(tc.x, 2)
@@ -722,14 +727,14 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(tc.a, 5)
 
     def test_default_args_starargs_and_keyonly(self):
-        spec = [('x', int32),
-                ('y', int32),
-                ('z', int32),
-                ('args', types.UniTuple(int32, 2)),
-                ('a', int32)]
+        spec = [("x", int32),
+                ("y", int32),
+                ("z", int32),
+                ("args", types.UniTuple(int32, 2)),
+                ("a", int32)]
 
         with self.assertRaises(errors.UnsupportedError) as raises:
-            jitclass(spec)(TestClass2)
+            jitclass(TestClass2, spec)
 
         msg = "VAR_POSITIONAL argument type unsupported"
         self.assertIn(msg, str(raises.exception))
@@ -755,7 +760,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 self.assertPreciseEqual(expect, got)
 
     def test_getitem(self):
-        spec = [('data', int32[:])]
+        spec = [("data", int32[:])]
 
         @jitclass(spec)
         class TestClass(object):
@@ -786,7 +791,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(get_index(t, 3), 3)
 
     def test_getitem_unbox(self):
-        spec = [('data', int32[:])]
+        spec = [("data", int32[:])]
 
         @jitclass(spec)
         class TestClass(object):
@@ -812,7 +817,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(t[2], 20)
 
     def test_getitem_complex_key(self):
-        spec = [('data', int32[:, :])]
+        spec = [("data", int32[:, :])]
 
         @jitclass(spec)
         class TestClass(object):
@@ -842,7 +847,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(t[complex(2, 2)], 4)
 
     def test_getitem_tuple_key(self):
-        spec = [('data', int32[:, :])]
+        spec = [("data", int32[:, :])]
 
         @jitclass(spec)
         class TestClass(object):
@@ -871,7 +876,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(t[2, 2], 22)
 
     def test_getitem_slice_key(self):
-        spec = [('data', int32[:])]
+        spec = [("data", int32[:])]
 
         @jitclass(spec)
         class TestClass(object):
@@ -911,7 +916,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         # See issue #3872, llvm 7 introduced a max label length of 1024 chars
         # Numba ships patched llvm 7.1 (ppc64le) and patched llvm 8 to undo this
         # change, this test is here to make sure long labels are ok:
-        alphabet = [chr(ord('a') + x) for x in range(26)]
+        alphabet = [chr(ord("a") + x) for x in range(26)]
 
         spec = [(letter * 10, float64) for letter in alphabet]
         spec.extend([(letter.upper() * 10, float64) for letter in alphabet])
@@ -931,7 +936,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         TruncatedLabel().meth2()
 
     def test_pickling(self):
-        @jitclass(spec=[])
+        @jitclass
         class PickleTestSubject(object):
             def __init__(self):
                 pass
@@ -948,14 +953,77 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 pass
 
         with warnings.catch_warnings(record=True) as ws:
-            numba.experimental.jitclass([])(Test)
+            numba.experimental.jitclass(Test)
             self.assertEqual(len(ws), 0)
 
-            numba.jitclass([])(Test)
+            numba.jitclass(Test)
             self.assertEqual(len(ws), 1)
             self.assertIs(ws[0].category, errors.NumbaDeprecationWarning)
             self.assertIn("numba.experimental.jitclass", ws[0].message.msg)
 
+    def test_jitclass_decorator_usecases(self):
+        spec = OrderedDict(x=float64)
 
-if __name__ == '__main__':
+        @jitclass()
+        class Test1:
+            x: float
+
+            def __init__(self):
+                self.x = 0
+
+        self.assertIsInstance(Test1, JitClassType)
+        self.assertDictEqual(Test1.class_type.struct, spec)
+
+        @jitclass(spec=spec)
+        class Test2:
+
+            def __init__(self):
+                self.x = 0
+
+        self.assertIsInstance(Test2, JitClassType)
+        self.assertDictEqual(Test2.class_type.struct, spec)
+
+        @jitclass
+        class Test3:
+            x: float
+
+            def __init__(self):
+                self.x = 0
+
+        self.assertIsInstance(Test3, JitClassType)
+        self.assertDictEqual(Test3.class_type.struct, spec)
+
+        @jitclass(spec)
+        class Test4:
+
+            def __init__(self):
+                self.x = 0
+
+        self.assertIsInstance(Test4, JitClassType)
+        self.assertDictEqual(Test4.class_type.struct, spec)
+
+    def test_jitclass_function_usecases(self):
+        spec = OrderedDict(x=float64)
+
+        class AnnotatedTest:
+            x: float
+
+            def __init__(self):
+                self.x = 0
+
+        JitTest1 = jitclass(AnnotatedTest)
+        self.assertIsInstance(JitTest1, JitClassType)
+        self.assertDictEqual(JitTest1.class_type.struct, spec)
+
+        class UnannotatedTest:
+
+            def __init__(self):
+                self.x = 0
+
+        JitTest2 = jitclass(UnannotatedTest, spec)
+        self.assertIsInstance(JitTest2, JitClassType)
+        self.assertDictEqual(JitTest2.class_type.struct, spec)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -186,12 +186,18 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         v = [1.0] * 100
         self.assertEqual(typeof(v), types.List(types.float64, reflected=True))
 
+        bad_v = [{1: 3}]
+        with self.assertRaises(ValueError) as raises:
+            typeof(bad_v)
+        self.assertIn("Cannot type list element type", str(raises.exception))
+
     def test_sets(self):
         v = set([1.0, 2.0, 3.0])
         self.assertEqual(typeof(v), types.Set(types.float64, reflected=True))
         v = frozenset(v)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as raises:
             typeof(v)
+        self.assertIn("Cannot determine Numba type of", str(raises.exception))
 
     def test_namedtuple(self):
         v = Point(1, 2)

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -5,6 +5,7 @@ import array
 from collections import namedtuple
 import enum
 import mmap
+import typing as py_typing
 
 import numpy as np
 
@@ -306,6 +307,77 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         self.assertEqual(ty2, types.Omitted(1.0))
         self.assertEqual(len({ty0, ty1, ty2}), 3)
         self.assertEqual(ty3, ty2)
+
+    def test_builtin_types(self):
+        self.assertEqual(typeof(int), typeof(0))
+        self.assertEqual(typeof(float), typeof(0.0))
+        self.assertEqual(typeof(complex), typeof(complex(0)))
+        self.assertEqual(typeof(str), typeof("numba"))
+
+    def test_python_typing(self):
+        # Single containers.
+        self.assertEqual(
+            typeof(py_typing.List[float]), types.List(types.float64))
+        self.assertEqual(typeof(py_typing.Dict[float, str]), types.DictType(
+            types.float64, types.string))
+        self.assertEqual(
+            typeof(py_typing.Set[complex]), types.Set(types.complex128))
+        self.assertEqual(typeof(py_typing.Tuple[float, complex]), types.Tuple(
+            [types.float64, types.complex128]))
+
+        # Optional.
+        self.assertEqual(
+            typeof(py_typing.Optional[float]), types.Optional(types.float64))
+        self.assertEqual(
+            typeof(py_typing.Union[str, None]), types.Optional(types.string))
+
+        # Nested Containers.
+        system_int_type = typeof(0)
+        IntList = py_typing.List[int]
+        self.assertEqual(
+            typeof(py_typing.List[IntList]),
+            types.List(types.List(system_int_type)),
+        )
+        self.assertEqual(
+            typeof(py_typing.List[py_typing.Dict[float, int]]),
+            types.List(types.DictType(types.float64, system_int_type)),
+        )
+        self.assertEqual(
+            typeof(
+                py_typing.Set[py_typing.Tuple[py_typing.Optional[int], float]]),
+            types.Set(types.Tuple(
+                [types.Optional(system_int_type), types.float64])),
+        )
+
+        # Exceptions.
+
+        # Optional[x] is a special case of Union[x, None].  We raise a
+        # ValueError if the right type is not NoneType.
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.Union[int, float])
+        self.assertIn("Cannot type Union that is not an Optional",
+                      str(raises.exception))
+
+        # Cannot type Any.
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.Optional[py_typing.Any])
+        self.assertIn("Cannot type optional inner type", str(raises.exception))
+
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.Set[py_typing.Any])
+        self.assertIn("Cannot type set element type", str(raises.exception))
+
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.List[py_typing.Any])
+        self.assertIn("Cannot type list element type", str(raises.exception))
+
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.Dict[py_typing.Any, float])
+        self.assertIn("Cannot type dict key type", str(raises.exception))
+
+        with self.assertRaises(ValueError) as raises:
+            typeof(py_typing.Dict[float, py_typing.Any])
+        self.assertIn("Cannot type dict value type", str(raises.exception))
 
 
 class DistinctChecker(object):

--- a/numba/tests/test_typingerror.py
+++ b/numba/tests/test_typingerror.py
@@ -211,7 +211,7 @@ class TestArgumentTypingError(unittest.TestCase):
             cfunc(1, foo, 1)
 
         expected=re.compile(("This error may have been caused by the following "
-                             "argument\(s\):\\n- argument 1:.*cannot determine "
+                             "argument\(s\):\\n- argument 1:.*Cannot determine "
                              "Numba type of "
                              "<class \'numba.tests.test_typingerror.Foo\'>"))
         self.assertTrue(expected.search(str(raises.exception)) is not None)

--- a/numba/typed/__init__.py
+++ b/numba/typed/__init__.py
@@ -1,2 +1,3 @@
 from .typeddict import Dict
 from .typedlist import List
+from .typedtuple import typed_tuple

--- a/numba/typed/typedtuple.py
+++ b/numba/typed/typedtuple.py
@@ -1,0 +1,165 @@
+import functools
+
+from numba import typeof, types, njit
+
+
+def typed_tuple(cls_or_spec=None, spec=None):
+    """
+    A function for creating tuple subclasses that are typed.
+
+    By enforcing the types of the elements, we can statically define the numba
+    type of this class.  This makes for significantly faster dispatch when
+    passing such a tuple to a jitted function from normal python code.
+
+    >>> class Point(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>>
+    >>> @typed_tuple
+    ... class TypedPoint(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>>
+    >>> @njit
+    >>> def point_mag(p):
+    ...     return (p.x**2 + p.y**2)**0.5
+    >>>
+    >>> p = Point(3, 4)
+    >>> tp = TypedPoint(3, 4)
+    >>>
+    >>> point_mag(p), point_mag(tp)
+    (5.0, 5.0)
+    >>> %timeit point_mag(p)
+    9.75 µs ± 356 ns per loop
+    >>> $timeit point_mag(tp)
+    535 ns ± 10.2 ns per loop
+
+    It makes no difference when used inside a jitted function.
+
+    >>> @njit
+    ... def make_point(x, y):
+    ...     return Point(x, y)
+    >>>
+    >>> @njit
+    ... def make_typed_point(x, y):
+    ...     return TypedPoint(x, y)
+    >>>
+    >>> make_point(3, 4), make_point(3, 4)
+    (Point(x=3, y=4), TypedPoint(x=3, y=4.0))
+    >>> %timeit make_point(3, 4)
+    1.73 µs ± 72.6 ns per loop
+    >>> %timeit make_typed_point(3, 4)
+    1.85 µs ± 40.6 ns per loop
+
+
+    Examples
+    --------
+
+    1) ``cls_or_spec = None``, ``spec = None``
+
+    >>> @typed_tuple()
+    ... class Point1(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>> Point1(0, 0)
+    Point1(x=0, y=0.0)
+
+    2) ``cls_or_spec = None``, ``spec = {"x": numba.int8}``
+
+    >>> @typed_tuple(spec=dict(x=numba.int8))
+    ... class Point2(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>> Point2(200, 1)
+    Point2(x=-56, y=1.0)
+
+    3) ``cls_or_spec = Point3``, ``spec = None``
+
+    >>> @typed_tuple
+    ... class Point3(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>> Point3(0, 0)
+    Point3(x=0, y=0.0)
+
+    4) ``cls_or_spec = Point4``,
+       ``spec = {"x": numba.intp, "y": numba.float64}``
+
+    >>> Point4 = typed_tuple(
+    ...     collections.namedtuple("Point4", ("x", "y")),
+    ...     [("x", numba.intp), ("y", numba.float64)],
+    ... )
+    >>> Point4(0, 0)
+    Point4(x=0, y=0.0)
+
+    5) ``cls_or_spec = {"x": numba.intp, "y": numba.float64}``,
+       ``spec = None``
+
+    >>> @typed_tuple(dict(x=numba.int8, y=numba.float64))
+    ... class Point5(typing.NamedTuple):
+    ...     x: int
+    ...     y: float
+    >>> Point5(2.718, 3.1415)
+    Point5(x=2, y=3.1415)
+
+    """
+    if spec:
+        spec = dict(spec)
+    elif cls_or_spec and not issubclass(cls_or_spec, tuple):
+        spec = dict(cls_or_spec)
+        cls_or_spec = None
+    else:
+        spec = dict()
+
+    _ctor_template = """
+def ctor(cls, {args}):
+    return _tuple_new(cls, typecheck_tuple(({args},)))
+"""
+
+    def add_typecheck(cls):
+        assert issubclass(cls, tuple)
+
+        # Get numba type for fields.
+        annotations = getattr(cls, "__annotations__", dict())
+        nb_types = []
+        for f in cls._fields:
+            if f in spec:
+                nb_types.append(spec[f])
+            elif f in annotations:
+                nb_types.append(typeof(annotations[f]))
+            else:
+                raise RuntimeError(f"Field {f} has no spec or annotation")
+        nb_types = tuple(nb_types)
+
+        # Create a jit function that will enforce typing.
+        raw_tuple_ty = types.BaseTuple.from_types(nb_types)
+        typecheck_tuple = njit((raw_tuple_ty,))(lambda t: t)
+
+        # Update cls.__new__ to use typecheck_tuple.
+        ctor_args = ", ".join(cls._fields)
+        ctor_source = _ctor_template.format(args=ctor_args)
+
+        exec_namespace = {
+            "__name__": f"typedtuple_{cls.__name__}",
+            "_tuple_new": tuple.__new__,
+            "typecheck_tuple": typecheck_tuple,
+        }
+        exec(ctor_source, exec_namespace)
+        ctor = exec_namespace["ctor"]
+
+        assignment_fields = functools.WRAPPER_ASSIGNMENTS + (
+            "__annotations__",
+            "__defaults__",
+        )
+        functools.update_wrapper(ctor, cls.__new__, assignment_fields)
+
+        cls.__untyped_new__ = cls.__new__
+        cls.__new__ = ctor
+        cls._numba_type_ = types.BaseTuple.from_types(nb_types, cls)
+
+        return cls
+
+    if cls_or_spec is None:
+        return add_typecheck
+    else:
+        return add_typecheck(cls_or_spec)


### PR DESCRIPTION
This PR adds a decorator `@typed_tuple` that can be used to enforce type constraints on a `namedtuple` class.  Doing this allows us to statically define the numba type, so we do not need to escape to python during dispatch when such a tuple is passed as an argument to a jitted function.  This gives an order of magnitude speedup in such cases (see docstring of `typed_tuple` for examples).

This PR is not complete; I clearly need to add documentation and test coverage.  It also depends on the typing work from https://github.com/numba/numba/pull/5609.  The actual commit for typed tuples is [here](https://github.com/numba/numba/commit/386d833c12a705ba04d965affb837fbb006ba67c).  I wanted to get feedback on the idea, and also provide another example of how inferred numba specs from type hints could work.  If we decide to go forward with this, I would rebase and add tests and docs once https://github.com/numba/numba/pull/5609 merges.