### PR TITLE
Set Literals

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -64,7 +64,6 @@ exclude =
     numba/core/types/iterators.py
     numba/core/types/scalars.py
     numba/core/fastmathpass.py
-    numba/cpython/setobj.py
     numba/core/options.py
     numba/cpython/printimpl.py
     numba/cpython/cmathimpl.py
@@ -304,7 +303,6 @@ exclude =
     numba/tests/test_chained_assign.py
     numba/tests/test_withlifting.py
     numba/tests/test_parfors.py
-    numba/tests/test_sets.py
     numba/tests/test_dyn_array.py
     numba/tests/test_objects.py
     numba/tests/test_random.py
@@ -322,7 +320,6 @@ exclude =
     numba/core/typing/listdecl.py
     numba/core/typing/builtins.py
     numba/core/typing/randomdecl.py
-    numba/core/typing/setdecl.py
     numba/core/typing/npydecl.py
     numba/core/typing/arraydecl.py
     numba/core/typing/collections.py

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -452,11 +452,6 @@ class List(MutableSequence, InitialValue):
         """
         return self.dtype
 
-    def can_convert_to(self, typingctx, other):
-        if not isinstance(other, List):
-            return
-        return typingctx.can_convert(self.dtype, other.dtype)
-
 
 class LiteralList(Literal, _HeterogeneousTuple):
     """A heterogeneous immutable list (basically a tuple with list semantics).
@@ -545,7 +540,7 @@ class Set(Container):
     def can_convert_to(self, typingctx, other):
         if not isinstance(other, Set):
             return
-        return typingctx.can_convert(self.dtype, other.dtype)
+        return self.dtype == other.dtype
 
 
 class SetIter(BaseContainerIterator):

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -452,6 +452,11 @@ class List(MutableSequence, InitialValue):
         """
         return self.dtype
 
+    def can_convert_to(self, typingctx, other):
+        if not isinstance(other, List):
+            return
+        return typingctx.can_convert(self.dtype, other.dtype)
+
 
 class LiteralList(Literal, _HeterogeneousTuple):
     """A heterogeneous immutable list (basically a tuple with list semantics).
@@ -536,6 +541,11 @@ class Set(Container):
             reflected = self.reflected or other.reflected
             if dtype is not None:
                 return Set(dtype, reflected)
+
+    def can_convert_to(self, typingctx, other):
+        if not isinstance(other, Set):
+            return
+        return typingctx.can_convert(self.dtype, other.dtype)
 
 
 class SetIter(BaseContainerIterator):

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -1,11 +1,9 @@
 import operator
 
 from numba.core import types
-from .templates import (ConcreteTemplate, AbstractTemplate, AttributeTemplate,
-                        CallableTemplate,  Registry, signature, bound_function,
-                        make_callable_template)
-# Ensure set is typed as a collection as well
-from numba.core.typing import collections
+from numba.core.typing.templates import (
+    AbstractTemplate, AttributeTemplate, Registry, signature, bound_function,
+)
 
 
 registry = Registry()
@@ -182,20 +180,30 @@ class SetComparison(AbstractTemplate):
                     types.boolean, a.copy(dtype=unified), b.copy(dtype=unified))
 
 
-for op_key in (operator.add, operator.sub, operator.and_, operator.or_, operator.xor, operator.invert):
+for op_key in (
+    operator.add,
+    operator.sub,
+    operator.and_,
+    operator.or_,
+    operator.xor,
+    operator.invert
+):
     @infer_global(op_key)
     class ConcreteSetOperator(SetOperator):
         key = op_key
 
 
-for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operator.ixor):
+for op_key in (
+    operator.iadd, operator.isub, operator.iand, operator.ior, operator.ixor
+):
     @infer_global(op_key)
     class ConcreteInplaceSetOperator(SetOperator):
         key = op_key
 
 
-for op_key in (operator.eq, operator.ne, operator.lt, operator.le, operator.ge, operator.gt):
+for op_key in (
+    operator.eq, operator.ne, operator.lt, operator.le, operator.ge, operator.gt
+):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key
-

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1457,5 +1457,5 @@ def set_is(context, builder, sig, args):
 @lower_cast(types.Set, types.Set)
 def set_to_set(context, builder, fromty, toty, val):
     # Casting from non-reflected to reflected
-    assert fromty.dtype == toty.dtype
+    assert unliteral(fromty.dtype) == unliteral(toty.dtype)
     return val

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -16,6 +16,7 @@ from numba.core.imputils import (lower_builtin, lower_cast,
                                     for_iter, call_len, RefType)
 from numba.core.utils import cached_property
 from numba.misc import quicksort
+from numba.core.types.misc import unliteral
 from numba.cpython import slicing
 from numba.extending import intrinsic
 


### PR DESCRIPTION
Working to address https://github.com/numba/numba/issues/5994.  This PR adds support for things like

```
@njit 
def foo(a):
    return set(a) | {1, 2}
```

It also reformats the touched files to be flake8 compliant.