### PR TITLE
Add support for math.isclose() and numpy.isclose()

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -182,6 +182,10 @@ def gen_sum_axis_impl(is_axis_const, const_axis_val, op, zero):
     def inner(arr, axis):
         """
         function that performs sums over one specific axis
+        # Create output array y
+        # Create output array y
+        y)
+        y)
 
         The third parameter to gen_index_tuple that generates the indexing
         tuples has to be a const so we can't just pass "axis" through since
@@ -4422,3 +4426,40 @@ def cross2d(a, b):
         return _cross2d_operation(a_, b_)
 
     return impl
+
+#----------------------------------------------------------------------------
+# Equality tests implemented on Floats
+# Implemented based on this feature request - https://github.com/numba/numba/issues/5977
+@overload(np.isclose)
+def np_isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+    if not type_can_asarray(a) or not type_can_asarray(b):
+        raise TypingError("Inputs a and b must be array-like.")
+    if not isinstance(rtol, float) or not isinstance(atol, float):
+        raise TypingError("Relative and absolute tolerance must be represented as floats.")
+    if not isinstance(equal_nan, bool):
+        raise TypingError("Equal_nan must be cast to a bool.")
+
+    def impl(a, b, rtol, atol, equal_nan):
+        a_ = np.asarray(a)
+        b_ = np.asarray(b)
+        # TODO: Handle support for broadcasting if its a matrix and a vector
+        if a_.shape != b_.shape:
+            raise ValueError(
+                "Operands could not be broadcast together with shapes {}, {}.".format(a_.shape, b_.shape)
+            )
+        # Python default behavior is to have NaN comparison be False, so handle equal_nan separately
+        return _isclose(a_, b_, rtol, atol, equal_nan)
+
+    return impl
+
+@register_jitable
+def _isclose(a, b, rtol, atol, equal_nan):
+    lhs = np.absolute(a - b)
+    rhs = (rtol * np.absolute(b) + atol)
+    y = lhs <= rhs
+    # Python default behavior is to have NaN comparison be False, so handle equal_nan separately
+    if equal_nan:
+        # Logically and together NaN between A and B and Or it with y
+        nans = np.logical_and(np.isnan(a), np.isnan(b))
+        y = np.logical_or(y, nans)
+    return y

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -182,10 +182,6 @@ def gen_sum_axis_impl(is_axis_const, const_axis_val, op, zero):
     def inner(arr, axis):
         """
         function that performs sums over one specific axis
-        # Create output array y
-        # Create output array y
-        y)
-        y)
 
         The third parameter to gen_index_tuple that generates the indexing
         tuples has to be a const so we can't just pass "axis" through since
@@ -4427,6 +4423,7 @@ def cross2d(a, b):
 
     return impl
 
+
 #----------------------------------------------------------------------------
 # Equality tests implemented on Floats
 # Implemented based on this feature request
@@ -4451,9 +4448,9 @@ def np_isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
 
 @register_jitable
 def _isclose(a, b, rtol, atol, equal_nan):
-    lhs = np.absolute(a - b)
-    rhs = (rtol * np.absolute(b) + atol)
-    y = lhs <= rhs
+    abs_diff = np.absolute(a - b)
+    min_tolerance = (rtol * np.absolute(b) + atol)
+    y = abs_diff <= min_tolerance
     # Python default behavior is to have NaN comparison be False,
     # so handle equal_nan separately
     if equal_nan:

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -4435,20 +4435,15 @@ def cross2d(a, b):
 def np_isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     if not type_can_asarray(a) or not type_can_asarray(b):
         raise TypingError("Inputs a and b must be array-like.")
-    if not isinstance(rtol, float) or not isinstance(atol, float):
-        raise TypingError("Relative and absolute tolerance must \
-                be represented as floats.")
-    if not isinstance(equal_nan, bool):
+    if not isinstance(rtol, types.Float) or not isinstance(atol, types.Float):
+        raise TypingError("Relative and absolute tolerance must " +
+                          "be represented as floats.")
+    if not isinstance(equal_nan, types.Boolean):
         raise TypingError("Equal_nan must be cast to a bool.")
 
