### PR TITLE
Fix dtype for atomic_add_double tests

### DIFF
--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -264,7 +264,7 @@ class TestCudaAtomics(CUDATestCase):
 
     @skip_unless_cc_50
     def test_atomic_add_double(self):
-        idx = np.random.randint(0, 32, size=32)
+        idx = np.random.randint(0, 32, size=32, dtype=np.int64)
         ary = np.zeros(32, np.float64)
         cuda_func = cuda.jit('void(int64[:], float64[:])')(atomic_add_double)
         cuda_func[1, 32](idx, ary)
@@ -295,7 +295,7 @@ class TestCudaAtomics(CUDATestCase):
 
     @skip_unless_cc_50
     def test_atomic_add_double_global(self):
-        idx = np.random.randint(0, 32, size=32)
+        idx = np.random.randint(0, 32, size=32, dtype=np.int64)
         ary = np.zeros(32, np.float64)
         cuda_func = cuda.jit('void(int64[:], float64[:])')(atomic_add_double_global)
         cuda_func[1, 32](idx, ary)


### PR DESCRIPTION
On Windows the default NumPy `int` is `int32`, but we compile the kernel for `int64` arguments, resulting in data being interpreted incorrectly in the kernel.

This is fixed by explicitly making the index arrays `int64` arrays.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
