### PR TITLE
[WIPDon't make a runtime call on import

### DIFF
--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -1,7 +1,7 @@
 from llvmlite.llvmpy.core import Module, Type, Builder
 from numba.cuda.cudadrv.nvvm import (NVVM, CompilationUnit, llvm_to_ptx,
                                      set_cuda_kernel, fix_data_layout,
-                                     get_arch_option, SUPPORTED_CC)
+                                     get_arch_option, get_supported_ccs)
 from ctypes import c_size_t, c_uint64, sizeof
 from numba.cuda.testing import unittest
 from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError
@@ -54,7 +54,7 @@ class TestNvvmDriver(unittest.TestCase):
     def test_nvvm_support(self):
         """Test supported CC by NVVM
         """
-        for arch in SUPPORTED_CC:
+        for arch in get_supported_ccs():
             self._test_nvvm_support(arch=arch)
 
     @unittest.skipIf(True, "No new CC unknown to NVVM yet")
@@ -80,10 +80,11 @@ class TestArchOption(unittest.TestCase):
         self.assertEqual(get_arch_option(5, 1), 'compute_50')
         self.assertEqual(get_arch_option(3, 7), 'compute_35')
         # Test known arch.
-        for arch in SUPPORTED_CC:
+        supported_cc = get_supported_ccs()
+        for arch in supported_cc:
             self.assertEqual(get_arch_option(*arch), 'compute_%d%d' % arch)
         self.assertEqual(get_arch_option(1000, 0),
-                         'compute_%d%d' % SUPPORTED_CC[-1])
+                         'compute_%d%d' % supported_cc[-1])
 
 
 @skip_on_cudasim('NVVM Driver unsupported in the simulator')


### PR DESCRIPTION
Calling `runtime.get_version()` on import initializes the CUDA driver, even though it creates no context. This is an issue for libraries that import Numba then set `CUDA_VISIBLE_DEVICES`, because the call at import time already initialized the driver and fixed the set of visible devices. This is an issue for, but not limited to, the Dask Local CUDA Cluster.

This PR fixes this by deferring the call to `runtime.get_version()` until the list of supported CCs is actually needed.

cc @kkraus14 @pentschev @quasiben