### PR TITLE
Enable typeguard in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,10 +105,11 @@ jobs:
         NUMPY: '1.18'
         CONDA_ENV: travisci
         TEST_START_INDEX: 14
-      py38_np118:
+      py38_np118_typeguard:
         PYTHON: '3.8'
         NUMPY: '1.18'
         CONDA_ENV: travisci
+        RUN_TYPEGUARD: yes
         TEST_START_INDEX: 15
       py37_np119:
         PYTHON: '3.7'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -42,11 +42,5 @@ jobs:
 
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH
-        conda install -y conda-forge::typeguard
-      displayName: 'Typeguard'
-      condition: eq(variables['RUN_TYPEGUARD'], 'yes')
-
-    - script: |
-        export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  pool: 
+  pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
@@ -39,6 +39,12 @@ jobs:
         mypy
       displayName: 'Mypy'
       condition: eq(variables['RUN_MYPY'], 'yes')
+
+    - script: |
+        export PATH=$HOME/miniconda3/bin:$PATH
+        conda install -y conda-forge::typeguard
+      displayName: 'Typeguard'
+      condition: eq(variables['RUN_TYPEGUARD'], 'yes')
 
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -89,6 +89,8 @@ if [ "$TEST_SVML" == "yes" ]; then $CONDA_INSTALL -c numba icc_rt; fi
 if [ "$TEST_THREADING" == "tbb" ]; then $CONDA_INSTALL tbb tbb-devel; fi
 # Install pickle5
 if [ "$TEST_PICKLE5" == "yes" ]; then $PIP_INSTALL pickle5; fi
+# Install typeguard
+if [ "$RUN_TYPEGUARD" == "yes" ]; then $CONDA_INSTALL conda-forge::typeguard; fi
 
 # environment dump for debug
 echo "DEBUG ENV:"

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -78,5 +78,8 @@ if [ "$RUN_COVERAGE" == "yes" ]; then
     coverage erase
     $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 else
+    if [ "$RUN_TYPEGUARD" == "yes" ]; then
+        export NUMBA_USE_TYPEGUARD=1
+    fi
     NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -77,9 +77,9 @@ if [ "$RUN_COVERAGE" == "yes" ]; then
     export PYTHONPATH=.
     coverage erase
     $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+elif [ "$RUN_TYPEGUARD" == "yes" ]; then
+    echo "INFO: Running with typeguard"
+    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 else
-    if [ "$RUN_TYPEGUARD" == "yes" ]; then
-        export NUMBA_USE_TYPEGUARD=1
-    fi
     NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 fi

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -207,6 +207,12 @@ in the test runner, there is a ``--log`` flag for convenience::
 
     $ python -m numba.runtests --log
 
+To enable :ref:`runtime type-checking <type_anno_check>`, set environment
+variable ``NUMBA_USE_TYPEGUARD=1`` and use the `runtests.py` from the source root
+instead. For example::
+
+    $ NUMBA_USE_TYPEGUARD=1 python runtests.py
+
 
 Development rules
 -----------------
@@ -336,6 +342,23 @@ to make sure. The Numba project's private build and test farm will actually
 exercise all the applicable tests on all the combinations noted above on real
 hardware!
 
+
+.. _type_anno_check:
+
+Type annotation and runtime type checking
+'''''''''''''''''''''''''''''''''''''''''
+
+Numba is slowly gaining type annotations. To facilitate the review of pull
+requests that adds typing annotations incrementally, the test suite uses
+`typeguard`_ to perform runtime type checking, which helps verify the validity
+of type annotations.
+
+To enable runtime type checking in the test suite, users can use the
+`runtests.py`_ in the source root as the test runner and set environment
+variable ``NUMBA_USE_TYPEGUARD=1``. For example::
+
+    $ NUMBA_USE_TYPEGUARD=1 python runtests.py numba.tests
+
 Things that help with pull requests
 '''''''''''''''''''''''''''''''''''
 
@@ -413,3 +436,7 @@ and check out ``_build/html/index.html``.  To push updates to the Web site::
 then verify the repository under the ``gh-pages`` directory.  Make sure the
 ``CNAME`` file is present and contains a single line for ``numba.pydata.org``.
 Finally, use ``git push`` to update the website.
+
+
+.. _typeguard: https://typeguard.readthedocs.io/en/latest/
+.. _runtests.py: https://github.com/numba/numba/blob/master/runtests.py

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -207,8 +207,8 @@ in the test runner, there is a ``--log`` flag for convenience::
 
     $ python -m numba.runtests --log
 
-To enable :ref:`runtime type-checking <type_anno_check>`, set environment
-variable ``NUMBA_USE_TYPEGUARD=1`` and use the `runtests.py` from the source root
+To enable :ref:`runtime type-checking <type_anno_check>`, set the environment
+variable ``NUMBA_USE_TYPEGUARD=1`` and use `runtests.py` from the source root
 instead. For example::
 
     $ NUMBA_USE_TYPEGUARD=1 python runtests.py
