### PR TITLE
Initial support for dynamic gufuncs

### DIFF
--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -356,7 +356,7 @@ on dynamic compilation.
 Dynamic generalized universal functions
 =======================================
 
-Similar to a dynamic universal function, if you do not specif any types to
+Similar to a dynamic universal function, if you do not specify any types to
 the :func:`~numba.guvectorize` decorator, your Python function will be used
 to build a dynamic generalized universal function, or :class:`~numba.GUFunc`.
 For example::

--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -418,6 +418,6 @@ One can also verify that Numpy ufunc casting rules are working as expected::
    >>> g(x, y, res)
    >>> res
 
-If you need support for varios type signatures, you should not rely on dynamic
+If you need precise support for various type signatures, you should not rely on dynamic
 compilation and instead, specify the types them as first
 argument in the :func:`~numba.guvectorize` decorator.

--- a/docs/source/user/vectorize.rst
+++ b/docs/source/user/vectorize.rst
@@ -157,6 +157,11 @@ argument, which must be filled in by the function.  This is because the
 array is actually allocated by NumPy's dispatch mechanism, which calls into
 the Numba-generated code.
 
+Similar to :func:`~numba.vectorize` decorator, :func:`~numba.guvectorize`
+also has two modes of operation: Eager, or decoration-time compilation and
+lazy, or call-time compilation.
+
+
 Here is a very simple example::
 
    @guvectorize([(int64[:], int64, int64[:])], '(n),()->(n)')
@@ -347,3 +352,72 @@ floating-point values.  For example::
 If you require precise support for various type signatures, you should
 specify them in the :func:`~numba.vectorize` decorator, and not rely
 on dynamic compilation.
+
+Dynamic generalized universal functions
+=======================================
+
+Similar to a dynamic universal function, if you do not specif any types to
+the :func:`~numba.guvectorize` decorator, your Python function will be used
+to build a dynamic generalized universal function, or :class:`~numba.GUFunc`.
+For example::
+
+   from numba import guvectorize
+
+   @guvectorize('(n),()->(n)')
+   def g(x, y, res):
+       for i in range(x.shape[0]):
+           res[i] = x[i] + y
+
+We can verify the resulting function :func:`g` is a :class:`~numba.GUFunc`
+instance that starts with no supported input types. For instance::
+
+   >>> g
+   <numba._GUFunc 'g'>
+   >>> g.ufunc
+   <ufunc 'g'>
+   >>> g.ufunc.types
+   []
+
+Similar to a :class:`~numba.DUFunc`, as one make calls to :func:`g()`,
+numba generates new kernels for previously unsupported input types. The
+following set of interpreter interactions will illustrate how dynamic
+compilation works for a :class:`~numba.GUFunc`::
+
+   >>> x = np.arange(5, dtype=np.int64)
+   >>> y = 10
+   >>> res = np.zeros_like(x)
+   >>> g(x, y, res)
+   >>> res
+   array([5, 6, 7, 8, 9])
+   >>> g.types
+   ['ll->l']
+
+If this was a normal :func:`guvectorize` function, we would have seen an
+exception complaining that the ufunc could not handle the given input types.
+When we call :func:`g()` with the input arguments, numba creates a new loop
+for the input types.
+
+We can add additional loops by calling :func:`g` with new arguments::
+
+   >>> x = np.arange(5, dtype=np.double)
+   >>> y = 2.2
+   >>> res = np.zeros_like(x)
+   >>> g(x, y, res)
+
+We can now verify that Numba added a second loop for dealing with
+floating-point inputs, :code:`"dd->d"`.
+
+   >>> g.types  # shorthand for g.ufunc.types
+   ['ll->l', 'dd->d']
+
+One can also verify that Numpy ufunc casting rules are working as expected::
+
+   >>> x = np.arange(5, dtype=np.int64)
+   >>> y = 2.2
+   >>> res = np.zeros_like(x)
+   >>> g(x, y, res)
+   >>> res
+
+If you need support for varios type signatures, you should not rely on dynamic
+compilation and instead, specify the types them as first
+argument in the :func:`~numba.guvectorize` decorator.

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -1,6 +1,6 @@
 from ctypes import byref, c_int, sizeof
 from numba.cuda.cudadrv.driver import (host_to_device, device_to_host, driver,
-                                      launch_kernel)
+                                       launch_kernel)
 from numba.cuda.cudadrv import devices, drvapi
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -448,7 +448,7 @@ def ufunc_find_matching_loop(ufunc, arg_types):
 
     for candidate in ufunc.types:
         ufunc_inputs = candidate[:ufunc.nin]
