### PR TITLE
Fix issue on invalid inlining of non-empty build_list by inline_arraycall

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -939,6 +939,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         list_var_def = get_definition(func_ir, list_var_def.value)
     # Check if the definition is a build_list
     require(isinstance(list_var_def, ir.Expr) and list_var_def.op ==  'build_list')
+    # The build_list must be empty
+    require(len(list_var_def.items) == 0)
 
     # Look for list_append in "last" block in loop body, which should be a block that is
     # a post-dominator of the loop header.

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -282,6 +282,16 @@ class TestArrayComprehension(unittest.TestCase):
         finally:
             ic.enable_inline_arraycall = True
 
+    def test_comp_with_array_noinline_issue_6053(self):
+        def comp_with_array_noinline(n):
+            lst = [0]
+            for i in range(n):
+                lst.append(i)
+            l = np.array(lst)
+            return l
+
+        self.check(comp_with_array_noinline, 5, assert_allocate_list=True)
+
     def test_comp_nest_with_array(self):
         def comp_nest_with_array(n):
             l = np.array([[i * j for j in range(n)] for i in range(n)])


### PR DESCRIPTION
fixes #6053

The issue is only affecting python3.8 due to different bytecode.

