### PR TITLE
Remove dead _Kernel.__call__

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -559,16 +559,6 @@ class _Kernel(serialize.ReduceMixin):
                     cufunc=self._func, link=self.linking, debug=self.debug,
                     call_helper=self.call_helper, extensions=self.extensions)
 
-    def __call__(self, *args, **kwargs):
-        assert not kwargs
-        griddim, blockdim = normalize_kernel_dimensions(self.griddim,
-                                                        self.blockdim)
-        self._kernel_call(args=args,
-                          griddim=griddim,
-                          blockdim=blockdim,
-                          stream=self.stream,
-                          sharedmem=self.sharedmem)
-
     def bind(self):
         """
         Force binding to current CUDA context


### PR DESCRIPTION
This is a fairly minor removal of dead code, but I keep coming across `_Kernel.__call__` when tracing through from a call to a kernel launch and getting confused, so I'm motivated to remove it.