-        ufunc_outputs = candidate[-ufunc.nout:]
+        ufunc_outputs = candidate[-ufunc.nout:] if ufunc.nout else []
         if 'O' in ufunc_inputs:
             # Skip object arrays
             continue

--- a/numba/np/ufunc/decorators.py
+++ b/numba/np/ufunc/decorators.py
@@ -46,8 +46,13 @@ class GUVectorize(_BaseVectorize):
         identity = cls.get_identity(kws)
         cache = cls.get_cache(kws)
         imp = cls.get_target_implementation(kws)
-        return imp(func, signature, identity=identity, cache=cache,
-                   targetoptions=kws)
+        if imp is gufunc.GUFunc:
+            is_dyn = kws.pop('is_dynamic', False)
+            return imp(func, signature, identity=identity, cache=cache,
+                       is_dynamic=is_dyn, targetoptions=kws)
+        else:
+            return imp(func, signature, identity=identity, cache=cache,
+                       targetoptions=kws)
 
 
 def vectorize(ftylist_or_function=(), **kws):
@@ -172,6 +177,7 @@ def guvectorize(*args, **kwargs):
     if len(args) == 1:
         ftylist = []
         signature = args[0]
+        kwargs.setdefault('is_dynamic', True)
     elif len(args) == 2:
         ftylist = args[0]
         signature = args[1]
@@ -188,8 +194,6 @@ def guvectorize(*args, **kwargs):
             guvec.add(fty)
         if len(ftylist) > 0:
             guvec.disable_compile()
-        else:
-            guvec.is_dynamic = True
         return guvec.build_ufunc()
 
     return wrap

--- a/numba/np/ufunc/decorators.py
+++ b/numba/np/ufunc/decorators.py
@@ -188,6 +188,8 @@ def guvectorize(*args, **kwargs):
             guvec.add(fty)
         if len(ftylist) > 0:
             guvec.disable_compile()
+        else:
+            guvec.is_dynamic = True
         return guvec.build_ufunc()
 
     return wrap

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -117,12 +117,6 @@ class GUFunc(object):
         return types.none(*l)
 
     def __call__(self, *args):
