### PR TITLE
Add support for tuple concatenation to array analysis. (#5396 continued)

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2056,7 +2056,7 @@ class ArrayAnalysis(object):
 
     def _analyze_op_arrayexpr(self, scope, equiv_set, expr):
         return self._analyze_broadcast(
-            scope, equiv_set, expr.loc, expr.list_vars(), expr.fn
+            scope, equiv_set, expr.loc, expr.list_vars(), None
         )
 
     def _analyze_op_build_tuple(self, scope, equiv_set, expr):

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2813,10 +2813,10 @@ class ArrayAnalysis(object):
                 shapes = [equiv_set.get_shape(x) for x in tups]
                 concat_shapes = sum(shapes, ())
                 return (concat_shapes, [])
-            # else arrays
             except errors.GuardException:
                 return None
 
+        # else arrays
         arrs = list(filter(lambda a: self._isarray(a.name), args))
         require(len(arrs) > 0)
         names = [x.name for x in arrs]

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2824,7 +2824,7 @@ class ArrayAnalysis(object):
                     return None
                 concat_shapes = sum(shapes, ())
                 return (concat_shapes, [])
-            except errors.GuardException:
+            except GuardException:
                 return None
 
         # else arrays

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2113,7 +2113,8 @@ class ArrayAnalysis(object):
             ".", "_"
         )
         if fname in UFUNC_MAP_OP:  # known numpy ufuncs
-            return self._analyze_broadcast(scope, equiv_set, expr.loc, args, None)
+            return self._analyze_broadcast(scope, equiv_set,
+                                           expr.loc, args, None)
         else:
             try:
                 fn = getattr(self, fname)

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2031,8 +2031,12 @@ class ArrayAnalysis(object):
                 expr.index_var = result[0]
             return result[1]
         shape = equiv_set._get_shape(var)
-        require(isinstance(expr.index, int) and expr.index < len(shape))
-        return shape[expr.index], []
+        if isinstance(expr.index, int):
+            require(expr.index < len(shape))
+            return shape[expr.index], []
+        elif isinstance(expr.index, slice):
+            return shape[expr.index], []
+        require(False)
 
     def _analyze_op_unary(self, scope, equiv_set, expr):
         require(expr.fn in UNARY_MAP_OP)
@@ -3004,7 +3008,7 @@ class ArrayAnalysis(object):
 
     def _istuple(self, varname):
         typ = self.typemap[varname]
-        return isinstance(typ, types.UniTuple)
+        return isinstance(typ, types.BaseTuple)
 
     def _sum_size(self, equiv_set, sizes):
         """Return the sum of the given list of sizes if they are all equivalent

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1568,6 +1568,22 @@ class TestParfors(TestParforsBase):
                                      types.Array(types.float64, 1, 'C'))) == 1)
 
     @skip_parfors_unsupported
+    def test_tuple_concat(self):
+        # issue5383
+        def test_impl(a):
+            n = len(a)
+            array_shape = n, n
+            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
+            k_list = indices[0, :]
+
+            for i, g in enumerate(a):
+                k_list[i, i] = i
+            return k_list
+
+        x = np.array([1, 1])
+        self.check(test_impl, x)
+
+    @skip_parfors_unsupported
     def test_tuple1(self):
         def test_impl(a):
             atup = (3, 4)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1643,10 +1643,11 @@ class TestParfors(TestParforsBase):
 
     @skip_parfors_unsupported
     def test_tuple_concat(self):
+        # issue5383
         def test_impl(a):
             n = len(a)
             array_shape = n, n
-            indices = np.zeros((1,) + array_shape, dtype=np.uint64)
+            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
             k_list = indices[0, :]
 
             for i, g in enumerate(a):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1568,22 +1568,6 @@ class TestParfors(TestParforsBase):
                                      types.Array(types.float64, 1, 'C'))) == 1)
 
     @skip_parfors_unsupported
-    def test_tuple_concat(self):
-        # issue5383
-        def test_impl(a):
-            n = len(a)
-            array_shape = n, n
-            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
-            k_list = indices[0, :]
-
-            for i, g in enumerate(a):
-                k_list[i, i] = i
-            return k_list
-
-        x = np.array([1, 1])
-        self.check(test_impl, x)
-
-    @skip_parfors_unsupported
     def test_tuple1(self):
         def test_impl(a):
             atup = (3, 4)
@@ -1663,7 +1647,24 @@ class TestParfors(TestParforsBase):
         def test_impl(a):
             n = len(a)
             array_shape = n, n
-            indices = np.zeros(((1,) + array_shape + (1,))[:-1], dtype=np.uint64)
+            indices = np.zeros(((1,) + array_shape + (1,)), dtype=np.uint64)
+            k_list = indices[0, :]
+
+            for i, g in enumerate(a):
+                k_list[i, i] = i
+            return k_list
+
+        x = np.array([1, 1])
+        self.check(test_impl, x)
+
+    @skip_parfors_unsupported
+    def test_tuple_concat_with_reverse_slice(self):
+        # issue5383
+        def test_impl(a):
+            n = len(a)
+            array_shape = n, n
+            indices = np.zeros(((1,) + array_shape + (1,))[:-1],
+                               dtype=np.uint64)
             k_list = indices[0, :]
 
             for i, g in enumerate(a):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1641,6 +1641,22 @@ class TestParfors(TestParforsBase):
                                     (types.Array(types.float64, 1, 'C'),
                                      types.Array(types.float64, 1, 'C'))) == 1)
 
+    @skip_parfors_unsupported
+    def test_tuple_concat(self):
+        def test_impl(a):
+            n = len(a)
+            array_shape = n, n
+            indices = np.zeros((1,) + array_shape, dtype=np.uint64)
+            k_list = indices[0, :]
+
+            for i, g in enumerate(a):
+                k_list[i, i] = i
+            return k_list
+
+        x = np.array([1, 1])
+        self.check(test_impl, x)
+
+
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):
     def check(self, pyfunc, *args, **kwargs):
         cfunc, cpfunc = self.compile_all(pyfunc, *args)


### PR DESCRIPTION
This pulls the patch series for fixing #5383 from https://github.com/numba/numba/pull/5396 and rebases on mainline.

CC @DrTodd13 please could you take a look and make sure that this is what you intended in #5396, thanks.