### PR TITLE
Fix ASCII flag in Unicode slicing (0.52.0rc2 regression)

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -1664,7 +1664,7 @@ def unicode_getitem(s, idx):
                 for i in range(slice_idx.start + slice_idx.step,
                                slice_idx.stop, slice_idx.step):
                     cp = _get_code_point(s, i)
-                    is_ascii |= _codepoint_is_ascii(cp)
+                    is_ascii &= _codepoint_is_ascii(cp)
                     new_kind = _codepoint_to_kind(cp)
                     if kind != new_kind:
                         kind = _pick_kind(kind, new_kind)

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -1302,10 +1302,10 @@ class TestUnicode(BaseTest):
         """
         @njit
         def f(s):
-            return s[::2]._is_ascii
+            return s[::2]._is_ascii, s[1::2]._is_ascii
 
         s = "¿abc¡Y tú, quién te cre\t\tes?"
-        self.assertEqual(f(s), 0)
+        self.assertEqual(f(s), (0, 1))
 
     def test_zfill(self):
         pyfunc = zfill_usecase

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -1297,8 +1297,8 @@ class TestUnicode(BaseTest):
 
     def test_slice_ascii_flag(self):
         """
-        Make sure ascii flag is False when ascii and non-ascii characters are mixed
-        in output of Unicode slicing.
+        Make sure ascii flag is False when ascii and non-ascii characters are
+        mixed in output of Unicode slicing.
         """
         @njit
         def f(s):

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -1295,6 +1295,18 @@ class TestUnicode(BaseTest):
                                          cfunc(s, sl),
                                          "'%s'[%d:%d:%d]?" % (s, i, j, k))
 
+    def test_slice_ascii_flag(self):
+        """
+        Make sure ascii flag is False when ascii and non-ascii characters are mixed
+        in output of Unicode slicing.
+        """
+        @njit
+        def f(s):
+            return s[::2]._is_ascii
+
+        s = "¿abc¡Y tú, quién te cre\t\tes?"
+        self.assertEqual(f(s), 0)
+
     def test_zfill(self):
         pyfunc = zfill_usecase
         cfunc = njit(pyfunc)


### PR DESCRIPTION
All characters should be ASCII for a string to be ASCII, so the flag computation should use 'and' instead of 'or'.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
