### PR TITLE
Deprecate target kwarg for numba.jit.

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -254,3 +254,22 @@ This feature will be moved with respect to this schedule:
 * Deprecation warnings will be issued in version 0.49.0
 * Support for importing from ``numba.jitclass`` will be removed in version
   0.52.0.
+
+Deprecation of the target kwarg
+===============================
+There have been a number of users attempting to use the ``target`` keyword
+argument that's meant for internal use only. We are deprecating this argument,
+as alternative solutions are available to achieve the same behaviour.
+
+Recommendations
+---------------
+Update the ``jit`` decorator as follows:
+
+* Change ``@numba.jit(..., target='cuda')`` to ``numba.cuda.jit(...)``.
+
+Schedule
+--------
+This feature will be moved with respect to this schedule:
+
+* Deprecation warnings will be issued in 0.51.0.
+* The target kwarg will be removed in version 0.53.0.

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -23,7 +23,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "Signatures should be passed as the first "
                                  "positional argument.")
 
-def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
+def jit(signature_or_function=None, locals={}, cache=False,
         pipeline_class=None, boundscheck=False, **options):
     """
     This decorator is used to compile a Python function into native code.
@@ -41,7 +41,7 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
         Mapping of local variable names to Numba types. Used to override the
         types deduced by Numba's type inference engine.
 
-    target: str
+    target (deprecated): str
         Specifies the target platform to compile for. Valid targets are cpu,
         gpu, npyufunc, and cuda. Defaults to cpu.
 
@@ -145,6 +145,11 @@ def jit(signature_or_function=None, locals={}, target='cpu', cache=False,
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
     if options.get('nopython', False) and options.get('forceobj', False):
         raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
+    if 'target' in options:
+        target = options.pop('target')
+        warnings.warn("The 'target' keyword argument is deprecated for the numba.jit decorator.", NumbaDeprecationWarning)
+    else:
+        target = options.pop('_target', 'cpu')
 
     options['boundscheck'] = boundscheck
 

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -147,7 +147,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
         raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
     if 'target' in options:
         target = options.pop('target')
-        warnings.warn("The 'target' keyword argument is deprecated for the numba.jit decorator.", NumbaDeprecationWarning)
+        warnings.warn("The 'target' keyword argument is deprecated.", NumbaDeprecationWarning)
     else:
         target = options.pop('_target', 'cpu')
 

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -79,7 +79,7 @@ class DUFunc(_internal._DUFunc):
     def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
         if isinstance(py_func, Dispatcher):
             py_func = py_func.py_func
-        dispatcher = jit(target='npyufunc',
+        dispatcher = jit(_target='npyufunc',
                          cache=cache,
                          **targetoptions)(py_func)
         self._initialize(dispatcher, identity)

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -227,7 +227,7 @@ class UFuncBuilder(_BaseUFuncBuilder):
     def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(target='npyufunc',
+        self.nb_func = jit(_target='npyufunc',
                            cache=cache,
                            **targetoptions)(py_func)
         self._sigs = []
@@ -292,7 +292,7 @@ class GUFuncBuilder(_BaseUFuncBuilder):
                  targetoptions={}):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(target='npyufunc', cache=cache)(py_func)
+        self.nb_func = jit(_target='npyufunc', cache=cache)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
         self.targetoptions = targetoptions


### PR DESCRIPTION
As discussed in the last weekly meeting related to #5951, I have deprecated the `target` kwarg in `numba.jit`, as it was stated that it's mostly for internal use. I have also renamed `target` to `_target` for internal use. A possibility is also to just use `_jit` in these places instead of `jit`.

Resolves #5951
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
