### PR TITLE
Docs for structref

### DIFF
--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -187,11 +187,11 @@ and the output of ``.inspect_types()`` demonstrates the cast (note the
 Implementing mutable structures
 -------------------------------
 
-.. warning:: Experimental feature. The API may change without warning.
+.. warning:: This is an experimental feature, the API may change without warning.
 
 The ``numba.experimental.structref`` module provides utilities for defining
-mutable pass-by-reference structures. The following example demonstrate the
-how to define a basic mutable struct:
+mutable pass-by-reference structures, a ``StructRef``. The following example demonstrate the
+how to define a basic mutable structure:
 
 Defining a StructRef
 ''''''''''''''''''''
@@ -204,7 +204,7 @@ Defining a StructRef
    :dedent: 0
    :linenos:
 
-The following tests the above mutable struct definition:
+The following demonstrates using the above mutable struct definition:
 
 .. literalinclude:: ../../../numba/tests/doc_examples/test_structref_usage.py
    :language: python
@@ -222,7 +222,7 @@ Methods and attributes can be attached using ``@overload_*`` as shown in the
 previous sections.
 
 The following demonstrates the use of ``@overload_method`` to insert a
-method to instances of ``MyStructType``:
+method for instances of ``MyStructType``:
 
 .. literalinclude:: ../../../numba/tests/doc_examples/test_structref_usage.py
    :language: python

--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -182,3 +182,59 @@ and the output of ``.inspect_types()`` demonstrates the cast (note the
         #   return $0.5
 
         y = cast_int_to_byte_ptr(x)
+
+
+Implementing mutable structures
+-------------------------------
+
+.. warning:: Experimental feature. The API may change without warning.
+
+The ``numba.experimental.structref`` module provides utilities for defining
+mutable pass-by-reference structures. The following example demonstrate the
+how to define a basic mutable struct:
+
+Defining a StructRef
+''''''''''''''''''''
+
+.. literalinclude:: ../../../numba/tests/doc_examples/test_structref_usage.py
+   :language: python
+   :caption: from ``numba/tests/doc_examples/test_structref_usage.py``
+   :start-after: magictoken.ex_structref_type_definition.begin
+   :end-before: magictoken.ex_structref_type_definition.end
+   :dedent: 0
+   :linenos:
+
+The following tests the above mutable struct definition:
+
+.. literalinclude:: ../../../numba/tests/doc_examples/test_structref_usage.py
+   :language: python
+   :caption: from ``test_type_definition`` of ``numba/tests/doc_examples/test_structref_usage.py``
+   :start-after: magictoken.ex_structref_type_definition_test.begin
+   :end-before: magictoken.ex_structref_type_definition_test.end
+   :dedent: 8
+   :linenos:
+
+
+Defining a method on StructRef
+''''''''''''''''''''''''''''''
+
+Methods and attributes can be attached using ``@overload_*`` as shown in the
+previous sections.
+
+The following demonstrates the use of ``@overload_method`` to insert a
+method to instances of ``MyStructType``:
+
+.. literalinclude:: ../../../numba/tests/doc_examples/test_structref_usage.py
+   :language: python
+   :caption: from ``test_overload_method`` of ``numba/tests/doc_examples/test_structref_usage.py``
+   :start-after: magictoken.ex_structref_method.begin
+   :end-before: magictoken.ex_structref_method.end
+   :dedent: 8
+   :linenos:
+
+
+``numba.experimental.structref`` API Reference
+''''''''''''''''''''''''''''''''''''''''''''''
+
+.. automodule:: numba.experimental.structref
+    :members:

--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -190,8 +190,8 @@ Implementing mutable structures
 .. warning:: This is an experimental feature, the API may change without warning.
 
 The ``numba.experimental.structref`` module provides utilities for defining
-mutable pass-by-reference structures, a ``StructRef``. The following example demonstrate the
-how to define a basic mutable structure:
+mutable pass-by-reference structures, a ``StructRef``. The following example
+demonstrates how to define a basic mutable structure:
 
 Defining a StructRef
 ''''''''''''''''''''

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -829,7 +829,7 @@ class StructRef(Type):
         super().__init__(name=name)
 
     def preprocess_fields(self, fields):
-        """Subclass can override this to do additional clean up on fields.
+        """Subclasses can override this to do additional clean up on fields.
 
         The default is an identity function.
 

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -736,10 +736,23 @@ class StructRef(Type):
                 raise ValueError(msg)
             return name, typ
 
-        self._fields = tuple(map(check_field_pair, fields))
+        fields = tuple(map(check_field_pair, fields))
+        self._fields = tuple(map(check_field_pair,
+                                 self.preprocess_fields(fields)))
         self._typename = self.__class__.__qualname__
         name = f"numba.{self._typename}{self._fields}"
         super().__init__(name=name)
+
+    def preprocess_fields(self, fields):
+        """Subclass can override this to do additional clean up on fields.
+
+        The default is an identity function.
+
+        Parameters:
+        -----------
+        fields : Sequence[Tuple[str, Type]]
+        """
+        return fields
 
     @property
     def field_dict(self):

--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -141,7 +141,8 @@ def define_boxing(struct_type, obj_class):
 
     - boxing turns an instance of `struct_type` into a PyObject of `obj_class`
     - unboxing turns an instance of `obj_class` into an instance of
-    `struct_type` in jit-code.
+      `struct_type` in jit-code.
+
 
     Use this directly instead of `define_proxy()` when the user does not
     want any constructor to be defined.
@@ -262,7 +263,10 @@ def register(struct_type):
     struct_type : type
         Returns the input argument so this can act like a decorator.
 
-    Example
+    Examples
+    --------
+
+    .. code-block::
 
         class MyStruct(numba.core.types.StructRef):
             ...  # the simplest subclass can be empty
@@ -322,6 +326,12 @@ def new(typingctx, struct_type):
 
 class StructRefProxy:
     """A PyObject proxy to the Numba allocated structref data structure.
+
+    Notes
+    -----
+
+    * Subclasses should not define ``__init__``.
+    * Subclasses can override ``__new__``.
     """
     __slots__ = ('_type', '_meminfo')
 

--- a/numba/tests/doc_examples/test_structref_usage.py
+++ b/numba/tests/doc_examples/test_structref_usage.py
@@ -9,6 +9,9 @@ from numba import njit
 from numba.core import types
 from numba.experimental import structref
 
+from numba.tests.support import skip_unless_scipy
+
+
 # Define a StructRef.
 # `structref.register` associates the type with the default data model.
 # This will also install getters and setters to the fields of
@@ -70,6 +73,7 @@ structref.define_proxy(MyStruct, MyStructType, ["name", "vector"])
 # magictoken.ex_structref_type_definition.end
 
 
+@skip_unless_scipy
 class TestStructRefUsage(unittest.TestCase):
     def test_type_definition(self):
         numpy.random.seed(0)

--- a/numba/tests/doc_examples/test_structref_usage.py
+++ b/numba/tests/doc_examples/test_structref_usage.py
@@ -1,0 +1,145 @@
+# "magictoken" is used for markers as beginning and ending of example text.
+
+import unittest
+
+# magictoken.ex_structref_type_definition.begin
+import numpy
+
+from numba import njit
+from numba.core import types
+from numba.experimental import structref
+
+# Define a StructRef.
+# `structref.register` associates the type with the default data model.
+# This will also install getters and setters to the fields of
+# the StructRef.
+@structref.register
+class MyStructType(types.StructRef):
+    def preprocess_fields(self, fields):
+        # This method is called by the type constructor for additional
+        # preprocessing on the fields.
+        # Here, we don't want the struct to take Literal types.
+        return tuple((name, types.unliteral(typ)) for name, typ in fields)
+
+
+# Define a Python type that can be use as a proxy to the StructRef
+# allocated inside Numba. Users can construct the StructRef via
+# the constructor for this type in python code and jit-code.
+class MyStruct(structref.StructRefProxy):
+    def __new__(cls, name, vector):
+        # It is optional to override the __new__ method.
+        # Doing so allow Python code to use keyword arguments,
+        # or add other customized behavior.
+        # The default __new__ takes `*args`.
+        # In addition, user should not override the __init__.
+        return structref.StructRefProxy.__new__(cls, name, vector)
+
+    # By default, the proxy type does not reflect the attributes or
+    # methods to the Python side. It is up to the users to define
+    # these. (These maybe automated in the future.)
+
+    @property
+    def name(self):
+        # To access a field, we can define a function that simply
+        # return the field in jit-code.
+        # The definition of MyStruct_get_name is shown later.
+        return MyStruct_get_name(self)
+
+    @property
+    def vector(self):
+        # The definition of MyStruct_get_vector is shown later.
+        return MyStruct_get_vector(self)
+
+
+@njit
+def MyStruct_get_name(self):
+    # In jit-code, the StructRef's attribute is exposed at
+    # structref.register
+    return self.name
+
+
+@njit
+def MyStruct_get_vector(self):
+    return self.vector
+
+
+# This associates the proxy with MyStructType for the given set of
+# fields. Notice how we are not contraining the type of each field.
+# Field types remain generic.
+structref.define_proxy(MyStruct, MyStructType, ["name", "vector"])
+# magictoken.ex_structref_type_definition.end
+
+
+class TestStructRefUsage(unittest.TestCase):
+    def test_type_definition(self):
+        numpy.random.seed(0)
+        # Redirect print
+        buf = []
+
+        def print(*args):
+            buf.append(args)
+
+        # magictoken.ex_structref_type_definition_test.begin
+        # Let's test our new StructRef.
+
+        # Define one in Python
+        alice = MyStruct("Alice", vector=numpy.random.random(3))
+
+        # Define one in jit-code
+        @njit
+        def make_bob():
+            bob = MyStruct("unname", vector=numpy.zeros(3))
+            # Mutate the attributes
+            bob.name = "Bob"
+            bob.vector = numpy.random.random(3)
+            return bob
+
+        bob = make_bob()
+
+        # Out: Alice: [0.5488135  0.71518937 0.60276338]
+        print(f"{alice.name}: {alice.vector}")
+        # Out: Bob: [0.88325739 0.73527629 0.87746707]
+        print(f"{bob.name}: {bob.vector}")
+
+        # Define a jit function to operate on the structs.
+        @njit
+        def distance(a, b):
+            return numpy.linalg.norm(a.vector - b.vector)
+
+        # Out: 0.4332647200356598
+        print(distance(alice, bob))
+        # magictoken.ex_structref_type_definition_test.end
+
+        self.assertEqual(len(buf), 3)
+
+    def test_overload_method(self):
+        # magictoken.ex_structref_method.begin
+        from numba.core.extending import overload_method
+        from numba.core.errors import TypingError
+
+        # Use @overload_method to add a method for
+        # MyStructType.distance(other)
+        # where *other* is an instance of MyStructType.
+        @overload_method(MyStructType, "distance")
+        def ol_distance(self, other):
+            # Guard that *other* is an instance of MyStructType
+            if not isinstance(other, MyStructType):
+                raise TypingError(
+                    f"*other* must be a {MyStructType}; got {other}"
+                )
+
+            def impl(self, other):
+                return numpy.linalg.norm(self.vector - other.vector)
+
+            return impl
+
+        # Test
+        @njit
+        def test():
+            alice = MyStruct("Alice", vector=numpy.random.random(3))
+            bob = MyStruct("Bob", vector=numpy.random.random(3))
+            # Use the method
+            return alice.distance(bob)
+        # magictoken.ex_structref_method.end
+
+        self.assertIsInstance(test(), float)

--- a/numba/tests/doc_examples/test_structref_usage.py
+++ b/numba/tests/doc_examples/test_structref_usage.py
@@ -76,7 +76,7 @@ structref.define_proxy(MyStruct, MyStructType, ["name", "vector"])
 @skip_unless_scipy
 class TestStructRefUsage(unittest.TestCase):
     def test_type_definition(self):
-        numpy.random.seed(0)
+        np.random.seed(0)
         # Redirect print
         buf = []
 
@@ -87,15 +87,15 @@ class TestStructRefUsage(unittest.TestCase):
         # Let's test our new StructRef.
 
         # Define one in Python
-        alice = MyStruct("Alice", vector=numpy.random.random(3))
+        alice = MyStruct("Alice", vector=np.random.random(3))
 
         # Define one in jit-code
         @njit
         def make_bob():
-            bob = MyStruct("unnamed", vector=numpy.zeros(3))
+            bob = MyStruct("unnamed", vector=np.zeros(3))
             # Mutate the attributes
             bob.name = "Bob"
-            bob.vector = numpy.random.random(3)
+            bob.vector = np.random.random(3)
             return bob
 
         bob = make_bob()
@@ -108,7 +108,7 @@ class TestStructRefUsage(unittest.TestCase):
         # Define a jit function to operate on the structs.
         @njit
         def distance(a, b):
-            return numpy.linalg.norm(a.vector - b.vector)
+            return np.linalg.norm(a.vector - b.vector)
 
         # Out: 0.4332647200356598
         print(distance(alice, bob))
@@ -133,15 +133,15 @@ class TestStructRefUsage(unittest.TestCase):
                 )
 
             def impl(self, other):
-                return numpy.linalg.norm(self.vector - other.vector)
+                return np.linalg.norm(self.vector - other.vector)
 
             return impl
 
         # Test
         @njit
         def test():
-            alice = MyStruct("Alice", vector=numpy.random.random(3))
-            bob = MyStruct("Bob", vector=numpy.random.random(3))
+            alice = MyStruct("Alice", vector=np.random.random(3))
+            bob = MyStruct("Bob", vector=np.random.random(3))
             # Use the method
             return alice.distance(bob)
         # magictoken.ex_structref_method.end

--- a/numba/tests/doc_examples/test_structref_usage.py
+++ b/numba/tests/doc_examples/test_structref_usage.py
@@ -3,7 +3,7 @@
 import unittest
 
 # magictoken.ex_structref_type_definition.begin
-import numpy
+import numpy as np
 
 from numba import njit
 from numba.core import types
@@ -30,16 +30,16 @@ class MyStructType(types.StructRef):
 # the constructor for this type in python code and jit-code.
 class MyStruct(structref.StructRefProxy):
     def __new__(cls, name, vector):
-        # It is optional to override the __new__ method.
-        # Doing so allow Python code to use keyword arguments,
+        # Overriding the __new__ method is optional, doing so
+        # allows Python code to use keyword arguments,
         # or add other customized behavior.
         # The default __new__ takes `*args`.
-        # In addition, user should not override the __init__.
+        # IMPORTANT: Users should not override __init__.
         return structref.StructRefProxy.__new__(cls, name, vector)
 
     # By default, the proxy type does not reflect the attributes or
-    # methods to the Python side. It is up to the users to define
-    # these. (These maybe automated in the future.)
+    # methods to the Python side. It is up to users to define
+    # these. (This may be automated in the future.)
 
     @property
     def name(self):
@@ -56,7 +56,7 @@ class MyStruct(structref.StructRefProxy):
 
 @njit
 def MyStruct_get_name(self):
-    # In jit-code, the StructRef's attribute is exposed at
+    # In jit-code, the StructRef's attribute is exposed via
     # structref.register
     return self.name
 
@@ -92,7 +92,7 @@ class TestStructRefUsage(unittest.TestCase):
         # Define one in jit-code
         @njit
         def make_bob():
-            bob = MyStruct("unname", vector=numpy.zeros(3))
+            bob = MyStruct("unnamed", vector=numpy.zeros(3))
             # Mutate the attributes
             bob.name = "Bob"
             bob.vector = numpy.random.random(3)


### PR DESCRIPTION
Based on #5978

* Added ``preprocess_fields`` to ``StructRef``. The change is needed for ``unliteral``'ing field types in the example.
* Added code example to docs with autodoc on ``structref`` module. 
* Examples are tested in testsuite