### PR TITLE
Access `replace_functions_map` via PreParforPass instance

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1350,7 +1350,7 @@ class PreParforPass(object):
     implementations of numpy functions if available.
     """
     def __init__(self, func_ir, typemap, calltypes, typingctx, options,
-                 swapped={}):
+                 swapped={}, replace_functions_map=replace_functions_map):
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
@@ -1358,6 +1358,7 @@ class PreParforPass(object):
         self.options = options
         # diagnostics
         self.swapped = swapped
+        self.replace_functions_map = replace_functions_map
         self.stats = {
             'replaced_func': 0,
             'replaced_dtype': 0,
@@ -1394,7 +1395,7 @@ class PreParforPass(object):
                         def replace_func():
                             func_def = get_definition(self.func_ir, expr.func)
                             callname = find_callname(self.func_ir, expr)
-                            repl_func = replace_functions_map.get(callname, None)
+                            repl_func = self.replace_functions_map.get(callname, None)
                             # Handle method on array type
                             if (repl_func is None and
                                 len(callname) == 2 and

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -411,7 +411,7 @@ def linspace_parallel_impl(return_type, *args):
     else:
         raise ValueError("parallel linspace with types {}".format(args))
 
-replace_functions_map = {
+swap_functions_map = {
     ('argmin', 'numpy'): lambda r,a: argmin_parallel_impl,
     ('argmax', 'numpy'): lambda r,a: argmax_parallel_impl,
     ('min', 'numpy'): min_parallel_impl,
@@ -1350,7 +1350,7 @@ class PreParforPass(object):
     implementations of numpy functions if available.
     """
     def __init__(self, func_ir, typemap, calltypes, typingctx, options,
-                 swapped={}, replace_functions_map=replace_functions_map):
+                 swapped={}, replace_functions_map=None):
         self.func_ir = func_ir
         self.typemap = typemap
         self.calltypes = calltypes
@@ -1358,6 +1358,8 @@ class PreParforPass(object):
         self.options = options
         # diagnostics
         self.swapped = swapped
+        if replace_functions_map is None:
+            replace_functions_map = swap_functions_map
         self.replace_functions_map = replace_functions_map
         self.stats = {
             'replaced_func': 0,

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -73,8 +73,6 @@ class BaseTest(TestCase):
 
             diagnostics = numba.parfors.parfor.ParforDiagnostics()
 
-            if swap_map is None:
-                swap_map = numba.parfors.parfor.replace_functions_map
             preparfor_pass = numba.parfors.parfor.PreParforPass(
                 tp.state.func_ir,
                 tp.state.typemap,
@@ -662,8 +660,8 @@ class TestPreParforPass(BaseTest):
         args = (arr,)
         argtypes = [typeof(x) for x in args]
 
-        swap_map = numba.parfors.parfor.replace_functions_map.copy()
-        swap_map.pop(("sum", "numpy"), None)
+        swap_map = numba.parfors.parfor.swap_functions_map.copy()
+        swap_map.pop(("sum", "numpy"))
         pre_pass = self.run_parfor_pre_pass(test_impl, argtypes, swap_map)
         self.assertEqual(pre_pass.stats["replaced_func"], 0)
         self.assertEqual(pre_pass.stats["replaced_dtype"], 0)


### PR DESCRIPTION
`replace_functions_map` is global variable from `numba.parfors.parfor`.
It is necessary to have possibility to modify `replace_functions_map`
depending on PreParforPass instance and access to it via the instance.

This PR is a proposal for starting a discussion.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
