### PR TITLE
Minor typo / grammar fixes to 5 minute guide

### DIFF
--- a/docs/source/user/5minguide.rst
+++ b/docs/source/user/5minguide.rst
@@ -6,7 +6,7 @@ A ~5 minute guide to Numba
 Numba is a just-in-time compiler for Python that works best on code that uses
 NumPy arrays and functions, and loops. The most common way to use Numba is
 through its collection of decorators that can be applied to your functions to
-instruct Numba to compile them. When a call is made to a Numba decorated
+instruct Numba to compile them. When a call is made to a Numba-decorated
 function it is compiled to machine code "just-in-time" for execution and all or
 part of your code can subsequently run at native machine code speed!
 
@@ -93,7 +93,7 @@ What is ``nopython`` mode?
 --------------------------
 The Numba ``@jit`` decorator fundamentally operates in two compilation modes,
 ``nopython`` mode and ``object`` mode. In the ``go_fast`` example above,
-``nopython=True`` is set in the ``@jit`` decorator, this is instructing Numba to
+``nopython=True`` is set in the ``@jit`` decorator; this is instructing Numba to
 operate in ``nopython`` mode. The behaviour of the ``nopython`` compilation mode
 is to essentially compile the decorated function so that it will run entirely
 without the involvement of the Python interpreter. This is the recommended and
@@ -101,7 +101,7 @@ best-practice way to use the Numba ``jit`` decorator as it leads to the best
 performance.
 
 Should the compilation in ``nopython`` mode fail, Numba can compile using
-``object mode``, this is a fall back mode for the ``@jit`` decorator if
+``object mode``. This is a fall back mode for the ``@jit`` decorator if
 ``nopython=True`` is not set (as seen in the ``use_pandas`` example above). In
 this mode Numba will identify loops that it can compile and compile those into
 functions that run in machine code, and it will run the rest of the code in the
@@ -110,10 +110,10 @@ interpreter. For best performance avoid using this mode!
 How to measure the performance of Numba?
 ----------------------------------------
 First, recall that Numba has to compile your function for the argument types
-given before it executes the machine code version of your function, this takes
+given before it executes the machine code version of your function. This takes
 time. However, once the compilation has taken place Numba caches the machine
 code version of your function for the particular types of arguments presented.
-If it is called again the with same types, it can reuse the cached version
+If it is called again with the same types, it can reuse the cached version
 instead of having to compile again.
 
 A really common mistake when measuring performance is to not account for the
@@ -154,7 +154,7 @@ This, for example prints::
 
 A good way to measure the impact Numba JIT has on your code is to time execution
 using the `timeit <https://docs.python.org/3/library/timeit.html>`_ module
-functions, these measure multiple iterations of execution and, as a result,
+functions; these measure multiple iterations of execution and, as a result,
 can be made to accommodate for the compilation time in the first execution.
 
 As a side note, if compilation time is an issue, Numba JIT supports
@@ -210,7 +210,6 @@ ctypes/cffi/cython interoperability:
   in ``nopython`` mode.
 * ``ctypes`` - The calling of :ref:`ctypes  <ctypes-support>` wrapped
   functions is supported in ``nopython`` mode.
-  .
 * Cython exported functions :ref:`are callable <cython-support>`.
 
 GPU targets:


### PR DESCRIPTION
This MR fixes some tiny oddities noticed while reading the [5 minute guide page](https://numba.readthedocs.io/en/stable/user/5minguide.html). Specifically:
* Fixes the typo in "If it is called again the with same types".
* Fixes a couple of comma splices and duplicate / missing punctuation.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
