### PR TITLE
ParallelAccelerator no long will convert StaticSetItem to SetItem because record arrays require StaticSetItems.

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -1004,13 +1004,13 @@ class SymbolicEquivSet(ShapeEquivSet):
     def set_shape_setitem(self, obj, shape):
         """remember shapes of SetItem IR nodes.
         """
-        assert isinstance(obj, ir.StaticSetItem) or isinstance(obj, ir.SetItem)
+        assert isinstance(obj, (ir.StaticSetItem, ir.SetItem))
         self.ext_shapes[obj] = shape
 
     def _get_shape(self, obj):
         """Overload _get_shape to retrieve the shape of SetItem IR nodes.
         """
-        if isinstance(obj, ir.StaticSetItem) or isinstance(obj, ir.SetItem):
+        if isinstance(obj, (ir.StaticSetItem, ir.SetItem)):
             require(obj in self.ext_shapes)
             return self.ext_shapes[obj]
         else:
@@ -1252,12 +1252,6 @@ class ArrayAnalysis(object):
         pending_transforms = []
         for inst in block.body:
             redefined = set()
-            if isinstance(inst, ir.StaticSetItem):
-                orig_calltype = self.calltypes[inst]
-                inst = ir.SetItem(
-                    inst.target, inst.index_var, inst.value, inst.loc
-                )
-                self.calltypes[inst] = orig_calltype
             pre, post = self._analyze_inst(
                 label, scope, equiv_set, inst, redefined
             )
@@ -1403,7 +1397,7 @@ class ArrayAnalysis(object):
             if not result:
                 return [], []
             if result[0] is not None:
-                assert isinstance(inst, ir.SetItem)
+                assert isinstance(inst, (ir.StaticSetItem, ir.SetItem))
                 inst.index = result[0]
             result = result[1]
             target_shape = result.kwargs['shape']

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1689,6 +1689,9 @@ class ConvertInplaceBinop:
         return self.pass_states.typingctx.resolve_function_type(fnty, tuple(args), {})
 
 
+def get_index_var(x):
+    return x.index if isinstance(x, ir.SetItem) else x.index_var
+
 class ConvertSetItemPass:
     """Parfor subpass to convert setitem on Arrays
     """
@@ -1713,11 +1716,10 @@ class ConvertSetItemPass:
             new_body = []
             equiv_set = pass_states.array_analysis.get_equiv_set(label)
             for instr in block.body:
-                if isinstance(instr, ir.StaticSetItem) or isinstance(instr, ir.SetItem):
+                if isinstance(instr, (ir.StaticSetItem, ir.SetItem)):
                     loc = instr.loc
                     target = instr.target
-                    index = (instr.index if isinstance(instr, ir.SetItem)
-                             else instr.index_var)
+                    index = get_index_var(instr)
                     value = instr.value
                     target_typ = pass_states.typemap[target.name]
                     index_typ = pass_states.typemap[index.name]
@@ -3435,9 +3437,9 @@ def get_parfor_outputs(parfor, parfor_params):
     outputs = []
     for blk in parfor.loop_body.values():
         for stmt in blk.body:
-            if isinstance(stmt, ir.SetItem):
-                if stmt.index.name == parfor.index_var.name:
-                    outputs.append(stmt.target.name)
+            if (isinstance(stmt, (ir.StaticSetItem, ir.SetItem)) and
+                get_index_var(stmt).name == parfor.index_var.name):
+                outputs.append(stmt.target.name)
     # make sure these written arrays are in parfor parameters (live coming in)
     outputs = list(set(outputs) & set(parfor_params))
     return sorted(outputs)
