### PR TITLE
Use NVVM bitcode IR interface

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -29,6 +29,10 @@ conda create -n %CONDA_ENV% -q -y python=%PYTHON% numpy=%NUMPY% cffi pip scipy j
 call activate %CONDA_ENV%
 @rem Install latest llvmlite build
 %CONDA_INSTALL% -c numba/label/dev llvmlite
+
+@rem Install t2bc
+%CONDA_INSTALL% -c gmarkall t2bc
+
 @rem Install dependencies for building the documentation
 if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx sphinx_rtd_theme pygments)
 @rem Install dependencies for code coverage (codecov.io)

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -78,6 +78,9 @@ fi
 # Install latest llvmlite build
 $CONDA_INSTALL -c numba/label/dev llvmlite
 
+# Install t2bc
+$CONDA_INSTALL gmarkall::t2bc
+
 # Install dependencies for building the documentation
 if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx=2.4.4 sphinx_rtd_theme pygments numpydoc; fi
 if [ "$BUILD_DOC" == "yes" ]; then $PIP_INSTALL rstcheck; fi


### PR DESCRIPTION
This PR uses the NVVM bitcode interface instead of the IR interface. It uses the [t2bc](https://github.com/gmarkall/t2bc) library to assemble the IR, which is built against LLVM 7.0.0 to match the IR version used by NVVM.

This is presently draft work, for testing on the buildfarm - it is aimed that t2bc will be integrated into the llvmlite repository, once it is known to be working for this PR.

@esc could this have a buildfarm run please? To test, the environment needs t2bc installed from my anaconda.org channel - see the changes to setup_conda_environment.{sh,cmd} below. Many thanks in advance!