### PR TITLE
remove hard-coded branch

### DIFF
--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -386,7 +386,7 @@ def _choose_gitdiff_tests(tests):
         raise ValueError("gitpython needed for git functionality")
     repo = Repo('.')
     path = os.path.join('numba', 'tests')
-    target = 'origin/master..HEAD'
+    target = 'HEAD'
     gdiff_paths = repo.git.diff(target, path, name_only=True).split()
     # normalise the paths as they are unix style from repo.git.diff
     gdiff_paths = [os.path.normpath(x) for x in gdiff_paths]


### PR DESCRIPTION
This allows to use the test-scripts more universal, e.g. within a usual ci setup.

Fixes a blocking bug in a typical travis-ci setup.
