### PR TITLE
Add prefer_literal option to overload API

### DIFF
--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -102,6 +102,12 @@ def overload(func, jit_options={}, strict=True, inline='never',
       holds the information from the callee. The function should return Truthy
       to determine whether to inline, this essentially permitting custom
       inlining rules (typical use might be cost models).
+
+    The *prefer_literal* option allows users to control if literal types should
+    be tried first or last. The default (`False`) is to use non-literal types.
+    Implementation that can specialize base on literal values should set the
+    option to `True`. Note, this option maybe expanded in the near future to
+    allow for more control (e.g. disabling non-literal types).
     """
     from numba.core.typing.templates import make_overload_template, infer_global
 

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -105,7 +105,7 @@ def overload(func, jit_options={}, strict=True, inline='never',
 
     The *prefer_literal* option allows users to control if literal types should
     be tried first or last. The default (`False`) is to use non-literal types.
-    Implementation that can specialize base on literal values should set the
+    Implementations that can specialize based on literal values should set the
     option to `True`. Note, this option maybe expanded in the near future to
     allow for more control (e.g. disabling non-literal types).
     """

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -55,7 +55,8 @@ def type_callable(func):
 _overload_default_jit_options = {'no_cpython_wrapper': True}
 
 
-def overload(func, jit_options={}, strict=True, inline='never'):
+def overload(func, jit_options={}, strict=True, inline='never',
+             prefer_literal=False):
     """
     A decorator marking the decorated function as typing and implementing
     *func* in nopython mode.
@@ -110,7 +111,7 @@ def overload(func, jit_options={}, strict=True, inline='never'):
 
     def decorate(overload_func):
         template = make_overload_template(func, overload_func, opts, strict,
-                                          inline)
+                                          inline, prefer_literal)
         infer(template)
         if callable(func):
             infer_global(func, types.Function(template))

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -208,6 +208,7 @@ def overload_method(typ, attr, **kwargs):
         template = make_overload_method_template(
             typ, attr, overload_func,
             inline=kwargs.get('inline', 'never'),
+            prefer_literal=kwargs.get('prefer_literal', False)
         )
         infer_getattr(template)
         overload(overload_func, **kwargs)(overload_func)

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -405,7 +405,11 @@ class BoundFunction(Callable, Opaque):
                         out = template.apply(unliteral_args, unliteral_kws)
                     except Exception as exc:
                         if isinstance(exc, errors.ForceLiteralArg):
-                            raise exc
+                            if template.prefer_literal:
+                                # For template that prefers literal types,
+                                # reaching here means that the literal types
+                                # have failed typing as well.
+                                raise exc
                         nonliteral_e = exc
                     else:
                         break

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -375,33 +375,40 @@ class BoundFunction(Callable, Opaque):
         template = self.template(context)
         literal_e = None
         nonliteral_e = None
+        out = None
 
+        choice = [True, False] if template.prefer_literal else [False, True]
+        for uselit in choice:
+            if uselit:
+                # Try with Literal
+                try:
+                    out = template.apply(args, kws)
+                except Exception as exc:
+                    if isinstance(exc, errors.ForceLiteralArg):
+                        raise exc
+                    literal_e = exc
+                    out = None
+                else:
+                    break
+            else:
+                # if the unliteral_args and unliteral_kws are the same as the literal
+                # ones, set up to not bother retrying
+                unliteral_args = tuple([unliteral(a) for a in args])
+                unliteral_kws = {k: unliteral(v) for k, v in kws.items()}
+                skip = unliteral_args == args and kws == unliteral_kws
 
-        # Try with Literal
-        try:
-            out = template.apply(args, kws)
-        except Exception as exc:
-            if isinstance(exc, errors.ForceLiteralArg):
-                raise exc
-            literal_e = exc
-            out = None
-
-        # if the unliteral_args and unliteral_kws are the same as the literal
-        # ones, set up to not bother retrying
-        unliteral_args = tuple([unliteral(a) for a in args])
-        unliteral_kws = {k: unliteral(v) for k, v in kws.items()}
-        skip = unliteral_args == args and kws == unliteral_kws
-
-        # If the above template application failed and the non-literal args are
-        # different to the literal ones, try again with literals rewritten as
-        # non-literals
-        if not skip and out is None:
-            try:
-                out = template.apply(unliteral_args, unliteral_kws)
-            except Exception as exc:
-                if isinstance(exc, errors.ForceLiteralArg):
-                    raise exc
-                nonliteral_e = exc
+                # If the above template application failed and the non-literal args are
+                # different to the literal ones, try again with literals rewritten as
+                # non-literals
+                if not skip and out is None:
+                    try:
+                        out = template.apply(unliteral_args, unliteral_kws)
+                    except Exception as exc:
+                        if isinstance(exc, errors.ForceLiteralArg):
+                            raise exc
+                        nonliteral_e = exc
+                    else:
+                        break
 
         if out is None and (nonliteral_e is not None or literal_e is not None):
             header = "- Resolution failure for {} arguments:\n{}\n"

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -393,8 +393,9 @@ class BoundFunction(Callable, Opaque):
             else:
                 # if the unliteral_args and unliteral_kws are the same as the literal
                 # ones, set up to not bother retrying
-                unliteral_args = tuple([unliteral(a) for a in args])
-                unliteral_kws = {k: unliteral(v) for k, v in kws.items()}
+                unliteral_args = tuple([_unlit_non_poison(a) for a in args])
+                unliteral_kws = {k: _unlit_non_poison(v)
+                                 for k, v in kws.items()}
                 skip = unliteral_args == args and kws == unliteral_kws
 
                 # If the above template application failed and the non-literal args are

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -744,8 +744,9 @@ def generic_index(self, args, kws):
     assert not kws
     return signature(types.intp, recvr=self.this)
 
-def install_array_method(name, generic):
-    my_attr = {"key": "array." + name, "generic": generic}
+def install_array_method(name, generic, prefer_literal=True):
+    my_attr = {"key": "array." + name, "generic": generic,
+               "prefer_literal": prefer_literal}
     temp_class = type("Array_" + name, (AbstractTemplate,), my_attr)
     def array_attribute_attachment(self, ary):
         return types.BoundFunction(temp_class, ary)
@@ -758,7 +759,7 @@ for fname in ["min", "max"]:
 
 # Functions that return a machine-width type, to avoid overflows
 install_array_method("prod", generic_expand)
-install_array_method("sum", sum_expand)
+install_array_method("sum", sum_expand, prefer_literal=True)
 
 # Functions that return a machine-width type, to avoid overflows
 for fname in ["cumsum", "cumprod"]:

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -1021,7 +1021,7 @@ def make_overload_attribute_template(typ, attr, overload_func, inline,
 
 
 def make_overload_method_template(typ, attr, overload_func, inline,
-                                  prefer_literal):
+                                  prefer_literal=False):
     """
     Make a template class for method *attr* of *typ* overloaded by
     *overload_func*.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -782,7 +782,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
 
 
 def make_overload_template(func, overload_func, jit_options, strict,
-                           inline, prefer_literal):
+                           inline, prefer_literal=False):
     """
     Make a template class for function *func* overloaded by *overload_func*.
     Compiler options are passed as a dictionary to *jit_options*.

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -985,6 +985,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
             _inline = self._inline
             _overload_func = staticmethod(self._overload_func)
             _inline_overloads = self._inline_overloads
+            prefer_literal = self.prefer_literal
 
             def generic(_, args, kws):
                 args = (typ,) + tuple(args)
@@ -1000,6 +1001,7 @@ class _OverloadMethodTemplate(_OverloadAttributeTemplate):
 
 
 def make_overload_attribute_template(typ, attr, overload_func, inline,
+                                     prefer_literal=False,
                                      base=_OverloadAttributeTemplate):
     """
     Make a template class for attribute *attr* of *typ* overloaded by
