### PR TITLE
Fix issue with cross drive use and relpath.

### DIFF
--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -375,7 +375,7 @@ class AbstractTemplate(FunctionTemplate):
             'kind': "overload",
             'name': getattr(impl, '__qualname__', impl.__name__),
             'sig': sig,
-            'filename': os.path.relpath(path, start=basepath),
+            'filename': utils.safe_relpath(path, start=basepath),
             'lines': (firstlineno, firstlineno + len(code) - 1),
             'docstring': impl.__doc__
         }
@@ -450,7 +450,7 @@ class CallableTemplate(FunctionTemplate):
             'name': getattr(self.key, '__name__',
                             getattr(impl, '__qualname__', impl.__name__),),
             'sig': sig,
-            'filename': os.path.relpath(path, start=basepath),
+            'filename': utils.safe_relpath(path, start=basepath),
             'lines': (firstlineno, firstlineno + len(code) - 1),
             'docstring': impl.__doc__
         }
@@ -778,7 +778,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             'kind': "overload",
             'name': getattr(impl, '__qualname__', impl.__name__),
             'sig': sig,
-            'filename': os.path.relpath(path, start=basepath),
+            'filename': utils.safe_relpath(path, start=basepath),
             'lines': (firstlineno, firstlineno + len(code) - 1),
             'docstring': impl.__doc__
         }
@@ -793,7 +793,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             'kind': "overload",
             'name': getattr(impl, '__qualname__', impl.__name__),
             'sig': sig,
-            'filename': os.path.relpath(path, start=basepath),
+            'filename': utils.safe_relpath(path, start=basepath),
             'lines': (firstlineno, firstlineno + len(code) - 1),
             'docstring': impl.__doc__
         }
@@ -861,7 +861,7 @@ class _IntrinsicTemplate(AbstractTemplate):
             'kind': "intrinsic",
             'name': getattr(impl, '__qualname__', impl.__name__),
             'sig': sig,
-            'filename': os.path.relpath(path, start=basepath),
+            'filename': utils.safe_relpath(path, start=basepath),
             'lines': (firstlineno, firstlineno + len(code) - 1),
             'docstring': impl.__doc__
         }

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -110,10 +110,12 @@ def safe_relpath(path, start=os.curdir):
     drives as technically they don't share the same root.
     See: https://bugs.python.org/issue7195 for details.
     """
-    # use commonpath to catch cross drive relative path, commonpath requires
-    # either all relative paths or all absolute paths, make them all absolute as
-    # this function itself is attempting to mitigate issues with relpath.
-    if not os.path.commonpath(map(os.path.abspath, (path, start))):
+    # find the drive letters for path and start and if they are not the same
+    # then don't use relpath!
+    drive_letter = lambda x: os.path.splitdrive(os.path.abspath(x))[0]
+    drive_path = drive_letter(path)
+    drive_start = drive_letter(path)
+    if drive_path != drive_start:
         return os.path.abspath(path)
     else:
         return os.path.relpath(path, start=start)

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -114,7 +114,7 @@ def safe_relpath(path, start=os.curdir):
     # then don't use relpath!
     drive_letter = lambda x: os.path.splitdrive(os.path.abspath(x))[0]
     drive_path = drive_letter(path)
-    drive_start = drive_letter(path)
+    drive_start = drive_letter(start)
     if drive_path != drive_start:
         return os.path.abspath(path)
     else:

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -104,6 +104,21 @@ def erase_traceback(exc_value):
     return exc_value.with_traceback(None)
 
 
+def safe_relpath(path, start=os.curdir):
+    """
+    Produces a "safe" relative path, on windows relpath doesn't work across
+    drives as technically they don't share the same root.
+    See: https://bugs.python.org/issue7195 for details.
+    """
+    # use commonpath to catch cross drive relative path, commonpath requires
+    # either all relative paths or all absolute paths, make them all absolute as
+    # this function itself is attempting to mitigate issues with relpath.
+    if not os.path.commonpath(map(os.path.abspath, (path, start))):
+        return os.path.abspath(path)
+    else:
+        return os.path.relpath(path, start=start)
+
+
 # Mapping between operator module functions and the corresponding built-in
 # operators.
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -277,7 +277,7 @@ def compile_device_template(pyfunc, debug=False, inline=False, opt=True):
                 'kind': "overload",
                 'name': getattr(cls.key, '__name__', "unknown"),
                 'sig': sig,
-                'filename': os.path.relpath(path, start=basepath),
+                'filename': utils.safe_relpath(path, start=basepath),
                 'lines': (firstlineno, firstlineno + len(code) - 1),
                 'docstring': pyfunc.__doc__
             }


### PR DESCRIPTION
As title. On windows relpath does not work across drives as they
technically do not share the same root. A utility function is
added to provide a "safe" relpath like function for use in future.

Previous fix was https://github.com/numba/numba/pull/5319.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
