### PR TITLE
CUDA tests: reduce managed memory allocation to 0.1 * GPU RAM

### DIFF
--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -43,7 +43,7 @@ class TestManagedAlloc(ContextResettingTestCase):
     def test_managed_alloc_driver_undersubscribe(self):
         msg = "Managed memory unsupported prior to CC 3.0"
         self.skip_if_cc_major_lt(3, msg)
-        self._test_managed_alloc_driver(0.5)
+        self._test_managed_alloc_driver(0.1)
 
     # This test is skipped by default because it is easy to hang the machine
     # for a very long time or get OOM killed if the GPU memory size is >50% of


### PR DESCRIPTION
0.5 * GPU RAM can allocate a sizeable proportion of system memory, which can cause stability issues. This change reduces the proportion of GPU memory allocated to 0.1 to make testing more resilient.

This may be involved in Issue #6371.

@stuartarchibald Could you try this on the buildfarm to see if any issues occur with this change please?