### PR TITLE
Added Bytearray boxing and fixed memory leak in Bytes boxing

### DIFF
--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -262,13 +262,17 @@ def unbox_unicodecharseq(typ, obj, c):
 @box(types.Bytes)
 def box_bytes(typ, val, c):
     obj = c.context.make_helper(c.builder, typ, val)
-    return c.pyapi.bytes_from_string_and_size(obj.data, obj.nitems)
+    ret = c.pyapi.bytes_from_string_and_size(obj.data, obj.nitems)
+    c.context.nrt.decref(c.builder, typ, val)
+    return ret
 
 
 @box(types.ByteArray)
 def box_bytearray(typ, val, c):
     obj = c.context.make_helper(c.builder, typ, val)
-    return c.pyapi.bytearray_from_string_and_size(obj.data, obj.nitems)
+    ret = c.pyapi.bytearray_from_string_and_size(obj.data, obj.nitems)
+    c.context.nrt.decref(c.builder, typ, val)
+    return ret
 
 
 @box(types.CharSeq)

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -265,6 +265,12 @@ def box_bytes(typ, val, c):
     return c.pyapi.bytes_from_string_and_size(obj.data, obj.nitems)
 
 
+@box(types.ByteArray)
+def box_bytearray(typ, val, c):
+    obj = c.context.make_helper(c.builder, typ, val)
+    return c.pyapi.bytearray_from_string_and_size(obj.data, obj.nitems)
+
+
 @box(types.CharSeq)
 def box_charseq(typ, val, c):
     rawptr = cgutils.alloca_once_value(c.builder, value=val)

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1147,6 +1147,12 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [string, size])
 
+    def bytearray_from_string_and_size(self, string, size):
+        fnty = Type.function(self.pyobj, [self.cstring, self.py_ssize_t])
+        fname = "PyByteArray_FromStringAndSize"
+        fn = self._get_function(fnty, name=fname)
+        return self.builder.call(fn, [string, size])
+
     def object_hash(self, obj):
         fnty = Type.function(self.py_hash_t, [self.pyobj,])
         fname = "PyObject_Hash"

--- a/numba/tests/test_buffer_protocol.py
+++ b/numba/tests/test_buffer_protocol.py
@@ -229,7 +229,7 @@ class TestBufferProtocol(MemoryLeakMixin, TestCase):
 
     def test_box(self):
         self.check_box(bytearray(b"abc"))
-        #self.check_box(b"xyz")
+        self.check_box(b"xyz")
 
 
 class TestMemoryView(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_buffer_protocol.py
+++ b/numba/tests/test_buffer_protocol.py
@@ -37,6 +37,12 @@ def iter_usecase(buf):
     return res
 
 
+
+@jit(nopython=True)
+def box_usecase(buf):
+    return buf
+
+
 def attrgetter(attr):
     code = """def func(x):
         return x.%(attr)s
@@ -120,6 +126,9 @@ class TestBufferProtocol(MemoryLeakMixin, TestCase):
     def _check_unary(self, jitfunc, *args):
         pyfunc = jitfunc.py_func
         self.assertPreciseEqual(jitfunc(*args), pyfunc(*args))
+
+    def check_box(self, obj):
+        self._check_unary(box_usecase, obj)
 
     def check_len(self, obj):
         self._check_unary(len_usecase, obj)
@@ -217,6 +226,10 @@ class TestBufferProtocol(MemoryLeakMixin, TestCase):
             self.check_iter(arr)
         for buf in self._readonlies():
             self.check_getitem(buf)
+
+    def test_box(self):
+        self.check_box(bytearray(b"abc"))
+        #self.check_box(b"xyz")
 
 
 class TestMemoryView(MemoryLeakMixin, TestCase):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Adds support for boxing of byte arrays. Addresses unboxing from #6459, but doesn't include slicing. I can add support for that if I have some feedback on what will need to be implemented.

I'm leaving this as WIP because I am unsure where the unittest belongs for this. I found a file dedicated to buffer protocols, but those didn't seem to include boxing.
