### PR TITLE
Fixes the jit decorator with target='cuda'

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -51,7 +51,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False, bind=True,
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')
 
-    if kws.get('boundscheck') == True:
+    if kws.pop('boundscheck', False):
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
     fastmath = kws.get('fastmath', False)

--- a/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
+++ b/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
@@ -1,7 +1,12 @@
-from numba import cuda
+from numba import jit, cuda
+from numba.core import config
 import numpy as np
 from numba.cuda.testing import CUDATestCase
 import unittest
+
+target = 'cuda'
+if config.ENABLE_CUDASIM:
+    target = 'cpu'
 
 
 class TestCudaJitNoTypes(CUDATestCase):
@@ -75,6 +80,16 @@ class TestCudaJitNoTypes(CUDATestCase):
         d_b.copy_to_host(b, stream)
 
         self.assertEqual(b[0], (a[0] + 1) + (2 + 1))
+
+    def test_jit(self):
+        N = 100
+
+        @jit(target=target)
+        def func(a):
+            for i in range(N):
+                a[i] += 1
+
+        func(np.ones(N, dtype=np.float64))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #5868. This PR fixes the `numba.jit` decorator with the `target='cuda'` keyword when the `boundscheck` argument isn't supplied.