### PR TITLE
Make a common standard API for querying ufunc impl

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1146,6 +1146,25 @@ class BaseContext(object):
         for lib in libs:
             colib.add_linking_library(lib)
 
+    def get_ufunc_info(self, ufunc_key):
+        """Get ufunc implementation given a ufunc object as the key.
+
+        The default implementation in BaseContext always raise a
+        ``NotImplementedError`` exception. Subclasses may raise ``KeyError``
+        to signal that the given ``ufunc_key`` is not available.
+
+        Parameters
+        ----------
+        ufunc_key : numpy ufunc
+
+        Returns
+        -------
+        res : dict[str, callable]
+            A mapping of NumPy ufunc type signature to the lower-level
+            implementation.
+        """
+        raise NotImplementedError("{self} does not support ufunc")
+
 
 class _wrap_impl(object):
     """

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1163,8 +1163,7 @@ class BaseContext(object):
             A mapping of NumPy ufunc type signature to the lower-level
             implementation.
         """
-        raise NotImplementedError("{self} does not support ufunc")
-
+        raise NotImplementedError(f"{self} does not support ufunc")
 
 class _wrap_impl(object):
     """

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1147,20 +1147,20 @@ class BaseContext(object):
             colib.add_linking_library(lib)
 
     def get_ufunc_info(self, ufunc_key):
-        """Get ufunc implementation given a ufunc object as the key.
+        """Get the ufunc implementation for a given ufunc object.
 
-        The default implementation in BaseContext always raise a
+        The default implementation in BaseContext always raises a
         ``NotImplementedError`` exception. Subclasses may raise ``KeyError``
         to signal that the given ``ufunc_key`` is not available.
 
         Parameters
         ----------
-        ufunc_key : numpy ufunc
+        ufunc_key : NumPy ufunc
 
         Returns
         -------
         res : dict[str, callable]
-            A mapping of NumPy ufunc type signature to the lower-level
+            A mapping of a NumPy ufunc type signature to a lower-level
             implementation.
         """
         raise NotImplementedError(f"{self} does not support ufunc")

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -17,6 +17,7 @@ import numba.core.entrypoints
 from numba.core.cpu_options import (ParallelOptions, FastMathOptions,
                                     InlineOptions)
 from numba.cpython import setobj, listobj
+from numba.np import ufunc_db
 
 # Keep those structures in sync with _dynfunc.c.
 
