### PR TITLE
remove invalid sanity check from randrange tests

### DIFF
--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -394,7 +394,6 @@ class TestRandom(BaseTest):
             ints.append(func2(5, 500000000))
             if func3 is not None:
                 ints.append(func3(5, 500000000, 3))
-        self.assertEqual(len(ints), len(set(ints)), ints)
         if is_numpy:
             rr = self._follow_numpy(ptr).randint
         else:


### PR DESCRIPTION
The sanity check assumes that all the integers generated by `randrange`
are unique implicity by converting to a `set`, however `randrange` can
not make such guarantees. The reason we are removing this is because it
makes the test unstable and causes radom failures every so often.

The resulting error looks like:

```
======================================================================
FAIL: test_random_randrange (numba.tests.test_random.TestRandom)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/opt/conda/envs/testenv_d03ff656-b9e2-4389-a4e7-02f1435193ed/lib/python3.7/site-packages/numba/tests/test_random.py", line 430, in test_random_randrange
max_width, False)
File "/opt/conda/envs/testenv_d03ff656-b9e2-4389-a4e7-02f1435193ed/lib/python3.7/site-packages/numba/tests/test_random.py", line 397, in _check_randrange
self.assertEqual(len(ints), len(set(ints)), ints)
AssertionError: 30 != 29 : [0, 524311, 3170417, 4751491, 6340830, 10297652, 2, 2637917, 6340832, 4751489, 6340832, 25953158, 18891276, 19415587, 31507523, 23642767, 16777803, 25953155, 18891278, 21529290, 34677746, 23642765, 13, 3956864, 4227225, 4751504, 9511229, 524312, 2113607, 3956861]
----------------------------------------------------------------------
```

Where in this case the number `6340832` is the duplicate.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
