### PR TITLE
Only test managed allocations on Linux

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -129,6 +129,9 @@ def managed_array(shape, dtype=np.float, strides=None, order='C', stream=0,
     Allocate a np.ndarray with a buffer that is managed.
     Similar to np.empty().
 
+    Managed memory is supported on Linux, and is considered experimental on
+    Windows.
+
     :param attach_global: A flag indicating whether to attach globally. Global
                           attachment implies that the memory is accessible from
                           any stream on any device. If ``False``, attachment is

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -1,5 +1,4 @@
 import numpy as np
-import platform
 from ctypes import byref, c_size_t
 from numba.cuda.cudadrv.driver import device_memset, driver
 from numba import cuda
@@ -9,6 +8,7 @@ from numba.tests.support import linux_only
 
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
+@linux_only
 class TestManagedAlloc(ContextResettingTestCase):
 
     def get_total_gpu_memory(self):
@@ -57,12 +57,8 @@ class TestManagedAlloc(ContextResettingTestCase):
     def test_managed_alloc_driver_oversubscribe(self):
         msg = "Oversubscription of managed memory unsupported prior to CC 6.0"
         self.skip_if_cc_major_lt(6, msg)
-        if platform.system() != "Linux":
-            msg = "Oversubscription of managed memory only supported on Linux"
-            self.skipTest(msg)
         self._test_managed_alloc_driver(2.0)
 
-    @linux_only
     def test_managed_alloc_driver_host_attach(self):
         msg = "Host attached managed memory is not accessible prior to CC 6.0"
         self.skip_if_cc_major_lt(6, msg)
@@ -115,7 +111,6 @@ class TestManagedAlloc(ContextResettingTestCase):
     def test_managed_array_attach_global(self):
         self._test_managed_array()
 
-    @linux_only
     def test_managed_array_attach_host(self):
         self._test_managed_array()
         msg = "Host attached managed memory is not accessible prior to CC 6.0"


### PR DESCRIPTION
Seeing if avoiding the use of managed allocations on Windows avoids the build farm issues.

@stuartarchibald can we try this on the buildfarm please?
