### PR TITLE
Make Numba pickle compatible with Ray.

### DIFF
--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -28,6 +28,7 @@ else:
     else:
         pickle = pickle38
 
+import cloudpickle
 
 #
 # Pickle support
@@ -162,7 +163,9 @@ def _numba_unpickle(address, bytedata, hashed):
 def dumps(obj):
     """Similar to `pickle.dumps()`. Returns the serialized object in bytes.
     """
-    pickler = NumbaPickler
+    pickler = cloudpickle.Pickler
+    #pickler = NumbaPickler
+    print("dumps:", obj, type(obj), pickler, type(pickler))
     with io.BytesIO() as buf:
         p = pickler(buf)
         p.dump(obj)
@@ -353,11 +356,12 @@ class SlowNumbaPickler(pickle._Pickler):
     dispatch[_CustomPickled] = _save_custom_pickled
 
 
-class FastNumbaPickler(pickle.Pickler):
+class FastNumbaPickler(cloudpickle.Pickler):
     """Faster version of the NumbaPickler through use of Python3.8+ features from
     the C Pickler, install `pickle5` for similar on older Python versions.
     """
     def reducer_override(self, obj):
+        print("reducer_override:", obj, type(obj))
         if isinstance(obj, FunctionType):
             return self._custom_reduce_func(obj)
         elif isinstance(obj, ModuleType):


### PR DESCRIPTION
@sklam Please have a look at this PR.  It is work-in-progress but would like your feedback.  I added some debug code in serialization.py to help me find where the unpickable generators are.  It turns out that StencilFunc was storing typingctx and targetctx and those contain generators.  In this PR, I don't store those in StencilFunc anymore but get them each time I need them in StencilFunc methods.  That seems to have eliminated the previous pickling error I was getting and now I'm not getting any pickling errors at all.  That is not to say pickling is working correctly...just no obvious errors...see below.

What I'm getting now is it looks like Ray is trying to run a Numba function in another process, presumably after unpickling, that invokes a Numba stencil.  star2 is the Numba stencil function.

```  File "python/ray/_raylet.pyx", line 463, in ray._raylet.execute_task
  File "python/ray/_raylet.pyx", line 415, in ray._raylet.execute_task.function_executor
  File "./todd-stencil.py", line 197, in run_step
    do_star2(A,B,W)
  File "/mnt/home/taanders/numba/intel_numba/numba/numba/core/dispatcher.py", line 420, in _compile_for_args
    error_rewrite(e, 'typing')
  File "/mnt/home/taanders/numba/intel_numba/numba/numba/core/dispatcher.py", line 361, in error_rewrite
    raise e.with_traceback(None)
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
Untyped global name 'star2': Cannot determine Numba type of <class 'numba.stencils.stencil.StencilFunc'>

File "todd-stencil.py", line 96:
def do_star2(A,B,W):
    <source elided>
    #star2(A,W, out=B)
    B += star2(A,W)
```