### PR TITLE
Fixes #5871. Segfault when calling pyapi.call() passing args as None

### DIFF
--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -942,7 +942,7 @@ class PythonAPI(object):
 
     def call(self, callee, args=None, kws=None):
         if args is None:
-            args = self.get_null_object()
+            args = self.tuple_new(0)
         if kws is None:
             kws = self.get_null_object()
         fnty = Type.function(self.pyobj, [self.pyobj] * 3)


### PR DESCRIPTION
As stated in the discussion on issue #5871 the fix was just a simple matter of replacing ``args = self.get_null_object()`` for ``args = self.tuple_new(0)`` at ``numba/core/pythonapi.py``.

If you will, could you add ``hacktoberfest-accepted`` to the labels of this PR so it can count for me as a valid contribution to the festival?

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat with the core developers, please
visit https://gitter.im/numba/numba for real-time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here are some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being made.

1. Please ensure that you have written unit tests for the changes made/features added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
