### PR TITLE
Restrict maximum version of python 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import Extension, find_packages, setup
 import versioneer
 
 min_python_version = "3.6"
+max_python_version = "3.9"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.15"
 min_llvmlite_version = "0.36.0.dev0"
@@ -372,7 +373,7 @@ metadata = dict(
     packages=packages,
     setup_requires=build_requires,
     install_requires=install_requires,
-    python_requires=">={}".format(min_python_version),
+    python_requires=">={},<{}".format(min_python_version, max_python_version),
     license="BSD",
     cmdclass=cmdclass,
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ def _guard_py_ver():
     cur_py = parse('.'.join(map(str, sys.version_info[:3])))
 
     if not min_py <= cur_py < max_py:
-        msg = 'cannot install on Python version {}; only supporting >={},<{}'
+        msg = ('Cannot install on Python version {}; only versions >={},<{} ',
+               'are supported.')
         raise RuntimeError(msg.format(cur_py, min_py, max_py))
 
 


### PR DESCRIPTION
Closes: #6482

With this patch, pip will show the follow error for unsupported python versions:

```
ERROR: Package 'numba' requires a different Python: 3.9.0 not in '>=3.6,<3.9'
```

