### PR TITLE
Testhound/cuda atomic or

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -185,6 +185,16 @@ Synchronization and Atomic Operations
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.
 
+.. function:: numba.cuda.atomic.atomic_and(array, idx, value)
+
+    Perform ``array[idx] &= value``. Supports int32, uint32, int64,  and uint64 only.
+    The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multi-dimensional arrays. The number of elements
+    in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
 .. function:: numba.cuda.atomic.max(array, idx, value)
 
     Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -185,12 +185,12 @@ Synchronization and Atomic Operations
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.
 
-.. function:: numba.cuda.atomic.atomic_and(array, idx, value)
+.. function:: numba.cuda.atomic.and_(array, idx, value)
 
-    Perform ``array[idx] &= value``. Supports int32, uint32, int64,  and uint64 only.
-    The ``idx`` argument can be an integer or a tuple of integer
-    indices for indexing into multi-dimensional arrays. The number of elements
-    in ``idx`` must match the number of dimensions of ``array``.
+    Perform ``array[idx] &= value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
 
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -195,6 +195,16 @@ Synchronization and Atomic Operations
     Returns the value of ``array[idx]`` before the storing the new value.
     Behaves like an atomic load.
 
+.. function:: numba.cuda.atomic.or_(array, idx, value)
+
+    Perform ``array[idx] |= value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before the storing the new value.
+    Behaves like an atomic load.
+
 .. function:: numba.cuda.atomic.max(array, idx, value)
 
     Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -309,7 +309,7 @@ Cuda_atomic_max = _gen(cuda.atomic.max, all_numba_types)
 Cuda_atomic_min = _gen(cuda.atomic.min, all_numba_types)
 Cuda_atomic_nanmax = _gen(cuda.atomic.nanmax, all_numba_types)
 Cuda_atomic_nanmin = _gen(cuda.atomic.nanmin, all_numba_types)
-Cuda_atomic_and = _gen(cuda.atomic.atomic_and, integer_numba_types)
+Cuda_atomic_and = _gen(cuda.atomic.and_, integer_numba_types)
 
 
 @register
@@ -373,7 +373,7 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_sub(self, mod):
         return types.Function(Cuda_atomic_sub)
 
-    def resolve_atomic_and(self, mod):
+    def resolve_and_(self, mod):
         return types.Function(Cuda_atomic_and)
 
     def resolve_max(self, mod):

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -373,6 +373,9 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_sub(self, mod):
         return types.Function(Cuda_atomic_sub)
 
+    def resolve_and(self, mod):
+        return types.Function(Cuda_atomic_and)
+
     def resolve_max(self, mod):
         return types.Function(Cuda_atomic_max)
 

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -373,7 +373,7 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_sub(self, mod):
         return types.Function(Cuda_atomic_sub)
 
-    def resolve_and(self, mod):
+    def resolve_atomic_and(self, mod):
         return types.Function(Cuda_atomic_and)
 
     def resolve_max(self, mod):

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -310,6 +310,7 @@ Cuda_atomic_min = _gen(cuda.atomic.min, all_numba_types)
 Cuda_atomic_nanmax = _gen(cuda.atomic.nanmax, all_numba_types)
 Cuda_atomic_nanmin = _gen(cuda.atomic.nanmin, all_numba_types)
 Cuda_atomic_and = _gen(cuda.atomic.and_, integer_numba_types)
+Cuda_atomic_or = _gen(cuda.atomic.or_, integer_numba_types)
 
 
 @register
@@ -375,6 +376,9 @@ class CudaAtomicTemplate(AttributeTemplate):
 
     def resolve_and_(self, mod):
         return types.Function(Cuda_atomic_and)
+
+    def resolve_or_(self, mod):
+        return types.Function(Cuda_atomic_or)
 
     def resolve_max(self, mod):
         return types.Function(Cuda_atomic_max)

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -300,12 +300,16 @@ all_numba_types = (types.float64, types.float32,
                    types.int32, types.uint32,
                    types.int64, types.uint64)
 
+integer_numba_types = (types.int32, types.uint32,
+                       types.int64, types.uint64)
+
 Cuda_atomic_add = _gen(cuda.atomic.add, all_numba_types)
 Cuda_atomic_sub = _gen(cuda.atomic.sub, all_numba_types)
 Cuda_atomic_max = _gen(cuda.atomic.max, all_numba_types)
 Cuda_atomic_min = _gen(cuda.atomic.min, all_numba_types)
 Cuda_atomic_nanmax = _gen(cuda.atomic.nanmax, all_numba_types)
 Cuda_atomic_nanmin = _gen(cuda.atomic.nanmin, all_numba_types)
