### PR TITLE
CUDA: Allow disabling NVVM optimizations, and fix debug issues

### DIFF
--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -32,6 +32,12 @@ class AbstractDIBuilder(object):
         pass
 
     @abc.abstractmethod
+    def initialize(self):
+        """Initialize the debug info. An opportunity for the debuginfo to
+        prepare any necessary data structures.
+        """
+
+    @abc.abstractmethod
     def finalize(self):
         """Finalize the debuginfo by emitting all necessary metadata.
         """
@@ -52,6 +58,9 @@ class DummyDIBuilder(AbstractDIBuilder):
     def mark_subprogram(self, function, name, loc):
         pass
 
+    def initialize(self):
+        pass
+
     def finalize(self):
         pass
 
@@ -66,6 +75,11 @@ class DIBuilder(AbstractDIBuilder):
         self.filepath = os.path.abspath(filepath)
         self.difile = self._di_file()
         self.subprograms = []
+        self.initialize()
+
+    def initialize(self):
+        # Create the compile unit now because it is referenced when
+        # constructing subprograms
         self.dicompileunit = self._di_compile_unit()
 
     def _var_type(self, lltype, size):
@@ -302,6 +316,7 @@ class NvvmDIBuilder(DIBuilder):
     def _di_compile_unit(self):
         filepair = self._filepair()
         empty = self.module.add_metadata([self._const_int(0)])
+        sp_metadata = self.module.add_metadata(self.subprograms)
         return self.module.add_metadata([
             self._const_int(self.DI_Compile_unit),         # tag
             filepair,                   # source directory and file pair
@@ -374,3 +389,11 @@ class NvvmDIBuilder(DIBuilder):
             None,                    # original scope
         ])
 
+    def initialize(self):
+        pass
+
+    def finalize(self):
+        # We create the compile unit at this point because subprograms is
+        # populated and can be referred to by the compile unit.
+        self.dicompileunit = self._di_compile_unit()
+        super().finalize()

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -202,7 +202,7 @@ class CompilationUnit(object):
             if options.pop('debug'):
                 opts.append('-g')
 
-        if options.get('opt'):
+        if 'opt' in options:
             opts.append('-opt=%d' % options.pop('opt'))
 
         if options.get('arch'):

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -38,7 +38,9 @@ class CUDATypingContext(typing.BaseContext):
                 if not val._can_compile:
                     raise ValueError('using cpu function on device '
                                      'but its compilation is disabled')
-                jd = jitdevice(val, debug=val.targetoptions.get('debug'))
+                opt = val.targetoptions.get('opt', True)
+                jd = jitdevice(val, debug=val.targetoptions.get('debug'),
+                               opt=opt)
                 # cache the device function for future use and to avoid
                 # duplicated copy of the same function.
                 val.__cudajitdevice = jd

--- a/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -50,6 +50,14 @@ class TestCudaDebugInfo(CUDATestCase):
 
             self._check(bar, sig=(types.int32[:],), expect=False)
 
+    def test_issue_5835(self):
+        # Invalid debug metadata would segfault NVVM when any function was
+        # compiled with debug turned on and optimization off. This eager
+        # compilation should not crash anything.
+        @cuda.jit((types.int32[::1],), debug=True, opt=False)
+        def f(x):
+            x[0] = 0
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_optimization.py
+++ b/numba/cuda/tests/cudapy/test_optimization.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+from numba.cuda.testing import skip_on_cudasim, CUDATestCase
+from numba import cuda, float64
+import unittest
+
+
+def kernel_func(x):
+    x[0] = 1
+
+
+def device_func(x, y, z):
+    return x * y + z
+
+
+# Fragments of code that are removed from kernel_func's PTX when optimization
+# is on
+removed_by_opt = ( '__local_depot0', 'call.uni', 'st.param.b64')
+
+
+@skip_on_cudasim('Simulator does not optimize code')
+class TestOptimization(CUDATestCase):
+    def test_eager_opt(self):
+        # Optimization should occur by default
+        kernel = cuda.jit((float64[::1],))(kernel_func)
+        ptx = kernel.inspect_asm()
+
+        for fragment in removed_by_opt:
+            with self.subTest(fragment=fragment):
+                self.assertNotIn(fragment, ptx)
+
+    def test_eager_noopt(self):
+        # Optimization disabled
+        kernel = cuda.jit((float64[::1],), opt=False)(kernel_func)
+        ptx = kernel.inspect_asm()
+
+        for fragment in removed_by_opt:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, ptx)
+
+    def test_lazy_opt(self):
+        # Optimization should occur by default
+        kernel = cuda.jit(opt=True)(kernel_func)
+        x = np.zeros(1, dtype=np.float64)
+        kernel[1, 1](x)
+
+        # Grab the PTX for the one definition that has just been jitted
+        ptx = next(iter(kernel.inspect_asm()))[1]
+
+        for fragment in removed_by_opt:
+            with self.subTest(fragment=fragment):
+                self.assertNotIn(fragment, ptx)
+
+    def test_lazy_noopt(self):
+        # Optimization disabled
+        kernel = cuda.jit(opt=False)(kernel_func)
+        x = np.zeros(1, dtype=np.float64)
+        kernel[1, 1](x)
+
+        # Grab the PTX for the one definition that has just been jitted
+        ptx = next(iter(kernel.inspect_asm().items()))[1]
+
+        for fragment in removed_by_opt:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, ptx)
+
+    def test_device_opt(self):
+        # Optimization should occur by default
+        device = cuda.jit(device=True)(device_func)
+        ptx = device.inspect_ptx((float64, float64, float64)).decode('utf-8')
+        self.assertIn('fma.rn.f64', ptx)
+
+    def test_device_noopt(self):
+        # Optimization disabled
+        device = cuda.jit(device=True, opt=False)(device_func)
+        ptx = device.inspect_ptx((float64, float64, float64)).decode('utf-8')
+        # Fused-multiply adds should be disabled when not optimizing
+        self.assertNotIn('fma.rn.f64', ptx)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_optimization.py
+++ b/numba/cuda/tests/cudapy/test_optimization.py
@@ -40,7 +40,7 @@ class TestOptimization(CUDATestCase):
 
     def test_lazy_opt(self):
         # Optimization should occur by default
-        kernel = cuda.jit(opt=True)(kernel_func)
+        kernel = cuda.jit(kernel_func)
         x = np.zeros(1, dtype=np.float64)
         kernel[1, 1](x)
 


### PR DESCRIPTION
This PR adds an additional kwarg to the `@cuda.jit` decorator, `opt`, which can be used to control NVVM optimization. Previously there was no way to control this - the documented `NUMBA_OPT` environment variable was ignored by the CUDA target. I haven't added support for the environment variable as I think it's likely to be of little use in typical CUDA applications - disabling optimization can easily bring a kernel over the total registers per SM with launch configurations that would otherwise have been usable. It also allows the rest of the program to run much more quickly if optimization is only disabled for kernels that specifically need it.

Disabling optimization would always result in an NVVM segfault due to invalid debuginfo metadata, so the fixes for this issue is also contained within this PR.

See individual commit messages for more details of fixes / changes.

Fixes #5835
Fixes #5836