### PR TITLE
CUDA: Lazily add libdevice to compilation units 

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -53,8 +53,8 @@ requirements:
     - tbb >=2019.5,<=2020.3    # [not (armv6l or armv7l or aarch64 or linux32)]
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
-    # CUDA 9.0 or later is required for CUDA support
-    - cudatoolkit >=9.0
+    # CUDA 9.2 or later is required for CUDA support
+    - cudatoolkit >=9.2
     # scipy 1.0 or later
     - scipy >=1.0
 

--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -44,7 +44,7 @@ Software
 --------
 
 Numba aims to support CUDA Toolkit versions released within the last 3 years. At
-the present time, you will need the CUDA toolkit version 9.0 or later installed.
+the present time, you will need the CUDA toolkit version 9.2 or later installed.
 
 CUDA is supported on 64-bit Linux and Windows. 32-bit platforms, and macOS are
 unsupported.

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -191,7 +191,7 @@ def _getpid():
 ERROR_MAP = _build_reverse_error_map()
 
 MISSING_FUNCTION_ERRMSG = """driver missing function: %s.
-Requires CUDA 9.0 or above.
+Requires CUDA 9.2 or above.
 """
 
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -321,18 +321,23 @@ def get_supported_ccs():
         # The CUDA Runtime may not be present
         cudart_version_major = 0
 
+    ctk_ver = f"{cudart_version_major}.{cudart_version_minor}"
+    unsupported_ver = f"CUDA Toolkit {ctk_ver} is unsupported by Numba - " \
+                      + "9.2 is the minimum required version."
+
     # List of supported compute capability in sorted order
     if cudart_version_major == 0:
         _supported_cc = ()
     elif cudart_version_major < 9:
         _supported_cc = ()
-        ctk_ver = f"{cudart_version_major}.{cudart_version_minor}"
-        msg = f"CUDA Toolkit {ctk_ver} is unsupported by Numba - 9.0 is the " \
-              + "minimum required version."
-        warnings.warn(msg)
+        warnings.warn(unsupported_ver)
     elif cudart_version_major == 9:
-        # CUDA 9.x
-        _supported_cc = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0) # noqa: E501
+        if cudart_version_minor != 2:
+            _supported_cc = ()
+            warnings.warn(unsupported_ver)
+        else:
+            # CUDA 9.2
+            _supported_cc = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0) # noqa: E501
     elif cudart_version_major == 10:
         # CUDA 10.x
         _supported_cc = (3, 0), (3, 5), (5, 0), (5, 2), (5, 3), (6, 0), (6, 1), (6, 2), (7, 0), (7, 2), (7, 5) # noqa: E501

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -132,7 +132,19 @@ class NVVM(object):
 
                 # Find & populate functions
                 for name, proto in inst._PROTOTYPES.items():
-                    func = getattr(inst.driver, name)
+                    try:
+                        func = getattr(inst.driver, name)
+                    except AttributeError:
+                        # CUDA 9.2 has no nvvmLazyAddModuleToProgram, but
+                        # nvvmAddModuleToProgram fulfils the same function,
+                        # just less efficiently, so we work around this here.
+                        # This workaround to be removed once support for CUDA
+                        # 9.2 is dropped.
+                        if name == 'nvvmLazyAddModuleToProgram':
+                            func = getattr(inst.driver,
+                                           'nvvmAddModuleToProgram')
+                        else:
+                            raise
                     func.restype = proto[0]
                     func.argtypes = proto[1:]
                     setattr(inst, name, func)

--- a/numba/cuda/cudadrv/runtime.py
+++ b/numba/cuda/cudadrv/runtime.py
@@ -128,7 +128,7 @@ class Runtime:
         if sys.platform not in ('linux', 'win32') or config.MACHINE_BITS != 64:
             # Only 64-bit Linux and Windows are supported
             return ()
-        return ((9, 0), (9, 1), (9, 2),
+        return ((9, 2),
                 (10, 0), (10, 1), (10, 2),
                 (11, 0), (11, 1), (11, 2))
 

--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -21,7 +21,7 @@ def set_visible_devices_and_check(q):
 if config.ENABLE_CUDASIM:
     SUPPORTED_VERSIONS = (-1, -1),
 else:
-    SUPPORTED_VERSIONS = ((9, 0), (9, 1), (9, 2),
+    SUPPORTED_VERSIONS = ((9, 2),
                           (10, 0), (10, 1), (10, 2),
                           (11, 0), (11, 1), (11, 2))
 


### PR DESCRIPTION
Modules should be lazily loaded where possible, in order to permit certain optimizations that make compilation more efficient and improve runtime performance.

This commit adds support for lazy loading and uses it for libdevice, since it is never the entry point to a compilation unit. This seems to have a noticeable effect on compilation speed. Running:

```
python -m numba.runtests numba.cuda.tests -m
```

prior to this PR gives:

```
Ran 1132 tests in 136.102s
```

on my system. With this PR, it gives:

```
Ran 1132 tests in 86.255s
```

This PR also drops support for CUDA 9.0 and 9.1 on the basis that they will be greater than three years old by the time 0.54 is released (9.1 released in December 2017), and `nvvmLazyAddModuleToProgram` was added in CUDA 9.2 - this avoids supporting two different paths through NVVM. Note that although examination of this PR suggests it would be straightforward to maintain both paths, I expect it to be problematic for future work based on #6769, in particular related to improving support for debug info.