### PR TITLE
Fix #6121

### DIFF
--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -1,0 +1,54 @@
+from numba import cuda, float32, int32
+from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
+
+
+@skip_on_cudasim('Dispatcher objects not used in the simulator')
+class TestDispatcher(CUDATestCase):
+    def _test_no_double_specialize(self, dispatcher):
+
+        with self.assertRaises(RuntimeError) as e:
+            dispatcher.specialize((float32[::1],))
+
+        self.assertIn('Dispatcher already specialized', str(e.exception))
+
+    def test_no_double_specialize_sig(self):
+        # Attempting to specialize a kernel jitted with a signature is illegal.
+        @cuda.jit('void(float32[::1])')
+        def f(x):
+            pass
+
+        self._test_no_double_specialize(f)
+
+    def test_no_double_specialize_no_sig(self):
+        # Attempting to specialize an already-specialized kernel is illegal.
+        @cuda.jit
+        def f(x):
+            pass
+
+        f_specialized = f.specialize((float32[::1],))
+        self._test_no_double_specialize(f_specialized)
+
+    def test_specialize_cache_same(self):
+        # Ensure that the same dispatcher is returned for the same argument
+        # types, and that different dispatchers are returned for different
+        # argument types.
+        @cuda.jit
+        def f(x):
+            pass
+
+        self.assertEqual(len(f.specializations), 0)
+
+        f_float32 = f.specialize((float32[::1],))
+        self.assertEqual(len(f.specializations), 1)
+
+        f_float32_2 = f.specialize((float32[::1],))
+        self.assertEqual(len(f.specializations), 1)
+        self.assertIs(f_float32, f_float32_2)
+
+        f_int32 = f.specialize((int32[::1],))
+        self.assertEqual(len(f.specializations), 2)
+        self.assertIsNot(f_int32, f_float32)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -7,7 +7,7 @@ class TestDispatcher(CUDATestCase):
     def _test_no_double_specialize(self, dispatcher, ty):
 
         with self.assertRaises(RuntimeError) as e:
-            dispatcher.specialize((ty,))
+            dispatcher.specialize(ty)
 
         self.assertIn('Dispatcher already specialized', str(e.exception))
 
@@ -27,7 +27,7 @@ class TestDispatcher(CUDATestCase):
         def f(x):
             pass
 
-        f_specialized = f.specialize((float32[::1],))
+        f_specialized = f.specialize(float32[::1])
         self._test_no_double_specialize(f_specialized, float32[::1])
 
     def test_no_double_specialize_sig_diff_types(self):
@@ -44,7 +44,7 @@ class TestDispatcher(CUDATestCase):
         def f(x):
             pass
 
-        f_specialized = f.specialize((int32[::1],))
+        f_specialized = f.specialize(int32[::1])
         self._test_no_double_specialize(f_specialized, float32[::1])
 
     def test_specialize_cache_same(self):
@@ -57,16 +57,41 @@ class TestDispatcher(CUDATestCase):
 
         self.assertEqual(len(f.specializations), 0)
 
-        f_float32 = f.specialize((float32[::1],))
+        f_float32 = f.specialize(float32[::1])
         self.assertEqual(len(f.specializations), 1)
 
-        f_float32_2 = f.specialize((float32[::1],))
+        f_float32_2 = f.specialize(float32[::1])
         self.assertEqual(len(f.specializations), 1)
         self.assertIs(f_float32, f_float32_2)
 
-        f_int32 = f.specialize((int32[::1],))
+        f_int32 = f.specialize(int32[::1])
         self.assertEqual(len(f.specializations), 2)
         self.assertIsNot(f_int32, f_float32)
+
+    def test_specialize_cache_same_with_ordering(self):
+        # Ensure that the same dispatcher is returned for the same argument
+        # types, and that different dispatchers are returned for different
+        # argument types, taking into account array ordering and multiple
+        # arguments.
+        @cuda.jit
+        def f(x, y):
+            pass
+
+        self.assertEqual(len(f.specializations), 0)
+
+        # 'A' order specialization
+        f_f32a_f32a = f.specialize(float32[:], float32[:])
+        self.assertEqual(len(f.specializations), 1)
+
+        # 'C' order specialization
+        f_f32c_f32c = f.specialize(float32[::1], float32[::1])
+        self.assertEqual(len(f.specializations), 2)
+        self.assertIsNot(f_f32a_f32a, f_f32c_f32c)
+
+        # Reuse 'C' order specialization
+        f_f32c_f32c_2 = f.specialize(float32[::1], float32[::1])
+        self.assertEqual(len(f.specializations), 2)
+        self.assertIs(f_f32c_f32c, f_f32c_f32c_2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Opening this PR to fix #6121 and iterate on it. The problem is that `forall` always returns a new `Dispatcher`, which immediately compiles the specialization. Prior to #5709 being merged, the cache of compilations was used and any previously-compiled kernel could be returned by `specialize`. The fix in this branch introduces a cache of specialized `Dispatcher` objects to work around the issue.
