### PR TITLE
CUDA: Replace `CachedPTX` and `CachedCUFunction` with `CUDACodeLibrary` functionality

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1148,12 +1148,12 @@ class Codegen(metaclass=ABCMeta):
         """
         return self._target_data
 
-    def create_library(self, name):
+    def create_library(self, name, **kwargs):
         """
         Create a :class:`CodeLibrary` object for use with this codegen
         instance.
         """
-        return self._library_class(self, name)
+        return self._library_class(self, name, **kwargs)
 
     def unserialize_library(self, serialized):
         return self._library_class._unserialize(self, serialized)

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -551,8 +551,12 @@ class CodeLibrary(metaclass=ABCMeta):
         """
         return self._codegen
 
+    @property
+    def name(self):
+        return self._name
+
     def __repr__(self):
-        return "<Library %r at 0x%x>" % (self._name, id(self))
+        return "<Library %r at 0x%x>" % (self.name, id(self))
 
     def _raise_if_finalized(self):
         if self._finalized:
@@ -641,8 +645,8 @@ class CPUCodeLibrary(CodeLibrary):
         super().__init__(codegen, name)
         self._linking_libraries = []   # maintain insertion order
         self._final_module = ll.parse_assembly(
-            str(self._codegen._create_empty_module(self._name)))
-        self._final_module.name = cgutils.normalize_ir_text(self._name)
+            str(self._codegen._create_empty_module(self.name)))
+        self._final_module.name = cgutils.normalize_ir_text(self.name)
         self._shared_module = None
 
     def _optimize_functions(self, ll_module):
@@ -742,7 +746,7 @@ class CPUCodeLibrary(CodeLibrary):
         self._raise_if_finalized()
 
         if config.DUMP_FUNC_OPT:
