### PR TITLE
fix abstract base class import

### DIFF
--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -2,7 +2,8 @@
 Calling conventions for Numba-compiled functions.
 """
 
-from collections import namedtuple, Iterable
+from collections import namedtuple
+from collections.abc import Iterable
 import itertools
 
 from llvmlite import ir


### PR DESCRIPTION
This was detected by the Fastparquet Numba integration testing.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/circleci/repo/fastparquet/fastparquet/__init__.py", line 5, in <module>
    from .core import read_thrift
  File "/home/circleci/repo/fastparquet/fastparquet/core.py", line 9, in <module>
    from . import encoding
  File "/home/circleci/repo/fastparquet/fastparquet/encoding.py", line 13, in <module>
    import numba
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/__init__.py", line 39, in <module>
    from numba.core.decorators import (cfunc, generated_jit, jit, njit, stencil,
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/core/decorators.py", line 12, in <module>
    from numba.stencils.stencil import stencil
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/stencils/stencil.py", line 11, in <module>
    from numba.core import types, typing, utils, ir, config, ir_utils, registry
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/core/registry.py", line 4, in <module>
    from numba.core import utils, typing, dispatcher, cpu
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/core/dispatcher.py", line 15, in <module>
    from numba.core import utils, types, errors, typing, serialize, config, compiler, sigutils
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/core/compiler.py", line 6, in <module>
    from numba.core import (utils, errors, typing, interpreter, bytecode, postproc,
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/site-packages/numba/core/callconv.py", line 5, in <module>
    from collections import namedtuple, Iterable
  File "<frozen importlib._bootstrap>", line 1032, in _handle_fromlist
  File "/home/circleci/repo/miniconda3/envs/fastparquet/lib/python3.7/collections/__init__.py", line 52, in __getattr__
    DeprecationWarning, stacklevel=2)
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
```
