### PR TITLE
Fix #6130 objmode cache segfault

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -276,8 +276,8 @@ numba_recreate_record(void *pdata, int size, PyObject *dtype) {
     PyArray_Descr *descr = NULL;
 
     if (dtype == NULL) {
-        PyErr_Format(PyExc_ValueError,
-            "In 'numba_recreate_record', 'descr' is NULL");
+        PyErr_Format(PyExc_Runtime,
+            "In 'numba_recreate_record', 'dtype' is NULL");
         return NULL;
     }
 

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -276,7 +276,7 @@ numba_recreate_record(void *pdata, int size, PyObject *dtype) {
     PyArray_Descr *descr = NULL;
 
     if (dtype == NULL) {
-        PyErr_Format(PyExc_Runtime,
+        PyErr_Format(PyExc_RuntimeError,
             "In 'numba_recreate_record', 'dtype' is NULL");
         return NULL;
     }

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -275,6 +275,12 @@ numba_recreate_record(void *pdata, int size, PyObject *dtype) {
     PyObject *record = NULL;
     PyArray_Descr *descr = NULL;
 
+    if (dtype == NULL) {
+        PyErr_Format(PyExc_ValueError,
+            "In 'numba_recreate_record', 'descr' is NULL");
+        return NULL;
+    }
+
     numpy = PyImport_ImportModuleNoBlock("numpy");
     if (!numpy) goto CLEANUP;
 

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -91,6 +91,7 @@ CR_FIELDS = ["typing_context",
              # List of functions to call to initialize on unserialization
              # (i.e cache load).
              "reload_init",
+             "referenced_envs",
              ]
 
 
@@ -158,6 +159,7 @@ class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
                  call_helper=None,
                  metadata=None,  # Do not store, arbitrary & potentially large!
                  reload_init=reload_init,
+                 referenced_envs=referenced_envs,
                  )
 
         # Load Environments

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -146,6 +146,7 @@ class EnvironmentManager(object):
                 getitem = self.pyapi.list_getitem(consts, index)
                 builder.store(getitem, ret)
             with br_null:
+                # This can happen when the Environment is accidentally released
                 self.pyapi.err_set_string(
                     "PyExc_RuntimeError",
                     "`env.consts` is NULL in `read_const`",

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -147,6 +147,7 @@ class EnvironmentManager(object):
                 builder.store(getitem, ret)
             with br_null:
                 # This can happen when the Environment is accidentally released
+                # and has subsequently been garbage collected.
                 self.pyapi.err_set_string(
                     "PyExc_RuntimeError",
                     "`env.consts` is NULL in `read_const`",

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -134,7 +134,13 @@ class EnvironmentManager(object):
         """
         assert index < len(self.env.consts)
 
-        return self.pyapi.list_getitem(self.env_body.consts, index)
+        builder = self.pyapi.builder
+        consts = self.env_body.consts
+        ret = cgutils.alloca_once(builder, self.pyapi.pyobj, zfill=True)
+        with builder.if_then(cgutils.is_not_null(builder, consts)):
+            getitem = self.pyapi.list_getitem(consts, index)
+            builder.store(getitem, ret)
+        return builder.load(ret)
 
 
 _IteratorLoop = namedtuple('_IteratorLoop', ('value', 'do_break'))

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -131,6 +131,9 @@ class EnvironmentManager(object):
         """
         Look up constant number *index* inside the environment body.
         A borrowed reference is returned.
+
+        The returned LLVM value may have NULL value at runtime which indicates
+        an error at runtime.
         """
         assert index < len(self.env.consts)
 

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -295,6 +295,11 @@ NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
     npy_intp *shape, *strides;
     int flags = 0;
 
+    if (descr == NULL) {
+        PyErr_Format(PyExc_TypeError, "descr == NULL");
+        return NULL;
+    }
+
     if (!NUMBA_PyArray_DescrCheck(descr)) {
         PyErr_Format(PyExc_TypeError,
                      "expected dtype object, got '%.200s'",

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -296,7 +296,8 @@ NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
     int flags = 0;
 
     if (descr == NULL) {
-        PyErr_Format(PyExc_ValueError, "In 'NRT_adapt_ndarray_to_python', 'descr' is NULL");
+        PyErr_Format(PyExc_RuntimeError,
+                     "In 'NRT_adapt_ndarray_to_python', 'descr' is NULL");
         return NULL;
     }
 

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -296,7 +296,7 @@ NRT_adapt_ndarray_to_python(arystruct_t* arystruct, int ndim,
     int flags = 0;
 
     if (descr == NULL) {
-        PyErr_Format(PyExc_TypeError, "descr == NULL");
+        PyErr_Format(PyExc_ValueError, "In 'NRT_adapt_ndarray_to_python', 'descr' is NULL");
         return NULL;
     }
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -19,6 +19,7 @@ import io
 import ctypes
 import multiprocessing as mp
 import warnings
+import traceback
 from contextlib import contextmanager
 
 import numpy as np
@@ -786,9 +787,28 @@ def run_in_new_process_caching(func, cache_dir_prefix=__name__, verbose=True):
         stdout: str
         stderr: str
     """
+    cache_dir = temp_directory(cache_dir_prefix)
+    return run_in_new_process_in_cache_dir(func, cache_dir, verbose=True)
+
+
+def run_in_new_process_in_cache_dir(func, cache_dir, verbose=True):
+    """Spawn a new process to run `func` with a temporary cache directory.
+
+    The childprocess's stdout and stderr will be captured and redirected to
+    the current process's stdout and stderr.
+
+    Similar to ``run_in_new_process_caching()`` but the ``cache_dir`` is a
+    directory path instead of a name prefix for the directory path.
+
+    Returns
+    -------
+    ret : dict
+        exitcode: 0 for success. 1 for exception-raised.
+        stdout: str
+        stderr: str
+    """
     ctx = mp.get_context('spawn')
     qout = ctx.Queue()
-    cache_dir = temp_directory(cache_dir_prefix)
     with override_env_config('NUMBA_CACHE_DIR', cache_dir):
         proc = ctx.Process(target=_remote_runner, args=[func, qout])
         proc.start()

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -788,7 +788,7 @@ def run_in_new_process_caching(func, cache_dir_prefix=__name__, verbose=True):
         stderr: str
     """
     cache_dir = temp_directory(cache_dir_prefix)
-    return run_in_new_process_in_cache_dir(func, cache_dir, verbose=True)
+    return run_in_new_process_in_cache_dir(func, cache_dir, verbose=verbose)
 
 
 def run_in_new_process_in_cache_dir(func, cache_dir, verbose=True):


### PR DESCRIPTION
Fixes #6130 

Thanks @juanjgalvez and @stuartarchibald for finding out the source of the problem on the lost `env`.

The patch makes sure the `CompileResult` acquires a reference to any referenced `Environment` objects. Changes to `numba/core/compiler.py` is the actual fix. The other non-test changes are for better error handling when an NULL pointer is encountered.