### PR TITLE
Reduce objmode and unpickling overhead

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -992,16 +992,16 @@ raise_error:
 NUMBA_EXPORT_FUNC(PyObject *)
 numba_unpickle(const char *data, int n)
 {
-    PyObject *buf, *obj;
+    PyObject *buf, *obj, *addr;
     static PyObject *loads;
 
     /* Caching the pickle.loads function shaves a couple µs here. */
     if (loads == NULL) {
         PyObject *picklemod;
-        picklemod = PyImport_ImportModule("pickle");
+        picklemod = PyImport_ImportModule("numba.core.serialize");
         if (picklemod == NULL)
             return NULL;
-        loads = PyObject_GetAttrString(picklemod, "loads");
+        loads = PyObject_GetAttrString(picklemod, "_numba_unpickle");
         Py_DECREF(picklemod);
         if (loads == NULL)
             return NULL;
@@ -1010,7 +1010,9 @@ numba_unpickle(const char *data, int n)
     buf = PyBytes_FromStringAndSize(data, n);
     if (buf == NULL)
         return NULL;
-    obj = PyObject_CallFunctionObjArgs(loads, buf, NULL);
+
+    addr = PyLong_FromVoidPtr(data);
+    obj = PyObject_CallFunctionObjArgs(loads, addr, buf, NULL);
     Py_DECREF(buf);
     return obj;
 }

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -878,7 +878,6 @@ numba_do_raise(PyObject *exc_packed)
         Py_XINCREF(value);
         Py_XINCREF(loc);
         if (PyExceptionClass_Check(exc)) {
-            Py_DECREF(exc_packed);
             /* It is a class, type used here just as a tmp var */
             type = PyObject_CallObject(exc, value);
             if (type == NULL)
@@ -891,8 +890,6 @@ numba_do_raise(PyObject *exc_packed)
             /* all ok, set type to the exc */
             Py_DECREF(type);
             type = exc;
-            Py_INCREF(type);
-            Py_INCREF(value);
         } else {
             /* this should be unreachable as typing should catch it */
             /* Not something you can raise.  You get an exception
@@ -1016,7 +1013,6 @@ numba_unpickle(const char *data, int n)
 
     addr = PyLong_FromVoidPtr(data);
     obj = PyObject_CallFunctionObjArgs(loads, addr, buf, NULL);
-    Py_DECREF(addr);
     Py_DECREF(buf);
     return obj;
 }

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -878,6 +878,7 @@ numba_do_raise(PyObject *exc_packed)
         Py_XINCREF(value);
         Py_XINCREF(loc);
         if (PyExceptionClass_Check(exc)) {
+            Py_DECREF(exc_packed);
             /* It is a class, type used here just as a tmp var */
             type = PyObject_CallObject(exc, value);
             if (type == NULL)
@@ -890,6 +891,8 @@ numba_do_raise(PyObject *exc_packed)
             /* all ok, set type to the exc */
             Py_DECREF(type);
             type = exc;
+            Py_INCREF(type);
+            Py_INCREF(value);
         } else {
             /* this should be unreachable as typing should catch it */
             /* Not something you can raise.  You get an exception
@@ -1013,6 +1016,7 @@ numba_unpickle(const char *data, int n)
 
     addr = PyLong_FromVoidPtr(data);
     obj = PyObject_CallFunctionObjArgs(loads, addr, buf, NULL);
+    Py_DECREF(addr);
     Py_DECREF(buf);
     return obj;
 }

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -316,7 +316,7 @@ class _MinimalCallHelper(object):
             msg = "unknown error %d in native function" % exc_id
             return SystemError, (msg,)
 
-# excinfo_t is the same LLVM type created by serialize_uncache()
+# The structure type constructed by PythonAPI.serialize_uncached()
 # i.e a {i8* pickle_buf, i32 pickle_bufsz, i8* hash_buf}
 excinfo_t = ir.LiteralStructType([GENERIC_POINTER, int32_t, GENERIC_POINTER])
 excinfo_ptr_t = ir.PointerType(excinfo_t)

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -316,8 +316,9 @@ class _MinimalCallHelper(object):
             msg = "unknown error %d in native function" % exc_id
             return SystemError, (msg,)
 
-
-excinfo_t = ir.LiteralStructType([GENERIC_POINTER, int32_t])
+# excinfo_t is the same LLVM type created by serialize_uncache()
+# i.e a {i8* pickle_buf, i32 pickle_bufsz, i8* hash_buf}
+excinfo_t = ir.LiteralStructType([GENERIC_POINTER, int32_t, GENERIC_POINTER])
 excinfo_ptr_t = ir.PointerType(excinfo_t)
 
 

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -169,7 +169,7 @@ class PyLower(BaseLower):
 
     @utils.cached_property
     def _omitted_typobj(self):
-        """Return a `OmittedArg` type instance in LLVM value suitable for
+        """Return a `OmittedArg` type instance as a LLVM value suitable for
         testing at runtime.
         """
         from numba.core.dispatcher import OmittedArg

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -5,6 +5,7 @@ Lowering implementation for object mode.
 
 import builtins
 import operator
+import inspect
 
 from llvmlite.llvmpy.core import Type, Constant
 import llvmlite.llvmpy.core as lc
@@ -75,10 +76,6 @@ class PyLower(BaseLower):
     def pre_lower(self):
         super(PyLower, self).pre_lower()
         self.init_pyapi()
-        # Pre-computed for later use
-        from numba.core.dispatcher import OmittedArg
-        self.omitted_typobj = self.pyapi.unserialize(
-            self.pyapi.serialize_object(OmittedArg))
 
     def post_lower(self):
         pass
@@ -170,6 +167,15 @@ class PyLower(BaseLower):
         else:
             raise NotImplementedError(type(inst), inst)
 
+    @utils.cached_property
+    def _omitted_typobj(self):
+        """Return a `OmittedArg` type instance in LLVM value suitable for
+        testing at runtime.
+        """
+        from numba.core.dispatcher import OmittedArg
+        return self.pyapi.unserialize(
+            self.pyapi.serialize_object(OmittedArg))
+
     def lower_assign(self, inst):
         """
         The returned object must have a new reference
@@ -188,21 +194,29 @@ class PyLower(BaseLower):
         elif isinstance(value, ir.Yield):
             return self.lower_yield(value)
         elif isinstance(value, ir.Arg):
+            # TODO: check why value.name may not exist
+            param = self.func_ir.func_id.pysig.parameters.get(value.name)
+
             obj = self.fnargs[value.index]
-            # When an argument is omitted, the dispatcher hands it as
-            # _OmittedArg(<default value>)
-            typobj = self.pyapi.get_type(obj)
             slot = cgutils.alloca_once_value(self.builder, obj)
-            is_omitted = self.builder.icmp_unsigned('==', typobj,
-                                                    self.omitted_typobj)
-            with self.builder.if_else(is_omitted, likely=False) as (omitted, present):
-                with present:
-                    self.incref(obj)
-                    self.builder.store(obj, slot)
-                with omitted:
-                    # The argument is omitted => get the default value
-                    obj = self.pyapi.object_getattr_string(obj, 'value')
-                    self.builder.store(obj, slot)
+            # Don't check for OmittedArg unless the argument has a default
+            if param is not None and param.default is inspect.Parameter.empty:
+                self.incref(obj)
+                self.builder.store(obj, slot)
+            else:
+                # When an argument is omitted, the dispatcher hands it as
+                # _OmittedArg(<default value>)
+                typobj = self.pyapi.get_type(obj)
+                is_omitted = self.builder.icmp_unsigned('==', typobj,
+                                                        self._omitted_typobj)
+                with self.builder.if_else(is_omitted, likely=False) as (omitted, present):
+                    with present:
+                        self.incref(obj)
+                        self.builder.store(obj, slot)
+                    with omitted:
+                        # The argument is omitted => get the default value
+                        obj = self.pyapi.object_getattr_string(obj, 'value')
+                        self.builder.store(obj, slot)
 
             return self.builder.load(slot)
         else:

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -194,7 +194,6 @@ class PyLower(BaseLower):
         elif isinstance(value, ir.Yield):
             return self.lower_yield(value)
         elif isinstance(value, ir.Arg):
-            # TODO: check why value.name may not exist
             param = self.func_ir.func_id.pysig.parameters.get(value.name)
 
             obj = self.fnargs[value.index]

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import contextlib
 import pickle
+import hashlib
 
 from llvmlite import ir
 from llvmlite.llvmpy.core import Type, Constant
@@ -1298,11 +1299,13 @@ class PythonAPI(object):
         Unserialize some data.  *structptr* should be a pointer to
         a {i8* data, i32 length} structure.
         """
-        fnty = Type.function(self.pyobj, (self.voidptr, ir.IntType(32)))
+        fnty = Type.function(self.pyobj,
+                             (self.voidptr, ir.IntType(32), self.voidptr))
         fn = self._get_function(fnty, name="numba_unpickle")
         ptr = self.builder.extract_value(self.builder.load(structptr), 0)
         n = self.builder.extract_value(self.builder.load(structptr), 1)
-        return self.builder.call(fn, (ptr, n))
+        hashed = self.builder.extract_value(self.builder.load(structptr), 2)
+        return self.builder.call(fn, (ptr, n, hashed))
 
     def serialize_uncached(self, obj):
         """
@@ -1314,11 +1317,19 @@ class PythonAPI(object):
         assert len(data) < 2**31
         name = ".const.pickledata.%s" % (id(obj) if config.DIFF_IR == 0 else "DIFF_IR")
         bdata = cgutils.make_bytearray(data)
+        # Make SHA1 hash on the pickled content
+        # NOTE: update buffer size in numba_unpickle() when changing the
+        #       hash algorithm.
+        hashed = cgutils.make_bytearray(hashlib.sha1(data).digest())
         arr = self.context.insert_unique_const(self.module, name, bdata)
+        hasharr = self.context.insert_unique_const(
+            self.module, f"{name}.sha1", hashed,
+        )
         # Then populate the structure constant
         struct = ir.Constant.literal_struct([
             arr.bitcast(self.voidptr),
             ir.Constant(ir.IntType(32), arr.type.pointee.count),
+            hasharr.bitcast(self.voidptr),
             ])
         return struct
 

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1310,7 +1310,7 @@ class PythonAPI(object):
     def serialize_uncached(self, obj):
         """
         Same as serialize_object(), but don't create a global variable,
-        simply return a literal {i8* data, i32 length} structure.
+        simply return a literal {i8* data, i32 length, i8* hashbuf} structure.
         """
         # First make the array constant
         data = serialize.dumps(obj)

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -138,12 +138,13 @@ _unpickled_memo = {}
 
 
 def _numba_unpickle(address, bytedata, hashed):
-    """Used by `numba_unpickle`.
+    """Used by `numba_unpickle` from _helperlib.c
 
     Parameters
     ----------
     address : int
-    bytedata: bytes
+    bytedata : bytes
+    hashed : bytes
 
     Returns
     -------

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -137,7 +137,7 @@ def _rebuild_code(marshal_version, bytecode_magic, marshalled):
 _unpickled_memo = {}
 
 
-def _numba_unpickle(address, bytedata):
+def _numba_unpickle(address, bytedata, hashed):
     """Used by `numba_unpickle`.
 
     Parameters
@@ -150,10 +150,11 @@ def _numba_unpickle(address, bytedata):
     obj : object
         unpickled object
     """
+    key = (address, hashed)
     try:
-        obj = _unpickled_memo[address]
+        obj = _unpickled_memo[key]
     except KeyError:
-        _unpickled_memo[address] = obj = pickle.loads(bytedata)
+        _unpickled_memo[key] = obj = pickle.loads(bytedata)
     return obj
 
 

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -100,7 +100,7 @@ class _ModuleCompiler(object):
 
     method_def_ptr = lc.Type.pointer(method_def_ty)
 
-    env_def_ty = lc.Type.struct((lt._void_star, lt._int32))
+    env_def_ty = lc.Type.struct((lt._void_star, lt._int32, lt._void_star))
     env_def_ptr = lc.Type.pointer(env_def_ty)
 
     def __init__(self, export_entries, module_name, use_nrt=False,

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -99,7 +99,7 @@ class _ModuleCompiler(object):
                                     lt._int8_star))
 
     method_def_ptr = lc.Type.pointer(method_def_ty)
-
+    # The structure type constructed by PythonAPI.serialize_uncached()
     env_def_ty = lc.Type.struct((lt._void_star, lt._int32, lt._void_star))
     env_def_ptr = lc.Type.pointer(env_def_ty)
 

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -59,6 +59,7 @@ extern void *nrt_atomic_add, *nrt_atomic_sub;
 typedef struct {
     const char *data;
     int len;
+    const char *hashbuf;
 } env_def_t;
 
 /* Environment GlobalVariable address type */
@@ -73,7 +74,7 @@ recreate_environment(PyObject *module, env_def_t env)
     EnvironmentObject *envobj;
     PyObject *env_consts;
 
-    env_consts = numba_unpickle(env.data, env.len);
+    env_consts = numba_unpickle(env.data, env.len, env.hashbuf);
     if (env_consts == NULL)
         return NULL;
     if (!PyList_Check(env_consts)) {

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -186,5 +186,23 @@ class TestDispatcherPickling(TestCase):
         """
         subprocess.check_call([sys.executable, "-c", code])
 
+
+class TestSerializationMisc(TestCase):
+    def test_numba_unpickle(self):
+        # Test that _numba_unpickle is memorizing its output
+        from numba.core.serialize import _numba_unpickle
+
+        random_obj = object()
+        bytebuf = pickle.dumps(random_obj)
+        hashed = hash(random_obj)
+
+        got1 = _numba_unpickle(id(random_obj), bytebuf, hashed)
+        # not the original object
+        self.assertIsNot(got1, random_obj)
+        got2 = _numba_unpickle(id(random_obj), bytebuf, hashed)
+        # unpickled results are the same objects
+        self.assertIs(got1, got2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Depends on https://github.com/numba/numba/pull/6017
Closes https://github.com/numba/numba/pull/6024

Proposed patch to reduce objmode function overhead and unpickling overhead.

- https://github.com/numba/numba/commit/831d5bf62dfa20006d68c05a3673cf0b4e6c754e Fixes objmode function unnecessarily unpickling the type object of `OmittedArg`, which is only needed for function that has default arguments.
- https://github.com/numba/numba/commit/2a6ac69f61058f5d0671679ff39bdb83a55ebf69 keeps a memo (a `dict`) to cache unpickled object by C `numba_unpickle()` to reduce overhead at unpickling at runtime. Keeping a memo allows us to clear the cached objects to reduce memory consumption.

**Background of the runtime unpickling**

Numba pickle python objects and reconstructs them at runtime for certain operations (like boxing, unboxing) that needs to reference live python objects. But a compiled function cannot hold references to live objects directly; otherwise, it can't be cached. Pickling let's us get around that problem by serializing live objects into a byte string that we can reconstruct at runtime.