-
-        # a gufunc is dynamic if no calls to `.add()` were made prior to this point  # noqa: E501
-        # if no calls were made, then, self.gufunc_builder._cres is empty
-        if len(self.gufunc_builder._cres) == 0:
-            self._is_dynamic = True
-
         # If compilation is disabled OR it is NOT a dynamic gufunc, call the underlying gufunc  # noqa: E501
         if self._frozen or not self.is_dynamic:
             return self.ufunc(*args)

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -14,10 +14,10 @@ class GUFunc(object):
     """
 
     def __init__(self, py_func, signature, identity=None, cache=None,
-                 targetoptions={}):
+                 is_dynamic=False, targetoptions={}):
         self.ufunc = None
         self._frozen = False
-        self._is_dynamic = False
+        self._is_dynamic = is_dynamic
 
         # GUFunc cannot inherit from GUFuncBuilder because "identity"
         # is a property of GUFunc. Thus, we hold a reference to a GUFuncBuilder
@@ -43,10 +43,6 @@ class GUFunc(object):
     @property
     def is_dynamic(self):
         return self._is_dynamic
-
-    @is_dynamic.setter
-    def is_dynamic(self, value):
-        self._is_dynamic = value
 
     @property
     def __doc__(self):

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -39,7 +39,6 @@ class GUFunc(object):
     @property
     def is_dynamic(self):
         return self._is_dynamic
-    
 
     @property
     def __doc__(self):
@@ -111,18 +110,18 @@ class GUFunc(object):
 
     def __call__(self, *args):
 
-        # a gufunc is dynamic if no calls to `.add()` were made prior to this point
+        # a gufunc is dynamic if no calls to `.add()` were made prior to this point  # noqa: E501
         # if no calls were made, then, self.gufunc_builder._cres is empty
         if len(self.gufunc_builder._cres) == 0:
             self._is_dynamic = True
 
-        # If compilation is disabled OR it is NOT a dynamic gufunc, call the underlying gufunc
+        # If compilation is disabled OR it is NOT a dynamic gufunc, call the underlying gufunc  # noqa: E501
         if self._frozen or not self.is_dynamic:
             return self.ufunc(*args)
 
-        if self._num_args_match(*args) == False:
-            # It is not allowed to call a dynamic gufunc without providing all the arguments
-            # see: https://github.com/numba/numba/pull/5938#discussion_r506429392
+        if self._num_args_match(*args) is False:
+            # It is not allowed to call a dynamic gufunc without providing all the arguments  # noqa: E501
+            # see: https://github.com/numba/numba/pull/5938#discussion_r506429392  # noqa: E501
             msg = (
                 f"Too few arguments for function '{self.__name__}'. "
                 "Note that the pattern `out = gufunc(Arg1, Arg2, ..., ArgN)` "

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -33,12 +33,20 @@ class GUFunc(object):
         return self
 
     def disable_compile(self):
+        """
+        Disable the compilation of new signatures at call time.
+        """
+        # If disabling compilation then there must be at least one signature
         assert len(self.gufunc_builder._sigs) > 0
         self._frozen = True
 
     @property
     def is_dynamic(self):
         return self._is_dynamic
+
+    @is_dynamic.setter
+    def is_dynamic(self, value):
+        self._is_dynamic = value
 
     @property
     def __doc__(self):

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -93,7 +93,8 @@ class GUFunc(object):
 
     def _get_signature(self, *args):
         parsed_sig = parse_signature(self.gufunc_builder.signature)
-        ewise_types = self._get_ewise_dtypes(args)  # [int32, int32, int32, ...]  # noqa: E501
+        # ewise_types is a list of [int32, int32, int32, ...]
+        ewise_types = self._get_ewise_dtypes(args)
 
         # first time calling the gufunc
         # generate a signature based on input arguments
@@ -113,17 +114,20 @@ class GUFunc(object):
         return types.none(*l)
 
     def __call__(self, *args):
-        # If compilation is disabled OR it is NOT a dynamic gufunc, call the underlying gufunc  # noqa: E501
+        # If compilation is disabled OR it is NOT a dynamic gufunc
+        # call the underlying gufunc
         if self._frozen or not self.is_dynamic:
             return self.ufunc(*args)
 
         if self._num_args_match(*args) is False:
-            # It is not allowed to call a dynamic gufunc without providing all the arguments  # noqa: E501
+            # It is not allowed to call a dynamic gufunc without
+            # providing all the arguments
             # see: https://github.com/numba/numba/pull/5938#discussion_r506429392  # noqa: E501
             msg = (
                 f"Too few arguments for function '{self.__name__}'. "
                 "Note that the pattern `out = gufunc(Arg1, Arg2, ..., ArgN)` "
-                "is not allowed. Use `gufunc(Arg1, Arg2, ..., ArgN, out) instead.")  # noqa: E501
+                "is not allowed. Use `gufunc(Arg1, Arg2, ..., ArgN, out) "
+                "instead.")
             raise TypeError(msg)
 
         # at this point we know the gufunc is a dynamic one

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -1,0 +1,130 @@
+from numba import typeof
+from numba.core import types
+from numba.np.ufunc.ufuncbuilder import GUFuncBuilder
+from numba.np.ufunc.sigparse import parse_signature
+from numba.np.numpy_support import ufunc_find_matching_loop
+
+
+class GUFunc(object):
+    """
+    Dynamic generalized universal function (GUFunc)
+    intended to act like a normal Numpy gufunc, but capable
+    of call-time (just-in-time) compilation of fast loops
+    specialized to inputs.
+    """
+
+    def __init__(self, py_func, signature, identity=None, cache=None,
+                 targetoptions={}):
+        self.ufunc = None
+        self._frozen = False
+
+        # GUFunc cannot inherit from GUFuncBuilder because "identity"
+        # is a property of GUFunc. Thus, we hold a reference to a GUFuncBuilder
+        # object here
+        self.gufunc_builder = GUFuncBuilder(
+            py_func, signature, identity, cache, targetoptions)
+
+    def add(self, fty):
+        self.gufunc_builder.add(fty)
+
+    def build_ufunc(self):
+        self.ufunc = self.gufunc_builder.build_ufunc()
+        return self
+
+    def disable_compile(self):
+        assert len(self.gufunc_builder._sigs) > 0
+        self._frozen = True
+
+    @property
+    def __doc__(self):
+        return self.ufunc.__doc__
+
+    @property
+    def __name__(self):
+        return self.ufunc.__name__
+
+    @property
+    def nin(self):
+        return self.ufunc.nin
+
+    @property
+    def nout(self):
+        return self.ufunc.nout
+
+    @property
+    def nargs(self):
+        return self.ufunc.nargs
+
+    @property
+    def ntypes(self):
+        return self.ufunc.ntypes
+
+    @property
+    def types(self):
+        return self.ufunc.types
+
+    @property
+    def identity(self):
+        return self.ufunc.identity
+
+    def _get_ewise_dtypes(self, args):
+        argtys = map(lambda x: typeof(x), args)
+        tys = []
+        for argty in argtys:
+            if isinstance(argty, types.Array):
+                tys.append(argty.dtype)
+            else:
+                tys.append(argty)
+        return tys
+
+    def _get_signature(self, *args):
+        parsed_sig = parse_signature(self.gufunc_builder.signature)
+        ewise_types = self._get_ewise_dtypes(args)  # [int32, int32, int32, ...]  # noqa: E501
+
+        # Two cases here can happen here
+        # 1. args contains the output array:
+        #      gufunc(A, B, C)
+        # 2. args doesn't contains the output array:
+        #      C = gufunc(A, B)
+        #
+        # In the latter case, one would have to guess the type
+        # and format (scalar or array). This behavior will be
+        # forbidden for now.
+        # See: https://github.com/numba/numba/pull/5938#issuecomment-661978921
+
+        # parsed_sig[1] has always length 1
+        if len(ewise_types) < len(parsed_sig[0]) + 1:
+            msg = (
+                f"Too few arguments for function '{self.__name__}'. "
+                "Note that the pattern `out = gufunc(Arg1, Arg2, ..., ArgN)` "
+                "is not allowed. Use `gufunc(Arg1, Arg2, ..., ArgN, out) instead.")  # noqa: E501
+            raise TypeError(msg)
+
+        # first time calling the gufunc
+        # generate a signature based on input arguments
+        l = []
+        for idx, sig_dim in enumerate(parsed_sig[0]):
+            ndim = len(sig_dim)
+            if ndim == 0:  # append scalar
+                l.append(ewise_types[idx])
+            else:
+                l.append(types.Array(ewise_types[idx], ndim, 'A'))
+
+        # add return type to signature
+        retty = ewise_types[-1]
+        ret_ndim = len(parsed_sig[-1][0]) or 1  # small hack to return scalar
+        l.append(types.Array(retty, ret_ndim, 'A'))
+
+        return types.none(*l)
+
+    def __call__(self, *args):
+
+        if self._frozen:
+            return self.ufunc(*args)
+
+        ewise = self._get_ewise_dtypes(args)
+        if not (self.ufunc and ufunc_find_matching_loop(self.ufunc, ewise)):
+            sig = self._get_signature(*args)
+            self.add(sig)
+            self.build_ufunc()
+        return self.ufunc(*args)

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -24,7 +24,7 @@ class GUFunc(object):
         # object here
         self.gufunc_builder = GUFuncBuilder(
             py_func, signature, identity, cache, targetoptions)
-    
+
     def __repr__(self):
         return f"<numba._GUFunc '{self.__name__}'>"
 

--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -24,6 +24,9 @@ class GUFunc(object):
         # object here
         self.gufunc_builder = GUFuncBuilder(
             py_func, signature, identity, cache, targetoptions)
+    
+    def __repr__(self):
+        return f"<numba._GUFunc '{self.__name__}'>"
 
     def add(self, fty):
         self.gufunc_builder.add(fty)

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -312,8 +312,8 @@ class GUFuncBuilder(_BaseUFuncBuilder):
 
     @global_compiler_lock
     def build_ufunc(self):
-        dtypelist = []
-        ptrlist = []
+        type_list = []
+        func_list = []
         if not self.nb_func:
             raise TypeError("No definition")
 
@@ -322,19 +322,19 @@ class GUFuncBuilder(_BaseUFuncBuilder):
         for sig in self._sigs:
             cres = self._cres[sig]
             dtypenums, ptr, env = self.build(cres)
-            dtypelist.append(dtypenums)
-            ptrlist.append(int(ptr))
+            type_list.append(dtypenums)
+            func_list.append(int(ptr))
             keepalive.append((cres.library, env))
 
-        datlist = [None] * len(ptrlist)
+        datalist = [None] * len(func_list)
 
-        inct = len(self.sin)
-        outct = len(self.sout)
+        nin = len(self.sin)
+        nout = len(self.sout)
 
         # Pass envs to fromfuncsig to bind to the lifetime of the ufunc object
         ufunc = _internal.fromfunc(
             self.py_func.__name__, self.py_func.__doc__,
-            ptrlist, dtypelist, inct, outct, datlist,
+            func_list, type_list, nin, nout, datalist,
             keepalive, self.identity, self.signature,
         )
         return ufunc

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -80,7 +80,7 @@ class TestDynamicGUFunc(TestCase):
 
         gufunc = GUVectorize(matmulcore, '(m,n),(n,p)->(m,p)',
                              target=self.target)
-
+        gufunc.is_dynamic = True
         matrix_ct = 10
         Ai64 = np.arange(matrix_ct * 2 * 4, dtype=np.int64).reshape(matrix_ct, 2, 4)
         Bi64 = np.arange(matrix_ct * 4 * 5, dtype=np.int64).reshape(matrix_ct, 4, 5)
@@ -106,6 +106,7 @@ class TestDynamicGUFunc(TestCase):
         # handled when the actual argument is an array,
         # causing the same value (first value) being repeated.
         gufunc = GUVectorize(axpy, '(), (), () -> ()', target=self.target)
+        gufunc.is_dynamic = True
         x = np.arange(10, dtype=np.intp)
         check_ufunc_output(gufunc, x)
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -79,8 +79,7 @@ class TestDynamicGUFunc(TestCase):
             np.testing.assert_allclose(C, Gold, rtol=1e-5, atol=1e-8)
 
         gufunc = GUVectorize(matmulcore, '(m,n),(n,p)->(m,p)',
-                             target=self.target)
-        gufunc.is_dynamic = True
+                             target=self.target, is_dynamic=True)
         matrix_ct = 10
         Ai64 = np.arange(matrix_ct * 2 * 4, dtype=np.int64).reshape(matrix_ct, 2, 4)
         Bi64 = np.arange(matrix_ct * 4 * 5, dtype=np.int64).reshape(matrix_ct, 4, 5)
@@ -105,8 +104,8 @@ class TestDynamicGUFunc(TestCase):
         # Test problem that the stride of "scalar" gufunc argument not properly
         # handled when the actual argument is an array,
         # causing the same value (first value) being repeated.
-        gufunc = GUVectorize(axpy, '(), (), () -> ()', target=self.target)
-        gufunc.is_dynamic = True
+        gufunc = GUVectorize(axpy, '(), (), () -> ()', target=self.target,
+                             is_dynamic=True)
         x = np.arange(10, dtype=np.intp)
         check_ufunc_output(gufunc, x)
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -127,6 +127,7 @@ class TestDynamicGUFunc(TestCase):
         # out is (10000)
         # The outter (leftmost) dimension must match or numpy broadcasting is performed.
 
+        self.assertTrue(sum_row.is_dynamic)
         inp = np.arange(30000, dtype=np.int32).reshape(10000, 3)
         out = np.zeros(10000, dtype=np.int32)
         sum_row(inp, out)

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -135,6 +135,10 @@ class TestDynamicGUFunc(TestCase):
         for i in range(inp.shape[0]):
             self.assertEqual(out[i], inp[i].sum())
 
+        msg = "Too few arguments for function 'sum_row'."
+        with self.assertRaisesRegex(TypeError, msg):
+            sum_row(inp)
+
 
 class TestGUVectorizeScalar(TestCase):
     """

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -128,6 +128,11 @@ class TestDynamicGUFunc(TestCase):
         # The outter (leftmost) dimension must match or numpy broadcasting is performed.
 
         inp = np.arange(30000, dtype=np.int32).reshape(10000, 3)
