### PR TITLE
Consider assignment lhs live if used in rhs (Fixes #6715)

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -664,7 +664,12 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
         else:
             lives |= {v.name for v in stmt.list_vars()}
             if isinstance(stmt, ir.Assign):
-                lives.remove(lhs.name)
+                # make sure lhs is not used in rhs, e.g. a = g(a)
+                rhs_vars = set()
+                if isinstance(stmt.value, ir.Expr):
+                    rhs_vars = {v.name for v in stmt.value.list_vars()}
+                if lhs.name not in rhs_vars:
+                    lives.remove(lhs.name)
 
         new_body.append(stmt)
     new_body.reverse()

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -665,10 +665,11 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map,
             lives |= {v.name for v in stmt.list_vars()}
             if isinstance(stmt, ir.Assign):
                 # make sure lhs is not used in rhs, e.g. a = g(a)
-                rhs_vars = set()
                 if isinstance(stmt.value, ir.Expr):
                     rhs_vars = {v.name for v in stmt.value.list_vars()}
-                if lhs.name not in rhs_vars:
+                    if lhs.name not in rhs_vars:
+                        lives.remove(lhs.name)
+                else:
                     lives.remove(lhs.name)
 
         new_body.append(stmt)

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -218,6 +218,18 @@ class TestRemoveDead(unittest.TestCase):
             # recover global state
             ir_utils.alias_func_extensions = old_ext_handlers
 
+    def test_rm_dead_rhs_vars(self):
+        """make sure lhs variable of assignment is considered live if used in
+        rhs (test for #6715).
+        """
+        @numba.njit
+        def func():
+            for i in range(3):
+                a = (lambda j: j)(i)
+                a = np.array(a)
+
+        func()
+
     @skip_parfors_unsupported
     def test_alias_parfor_extension(self):
         """Make sure aliases are considered in remove dead extension for

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -222,13 +222,13 @@ class TestRemoveDead(unittest.TestCase):
         """make sure lhs variable of assignment is considered live if used in
         rhs (test for #6715).
         """
-        @numba.njit
         def func():
             for i in range(3):
                 a = (lambda j: j)(i)
                 a = np.array(a)
+            return a
 
-        func()
+        self.assertEqual(func(), numba.njit(func)())
 
     @skip_parfors_unsupported
     def test_alias_parfor_extension(self):


### PR DESCRIPTION
As title. Numba 0.53 exposes this bug since it avoids extra temporary assignments.
Closes #6715.
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
