### PR TITLE
CUDA: Add a function to query whether the runtime version is supported.

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -213,7 +213,7 @@ accessed through ``cuda.runtime``, which is an instance of the
 :class:`numba.cuda.cudadrv.runtime.Runtime` class:
 
 .. autoclass:: numba.cuda.cudadrv.runtime.Runtime
-   :members: get_version, is_supported_version
+   :members: get_version, is_supported_version, supported_versions
 
 Whether the current runtime is officially supported and tested with the current
 version of Numba can also be queried:

--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -213,4 +213,9 @@ accessed through ``cuda.runtime``, which is an instance of the
 :class:`numba.cuda.cudadrv.runtime.Runtime` class:
 
 .. autoclass:: numba.cuda.cudadrv.runtime.Runtime
-   :members: get_version
+   :members: get_version, is_supported_version
+
+Whether the current runtime is officially supported and tested with the current
+version of Numba can also be queried:
+
+.. autofunction:: numba.cuda.is_supported_version

--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -45,7 +45,11 @@ Software
 
 Numba aims to support CUDA Toolkit versions released within the last 3 years. At
 the present time, you will need the CUDA toolkit version 9.0 or later installed.
-If you are using Conda, just type::
+
+CUDA is supported on 64-bit Linux and Windows. 32-bit platforms, and macOS are
+unsupported.
+
+If you are using Conda, you can install the CUDA toolkit with::
 
    $ conda install cudatoolkit
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -14,7 +14,7 @@ Our supported platforms are:
 * Windows 7 and later (32-bit and 64-bit)
 * OS X 10.9 and later (64-bit)
 * \*BSD (unofficial support only)
-* NVIDIA GPUs of compute capability 2.0 and later
+* NVIDIA GPUs of compute capability 3.0 and later
 * AMD ROC dGPUs (linux only and not for AMD Carrizo or Kaveri APU)
 * ARMv7 (32-bit little-endian, such as Raspberry Pi 2 and 3)
 * ARMv8 (64-bit little-endian, such as the NVIDIA Jetson)

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -118,10 +118,15 @@ class Runtime:
         Returns True if the CUDA Runtime is a supported version.
         """
 
-        supported_versions = ((9, 0), (9, 1), (9, 2),
-                              (10, 0), (10, 1), (10, 2),
-                              (11, 0), (11, 1), (11, 2))
-        return self.get_version() in supported_versions
+        return self.get_version() in self.supported_versions
+
+    @property
+    def supported_versions(self):
+        """A tuple of supported CUDA toolkit versions. Versions are given in
+        the form ``(major_version, minor_version)``."""
+        return ((9, 0), (9, 1), (9, 2),
+                (10, 0), (10, 1), (10, 2),
+                (11, 0), (11, 1), (11, 2))
 
 
 runtime = Runtime()

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -7,6 +7,7 @@ really used in Numba except for querying the Runtime version.
 
 import ctypes
 import functools
+import sys
 
 from numba.core import config
 from numba.cuda.cudadrv.driver import ERROR_MAP, make_logger
@@ -124,6 +125,9 @@ class Runtime:
     def supported_versions(self):
         """A tuple of supported CUDA toolkit versions. Versions are given in
         the form ``(major_version, minor_version)``."""
+        if sys.platform not in ('linux', 'win32') or config.MACHINE_BITS != 64:
+            # Only 64-bit Linux and Windows are supported
+            return ()
         return ((9, 0), (9, 1), (9, 2),
                 (10, 0), (10, 1), (10, 2),
                 (11, 0), (11, 1), (11, 2))

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -123,7 +123,7 @@ class Runtime:
 
     @property
     def supported_versions(self):
-        """A tuple of supported CUDA toolkit versions. Versions are given in
+        """A tuple of all supported CUDA toolkit versions. Versions are given in
         the form ``(major_version, minor_version)``."""
         if sys.platform not in ('linux', 'win32') or config.MACHINE_BITS != 64:
             # Only 64-bit Linux and Windows are supported

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -113,5 +113,15 @@ class Runtime:
         minor = (rtver.value - (major * 1000)) // 10
         return (major, minor)
 
