### PR TITLE
Extending the extension API for hardware targets

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -230,11 +230,14 @@ class BaseContext(object):
     # the function descriptor
     fndesc = None
 
-    def __init__(self, typing_context):
+    def __init__(self, typing_context, target):
         _load_global_helpers()
 
         self.address_size = utils.MACHINE_BITS
         self.typing_context = typing_context
+        from numba.core.extending_hardware import hardware_registry
+        self.target_name = target
+        self.target = hardware_registry[target]
 
         # A mapping of installed registries to their loaders
         self._registries = {}

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -435,7 +435,7 @@ class Compiler(CompilerBase):
             pms.append(
                 DefaultPassBuilder.define_objectmode_pipeline(self.state)
             )
-        return pms
+        return [pms[0]] # hack for now, stop fallback
 
 
 class DefaultPassBuilder(object):

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -163,14 +163,12 @@ class CPUContext(BaseContext):
         library.add_ir_module(wrapper_module)
 
     def create_cfunc_wrapper(self, library, fndesc, env, call_helper):
-
         wrapper_module = self.create_module("cfunc_wrapper")
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
         wrapper_callee = wrapper_module.add_function(fnty, fndesc.llvm_func_name)
 
         ll_argtypes = [self.get_value_type(ty) for ty in fndesc.argtypes]
         ll_return_type = self.get_value_type(fndesc.restype)
