### PR TITLE
Setting mypy on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 htmlcov/
 .idea/
 .vscode/
+.mypy_cache/
 .ipynb_checkpoints/
 __pycache__/
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ jobs:
         CONDA_ENV: travisci
         RUN_COVERAGE: yes
         RUN_FLAKE8: yes
+        RUN_MYPY: yes
         TEST_START_INDEX: 4
       py36_np117_doc:
         PYTHON: '3.6'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -35,5 +35,12 @@ jobs:
 
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH
+        conda install -y mypy
+        mypy -p numba.core.types --ignore-missing-imports --follow-imports skip
+      displayName: 'Mypy'
+      condition: eq(variables['RUN_MYPY'], 'yes')
+
+    - script: |
+        export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -36,7 +36,7 @@ jobs:
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y mypy
-        mypy -p numba.core.types --ignore-missing-imports --follow-imports skip
+        mypy -p numba.core.types
       displayName: 'Mypy'
       condition: eq(variables['RUN_MYPY'], 'yes')
 

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -36,7 +36,7 @@ jobs:
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y mypy
-        mypy -p numba.core.types
+        mypy
       displayName: 'Mypy'
       condition: eq(variables['RUN_MYPY'], 'yes')
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -249,6 +249,10 @@ checklist. If you want to contribute type hints to enable a new file to be in th
 ``files`` variable in ``mypy.ini``, and decide what level of compliance you are targetting. Level 3 is basic static
 checks, while levels 2 and 1 represent stricter checking. The levels are described in details in ``mypy.ini``.
 
+There is potential for confusion between the Numba module ``typing`` and Python built-in module ``typing`` used for type
+hints, as well as between Numba types---such as ``Dict`` or ``Literal``---and ``typing`` types of the same name.
+To mitigate the risk of confusion we use a naming convention by which objects of the built-in ``typing`` module are
+imported with an ``pt`` prefix. For example, ``typing.Dict`` is imported as ``from typing import Dict as ptDict``.
 
 Stability
 '''''''''

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -236,6 +236,20 @@ and then running::
 from the root of the Numba repository. Now ``flake8`` will be run each time
 you commit changes. You can skip this check with ``git commit --no-verify``.
 
+Numba has started the process of using `type hints <https://www.python.org/dev/peps/pep-0484/>`_ in its code base. This
+will be a gradual process of extending the number of files that use type hints, as well as going from voluntary to
+mandatory type hints for new features. `Mypy <http://mypy-lang.org/>`_ is used for automated static checking.
+
+At the moment, only certain files are checked by mypy. The list can be found in ``mypy.ini``. When making changes to
+those files, it is necessary to add the required type hints such that mypy tests will pass. Only in exceptional
+circumstances should ``type: ignore`` comments be used.
+
+If you are contributing a new feature, we encourage you to use type hints, even if the file is not currently in the
+checklist. If you want to contribute type hints to enable a new file to be in the checklist, please add the file to the
+``files`` variable in ``mypy.ini``, and decide what level of compliance you are targetting. Level 3 is basic static
+checks, while levels 2 and 1 represent stricter checking. The levels are described in details in ``mypy.ini``.
+
+
 Stability
 '''''''''
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,50 @@
 # Global options:
 
 [mypy]
-warn_return_any = False
 warn_unused_configs = True
-ignore_missing_imports = True
 follow_imports = skip
+show_error_context = True
+files = **/numba/core/types/*.py, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py
 
 # Per-module options:
-[mypy-mycode.core.typing]
+# Level 1 - modules checked on the strictest settings.
+;[mypy-]
+;warn_return_any = True
+;disallow_any_expr = True
+;disallow_any_explicit = True
+;disallow_any_generics = True
+;disallow_subclassing_any = True
+;disallow_untyped_calls = True
+;disallow_untyped_defs = True
+;disallow_incomplete_defs = True
+;check_untyped_defs = True
+;disallow_untyped_decorators = True
+;warn_unused_ignores = True
+;follow_imports = normal
+;warn_unreachable = True
+;strict_equality = True
+
+# Level 2 - module that pass reasonably strict settings.
+#           No untyped functions allowed. Imports must be typed or explicitly ignored.
+;[mypy-]
+;warn_return_any = True
+;disallow_untyped_defs = True
+;disallow_incomplete_defs = True
+;follow_imports = normal
+
+# Level 3 - modules that pass mypy default settings
+[mypy-numba.core.typing.*, numba.core.datamodel.*, numba.core.rewrites.*]
 warn_return_any = True
+
+# Level 4 - modules that do not pass mypy check: they are excluded from "files" setting in global section
+
+# External packages that lack annotations
+[mypy-llvmlite.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-winreg.*]
+# this can be removed after Mypy 0.78 is out with the latest typeshed
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ show_error_context = True
 files = **/numba/core/types/*.py, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py
 
 # Per-module options:
+# To classify a given module as Level 1, 2 or 3 it must be added both in files (variable above) and in the lists below.
 # Level 1 - modules checked on the strictest settings.
 ;[mypy-]
 ;warn_return_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 
 [mypy]
 warn_unused_configs = True
-follow_imports = skip
+follow_imports = silent
 show_error_context = True
 files = **/numba/core/types/*.py, **/numba/core/datamodel/*.py, **/numba/core/rewrites/*.py, **/numba/core/unsafe/*.py
 
@@ -32,8 +32,9 @@ files = **/numba/core/types/*.py, **/numba/core/datamodel/*.py, **/numba/core/re
 ;disallow_incomplete_defs = True
 ;follow_imports = normal
 
