### PR TITLE
#3468 continued: Add support for `np.clip`

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -276,6 +276,7 @@ The following methods of Numpy arrays are supported in their basic form
 * :meth:`~numpy.ndarray.any`
 * :meth:`~numpy.ndarray.argmax`
 * :meth:`~numpy.ndarray.argmin`
+* :meth:`~numpy.ndarray.clip`
 * :meth:`~numpy.ndarray.conj`
 * :meth:`~numpy.ndarray.conjugate`
 * :meth:`~numpy.ndarray.cumprod`

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1800,40 +1800,26 @@ def np_clip(a, a_min, a_max, out=None):
     a_min_is_none = a_min is None or isinstance(a_min, types.NoneType)
     a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)
 
-    if a_min_is_none and a_max_is_none:
-        def np_clip_impl(a, a_min, a_max, out=None):
-            # implementation for no bounds
+    def np_clip_impl(a, a_min, a_max, out=None):
+        if a_min_is_none and a_max_is_none:
             raise ValueError("array_clip: must set either max or min")
 
-    elif a_min_is_none:
-        def np_clip_impl(a, a_min, a_max, out=None):
-            # implementation for upper-bound only
-            ret = _alloc_out(a, out)
-            for index, val in np.ndenumerate(a):
+        ret = _alloc_out(a, out)
+
+        for index, val in np.ndenumerate(a):
+            if a_min_is_none:
                 if val > a_max:
                     ret[index] = a_max
                 else:
                     ret[index] = val
-            return ret
-
-    elif a_max_is_none:
-        def np_clip_impl(a, a_min, a_max, out=None):
-            # implementation for lower-bound only
-            ret = _alloc_out(a, out)
-            for index, val in np.ndenumerate(a):
+            elif a_max_is_none:
                 if val < a_min:
                     ret[index] = a_min
                 else:
                     ret[index] = val
-            return ret
-
-    else:
-        def np_clip_impl(a, a_min, a_max, out=None):
-            # implementation when both bounds defined
-            ret = _alloc_out(a, out)
-            for index, val in np.ndenumerate(a):
+            else:
                 ret[index] = min(max(val, a_min), a_max)
-            return ret
+        return ret
 
     return np_clip_impl
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1776,6 +1776,19 @@ def array_flatten(context, builder, sig, args):
 
 @overload(np.clip)
 def np_clip(a, a_min, a_max, out=None):
+    if not type_can_asarray(a):
+        raise errors.TypingError('The argument "a" must be array-like')
+
+    if not isinstance(a_min, (types.NoneType, types.Number)):
+        raise errors.TypingError('The argument "a_min" must be a number')
+
+    if not isinstance(a_max, (types.NoneType, types.Number)):
+        raise errors.TypingError('The argument "a_max" must be a number')
+
+    if not isinstance(out, (types.NoneType, types.Array)):
+        msg = 'The argument "out" must be an array if it is provided'
+        raise errors.TypingError(msg)
+
     # TODO: support scalar a (issue #3469)
     a_min_is_none = a_min is None or isinstance(a_min, types.NoneType)
     a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1774,6 +1774,82 @@ def array_flatten(context, builder, sig, args):
     return res
 
 
