### PR TITLE
[WIP] remove deprecated tbb::task_scheduler_init, use new api

### DIFF
--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -348,7 +348,7 @@ def _check_tbb_version_compatible():
         elif _IS_OSX:
             libtbb_name = 'libtbb.dylib'
         elif _IS_LINUX:
-            libtbb_name = 'libtbb.so.2'
+            libtbb_name = 'libtbb.so.12'
         else:
             raise ValueError("Unknown operating system")
         libtbb = CDLL(libtbb_name)
@@ -361,8 +361,8 @@ def _check_tbb_version_compatible():
                    "version 2019.5 or later i.e., "
                    "TBB_INTERFACE_VERSION >= 11005. Found "
                    "TBB_INTERFACE_VERSION = %s. The TBB "
-                   "threading layer is disabled.")
-            problem = errors.NumbaWarning(msg % tbb_iface_ver)
+                   "threading layer is disabled.") % tbb_iface_ver
+            problem = errors.NumbaWarning(msg)
             warnings.warn(problem)
             raise ImportError("Problem with TBB. Reason: %s" % msg)
     except (ValueError, OSError) as e:

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -308,12 +308,12 @@ static void unload_tbb(void)
 
 static void launch_threads(int count)
 {
-#if HAS_TASK_SCHEDULER_INIT
-    if(tsi)
+    if(tg)
         return;
-#endif
+
     if(_DEBUG)
         puts("Using TBB");
+
     if(count < 1)
         count = tbb::task_arena::automatic;
 #if HAS_TASK_SCHEDULER_INIT

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -31,12 +31,22 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #error "TBB version is too old, 2019 update 5, i.e. TBB_INTERFACE_VERSION >= 11005 required"
 #endif
 
+#define HAS_TASK_SCHEDULER_INIT (TBB_INTERFACE_VERSION < 12002)
+
+#if HAS_TASK_SCHEDULER_INIT
+#define TSI_INIT(count) tbb::task_scheduler_init(count)
+#define TSI_TERMINATE(tsi) tsi->blocking_terminate(std::nothrow)
+#endif
+
 #define _DEBUG 0
 #define _TRACE_SPLIT 0
 
 static tbb::task_group *tg = NULL;
+
+#if HAS_TASK_SCHEDULER_INIT
 static tbb::task_scheduler_init *tsi = NULL;
 static int tsi_count = 0;
+#endif
 
 #ifdef _MSC_VER
 #define THREAD_LOCAL(ty) __declspec(thread) ty
@@ -75,7 +85,11 @@ get_num_threads(void)
 static int
 get_thread_id(void)
 {
+#if TBB_INTERFACE_VERSION < 12002
     return tbb::task_arena::current_thread_index();
+#else
+    return tbb::this_task_arena::current_thread_index();
+#endif
 }
 
 // watch the arena, if it decides to create more threads/add threads into the
@@ -213,12 +227,14 @@ static bool is_main_thread()
     return std::this_thread::get_id() == init_thread_id;
 }
 
+#if HAS_TASK_SCHEDULER_INIT
 static void ignore_blocking_terminate_assertion( const char*, int, const char*, const char * )
 {
     tbb::internal::runtime_warning("Unable to wait for threads to shut down before fork(). It can break multithreading in child process\n");
 }
 
 static void ignore_assertion( const char*, int, const char*, const char * ) {}
+#endif
 
 static void prepare_fork(void)
 {
@@ -226,6 +242,7 @@ static void prepare_fork(void)
     {
         puts("Suspending TBB: prepare fork");
     }
+#if HAS_TASK_SCHEDULER_INIT
     if(tsi)
     {
         if(is_main_thread())
@@ -243,6 +260,7 @@ static void prepare_fork(void)
                             "child process.\n");
         }
     }
+#endif
 }
 
 static void reset_after_fork(void)
@@ -251,18 +269,21 @@ static void reset_after_fork(void)
     {
         puts("Resuming TBB: after fork");
     }
