### PR TITLE
Fix segfault and errors in #6668

### DIFF
--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -950,6 +950,11 @@ class PythonAPI(object):
         fn = self._get_function(fnty, name="PyObject_Call")
         return self.builder.call(fn, (callee, args, kws))
 
+    def object_type(self, obj):
+        fnty = Type.function(self.pyobj, [self.pyobj] * 1)
+        fn = self._get_function(fnty, name="PyObject_Type")
+        return self.builder.call(fn, (obj,))
+
     def object_istrue(self, obj):
         fnty = Type.function(Type.int(), [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_IsTrue")

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -951,6 +951,8 @@ class PythonAPI(object):
         return self.builder.call(fn, (callee, args, kws))
 
     def object_type(self, obj):
+        """Emit a call to ``PyObject_Type(obj)`` to get the type of ``obj``.
+        """
         fnty = Type.function(self.pyobj, [self.pyobj] * 1)
         fn = self._get_function(fnty, name="PyObject_Type")
         return self.builder.call(fn, (obj,))

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -953,7 +953,7 @@ class PythonAPI(object):
     def object_type(self, obj):
         """Emit a call to ``PyObject_Type(obj)`` to get the type of ``obj``.
         """
-        fnty = Type.function(self.pyobj, [self.pyobj] * 1)
+        fnty = Type.function(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_Type")
         return self.builder.call(fn, (obj,))
 

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -247,8 +247,9 @@ class _ObjModeContextType(WithContext):
         if getattr(typ, "reflected", False):
             msgbuf = [
                 "Objmode context failed.",
-                f"Argument {name!r} is using unsupported type: {typ}.",
-                f"Reflected types is not supported.",
+                f"Argument {name!r} is declared as "
+                f"an unsupported type: {typ}.",
+                f"Reflected types are not supported.",
             ]
             raise errors.CompilerError(" ".join(msgbuf), loc=loc)
 

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -226,7 +226,23 @@ class _ObjModeContextType(WithContext):
                     "type annotation",
                 )
 
+        # Legalize the types for objmode
+        for name, typ in typeanns.items():
+            self._legalize_arg_type(name, typ, loc)
+
         return typeanns
+
+    def _legalize_arg_type(self, name, typ, loc):
+        def report_error(msg):
+            msgbuf = [
+                "Objmode context failed.",
+                f"Argument {name!r} is using unsupported type.",
+                msg,
+            ]
+            raise errors.CompilerError(" ".join(msgbuf), loc=loc)
+
+        if getattr(typ, "reflected", False):
+            report_error(f"Reflected types is not supported.")
 
     def mutate_with_body(self, func_ir, blocks, blk_start, blk_end,
                          body_blocks, dispatcher_factory, extra):

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -233,16 +233,24 @@ class _ObjModeContextType(WithContext):
         return typeanns
 
     def _legalize_arg_type(self, name, typ, loc):
-        def report_error(msg):
+        """Legalize the argument type
+
+        Parameters
+        ----------
+        name: str
+            argument name.
+        typ: numba.core.types.Type
+            argument type.
+        loc: numba.core.ir.Loc
+            source location for error reporting.
+        """
+        if getattr(typ, "reflected", False):
             msgbuf = [
                 "Objmode context failed.",
                 f"Argument {name!r} is using unsupported type.",
-                msg,
+                f"Reflected types is not supported.",
             ]
             raise errors.CompilerError(" ".join(msgbuf), loc=loc)
-
-        if getattr(typ, "reflected", False):
-            report_error(f"Reflected types is not supported.")
 
     def mutate_with_body(self, func_ir, blocks, blk_start, blk_end,
                          body_blocks, dispatcher_factory, extra):

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -247,7 +247,7 @@ class _ObjModeContextType(WithContext):
         if getattr(typ, "reflected", False):
             msgbuf = [
                 "Objmode context failed.",
-                f"Argument {name!r} is using unsupported type.",
+                f"Argument {name!r} is using unsupported type: {typ}.",
                 f"Reflected types is not supported.",
             ]
             raise errors.CompilerError(" ".join(msgbuf), loc=loc)

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -959,7 +959,7 @@ class TestLiftObj(MemoryLeak, TestCase):
             ("Objmode context failed. "
              "Argument 'out' is declared as an unsupported type: "
              "reflected list(int64)<iv=None>. "
-             "Reflected types is not supported."),
+             "Reflected types are not supported."),
             str(raises.exception),
         )
 
@@ -975,9 +975,9 @@ class TestLiftObj(MemoryLeak, TestCase):
             test2()
         self.assertIn(
             ("Objmode context failed. "
-             "Argument 'out' is declared as an unsupported type: "
+             "Argument 'result' is declared as an unsupported type: "
              "reflected set(int64). "
-             "Reflected types is not supported."),
+             "Reflected types are not supported."),
             str(raises.exception),
         )
 

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -957,7 +957,8 @@ class TestLiftObj(MemoryLeak, TestCase):
             test2()
         self.assertIn(
             ("Objmode context failed. "
-             "Argument 'out' is using unsupported type. "
+             "Argument 'out' is using unsupported type: "
+             "reflected list(int64)<iv=None>. "
              "Reflected types is not supported."),
             str(raises.exception),
         )
