### PR TITLE
CUDA: Add optional Driver API argument logging

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -417,6 +417,20 @@ GPU support
    takes place, and the user of Numba (and other CUDA libraries) is responsible
    for ensuring correctness with respect to synchronization on streams.
 
+.. envvar:: NUMBA_CUDA_LOG_LEVEL
+
+   For debugging purposes. If no other logging is configured, the value of this
+   variable is the logging level for CUDA API calls. The default value is
+   ``CRITICAL`` - to trace all API calls on standard error, set this to
+   ``DEBUG``.
+
+.. envvar:: NUMBA_CUDA_LOG_API_ARGS
+
+   By default the CUDA API call logs only give the names of functions called.
+   Setting this variable to 1 also includes the values of arguments to Driver
+   API calls in the logs.
+
+
 Threading Control
 -----------------
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -323,6 +323,9 @@ class _EnvReloader(object):
         #       Any existing logging configuration is preserved.
         CUDA_LOG_LEVEL = _readenv("NUMBA_CUDA_LOG_LEVEL", str, '')
 
+        # Include argument values in the CUDA Driver API logs
+        CUDA_LOG_API_ARGS = _readenv("NUMBA_CUDA_LOG_API_ARGS", int, 0)
+
         # Maximum number of pending CUDA deallocations (default: 10)
         CUDA_DEALLOCS_COUNT = _readenv("NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT",
                                        int, 10)


### PR DESCRIPTION
(Background: I often find myself making a temporary change like this locally, but I think being able to turn this on and off generally would be useful, and I'm also fed up of applying / reverting a change like this to my local repo :-) )

Setting the config variable `CUDA_LOG_API_ARGS` enables logging of Driver API function arguments in the CUDA logs.

This commit also documents this variable along with the `CUDA_LOG_LEVEL` config variable.

Without the API argument logging, logs look like (for example):

```
$ NUMBA_CUDA_LOG_LEVEL=DEBUG python -c "from numba import cuda; cuda.device_array(1)"
== CUDA [237]  INFO -- init
== CUDA [238] DEBUG -- call driver api: cuInit
== CUDA [275] DEBUG -- call driver api: cuCtxGetCurrent
== CUDA [275] DEBUG -- call driver api: cuCtxGetCurrent
== CUDA [275] DEBUG -- call driver api: cuDeviceGetCount
== CUDA [275] DEBUG -- call driver api: cuDeviceGet
== CUDA [275] DEBUG -- call driver api: cuDeviceComputeCapability
== CUDA [275] DEBUG -- call driver api: cuDeviceGetName
== CUDA [275] DEBUG -- call driver api: cuDeviceGetUuid
== CUDA [275] DEBUG -- call driver api: cuDeviceGet
== CUDA [275] DEBUG -- call driver api: cuDeviceComputeCapability
== CUDA [275] DEBUG -- call driver api: cuDeviceGetName
== CUDA [275] DEBUG -- call driver api: cuDeviceGetUuid
== CUDA [276] DEBUG -- call driver api: cuDevicePrimaryCtxRetain
== CUDA [370] DEBUG -- call driver api: cuCtxPushCurrent_v2
== CUDA [370] DEBUG -- call driver api: cuMemGetInfo_v2
== CUDA [371] DEBUG -- call driver api: cuMemAlloc_v2
== CUDA [371]  INFO -- add pending dealloc: cuMemFree_v2 8 bytes
```

With API argument logging, this becomes:

```
$ NUMBA_CUDA_LOG_API_ARGS=1 NUMBA_CUDA_LOG_LEVEL=DEBUG python -c "from numba import cuda; cuda.device_array(1)"
== CUDA [242]  INFO -- init
== CUDA [242] DEBUG -- call driver api: cuInit(0)
== CUDA [276] DEBUG -- call driver api: cuCtxGetCurrent(<cparam 'P' (0x7ff5954c9310)>)
== CUDA [276] DEBUG -- call driver api: cuCtxGetCurrent(<cparam 'P' (0x7ff5954c9310)>)
== CUDA [276] DEBUG -- call driver api: cuDeviceGetCount(<cparam 'P' (0x7ff5954c9310)>)
== CUDA [276] DEBUG -- call driver api: cuDeviceGet(<cparam 'P' (0x7ff5954c9310)>, 0)
== CUDA [276] DEBUG -- call driver api: cuDeviceComputeCapability(<cparam 'P' (0x7ff5953faa90)>, <cparam 'P' (0x7ff5953fa990)>, 0)
== CUDA [277] DEBUG -- call driver api: cuDeviceGetName(<numba.cuda.cudadrv.driver.c_char_Array_128 object at 0x7ff5953fabc0>, 128, 0)
== CUDA [277] DEBUG -- call driver api: cuDeviceGetUuid(<cparam 'P' (0x7ff5953fad90)>, 0)
== CUDA [277] DEBUG -- call driver api: cuDeviceGet(<cparam 'P' (0x7ff5954c9310)>, 1)
== CUDA [277] DEBUG -- call driver api: cuDeviceComputeCapability(<cparam 'P' (0x7ff5953fad10)>, <cparam 'P' (0x7ff5953fad90)>, 1)
== CUDA [277] DEBUG -- call driver api: cuDeviceGetName(<numba.cuda.cudadrv.driver.c_char_Array_128 object at 0x7ff5953fabc0>, 128, 1)
== CUDA [277] DEBUG -- call driver api: cuDeviceGetUuid(<cparam 'P' (0x7ff5953faa90)>, 1)
== CUDA [277] DEBUG -- call driver api: cuDevicePrimaryCtxRetain(<cparam 'P' (0x7ff5954c9310)>, 0)
== CUDA [367] DEBUG -- call driver api: cuCtxPushCurrent_v2(c_void_p(94307166233376))
== CUDA [367] DEBUG -- call driver api: cuMemGetInfo_v2(<cparam 'P' (0x7ff5953fa990)>, <cparam 'P' (0x7ff5953faa90)>)
== CUDA [367] DEBUG -- call driver api: cuMemAlloc_v2(<cparam 'P' (0x7ff5953d3310)>, 8)
== CUDA [367]  INFO -- add pending dealloc: cuMemFree_v2 8 bytes
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
