### PR TITLE
Add more accessible version information

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -6,10 +6,34 @@ import platform
 import re
 import sys
 import warnings
+from collections import namedtuple
 
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+_version_info = namedtuple('version_info',
+                           ('major minor patch short full '
+                            'string tuple git_revision'))
+def _gen_v_info():
+    parts = __version__.split('.')
+    def try_int(x):
+        try:
+            return int(x)
+        except ValueError:
+            return None
+    major = try_int(parts[0])
+    minor = try_int(parts[1])
+    patch = try_int(parts[2])
+    short = (major, minor)
+    full = (major, minor, patch)
+    string = __version__
+    tup = tuple(string.split('.'))
+    git_revision = tup[3] if len(tup) >= 4 else None
+    return _version_info(major, minor, patch, short, full, string, tup,
+                         git_revision)
+version_info = _gen_v_info()
+del _gen_v_info
 
 from numba.core import config
 from numba.testing import _runtests as runtests


### PR DESCRIPTION
As title.

Opened this largely for feedback on the subject! Motivation is that a simple "check if Numba version is high enough to support some feature or other" involves doing something like:

```python
from numba import __version__
assert tuple(int(x) for x in __version__.split('.')[:2]) >= (0, 51)
```

The currently present `numba.__version__` gives something like:

```pycon
In [1]: import numba                                                                                                            

In [2]: numba.__version__                                                                                                       
Out[2]: '0.52.0dev0+1.g115af3162'
```
this PR adds `version_info` which gives this:
```pycon
In [3]: numba.version_info                                                                                                      
Out[3]: version_info(major=0, minor=52, patch=None, short=(0, 52), full=(0, 52, None), string='0.52.0dev0+1.g115af3162', tuple=('0', '52', '0dev0+1', 'g115af3162'), git_revision='g115af3162')
```
which makes it much easier to e.g. assert that Numba >= 0.51, e.g.
```pycon
In [4]: assert numba.version_info.short > (0, 51) 
```
