### PR TITLE
Fix overspecialize of literal

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -253,6 +253,9 @@ class UniTuple(BaseAnonymousTuple, _HomogeneousTuple, Sequence):
             if dtype is not None:
                 return UniTuple(dtype=dtype, count=self.count)
 
+    def __unliteral__(self):
+        return type(self)(dtype=unliteral(self.dtype), count=self.count)
+
 
 class UniTupleIter(BaseContainerIterator):
     """

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -200,7 +200,7 @@ class BaseAnonymousTuple(BaseTuple):
             return max(kinds)
 
     def __unliteral__(self):
-        return type(self).from_types([unliteral(t) for t in self])
+        return type(self)([unliteral(t) for t in self])
 
 
 class _HomogeneousTuple(Sequence, BaseTuple):

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -200,7 +200,7 @@ class BaseAnonymousTuple(BaseTuple):
             return max(kinds)
 
     def __unliteral__(self):
-        return type(self)([unliteral(t) for t in self])
+        return type(self).from_types([unliteral(t) for t in self])
 
 
 class _HomogeneousTuple(Sequence, BaseTuple):

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -200,7 +200,7 @@ class BaseAnonymousTuple(BaseTuple):
             return max(kinds)
 
     def __unliteral__(self):
-        return BaseTuple.from_types([unliteral(t) for t in self])
+        return type(self).from_types([unliteral(t) for t in self])
 
 
 class _HomogeneousTuple(Sequence, BaseTuple):

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -271,8 +271,10 @@ class BaseFunction(Callable):
         self._depth += 1
         for temp_cls in self.templates:
             temp = temp_cls(context)
-            # choice = [True, False]    # oldbehavior
-            choice = [False, True]    # newbehavior
+            oldbehavior = [True, False]    # oldbehavior
+            newbehavior = [False, True]    # newbehavior
+
+            choice = oldbehavior if temp.prefer_literal else newbehavior
             for uselit in choice:
                 try:
                     if uselit:

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -280,8 +280,17 @@ class BaseFunction(Callable):
                     if uselit:
                         sig = temp.apply(args, kws)
                     else:
-                        nolitargs = tuple([unliteral(a) for a in args])
-                        nolitkws = {k: unliteral(v) for k, v in kws.items()}
+
+                        def unlit_non_poison(ty):
+                            out = unliteral(ty)
+                            if isinstance(out, types.Poison):
+                                m = "Poison type used in arguments"
+                                raise TypingError(m)
+                            return out
+
+                        nolitargs = tuple([unlit_non_poison(a) for a in args])
+                        nolitkws = {k: unlit_non_poison(v)
+                                    for k, v in kws.items()}
                         sig = temp.apply(nolitargs, nolitkws)
                 except Exception as e:
                     sig = None

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -271,7 +271,9 @@ class BaseFunction(Callable):
         self._depth += 1
         for temp_cls in self.templates:
             temp = temp_cls(context)
-            for uselit in [True, False]:
+            # choice = [True, False]    # oldbehavior
+            choice = [False, True]    # newbehavior
+            for uselit in choice:
                 try:
                     if uselit:
                         sig = temp.apply(args, kws)

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -225,7 +225,7 @@ class _ResolutionFailures(object):
 
 
 def _unlit_non_poison(ty):
-    """Apply unliteral(ty) and raise TypingError if type is a Poison.
+    """Apply unliteral(ty) and raise a TypingError if type is Poison.
     """
     out = unliteral(ty)
     if isinstance(out, types.Poison):
@@ -283,7 +283,7 @@ class BaseFunction(Callable):
         self._depth += 1
         for temp_cls in self.templates:
             temp = temp_cls(context)
-            # Template can override the
+            # The template can override the default and prefer literal args
             choice = prefer_lit if temp.prefer_literal else prefer_not
             for uselit in choice:
                 try:

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -229,7 +229,7 @@ def _unlit_non_poison(ty):
     """
     out = unliteral(ty)
     if isinstance(out, types.Poison):
-        m = "Poison type used in arguments"
+        m = f"Poison type used in arguments; got {out}"
         raise TypingError(m)
     return out
 

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -224,6 +224,16 @@ class _ResolutionFailures(object):
         raise errors.TypingError(self.format())
 
 
+def _unlit_non_poison(ty):
+    """Apply unliteral(ty) and raise TypingError if type is a Poison.
+    """
+    out = unliteral(ty)
+    if isinstance(out, types.Poison):
+        m = "Poison type used in arguments"
+        raise TypingError(m)
+    return out
+
+
 class BaseFunction(Callable):
     """
     Base type class for some function types.
