### PR TITLE
CUDA: Add support for passing tuples and namedtuples to kernels

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -756,6 +756,12 @@ class _Kernel(serialize.ReduceMixin):
             devrec = wrap_arg(val).to_device(retr, stream)
             kernelargs.append(devrec)
 
+        elif isinstance(ty, (types.UniTuple, types.Tuple, types.NamedUniTuple,
+                             types.NamedTuple)):
+            assert len(ty) == len(val)
+            for t, v in zip(ty, val):
+                self._prepare_args(t, v, stream, retr, kernelargs)
+
         else:
             raise NotImplementedError(ty, val)
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -756,8 +756,7 @@ class _Kernel(serialize.ReduceMixin):
             devrec = wrap_arg(val).to_device(retr, stream)
             kernelargs.append(devrec)
 
-        elif isinstance(ty, (types.UniTuple, types.Tuple, types.NamedUniTuple,
-                             types.NamedTuple)):
+        elif isinstance(ty, types.BaseTuple):
             assert len(ty) == len(val)
             for t, v in zip(ty, val):
                 self._prepare_args(t, v, stream, retr, kernelargs)

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -1,4 +1,5 @@
 import numpy as np
+from collections import namedtuple
 
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
@@ -20,6 +21,83 @@ class TestCudaArrayArg(CUDATestCase):
         y = np.zeros_like(x)
         kernel[10, 1](x, y)
         self.assertTrue(np.all(x == y))
+
+    def test_unituple(self):
+        @cuda.jit
+        def f(r, x):
+            r[0] = x[0]
+            r[1] = x[1]
+            r[2] = x[2]
+
+        x = (1, 2, 3)
+        r = np.zeros(len(x), dtype=np.int64)
+        f[1, 1](r, x)
+
+        for i in range(len(x)):
+            self.assertEqual(r[i], x[i])
+
+    def test_tuple(self):
+        @cuda.jit
+        def f(r1, r2, x):
+            r1[0] = x[0]
+            r1[1] = x[1]
+            r1[2] = x[2]
+            r2[0] = x[3]
+            r2[1] = x[4]
+            r2[2] = x[5]
+
+        x = (1, 2, 3, 4.5, 5.5, 6.5)
+        r1 = np.zeros(len(x) // 2, dtype=np.int64)
+        r2 = np.zeros(len(x) // 2, dtype=np.float64)
+        f[1, 1](r1, r2, x)
+
+        for i in range(len(r1)):
+            self.assertEqual(r1[i], x[i])
+
+        for i in range(len(r2)):
+            self.assertEqual(r2[i], x[i + len(r1)])
+
+    def test_namedunituple(self):
+        @cuda.jit
+        def f(r, x):
+            r[0] = x.x
+            r[1] = x.y
+
+        Point = namedtuple('Point', ('x', 'y'))
+        x = Point(1, 2)
+        r = np.zeros(len(x), dtype=np.int64)
+        f[1, 1](r, x)
+
+        self.assertEqual(r[0], x.x)
+        self.assertEqual(r[1], x.y)
+
+    def test_namedtuple(self):
+        @cuda.jit
+        def f(r1, r2, x):
+            r1[0] = x.x
+            r1[1] = x.y
+            r2[0] = x.r
+
+        Point = namedtuple('Point', ('x', 'y', 'r'))
+        x = Point(1, 2, 2.236)
+        r1 = np.zeros(2, dtype=np.int64)
+        r2 = np.zeros(1, dtype=np.float64)
+        f[1, 1](r1, r2, x)
+
+        self.assertEqual(r1[0], x.x)
+        self.assertEqual(r1[1], x.y)
+        self.assertEqual(r2[0], x.r)
+
+    def test_empty_tuple(self):
+        @cuda.jit
+        def f(r, x):
+            r[0] = len(x)
+
+        x = tuple()
+        r = np.ones(1, dtype=np.int64)
+        f[1, 1](r, x)
+
+        self.assertEqual(r[0], 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #4405.

This adds support for tuples as per @heyer2's suggestion, and namedtuples with @atait's suggestion. Tests for passing each, and an empty tuple are added.

This passes tests for me locally with the hardware target and cudasim.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
mailing list https://groups.google.com/a/continuum.io/forum/#!forum/numba-users.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
