### PR TITLE
Skips failing tests if SVML is present.

### DIFF
--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2700,6 +2700,7 @@ class TestParforsVectorizer(TestPrangeBase):
     match_vsqrtpd_on_zmm = re.compile('\n\s+vsqrtpd\s+.*zmm.*\n')
 
     @linux_only
+    @unittest.skipIf(config.USING_SVML, "SVML uses 256bit registers")
     def test_vectorizer_fastmath_asm(self):
         """ This checks that if fastmath is set and the underlying hardware
         is suitable, and the function supplied is amenable to fastmath based
@@ -2743,6 +2744,7 @@ class TestParforsVectorizer(TestPrangeBase):
             self.assertTrue('zmm' not in v)
 
     @linux_only
+    @unittest.skipIf(config.USING_SVML, "SVML uses 256bit registers")
     def test_unsigned_refusal_to_vectorize(self):
         """ This checks that if fastmath is set and the underlying hardware
         is suitable, and the function supplied is amenable to fastmath based


### PR DESCRIPTION
Seems like with SVML enabled the 512bit instruction generation is
being ignored. Skip these tests that explicitly check for `zmm*`
use if SVML is present.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
