### PR TITLE
Add support for CUDA atomic subtract operations

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -177,10 +177,10 @@ Synchronization and Atomic Operations
 
 .. function:: numba.cuda.atomic.sub(array, idx, value)
 
-    Perform ``array[idx] -= value``. Support int32, int64, float32 and
+    Perform ``array[idx] -= value``. Supports int32, int64, float32 and
     float64 only. The ``idx`` argument can be an integer or a tuple of integer
-    indices for indexing into multiple dimensional arrays. The number of element
-    in ``idx`` must match the number of dimension of ``array``.
+    indices for indexing into multi-dimensional arrays. The number of elements
+    in ``idx`` must match the number of dimensions of ``array``.
 
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -175,6 +175,16 @@ Synchronization and Atomic Operations
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.
 
+.. function:: numba.cuda.atomic.sub(array, idx, value)
+
+    Perform ``array[idx] -= value``. Support int32, int64, float32 and
+    float64 only. The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multiple dimensional arrays. The number of element
+    in ``idx`` must match the number of dimension of ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
 .. function:: numba.cuda.atomic.max(array, idx, value)
 
     Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -283,6 +283,18 @@ class Cuda_atomic_add(AbstractTemplate):
         elif ary.ndim > 1:
             return signature(ary.dtype, ary, idx, ary.dtype)
 
+@register
+class Cuda_atomic_sub(AbstractTemplate):
+    key = cuda.atomic.sub
+
+    def generic(self, args, kws):
+        assert not kws
+        ary, idx, val = args
+
+        if ary.ndim == 1:
+            return signature(ary.dtype, ary, types.intp, ary.dtype)
+        elif ary.ndim > 1:
+            return signature(ary.dtype, ary, idx, ary.dtype)
 
 class Cuda_atomic_maxmin(AbstractTemplate):
     def generic(self, args, kws):
@@ -380,6 +392,9 @@ class CudaAtomicTemplate(AttributeTemplate):
 
     def resolve_add(self, mod):
         return types.Function(Cuda_atomic_add)
