### PR TITLE
CUDA: Remove deprecated items, expect CUDA 11.1

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -783,11 +783,10 @@ class Dispatcher(serialize.ReduceMixin):
     Dispatcher objects are not to be constructed by the user, but instead are
     created using the :func:`numba.cuda.jit` decorator.
     '''
-    def __init__(self, func, sigs, bind, targetoptions):
+    def __init__(self, func, sigs, targetoptions):
         super().__init__()
         self.py_func = func
         self.sigs = []
-        self._bind = bind
         self.link = targetoptions.pop('link', (),)
         self._can_compile = True
 
@@ -896,7 +895,7 @@ class Dispatcher(serialize.ReduceMixin):
         targetoptions = self.targetoptions
         targetoptions['link'] = self.link
         specialization = Dispatcher(self.py_func, [types.void(*argtypes)],
-                                    self._bind, targetoptions)
+                                    targetoptions)
         self.specializations[cc, argtypes] = specialization
         return specialization
 
@@ -948,8 +947,7 @@ class Dispatcher(serialize.ReduceMixin):
                                     link=self.link,
                                     **self.targetoptions)
             self.definitions[(cc, argtypes)] = kernel
-            if self._bind:
-                kernel.bind()
+            kernel.bind()
             self.sigs.append(sig)
         return kernel
 
@@ -1030,11 +1028,11 @@ class Dispatcher(serialize.ReduceMixin):
             defn.bind()
 
     @classmethod
-    def _rebuild(cls, py_func, sigs, bind, targetoptions):
+    def _rebuild(cls, py_func, sigs, targetoptions):
         """
         Rebuild an instance.
         """
-        instance = cls(py_func, sigs, bind, targetoptions)
+        instance = cls(py_func, sigs, targetoptions)
         return instance
 
     def _reduce_states(self):
@@ -1042,5 +1040,5 @@ class Dispatcher(serialize.ReduceMixin):
         Reduce the instance for serialization.
         Compiled definitions are discarded.
         """
-        return dict(py_func=self.py_func, sigs=self.sigs, bind=self._bind,
+        return dict(py_func=self.py_func, sigs=self.sigs,
                     targetoptions=self.targetoptions)

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -4,7 +4,6 @@ on the object.  If it exists and evaluate to True, it must define shape,
 strides, dtype and size attributes similar to a NumPy ndarray.
 """
 
-import warnings
 import math
 import functools
 import operator
@@ -62,8 +61,7 @@ class DeviceNDArrayBase(object):
     __cuda_memory__ = True
     __cuda_ndarray__ = True     # There must be gpu_data attribute
 
-    def __init__(self, shape, strides, dtype, stream=0, writeback=None,
-                 gpu_data=None):
+    def __init__(self, shape, strides, dtype, stream=0, gpu_data=None):
         """
         Args
         ----
@@ -76,8 +74,6 @@ class DeviceNDArrayBase(object):
             data type as np.dtype coercible object.
         stream
             cuda stream.
-        writeback
-            Deprecated.
         gpu_data
             user provided device memory for the ndarray data buffer
         """
@@ -110,8 +106,6 @@ class DeviceNDArrayBase(object):
             self.alloc_size = 0
 
         self.gpu_data = gpu_data
-
-        self.__writeback = writeback    # should deprecate the use of this
         self.stream = stream
 
     @property
@@ -273,14 +267,6 @@ class DeviceNDArrayBase(object):
                 hostary = np.ndarray(shape=self.shape, dtype=self.dtype,
                                      strides=self.strides, buffer=hostary)
         return hostary
-
-    def to_host(self, stream=0):
-        stream = self._default_stream(stream)
-        warnings.warn("to_host() is deprecated and will be removed",
-                      DeprecationWarning)
-        if self.__writeback is None:
-            raise ValueError("no associated writeback array")
-        self.copy_to_host(self.__writeback, stream=stream)
 
     def split(self, section, stream=0):
         """Split the array into equal partition of the `section` size.
@@ -693,8 +679,8 @@ class ManagedNDArray(DeviceNDArrayBase, np.ndarray):
 
 def from_array_like(ary, stream=0, gpu_data=None):
     "Create a DeviceNDArray object that is like ary."
-    return DeviceNDArray(ary.shape, ary.strides, ary.dtype,
-                         writeback=ary, stream=stream, gpu_data=gpu_data)
+    return DeviceNDArray(ary.shape, ary.strides, ary.dtype, stream=stream,
+                         gpu_data=gpu_data)
 
 
 def from_record_like(rec, stream=0, gpu_data=None):

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1880,7 +1880,7 @@ class Stream(object):
         callback will block later work in the stream and may block other
         callbacks from being executed.
 
-        Note: This driver function underlying this method is marked for
+        Note: The driver function underlying this method is marked for
         eventual deprecation and may be replaced in a future CUDA release.
 
         :param callback: Callback function with arguments (stream, status, arg).

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -482,15 +482,6 @@ class Device(object):
             'pci_device_id': self.PCI_DEVICE_ID,
         }
 
-    @property
-    def COMPUTE_CAPABILITY(self):
-        """
-        For backward compatibility
-        """
-        warnings.warn("Deprecated attribute 'COMPUTE_CAPABILITY'; use lower "
-                      "case version", DeprecationWarning)
-        return self.compute_capability
-
     def __repr__(self):
         return "<CUDA device %d '%s'>" % (self.id, self.name)
 
@@ -1889,8 +1880,8 @@ class Stream(object):
         callback will block later work in the stream and may block other
         callbacks from being executed.
 
-        Note: This function is marked as deprecated and may be replaced in a
-        future CUDA release.
+        Note: This driver function underlying this method is marked for
+        eventual deprecation and may be replaced in a future CUDA release.
 
         :param callback: Callback function with arguments (stream, status, arg).
         :param arg: User data to be passed to the callback function.

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,6 +1,5 @@
-from warnings import warn
 from numba.core import types, config, sigutils
-from numba.core.errors import NumbaDeprecationWarning
+from numba.core.errors import DeprecationError
 from .compiler import (compile_device, declare_device_function, Dispatcher,
                        compile_device_template)
 from .simulator.kernel import FakeCUDAKernel
@@ -20,8 +19,8 @@ def jitdevice(func, link=[], debug=None, inline=False, opt=True):
     return compile_device_template(func, debug=debug, inline=inline, opt=opt)
 
 
-def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
-        link=[], debug=None, opt=True, **kws):
+def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
+        opt=True, **kws):
     """
     JIT compile a python function conforming to the CUDA Python specification.
     If a signature is supplied, then a function is returned that takes a
@@ -37,8 +36,6 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
        .. note:: A kernel cannot have any return value.
     :param device: Indicates whether this is a device function.
     :type device: bool
-    :param bind: (Deprecated) Force binding to CUDA context immediately
-    :type bind: bool
     :param link: A list of files containing PTX source to link with the function
     :type link: list
     :param debug: If True, check for exceptions thrown when executing the
@@ -64,18 +61,18 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
     if kws.get('boundscheck'):
         raise NotImplementedError("bounds checking is not supported for CUDA")
 
-    if argtypes is not None:
+    if kws.get('argtypes') is not None:
         msg = _msg_deprecated_signature_arg.format('argtypes')
-        warn(msg, category=NumbaDeprecationWarning)
-
-    if 'bind' in kws:
+        raise DeprecationError(msg)
+    if kws.get('restype') is not None:
+        msg = _msg_deprecated_signature_arg.format('restype')
+        raise DeprecationError(msg)
+    if kws.get('bind') is not None:
         msg = _msg_deprecated_signature_arg.format('bind')
-        warn(msg, category=NumbaDeprecationWarning)
-    else:
-        bind = True
+        raise DeprecationError(msg)
 
     fastmath = kws.get('fastmath', False)
-    if argtypes is None and not sigutils.is_signature(func_or_sig):
+    if not sigutils.is_signature(func_or_sig):
         if func_or_sig is None:
             if config.ENABLE_CUDASIM:
                 def autojitwrapper(func):
@@ -99,7 +96,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
                 targetoptions['opt'] = opt
                 targetoptions['link'] = link
                 sigs = None
-                return Dispatcher(func_or_sig, sigs, bind=bind,
+                return Dispatcher(func_or_sig, sigs,
                                   targetoptions=targetoptions)
 
     else:
@@ -114,15 +111,11 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
             raise ValueError(msg)
         elif sigutils.is_signature(func_or_sig):
             sigs = [func_or_sig]
-        elif func_or_sig is None:
-            # Handle the deprecated argtypes / restype specification
-            restype = kws.get('restype', types.void)
-            sigs = [restype(*argtypes)]
         else:
             raise ValueError("Expecting signature or list of signatures")
 
         for sig in sigs:
-            restype, argtypes = convert_types(sig, argtypes)
+            argtypes, restype = sigutils.normalize_signature(sig)
 
             if restype and not device and restype != types.void:
                 raise TypeError("CUDA kernel must have void return type.")
@@ -132,8 +125,7 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
             targetoptions['debug'] = debug
             targetoptions['link'] = link
             targetoptions['opt'] = opt
-            return Dispatcher(func, sigs, bind=bind,
-                              targetoptions=targetoptions)
+            return Dispatcher(func, sigs, targetoptions=targetoptions)
 
         def device_jit(func):
             return compile_device(func, restype, argtypes, inline=inline,
@@ -145,14 +137,6 @@ def jit(func_or_sig=None, argtypes=None, device=False, inline=False,
             return kernel_jit
 
 
-def declare_device(name, restype=None, argtypes=None):
-    restype, argtypes = convert_types(restype, argtypes)
+def declare_device(name, sig):
+    argtypes, restype = sigutils.normalize_signature(sig)
     return declare_device_function(name, restype, argtypes)
-
-
-def convert_types(restype, argtypes):
-    # eval type string
-    if sigutils.is_signature(restype):
-        argtypes, restype = sigutils.normalize_signature(restype)
-
-    return restype, argtypes

--- a/numba/cuda/simulator/cudadrv/devicearray.py
+++ b/numba/cuda/simulator/cudadrv/devicearray.py
@@ -3,7 +3,6 @@ The Device Array API is not implemented in the simulator. This module provides
 stubs to allow tests to import correctly.
 '''
 from contextlib import contextmanager