-    def impl(a, b, rtol, atol, equal_nan):
+    def impl(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
         a_ = np.asarray(a)
         b_ = np.asarray(b)
-        if a_.shape != b_.shape:
-            raise ValueError(
-                "Operands could not be broadcast together with shapes {}, \
-                        {}.".format(a_.shape, b_.shape)
-            )
         return _isclose(a_, b_, rtol, atol, equal_nan)
 
     return impl

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -4429,35 +4429,38 @@ def cross2d(a, b):
 
 #----------------------------------------------------------------------------
 # Equality tests implemented on Floats
-# Implemented based on this feature request - https://github.com/numba/numba/issues/5977
+# Implemented based on this feature request
+# - https://github.com/numba/numba/issues/5977
 @overload(np.isclose)
 def np_isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
     if not type_can_asarray(a) or not type_can_asarray(b):
         raise TypingError("Inputs a and b must be array-like.")
     if not isinstance(rtol, float) or not isinstance(atol, float):
-        raise TypingError("Relative and absolute tolerance must be represented as floats.")
+        raise TypingError("Relative and absolute tolerance must \
+                be represented as floats.")
     if not isinstance(equal_nan, bool):
         raise TypingError("Equal_nan must be cast to a bool.")
 
     def impl(a, b, rtol, atol, equal_nan):
         a_ = np.asarray(a)
         b_ = np.asarray(b)
-        # TODO: Handle support for broadcasting if its a matrix and a vector
         if a_.shape != b_.shape:
             raise ValueError(
-                "Operands could not be broadcast together with shapes {}, {}.".format(a_.shape, b_.shape)
+                "Operands could not be broadcast together with shapes {}, \
+                        {}.".format(a_.shape, b_.shape)
             )
-        # Python default behavior is to have NaN comparison be False, so handle equal_nan separately
         return _isclose(a_, b_, rtol, atol, equal_nan)
 
     return impl
+
 
 @register_jitable
 def _isclose(a, b, rtol, atol, equal_nan):
     lhs = np.absolute(a - b)
     rhs = (rtol * np.absolute(b) + atol)
     y = lhs <= rhs
-    # Python default behavior is to have NaN comparison be False, so handle equal_nan separately
+    # Python default behavior is to have NaN comparison be False,
+    # so handle equal_nan separately
     if equal_nan:
         # Logically and together NaN between A and B and Or it with y
         nans = np.logical_and(np.isnan(a), np.isnan(b))

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -4451,10 +4451,16 @@ def _isclose(a, b, rtol, atol, equal_nan):
     abs_diff = np.absolute(a - b)
     min_tolerance = (rtol * np.absolute(b) + atol)
     y = abs_diff <= min_tolerance
+    # Opposite values of infinity will produce an equality in the
+    # prev line, so check for no infinities. We only need to check one side
+    # because the LHS will always be either inf or NaN if there is an inf
+    y = np.logical_and(y, np.logical_not(np.isinf(abs_diff)))
     # Python default behavior is to have NaN comparison be False,
     # so handle equal_nan separately
     if equal_nan:
         # Logically and together NaN between A and B and Or it with y
         nans = np.logical_and(np.isnan(a), np.isnan(b))
         y = np.logical_or(y, nans)
-    return y
+    # Add an extra equality check in case there is an inf
+    equality = a == b
+    return np.logical_or(y, equality)

--- a/numba/tests/test_mathlib.py
+++ b/numba/tests/test_mathlib.py
@@ -11,6 +11,8 @@ from numba.core.config import IS_WIN32, IS_32BITS
 from numba.tests.support import TestCase, CompilationCache, tag
 import unittest
 from numba.np import numpy_support
+from numba import jit
+from numba.core.errors import TypingError
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.set("enable_pyobject")
@@ -171,6 +173,9 @@ def ldexp(x, e):
 def get_constants():
     return math.pi, math.e
 
+
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return math.isclose(a, b, rel_tol=rel_tol, abs_tol=abs_tol)
 
 class TestMathLib(TestCase):
 
@@ -649,6 +654,147 @@ class TestMathLib(TestCase):
 
     def test_ldexp_npm(self):
         self.test_ldexp(flags=no_pyobj_flags)
+
+    def test_isclose(self):
+        pyfunc = isclose
+        cfunc = jit(nopython=True)(pyfunc)
+        # Examples using floats, integers, inf, and NaN
+        pairs = [
+            # Two integers
+            (
+                4,
+                4
+            ),
+            (
+                4,
+                3
+            ),
+            # One integer and one float
+            (
+                3.0,
+                4
+            ),
+            (
+                4,
+                4.0 - 1e-09,
+            ),
+            # Two floats
+            (
+                3.99,
+                4.0
+            ),
+            (
+                4.0,
+                4.0 - 1e-09,
+            ),
+            # Test NaN
+            (
+                math.nan,
+                math.nan
+            ),
+            (
+                math.nan,
+                0.0
+            ),
+            # Test inf
+            (
+                math.inf,
+                math.inf
+            ),
+            (
+                -math.inf,
+                -math.inf
+            ),
+            (
+                math.inf,
+                math.nan
+            )
+        ]
+
+        for a, b in pairs:
+            expected = pyfunc(a, b)
+            got = cfunc(a, b)
+            self.assertPreciseEqual(expected, got)
+
+    def test_isclose_optional(self):
+        pyfunc = isclose
+        cfunc = jit(nopython=True)(isclose)
+        # Examples using floats, integers, inf, and NaN
+        args = [
+            # Test relative tolerance
+            (
+                4,
+                3,
+                0.5,
+                0.0
+            ),
+            # Test absolute tolerance
+            (
+                3.0,
+                4,
+                0.0,
+                1.0,
+            ),
+            # Test both set to 0
+            (
+                4.0,
+                4.0 - 1e-09,
+                0.0,
+                0.0
+            )
+        ]
+
+        for a, b, rel_tol, abs_tol in args:
+            expected = pyfunc(a, b, rel_tol, abs_tol)
+            got = cfunc(a, b, rel_tol, abs_tol)
+            self.assertPreciseEqual(expected, got)
+
+    def test_isclose_exceptions(self):
+        pyfunc = isclose
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Verify that every argument must be a scalar
+        with self.assertRaises(TypingError) as raises:
+            cfunc(
+                (1.0,),
+                1.0
+            )
+        self.assertIn(
+            "All arguments must be scalars.",
+            str(raises.exception)
+        )
+
+        with self.assertRaises(TypingError) as raises:
+            cfunc(
+                1.0,
+                (1.0,)
+            )
+        self.assertIn(
+            "All arguments must be scalars.",
+            str(raises.exception)
+        )
+        
+        with self.assertRaises(TypingError) as raises:
+            cfunc(
+                1.0,
+                1.0,
+                rel_tol=(1.0,)
+            )
+        self.assertIn(
+            "All arguments must be scalars.",
+            str(raises.exception)
+        )
+
+        with self.assertRaises(TypingError) as raises:
+            cfunc(
+                1.0,
+                1.0,
+                abs_tol=(1.0,)
+            )
+        self.assertIn(
+            "All arguments must be scalars.",
+            str(raises.exception)
+        )
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3739,6 +3739,15 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             (
                 (1, 2),
                 (4, 5)
+            ),
+            # Test Inf
+            (
+                np.array([np.inf, np.inf]),
+                np.array([np.inf, -np.inf])
+            ),
+            (
+                np.array([-np.inf, -np.inf]),
+                np.array([-np.inf, np.inf])
             )
         ]
 
