### PR TITLE
[WIP] Add Basic Travis CI (ppc64le)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+group: travis_latest
+os: linux
+dist: xenial
+arch:
+  - amd64
+  - ppc64le
+env:
+  - PYTHON='3.6' NUMPY='1.15' CONDA_ENV=travisci TEST_START_INDEX=0
+
+
+before_script:
+  - git remote set-branches --add origin master
+  - git fetch origin master --depth=1
+script:
+  - while sleep 9m; do echo -e "\n\n[ avoid travis timeout ]\n\n"; done &
+  - buildscripts/incremental/install_miniconda.sh
+  - export PATH=$HOME/miniconda3/bin:$PATH
+  - buildscripts/incremental/setup_conda_environment.sh
+  - buildscripts/incremental/build.sh
+  - buildscripts/incremental/test.sh


### PR DESCRIPTION
re #6629 
depends on #6724
contains workaround described within https://github.com/numba/numba/pull/6710#issuecomment-781567378


This enables a basic Travis CI which runs tests for ppc64le (and potentially other architectures not available on azure pipelines).

The tests run additionally on amd64 for reference, to ensure the validity of the test-scripts and the travis setup itself. This can be removed later to avoid duplication (as amd64 tests run already on azure).

## Possible Solution

> (https://github.com/numba/numba/pull/6732#issuecomment-782173020) Possibly a midway solution could be to **have the .travis.yml without enabling travis on numbas repo**. Contributors can activate travis on their fork (dealing there with the free minutes). This can be extended to other architectures which are unsupported in azure, but supported by travis.