-
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)
         wrapfn = wrapper_module.add_function(wrapty, fndesc.llvm_cfunc_wrapper_name)
         builder = ir.IRBuilder(wrapfn.append_basic_block('entry'))

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -190,6 +190,7 @@ def func_jit(signature_or_function=None, locals={}, cache=False,
 
 
 class jit(JitDecorator):
+    # TODO: Fix this, it's wrong in multiple ways!
     def __init__(self, *args, **kwargs):
         self._args = args
         self._kwargs = kwargs
@@ -213,8 +214,8 @@ class jit(JitDecorator):
     def dispatcher_wrapper(self):
         return func_jit(self.py_func, **self._kwargs)
 
-
-jit_registry[hardware_registry['cpu']] = jit
+# Register the cpu token as using `jit` as the jitter
+jit_registry['cpu'] = jit
 
 def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
     dispatcher = registry.dispatcher_registry[hardware_registry[target]]

--- a/numba/core/descriptors.py
+++ b/numba/core/descriptors.py
@@ -2,6 +2,7 @@
 Target Descriptors
 """
 
-
 class TargetDescriptor(object):
-    pass
+
+    def __init__(self, target_name):
+        self._target_name = target_name

--- a/numba/core/extending_hardware.py
+++ b/numba/core/extending_hardware.py
@@ -1,0 +1,61 @@
+from abc import ABC, abstractmethod
+from numba.core.registry import TargetRegistry
+
+from threading import local as tls
+
+_active_context = tls()
+_active_context.default ='cpu'
+
+class hardware_target(object):
+    def __init__(self, name):
+        self._orig_target = getattr(_active_context, 'target', 'default')
+        self.target = name
+
+    def __enter__(self):
+        _active_context.target = self.target
+
+    def __exit__(self, ty, val, tb):
+        _active_context = self._orig_target
+
+def current_target():
+    return _active_context.target
+
+hardware_registry = TargetRegistry()
+
+class JitDecorator(ABC):
+
+    @abstractmethod
+    def __call__(self):
+        return NotImplemented
+
+
+class Generic(ABC):
+    """Mark the hardware target as generic, i.e. suitable for compilation on
+    any target. All hardware must inherit from this.
+    """
+
+class CPU(Generic):
+    """Mark the hardware target as CPU.
+    """
+
+class GPU(Generic):
+    """Mark the hardware target as GPU, i.e. suitable for compilation on a GPU
+    target.
+    """
+
+class CUDA(GPU):
+    """Mark the hardware target as CUDA.
+    """
+
+class ROCm(GPU):
+    """Mark the hardware target as ROCm.
+    """
+
+hardware_registry['generic'] = Generic
+hardware_registry['CPU'] = CPU
+hardware_registry['cpu'] = CPU
+hardware_registry['GPU'] = GPU
+hardware_registry['gpu'] = GPU
+hardware_registry['CUDA'] = CUDA
+hardware_registry['cuda'] = CUDA
+hardware_registry['ROCm'] = ROCm

--- a/numba/core/extending_hardware.py
+++ b/numba/core/extending_hardware.py
@@ -8,7 +8,8 @@ _active_context.default ='cpu'
 
 class hardware_target(object):
     def __init__(self, name):
-        self._orig_target = getattr(_active_context, 'target', 'default')
+        self._orig_target = getattr(_active_context, 'target',
+                                    _active_context.default)
         self.target = name
 
     def __enter__(self):
@@ -18,7 +19,7 @@ class hardware_target(object):
         _active_context = self._orig_target
 
 def current_target():
-    return _active_context.target
+    return getattr(_active_context, 'target', _active_context.default)
 
 hardware_registry = TargetRegistry()
 

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -418,12 +418,12 @@ class Expr(Inst):
         return cls(op=op, loc=loc, fn=fn, value=value)
 
     @classmethod
-    def call(cls, func, args, kws, loc, vararg=None):
+    def call(cls, func, args, kws, loc, vararg=None, hardware=None):
         assert isinstance(func, Var)
         assert isinstance(loc, Loc)
         op = 'call'
         return cls(op=op, loc=loc, func=func, args=args, kws=kws,
-                   vararg=vararg)
+                   vararg=vararg, hardware=hardware)
 
     @classmethod
     def build_tuple(cls, items, loc):

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -250,7 +250,7 @@ class BaseLower(object):
         if self.genlower:
             raise UnsupportedError('generator as a first-class function type')
         self.context.create_cfunc_wrapper(self.library, self.fndesc,
-                                          self.env, self.call_helper)
+                                        self.env, self.call_helper)
 
     def setup_function(self, fndesc):
         # Setup function
@@ -983,7 +983,14 @@ class Lower(BaseLower):
             argvals = self.fold_call_args(
                 fnty, signature, expr.args, expr.vararg, expr.kws,
             )
-        impl = self.context.get_function(fnty, signature)
+        tname = expr.hardware
+        if tname is not None:
+            from numba.core import registry
+            disp = registry.dispatcher_registry[tname]
+            hw_ctx = disp.targetdescr.target_context
+            impl = hw_ctx.get_function(fnty, signature)
+        else:
+            impl = self.context.get_function(fnty, signature)
         if signature.recvr:
             # The "self" object is passed as the function object
             # for bounded function

--- a/numba/core/registry.py
+++ b/numba/core/registry.py
@@ -28,7 +28,7 @@ class CPUTarget(TargetDescriptor):
     @utils.cached_property
     def _toplevel_target_context(self):
         # Lazily-initialized top-level target context, for all threads
-        return cpu.CPUContext(self.typing_context)
+        return cpu.CPUContext(self.typing_context, self._target_name)
 
     @utils.cached_property
     def _toplevel_typing_context(self):
@@ -66,7 +66,7 @@ class CPUTarget(TargetDescriptor):
 
 
 # The global CPU target
-cpu_target = CPUTarget()
+cpu_target = CPUTarget('cpu')
 
 
 class CPUDispatcher(dispatcher.Dispatcher):
@@ -95,6 +95,6 @@ class TargetRegistry(utils.UniqueDict):
             del self.ondemand[item]
         return super(TargetRegistry, self).__getitem__(item)
 
-
 dispatcher_registry = TargetRegistry()
-dispatcher_registry['cpu'] = CPUDispatcher
+from numba.core.extending_hardware import hardware_registry
+dispatcher_registry[hardware_registry['cpu']] = CPUDispatcher

--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -59,13 +59,13 @@ class CallStack(Sequence):
         return len(self._stack)
 
     @contextlib.contextmanager
-    def register(self, typeinfer, func_id, args):
+    def register(self, target, typeinfer, func_id, args):
         # guard compiling the same function with the same signature
         if self.match(func_id.func, args):
             msg = "compiler re-entrant to the same function signature"
             raise RuntimeError(msg)
         self._lock.acquire()
-        self._stack.append(CallFrame(typeinfer, func_id, args))
+        self._stack.append(CallFrame(target, typeinfer, func_id, args))
         try:
             yield
         finally:
@@ -104,10 +104,11 @@ class CallFrame(object):
     """
     A compile-time call frame
     """
-    def __init__(self, typeinfer, func_id, args):
+    def __init__(self, target, typeinfer, func_id, args):
         self.typeinfer = typeinfer
         self.func_id = func_id
         self.args = args
+        self.target = target
         self._inferred_retty = set()
 
     def __repr__(self):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -683,8 +683,6 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         try:
             impl, args = self._impl_cache[cache_key]
         except KeyError:
-            #import pdb; pdb.set_trace()
-            #pass
             impl, args = self._build_impl(cache_key, args, kws)
         return impl, args
 
@@ -880,8 +878,13 @@ class _IntrinsicTemplate(AbstractTemplate):
         Type the intrinsic by the arguments.
         """
         from numba.core.imputils import lower_builtin
-
         cache_key = self.context, args, tuple(kws.items())
+        from numba.core.registry import dispatcher_registry
+        hwstr = self.metadata.get('hardware', 'cpu')
+        disp = dispatcher_registry[hwstr]
+        tgtctx = disp.targetdescr.target_context
+        reg = next(iter(tgtctx._registries))
+        lower_builtin = reg.lower
         try:
             return self._impl_cache[cache_key]
         except KeyError:

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -29,6 +29,9 @@ class UFuncTargetOptions(TargetOptions):
 class UFuncTarget(TargetDescriptor):
     options = UFuncTargetOptions
 
+    def __init__(self):
+        super().__init__('ufunc')
+
     @property
     def typing_context(self):
         return cpu_target.typing_context


### PR DESCRIPTION
This PR is a draft, it contains some exploratory patches with ideas about:

1. How to make it so that it is easier to extend Numba to new hardware targets, in particular through a new kwarg `hardware=` on commonly used extension APIs e.g. `@overload`
2. Expressing a hardware hierarchy such that implementations of functions are only as specific as they need to be for a given piece of hardware. For example `hash()` is trivially implemented as `lambda x: x.__hash__()` no matter what the hardware target, therefore `hardware='generic'` would be an appropriate target. This is to help with code reuse.
3. Making it possible to "offload" selected functions from one target to another via compiler passes comprising part of a custom compilation pipeline.
4. Permitting context based management of the "current" target for a function that's being jitted.

Some of these concepts are demonstrated here for a new "dummy" target, the "DPU" (Dummy Processing Unit): https://gist.github.com/stuartarchibald/7051191e0f0cb09ba9c2d42c7c21ced6
this is probably the place to start looking at the impact of this change.

This branch breaks a load of things, contains numerous (and some quite horrible) hacks to get things to "work", and has a lot of "undesigned" parts. However, it's a starting point for making this possible and lays down some of the ground work for more abstract constraints in overloads such as declarative typing and selecting overload implementations based on metadata.

Do not merge!