@@ -3755,17 +3764,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             (
                 np.array([1, 2]),
                 np.array([[4, 5], [1, 2]])
-            )
+            ),
             # 2x2 (with broadcasting 2d x 1d)
-            #(
-            #    np.array([[1, 2], [4, 5]]),
-            #    np.array([1, 2])
-            #),
+            (
+                np.array([[1, 2], [4, 5]]),
+                np.array([1, 2])
+            ),
             # 2x2 (with higher order broadcasting)
-            #(
-            #    np.arange(36).reshape(6, 3, 2),
-            #    np.arange(6).reshape(3, 2)
-            #)
+            (
+                np.arange(36).reshape(6, 3, 2),
+                np.arange(6).reshape(3, 2)
+            )
         ]
 
         for a, b in pairs:

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -3755,17 +3755,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             (
                 np.array([1, 2]),
                 np.array([[4, 5], [1, 2]])
-            ),
-            # 2x2 (with broadcasting 2d x 1d)
-            (
-                np.array([[1, 2], [4, 5]]),
-                np.array([1, 2])
-            ),
-            # 2x2 (with higher order broadcasting)
-            (
-                np.arange(36).reshape(6, 3, 2),
-                np.arange(6).reshape(3, 2)
             )
+            # 2x2 (with broadcasting 2d x 1d)
+            #(
+            #    np.array([[1, 2], [4, 5]]),
+            #    np.array([1, 2])
+            #),
+            # 2x2 (with higher order broadcasting)
+            #(
+            #    np.arange(36).reshape(6, 3, 2),
+            #    np.arange(6).reshape(3, 2)
+            #)
         ]
 
         for a, b in pairs:
@@ -3930,16 +3930,15 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         )
 
         # Test A and B with different dims (not broadcastable)
-        a = np.array([1, 2], [3, 4])
-        b = np.array([5, 6, 7], [8, 9, 10])
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([[5, 6, 7], [8, 9, 10]])
         with self.assertRaises(ValueError) as raises:
             cfunc(
                 a,
                 b
             )
         self.assertIn(
-            "Operands could not be broadcast together with shapes \
-                    {}, {}.".format(a.shape, b.shape),
+            "unable to broadcast",
             str(raises.exception)
         )
 


### PR DESCRIPTION
I am implementing support for np.isclose and math.isclose in response to issue #5977. I have currently added support for the numpy implementation but the math implementation has not started yet. My changes add a new function to arraymath.py and four new unit tests. I should have complete support for optional arguments, although there may be issues where I am not doing type conversions that should be allowed.
