### PR TITLE
Add discourse badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ Numba
    :target: https://gitter.im/numba/numba?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
    :alt: Gitter
 
+.. image:: https://img.shields.io/badge/discuss-on%20discourse-blue
+   :target: https://numba.discourse.group/
+   :alt: Discourse
+
 A Just-In-Time Compiler for Numerical Functions in Python
 #########################################################
 


### PR DESCRIPTION
This PR adds a small badge with a link to Discourse next to the Gitter badge in the Readme.rst. 
Simply check here to get an impression: https://github.com/HPLegion/numba/blob/discourse-badge/README.rst

Text and color are of course open for debate :)