### PR TITLE
Add structref as a mutable struct that is pass-by-ref

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -60,7 +60,6 @@ exclude =
     numba/core/types/abstract.py
     numba/core/types/functions.py
     numba/core/types/misc.py
-    numba/core/types/containers.py
     numba/core/types/npytypes.py
     numba/core/types/common.py
     numba/core/types/iterators.py

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -82,7 +82,7 @@ These define aspects of the public Numba interface.
   regular functions on the CPU
 - :ghfile:`numba/core/extending.py` - Public decorators for extending Numba
   (``overload``, ``intrinsic``, etc)
-  - :ghfile:`numba/core/structref.py` - Public API for defining a mutable struct
+  - :ghfile:`numba/experimental/structref.py` - Public API for defining a mutable struct
 - :ghfile:`numba/core/ccallback.py` - ``@cfunc`` decorator for compiling
   functions to a fixed C signature.  Used to make callbacks.
 - :ghfile:`numba/np/ufunc/decorators.py` - ufunc/gufunc compilation

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -82,6 +82,7 @@ These define aspects of the public Numba interface.
   regular functions on the CPU
 - :ghfile:`numba/core/extending.py` - Public decorators for extending Numba
   (``overload``, ``intrinsic``, etc)
+  - :ghfile:`numba/core/structref.py` - Public API for defining mutable struct
 - :ghfile:`numba/core/ccallback.py` - ``@cfunc`` decorator for compiling
   functions to a fixed C signature.  Used to make callbacks.
 - :ghfile:`numba/np/ufunc/decorators.py` - ufunc/gufunc compilation

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -82,7 +82,7 @@ These define aspects of the public Numba interface.
   regular functions on the CPU
 - :ghfile:`numba/core/extending.py` - Public decorators for extending Numba
   (``overload``, ``intrinsic``, etc)
-  - :ghfile:`numba/core/structref.py` - Public API for defining mutable struct
+  - :ghfile:`numba/core/structref.py` - Public API for defining a mutable struct
 - :ghfile:`numba/core/ccallback.py` - ``@cfunc`` decorator for compiling
   functions to a fixed C signature.  Used to make callbacks.
 - :ghfile:`numba/np/ufunc/decorators.py` - ufunc/gufunc compilation

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1342,3 +1342,25 @@ class DeferredStructModel(CompositeModel):
     def traverse(self, builder):
         return [(self.actual_fe_type,
                  lambda value: builder.extract_value(value, [0]))]
+
+
+@register_default(types.StructPayloadType)
+class StructPayloadModel(StructModel):
+    """Model for the payload of a mutable struct
+    """
+    def __init__(self, dmm, fe_typ):
+        members = fe_typ.fields
+        super().__init__(dmm, fe_typ, members)
+
+
+class StructRefModel(StructModel):
+    """Model for a mutable struct.
+    A reference to the payload
+    """
+    def __init__(self, dmm, fe_typ):
+        dtype = fe_typ.get_data_type()
+        members = [
+            ("meminfo", types.MemInfoPointer(dtype)),
+        ]
+        super().__init__(dmm, fe_typ, members)
+

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1344,7 +1344,7 @@ class DeferredStructModel(CompositeModel):
                  lambda value: builder.extract_value(value, [0]))]
 
 
-@register_default(types.StructPayloadType)
+@register_default(types.StructRefPayload)
 class StructPayloadModel(StructModel):
     """Model for the payload of a mutable struct
     """

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1349,7 +1349,7 @@ class StructPayloadModel(StructModel):
     """Model for the payload of a mutable struct
     """
     def __init__(self, dmm, fe_typ):
-        members = fe_typ.fields
+        members = tuple(fe_typ.field_dict.items())
         super().__init__(dmm, fe_typ, members)
 
 

--- a/numba/core/structref.py
+++ b/numba/core/structref.py
@@ -95,14 +95,17 @@ def define_attributes(struct_typeclass):
         [instance, val] = args
         utils = _Utils(context, builder, inst_type)
         dataval = utils.get_data_struct(instance)
+        # cast val to the correct type
+        field_type = inst_type.field_dict[attr]
+        casted = context.cast(builder, val, val_type, field_type)
         # read old
-        old_value = getattr(dataval, attr, val)
+        old_value = getattr(dataval, attr)
         # incref new value
