### PR TITLE
Lower math.frexp and math.ldexp in numba.cuda

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -138,6 +138,8 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.exp`
 * :func:`math.expm1`
 * :func:`math.fabs`
+* :func:`math.frexp`
+* :func:`math.ldexp`
 * :func:`math.gamma`
 * :func:`math.lgamma`
 * :func:`math.log`

--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -85,6 +85,22 @@ class Math_pow(ConcreteTemplate):
     ]
 
 
+@infer_global(math.frexp)
+class Math_frexp(ConcreteTemplate):
+    cases = [
+        signature(types.Tuple([types.float32, types.int32]), types.float32),
+        signature(types.Tuple([types.float64, types.int32]), types.float64),
+    ]
+
+
+@infer_global(math.ldexp)
+class Math_ldexp(ConcreteTemplate):
+    cases = [
+        signature(types.float32, types.float32, types.int32),
+        signature(types.float64, types.float64, types.int32),
+    ]
+
+
 @infer_global(math.isinf)
 @infer_global(math.isnan)
 class Math_isnan(ConcreteTemplate):

--- a/numba/cuda/libdevice.py
+++ b/numba/cuda/libdevice.py
@@ -67,13 +67,13 @@ lower(math.pow, types.float64, types.int32)(powi_implement('__nv_powi'))
 
 def frexp_implement(nvname):
     def core(context, builder, sig, args):
-        argty, expty = sig.return_type
-        R = context.get_value_type(argty)
-        I = context.get_value_type(expty)
-        fnty = Type.function(R, [R, Type.pointer(I)])
+        fracty, expty = sig.return_type
+        float_type = context.get_value_type(fracty)
+        int_type = context.get_value_type(expty)
+        fnty = Type.function(float_type, [float_type, Type.pointer(int_type)])
 
         fn = builder.module.get_or_insert_function(fnty, name=nvname)
-        expptr = cgutils.alloca_once(builder, I, name='exp')
+        expptr = cgutils.alloca_once(builder, int_type, name='exp')
 
         ret = builder.call(fn, (args[0], expptr))
         ret = cgutils.make_anonymous_struct(builder,

--- a/numba/cuda/libdevice.py
+++ b/numba/cuda/libdevice.py
@@ -76,10 +76,7 @@ def frexp_implement(nvname):
         expptr = cgutils.alloca_once(builder, int_type, name='exp')
 
         ret = builder.call(fn, (args[0], expptr))
-        ret = cgutils.make_anonymous_struct(builder,
-                                            (ret, builder.load(expptr)))
-
-        return ret
+        return cgutils.pack_struct(builder, (ret, builder.load(expptr)))
 
     return core
 

--- a/numba/cuda/tests/cudapy/test_frexp_ldexp.py
+++ b/numba/cuda/tests/cudapy/test_frexp_ldexp.py
@@ -1,56 +1,65 @@
 import numpy as np
 import math
 from numba import cuda
-from numba.types import float32, float64, int32
+from numba.types import float32, float64, int32, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
-def simple_frexp(x, exp, arg):
-    x[0], exp[0] = math.frexp(arg)
+def simple_frexp(aryx, aryexp, arg):
+    aryx[0], aryexp[0] = math.frexp(arg)
 
 
-def simple_ldexp(val, arg, exp):
-    val[0] = math.ldexp(arg, exp)
+def simple_ldexp(aryx, arg, exp):
+    aryx[0] = math.ldexp(arg, exp)
 
 
 class TestCudaFrexpLdexp(CUDATestCase):
-    def template_test_frexp_ldexp(self, value, npyty, npmty):
-        frexp_kernel = cuda.jit((npmty[:], int32[:], npmty))(simple_frexp)
+    def template_test_frexp(self, nptype, nbtype):
+        compiled = cuda.jit(void(nbtype[:], int32[:], nbtype))(simple_frexp)
+        arg = 3.1415
+        aryx = np.zeros(1, dtype=nptype)
+        aryexp = np.zeros(1, dtype=np.int32)
+        compiled[1, 1](aryx, aryexp, arg)
+        np.testing.assert_array_equal(aryx, nptype(0.785375))
+        self.assertEquals(aryexp, 2)
 
-        arg = npyty(value)
-        x = np.empty(1, dtype=npyty)
-        xneg = np.empty_like(x)
-        exp = np.empty_like(x, dtype=np.int32)
-        npx, npexp = np.frexp(arg)
+        arg = np.inf
+        compiled[1, 1](aryx, aryexp, arg)
+        np.testing.assert_array_equal(aryx, nptype(np.inf))
+        self.assertEquals(aryexp, 0)  # np.frexp gives -1
 
-        frexp_kernel[1, 1](x, exp, arg)
+        arg = np.nan
+        compiled[1, 1](aryx, aryexp, arg)
+        np.testing.assert_array_equal(aryx, nptype(np.nan))
+        self.assertEquals(aryexp, 0)  # np.frexp gives -1
 
-        np.testing.assert_array_equal(x, npx)
-        self.assertEquals(exp, npexp)
+    def template_test_ldexp(self, nptype, nbtype):
+        compiled = cuda.jit(void(nbtype[:], nbtype, int32))(simple_ldexp)
+        arg = 0.785375
+        exp = 2
+        aryx = np.zeros(1, dtype=nptype)
+        compiled[1, 1](aryx, arg, exp)
+        np.testing.assert_array_equal(aryx, nptype(3.1415))
 
-        frexp_kernel[1, 1](xneg, exp, -arg)
+        arg = np.inf
+        compiled[1, 1](aryx, arg, exp)
+        np.testing.assert_array_equal(aryx, nptype(np.inf))
 
-        np.testing.assert_array_equal(xneg, -npx)
-        self.assertEquals(exp, npexp)
+        arg = np.nan
+        compiled[1, 1](aryx, arg, exp)
+        np.testing.assert_array_equal(aryx, nptype(np.nan))
 
-        ldexp_kernel = cuda.jit((npmty[:], npmty, int32))(simple_ldexp)
+    def test_frexp_f4(self):
+        self.template_test_frexp(np.float32, float32)
 
-        val = np.empty(1, dtype=npyty)
+    def test_ldexp_f4(self):
+        self.template_test_ldexp(np.float32, float32)
 
-        ldexp_kernel[1, 1](val, x.item(), exp.item())
+    def test_frexp_f8(self):
+        self.template_test_frexp(np.float64, float64)
 
-        np.testing.assert_array_equal(val, np.ldexp(x, exp))
-        np.testing.assert_array_equal(val, arg)  # roundtrip
-
-        ldexp_kernel[1, 1](val, xneg.item(), exp.item())
-
-        np.testing.assert_array_equal(val, np.ldexp(xneg, exp))
-        np.testing.assert_array_equal(val, -arg)  # roundtrip
-
-    def test_ldexp_frexp(self):
-        for value in [0., 3.1e-10, 0.785375, 2., 1.3e10]:
-            self.template_test_frexp_ldexp(value, np.float32, float32)
-            self.template_test_frexp_ldexp(value, np.float64, float64)
+    def test_ldexp_f8(self):
+        self.template_test_ldexp(np.float64, float64)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_frexp_ldexp.py
+++ b/numba/cuda/tests/cudapy/test_frexp_ldexp.py
@@ -1,51 +1,56 @@
 import numpy as np
 import math
 from numba import cuda
+from numba.types import float32, float64, int32
 from numba.cuda.testing import unittest, CUDATestCase
 
 
-def simple_frexp(aryx, aryexp, arg):
-    aryx[0], aryexp[0] = math.frexp(arg)
+def simple_frexp(x, exp, arg):
+    x[0], exp[0] = math.frexp(arg)
 
 
-def simple_ldexp(aryx, arg, exp):
-    aryx[0] = math.ldexp(arg, exp)
+def simple_ldexp(val, arg, exp):
+    val[0] = math.ldexp(arg, exp)
 
 
 class TestCudaFrexpLdexp(CUDATestCase):
-    def test_frexp_f4(self):
-        compiled = cuda.jit("void(f4[:], int32[:], f4)")(simple_frexp)
-        arg = 3.1415
-        aryx = np.zeros(1, dtype=np.float32)
-        aryexp = np.zeros(1, dtype=np.int32)
-        compiled[1, 1](aryx, aryexp, arg)
-        np.testing.assert_array_equal(aryx, np.float32(0.785375))
-        self.assertEquals(aryexp, 2)
+    def template_test_frexp_ldexp(self, value, npyty, npmty):
+        frexp_kernel = cuda.jit((npmty[:], int32[:], npmty))(simple_frexp)
 
-    def test_ldexp_f4(self):
-        compiled = cuda.jit("void(f4[:], f4, int32)")(simple_ldexp)
-        arg = 0.785375
-        exp = 2
-        aryx = np.zeros(1, dtype=np.float32)
-        compiled[1, 1](aryx, arg, exp)
-        np.testing.assert_array_equal(aryx, np.float32(3.1415))
+        arg = npyty(value)
+        x = np.empty(1, dtype=npyty)
+        xneg = np.empty_like(x)
+        exp = np.empty_like(x, dtype=np.int32)
+        npx, npexp = np.frexp(arg)
 
-    def test_frexp_f8(self):
-        compiled = cuda.jit("void(f8[:], int32[:], f8)")(simple_frexp)
-        arg = 0.017
-        aryx = np.zeros(1, dtype=np.float64)
-        aryexp = np.zeros(1, dtype=np.int32)
-        compiled[1, 1](aryx, aryexp, arg)
-        np.testing.assert_array_equal(aryx, np.float64(0.544))
-        self.assertEquals(aryexp, -5)
+        frexp_kernel[1, 1](x, exp, arg)
 
-    def test_ldexp_f8(self):
-        compiled = cuda.jit("void(f8[:], f8, int32)")(simple_ldexp)
-        arg = 0.544
-        exp = -5
-        aryx = np.zeros(1, dtype=np.float64)
-        compiled[1, 1](aryx, arg, exp)
-        np.testing.assert_array_equal(aryx, np.float64(0.017))
+        np.testing.assert_array_equal(x, npx)
+        self.assertEquals(exp, npexp)
+
+        frexp_kernel[1, 1](xneg, exp, -arg)
+
+        np.testing.assert_array_equal(xneg, -npx)
+        self.assertEquals(exp, npexp)
+
+        ldexp_kernel = cuda.jit((npmty[:], npmty, int32))(simple_ldexp)
+
+        val = np.empty(1, dtype=npyty)
+
+        ldexp_kernel[1, 1](val, x.item(), exp.item())
+
+        np.testing.assert_array_equal(val, np.ldexp(x, exp))
+        np.testing.assert_array_equal(val, arg)  # roundtrip
+
+        ldexp_kernel[1, 1](val, xneg.item(), exp.item())
+
+        np.testing.assert_array_equal(val, np.ldexp(xneg, exp))
+        np.testing.assert_array_equal(val, -arg)  # roundtrip
+
+    def test_ldexp_frexp(self):
+        for value in [0., 3.1e-10, 0.785375, 2., 1.3e10]:
+            self.template_test_frexp_ldexp(value, np.float32, float32)
+            self.template_test_frexp_ldexp(value, np.float64, float64)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_frexp_ldexp.py
+++ b/numba/cuda/tests/cudapy/test_frexp_ldexp.py
@@ -1,0 +1,52 @@
+import numpy as np
+import math
+from numba import cuda
+from numba.cuda.testing import unittest, CUDATestCase
+
+
+def simple_frexp(aryx, aryexp, arg):
+    aryx[0], aryexp[0] = math.frexp(arg)
+
+
+def simple_ldexp(aryx, arg, exp):
+    aryx[0] = math.ldexp(arg, exp)
+
+
+class TestCudaFrexpLdexp(CUDATestCase):
+    def test_frexp_f4(self):
+        compiled = cuda.jit("void(f4[:], int32[:], f4)")(simple_frexp)
+        arg = 3.1415
+        aryx = np.zeros(1, dtype=np.float32)
+        aryexp = np.zeros(1, dtype=np.int32)
+        compiled[1, 1](aryx, aryexp, arg)
+        np.testing.assert_array_equal(aryx, np.float32(0.785375))
+        self.assertEquals(aryexp, 2)
+
+    def test_ldexp_f4(self):
+        compiled = cuda.jit("void(f4[:], f4, int32)")(simple_ldexp)
+        arg = 0.785375
+        exp = 2
+        aryx = np.zeros(1, dtype=np.float32)
+        compiled[1, 1](aryx, arg, exp)
+        np.testing.assert_array_equal(aryx, np.float32(3.1415))
+
+    def test_frexp_f8(self):
+        compiled = cuda.jit("void(f8[:], int32[:], f8)")(simple_frexp)
+        arg = 0.017
+        aryx = np.zeros(1, dtype=np.float64)
+        aryexp = np.zeros(1, dtype=np.int32)
+        compiled[1, 1](aryx, aryexp, arg)
+        np.testing.assert_array_equal(aryx, np.float64(0.544))
+        self.assertEquals(aryexp, -5)
+
+    def test_ldexp_f8(self):
+        compiled = cuda.jit("void(f8[:], f8, int32)")(simple_ldexp)
+        arg = 0.544
+        exp = -5
+        aryx = np.zeros(1, dtype=np.float64)
+        compiled[1, 1](aryx, arg, exp)
+        np.testing.assert_array_equal(aryx, np.float64(0.017))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
NVVM libdevice functions being used:

    __nv_frexp, __nv_frexpf
    __nv_ldexp, __nv_ldexpf

See also #6026

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
