### PR TITLE
Resolves incorrectly hoisted list in parfor.

### DIFF
--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -677,7 +677,7 @@ def compute_def_once(loop_body, typemap):
     getattr_taken = {}
     module_assigns = {}
     compute_def_once_internal(loop_body, def_once, def_more, getattr_taken, typemap, module_assigns)
-    return def_once
+    return def_once, def_more
 
 def find_vars(var, varset):
     assert isinstance(var, ir.Var)
@@ -744,7 +744,7 @@ def hoist(parfor_params, loop_body, typemap, wrapped_blocks):
     not_hoisted = []
 
     # Compute the set of variable defined exactly once in the loop body.
-    def_once = compute_def_once(loop_body, typemap)
+    def_once, def_more = compute_def_once(loop_body, typemap)
     (call_table, reverse_call_table) = get_call_table(wrapped_blocks)
 
     setitems = set()
@@ -753,6 +753,8 @@ def hoist(parfor_params, loop_body, typemap, wrapped_blocks):
     dep_on_param = list(set(dep_on_param).difference(setitems))
     if config.DEBUG_ARRAY_OPT >= 1:
         print("hoist - def_once:", def_once, "setitems:", setitems, "itemsset:", itemsset, "dep_on_param:", dep_on_param, "parfor_params:", parfor_params)
+    for si in setitems:
+        add_to_def_once_sets(si, def_once, def_more)
 
     for label, block in loop_body.items():
         new_block = []

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3683,7 +3683,7 @@ class TestParforsDiagnostics(TestParforsBase):
         self.check(test_impl,)
         cpfunc = self.compile_parallel(test_impl, ())
         diagnostics = cpfunc.metadata['parfor_diagnostics']
-        self.assert_diagnostics(diagnostics, hoisted_allocations=1)
+        self.assert_diagnostics(diagnostics, hoisted_allocations=0)
 
 
 if __name__ == "__main__":

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2540,6 +2540,21 @@ class TestPrange(TestPrangeBase):
         image = np.zeros((3, 3), dtype=np.int32)
         self.prange_tester(test_impl, image, 0, 0)
 
+    @skip_parfors_unsupported
+    def test_list_setitem_hoisting(self):
+        # issue5979
+        # Don't hoist list initialization if list item set.
+        def test_impl():
+            n = 5
+            a = np.empty(n, dtype=np.int64)
+            for k in nb.prange(5):
+                X = [0]
+                X[0] = 1
+                a[k] = X[0]
+            return a
+
+        self.prange_tester(test_impl)
+
 
 @skip_parfors_unsupported
 @x86_only

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2547,7 +2547,7 @@ class TestPrange(TestPrangeBase):
         def test_impl():
             n = 5
             a = np.empty(n, dtype=np.int64)
-            for k in nb.prange(5):
+            for k in range(5):
                 X = [0]
                 X[0] = 1
                 a[k] = X[0]

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3683,7 +3683,7 @@ class TestParforsDiagnostics(TestParforsBase):
         self.check(test_impl,)
         cpfunc = self.compile_parallel(test_impl, ())
         diagnostics = cpfunc.metadata['parfor_diagnostics']
-        self.assert_diagnostics(diagnostics, hoisted_allocations=0)
+        self.assert_diagnostics(diagnostics, hoisted_allocations=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #5979

Treat setitems in a parfor body as if they were definitions so that a list initialization in a parfor body will not be incorrectly hoisted.