### PR TITLE
CUDA: Fix #5820, adding atomic nanmin / nanmax

### DIFF
--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -314,6 +314,16 @@ class Cuda_atomic_min(Cuda_atomic_maxmin):
 
 
 @register
+class Cuda_atomic_nanmax(Cuda_atomic_maxmin):
+    key = cuda.atomic.nanmax
+
+
+@register
+class Cuda_atomic_nanmin(Cuda_atomic_maxmin):
+    key = cuda.atomic.nanmin
+
+
+@register
 class Cuda_atomic_compare_and_swap(AbstractTemplate):
     key = cuda.atomic.compare_and_swap
 
@@ -376,6 +386,12 @@ class CudaAtomicTemplate(AttributeTemplate):
 
     def resolve_min(self, mod):
         return types.Function(Cuda_atomic_min)
+
+    def resolve_nanmin(self, mod):
+        return types.Function(Cuda_atomic_nanmin)
+
+    def resolve_nanmax(self, mod):
+        return types.Function(Cuda_atomic_nanmax)
 
     def resolve_compare_and_swap(self, mod):
         return types.Function(Cuda_atomic_compare_and_swap)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -508,16 +508,16 @@ def llvm_to_ptx(llvmir, **opts):
                                     PTR_OR_VAL='ptr')),
         ('declare float @___numba_atomic_float_nanmax(float*, float)',
          ir_numba_atomic_max.format(T='float', Ti='i32', NAN='nan', OP='ult',
-                                    PTR_OR_VAL='ptr')),
+                                    PTR_OR_VAL='')),
         ('declare double @___numba_atomic_double_nanmax(double*, double)',
          ir_numba_atomic_max.format(T='double', Ti='i64', NAN='nan', OP='ult',
-                                    PTR_OR_VAL='ptr')),
+                                    PTR_OR_VAL='')),
         ('declare float @___numba_atomic_float_nanmin(float*, float)',
          ir_numba_atomic_min.format(T='float', Ti='i32', NAN='nan', OP='ugt',
-                                    PTR_OR_VAL='ptr')),
+                                    PTR_OR_VAL='')),
         ('declare double @___numba_atomic_double_nanmin(double*, double)',
          ir_numba_atomic_min.format(T='double', Ti='i64', NAN='nan', OP='ugt',
-                                    PTR_OR_VAL='ptr')),
+                                    PTR_OR_VAL='')),
         ('immarg', '')
     ]
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -404,13 +404,13 @@ define internal {T} @___numba_atomic_{T}_max({T}* %ptr, {T} %val) alwaysinline {
 entry:
     %ptrval = load volatile {T}, {T}* %ptr
     ; Check if either value is a NaN and return *ptr early if so
-    %valnan = fcmp uno {T} %val, %ptrval
+    %valnan = fcmp uno {T} %val, %{PTR_OR_VAL}val
     br i1 %valnan, label %done, label %lt_check
 
 lt_check:
     %dold = phi {T} [ %ptrval, %entry ], [ %dcas, %attempt ]
-    ; Continue attempts if dold < val
-    %lt = fcmp nnan olt {T} %dold, %val
+    ; Continue attempts if dold < val or dold is NaN (using if ult semantics)
+    %lt = fcmp {OP} {T} %dold, %val
     br i1 %lt, label %attempt, label %done
 
 attempt:
@@ -435,13 +435,13 @@ define internal {T} @___numba_atomic_{T}_min({T}* %ptr, {T} %val) alwaysinline{{
 entry:
     %ptrval = load volatile {T}, {T}* %ptr
     ; Check if either value is a NaN and return *ptr early if so
-    %valnan = fcmp uno {T} %val, %ptrval
+    %valnan = fcmp uno {T} %val, %{PTR_OR_VAL}val
     br i1 %valnan, label %done, label %gt_check
 
 gt_check:
     %dold = phi {T} [ %ptrval, %entry ], [ %dcas, %attempt ]
     ; Continue attempts if dold > val
-    %lt = fcmp nnan ogt {T} %dold, %val
+    %lt = fcmp {OP} {T} %dold, %val
     br i1 %lt, label %attempt, label %done
 
 attempt:
@@ -495,13 +495,29 @@ def llvm_to_ptx(llvmir, **opts):
         ('declare double @___numba_atomic_double_add(double*, double)',
          ir_numba_atomic_double_add),
         ('declare float @___numba_atomic_float_max(float*, float)',
-         ir_numba_atomic_max.format(T='float', Ti='i32')),
+         ir_numba_atomic_max.format(T='float', Ti='i32', OP='nnan olt',
+                                    PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_max(double*, double)',
-         ir_numba_atomic_max.format(T='double', Ti='i64')),
+         ir_numba_atomic_max.format(T='double', Ti='i64', OP='nnan olt',
+                                    PTR_OR_VAL='ptr')),
         ('declare float @___numba_atomic_float_min(float*, float)',
-         ir_numba_atomic_min.format(T='float', Ti='i32')),
+         ir_numba_atomic_min.format(T='float', Ti='i32', OP='nnan ogt',
+                                    PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_min(double*, double)',
-         ir_numba_atomic_min.format(T='double', Ti='i64')),
+         ir_numba_atomic_min.format(T='double', Ti='i64', OP='nnan ogt',
+                                    PTR_OR_VAL='ptr')),
+        ('declare float @___numba_atomic_float_nanmax(float*, float)',
+         ir_numba_atomic_max.format(T='float', Ti='i32', OP='ult',
+                                    PTR_OR_VAL='ptr')),
+        ('declare double @___numba_atomic_double_nanmax(double*, double)',
+         ir_numba_atomic_max.format(T='double', Ti='i64', OP='ult',
+                                    PTR_OR_VAL='ptr')),
+        ('declare float @___numba_atomic_float_nanmin(float*, float)',
+         ir_numba_atomic_min.format(T='float', Ti='i32', OP='ugt',
+                                    PTR_OR_VAL='ptr')),
+        ('declare double @___numba_atomic_double_nanmin(double*, double)',
+         ir_numba_atomic_min.format(T='double', Ti='i64', OP='ugt',
+                                    PTR_OR_VAL='ptr')),
         ('immarg', '')
     ]
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -452,8 +452,6 @@ attempt:
     br label %gt_check
 
 done:
