### PR TITLE
Fix bug in initial value unify.

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -442,7 +442,7 @@ class List(MutableSequence, InitialValue):
                     use = siv
                     if siv is None:
                         use = oiv
-                    return List(dtype, reflected, use.initial_value)
+                    return List(dtype, reflected, use)
                 else:
                     return List(dtype, reflected)
 

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -1516,6 +1516,22 @@ class TestListInitialValues(MemoryLeakMixin, TestCase):
             larg = baz.signatures[0][0]
             self.assertEqual(larg.initial_value, iv)
 
+    def test_list_of_list_ctor(self):
+        # see issue 6082
+        @njit
+        def bar(x):
+            pass
+
+        @njit
+        def foo():
+            x = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 6]]
+            bar(x)
+
+        foo()
+        larg = bar.signatures[0][0]
+        self.assertEqual(larg.initial_value, None)
+        self.assertEqual(larg.dtype.initial_value, None)
+
 
 class TestLiteralLists(MemoryLeakMixin, TestCase):
 


### PR DESCRIPTION
As title, the ctor initial value was already an initial value, it
didn't need the getattr on it.

Fixes #6082

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
