### PR TITLE
Refactoring ParforDiagnostics

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -889,7 +889,7 @@ class ParforDiagnostics(object):
             if print_loop_search:
                 print_wrapped(fmt % (pf.id, loc, r_pattern))
             parfors_simple[pf.id] = (pf, loc, r_pattern)
-            return parfors_simple
+        return parfors_simple
 
     def get_all_lines(self, parfors_simple):
         # ensure adjacency lists are the same size for both sets of info
@@ -983,6 +983,17 @@ class ParforDiagnostics(object):
         # This prints the unoptimised parfors state
         sword = '+--'
         fac = len(sword)
+        fadj, froots = self.compute_graph_info(self.fusion_info)
+        nadj, _nroots = self.compute_graph_info(self.nested_fusion_info)
+
+        if len(fadj) > len(nadj):
+            lim = len(fadj)
+            tmp = nadj
+        else:
+            lim = len(nadj)
+            tmp = fadj
+        for x in range(len(tmp), lim):
+            tmp.append([])
 
         def print_nest(fadj_, nadj_, theroot, reported, region_id):
             def print_g(fadj_, nadj_, nroot, depth):
@@ -1038,6 +1049,17 @@ class ParforDiagnostics(object):
         # occurred during loop fusion and rewriting of loop nests
         sword = '+--'
         fac = len(sword)
+        fadj, froots = self.compute_graph_info(self.fusion_info)
+        nadj, _nroots = self.compute_graph_info(self.nested_fusion_info)
+
+        if len(fadj) > len(nadj):
+            lim = len(fadj)
+            tmp = nadj
+        else:
+            lim = len(nadj)
+            tmp = fadj
+        for x in range(len(tmp), lim):
+            tmp.append([])
 
         summary = dict()
         # region : {fused, serialized}

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -862,6 +862,318 @@ class ParforDiagnostics(object):
                             pass
         return line
 
