### PR TITLE
CUDA EMM enhancements - add default get_ipc_handle implementation, skip a test conditionally

### DIFF
--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -166,6 +166,19 @@ follows:
    :member-order: bysource
 
 
+The IPC Handle Mixin
+--------------------
+
+An implementation of the ``get_ipc_handle()`` function is is provided in the
+``GetIpcHandleMixin`` class. This uses the driver API to determine the base
+address of an allocation for opening an IPC handle. If this implementation is
+appropriate for an EMM plugin, it can be added by mixing in the
+``GetIpcHandleMixin`` class:
+
+.. autoclass:: numba.cuda.GetIpcHandleMixin
+   :members: get_ipc_handle
+
+
 Classes and structures of returned objects
 ==========================================
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -804,7 +804,28 @@ class HostOnlyCUDAMemoryManager(BaseCUDAMemoryManager):
             yield
 
 
-class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
+class GetIpcHandleMixin:
+    """A class that provides a default implementation of ``get_ipc_handle()``.
+    """
+
+    def get_ipc_handle(self, memory):
+        """Open an IPC memory handle by using ``cuMemGetAddressRange`` to
+        determine the base pointer of the allocation. An IPC handle of type
+        ``cu_ipc_mem_handle`` is constructed and initialized with
+        ``cuIpcGetMemHandle``. A :class:`numba.cuda.IpcHandle` is returned,
+        populated with the underlying ``ipc_mem_handle``.
+        """
+        base, end = device_extents(memory)
+        ipchandle = drvapi.cu_ipc_mem_handle()
+        driver.cuIpcGetMemHandle(byref(ipchandle), base)
+        source_info = self.context.device.get_device_identity()
+        offset = memory.handle.value - base
+
+        return IpcHandle(memory, ipchandle, memory.size, source_info,
+                         offset=offset)
+
+
+class NumbaCUDAMemoryManager(GetIpcHandleMixin, HostOnlyCUDAMemoryManager):
     """Internal on-device memory management for Numba. This is implemented using
     the EMM Plugin interface, but is not part of the public API."""
 
@@ -833,16 +854,6 @@ class NumbaCUDAMemoryManager(HostOnlyCUDAMemoryManager):
         total = c_size_t()
         driver.cuMemGetInfo(byref(free), byref(total))
         return MemoryInfo(free=free.value, total=total.value)
-
-    def get_ipc_handle(self, memory):
-        base, end = device_extents(memory)
-        ipchandle = drvapi.cu_ipc_mem_handle()
-        driver.cuIpcGetMemHandle(byref(ipchandle), base)
-        source_info = self.context.device.get_device_identity()
-        offset = memory.handle.value - base
-
-        return IpcHandle(memory, ipchandle, memory.size, source_info,
-                         offset=offset)
 
     @property
     def interface_version(self):

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -9,8 +9,8 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,
-                                       MemoryPointer, MappedMemory,
-                                       PinnedMemory, MemoryInfo,
+                                       GetIpcHandleMixin, MemoryPointer,
+                                       MappedMemory, PinnedMemory, MemoryInfo,
                                        IpcHandle, set_memory_manager)
 from .cudadrv import nvvm
 from numba.cuda import initialize

--- a/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -31,7 +31,10 @@ class TestContextAPI(CUDATestCase):
         cuda.close()
 
     def test_context_memory(self):
-        mem = cuda.current_context().get_memory_info()
+        try:
+            mem = cuda.current_context().get_memory_info()
+        except NotImplementedError:
+            self.skipTest('EMM Plugin does not implement get_memory_info()')
 
         self.assertIsInstance(mem.free, numbers.Number)
         self.assertEquals(mem.free, mem[0])


### PR DESCRIPTION
In some cases there need not be a specialized implementation of `get_ipc_handle` for an EMM plugin - for example, RMM no longer requires one: see https://github.com/rapidsai/rmm/pull/401#issuecomment-642506112.

This PR adds a mixin that provides Numba's implementation of `get_ipc_handle` for an EMM plugin to use. It has been tested with the Numba testsuite locally with both the default memory manager and using a modified version of RMM that uses the mixin.

One test fails with an EMM plugin (`TestContextAPI.test_context_memory`) if the plugin does not implement `get_memory_info`, so a small fix for this - skipping the test as appropriate - is rolled into this PR.

