### PR TITLE
CUDA: Fix #6339, performance regression launching specialized kernels

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -870,9 +870,12 @@ class Dispatcher(serialize.ReduceMixin):
         '''
         Compile if necessary and invoke this kernel with *args*.
         '''
-        argtypes = tuple(
-            [self.typingctx.resolve_argument_type(a) for a in args])
-        kernel = self.compile(argtypes)
+        if self.specialized:
+            kernel = self.definition
+        else:
+            argtypes = tuple([self.typingctx.resolve_argument_type(a)
+                              for a in args])
+            kernel = self.compile(argtypes)
         kernel.launch(args, griddim, blockdim, stream, sharedmem)
 
     def specialize(self, *args):


### PR DESCRIPTION
The behavior of the CUDA dispatcher is to not check the argument types when launching specialized kernels. Therefore, there is no need to resolve the argument types when launching a specialized kernel - the specialized definition can be used directly.

Prior to this commit, the benchmark:

```python
from numba import cuda
import numpy as np

@cuda.jit('void()')
def some_kernel_1():
    return

@cuda.jit('void(float32[:])')
def some_kernel_2(arr1):
    return

@cuda.jit('void(float32[:],float32[:])')
def some_kernel_3(arr1,arr2):
    return

@cuda.jit('void(float32[:],float32[:],float32[:])')
def some_kernel_4(arr1,arr2,arr3):
    return

@cuda.jit('void(float32[:],float32[:],float32[:],float32[:])')
def some_kernel_5(arr1,arr2,arr3,arr4):
    return

arr = cuda.device_array(10000, dtype=np.float32)

%timeit some_kernel_1[1, 1]()
%timeit some_kernel_2[1, 1](arr)
%timeit some_kernel_3[1, 1](arr,arr)
%timeit some_kernel_4[1, 1](arr,arr,arr)
%timeit some_kernel_5[1, 1](arr,arr,arr,arr)
```

Gives:

```
27.6 µs ± 228 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
62.6 µs ± 278 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
87.9 µs ± 700 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
109 µs ± 405 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
131 µs ± 365 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

After this commit, it gives:

```
19.1 µs ± 49.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
31.8 µs ± 38 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
40.4 µs ± 42.6 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
48.5 µs ± 43.1 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
56 µs ± 30.8 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Tests pass for me locally with a Quadro RTX 8000 + Quadro P2200, in parallel and in serial.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