-        context.nrt.incref(builder, val_type, val)
+        context.nrt.incref(builder, val_type, casted)
         # decref old value (must be last in case new value is old value)
         context.nrt.decref(builder, val_type, old_value)
         # write new
-        setattr(dataval, attr, val)
+        setattr(dataval, attr, casted)
 
 
 def define_boxing(struct_type, obj_ctor):

--- a/numba/core/structref.py
+++ b/numba/core/structref.py
@@ -1,0 +1,181 @@
+"""Utilities for defining a mutable struct.
+
+A mutable struct is passed by reference;
+hence, structref (a reference to a struct).
+
+"""
+
+from numba.core import types, imputils, cgutils
+from numba.core.datamodel import default_manager, models
+from numba.core.extending import (
+    infer_getattr,
+    lower_getattr_generic,
+    lower_setattr_generic,
+    box,
+    unbox,
+    NativeValue,
+    intrinsic,
+)
+from numba.core.typing.templates import AttributeTemplate
+
+
+class _Utils:
+    def __init__(self, context, builder, struct_type):
+        self.context = context
+        self.builder = builder
+        self.struct_type = struct_type
+
+    def new_struct_ref(self, mi):
+        context = self.context
+        builder = self.builder
+        struct_type = self.struct_type
+
+        st = cgutils.create_struct_proxy(struct_type)(context, builder)
+        st.meminfo = mi
+        return st
+
+    def get_struct_ref(self, val):
+        context = self.context
+        builder = self.builder
+        struct_type = self.struct_type
+
+        return cgutils.create_struct_proxy(struct_type)(
+            context, builder, value=val
+        )
+
+    def get_data_pointer(self, val):
+        context = self.context
+        builder = self.builder
+        struct_type = self.struct_type
+
+        structval = self.get_struct_ref(val)
+        meminfo = structval.meminfo
+        data_ptr = context.nrt.meminfo_data(builder, meminfo)
+
+        valtype = struct_type.get_data_type()
+        model = context.data_model_manager[valtype]
+        alloc_type = model.get_value_type()
+        data_ptr = builder.bitcast(data_ptr, alloc_type.as_pointer())
+        return data_ptr
+
+    def get_data_struct(self, val):
+        context = self.context
+        builder = self.builder
+        struct_type = self.struct_type
+
+        data_ptr = self.get_data_pointer(val)
+        valtype = struct_type.get_data_type()
+        dataval = cgutils.create_struct_proxy(valtype)(
+            context, builder, ref=data_ptr
+        )
+        return dataval
+
+
+def define_attributes(struct_typeclass):
+    @infer_getattr
+    class StructAttribute(AttributeTemplate):
+        key = struct_typeclass
+
+        def generic_resolve(self, typ, attr):
+            if attr in typ.field_dict:
+                attrty = typ.field_dict[attr]
+                return attrty
+
+    @lower_getattr_generic(struct_typeclass)
+    def struct_getattr_impl(context, builder, typ, val, attr):
+        utils = _Utils(context, builder, typ)
+        dataval = utils.get_data_struct(val)
+        ret = getattr(dataval, attr)
+        fieldtype = typ.field_dict[attr]
+        return imputils.impl_ret_borrowed(context, builder, fieldtype, ret)
+
+    @lower_setattr_generic(struct_typeclass)
+    def struct_setattr_impl(context, builder, sig, args, attr):
+        [inst_type, val_type] = sig.args
+        [instance, val] = args
+        utils = _Utils(context, builder, inst_type)
+        dataval = utils.get_data_struct(instance)
+        # read old
+        old_value = getattr(dataval, attr, val)
+        # incref new value
+        context.nrt.incref(builder, val_type, val)
+        # decref old value (must be last in case new value is old value)
+        context.nrt.decref(builder, val_type, old_value)
+        # write new
+        setattr(dataval, attr, val)
+
+
+def define_boxing(struct_type, obj_ctor):
+    @box(struct_type)
+    def box_struct_ref(typ, val, c):
+        """
+        Convert a raw pointer to a Python int.
+        """
+        utils = _Utils(c.context, c.builder, typ)
+        struct_ref = utils.get_struct_ref(val)
+        meminfo = struct_ref.meminfo
+
+        mip_type = types.MemInfoPointer(types.voidptr)
+        boxed_meminfo = c.box(mip_type, meminfo)
+
+        ctor_pyfunc = c.pyapi.unserialize(c.pyapi.serialize_object(obj_ctor))
+        ty_pyobj = c.pyapi.unserialize(c.pyapi.serialize_object(typ))
+        res = c.pyapi.call_function_objargs(
+            ctor_pyfunc, [ty_pyobj, boxed_meminfo],
+        )
+        c.pyapi.decref(ctor_pyfunc)
+        c.pyapi.decref(ty_pyobj)
+        c.pyapi.decref(boxed_meminfo)
+        return res
+
+    @unbox(struct_type)
+    def unbox_struct_ref(typ, obj, c):
+        mi_obj = c.pyapi.object_getattr_string(obj, "_mi")
+
+        mip_type = types.MemInfoPointer(types.voidptr)
+
+        mi = c.unbox(mip_type, mi_obj).value
+
+        utils = _Utils(c.context, c.builder, typ)
+        struct_ref = utils.new_struct_ref(mi)
+        out = struct_ref._getvalue()
+
+        c.pyapi.decref(mi_obj)
+        return NativeValue(out)
+
+
+def register(struct_type):
+    default_manager.register(struct_type, models.StructRefModel)
+    define_attributes(struct_type)
+
+
+@intrinsic
+def new(typingctx, struct_type):
+    from numba.experimental.jitclass.base import imp_dtor
+
+    inst_type = struct_type.instance_type
+
+    def codegen(context, builder, signature, args):
+        # FIXME: mostly the same as jitclass ctor_impl()
+        model = context.data_model_manager[inst_type.get_data_type()]
+        alloc_type = model.get_value_type()
+        alloc_size = context.get_abi_sizeof(alloc_type)
+
+        meminfo = context.nrt.meminfo_alloc_dtor(
+            builder,
+            context.get_constant(types.uintp, alloc_size),
+            imp_dtor(context, builder.module, inst_type),
+        )
+        data_pointer = context.nrt.meminfo_data(builder, meminfo)
+        data_pointer = builder.bitcast(data_pointer, alloc_type.as_pointer())
+
+        # Nullify all data
+        builder.store(cgutils.get_null_value(alloc_type), data_pointer)
+
+        inst_struct = context.make_helper(builder, inst_type)
+        inst_struct.meminfo = meminfo
+
+        return inst_struct._getvalue()
+
+    sig = inst_type(struct_type)
+    return sig, codegen

