### PR TITLE
#3203 additional info in cuda detect

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -491,8 +491,9 @@ def detect():
         attrs += [('pci device id', dev.PCI_DEVICE_ID)]
         attrs += [('pci bus id', dev.PCI_BUS_ID)]
         attrs += [('Watchdog Enabled', dev.KERNEL_EXEC_TIMEOUT)]
-        attrs += [('Compute Mode', dev.TCC_DRIVER)]
-        attrs += [('Single To Double Precision Perf ratio', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
+        attrs += [('Compute Mode', "TCC" if dev.TCC_DRIVER else "WDDM")]
+        # A large number (>3) indicates a card with slow double precision.
+        attrs += [('FP32:FP64 Performance', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'
         else:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -492,8 +492,8 @@ def detect():
         attrs += [('pci bus id', dev.PCI_BUS_ID)]
         attrs += [('Watchdog Enabled', dev.KERNEL_EXEC_TIMEOUT)]
         attrs += [('Compute Mode', "TCC" if dev.TCC_DRIVER else "WDDM")]
-        # A large number of FP32 to FP64 ratio(>3) indicates a card with slow double precision.
-        attrs += [('FP32/FP64 Performance Ratio', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
+        attrs += [('FP32/FP64 Performance Ratio',
+                   dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'
         else:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -4,6 +4,7 @@ API that are reported to numba.cuda
 
 
 import contextlib
+import os
 
 import numpy as np
 
@@ -494,7 +495,8 @@ def detect():
         attrs += [('PCI Device ID', dev.PCI_DEVICE_ID)]
         attrs += [('PCI Bus ID', dev.PCI_BUS_ID)]
         attrs += [('Watchdog', 'Enabled' if kernel_timeout else 'Disabled')]
-        attrs += [('Compute Mode', 'TCC' if tcc else 'WDDM')]
+        if os.name == "nt":
+            attrs += [('Compute Mode', 'TCC' if tcc else 'WDDM')]
         attrs += [('FP32/FP64 Performance Ratio', fp32_to_fp64_ratio)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -490,6 +490,9 @@ def detect():
         attrs += [('compute capability', '%d.%d' % cc)]
         attrs += [('pci device id', dev.PCI_DEVICE_ID)]
         attrs += [('pci bus id', dev.PCI_BUS_ID)]
+        attrs += [('Watchdog Enabled', dev.KERNEL_EXEC_TIMEOUT)]
+        attrs += [('Compute Mode', dev.TCC_DRIVER)]
+        attrs += [('Single To Double Precision Perf ratio', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'
         else:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -487,13 +487,15 @@ def detect():
     for dev in devlist:
         attrs = []
         cc = dev.compute_capability
+        kernel_timeout = dev.KERNEL_EXEC_TIMEOUT
+        tcc = dev.TCC_DRIVER
+        fp32_to_fp64_ratio = dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO
         attrs += [('Compute Capability', '%d.%d' % cc)]
         attrs += [('PCI Device ID', dev.PCI_DEVICE_ID)]
         attrs += [('PCI Bus ID', dev.PCI_BUS_ID)]
-        attrs += [('Watchdog', "Enabled" if dev.KERNEL_EXEC_TIMEOUT else "Disabled")]
-        attrs += [('Compute Mode', "TCC" if dev.TCC_DRIVER else "WDDM")]
-        attrs += [('FP32/FP64 Performance Ratio',
-                   dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
+        attrs += [('Watchdog', 'Enabled' if kernel_timeout else 'Disabled')]
+        attrs += [('Compute Mode', 'TCC' if tcc else 'WDDM')]
+        attrs += [('FP32/FP64 Performance Ratio', fp32_to_fp64_ratio)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'
         else:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -492,8 +492,8 @@ def detect():
         attrs += [('pci bus id', dev.PCI_BUS_ID)]
         attrs += [('Watchdog Enabled', dev.KERNEL_EXEC_TIMEOUT)]
         attrs += [('Compute Mode', "TCC" if dev.TCC_DRIVER else "WDDM")]
-        # A large number (>3) indicates a card with slow double precision.
-        attrs += [('FP32:FP64 Performance', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
+        # A large number of FP32 to FP64 ratio(>3) indicates a card with slow double precision.
+        attrs += [('FP32/FP64 Performance Ratio', dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]
         if cc < (2, 0):
             support = '[NOT SUPPORTED: CC < 2.0]'
         else:

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -487,10 +487,10 @@ def detect():
     for dev in devlist:
         attrs = []
         cc = dev.compute_capability
-        attrs += [('compute capability', '%d.%d' % cc)]
-        attrs += [('pci device id', dev.PCI_DEVICE_ID)]
-        attrs += [('pci bus id', dev.PCI_BUS_ID)]
-        attrs += [('Watchdog Enabled', dev.KERNEL_EXEC_TIMEOUT)]
+        attrs += [('Compute Capability', '%d.%d' % cc)]
+        attrs += [('PCI Device ID', dev.PCI_DEVICE_ID)]
+        attrs += [('PCI Bus ID', dev.PCI_BUS_ID)]
+        attrs += [('Watchdog', "Enabled" if dev.KERNEL_EXEC_TIMEOUT else "Disabled")]
         attrs += [('Compute Mode', "TCC" if dev.TCC_DRIVER else "WDDM")]
         attrs += [('FP32/FP64 Performance Ratio',
                    dev.SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO)]


### PR DESCRIPTION
PR related to Issue #3203.

`numba.cuda.detect()` now prints `Watchdog Enabled` Status, `Compute Mode` and `Single precision to Double-precision performance ratio`