### PR TITLE
Duplicate NumPy's PyArray_DescrCheck macro

### DIFF
--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -31,6 +31,8 @@
  *
  * This macro definition is copied from:
  * https://github.com/numpy/numpy/commit/6108b5d1e138d07e3c9f2a4e3b1933749ad0e698#diff-ad2213da23136c5fc5883d9eb2d88666R26
+ *
+ * NOTE: This is the NumPy 1.18 and above version of the macro.
  */
 #define NUMBA_PyArray_DescrCheck(op) PyObject_TypeCheck(op, &PyArrayDescr_Type)
 

--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -17,4 +17,21 @@
 #define VISIBILITY_HIDDEN
 #endif
 
+/*
+ * Numba's version of the PyArray_DescrCheck macro from NumPy, use it as a
+ * direct replacement of NumPy's PyArray_DescrCheck to ensure binary
+ * compatibility.
+ *
+ * Details of why this is needed:
+ * NumPy 1.18 changed the definition of the PyArray_DescrCheck macro here:
+ * https://github.com/numpy/numpy/commit/6108b5d1e138d07e3c9f2a4e3b1933749ad0e698
+ * the result of this being that building against NumPy <1.18 would prevent
+ * Numba running against NumPy >= 1.20 as noted here:
+ * https://github.com/numba/numba/issues/6041#issuecomment-665132199
+ *
+ * This macro definition is copied from:
+ * https://github.com/numpy/numpy/commit/6108b5d1e138d07e3c9f2a4e3b1933749ad0e698#diff-ad2213da23136c5fc5883d9eb2d88666R26
+ */
+#define NUMBA_PyArray_DescrCheck(op) PyObject_TypeCheck(op, &PyArrayDescr_Type)
+
 #endif /* NUMBA_COMMON_H_ */

--- a/numba/_typeof.c
+++ b/numba/_typeof.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <assert.h>
 
+#include "_numba_common.h"
 #include "_typeof.h"
 #include "_hashtable.h"
 
@@ -372,7 +373,7 @@ compute_fingerprint(string_writer_t *w, PyObject *val)
         PyBuffer_Release(&buf);
         return 0;
     }
-    if (PyArray_DescrCheck(val)) {
+    if (NUMBA_PyArray_DescrCheck(val)) {
         TRY(string_writer_put_char, w, OP_NP_DTYPE);
         return compute_dtype_fingerprint(w, (PyArray_Descr *) val);
     }

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -10,6 +10,7 @@
 #include <numpy/arrayscalars.h>
 
 #include "../../_arraystruct.h"
+#include "../../_numba_common.h"
 #include "nrt.h"
 
 
@@ -294,7 +295,7 @@ NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
     npy_intp *shape, *strides;
     int flags = 0;
 
-    if (!PyArray_DescrCheck(descr)) {
+    if (!NUMBA_PyArray_DescrCheck(descr)) {
         PyErr_Format(PyExc_TypeError,
                      "expected dtype object, got '%.200s'",
                      Py_TYPE(descr)->tp_name);


### PR DESCRIPTION
As title, workaround for NumPy ABI compatibility issue.

Closes #6041

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
