### PR TITLE
Add support for overloading the __call__ operator

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -563,15 +563,6 @@ class BaseContext(object):
                 # Raise exception for the type instance, for a better error message
                 pass
 
-            # It's a type instance => try to find a definition for the type class
-            # TODO: this is weird, why are both static and non-static calls in
-            # the same place.
-            try:
-                return self.get_function(type(fn), sig)
-            except NotImplementedError:
-                # Raise exception for the type instance, for a better error message
-                pass
-
         # Automatically refresh the context to load new registries if we are
         # calling the first time.
         if _firstcall:

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -556,7 +556,7 @@ class ExternalFunction(Function):
         return self.symbol, self.sig
 
 
-class NamedTupleClass(Callable, Opaque):
+class NamedTupleClass(Opaque):
     """
     Type class for namedtuple classes.
     """
@@ -566,19 +566,12 @@ class NamedTupleClass(Callable, Opaque):
         name = "class(%s)" % (instance_class)
         super(NamedTupleClass, self).__init__(name)
 
-    def get_call_type(self, context, args, kws):
-        # Overridden by the __call__ constructor resolution in typing.collections
-        return None
-
-    def get_call_signatures(self):
-        return (), True
-
     @property
     def key(self):
         return self.instance_class
 
 
-class NumberClass(Callable, DTypeSpec, Opaque):
+class NumberClass(DTypeSpec, Opaque):
     """
     Type class for number classes (e.g. "np.float64").
     """
@@ -587,13 +580,6 @@ class NumberClass(Callable, DTypeSpec, Opaque):
         self.instance_type = instance_type
         name = "class(%s)" % (instance_type,)
         super(NumberClass, self).__init__(name)
-
-    def get_call_type(self, context, args, kws):
-        # Overridden by the __call__ constructor resolution in typing.builtins
-        return None
-
-    def get_call_signatures(self):
-        return (), True
 
     @property
     def key(self):

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -771,7 +771,7 @@ class NumberClassAttribute(AttributeTemplate):
                 # Scalar constructor, e.g. np.int32(42)
                 return ty
 
-        return types.Function(make_callable_template(key=ty, typer=typer))
+        return types.Function(make_callable_template(key=(ty, '__call__'), typer=typer))
 
 
 @infer_getattr
@@ -809,7 +809,7 @@ class TypeRefAttribute(AttributeTemplate):
                         self.pysig = result.pysig
                     return result
 
-            return types.Function(make_callable_template(key=ty,
+            return types.Function(make_callable_template(key=(ty, '__call__'),
                                                          typer=Redirect(self.context)))
 
 

--- a/numba/core/typing/collections.py
+++ b/numba/core/typing/collections.py
@@ -118,4 +118,4 @@ class NamedTupleClassAttribute(AttributeTemplate):
 
         # Override the typer's pysig to match the namedtuple constructor's
         typer.pysig = pysig
-        return types.Function(make_callable_template(self.key, typer))
+        return types.Function(make_callable_template((self.key, '__call__'), typer))

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -279,7 +279,7 @@ def complex_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-@lower_builtin(types.NumberClass, types.Any)
+@lower_builtin((types.NumberClass, '__call__'), types.Any)
 def number_constructor(context, builder, sig, args):
     """
     Call a number class, e.g. np.int32(...)
@@ -544,7 +544,7 @@ def iterable_max(iterable):
     return min_max_impl(iterable, greater_than)
 
 
-@lower_builtin(types.TypeRef, types.VarArg(types.Any))
+@lower_builtin((types.TypeRef, '__call__'), types.VarArg(types.Any))
 def redirect_type_ctor(context, builder, sig, args):
     """Redirect constructor implementation to `numba_typeref_ctor(cls, *args)`,
     which should be overloaded by type implementator.

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -14,7 +14,7 @@ from numba.core import typing, types, cgutils
 from numba.core.extending import overload_method, overload, intrinsic
 
 
-@lower_builtin(types.NamedTupleClass, types.VarArg(types.Any))
+@lower_builtin((types.NamedTupleClass, '__call__'), types.VarArg(types.Any))
 def namedtuple_constructor(context, builder, sig, args):
     # A namedtuple has the same representation as a regular tuple
     # the arguments need casting (lower_cast) from the types in the ctor args

--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -531,7 +531,7 @@ def imp_dtor(context, module, instance_type):
     return dtor_fn
 
 
-@ClassBuilder.class_impl_registry.lower(types.ClassType,
+@ClassBuilder.class_impl_registry.lower((types.ClassType, '__call__'),
                                         types.VarArg(types.Any))
 def ctor_impl(context, builder, sig, args):
     """


### PR DESCRIPTION
With this in place, `@numba.extending.overload_method(ExtensionType, '__call__')` appears to work.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Possibly a fix for #5885.