-from warnings import warn
 
 import numpy as np
 
@@ -147,10 +146,6 @@ class FakeCUDAArray(object):
                 copy=False)
             check_array_compatibility(self_core, ary_core)
         np.copyto(self_core._ary, ary_core)
-
-    def to_host(self):
-        warn('to_host() is deprecated and will be removed')
-        raise NotImplementedError
 
     @property
     def shape(self):

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -78,8 +78,8 @@ class TestLinker(CUDATestCase):
             i = cuda.grid(1)
             x[i] += bar(y[i])
 
-        A = np.array([123])
-        B = np.array([321])
+        A = np.array([123]).astype(np.int32)
+        B = np.array([321]).astype(np.int32)
 
         foo[1, 1](A, B)
 

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -78,8 +78,8 @@ class TestLinker(CUDATestCase):
             i = cuda.grid(1)
             x[i] += bar(y[i])
 
-        A = np.array([123]).astype(np.int32)
-        B = np.array([321]).astype(np.int32)
+        A = np.array([123], dtype=np.int32)
+        B = np.array([321], dtype=np.int32)
 
         foo[1, 1](A, B)
 

--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -23,7 +23,7 @@ class TestRuntime(unittest.TestCase):
             supported_versions = (-1, -1),
         else:
             supported_versions = ((9, 0), (9, 1), (9, 2), (10, 0),
-                                  (10, 1), (10, 2), (11, 0))
+                                  (10, 1), (10, 2), (11, 0), (11, 1))
         self.assertIn(runtime.get_version(), supported_versions)
 
 

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -1,6 +1,6 @@
 import numpy as np
 import math
