### PR TITLE
Type check function in jit decorator

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -10,8 +10,7 @@ import logging
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
-from numba.core import config, sigutils, registry
-from numba.core.dispatcher import _DispatcherBase
+from numba.core import config, extending, sigutils, registry
 
 
 _logger = logging.getLogger(__name__)
@@ -180,17 +179,17 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
     dispatcher = registry.dispatcher_registry[target]
 
     def wrapper(func):
-        if isinstance(func, _DispatcherBase):
+        if extending.is_jitted(func):
             raise TypeError(
-                "@jit decorator called on an already jitted function "
+                "A jit decorator was called on an already jitted function "
                 f"{func}.  If trying to access the original python "
                 f"function, use the {func}.py_func attribute."
             )
 
         if not inspect.isfunction(func):
             raise TypeError(
-                f"Object passed to @jit decorator is not a function (got "
-                f"type {type(func)})."
+                "The decorated object is not a function (got type "
+                f"{type(func)})."
             )
 
         if config.ENABLE_CUDASIM and target == 'cuda':

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -594,7 +594,7 @@ class TestDispatcher(BaseTest):
         expected_sigs = [(types.complex128,)]
         self.assertEqual(jitfoo.signatures, expected_sigs)
 
-    def test_dispatcher_throws(self):
+    def test_dispatcher_raises_for_invalid_decoration(self):
         # For context see https://github.com/numba/numba/issues/4750.
 
         @jit(nopython=True)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -594,6 +594,27 @@ class TestDispatcher(BaseTest):
         expected_sigs = [(types.complex128,)]
         self.assertEqual(jitfoo.signatures, expected_sigs)
 
+    def test_dispatcher_throws(self):
+        # For context see https://github.com/numba/numba/issues/4750.
+
+        @jit(nopython=True)
+        def foo(x):
+            return x
+
+        with self.assertRaises(TypeError) as raises:
+            jit(foo)
+        err_msg = str(raises.exception)
+        self.assertIn("foo", err_msg)
+        self.assertIn(".py_func", err_msg)
+        self.assertIn("already jitted function", err_msg)
+
+        with self.assertRaises(TypeError) as raises:
+            jit(BaseTest)
+        err_msg = str(raises.exception)
+        self.assertIn(
+            "Object passed to @jit decorator is not a function", err_msg)
+        self.assertIn(f"{type(BaseTest)}", err_msg)
+
 
 class TestSignatureHandling(BaseTest):
     """

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -604,15 +604,15 @@ class TestDispatcher(BaseTest):
         with self.assertRaises(TypeError) as raises:
             jit(foo)
         err_msg = str(raises.exception)
+        self.assertIn(
+            "A jit decorator was called on an already jitted function", err_msg)
         self.assertIn("foo", err_msg)
         self.assertIn(".py_func", err_msg)
-        self.assertIn("already jitted function", err_msg)
 
         with self.assertRaises(TypeError) as raises:
             jit(BaseTest)
         err_msg = str(raises.exception)
-        self.assertIn(
-            "Object passed to @jit decorator is not a function", err_msg)
+        self.assertIn("The decorated object is not a function", err_msg)
         self.assertIn(f"{type(BaseTest)}", err_msg)
 
 


### PR DESCRIPTION
Type check the argument to the jit decorator to make sure it's a python function.
In response to https://github.com/numba/numba/issues/4750.