### PR TITLE
Suppress typeguard warnings that affect testing.

### DIFF
--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -79,7 +79,7 @@ if [ "$RUN_COVERAGE" == "yes" ]; then
     $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 elif [ "$RUN_TYPEGUARD" == "yes" ]; then
     echo "INFO: Running with typeguard"
-    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -Wignore:::typeguard runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 PYTHONWARNINGS="ignore:::typeguard" $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 else
     NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -79,7 +79,7 @@ if [ "$RUN_COVERAGE" == "yes" ]; then
     $SEGVCATCH coverage run runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 elif [ "$RUN_TYPEGUARD" == "yes" ]; then
     echo "INFO: Running with typeguard"
-    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+    NUMBA_USE_TYPEGUARD=1 NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -Wignore:::typeguard runtests.py -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 else
     NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -j "$TEST_START_INDEX,None,$TEST_COUNT" --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 fi

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -111,7 +111,9 @@ class TestBuiltins(unittest.TestCase):
             cfunc = jit(do_loop)
             cfunc(x)
 
-            self.assertEqual(len(w), 4)
+            msg = '\n'.join(f"----------\n{x.message}" for x in w)
+
+            self.assertEqual(len(w), 4, msg=msg)
 
             # Type inference failure (1st pass, in npm, fall-back to objmode
             # with looplift)

--- a/numba/tests/test_warnings.py
+++ b/numba/tests/test_warnings.py
@@ -106,6 +106,7 @@ class TestBuiltins(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always', NumbaWarning)
+            warnings.filterwarnings('ignore', module="typeguard")
 
             x = np.ones(4, dtype=np.float32)
             cfunc = jit(do_loop)


### PR DESCRIPTION
New typeguard 2.11.1 is released and there're new warnings raised for everything time it finds something that is not annotated. We need to suppress these warnings for tests that checks on warnings to pass.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