+def _alloc_out(a, X):
+    # dummy function that takes the arg we need to resolved (X)
+    # and the information needed to do so (a)
+    pass
+
+
+@overload(_alloc_out)
+def _alloc_out_impl(a, X):
+    # overload the dummy function to return empty_like(a) if X is None else X
+    # with type-specific implementations, in order to fully determine type of X
+    # https://github.com/numba/numba/pull/3468#issuecomment-437974147
+    if X is None or isinstance(X, types.NoneType):
+        def impl(a, X):
+            return np.empty_like(a)
+    else:
+        def impl(a, X):
+            return X
+    return impl
+
+
+@overload(np.clip)
+def np_clip(a, a_min, a_max, out=None):
+    # TODO: support scalar a (issue #3469)
+    a_min_is_none = a_min is None or isinstance(a_min, types.NoneType)
+    a_max_is_none = a_max is None or isinstance(a_max, types.NoneType)
+
+    if a_min_is_none and a_max_is_none:
+        def np_clip_impl(a, a_min, a_max, out=None):
+            # implementation for no bounds
+            raise ValueError("array_clip: must set either max or min")
+
+    elif a_min_is_none:
+        def np_clip_impl(a, a_min, a_max, out=None):
+            # implementation for upper-bound only
+            ret = _alloc_out(a, out)
+            for index, val in np.ndenumerate(a):
+                if val > a_max:
+                    ret[index] = a_max
+                else:
+                    ret[index] = val
+            return ret
+
+    elif a_max_is_none:
+        def np_clip_impl(a, a_min, a_max, out=None):
+            # implementation for lower-bound only
+            ret = _alloc_out(a, out)
+            for index, val in np.ndenumerate(a):
+                if val < a_min:
+                    ret[index] = a_min
+                else:
+                    ret[index] = val
+            return ret
+
+    else:
+        def np_clip_impl(a, a_min, a_max, out=None):
+            # implementation when both bounds defined
+            ret = _alloc_out(a, out)
+            for index, val in np.ndenumerate(a):
+                if val < a_min:
+                    ret[index] = a_min
+                elif val > a_max:
+                    ret[index] = a_max
+                else:
+                    ret[index] = val
+            return ret
+
+    return np_clip_impl
+
+
+@overload_method(types.Array, 'clip')
+def array_clip(a, a_min=None, a_max=None, out=None):
+    def impl(a, a_min=None, a_max=None, out=None):
+        return np.clip(a, a_min, a_max, out)
+    return impl
+
+
 def _change_dtype(context, builder, oldty, newty, ary):
     """
     Attempt to fix up *ary* for switching from *oldty* to *newty*.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1832,12 +1832,7 @@ def np_clip(a, a_min, a_max, out=None):
             # implementation when both bounds defined
             ret = _alloc_out(a, out)
             for index, val in np.ndenumerate(a):
-                if val < a_min:
-                    ret[index] = a_min
-                elif val > a_max:
-                    ret[index] = a_max
-                else:
-                    ret[index] = val
+                ret[index] = min(max(val, a_min), a_max)
             return ret
 
     return np_clip_impl

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1774,26 +1774,6 @@ def array_flatten(context, builder, sig, args):
     return res
 
 
-def _alloc_out(a, X):
-    # dummy function that takes the arg we need to resolved (X)
-    # and the information needed to do so (a)
-    pass
-
-
-@overload(_alloc_out)
-def _alloc_out_impl(a, X):
-    # overload the dummy function to return empty_like(a) if X is None else X
-    # with type-specific implementations, in order to fully determine type of X
-    # https://github.com/numba/numba/pull/3468#issuecomment-437974147
-    if X is None or isinstance(X, types.NoneType):
-        def impl(a, X):
-            return np.empty_like(a)
-    else:
-        def impl(a, X):
-            return X
-    return impl
-
-
 @overload(np.clip)
 def np_clip(a, a_min, a_max, out=None):
     # TODO: support scalar a (issue #3469)
@@ -1804,7 +1784,7 @@ def np_clip(a, a_min, a_max, out=None):
         if a_min_is_none and a_max_is_none:
             raise ValueError("array_clip: must set either max or min")
 
-        ret = _alloc_out(a, out)
+        ret = np.empty_like(a) if out is None else out
 
         for index, val in np.ndenumerate(a):
             if a_min_is_none:

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1350,9 +1350,8 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                            array_clip_kwargs]:
                 cfunc = jit(nopython=True)(pyfunc)
 
-                with self.assertRaises(ValueError):
-                    pyfunc(a, None, None)
-                with self.assertRaises(ValueError):
+                msg = "array_clip: must set either max or min"
+                with self.assertRaisesRegex(ValueError, msg):
                     cfunc(a, None, None)
 
                 np.testing.assert_equal(pyfunc(a, 0, None), cfunc(a, 0, None))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -241,6 +241,10 @@ def np_clip_kwargs(a, a_min, a_max, out=None):
 def array_clip(a, a_min=None, a_max=None, out=None):
     return a.clip(a_min, a_max, out)
 
+def array_clip_kwargs(a, a_min=None, a_max=None, out=None):
+    return a.clip(a_min, a_max, out=out)
+
+
 def array_conj(a):
     return a.conj()
 
@@ -1342,7 +1346,8 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # TODO: scalars are not tested (issue #3469)
         for a in (np.linspace(-10, 10, 101),
                   np.linspace(-10, 10, 40).reshape(5, 2, 4)):
-            for pyfunc in [np_clip, np_clip_kwargs, array_clip]:
+            for pyfunc in [np_clip, np_clip_kwargs, array_clip,
+                           array_clip_kwargs]:
                 cfunc = jit(nopython=True)(pyfunc)
 
                 with self.assertRaises(ValueError):

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1366,7 +1366,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                 # verifies that type-inference is working on the return value
                 # this used to trigger issue #3489
                 def lower_clip_result(a):
-                    return np.expm1(pyfunc(a, -5, 5))
+                    return np.expm1(cfunc(a, -5, 5))
                 np.testing.assert_almost_equal(
                     lower_clip_result(a),
                     jit(nopython=True)(lower_clip_result)(a))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -235,6 +235,9 @@ def array_imag(a):
 def np_clip(a, a_min, a_max, out=None):
     return np.clip(a, a_min, a_max, out)
 
+def np_clip_kwargs(a, a_min, a_max, out=None):
+    return np.clip(a, a_min, a_max, out=out)
+
 def array_clip(a, a_min=None, a_max=None, out=None):
     return a.clip(a_min, a_max, out)
 
@@ -1339,7 +1342,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         # TODO: scalars are not tested (issue #3469)
         for a in (np.linspace(-10, 10, 101),
                   np.linspace(-10, 10, 40).reshape(5, 2, 4)):
-            for pyfunc in [np_clip, array_clip]:
+            for pyfunc in [np_clip, np_clip_kwargs, array_clip]:
                 cfunc = jit(nopython=True)(pyfunc)
 
                 with self.assertRaises(ValueError):

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1374,6 +1374,30 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                     lower_clip_result(a),
                     jit(nopython=True)(lower_clip_result)(a))
 
+    def test_clip_bad_array(self):
+        cfunc = jit(nopython=True)(np_clip)
+        msg = '.*The argument "a" must be array-like.*'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(None, 0, 10)
+
+    def test_clip_bad_min(self):
+        cfunc = jit(nopython=True)(np_clip)
+        msg = '.*The argument "a_min" must be a number.*'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(1, 'a', 10)
+
+    def test_clip_bad_max(self):
+        cfunc = jit(nopython=True)(np_clip)
+        msg = '.*The argument "a_max" must be a number.*'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(1, 1, 'b')
+
+    def test_clip_bad_out(self):
+        cfunc = jit(nopython=True)(np_clip)
+        msg = '.*The argument "out" must be an array if it is provided.*'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(5, 1, 10, out=6)
+
     def test_conj(self):
         for pyfunc in [array_conj, array_conjugate]:
             cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -1365,14 +1365,6 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
                                         cfunc(a, -5, 5, cout))
                 np.testing.assert_equal(pyout, cout)
 
-                # This test exhibits undefined behaviour since min > max, but
-                # we'll make sure it's consistent with NumPy, which computes
-                # min(max(val, a_min), a_max) since 1.17. Prior to that min and
-                # max were the other way round, so we're not consistent with
-                # older NumPy versions.
-                if numpy_version > (1, 16):
-                    np.testing.assert_equal(pyfunc(a, 8, 5), cfunc(a, 8, 5))
-
                 # verifies that type-inference is working on the return value
                 # this used to trigger issue #3489
                 def lower_clip_result(a):


### PR DESCRIPTION
This PR contains the code from #3468, rebased on master and current issues resolved. After rebasing, the following two issues were present:

1. NumPy behaviour for clip where min > max changed, making the check `np.testing.assert_equal(pyfunc(a, 8, 5), cfunc(a, 8, 5))` fail. The fix to this is to implement `np_clip_impl` similarly to `_NPY_CLIP`, which is defined as `_NPY_<type>_MIN(_NPY_<type>_MAX((x), (min)), (max))`.
2. The `lower_clip_result` function in the test should call the jitted function, not the Python one.

cc @arvoelke