+Cuda_atomic_and = _gen(cuda.atomic.atomic_and, integer_numba_types)
 
 
 @register

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -615,6 +615,15 @@ def ptx_atomic_and(context, builder, dtype, ptr, val):
     else:
         raise TypeError('Unimplemented atomic and with %s array' % dtype)
 
+@lower(stubs.atomic.or_, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.or_, types.Array, types.UniTuple, types.Any)
+@lower(stubs.atomic.or_, types.Array, types.Tuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_or(context, builder, dtype, ptr, val):
+    if dtype in (types.int32, types.int64, types.uint32, types.uint64):
+        return builder.atomic_rmw('or', ptr, val, 'monotonic')
+    else:
+        raise TypeError('Unimplemented atomic or with %s array' % dtype)
 
 @lower(stubs.atomic.max, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.max, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -605,9 +605,9 @@ def ptx_atomic_sub(context, builder, dtype, ptr, val):
         return builder.atomic_rmw('sub', ptr, val, 'monotonic')
 
 
-@lower(stubs.atomic.atomic_and, types.Array, types.intp, types.Any)
-@lower(stubs.atomic.atomic_and, types.Array, types.UniTuple, types.Any)
-@lower(stubs.atomic.atomic_and, types.Array, types.Tuple, types.Any)
+@lower(stubs.atomic.and_, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.and_, types.Array, types.UniTuple, types.Any)
+@lower(stubs.atomic.and_, types.Array, types.Tuple, types.Any)
 @_atomic_dispatcher
 def ptx_atomic_and(context, builder, dtype, ptr, val):
     if dtype in (types.int32, types.int64, types.uint32, types.uint64):

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -615,6 +615,7 @@ def ptx_atomic_and(context, builder, dtype, ptr, val):
     else:
         raise TypeError('Unimplemented atomic and with %s array' % dtype)
 
+
 @lower(stubs.atomic.or_, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.or_, types.Array, types.UniTuple, types.Any)
 @lower(stubs.atomic.or_, types.Array, types.Tuple, types.Any)
@@ -624,6 +625,7 @@ def ptx_atomic_or(context, builder, dtype, ptr, val):
         return builder.atomic_rmw('or', ptr, val, 'monotonic')
     else:
         raise TypeError('Unimplemented atomic or with %s array' % dtype)
+
 
 @lower(stubs.atomic.max, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.max, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -604,6 +604,16 @@ def ptx_atomic_sub(context, builder, dtype, ptr, val):
     else:
         return builder.atomic_rmw('sub', ptr, val, 'monotonic')
 
+@lower(stubs.atomic.atomic_and, types.Array, types.intp, types.Any)
+@lower(stubs.atomic.atomic_and, types.Array, types.UniTuple, types.Any)
+@lower(stubs.atomic.atomic_and, types.Array, types.Tuple, types.Any)
+@_atomic_dispatcher
+def ptx_atomic_and(context, builder, dtype, ptr, val):
+    if dtype in (types.int32, types.int64, types.uint32, types.uint64):
+        return builder.atomic_rmw('and', ptr, val, 'monotonic')
+    else:
+        raise TypeError('Unimplemented atomic and with %s array' % dtype)
+
 
 @lower(stubs.atomic.max, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.max, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -604,6 +604,7 @@ def ptx_atomic_sub(context, builder, dtype, ptr, val):
     else:
         return builder.atomic_rmw('sub', ptr, val, 'monotonic')
 
+
 @lower(stubs.atomic.atomic_and, types.Array, types.intp, types.Any)
 @lower(stubs.atomic.atomic_and, types.Array, types.UniTuple, types.Any)
 @lower(stubs.atomic.atomic_and, types.Array, types.Tuple, types.Any)

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -126,7 +126,7 @@ class FakeCUDAAtomic(object):
         return old
 
     def or_(self, array, index, val):
-        with andlock:
+        with orlock:
             old = array[index]
             array[index] |= val
         return old

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -99,6 +99,7 @@ class FakeCUDAShared(object):
 
 addlock = threading.Lock()
 sublock = threading.Lock()
+andlock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
 caslock = threading.Lock()
@@ -117,8 +118,8 @@ class FakeCUDAAtomic(object):
             array[index] -= val
         return old
 
-    def atomic_and(self, array, index, val):
-        with sublock:
+    def and_(self, array, index, val):
+        with andlock:
             old = array[index]
             array[index] &= val
         return old

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -117,6 +117,12 @@ class FakeCUDAAtomic(object):
             array[index] -= val
         return old
 
+    def atomic_and(self, array, index, val):
+        with sublock:
+            old = array[index]
+            array[index] &= val
+        return old
+
     def max(self, array, index, val):
         with maxlock:
             old = array[index]

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -100,6 +100,7 @@ class FakeCUDAShared(object):
 addlock = threading.Lock()
 sublock = threading.Lock()
 andlock = threading.Lock()
+orlock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
 caslock = threading.Lock()
@@ -122,6 +123,12 @@ class FakeCUDAAtomic(object):
         with andlock:
             old = array[index]
             array[index] &= val
+        return old
+
+    def or_(self, array, index, val):
+        with andlock:
+            old = array[index]
+            array[index] |= val
         return old
 
     def max(self, array, index, val):

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -399,7 +399,7 @@ class atomic(Stub):
         atomically.
         """
 
-    class atomic_and(Stub):
+    class and_(Stub):
         """atomic_and(ary, idx, val)
 
         Perform atomic ary[idx] &= val. Supported on int32, int64, uint32 and

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -399,6 +399,16 @@ class atomic(Stub):
         atomically.
         """
 
+    class atomic_and(Stub):
+        """atomic_and(ary, idx, val)
+
+        Perform atomic ary[idx] &= val. Supported on int32, int64, uint32 and
+        uint64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
     class max(Stub):
         """max(ary, idx, val)
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -400,7 +400,7 @@ class atomic(Stub):
         """
 
     class and_(Stub):
-        """atomic_and(ary, idx, val)
+        """and_(ary, idx, val)
 
         Perform atomic ary[idx] &= val. Supported on int32, int64, uint32 and
         uint64 operands only.

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -409,6 +409,16 @@ class atomic(Stub):
         atomically.
         """
 
+    class or_(Stub):
+        """or_(ary, idx, val)
+
+        Perform atomic ary[idx] |= val. Supported on int32, int64, uint32 and
+        uint64 operands only.
+
+        Returns the old value at the index location as if it is loaded
+        atomically.
+        """
+
     class max(Stub):
         """max(ary, idx, val)
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -195,7 +195,7 @@ def atomic_sub_double_global_3(ary):
 
 def atomic_and(ary, op2):
     atomic_binary_1dim_shared(ary, ary, op2, uint32, 32,
-                              cuda.atomic.and_, atomic_cast_none, 0)
+                              cuda.atomic.and_, atomic_cast_none, 1)
 
 
 def atomic_and2(ary, op2):
@@ -521,7 +521,7 @@ class TestCudaAtomics(CUDATestCase):
         cuda_func = cuda.jit('void(uint32[:], uint32)')(atomic_and)
         cuda_func[1, 32](ary, rand_const)
 
-        gold = np.zeros(32, dtype=np.uint32)
+        gold = ary.copy()
         for i in range(orig.size):
             gold[orig[i]] &= rand_const
 
@@ -546,12 +546,12 @@ class TestCudaAtomics(CUDATestCase):
     def test_atomic_and_global(self):
         rand_const = np.random.randint(500)
         idx = np.random.randint(0, 32, size=32, dtype=np.int32)
-        ary = np.zeros(32, np.int32)
+        ary = np.random.randint(0, 32, size=32, dtype=np.int32)
         sig = 'void(int32[:], int32[:], int32)'
         cuda_func = cuda.jit(sig)(atomic_and_global)
         cuda_func[1, 32](idx, ary, rand_const)
 
-        gold = np.zeros(32, dtype=np.int32)
+        gold = ary.copy()
         for i in range(idx.size):
             gold[idx[i]] &= rand_const
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -553,7 +553,7 @@ class TestCudaAtomics(CUDATestCase):
 
         gold = np.zeros(32, dtype=np.int32)
         for i in range(idx.size):
-            gold[idx[i]] &= 1
+            gold[idx[i]] &= rand_const
 
         np.testing.assert_equal(ary, gold)
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -216,6 +216,7 @@ def atomic_and_global_2(ary, op2):
     atomic_binary_2dim_global(ary, op2, cuda.atomic.and_,
                               atomic_cast_none)
 
+
 def atomic_or(ary, op2):
     atomic_binary_1dim_shared(ary, ary, op2, uint32, 32,
                               cuda.atomic.or_, atomic_cast_none, 0)
@@ -238,6 +239,7 @@ def atomic_or_global(idx, ary, op2):
 def atomic_or_global_2(ary, op2):
     atomic_binary_2dim_global(ary, op2, cuda.atomic.or_,
                               atomic_cast_none)
+
 
 def gen_atomic_extreme_funcs(func):
 
@@ -619,12 +621,12 @@ class TestCudaAtomics(CUDATestCase):
     def test_atomic_or_global(self):
         rand_const = np.random.randint(500)
         idx = np.random.randint(0, 32, size=32, dtype=np.int32)
-        ary = np.zeros(32, np.int32)
+        ary = np.random.randint(0, 32, size=32, dtype=np.int32)
         sig = 'void(int32[:], int32[:], int32)'
         cuda_func = cuda.jit(sig)(atomic_or_global)
         cuda_func[1, 32](idx, ary, rand_const)
 
-        gold = np.zeros(32, dtype=np.int32)
+        gold = ary.copy()
         for i in range(idx.size):
             gold[idx[i]] |= rand_const
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -216,6 +216,28 @@ def atomic_and_global_2(ary, op2):
     atomic_binary_2dim_global(ary, op2, cuda.atomic.and_,
                               atomic_cast_none)
 
+def atomic_or(ary, op2):
+    atomic_binary_1dim_shared(ary, ary, op2, uint32, 32,
+                              cuda.atomic.or_, atomic_cast_none, 0)
+
+
+def atomic_or2(ary, op2):
+    atomic_binary_2dim_shared(ary, op2, uint32, (4, 8),
+                              cuda.atomic.or_, atomic_cast_none)
+
+
+def atomic_or3(ary, op2):
+    atomic_binary_2dim_shared(ary, op2, uint32, (4, 8),
+                              cuda.atomic.or_, atomic_cast_to_uint64)
+
+
+def atomic_or_global(idx, ary, op2):
+    atomic_binary_1dim_global(ary, idx, 32, op2, cuda.atomic.or_)
+
+
+def atomic_or_global_2(ary, op2):
+    atomic_binary_2dim_global(ary, op2, cuda.atomic.or_,
+                              atomic_cast_none)
 
 def gen_atomic_extreme_funcs(func):
 
@@ -564,6 +586,57 @@ class TestCudaAtomics(CUDATestCase):
         cuda_func = cuda.jit('void(uint32[:,:], uint32)')(atomic_and_global_2)
         cuda_func[1, (4, 8)](ary, rand_const)
         np.testing.assert_equal(ary, orig & rand_const)
+
+    def test_atomic_or(self):
+        rand_const = np.random.randint(500)
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(uint32[:], uint32)')(atomic_or)
+        cuda_func[1, 32](ary, rand_const)
+
+        gold = np.zeros(32, dtype=np.uint32)
+        for i in range(orig.size):
+            gold[orig[i]] |= rand_const
+
+        self.assertTrue(np.all(ary == gold))
+
+    def test_atomic_or2(self):
+        rand_const = np.random.randint(500)
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_and2 = cuda.jit('void(uint32[:,:], uint32)')(atomic_or2)
+        cuda_atomic_and2[1, (4, 8)](ary, rand_const)
+        self.assertTrue(np.all(ary == orig | rand_const))
+
+    def test_atomic_or3(self):
+        rand_const = np.random.randint(500)
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_atomic_and3 = cuda.jit('void(uint32[:,:], uint32)')(atomic_or3)
+        cuda_atomic_and3[1, (4, 8)](ary, rand_const)
+        self.assertTrue(np.all(ary == orig | rand_const))
+
+    def test_atomic_or_global(self):
+        rand_const = np.random.randint(500)
+        idx = np.random.randint(0, 32, size=32, dtype=np.int32)
+        ary = np.zeros(32, np.int32)
+        sig = 'void(int32[:], int32[:], int32)'
+        cuda_func = cuda.jit(sig)(atomic_or_global)
+        cuda_func[1, 32](idx, ary, rand_const)
+
+        gold = np.zeros(32, dtype=np.int32)
+        for i in range(idx.size):
+            gold[idx[i]] |= rand_const
+
+        np.testing.assert_equal(ary, gold)
+
+    def test_atomic_or_global_2(self):
+        rand_const = np.random.randint(500)
+        ary = np.random.randint(0, 32, size=32).astype(np.uint32).reshape(4, 8)
+        orig = ary.copy()
+        cuda_func = cuda.jit('void(uint32[:,:], uint32)')(atomic_or_global_2)
+        cuda_func[1, (4, 8)](ary, rand_const)
+        np.testing.assert_equal(ary, orig | rand_const)
 
     def check_atomic_max(self, dtype, lo, hi):
         vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)


### PR DESCRIPTION
This pull request adds support for cuda atomic "or". Note the operation is name "cuda.atomic.or_" due to "or" being a reserved word in python. Additionally this branch is a sub-branch of testhound/cuda_atomic_and.
