### PR TITLE
Link to read the docs instead of numba homepage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,12 @@ Distribution: https://www.anaconda.com/download
 
    $ conda install numba
 
-For more options, see the Installation Guide: https://numba.pydata.org/numba-doc/latest/user/installing.html
+For more options, see the Installation Guide: https://numba.readthedocs.io/en/latest/user/installing.html
 
 Documentation
 =============
 
-https://numba.pydata.org/numba-doc/latest/index.html
+https://numba.readthedocs.io/en/latest/index.html
 
 
 Mailing Lists

--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,12 @@ Distribution: https://www.anaconda.com/download
 
    $ conda install numba
 
-For more options, see the Installation Guide: https://numba.readthedocs.io/en/latest/user/installing.html
+For more options, see the Installation Guide: https://numba.readthedocs.io/en/stable/user/installing.html
 
 Documentation
 =============
 
-https://numba.readthedocs.io/en/latest/index.html
+https://numba.readthedocs.io/en/stable/index.html
 
 
 Mailing Lists


### PR DESCRIPTION
Hi everyone :-)

I just noticed that the links in the project readme were still pointing to the documentation hosted on pydata.org, which seems to be out of date.

According to my understanding readthedocs is now the preferred choice, so I just updated the links.

A minor question is if the link should point to `/latest` or to a different tag.

Cheers!
