### PR TITLE
Update repomap

### DIFF
--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -5,11 +5,6 @@ The Numba repository is quite large, and due to age has functionality spread
 around many locations.  To help orient developers, this document will try to
 summarize where different categories of functionality can be found.
 
-.. note::
-    It is likely that the organization of the code base will change in the
-    future to improve organization.  Follow `issue #3807 <https://github.com/numba/numba/issues/3807>`_
-    for more details.
-
 
 Support Files
 -------------
@@ -25,6 +20,7 @@ Build and Packaging
 - :ghfile:`.flake8` - Preferences for code formatting.  Files should be
   fixed and removed from the exception list as time allows.
 - :ghfile:`.pre-commit-config.yaml` - Configuration file for pre-commit hooks.
+- :ghfile:`.readthedocs.yml` - Configuration file for Read the Docs.
 - :ghfile:`buildscripts/condarecipe.local` - Conda build recipe
 - :ghfile:`buildscripts/condarecipe_clone_icc_rt` - Recipe to build a
   standalone icc_rt package.
@@ -61,6 +57,8 @@ Documentation
 - :ghfile:`docs/gh-pages.py` - Utility script to update Numba docs (stored
   as gh-pages)
 - :ghfile:`docs/make.bat` - Not used (remove?)
+- :ghfile:`docs/requirements.txt` - Pip package requirements for building docs
+  with Read the Docs.
 - :ghfile:`numba/scripts/generate_lower_listing.py` - Dump all registered
   implementations decorated with ``@lower*`` for reference
   documentation.  Currently misses implementations from the higher


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Update `repomap.rst`:
- Remove reference to #3807 (closed)
- Reflect changes made in #5782 

It also seems like `docs/make.bat`, `docs/Makefile`, and possibly `docs/gh-pages.py` could all be removed. It doesn't seem like the numba/numba-doc repo has ever been used.