+    def get_parfors_simple(self, print_loop_search):
+        parfors_simple = dict()
+
+        # print in line order, parfors loop id is based on discovery order
+        for pf in sorted(self.initial_parfors, key=lambda x: x.loc.line):
+            # use 0 here, the parfors are mutated by the time this routine
+            # is called, however, fusion appends the patterns so we can just
+            # pull in the first as a "before fusion" emulation
+            r_pattern = pf.patterns[0]
+            pattern = pf.patterns[0]
+            loc = pf.loc
+            if isinstance(pattern, tuple):
+                if pattern[0] == 'prange':
+                    if pattern[1] == 'internal':
+                        replfn = '.'.join(reversed(list(pattern[2][0])))
+                        loc = pattern[2][1]
+                        r_pattern = '%s %s' % (replfn, '(internal parallel version)')
+                    elif pattern[1] == 'user':
+                        r_pattern = "user defined prange"
+                    elif pattern[1] == 'pndindex':
+                        r_pattern = "internal pndindex" #FIXME: trace this!
+                    else:
+                        assert 0
+            fmt = 'Parallel for-loop #%s: is produced from %s:\n    %s\n \n'
+            if print_loop_search:
+                print_wrapped(fmt % (pf.id, loc, r_pattern))
+            parfors_simple[pf.id] = (pf, loc, r_pattern)
+            return parfors_simple
+
+    def get_all_lines(self, parfors_simple):
+        # ensure adjacency lists are the same size for both sets of info
+        # (nests and fusion may not traverse the same space, for
+        # convenience [] is used as a condition to halt recursion)
+        fadj, froots = self.compute_graph_info(self.fusion_info)
+        nadj, _nroots = self.compute_graph_info(self.nested_fusion_info)
+
+        if len(fadj) > len(nadj):
+            lim = len(fadj)
+            tmp = nadj
+        else:
+            lim = len(nadj)
+            tmp = fadj
+        for x in range(len(tmp), lim):
+            tmp.append([])
+
+        # This computes the roots of true loop nests (i.e. loops containing
+        # loops opposed to just a loop that's a root).
+        nroots = set()
+        if _nroots:
+            for r in _nroots:
+                if nadj[r] != []:
+                    nroots.add(r)
+        all_roots = froots ^ nroots
+
+        # This computes all the parfors at the top level that are either:
+        # - roots of loop fusion
+        # - roots of true loop nests
+        # it then combines these based on source line number for ease of
+        # producing output ordered in a manner similar to the code structure
+        froots_lines = {}
+        for x in froots:
+            line = self.sort_pf_by_line(x, parfors_simple)
+            froots_lines[line] = 'fuse', x, fadj
+
+        nroots_lines = {}
+        for x in nroots:
+            line = self.sort_pf_by_line(x, parfors_simple)
+            nroots_lines[line] = 'nest', x, nadj
+
+        all_lines = froots_lines.copy()
+        all_lines.update(nroots_lines)
+        return all_lines
+
+    def source_listing(self, parfors_simple, purpose_str):
+        filename = self.func_ir.loc.filename
+        count = self.count_parfors()
+        func_name = self.func_ir.func_id.func
+        try:
+            lines = inspect.getsource(func_name).splitlines()
+        except OSError: # generated function
+            lines = None
+        if lines and parfors_simple:
+            src_width = max([len(x) for x in lines])
+            map_line_to_pf = defaultdict(list) # parfors can alias lines
+            for k, v in parfors_simple.items():
+                # TODO: do a better job of tracking parfors that are not in
+                # this file but are referred to, e.g. np.arange()
+                if parfors_simple[k][1].filename == filename:
+                    match_line = self.sort_pf_by_line(k, parfors_simple)
+                    map_line_to_pf[match_line].append(str(k))
+
+            max_pf_per_line = max([1] + [len(x) for x in map_line_to_pf.values()])
+            width = src_width + (1 + max_pf_per_line * (len(str(count)) + 2))
+            newlines = []
+            newlines.append('\n')
+            newlines.append('Parallel loop listing for %s' % purpose_str)
+            newlines.append(width * '-' + '|loop #ID')
+            fmt = '{0:{1}}| {2}'
+            # why are these off by 1?
+            lstart = max(0, self.func_ir.loc.line - 1)
+            for no, line in enumerate(lines, lstart):
+                pf_ids = map_line_to_pf.get(no, None)
+                if pf_ids is not None:
+                    pfstr = '#' + ', '.join(pf_ids)
+                else:
+                    pfstr = ''
+                stripped = line.strip('\n')
+                srclen = len(stripped)
+                if pf_ids:
+                    l = fmt.format(width * '-', width, pfstr)
+                else:
+                    l = fmt.format(width * ' ', width, pfstr)
+                newlines.append(stripped + l[srclen:])
+            print('\n'.join(newlines))
+        else:
+            print("No source available")
+
+    def print_unoptimised(self, lines):
+        # This prints the unoptimised parfors state
+        sword = '+--'
+        fac = len(sword)
+
+        def print_nest(fadj_, nadj_, theroot, reported, region_id):
+            def print_g(fadj_, nadj_, nroot, depth):
+                print_wrapped(fac * depth * ' ' + '%s%s %s' % (sword, nroot, '(parallel)'))
+                for k in nadj_[nroot]:
+                    if nadj_[k] == []:
+                        msg = []
+                        msg.append(fac * (depth + 1) * ' ' + '%s%s %s' % (sword, k, '(parallel)'))
+                        if fadj_[k] != [] and k not in reported:
+                            fused = self.reachable_nodes(fadj_, k)
+                            for i in fused:
+                                msg.append(fac * (depth + 1) * ' ' + '%s%s %s' % (sword, i, '(parallel)'))
+                        reported.append(k)
+                        print_wrapped('\n'.join(msg))
+                    else:
+                        print_g(fadj_, nadj_, k, depth + 1)
+
+            if nadj_[theroot] != []:
+                print_wrapped("Parallel region %s:" % region_id)
+                print_g(fadj_, nadj_, theroot, 0)
+                print("\n")
+                region_id = region_id + 1
+            return region_id
+
+        def print_fuse(ty, pf_id, adj, depth, region_id):
+            msg = []
+            print_wrapped("Parallel region %s:" % region_id)
+            msg.append(fac * depth * ' ' + '%s%s %s' % (sword, pf_id, '(parallel)'))
+            if adj[pf_id] != []:
+                fused = sorted(self.reachable_nodes(adj, pf_id))
+                for k in fused:
+                    msg.append(fac * depth * ' ' + '%s%s %s' % (sword, k, '(parallel)'))
+            region_id = region_id + 1
+            print_wrapped('\n'.join(msg))
+            print("\n")
+            return region_id
+
+        # Walk the parfors by src line and print optimised structure
+        region_id = 0
+        reported = []
+        for line, info in sorted(lines.items()):
+            opt_ty, pf_id, adj = info
+            if opt_ty == 'fuse':
+                if pf_id not in reported:
+                    region_id = print_fuse('f', pf_id, adj, 0, region_id)
+            elif opt_ty == 'nest':
+                region_id = print_nest(fadj, nadj, pf_id, reported, region_id)
+            else:
+                assert 0
+
+    def print_optimised(self, lines):
+        # This prints the optimised output based on the transforms that
+        # occurred during loop fusion and rewriting of loop nests
+        sword = '+--'
+        fac = len(sword)
+
+        summary = dict()
+        # region : {fused, serialized}
+
+        def print_nest(fadj_, nadj_, theroot, reported, region_id):
+            def print_g(fadj_, nadj_, nroot, depth):
+                for k in nadj_[nroot]:
+                    msg = fac * depth * ' ' + '%s%s %s' % (sword, k, '(serial')
+                    if nadj_[k] == []:
+                        fused = []
+                        if fadj_[k] != [] and k not in reported:
+                            fused = sorted(self.reachable_nodes(fadj_, k))
+                            msg += ", fused with loop(s): "
+                            msg += ', '.join([str(x) for x in fused])
+                        msg += ')'
+                        reported.append(k)
+                        print_wrapped(msg)
+                        summary[region_id]['fused'] += len(fused)
+                    else:
+                        print_wrapped(msg + ')')
+                        print_g(fadj_, nadj_, k, depth + 1)
+                    summary[region_id]['serialized'] += 1
+
+            if nadj_[theroot] != []:
+                print_wrapped("Parallel region %s:" % region_id)
+                print_wrapped('%s%s %s' % (sword, theroot, '(parallel)'))
+                summary[region_id] = {'root': theroot, 'fused': 0, 'serialized': 0}
+                print_g(fadj_, nadj_, theroot, 1)
+                print("\n")
+                region_id = region_id + 1
+            return region_id
+
+        def print_fuse(ty, pf_id, adj, depth, region_id):
+            print_wrapped("Parallel region %s:" % region_id)
+            msg = fac * depth * ' ' + '%s%s %s' % (sword, pf_id, '(parallel')
+            fused = []
+            if adj[pf_id] != []:
+                fused = sorted(self.reachable_nodes(adj, pf_id))
+                msg += ", fused with loop(s): "
+                msg += ', '.join([str(x) for x in fused])
+
+            summary[region_id] = {'root': pf_id, 'fused': len(fused), 'serialized': 0}
+            msg += ')'
+            print_wrapped(msg)
+            print("\n")
+            region_id = region_id + 1
+            return region_id
+
+        # Walk the parfors by src line and print optimised structure
+        region_id = 0
+        reported = []
+        for line, info in sorted(lines.items()):
+            opt_ty, pf_id, adj = info
+            if opt_ty == 'fuse':
+                if pf_id not in reported:
+                    region_id = print_fuse('f', pf_id, adj, 0, region_id)
+            elif opt_ty == 'nest':
+                region_id = print_nest(fadj, nadj, pf_id, reported, region_id)
+            else:
+                assert 0
+
+        # print the summary of the fuse/serialize rewrite
+        if summary:
+            for k, v in sorted(summary.items()):
+                msg = ('\n \nParallel region %s (loop #%s) had %s '
+                    'loop(s) fused')
+                root = v['root']
+                fused = v['fused']
+                serialized = v['serialized']
+                if serialized != 0:
+                    msg += (' and %s loop(s) '
+                    'serialized as part of the larger '
+                    'parallel loop (#%s).')
+                    print_wrapped(msg % (k, root, fused, serialized, root))
+                else:
+                    msg += '.'
+                    print_wrapped(msg % (k, root, fused))
+        else:
+            print_wrapped("Parallel structure is already optimal.")
+
+    def allocation_hoist(self):
+        found = False
+        print('Allocation hoisting:')
+        for pf_id, data in self.hoist_info.items():
+            stmt = data.get('hoisted', [])
+            for inst in stmt:
+                if isinstance(inst.value, ir.Expr):
+                    try:
+                        attr = inst.value.attr
+                        if attr == 'empty':
+                            msg = ("The memory allocation derived from the "
+                                "instruction at %s is hoisted out of the "
+                                "parallel loop labelled #%s (it will be "
+                                "performed before the loop is executed and "
+                                "reused inside the loop):")
+                            loc = inst.loc
+                            print_wrapped(msg % (loc, pf_id))
+                            try:
+                                path = os.path.relpath(loc.filename)
+                            except ValueError:
+                                path = os.path.abspath(loc.filename)
+                            lines = linecache.getlines(path)
+                            if lines and loc.line:
+                                print_wrapped("   Allocation:: " + lines[0 if loc.line < 2 else loc.line - 1].strip())
+                            print_wrapped("    - numpy.empty() is used for the allocation.\n")
+                            found = True
+                    except (KeyError, AttributeError):
+                        pass
+        if not found:
+            print_wrapped('No allocation hoisting found')
+
+    def instruction_hoist(self):
+        print("")
+        print('Instruction hoisting:')
+        hoist_info_printed = False
+        if self.hoist_info:
+            for pf_id, data in self.hoist_info.items():
+                hoisted = data.get('hoisted', None)
+                not_hoisted = data.get('not_hoisted', None)
+                if not hoisted and not not_hoisted:
+                    print("loop #%s has nothing to hoist." % pf_id)
+                    continue
+
+                print("loop #%s:" % pf_id)
+                if hoisted:
+                    print("  Has the following hoisted:")
+                    [print("    %s" % y) for y in hoisted]
+                    hoist_info_printed = True
+                if not_hoisted:
+                    print("  Failed to hoist the following:")
+                    [print("    %s: %s" % (y, x)) for x, y in not_hoisted]
+                    hoist_info_printed = True
+        if not hoist_info_printed:
+            print_wrapped('No instruction hoisting found')
+        print_wrapped(80 * '-')
+
     def dump(self, level=1):
         if not self.has_setup:
             raise RuntimeError("self.setup has not been called")
