### PR TITLE
Permit switching off boundschecking when debug is on.

### DIFF
--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -649,7 +649,10 @@ by example, debugging a 'segfault' (memory access violation signalling
     from numba import njit, gdb_init
     import numpy as np
 
-    @njit(debug=True)
+    # NOTE debug=True switches bounds-checking on, but for the purposes of this
+    # example it is explicitly turned off so that the out of bounds index is
+    # not caught!
+    @njit(debug=True, boundscheck=False)
     def foo(a, index):
         gdb_init() # instruct Numba to attach gdb at this location, but not to pause execution
         b = a + 1

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -239,7 +239,7 @@ class CPUTargetOptions(TargetOptions):
         "nogil": bool,
         "forceobj": bool,
         "looplift": bool,
-        "boundscheck": bool,
+        "boundscheck": lambda X: bool(X) if X is not None else None,
         "debug": bool,
         "_nrt": bool,
         "no_rewrites": bool,

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -24,7 +24,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 def jit(signature_or_function=None, locals={}, cache=False,
-        pipeline_class=None, boundscheck=False, **options):
+        pipeline_class=None, boundscheck=None, **options):
     """
     This decorator is used to compile a Python function into native code.
 
@@ -84,15 +84,18 @@ def jit(signature_or_function=None, locals={}, cache=False,
                 NOTE: This inlining is performed at the Numba IR level and is in
                 no way related to LLVM inlining.
 
-            boundscheck: bool
+            boundscheck: bool or None
                 Set to True to enable bounds checking for array indices. Out
                 of bounds accesses will raise IndexError. The default is to
-                not do bounds checking. If bounds checking is disabled, out of
-                bounds accesses can produce garbage results or segfaults.
+                not do bounds checking. If False, bounds checking is disabled,
+                out of bounds accesses can produce garbage results or segfaults.
                 However, enabling bounds checking will slow down typical
                 functions, so it is recommended to only use this flag for
                 debugging. You can also set the NUMBA_BOUNDSCHECK environment
-                variable to 0 or 1 to globally override this flag.
+                variable to 0 or 1 to globally override this flag. The default
+                value is None, which under normal execution equates to False,
+                but if debug is set to True then bounds checking will be
+                enabled.
 
     Returns
     --------

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -47,17 +47,23 @@ class TargetOptions(object):
             flags.set("nrt")
 
         debug_mode = kws.pop('debug', config.DEBUGINFO_DEFAULT)
-        bounds_check_explicit = 'boundscheck' in kws
-        # if debug mode is requested, switch on debug info
+
+        # boundscheck is supplied
+        if 'boundscheck' in kws:
+            boundscheck = kws.pop("boundscheck")
+            if boundscheck is None and debug_mode:
+                # if it's None and debug is on then set it
+                flags.set("boundscheck")
+            else:
+                # irrespective of debug set it to the requested value
+                flags.set("boundscheck", boundscheck)
+        else:
+            # no boundscheck given, if debug mode, set it
+            if debug_mode:
+                flags.set("boundscheck")
+
         if debug_mode:
             flags.set("debuginfo")
-        # if bounds check is explicitly requested, the set the value for it
-        if bounds_check_explicit:
-            flags.set("boundscheck", kws.pop('boundscheck'))
-        elif debug_mode:
-            # debug mode is requested with no boundscheck option explicitly set
-            # so turn it on
-            flags.set("boundscheck")
 
 
         if kws.pop('nogil', False):

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -43,15 +43,18 @@ class TargetOptions(object):
         if kws.pop('looplift', True):
             flags.set("enable_looplift")
 
-        if kws.pop('boundscheck', False):
-            flags.set("boundscheck")
-
         if kws.pop('_nrt', True):
             flags.set("nrt")
 
         if kws.pop('debug', config.DEBUGINFO_DEFAULT):
             flags.set("debuginfo")
             flags.set("boundscheck")
+
+        # This is checked for logically after 'debug' as it's possible to want
+        # to have debuginfo on from the kwarg debug=True but to have boundscheck
+        # off.
+        if 'boundscheck' in kws:
+            flags.set("boundscheck", kws.pop('boundscheck'))
 
         if kws.pop('nogil', False):
             flags.set("release_gil")

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -46,15 +46,19 @@ class TargetOptions(object):
         if kws.pop('_nrt', True):
             flags.set("nrt")
 
-        if kws.pop('debug', config.DEBUGINFO_DEFAULT):
+        debug_mode = kws.pop('debug', config.DEBUGINFO_DEFAULT)
+        bounds_check_explicit = 'boundscheck' in kws
+        # if debug mode is requested, switch on debug info
+        if debug_mode:
             flags.set("debuginfo")
+        # if bounds check is explicitly requested, the set the value for it
+        if bounds_check_explicit:
+            flags.set("boundscheck", kws.pop('boundscheck'))
+        elif debug_mode:
+            # debug mode is requested with no boundscheck option explicitly set
+            # so turn it on
             flags.set("boundscheck")
 
-        # This is checked for logically after 'debug' as it's possible to want
-        # to have debuginfo on from the kwarg debug=True but to have boundscheck
-        # off.
-        if 'boundscheck' in kws:
-            flags.set("boundscheck", kws.pop('boundscheck'))
 
         if kws.pop('nogil', False):
             flags.set("release_gil")

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -80,7 +80,7 @@ def jit(func_or_sig=None, device=False, debug=False, argtypes=None,
         boundscheck=None,
         ):
     # Here for API compatibility
-    if boundscheck or (debug and boundscheck is None):
+    if boundscheck:
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
     if link is not None:

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -80,7 +80,7 @@ def jit(func_or_sig=None, device=False, debug=False, argtypes=None,
         boundscheck=None,
         ):
     # Here for API compatibility
-    if boundscheck:
+    if boundscheck or (debug and boundscheck is None):
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
     if link is not None:

--- a/numba/tests/test_jit_module.py
+++ b/numba/tests/test_jit_module.py
@@ -156,7 +156,7 @@ jit_module({jit_options})
             # Test that manual jit-wrapping overrides jit_module options
             self.assertEqual(test_module.inc.targetoptions,
                              {'nogil': True, 'forceobj': True,
-                              'boundscheck': False})
+                              'boundscheck': None})
 
     def test_jit_module_logging_output(self):
         logger = logging.getLogger('numba.core.decorators')


### PR DESCRIPTION
Dispatcher kwarg `debug=True` switches on both debuginfo and
boundschecking, its reasonable to just want the debuginfo part.
Also setting `debug=True` meant the value of the `boundscheck`
kwarg was just ignored. This fixes it and fixes the gdb docs to
note this.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
