### PR TITLE
Un-skip tests that were skipped because of #4026.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -81,10 +81,10 @@ _is_armv7l = platform.machine() == 'armv7l'
 
 disabled_test = unittest.skipIf(True, 'Test disabled')
 
-# See issue #4026, PPC64LE LLVM bug
-skip_ppc64le_issue4026 = unittest.skipIf(platform.machine() == 'ppc64le',
-                                         ("Hits: 'LLVM Invalid PPC CTR Loop! "
-                                          "UNREACHABLE executed' bug"))
+# See issue #4563, PPC64LE LLVM bug
+skip_ppc64le_issue4563 = unittest.skipIf(platform.machine() == 'ppc64le',
+                                         ("Hits: 'Parameter area must exist "
+                                          "to pass an argument in memory'"))
 
 try:
     import scipy.linalg.cython_lapack

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -11,7 +11,7 @@ import numpy as np
 from numba import jit, njit, typeof
 from numba.core import errors
 from numba.tests.support import (TestCase, tag, needs_lapack, needs_blas,
-                                 _is_armv7l, skip_ppc64le_issue4026)
+                                 _is_armv7l)
 from .matmul_usecase import matmul_usecase
 import unittest
 
@@ -797,7 +797,6 @@ class TestLinalgInv(TestLinalgBase):
         np.testing.assert_allclose(expected, got)
 
 
-@skip_ppc64le_issue4026
 class TestLinalgCholesky(TestLinalgBase):
     """
     Tests for np.linalg.cholesky.

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -17,7 +17,7 @@ from numba.core.config import IS_WIN32, IS_32BITS
 from numba.core.utils import pysignature
 from numba.np.extensions import cross2d
 from numba.tests.support import (TestCase, CompilationCache, MemoryLeakMixin,
-                                 needs_blas, skip_ppc64le_issue4026)
+                                 needs_blas)
 import unittest
 
 
@@ -579,8 +579,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             str(raises.exception)
         )
 
-    # hits "Invalid PPC CTR loop!" issue on power systems, see e.g. #4026
-    @skip_ppc64le_issue4026
     def test_delete(self):
 
         def arrays():

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -21,8 +21,7 @@ from numba.core import (
     errors
 )
 from numba.core.registry import cpu_target
-from numba.tests.support import (TestCase, is_parfors_unsupported,
-                                 skip_ppc64le_issue4026)
+from numba.tests.support import (TestCase, is_parfors_unsupported)
 
 
 class MyPipeline(object):
@@ -192,7 +191,6 @@ class TestConvertSetItemPass(BaseTest):
 
         self.run_parallel(test_impl)
 
-    @skip_ppc64le_issue4026
     def test_setitem_gather_if_scalar(self):
         def test_impl():
             n = 10
@@ -209,7 +207,6 @@ class TestConvertSetItemPass(BaseTest):
 
         self.run_parallel(test_impl)
 
-    @skip_ppc64le_issue4026
     def test_setitem_gather_if_array(self):
         def test_impl():
             n = 10

--- a/numba/tests/test_unicode_array.py
+++ b/numba/tests/test_unicode_array.py
@@ -4,7 +4,7 @@ import unittest
 from numba import jit, from_dtype
 from numba.core import types, utils
 from numba.typed import Dict
-from numba.tests.support import (TestCase, skip_ppc64le_issue4026)
+from numba.tests.support import (TestCase, skip_ppc64le_issue4563)
 
 require_py37 = unittest.skipIf(utils.PYVERSION < (3, 7), "requires Python 3.7+")
 
@@ -216,7 +216,7 @@ def return_not(x, i):
     return not x[i]
 
 
-@skip_ppc64le_issue4026
+@skip_ppc64le_issue4563
 class TestUnicodeArray(TestCase):
 
     def _test(self, pyfunc, cfunc, *args, **kwargs):


### PR DESCRIPTION
These tests are passing as of LLVM 10, except for the Unicode
array one which was actually caused by #4563 anyways.  Since that
is the only remaining failure, go ahead and change the skip flag
to point to #4563.

Closes #4026 