-from numba import cuda, double
+from numba import cuda, double, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
@@ -64,7 +64,7 @@ class TestBlackScholes(CUDATestCase):
             black_scholes(callResultNumpy, putResultNumpy, stockPrice,
                           optionStrike, optionYears, RISKFREE, VOLATILITY)
 
-        @cuda.jit(argtypes=(double,), restype=double, device=True, inline=True)
+        @cuda.jit(double(double), device=True, inline=True)
         def cnd_cuda(d):
             K = 1.0 / (1.0 + 0.2316419 * math.fabs(d))
             ret_val = (RSQRT2PI * math.exp(-0.5 * d * d) *
@@ -73,8 +73,8 @@ class TestBlackScholes(CUDATestCase):
                 ret_val = 1.0 - ret_val
             return ret_val
 
-        @cuda.jit(argtypes=(double[:], double[:], double[:], double[:],
-                            double[:], double, double))
+        @cuda.jit(void(double[:], double[:], double[:], double[:], double[:],
+                       double, double))
         def black_scholes_cuda(callResult, putResult, S, X, T, R, V):
             i = cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
             if i >= S.shape[0]:

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -104,8 +104,8 @@ class TestCudaConstantMemory(CUDATestCase):
                 "as we're adding to it, load as a double")
 
     def test_const_empty(self):