@@ -266,30 +276,22 @@ class BaseFunction(Callable):
         return self._impl_keys[sig.args]
 
     def get_call_type(self, context, args, kws):
+        prefer_lit = [True, False]    # old behavior preferring literal
+        prefer_not = [False, True]    # new behavior preferring non-literal
         failures = _ResolutionFailures(context, self, args, kws,
                                        depth=self._depth)
         self._depth += 1
         for temp_cls in self.templates:
             temp = temp_cls(context)
-            oldbehavior = [True, False]    # oldbehavior
-            newbehavior = [False, True]    # newbehavior
-
-            choice = oldbehavior if temp.prefer_literal else newbehavior
+            # Template can override the
+            choice = prefer_lit if temp.prefer_literal else prefer_not
             for uselit in choice:
                 try:
                     if uselit:
                         sig = temp.apply(args, kws)
                     else:
-
-                        def unlit_non_poison(ty):
-                            out = unliteral(ty)
-                            if isinstance(out, types.Poison):
-                                m = "Poison type used in arguments"
-                                raise TypingError(m)
-                            return out
-
-                        nolitargs = tuple([unlit_non_poison(a) for a in args])
-                        nolitkws = {k: unlit_non_poison(v)
+                        nolitargs = tuple([_unlit_non_poison(a) for a in args])
+                        nolitkws = {k: _unlit_non_poison(v)
                                     for k, v in kws.items()}
                         sig = temp.apply(nolitargs, nolitkws)
                 except Exception as e:

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -416,6 +416,8 @@ class ArrayAttribute(AttributeTemplate):
         assert not args
         kwargs = dict(kws)
         kind = kwargs.pop('kind', types.StringLiteral('quicksort'))
+        if not isinstance(kind, types.StringLiteral):
+            raise errors.TypingError('"kind" must be a string literal')
         if kwargs:
             msg = "Unsupported keywords: {!r}"
             raise TypingError(msg.format([k for k in kwargs.keys()]))

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -340,6 +340,7 @@ class Numpy_method_redirection(AbstractTemplate):
     A template redirecting a Numpy global function (e.g. np.sum) to an
     array method of the same name (e.g. ndarray.sum).
     """
+    prefer_literal = True
 
     def generic(self, args, kws):
         pysig = None

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -341,7 +341,7 @@ class Numpy_method_redirection(AbstractTemplate):
     array method of the same name (e.g. ndarray.sum).
     """
 
-    # Argument like *axis* can specialize on literals but also support
+    # Arguments like *axis* can specialize on literals but also support
     # non-literals
     prefer_literal = True
 

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -340,6 +340,9 @@ class Numpy_method_redirection(AbstractTemplate):
     A template redirecting a Numpy global function (e.g. np.sum) to an
     array method of the same name (e.g. ndarray.sum).
     """
+
+    # Argument like *axis* can specialize on literals but also support
+    # non-literals
     prefer_literal = True
 
     def generic(self, args, kws):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -251,7 +251,7 @@ class FunctionTemplate(ABC):
     # Set to true to disable unsafe cast.
     # subclass overide-able
     unsafe_casting = True
-    # Set to true to require exact match without casting
+    # Set to true to require exact match without casting.
     # subclass overide-able
     exact_match_required = False
     # Set to true to prefer literal arguments.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -710,10 +710,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         disp = jitdecor(pyfunc)
         # Make sure that the implementation can be fully compiled
         disp_type = types.Dispatcher(disp)
-        try:
-            disp_type.get_call_type(self.context, args, kws)
-        except TypingError:
-            raise
+        disp_type.get_call_type(self.context, args, kws)
         if cache_key is not None:
             self._impl_cache[cache_key] = disp, args
         return disp, args

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -252,6 +252,7 @@ class FunctionTemplate(ABC):
     # subclass overide-able
     unsafe_casting = True
     exact_match_required = False
+    prefer_literal = False
 
     def __init__(self, context):
         self.context = context
@@ -300,6 +301,8 @@ class FunctionTemplate(ABC):
         info = self.get_template_info()
         srcinfo = f"{info['filename']}:{info['lines'][0]}"
         return f"<{self.__class__.__name__} {self.key} {srcinfo}>"
+
+    __repr__ = __str__
 
 
 class AbstractTemplate(FunctionTemplate):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -300,7 +300,7 @@ class FunctionTemplate(ABC):
     def __str__(self):
         info = self.get_template_info()
         srcinfo = f"{info['filename']}:{info['lines'][0]}"
-        return f"<{self.__class__.__name__} {self.key} {srcinfo}>"
+        return f"<{self.__class__.__name__} {srcinfo}>"
 
     __repr__ = __str__
 

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -687,6 +687,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             # should be using.
             sig, pyfunc = ovf_result
             args = sig.args
+            kws = {}
             cache_key = None            # don't cache
         else:
             # Regular case
@@ -707,9 +708,9 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         # Make sure that the implementation can be fully compiled
         disp_type = types.Dispatcher(disp)
         try:
-            disp_type.get_call_type(self.context, args, {})
+            disp_type.get_call_type(self.context, args, kws)
         except TypingError:
-            return None, None
+            raise
         if cache_key is not None:
             self._impl_cache[cache_key] = disp, args
         return disp, args

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -251,7 +251,13 @@ class FunctionTemplate(ABC):
     # Set to true to disable unsafe cast.
     # subclass overide-able
     unsafe_casting = True
+    # Set to true to require exact match without casting
+    # subclass overide-able
     exact_match_required = False
+    # Set to true to prefer literal arguments.
+    # Useful for definitions that specialize on literal but also support
+    # non-literals.
+    # subclass overide-able
     prefer_literal = False
 
     def __init__(self, context):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -296,6 +296,11 @@ class FunctionTemplate(ABC):
         """
         pass
 
+    def __str__(self):
+        info = self.get_template_info()
+        srcinfo = f"{info['filename']}:{info['lines'][0]}"
+        return f"<{self.__class__.__name__} {self.key} {srcinfo}>"
+
 
 class AbstractTemplate(FunctionTemplate):
     """

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -704,6 +704,12 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         # Make dispatcher
         jitdecor = jit(nopython=True, **self._jit_options)
         disp = jitdecor(pyfunc)
+        # Make sure that the implementation can be fully compiled
+        disp_type = types.Dispatcher(disp)
+        try:
+            disp_type.get_call_type(self.context, args, {})
+        except TypingError:
+            return None, None
         if cache_key is not None:
             self._impl_cache[cache_key] = disp, args
         return disp, args

--- a/numba/misc/literal.py
+++ b/numba/misc/literal.py
@@ -15,7 +15,7 @@ def _ov_literally(obj):
 
 @overload(literal_unroll)
 def literal_unroll_impl(container):
-    if not isinstance(container, (types.Literal, types.InitialValue)):
+    if isinstance(container, types.Poison):
         m = f"Invalid use of non-Literal type in literal_unroll({container})"
         raise TypingError(m)
 

--- a/numba/misc/literal.py
+++ b/numba/misc/literal.py
@@ -15,6 +15,9 @@ def _ov_literally(obj):
 
 @overload(literal_unroll)
 def literal_unroll_impl(container):
+    if not isinstance(container, (types.Literal, types.InitialValue)):
+        m = f"Invalid use of non-Literal type in literal_unroll({container})"
+        raise TypingError(m)
 
     def impl(container):
         return container

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -143,6 +143,8 @@ def assert_equiv(typingctx, *val):
         or isinstance(a, types.Integer)
         for a in val[0][1:]
     )
+    if not isinstance(val[0][0], types.StringLiteral):
+        raise errors.TypingError('first argument must be a StringLiteral')
 
     def codegen(context, builder, sig, args):
         assert len(args) == 1  # it is a vararg tuple


### PR DESCRIPTION
Fix overspecialization of literals due to excessive literal dispatch. The key change is flipping the preference to use non-literal type over literal type. All other changes are for fixes to make the tests pass. 

I don't think there are any realistic test that we can add to check for the reduction in specialization. However, the https://github.com/numba/numba/pull/6035#issuecomment-665680185 provides how I have measured the changes in literal dispatch.