+
+    def resolve_sub(self, mod):
+        return types.Function(Cuda_atomic_sub)
 
     def resolve_max(self, mod):
         return types.Function(Cuda_atomic_max)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -510,7 +510,7 @@ def llvm_to_ptx(llvmir, **opts):
     replacements = [
         ('declare i32 @___numba_cas_hack(i32*, i32, i32)',
          ir_numba_cas_hack),
-        ('declare doubleQ @___numba_atomic_double_add(double*, double)',
+        ('declare double @___numba_atomic_double_add(double*, double)',
          ir_numba_atomic_double_add),
         ('declare float @___numba_atomic_float_sub(float*, float)',
          ir_numba_atomic_binary.format(T='float', Ti='i32', OP='fsub',

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -549,6 +549,23 @@ def ptx_atomic_add_tuple(context, builder, dtype, ptr, val):
         return builder.atomic_rmw('add', ptr, val, 'monotonic')
 
 
+@lower(stubs.atomic.sub, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.sub, types.Array, types.UniTuple, types.Any)
+@lower(stubs.atomic.sub, types.Array, types.Tuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_sub_tuple(context, builder, dtype, ptr, val):
+    if dtype == types.float32:
+        lmod = builder.module
+        return builder.call(nvvmutils.declare_atomic_sub_float32(lmod),
+                            (ptr, val))
+    elif dtype == types.float64:
+        lmod = builder.module
+        return builder.call(nvvmutils.declare_atomic_sub_float64(lmod),
+                            (ptr, val))
+    else:
+        return builder.atomic_rmw('sub', ptr, val, 'monotonic')
+
+
 @lower(stubs.atomic.max, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.max, types.Array, types.Tuple, types.Any)
 @lower(stubs.atomic.max, types.Array, types.UniTuple, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -553,7 +553,7 @@ def ptx_atomic_add_tuple(context, builder, dtype, ptr, val):
 @lower(stubs.atomic.sub, types.Array, types.UniTuple, types.Any)
 @lower(stubs.atomic.sub, types.Array, types.Tuple, types.Any)
 @_atomic_dispatcher
-def ptx_atomic_sub_tuple(context, builder, dtype, ptr, val):
+def ptx_atomic_sub(context, builder, dtype, ptr, val):
     if dtype == types.float32:
         lmod = builder.module
         return builder.call(nvvmutils.declare_atomic_sub_float32(lmod),

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -33,6 +33,17 @@ def declare_atomic_add_float64(lmod):
         (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
     return lmod.get_or_insert_function(fnty, fname)
 
+def declare_atomic_sub_float32(lmod):
+    fname = '___numba_atomic_float_sub'
+    fnty = lc.Type.function(lc.Type.float(),
+        (lc.Type.pointer(lc.Type.float(), 0), lc.Type.float()))
+    return lmod.get_or_insert_function(fnty, name=fname)
+
+def declare_atomic_sub_float64(lmod):
+    fname = '___numba_atomic_double_sub'
+    fnty = lc.Type.function(lc.Type.double(),
+        (lc.Type.pointer(lc.Type.double()), lc.Type.double()))
+    return lmod.get_or_insert_function(fnty, fname)
 
 def declare_atomic_max_float32(lmod):
     fname = '___numba_atomic_float_max'

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -36,7 +36,7 @@ def declare_atomic_add_float64(lmod):
 def declare_atomic_sub_float32(lmod):
     fname = '___numba_atomic_float_sub'
     fnty = lc.Type.function(lc.Type.float(),
-        (lc.Type.pointer(lc.Type.float(), 0), lc.Type.float()))
+        (lc.Type.pointer(lc.Type.float()), lc.Type.float()))
     return lmod.get_or_insert_function(fnty, name=fname)
 
 def declare_atomic_sub_float64(lmod):

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -97,6 +97,7 @@ class FakeCUDAShared(object):
         return res
 
 addlock = threading.Lock()
+sublock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
 caslock = threading.Lock()
@@ -107,6 +108,12 @@ class FakeCUDAAtomic(object):
         with addlock:
             old = array[index]
             array[index] += val
+        return old
+
+    def sub(self, array, index, val):
+        with sublock:
+            old = array[index]
+            array[index] -= val
         return old
 
     def max(self, array, index, val):

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -390,6 +390,16 @@ class atomic(Stub):
         atomically.
         """
 
+    class sub(Stub):
+        """sub(ary, idx, val)
+
+        Perform atomic ary[idx] -= val. Supported on int32, float32, and
+        float64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
     class max(Stub):
         """max(ary, idx, val)
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -137,6 +137,113 @@ def atomic_add_double_3(ary):
     cuda.syncthreads()
     ary[tx, ty] = sm[tx, ty]
 
+def atomic_sub(ary):
+    tid = cuda.threadIdx.x
+    sm = cuda.shared.array(32, uint32)
+    sm[tid] = 0
+    cuda.syncthreads()
+    bin = ary[tid] % 32
+    cuda.atomic.sub(sm, bin, 1)
+    cuda.syncthreads()
+    ary[tid] = sm[tid]
+
+
+def atomic_sub2(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), uint32)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, ty), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+
+def atomic_sub3(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), uint32)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, uint64(ty)), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+def atomic_sub_float(ary):
+    tid = cuda.threadIdx.x
+    sm = cuda.shared.array(32, float32)
+    sm[tid] = 0
+    cuda.syncthreads()
+    bin = int(ary[tid] % 32)
+    cuda.atomic.sub(sm, bin, 1.0)
+    cuda.syncthreads()
+    ary[tid] = sm[tid]
+
+def atomic_sub_float_2(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), float32)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, ty), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+def atomic_sub_float_3(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), float32)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, uint64(ty)), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+def atomic_sub_double(idx, ary):
+    tid = cuda.threadIdx.x
+    sm = cuda.shared.array(32, float64)
+    sm[tid] = 0.0
+    cuda.syncthreads()
+    bin = idx[tid] % 32
+    cuda.atomic.sub(sm, bin, 1.0)
+    cuda.syncthreads()
+    ary[tid] = sm[tid]
+
+def atomic_sub_double_2(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), float64)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, ty), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+def atomic_sub_double_3(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    sm = cuda.shared.array((4, 8), float64)
+    sm[tx, ty] = ary[tx, ty]
+    cuda.syncthreads()
+    cuda.atomic.sub(sm, (tx, uint64(ty)), 1)
+    cuda.syncthreads()
+    ary[tx, ty] = sm[tx, ty]
+
+def atomic_sub_double_global(idx, ary):
+    tid = cuda.threadIdx.x
+    bin = idx[tid] % 32
+    cuda.atomic.sub(ary, bin, 1.0)
+
+def atomic_sub_double_global_2(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    cuda.atomic.sub(ary, (tx, ty), 1)
+
+def atomic_sub_double_global_3(ary):
+    tx = cuda.threadIdx.x
+    ty = cuda.threadIdx.y
+    cuda.atomic.sub(ary, (tx, uint64(ty)), 1)
+
 def gen_atomic_extreme_funcs(func):
 
     fns = dedent(
@@ -323,6 +430,110 @@ class TestCudaAtomics(CUDATestCase):
 
         np.testing.assert_equal(ary, orig + 1)
         self.assertCorrectFloat64Atomics(cuda_func, shared=False)
+
+    def test_atomic_sub(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32)
+        orig = ary.copy()
+        cuda_atomic_sub = cuda.jit('void(uint32[:])')(atomic_sub)
+        cuda_atomic_sub[1, 32](ary)
+
+        gold = np.zeros(32, dtype=np.uint32)
+        for i in range(orig.size):
+            gold[orig[i]] -= 1
+
+        self.assertTrue(np.all(ary == gold))
+
+    def test_atomic_sub2(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_sub2 = cuda.jit('void(uint32[:,:])')(atomic_sub2)
+        cuda_atomic_sub2[1, (4, 8)](ary)
+        self.assertTrue(np.all(ary == orig - 1))
+
+    def test_atomic_sub3(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_sub3 = cuda.jit('void(uint32[:,:])')(atomic_sub3)
+        cuda_atomic_sub3[1, (4, 8)](ary)
+        self.assertTrue(np.all(ary == orig - 1))
+
+    def test_atomic_sub_float(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float32)
+        orig = ary.copy().astype(np.intp)
+        cuda_atomic_sub_float = cuda.jit('void(float32[:])')(atomic_sub_float)
+        cuda_atomic_sub_float[1, 32](ary)
+
+        gold = np.zeros(32, dtype=np.float32)
+        for i in range(orig.size):
+            gold[orig[i]] -= 1.0
+
+        self.assertTrue(np.all(ary == gold))
+
+    def test_atomic_sub_float_2(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_sub2 = cuda.jit('void(float32[:,:])')(atomic_sub_float_2)
+        cuda_atomic_sub2[1, (4, 8)](ary)
+        self.assertTrue(np.all(ary == orig - 1))
+
+    def test_atomic_sub_float_3(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_sub3 = cuda.jit('void(float32[:,:])')(atomic_sub_float_3)
+        cuda_atomic_sub3[1, (4, 8)](ary)
+        self.assertTrue(np.all(ary == orig - 1))
+
+    def test_atomic_sub_double(self):
+        idx = np.random.randint(0, 32, size=32, dtype=np.int64)
+        ary = np.zeros(32, np.float64)
+        cuda_func = cuda.jit('void(int64[:], float64[:])')(atomic_sub_double)
+        cuda_func[1, 32](idx, ary)
+
+        gold = np.zeros(32, dtype=np.float64)
+        for i in range(idx.size):
+            gold[idx[i]] -= 1.0
+
+        np.testing.assert_equal(ary, gold)
+
+    def test_atomic_sub_double_2(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float64).reshape(4, 8)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(float64[:,:])')(atomic_sub_double_2)
+        cuda_func[1, (4, 8)](ary)
+        np.testing.assert_equal(ary, orig - 1)
+
+    def test_atomic_sub_double_3(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float64).reshape(4, 8)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(float64[:,:])')(atomic_sub_double_3)
+        cuda_func[1, (4, 8)](ary)
+        np.testing.assert_equal(ary, orig - 1)
+
+    def test_atomic_sub_double_global(self):
+        idx = np.random.randint(0, 32, size=32, dtype=np.int64)
+        ary = np.zeros(32, np.float64)
+        cuda_func = cuda.jit('void(int64[:], float64[:])')(atomic_sub_double_global)
+        cuda_func[1, 32](idx, ary)
+
+        gold = np.zeros(32, dtype=np.float64)
+        for i in range(idx.size):
+            gold[idx[i]] -= 1.0
+
+        np.testing.assert_equal(ary, gold)
+
+    def test_atomic_sub_double_global_2(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float64).reshape(4, 8)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(float64[:,:])')(atomic_sub_double_global_2)
+        cuda_func[1, (4, 8)](ary)
+        np.testing.assert_equal(ary, orig - 1)
+
+    def test_atomic_sub_double_global_3(self):
+        ary = np.random.randint(0, 32, size=32).astype(np.float64).reshape(4, 8)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(float64[:,:])')(atomic_sub_double_global_3)
+        cuda_func[1, (4, 8)](ary)
+        np.testing.assert_equal(ary, orig - 1)
 
     def check_atomic_max(self, dtype, lo, hi):
         vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)


### PR DESCRIPTION
This pull request adds support for CUDA atomic subtract.

1. Adds support for atomic subtract
2. Adds units tests for integer, float32 and float64
3. Adds documentation for atomic subtract.