### PR TITLE
Fix #6632 support alternative dtype string spellings

### DIFF
--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -439,7 +439,12 @@ def parse_dtype(dtype):
     elif isinstance(dtype, types.TypeRef):
         return dtype.instance_type
     elif isinstance(dtype, types.StringLiteral):
-        dt = getattr(np, dtype.literal_value, None)
+        try:
+            dtstr = dtype.literal_value
+            dt = np.dtype(dtstr).type
+        except TypeError:
+            msg = f"Invalid NumPy dtype specified: '{dtstr}'"
+            raise TypingError(msg)
         if dt is not None:
             return from_dtype(dt)
 

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -439,8 +439,8 @@ def parse_dtype(dtype):
     elif isinstance(dtype, types.TypeRef):
         return dtype.instance_type
     elif isinstance(dtype, types.StringLiteral):
+        dtstr = dtype.literal_value
         try:
-            dtstr = dtype.literal_value
             dt = np.dtype(dtstr).type
         except TypeError:
             msg = f"Invalid NumPy dtype specified: '{dtstr}'"

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -441,12 +441,11 @@ def parse_dtype(dtype):
     elif isinstance(dtype, types.StringLiteral):
         dtstr = dtype.literal_value
         try:
-            dt = np.dtype(dtstr).type
+            dt = np.dtype(dtstr)
         except TypeError:
             msg = f"Invalid NumPy dtype specified: '{dtstr}'"
             raise TypingError(msg)
