### PR TITLE
setup.py: fix py version guard

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def _guard_py_ver():
     cur_py = parse('.'.join(map(str, sys.version_info[:3])))
 
     if not min_py <= cur_py < max_py:
-        msg = ('Cannot install on Python version {}; only versions >={},<{} ',
+        msg = ('Cannot install on Python version {}; only versions >={},<{} '
                'are supported.')
         raise RuntimeError(msg.format(cur_py, min_py, max_py))
 


### PR DESCRIPTION
Previously, an errant comma made the error message a tuple instead of a
split string literal, so the error was unrelated to the one intended to
be thrown.