### PR TITLE
speed up a couple of really slow unittests

### DIFF
--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2609,8 +2609,9 @@ class TestBasics(TestLinalgSystems):  # TestLinalgSystems for 1d test
             with self.assertNoNRTLeak():
                 cfunc(a, b, **kwargs)
 
-        for size1, size2, dtype in \
-                product(self.sizes, self.sizes, self.dtypes):
+        dts = cycle(self.dtypes)
+        for size1, size2 in product(self.sizes, self.sizes):
+            dtype = next(dts)
             (a, b) = self._get_input(size1, size2, dtype)
             check(a, b)
             c = np.empty((np.asarray(a).size, np.asarray(b).size),

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -503,8 +503,8 @@ class TestUnicode(BaseTest):
             self.assertEqual(pyfunc(s), cfunc(s), msg=msg.format(s))
 
     def test_expandtabs_with_tabsize(self):
-        pyfuncs = [expandtabs_with_tabsize_usecase,
-                   expandtabs_with_tabsize_kwarg_usecase]
+        fns = [njit(expandtabs_with_tabsize_usecase),
+               njit(expandtabs_with_tabsize_kwarg_usecase)]
         messages = ['Results of "{}".expandtabs({}) must be equal',
                     'Results of "{}".expandtabs(tabsize={}) must be equal']
 
@@ -513,9 +513,8 @@ class TestUnicode(BaseTest):
 
         for s in cases:
             for tabsize in range(-1, 10):
-                for pyfunc, msg in zip(pyfuncs, messages):
-                    cfunc = njit(pyfunc)
-                    self.assertEqual(pyfunc(s, tabsize), cfunc(s, tabsize),
+                for fn, msg in zip(fns, messages):
+                    self.assertEqual(fn.py_func(s, tabsize), fn(s, tabsize),
                                      msg=msg.format(s, tabsize))
 
     def test_expandtabs_exception_noninteger_tabsize(self):


### PR DESCRIPTION
Speeds up two of the worst offending slow unit tests.

* `numba.tests.test_linalg.TestBasics.test_outer`: 147s -> 82s
* `numba.tests.test_unicode.TestUnicode.test_expandtabs_with_tabsize`: 49.5s -> 2.39s

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
