### PR TITLE
Avoid unnecessary ir.Del generation and removal

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1412,7 +1412,6 @@ def restore_copy_var_names(blocks, save_copies, typemap):
     replace_var_names(blocks, rename_dict)
 
 def simplify(func_ir, typemap, calltypes):
-    remove_dels(func_ir.blocks)
     # get copies in to blocks and out from blocks
     in_cps, out_cps = copy_propagate(func_ir.blocks, typemap)
     # table mapping variable names to ir.Var objects to help replacement

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -16,7 +16,7 @@ from numba.core.annotations import type_annotations
 from numba.core.ir_utils import (raise_on_unsupported_feature, warn_deprecated,
                                  check_and_legalize_ir, guard,
                                  dead_code_elimination, simplify_CFG,
-                                 get_definition, remove_dels,
+                                 get_definition,
                                  build_definitions, compute_cfg_from_blocks,
                                  is_operator_or_getitem)
 from numba.core import postproc

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -289,8 +289,6 @@ class ParforPass(FunctionPass):
                                          state.parfor_diagnostics)
         parfor_pass.run()
 
-        remove_dels(state.func_ir.blocks)
-
         # check the parfor pass worked and warn if it didn't
         has_parfor = False
         for blk in state.func_ir.blocks.values():

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2802,9 +2802,6 @@ class ParforPass(ParforPassStates):
                             new_block.append(ir_print)
                 block.body = new_block
 
-        # run post processor again to generate Del nodes
-        post_proc = postproc.PostProcessor(self.func_ir)
-        post_proc.run(True)
         if self.func_ir.is_generator:
             fix_generator_types(self.func_ir.generator_info, self.return_type,
                                 self.typemap)
@@ -3196,10 +3193,6 @@ def lower_parfor_sequential(typingctx, func_ir, typemap, calltypes):
     dprint_func_ir(func_ir, "after parfor sequential lowering")
     simplify(func_ir, typemap, calltypes)
     dprint_func_ir(func_ir, "after parfor sequential simplify")
-    # add dels since simplify removes dels
-    post_proc = postproc.PostProcessor(func_ir)
-    post_proc.run(True)
-    return
 
 
 def _lower_parfor_sequential_block(


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Removes unnecessary ir.Del generation and removal in Parfor code, which used to be necessary. This simplifies the code (and may slightly improve compilation time).