### PR TITLE
Use Python 3 style OSError handling

### DIFF
--- a/numba/core/annotations/type_annotations.py
+++ b/numba/core/annotations/type_annotations.py
@@ -18,7 +18,7 @@ class SourceLines(Mapping):
 
         try:
             lines, startno = inspect.getsourcelines(func)
-        except IOError:
+        except OSError:
             self.lines = ()
             self.startno = 0
         else:

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -115,11 +115,7 @@ class _CacheLocator(metaclass=ABCMeta):
 
     def ensure_cache_path(self):
         path = self.get_cache_path()
-        try:
-            os.makedirs(path)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+        os.makedirs(path, exist_ok=True)
         # Ensure the directory is writable by trying to write a temporary file
         tempfile.TemporaryFile(dir=path).close()
 
@@ -502,7 +498,7 @@ class IndexDataCacheFile(object):
             return
         try:
             return self._load_data(data_name)
-        except EnvironmentError:
+        except OsError:
             # File could have been removed while the index still refers it.
             return
 
@@ -515,11 +511,9 @@ class IndexDataCacheFile(object):
             with open(self._index_path, "rb") as f:
                 version = pickle.load(f)
                 data = f.read()
-        except EnvironmentError as e:
+        except FileNotFoundError:
             # Index doesn't exist yet?
-            if e.errno in (errno.ENOENT,):
-                return {}
-            raise
+            return {}
         if version != self._version:
             # This is another version.  Avoid trying to unpickling the
             # rest of the stream, as that may fail.
@@ -683,7 +677,7 @@ class Cache(_Cache):
             # from several processes (see #2028)
             try:
                 yield
-            except EnvironmentError as e:
+            except OsError as e:
                 if e.errno != errno.EACCES:
                     raise
         else:

--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -234,7 +234,7 @@ def _exec_command(command, use_shell=None, use_tee=None, **env):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True)
-    except EnvironmentError:
+    except OSError:
         # Return 127, as os.spawn*() and /bin/sh do
         return '', 127
     text, err = proc.communicate()

--- a/numba/testing/_runtests.py
+++ b/numba/testing/_runtests.py
@@ -106,7 +106,7 @@ class _FailedFirstRunner(object):
 
         try:
             fobj = open(self.cache_filename)
-        except IOError:
+        except OSError:
             failed_tests = []
         else:
             with fobj as fin:

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -5,7 +5,6 @@ Assorted utilities for use in tests.
 import cmath
 import contextlib
 import enum
-import errno
 import gc
 import math
 import platform
@@ -581,9 +580,8 @@ _trashcan_timeout = 24 * 3600  # 1 day
 def _create_trashcan_dir():
     try:
         os.mkdir(_trashcan_dir)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    except FileExistsError:
+        pass
 
 def _purge_trashcan_dir():
     freshness_threshold = time.time() - _trashcan_timeout

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -1,4 +1,3 @@
-import errno
 import multiprocessing
 import os
 import platform
@@ -127,8 +126,6 @@ def check_access_is_preventable():
     tempdir = temp_directory('test_cache')
     test_dir = (os.path.join(tempdir, 'writable_test'))
     os.mkdir(test_dir)
-    # assume access prevention is not possible
-    ret = False
     # check a write is possible
     with open(os.path.join(test_dir, 'write_ok'), 'wt') as f:
         f.write('check1')
@@ -137,19 +134,18 @@ def check_access_is_preventable():
     try:
         with open(os.path.join(test_dir, 'write_forbidden'), 'wt') as f:
             f.write('check2')
-    except (OSError, IOError) as e:
+        # access prevention is not possible
+        return False
+    except PermissionError as e:
         # Check that the cause of the exception is due to access/permission
         # as per
         # https://github.com/conda/conda/blob/4.5.0/conda/gateways/disk/permissions.py#L35-L37  # noqa: E501
-        eno = getattr(e, 'errno', None)
-        if eno in (errno.EACCES, errno.EPERM):
-            # errno reports access/perm fail so access prevention via
-            # `chmod 500` works for this user.
-            ret = True
+        # errno reports access/perm fail so access prevention via
+        # `chmod 500` works for this user.
+        return True
     finally:
         os.chmod(test_dir, 0o775)
         shutil.rmtree(test_dir)
-    return ret
 
 
 _access_preventable = check_access_is_preventable()
@@ -1033,9 +1029,8 @@ class BaseCacheTest(TestCase):
             for fn in cached:
                 try:
                     os.unlink(fn)
-                except OSError as e:
-                    if e.errno != errno.ENOENT:
-                        raise
+                except FileNotFoundError:
+                    pass
         mod = import_dynamic(self.modname)
         self.assertEqual(mod.__file__.rstrip('co'), self.modfile)
         return mod
@@ -1044,9 +1039,7 @@ class BaseCacheTest(TestCase):
         try:
             return [fn for fn in os.listdir(self.cache_dir)
                     if not fn.endswith(('.pyc', ".pyo"))]
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
+        except FileNotFoundError:
             return []
 
     def get_cache_mtimes(self):


### PR DESCRIPTION
In Python 3 there is no need to check `errno` any more for most use-cases, as there are specific exception subclasses.

IOError and EnvironmentError are now aliases of OSError, so those are changed here too.

I've left versioneer alone since that's vendored code.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
