### PR TITLE
Fix #6697: Wrong dtype when using np.asarray on DeviceNDArray

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -483,7 +483,10 @@ class DeviceNDArray(DeviceNDArrayBase):
         """
         :return: an `numpy.ndarray`, so copies to the host.
         """
-        return self.copy_to_host().__array__(dtype)
+        if dtype:
+            return self.copy_to_host().__array__(dtype)
+        else:
+            return self.copy_to_host().__array__()
 
     def __len__(self):
         return self.shape[0]

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -87,6 +87,12 @@ class TestArrayAttr(CUDATestCase):
         got = dary_reshaped.copy_to_host()
         self.assertPreciseEqual(expect, got)
 
+    def test_bug6697(self):
+        ary = np.arange(10, dtype=np.int16)
+        dary = cuda.to_device(ary)
+        got = np.asarray(dary)
+        self.assertEqual(got.dtype, dary.dtype)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_array_attr.py
+++ b/numba/cuda/tests/cudadrv/test_array_attr.py
@@ -87,12 +87,6 @@ class TestArrayAttr(CUDATestCase):
         got = dary_reshaped.copy_to_host()
         self.assertPreciseEqual(expect, got)
 
-    def test_bug6697(self):
-        ary = np.arange(10, dtype=np.int16)
-        dary = cuda.to_device(ary)
-        got = np.asarray(dary)
-        self.assertEqual(got.dtype, dary.dtype)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -407,6 +407,12 @@ class TestCudaNDArray(CUDATestCase):
         d = cuda.to_device(a)
         self.assertEqual(d._numba_type_.layout, 'A')
 
+    def test_bug6697(self):
+        ary = np.arange(10, dtype=np.int16)
+        dary = cuda.to_device(ary)
+        got = np.asarray(dary)
+        self.assertEqual(got.dtype, dary.dtype)
+
 
 class TestRecarray(CUDATestCase):
     def test_recarray(self):


### PR DESCRIPTION
Closes #6697

I was not sure about where tests for this should go, for now, the test is in `numba/cuda/tests/cudadrv/test_array_attr.py`.  