### PR TITLE
DOC: add where to get dev builds from to FAQ 

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -263,6 +263,12 @@ value, for example::
 
    import locale
    locale.setlocale(locale.LC_NUMERIC, 'C')
+How do I get Numba dev builds?
+------------------------------
+
+Prerelease versions of Numba can be installed with conda:
+``conda install -c numba/label/dev numba``
+
 
 
 Miscellaneous


### PR DESCRIPTION
Fixes [#3762](https://github.com/numba/numba/issues/3762).

This adds Q/A to faq regarding where to get dev builds