@@ -974,7 +975,8 @@ class TestLiftObj(MemoryLeak, TestCase):
             test2()
         self.assertIn(
             ("Objmode context failed. "
-             "Argument 'result' is using unsupported type. "
+             "Argument 'result' is using unsupported type: "
+             "reflected set(int64). "
              "Reflected types is not supported."),
             str(raises.exception),
         )
@@ -990,8 +992,11 @@ class TestLiftObj(MemoryLeak, TestCase):
         with self.assertRaises(TypeError) as raises:
             test4()
         self.assertIn(
-            ("can't unbox <class 'numba.typed.typeddict.Dict'> "
-             "from <class 'dict'>"),
+            ("can't unbox a <class 'dict'> "
+             "as a <class 'numba.typed.typeddict.Dict'>"),
+            str(raises.exception),
+        )
+
             str(raises.exception),
         )
 

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -955,12 +955,12 @@ class TestLiftObj(MemoryLeak, TestCase):
 
         with self.assertRaises(errors.CompilerError) as raises:
             test2()
-        self.assertIn(
-            ("Objmode context failed. "
-             "Argument 'out' is declared as an unsupported type: "
-             "reflected list(int64)<iv=None>. "
-             "Reflected types are not supported."),
+        self.assertRegex(
             str(raises.exception),
+            (r"Objmode context failed. "
+             r"Argument 'out' is declared as an unsupported type: "
+             r"reflected list\(int(32|64)\)<iv=None>. "
+             r"Reflected types are not supported."),
         )
 
     def test_objmode_reflected_set(self):
@@ -973,12 +973,12 @@ class TestLiftObj(MemoryLeak, TestCase):
 
         with self.assertRaises(errors.CompilerError) as raises:
             test2()
-        self.assertIn(
-            ("Objmode context failed. "
-             "Argument 'result' is declared as an unsupported type: "
-             "reflected set(int64). "
-             "Reflected types are not supported."),
+        self.assertRegex(
             str(raises.exception),
+            (r"Objmode context failed. "
+             r"Argument 'result' is declared as an unsupported type: "
+             r"reflected set\(int(32|64)\). "
+             r"Reflected types are not supported."),
         )
 
     def test_objmode_typed_dict(self):

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -1007,10 +1007,12 @@ class TestLiftObj(MemoryLeak, TestCase):
 
         with self.assertRaises(TypeError) as raises:
             test4()
-        self.assertIn(
-            ("can't unbox a <class 'list'> "
-             "as a <class 'numba.typed.typedlist.List'>"),
+        # Note: in python3.6, the Generic[T] on typedlist is causing it to
+        #       format differently.
+        self.assertRegex(
             str(raises.exception),
+            (r"can't unbox a <class 'list'> "
+             r"as a (<class ')?numba.typed.typedlist.List('>)?"),
         )
 
 

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -997,6 +997,19 @@ class TestLiftObj(MemoryLeak, TestCase):
             str(raises.exception),
         )
 
+    def test_objmode_typed_list(self):
+        ret_type = types.ListType(types.int64)
+        @njit
+        def test4():
+            with objmode(res=ret_type):
+                res = [1, 2]
+            return res
+
+        with self.assertRaises(TypeError) as raises:
+            test4()
+        self.assertIn(
+            ("can't unbox a <class 'list'> "
+             "as a <class 'numba.typed.typedlist.List'>"),
             str(raises.exception),
         )
 

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -957,7 +957,7 @@ class TestLiftObj(MemoryLeak, TestCase):
             test2()
         self.assertIn(
             ("Objmode context failed. "
-             "Argument 'out' is using unsupported type: "
+             "Argument 'out' is declared as an unsupported type: "
              "reflected list(int64)<iv=None>. "
              "Reflected types is not supported."),
             str(raises.exception),
@@ -975,7 +975,7 @@ class TestLiftObj(MemoryLeak, TestCase):
             test2()
         self.assertIn(
             ("Objmode context failed. "
-             "Argument 'result' is using unsupported type: "
+             "Argument 'out' is declared as an unsupported type: "
              "reflected set(int64). "
              "Reflected types is not supported."),
             str(raises.exception),

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -945,7 +945,6 @@ class TestLiftObj(MemoryLeak, TestCase):
             output = x / 10
         return output
 
-
     def test_objmode_reflected_list(self):
         ret_type = typeof([1, 2, 3, 4, 5])
         @njit
@@ -991,7 +990,8 @@ class TestLiftObj(MemoryLeak, TestCase):
         with self.assertRaises(TypeError) as raises:
             test4()
         self.assertIn(
-            "can't unbox <class 'numba.typed.typeddict.Dict'> from <class 'dict'>",
+            ("can't unbox <class 'numba.typed.typeddict.Dict'> "
+             "from <class 'dict'>"),
             str(raises.exception),
         )
 

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -260,27 +260,57 @@ def box_dicttype(typ, val, c):
 def unbox_dicttype(typ, val, c):
     context = c.context
 
-    miptr = c.pyapi.object_getattr_string(val, '_opaque')
+    dict_type = c.pyapi.unserialize(c.pyapi.serialize_object(Dict))
+    valtype = c.pyapi.object_type(val)
+    same_type = c.builder.icmp_unsigned("==", valtype, dict_type)
 
-    mip_type = types.MemInfoPointer(types.voidptr)
-    native = c.unbox(mip_type, miptr)
+    with c.builder.if_else(same_type) as (then, orelse):
+        with then:
+            miptr = c.pyapi.object_getattr_string(val, '_opaque')
 
-    mi = native.value
+            mip_type = types.MemInfoPointer(types.voidptr)
+            native = c.unbox(mip_type, miptr)
 
-    argtypes = mip_type, typeof(typ)
+            mi = native.value
 
-    def convert(mi, typ):
-        return dictobject._from_meminfo(mi, typ)
+            argtypes = mip_type, typeof(typ)
 
-    sig = signature(typ, *argtypes)
-    nil_typeref = context.get_constant_null(argtypes[1])
-    args = (mi, nil_typeref)
-    is_error, dctobj = c.pyapi.call_jit_code(convert , sig, args)
-    # decref here because we are stealing a reference.
-    c.context.nrt.decref(c.builder, typ, dctobj)
+            def convert(mi, typ):
+                return dictobject._from_meminfo(mi, typ)
 
-    c.pyapi.decref(miptr)
-    return NativeValue(dctobj, is_error=is_error)
+            sig = signature(typ, *argtypes)
+            nil_typeref = context.get_constant_null(argtypes[1])
+            args = (mi, nil_typeref)
+            is_error, dctobj = c.pyapi.call_jit_code(convert , sig, args)
+            # decref here because we are stealing a reference.
+            c.context.nrt.decref(c.builder, typ, dctobj)
+
+            c.pyapi.decref(miptr)
+            bb_unboxed = c.builder.basic_block
+
+        with orelse:
+            # Raise error on incorrect type
+            c.pyapi.err_format(
+                "PyExc_TypeError",
+                "can't unbox %S from %S",
+                dict_type, valtype
+            )
+            bb_else = c.builder.basic_block
+
+    dctobj_res = c.builder.phi(dctobj.type)
+    is_error_res = c.builder.phi(is_error.type)
+
+    dctobj_res.add_incoming(dctobj, bb_unboxed)
+    dctobj_res.add_incoming(dctobj.type(None), bb_else)
+
+    is_error_res.add_incoming(is_error, bb_unboxed)
+    is_error_res.add_incoming(cgutils.true_bit, bb_else)
+
+    # cleanup
+    c.pyapi.decref(dict_type)
+    c.pyapi.decref(valtype)
+
+    return NativeValue(dctobj_res, is_error=is_error_res)
 
 
 @type_callable(DictType)

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -260,6 +260,7 @@ def box_dicttype(typ, val, c):
 def unbox_dicttype(typ, val, c):
     context = c.context
 
+    # Check that `type(val) is Dict`
     dict_type = c.pyapi.unserialize(c.pyapi.serialize_object(Dict))
     valtype = c.pyapi.object_type(val)
     same_type = c.builder.icmp_unsigned("==", valtype, dict_type)
@@ -297,6 +298,7 @@ def unbox_dicttype(typ, val, c):
             )
             bb_else = c.builder.basic_block
 
+    # Phi nodes to gather the output
     dctobj_res = c.builder.phi(dctobj.type)
     is_error_res = c.builder.phi(is_error.type)
 

--- a/numba/typed/typeddict.py
+++ b/numba/typed/typeddict.py
@@ -293,8 +293,8 @@ def unbox_dicttype(typ, val, c):
             # Raise error on incorrect type
             c.pyapi.err_format(
                 "PyExc_TypeError",
-                "can't unbox %S from %S",
-                dict_type, valtype
+                "can't unbox a %S as a %S",
+                valtype, dict_type,
             )
             bb_else = c.builder.basic_block
 


### PR DESCRIPTION
by guarding against invalid use and unsupported types.

This patch fixes usecases:

- 2, 3: reflected containers are not supported because their boxing/unboxing logic is assuming that the original PyObject to continue to exist after unboxing and through boxing; i.e. assumptions on arguments existing throughout the lifetime of a function call. However, this assumption does not hold in the case of objmode. The unboxed object is dead after unbox. Users should instead use `typed.List` instead.
- 4: it is a user error to use python `dict` when the objmode context is expecting a `typed.Dict`. The patch fixes the unboxer to check for the type of the incoming value and raises `TypeError` appropriately.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
