### PR TITLE
cleanup: Use PythonAPI.bool_from_bool in more places

### DIFF
--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -16,8 +16,7 @@ from numba.np import numpy_support
 
 @box(types.Boolean)
 def box_bool(typ, val, c):
-    longval = c.builder.zext(val, c.pyapi.long)
-    return c.pyapi.bool_from_long(longval)
+    return c.pyapi.bool_from_bool(val)
 
 @unbox(types.Boolean)
 def unbox_boolean(typ, obj, c):

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -259,9 +259,7 @@ class PyLower(BaseLower):
             elif expr.fn == operator.not_:
                 res = self.pyapi.object_not(value)
                 self.check_int_status(res)
-
-                longval = self.builder.zext(res, self.pyapi.long)
-                res = self.pyapi.bool_from_long(longval)
+                res = self.pyapi.bool_from_bool(res)
             elif expr.fn == operator.invert:
                 res = self.pyapi.number_invert(value)
             else:

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -950,10 +950,10 @@ class PythonAPI(object):
             return self.builder.call(fn, (lhs, rhs, lopid))
         elif opstr == 'is':
             bitflag = self.builder.icmp(lc.ICMP_EQ, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr == 'is not':
             bitflag = self.builder.icmp(lc.ICMP_NE, lhs, rhs)
-            return self.from_native_value(types.boolean, bitflag)
+            return self.bool_from_bool(bitflag)
         elif opstr in ('in', 'not in'):
             fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
             fn = self._get_function(fnty, name="PySequence_Contains")


### PR DESCRIPTION
The body of bool_from_bool contains exactly the sign extension that was being performed at the callers of bool_from_long.
There is no need for `PythonAPI.object_richcompare` to go through the full unboxer for identity comparisons.

Extracted from gh-4929.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
