### PR TITLE
Never add multiply defined scalars to shape data structures.

### DIFF
--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2694,7 +2694,8 @@ class TestPrange(TestPrangeBase):
             for x in range(1):
                 i_row = 0
                 for _ in range(n_rows):
-                    c[0] = a[i_row, 0]
+                    bi = b[i_row]
+                    c[:] = a[i_row, :bi]
                     i_row += 1
                     if i_row >= n_rows:
                         i_row -= n_rows

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2686,6 +2686,25 @@ class TestPrange(TestPrangeBase):
 
         self.prange_tester(test_impl)
 
+    @skip_parfors_unsupported
+    def test_multi_defined_array_index(self):
+        # issue6597
+        def test_impl(a, b, c):
+            n_rows = b.shape[0]
+            for x in range(1):
+                i_row = 0
+                for _ in range(n_rows):
+                    c[0] = a[i_row, 0]
+                    i_row += 1
+                    if i_row >= n_rows:
+                        i_row -= n_rows
+            return c
+
+        a = np.arange(10).reshape((10, 1))
+        b = np.ones(10, dtype=np.int)
+        c = np.ones(1, dtype=np.int)
+        self.prange_tester(test_impl, a, b, c, patch_instance=[0])
+
 
 @skip_parfors_unsupported
 @x86_only


### PR DESCRIPTION
Resolves #6597. 

Previously, we would add scalars and detect multiple definitions along the way and then we'd remove them at the end.  The problem with that approach is that intermediate steps consult the data structures and may think that a variable is a constant at some point (and then use the constant in some build_tuple expr) when in reality the variable is in a loop and may be updated by the later part of the loop in a previous iteration.  Now, we exclude non-array variables with multiple definitions from ever going in the data structures.
