### PR TITLE
CUDA: Add mapped_array_like and pinned_array_like

### DIFF
--- a/docs/source/cuda-reference/memory.rst
+++ b/docs/source/cuda-reference/memory.rst
@@ -5,7 +5,9 @@ Memory Management
 .. autofunction:: numba.cuda.device_array
 .. autofunction:: numba.cuda.device_array_like
 .. autofunction:: numba.cuda.pinned_array
+.. autofunction:: numba.cuda.pinned_array_like
 .. autofunction:: numba.cuda.mapped_array
+.. autofunction:: numba.cuda.mapped_array_like
 .. autofunction:: numba.cuda.pinned
 .. autofunction:: numba.cuda.mapped
 

--- a/docs/source/cuda/memory.rst
+++ b/docs/source/cuda/memory.rst
@@ -52,6 +52,21 @@ Pinned memory
    :noindex:
 .. autofunction:: numba.cuda.pinned_array
    :noindex:
+.. autofunction:: numba.cuda.pinned_array_like
+   :noindex:
+
+
+Mapped memory
+=============
+
+.. autofunction:: numba.cuda.mapped
+   :noindex:
+.. autofunction:: numba.cuda.mapped_array
+   :noindex:
+.. autofunction:: numba.cuda.mapped_array_like
+   :noindex:
+
+
 
 Streams
 =======

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -130,8 +130,8 @@ def device_array(shape, dtype=np.float, strides=None, order='C', stream=0):
 def pinned_array(shape, dtype=np.float, strides=None, order='C'):
     """pinned_array(shape, dtype=np.float, strides=None, order='C')
 
-    Allocate a np.ndarray with a buffer that is pinned (pagelocked).
-    Similar to np.empty().
+    Allocate an :class:`ndarray <numpy.ndarray>` with a buffer that is pinned
+    (pagelocked).  Similar to :func:`np.empty() <numpy.empty>`.
     """
     shape, strides, dtype = _prepare_shape_strides_dtype(shape, strides, dtype,
                                                          order)
@@ -227,23 +227,22 @@ def _fill_stride_by_order(shape, dtype, order):
     return tuple(strides)
 
 
-def device_array_like(ary, stream=0):
-    """Call cuda.devicearray() with information from the array.
+def _contiguous_strides_like_array(ary):
     """
