### PR TITLE
Better error message on NotDefinedError

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -544,8 +544,8 @@ class NotDefinedError(IRError):
 
     def __init__(self, name, loc=None):
         self.name = name
-        msg = "The compiler failed to analyze the bytecode\n \
-               Variable '%s' is not defined." % name
+        msg = ("The compiler failed to analyze the bytecode. "
+               "Variable '%s' is not defined." % name)
         super(NotDefinedError, self).__init__(msg, loc=loc)
 
 

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -544,7 +544,8 @@ class NotDefinedError(IRError):
 
     def __init__(self, name, loc=None):
         self.name = name
-        msg = "The compiler failed to analyze the bytecode"
+        msg = "The compiler failed to analyze the bytecode\n \
+               Variable '%s' is not defined." % name
         super(NotDefinedError, self).__init__(msg, loc=loc)
 
 

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -544,7 +544,7 @@ class NotDefinedError(IRError):
 
     def __init__(self, name, loc=None):
         self.name = name
-        msg = "Variable '%s' is not defined." % name
+        msg = "The compiler failed to analyze the bytecode"
         super(NotDefinedError, self).__init__(msg, loc=loc)
 
 


### PR DESCRIPTION
I started working on this because of #6163 , which mentions #6142 .

The only change I made is in the message that is passed to the constructor in the erros.py file.
```python
msg = "The compiler failed to analyze the bytecode"
```
If I understood it correctly that's where it should be but this is my first contribution here, if it's incorrect  maybe someone can give a hint on where I should do this work because I didn't find the exact place where I'd catch this error specifically with the "with...as" statements.

Thanks in advance