### PR TITLE
Raise exception when no supported architectures are found

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -320,6 +320,11 @@ def find_closest_arch(mycc):
     """
     supported_cc = get_supported_ccs()
 
+    if not supported_cc:
+        msg = "No supported GPU compute capabilities found. " \
+              "Please check your cudatoolkit version matches your CUDA version."
+        raise NvvmSupportError(msg)
+
     for i, cc in enumerate(supported_cc):
         if cc == mycc:
             # Matches

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -293,7 +293,7 @@ def get_supported_ccs():
 
     # List of supported compute capability in sorted order
     if cudart_version_major == 0:
-        _supported_cc = (),
+        _supported_cc = ()
     elif cudart_version_major < 9:
         # CUDA 8.x
         _supported_cc = (2, 0), (2, 1), (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2) # noqa: E501


### PR DESCRIPTION
Fixes #6223.

When there is a `cudatoolkit` version mismatch `get_supported_ccs()` will return `(())`. This PR adds a boolean check and raises a `NvvmSupportError` if there are no supported versions in the list.