-        if dt is not None:
-            return from_dtype(dt)
+        return from_dtype(dt)
 
 def _parse_nested_sequence(context, typ):
     """

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -95,13 +95,18 @@ def from_dtype(dtype):
     try:
         return FROM_DTYPE[dtype]
     except KeyError:
-        char = dtype.char
+        pass
 
+    try:
+        char = dtype.char
+    except AttributeError:
+        pass
+    else:
         if char in 'SU':
             return _from_str_dtype(dtype)
         if char in 'mM':
             return _from_datetime_dtype(dtype)
-        if char in 'V':
+        if char in 'V' and dtype.subdtype is not None:
             subtype = from_dtype(dtype.subdtype[0])
             return types.NestedArray(subtype, dtype.shape)
 

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -637,6 +637,14 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
             return pyfunc(n, 'c8')
         self.check_1d(func)
 
+    def test_1d_dtype_str_structured_dtype(self):
+        # test_1d_dtype_str but using a structured dtype
+        pyfunc = self.pyfunc
+        _dtype = "i4, (2,3)f8"
+        def func(n):
+            return pyfunc(n, _dtype)
+        self.check_1d(func)
+
     def test_1d_dtype_non_const_str(self):
         pyfunc = self.pyfunc
 
@@ -722,6 +730,10 @@ class TestNdOnes(TestNdZeros):
     def setUp(self):
         super(TestNdOnes, self).setUp()
         self.pyfunc = np.ones
+
+    @unittest.expectedFailure
+    def test_1d_dtype_str_structured_dtype(self):
+        super().test_1d_dtype_str_structured_dtype()
 
 
 class TestNdFull(ConstructorBaseTest, TestCase):

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -625,6 +625,18 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
             return pyfunc(n, 'complex128')
         self.check_1d(func)
 
+    def test_1d_dtype_str_alternative_spelling(self):
+        # like test_1d_dtype_str but using the shorthand type spellings
+        pyfunc = self.pyfunc
+        _dtype = 'i4'
+        def func(n):
+            return pyfunc(n, _dtype)
+        self.check_1d(func)
+
+        def func(n):
+            return pyfunc(n, 'c8')
+        self.check_1d(func)
+
     def test_1d_dtype_non_const_str(self):
         pyfunc = self.pyfunc
 
@@ -640,6 +652,19 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
         restr = r'\b{}\(int.*?, unicode_type\)\B'
         regex = re.compile(restr.format(pyfunc.__name__))
         self.assertRegex(excstr, regex)
+
+    def test_1d_dtype_invalid_str(self):
+        pyfunc = self.pyfunc
+
+        @njit
+        def func(n):
+            return pyfunc(n, 'ABCDEF')
+
+        with self.assertRaises(TypingError) as raises:
+            func(5)
+
+        excstr = str(raises.exception)
+        self.assertIn("Invalid NumPy dtype specified: 'ABCDEF'", excstr)
 
     def test_2d(self):
         pyfunc = self.pyfunc
@@ -673,6 +698,13 @@ class TestNdZeros(ConstructorBaseTest, TestCase):
         pyfunc = self.pyfunc
         def func(m, n):
             return pyfunc((m, n), dtype='complex64')
+        self.check_2d(func)
+
+    def test_2d_dtype_str_kwarg_alternative_spelling(self):
+        # as test_2d_dtype_str_kwarg but with the numpy shorthand type spelling
+        pyfunc = self.pyfunc
+        def func(m, n):
+            return pyfunc((m, n), dtype='c8')
         self.check_2d(func)
 
     def test_alloc_size(self):
@@ -723,6 +755,12 @@ class TestNdFull(ConstructorBaseTest, TestCase):
             return np.full(n, 4.5, 'bool_')
         self.check_1d(func)
 
+    def test_1d_dtype_str_alternative_spelling(self):
+        # like test_1d_dtype_str but using the shorthand type spelling
+        def func(n):
+            return np.full(n, 4.5, '?')
+        self.check_1d(func)
+
     def test_1d_dtype_non_const_str(self):
 
         @njit
@@ -737,6 +775,18 @@ class TestNdFull(ConstructorBaseTest, TestCase):
         restr = r'\bfull\(UniTuple\(int.*? x 1\), float64, unicode_type\)\B'
         regex = re.compile(restr)
         self.assertRegex(excstr, regex)
+
+    def test_1d_dtype_invalid_str(self):
+
+        @njit
+        def func(n, fv):
+            return np.full(n, fv, 'ABCDEF')
+
+        with self.assertRaises(TypingError) as raises:
+            func(np.ones(4), 4.5)
+
+        excstr = str(raises.exception)
+        self.assertIn("Invalid NumPy dtype specified: 'ABCDEF'", excstr)
 
     def test_2d(self):
         def func(m, n):
@@ -888,10 +938,10 @@ class TestNdEmptyLike(ConstructorLikeBaseTest, TestCase):
             return pyfunc(arr, dtype='int32')
         self.check_like(func, np.float64)
 
-    def test_like_dtype_str_kwarg(self):
+    def test_like_dtype_str_kwarg_alternative_spelling(self):
         pyfunc = self.pyfunc
         def func(arr):
-            return pyfunc(arr, dtype='int32')
+            return pyfunc(arr, dtype='i4')
         self.check_like(func, np.float64)
 
     def test_like_dtype_non_const_str(self):
@@ -910,6 +960,19 @@ class TestNdEmptyLike(ConstructorLikeBaseTest, TestCase):
         self.assertIn(
             '{}(array(float64, 1d, C), unicode_type)'.format(pyfunc.__name__),
             excstr)
+
+    def test_like_dtype_invalid_str(self):
+        pyfunc = self.pyfunc
+
+        @njit
+        def func(n):
+            return pyfunc(n, 'ABCDEF')
+
+        with self.assertRaises(TypingError) as raises:
+            func(np.ones(4))
+
+        excstr = str(raises.exception)
+        self.assertIn("Invalid NumPy dtype specified: 'ABCDEF'", excstr)
 
 
 class TestNdZerosLike(TestNdEmptyLike):
@@ -985,6 +1048,11 @@ class TestNdFullLike(ConstructorLikeBaseTest, TestCase):
             return np.full_like(arr, 4.5, 'bool_')
         self.check_like(func, np.float64)
 
+    def test_like_dtype_str_kwarg_alternative_spelling(self):
+        def func(arr):
+            return np.full_like(arr, 4.5, dtype='?')
+        self.check_like(func, np.float64)
+
     def test_like_dtype_non_const_str_kwarg(self):
 
         @njit
@@ -998,6 +1066,18 @@ class TestNdFullLike(ConstructorLikeBaseTest, TestCase):
         self.assertIn('No match', excstr)
         self.assertIn('full_like(array(float64, 1d, C), float64, unicode_type)',
                       excstr)
+
+    def test_like_dtype_invalid_str(self):
+
+        @njit
+        def func(arr, fv):
+            return np.full_like(arr, fv, "ABCDEF")
+
+        with self.assertRaises(TypingError) as raises:
+            func(np.ones(4), 3.4)
+
+        excstr = str(raises.exception)
+        self.assertIn("Invalid NumPy dtype specified: 'ABCDEF'", excstr)
 
 
 class TestNdIdentity(BaseTest):


### PR DESCRIPTION
As title. Support for alternative ways of spelling dtypes
with strings.

Fixes #6632

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
