### PR TITLE
Fix llvmlite dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
-numpy>=1.10
-llvmlite>=0.36.0dev0,<0.37
+numpy>=1.11
+llvmlite>=0.36.0rc1,<0.37
 argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
--e .
+setuptools
+numpy>=1.10
+llvmlite>=0.36.0dev0,<0.37
+argparse


### PR DESCRIPTION
The build farm is reporting: 

```
[2021-02-25 00:29:11,859] {docker_operator.py:265} INFO - /opt/conda/envs/testenv_5bfbfbf2-26a7-4afe-907e-39fa2477747c/lib/python3.8/site-packages/numba/tests/test_entrypoints.py:65: UserWarning: Numba extension module '_test_numba_extension' failed to load due to 'VersionConflict((llvmlite 0.37.0.dev0 (/opt/conda/envs/testenv_5bfbfbf2-26a7-4afe-907e-39fa2477747c/lib/python3.8/site-packages), Requirement.parse('llvmlite<0.37,>=0.36.0rc1')))'.
[2021-02-25 00:29:11,859] {docker_operator.py:265} INFO - entrypoints.init_all()
```

This is an experimental PR to try to fix that.