--- a/numba/core/structref.py
+++ b/numba/core/structref.py
@@ -132,7 +132,7 @@ def define_boxing(struct_type, obj_class):
 
     - boxing turns an instance of `struct_type` into a PyObject of `obj_class`
     - unboxing turns an instance of `obj_class` into an instance of
-    `strruct_type` in jit-code.
+    `struct_type` in jit-code.
 
     Use this directly instead of `define_proxy()` when the user does not
     want any constructor to be defined.
@@ -240,7 +240,7 @@ def register(struct_type):
     """Register a `numba.core.types.StructRef` for use in jit-code.
 
     This defines the data-model for lowering an instance of `struct_type`.
-    This defines attributes accessor and mutators for an instance of
+    This defines attributes accessor and mutator for an instance of
     `struct_type`.
 
     Parameters
@@ -274,7 +274,7 @@ def new(typingctx, struct_type):
 
     A jit-code only intrinsic. Used to allocate an **empty** mutable struct.
     The fields are zero-initialized and must be set manually after calling
-    thie function.
+    the function.
 
     Example:
 

--- a/numba/core/structref.py
+++ b/numba/core/structref.py
@@ -4,7 +4,6 @@ A mutable struct is passed by reference;
 hence, structref (a reference to a struct).
 
 """
-
 from numba.core import types, imputils, cgutils
 from numba.core.datamodel import default_manager, models
 from numba.core.extending import (
@@ -180,6 +179,7 @@ def ctor({params}):
 def register(struct_type):
     default_manager.register(struct_type, models.StructRefModel)
     define_attributes(struct_type)
+    return struct_type
 
 
 @intrinsic
@@ -212,3 +212,25 @@ def new(typingctx, struct_type):
 
     sig = inst_type(struct_type)
     return sig, codegen
+
+
+class StructRefProxy:
+    def __init__(self, ty, mi):
+        self._ty = ty
+        self._mi = mi
+
+    @property
+    def _numba_type_(self):
+        return self._ty
+
+
+def _StructRefProxy_wrapper(ty, mi):
+    return StructRefProxy(ty, mi)
+
+
+def _init():
+    register(types.StructRef)
+    define_boxing(types.StructRef, _StructRefProxy_wrapper)
+
+
+_init()

--- a/numba/core/structref.py
+++ b/numba/core/structref.py
@@ -29,7 +29,7 @@ class _Utils:
         self.struct_type = struct_type
 
     def new_struct_ref(self, mi):
-        """Turn a MemInfo of `StructRefPayload` to a `StructRef`
+        """Encapsulate the MemInfo from a `StructRefPayload` in a `StructRef`
         """
         context = self.context
         builder = self.builder
@@ -360,6 +360,6 @@ class StructRefProxy:
     def _numba_type_(self):
         """Returns the Numba type instance for this structref instance.
 
-        Subclass should NOT override.
+        Subclasses should NOT override.
         """
         return self._type

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -728,12 +728,12 @@ class StructRef(Type):
         return MappingProxyType(dict(self._fields))
 
     def get_data_type(self):
-        return StructPayloadType(
+        return StructRefPayload(
             typename=self.__class__.__name__, fields=self._fields,
         )
 
 
-class StructPayloadType(Type):
+class StructRefPayload(Type):
     """The type of the payload of a mutable struct.
     """
 

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -732,7 +732,7 @@ class StructRef(Type):
                 msg = "expecting a str for field name"
                 raise ValueError(msg)
             if not isinstance(typ, Type):
-                msg = f"expecting a Numba Type for field type"
+                msg = "expecting a Numba Type for field type"
                 raise ValueError(msg)
             return name, typ
 

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -722,7 +722,7 @@ class StructRef(Type):
         Parameters
         ----------
         fields : Sequence
-            A sequence of field description, which is a 2-tuple-like object
+            A sequence of field descriptions, which is a 2-tuple-like object
             containing `(name, type)`, where `name` is a `str` for the field
             name, and `type` is a numba type for the field type.
         """
@@ -733,7 +733,7 @@ class StructRef(Type):
 
     @property
     def field_dict(self):
-        """Return a immutable mapping for the field names and their
+        """Return an immutable mapping for the field names and their
         corresponding types.
         """
         return MappingProxyType(dict(self._fields))

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -726,7 +726,17 @@ class StructRef(Type):
             containing `(name, type)`, where `name` is a `str` for the field
             name, and `type` is a numba type for the field type.
         """
-        self._fields = tuple(map(tuple, fields))
+        def check_field_pair(fieldpair):
+            name, typ = fieldpair
+            if not isinstance(name, str):
+                msg = "expecting a str for field name"
+                raise ValueError(msg)
+            if not isinstance(typ, Type):
+                msg = f"expecting a Numba Type for field type"
+                raise ValueError(msg)
+            return name, typ
+
+        self._fields = tuple(map(check_field_pair, fields))
         self._typename = self.__class__.__qualname__
         name = f"numba.{self._typename}{self._fields}"
         super().__init__(name=name)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -700,7 +700,7 @@ class StructPayloadType(Type):
     def __init__(self, typename, fields):
         self._typename = typename
         self._fields = tuple(fields)
-        super().__init__(name=f"mutstruct.payload.{typename}")
+        super().__init__(name=f"mutstruct.payload.{typename}.{self._fields}")
 
     @property
     def fields(self):

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -718,16 +718,32 @@ class StructRef(Type):
     """A mutable struct.
     """
     def __init__(self, fields):
-        self._fields = tuple(fields)
+        """
+        Parameters
+        ----------
+        fields : Sequence
+            A sequence of field description, which is a 2-tuple-like object
+            containing `(name, type)`, where `name` is a `str` for the field
+            name, and `type` is a numba type for the field type.
+        """
+        self._fields = tuple(map(tuple, fields))
         self._typename = self.__class__.__qualname__
-        name = f"numba.{self._typename}.{self._fields}"
+        name = f"numba.{self._typename}{self._fields}"
         super().__init__(name=name)
 
     @property
     def field_dict(self):
+        """Return a immutable mapping for the field names and their
+        corresponding types.
+        """
         return MappingProxyType(dict(self._fields))
 
     def get_data_type(self):
+        """Get the payload type for the actual underlying structure referred
+        to by this struct reference.
+
+        See also: `ClassInstanceType.get_data_type`
+        """
         return StructRefPayload(
             typename=self.__class__.__name__, fields=self._fields,
         )
@@ -742,8 +758,8 @@ class StructRefPayload(Type):
     def __init__(self, typename, fields):
         self._typename = typename
         self._fields = tuple(fields)
-        super().__init__(name=f"mutstruct.payload.{typename}.{self._fields}")
+        super().__init__(name=f"numba.{typename}{self._fields}.payload")
 
     @property
-    def fields(self):
-        return self._fields
+    def field_dict(self):
+        return MappingProxyType(dict(self._fields))

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -719,8 +719,9 @@ class StructRef(Type):
     """
     def __init__(self, fields):
         self._fields = tuple(fields)
-        classname = self.__class__.__name__
-        super().__init__(name=f"numba.structref.{classname}{self._fields}")
+        self._typename = self.__class__.__qualname__
+        name = f"numba.{self._typename}.{self._fields}"
+        super().__init__(name=name)
 
     @property
     def field_dict(self):

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -690,3 +690,18 @@ class DictIteratorType(SimpleIteratorType):
         name = "iter[{}->{}],{}".format(iterable.parent, yield_type,
                                         iterable.name)
         super(DictIteratorType, self).__init__(name, yield_type)
+
+
+class StructPayloadType(Type):
+    """The type of the payload of a mutable struct.
+    """
+    mutable = True
+
+    def __init__(self, typename, fields):
+        self._typename = typename
+        self._fields = tuple(fields)
+        super().__init__(name=f"mutstruct.payload.{typename}")
+
+    @property
+    def fields(self):
+        return self._fields

--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -147,7 +147,7 @@ def define_boxing(struct_type, obj_class):
     want any constructor to be defined.
     """
     if struct_type is types.StructRef:
-        raise TypeError(f"cannot register {types.StructRef}")
+        raise ValueError(f"cannot register {types.StructRef}")
 
     obj_ctor = obj_class._numba_box_
 
@@ -271,7 +271,7 @@ def register(struct_type):
 
     """
     if struct_type is types.StructRef:
-        raise TypeError(f"cannot register {types.StructRef}")
+        raise ValueError(f"cannot register {types.StructRef}")
     default_manager.register(struct_type, models.StructRefModel)
     define_attributes(struct_type)
     return struct_type

--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -258,7 +258,7 @@ def register(struct_type):
         class MyStruct(numba.core.types.StructRef):
             ...  # the simplest subclass can be empty
 
-        numba.core.structref.register(MyStruct)
+        numba.experimental.structref.register(MyStruct)
 
     """
     if struct_type is types.StructRef:

--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -24,6 +24,15 @@ class _Utils:
     """Internal builder-code utils for structref definitions.
     """
     def __init__(self, context, builder, struct_type):
+        """
+        Parameters
+        ----------
+        context :
+            a numba target context
+        builder :
+            a llvmlite IRBuilder
+        struct_type : numba.core.types.StructRef
+        """
         self.context = context
         self.builder = builder
         self.struct_type = struct_type

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -16,7 +16,7 @@ from numba.tests.support import (
 @structref.register
 class MySimplerStructType(types.StructRef):
     """
-    Test associated to this type represent the lowest level uses of structref.
+    Test associated with this type represent the lowest level uses of structref.
     """
     pass
 
@@ -64,7 +64,7 @@ class MyStructType(types.StructRef):
 
 # Call to define_proxy is needed to register the use of `MyStruct` as a
 # PyObject proxy for creating a Numba-allocated structref.
-# The `MyStruct` class and then be used in both jit-code and interpreted-code.
+# The `MyStruct` class can then be used in both jit-code and interpreted-code.
 structref.define_proxy(
     MyStruct,
     MyStructType,

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -6,7 +6,8 @@ import warnings
 import numpy as np
 
 from numba import typed, njit, errors
-from numba.core import types, structref
+from numba.core import types
+from numba.experimental import structref
 from numba.extending import overload_method
 from numba.tests.support import (
     MemoryLeakMixin, TestCase, temp_directory, override_config,

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -124,6 +124,26 @@ def compute_fields(st):
 
 
 class TestStructRefBasic(MemoryLeakMixin, TestCase):
+    def test_structref_type(self):
+        sr = types.StructRef([('a', types.int64)])
+        self.assertEqual(sr.field_dict['a'], types.int64)
+        sr = types.StructRef([('a', types.int64), ('b', types.float64)])
+        self.assertEqual(sr.field_dict['a'], types.int64)
+        self.assertEqual(sr.field_dict['b'], types.float64)
+        # bad case
+        with self.assertRaisesRegex(ValueError,
+                                    "expecting a str for field name"):
+            types.StructRef([(1, types.int64)])
+        with self.assertRaisesRegex(ValueError,
+                                    "expecting a Numba Type for field type"):
+            types.StructRef([('a', 123)])
+
+    def test_invalid_uses(self):
+        with self.assertRaisesRegex(ValueError, "cannot register"):
+            structref.register(types.StructRef)
+        with self.assertRaisesRegex(ValueError, "cannot register"):
+            structref.define_boxing(types.StructRef, MyStruct)
+
     def test_MySimplerStructType(self):
         vs = np.arange(10, dtype=np.intp)
         ctr = 13

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -91,7 +91,7 @@ def bar(st):
 
 class TestStructRef(MemoryLeakMixin, TestCase):
     def test_basic(self):
-        vs = np.arange(10)
+        vs = np.arange(10, dtype=np.intp)
         ctr = 10
 
         foo_expected = vs + vs

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -1,0 +1,103 @@
+"""
+Test mutable struct, aka, structref
+"""
+
+from types import MappingProxyType
+
+import numpy as np
+
+from numba.core import types
+from numba import njit
+
+
+from numba.core import structref
+from numba.tests.support import MemoryLeakMixin, TestCase
+
+
+class MyStruct(types.Type):
+    def __init__(self, typename, fields):
+        self._typename = typename
+        self._fields = tuple(fields)
+        super().__init__(name=f"numba.structref.{self.__class__.__name__}")
+
+    @property
+    def fields(self):
+        return self._fields
+
+    @property
+    def field_dict(self):
+        return MappingProxyType(dict(self._fields))
+
+    def get_data_type(self):
+        return types.StructPayloadType(
+            typename=self._typename, fields=self._fields,
+        )
+
+
+structref.register(MyStruct)
+
+my_struct_ty = MyStruct(
+    "MyStruct", fields=[("values", types.intp[:]), ("counter", types.intp)]
+)
+
+
+class MyStructWrap:
+    def __init__(self, ty, mi):
+        self._ty = ty
+        self._mi = mi
+
+    @property
+    def _numba_type_(self):
+        return self._ty
+
+
+def object_ctor(ty, mi):
+    return MyStructWrap(ty, mi)
+
+
+structref.define_boxing(MyStruct, object_ctor)
+
+
+@njit
+def my_struct(values, counter):
+    st = structref.new(my_struct_ty)
+    my_struct_init(st, values, counter)
+    return st
+
+
+@njit
+def my_struct_init(self, values, counter):
+    self.values = values
+    self.counter = counter
+
+
+@njit
+def foo(vs, ctr):
+    st = my_struct(vs, counter=ctr)
+    st.values += st.values
+    st.counter *= ctr
+    return st
+
+
+@njit
+def get_values(st):
+    return st.values
+
+
+@njit
+def bar(st):
+    return st.values + st.counter
+
+
+class TestStructRef(MemoryLeakMixin, TestCase):
+    def test_basic(self):
+        vs = np.arange(10)
+        ctr = 10
+
+        foo_expected = vs + vs
+        foo_got = foo(vs, ctr)
+        self.assertPreciseEqual(foo_expected, get_values(foo_got))
+
+        bar_expected = foo_expected + (ctr * ctr)
+        bar_got = bar(foo_got)
+        self.assertPreciseEqual(bar_expected, bar_got)


### PR DESCRIPTION
Closes https://github.com/numba/numba/issues/5397

Add `structref` to support mutable structure that can be extended like typical custom types (i.e. with `@overload` and friends). Also, support some nice default to minimizing work; i.e. default boxer/unboxer, default getter/setter, default constructor.

TODOs:

- add docs. to be included in a different PR.