### PR TITLE
CUDA: Fix compile to PTX with debug for CUDA 11.2

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -50,6 +50,7 @@ class JITCUDACodegen(BaseCPUCodegen):
         ir_module.triple = CUDA_TRIPLE[utils.MACHINE_BITS]
         if self._data_layout:
             ir_module.data_layout = self._data_layout
+        nvvm.add_ir_version(ir_module)
         return ir_module
 
     def _module_pass_manager(self):

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -30,12 +30,10 @@ from .args import wrap_arg
 
 @global_compiler_lock
 def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
-    # First compilation will trigger the initialization of the CUDA backend.
-    from .descriptor import CUDATargetDesc
+    from .descriptor import cuda_target
+    typingctx = cuda_target.typingctx
+    targetctx = cuda_target.targetctx
 
-    typingctx = CUDATargetDesc.typingctx
-    targetctx = CUDATargetDesc.targetctx
-    # TODO handle debug flag
     flags = compiler.Flags()
     # Do not compile (generate native code), just lower (to LLVM)
     flags.set('no_compile')
@@ -249,7 +247,7 @@ def compile_device_template(pyfunc, debug=False, inline=False, opt=True):
     """Create a DeviceFunctionTemplate object and register the object to
     the CUDA typing context.
     """
-    from .descriptor import CUDATargetDesc
+    from .descriptor import cuda_target
 
     dft = DeviceFunctionTemplate(pyfunc, debug=debug, inline=inline, opt=opt)
 
@@ -275,7 +273,7 @@ def compile_device_template(pyfunc, debug=False, inline=False, opt=True):
             }
             return info
 
-    typingctx = CUDATargetDesc.typingctx
+    typingctx = cuda_target.typingctx
     typingctx.insert_user_function(dft, device_function_template)
     return dft
 
@@ -285,10 +283,9 @@ def compile_device(pyfunc, return_type, args, inline=True, debug=False):
 
 
 def declare_device_function(name, restype, argtypes):
-    from .descriptor import CUDATargetDesc
-
-    typingctx = CUDATargetDesc.typingctx
-    targetctx = CUDATargetDesc.targetctx
+    from .descriptor import cuda_target
+    typingctx = cuda_target.typingctx
+    targetctx = cuda_target.targetctx
     sig = typing.signature(restype, *argtypes)
     extfn = ExternFunction(name, sig)
 
@@ -869,9 +866,9 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         self.targetoptions['extensions'] = \
             list(self.targetoptions.get('extensions', []))
 
-        from .descriptor import CUDATargetDesc
+        from .descriptor import cuda_target
 
-        self.typingctx = CUDATargetDesc.typingctx
+        self.typingctx = cuda_target.typingctx
 
         self._tm = default_type_manager
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -896,15 +896,17 @@ def _replace_llvm_memset_declaration(m):
 def set_cuda_kernel(lfunc):
     from llvmlite.llvmpy.core import MetaData, MetaDataString, Constant, Type
 
-    m = lfunc.module
+    mod = lfunc.module
 
-    ops = lfunc, MetaDataString.get(m, "kernel"), Constant.int(Type.int(), 1)
-    md = MetaData.get(m, ops)
+    ops = lfunc, MetaDataString.get(mod, "kernel"), Constant.int(Type.int(), 1)
+    md = MetaData.get(mod, ops)
 
-    nmd = m.get_or_insert_named_metadata('nvvm.annotations')
+    nmd = mod.get_or_insert_named_metadata('nvvm.annotations')
     nmd.add(md)
 
-    # Set NVVM IR version
+
+def add_ir_version(mod):
+    """Add NVVM IR version to module"""
     i32 = ir.IntType(32)
     if NVVM().is_nvvm70:
         # NVVM IR 1.6, DWARF 3.0
@@ -913,8 +915,8 @@ def set_cuda_kernel(lfunc):
         # NVVM IR 1.1, DWARF 2.0
         ir_versions = [i32(1), i32(2), i32(2), i32(0)]
 
-    md_ver = m.add_metadata(ir_versions)
-    m.add_named_metadata('nvvmir.version', md_ver)
+    md_ver = mod.add_metadata(ir_versions)
+    mod.add_named_metadata('nvvmir.version', md_ver)
 
 
 def fix_data_layout(module):

--- a/numba/cuda/descriptor.py
+++ b/numba/cuda/descriptor.py
@@ -3,11 +3,30 @@ from numba.core.options import TargetOptions
 from .target import CUDATargetContext, CUDATypingContext
 
 
-class CPUTargetOptions(TargetOptions):
+class CUDATargetOptions(TargetOptions):
     OPTIONS = {}
 
 
-class CUDATargetDesc(TargetDescriptor):
-    options = CPUTargetOptions
-    typingctx = CUDATypingContext()
-    targetctx = CUDATargetContext(typingctx)
+class CUDATarget(TargetDescriptor):
+    def __init__(self):
+        self.options = CUDATargetOptions
+        # The typing and target contexts are initialized only when needed -
+        # this prevents an attempt to load CUDA libraries at import time on
+        # systems that might not have them present.
+        self._typingctx = None
+        self._targetctx = None
+
+    @property
+    def typingctx(self):
+        if self._typingctx is None:
+            self._typingctx = CUDATypingContext()
+        return self._typingctx
+
+    @property
+    def targetctx(self):
+        if self._targetctx is None:
+            self._targetctx = CUDATargetContext(self._typingctx)
+        return self._targetctx
+
+
+cuda_target = CUDATarget()

--- a/numba/cuda/tests/cudapy/test_const_string.py
+++ b/numba/cuda/tests/cudapy/test_const_string.py
@@ -7,10 +7,10 @@ from llvmlite import ir
 class TestCudaConstString(unittest.TestCase):
     def test_const_string(self):
         # These imports are incompatible with CUDASIM
-        from numba.cuda.descriptor import CUDATargetDesc
+        from numba.cuda.descriptor import cuda_target
         from numba.cuda.cudadrv.nvvm import llvm_to_ptx, ADDRSPACE_CONSTANT
 
-        targetctx = CUDATargetDesc.targetctx
+        targetctx = cuda_target.targetctx
         mod = targetctx.create_module("")
         textstring = 'A Little Brown Fox'
         gv0 = targetctx.insert_const_string(mod, textstring)


### PR DESCRIPTION
The NVVM IR version metadata needs to be present in all modules passed to NVVM. The IR version was only set when kernel wrapper functions were generated, so device functions never had the IR version added.

This commit remedies this by adding the IR version to all modules in the CUDA target, rather than relying on the kernel wrapper generation function to do it.

It is hard to get at the IR at the right time before it is turned into a ModuleRef from the llvmlite binding layer - in order to work around this, a callback facility is added to the lowering that allows the metadata to be added in just after the module creation.

Fixes #6719.