### PR TITLE
Fix #6177. Remove AOT dependency on the Numba package

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -978,7 +978,7 @@ numba_do_raise(PyObject *exc_packed)
     return status;
 }
 
-#ifdef NUMBA_COMPILING_AOT
+#ifdef PYCC_COMPILING
 /* AOT avoid the use of `numba.core.serialize` */
 NUMBA_EXPORT_FUNC(PyObject *)
 numba_unpickle(const char *data, int n, const char *hashed)

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -978,6 +978,35 @@ numba_do_raise(PyObject *exc_packed)
     return status;
 }
 
+#ifdef NUMBA_COMPILING_AOT
+/* AOT avoid the use of `numba.core.serialize` */
+NUMBA_EXPORT_FUNC(PyObject *)
+numba_unpickle(const char *data, int n, const char *hashed)
+{
+    PyObject *buf, *obj;
+    static PyObject *loads;
+
+    /* Caching the pickle.loads function shaves a couple µs here. */
+    if (loads == NULL) {
+        PyObject *picklemod;
+        picklemod = PyImport_ImportModule("pickle");
+        if (picklemod == NULL)
+            return NULL;
+        loads = PyObject_GetAttrString(picklemod, "loads");
+        Py_DECREF(picklemod);
+        if (loads == NULL)
+            return NULL;
+    }
+
+    buf = PyBytes_FromStringAndSize(data, n);
+    if (buf == NULL)
+        return NULL;
+    obj = PyObject_CallFunctionObjArgs(loads, buf, NULL);
+    Py_DECREF(buf);
+    return obj;
+}
+
+#else
 
 NUMBA_EXPORT_FUNC(PyObject *)
 numba_unpickle(const char *data, int n, const char *hashed)
@@ -1014,6 +1043,7 @@ error:
     Py_DECREF(buf);
     return obj;
 }
+#endif
 
 /*
  * Unicode helpers

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -13,6 +13,8 @@
 #define NUMBA_EXPORT_FUNC(_rettype) VISIBILITY_HIDDEN _rettype
 #define NUMBA_EXPORT_DATA(_vartype) VISIBILITY_HIDDEN _vartype
 
+#define NUMBA_COMPILING_AOT
+
 #include "../_helperlib.c"
 #include "../_dynfunc.c"
 

--- a/numba/pycc/modulemixin.c
+++ b/numba/pycc/modulemixin.c
@@ -13,7 +13,7 @@
 #define NUMBA_EXPORT_FUNC(_rettype) VISIBILITY_HIDDEN _rettype
 #define NUMBA_EXPORT_DATA(_vartype) VISIBILITY_HIDDEN _vartype
 
-#define NUMBA_COMPILING_AOT
+#define PYCC_COMPILING
 
 #include "../_helperlib.c"
 #include "../_dynfunc.c"

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -182,6 +182,10 @@ class TestCC(BasePYCCTest):
     def check_cc_compiled_in_subprocess(self, lib, code):
         prolog = """if 1:
             import sys
+            import types
+            # to disable numba package
+            sys.modules['numba'] = types.ModuleType('numba')
+
             sys.path.insert(0, %(path)r)
             import %(name)s as lib
             """ % {'name': lib.__name__,

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -185,6 +185,12 @@ class TestCC(BasePYCCTest):
             import types
             # to disable numba package
             sys.modules['numba'] = types.ModuleType('numba')
+            try:
+                from numba import njit
+            except ImportError:
+                pass
+            else:
+                raise RuntimeError('cannot disable numba package')
 
             sys.path.insert(0, %(path)r)
             import %(name)s as lib


### PR DESCRIPTION
Fix #6177 

- Re-add old `numba_unpickle()` implementation that does not depend on the `numba` package.
- Use `NUMBA_COMPILING_AOT` macro to control which implementation to use.
- existing AOT tests are modified to disable the `numba` package.