### PR TITLE
CUDA: Remove test of runtime being a supported version

### DIFF
--- a/numba/cuda/tests/cudadrv/test_runtime.py
+++ b/numba/cuda/tests/cudadrv/test_runtime.py
@@ -27,9 +27,6 @@ else:
 
 
 class TestRuntime(unittest.TestCase):
-    def test_get_version(self):
-        self.assertIn(runtime.get_version(), SUPPORTED_VERSIONS)
-
     def test_is_supported_version_true(self):
         for v in SUPPORTED_VERSIONS:
             with patch.object(runtime, 'get_version', return_value=v):


### PR DESCRIPTION
This test fails if one uses a CUDA runtime version that is not recognized as being supported by Numba. The problem with this is that a user running the tests against a newer version of CUDA (supposing a version 11.3, or 12.x version existed) would report this test as failing, even though there might not be anything wrong with using the current version of Numba with the future CUDA toolkit version. (Running the version of Numba with a newer toolkit might not be officially supported, but that's no reason to prevent the test suite from passing 100% with it if it otherwise would have done)

This PR removes the offending test.