### PR TITLE
Fix array analysis regression in 0.52 RC2 for tuple of 1D arrays

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2065,13 +2065,14 @@ class ArrayAnalysis(object):
 
     def _analyze_op_build_tuple(self, scope, equiv_set, expr):
         # For the moment, we can't do anything with tuples that
-        # contain arrays, compared to array dimensions.  Return
-        # None to say we won't track this tuple if a part of it
+        # contain multi-dimensional arrays, compared to array dimensions.
+        # Return None to say we won't track this tuple if a part of it
         # is an array.
         for x in expr.items:
             if (
                 isinstance(x, ir.Var)
                 and isinstance(self.typemap[x.name], types.ArrayCompatible)
+                and self.typemap[x.name].ndim > 1
             ):
                 return None
 

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -391,6 +391,15 @@ class TestArrayAnalysis(TestCase):
         self._compile_and_test(test_tup_arg,
             (types.Tuple((int_arr_typ, int_arr_typ)),), asserts=None)
 
+        def test_arr_in_tup(m):
+            A = np.ones(m)
+            S = (A,)
+            B = np.ones(len(S[0]))
+            return B
+
+        self._compile_and_test(test_arr_in_tup, (types.intp,),
+                               equivs=[self.with_equiv("A", "B")])
+
         T = namedtuple("T", ['a','b'])
         def test_namedtuple(n):
             r = T(n, n)


### PR DESCRIPTION
Enable array analysis for 1D arrays in tuples (the check in #6408 was too restrictive).
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