+
+        msg = "Too few arguments for function 'sum_row'."
+        with self.assertRaisesRegex(TypeError, msg):
+            sum_row(inp)
+
         out = np.zeros(10000, dtype=np.int32)
         sum_row(inp, out)
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -128,11 +128,6 @@ class TestDynamicGUFunc(TestCase):
         # The outter (leftmost) dimension must match or numpy broadcasting is performed.
 
         inp = np.arange(30000, dtype=np.int32).reshape(10000, 3)
-
-        msg = "Too few arguments for function 'sum_row'."
-        with self.assertRaisesRegex(TypeError, msg):
-            sum_row(inp)
-
         out = np.zeros(10000, dtype=np.int32)
         sum_row(inp, out)
 

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -68,6 +68,74 @@ class TestGUFuncParallel(TestGUFunc):
     target = 'parallel'
 
 
+class TestDynamicGUFunc(TestCase):
+    target = 'cpu'
+
+    def test_dynamic_matmul(self):
+
+        def check_matmul_gufunc(gufunc, A, B, C):
+            gufunc(A, B, C)
+            Gold = ut.matrix_multiply(A, B)
+            np.testing.assert_allclose(C, Gold, rtol=1e-5, atol=1e-8)
+
+        gufunc = GUVectorize(matmulcore, '(m,n),(n,p)->(m,p)',
+                             target=self.target)
+
+        matrix_ct = 10
+        Ai64 = np.arange(matrix_ct * 2 * 4, dtype=np.int64).reshape(matrix_ct, 2, 4)
+        Bi64 = np.arange(matrix_ct * 4 * 5, dtype=np.int64).reshape(matrix_ct, 4, 5)
+        Ci64 = np.arange(matrix_ct * 2 * 5, dtype=np.int64).reshape(matrix_ct, 2, 5)
+        check_matmul_gufunc(gufunc, Ai64, Bi64, Ci64)
+
+        A = np.arange(matrix_ct * 2 * 4, dtype=np.float32).reshape(matrix_ct, 2, 4)
+        B = np.arange(matrix_ct * 4 * 5, dtype=np.float32).reshape(matrix_ct, 4, 5)
+        C = np.arange(matrix_ct * 2 * 5, dtype=np.float32).reshape(matrix_ct, 2, 5)
+        check_matmul_gufunc(gufunc, A, B, C)  # trigger compilation
+
+        assert len(gufunc.types) == 2  # ensure two versions of gufunc
+
+
+    def test_dynamic_ufunc_like(self):
+
+        def check_ufunc_output(gufunc, x):
+            out = np.zeros(10, dtype=x.dtype)
+            gufunc(x, x, x, out)
+            np.testing.assert_equal(out, x * x + x)
+
+        # Test problem that the stride of "scalar" gufunc argument not properly
+        # handled when the actual argument is an array,
+        # causing the same value (first value) being repeated.
+        gufunc = GUVectorize(axpy, '(), (), () -> ()', target=self.target)
+        x = np.arange(10, dtype=np.intp)
+        check_ufunc_output(gufunc, x)
+
+
+    def test_dynamic_scalar_output(self):
+        """
+        Note that scalar output is a 0-dimension array that acts as
+        a pointer to the output location.
+        """
+
+        @guvectorize('(n)->()', target=self.target, nopython=True)
+        def sum_row(inp, out):
+            tmp = 0.
+            for i in range(inp.shape[0]):
+                tmp += inp[i]
+            out[()] = tmp
+
+        # inp is (10000, 3)
+        # out is (10000)
+        # The outter (leftmost) dimension must match or numpy broadcasting is performed.
+
+        inp = np.arange(30000, dtype=np.int32).reshape(10000, 3)
+        out = np.zeros(10000, dtype=np.int32)
+        sum_row(inp, out)
+
+        # verify result
+        for i in range(inp.shape[0]):
+            assert out[i] == inp[i].sum()
+
+
 class TestGUVectorizeScalar(TestCase):
     """
     Nothing keeps user from out-of-bound memory access

--- a/numba/tests/npyufunc/test_gufunc.py
+++ b/numba/tests/npyufunc/test_gufunc.py
@@ -92,7 +92,7 @@ class TestDynamicGUFunc(TestCase):
         C = np.arange(matrix_ct * 2 * 5, dtype=np.float32).reshape(matrix_ct, 2, 5)
         check_matmul_gufunc(gufunc, A, B, C)  # trigger compilation
 
-        assert len(gufunc.types) == 2  # ensure two versions of gufunc
+        self.assertEqual(len(gufunc.types), 2)  # ensure two versions of gufunc
 
 
     def test_dynamic_ufunc_like(self):
@@ -133,7 +133,7 @@ class TestDynamicGUFunc(TestCase):
 
         # verify result
         for i in range(inp.shape[0]):
-            assert out[i] == inp[i].sum()
+            self.assertEqual(out[i], inp[i].sum())
 
 
 class TestGUVectorizeScalar(TestCase):
@@ -165,7 +165,7 @@ class TestGUVectorizeScalar(TestCase):
 
         # verify result
         for i in range(inp.shape[0]):
-            assert out[i] == inp[i].sum()
+            self.assertEqual(out[i], inp[i].sum())
 
     def test_scalar_input(self):
 


### PR DESCRIPTION
As title. This PR enables the following:

```python
@guvectorize([(int64[:], int64, int64[:])], '(n),()->(n)')
def g(x, y, res):
    for i in range(x.shape[0]):
        res[i] = x[i] + y

@guvectorize('(n),()->(n)')
def f(x, y, res):
    for i in range(x.shape[0]):
        res[i] = x[i] + y


x = np.arange(5, dtype=np.int32)
y = nb_types.int32(10)
res = np.zeros(5, dtype=np.int32)
g(x, y, res)
f(x, y, res)
```