@@ -229,6 +230,10 @@ class CPUContext(BaseContext):
         '''
         aryty = types.Array(types.int32, ndim, 'A')
         return self.get_abi_sizeof(self.get_value_type(aryty))
+
+    # Overrides
+    def get_ufunc_info(self, ufunc_key):
+        return ufunc_db.get_ufunc_info(ufunc_key)
 
 
 # ----------------------------------------------------------------------------

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -448,7 +448,12 @@ def _ufunc_db_function(ufunc):
             super(_KernelImpl, self).__init__(context, builder, outer_sig)
             loop = ufunc_find_matching_loop(
                 ufunc, outer_sig.args + tuple(_unpack_output_types(ufunc, outer_sig)))
-            self.fn = ufunc_db.get_ufunc_info(ufunc).get(loop.ufunc_sig)
+
+            if hasattr(context, 'ufunc_db'):
+                self.fn = context.ufunc_db[ufunc].get(loop.ufunc_sig)
+            else:
+                self.fn = ufunc_db.get_ufunc_info(ufunc).get(loop.ufunc_sig)
+
             self.inner_sig = _ufunc_loop_sig(loop.outputs, loop.inputs)
 
             if self.fn is None:

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -539,7 +539,7 @@ def array_positive_impl(context, builder, sig, args):
 
 def _register_ufuncs():
     kernels = {}
-    # Assuming ufunc implementation for the CPUContext.
+    # NOTE: Assuming ufunc implementation for the CPUContext.
     for ufunc in ufunc_db.get_ufuncs():
         kernels[ufunc] = register_ufunc_kernel(ufunc, _ufunc_db_function(ufunc))
 

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -448,12 +448,7 @@ def _ufunc_db_function(ufunc):
             super(_KernelImpl, self).__init__(context, builder, outer_sig)
             loop = ufunc_find_matching_loop(
                 ufunc, outer_sig.args + tuple(_unpack_output_types(ufunc, outer_sig)))
-
-            if hasattr(context, 'ufunc_db'):
-                self.fn = context.ufunc_db[ufunc].get(loop.ufunc_sig)
-            else:
-                self.fn = ufunc_db.get_ufunc_info(ufunc).get(loop.ufunc_sig)
-
+            self.fn = context.get_ufunc_info(ufunc).get(loop.ufunc_sig)
             self.inner_sig = _ufunc_loop_sig(loop.outputs, loop.inputs)
 
             if self.fn is None:
@@ -544,7 +539,7 @@ def array_positive_impl(context, builder, sig, args):
 
 def _register_ufuncs():
     kernels = {}
-
+    # Assuming ufunc implementation for the CPUContext.
     for ufunc in ufunc_db.get_ufuncs():
         kernels[ufunc] = register_ufunc_kernel(ufunc, _ufunc_db_function(ufunc))
 

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -279,7 +279,7 @@ def supported_ufunc_loop(ufunc, loop):
     legacy and when implementing new ufuncs the ufunc_db should be preferred,
     as it allows for a more fine-grained incremental support.
     """
-    # Assuming ufunc for the CPUContext
+    # NOTE: Assuming ufunc for the CPUContext
     from numba.np import ufunc_db
     loop_sig = loop.ufunc_sig
     try:

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -279,6 +279,7 @@ def supported_ufunc_loop(ufunc, loop):
     legacy and when implementing new ufuncs the ufunc_db should be preferred,
     as it allows for a more fine-grained incremental support.
     """
+    # Assuming ufunc for the CPUContext
     from numba.np import ufunc_db
     loop_sig = loop.ufunc_sig
     try:

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -1789,7 +1789,7 @@ class TestUfuncOnContext(TestCase):
         self.assertEqual(raises.exception.args, (badkey,))
 
     def test_base_get_ufunc_info(self):
-        # The BaseContext always raise NotImplementedError
+        # The BaseContext always raises NotImplementedError
         targetctx = BaseContext(cpu_target.typing_context)
         with self.assertRaises(NotImplementedError) as raises:
             targetctx.get_ufunc_info(np.add)

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -18,6 +18,9 @@ from numba.core.errors import LoweringError, TypingError
 from numba.tests.support import TestCase, CompilationCache, MemoryLeakMixin, tag
 from numba.core.typing.npydecl import supported_ufuncs, all_ufuncs
 from numba.np import numpy_support
+from numba.core.registry import cpu_target
+from numba.core.base import BaseContext
+from numba.np import ufunc_db
 
 is32bits = tuple.__itemsize__ == 4
 iswindows = sys.platform.startswith('win32')
@@ -1766,6 +1769,34 @@ class TestUFuncCompilationThreadSafety(TestCase):
         for t in threads:
             t.join()
         self.assertFalse(errors)
+
+
+class TestUfuncOnContext(TestCase):
+    def test_cpu_get_ufunc_info(self):
+        # The CPU context defines get_ufunc_info that is the same as
+        # ufunc_db.get_ufunc_info.
+        targetctx = cpu_target.target_context
+        # Check: get_ufunc_info returns a dict
+        add_info = targetctx.get_ufunc_info(np.add)
+        self.assertIsInstance(add_info, dict)
+        # Check: it is the same as ufunc_db.get_ufunc_info
+        expected = ufunc_db.get_ufunc_info(np.add)
+        self.assertEqual(add_info, expected)
+        # Check: KeyError raised on bad key
+        badkey = object()
+        with self.assertRaises(KeyError) as raises:
+            ufunc_db.get_ufunc_info(badkey)
+        self.assertEqual(raises.exception.args, (badkey,))
+
+    def test_base_get_ufunc_info(self):
+        # The BaseContext always raise NotImplementedError
+        targetctx = BaseContext(cpu_target.typing_context)
+        with self.assertRaises(NotImplementedError) as raises:
+            targetctx.get_ufunc_info(np.add)
+        self.assertRegex(
+            str(raises.exception),
+            r"<numba\..*\.BaseContext object at .*> does not support ufunc",
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Expanding on https://github.com/numba/numba/pull/6467

- Instead of directly exposing `ufunc_db`, expose a `Context.get_ufunc_info(ufunc_key)` which mirrors the functionality of `ufunc_db.get_ufunc_info`.
- no longer need to branch in npyimpl.py.
