### PR TITLE
Add pipeline_class argument to @cfunc as supported by @jit.

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -257,7 +257,7 @@ def njit(*args, **kws):
     return jit(*args, **kws)
 
 
-def cfunc(sig, locals={}, cache=False, **options):
+def cfunc(sig, locals={}, cache=False, pipeline_class=None, **options):
     """
     This decorator is used to compile a Python function into a C callback
     usable with foreign C libraries.
@@ -272,7 +272,10 @@ def cfunc(sig, locals={}, cache=False, **options):
 
     def wrapper(func):
         from numba.core.ccallback import CFunc
-        res = CFunc(func, sig, locals=locals, options=options)
+        additional_args = {}
+        if pipeline_class is not None:
+            additional_args['pipeline_class'] = pipeline_class
+        res = CFunc(func, sig, locals=locals, options=options, **additional_args)
         if cache:
             res.enable_caching()
         res.compile()

--- a/numba/tests/test_pipeline.py
+++ b/numba/tests/test_pipeline.py
@@ -3,7 +3,7 @@ from numba.core.compiler_machinery import (FunctionPass, AnalysisPass,
                                            register_pass)
 from numba.core.untyped_passes import InlineInlinables
 from numba.core.typed_passes import IRLegalization
-from numba import jit, generated_jit, objmode, njit
+from numba import jit, generated_jit, objmode, njit, cfunc
 from numba.core import types, postproc, errors
 from numba.core.ir import FunctionIR
 from numba.tests.support import TestCase
@@ -40,6 +40,17 @@ class TestCustomPipeline(TestCase):
         self.assertEqual(foo(4), 4)
         self.assertListEqual(self.pipeline_class.custom_pipeline_cache,
                              [foo.py_func])
+
+    def test_cfunc_custom_pipeline(self):
+        self.assertListEqual(self.pipeline_class.custom_pipeline_cache, [])
+
+        @cfunc(types.int64(types.int64), pipeline_class=self.pipeline_class)
+        def foo(x):
+            return x
+
+        self.assertEqual(foo(4), 4)
+        self.assertListEqual(self.pipeline_class.custom_pipeline_cache,
+                             [foo.__wrapped__])
 
     def test_generated_jit_custom_pipeline(self):
         self.assertListEqual(self.pipeline_class.custom_pipeline_cache, [])


### PR DESCRIPTION
This allows custom compiler pipelines to be used for cfuncs and makes the APIs consistent.