+    def is_supported_version(self):
+        """
+        Returns True if the CUDA Runtime is a supported version.
+        """
+
+        supported_versions = ((9, 0), (9, 1), (9, 2),
+                              (10, 0), (10, 1), (10, 2),
+                              (11, 0), (11, 1), (11, 2))
+        return self.get_version() in supported_versions
+
 
 runtime = Runtime()

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -52,7 +52,7 @@ def is_available():
 
 
 def is_supported_version():
-    """Returns true if the CUDA Runtime is a supported version.
+    """Returns True if the CUDA Runtime is a supported version.
 
     Unsupported versions (e.g. newer versions than those known to Numba)
     may still work; this function provides a facility to check whether the

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -51,6 +51,23 @@ def is_available():
     return driver_is_available and nvvm.is_available()
 
 
+def is_supported_version():
+    """Returns true if the CUDA Runtime is a supported version.
+
+    Unsupported versions (e.g. newer versions than those known to Numba)
+    may still work; this function provides a facility to check whether the
+    current Numba version is tested and known to work with the current
+    runtime version. If the current version is unsupported, the caller can
+    decide how to act. Options include:
+
+    - Continuing silently,
+    - Emitting a warning,
+    - Generating an error or otherwise preventing the use of CUDA.
+    """
+
+    return runtime.is_supported_version()
+
+
 def cuda_error():
     """Returns None or an exception if the CUDA driver fails to initialize.
     """

--- a/numba/cuda/simulator/cudadrv/runtime.py
+++ b/numba/cuda/simulator/cudadrv/runtime.py
@@ -8,5 +8,8 @@ class FakeRuntime(object):
     def get_version(self):
         return (-1, -1)
 
+    def is_supported_version(self):
+        return True
+
 
 runtime = FakeRuntime()

--- a/numba/cuda/simulator/cudadrv/runtime.py
+++ b/numba/cuda/simulator/cudadrv/runtime.py
@@ -11,5 +11,9 @@ class FakeRuntime(object):
     def is_supported_version(self):
         return True
 
+    @property
+    def supported_versions(self):
+        return (-1, -1),
+
 
 runtime = FakeRuntime()

--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 from numba.core import config
 from numba.cuda.cudadrv.runtime import runtime
-from numba.cuda.testing import unittest, SerialMixin
+from numba.cuda.testing import unittest, SerialMixin, skip_on_cudasim
 from unittest.mock import patch
 
 
@@ -35,6 +35,7 @@ class TestRuntime(unittest.TestCase):
             with patch.object(runtime, 'get_version', return_value=v):
                 self.assertTrue(runtime.is_supported_version())
 
+    @skip_on_cudasim('The simulator always simulates a supported runtime')
     def test_is_supported_version_false(self):
         # Check with an old unsupported version and some potential future
         # versions

--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -43,6 +43,9 @@ class TestRuntime(unittest.TestCase):
             with patch.object(runtime, 'get_version', return_value=v):
                 self.assertFalse(runtime.is_supported_version())
 
+    def test_supported_versions(self):
+        self.assertEqual(SUPPORTED_VERSIONS, runtime.supported_versions)
+
 
 class TestVisibleDevices(unittest.TestCase, SerialMixin):
     def test_visible_devices_set_after_import(self):

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -138,7 +138,7 @@ class TestCudaConstantMemory(CUDATestCase):
             # and > 11.1 use a vector of 2x f32. The root cause of these
             # codegen differences is not known, but must be accounted for in
             # this test.
-            if cuda.runtime.get_version() in ((8, 0), (9, 0), (9, 1), (11, 2)):
+            if cuda.runtime.get_version() in ((9, 0), (9, 1), (11, 2)):
                 complex_load = 'ld.const.v2.f32'
                 description = 'Load the complex as a vector of 2x f32'
             else:


### PR DESCRIPTION
`numba.cuda.is_supported_version()` returns `True` if the CUDA Runtime is a supported version (as suggested in #6645). The list of supported versions matches those with which the current version of Numba is tested.

Unsupported versions (e.g. newer versions than those known to Numba) may still work. If the current version is unsupported, the caller can decide how to act. Options include:

- Continuing silently,
- Emitting a warning,
- Generating an error or otherwise preventing the use of CUDA.


Notes:

- Based on #6661, which adds support for CUDA 11.2
- Also removes a reference to an unsupported version (8.0) in `test_constmem`.
- Fixes #6645.