@@ -919,33 +1231,7 @@ class ParforDiagnostics(object):
 #----------- search section
         if print_loop_search:
             print_wrapped('Looking for parallel loops'.center(_termwidth, '-'))
-
-        parfors_simple = dict()
-
-        # print in line order, parfors loop id is based on discovery order
-        for pf in sorted(self.initial_parfors, key=lambda x: x.loc.line):
-            # use 0 here, the parfors are mutated by the time this routine
-            # is called, however, fusion appends the patterns so we can just
-            # pull in the first as a "before fusion" emulation
-            r_pattern = pf.patterns[0]
-            pattern = pf.patterns[0]
-            loc = pf.loc
-            if isinstance(pattern, tuple):
-                if pattern[0] == 'prange':
-                    if pattern[1] == 'internal':
-                        replfn = '.'.join(reversed(list(pattern[2][0])))
-                        loc = pattern[2][1]
-                        r_pattern = '%s %s' % (replfn, '(internal parallel version)')
-                    elif pattern[1] == 'user':
-                        r_pattern = "user defined prange"
-                    elif pattern[1] == 'pndindex':
-                        r_pattern = "internal pndindex" #FIXME: trace this!
-                    else:
-                        assert 0
-            fmt = 'Parallel for-loop #%s: is produced from %s:\n    %s\n \n'
-            if print_loop_search:
-                print_wrapped(fmt % (pf.id, loc, r_pattern))
-            parfors_simple[pf.id] = (pf, loc, r_pattern)
+        parfors_simple = self.get_parfors_simple(print_loop_search)
 
         count = self.count_parfors()
         if print_loop_search:
