### PR TITLE
Fix problem in branch pruning with LiteralStrKeyDict

### DIFF
--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -396,7 +396,12 @@ def dead_branch_prune(func_ir, called_args):
         # literal type, return the type itself so comparisons like `x == None`
         # still work as e.g. x = types.int64 will never be None/NoneType so
         # the branch can still be pruned
-        return getattr(input_arg_ty, 'literal_type', Unknown())
+        try:
+            return getattr(input_arg_ty, 'literal_type', Unknown())
+        except ValueError:
+            # some things have a literal_value but their literal_type is
+            # meaningless, for example LiteralStrKeyDict
+            return Unknown()
 
     if DEBUG > 1:
         print("before".center(80, '-'))

--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -396,12 +396,7 @@ def dead_branch_prune(func_ir, called_args):
         # literal type, return the type itself so comparisons like `x == None`
         # still work as e.g. x = types.int64 will never be None/NoneType so
         # the branch can still be pruned
-        try:
-            return getattr(input_arg_ty, 'literal_type', Unknown())
-        except ValueError:
-            # some things have a literal_value but their literal_type is
-            # meaningless, for example LiteralStrKeyDict
-            return Unknown()
+        return getattr(input_arg_ty, 'literal_type', Unknown())
 
     if DEBUG > 1:
         print("before".center(80, '-'))

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -440,7 +440,15 @@ class Literal(Type):
         if self._literal_type_cache is None:
             from numba.core import typing
             ctx = typing.Context()
-            res = ctx.resolve_value_type(self.literal_value)
+            try:
+                res = ctx.resolve_value_type(self.literal_value)
+            except ValueError:
+                # Not all literal types have a literal_value that can be
+                # resolved to a type, for example, LiteralStrKeyDict has a
+                # literal_value that is a python dict for which there's no
+                # `typeof` support.
+                msg = "{} has no attribute 'literal_type'".format(self)
+                raise AttributeError(msg)
             self._literal_type_cache = res
 
         return self._literal_type_cache

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -2071,6 +2071,25 @@ class TestLiteralStrKeyDict(MemoryLeakMixin, TestCase):
 
         foo()
 
+    def test_dict_as_arg(self):
+        @njit
+        def bar(fake_kwargs=None):
+            if fake_kwargs is not None:
+                # Add 10 to array in key 'd'
+                fake_kwargs['d'][:] += 10
+
+        @njit
+        def foo():
+            a = 1
+            b = 2j
+            c = 'string'
+            d = np.zeros(3)
+            e = {'a': a, 'b': b, 'c': c, 'd': d}
+            bar(fake_kwargs=e)
+            return e['d']
+
+        np.testing.assert_allclose(foo(), np.ones(3) * 10)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Branch pruning tries to evaluate literal types via (eventually)
`typeof(literal_value)`, LiteralStrKeyDict's `literal_value`
is a python dict and has no associated `typeof` translation.
This patch mitigates such a query breaking the branch pruning
pass.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
