### PR TITLE
Correcting typo in numba sysinfo output

### DIFF
--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -593,7 +593,7 @@ def display_sysinfo(info=None, sep_pos=45):
         ("CUDA Driver Version", info.get(_cu_drv_ver, '?')),
         ("CUDA Detect Output:",),
         (info.get(_cu_detect_out, "None"),),
-        ("CUDA Librairies Test Output:",),
+        ("CUDA Libraries Test Output:",),
         (info.get(_cu_lib_test, "None"),),
         ("",),
         ("__ROC information__",),


### PR DESCRIPTION
The following is an extract of the output when running numba -s in Windows, note the mis-spelling of "Libraries" as "Librairies". The pull request fixes the typo.

> __CUDA Information__
> CUDA Device Initialized                       : True
> CUDA Driver Version                           : 11010
> CUDA Detect Output:
> Found 1 CUDA devices
> id 0    b'GeForce GTX 1050 Ti with Max-Q Design'                              [SUPPORTED]
>                       compute capability: 6.1
>                            pci device id: 0
>                               pci bus id: 1
> Summary:
>         1/1 devices are supported
> 
> CUDA Librairies Test Output:
> Finding cublas from CUDA_HOME
>         named  cublas64_11.dll
>         trying to open library...       ok
> Finding cusparse from CUDA_HOME
>         named  cusparse64_11.dll
>         trying to open library...       ok