### PR TITLE
Prevent cache busting by the UUID of Dispatcher

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -691,6 +691,25 @@ class Cache(_Cache):
             # No such conditions under non-Windows OSes
             yield
 
+    def _get_dependencies(self, cvar):
+        deps = [cvar]
+        if hasattr(cvar, 'py_func'):
+            # TODO: does the cache key need to depend on any other
+            # attributes of the Dispatcher?
+            closure = cvar.py_func.__closure__
+            deps = [cvar.py_func.__code__.co_code]
+        elif hasattr(cvar, '__closure__'):
+            closure = cvar.__closure__
+            # if cvar is a function and closes over a Dispatcher, the
+            # cache will be busted because of the uuid that is regenerated
+            deps = [cvar.__code__.co_code]
+        else:
+            closure = None
+        if closure is not None:
+            for x in closure:
+                deps.extend(self._get_dependencies(x.cell_contents))
+        return deps
+
     def _index_key(self, sig, codegen):
         """
         Compute index key for the given signature and codegen.
@@ -699,8 +718,8 @@ class Cache(_Cache):
         a hash of the cell_contents.
         """
         codebytes = self._py_func.__code__.co_code
-        if self._py_func.__closure__ is not None:
-            cvars = tuple([x.cell_contents for x in self._py_func.__closure__])
+        cvars = self._get_dependencies(self._py_func)
+        if len(cvars) > 0:
             cvarbytes = dumps(cvars)
         else:
             cvarbytes = b''

--- a/numba/tests/cache_usecases.py
+++ b/numba/tests/cache_usecases.py
@@ -99,17 +99,17 @@ def ambiguous_function(x):
 renamed_function2 = ambiguous_function
 
 
-def make_closure(x):
+def make_closure(x, f):
     @jit(cache=True, nopython=True)
     def closure(y):
-        return x + y
+        return x + f(y)
 
     return closure
 
-closure1 = make_closure(3)
-closure2 = make_closure(5)
-closure3 = make_closure(7)
-closure4 = make_closure(9)
+closure1 = make_closure(3, simple_usecase)
+closure2 = make_closure(5, simple_usecase)
+closure3 = make_closure(7, simple_usecase)
+closure4 = make_closure(9, simple_usecase)
 
 
 biggie = np.arange(10**6)

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1264,7 +1264,7 @@ class TestCache(BaseCacheUsecasesTest):
             self.assertPreciseEqual(f(3), 10) # 3 + 7 = 8
             f = mod.closure4
             self.assertPreciseEqual(f(3), 12) # 3 + 9 = 12
-            self.check_pycache(5) # 1 nbi, 4 nbc
+            self.check_pycache(7) # 2 nbi (make_closure + simple_usecase), 5 nbc
 
     def test_cache_reuse(self):
         mod = self.import_module()


### PR DESCRIPTION
First steps towards fixing #6264.

This PR changes the cache key to explicitly include the bytecode of python functions captured in closures, and also their transitive dependencies. Before, the whole `Dispatcher` object was pickled and included in the key, which changes for each "run" (i.e. each time a new python interpreter is started) because of the UUID.

I'm not sure if this is enough, or if other attributes of the `Dispatcher` objects also need to be included in the key.

As @sklam noted in the issue, the referenced functions may also need to be cached (except if they are inlined?), but I'm not sure what the best approach would be, or if the user should be required to explicitly mark them to be cached.

Please let me know if this goes into the right direction, thanks!

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
