### PR TITLE
CUDA: Prevent auto-upgrade of atomic intrinsics

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -500,6 +500,12 @@ def llvm_to_ptx(llvmir, **opts):
     for decl, fn in replacements:
         llvmir = llvmir.replace(decl, fn)
 
+    # llvm.numba_nvvm.atomic is used to prevent LLVM 9 onwards auto-upgrading
+    # these intrinsics into atomicrmw instructions, which are not recognized by
+    # NVVM. We can now replace them with the real intrinsic names, ready to
+    # pass to NVVM.
+    llvmir = llvmir.replace('llvm.numba_nvvm.atomic', 'llvm.nvvm.atomic')
+
     llvmir = llvm39_to_34_ir(llvmir)
     cu.add_module(llvmir.encode('utf8'))
     cu.add_module(libdevice.get())

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -12,8 +12,13 @@ def declare_atomic_cas_int32(lmod):
     return lmod.get_or_insert_function(fnty, fname)
 
 
+# For atomic intrinsics, "numba_nvvm" prevents LLVM 9 onwards auto-upgrading
+# them into atomicrmw instructions that are not recognized by NVVM. It is
+# replaced with "nvvm" in llvm_to_ptx later, after the module has been parsed
+# and dumped by LLVM.
+
 def declare_atomic_add_float32(lmod):
-    fname = 'llvm.nvvm.atomic.load.add.f32.p0f32'
+    fname = 'llvm.numba_nvvm.atomic.load.add.f32.p0f32'
     fnty = lc.Type.function(lc.Type.float(),
         (lc.Type.pointer(lc.Type.float(), 0), lc.Type.float()))
     return lmod.get_or_insert_function(fnty, name=fname)
@@ -21,7 +26,7 @@ def declare_atomic_add_float32(lmod):
 
 def declare_atomic_add_float64(lmod):
     if current_context().device.compute_capability >= (6, 0):
-        fname = 'llvm.nvvm.atomic.load.add.f64.p0f64'
+        fname = 'llvm.numba_nvvm.atomic.load.add.f64.p0f64'
     else:
         fname = '___numba_atomic_double_add'
     fnty = lc.Type.function(lc.Type.double(),


### PR DESCRIPTION
LLVM 9 onwards auto-upgrade the atomic intrinsics into an atomicrmw form unsupported by NVVM. This commit prevents the auto-upgrade by changing the "nvvm" component of the intrinsic to "numba_nvvm" until after it has been parsed and dumped by LLVM.

With thanks to Stuart Archibald for the suggestion and initial patch, and Val Haenel for catching the issue in the buildfarm prior to release.

This should fix the issue described in https://github.com/numba/llvmlite/pull/606#issuecomment-669119556
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
