### PR TITLE
Add support for fastmath 32-bit floating point divide

### DIFF
--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -1,7 +1,7 @@
 import math
 import operator
 from llvmlite import ir
-from numba.core import types, typing, utils
+from numba.core import types, typing, utils, cgutils
 from numba.core.imputils import Registry
 from numba.types import float32, float64, int64, uint64
 from numba.cuda import libdevice
@@ -69,6 +69,22 @@ binarys_fastmath['powf'] = 'fast_powf'
 @lower(math.isnan, types.Integer)
 def math_isinf_isnan_int(context, builder, sig, args):
     return context.get_constant(types.boolean, 0)
+
+
+@lower(operator.truediv, types.float32, types.float32)
+def maybe_fast_truediv(context, builder, sig, args):
+    with cgutils.if_zero(builder, args[1]):
+        context.error_model.fp_zero_division(builder, ("division by zero",))
+
+    if context.fastmath:
+        fast_replacement = 'fast_fdividef'
+        actual_libfunc = getattr(libdevice, fast_replacement)
+        sig = typing.signature(float32, float32, float32)
+        libfunc_impl = context.get_function(actual_libfunc, sig)
+        return libfunc_impl(builder, args)
+    else:
+        res = builder.fdiv(*args)
+        return res
 
 
 @lower(math.isfinite, types.Integer)

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -73,16 +73,13 @@ def math_isinf_isnan_int(context, builder, sig, args):
 
 @lower(operator.truediv, types.float32, types.float32)
 def maybe_fast_truediv(context, builder, sig, args):
-    with cgutils.if_zero(builder, args[1]):
-        context.error_model.fp_zero_division(builder, ("division by zero",))
-
     if context.fastmath:
-        fast_replacement = 'fast_fdividef'
-        actual_libfunc = getattr(libdevice, fast_replacement)
         sig = typing.signature(float32, float32, float32)
-        libfunc_impl = context.get_function(actual_libfunc, sig)
-        return libfunc_impl(builder, args)
+        impl = context.get_function(libdevice.fast_fdividef, sig)
+        return impl(builder, args)
     else:
+        with cgutils.if_zero(builder, args[1]):
+            context.error_model.fp_zero_division(builder, ("division by zero",))
         res = builder.fdiv(*args)
         return res
 

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -5,6 +5,7 @@ import unittest
 
 
 class TestFastMathOption(CUDATestCase):
+    @skip_on_cudasim('fast divide not available in CUDASIM')
     def test_kernel(self):
 
         def foo(arr, val):
@@ -15,8 +16,8 @@ class TestFastMathOption(CUDATestCase):
         fastver = cuda.jit("void(float32[:], float32)", fastmath=True)(foo)
         precver = cuda.jit("void(float32[:], float32)")(foo)
 
-        self.assertIn('div.full.ftz.f32', fastver.ptx)
-        self.assertNotIn('div.full.ftz.f32', precver.ptx)
+        self.assertIn('div.approx.ftz.f32', fastver.ptx)
+        self.assertNotIn('div.approx.ftz.f32', precver.ptx)
 
     @skip_on_cudasim('fast cos not available in CUDASIM')
     def test_cosf(self):
@@ -104,6 +105,17 @@ class TestFastMathOption(CUDATestCase):
         slowver = cuda.jit("void(float32[::1], float32, float32)")(f8)
         self.assertIn('lg2.approx.ftz.f32 ', fastver.ptx)
         self.assertNotIn('lg2.approx.ftz.f32 ', slowver.ptx)
+
+    @skip_on_cudasim('fast divide not available in CUDASIM')
+    def test_divf(self):
+        def f9(r, x, y):
+            r[0] = x / y
+
+        fastver = cuda.jit("void(float32[::1], float32, float32)",
+                           fastmath=True)(f9)
+        slowver = cuda.jit("void(float32[::1], float32, float32)")(f9)
+        self.assertIn('div.approx.ftz.f32 ', fastver.ptx)
+        self.assertNotIn('div.approx.ftz.f32 ', slowver.ptx)
 
     def test_device(self):
         # fastmath option is ignored for device function


### PR DESCRIPTION
This pull request adds support for generating more efficient code for 32-bit floating point divides in the presence of fastmath. This should be the final piece to: https://github.com/numba/numba/issues/6183.
