### PR TITLE
CUDA docs: Add notes on resetting the EMM plugin

### DIFF
--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -278,7 +278,7 @@ any contexts, as EMM Plugin instances are instantiated along with contexts.
 .. autofunction:: numba.cuda.set_memory_manager
 
 
-Re-setting the memory manager
+Resetting the memory manager
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is recommended that the memory manager is set once prior to using any CUDA
@@ -305,4 +305,3 @@ to set the memory manager multiple times, noting the following:
           ``@cuda.jit`` prior to context destruction will need to be
           re-defined, as the code underlying them will also have been unloaded
           from the GPU.
-

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -272,10 +272,37 @@ Function
 --------
 
 The :func:`~numba.cuda.set_memory_manager` function can be used to set the
-memory manager at runtime. This must be called prior to the initialization of
-any contexts, and EMM Plugin instances are instantiated along with contexts.
-
-It is recommended that the memory manager is set once prior to using any CUDA
-functionality, and left unchanged for the remainder of execution.
+memory manager at runtime. This should be called prior to the initialization of
+any contexts, as EMM Plugin instances are instantiated along with contexts.
 
 .. autofunction:: numba.cuda.set_memory_manager
+
+
+Re-setting the memory manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is recommended that the memory manager is set once prior to using any CUDA
+functionality, and left unchanged for the remainder of execution. It is possible
+to set the memory manager multiple times, noting the following:
+
+* At the time of their creation, contexts are bound to an instance of a memory
+  manager for their lifetime.
+* Changing the memory manager will have no effect on existing contexts - only
+  contexts created after the memory manager was updated will use instances of
+  the new memory manager.
+* :func:`numba.cuda.close` can be used to destroy contexts after setting the
+  memory manager so that they get re-created with the new memory manager.
+
+  - This will invalidate any arrays, streams, events, and modules owned by the
+    context.
+  - Attempting to use invalid arrays, streams, or events will likely fail with
+    an exception being raised due to a ``CUDA_ERROR_INVALID_CONTEXT`` or
+    ``CUDA_ERROR_CONTEXT_IS_DESTROYED`` return code from a Driver API function.
+  - Attempting to use an invalid module will result in similar, or in some
+    cases a segmentation fault / access violation.
+
+.. note:: The invalidation of modules means that all functions compiled with
+          ``@cuda.jit`` prior to context destruction will need to be
+          re-defined, as the code underlying them will also have been unloaded
+          from the GPU.
+

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -303,5 +303,5 @@ to set the memory manager multiple times, noting the following:
 
 .. note:: The invalidation of modules means that all functions compiled with
           ``@cuda.jit`` prior to context destruction will need to be
-          re-defined, as the code underlying them will also have been unloaded
+          redefined, as the code underlying them will also have been unloaded
           from the GPU.

--- a/docs/source/cuda/external-memory.rst
+++ b/docs/source/cuda/external-memory.rst
@@ -279,7 +279,7 @@ any contexts, as EMM Plugin instances are instantiated along with contexts.
 
 
 Resetting the memory manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is recommended that the memory manager is set once prior to using any CUDA
 functionality, and left unchanged for the remainder of execution. It is possible


### PR DESCRIPTION
There are some legitimate uses for re-setting the EMM plugin. Examples:

* In the Numba testsuite: https://github.com/numba/numba/blob/master/numba/cuda/tests/cudadrv/test_emm_plugins.py#L107-L115
* Dask-cuda tests: https://github.com/rapidsai/dask-cuda/issues/313 / https://github.com/rapidsai/dask-cuda/pull/315

This PR adds some notes explaining how to re-set the memory manager, and explains the side-effects / pitfalls of doing so.