-    # Avoid attempting to recompute strides if the default strides will be
-    # sufficient to create a contiguous array.
-    if ary.flags['C_CONTIGUOUS'] or ary.ndim <= 1:
-        return device_array(shape=ary.shape, dtype=ary.dtype, stream=stream)
-    elif ary.flags['F_CONTIGUOUS']:
-        return device_array(shape=ary.shape, dtype=ary.dtype, order='F',
-                            stream=stream)
+    Given an array, compute strides for a new contiguous array of the same
+    shape.
+    """
+    # Don't recompute strides if the default strides will be sufficient to
+    # create a contiguous array.
+    if ary.flags['C_CONTIGUOUS'] or ary.flags['F_CONTIGUOUS'] or ary.ndim <= 1:
+        return None
 
     # Otherwise, we need to compute new strides using an algorithm adapted from
     # NumPy v1.17.4's PyArray_NewLikeArrayWithShape in
     # core/src/multiarray/ctors.c. We permute the strides in ascending order
     # then compute the stride for the dimensions with the same permutation.
 
-    # Stride permuation. E.g. a stride array (4, -2, 12) becomes
+    # Stride permutation. E.g. a stride array (4, -2, 12) becomes
     # [(1, -2), (0, 4), (2, 12)]
     strideperm = [ x for x in enumerate(ary.strides) ]
     strideperm.sort(key = lambda x: x[1])
@@ -254,10 +253,47 @@ def device_array_like(ary, stream=0):
     for i_perm, _ in strideperm:
         strides[i_perm] = stride
         stride *= ary.shape[i_perm]
-    strides = tuple(strides)
+    return tuple(strides)
 
+
+def _order_like_array(ary):
+    if ary.flags['F_CONTIGUOUS'] and not ary.flags['C_CONTIGUOUS']:
+        return 'F'
+    else:
+        return 'C'
+
+
+def device_array_like(ary, stream=0):
+    """
+    Call :func:`device_array() <numba.cuda.device_array>` with information from
+    the array.
+    """
+    strides = _contiguous_strides_like_array(ary)
+    order = _order_like_array(ary)
     return device_array(shape=ary.shape, dtype=ary.dtype, strides=strides,
-                        stream=stream)
+                        order=order, stream=stream)
+
+
+def mapped_array_like(ary, stream=0, portable=False, wc=False):
+    """
+    Call :func:`mapped_array() <numba.cuda.mapped_array>` with the information
+    from the array.
+    """
+    strides = _contiguous_strides_like_array(ary)
+    order = _order_like_array(ary)
+    return mapped_array(shape=ary.shape, dtype=ary.dtype, strides=strides,
+                        order=order, stream=stream, portable=portable, wc=wc)
+
+
+def pinned_array_like(ary):
+    """
+    Call :func:`pinned_array() <numba.cuda.pinned_array>` with the information
+    from the array.
+    """
+    strides = _contiguous_strides_like_array(ary)
+    order = _order_like_array(ary)
+    return pinned_array(shape=ary.shape, dtype=ary.dtype, strides=strides,
+                        order=order)
 
 
 # Stream helper

--- a/numba/cuda/simulator/__init__.py
+++ b/numba/cuda/simulator/__init__.py
@@ -1,7 +1,7 @@
 from .api import *
 from .reduction import Reduce
 from .cudadrv.devicearray import (device_array, device_array_like, pinned,
-                    pinned_array, to_device, auto_device)
+                    pinned_array, pinned_array_like, to_device, auto_device)
 from .cudadrv import devicearray
 from .cudadrv.devices import require_context, gpus
 from .cudadrv.devices import get_context as current_context

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -277,24 +277,25 @@ def device_array(*args, **kwargs):
     return FakeCUDAArray(np.ndarray(*args, **kwargs), stream=stream)
 
 
-def device_array_like(ary, stream=0):
-    # Avoid attempting to recompute strides if the default strides will be
-    # sufficient to create a contiguous array.
-    if ary.flags['C_CONTIGUOUS'] or ary.ndim <= 1:
-        return FakeCUDAArray(np.ndarray(shape=ary.shape, dtype=ary.dtype))
-    elif ary.flags['F_CONTIGUOUS']:
-        return FakeCUDAArray(np.ndarray(shape=ary.shape, dtype=ary.dtype,
-                                        order='F'))
+def _contiguous_strides_like_array(ary):
+    """
+    Given an array, compute strides for a new contiguous array of the same
+    shape.
+    """
+    # Don't recompute strides if the default strides will be sufficient to
+    # create a contiguous array.
+    if ary.flags['C_CONTIGUOUS'] or ary.flags['F_CONTIGUOUS'] or ary.ndim <= 1:
+        return None
 
     # Otherwise, we need to compute new strides using an algorithm adapted from
-    # NumPy's v1.17.4's PyArray_NewLikeArrayWithShape in
+    # NumPy v1.17.4's PyArray_NewLikeArrayWithShape in
     # core/src/multiarray/ctors.c. We permute the strides in ascending order
     # then compute the stride for the dimensions with the same permutation.
 
-    # Stride permuation. E.g. a stride array (4, -2, 12) becomes
+    # Stride permutation. E.g. a stride array (4, -2, 12) becomes
     # [(1, -2), (0, 4), (2, 12)]
-    strideperm = [x for x in enumerate(ary.strides)]
-    strideperm.sort(key=lambda x: x[1])
+    strideperm = [ x for x in enumerate(ary.strides) ]
+    strideperm.sort(key = lambda x: x[1])
 
     # Compute new strides using permutation
     strides = [0] * len(ary.strides)
@@ -302,10 +303,27 @@ def device_array_like(ary, stream=0):
     for i_perm, _ in strideperm:
         strides[i_perm] = stride
         stride *= ary.shape[i_perm]
-    strides = tuple(strides)
+    return tuple(strides)
 
-    return FakeCUDAArray(np.ndarray(shape=ary.shape, dtype=ary.dtype, strides=strides))
 
+def _order_like_array(ary):
+    if ary.flags['F_CONTIGUOUS'] and not ary.flags['C_CONTIGUOUS']:
+        return 'F'
+    else:
+        return 'C'
+
+
+def device_array_like(ary, stream=0):
+    strides = _contiguous_strides_like_array(ary)
+    order = _order_like_array(ary)
+    return device_array(shape=ary.shape, dtype=ary.dtype, strides=strides,
+                        order=order)
+
+def pinned_array_like(ary):
+    strides = _contiguous_strides_like_array(ary)
+    order = _order_like_array(ary)
+    return pinned_array(shape=ary.shape, dtype=ary.dtype, strides=strides,
+                        order=order)
 
 def auto_device(ary, stream=0, copy=True):
     if isinstance(ary, FakeCUDAArray):

--- a/numba/cuda/tests/cudapy/test_array.py
+++ b/numba/cuda/tests/cudapy/test_array.py
@@ -2,7 +2,14 @@ import numpy as np
 
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim, skip_unless_cudasim
-from numba import cuda
+from numba import config, cuda
+
+
+if config.ENABLE_CUDASIM:
+    ARRAY_LIKE_FUNCTIONS = (cuda.device_array_like, cuda.pinned_array_like)
+else:
+    ARRAY_LIKE_FUNCTIONS = (cuda.device_array_like, cuda.mapped_array_like,
+                            cuda.pinned_array_like)
 
 
 class TestCudaArray(CUDATestCase):
@@ -60,126 +67,160 @@ class TestCudaArray(CUDATestCase):
         d, _ = cuda.devicearray.auto_device(2)
         self.assertTrue(np.all(d.copy_to_host() == np.array(2)))
 
-    def _test_device_array_like_same(self, d_a):
+    def _test_array_like_same(self, like_func, array):
         """
