### PR TITLE
Don't pass reduction variables known in an outer parfor to inner parfors when analyzing reductions.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3436,7 +3436,7 @@ def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=
             if isinstance(stmt, Parfor):
                 # recursive parfors can have reductions like test_prange8
                 get_parfor_reductions(func_ir, stmt, parfor_params, calltypes,
-                    reductions, reduce_varnames, param_uses, param_nodes, var_to_param)
+                    reductions, reduce_varnames, None, param_nodes, var_to_param)
 
     for param, used_vars in param_uses.items():
         # a parameter is a reduction variable if its value is used to update it

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2343,6 +2343,33 @@ class TestPrange(TestPrangeBase):
                'operators.')
         self.assertIn(msg, str(raises.exception))
 
+    @skip_parfors_unsupported
+    def test_prange_two_conditional_reductions(self):
+        # issue6414
+        def test_impl():
+            A = B = 0
+            for k in range(1):
+                if k == 2:
+                    A += 1
+                else:
+                    x = np.zeros((1, 1))
+                    if x[0, 0]:
+                        B += 1
+            return A, B
+        self.prange_tester(test_impl)
+
+    @skip_parfors_unsupported
+    def test_prange_nested_reduction1(self):
+        # issue6414
+        def test_impl():
+            A = 0
+            for k in range(1):
+                for i in range(1):
+                    if i == 0:
+                        A += 1
+            return A
+        self.prange_tester(test_impl)
+
 #    @skip_parfors_unsupported
     @disabled_test
     def test_check_error_model(self):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2360,7 +2360,6 @@ class TestPrange(TestPrangeBase):
 
     @skip_parfors_unsupported
     def test_prange_nested_reduction1(self):
-        # issue6414
         def test_impl():
             A = 0
             for k in range(1):


### PR DESCRIPTION
Resolves #6414 