### PR TITLE
Fix #6023

### DIFF
--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -189,6 +189,11 @@ def iternext_unituple(context, builder, sig, args, result):
 
 @overload(operator.getitem)
 def getitem_literal_idx(tup, idx):
+    """
+    Adds overload for BaseTuple getitem to cover cases when
+    const inference and RewriteConstGetitems cannot replace it with
+    static_getitem.
+    """
     if not (isinstance(tup, types.BaseTuple)
             and isinstance(idx, types.IntegerLiteral)):
         return None

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -190,9 +190,9 @@ def iternext_unituple(context, builder, sig, args, result):
 @overload(operator.getitem)
 def getitem_literal_idx(tup, idx):
     """
-    Adds overload for BaseTuple getitem to cover cases when
-    const inference and RewriteConstGetitems cannot replace it with
-    static_getitem.
+    Overloads BaseTuple getitem to cover cases where constant
+    inference and RewriteConstGetitems cannot replace it
+    with a static_getitem.
     """
     if not (isinstance(tup, types.BaseTuple)
             and isinstance(idx, types.IntegerLiteral)):

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -187,6 +187,19 @@ def iternext_unituple(context, builder, sig, args, result):
         builder.store(nidx, iterval.index)
 
 
+@overload(operator.getitem)
+def getitem_literal_idx(tup, idx):
+    if not (isinstance(tup, types.BaseTuple)
+            and isinstance(idx, types.IntegerLiteral)):
+        return None
+
+    idx_val = idx.literal_value
+    def getitem_literal_idx_impl(tup, idx):
+        return tup[idx_val]
+
+    return getitem_literal_idx_impl
+
+
 @lower_builtin('typed_getitem', types.BaseTuple, types.Any)
 def getitem_typed(context, builder, sig, args):
     tupty, _ = sig.args


### PR DESCRIPTION
Adds overload for BaseTuple getitem to cover cases when
const inference and RewriteConstGetitems cannot replace it with
static_getitem.