@@ -349,11 +349,11 @@ Type annotation and runtime type checking
 '''''''''''''''''''''''''''''''''''''''''
 
 Numba is slowly gaining type annotations. To facilitate the review of pull
-requests that adds typing annotations incrementally, the test suite uses
-`typeguard`_ to perform runtime type checking, which helps verify the validity
+requests that are incrementally adding type annotations, the test suite uses
+`typeguard`_ to perform runtime type checking. This helps verify the validity
 of type annotations.
 
-To enable runtime type checking in the test suite, users can use the
+To enable runtime type checking in the test suite, users can use
 `runtests.py`_ in the source root as the test runner and set environment
 variable ``NUMBA_USE_TYPEGUARD=1``. For example::
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -266,6 +266,8 @@ vary with target operating system and hardware. The following lists them all
   * ``graphviz`` - for some CFG inspection functionality.
   * ``pickle5`` - provides Python 3.8 pickling features for faster pickling in
     Python 3.6 and 3.7.
+  * ``typeguard`` - used by ``runtests.py`` for
+    :ref:`runtime type-checking <type_anno_check>`.
 
 * To build the documentation:
 

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -525,7 +525,7 @@ class CodeLibrary(object):
     _object_caching_enabled = False
     _disable_inspection = False
 
-    def __init__(self, codegen: "CodeLibrary", name: str):
+    def __init__(self, codegen: "BaseCPUCodegen", name: str):
         self._codegen = codegen
         self._name = name
         self._linking_libraries = []   # maintain insertion order

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -525,7 +525,7 @@ class CodeLibrary(object):
     _object_caching_enabled = False
     _disable_inspection = False
 
-    def __init__(self, codegen, name):
+    def __init__(self, codegen: "CodeLibrary", name: str):
         self._codegen = codegen
         self._name = name
         self._linking_libraries = []   # maintain insertion order

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -85,6 +85,13 @@ skip_ppc64le_issue4563 = unittest.skipIf(platform.machine() == 'ppc64le',
                                          ("Hits: 'Parameter area must exist "
                                           "to pass an argument in memory'"))
 
+# Typeguard
+has_typeguard = bool(os.environ.get('NUMBA_USE_TYPEGUARD', 0))
+
+skip_unless_typeguard = unittest.skipUnless(
+    has_typeguard, "Typeguard is not enabled",
+)
+
 try:
     import scipy.linalg.cython_lapack
     has_lapack = True

--- a/numba/tests/test_typeguard.py
+++ b/numba/tests/test_typeguard.py
@@ -1,0 +1,31 @@
+"""
+Tests to ensure that typeguard is working as expected.
+Mostly this contains negative test to proof that typeguard can catch errors.
+"""
+
+from numba.tests.support import TestCase, skip_unless_typeguard
+
+
+def guard_args(val: int):
+    return
+
+
+def guard_ret(val) -> int:
+    return val
+
+
+@skip_unless_typeguard
+class TestTypeGuard(TestCase):
+    def test_check_args(self):
+        with self.assertRaises(TypeError):
+            guard_args(float(1.2))
+
+    def test_check_ret(self):
+        with self.assertRaises(TypeError):
+            guard_ret(float(1.2))
+
+    def test_check_does_not_work_with_inner_func(self):
+        def guard(val: int) -> int:
+            return
+
+        guard(float(1.2))

--- a/numba/tests/test_typeguard.py
+++ b/numba/tests/test_typeguard.py
@@ -30,5 +30,6 @@ class TestTypeGuard(TestCase):
 
         guard(float(1.2))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_typeguard.py
+++ b/numba/tests/test_typeguard.py
@@ -1,8 +1,8 @@
 """
 Tests to ensure that typeguard is working as expected.
-Mostly this contains negative test to proof that typeguard can catch errors.
+This mostly contains negative tests as proof that typeguard can catch errors.
 """
-
+import unittest
 from numba.tests.support import TestCase, skip_unless_typeguard
 
 
@@ -29,3 +29,6 @@ class TestTypeGuard(TestCase):
             return
 
         guard(float(1.2))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
-
 import runpy
 import os
+
+if bool(os.environ.get('NUMBA_USE_TYPEGUARD')):
+    # The typeguard import hook must be installed prior to importing numba.
+    # Therefore, this cannot be part of the numba package.
+    from typeguard.importhook import install_import_hook
+    install_import_hook(packages=['numba'])
 
 # ensure full tracebacks are available and no help messages appear in test mode
 os.environ['NUMBA_DEVELOPER_MODE'] = '1'


### PR DESCRIPTION
Enable [typeguard](https://github.com/agronholm/typeguard) in CI to perform runtime type checking.