@@ -1012,18 +1014,21 @@ def make_overload_attribute_template(typ, attr, overload_func, inline,
                _inline=staticmethod(InlineOptions(inline)),
                _inline_overloads={},
                _overload_func=staticmethod(overload_func),
+               prefer_literal=prefer_literal,
                )
-    return type(base)(name, (base,), dct)
+    obj = type(base)(name, (base,), dct)
+    return obj
 
 
-def make_overload_method_template(typ, attr, overload_func, inline):
+def make_overload_method_template(typ, attr, overload_func, inline,
+                                  prefer_literal):
     """
     Make a template class for method *attr* of *typ* overloaded by
     *overload_func*.
     """
     return make_overload_attribute_template(
         typ, attr, overload_func, inline=inline,
-        base=_OverloadMethodTemplate,
+        base=_OverloadMethodTemplate, prefer_literal=prefer_literal,
     )
 
 

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -782,7 +782,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
 
 
 def make_overload_template(func, overload_func, jit_options, strict,
-                           inline):
+                           inline, prefer_literal):
     """
     Make a template class for function *func* overloaded by *overload_func*.
     Compiler options are passed as a dictionary to *jit_options*.
@@ -793,7 +793,7 @@ def make_overload_template(func, overload_func, jit_options, strict,
     dct = dict(key=func, _overload_func=staticmethod(overload_func),
                _impl_cache={}, _compiled_overloads={}, _jit_options=jit_options,
                _strict=strict, _inline=staticmethod(InlineOptions(inline)),
-               _inline_overloads={})
+               _inline_overloads={}, prefer_literal=prefer_literal)
     return type(base)(name, (base,), dct)
 
 


### PR DESCRIPTION
Based on https://github.com/numba/numba/pull/6035

Add `prefer_literal` option to `@overload` and `@overload_method`.
Fixes method dispatch in `BoundFunction` to follow #6035 