### PR TITLE
Update the deprecation notices for 0.50.1

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -100,8 +100,8 @@ Schedule
 This feature will be removed with respect to this schedule:
 
 * Pending-deprecation warnings will be issued in version 0.44.0
-* Deprecation warnings and replacements will be issued in version 0.50.0
-* Support will be removed in version 0.51.0
+* Deprecation warnings and replacements will be issued in version 0.52.0
+* Support will be removed in version 0.53.0
 
 Recommendations
 ---------------
@@ -205,7 +205,7 @@ Schedule
 This feature will be removed with respect to this schedule:
 
 * Deprecation warnings will be issued in version 0.44.0
-* Support will be removed in version 0.50.0
+* Support will be removed in version 0.54.0
 
 Recommendations
 ---------------
@@ -253,4 +253,4 @@ This feature will be moved with respect to this schedule:
 
 * Deprecation warnings will be issued in version 0.49.0
 * Support for importing from ``numba.jitclass`` will be removed in version
-  0.51.0.
+  0.52.0.


### PR DESCRIPTION
These got missed in the 0.50.0 release.

Note the extension to the `numba.jitclass` import shim deprecation
timeline, this adds another 6-7 weeks giving users approximately
five months notice of the change.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
