### PR TITLE
Adapt docs: full example does no longer exist

### DIFF
--- a/docs/source/user/cfunc.rst
+++ b/docs/source/user/cfunc.rst
@@ -194,11 +194,6 @@ Due to ABI limitations, structures should be passed as pointers
 using ``types.CPointer(my_struct)`` as the argument type.  Inside the ``cfunc``
 body, the ``my_struct*`` can be accessed with ``carray``.
 
-Full example
-------------
-
-See full example in ``examples/notebooks/Accessing C Struct Data.ipynb``.
-
 
 Signature specification
 =======================


### PR DESCRIPTION
I searched for this example notebook. Does anyone know, were they can be found, now?

Future Work:
Maybe extend the documentation on how to create in instance of `types.Record` that can be passed to a `cfunc`

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