-        jcuconstEmpty = cuda.jit('void(float64[:])')(cuconstEmpty)
-        A = np.full(1, fill_value=-1, dtype=int)
+        jcuconstEmpty = cuda.jit('void(int64[:])')(cuconstEmpty)
+        A = np.full(1, fill_value=-1, dtype=np.int64)
         jcuconstEmpty[1, 1](A)
         self.assertTrue(np.all(A == 0))
 
@@ -144,8 +144,8 @@ class TestCudaConstantMemory(CUDATestCase):
             self.assertIn(complex_load, jcuconst3d.ptx, description)
 
     def test_const_record_empty(self):
-        jcuconstRecEmpty = cuda.jit('void(float64[:])')(cuconstRecEmpty)
-        A = np.full(1, fill_value=-1, dtype=int)
+        jcuconstRecEmpty = cuda.jit('void(int64[:])')(cuconstRecEmpty)
+        A = np.full(1, fill_value=-1, dtype=np.int64)
         jcuconstRecEmpty[1, 1](A)
         self.assertTrue(np.all(A == 0))
 

--- a/numba/cuda/tests/cudapy/test_idiv.py
+++ b/numba/cuda/tests/cudapy/test_idiv.py
@@ -1,12 +1,12 @@
 import numpy as np
-from numba import cuda, float32, float64, int32
+from numba import cuda, float32, float64, int32, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
 class TestCudaIDiv(CUDATestCase):
     def test_inplace_div(self):
 
-        @cuda.jit(argtypes=[float32[:, :], int32, int32])
+        @cuda.jit(void(float32[:, :], int32, int32))
         def div(grid, l_x, l_y):
             for x in range(l_x):
                 for y in range(l_y):
@@ -20,7 +20,7 @@ class TestCudaIDiv(CUDATestCase):
 
     def test_inplace_div_double(self):
 
-        @cuda.jit(argtypes=[float64[:, :], int32, int32])
+        @cuda.jit(void(float64[:, :], int32, int32))
         def div_double(grid, l_x, l_y):
             for x in range(l_x):
                 for y in range(l_y):

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -215,7 +215,7 @@ class TestCudaIntrinsic(CUDATestCase):
         self.assertEqual(ary[1], nctaid[1] * ntid[1])
 
     def test_intrinsic_forloop_step(self):
-        compiled = cuda.jit("void(float32[:,::1])")(intrinsic_forloop_step)
+        compiled = cuda.jit("void(int32[:,::1])")(intrinsic_forloop_step)
         ntid = (4, 3)
         nctaid = (5, 6)
         shape = (ntid[0] * nctaid[0], ntid[1] * nctaid[1])
@@ -317,7 +317,7 @@ class TestCudaIntrinsic(CUDATestCase):
         http://docs.nvidia.com/cuda/nvvm-ir-spec/index.html#bit-manipulations-intrinics
         """
         compiled = cuda.jit("void(int32[:], uint32)")(simple_clz)
-        ary = np.zeros(1, dtype=np.uint32)
+        ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
         self.assertEquals(ary[0], 11)
 
@@ -348,7 +348,7 @@ class TestCudaIntrinsic(CUDATestCase):
 
     def test_ffs_u4(self):
         compiled = cuda.jit("void(int32[:], uint32)")(simple_ffs)
-        ary = np.zeros(1, dtype=np.uint32)
+        ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
         self.assertEquals(ary[0], 20)
 

--- a/numba/cuda/tests/cudapy/test_matmul.py
+++ b/numba/cuda/tests/cudapy/test_matmul.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numba import cuda, float32
+from numba import cuda, float32, void
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.core import config
 
@@ -18,7 +18,7 @@ class TestCudaMatMul(CUDATestCase):
 
     def test_func(self):
 
-        @cuda.jit(argtypes=[float32[:, ::1], float32[:, ::1], float32[:, ::1]])
+        @cuda.jit(void(float32[:, ::1], float32[:, ::1], float32[:, ::1]))
         def cu_square_matrix_mul(A, B, C):
             sA = cuda.shared.array(shape=SM_SIZE, dtype=float32)
             sB = cuda.shared.array(shape=(tpb, tpb), dtype=float32)

--- a/numba/cuda/tests/cudapy/test_nondet.py
+++ b/numba/cuda/tests/cudapy/test_nondet.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import cuda, float32
+from numba import cuda, float32, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
@@ -15,7 +15,7 @@ class TestCudaNonDet(CUDATestCase):
         precondition.
         """
 
