### PR TITLE
Split optimisation passes.

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1043,7 +1043,7 @@ class BaseCPUCodegen(object):
         self._target_data = engine.target_data
         self._data_layout = str(self._target_data)
         self._mpm_cheap = self._module_pass_manager(loop_vectorize=False,
-                                                    opt=2)
+                                                    opt=1)
         self._mpm_full = self._module_pass_manager()
 
         self._engine.set_object_cache(self._library_class._object_compiled_hook,

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1127,15 +1127,8 @@ class BaseCPUCodegen(object):
         or function pass manager.  Otherwise some optimizations will be
         missed...
         """
-        if 'opt' in kwargs:
-            opt_level = kwargs.pop('opt')
-        else:
-            opt_level = config.OPT
-
-        if 'loop_vectorize' in kwargs:
-            loop_vectorize = kwargs.pop('loop_vectorize')
-        else:
-            loop_vectorize = config.LOOP_VECTORIZE
+        opt_level = kwargs.pop('opt', config.OPT)
+        loop_vectorize = kwargs.pop('loop_vectorize', config.LOOP_VECTORIZE)
 
         pmb = lp.create_pass_manager_builder(
             opt=opt_level, loop_vectorize=loop_vectorize, **kwargs)

--- a/numba/tests/test_vectorization.py
+++ b/numba/tests/test_vectorization.py
@@ -1,0 +1,36 @@
+import numpy as np
+from numba import njit, types
+from unittest import TestCase
+from numba.tests.support import override_env_config
+
+_DEBUG = False
+if _DEBUG:
+    from llvmlite import binding as llvm
+    # Prints debug info from the LLVMs vectorizer
+    llvm.set_option("", "--debug-only=loop-vectorize")
+
+
+class TestVectorization(TestCase):
+    """
+    Tests to assert that code which should vectorize does indeed vectorize
+    """
+    def gen_ir(self, func, args_tuple, **flags):
+        with override_env_config(
+            "NUMBA_CPU_NAME", "skylake-avx512"
+        ), override_env_config("NUMBA_CPU_FEATURES", ""):
+            jobj = njit(**flags)(func)
+            jobj.compile(args_tuple)
+            ol = jobj.overloads[jobj.signatures[0]]
+            return ol.library.get_llvm_str()
+
+    def test_nditer_loop(self):
+        # see https://github.com/numba/numba/issues/5033
+        def do_sum(x):
+            acc = 0
+            for v in np.nditer(x):
+                acc += v.item()
+            return acc
+
+        llvm_ir = self.gen_ir(do_sum, (types.float64[::1],), fastmath=True)
+        self.assertIn("vector.body", llvm_ir)
+        self.assertIn("llvm.loop.isvectorized", llvm_ir)


### PR DESCRIPTION
This splits up the module level optimisation passes as follows:

1. Runs a cheap pass to inline across the module, this in an
   attempt to bring as many refops into the same function as
   possible.
2. Runs the reference count pruning pass.
3. Runs the full optimisation suite, this should discover many
   more opportunities for optimisation as a result of the inline
   and refop prune.

Closes #5033

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