@@ -4135,8 +4137,8 @@ def remove_dead_parfor(parfor, lives, lives_n_aliases, arg_aliases, alias_map, f
             alias_lives = in_lives & alias_set
             for v in alias_lives:
                 in_lives |= alias_map[v]
-            if (isinstance(stmt, ir.SetItem) and
-                stmt.index.name == parfor.index_var.name and
+            if (isinstance(stmt, (ir.StaticSetItem, ir.SetItem)) and
+                get_index_var(stmt).name == parfor.index_var.name and
                 stmt.target.name not in in_lives and
                 stmt.target.name not in arg_aliases):
                 continue
@@ -4173,8 +4175,9 @@ def _update_parfor_get_setitems(block_body, index_var, alias_map,
     replace getitems of a previously set array in a block of parfor loop body
     """
     for stmt in block_body:
-        if (isinstance(stmt, ir.SetItem) and stmt.index.name ==
-                index_var.name and stmt.target.name not in lives):
+        if (isinstance(stmt, (ir.StaticSetItem, ir.SetItem)) and
+            get_index_var(stmt).name == index_var.name and
+            stmt.target.name not in lives):
             # saved values of aliases of SetItem target array are invalid
             for w in alias_map.get(stmt.target.name, []):
                 saved_values.pop(w, None)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1692,6 +1692,7 @@ class ConvertInplaceBinop:
 def get_index_var(x):
     return x.index if isinstance(x, ir.SetItem) else x.index_var
 
+
 class ConvertSetItemPass:
     """Parfor subpass to convert setitem on Arrays
     """

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -717,7 +717,7 @@ def _hoist_internal(inst, dep_on_param, call_table, hoisted, not_hoisted,
 
 def find_setitems_block(setitems, itemsset, block, typemap):
     for inst in block.body:
-        if isinstance(inst, ir.StaticSetItem) or isinstance(inst, ir.SetItem):
+        if isinstance(inst, (ir.StaticSetItem, ir.SetItem)):
             setitems.add(inst.target.name)
             # If we store a non-mutable object into an array then that is safe to hoist.
             # If the stored object is mutable and you hoist then multiple entries in the

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2801,7 +2801,7 @@ class TestPrange(TestPrangeBase):
         self.prange_tester(test_impl)
 
     @skip_parfors_unsupported
-    def test_record_array(self):
+    def test_record_array_setitem(self):
         # issue6704
         state_dtype = np.dtype([('var', np.int32)])
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2800,6 +2800,22 @@ class TestPrange(TestPrangeBase):
 
         self.prange_tester(test_impl)
 
+    @skip_parfors_unsupported
+    def test_record_array(self):
+        # issue6704
+        state_dtype = np.dtype([('var', np.int32)])
+
+        def test_impl(states):
+            for i in range(1):
+                states[i]['var'] = 1
+
+        def comparer(a, b):
+            assert(a[0]['var'] == b[0]['var'])
+
+        self.prange_tester(test_impl,
+                           np.empty(shape=1, dtype=state_dtype),
+                           check_arg_equality=[comparer])
+
 
 @skip_parfors_unsupported
 @x86_only

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2813,7 +2813,7 @@ class TestPrange(TestPrangeBase):
             assert(a[0]['var'] == b[0]['var'])
 
         self.prange_tester(test_impl,
-                           np.empty(shape=1, dtype=state_dtype),
+                           np.zeros(shape=1, dtype=state_dtype),
                            check_arg_equality=[comparer])
 
     @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2816,6 +2816,25 @@ class TestPrange(TestPrangeBase):
                            np.empty(shape=1, dtype=state_dtype),
                            check_arg_equality=[comparer])
 
+    @skip_parfors_unsupported
+    def test_record_array_setitem_yield_array(self):
+        state_dtype = np.dtype([('x', np.intp)])
+
+        def test_impl(states):
+            n = states.size
+            for i in range(states.size):
+                states["x"][i] = 7 + i
+            return states
+
+        states = np.zeros(10, dtype=state_dtype)
+
+        def comparer(a, b):
+            np.testing.assert_equal(a, b)
+
+        self.prange_tester(test_impl,
+                           states,
+                           check_arg_equality=[comparer])
+
 
 @skip_parfors_unsupported
 @x86_only


### PR DESCRIPTION
Resolves #6704.
