### PR TITLE
Fix Typeguard error

### DIFF
--- a/numba/np/ufunc/gufunc.py
+++ b/numba/np/ufunc/gufunc.py
@@ -24,6 +24,7 @@ class GUFunc(object):
         # object here
         self.gufunc_builder = GUFuncBuilder(
             py_func, signature, identity, cache, targetoptions)
+        self.__name__ = self.gufunc_builder.py_func.__name__
 
     def __repr__(self):
         return f"<numba._GUFunc '{self.__name__}'>"
@@ -50,10 +51,6 @@ class GUFunc(object):
     @property
     def __doc__(self):
         return self.ufunc.__doc__
-
-    @property
-    def __name__(self):
-        return self.gufunc_builder.py_func.__name__
 
     @property
     def nin(self):


### PR DESCRIPTION
Typeguard reports:

```
TypeError: can only assign string to GUFunc.__name__, not 'property'
```

It seems that setting `__name__` in `__init__` should achieve the same effect, and avoid the Typeguard error.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
