### PR TITLE
Fix setup.py build command detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,21 +121,14 @@ def is_building():
         # User forgot to give an argument probably, let setuptools handle that.
         return True
 
-    info_commands = ['--help-commands', '--name', '--version', '-V',
-                     '--fullname', '--author', '--author-email',
-                     '--maintainer', '--maintainer-email', '--contact',
-                     '--contact-email', '--url', '--license', '--description',
-                     '--long-description', '--platforms', '--classifiers',
-                     '--keywords', '--provides', '--requires', '--obsoletes']
-    # Add commands that do more than print info, but also don't need
-    # any build step.
-    info_commands.extend(['egg_info', 'install_egg_info', 'rotate'])
+    build_commands = ['build', 'build_py', 'build_ext', 'build_clib'
+                      'build_scripts', 'install', 'install_lib',
+                      'install_headers', 'install_scripts', 'install_data',
+                      'sdist', 'bdist', 'bdist_dumb', 'bdist_rpm',
+                      'bdist_wininst', 'check', 'build_doc', 'bdist_wheel',
+                      'bdist_egg', 'develop', 'easy_install', 'test']
+    return any(bc in sys.argv[1:] for bc in build_commands)
 
-    for command in info_commands:
-        if command in sys.argv[1:]:
-            return False
-
-    return True
 
 
 def get_ext_modules():


### PR DESCRIPTION
Fixes #6687 

### Context

`metadata['ext_modules']` in setup.py is populated only if a build command is detected. However there is a problem with how this detection was implemented. Currently it checks whether an info command is present in sys.argv, assuming that there is only ever one command passed. This breaks if build and info commands are combined.

This check was introduced in #2033 to prevent importing numpy on the module level.

I tried to rewrite such that the check is now looking for build related commands explicitly.
I mostly went with intuition on which commands should populate the field (and therefore need to import numpy). I am aware that some of those commands don't trigger build_ext, so I am happy to take suggestions for which commands to filter.

All possible commands as per setuptools help are
```
python setup.py --help-commands

Standard commands:
  build             build everything needed to install
  build_py          "build" pure Python modules (copy to build directory)
  build_ext         build C/C++ extensions (compile/link to build directory)
  build_clib        build C/C++ libraries used by Python extensions
  build_scripts     "build" scripts (copy and fixup #! line)
  clean             clean up temporary files from 'build' command
  install           install everything from build directory
  install_lib       install all Python modules (extensions and pure Python)
  install_headers   install C/C++ header files
  install_scripts   install scripts (Python or otherwise)
  install_data      install data files
  sdist             create a source distribution (tarball, zip file, etc.)
  register          register the distribution with the Python package index
  bdist             create a built (binary) distribution
  bdist_dumb        create a "dumb" built distribution
  bdist_rpm         create an RPM distribution
  bdist_wininst     create an executable installer for MS Windows
  check             perform some checks on the package
  upload            upload binary package to PyPI

Extra commands:
  version           report generated version string
  versioneer        install/upgrade Versioneer files: __init__.py SRC/_version.py
  build_doc         build documentation
  bdist_wheel       create a wheel distribution
  alias             define a shortcut to invoke one or more commands
  bdist_egg         create an "egg" distribution
  develop           install package in 'development mode'
  dist_info         create a .dist-info directory
  easy_install      Find/get/install Python packages
  egg_info          create a distribution's .egg-info directory
  install_egg_info  Install an .egg-info directory for the package
  rotate            delete older distributions, keeping N newest files
  saveopts          save supplied options to setup.cfg or other config file
  setopt            set an option in setup.cfg or another config file
  test              run unit tests after in-place build (deprecated)
  upload_docs       Upload documentation to PyPI

```
