### PR TITLE
FIX: Fixes for literals

### DIFF
--- a/numba/core/annotations/type_annotations.py
+++ b/numba/core/annotations/type_annotations.py
@@ -272,7 +272,7 @@ class TypeAnnotation(object):
         return self.annotate()
 
 
-re_longest_white_prefix = re.compile('^\s*')
+re_longest_white_prefix = re.compile(r'^\s*')
 
 
 def _getindent(text):

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -233,7 +233,7 @@ class _CFG(object):
         nrt_meminfo = re.compile("@NRT_MemInfo")
         ll_intrin_calls = re.compile(r".*call.*@llvm\..*")
         ll_function_call = re.compile(r".*call.*@.*")
-        ll_raise = re.compile("ret i32.*\!ret_is_raise.*")
+        ll_raise = re.compile(r"ret i32.*\!ret_is_raise.*")
         ll_return = re.compile("ret i32 [^1],?.*")
 
         # wrapper function for line wrapping LLVM lines

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -26,7 +26,7 @@ class Loc(object):
     """Source location
 
     """
-    _defmatcher = re.compile('def\s+(\w+)\(.*')
+    _defmatcher = re.compile(r'def\s+(\w+)\(.*')
 
     def __init__(self, filename, line, col=None, maybe_decorator=False):
         """ Arguments:
@@ -1570,12 +1570,12 @@ class FunctionIR(object):
                 label = sb.getvalue()
             if include_ir:
                 label = ''.join(
-                    ['  {}\l'.format(x) for x in label.splitlines()],
+                    [r'  {}\l'.format(x) for x in label.splitlines()],
                 )
-                label = "block {}\l".format(k) + label
+                label = r"block {}\l".format(k) + label
                 g.node(str(k), label=label, shape='rect')
             else:
-                label = "{}\l".format(k)
+                label = r"{}\l".format(k)
                 g.node(str(k), label=label, shape='circle')
         # Populate the edges
         for src, blk in self.blocks.items():

--- a/numba/misc/appdirs.py
+++ b/numba/misc/appdirs.py
@@ -95,7 +95,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.
@@ -201,7 +201,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_config_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.


### PR DESCRIPTION
Takes care of some warnings of the form:
```
../numba/numba/core/ir.py:29
  /home/larsoner/python/numba/numba/core/ir.py:29: DeprecationWarning: invalid escape sequence \s
    _defmatcher = re.compile('def\s+(\w+)\(.*')
```