### PR TITLE
[WIP] Add no_unliteral flag to overloads

### DIFF
--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -55,7 +55,7 @@ def type_callable(func):
 _overload_default_jit_options = {'no_cpython_wrapper': True}
 
 
-def overload(func, jit_options={}, strict=True, inline='never'):
+def overload(func, jit_options={}, strict=True, inline="never", no_unliteral=False):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode.
@@ -109,8 +109,9 @@ def overload(func, jit_options={}, strict=True, inline='never'):
     opts.update(jit_options)  # let user options override
 
     def decorate(overload_func):
-        template = make_overload_template(func, overload_func, opts, strict,
-                                          inline)
+        template = make_overload_template(
+            func, overload_func, opts, strict, inline, no_unliteral
+        )
         infer(template)
         if callable(func):
             infer_global(func, types.Function(template))
@@ -205,8 +206,11 @@ def overload_method(typ, attr, **kwargs):
 
     def decorate(overload_func):
         template = make_overload_method_template(
-            typ, attr, overload_func,
-            inline=kwargs.get('inline', 'never'),
+            typ,
+            attr,
+            overload_func,
+            inline=kwargs.get("inline", "never"),
+            no_unliteral=kwargs.get("no_unliteral", False),
         )
         infer_getattr(template)
         overload(overload_func, **kwargs)(overload_func)


### PR DESCRIPTION
This flag avoids calling overloads again without literal types if the first call with literals was unsuccessful.
Closes #5411.

I think having the opposite option of just calling without literals is also helpful to avoid overspecialization. So this flag can be renamed/expanded to support both.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
