### PR TITLE
Fix `typed.Dict` and `typed.List` crashing on parametrized types

### DIFF
--- a/numba/tests/test_dictimpl.py
+++ b/numba/tests/test_dictimpl.py
@@ -648,4 +648,4 @@ class TestDictImpl(TestCase):
         set_parametrized_data.targetctx.init()
 
         for ii in range(50):  # <- somtimes works a few times
-            assert set_parametrized_data(x, y) is None
+            self.assertIsNone(set_parametrized_data(x, y))

--- a/numba/tests/test_dictimpl.py
+++ b/numba/tests/test_dictimpl.py
@@ -226,6 +226,7 @@ def unbox_parametrized(typ, obj, context):
 @generated_jit
 def dict_vs_cache_vs_parametrized(v):
     typ = v
+
     def objmode_vs_cache_vs_parametrized_impl(v):
         # typed.List shows same behaviour after fix for #6397
         d = typed.Dict.empty(types.unicode_type, typ)

--- a/numba/tests/test_dictimpl.py
+++ b/numba/tests/test_dictimpl.py
@@ -3,10 +3,7 @@ Testing C implementation of the numba dictionary
 """
 
 import ctypes
-import os
 import random
-import subprocess
-import sys
 
 from numba.tests.support import TestCase
 from numba import generated_jit, _helperlib, jit, typed, types
@@ -644,7 +641,8 @@ class TestDictImpl(TestCase):
         x, y = Parametrized(('a', 'b')), Parametrized(('a',))
         set_parametrized_data(x, y)
 
-        # reset dispatchers and targetctx to force re-load from cache as a new process would jit
+        # reset dispatchers and targetctx to force re-load from cache as if a
+        # new process would jit the function
         set_parametrized_data._make_finalizer()()
         set_parametrized_data._reset_overloads()
         set_parametrized_data.targetctx.init()

--- a/numba/tests/test_dictimpl.py
+++ b/numba/tests/test_dictimpl.py
@@ -236,14 +236,14 @@ def dict_vs_cache_vs_parametrized(v):
 
 
 def dict_vs_cache_vs_parametrized_worker():
-    """crashes when run more than once
-    (ie when compiled function is loaded from cache)"""
+    """Has had tendency to segfault when run more than once
+    (i.e. when compiled function is loaded from cache)"""
     @jit(nopython=True, cache=True)
     def get_unit_system_data(x, y):
         dict_vs_cache_vs_parametrized(x)
         dict_vs_cache_vs_parametrized(y)
 
-    x, y = Parametrized(('horst', 'hanz')), Parametrized(('horst',))
+    x, y = Parametrized(('a', 'b')), Parametrized(('a',))
 
     for ii in range(50):  # <- somtimes works a few times
         assert get_unit_system_data(x, y) is None

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -283,9 +283,9 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
 
         dm_key = context.data_model_manager[keyty.instance_type]
         if dm_key.contains_nrt_meminfo():
-            equal = _get_equal(context, builder.module, dm_key, 'dict')
+            equal = _get_equal(context, builder.module, dm_key, 'dict_key')
             key_incref, key_decref = _get_incref_decref(
-                context, builder.module, dm_key, 'dict'
+                context, builder.module, dm_key, 'dict_key'
             )
             builder.store(
                 builder.bitcast(equal, key_equal_ptr.type.pointee),
@@ -303,7 +303,7 @@ def _dict_set_method_table(typingctx, dp, keyty, valty):
         dm_val = context.data_model_manager[valty.instance_type]
         if dm_val.contains_nrt_meminfo():
             val_incref, val_decref = _get_incref_decref(
-                context, builder.module, dm_val, 'dict'
+                context, builder.module, dm_val, 'dict_value'
             )
             builder.store(
                 builder.bitcast(val_incref, val_incref_ptr.type.pointee),

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -141,7 +141,7 @@ def _get_incref_decref(context, module, datamodel, container_element_type):
 
     decref_fn = module.get_or_insert_function(
         refct_fnty,
-        name='{}.{}_decref'.format(
+        name='.numba_{}.{}_decref'.format(
             context.fndesc.mangled_name, container_element_type),
     )
     builder = ir.IRBuilder(decref_fn.append_basic_block())
@@ -179,7 +179,7 @@ def _get_equal(context, module, datamodel, container_element_type):
 
     wrapfn = module.get_or_insert_function(
         wrapfnty,
-        name='{}.{}_equal.wrap'.format(
+        name='.numba_{}.{}_equal.wrap'.format(
             context.fndesc.mangled_name, container_element_type)
     )
     build_wrapper(wrapfn)
@@ -187,7 +187,7 @@ def _get_equal(context, module, datamodel, container_element_type):
     equal_fnty = ir.FunctionType(ir.IntType(32), [data_ptr_ty, data_ptr_ty])
     equal_fn = module.get_or_insert_function(
         equal_fnty,
-        name='{}.{}_equal'.format(
+        name='.numba_{}.{}_equal'.format(
             context.fndesc.mangled_name, container_element_type),
     )
     builder = Builder(equal_fn.append_basic_block())

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -128,7 +128,7 @@ def _get_incref_decref(context, module, datamodel, container_element_type):
     refct_fnty = ir.FunctionType(ir.VoidType(), [data_ptr_ty])
     incref_fn = module.get_or_insert_function(
         refct_fnty,
-        name='{}.{}_incref'.format(
+        name='.numba_{}.{}_incref'.format(
             context.fndesc.mangled_name, container_element_type),
     )
 

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -120,7 +120,7 @@ def _container_get_meminfo(context, builder, container_ty, c):
     return conatainer_struct.meminfo
 
 
-def _get_incref_decref(context, module, datamodel, container_type):
+def _get_incref_decref(context, module, datamodel, container_element_type):
     assert datamodel.contains_nrt_meminfo()
 
     fe_type = datamodel.fe_type
@@ -128,7 +128,8 @@ def _get_incref_decref(context, module, datamodel, container_type):
     refct_fnty = ir.FunctionType(ir.VoidType(), [data_ptr_ty])
     incref_fn = module.get_or_insert_function(
         refct_fnty,
-        name='.numba_{}_incref${}'.format(container_type, fe_type),
+        name='{}.{}_incref'.format(
+            context.fndesc.mangled_name, container_element_type),
     )
 
     builder = ir.IRBuilder(incref_fn.append_basic_block())
@@ -140,7 +141,8 @@ def _get_incref_decref(context, module, datamodel, container_type):
 
     decref_fn = module.get_or_insert_function(
         refct_fnty,
-        name='.numba_{}_decref${}'.format(container_type, fe_type),
+        name='{}.{}_decref'.format(
+            context.fndesc.mangled_name, container_element_type),
     )
     builder = ir.IRBuilder(decref_fn.append_basic_block())
     context.nrt.decref(
@@ -152,7 +154,7 @@ def _get_incref_decref(context, module, datamodel, container_type):
     return incref_fn, decref_fn
 
 
-def _get_equal(context, module, datamodel, container_type):
+def _get_equal(context, module, datamodel, container_element_type):
     assert datamodel.contains_nrt_meminfo()
 
     fe_type = datamodel.fe_type
@@ -177,14 +179,16 @@ def _get_equal(context, module, datamodel, container_type):
 
     wrapfn = module.get_or_insert_function(
         wrapfnty,
-        name='.numba_{}_item_equal.wrap${}'.format(container_type, fe_type)
+        name='{}.{}_equal.wrap'.format(
+            context.fndesc.mangled_name, container_element_type)
     )
     build_wrapper(wrapfn)
 
     equal_fnty = ir.FunctionType(ir.IntType(32), [data_ptr_ty, data_ptr_ty])
     equal_fn = module.get_or_insert_function(
         equal_fnty,
-        name='.numba_{}_item_equal${}'.format(container_type, fe_type),
+        name='{}.{}_equal'.format(
+            context.fndesc.mangled_name, container_element_type),
     )
     builder = Builder(equal_fn.append_basic_block())
     lhs = datamodel.load_from_data_pointer(builder, equal_fn.args[0])


### PR DESCRIPTION
Fixes #6401 as described [here](https://github.com/numba/numba/issues/6401#issuecomment-713474356)