### PR TITLE
Use O0 to enable inline and not affect loop-vectorization by later O3…

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1071,7 +1071,7 @@ class BaseCPUCodegen(object):
         self._data_layout = str(self._target_data)
         self._mpm_cheap = self._module_pass_manager(loop_vectorize=False,
                                                     slp_vectorize=False,
-                                                    opt=1)
+                                                    opt=0)
         self._mpm_full = self._module_pass_manager()
 
         self._engine.set_object_cache(self._library_class._object_compiled_hook,


### PR DESCRIPTION
… passes

- this seems to fix ufunc not being vectorized


Related to #6371: 

> OSX, all builds: Bizarrely, numba.tests.npufunc.test_errors.TestFloatingPointExceptions.test_remainder_float is failing with an assertion error, the length of the warnings/error messages doesn't match (essentially, none were found when one was expected).