### PR TITLE
Fix typed dict error with uninitialized padding bytes 

### DIFF
--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -915,6 +915,18 @@ def memset(builder, ptr, size, value):
     builder.call(fn, [ptr, value, size, bool_t(0)])
 
 
+def memset_padding(builder, ptr):
+    """
+    Fill padding bytes of the pointee with zeros.
+    """
+    # Load existing value
+    val = builder.load(ptr)
+    # Fill pointee with zeros
+    memset(builder, ptr, sizeof(builder, ptr.type), 0)
+    # Store value back
+    builder.store(val, ptr)
+
+
 def global_constant(builder_or_module, name, value, linkage='internal'):
     """
     Get or create a (LLVM module-)global constant with *name* or *value*.

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -373,10 +373,10 @@ def alloca_once(builder, ty, size=None, name='', zfill=False):
     with builder.goto_entry_block():
         ptr = builder.alloca(ty, size=size, name=name)
         # Always zero-fill at init-site.  This is safe.
-        memset(builder, ptr, sizeof(builder, ptr.type), int8_t(0))
+        builder.store(ptr.type.pointee(None), ptr)
     # Also zero-fill at the use-site
     if zfill:
-        memset(builder, ptr, sizeof(builder, ptr.type), int8_t(0))
+        builder.store(ptr.type.pointee(None), ptr)
     return ptr
 
 
@@ -388,7 +388,7 @@ def sizeof(builder, ptr_type):
     return builder.ptrtoint(offset, intp_t)
 
 
-def alloca_once_value(builder, value, name='', zfill=True):
+def alloca_once_value(builder, value, name='', zfill=False):
     """
     Like alloca_once(), but passing a *value* instead of a type.  The
     type is inferred and the allocated slot is also initialized with the

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -931,7 +931,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         self.assertEqual(foo(), foo.py_func())
 
     def test_issue6570_alignment_padding(self):
-        # Create a key type that is 12-byte long on a 8-byte aligned system
+        # Create a key type that is 12-bytes long on a 8-byte aligned system
         # so that the a 4-byte padding is needed.
         # If the 4-byte padding is not zero-filled, it will have garbage data
         # that affects key matching in the lookup.

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -936,6 +936,7 @@ class TestDictObject(MemoryLeakMixin, TestCase):
         # If the 4-byte padding is not zero-filled, it will have garbage data
         # that affects key matching in the lookup.
         keyty = types.Tuple([types.uint64, types.float32])
+
         @njit
         def foo():
             d = dictobject.new_dict(keyty, float64)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -930,6 +930,23 @@ class TestDictObject(MemoryLeakMixin, TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
+    def test_issue6570_alignment_padding(self):
+        # Create a key type that is 12-byte long on a 8-byte aligned system
+        # so that the a 4-byte padding is needed.
+        # If the 4-byte padding is not zero-filled, it will have garbage data
+        # that affects key matching in the lookup.
+        keyty = types.Tuple([types.uint64, types.float32])
+        @njit
+        def foo():
+            d = dictobject.new_dict(keyty, float64)
+            t1 = np.array([3], dtype=np.uint64)
+            t2 = np.array([5.67], dtype=np.float32)
+            v1 = np.array([10.23], dtype=np.float32)
+            d[(t1[0], t2[0])] = v1[0]
+            return (t1[0], t2[0]) in d
+
+        self.assertTrue(foo())
+
 
 class TestDictTypeCasting(TestCase):
     def check_good(self, fromty, toty):

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -343,6 +343,8 @@ def _dict_insert(typingctx, d, key, hashval, val):
         data_val = dm_val.as_data(builder, val)
 
         ptr_key = cgutils.alloca_once_value(builder, data_key)
+        cgutils.memset_padding(builder, ptr_key)
+
         ptr_val = cgutils.alloca_once_value(builder, data_val)
         # TODO: the ptr_oldval is not used.  needed for refct
         ptr_oldval = cgutils.alloca_once(builder, data_val.type)
@@ -435,6 +437,7 @@ def _dict_lookup(typingctx, d, key, hashval):
 
         data_key = dm_key.as_data(builder, key)
         ptr_key = cgutils.alloca_once_value(builder, data_key)
+        cgutils.memset_padding(builder, ptr_key)
 
         ll_val = context.get_data_type(td.value_type)
         ptr_val = cgutils.alloca_once(builder, ll_val)


### PR DESCRIPTION
Fix #6570 

The issue was that some data type requires padding bytes to be properly addressable. The `alloca` in Numba does not fill the initialize the padding bytes and the typed dict implementation key comparison is a simple byte comparison. Since the padding bytes could have garbage data, the key comparison was failing unexpectedly and non-deterministically depending on the values that happen to be in the paddings.