### PR TITLE
MAINT: Switch to np.compat for long

### DIFF
--- a/numba/core/types/__init__.py
+++ b/numba/core/types/__init__.py
@@ -105,8 +105,8 @@ int_ = _make_signed(np.int_)
 uint = _make_unsigned(np.int_)
 intc = _make_signed(np.intc) # C-compat int
 uintc = _make_unsigned(np.uintc) # C-compat uint
-long_ = _make_signed(np.long)
-ulong = _make_unsigned(np.long)
+long_ = _make_signed(int)  # int is an alias for long in Python3+
+ulong = _make_unsigned(int)
 longlong = _make_signed(np.longlong)
 ulonglong = _make_unsigned(np.longlong)
 


### PR DESCRIPTION
On latest `numpy` master, gets rid of warnings of the form:
```
../numba/numba/core/types/__init__.py:109
  /home/larsoner/python/numba/numba/core/types/__init__.py:109: DeprecationWarning: `np.long` is a deprecated alias for `np.compat.long`. Use `np.compat.long` by itself, which is identical in behavior, to silence this warning. In the likely event your code does not need to work on Python 2 you can use the builtin ``int`` for which ``np.compat.long`` is itself an alias. If you specifically wanted the numpy scalar type, use `np.int_` here.
    ulong = _make_unsigned(np.long)
```
by using the second suggestion (use `int`) since `setup.py` lists 3.6 as the min version. Admittedly I don't know if this is actually what's intended or what this might break, so feel free to close if there is a better fix -- I mostly just want to bring the warning to your attention!