### PR TITLE
docs: fix simple typo, consevatively -> conservatively

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3996,7 +3996,7 @@ def remove_duplicate_definitions(blocks, nameset):
 
 
 def has_cross_iter_dep(parfor):
-    # we consevatively assume there is cross iteration dependency when
+    # we conservatively assume there is cross iteration dependency when
     # the parfor index is used in any expression since the expression could
     # be used for indexing arrays
     # TODO: make it more accurate using ud-chains


### PR DESCRIPTION
There is a small typo in numba/parfors/parfor.py.

Should read `conservatively` rather than `consevatively`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md