-# Level 3 - modules that pass mypy default settings
-[mypy-numba.core.typing.*, numba.core.datamodel.*, numba.core.rewrites.*]
+# Level 3 - modules that pass mypy default settings (only those in `files` global setting and not in previous levels)
+#           Function/variables are annotated to avoid mypy erros, but annotations are not complete.
+[mypy-numba.core.*]
 warn_return_any = True
 
 # Level 4 - modules that do not pass mypy check: they are excluded from "files" setting in global section

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+# Global options:
+
+[mypy]
+warn_return_any = False
+warn_unused_configs = True
+ignore_missing_imports = True
+follow_imports = skip
+
+# Per-module options:
+[mypy-mycode.core.typing]
+warn_return_any = True

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+from typing import Dict as mpDict, Type as mpType
 import itertools
 import weakref
 
@@ -21,7 +22,7 @@ def _autoincr():
     assert n < 2 ** 32, "Limited to 4 billion types"
     return n
 
-_typecache = {}
+_typecache: mpDict[weakref.ref, weakref.ref] = {}
 
 def _on_type_disposal(wr, _pop=_typecache.pop):
     _pop(wr, None)
@@ -405,7 +406,7 @@ class Literal(Type):
     # for constructing a numba type for a given Python type.
     # It is used in `literal(val)` function.
     # To add new Literal subclass, register a new mapping to this dict.
-    ctor_map = {}
+    ctor_map: mpDict[type, mpType[Literal]] = {}
 
     # *_literal_type_cache* is used to cache the numba type of the given value.
     _literal_type_cache = None

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
-from typing import Dict as mpDict, Type as mpType
+from typing import Dict as ptDict, Type as ptType
 import itertools
 import weakref
 
@@ -22,7 +22,7 @@ def _autoincr():
     assert n < 2 ** 32, "Limited to 4 billion types"
     return n
 
-_typecache: mpDict[weakref.ref, weakref.ref] = {}
+_typecache: ptDict[weakref.ref, weakref.ref] = {}
 
 def _on_type_disposal(wr, _pop=_typecache.pop):
     _pop(wr, None)
@@ -406,7 +406,7 @@ class Literal(Type):
     # for constructing a numba type for a given Python type.
     # It is used in `literal(val)` function.
     # To add new Literal subclass, register a new mapping to this dict.
-    ctor_map: mpDict[type, mpType['Literal']] = {}
+    ctor_map: ptDict[type, ptType['Literal']] = {}
 
     # *_literal_type_cache* is used to cache the numba type of the given value.
     _literal_type_cache = None

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -406,7 +406,7 @@ class Literal(Type):
     # for constructing a numba type for a given Python type.
     # It is used in `literal(val)` function.
     # To add new Literal subclass, register a new mapping to this dict.
-    ctor_map: mpDict[type, mpType[Literal]] = {}
+    ctor_map: mpDict[type, mpType['Literal']] = {}
 
     # *_literal_type_cache* is used to cache the numba type of the given value.
     _literal_type_cache = None


### PR DESCRIPTION
This PR sets a CI run with mypy. To avoid a persistent failure (over 500 errors if left to run freely), the run is limited a few sub-packages from `numba.core` (types, datamodel, rewrites and unsafe). This list can be extended as more modules are annotated.

Since many names in the `typing` package would conflict with Numba's (including `typing` itself), I use aliases prefixed with `mp`, e.g. `mpDict`, `mpType`.

A `mypy_typing` folder is created in `numba.core` for any type definitions that could be needed. I suggest that each sub-package (core, numpy, etc) manages its own type definitions within its folder.

Additionally, two errors from `types` package are solved:

Before
```bash
~/numba$ mypy -p numba.core.types

numba/core/types/abstract.py:24: error: Need type annotation for '_typecache' (hint: "_typecache: Dict[<type>, <type>] = ...")
numba/core/types/abstract.py:408: error: Need type annotation for 'ctor_map' (hint: "ctor_map: Dict[<type>, <type>] = ...")
Found 2 errors in 1 file (checked 10 source files)
```
after 

```bash
~/numba$ mypy -p numba.core.types
Success: no issues found in 10 source files
```
