### PR TITLE
Add LLVM pass timer

### DIFF
--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -24,5 +24,6 @@ Developer Manual
    caching.rst
    threading_implementation.rst
    literal.rst
+   llvm_timings.rst
    debugging.rst
    roadmap.rst

--- a/docs/source/developer/llvm_timings.rst
+++ b/docs/source/developer/llvm_timings.rst
@@ -25,7 +25,7 @@ Code Example
    :caption: from ``test_pass_timings`` of ``numba/tests/doc_examples/test_llvm_pass_timings.py``
    :start-after: magictoken.ex_llvm_pass_timings.begin
    :end-before: magictoken.ex_llvm_pass_timings.end
-   :dedent: 12
+   :dedent: 16
    :linenos:
 
 Example output:

--- a/docs/source/developer/llvm_timings.rst
+++ b/docs/source/developer/llvm_timings.rst
@@ -8,9 +8,9 @@ Notes on timing LLVM
 Getting LLVM Pass Timings
 -------------------------
 
-The dispatcher stores LLVM pass timings in the metadata under the
-``llvm_pass_timings`` key. The timings info contains details on how much time
-has spent for each pass. The pass timings are also grouped by their purpose.
+The dispatcher stores LLVM pass timings in the dispatcher object metadata under the
+``llvm_pass_timings`` key. The timings information contains details on how much time
+has been spent in each pass. The pass timings are also grouped by their purpose.
 For example, there will be pass timings for function-level pre-optimizations,
 module-level optimizations, and object code generation.
 

--- a/docs/source/developer/llvm_timings.rst
+++ b/docs/source/developer/llvm_timings.rst
@@ -8,8 +8,10 @@ Notes on timing LLVM
 Getting LLVM Pass Timings
 -------------------------
 
-The dispatcher stores LLVM pass timings in the dispatcher object metadata under the
-``llvm_pass_timings`` key. The timings information contains details on how much time
+The dispatcher stores LLVM pass timings in the dispatcher object metadata under
+the ``llvm_pass_timings`` key when :envvar:`NUMBA_LLVM_PASS_TIMINGS` is
+enabled or ``numba.config.LLVM_PASS_TIMINGS`` is set to truthy.
+The timings information contains details on how much time
 has been spent in each pass. The pass timings are also grouped by their purpose.
 For example, there will be pass timings for function-level pre-optimizations,
 module-level optimizations, and object code generation.

--- a/docs/source/developer/llvm_timings.rst
+++ b/docs/source/developer/llvm_timings.rst
@@ -30,62 +30,62 @@ Example output:
 
 .. code-block:: text
 
