### PR TITLE
Enable negative indexing for cuda atomic operations

### DIFF
--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -607,7 +607,8 @@ def _atomic_dispatcher(dispatch_fn):
                             (aryty.ndim, len(indty)))
 
         lary = context.make_array(aryty)(context, builder, ary)
-        ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices)
+        ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices,
+                                       wraparound=True)
         # dispatcher to implementation base on dtype
         return dispatch_fn(context, builder, dtype, ptr, val)
     return imp


### PR DESCRIPTION
Ref #6496 

As titled, enables wraparound in CUDA atomic operations.

Instead of adding new tests, I modified existing add atomics tests `test_atomic_add_*` to prevent unnecessary redundancy in test code. 
If the separate test is a must then I can add that too. 