### PR TITLE
Fix Issue #6167: Failure in test_cuda_submodules

### DIFF
--- a/numba/cuda/simulator/cudadrv/nvvm.py
+++ b/numba/cuda/simulator/cudadrv/nvvm.py
@@ -15,9 +15,11 @@ llvm_to_ptx = None
 set_cuda_kernel = None
 fix_data_layout = None
 get_arch_option = None
-SUPPORTED_CC = None
 LibDevice = None
 NvvmError = None
 
 def is_available():
     return False
+
+def get_supported_ccs():
+    return ()


### PR DESCRIPTION
PR #6147 broke the test_cuda_submodules test because the test_nvvm_driver test could no longer be imported - the change from `SUPPORTED_CC` to `get_supported_ccs` in nvvm.py was not reflected in the CUDA simulator.

This PR fixes the issue by changing `SUPPORTED_CC` to `get_supported_ccs` in the simulator.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
