### PR TITLE
Testhound/cuda cuberoot

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -445,8 +445,9 @@ precision parts of the CUDA Toolkit documentation.
 
 .. function:: numba.cuda.cbrt (x)
 
-   Perform the cube root operation, x ** (1/3). Named after the ``cbrt`` and ``cbrtf`` in
-   the C api. Supports float32, and float64 arguments only.
+   Perform the cube root operation, x ** (1/3). Named after the functions
+   ``cbrt`` and ``cbrtf`` in the C api. Supports float32, and float64 arguments
+   only.
 
 Control Flow Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -443,6 +443,10 @@ precision parts of the CUDA Toolkit documentation.
    the C api, but maps to the ``fma.rn.f32`` and ``fma.rn.f64`` (round-to-nearest-even)
    PTX instructions.
 
+.. function:: numba.cuda.cbrt (x)
+
+   Perform the cube root operation, x ** (1/3). Named after the ``cbrt`` and ``cbrtf`` in
+   the C api. Supports float32, and float64 arguments only.
 
 Control Flow Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -238,6 +238,16 @@ class Cuda_fma(ConcreteTemplate):
 
 
 @register
+class Cuda_cbrt(ConcreteTemplate):
+
+    key = cuda.cbrt
+    cases = [
+        signature(types.float32, types.float32),
+        signature(types.float64, types.float64),
+    ]
+
+
+@register
 class Cuda_brev(ConcreteTemplate):
     key = cuda.brev
     cases = [
@@ -491,6 +501,9 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_fma(self, mod):
         return types.Function(Cuda_fma)
+
+    def resolve_cbrt(self, mod):
+        return types.Function(Cuda_cbrt)
 
     def resolve_syncthreads(self, mod):
         return types.Function(Cuda_syncthreads)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -387,6 +387,28 @@ def ptx_popc(context, builder, sig, args):
 def ptx_fma(context, builder, sig, args):
     return builder.fma(*args)
 
+# See:
+# https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_cbrt.html#__nv_cbrt
+# https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_cbrtf.html#__nv_cbrtf
+
+
+cbrt_funcs = {
+    types.float32: '__nv_cbrtf',
+    types.float64: '__nv_cbrt',
+}
+
+
+@lower(stubs.cbrt, types.float32)
+@lower(stubs.cbrt, types.float64)
+def ptx_cbrt(context, builder, sig, args):
+    ty = sig.return_type
+    fname = cbrt_funcs[ty]
+    fty = context.get_value_type(ty)
+    lmod = builder.module
+    fnty = Type.function(fty, [fty])
+    fn = lmod.get_or_insert_function(fnty, name=fname)
+    return builder.call(fn, args)
+
 
 @lower(stubs.brev, types.u4)
 def ptx_brev_u4(context, builder, sig, args):

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -5,7 +5,7 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     const, grid, gridsize, atomic, shfl_sync_intrinsic,
                     vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
-                    threadfence, selp, popc, brev, clz, ffs, fma,
+                    threadfence, selp, popc, brev, clz, ffs, fma, cbrt,
                     cg)
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -304,6 +304,9 @@ class FakeCUDAModule(object):
     def fma(self, a, b, c):
         return a * b + c
 
+    def cbrt(self, a):
+        return a ** (1 / 3)
+
     def brev(self, val):
         return int('{:032b}'.format(val)[::-1], 2)
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -392,6 +392,14 @@ class fma(Stub):
     """
 
 
+class cbrt(Stub):
+    """"
+    cbrt(a)
+
+    Perform the cube root operation.
+    """
+
+
 #-------------------------------------------------------------------------------
 # atomic
 

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -67,6 +67,10 @@ def simple_fma(ary, a, b, c):
     ary[0] = cuda.fma(a, b, c)
 
 
+def simple_cbrt(ary, a):
+    ary[0] = cuda.cbrt(a)
+
+
 def simple_brev(ary, c):
     ary[0] = cuda.brev(c)
 
@@ -287,6 +291,20 @@ class TestCudaIntrinsic(CUDATestCase):
         ary = np.zeros(1, dtype=np.float64)
         compiled[1, 1](ary, 2., 3., 4.)
         np.testing.assert_allclose(ary[0], 2 * 3 + 4)
+
+    def test_cbrt_f32(self):
+        compiled = cuda.jit("void(float32[:], float32)")(simple_cbrt)
+        ary = np.zeros(1, dtype=np.float32)
+        cbrt_arg = 2.
+        compiled[1, 1](ary, cbrt_arg)
+        np.testing.assert_allclose(ary[0], cbrt_arg ** (1 / 3))
+
+    def test_cbrt_f64(self):
+        compiled = cuda.jit("void(float64[:], float64)")(simple_cbrt)
+        ary = np.zeros(1, dtype=np.float64)
+        cbrt_arg = 6.
+        compiled[1, 1](ary, cbrt_arg)
+        np.testing.assert_allclose(ary[0], cbrt_arg ** (1 / 3))
 
     def test_brev_u4(self):
         compiled = cuda.jit("void(uint32[:], uint32)")(simple_brev)


### PR DESCRIPTION
This pull request implements the cuberoot function as an intrinsic for the cuda backend. This functionality is based on this issue:

https://github.com/numba/numba/issues/6051 (Cube Root Intrinsic for CUDA)