-    ; Return min
-    %ret = phi {T} [ %ptrval, %entry ], [ %dold, %gt_check ]
     ret {T} %ptrval
 }}
 """

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -400,7 +400,7 @@ done:
 
 
 ir_numba_atomic_max = """
-define internal {T} @___numba_atomic_{T}_max({T}* %ptr, {T} %val) alwaysinline {{
+define internal {T} @___numba_atomic_{T}_{NAN}max({T}* %ptr, {T} %val) alwaysinline {{
 entry:
     %ptrval = load volatile {T}, {T}* %ptr
     ; Check if either value is a NaN and return *ptr early if so
@@ -431,7 +431,7 @@ done:
 
 
 ir_numba_atomic_min = """
-define internal {T} @___numba_atomic_{T}_min({T}* %ptr, {T} %val) alwaysinline{{
+define internal {T} @___numba_atomic_{T}_{NAN}min({T}* %ptr, {T} %val) alwaysinline{{
 entry:
     %ptrval = load volatile {T}, {T}* %ptr
     ; Check if either value is a NaN and return *ptr early if so
@@ -495,28 +495,28 @@ def llvm_to_ptx(llvmir, **opts):
         ('declare double @___numba_atomic_double_add(double*, double)',
          ir_numba_atomic_double_add),
         ('declare float @___numba_atomic_float_max(float*, float)',
-         ir_numba_atomic_max.format(T='float', Ti='i32', OP='nnan olt',
+         ir_numba_atomic_max.format(T='float', Ti='i32', NAN='', OP='nnan olt',
                                     PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_max(double*, double)',
-         ir_numba_atomic_max.format(T='double', Ti='i64', OP='nnan olt',
+         ir_numba_atomic_max.format(T='double', Ti='i64', NAN='', OP='nnan olt',
                                     PTR_OR_VAL='ptr')),
         ('declare float @___numba_atomic_float_min(float*, float)',
-         ir_numba_atomic_min.format(T='float', Ti='i32', OP='nnan ogt',
+         ir_numba_atomic_min.format(T='float', Ti='i32', NAN='', OP='nnan ogt',
                                     PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_min(double*, double)',
-         ir_numba_atomic_min.format(T='double', Ti='i64', OP='nnan ogt',
+         ir_numba_atomic_min.format(T='double', Ti='i64', NAN='', OP='nnan ogt',
                                     PTR_OR_VAL='ptr')),
         ('declare float @___numba_atomic_float_nanmax(float*, float)',
-         ir_numba_atomic_max.format(T='float', Ti='i32', OP='ult',
+         ir_numba_atomic_max.format(T='float', Ti='i32', NAN='nan', OP='ult',
                                     PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_nanmax(double*, double)',
-         ir_numba_atomic_max.format(T='double', Ti='i64', OP='ult',
+         ir_numba_atomic_max.format(T='double', Ti='i64', NAN='nan', OP='ult',
                                     PTR_OR_VAL='ptr')),
         ('declare float @___numba_atomic_float_nanmin(float*, float)',
-         ir_numba_atomic_min.format(T='float', Ti='i32', OP='ugt',
+         ir_numba_atomic_min.format(T='float', Ti='i32', NAN='nan', OP='ugt',
                                     PTR_OR_VAL='ptr')),
         ('declare double @___numba_atomic_double_nanmin(double*, double)',
-         ir_numba_atomic_min.format(T='double', Ti='i64', OP='ugt',
+         ir_numba_atomic_min.format(T='double', Ti='i64', NAN='nan', OP='ugt',
                                     PTR_OR_VAL='ptr')),
         ('immarg', '')
     ]

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -423,9 +423,7 @@ attempt:
     br label %lt_check
 
 done:
-    ; Return max
-    %ret = phi {T} [ %ptrval, %entry ], [ %dold, %lt_check ]
-    ret {T} %ret
+    ret {T} %ptrval
 }}
 """
 
@@ -456,7 +454,7 @@ attempt:
 done:
     ; Return min
     %ret = phi {T} [ %ptrval, %entry ], [ %dold, %gt_check ]
-    ret {T} %ret
+    ret {T} %ptrval
 }}
 """
 

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -578,6 +578,46 @@ def ptx_atomic_min(context, builder, dtype, ptr, val):
         raise TypeError('Unimplemented atomic min with %s array' % dtype)
 
 
+@lower(stubs.atomic.nanmax, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.nanmax, types.Array, types.Tuple, types.Any)
+@lower(stubs.atomic.nanmax, types.Array, types.UniTuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_nanmax(context, builder, dtype, ptr, val):
+    lmod = builder.module
+    if dtype == types.float64:
+        return builder.call(nvvmutils.declare_atomic_nanmax_float64(lmod),
+                            (ptr, val))
+    elif dtype == types.float32:
+        return builder.call(nvvmutils.declare_atomic_nanmax_float32(lmod),
+                            (ptr, val))
+    elif dtype in (types.int32, types.int64):
+        return builder.atomic_rmw('max', ptr, val, ordering='monotonic')
+    elif dtype in (types.uint32, types.uint64):
+        return builder.atomic_rmw('umax', ptr, val, ordering='monotonic')
+    else:
+        raise TypeError('Unimplemented atomic max with %s array' % dtype)
+
+
+@lower(stubs.atomic.nanmin, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.nanmin, types.Array, types.Tuple, types.Any)
+@lower(stubs.atomic.nanmin, types.Array, types.UniTuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_min(context, builder, dtype, ptr, val):
+    lmod = builder.module
+    if dtype == types.float64:
+        return builder.call(nvvmutils.declare_atomic_nanmin_float64(lmod),
+                            (ptr, val))
+    elif dtype == types.float32:
+        return builder.call(nvvmutils.declare_atomic_nanmin_float32(lmod),
+                            (ptr, val))
+    elif dtype in (types.int32, types.int64):
+        return builder.atomic_rmw('min', ptr, val, ordering='monotonic')
+    elif dtype in (types.uint32, types.uint64):
+        return builder.atomic_rmw('umin', ptr, val, ordering='monotonic')
+    else:
+        raise TypeError('Unimplemented atomic min with %s array' % dtype)
+
+
 @lower(stubs.atomic.compare_and_swap, types.Array, types.Any, types.Any)
 def ptx_atomic_cas_tuple(context, builder, sig, args):
     aryty, oldty, valty = sig.args

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -602,7 +602,7 @@ def ptx_atomic_nanmax(context, builder, dtype, ptr, val):
 @lower(stubs.atomic.nanmin, types.Array, types.Tuple, types.Any)
 @lower(stubs.atomic.nanmin, types.Array, types.UniTuple, types.Any)
 @_atomic_dispatcher
-def ptx_atomic_min(context, builder, dtype, ptr, val):
+def ptx_atomic_nanmin(context, builder, dtype, ptr, val):
     lmod = builder.module
     if dtype == types.float64:
         return builder.call(nvvmutils.declare_atomic_nanmin_float64(lmod),

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -83,6 +83,7 @@ def declare_atomic_nanmin_float64(lmod):
         (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
     return lmod.get_or_insert_function(fnty, fname)
 
+
 def insert_addrspace_conv(lmod, elemtype, addrspace):
     addrspacename = {
         nvvm.ADDRSPACE_SHARED: 'shared',

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -56,6 +56,32 @@ def declare_atomic_min_float64(lmod):
         (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
     return lmod.get_or_insert_function(fnty, fname)
 
+def declare_atomic_nanmax_float32(lmod):
+    fname = '___numba_atomic_float_nanmax'
+    fnty = lc.Type.function(lc.Type.float(),
+        (lc.Type.pointer(lc.Type.float()), lc.Type.float()))
+    return lmod.get_or_insert_function(fnty, fname)
+
+
+def declare_atomic_nanmax_float64(lmod):
+    fname = '___numba_atomic_double_nanmax'
+    fnty = lc.Type.function(lc.Type.double(),
+        (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
+    return lmod.get_or_insert_function(fnty, fname)
+
+
+def declare_atomic_nanmin_float32(lmod):
+    fname = '___numba_atomic_float_nanmin'
+    fnty = lc.Type.function(lc.Type.float(),
+        (lc.Type.pointer(lc.Type.float()), lc.Type.float()))
+    return lmod.get_or_insert_function(fnty, fname)
+
+
+def declare_atomic_nanmin_float64(lmod):
+    fname = '___numba_atomic_double_nanmin'
+    fnty = lc.Type.function(lc.Type.double(),
+        (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
+    return lmod.get_or_insert_function(fnty, fname)
 
 def insert_addrspace_conv(lmod, elemtype, addrspace):
     addrspacename = {

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -121,6 +121,14 @@ class FakeCUDAAtomic(object):
             array[index] = min(old, val)
         return old
 
+    def nanmax(self, array, index, val):
+        with maxlock:
+            array[index] = np.nanmax([array[index], val])
+
+    def nanmin(self, array, index, val):
+        with maxlock:
+            array[index] = np.nanmin([array[index], val])
+
     def compare_and_swap(self, array, old, val):
         with caslock:
             index = (0,) * array.ndim

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -123,11 +123,15 @@ class FakeCUDAAtomic(object):
 
     def nanmax(self, array, index, val):
         with maxlock:
+            old = array[index]
             array[index] = np.nanmax([array[index], val])
+        return old
 
     def nanmin(self, array, index, val):
-        with maxlock:
+        with minlock:
+            old = array[index]
             array[index] = np.nanmin([array[index], val])
+        return old
 
     def compare_and_swap(self, array, old, val):
         with caslock:

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -274,7 +274,8 @@ class match_any_sync(Stub):
     match_any_sync(mask, value)
 
     Nvvm intrinsic for performing a compare and broadcast across a warp.
-    Returns a mask of threads that have same value as the given value from within the masked warp.
+    Returns a mask of threads that have same value as the given value from
+    within the masked warp.
     '''
     _description_ = '<match_any_sync()>'
 
@@ -358,7 +359,8 @@ class selp(Stub):
     """
     selp(a, b, c)
 
-    Select between source operands, based on the value of the predicate source operand.
+    Select between source operands, based on the value of the predicate source
+    operand.
     """
 
 #-------------------------------------------------------------------------------
@@ -394,7 +396,8 @@ class atomic(Stub):
 
         Perform atomic ary[idx] = max(ary[idx], val).
 
-        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+        Supported on int32, int64, uint32, uint64, float32, float64 operands
+        only.
 
         Returns the old value at the index location as if it is loaded
         atomically.
@@ -405,7 +408,8 @@ class atomic(Stub):
 
         Perform atomic ary[idx] = min(ary[idx], val).
 
-        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+        Supported on int32, int64, uint32, uint64, float32, float64 operands
+        only.
 
         Returns the old value at the index location as if it is loaded
         atomically.
@@ -416,9 +420,11 @@ class atomic(Stub):
 
         Perform atomic ary[idx] = max(ary[idx], val).
 
-        NOTE: NaN is treated as a missing value, max(NaN, n) == max(n, NaN) == n
+        NOTE: NaN is treated as a missing value such that:
+        nanmax(NaN, n) == n, nanmax(n, NaN) == n
 
-        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+        Supported on int32, int64, uint32, uint64, float32, float64 operands
+        only.
 
         Returns the old value at the index location as if it is loaded
         atomically.
@@ -429,9 +435,11 @@ class atomic(Stub):
 
         Perform atomic ary[idx] = min(ary[idx], val).
 
-        NOTE: NaN is treated as a missing value, min(NaN, n) == min(n, NaN) == n
+        NOTE: NaN is treated as a missing value, such that:
+        nanmin(NaN, n) == n, nanmin(n, NaN) == n
 
-        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+        Supported on int32, int64, uint32, uint64, float32, float64 operands
+        only.
 
         Returns the old value at the index location as if it is loaded
         atomically.

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -411,6 +411,32 @@ class atomic(Stub):
         atomically.
         """
 
+    class nanmax(Stub):
+        """nanmax(ary, idx, val)
+
+        Perform atomic ary[idx] = max(ary[idx], val).
+
+        NOTE: NaN is treated as a missing value, max(NaN, n) == max(n, NaN) == n
+
+        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
+    class nanmin(Stub):
+        """nanmin(ary, idx, val)
+
+        Perform atomic ary[idx] = min(ary[idx], val).
+
+        NOTE: NaN is treated as a missing value, min(NaN, n) == min(n, NaN) == n
+
+        Supported on int32, int64, uint32, uint64, float32, float64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
     class compare_and_swap(Stub):
         """compare_and_swap(ary, old, val)
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -527,12 +527,19 @@ class TestCudaAtomics(CUDATestCase):
 
         self._test_atomic_returns_old(kernel, 10)
 
-    def test_atomic_max_returns_old(self):
+    def test_atomic_max_returns_no_replace(self):
         @cuda.jit
         def kernel(x):
             x[1] = cuda.atomic.max(x, 0, 1)
 
         self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_max_returns_old_replace(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.max(x, 0, 10)
+
+        self._test_atomic_returns_old(kernel, 1)
 
     def test_atomic_max_returns_old_nan_in_array(self):
         @cuda.jit
@@ -548,12 +555,19 @@ class TestCudaAtomics(CUDATestCase):
 
         self._test_atomic_returns_old(kernel, 10)
 
-    def test_atomic_min_returns_old(self):
+    def test_atomic_min_returns_old_no_replace(self):
         @cuda.jit
         def kernel(x):
             x[1] = cuda.atomic.min(x, 0, 11)
 
         self._test_atomic_returns_old(kernel, 10)
+
+    def test_atomic_min_returns_old_replace(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.min(x, 0, 10)
+
+        self._test_atomic_returns_old(kernel, 11)
 
     def test_atomic_min_returns_old_nan_in_array(self):
         @cuda.jit
@@ -565,9 +579,9 @@ class TestCudaAtomics(CUDATestCase):
     def test_atomic_min_returns_old_nan_val(self):
         @cuda.jit
         def kernel(x):
-            x[1] = cuda.atomic.min(x, 0, 11)
+            x[1] = cuda.atomic.min(x, 0, np.nan)
 
-        self._test_atomic_returns_old(kernel, np.nan)
+        self._test_atomic_returns_old(kernel, 11)
 
     # Tests for atomic nanmin/nanmax
 
@@ -688,12 +702,19 @@ class TestCudaAtomics(CUDATestCase):
         else:
             self.assertEqual(x[1], initial)
 
-    def test_atomic_nanmax_returns_old(self):
+    def test_atomic_nanmax_returns_old_no_replace(self):
         @cuda.jit
         def kernel(x):
             x[1] = cuda.atomic.nanmax(x, 0, 1)
 
         self._test_atomic_nan_returns_old(kernel, 10)
+
+    def test_atomic_nanmax_returns_old_replace(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmax(x, 0, 10)
+
+        self._test_atomic_nan_returns_old(kernel, 1)
 
     def test_atomic_nanmax_returns_old_nan_in_array(self):
         @cuda.jit
@@ -709,12 +730,19 @@ class TestCudaAtomics(CUDATestCase):
 
         self._test_atomic_nan_returns_old(kernel, 10)
 
-    def test_atomic_nanmin_returns_old(self):
+    def test_atomic_nanmin_returns_old_no_replace(self):
         @cuda.jit
         def kernel(x):
             x[1] = cuda.atomic.nanmin(x, 0, 11)
 
         self._test_atomic_nan_returns_old(kernel, 10)
+
+    def test_atomic_nanmin_returns_old_replace(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmin(x, 0, 10)
+
+        self._test_atomic_nan_returns_old(kernel, 11)
 
     def test_atomic_nanmin_returns_old_nan_in_array(self):
         @cuda.jit

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -1,5 +1,6 @@
 import random
 import numpy as np
+from textwrap import dedent
 
 from numba import cuda, uint32, uint64, float32, float64
 from numba.cuda.testing import unittest, CUDATestCase
@@ -136,43 +137,52 @@ def atomic_add_double_3(ary):
     cuda.syncthreads()
     ary[tx, ty] = sm[tx, ty]
 
+def gen_atomic_extreme_funcs(func):
 
-def atomic_max(res, ary):
-    tx = cuda.threadIdx.x
-    bx = cuda.blockIdx.x
-    cuda.atomic.max(res, 0, ary[tx, bx])
+    fns = dedent(
+    """
+    def atomic(res, ary):
+        tx = cuda.threadIdx.x
+        bx = cuda.blockIdx.x
+        {func}(res, 0, ary[tx, bx])
 
+    def atomic_double_normalizedindex(res, ary):
+        tx = cuda.threadIdx.x
+        bx = cuda.blockIdx.x
+        {func}(res, 0, ary[tx, uint64(bx)])
 
-def atomic_min(res, ary):
-    tx = cuda.threadIdx.x
-    bx = cuda.blockIdx.x
-    cuda.atomic.min(res, 0, ary[tx, bx])
+    def atomic_double_oneindex(res, ary):
+        tx = cuda.threadIdx.x
+        {func}(res, 0, ary[tx])
 
+    def atomic_double_shared(res, ary):
+        tid = cuda.threadIdx.x
+        smary = cuda.shared.array(32, float64)
+        smary[tid] = ary[tid]
+        smres = cuda.shared.array(1, float64)
+        if tid == 0:
+            smres[0] = res[0]
+        cuda.syncthreads()
+        {func}(smres, 0, smary[tid])
+        cuda.syncthreads()
+        if tid == 0:
+            res[0] = smres[0]
+    """).format(func=func)
+    ld = {}
+    exec(fns, {'cuda': cuda, 'float64': float64, 'uint64': uint64}, ld)
+    return (ld['atomic'], ld['atomic_double_normalizedindex'],
+            ld['atomic_double_oneindex'], ld['atomic_double_shared'])
 
-def atomic_max_double_normalizedindex(res, ary):
-    tx = cuda.threadIdx.x
-    bx = cuda.blockIdx.x
-    cuda.atomic.max(res, 0, ary[tx, uint64(bx)])
-
-
-def atomic_max_double_oneindex(res, ary):
-    tx = cuda.threadIdx.x
-    cuda.atomic.max(res, 0, ary[tx])
-
-
-def atomic_max_double_shared(res, ary):
-    tid = cuda.threadIdx.x
-    smary = cuda.shared.array(32, float64)
-    smary[tid] = ary[tid]
-    smres = cuda.shared.array(1, float64)
-    if tid == 0:
-        smres[0] = res[0]
-    cuda.syncthreads()
-    cuda.atomic.max(smres, 0, smary[tid])
-    cuda.syncthreads()
-    if tid == 0:
-        res[0] = smres[0]
-
+(atomic_max, atomic_max_double_normalizedindex, atomic_max_double_oneindex,
+ atomic_max_double_shared) = gen_atomic_extreme_funcs('cuda.atomic.max')
+(atomic_min, atomic_min_double_normalizedindex, atomic_min_double_oneindex,
+ atomic_min_double_shared) = gen_atomic_extreme_funcs('cuda.atomic.min')
+(atomic_nanmax, atomic_nanmax_double_normalizedindex,
+ atomic_nanmax_double_oneindex, atomic_nanmax_double_shared) = \
+     gen_atomic_extreme_funcs('cuda.atomic.nanmax')
+(atomic_nanmin, atomic_nanmin_double_normalizedindex,
+ atomic_nanmin_double_oneindex, atomic_nanmin_double_shared) = \
+     gen_atomic_extreme_funcs('cuda.atomic.nanmin')
 
 def atomic_compare_and_swap(res, old, ary):
     gid = cuda.grid(1)
@@ -342,6 +352,26 @@ class TestCudaAtomics(CUDATestCase):
     def test_atomic_max_double(self):
         self.check_atomic_max(dtype=np.float64, lo=-65535, hi=65535)
 
+    def test_atomic_max_double_normalizedindex(self):
+        vals = np.random.randint(0, 65535, size=(32, 32)).astype(np.float64)
+        res = np.zeros(1, np.float64)
+        cuda_func = cuda.jit('void(float64[:], float64[:,:])')(
+            atomic_max_double_normalizedindex)
+        cuda_func[32, 32](res, vals)
+
+        gold = np.max(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_max_double_oneindex(self):
+        vals = np.random.randint(0, 128, size=32).astype(np.float64)
+        res = np.zeros(1, np.float64)
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(
+            atomic_max_double_oneindex)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.max(vals)
+        np.testing.assert_equal(res, gold)
+
     def check_atomic_min(self, dtype, lo, hi):
         vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)
         res = np.array([65535], dtype=vals.dtype)
@@ -371,24 +401,24 @@ class TestCudaAtomics(CUDATestCase):
     def test_atomic_min_double(self):
         self.check_atomic_min(dtype=np.float64, lo=-65535, hi=65535)
 
-    def test_atomic_max_double_normalizedindex(self):
+    def test_atomic_min_double_normalizedindex(self):
         vals = np.random.randint(0, 65535, size=(32, 32)).astype(np.float64)
-        res = np.zeros(1, np.float64)
+        res = np.ones(1, np.float64) * 65535
         cuda_func = cuda.jit('void(float64[:], float64[:,:])')(
-            atomic_max_double_normalizedindex)
+            atomic_min_double_normalizedindex)
         cuda_func[32, 32](res, vals)
 
-        gold = np.max(vals)
+        gold = np.min(vals)
         np.testing.assert_equal(res, gold)
 
-    def test_atomic_max_double_oneindex(self):
+    def test_atomic_min_double_oneindex(self):
         vals = np.random.randint(0, 128, size=32).astype(np.float64)
-        res = np.zeros(1, np.float64)
+        res = np.ones(1, np.float64) * 128
         cuda_func = cuda.jit('void(float64[:], float64[:])')(
-            atomic_max_double_oneindex)
+            atomic_min_double_oneindex)
         cuda_func[1, 32](res, vals)
 
-        gold = np.max(vals)
+        gold = np.min(vals)
         np.testing.assert_equal(res, gold)
 
     # Taken together, _test_atomic_minmax_nan_location and
@@ -440,6 +470,15 @@ class TestCudaAtomics(CUDATestCase):
         cuda_func[1, 32](res, vals)
 
         gold = np.max(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_min_double_shared(self):
+        vals = np.random.randint(0, 32, size=32).astype(np.float64)
+        res = np.ones(1, np.float64) * 32
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(atomic_min_double_shared)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.min(vals)
         np.testing.assert_equal(res, gold)
 
     def test_atomic_compare_and_swap(self):
@@ -529,6 +568,111 @@ class TestCudaAtomics(CUDATestCase):
             x[1] = cuda.atomic.min(x, 0, 11)
 
         self._test_atomic_returns_old(kernel, np.nan)
+
+    # Tests for atomic nanmin/nanmax
+
+    # nanmax tests
+    def check_atomic_nanmax(self, dtype, lo, hi):
+        vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)
+        vals[1::2] = np.nan
+        res = np.zeros(1, dtype=vals.dtype)
+        cuda_func = cuda.jit(atomic_nanmax)
+        cuda_func[32, 32](res, vals)
+        gold = np.nanmax(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_nanmax_int32(self):
+        self.check_atomic_nanmax(dtype=np.int32, lo=-65535, hi=65535)
+
+    def test_atomic_nanmax_uint32(self):
+        self.check_atomic_nanmax(dtype=np.uint32, lo=0, hi=65535)
+
+    @skip_unless_cc_32
+    def test_atomic_nanmax_int64(self):
+        self.check_atomic_nanmax(dtype=np.int64, lo=-65535, hi=65535)
+
+    @skip_unless_cc_32
+    def test_atomic_nanmax_uint64(self):
+        self.check_atomic_nanmax(dtype=np.uint64, lo=0, hi=65535)
+
+    def test_atomic_nanmax_float32(self):
+        self.check_atomic_nanmax(dtype=np.float32, lo=-65535, hi=65535)
+
+    def test_atomic_nanmax_double(self):
+        self.check_atomic_nanmax(dtype=np.float64, lo=-65535, hi=65535)
+
+    def test_atomic_nanmax_double_shared(self):
+        vals = np.random.randint(0, 32, size=32).astype(np.float64)
+        vals[1::2] = np.nan
+        res = np.array([0], dtype=vals.dtype)
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(atomic_nanmax_double_shared)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.nanmax(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_nanmax_double_oneindex(self):
+        vals = np.random.randint(0, 128, size=32).astype(np.float64)
+        vals[1::2] = np.nan
+        res = np.zeros(1, np.float64)
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(
+            atomic_max_double_oneindex)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.nanmax(vals)
+        np.testing.assert_equal(res, gold)
+
+    # nanmin tests
+    def check_atomic_nanmin(self, dtype, lo, hi):
+        vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)
+        vals[1::2] = np.nan
+        res = np.array([65535], dtype=vals.dtype)
+        cuda_func = cuda.jit(atomic_nanmin)
+        cuda_func[32, 32](res, vals)
+
+        gold = np.nanmin(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_nanmin_int32(self):
+        self.check_atomic_nanmin(dtype=np.int32, lo=-65535, hi=65535)
+
+    def test_atomic_nanmin_uint32(self):
+        self.check_atomic_nanmin(dtype=np.uint32, lo=0, hi=65535)
+
+    @skip_unless_cc_32
+    def test_atomic_nanmin_int64(self):
+        self.check_atomic_nanmin(dtype=np.int64, lo=-65535, hi=65535)
+
+    @skip_unless_cc_32
+    def test_atomic_nanmin_uint64(self):
+        self.check_atomic_nanmin(dtype=np.uint64, lo=0, hi=65535)
+
+    def test_atomic_nanmin_float(self):
+        self.check_atomic_nanmin(dtype=np.float32, lo=-65535, hi=65535)
+
+    def test_atomic_nanmin_double(self):
+        self.check_atomic_nanmin(dtype=np.float64, lo=-65535, hi=65535)
+
+    def test_atomic_nanmin_double_shared(self):
+        vals = np.random.randint(0, 32, size=32).astype(np.float64)
+        vals[1::2] = np.nan
+        res = np.array([32], dtype=vals.dtype)
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(atomic_nanmin_double_shared)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.nanmin(vals)
+        np.testing.assert_equal(res, gold)
+
+    def test_atomic_nanmin_double_oneindex(self):
+        vals = np.random.randint(0, 128, size=32).astype(np.float64)
+        vals[1::2] = np.nan
+        res = np.array([128], np.float64)
+        cuda_func = cuda.jit('void(float64[:], float64[:])')(
+            atomic_min_double_oneindex)
+        cuda_func[1, 32](res, vals)
+
+        gold = np.nanmin(vals)
+        np.testing.assert_equal(res, gold)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -675,5 +675,61 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_equal(res, gold)
 
 
+    # Returning old value tests
+
+    def _test_atomic_nan_returns_old(self, kernel, initial):
+        x = np.zeros(2, dtype=np.float32)
+        x[0] = initial
+        x[1] = np.nan
+        kernel[1, 1](x)
+        if np.isnan(initial):
+            self.assertFalse(np.isnan(x[0]))
+            self.assertTrue(np.isnan(x[1]))
+        else:
+            self.assertEqual(x[1], initial)
+
+    def test_atomic_nanmax_returns_old(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmax(x, 0, 1)
+
+        self._test_atomic_nan_returns_old(kernel, 10)
+
+    def test_atomic_nanmax_returns_old_nan_in_array(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmax(x, 0, 1)
+
+        self._test_atomic_nan_returns_old(kernel, np.nan)
+
+    def test_atomic_nanmax_returns_old_nan_val(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmax(x, 0, np.nan)
+
+        self._test_atomic_nan_returns_old(kernel, 10)
+
+    def test_atomic_nanmin_returns_old(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmin(x, 0, 11)
+
+        self._test_atomic_nan_returns_old(kernel, 10)
+
+    def test_atomic_nanmin_returns_old_nan_in_array(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmin(x, 0, 11)
+
+        self._test_atomic_nan_returns_old(kernel, np.nan)
+
+    def test_atomic_nanmin_returns_old_nan_val(self):
+        @cuda.jit
+        def kernel(x):
+            x[1] = cuda.atomic.nanmin(x, 0, np.nan)
+
+        self._test_atomic_nan_returns_old(kernel, 11)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This continues on from PR #5941, to fix #5820 by adding implementations of atomic `nanmin` and `nanmax` for CUDA.

It turned out that the `max` and `min` atomic functions also failed to return the old value when it was replaced, so a fix for this is included.