### PR TITLE
CUDA: Don't optimize IR before sending it to NVVM

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -16,18 +16,7 @@ class CUDACodeLibrary(CodeLibrary):
         pass
 
     def _optimize_final_module(self):
-        # Run some lightweight optimization to simplify the module.
-        # This seems to workaround a libnvvm compilation bug (see #1341)
-        pmb = ll.PassManagerBuilder()
-        pmb.opt_level = 1
-        pmb.disable_unit_at_a_time = False
-        pmb.disable_unroll_loops = True
-        pmb.loop_vectorize = False
-        pmb.slp_vectorize = False
-
-        pm = ll.ModulePassManager()
-        pmb.populate(pm)
-        pm.run(self._final_module)
+        pass
 
     def _finalize_specific(self):
         # Fix global naming

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -12,6 +12,9 @@ CUDA_TRIPLE = {32: 'nvptx-nvidia-cuda',
 
 
 class CUDACodeLibrary(CodeLibrary):
+    # We don't optimize the IR at the function or module level because it is
+    # optimized by NVVM after we've passed it on.
+
     def _optimize_functions(self, ll_module):
         pass
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -674,7 +674,11 @@ def _replace_llvm_memset_usage(m):
     Used as functor for `re.sub.
     """
     params = list(m.group(1).split(','))
-    align = re.search(r'align (\d+)', params[0]).group(1)
+    align_attr = re.search(r'align (\d+)', params[0])
+    if not align_attr:
+        raise ValueError("No alignment attribute on memset dest")
+    else:
+        align = align_attr.group(1)
     params.insert(-1, 'i32 {}'.format(align))
     out = ', '.join(params)
     return '({})'.format(out)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -676,7 +676,7 @@ def _replace_llvm_memset_usage(m):
     params = list(m.group(1).split(','))
     align_attr = re.search(r'align (\d+)', params[0])
     if not align_attr:
-        raise ValueError("No alignment attribute on memset dest")
+        raise ValueError("No alignment attribute found on memset dest")
     else:
         align = align_attr.group(1)
     params.insert(-1, 'i32 {}'.format(align))

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -133,7 +133,7 @@ class TestCudaConstantMemory(CUDATestCase):
         self.assertTrue(np.all(A == CONST3D))
 
         if not ENABLE_CUDASIM:
-            if cuda.runtime.get_version() == (9, 0):
+            if cuda.runtime.get_version() in ((8, 0), (9, 0)):
                 complex_load = 'ld.const.v2.f32'
                 description = 'Load the complex as a vector of 2x f32'
             else:

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -133,7 +133,7 @@ class TestCudaConstantMemory(CUDATestCase):
         self.assertTrue(np.all(A == CONST3D))
 
         if not ENABLE_CUDASIM:
-            if cuda.runtime.get_version() in ((8, 0), (9, 0)):
+            if cuda.runtime.get_version() in ((8, 0), (9, 0), (9, 1)):
                 complex_load = 'ld.const.v2.f32'
                 description = 'Load the complex as a vector of 2x f32'
             else:

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -196,8 +196,9 @@ class TestCudaConstantMemory(CUDATestCase):
         np.testing.assert_allclose(E, CONST_RECORD_ALIGN['z'])
 
     @skip_on_cudasim('PTX inspection not supported on the simulator')
-    @unittest.expectedFailure
     def test_const_record_align_optimization(self):
+        rtver = cuda.runtime.get_version()
+
         A = np.zeros(2, dtype=np.float64)
         B = np.zeros(2, dtype=np.float64)
         C = np.zeros(2, dtype=np.float64)

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -133,10 +133,14 @@ class TestCudaConstantMemory(CUDATestCase):
         self.assertTrue(np.all(A == CONST3D))
 
         if not ENABLE_CUDASIM:
-            self.assertIn(
-                'ld.const.f32',
-                jcuconst3d.ptx,
-                "load each half of the complex as f32")
+            if cuda.runtime.get_version() == (9, 0):
+                complex_load = 'ld.const.v2.f32'
+                description = 'Load the complex as a vector of 2x f32'
+            else:
+                complex_load = 'ld.const.f32'
+                description =  'load each half of the complex as f32'
+
+            self.assertIn(complex_load, jcuconst3d.ptx, description)
 
     def test_const_record_empty(self):
         jcuconstRecEmpty = cuda.jit('void(float64[:])')(cuconstRecEmpty)

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -5,6 +5,13 @@ from numba.core import types, utils
 import unittest
 
 
+original = "call void @llvm.memset.p0i8.i64(" \
+           "i8* align 4 %arg.x.41, i8 0, i64 %0, i1 false)"
+
+missing_align = "call void @llvm.memset.p0i8.i64(" \
+                "i8* %arg.x.41, i8 0, i64 %0, i1 false)"
+
+
 @skip_on_cudasim('libNVVM not supported in simulator')
 @unittest.skipIf(utils.MACHINE_BITS == 32, "CUDA not support for 32-bit")
 @unittest.skipIf(not nvvm.is_available(), "No libNVVM")
@@ -29,25 +36,9 @@ class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
         In LLVM7 the alignment parameter can be implicitly provided as
         an attribute to pointer in the first argument.
         """
-        def foo(x):
-            # Triggers a generation of llvm.memset
-            for i in range(x.size):
-                x[i] = 0
-
-        cukern = compile_kernel(foo, args=(types.int32[::1],), link=())
-        original = cukern._func.ptx.llvmir
-        self.assertIn("call void @llvm.memset", original)
         fixed = nvvm.llvm39_to_34_ir(original)
         self.assertIn("call void @llvm.memset", fixed)
-        # Check original IR
-        for ln in original.splitlines():
-            if 'call void @llvm.memset' in ln:
-                # Missing i32 4 in the 2nd last argument
-                self.assertRegexpMatches(
-                    ln,
-                    r'i64 %\d+, i1 false\)'.replace(' ', r'\s+'),
-                )
-        # Check fixed IR
+
         for ln in fixed.splitlines():
             if 'call void @llvm.memset' in ln:
                 # The i32 4 is the alignment
@@ -55,6 +46,16 @@ class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
                     ln,
                     r'i32 4, i1 false\)'.replace(' ', r'\s+'),
                 )
+
+    def test_nvvm_memset_fixup_missing_align(self):
+        """
+        We require alignment to be specified as a parameter attribute to the
+        dest argument of a memset.
+        """
+        with self.assertRaises(ValueError) as e:
+            nvvm.llvm39_to_34_ir(missing_align)
+
+        self.assertIn(str(e.exception), "No alignment attribute on memset dest")
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -55,7 +55,8 @@ class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             nvvm.llvm39_to_34_ir(missing_align)
 
-        self.assertIn(str(e.exception), "No alignment attribute on memset dest")
+        self.assertIn(str(e.exception),
+                      "No alignment attribute found on memset dest")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are various issues created by optimizing the IR before sending it to NVVM, in particular:

- Issue #5576: Optimizing the IR before sending it to NVVM results in code that makes out-of-bounds accesses.
- Issue #6022: Optimization generates memset intrinsics incompatible with LLVM 3.4 (NVVM).
- IR auto-upgrade breaks the IR for LLVM 3.4 due to changes in atomic instructions. This requires a patch to the LLVM version used for llvmlite, which is problematic because many distributions won't carry this patch. (ref: https://github.com/numba/llvmlite/pull/593)

Optimizing IR prior to sending it to NVVM was originally added to work around an NVVM bug documented as Issue #1341. The cause of issue #1341 is now resolved in NVVM, and has been since CUDA 7.5 - the test script at https://gist.github.com/sklam/f62f1f48bb0be78f9ceb executes in a fraction of a second and consumes around 100MB of RAM - the bug manifested itself as a long compilation time with gigabytes of RAM consumed.

There are some side-effects to not optimizing before sending to NVVM, which are reflected in the tests:

- `TestCudaConstantMemory.test_const_array_3d`: Instead of reading the complex value as a vector of u32s, there are two individual loads of the real and imaginary parts as f32s. This is not expected to have a negative impact on performance, since coalesced reading of f32s will use memory bandwidth effectively.
- `TestCudaConstantMemory.test_const_record`: The generated code here appears less optimal than it previously was - instead of loading three 8-bit members in a single 32-bit read, the reads are now individual 8-bit reads.
- `TestCudaConstantMemory.test_const_record_align`: A similar issue to test_const_record.
- `TestNvvmWithoutCuda.test_nvvm_memset_fixup`: now that IR is not optimized prior to sending to NVVM, memsets no longer appear in the IR. It is desirable to keep the memset fixup functionality and test so that Numba and its extensions will be able to use memsets (e.g. from `cgutils.memset`), so this test is modified to use strings of IR rather than relying on memsets naturally being produced as part of the compilation process. It is possible to generate a memset without an alignment attribute on the destination with `cgutils.memset`, so a check for this error and a test of the check are also added.

For the issues with less optimal code being generated in `TestCudaConstantMemory`, the tests for the optimal code have been moved into new test cases that are marked as expected fails - it would be better to keep these tests and note the sub-optimal behaviour, with the expectation that a future version of NVVM may improve on the code it currently generates.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
