### PR TITLE
CUDA: Fix reduce docs and style improvements

### DIFF
--- a/docs/source/cuda/reduction.rst
+++ b/docs/source/cuda/reduction.rst
@@ -3,7 +3,7 @@ GPU Reduction
 
 Writing a reduction algorithm for CUDA GPU can be tricky.  Numba provides a
 ``@reduce`` decorator for converting a simple binary operation into a reduction
-kernel. A example follows::
+kernel. An example follows::
 
     import numpy
     from numba import cuda

--- a/docs/source/cuda/reduction.rst
+++ b/docs/source/cuda/reduction.rst
@@ -3,12 +3,7 @@ GPU Reduction
 
 Writing a reduction algorithm for CUDA GPU can be tricky.  Numba provides a
 ``@reduce`` decorator for converting a simple binary operation into a reduction
-kernel.
-
-``@reduce``
-------------
-
-Example::
+kernel. A example follows::
 
     import numpy
     from numba import cuda
@@ -26,12 +21,13 @@ Lambda functions can also be used here::
 
     sum_reduce = cuda.reduce(lambda a, b: a + b)
 
-class Reduce
--------------
+The Reduce class
+----------------
 
 The ``reduce`` decorator creates an instance of the ``Reduce`` class.
-(Currently, ``reduce`` is an alias to ``Reduce``, but this behavior is not
-guaranteed.)
+Currently, ``reduce`` is an alias to ``Reduce``, but this behavior is not
+guaranteed.
 
 .. autoclass:: numba.cuda.Reduce
    :members: __init__, __call__
+   :member-order: bysource

--- a/numba/cuda/kernels/reduction.py
+++ b/numba/cuda/kernels/reduction.py
@@ -160,17 +160,18 @@ def _gpu_reduce_factory(fn, nbtype):
 
 
 class Reduce(object):
+    """Create a reduction object that reduces values using a given binary
+    function. The binary function is compiled once and cached inside this
+    object. Keeping this object alive will prevent re-compilation.
+    """
+
     _cache = {}
 
     def __init__(self, functor):
-        """Create a reduction object that reduces values using a given binary
-        function. The binary function is compiled once and cached inside this
-        object. Keeping this object alive will prevent re-compilation.
-
-        :param binop: A function to be compiled as a CUDA device function that
-                    will be used as the binary operation for reduction on a
-                    CUDA device. Internally, it is compiled using
-                    ``cuda.jit(device=True)``.
+        """
+        :param functor: A function implementing a binary operation for
+                        reduction. It will be compiled as a CUDA device
+                        function using ``cuda.jit(device=True)``.
         """
         self._functor = functor
 
@@ -186,10 +187,7 @@ class Reduce(object):
     def __call__(self, arr, size=None, res=None, init=0, stream=0):
         """Performs a full reduction.
 
-        :param arr: A host or device array. If a device array is given, the
-                    reduction is performed inplace and the values in the array
-                    are overwritten. If a host array is given, it is copied to
-                    the device automatically.
+        :param arr: A host or device array.
         :param size: Optional integer specifying the number of elements in
                     ``arr`` to reduce. If this parameter is not specified, the
                     entire array is reduced.


### PR DESCRIPTION
The reduce docs were a little inaccurante - there are no circumstances under which the reduce kernel overwrites the input array (since the implementation was rewritten in 151753b2e346dfadfcc84de46eb25de25b8044e7), and the name of a parameter was incorrect. This PR fixes these issues, and makes some stylistic chances to improve readability.