### PR TITLE
Fix default arguments with multiprocessing 

### DIFF
--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -66,7 +66,7 @@ def _reduce_function(func, globs):
         cells = [cell.cell_contents for cell in func.__closure__]
     else:
         cells = None
-    return _reduce_code(func.__code__), globs, func.__name__, cells
+    return _reduce_code(func.__code__), globs, func.__name__, cells, func.__defaults__
 
 def _reduce_code(code):
     """
@@ -80,7 +80,7 @@ def _dummy_closure(x):
     """
     return lambda: x
 
-def _rebuild_function(code_reduced, globals, name, cell_values):
+def _rebuild_function(code_reduced, globals, name, cell_values, defaults):
     """
     Rebuild a function from its _reduce_function() results.
     """
@@ -96,7 +96,7 @@ def _rebuild_function(code_reduced, globals, name, cell_values):
         # If the module can't be found, avoid passing it (it would produce
         # errors when lowering).
         del globals['__name__']
-    return FunctionType(code, globals, name, (), cells)
+    return FunctionType(code, globals, name, defaults, cells)
 
 def _rebuild_code(marshal_version, bytecode_magic, marshalled):
     """

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -15,7 +15,7 @@ from io import StringIO
 
 import numpy as np
 
-from numba import jit, generated_jit, typeof
+from numba import njit, jit, generated_jit, typeof
 from numba.core import types, errors, codegen
 from numba import _dispatcher
 from numba.core.compiler import compile_isolated
@@ -1963,6 +1963,47 @@ class TestNoRetryFailedSignature(unittest.TestCase):
         # compilation.
         self.assertEqual(ct_ok, 1)
         self.assertEqual(ct_bad, 1)
+
+
+class TestMultiprocessingDefaultParameters(unittest.TestCase):
+    def run_fc_multiproc(self, fc):
+        try:
+            ctx = multiprocessing.get_context('spawn')
+        except AttributeError:
+            ctx = multiprocessing
+        with ctx.Pool(1) as p:
+            self.assertEqual(p.map(fc, [1, 2, 3]), list(map(fc, [1, 2, 3])))
+
+    def test_int_def_param(self):
+        """ Tests issue #4888"""
+
+        @njit
+        def add(x, y=1):
+            return x + y
+
+        self.run_fc_multiproc(add)
+
+    def test_none_def_param(self):
+        """ Tests None as a default parameter"""
+
+        @njit
+        def add(x, y=None):
+            return x + (1 if y else 2)
+
+        self.run_fc_multiproc(add)
+
+    def test_function_def_param(self):
+        """ Tests a function as a default parameter"""
+
+        @njit
+        def mult(x, y):
+            return x*y
+
+        @njit
+        def add(x, func=mult):
+            return x + func(x, x)
+
+        self.run_fc_multiproc(add)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -26,7 +26,8 @@ from numba.tests.support import (TestCase, temp_directory, import_dynamic,
 from numba.np.numpy_support import as_dtype
 from numba.core.caching import _UserWideCacheLocator
 from numba.core.dispatcher import Dispatcher
-from numba.tests.support import skip_parfors_unsupported, needs_lapack
+from numba.tests.support import (skip_parfors_unsupported, needs_lapack,
+                                 SerialMixin)
 
 import llvmlite.binding as ll
 import unittest
@@ -1965,10 +1966,10 @@ class TestNoRetryFailedSignature(unittest.TestCase):
         self.assertEqual(ct_bad, 1)
 
 
-class TestMultiprocessingDefaultParameters(unittest.TestCase):
+class TestMultiprocessingDefaultParameters(SerialMixin, unittest.TestCase):
     def run_fc_multiproc(self, fc):
         try:
-            ctx = multiprocessing.get_context('spawn')
+            ctx = multiprocessing.get_context('fork')
         except AttributeError:
             ctx = multiprocessing
         with ctx.Pool(1) as p:

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1998,7 +1998,7 @@ class TestMultiprocessingDefaultParameters(SerialMixin, unittest.TestCase):
 
         @njit
         def mult(x, y):
-            return x*y
+            return x * y
 
         @njit
         def add(x, func=mult):

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1969,7 +1969,7 @@ class TestNoRetryFailedSignature(unittest.TestCase):
 class TestMultiprocessingDefaultParameters(SerialMixin, unittest.TestCase):
     def run_fc_multiproc(self, fc):
         try:
-            ctx = multiprocessing.get_context('fork')
+            ctx = multiprocessing.get_context('spawn')
         except AttributeError:
             ctx = multiprocessing
         with ctx.Pool(1) as p:


### PR DESCRIPTION
closes #4888

Default arguments were not included in the (de)serialization of the Dispatcher object, resulting in rebuilt Dispatchers that lost the default arguments and failed when called without explicit values for that parameter.

Simply adding the default values to the output of `__reduce__` and using them to rebuild the Dispatcher fixes the problem.