### PR TITLE
Add test to ensure Numba imports without warnings.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -171,7 +171,6 @@ exclude =
     numba/tests/test_extended_arg.py
     numba/tests/test_alignment.py
     numba/tests/test_multi3.py
-    numba/tests/test_import.py
     numba/tests/test_overlap.py
     numba/tests/test_array_attr.py
     numba/tests/test_array_methods.py

--- a/numba/tests/test_import.py
+++ b/numba/tests/test_import.py
@@ -1,8 +1,8 @@
+import unittest
 import subprocess
 import sys
 
 from numba.tests.support import TestCase
-import unittest
 
 
 class TestNumbaImport(TestCase):
@@ -10,22 +10,33 @@ class TestNumbaImport(TestCase):
     Test behaviour of importing Numba.
     """
 
+    def run_in_subproc(self, code, flags=None):
+        if flags is None:
+            flags = []
+        cmd = [sys.executable,] + flags + ["-c", code]
+        popen = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        out, err = popen.communicate()
+        if popen.returncode != 0:
+            msg = "process failed with code %s: stderr follows\n%s\n"
+            raise AssertionError(msg % (popen.returncode, err.decode()))
+        return out, err
+
     def test_laziness(self):
         """
         Importing top-level numba features should not import too many modules.
         """
         # A heuristic set of modules that shouldn't be imported immediately
-        blacklist = [
-            'cffi',
-            'distutils',
-            'numba.cuda',
-            'numba.cpython.mathimpl',
-            'numba.cpython.randomimpl',
-            'numba.tests',
-            'numba.core.typing.collections',
-            'numba.core.typing.listdecl',
-            'numba.core.typing.npdatetime',
-            ]
+        blacklist = ['cffi',
+                     'distutils',
+                     'numba.cuda',
+                     'numba.cpython.mathimpl',
+                     'numba.cpython.randomimpl',
+                     'numba.tests',
+                     'numba.core.typing.collections',
+                     'numba.core.typing.listdecl',
+                     'numba.core.typing.npdatetime',
+                     ]
         # Sanity check the modules still exist...
         for mod in blacklist:
             if mod not in ('cffi',):
@@ -38,13 +49,18 @@ class TestNumbaImport(TestCase):
             print(list(sys.modules))
             """
 
-        popen = subprocess.Popen([sys.executable, "-c", code],
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = popen.communicate()
-        if popen.returncode != 0:
-            raise AssertionError("process failed with code %s: stderr follows\n%s\n"
-                                 % (popen.returncode, err.decode()))
-
+        out, _ = self.run_in_subproc(code)
         modlist = set(eval(out.strip()))
         unexpected = set(blacklist) & set(modlist)
         self.assertFalse(unexpected, "some modules unexpectedly imported")
+
+    def test_no_accidental_warnings(self):
+        # checks that importing Numba isn't accidentally triggering warnings due
+        # to e.g. deprecated use of import locations from Python's stdlib
+        code = "import numba"
+        flags = ["-Werror",]
+        self.run_in_subproc(code, flags)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With view of catching issues like that fixed in #6486 as the
entire code base is not yet run under flake8.

Also fixes this test module and makes it flake8 compliant.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
