### PR TITLE
CUDA: Fix `cuda.test()`

### DIFF
--- a/numba/cuda/__init__.py
+++ b/numba/cuda/__init__.py
@@ -1,4 +1,4 @@
-import numba.testing
+from numba import runtests
 from numba.core import config
 
 if config.ENABLE_CUDASIM:
@@ -13,4 +13,4 @@ def test(*args, **kwargs):
     if not is_available():
         raise cuda_error()
 
-    return numba.testing.test("numba.cuda.tests", *args, **kwargs)
+    return runtests.main("numba.cuda.tests", *args, **kwargs)


### PR DESCRIPTION
Whilst looking at #1474 I noticed that `cuda.test()` doesn't actually work:

```
$ python -c "from numba import cuda; cuda.test()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/gmarkall/numbadev/numba/numba/cuda/__init__.py", line 16, in test
    return numba.testing.test("numba.cuda.tests", *args, **kwargs)
AttributeError: module 'numba.testing' has no attribute 'test'
```

This PR fixes running `cuda.test()` by calling `runtests.main` instead of the non-existent `numba.testing.test`.