-    Printing pass timings for JITCodeLibrary('DocsLLVMPassTimings.test_pass_timings.<locals>.foo')
-    Total time: 0.0360
-    == #0 Function passes '_ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
-     Percent: 5.0%
-     Total 0.0018s
-     Top timings:
-       0.0015s ( 81.5%) SROA #3
-       0.0002s (  9.3%) Early CSE #2
-       0.0001s (  4.3%) Simplify the CFG #9
-       0.0000s (  1.4%) Prune NRT refops #4
-       0.0000s (  1.0%) Post-Dominator Tree Construction #5
-    == #1 Function passes '_ZN7cpython5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
-     Percent: 0.8%
-     Total 0.0003s
-     Top timings:
-       0.0001s ( 32.1%) Simplify the CFG #10
-       0.0001s ( 24.7%) Lower 'expect' Intrinsics #2
-       0.0000s ( 15.2%) SROA #4
-       0.0000s (  8.8%) Prune NRT refops #5
-       0.0000s (  5.5%) Post-Dominator Tree Construction #6
-    == #2 Function passes 'cfunc._ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
-     Percent: 0.3%
-     Total 0.0001s
-     Top timings:
-       0.0000s ( 27.2%) Lower 'expect' Intrinsics #3
-       0.0000s ( 26.7%) Simplify the CFG #11
-       0.0000s ( 13.2%) Prune NRT refops #6
-       0.0000s (  7.7%) Post-Dominator Tree Construction #7
-       0.0000s (  7.0%) Dominator Tree Construction #29
-    == #3 Module passes (cheap)
-     Percent: 3.6%
-     Total 0.0013s
-     Top timings:
-       0.0007s ( 54.3%) Combine redundant instructions
-       0.0001s (  5.1%) Function Integration/Inlining
-       0.0001s (  4.7%) Natural Loop Information
-       0.0001s (  4.6%) Prune NRT refops #2
-       0.0000s (  3.3%) Dominator Tree Construction #3
-    == #4 Module passes (full)
-     Percent: 43.3%
-     Total 0.0156s
-     Top timings:
-       0.0030s ( 19.2%) Combine redundant instructions #9
-       0.0021s ( 13.3%) Combine redundant instructions #7
-       0.0010s (  6.6%) Induction Variable Simplification
-       0.0007s (  4.8%) Unroll loops #2
-       0.0007s (  4.8%) Loop Vectorization
-    == #5 Finalize object
-     Percent: 46.9%
-     Total 0.0169s
-     Top timings:
-       0.0059s ( 35.2%) X86 DAG->DAG Instruction Selection #2
-       0.0019s ( 11.1%) Greedy Register Allocator #2
-       0.0014s (  8.0%) Machine Instruction Scheduler #2
-       0.0009s (  5.6%) Loop Strength Reduction
-       0.0004s (  2.1%) Induction Variable Users
+  Printing pass timings for JITCodeLibrary('DocsLLVMPassTimings.test_pass_timings.<locals>.foo')
+  Total time: 0.0376
+  == #0 Function passes on '_ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+  Percent: 4.8%
+  Total 0.0018s
+  Top timings:
+    0.0015s ( 81.6%) SROA #3
+    0.0002s (  9.3%) Early CSE #2
+    0.0001s (  4.0%) Simplify the CFG #9
+    0.0000s (  1.5%) Prune NRT refops #4
+    0.0000s (  1.1%) Post-Dominator Tree Construction #5
+  == #1 Function passes on '_ZN7cpython5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+  Percent: 0.8%
+  Total 0.0003s
+  Top timings:
+    0.0001s ( 30.4%) Simplify the CFG #10
+    0.0001s ( 24.1%) Early CSE #3
+    0.0001s ( 17.8%) SROA #4
+    0.0000s (  8.8%) Prune NRT refops #5
+    0.0000s (  5.6%) Post-Dominator Tree Construction #6
+  == #2 Function passes on 'cfunc._ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+  Percent: 0.5%
+  Total 0.0002s
+  Top timings:
+    0.0001s ( 27.7%) Early CSE #4
+    0.0001s ( 26.8%) Simplify the CFG #11
+    0.0000s ( 13.8%) Prune NRT refops #6
+    0.0000s (  7.4%) Post-Dominator Tree Construction #7
+    0.0000s (  6.7%) Dominator Tree Construction #29
+  == #3 Module passes (cheap optimization for refprune)
+  Percent: 3.7%
+  Total 0.0014s
+  Top timings:
+    0.0007s ( 52.0%) Combine redundant instructions
+    0.0001s (  5.4%) Function Integration/Inlining
+    0.0001s (  4.9%) Prune NRT refops #2
+    0.0001s (  4.8%) Natural Loop Information
+    0.0001s (  4.6%) Post-Dominator Tree Construction #2
+  == #4 Module passes (full optimization)
+  Percent: 43.9%
+  Total 0.0165s
+  Top timings:
+    0.0032s ( 19.5%) Combine redundant instructions #9
+    0.0022s ( 13.5%) Combine redundant instructions #7
+    0.0010s (  6.1%) Induction Variable Simplification
+    0.0008s (  4.8%) Unroll loops #2
+    0.0007s (  4.5%) Loop Vectorization
+  == #5 Finalize object
+  Percent: 46.3%
+  Total 0.0174s
+  Top timings:
+    0.0060s ( 34.6%) X86 DAG->DAG Instruction Selection #2
+    0.0019s ( 11.0%) Greedy Register Allocator #2
+    0.0013s (  7.4%) Machine Instruction Scheduler #2
+    0.0012s (  7.1%) Loop Strength Reduction
+    0.0004s (  2.3%) Induction Variable Users
 
 
 API for custom analysis

--- a/docs/source/developer/llvm_timings.rst
+++ b/docs/source/developer/llvm_timings.rst
@@ -1,0 +1,105 @@
+.. _developer-llvm-timings:
+
+====================
+Notes on timing LLVM
+====================
+
+
+Getting LLVM Pass Timings
+-------------------------
+
+The dispatcher stores LLVM pass timings in the metadata under the
+``llvm_pass_timings`` key. The timings info contains details on how much time
+has spent for each pass. The pass timings are also grouped by their purpose.
+For example, there will be pass timings for function-level pre-optimizations,
+module-level optimizations, and object code generation.
+
+
+Code Example
+~~~~~~~~~~~~
+
+.. literalinclude:: ../../../numba/tests/doc_examples/test_llvm_pass_timings.py
+   :language: python
+   :caption: from ``test_pass_timings`` of ``numba/tests/doc_examples/test_llvm_pass_timings.py``
+   :start-after: magictoken.ex_llvm_pass_timings.begin
+   :end-before: magictoken.ex_llvm_pass_timings.end
+   :dedent: 12
+   :linenos:
+
+Example output:
+
+.. code-block:: text
+
+    Printing pass timings for JITCodeLibrary('DocsLLVMPassTimings.test_pass_timings.<locals>.foo')
+    Total time: 0.0360
+    == #0 Function passes '_ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+     Percent: 5.0%
+     Total 0.0018s
+     Top timings:
+       0.0015s ( 81.5%) SROA #3
+       0.0002s (  9.3%) Early CSE #2
+       0.0001s (  4.3%) Simplify the CFG #9
+       0.0000s (  1.4%) Prune NRT refops #4
+       0.0000s (  1.0%) Post-Dominator Tree Construction #5
+    == #1 Function passes '_ZN7cpython5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+     Percent: 0.8%
+     Total 0.0003s
+     Top timings:
+       0.0001s ( 32.1%) Simplify the CFG #10
+       0.0001s ( 24.7%) Lower 'expect' Intrinsics #2
+       0.0000s ( 15.2%) SROA #4
+       0.0000s (  8.8%) Prune NRT refops #5
+       0.0000s (  5.5%) Post-Dominator Tree Construction #6
+    == #2 Function passes 'cfunc._ZN5numba5tests12doc_examples22test_llvm_pass_timings19DocsLLVMPassTimings17test_pass_timings12$3clocals$3e7foo$241Ex'
+     Percent: 0.3%
+     Total 0.0001s
+     Top timings:
+       0.0000s ( 27.2%) Lower 'expect' Intrinsics #3
+       0.0000s ( 26.7%) Simplify the CFG #11
+       0.0000s ( 13.2%) Prune NRT refops #6
+       0.0000s (  7.7%) Post-Dominator Tree Construction #7
+       0.0000s (  7.0%) Dominator Tree Construction #29
+    == #3 Module passes (cheap)
+     Percent: 3.6%
+     Total 0.0013s
+     Top timings:
+       0.0007s ( 54.3%) Combine redundant instructions
+       0.0001s (  5.1%) Function Integration/Inlining
+       0.0001s (  4.7%) Natural Loop Information
+       0.0001s (  4.6%) Prune NRT refops #2
+       0.0000s (  3.3%) Dominator Tree Construction #3
+    == #4 Module passes (full)
+     Percent: 43.3%
+     Total 0.0156s
+     Top timings:
+       0.0030s ( 19.2%) Combine redundant instructions #9
+       0.0021s ( 13.3%) Combine redundant instructions #7
+       0.0010s (  6.6%) Induction Variable Simplification
+       0.0007s (  4.8%) Unroll loops #2
+       0.0007s (  4.8%) Loop Vectorization
+    == #5 Finalize object
+     Percent: 46.9%
+     Total 0.0169s
+     Top timings:
+       0.0059s ( 35.2%) X86 DAG->DAG Instruction Selection #2
+       0.0019s ( 11.1%) Greedy Register Allocator #2
+       0.0014s (  8.0%) Machine Instruction Scheduler #2
+       0.0009s (  5.6%) Loop Strength Reduction
+       0.0004s (  2.1%) Induction Variable Users
+
+
+API for custom analysis
+~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to get more details then the summary text in the above example.
+The pass timings are stored in a
+:class:`numba.misc.llvm_pass_timings.PassTimingsCollection`, which contains
+methods for accessing individual record for each pass.
+
+.. autoclass:: numba.misc.llvm_pass_timings.PassTimingsCollection
+    :members: get_total_time, list_longest_first, summary, __getitem__, __len__
+
+.. autoclass:: numba.misc.llvm_pass_timings.ProcessedPassTimings
+    :members: get_raw_data, get_total_time, list_records, list_top, summary
+
+.. autoclass:: numba.misc.llvm_pass_timings.PassTimingRecord

