### PR TITLE
Testhound/cuda atomic and

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -185,6 +185,16 @@ Synchronization and Atomic Operations
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.
 
+.. function:: numba.cuda.atomic.atomic_and(array, idx, value)
+
+    Perform ``array[idx] &= value``. Supports int32, uint32, int64,  and uint64 only.
+    The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multi-dimensional arrays. The number of elements
+    in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
 .. function:: numba.cuda.atomic.max(array, idx, value)
 
     Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -373,6 +373,9 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_sub(self, mod):
         return types.Function(Cuda_atomic_sub)
 
+    def resolve_and(self, mod):
+        return types.Function(Cuda_atomic_and)
+
     def resolve_max(self, mod):
         return types.Function(Cuda_atomic_max)
 

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -373,7 +373,7 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_sub(self, mod):
         return types.Function(Cuda_atomic_sub)
 
-    def resolve_and(self, mod):
+    def resolve_atomic_and(self, mod):
         return types.Function(Cuda_atomic_and)
 
     def resolve_max(self, mod):

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -300,12 +300,16 @@ all_numba_types = (types.float64, types.float32,
                    types.int32, types.uint32,
                    types.int64, types.uint64)
 
+integer_numba_types = (types.int32, types.uint32,
+                       types.int64, types.uint64)
+
 Cuda_atomic_add = _gen(cuda.atomic.add, all_numba_types)
 Cuda_atomic_sub = _gen(cuda.atomic.sub, all_numba_types)
 Cuda_atomic_max = _gen(cuda.atomic.max, all_numba_types)
 Cuda_atomic_min = _gen(cuda.atomic.min, all_numba_types)
 Cuda_atomic_nanmax = _gen(cuda.atomic.nanmax, all_numba_types)
 Cuda_atomic_nanmin = _gen(cuda.atomic.nanmin, all_numba_types)
+Cuda_atomic_and = _gen(cuda.atomic.atomic_and, integer_numba_types)
 
 
 @register

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -604,6 +604,16 @@ def ptx_atomic_sub(context, builder, dtype, ptr, val):
     else:
         return builder.atomic_rmw('sub', ptr, val, 'monotonic')
 
+@lower(stubs.atomic.atomic_and, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.atomic_and, types.Array, types.UniTuple, types.Any)
+@lower(stubs.atomic.atomic_and, types.Array, types.Tuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_and(context, builder, dtype, ptr, val):
+    if dtype in (types.int32, types.int64, types.uint32, types.uint64):
+        return builder.atomic_rmw('and', ptr, val, 'monotonic')
+    else:
+        raise TypeError('Unimplemented atomic and with %s array' % dtype)
+
 
 @lower(stubs.atomic.max, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.max, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -604,6 +604,7 @@ def ptx_atomic_sub(context, builder, dtype, ptr, val):
     else:
         return builder.atomic_rmw('sub', ptr, val, 'monotonic')
 
+
 @lower(stubs.atomic.atomic_and, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.atomic_and, types.Array, types.UniTuple, types.Any)
 @lower(stubs.atomic.atomic_and, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -117,6 +117,12 @@ class FakeCUDAAtomic(object):
             array[index] -= val
         return old
 
+    def atomic_and(self, array, index, val):
+        with sublock:
+            old = array[index]
+            array[index] &= val
+        return old
+
     def max(self, array, index, val):
         with maxlock:
             old = array[index]

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -399,6 +399,16 @@ class atomic(Stub):
         atomically.
         """
 
+    class atomic_and(Stub):
+        """atomic_and(ary, idx, val)
+
+        Perform atomic ary[idx] &= val. Supported on int32, int64, uint32 and
+        uint64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
     class max(Stub):
         """max(ary, idx, val)
 


### PR DESCRIPTION
This pull request adds support for cuda atomic "and". Note that I was force to name the operation "cuda.atomic.atomic_and" instead of "cuda.atomic.and" because "and" is a reserved word.