-            dump("FUNCTION OPTIMIZED DUMP %s" % self._name,
+            dump("FUNCTION OPTIMIZED DUMP %s" % self.name,
                  self.get_llvm_str(), 'llvm')
 
         # Link libraries for shared code
@@ -797,10 +801,10 @@ class CPUCodeLibrary(CodeLibrary):
         self._finalized = True
 
         if config.DUMP_OPTIMIZED:
-            dump("OPTIMIZED DUMP %s" % self._name, self.get_llvm_str(), 'llvm')
+            dump("OPTIMIZED DUMP %s" % self.name, self.get_llvm_str(), 'llvm')
 
         if config.DUMP_ASSEMBLY:
-            dump("ASSEMBLY %s" % self._name, self.get_asm_str(), 'asm')
+            dump("ASSEMBLY %s" % self.name, self.get_asm_str(), 'asm')
 
     def get_defined_functions(self):
         """
@@ -905,7 +909,7 @@ class CPUCodeLibrary(CodeLibrary):
         Serialize this library using its bitcode as the cached representation.
         """
         self._ensure_finalized()
-        return (self._name, 'bitcode', self._final_module.as_bitcode())
+        return (self.name, 'bitcode', self._final_module.as_bitcode())
 
     def serialize_using_object_code(self):
         """
@@ -916,7 +920,7 @@ class CPUCodeLibrary(CodeLibrary):
         self._ensure_finalized()
         data = (self._get_compiled_object(),
                 self._get_module_for_linking().as_bitcode())
-        return (self._name, 'object', data)
+        return (self.name, 'object', data)
 
     @classmethod
     def _unserialize(cls, codegen, state):

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -569,7 +569,7 @@ class CodeLibrary(metaclass=ABCMeta):
 
     def create_ir_module(self, name):
         """
-        Create a LLVM IR module for use by this library.
+        Create an LLVM IR module for use by this library.
         """
         self._raise_if_finalized()
         ir_module = self._codegen._create_empty_module(name)
@@ -585,7 +585,7 @@ class CodeLibrary(metaclass=ABCMeta):
     @abstractmethod
     def add_ir_module(self, ir_module):
         """
-        Add a LLVM IR module's contents to this library.
+        Add an LLVM IR module's contents to this library.
         """
 
     @abstractmethod

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -44,7 +44,7 @@ def disassemble_cubin(cubin):
             os.unlink(fname)
 
 
-class CUDACodeLibrary(CodeLibrary, serialize.ReduceMixin):
+class CUDACodeLibrary(serialize.ReduceMixin, CodeLibrary):
     """
     The CUDACodeLibrary generates PTX, SASS, cubins for multiple different
     compute capabilities. It also loads cubins to multiple devices (via

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -1,27 +1,186 @@
 from llvmlite import binding as ll
 from llvmlite.llvmpy import core as lc
 
+from numba.core import config, serialize
 from numba.core.codegen import Codegen, CodeLibrary
-from .cudadrv import nvvm
+from .cudadrv import devices, driver, nvvm
+
+import ctypes
+import numpy as np
+import os
+import subprocess
+import tempfile
 
 
 CUDA_TRIPLE = 'nvptx64-nvidia-cuda'
 
 
-class CUDACodeLibrary(CodeLibrary):
+def disassemble_cubin(cubin):
+    # nvdisasm only accepts input from a file, so we need to write out to a
+    # temp file and clean up afterwards.
+    fd = None
+    fname = None
+    try:
+        fd, fname = tempfile.mkstemp()
+        with open(fname, 'wb') as f:
+            f.write(cubin)
 
-    def __init__(self, codegen, name):
+        try:
+            cp = subprocess.run(['nvdisasm', fname], check=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        except FileNotFoundError as e:
+            if e.filename == 'nvdisasm':
+                msg = ("nvdisasm is required for SASS inspection, and has not "
+                       "been found.\n\nYou may need to install the CUDA "
+                       "toolkit and ensure that it is available on your "
+                       "PATH.\n")
+                raise RuntimeError(msg)
+        return cp.stdout.decode('utf-8')
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if fname is not None:
+            os.unlink(fname)
+
+
+class CUDACodeLibrary(CodeLibrary, serialize.ReduceMixin):
+    """
+    The CUDACodeLibrary generates PTX, SASS, cubins for multiple different
+    compute capabilities. It also loads cubins to multiple devices (via
+    get_cufunc), which may be of different compute capabilities.
+    """
+
+    def __init__(self, codegen, name, entry_name=None, max_registers=None,
+                 nvvm_options=None):
+        """
+        codegen:
+            Codegen object.
+        name:
+            Name of the function in the source.
+        entry_name:
+            Name of the kernel function in the binary, if this is a global
+            kernel and not a device function.
+        max_registers:
+            The maximum register usage to aim for when linking.
+        nvvm_options:
+                Dict of options to pass to NVVM.
+        """
         super().__init__(codegen, name)
+
+        # The llvmlite module for this library.
         self._module = None
-        self._linked_modules = []
+        # CodeLibrary objects that will be "linked" into this library. The
+        # modules within them are compiled from NVVM IR to PTX along with the
+        # IR from this module - in that sense they are "linked" by NVVM at PTX
+        # generation time, rather than at link time.
+        self._linking_libraries = set()
+        # Files to link with the generated PTX. These are linked using the
+        # Driver API at link time.
+        self._linking_files = set()
+
+        # Maps CC -> PTX string
+        self._ptx_cache = {}
+        # Maps CC -> cubin
+        self._cubin_cache = {}
+        # Maps CC -> linker info output for cubin
+        self._linkerinfo_cache = {}
+        # Maps Device numeric ID -> cufunc
+        self._cufunc_cache = {}
+
+        self._max_registers = max_registers
+        if nvvm_options is None:
+            nvvm_options = {}
+        self._nvvm_options = nvvm_options
+        self._entry_name = entry_name
 
     def get_llvm_str(self):
         return str(self._module)
 
-    def get_asm_str(self):
-        # Return nothing: we can only dump assembly code when it is later
-        # generated (in numba.cuda.compiler).
-        return None
+    def get_asm_str(self, cc=None):
+        if not cc:
+            ctx = devices.get_context()
+            device = ctx.device
+            cc = device.compute_capability
+
+        ptx = self._ptx_cache.get(cc, None)
+        if ptx:
+            return ptx
+
+        arch = nvvm.get_arch_option(*cc)
+        options = self._nvvm_options.copy()
+        options['arch'] = arch
+
+        irs = [str(mod) for mod in self.modules]
+        ptx = nvvm.llvm_to_ptx(irs, **options)
+        ptx = ptx.decode().strip('\x00').strip()
+
+        if config.DUMP_ASSEMBLY:
+            print(("ASSEMBLY %s" % self._name).center(80, '-'))
+            print(ptx)
+            print('=' * 80)
+
+        self._ptx_cache[cc] = ptx
+
+        return ptx
+
+    def get_cubin(self, cc=None):
+        if cc is None:
+            ctx = devices.get_context()
+            device = ctx.device
+            cc = device.compute_capability
+
+        cubin = self._cubin_cache.get(cc, None)
+        if cubin:
+            return cubin
+
+        ptx = self.get_asm_str(cc=cc)
+        linker = driver.Linker(max_registers=self._max_registers, cc=cc)
+        linker.add_ptx(ptx.encode())
+        for path in self._linking_files:
+            linker.add_file_guess_ext(path)
+        cubin_buf, size = linker.complete()
+
+        # We take a copy of the cubin because it's owned by the linker
+        cubin_ptr = ctypes.cast(cubin_buf, ctypes.POINTER(ctypes.c_char))
+        cubin = bytes(np.ctypeslib.as_array(cubin_ptr, shape=(size,)))
+        self._cubin_cache[cc] = cubin
+        self._linkerinfo_cache[cc] = linker.info_log
+
+        return cubin
+
+    def get_cufunc(self):
+        if self._entry_name is None:
+            msg = "Missing entry_name - are you trying to get the cufunc " \
+                  "for a device function?"
+            raise RuntimeError(msg)
+
+        ctx = devices.get_context()
+        device = ctx.device
+
+        cufunc = self._cufunc_cache.get(device.id, None)
+        if cufunc:
+            return cufunc
+
+        cubin = self.get_cubin(cc=device.compute_capability)
+        module = ctx.create_module_image(cubin)
+
+        # Load
+        cufunc = module.get_function(self._entry_name)
+
+        # Populate caches
+        self._cufunc_cache[device.id] = cufunc
+
+        return cufunc
+
+    def get_linkerinfo(self, cc):
+        try:
+            return self._linkerinfo_cache[cc]
+        except KeyError:
+            raise KeyError(f'No linkerinfo for CC {cc}')
+
+    def get_sass(self, cc=None):
+        return disassemble_cubin(self.get_cubin(cc=cc))
 
     def add_ir_module(self, mod):
         self._raise_if_finalized()
@@ -37,9 +196,10 @@ class CUDACodeLibrary(CodeLibrary):
         # won't be able to finalize again after adding new ones
         self._raise_if_finalized()
 
-        for mod in library.modules:
-            if mod not in self._linked_modules:
-                self._linked_modules.append(mod)
+        self._linking_libraries.add(library)
+
+    def add_linking_file(self, filepath):
+        self._linking_files.add(filepath)
 
     def get_function(self, name):
         for fn in self._module.functions:
@@ -49,7 +209,8 @@ class CUDACodeLibrary(CodeLibrary):
 
     @property
     def modules(self):
-        return [self._module] + self._linked_modules
+        return [self._module] + [mod for lib in self._linking_libraries
+                                 for mod in lib.modules]
 
     def finalize(self):
         # Unlike the CPUCodeLibrary, we don't invoke the binding layer here -
@@ -69,12 +230,58 @@ class CUDACodeLibrary(CodeLibrary):
         #
         # See also discussion on PR #890:
         # https://github.com/numba/numba/pull/890
-        for mod in self._linked_modules:
-            for fn in mod.functions:
+        for library in self._linking_libraries:
+            for fn in library._module.functions:
                 if not fn.is_declaration and fn.linkage != 'external':
                     fn.linkage = 'linkonce_odr'
 
         self._finalized = True
+
+    def _reduce_states(self):
+        """
+        Reduce the instance for serialization. We retain the PTX and cubins,
+        but loaded functions are discarded. They are recreated when needed
+        after unserialization.
+        """
+        if self._linking_files:
+            msg = ('cannot pickle CUDACodeLibrary function with additional '
+                   'libraries to link against')
+            raise RuntimeError(msg)
+        return dict(
+            codegen=self._codegen,
+            name=self.name,
+            entry_name=self._entry_name,
+            module=self._module,
+            linking_libraries=self._linking_libraries,
+            ptx_cache=self._ptx_cache,
+            cubin_cache=self._cubin_cache,
+            linkerinfo_cache=self._linkerinfo_cache,
+            max_registers=self._max_registers,
+            nvvm_options=self._nvvm_options
+        )
+
+    @classmethod
+    def _rebuild(cls, codegen, name, entry_name, module, linking_libraries,
+                 ptx_cache, cubin_cache, linkerinfo_cache, max_registers,
+                 nvvm_options):
+        """
+        Rebuild an instance.
+        """
+        instance = cls.__new__(cls)
+        super(cls, instance).__init__(codegen, name)
+        instance._entry_name = entry_name
+
+        instance._module = module
+        instance._linking_libraries = linking_libraries
+        instance._linking_files = set()
+
+        instance._ptx_cache = ptx_cache
+        instance._cubin_cache = cubin_cache
+        instance._linkerinfo_cache = linkerinfo_cache
+        instance._cufunc_cache = {}
+
+        instance._max_registers = max_registers
+        instance._nvvm_options = nvvm_options
 
 
 class JITCUDACodegen(Codegen):

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -241,7 +241,7 @@ class CUDACodeLibrary(CodeLibrary, serialize.ReduceMixin):
         """
         Reduce the instance for serialization. We retain the PTX and cubins,
         but loaded functions are discarded. They are recreated when needed
-        after unserialization.
+        after deserialization.
         """
         if self._linking_files:
             msg = ('cannot pickle CUDACodeLibrary function with additional '

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -3,9 +3,7 @@ import ctypes
 import functools
 import inspect
 import os
-import subprocess
 import sys
-import tempfile
 
 import numpy as np
 
@@ -15,7 +13,7 @@ from numba.core import (types, typing, utils, funcdesc, serialize, config,
                         compiler, sigutils)
 from numba.core.typeconv.rules import default_type_manager
 from numba.core.compiler import (CompilerBase, DefaultPassBuilder,
-                                 compile_result)
+                                 compile_result, Flags)
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.compiler_machinery import (LoweringPass, PassManager,
                                            register_pass)
@@ -31,6 +29,10 @@ from .cudadrv import nvvm, driver
 from .errors import missing_launch_config_msg, normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
+
+
+class CUDAFlags(Flags):
+    OPTIONS = { **Flags.OPTIONS, **{'nvvm_options': None}}
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
@@ -61,6 +63,30 @@ class CUDABackend(LoweringPass):
         return True
 
 
+@register_pass(mutates_CFG=False, analysis_only=False)
+class CreateLibrary(LoweringPass):
+    """
+    Create a CUDACodeLibrary for the NativeLowering pass to populate. The
+    NativeLowering pass will create a code library if none exists, but we need
+    to set it up with nvvm_options from the flags if they are present.
+    """
+
+    _name = "create_library"
+
+    def __init__(self):
+        LoweringPass.__init__(self)
+
+    def run_pass(self, state):
+        codegen = state.targetctx.codegen()
+        name = state.func_id.func_qualname
+        nvvm_options = state.flags.nvvm_options
+        state.library = codegen.create_library(name, nvvm_options=nvvm_options)
+        # Enable object caching upfront so that the library can be serialized.
+        state.library.enable_object_caching()
+
+        return True
+
+
 class CUDACompiler(CompilerBase):
     def define_pipelines(self):
         dpb = DefaultPassBuilder
@@ -85,6 +111,7 @@ class CUDACompiler(CompilerBase):
                     "ensure IR is legal prior to lowering")
 
         # lower
+        pm.add_pass(CreateLibrary, "create library")
         pm.add_pass(NativeLowering, "native lowering")
         pm.add_pass(CUDABackend, "cuda backend")
 
@@ -93,12 +120,13 @@ class CUDACompiler(CompilerBase):
 
 
 @global_compiler_lock
-def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
+def compile_cuda(pyfunc, return_type, args, debug=False, inline=False,
+                 nvvm_options=None):
     from .descriptor import cuda_target
     typingctx = cuda_target.typingctx
     targetctx = cuda_target.targetctx
 
-    flags = compiler.Flags()
+    flags = CUDAFlags()
     # Do not compile (generate native code), just lower (to LLVM)
     flags.set('no_compile')
     flags.set('no_cpython_wrapper')
@@ -107,6 +135,9 @@ def compile_cuda(pyfunc, return_type, args, debug=False, inline=False):
         flags.set('debuginfo')
     if inline:
         flags.set('forceinline')
+    if nvvm_options:
+        flags.set('nvvm_options', nvvm_options)
+
     # Run compilation pipeline
     cres = compiler.compile_extra(typingctx=typingctx,
                                   targetctx=targetctx,
@@ -153,28 +184,27 @@ def compile_ptx(pyfunc, args, debug=False, device=False, fastmath=False,
     :return: (ptx, resty): The PTX code and inferred return type
     :rtype: tuple
     """
-    cres = compile_cuda(pyfunc, None, args, debug=debug)
+    nvvm_options = {
+        'debug': debug,
+        'fastmath': fastmath,
+        'opt': 3 if opt else 0
+    }
+
+    cres = compile_cuda(pyfunc, None, args, debug=debug,
+                        nvvm_options=nvvm_options)
     resty = cres.signature.return_type
     if device:
-        llvm_modules = cres.library.modules
+        lib = cres.library
     else:
         fname = cres.fndesc.llvm_func_name
         tgt = cres.target_context
         lib, kernel = tgt.prepare_cuda_kernel(cres.library, fname,
-                                              cres.signature.args, debug=debug)
-        llvm_modules = lib.modules
-
-    options = {
-        'debug': debug,
-        'fastmath': fastmath,
-    }
+                                              cres.signature.args, debug,
+                                              nvvm_options)
 
     cc = cc or config.CUDA_DEFAULT_PTX_CC
-    opt = 3 if opt else 0
-    arch = nvvm.get_arch_option(*cc)
-    llvmir = [str(mod) for mod in llvm_modules]
-    ptx = nvvm.llvm_to_ptx(llvmir, opt=opt, arch=arch, **options)
-    return ptx.decode('utf-8'), resty
+    ptx = lib.get_asm_str(cc=cc)
+    return ptx, resty
 
 
 def compile_ptx_for_current_device(pyfunc, args, debug=False, device=False,
@@ -185,35 +215,6 @@ def compile_ptx_for_current_device(pyfunc, args, debug=False, device=False,
     cc = get_current_device().compute_capability
     return compile_ptx(pyfunc, args, debug=-debug, device=device,
                        fastmath=fastmath, cc=cc, opt=True)
-
-
-def disassemble_cubin(cubin):
-    # nvdisasm only accepts input from a file, so we need to write out to a
-    # temp file and clean up afterwards.
-    fd = None
-    fname = None
-    try:
-        fd, fname = tempfile.mkstemp()
-        with open(fname, 'wb') as f:
-            f.write(cubin)
-
-        try:
-            cp = subprocess.run(['nvdisasm', fname], check=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        except FileNotFoundError as e:
-            if e.filename == 'nvdisasm':
-                msg = ("nvdisasm is required for SASS inspection, and has not "
-                       "been found.\n\nYou may need to install the CUDA "
-                       "toolkit and ensure that it is available on your "
-                       "PATH.\n")
-                raise RuntimeError(msg)
-        return cp.stdout.decode('utf-8')
-    finally:
-        if fd is not None:
-            os.close(fd)
-        if fname is not None:
-            os.unlink(fname)
 
 
 class DeviceFunctionTemplate(serialize.ReduceMixin):
@@ -437,122 +438,17 @@ class ForAll(object):
         # Else, ask the driver to give a good config
         else:
             ctx = get_context()
+            # Kernel is specialized, so there's only one definition - get it so
+            # we can get the cufunc from the code library
+            defn = next(iter(kernel.overloads.values()))
             kwargs = dict(
-                func=kernel._func.get(),
+                func=defn._codelibrary.get_cufunc(),
                 b2d_func=0,     # dynamic-shared memory is constant to blksz
                 memsize=self.sharedmem,
                 blocksizelimit=1024,
             )
             _, tpb = ctx.get_max_potential_block_size(**kwargs)
             return tpb
-
-
-class CachedPTX(object):
-    """A PTX cache that uses compute capability as a cache key
-    """
-    def __init__(self, name, llvmir, options):
-        self.name = name
-        self.llvmir = llvmir
-        self.cache = {}
-        self._extra_options = options.copy()
-
-    def get(self, cc=None):
-        """
-        Get PTX for the current active context.
-        """
-        if not cc:
-            cuctx = get_context()
-            device = cuctx.device
-            cc = device.compute_capability
-
-        ptx = self.cache.get(cc)
-        if ptx is None:
-            arch = nvvm.get_arch_option(*cc)
-            ptx = nvvm.llvm_to_ptx(self.llvmir, arch=arch,
-                                   **self._extra_options)
-            self.cache[cc] = ptx
-            if config.DUMP_ASSEMBLY:
-                print(("ASSEMBLY %s" % self.name).center(80, '-'))
-                print(ptx.decode('utf-8'))
-                print('=' * 80)
-        return ptx
-
-
-class CachedCUFunction(serialize.ReduceMixin):
-    """
-    Get or compile CUDA function for the current active context
-
-    Uses device ID as key for cache.
-    """
-
-    def __init__(self, entry_name, ptx, linking, max_registers):
-        self.entry_name = entry_name
-        self.ptx = ptx
-        self.linking = linking
-        self.cache = {}
-        self.ccinfos = {}
-        self.cubins = {}
-        self.max_registers = max_registers
-
-    def get(self):
-        cuctx = get_context()
-        device = cuctx.device
-        cufunc = self.cache.get(device.id)
-        if cufunc is None:
-            ptx = self.ptx.get()
-
-            # Link
-            linker = driver.Linker(max_registers=self.max_registers)
-            linker.add_ptx(ptx)
-            for path in self.linking:
-                linker.add_file_guess_ext(path)
-            cubin, size = linker.complete()
-            compile_info = linker.info_log
-            module = cuctx.create_module_image(cubin)
-
-            # Load
-            cufunc = module.get_function(self.entry_name)
-
-            # Populate caches
-            self.cache[device.id] = cufunc
-            self.ccinfos[device.id] = compile_info
-            # We take a copy of the cubin because it's owned by the linker
-            cubin_ptr = ctypes.cast(cubin, ctypes.POINTER(ctypes.c_char))
-            cubin_data = np.ctypeslib.as_array(cubin_ptr, shape=(size,)).copy()
-            self.cubins[device.id] = cubin_data
-        return cufunc
-
-    def get_sass(self):
-        self.get()  # trigger compilation
-        device = get_context().device
-        return disassemble_cubin(self.cubins[device.id])
-
-    def get_info(self):
-        self.get()   # trigger compilation
-        cuctx = get_context()
-        device = cuctx.device
-        ci = self.ccinfos[device.id]
-        return ci
-
-    def _reduce_states(self):
-        """
-        Reduce the instance for serialization.
-        Pre-compiled PTX code string is serialized inside the `ptx` (CachedPTX).
-        Loaded CUfunctions are discarded. They are recreated when unserialized.
-        """
-        if self.linking:
-            msg = ('cannot pickle CUDA kernel function with additional '
-                   'libraries to link against')
-            raise RuntimeError(msg)
-        return dict(entry_name=self.entry_name, ptx=self.ptx,
-                    linking=self.linking, max_registers=self.max_registers)
-
-    @classmethod
-    def _rebuild(cls, entry_name, ptx, linking, max_registers):
-        """
-        Rebuild an instance.
-        """
-        return cls(entry_name, ptx, linking, max_registers)
 
 
 class _Kernel(serialize.ReduceMixin):
@@ -576,49 +472,43 @@ class _Kernel(serialize.ReduceMixin):
                             inline=inline)
         fname = cres.fndesc.llvm_func_name
         args = cres.signature.args
-        lib, kernel = cres.target_context.prepare_cuda_kernel(cres.library,
-                                                              fname,
-                                                              args,
-                                                              debug=self.debug)
 
-        options = {
+        nvvm_options = {
             'debug': self.debug,
             'fastmath': fastmath,
             'opt': 3 if opt else 0
         }
 
-        llvm_ir = [str(mod) for mod in lib.modules]
-        pretty_name = cres.fndesc.qualname
-        ptx = CachedPTX(pretty_name, llvm_ir, options=options)
+        tgt_ctx = cres.target_context
+        lib, kernel = tgt_ctx.prepare_cuda_kernel(cres.library, fname, args,
+                                                  debug, nvvm_options,
+                                                  max_registers)
 
         if not link:
             link = []
 
         # A kernel needs cooperative launch if grid_sync is being used.
-        self.cooperative = False
-        for ir in ptx.llvmir:
-            if 'cudaCGGetIntrinsicHandle' in ir:
-                self.cooperative = True
+        self.cooperative = 'cudaCGGetIntrinsicHandle' in lib.get_asm_str()
         # We need to link against cudadevrt if grid sync is being used.
         if self.cooperative:
             link.append(get_cudalib('cudadevrt', static=True))
 
-        cufunc = CachedCUFunction(kernel.name, ptx, link, max_registers)
+        for filepath in link:
+            lib.add_linking_file(filepath)
 
         # populate members
         self.entry_name = kernel.name
         self.signature = cres.signature
         self._type_annotation = cres.type_annotation
-        self._func = cufunc
+        self._codelibrary = lib
         self.call_helper = cres.call_helper
-        self.link = link
 
     @property
     def argument_types(self):
         return tuple(self.signature.args)
 
     @classmethod
-    def _rebuild(cls, cooperative, name, argtypes, cufunc, link, debug,
+    def _rebuild(cls, cooperative, name, argtypes, codelibrary, link, debug,
                  call_helper, extensions):
         """
         Rebuild an instance.
@@ -630,9 +520,8 @@ class _Kernel(serialize.ReduceMixin):
         instance.cooperative = cooperative
         instance.entry_name = name
         instance.argument_types = tuple(argtypes)
-        instance.link = tuple(link)
         instance._type_annotation = None
-        instance._func = cufunc
+        instance._codelibrary = codelibrary
         instance.debug = debug
         instance.call_helper = call_helper
         instance.extensions = extensions
@@ -647,7 +536,7 @@ class _Kernel(serialize.ReduceMixin):
         Stream information is discarded.
         """
         return dict(cooperative=self.cooperative, name=self.entry_name,
-                    argtypes=self.argtypes, cufunc=self._func, link=self.link,
+                    argtypes=self.argtypes, codelibrary=self.codelibrary,
                     debug=self.debug, call_helper=self.call_helper,
                     extensions=self.extensions)
 
@@ -655,14 +544,14 @@ class _Kernel(serialize.ReduceMixin):
         """
         Force binding to current CUDA context
         """
-        self._func.get()
+        self._codelibrary.get_cufunc()
 
     @property
     def ptx(self):
         '''
         PTX code for this kernel.
         '''
-        return self._func.ptx.get().decode('utf8')
+        return self._codelibrary.get_asm_str()
 
     @property
     def device(self):
@@ -676,19 +565,19 @@ class _Kernel(serialize.ReduceMixin):
         '''
         The number of registers used by each thread for this kernel.
         '''
-        return self._func.get().attrs.regs
+        return self._codelibrary.get_cufunc().attrs.regs
 
     def inspect_llvm(self):
         '''
         Returns the LLVM IR for this kernel.
         '''
-        return "\n\n".join([str(ir) for ir in self._func.ptx.llvmir])
+        return self._codelibrary.get_asm_str()
 
     def inspect_asm(self, cc):
         '''
         Returns the PTX code for this kernel.
         '''
-        return self._func.ptx.get(cc).decode('ascii')
+        return self._codelibrary.get_asm_str(cc=cc)
 
     def inspect_sass(self):
         '''
@@ -696,7 +585,7 @@ class _Kernel(serialize.ReduceMixin):
 
         Requires nvdisasm to be available on the PATH.
         '''
-        return self._func.get_sass()
+        return self._codelibrary.get_sass()
 
     def inspect_types(self, file=None):
         '''
@@ -727,7 +616,7 @@ class _Kernel(serialize.ReduceMixin):
         :return: The maximum number of blocks in the grid.
         '''
         ctx = get_context()
-        cufunc = self._func.get()
+        cufunc = self._codelibrary.get_cufunc()
 
         if isinstance(blockdim, tuple):
             blockdim = functools.reduce(lambda x, y: x * y, blockdim)
@@ -739,7 +628,7 @@ class _Kernel(serialize.ReduceMixin):
 
     def launch(self, args, griddim, blockdim, stream=0, sharedmem=0):
         # Prepare kernel
-        cufunc = self._func.get()
+        cufunc = self._codelibrary.get_cufunc()
 
         if self.debug:
             excname = cufunc.name + "__errcode__"
@@ -1117,13 +1006,6 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         warn('Use overloads instead of definitions',
              category=NumbaDeprecationWarning)
         return self.overloads
-
-    @property
-    def _func(self):
-        if self.specialized:
-            return next(iter(self.overloads.values()))._func
-        else:
-            return {sig: defn._func for sig, defn in self.overloads.items()}
 
     def get_regs_per_thread(self, signature=None):
         '''

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -296,10 +296,6 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
         -------
         ptx : bytes
         """
-        if nvvm_options:
-            msg = 'nvvm_options kwarg for inspect_ptx is deprecated'
-            warn(msg, category=NumbaDeprecationWarning)
-
         llvmir = self.inspect_llvm(args)
         # Make PTX
         cuctx = get_context()

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -570,7 +570,7 @@ class _Kernel(serialize.ReduceMixin):
         '''
         Returns the LLVM IR for this kernel.
         '''
-        return self._codelibrary.get_asm_str()
+        return self._codelibrary.get_llvm_str()
 
     def inspect_asm(self, cc):
         '''

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -2124,7 +2124,10 @@ FILE_EXTENSION_MAP = {
 
 
 class Linker(object):
-    def __init__(self, max_registers=0):
+    """
+    Links for current device if no CC given
+    """
+    def __init__(self, max_registers=0, cc=None):
         logsz = int(get_numba_envvar('CUDA_LOG_SIZE', 1024))
         linkerinfo = (c_char * logsz)()
         linkererrors = (c_char * logsz)()
@@ -2139,7 +2142,14 @@ class Linker(object):
         if max_registers:
             options[enums.CU_JIT_MAX_REGISTERS] = c_void_p(max_registers)
 
-        raw_keys = list(options.keys()) + [enums.CU_JIT_TARGET_FROM_CUCONTEXT]
+        if cc is None:
+            # No option value is needed, but we need something as a placeholder
+            options[enums.CU_JIT_TARGET_FROM_CUCONTEXT] = 1
+        else:
+            cc_val = cc[0] * 10 + cc[1]
+            options[enums.CU_JIT_TARGET] = c_void_p(cc_val)
+
+        raw_keys = list(options.keys())
         raw_values = list(options.values())
         del options
 

--- a/numba/cuda/tests/cudapy/test_cooperative_groups.py
+++ b/numba/cuda/tests/cudapy/test_cooperative_groups.py
@@ -96,7 +96,7 @@ class TestCudaCooperativeGroups(CUDATestCase):
 
         for key, defn in no_sync.definitions.items():
             self.assertFalse(defn.cooperative)
-            for link in defn._func.linking:
+            for link in defn._codelibrary._linking_files:
                 self.assertNotIn('cudadevrt', link)
 
     @skip_unless_cc_60

--- a/numba/cuda/tests/cudapy/test_cooperative_groups.py
+++ b/numba/cuda/tests/cudapy/test_cooperative_groups.py
@@ -80,8 +80,8 @@ class TestCudaCooperativeGroups(CUDATestCase):
     def test_sync_group_is_cooperative(self):
         A = np.full(1, fill_value=np.nan)
         sync_group[1, 1](A)
-        # this_grid should have been determined to be cooperative
-        for key, defn in this_grid.definitions.items():
+        # sync_group should have been determined to be cooperative
+        for key, defn in sync_group.definitions.items():
             self.assertTrue(defn.cooperative)
 
     @skip_on_cudasim("Simulator does not implement linking")

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -30,7 +30,7 @@ class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
             x[0] = 123
 
         cukern = compile_kernel(foo, args=(types.int32[::1],), link=())
-        llvmir = cukern._func.ptx.llvmir
+        llvmir = cukern._codelibrary.get_llvm_str()
         ptx = nvvm.llvm_to_ptx(llvmir)
         self.assertIn("foo", ptx.decode('ascii'))
 


### PR DESCRIPTION
Note: This PR is based on #6735 - the latest four commits are unique to this PR and can each be examined individually to understand the changes here.

This commit removes `CachedPTX` and `CachedCUFunction`, replacing them with additions to the `CUDACodeLibrary`. This aligns the CUDA target with more of the infrastructure in the core of Numba, simplifies the organization of code generation and caching, and provides some other benefits - generally it lays the foundation for implementations of on-disk caching of compiled kernels, ahead-of-time compilation, and improving debugging support for CUDA kernels. This description is expanded on in the final commit's message.

This PR also includes some other small changes and fixes - see individual commit messages for details.