### PR TITLE
Block matplotlib in test examples

### DIFF
--- a/numba/tests/doc_examples/test_examples.py
+++ b/numba/tests/doc_examples/test_examples.py
@@ -1,11 +1,32 @@
 # Contents in this file are referenced from the sphinx-generated docs.
 # "magictoken" is used for markers as beginning and ending of example text.
 
+import sys
 import unittest
 from numba.tests.support import captured_stdout
 
 
+class MatplotlibBlocker:
+    '''Blocks the import of matplotlib, so that doc examples that attempt to
+    plot the output don't result in plots popping up and blocking testing.'''
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == 'matplotlib':
+            msg = 'Blocked import of matplotlib for test suite run'
+            raise ImportError(msg)
+
+
 class DocsExamplesTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mpl_blocker = MatplotlibBlocker()
+
+    def setUp(self):
+        sys.meta_path.insert(0, self._mpl_blocker)
+
+    def tearDown(self):
+        sys.meta_path.remove(self._mpl_blocker)
 
     def test_mandelbrot(self):
         with captured_stdout():


### PR DESCRIPTION
The mandelbrot doc test example plots the mandelbrot set. This is nice for the purposes of the example, but results in a plot popping up and blocking further tests when the suite is run on a machine with matplotlib installed.

This PR prevents plotting when running the test, by blocking the import of matplotlib during the examples tests.