### PR TITLE
Fix tiny formatting error in ROC kernel docs

### DIFF
--- a/docs/source/roc/kernels.rst
+++ b/docs/source/roc/kernels.rst
@@ -95,7 +95,7 @@ workitem per workgroup) is often crucial:
 * On the software side, the workgroup size determines how many threads
   share a given area of :ref:`shared memory <roc-shared-memory>`.
 * On the hardware side, the workgroup size must be large enough for full
-   occupation of execution units.
+  occupation of execution units.
 
 Multi-dimensional workgroup and grid
 ---------------------------------------


### PR DESCRIPTION
Removes a tiny space that caused a the bullet point in the list list to be printed in bold instead. Noticed it [here](https://numba.readthedocs.io/en/stable/roc/kernels.html#choosing-the-workgroup-size).

![Screenshot from 2021-03-09 19-51-17](https://user-images.githubusercontent.com/4403130/110522363-1a43a500-8111-11eb-92c5-214616fff978.png)
