### PR TITLE
Fix "Internal error ... local variable 'errstr' referenced before assignment during BoundFunction(...)"

### DIFF
--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -401,8 +401,8 @@ class BoundFunction(Callable, Opaque):
                     else:
                         bt = [""]
                     nd2indent = '\n{}'.format(2 * indent)
-                    errstr += _termcolor.reset(nd2indent +
-                                               nd2indent.join(bt_as_lines))
+                    errstr = _termcolor.reset(nd2indent +
+                                               nd2indent.join(_bt_as_lines(bt)))
                     return _termcolor.reset(errstr)
             else:
                 add_bt = lambda X: ''


### PR DESCRIPTION
In cc673c1 a change had been introduced in `numba/core/types/functions.py:399` which includes two problems that can occur (only) when `config.DEVELOPER_MODE` is active:
* it uses the `errstr` variable before assignment
* it does not use the real function call to `_bt_as_lines(bt)`

This pull request fixes both problems.