### PR TITLE
Do not try to terminate TBB if fork was called not from main thread

### DIFF
--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -163,6 +163,13 @@ system level libraries, some additional things to note:
   program that is using the ``omp`` threading layer, a detection mechanism is
   present that will try and gracefully terminate the forked child and print an
   error message to ``STDERR``.
+* On systems with the ``fork(2)`` system call available, if the TBB backed
+  threading layer is in use and a ``fork`` call is made from a thread other than
+  the thread that launched TBB (typically the main thread) then this results in
+  undefined behaviour and a warning will be displayed on ``STDERR``. As
+  ``spawn`` is essentially ``fork`` followed by ``exec`` it is safe to ``spawn``
+  from a non-main thread, but as this cannot be differentiated from just a
+  ``fork`` call the warning message will still be displayed.
 * On OSX, the ``intel-openmp`` package is required to enable the OpenMP based
   threading layer.
 

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -236,9 +236,11 @@ static void prepare_fork(void)
             tbb::set_assertion_handler(orig);
             need_reinit_after_fork = true;
         }
-        else if (_DEBUG)
+        else
         {
-            puts("NUMBA: Attempt to fork from non-main thread, TBB may be in incorrect state in child processes");
+            fprintf(stderr, "Numba: Attempted to fork from a non-main thread, "
+                            "the TBB library may be in an invalid state in the "
+                            "child process.");
         }
     }
 }

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -15,6 +15,7 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #include <tbb/tbb.h>
 #include <string.h>
 #include <stdio.h>
+#include <thread>
 #include "workqueue.h"
 
 #include "gufunc_scheduler.h"
@@ -29,9 +30,6 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #if TBB_INTERFACE_VERSION < 11006
 #error "TBB version is too old, 2019 update 5, i.e. TBB_INTERFACE_VERSION >= 11005 required"
 #endif
-
-#define TSI_INIT(count) tbb::task_scheduler_init(count)
-#define TSI_TERMINATE(tsi) tsi->blocking_terminate(std::nothrow)
 
 #define _DEBUG 0
 #define _TRACE_SPLIT 0
@@ -202,12 +200,25 @@ parallel_for(void *fn, char **args, size_t *dimensions, size_t *steps, void *dat
     });
 }
 
-void ignore_blocking_terminate_assertion( const char*, int, const char*, const char * )
+static std::thread::id init_thread_id;
+static THREAD_LOCAL(bool) need_reinit_after_fork = false;
+
+static void set_main_thread()
+{
+    init_thread_id = std::this_thread::get_id();
+}
+
+static bool is_main_thread()
+{
+    return std::this_thread::get_id() == init_thread_id;
+}
+
+static void ignore_blocking_terminate_assertion( const char*, int, const char*, const char * )
 {
     tbb::internal::runtime_warning("Unable to wait for threads to shut down before fork(). It can break multithreading in child process\n");
 }
 
-void ignore_assertion( const char*, int, const char*, const char * ) {}
+static void ignore_assertion( const char*, int, const char*, const char * ) {}
 
 static void prepare_fork(void)
 {
@@ -217,9 +228,18 @@ static void prepare_fork(void)
     }
     if(tsi)
     {
-        assertion_handler_type orig = tbb::set_assertion_handler(ignore_blocking_terminate_assertion);
-        TSI_TERMINATE(tsi);
-        tbb::set_assertion_handler(orig);
+        if(is_main_thread())
+        {
+            // TBB thread termination must always be called from same thread that called initialize
+            assertion_handler_type orig = tbb::set_assertion_handler(ignore_blocking_terminate_assertion);
+            tsi->blocking_terminate(std::nothrow);
+            tbb::set_assertion_handler(orig);
+            need_reinit_after_fork = true;
+        }
+        else if (_DEBUG)
+        {
+            puts("NUMBA: Attempt to fork from non-main thread, TBB may be in incorrect state in child processes");
+        }
     }
 }
 
@@ -229,8 +249,12 @@ static void reset_after_fork(void)
     {
         puts("Resuming TBB: after fork");
     }
-    if(tsi)
+    if(tsi && need_reinit_after_fork)
+    {
         tsi->initialize(tsi_count);
+        set_main_thread();
+        need_reinit_after_fork = false;
+    }
 }
 
 #if PY_MAJOR_VERSION >= 3
@@ -262,11 +286,14 @@ static void launch_threads(int count)
         puts("Using TBB");
     if(count < 1)
         count = tbb::task_scheduler_init::automatic;
-    tsi = new TSI_INIT(tsi_count = count);
+    tsi_count = count;
+    tsi = new tbb::task_scheduler_init(count);
     tg = new tbb::task_group;
     tg->run([] {}); // start creating threads asynchronously
 
     _INIT_NUM_THREADS = count;
+
+    set_main_thread();
 
 #ifndef _MSC_VER
     pthread_atfork(prepare_fork, reset_after_fork, reset_after_fork);

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -240,7 +240,7 @@ static void prepare_fork(void)
         {
             fprintf(stderr, "Numba: Attempted to fork from a non-main thread, "
                             "the TBB library may be in an invalid state in the "
-                            "child process.");
+                            "child process.\n");
         }
     }
 }

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -873,7 +873,7 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
             from numba import njit, prange, objmode
             import os
 
-            def runner(e_running, e_proceed):
+            def runner():
                 @njit(parallel=True, nogil=True)
                 def work():
                     acc = 0
@@ -887,7 +887,7 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
                     return acc
                 work()
 
-            def forker(e_running, e_proceed):
+            def forker():
                 # wait for the jit function to say it's running
                 while not e_running.isSet():
                     pass
@@ -898,10 +898,8 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
 
             e_running = threading.Event()
             e_proceed = threading.Event()
-            numba_runner = threading.Thread(target=runner,
-                                            args=(e_running, e_proceed,))
-            fork_runner =  threading.Thread(target=forker,
-                                            args=(e_running, e_proceed,))
+            numba_runner = threading.Thread(target=runner,)
+            fork_runner =  threading.Thread(target=forker,)
 
             threads = (numba_runner, fork_runner)
             for t in threads:

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -863,6 +863,7 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
 
     _DEBUG = False
 
+    @linux_only # os.fork required.
     def test_fork_from_non_main_thread(self):
         # See issue #5973 and PR #6208 for context.
         runme = """if 1:


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This is an attempt to fix #5973

TBB termination routines must always be called from same thread TBB was initialized.
But `python.multiprocessing` creates separate thread to manage its child processes.
Also `multiprocessing` can use either `fork` or `spawn`  strategies, but internally `spawn` is just `fork` + `exec` and there is no way to separate these 2 cases from `pthread_atfork` perspective.

Only fork from main thread is 'safe' and do TBB finalization/init only from main thread. Child processes forked from other threads can have TBB in invalid state, but they won't crash if user won't use TBB there. And this is better than immediately crashing parent process on fork from 'wrong' thread.

This is not ideal, but I don't see better solution yet.

CC @stuartarchibald 
