### PR TITLE
Lower math.isfinite in numba.cuda

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -152,6 +152,7 @@ The following functions from the :mod:`math` module are supported:
 * :func:`math.modf`
 * :func:`math.isnan`
 * :func:`math.isinf`
+* :func:`math.isfinite`
 
 
 ``operator``

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -474,6 +474,11 @@ def math_isinf_isnan_int(context, builder, sig, args):
     return lc.Constant.int(lc.Type.int(1), 0)
 
 
+@lower(math.isfinite, types.Integer)
+def math_isfinite_int(context, builder, sig, args):
+    return lc.Constant.int(lc.Type.int(1), 1)
+
+
 def gen_deg_rad(const):
     def impl(context, builder, sig, args):
         argty, = sig.args

--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -87,6 +87,7 @@ class Math_pow(ConcreteTemplate):
 
 @infer_global(math.isinf)
 @infer_global(math.isnan)
+@infer_global(math.isfinite)
 class Math_isnan(ConcreteTemplate):
     cases = [
         signature(types.boolean, types.int64),

--- a/numba/cuda/libdevice.py
+++ b/numba/cuda/libdevice.py
@@ -68,6 +68,7 @@ lower(math.pow, types.float64, types.int32)(powi_implement('__nv_powi'))
 booleans = []
 booleans += [('__nv_isnand', '__nv_isnanf', math.isnan)]
 booleans += [('__nv_isinfd', '__nv_isinff', math.isinf)]
+booleans += [('__nv_isfinited', '__nv_finitef', math.isfinite)]
 
 unarys = []
 unarys += [('__nv_ceil', '__nv_ceilf', math.ceil)]

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -207,6 +207,29 @@ class TestCudaMath(CUDATestCase):
         self.assertTrue(np.allclose(npfunc(A), B))
 
 
+    def unary_bool_special_values(self, func, npfunc, npdtype, npmtype):
+        fi = np.finfo(npdtype)
+        denorm = fi.tiny / 4
+        A = np.array([0., denorm, fi.tiny, 0.5, 1., fi.max, np.inf, np.nan],
+                     dtype=npdtype)
+        B = np.empty_like(A, dtype=np.int32)
+        cfunc = cuda.jit((npmtype[::1], int32[::1]))(func)
+
+        cfunc[1, A.size](A, B)
+        np.testing.assert_array_equal(B, npfunc(A))
+
+        cfunc[1, A.size](-A, B)
+        np.testing.assert_array_equal(B, npfunc(-A))
+
+
+    def unary_bool_special_values_float32(self, func, npfunc):
+        self.unary_bool_special_values(func, npfunc, np.float32, float32)
+
+
+    def unary_bool_special_values_float64(self, func, npfunc):
+        self.unary_bool_special_values(func, npfunc, np.float64, float64)
+
+
     def unary_bool_template_float32(self, func, npfunc, start=0, stop=1):
         self.unary_template(func, npfunc, np.float32, float32, start, stop)
 
@@ -575,6 +598,8 @@ class TestCudaMath(CUDATestCase):
         self.unary_bool_template_float64(math_isnan, np.isnan)
         self.unary_bool_template_int32(math_isnan, np.isnan)
         self.unary_bool_template_int64(math_isnan, np.isnan)
+        self.unary_bool_special_values_float32(math_isnan, np.isnan)
+        self.unary_bool_special_values_float64(math_isnan, np.isnan)
 
     #------------------------------------------------------------------------------
     # test_math_isinf
@@ -585,6 +610,8 @@ class TestCudaMath(CUDATestCase):
         self.unary_bool_template_float64(math_isinf, np.isinf)
         self.unary_bool_template_int32(math_isinf, np.isinf)
         self.unary_bool_template_int64(math_isinf, np.isinf)
+        self.unary_bool_special_values_float32(math_isinf, np.isinf)
+        self.unary_bool_special_values_float64(math_isinf, np.isinf)
 
     #------------------------------------------------------------------------------
     # test_math_isfinite
@@ -595,6 +622,8 @@ class TestCudaMath(CUDATestCase):
         self.unary_bool_template_float64(math_isfinite, np.isfinite)
         self.unary_bool_template_int32(math_isfinite, np.isfinite)
         self.unary_bool_template_int64(math_isfinite, np.isfinite)
+        self.unary_bool_special_values_float32(math_isfinite, np.isfinite)
+        self.unary_bool_special_values_float64(math_isfinite, np.isfinite)
 
     #------------------------------------------------------------------------------
     # test_math_degrees

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -162,13 +162,21 @@ def math_isinf(A, B):
     i = cuda.grid(1)
     B[i] = math.isinf(A[i])
 
+
+def math_isfinite(A, B):
+    i = cuda.grid(1)
+    B[i] = math.isfinite(A[i])
+
+
 def math_degrees(A, B):
     i = cuda.grid(1)
     B[i] = math.degrees(A[i])
 
+
 def math_radians(A, B):
     i = cuda.grid(1)
     B[i] = math.radians(A[i])
+
 
 def math_pow_binop(A, B, C):
     i = cuda.grid(1)
@@ -575,8 +583,18 @@ class TestCudaMath(CUDATestCase):
     def test_math_isinf(self):
         self.unary_bool_template_float32(math_isinf, np.isinf)
         self.unary_bool_template_float64(math_isinf, np.isinf)
-        self.unary_bool_template_int32(math_isinf, np.isnan)
-        self.unary_bool_template_int64(math_isinf, np.isnan)
+        self.unary_bool_template_int32(math_isinf, np.isinf)
+        self.unary_bool_template_int64(math_isinf, np.isinf)
+
+    #------------------------------------------------------------------------------
+    # test_math_isfinite
+
+
+    def test_math_isfinite(self):
+        self.unary_bool_template_float32(math_isfinite, np.isfinite)
+        self.unary_bool_template_float64(math_isfinite, np.isfinite)
+        self.unary_bool_template_int32(math_isfinite, np.isfinite)
+        self.unary_bool_template_int64(math_isfinite, np.isfinite)
 
     #------------------------------------------------------------------------------
     # test_math_degrees


### PR DESCRIPTION
The `float` variant of `__nv_isfinited` is called `__nv_finitef`.