### PR TITLE
fix aarch64/python_3.8 failure on master

### DIFF
--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -1260,7 +1260,7 @@ class pyStencilGenerator:
             ast.copy_location(returner, node)
 
             add_kwarg = [ast.arg('neighborhood', None)]
-            defaults = [ast.Name(id='None', ctx=ast.Load())]
+            defaults = [ast.Name(id='Name', ctx=ast.Load())]
 
             newargs = ast.arguments(
                 args=node.args.args +

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -1260,7 +1260,7 @@ class pyStencilGenerator:
             ast.copy_location(returner, node)
 
             add_kwarg = [ast.arg('neighborhood', None)]
-            defaults = [ast.Name(id='Name', ctx=ast.Load())]
+            defaults = []
 
             newargs = ast.arguments(
                 args=node.args.args +


### PR DESCRIPTION
As part of the smoke-test strategy, we discovered the following test
failures on master for the `aarch64` target and Python 3.8, around 29
Jul 2020:

```
INFO - ======================================================================
INFO - ERROR: test_basic96 (numba.tests.test_stencils.TestManyStencils)
INFO - 1D slice.
INFO - ----------------------------------------------------------------------
INFO - Traceback (most recent call last):
INFO - File "/opt/conda/envs/testenv_17dc0518-6796-4cd9-8247-44db76254a67/lib/python3.8/site-packages/numba/tests/test_stencils.py", line 2759, in test_basic96
INFO - self.check(kernel, a, options={'neighborhood': ((-1, 1),)})
INFO - File "/opt/conda/envs/testenv_17dc0518-6796-4cd9-8247-44db76254a67/lib/python3.8/site-packages/numba/tests/test_stencils.py", line 1668, in check
INFO - raise RuntimeError(str1 + str2)
INFO - RuntimeError: The following implementations should not have raised an exception but did:
INFO - ['pyStencil']
INFO - Errors were:
INFO -
INFO - pyStencil: Message: <class 'ValueError'>: Name node can't be used with 'None' constant
```

This was reproduced using the `aarch64` emulation provided by qemu and
Docker on Mac OSX and shown to be present in the most recent release
0.50.1.

Further investigation lead to some potentially related clues at:

https://github.com/beetbox/beets/pull/3621

.. and eventual trial and error led to this fix.

It is unclear, exactly where the error came from and why it  only showed
up in Python  3.8 on `aarch64`.

It should be noted, that this was only noticed as the smoke tests
executes the tests  with Python 3.8 on this target. The regular tests,
only executed the tests with Pythons 3.6 and 3.7. So, the regular tests
should also include Python 3.8 on the farm to prevent any regressions.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
