### PR TITLE
Fast path for overload attribute matching

### DIFF
--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -135,6 +135,7 @@ class BaseContext(object):
         self._registries = {}
         # Typing declarations extracted from the registries or other sources
         self._functions = defaultdict(list)
+        self._overload_attributes = defaultdict(dict)
         self._attributes = defaultdict(list)
         self._globals = utils.UniqueDict()
         self.tm = rules.default_type_manager
@@ -245,10 +246,20 @@ class BaseContext(object):
             # XXX fold this into the __call__ attribute logic?
             return func.get_call_type(self, args, kws)
 
-    def _get_attribute_templates(self, typ):
+    def _get_attribute_templates(self, typ, attr):
         """
         Get matching AttributeTemplates for the Numba type.
         """
+        # check the overload templates first (fast path for overload cases)
+        if typ in self._overload_attributes:
+            if attr in self._overload_attributes[typ]:
+                yield self._overload_attributes[typ][attr]
+        else:
+            for cls in type(typ).__mro__:
+                if cls in self._overload_attributes:
+                    if attr in self._overload_attributes[cls]:
+                        yield self._overload_attributes[cls][attr]
+
         if typ in self._attributes:
             for attrinfo in self._attributes[typ]:
                 yield attrinfo
@@ -283,7 +294,7 @@ class BaseContext(object):
                 return attrty
 
     def find_matching_getattr_template(self, typ, attr):
-        for template in self._get_attribute_templates(typ):
+        for template in self._get_attribute_templates(typ, attr):
             return_type = template.resolve(typ, attr)
             if return_type is not None:
                 return {
@@ -297,7 +308,7 @@ class BaseContext(object):
         to the given *value* type.
         A function signature is returned, or None if resolution failed.
         """
-        for attrinfo in self._get_attribute_templates(target):
+        for attrinfo in self._get_attribute_templates(target, attr):
             expectedty = attrinfo.resolve(target, attr)
             # NOTE: convertibility from *value* to *expectedty* is left to
             # the caller.
@@ -486,7 +497,10 @@ class BaseContext(object):
 
     def insert_attributes(self, at):
         key = at.key
-        self._attributes[key].append(at)
+        if hasattr(at, "_attr"):
+            self._overload_attributes[key][at._attr] = at
+        else:
+            self._attributes[key].append(at)
 
     def insert_function(self, ft):
         key = ft.key


### PR DESCRIPTION
Attribute typing tries all the templates for a data type, since a generic function of any template may match an attribute.
However, overload_method/overload_attribute only match a single attribute and have `_attr` stored, so there is no need for testing all templates. Some complex types have hundreds of attributes so this can matter sometimes. This PR provides a fast path for overloads, which would accelerate the common cases. Some benchmarking shows compilation time difference (not massive but significant).

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