@@ -965,46 +1251,7 @@ class ParforDiagnostics(object):
             path = os.path.abspath(filename)
 
         if print_source_listing:
-            func_name = self.func_ir.func_id.func
-            try:
-                lines = inspect.getsource(func_name).splitlines()
-            except OSError: # generated function
-                lines = None
-            if lines:
-                src_width = max([len(x) for x in lines])
-                map_line_to_pf = defaultdict(list) # parfors can alias lines
-                for k, v in parfors_simple.items():
-                    # TODO: do a better job of tracking parfors that are not in
-                    # this file but are referred to, e.g. np.arange()
-                    if parfors_simple[k][1].filename == filename:
-                        match_line = self.sort_pf_by_line(k, parfors_simple)
-                        map_line_to_pf[match_line].append(str(k))
-
-                max_pf_per_line = max([1] + [len(x) for x in map_line_to_pf.values()])
-                width = src_width + (1 + max_pf_per_line * (len(str(count)) + 2))
-                newlines = []
-                newlines.append('\n')
-                newlines.append('Parallel loop listing for %s' % purpose_str)
-                newlines.append(width * '-' + '|loop #ID')
-                fmt = '{0:{1}}| {2}'
-                # why are these off by 1?
-                lstart = max(0, self.func_ir.loc.line - 1)
-                for no, line in enumerate(lines, lstart):
-                    pf_ids = map_line_to_pf.get(no, None)
-                    if pf_ids is not None:
-                        pfstr = '#' + ', '.join(pf_ids)
-                    else:
-                        pfstr = ''
-                    stripped = line.strip('\n')
-                    srclen = len(stripped)
-                    if pf_ids:
-                        l = fmt.format(width * '-', width, pfstr)
-                    else:
-                        l = fmt.format(width * ' ', width, pfstr)
-                    newlines.append(stripped + l[srclen:])
-                print('\n'.join(newlines))
-            else:
-                print("No source available")
+            self.source_listing(parfors_simple, purpose_str)
 
 #---------- these are used a lot here on in
         sword = '+--'
