### PR TITLE
Fix and test #6095

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2679,8 +2679,6 @@ def _find_mask(typemap, func_ir, arr_def):
                 mask_indices.append(None)
             # Handle integer index
             elif isinstance(index_typ, types.Integer):
-                # The follow is never tested
-                raise AssertionError('unreachable')
                 count_consts += 1
                 mask_indices.append(ind)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3568,6 +3568,22 @@ class TestParforsMisc(TestParforsBase):
             foo.py_func(src, method, out)
         )
 
+    @skip_parfors_unsupported
+    def test_issue6095_numpy_max(self):
+        @njit(parallel=True)
+        def find_maxima_3D_jit(args):
+            package = args
+            for index in range(0, 10):
+                z_stack = package[index, :, :]
+            return np.max(z_stack)
+
+        np.random.seed(0)
+        args = np.random.random((10, 10, 10))
+        self.assertPreciseEqual(
+            find_maxima_3D_jit(args),
+            find_maxima_3D_jit.py_func(args),
+        )
+
 
 @skip_parfors_unsupported
 class TestParforsDiagnostics(TestParforsBase):


### PR DESCRIPTION
Fixes #6095 

The issue is caused by Parfor analysis being turned off because it was never tested. This patch simply re-enables it and adds test.