### PR TITLE
Store partial typing errors in compiler state

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -515,7 +515,7 @@ class InlineWorker(object):
         # call branch pruning to simplify IR and avoid inference errors
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         numba.core.analysis.dead_branch_prune(callee_ir, arg_typs)
-        f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
+        f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
                 self.typingctx, callee_ir, arg_typs, None)
         canonicalize_array_math(callee_ir, f_typemap,
                                 f_calltypes, self.typingctx)
@@ -627,10 +627,10 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         numba.core.analysis.dead_branch_prune(callee_ir, arg_typs)
         try:
-            f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
+            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
                     typingctx, callee_ir, arg_typs, None)
         except Exception:
-            f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
+            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
                     typingctx, callee_ir, arg_typs, None)
             pass
         canonicalize_array_math(callee_ir, f_typemap,

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1636,7 +1636,7 @@ def compile_to_numba_ir(mk_func, glbls, typingctx=None, arg_typs=None,
     # perform type inference if typingctx is available and update type
     # data structures typemap and calltypes
     if typingctx:
-        f_typemap, f_return_type, f_calltypes = typed_passes.type_inference_stage(
+        f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
                 typingctx, f_ir, arg_typs, None)
         # remove argument entries like arg.a from typemap
         arg_names = [vname for vname in f_typemap if vname.startswith("arg.")]

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from copy import copy
 import warnings
 
@@ -21,6 +21,15 @@ from numba.core.ir_utils import (raise_on_unsupported_feature, warn_deprecated,
                                  is_operator_or_getitem)
 from numba.core import postproc
 from llvmlite import binding as llvm
+
+
+# Outputs of type inference pass
+_TypingResults = namedtuple("_TypingResults", [
+    "typemap",
+    "return_type",
+    "calltypes",
+    "typing_errors",
+])
 
 
 @contextmanager
@@ -76,7 +85,7 @@ def type_inference_stage(typingctx, interp, args, return_type, locals={},
     # Output all Numba warnings
     warnings.flush()
 
-    return typemap, restype, calltypes, errs
+    return _TypingResults(typemap, restype, calltypes, errs)
 
 
 class BaseTypeInference(FunctionPass):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -635,7 +635,12 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             template, pysig, folded_args, kws = resolve(new_args, kws)
             ir = inline_worker.run_untyped_passes(disp_type.dispatcher.py_func)
 
-            typemap, return_type, calltypes = typed_passes.type_inference_stage(
+            (
+                typemap,
+                return_type,
+                calltypes,
+                _
+            ) = typed_passes.type_inference_stage(
                 self.context, ir, folded_args, None)
             sig = Signature(return_type, folded_args, None)
             # this stores a load of info for the cost model function if supplied

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -334,7 +334,7 @@ class StencilFunc(object):
                              "be the primary input array.")
 
         from numba.core import typed_passes
-        typemap, return_type, calltypes = typed_passes.type_inference_stage(
+        typemap, return_type, calltypes, _ = typed_passes.type_inference_stage(
                 self._typingctx,
                 self.kernel_ir,
                 argtys,

--- a/numba/stencils/stencilparfor.py
+++ b/numba/stencils/stencilparfor.py
@@ -669,7 +669,7 @@ def get_stencil_ir(sf, typingctx, args, scope, loc, input_dict, typemap,
 
         rewrites.rewrite_registry.apply('before-inference', tp.state)
 
-        tp.state.typemap, tp.state.return_type, tp.state.calltypes = type_inference_stage(
+        tp.state.typemap, tp.state.return_type, tp.state.calltypes, _ = type_inference_stage(
             tp.state.typingctx, tp.state.func_ir, tp.state.args, None)
 
         type_annotations.TypeAnnotation(

--- a/numba/tests/test_copy_propagate.py
+++ b/numba/tests/test_copy_propagate.py
@@ -60,7 +60,7 @@ class TestCopyPropagate(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes, _ = type_inference_stage(typingctx, test_ir, args, None)
             #print("typemap = ", typemap)
             #print("return_type = ", return_type)
             type_annotation = type_annotations.TypeAnnotation(
@@ -87,7 +87,7 @@ class TestCopyPropagate(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes, _ = type_inference_stage(typingctx, test_ir, args, None)
             type_annotation = type_annotations.TypeAnnotation(
                 func_ir=test_ir,
                 typemap=typemap,

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -544,7 +544,7 @@ class TestLowLevelExtending(TestCase):
         test_ir = compiler.run_frontend(mk_func_test_impl)
         typingctx = cpu_target.typing_context
         typingctx.refresh()
-        typemap, _, _ = type_inference_stage(typingctx, test_ir, (), None)
+        typemap, _, _, _ = type_inference_stage(typingctx, test_ir, (), None)
         self.assertTrue(
             any(
                 isinstance(a, types.MakeFunctionLiteral)

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -544,11 +544,11 @@ class TestLowLevelExtending(TestCase):
         test_ir = compiler.run_frontend(mk_func_test_impl)
         typingctx = cpu_target.typing_context
         typingctx.refresh()
-        typemap, _, _, _ = type_inference_stage(typingctx, test_ir, (), None)
+        typing_res = type_inference_stage(typingctx, test_ir, (), None)
         self.assertTrue(
             any(
                 isinstance(a, types.MakeFunctionLiteral)
-                for a in typemap.values()
+                for a in typing_res.typemap.values()
             )
         )
 

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -36,10 +36,10 @@ class TestIrUtils(TestCase):
 
         test_ir = compiler.run_frontend(test_func)
         typingctx = cpu_target.typing_context
-        typemap, _, _, _ = type_inference_stage(
+        typing_res = type_inference_stage(
             typingctx, test_ir, (), None)
         matched_call = ir_utils.find_callname(
-            test_ir, test_ir.blocks[0].body[8].value, typemap)
+            test_ir, test_ir.blocks[0].body[8].value, typing_res.typemap)
         self.assertTrue(isinstance(matched_call, tuple) and
                         len(matched_call) == 2 and
                         matched_call[0] == 'append')

--- a/numba/tests/test_ir_utils.py
+++ b/numba/tests/test_ir_utils.py
@@ -36,7 +36,7 @@ class TestIrUtils(TestCase):
 
         test_ir = compiler.run_frontend(test_func)
         typingctx = cpu_target.typing_context
-        typemap, _, _ = type_inference_stage(
+        typemap, _, _, _ = type_inference_stage(
             typingctx, test_ir, (), None)
         matched_call = ir_utils.find_callname(
             test_ir, test_ir.blocks[0].body[8].value, typemap)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -352,7 +352,7 @@ def get_optimized_numba_ir(test_func, args, **kws):
 
         rewrites.rewrite_registry.apply('before-inference', tp.state)
 
-        tp.state.typemap, tp.state.return_type, tp.state.calltypes = \
+        tp.state.typemap, tp.state.return_type, tp.state.calltypes, _ = \
         typed_passes.type_inference_stage(tp.state.typingctx, tp.state.func_ir,
             tp.state.args, None)
 

--- a/numba/tests/test_parfors_passes.py
+++ b/numba/tests/test_parfors_passes.py
@@ -66,6 +66,7 @@ class BaseTest(TestCase):
                 tp.state.typemap,
                 tp.state.return_type,
                 tp.state.calltypes,
+                _
             ) = typed_passes.type_inference_stage(
                 tp.state.typingctx, tp.state.func_ir, tp.state.args, None
             )

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -75,7 +75,7 @@ class TestRemoveDead(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes = type_inference_stage(typingctx, test_ir, args, None)
+            typemap, return_type, calltypes, _ = type_inference_stage(typingctx, test_ir, args, None)
             type_annotation = type_annotations.TypeAnnotation(
                 func_ir=test_ir,
                 typemap=typemap,

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -3,6 +3,7 @@ import itertools
 
 import numpy as np
 
+import numba
 from numba.core.compiler import compile_isolated
 from numba import jit
 from numba.core import errors, ir, types, typing, typeinfer, utils
@@ -10,6 +11,9 @@ from numba.core.typeconv import Conversion
 
 from numba.tests.support import TestCase, tag
 from numba.tests.test_typeconv import CompatibilityTestMixin
+from numba.core.untyped_passes import TranslateByteCode, IRProcessing
+from numba.core.typed_passes import PartialTypeInference
+from numba.core.compiler_machinery import FunctionPass, register_pass
 import unittest
 
 
@@ -757,6 +761,76 @@ class TestFoldArguments(unittest.TestCase):
         for case in cases:
             with self.subTest(**case):
                 self.check_fold_arguments_list_inputs(**case)
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class DummyCR(FunctionPass):
+    """Dummy pass to add "cr" to compiler state to avoid errors in TyperCompiler since
+    it doesn't have lowering.
+    """
+
+    _name = "dummy_cr"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        state.cr = 1  # arbitrary non-None value
+        return True
+
+
+class TyperCompiler(numba.core.compiler.CompilerBase):
+    """A compiler pipeline that skips passes after typing (provides partial typing info
+    but not lowering).
+    """
+
+    def define_pipelines(self):
+        pm = numba.core.compiler_machinery.PassManager("custom_pipeline")
+        pm.add_pass(TranslateByteCode, "analyzing bytecode")
+        pm.add_pass(IRProcessing, "processing IR")
+        pm.add_pass(PartialTypeInference, "do partial typing")
+        pm.add_pass_after(DummyCR, PartialTypeInference)
+        pm.finalize()
+        return [pm]
+
+
+def get_func_typing_errs(func, arg_types):
+    """
+    Get typing errors for function 'func'. It creates a pipeline that runs untyped
+    passes as well as type inference.
+    """
+    typingctx = numba.core.registry.cpu_target.typing_context
+    targetctx = numba.core.registry.cpu_target.target_context
+    library = None
+    return_type = None
+    _locals = {}
+    flags = numba.core.compiler.Flags()
+
+    pipeline = TyperCompiler(
+        typingctx, targetctx, library, arg_types, return_type, flags, _locals
+    )
+    pipeline.compile_extra(func)
+    return pipeline.state.typing_errors
+
+
+class TestPartialTypingErrors(unittest.TestCase):
+    """
+    Make sure partial typing stores type errors in compiler state properly
+    """
+
+    def test_partial_typing_error(self):
+        # example with type unification error
+        def impl(flag):
+            if flag:
+                a = 1
+            else:
+                a = np.ones(3)
+            return a
+
+        typing_errs = get_func_typing_errs(impl, (types.bool_,))
+        self.assert_(isinstance(typing_errs, list) and len(typing_errs) == 1)
+        self.assert_(isinstance(typing_errs[0], errors.TypingError)
+            and "Cannot unify" in typing_errs[0].msg)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_typeinfer.py
+++ b/numba/tests/test_typeinfer.py
@@ -828,8 +828,8 @@ class TestPartialTypingErrors(unittest.TestCase):
             return a
 
         typing_errs = get_func_typing_errs(impl, (types.bool_,))
-        self.assert_(isinstance(typing_errs, list) and len(typing_errs) == 1)
-        self.assert_(isinstance(typing_errs[0], errors.TypingError)
+        self.assertTrue(isinstance(typing_errs, list) and len(typing_errs) == 1)
+        self.assertTrue(isinstance(typing_errs[0], errors.TypingError)
             and "Cannot unify" in typing_errs[0].msg)
 
 


### PR DESCRIPTION
As title. Helps with usability of partial type inference significantly. The test infrastructure for this is useful by itself as well.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