@@ -1075,198 +1322,16 @@ class ParforDiagnostics(object):
                     print_wrapped("")
 
 #---------- compute various properties and orderings in the data for subsequent use
-
-            # ensure adjacency lists are the same size for both sets of info
-            # (nests and fusion may not traverse the same space, for
-            # convenience [] is used as a condition to halt recursion)
-            fadj, froots = self.compute_graph_info(self.fusion_info)
-            nadj, _nroots = self.compute_graph_info(self.nested_fusion_info)
-
-            if len(fadj) > len(nadj):
-                lim = len(fadj)
-                tmp = nadj
-            else:
-                lim = len(nadj)
-                tmp = fadj
-            for x in range(len(tmp), lim):
-                tmp.append([])
-
-            # This computes the roots of true loop nests (i.e. loops containing
-            # loops opposed to just a loop that's a root).
-            nroots = set()
-            if _nroots:
-                for r in _nroots:
-                    if nadj[r] != []:
-                        nroots.add(r)
-            all_roots = froots ^ nroots
-
-            # This computes all the parfors at the top level that are either:
-            # - roots of loop fusion
-            # - roots of true loop nests
-            # it then combines these based on source line number for ease of
-            # producing output ordered in a manner similar to the code structure
-            froots_lines = {}
-            for x in froots:
-                line = self.sort_pf_by_line(x, parfors_simple)
-                froots_lines[line] = 'fuse', x, fadj
-
-            nroots_lines = {}
-            for x in nroots:
-                line = self.sort_pf_by_line(x, parfors_simple)
-                nroots_lines[line] = 'nest', x, nadj
-
-            all_lines = froots_lines.copy()
-            all_lines.update(nroots_lines)
-
-            # nroots, froots, nadj and fadj are all set up correctly
-            # define some print functions
-
-            def print_unoptimised(lines):
-                # This prints the unoptimised parfors state
-
-                fac = len(sword)
-
-                def print_nest(fadj_, nadj_, theroot, reported, region_id):
-                    def print_g(fadj_, nadj_, nroot, depth):
-                        print_wrapped(fac * depth * ' ' + '%s%s %s' % (sword, nroot, '(parallel)'))
-                        for k in nadj_[nroot]:
-                            if nadj_[k] == []:
-                                msg = []
-                                msg.append(fac * (depth + 1) * ' ' + '%s%s %s' % (sword, k, '(parallel)'))
-                                if fadj_[k] != [] and k not in reported:
-                                    fused = self.reachable_nodes(fadj_, k)
-                                    for i in fused:
-                                        msg.append(fac * (depth + 1) * ' ' + '%s%s %s' % (sword, i, '(parallel)'))
-                                reported.append(k)
-                                print_wrapped('\n'.join(msg))
-                            else:
-                                print_g(fadj_, nadj_, k, depth + 1)
-
-                    if nadj_[theroot] != []:
-                        print_wrapped("Parallel region %s:" % region_id)
-                        print_g(fadj_, nadj_, theroot, 0)
-                        print("\n")
-                        region_id = region_id + 1
-                    return region_id
-
-                def print_fuse(ty, pf_id, adj, depth, region_id):
-                    msg = []
-                    print_wrapped("Parallel region %s:" % region_id)
-                    msg.append(fac * depth * ' ' + '%s%s %s' % (sword, pf_id, '(parallel)'))
-                    if adj[pf_id] != []:
-                        fused = sorted(self.reachable_nodes(adj, pf_id))
-                        for k in fused:
-                            msg.append(fac * depth * ' ' + '%s%s %s' % (sword, k, '(parallel)'))
-                    region_id = region_id + 1
-                    print_wrapped('\n'.join(msg))
-                    print("\n")
-                    return region_id
-
-                # Walk the parfors by src line and print optimised structure
-                region_id = 0
-                reported = []
-                for line, info in sorted(lines.items()):
-                    opt_ty, pf_id, adj = info
-                    if opt_ty == 'fuse':
-                        if pf_id not in reported:
-                            region_id = print_fuse('f', pf_id, adj, 0, region_id)
-                    elif opt_ty == 'nest':
-                        region_id = print_nest(fadj, nadj, pf_id, reported, region_id)
-                    else:
-                        assert 0
-
-            def print_optimised(lines):
-                # This prints the optimised output based on the transforms that
-                # occurred during loop fusion and rewriting of loop nests
-                fac = len(sword)
-
-                summary = dict()
-                # region : {fused, serialized}
-
-                def print_nest(fadj_, nadj_, theroot, reported, region_id):
-                    def print_g(fadj_, nadj_, nroot, depth):
-                        for k in nadj_[nroot]:
-                            msg = fac * depth * ' ' + '%s%s %s' % (sword, k, '(serial')
-                            if nadj_[k] == []:
-                                fused = []
-                                if fadj_[k] != [] and k not in reported:
-                                    fused = sorted(self.reachable_nodes(fadj_, k))
-                                    msg += ", fused with loop(s): "
-                                    msg += ', '.join([str(x) for x in fused])
-                                msg += ')'
-                                reported.append(k)
-                                print_wrapped(msg)
-                                summary[region_id]['fused'] += len(fused)
-                            else:
-                                print_wrapped(msg + ')')
-                                print_g(fadj_, nadj_, k, depth + 1)
-                            summary[region_id]['serialized'] += 1
-
-                    if nadj_[theroot] != []:
-                        print_wrapped("Parallel region %s:" % region_id)
-                        print_wrapped('%s%s %s' % (sword, theroot, '(parallel)'))
-                        summary[region_id] = {'root': theroot, 'fused': 0, 'serialized': 0}
-                        print_g(fadj_, nadj_, theroot, 1)
-                        print("\n")
-                        region_id = region_id + 1
-                    return region_id
-
-                def print_fuse(ty, pf_id, adj, depth, region_id):
-                    print_wrapped("Parallel region %s:" % region_id)
-                    msg = fac * depth * ' ' + '%s%s %s' % (sword, pf_id, '(parallel')
-                    fused = []
-                    if adj[pf_id] != []:
-                        fused = sorted(self.reachable_nodes(adj, pf_id))
-                        msg += ", fused with loop(s): "
-                        msg += ', '.join([str(x) for x in fused])
-
-                    summary[region_id] = {'root': pf_id, 'fused': len(fused), 'serialized': 0}
-                    msg += ')'
-                    print_wrapped(msg)
-                    print("\n")
-                    region_id = region_id + 1
-                    return region_id
-
-                # Walk the parfors by src line and print optimised structure
-                region_id = 0
-                reported = []
-                for line, info in sorted(lines.items()):
-                    opt_ty, pf_id, adj = info
-                    if opt_ty == 'fuse':
-                        if pf_id not in reported:
-                            region_id = print_fuse('f', pf_id, adj, 0, region_id)
-                    elif opt_ty == 'nest':
-                        region_id = print_nest(fadj, nadj, pf_id, reported, region_id)
-                    else:
-                        assert 0
-
-                # print the summary of the fuse/serialize rewrite
-                if summary:
-                    for k, v in sorted(summary.items()):
-                        msg = ('\n \nParallel region %s (loop #%s) had %s '
-                            'loop(s) fused')
-                        root = v['root']
-                        fused = v['fused']
-                        serialized = v['serialized']
-                        if serialized != 0:
-                            msg += (' and %s loop(s) '
-                            'serialized as part of the larger '
-                            'parallel loop (#%s).')
-                            print_wrapped(msg % (k, root, fused, serialized, root))
-                        else:
-                            msg += '.'
-                            print_wrapped(msg % (k, root, fused))
-                else:
-                    print_wrapped("Parallel structure is already optimal.")
+            all_lines = self.get_all_lines(parfors_simple)
 
             if print_pre_optimised:
                 print(' Before Optimisation '.center(_termwidth,'-'))