--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -255,7 +255,8 @@ Misc Support
 - :ghfile:`numba/core/caching.py` - Disk cache for compiled functions
 - :ghfile:`numba/np/npdatetime.py` - Helper functions for implementing NumPy
   datetime64 support
-
+- :ghfile:`numba/misc/llvm_pass_timings.py` - Helper to record timings of
+  LLVM passes.
 
 Core Python Data Types
 ''''''''''''''''''''''

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -228,6 +228,14 @@ These variables influence what is printed out during compilation of
 
    Dump the native assembly code of compiled functions.
 
+.. envvar:: NUMBA_LLVM_PASS_TIMINGS
+
+    Set to ``1`` to enable recording of pass timings in LLVM;
+    e.g. ``NUMBA_LLVM_PASS_TIMINGS=1``.
+    See :ref:`developer-llvm-timings`.
+
+    *Default value*: ``0`` (Off)
+
 .. seealso::
    :ref:`numba-troubleshooting` and :ref:`architecture`.
 

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -577,7 +577,7 @@ class CodeLibrary(object):
             # Run function-level optimizations to reduce memory usage and improve
             # module-level optimization.
             for func in ll_module.functions:
-                k = f"function passes {func.name!r}"
+                k = f"Function passes {func.name!r}"
                 with self._recorded_timings.record(k):
                     fpm.initialize()
                     fpm.run(func)
@@ -967,7 +967,8 @@ class JITCodeLibrary(CodeLibrary):
 
     def _finalize_specific(self):
         self._codegen._scan_and_fix_unresolved_refs(self._final_module)
-        self._codegen._engine.finalize_object()
+        with self._recorded_timings.record("Finalize object"):
+            self._codegen._engine.finalize_object()
 
 
 class RuntimeLinker(object):

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -594,10 +594,7 @@ class CodeLibrary(object):
             self._codegen._mpm_cheap.run(self._final_module)
         # Refop pruning is then run on the heavily inlined function
         if not config.LLVM_REFPRUNE_PASS:
-            with self._recorded_timings.record("Legacy refprune"):
-                self._final_module = remove_redundant_nrt_refct(
-                    self._final_module,
-                )
+            self._final_module = remove_redundant_nrt_refct(self._final_module)
         full_name = "Module passes (full optimization)"
         with self._recorded_timings.record(full_name):
             # The full optimisation suite is then run on the refop pruned IR

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -577,7 +577,7 @@ class CodeLibrary(object):
             # Run function-level optimizations to reduce memory usage and improve
             # module-level optimization.
             for func in ll_module.functions:
-                k = f"Function passes {func.name!r}"
+                k = f"Function passes on {func.name!r}"
                 with self._recorded_timings.record(k):
                     fpm.initialize()
                     fpm.run(func)
@@ -587,7 +587,8 @@ class CodeLibrary(object):
         """
         Internal: optimize this library's final module.
         """
-        with self._recorded_timings.record("Module passes (cheap)"):
+        cheap_name = "Module passes (cheap optimization for refprune)"
+        with self._recorded_timings.record(cheap_name):
             # A cheaper optimisation pass is run first to try and get as many
             # refops into the same function as possible via inlining
             self._codegen._mpm_cheap.run(self._final_module)
@@ -597,7 +598,8 @@ class CodeLibrary(object):
                 self._final_module = remove_redundant_nrt_refct(
                     self._final_module,
                 )
-        with self._recorded_timings.record("Module passes (full)"):
+        full_name = "Module passes (full optimization)"
+        with self._recorded_timings.record(full_name):
             # The full optimisation suite is then run on the refop pruned IR
             self._codegen._mpm_full.run(self._final_module)
 

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -17,7 +17,7 @@ from numba.core.runtime import rtsys
 from numba.core.compiler_lock import require_global_compiler_lock
 from numba.core.errors import NumbaInvalidConfigWarning
 from numba.misc.inspection import disassemble_elf_to_cfg
-from numba.misc.llvm_pass_timings import PassTimingCollection
+from numba.misc.llvm_pass_timings import PassTimingsCollection
 
 
 _x86arch = frozenset(['x86', 'i386', 'i486', 'i586', 'i686', 'i786',
@@ -537,7 +537,7 @@ class CodeLibrary(object):
         # Track names of the dynamic globals
         self._dynamic_globals = []
         ptc_name = f"{self.__class__.__name__}({self._name!r})"
-        self._recorded_timings = PassTimingCollection(ptc_name)
+        self._recorded_timings = PassTimingsCollection(ptc_name)
 
     @property
     def has_dynamic_globals(self):

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -17,6 +17,7 @@ from numba.core.runtime import rtsys
 from numba.core.compiler_lock import require_global_compiler_lock
 from numba.core.errors import NumbaInvalidConfigWarning
 from numba.misc.inspection import disassemble_elf_to_cfg
+from numba.misc.llvm_pass_timings import PassTimingCollection
 
 
 _x86arch = frozenset(['x86', 'i386', 'i486', 'i586', 'i686', 'i786',
@@ -535,11 +536,17 @@ class CodeLibrary(object):
         self._shared_module = None
         # Track names of the dynamic globals
         self._dynamic_globals = []
+        ptc_name = f"{self.__class__.__name__}({self._name!r})"
+        self._recorded_timings = PassTimingCollection(ptc_name)
 
     @property
     def has_dynamic_globals(self):
         self._ensure_finalized()
         return len(self._dynamic_globals) > 0
+
+    @property
+    def recorded_timings(self):
+        return self._recorded_timings
 
     @property
     def codegen(self):
@@ -570,22 +577,29 @@ class CodeLibrary(object):
             # Run function-level optimizations to reduce memory usage and improve
             # module-level optimization.
             for func in ll_module.functions:
-                fpm.initialize()
-                fpm.run(func)
-                fpm.finalize()
+                k = f"function passes {func.name!r}"
+                with self._recorded_timings.record(k):
+                    fpm.initialize()
+                    fpm.run(func)
+                    fpm.finalize()
 
     def _optimize_final_module(self):
         """
         Internal: optimize this library's final module.
         """
-        # A cheaper optimisation pass is run first to try and get as many
-        # refops into the same function as possible via inlining
-        self._codegen._mpm_cheap.run(self._final_module)
+        with self._recorded_timings.record("Module passes (cheap)"):
+            # A cheaper optimisation pass is run first to try and get as many
+            # refops into the same function as possible via inlining
+            self._codegen._mpm_cheap.run(self._final_module)
         # Refop pruning is then run on the heavily inlined function
         if not config.LLVM_REFPRUNE_PASS:
-            self._final_module = remove_redundant_nrt_refct(self._final_module)
-        # The full optimisation suite is then run on the refop pruned IR
-        self._codegen._mpm_full.run(self._final_module)
+            with self._recorded_timings.record("Legacy refprune"):
+                self._final_module = remove_redundant_nrt_refct(
+                    self._final_module,
+                )
+        with self._recorded_timings.record("Module passes (full)"):
+            # The full optimisation suite is then run on the refop pruned IR
+            self._codegen._mpm_full.run(self._final_module)
 
     def _get_module_for_linking(self):
         """

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -391,6 +391,13 @@ class _EnvReloader(object):
             "all" if LLVM_REFPRUNE_PASS else "",
         )
 
+        # Timing support.
+
+        # LLVM_PASS_TIMINGS enables LLVM recording of pass timings.
+        LLVM_PASS_TIMINGS = _readenv(
+            "NUMBA_LLVM_PASS_TIMINGS", int, 0,
+        )
+
         # Inject the configuration values into the module globals
         for name, value in locals().copy().items():
             if name.isupper():

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -406,6 +406,9 @@ class NativeLowering(LoweringPass):
             # capture pruning stats
             post_stats = llvm.passmanagers.dump_refprune_stats()
             metadata['prune_stats'] = post_stats - pre_stats
+
+            # Save the LLVM pass timings
+            metadata['llvm_pass_timings'] = library.recorded_timings
         return True
 
 

--- a/numba/misc/llvm_pass_timings.py
+++ b/numba/misc/llvm_pass_timings.py
@@ -35,7 +35,7 @@ class RecordLLVMPassTimings:
 
         Returns
         -------
-        timings : ProcessedPassTimings
+        timings: ProcessedPassTimings
         """
         return ProcessedPassTimings(self._data)
 
@@ -64,7 +64,7 @@ def _adjust_timings(records):
 
     Returns
     -------
-    res : List[PassTimingRecord]
+    res: List[PassTimingRecord]
     """
     total_rec = records[-1]
     assert total_rec.pass_name == "Total"  # guard for implementation error
@@ -119,7 +119,7 @@ class ProcessedPassTimings:
 
         Returns
         -------
-        res : str
+        res: str
         """
         return self._raw_data
 
@@ -128,7 +128,7 @@ class ProcessedPassTimings:
 
         Returns
         -------
-        res : float
+        res: float
         """
         return self.list_records()[-1].wall_time
 
@@ -137,7 +137,7 @@ class ProcessedPassTimings:
 
         Returns
         -------
-        res : List[PassTimingRecord]
+        res: List[PassTimingRecord]
         """
         return self._processed
 
@@ -146,13 +146,13 @@ class ProcessedPassTimings:
 
         Parameters
         ----------
-        n : int
+        n: int
             This limits the maximum number of items to show.
             This function will show the ``n`` most time-consuming passes.
 
         Returns
         -------
-        res : List[PassTimingRecord]
+        res: List[PassTimingRecord]
             Returns the top(n) most time-consuming passes in descending order.
         """
         records = self.list_records()
@@ -164,15 +164,15 @@ class ProcessedPassTimings:
 
         Parameters
         ----------
-        topn : int; optional
+        topn: int; optional
             This limits the maximum number of items to show.
             This function will show the ``topn`` most time-consuming passes.
-        indent : int; optional
+        indent: int; optional
             Set the indentation level. Defaults to 0 for no indentation.
 
         Returns
         -------
-        res : str
+        res: str
         """
         buf = []
         prefix = " " * indent
@@ -290,7 +290,7 @@ class PassTimingsCollection(Sequence):
 
         Parameters
         ----------
-        name : str
+        name: str
             Name for the records.
         """
         if config.LLVM_PASS_TIMINGS:
@@ -310,9 +310,9 @@ class PassTimingsCollection(Sequence):
 
         Parameters
         ----------
-        name : str
+        name: str
             Name for the records.
-        timings : ProcessedPassTimings
+        timings: ProcessedPassTimings
             the timing records.
         """
         self._records.append(NamedTimings(name, timings))
@@ -322,7 +322,7 @@ class PassTimingsCollection(Sequence):
 
         Returns
         -------
-        res : float or None
+        res: float or None
             Returns the total number of seconds or None if no timings were
             recorded
         """
@@ -336,7 +336,7 @@ class PassTimingsCollection(Sequence):
 
         Returns
         -------
-        res : List[ProcessedPassTimings]
+        res: List[ProcessedPassTimings]
         """
         return sorted(self._records,
                       key=lambda x: x.timings.get_total_time(),
@@ -353,13 +353,13 @@ class PassTimingsCollection(Sequence):
 
         Parameters
         ----------
-        topn : int; optional, default=5.
+        topn: int; optional, default=5.
             This limits the maximum number of items to show.
             This function will show the ``topn`` most time-consuming passes.
 
         Returns
         -------
-        res : str
+        res: str
 
         See also ``ProcessedPassTimings.summary()``
         """
@@ -383,7 +383,7 @@ class PassTimingsCollection(Sequence):
 
         Returns
         -------
-        res : (name, timings)
+        res: (name, timings)
             A named tuple with two fields:
 
             - name: str

--- a/numba/misc/llvm_pass_timings.py
+++ b/numba/misc/llvm_pass_timings.py
@@ -327,8 +327,20 @@ class PassTimingsCollection(Sequence):
                       key=lambda x: x.timings.get_total_time(),
                       reverse=True)
 
-    def summary(self):
-        """Returns a string representing the summary of the timings.
+    def summary(self, topn=5):
+        """Return a string representing the summary of the timings.
+
+        Parameters
+        ----------
+        topn : int; optional
+            This limits the maximum number of items to show.
+            This function will show the ``topn`` most time-consuming passes.
+
+        Returns
+        -------
+        res : str
+
+        See also ``ProcessedPassTimings.summary()``
         """
         buf = []
         ap = buf.append
@@ -339,7 +351,7 @@ class PassTimingsCollection(Sequence):
             ap(f"== #{i} {r.name}")
             percent = r.timings.get_total_time() / overall_time * 100
             ap(f" Percent: {percent:.1f}%")
-            ap(r.timings.summary(indent=1))
+            ap(r.timings.summary(topn=topn, indent=1))
         return "\n".join(buf)
 
     def __getitem__(self, i):

--- a/numba/misc/llvm_pass_timings.py
+++ b/numba/misc/llvm_pass_timings.py
@@ -1,0 +1,297 @@
+import re
+import itertools
+import operator
+import heapq
+from collections import namedtuple
+from collections.abc import Sequence
+from contextlib import contextmanager
+
+from numba.core.utils import cached_property
+
+import llvmlite.binding as llvm
+
+
+class RecordLLVMPassTimings:
+    """A helper context manager to track LLVM pass timings.
+    """
+
+    __slots__ = ["_data"]
+
+    def __enter__(self):
+        """Enables the pass timing in LLVM.
+        """
+        llvm.enable_time_passes()
+        return self
+
+    def __exit__(self, exc_val, exc_type, exc_tb):
+        """Reset timings and save report internally.
+        """
+        self._data = llvm.report_and_reset_timings()
+        return
+
+    def get(self):
+        """Retrieve timing data for processing.
+
+        Returns
+        -------
+        timings : _ProcessedPassTimings
+        """
+        return _ProcessedPassTimings(self._data)
+
+
+_PassTimingRecord = namedtuple(
+    "_PassTimingRecord",
+    [
+        "user_time",
+        "user_percent",
+        "system_time",
+        "system_percent",
+        "user_system_time",
+        "user_system_percent",
+        "wall_time",
+        "wall_percent",
+        "pass_name",
+    ],
+)
+
+
+def _adjust_timings(records):
+    """Adjust timing records because of truncated information.
+
+    Details: The percent information can be used to improve the timing
+    information.
+
+    Returns
+    -------
+    res : List[_PassTimingRecord]
+    """
+    total_rec = records[-1]
+    assert total_rec.pass_name == "Total"  # guard for implementation error
+
+    def make_adjuster(attr):
+        time_attr = f"{attr}_time"
+        percent_attr = f"{attr}_percent"
+        time_getter = operator.attrgetter(time_attr)
+
+        def adjust(d):
+            """Compute percent x total_time = adjusted"""
+            total = time_getter(total_rec)
+            adjusted = total * d[percent_attr] * 0.01
+            d[time_attr] = adjusted
+            return d
+
+        return adjust
+
+    # Make adjustment functions for each field
+    adj_fns = [
+        make_adjuster(x) for x in ["user", "system", "user_system", "wall"]
+    ]
+
+    # Extract dictionaries from the namedtuples
+    dicts = map(lambda x: x._asdict(), records)
+
+    def chained(d):
+        # Chain the adjustment functions
+        for fn in adj_fns:
+            d = fn(d)
+        # Reconstruct the namedtuple
+        return _PassTimingRecord(**d)
+
+    return list(map(chained, dicts))
+
+
+class _ProcessedPassTimings:
+    """A class for processing and grouping raw timing data from LLVM.
+
+    The processing is done lazily so we don't waste time processing unused
+    timing information.
+
+    The per-pass timings are grouped because LLVM may sometime print multiple
+    timing report.
+    """
+
+    def __init__(self, raw_data):
+        self._raw_data = raw_data
+
+    def __bool__(self):
+        return bool(self._raw_data)
+
+    def get_raw_data(self):
+        """Returns the raw string data
+        """
+        return self._raw_data
+
+    def get_total_time(self):
+        """Compute the total time spend in all pass-groups.
+        """
+        return sum(grp[-1].wall_time for grp in self.list_pass_groups())
+
+    def list_pass_groups(self):
+        """Get the processed data for all pass-groups.
+
+        Returns
+        -------
+        res : List[List[_PassTimingRecord]]
+        """
+        return self._processed
+
+    def list_tops(self, n):
+        """Returns the top(n) most time-consuming (by wall-time) passes for
+        each group.
+
+        Parameters
+        ----------
+        n : int
+            This limits the maximum number of items to show.
+            This function will show the ``n`` most time-consuming passes.
+
+        Returns
+        -------
+        res : List[List[_PassTimingRecord]]
+            Returns the top(n) most time-consuming passes in descending order
+            for each pass-group.
+        """
+        key = operator.attrgetter("wall_time")
+        return [
+            heapq.nlargest(n, grp[:-1], key) for grp in self.list_pass_groups()
+        ]
+
+    def summary(self, topn=5):
+        """Return a string summarizing the timing information.
+
+        Parameters
+        ----------
+        topn : int
+            This limits the maximum number of items to show per pass group.
+            This function will show the ``topn`` most time-consuming passes.
+
+        Returns
+        -------
+        res : str
+        """
+        buf = []
+        ap = buf.append
+        for i, top in enumerate(self.list_tops(topn), 1):
+            ap(f"Pass group #{i} took {self.get_total_time():.4f}s")
+            ap("  Top timings:")
+            for p in top:
+                ap(f"  {p.wall_time:.4f}s ({p.wall_percent:5}%) {p.pass_name}")
+        return "\n".join(buf)
+
+    @cached_property
+    def _processed(self):
+        """A cached property for lazily processing the data and returning it.
+
+        See ``_process()`` for details.
+        """
+        return self._process()
+
+    def _process(self):
+        """Parses the raw string data from LLVM timing report and attempts
+        to improve the data by recomputing the times
+        (See `_adjust_timings()``).
+        """
+
+        def parse(raw_data):
+            """A generator that parses the raw_data line-by-line to extract
+            timing information for each pass.
+            """
+            lines = raw_data.splitlines()
+            n = r"\s*((?:[0-9]+\.)?[0-9]+)"
+            pat = f"\\s+{n}\\s*\\({n}%\\)" * 4 + r"\s*(.*)"
+
+            for ln in lines:
+                m = re.match(pat, ln)
+                if m is not None:
+                    raw_data = m.groups()
+                    rec = _PassTimingRecord(
+                        *map(float, raw_data[:-1]), *raw_data[-1:]
+                    )
+                    yield rec
+                    if rec.pass_name == "Total":
+                        # "Total" means a pass group has completed
+                        yield None
+
+        # Parse iterator
+        parse_iter = iter(parse(self._raw_data))
+        runs = []
+
+        def not_none(x):
+            return x is not None
+
+        while True:
+            # Group the timings by pass group
+            grouped = list(itertools.takewhile(not_none, parse_iter))
+            if grouped:
+                # Save the pass group
+                runs.append(_adjust_timings(grouped))
+            else:
+                # Nothing yielded, parsing is done
+                break
+
+        return runs
+
+
+_NamedTimings = namedtuple("_NamedTimings", ["name", "timings"])
+
+
+class PassTimingCollection(Sequence):
+    """A collection of pass timings.
+    """
+
+    def __init__(self, name):
+        self._name = name
+        self._records = []
+
+    @contextmanager
+    def record(self, name):
+        """Record timings
+
+        See also ``RecordLLVMPassTimings``
+
+        Parameters
+        ----------
+        name : str
+            Name for the records.
+        """
+        with RecordLLVMPassTimings() as timings:
+            yield
+        rec = timings.get()
+        # Only keep non-empty records
+        if rec:
+            self.append(name, rec)
+
+    def append(self, name, timings):
+        """Append timing records
+
+        Parameters
+        ----------
+        name : str
+            Name for the records.
+        timings : _ProcessedPassTimings
+            the timing records.
+        """
+        self._records.append(_NamedTimings(name, timings))
+
+    def __getitem__(self, i):
+        """Get the i-th timing record.
+
+        Returns
+        -------
+        res : _NamedTimings
+        """
+        return self._records[i]
+
+    def __len__(self):
+        """Length of this collection.
+        """
+        return len(self._records)
+
+    def __str__(self):
+        buf = []
+        ap = buf.append
+        ap(f"Printing pass timings for {self._name}")
+        for r in self._records:
+            ap(f"== {r.name}")
+            ap(r.timings.summary())
+        return "\n".join(buf)

--- a/numba/misc/llvm_pass_timings.py
+++ b/numba/misc/llvm_pass_timings.py
@@ -332,7 +332,7 @@ class PassTimingsCollection(Sequence):
 
         Parameters
         ----------
-        topn : int; optional
+        topn : int; optional, default=5.
             This limits the maximum number of items to show.
             This function will show the ``topn`` most time-consuming passes.
 

--- a/numba/tests/doc_examples/test_llvm_pass_timings.py
+++ b/numba/tests/doc_examples/test_llvm_pass_timings.py
@@ -1,37 +1,30 @@
 # "magictoken" is used for markers as beginning and ending of example text.
 
 import unittest
-
-from numba.core import config
-from numba.tests.support import captured_stdout
+from numba.tests.support import captured_stdout, override_config
 
 
 class DocsLLVMPassTimings(unittest.TestCase):
-    def setUp(self):
-        self.__old_LLVM_PASS_TIMINGS = config.LLVM_PASS_TIMINGS
-        config.LLVM_PASS_TIMINGS = 1
-
-    def tearDown(self):
-        config.LLVM_PASS_TIMINGS = self.__old_LLVM_PASS_TIMINGS
 
     def test_pass_timings(self):
-        with captured_stdout() as stdout:
-            # magictoken.ex_llvm_pass_timings.begin
-            import numba
+        with override_config('LLVM_PASS_TIMINGS', True):
+            with captured_stdout() as stdout:
+                # magictoken.ex_llvm_pass_timings.begin
+                import numba
 
-            @numba.njit
-            def foo(n):
-                c = 0
-                for i in range(n):
-                    for j in range(i):
-                        c += j
-                return c
+                @numba.njit
+                def foo(n):
+                    c = 0
+                    for i in range(n):
+                        for j in range(i):
+                            c += j
+                    return c
 
-            foo(10)
-            md = foo.get_metadata(foo.signatures[0])
-            print(md['llvm_pass_timings'])
-            # magictoken.ex_llvm_pass_timings.end
-        self.assertIn("Finalize object", stdout.getvalue())
+                foo(10)
+                md = foo.get_metadata(foo.signatures[0])
+                print(md['llvm_pass_timings'])
+                # magictoken.ex_llvm_pass_timings.end
+            self.assertIn("Finalize object", stdout.getvalue())
 
 
 if __name__ == '__main__':

--- a/numba/tests/doc_examples/test_llvm_pass_timings.py
+++ b/numba/tests/doc_examples/test_llvm_pass_timings.py
@@ -1,10 +1,18 @@
 # "magictoken" is used for markers as beginning and ending of example text.
 
 import unittest
+
+from numba.core import config
 from numba.tests.support import captured_stdout
 
 
 class DocsLLVMPassTimings(unittest.TestCase):
+    def setUp(self):
+        self.__old_LLVM_PASS_TIMINGS = config.LLVM_PASS_TIMINGS
+        config.LLVM_PASS_TIMINGS = 1
+
+    def tearDown(self):
+        config.LLVM_PASS_TIMINGS = self.__old_LLVM_PASS_TIMINGS
 
     def test_pass_timings(self):
         with captured_stdout() as stdout:

--- a/numba/tests/doc_examples/test_llvm_pass_timings.py
+++ b/numba/tests/doc_examples/test_llvm_pass_timings.py
@@ -1,0 +1,30 @@
+# "magictoken" is used for markers as beginning and ending of example text.
+
+import unittest
+from numba.tests.support import captured_stdout
+
+
+class DocsLLVMPassTimings(unittest.TestCase):
+
+    def test_pass_timings(self):
+        with captured_stdout() as stdout:
+            # magictoken.ex_llvm_pass_timings.begin
+            import numba
+
+            @numba.njit
+            def foo(n):
+                c = 0
+                for i in range(n):
+                    for j in range(i):
+                        c += j
+                return c
+
+            foo(10)
+            md = foo.get_metadata(foo.signatures[0])
+            print(md['llvm_pass_timings'])
+            # magictoken.ex_llvm_pass_timings.end
+        self.assertIn("Finalize object", stdout.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_llvm_pass_timings.py
+++ b/numba/tests/test_llvm_pass_timings.py
@@ -1,18 +1,11 @@
 import unittest
 
 from numba import njit
-from numba.core import config
-from numba.tests.support import TestCase
+from numba.tests.support import TestCase, override_config
 from numba.misc import llvm_pass_timings as lpt
 
 
 class TestLLVMPassTimings(TestCase):
-    def setUp(self):
-        self.__old_LLVM_PASS_TIMINGS = config.LLVM_PASS_TIMINGS
-        config.LLVM_PASS_TIMINGS = 1
-
-    def tearDown(self):
-        config.LLVM_PASS_TIMINGS = self.__old_LLVM_PASS_TIMINGS
 
     def test_usage(self):
         @njit
@@ -22,7 +15,8 @@ class TestLLVMPassTimings(TestCase):
                 c += i
             return c
 
-        foo(10)
+        with override_config('LLVM_PASS_TIMINGS', True):
+            foo(10)
 
         md = foo.get_metadata(foo.signatures[0])
         timings = md['llvm_pass_timings']
@@ -49,7 +43,9 @@ class TestLLVMPassTimings(TestCase):
                     c += j
             return c
 
-        foo(10)
+        with override_config('LLVM_PASS_TIMINGS', True):
+            foo(10)
+
         md = foo.get_metadata(foo.signatures[0])
         timings_collection = md['llvm_pass_timings']
         # Check: get_total_time()
@@ -75,7 +71,8 @@ class TestLLVMPassTimingsDisabled(TestCase):
                 c += i
             return c
 
-        foo(10)
+        with override_config('LLVM_PASS_TIMINGS', False):
+            foo(10)
 
         md = foo.get_metadata(foo.signatures[0])
         timings = md['llvm_pass_timings']

--- a/numba/tests/test_llvm_pass_timings.py
+++ b/numba/tests/test_llvm_pass_timings.py
@@ -22,7 +22,7 @@ class TestLLVMPassTimings(TestCase):
         self.assertIsInstance(timings, lpt.PassTimingsCollection)
         # Check: basic for __str__
         text = str(timings)
-        self.assertIn("Module passes (full)", text)
+        self.assertIn("Module passes (full optimization)", text)
         # Check: there must be more than one record
         self.assertGreater(len(timings), 0)
         # Check: __getitem__

--- a/numba/tests/test_llvm_pass_timings.py
+++ b/numba/tests/test_llvm_pass_timings.py
@@ -27,10 +27,10 @@ class TestLLVMPassTimings(TestCase):
         self.assertGreater(len(timings), 0)
         # Check: __getitem__
         last = timings[-1]
-        self.assertIsInstance(last, lpt._NamedTimings)
-        # Check: _NamedTimings
+        self.assertIsInstance(last, lpt.NamedTimings)
+        # Check: NamedTimings
         self.assertIsInstance(last.name, str)
-        self.assertIsInstance(last.timings, lpt._ProcessedPassTimings)
+        self.assertIsInstance(last.timings, lpt.ProcessedPassTimings)
 
     def test_analyze(self):
         @njit

--- a/numba/tests/test_llvm_pass_timings.py
+++ b/numba/tests/test_llvm_pass_timings.py
@@ -19,7 +19,7 @@ class TestLLVMPassTimings(TestCase):
         md = foo.get_metadata(foo.signatures[0])
         timings = md['llvm_pass_timings']
         # Check: timing is of correct type
-        self.assertIsInstance(timings, lpt.PassTimingCollection)
+        self.assertIsInstance(timings, lpt.PassTimingsCollection)
         # Check: basic for __str__
         text = str(timings)
         self.assertIn("== Module passes (full)", text)

--- a/numba/tests/test_llvm_pass_timings.py
+++ b/numba/tests/test_llvm_pass_timings.py
@@ -1,0 +1,37 @@
+import unittest
+
+from numba import njit
+from numba.tests.support import TestCase
+from numba.misc import llvm_pass_timings as lpt
+
+
+class TestLLVMPassTimings(TestCase):
+    def test_usage(self):
+        @njit
+        def foo(n):
+            c = 0
+            for i in range(n):
+                c += i
+            return c
+
+        foo(10)
+
+        md = foo.get_metadata(foo.signatures[0])
+        timings = md['llvm_pass_timings']
+        # Check: timing is of correct type
+        self.assertIsInstance(timings, lpt.PassTimingCollection)
+        # Check: basic for __str__
+        text = str(timings)
+        self.assertIn("== Module passes (full)", text)
+        # Check: there must be more than one record
+        self.assertGreater(len(timings), 0)
+        # Check: __getitem__
+        last = timings[-1]
+        self.assertIsInstance(last, lpt._NamedTimings)
+        # Check: _NamedTimings
+        self.assertIsInstance(last.name, str)
+        self.assertIsInstance(last.timings, lpt._ProcessedPassTimings)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Depends on https://github.com/numba/llvmlite/pull/624

- expose `llvm:: report_and_reset_timings()`
- provide python API to access the information