-        @cuda.jit(argtypes=[float32[:, :], float32[:, :], float32[:]])
+        @cuda.jit(void(float32[:, :], float32[:, :], float32[:]))
         def diagproduct(c, a, b):
             startX, startY = cuda.grid(2)
             gridX = cuda.gridDim.x * cuda.blockDim.x

--- a/numba/cuda/tests/cudapy/test_optimization.py
+++ b/numba/cuda/tests/cudapy/test_optimization.py
@@ -45,7 +45,7 @@ class TestOptimization(CUDATestCase):
         kernel[1, 1](x)
 
         # Grab the PTX for the one definition that has just been jitted
-        ptx = next(iter(kernel.inspect_asm()))[1]
+        ptx = next(iter(kernel.inspect_asm().items()))[1]
 
         for fragment in removed_by_opt:
             with self.subTest(fragment=fragment):

--- a/numba/cuda/tests/cudapy/test_powi.py
+++ b/numba/cuda/tests/cudapy/test_powi.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from numba import cuda, float64, int8, int32
+from numba import cuda, float64, int8, int32, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
@@ -52,7 +52,7 @@ def random_complex(N):
 
 class TestCudaPowi(CUDATestCase):
     def test_powi(self):
-        dec = cuda.jit(argtypes=[float64[:, :], int8, float64[:, :]])
+        dec = cuda.jit(void(float64[:, :], int8, float64[:, :]))
         kernel = dec(cu_mat_power)
 
         power = 2
@@ -62,7 +62,7 @@ class TestCudaPowi(CUDATestCase):
         self.assertTrue(np.allclose(Aout, A ** power))
 
     def test_powi_binop(self):
-        dec = cuda.jit(argtypes=[float64[:, :], int8, float64[:, :]])
+        dec = cuda.jit(void(float64[:, :], int8, float64[:, :]))
         kernel = dec(cu_mat_power_binop)
 
         power = 2

--- a/numba/cuda/tests/cudapy/test_py2_div_issue.py
+++ b/numba/cuda/tests/cudapy/test_py2_div_issue.py
@@ -1,11 +1,11 @@
 import numpy as np
-from numba import cuda, float32, int32
+from numba import cuda, float32, int32, void
 from numba.cuda.testing import unittest, CUDATestCase
 
 
 class TestCudaPy2Div(CUDATestCase):
     def test_py2_div_issue(self):
-        @cuda.jit(argtypes=[float32[:], float32[:], float32[:], int32])
+        @cuda.jit(void(float32[:], float32[:], float32[:], int32))
         def preCalc(y, yA, yB, numDataPoints):
             i = cuda.grid(1)
             # k is unused, but may be part of the trigger for the bug this


### PR DESCRIPTION
Based on #6377 as it removes the use of deprecated options in the test suite.

Remove items from the CUDA target that are deprecated:

- `Device.COMPUTE_CAPABILITY`: Deprecated since 2014 when NumbaPro was open-sourced.
- `DeviceNDArrayBase.to_host`: Likewise.
- `argtypes`, `restype`, and `bind` kwargs to the `cuda.jit` decorator: Deprecated in 0.51.0.

There is some associated code that is also removed - e.g. that influenced by the `bind` kwarg, and the `__writeback` member of `DeviceNDArrayBase`.

This PR also simplifies `declare_device`, as it is only called with a signature now.

Since CUDA 11.1 is now out, `test_runtime` is modified to expect it as a valid version as well.

Whilst working on this PR, I noticed that the comment about the deprecation of the underlying CUDA driver function in `add_callback` was inaccurate, so I've changed the text to reflect that it is not presently deprecated.