-                print_unoptimised(all_lines)
+                self.print_unoptimised(all_lines)
                 print(_termwidth * '-')
 
             if print_post_optimised:
                 print(' After Optimisation '.center(_termwidth,'-'))
-                print_optimised(all_lines)
+                self.print_optimised(all_lines)
                 print(_termwidth * '-')
             print_wrapped("")
             print_wrapped(_termwidth * '-')
@@ -1277,60 +1342,10 @@ class ParforDiagnostics(object):
                 print_wrapped('Loop invariant code motion'.center(80, '-'))
 
             if print_allocation_hoist:
-                found = False
-                print('Allocation hoisting:')
-                for pf_id, data in self.hoist_info.items():
-                    stmt = data.get('hoisted', [])
-                    for inst in stmt:
-                        if isinstance(inst.value, ir.Expr):
-                            try:
-                                attr = inst.value.attr
-                                if attr == 'empty':
-                                    msg = ("The memory allocation derived from the "
-                                        "instruction at %s is hoisted out of the "
-                                        "parallel loop labelled #%s (it will be "
-                                        "performed before the loop is executed and "
-                                        "reused inside the loop):")
-                                    loc = inst.loc
-                                    print_wrapped(msg % (loc, pf_id))
-                                    try:
-                                        path = os.path.relpath(loc.filename)
-                                    except ValueError:
-                                        path = os.path.abspath(loc.filename)
-                                    lines = linecache.getlines(path)
-                                    if lines and loc.line:
-                                        print_wrapped("   Allocation:: " + lines[0 if loc.line < 2 else loc.line - 1].strip())
-                                    print_wrapped("    - numpy.empty() is used for the allocation.\n")
-                                    found = True
-                            except (KeyError, AttributeError):
-                                pass
-                if not found:
-                    print_wrapped('No allocation hoisting found')
+                self.allocation_hoist()
+
             if print_instruction_hoist:
-                print("")
-                print('Instruction hoisting:')
-                hoist_info_printed = False
-                if self.hoist_info:
-                    for pf_id, data in self.hoist_info.items():
-                        hoisted = data.get('hoisted', None)
-                        not_hoisted = data.get('not_hoisted', None)
-                        if not hoisted and not not_hoisted:
-                            print("loop #%s has nothing to hoist." % pf_id)
-                            continue
-
-                        print("loop #%s:" % pf_id)
-                        if hoisted:
-                            print("  Has the following hoisted:")
-                            [print("    %s" % y) for y in hoisted]
-                            hoist_info_printed = True
-                        if not_hoisted:
-                            print("  Failed to hoist the following:")
-                            [print("    %s: %s" % (y, x)) for x, y in not_hoisted]
-                            hoist_info_printed = True
-                if not hoist_info_printed:
-                    print_wrapped('No instruction hoisting found')
-                print_wrapped(80 * '-')
-
+                self.instruction_hoist()
 
         else: # there are no parfors
             print_wrapped('Function %s, %s, has no parallel for-loops.'.format(name, line))


### PR DESCRIPTION
We need to be able to get "all_lines" to reuse it in our ExtendedParforDiagnostics to avoid code duplication.
Also now "dump" function is too complicated so this refactoring was made.