-        Tests of device_array_like where shape, strides, dtype, and flags should
+        Tests of *_array_like where shape, strides, dtype, and flags should
         all be equal.
         """
-        d_a_like = cuda.device_array_like(d_a)
-        self.assertEqual(d_a.shape, d_a_like.shape)
-        self.assertEqual(d_a.strides, d_a_like.strides)
-        self.assertEqual(d_a.dtype, d_a_like.dtype)
-        self.assertEqual(d_a.flags['C_CONTIGUOUS'], d_a_like.flags['C_CONTIGUOUS'])
-        self.assertEqual(d_a.flags['F_CONTIGUOUS'], d_a_like.flags['F_CONTIGUOUS'])
+        array_like = like_func(array)
+        self.assertEqual(array.shape, array_like.shape)
+        self.assertEqual(array.strides, array_like.strides)
+        self.assertEqual(array.dtype, array_like.dtype)
+        self.assertEqual(array.flags['C_CONTIGUOUS'], array_like.flags['C_CONTIGUOUS'])
+        self.assertEqual(array.flags['F_CONTIGUOUS'], array_like.flags['F_CONTIGUOUS'])
 
-    def test_device_array_like_1d(self):
+    def test_array_like_1d(self):
         d_a = cuda.device_array(10, order='C')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_2d(self):
+    def test_array_like_2d(self):
         d_a = cuda.device_array((10, 12), order='C')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_2d_transpose(self):
+    def test_array_like_2d_transpose(self):
         d_a = cuda.device_array((10, 12), order='C')
-        self._test_device_array_like_same(d_a.T)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_3d(self):
+    def test_array_like_3d(self):
         d_a = cuda.device_array((10, 12, 14), order='C')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_1d_f(self):
+    def test_array_like_1d_f(self):
         d_a = cuda.device_array(10, order='F')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_2d_f(self):
+    def test_array_like_2d_f(self):
         d_a = cuda.device_array((10, 12), order='F')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_2d_f_transpose(self):
+    def test_array_like_2d_f_transpose(self):
         d_a = cuda.device_array((10, 12), order='F')
-        self._test_device_array_like_same(d_a.T)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def test_device_array_like_3d_f(self):
+    def test_array_like_3d_f(self):
         d_a = cuda.device_array((10, 12, 14), order='F')
-        self._test_device_array_like_same(d_a)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_same(like_func, d_a)
 
-    def _test_device_array_like_view(self, view, d_view):
+    def _test_array_like_view(self, like_func, view, d_view):
         """
         Tests of device_array_like where the original array is a view - the
         strides should not be equal because a contiguous array is expected.
         """
-        d_like = cuda.device_array_like(d_view)
-        self.assertEqual(d_view.shape, d_like.shape)
-        self.assertEqual(d_view.dtype, d_like.dtype)
+        nb_like = like_func(d_view)
+        self.assertEqual(d_view.shape, nb_like.shape)
+        self.assertEqual(d_view.dtype, nb_like.dtype)
 
         # Use NumPy as a reference for the expected strides
-        like = np.zeros_like(view)
-        self.assertEqual(d_like.strides, like.strides)
-        self.assertEqual(d_like.flags['C_CONTIGUOUS'], like.flags['C_CONTIGUOUS'])
-        self.assertEqual(d_like.flags['F_CONTIGUOUS'], like.flags['F_CONTIGUOUS'])
+        np_like = np.zeros_like(view)
+        self.assertEqual(nb_like.strides, np_like.strides)
+        self.assertEqual(nb_like.flags['C_CONTIGUOUS'],
+                         np_like.flags['C_CONTIGUOUS'])
+        self.assertEqual(nb_like.flags['F_CONTIGUOUS'],
+                         np_like.flags['F_CONTIGUOUS'])
 
-    def test_device_array_like_1d_view(self):
+    def test_array_like_1d_view(self):
         shape = 10
         view = np.zeros(shape)[::2]
         d_view = cuda.device_array(shape)[::2]
-        self._test_device_array_like_view(view, d_view)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_view(like_func, view, d_view)
 
-    def test_device_array_like_1d_view_f(self):
+    def test_array_like_1d_view_f(self):
         shape = 10
         view = np.zeros(shape, order='F')[::2]
         d_view = cuda.device_array(shape, order='F')[::2]
-        self._test_device_array_like_view(view, d_view)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_view(like_func, view, d_view)
 
-    def test_device_array_like_2d_view(self):
+    def test_array_like_2d_view(self):
         shape = (10, 12)
         view = np.zeros(shape)[::2, ::2]
         d_view = cuda.device_array(shape)[::2, ::2]
-        self._test_device_array_like_view(view, d_view)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_view(like_func, view, d_view)
 
-    def test_device_array_like_2d_view_f(self):
+    def test_array_like_2d_view_f(self):
         shape = (10, 12)
         view = np.zeros(shape, order='F')[::2, ::2]
         d_view = cuda.device_array(shape, order='F')[::2, ::2]
-        self._test_device_array_like_view(view, d_view)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_view(like_func, view, d_view)
 
     @skip_on_cudasim('Numba and NumPy stride semantics differ for transpose')
-    def test_device_array_like_2d_view_transpose_device(self):
+    def test_array_like_2d_view_transpose_device(self):
         shape = (10, 12)
         view = np.zeros(shape)[::2, ::2].T
         d_view = cuda.device_array(shape)[::2, ::2].T
-        # This is a special case (see issue #4974) because creating the
-        # transpose creates a new contiguous allocation with different strides.
-        # In this case, rather than comparing against NumPy, we can only compare
-        # against expected values.
-        d_like = cuda.device_array_like(d_view)
-        self.assertEqual(d_view.shape, d_like.shape)
-        self.assertEqual(d_view.dtype, d_like.dtype)
-        self.assertEqual((40, 8), d_like.strides)
-        self.assertTrue(d_like.is_c_contiguous())
-        self.assertFalse(d_like.is_f_contiguous())
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                # This is a special case (see issue #4974) because creating the
+                # transpose creates a new contiguous allocation with different
+                # strides.  In this case, rather than comparing against NumPy,
+                # we can only compare against expected values.
+                like = like_func(d_view)
+                self.assertEqual(d_view.shape, like.shape)
+                self.assertEqual(d_view.dtype, like.dtype)
+                self.assertEqual((40, 8), like.strides)
+                self.assertTrue(like.flags['C_CONTIGUOUS'])
+                self.assertFalse(like.flags['F_CONTIGUOUS'])
 
     @skip_unless_cudasim('Numba and NumPy stride semantics differ for transpose')
-    def test_device_array_like_2d_view_transpose_simulator(self):
+    def test_array_like_2d_view_transpose_simulator(self):
         shape = (10, 12)
         view = np.zeros(shape)[::2, ::2].T
         d_view = cuda.device_array(shape)[::2, ::2].T
-        # On the simulator, the transpose has different strides to on a CUDA
-        # device (See issue #4974). Here we can compare strides against NumPy as
-        # a reference.
-        like = np.zeros_like(view)
-        d_like = cuda.device_array_like(d_view)
-        self.assertEqual(d_view.shape, d_like.shape)
-        self.assertEqual(d_view.dtype, d_like.dtype)
-        self.assertEqual(like.strides, d_like.strides)
-        self.assertEqual(like.flags['C_CONTIGUOUS'], d_like.flags['C_CONTIGUOUS'])
-        self.assertEqual(like.flags['F_CONTIGUOUS'], d_like.flags['F_CONTIGUOUS'])
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                # On the simulator, the transpose has different strides to on a
+                # CUDA device (See issue #4974). Here we can compare strides
+                # against NumPy as a reference.
+                np_like = np.zeros_like(view)
+                nb_like = like_func(d_view)
+                self.assertEqual(d_view.shape, nb_like.shape)
+                self.assertEqual(d_view.dtype, nb_like.dtype)
+                self.assertEqual(np_like.strides, nb_like.strides)
+                self.assertEqual(np_like.flags['C_CONTIGUOUS'],
+                                 nb_like.flags['C_CONTIGUOUS'])
+                self.assertEqual(np_like.flags['F_CONTIGUOUS'],
+                                 nb_like.flags['F_CONTIGUOUS'])
 
-    def test_device_array_like_2d_view_f_transpose(self):
+    def test_array_like_2d_view_f_transpose(self):
         shape = (10, 12)
         view = np.zeros(shape, order='F')[::2, ::2].T
         d_view = cuda.device_array(shape, order='F')[::2, ::2].T
-        self._test_device_array_like_view(view, d_view)
+        for like_func in ARRAY_LIKE_FUNCTIONS:
+            with self.subTest(like_func=like_func):
+                self._test_array_like_view(like_func, view, d_view)
 
     @skip_on_cudasim('Kernel definitions not created in the simulator')
     def test_issue_4628(self):


### PR DESCRIPTION
Includes:

- Code changes to add `mapped_array_like` and `pinned_array_like`.
- Documentation updates and a couple of small doc fixes in related areas.
- Tests of `device_array_like` updated to test all the `*_array_like` functions.

`mapped_array_like` is not added to the simulator because `mapped_array` doesn't exist in the simulator at present (See #6047).

See also #5131 - this doesn't add everything in that issue, but is a start.