### PR TITLE
Add UUID to CUDA devices

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -84,7 +84,11 @@ the functionality of the selected device:
 
    .. attribute:: name
 
-      The name of the device (e.g. "GeForce GTX 970")
+      The name of the device (e.g. "GeForce GTX 970").
+
+   .. attribute:: uuid
+
+      The UUID of the device (e.g. "GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643").
 
    .. method:: reset
 

--- a/docs/source/cuda/device-management.rst
+++ b/docs/source/cuda/device-management.rst
@@ -86,7 +86,7 @@ For example, to obtain the UUID of the current device:
 
 .. code-block:: python
 
-   dev = cuda.get_context().device
+   dev = cuda.current_context().device
    # prints e.g. "GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643"
    print(dev.uuid)
 

--- a/docs/source/cuda/device-management.rst
+++ b/docs/source/cuda/device-management.rst
@@ -74,3 +74,19 @@ which the current GPU context can also be retrieved:
     :members: current
     :noindex:
 
+
+Device UUIDs
+============
+
+The UUID of a device (equal to that returned by ``nvidia-smi -L``) is available
+in the :attr:`uuid <numba.cuda.cudadrv.driver.Device.uuid>` attribute of a CUDA
+device object.
+
+For example, to obtain the UUID of the current device:
+
+.. code-block:: python
+
+   dev = cuda.get_context().device
+   # prints e.g. "GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643"
+   print(dev.uuid)
+

--- a/numba/cuda/cudadrv/drvapi.py
+++ b/numba/cuda/cudadrv/drvapi.py
@@ -16,6 +16,7 @@ cu_event = c_void_p
 cu_link_state = c_void_p
 cu_function_attribute = c_int
 cu_ipc_mem_handle = (c_byte * _extras.CUDA_IPC_HANDLE_SIZE)   # 64 bytes wide
+cu_uuid = (c_byte * 16)         # Device UUID
 
 cu_stream_callback_pyobj = CFUNCTYPE(None, cu_stream, c_int, py_object)
 
@@ -388,4 +389,6 @@ API_PROTOTYPES = {
     'cuDeviceCanAccessPeer': (c_int,
                               POINTER(c_int), cu_device, cu_device),
 
+    # CUresult cuDeviceGetUuid ( CUuuid* uuid, CUdevice dev )
+    'cuDeviceGetUuid': (c_int, POINTER(cu_uuid), cu_device),
 }

--- a/numba/cuda/simulator/cudadrv/devices.py
+++ b/numba/cuda/simulator/cudadrv/devices.py
@@ -4,13 +4,19 @@ from collections import namedtuple
 _MemoryInfo = namedtuple("_MemoryInfo", "free,total")
 
 
-class FakeCUDAContext(object):
+class FakeCUDADevice:
+    def __init__(self):
+        self.uuid = 'GPU-00000000-0000-0000-0000-000000000000'
+
+
+class FakeCUDAContext:
     '''
     This stub implements functionality only for simulating a single GPU
     at the moment.
     '''
-    def __init__(self, device):
-        self._device = device
+    def __init__(self, device_id):
+        self._device_id = device_id
+        self._device = FakeCUDADevice()
 
     def __enter__(self):
         pass
@@ -23,6 +29,10 @@ class FakeCUDAContext(object):
 
     @property
     def id(self):
+        return self._device_id
+
+    @property
+    def device(self):
         return self._device
 
     @property
@@ -53,7 +63,7 @@ class FakeCUDAContext(object):
         return self.memalloc(sz)
 
 
-class FakeDeviceList(object):
+class FakeDeviceList:
     '''
     This stub implements a device list containing a single GPU. It also
     keeps track of the GPU status, i.e. whether the context is closed or not,

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -5,6 +5,7 @@ from numba.cuda.cudadrv import devices, drvapi
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
 
+
 ptx1 = '''
     .version 1.4
     .target sm_10, map_f64_to_f32
@@ -188,6 +189,29 @@ class TestCudaDriver(CUDATestCase):
                                                                 128, 128)
         self.assertTrue(grid > 0)
         self.assertTrue(block > 0)
+
+
+class TestDevice(CUDATestCase):
+    def test_device_get_uuid(self):
+        # A device UUID looks like:
+        #
+        #     GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643
+        #
+        # To test, we construct an RE that matches this form and verify that
+        # the returned UUID matches.
+        #
+        # Device UUIDs may not conform to parts of the UUID specification (RFC
+        # 4122) pertaining to versions and variants, so we do not extract and
+        # validate the values of these bits.
+
+        h = '[0-9a-f]{%d}'
+        h4 = h % 4
+        h8 = h % 8
+        h12 = h % 12
+        uuid_format = f'^GPU-{h8}-{h4}-{h4}-{h4}-{h12}$'
+
+        dev = devices.get_context().device
+        self.assertRegex(dev.uuid, uuid_format)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a `uuid` attribute to CUDA devices, which matches the UUID given by `nvidia-smi -L`.

There are some minor grammatical fixes in the documentation, and removal of the redundant use `(object)` in class declaration in the simulator (which was used to declare the classes as new-style in Python 2).