+
+#if HAS_TASK_SCHEDULER_INIT
     if(tsi && need_reinit_after_fork)
     {
         tsi->initialize(tsi_count);
         set_main_thread();
         need_reinit_after_fork = false;
     }
+#endif
 }
 
 #if PY_MAJOR_VERSION >= 3
 static void unload_tbb(void)
 {
-    if(tsi)
+    if (tg)
     {
         if(_DEBUG)
         {
@@ -271,25 +292,34 @@ static void unload_tbb(void)
         tg->wait();
         delete tg;
         tg = NULL;
+    }
+#if HAS_TASK_SCHEDULER_INIT
+    if(tsi)
+    {
         assertion_handler_type orig = tbb::set_assertion_handler(ignore_assertion);
         tsi->terminate(); // no blocking terminate is needed here
         tbb::set_assertion_handler(orig);
         delete tsi;
         tsi = NULL;
     }
+#endif
 }
 #endif
 
 static void launch_threads(int count)
 {
+#if HAS_TASK_SCHEDULER_INIT
     if(tsi)
         return;
+#endif
     if(_DEBUG)
         puts("Using TBB");
     if(count < 1)
-        count = tbb::task_scheduler_init::automatic;
+        count = tbb::task_arena::automatic;
+#if HAS_TASK_SCHEDULER_INIT
     tsi_count = count;
     tsi = new tbb::task_scheduler_init(count);
+#endif
     tg = new tbb::task_group;
     tg->run([] {}); // start creating threads asynchronously
 

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -32,6 +32,7 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #endif
 
 #define HAS_TASK_SCHEDULER_INIT (TBB_INTERFACE_VERSION < 12002)
+#define HAS_TASK_SCHEDULER_HANDLE (TBB_INTERFACE_VERSION >= 12003)
 
 #if HAS_TASK_SCHEDULER_INIT
 #define TSI_INIT(count) tbb::task_scheduler_init(count)
@@ -46,6 +47,10 @@ static tbb::task_group *tg = NULL;
 #if HAS_TASK_SCHEDULER_INIT
 static tbb::task_scheduler_init *tsi = NULL;
 static int tsi_count = 0;
+#endif
+
+#if HAS_TASK_SCHEDULER_HANDLE
+static tbb::task_scheduler_handle tsh;
 #endif
 
 #ifdef _MSC_VER
@@ -261,6 +266,12 @@ static void prepare_fork(void)
         }
     }
 #endif
+#if HAS_TASK_SCHEDULER_HANDLE
+    if (!tbb::finalize(tsh, std::nothrow))
+    {
+        puts("Unable to join threads to shut down before fork(). It can break multithreading in child process\n");
+    }
+#endif
 }
 
 static void reset_after_fork(void)
@@ -303,6 +314,10 @@ static void unload_tbb(void)
         tsi = NULL;
     }
 #endif
+#if HAS_TASK_SCHEDULER_HANDLE
+    // bloking terminate is not strictly required here, ignore return value
+    (void)tbb::finalize(tsh, std::nothrow);
+#endif
 }
 #endif
 
@@ -319,6 +334,10 @@ static void launch_threads(int count)
 #if HAS_TASK_SCHEDULER_INIT
     tsi_count = count;
     tsi = new tbb::task_scheduler_init(count);
+#endif
+
+#if HAS_TASK_SCHEDULER_HANDLE
+    tsh = tbb::task_scheduler_handle::get();
 #endif
     tg = new tbb::task_group;
     tg->run([] {}); // start creating threads asynchronously
@@ -340,7 +359,6 @@ static void synchronize(void)
 static void ready(void)
 {
 }
-
 
 MOD_INIT(tbbpool)
 {


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

`task_scheduler_init` was removed in TBB_INTERFACE_VERSION == 12002 and new replacement api was added in 12003.

Also, 12002 lib is no longer binary compatible with previous versions so library name was changed (not properly handled yet).
Fork safety selection logic also wasn't updated.