### PR TITLE
Mostly CUDA: Replace llvmpy API usage with llvmlite APIs

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -428,7 +428,7 @@ class BaseContext(object):
 
     def declare_function(self, module, fndesc):
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        fn = cgutils.get_or_insert_function(module, fnty, name=fndesc.mangled_name)
+        fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)
         self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes, noalias=fndesc.noalias)
         if fndesc.inline:
             fn.attributes.add('alwaysinline')
@@ -436,7 +436,7 @@ class BaseContext(object):
 
     def declare_external_function(self, module, fndesc):
         fnty = self.get_external_function_type(fndesc)
-        fn = module.get_or_insert_function(fnty, name=fndesc.mangled_name)
+        fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)
         assert fn.is_declaration
         for ak, av in zip(fndesc.args, fn.args):
             av.name = "arg.%s" % ak
@@ -787,7 +787,7 @@ class BaseContext(object):
         mod = builder.module
         cstring = GENERIC_POINTER
         fnty = Type.function(Type.int(), [cstring])
-        puts = mod.get_or_insert_function(fnty, "puts")
+        puts = cgutils.get_or_insert_function(mod, fnty, "puts")
         return builder.call(puts, [text])
 
     def debug_print(self, builder, text):
@@ -802,7 +802,7 @@ class BaseContext(object):
         else:
             cstr = format_string
         fnty = Type.function(Type.int(), (GENERIC_POINTER,), var_arg=True)
-        fn = mod.get_or_insert_function(fnty, "printf")
+        fn = cgutils.get_or_insert_function(mod, fnty, "printf")
         return builder.call(fn, (cstr,) + tuple(args))
 
     def get_struct_type(self, struct):

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -766,7 +766,7 @@ class BaseContext(object):
         try:
             gv = module.get_global_variable_named(name)
         except LLVMException:
-            gv = module.add_global_variable(typ, name)
+            gv = cgutils.add_global_variable(module, typ, name)
             if dllimport and self.aot_mode and sys.platform == 'win32':
                 gv.storage_class = "dllimport"
         return gv
@@ -1087,7 +1087,7 @@ class BaseContext(object):
         addr = self.get_constant(types.uintp, intaddr).inttoptr(llvoidptr)
         # Use a unique name by embedding the address value
         symname = 'numba.dynamic.globals.{:x}'.format(intaddr)
-        gv = mod.add_global_variable(llvoidptr, name=symname)
+        gv = cgutils.add_global_variable(mod, llvoidptr, symname)
         # Use linkonce linkage to allow merging with other GV of the same name.
         # And, avoid optimization from assuming its value.
         gv.linkage = 'linkonce'

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -764,8 +764,8 @@ class BaseContext(object):
         """
         module = builder.function.module
         try:
-            gv = module.get_global_variable_named(name)
-        except LLVMException:
+            gv = module.globals[name]
+        except KeyError:
             gv = cgutils.add_global_variable(module, typ, name)
             if dllimport and self.aot_mode and sys.platform == 'win32':
                 gv.storage_class = "dllimport"
@@ -1122,7 +1122,7 @@ class BaseContext(object):
     def create_module(self, name):
         """Create a LLVM module
         """
-        return lc.Module(name)
+        return ir.Module(name)
 
     @property
     def active_code_library(self):

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -428,7 +428,7 @@ class BaseContext(object):
 
     def declare_function(self, module, fndesc):
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        fn = module.get_or_insert_function(fnty, name=fndesc.mangled_name)
+        fn = cgutils.get_or_insert_function(module, fnty, name=fndesc.mangled_name)
         self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes, noalias=fndesc.noalias)
         if fndesc.inline:
             fn.attributes.add('alwaysinline')

--- a/numba/core/callwrapper.py
+++ b/numba/core/callwrapper.py
@@ -1,5 +1,6 @@
 from llvmlite.llvmpy.core import Type, Builder, Constant
 import llvmlite.llvmpy.core as lc
+from llvmlite import ir
 
 from numba.core import types, config, cgutils
 
@@ -105,7 +106,7 @@ class PyCallWrapper(object):
         # (see CPython's methodobject.h)
         pyobj = self.context.get_argument_type(types.pyobject)
         wrapty = Type.function(pyobj, [pyobj, pyobj, pyobj])
-        wrapper = self.module.add_function(wrapty, name=wrapname)
+        wrapper = ir.Function(self.module, wrapty, name=wrapname)
 
         builder = Builder(wrapper.append_basic_block('entry'))
 

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -410,6 +410,29 @@ def insert_pure_function(module, fnty, name):
     return fn
 
 
+def get_or_insert_function(module, fnty, name):
+    """
+    Get the function named *name* with type *fnty* from *module*, or insert it
+    if it doesn't exist.
+    """
+    fn = module.globals.get(name, None)
+    if fn is None:
+        fn = ir.Function(module, fnty, name)
+    return fn
+
+
+def get_or_insert_named_metadata(module, name):
+    try:
+        return module.get_named_metadata(name)
+    except KeyError:
+        return module.add_named_metadata(name)
+
+
+def add_global_variable(module, ty, name, addrspace=0):
+    unique_name = module.get_unique_name(name)
+    return ir.GlobalVariable(module, ty, unique_name, addrspace)
+
+
 def terminate(builder, bbend):
     bb = builder.basic_block
     if bb.terminator is None:
@@ -935,7 +958,7 @@ def global_constant(builder_or_module, name, value, linkage='internal'):
         module = builder_or_module
     else:
         module = builder_or_module.module
-    data = module.add_global_variable(value.type, name=name)
+    data = add_global_variable(module, value.type, name)
     data.linkage = linkage
     data.global_constant = True
     data.initializer = value

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -404,7 +404,7 @@ def insert_pure_function(module, fnty, name):
     Insert a pure function (in the functional programming sense) in the
     given module.
     """
-    fn = module.get_or_insert_function(fnty, name=name)
+    fn = get_or_insert_function(module, fnty, name)
     fn.attributes.add("readonly")
     fn.attributes.add("nounwind")
     return fn

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1126,7 +1126,7 @@ class BaseCPUCodegen(object):
                                       self._library_class._object_getbuffer_hook)
 
     def _create_empty_module(self, name):
-        ir_module = lc.Module(cgutils.normalize_ir_text(name))
+        ir_module = llvmir.Module(cgutils.normalize_ir_text(name))
         ir_module.triple = ll.get_process_triple()
         if self._data_layout:
             ir_module.data_layout = self._data_layout

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -156,7 +156,7 @@ class CPUContext(BaseContext):
                                release_gil=False):
         wrapper_module = self.create_module("wrapper")
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        wrapper_callee = wrapper_module.add_function(fnty, fndesc.llvm_func_name)
+        wrapper_callee = ir.Function(wrapper_module, fnty, fndesc.llvm_func_name)
         builder = PyCallWrapper(self, wrapper_module, wrapper_callee,
                                 fndesc, env, call_helper=call_helper,
                                 release_gil=release_gil)
@@ -167,13 +167,13 @@ class CPUContext(BaseContext):
 
         wrapper_module = self.create_module("cfunc_wrapper")
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        wrapper_callee = wrapper_module.add_function(fnty, fndesc.llvm_func_name)
+        wrapper_callee = ir.Function(wrapper_module, fnty, fndesc.llvm_func_name)
 
         ll_argtypes = [self.get_value_type(ty) for ty in fndesc.argtypes]
         ll_return_type = self.get_value_type(fndesc.restype)
 
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)
-        wrapfn = wrapper_module.add_function(wrapty, fndesc.llvm_cfunc_wrapper_name)
+        wrapfn = ir.Function(wrapper_module, wrapty, fndesc.llvm_cfunc_wrapper_name)
         builder = ir.IRBuilder(wrapfn.append_basic_block('entry'))
 
         status, out = self.call_conv.call_function(

--- a/numba/core/generators.py
+++ b/numba/core/generators.py
@@ -177,8 +177,8 @@ class BaseGeneratorLower(object):
         """
         fnty = Type.function(Type.void(),
                              [self.context.get_value_type(self.gentype)])
-        function = lower.module.get_or_insert_function(
-            fnty, name=self.gendesc.llvm_finalizer_name)
+        function = cgutils.get_or_insert_function(
+            lower.module, fnty, self.gendesc.llvm_finalizer_name)
         entry_block = function.append_basic_block('entry')
         builder = Builder(entry_block)
 

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1217,9 +1217,10 @@ class PythonAPI(object):
             cgutils.voidptr_t,
             [cgutils.voidptr_t, cgutils.voidptr_t],
             )
-        fn = mod.get_or_insert_function(
+        fn = cgutils.get_or_insert_function(
+            mod,
             fnty,
-            name="NRT_meminfo_new_from_pyobject",
+            "NRT_meminfo_new_from_pyobject",
             )
         fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
         fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
@@ -1232,9 +1233,10 @@ class PythonAPI(object):
             self.pyobj,
             [cgutils.voidptr_t]
         )
-        fn = mod.get_or_insert_function(
+        fn = cgutils.get_or_insert_function(
+            mod,
             fnty,
-            name='NRT_meminfo_as_pyobject',
+            'NRT_meminfo_as_pyobject',
         )
         fn.return_value.add_attribute("noalias")
         return self.builder.call(fn, [miptr])
@@ -1245,9 +1247,10 @@ class PythonAPI(object):
             cgutils.voidptr_t,
             [self.pyobj]
         )
-        fn = mod.get_or_insert_function(
+        fn = cgutils.get_or_insert_function(
+            mod,
             fnty,
-            name='NRT_meminfo_from_pyobject',
+            'NRT_meminfo_from_pyobject',
         )
         fn.return_value.add_attribute("noalias")
         return self.builder.call(fn, [miobj])
@@ -1272,7 +1275,7 @@ class PythonAPI(object):
     # ------ utils -----
 
     def _get_function(self, fnty, name):
-        return self.module.get_or_insert_function(fnty, name=name)
+        return cgutils.get_or_insert_function(self.module, fnty, name)
 
     def alloca_obj(self):
         return self.builder.alloca(self.pyobj)

--- a/numba/core/runtime/context.py
+++ b/numba/core/runtime/context.py
@@ -24,7 +24,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = mod.get_or_insert_function(fnty, name="NRT_Allocate")
+        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_Allocate")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
@@ -36,7 +36,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(), [cgutils.voidptr_t])
-        fn = mod.get_or_insert_function(fnty, name="NRT_Free")
+        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_Free")
         return builder.call(fn, [ptr])
 
     def meminfo_alloc(self, builder, size):
@@ -49,7 +49,7 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_alloc_safe")
+        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_MemInfo_alloc_safe")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
@@ -59,8 +59,8 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = mod.get_or_insert_function(fnty,
-                                        name="NRT_MemInfo_alloc_dtor_safe")
+        fn = cgutils.get_or_insert_function(mod, fnty,
+                                            "NRT_MemInfo_alloc_dtor_safe")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size,
                                  builder.bitcast(dtor, cgutils.voidptr_t)])
@@ -78,8 +78,8 @@ class NRTContext(object):
         mod = builder.module
         u32 = ir.IntType(32)
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t, u32])
-        fn = mod.get_or_insert_function(fnty,
-                                        name="NRT_MemInfo_alloc_safe_aligned")
+        fn = cgutils.get_or_insert_function(mod, fnty,
+                                            "NRT_MemInfo_alloc_safe_aligned")
         fn.return_value.add_attribute("noalias")
         if isinstance(align, int):
             align = self._context.get_constant(types.uint32, align)
@@ -99,7 +99,8 @@ class NRTContext(object):
 
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t, [cgutils.intp_t])
-        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_new_varsize")
+        fn = cgutils.get_or_insert_function(mod, fnty,
+                                            "NRT_MemInfo_new_varsize")
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [size])
 
@@ -113,8 +114,8 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.intp_t, cgutils.voidptr_t])
-        fn = mod.get_or_insert_function(
-            fnty, name="NRT_MemInfo_new_varsize_dtor")
+        fn = cgutils.get_or_insert_function(
+            mod, fnty, "NRT_MemInfo_new_varsize_dtor")
         return builder.call(fn, [size, dtor])
 
     def meminfo_varsize_alloc(self, builder, meminfo, size):
@@ -149,7 +150,8 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(ir.VoidType(),
                                [cgutils.voidptr_t, cgutils.voidptr_t])
-        fn = mod.get_or_insert_function(fnty, name="NRT_MemInfo_varsize_free")
+        fn = cgutils.get_or_insert_function(mod, fnty,
+                                            "NRT_MemInfo_varsize_free")
         return builder.call(fn, (meminfo, ptr))
 
     def _call_varsize_alloc(self, builder, meminfo, size, funcname):
@@ -158,7 +160,7 @@ class NRTContext(object):
         mod = builder.module
         fnty = ir.FunctionType(cgutils.voidptr_t,
                                [cgutils.voidptr_t, cgutils.intp_t])
-        fn = mod.get_or_insert_function(fnty, name=funcname)
+        fn = cgutils.get_or_insert_function(mod, fnty, funcname)
         fn.return_value.add_attribute("noalias")
         return builder.call(fn, [meminfo, size])
 
@@ -173,8 +175,8 @@ class NRTContext(object):
         from numba.core.runtime.nrtdynmod import meminfo_data_ty
 
         mod = builder.module
-        fn = mod.get_or_insert_function(meminfo_data_ty,
-                                        name="NRT_MemInfo_data_fast")
+        fn = cgutils.get_or_insert_function(mod, meminfo_data_ty,
+                                            "NRT_MemInfo_data_fast")
         return builder.call(fn, [meminfo])
 
     def get_meminfos(self, builder, ty, val):
@@ -204,7 +206,8 @@ class NRTContext(object):
         meminfos = self.get_meminfos(builder, typ, value)
         for _, mi in meminfos:
             mod = builder.module
-            fn = mod.get_or_insert_function(incref_decref_ty, name=funcname)
+            fn = cgutils.get_or_insert_function(mod, incref_decref_ty,
+                                                funcname)
             # XXX "nonnull" causes a crash in test_dyn_array: can this
             # function be called with a NULL pointer?
             fn.args[0].add_attribute("noalias")
@@ -230,7 +233,7 @@ class NRTContext(object):
 
         fnty = ir.FunctionType(cgutils.voidptr_t, ())
         mod = builder.module
-        fn = mod.get_or_insert_function(fnty, name="NRT_get_api")
+        fn = cgutils.get_or_insert_function(mod, fnty, "NRT_get_api")
         return builder.call(fn, ())
 
     def eh_check(self, builder):

--- a/numba/core/runtime/nrtdynmod.py
+++ b/numba/core/runtime/nrtdynmod.py
@@ -69,8 +69,9 @@ def _define_nrt_decref(module, atomic_decr):
                                                "NRT_decref")
     # Cannot inline this for refcount pruning to work
     fn_decref.attributes.add('noinline')
-    calldtor = module.add_function(ir.FunctionType(ir.VoidType(), [_pointer_type]),
-                                   name="NRT_MemInfo_call_dtor")
+    calldtor = ir.Function(module,
+                           ir.FunctionType(ir.VoidType(), [_pointer_type]),
+                           name="NRT_MemInfo_call_dtor")
 
     builder = ir.IRBuilder(fn_decref.append_basic_block())
     [ptr] = fn_decref.args

--- a/numba/core/runtime/nrtdynmod.py
+++ b/numba/core/runtime/nrtdynmod.py
@@ -31,8 +31,8 @@ def _define_nrt_meminfo_data(module):
     Implement NRT_MemInfo_data_fast in the module.  This allows LLVM
     to inline lookup of the data pointer.
     """
-    fn = module.get_or_insert_function(meminfo_data_ty,
-                                       name="NRT_MemInfo_data_fast")
+    fn = cgutils.get_or_insert_function(module, meminfo_data_ty,
+                                        "NRT_MemInfo_data_fast")
     builder = ir.IRBuilder(fn.append_basic_block())
     [ptr] = fn.args
     struct_ptr = builder.bitcast(ptr, _meminfo_struct_type.as_pointer())
@@ -44,8 +44,8 @@ def _define_nrt_incref(module, atomic_incr):
     """
     Implement NRT_incref in the module
     """
-    fn_incref = module.get_or_insert_function(incref_decref_ty,
-                                              name="NRT_incref")
+    fn_incref = cgutils.get_or_insert_function(module, incref_decref_ty,
+                                              "NRT_incref")
     # Cannot inline this for refcount pruning to work
     fn_incref.attributes.add('noinline')
     builder = ir.IRBuilder(fn_incref.append_basic_block())
@@ -65,8 +65,8 @@ def _define_nrt_decref(module, atomic_decr):
     """
     Implement NRT_decref in the module
     """
-    fn_decref = module.get_or_insert_function(incref_decref_ty,
-                                              name="NRT_decref")
+    fn_decref = cgutils.get_or_insert_function(module, incref_decref_ty,
+                                               "NRT_decref")
     # Cannot inline this for refcount pruning to work
     fn_decref.attributes.add('noinline')
     calldtor = module.add_function(ir.FunctionType(ir.VoidType(), [_pointer_type]),

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -235,7 +235,7 @@ def round_impl_unary(context, builder, sig, args):
     llty = context.get_value_type(fltty)
     module = builder.module
     fnty = Type.function(llty, [llty])
-    fn = module.get_or_insert_function(fnty, name=_round_intrinsic(fltty))
+    fn = cgutils.get_or_insert_function(module, fnty, _round_intrinsic(fltty))
     res = builder.call(fn, args)
     # unary round() returns an int
     res = builder.fptosi(res, context.get_value_type(sig.return_type))

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -278,7 +278,8 @@ class ListInstance(_ListPayloadMixin):
         mod = builder.module
         # Declare dtor
         fnty = ir.FunctionType(ir.VoidType(), [cgutils.voidptr_t])
-        fn = mod.get_or_insert_function(fnty, name='.dtor.list.{}'.format(self.dtype))
+        fn = cgutils.get_or_insert_function(mod, fnty,
+                                            '.dtor.list.{}'.format(self.dtype))
         if not fn.is_declaration:
             # End early if the dtor is already defined
             return fn

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -251,8 +251,8 @@ def isfinite_int_impl(context, builder, sig, args):
 def copysign_float_impl(context, builder, sig, args):
     lty = args[0].type
     mod = builder.module
-    fn = mod.get_or_insert_function(lc.Type.function(lty, (lty, lty)),
-                                    'llvm.copysign.%s' % lty.intrinsic_name)
+    fn = cgutils.get_or_insert_function(mod, lc.Type.function(lty, (lty, lty)),
+                                        'llvm.copysign.%s' % lty.intrinsic_name)
     res = builder.call(fn, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
@@ -271,7 +271,7 @@ def frexp_impl(context, builder, sig, args):
         "float": "numba_frexpf",
         "double": "numba_frexp",
         }[str(fltty)]
-    fn = builder.module.get_or_insert_function(fnty, name=fname)
+    fn = cgutils.get_or_insert_function(builder.module, fnty, fname)
     res = builder.call(fn, (val, expptr))
     res = cgutils.make_anonymous_struct(builder, (res, builder.load(expptr)))
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -609,7 +609,7 @@ def real_divmod(context, builder, x, y):
     module = builder.module
     fname = context.mangler(".numba.python.rem", [x.type])
     fnty = Type.function(floatty, (floatty, floatty, Type.pointer(floatty)))
-    fn = module.get_or_insert_function(fnty, fname)
+    fn = cgutils.get_or_insert_function(module, fnty, fname)
 
     if fn.is_declaration:
         fn.linkage = lc.LINKAGE_LINKONCE_ODR

--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -995,7 +995,7 @@ def complex_power_impl(context, builder, sig, args):
                 types.complex128: "numba_cpow",
                 }[ty]
             fnty = Type.function(Type.void(), [pa.type] * 3)
-            cpow = module.get_or_insert_function(fnty, name=func_name)
+            cpow = cgutils.get_or_insert_function(module, fnty, func_name)
             builder.call(cpow, (pa, pb, pc))
 
     res = builder.load(pc)

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -60,7 +60,7 @@ def get_state_ptr(context, builder, name):
     assert name in ('py', 'np')
     func_name = "numba_get_%s_random_state" % name
     fnty = ir.FunctionType(rnd_state_ptr_t, ())
-    fn = builder.module.get_or_insert_function(fnty, func_name)
+    fn = cgutils.get_or_insert_function(builder.module, fnty, func_name)
     # These two attributes allow LLVM to hoist the function call
     # outside of loops.
     fn.attributes.add('readnone')
@@ -98,7 +98,8 @@ def get_rnd_shuffle(builder):
     Get the internal function to shuffle the MT taste.
     """
     fnty = ir.FunctionType(ir.VoidType(), (rnd_state_ptr_t,))
-    fn = builder.function.module.get_or_insert_function(fnty, "numba_rnd_shuffle")
+    fn = cgutils.get_or_insert_function(builder.function.module, fnty,
+                                               "numba_rnd_shuffle")
     fn.args[0].add_attribute("nocapture")
     return fn
 
@@ -211,7 +212,8 @@ def seed_impl(context, builder, sig, args):
 def _seed_impl(context, builder, sig, args, state_ptr):
     seed_value, = args
     fnty = ir.FunctionType(ir.VoidType(), (rnd_state_ptr_t, int32_t))
-    fn = builder.function.module.get_or_insert_function(fnty, "numba_rnd_init")
+    fn = cgutils.get_or_insert_function(builder.function.module, fnty,
+                                        "numba_rnd_init")
     builder.call(fn, (state_ptr, seed_value))
     return context.get_constant(types.none, None)
 
@@ -341,7 +343,8 @@ def _randrange_impl(context, builder, start, stop, step, state):
         context.call_conv.return_user_exc(builder, ValueError, (msg,))
 
     fnty = ir.FunctionType(ty, [ty, cgutils.true_bit.type])
-    fn = builder.function.module.get_or_insert_function(fnty, "llvm.ctlz.%s" % ty)
+    fn = cgutils.get_or_insert_function(builder.function.module, fnty,
+                                        "llvm.ctlz.%s" % ty)
     # Since the upper bound is exclusive, we need to subtract one before
     # calculating the number of bits. This leads to a special case when
     # n == 1; there's only one possible result, so we don't need bits from
@@ -1052,8 +1055,8 @@ def poisson_impl(context, builder, sig, args):
             # For lambda >= 10.0, we switch to a more accurate
             # algorithm (see _random.c).
             fnty = ir.FunctionType(int64_t, (rnd_state_ptr_t, double))
-            fn = builder.function.module.get_or_insert_function(fnty,
-                                                                "numba_poisson_ptrs")
+            fn = cgutils.get_or_insert_function(builder.function.module, fnty,
+                                                "numba_poisson_ptrs")
             ret = builder.call(fn, (state_ptr, lam))
             builder.store(ret, retptr)
             builder.branch(bbend)

--- a/numba/cpython/unicode_support.py
+++ b/numba/cpython/unicode_support.py
@@ -104,7 +104,8 @@ def _gettyperecord_impl(typingctx, codepoint):
             ll_uchar_ptr,  # digit
             ll_ushort_ptr, # flags
         ])
-        fn = builder.module.get_or_insert_function(
+        fn = cgutils.get_or_insert_function(
+            builder.module,
             fnty, name="numba_gettyperecord")
         upper = cgutils.alloca_once(builder, ll_intc, name='upper')
         lower = cgutils.alloca_once(builder, ll_intc, name='lower')
@@ -164,7 +165,8 @@ def _PyUnicode_ExtendedCase(typingctx, index):
         ll_Py_UCS4 = context.get_value_type(_Py_UCS4)
         ll_intc = context.get_value_type(types.intc)
         fnty = lc.Type.function(ll_Py_UCS4, [ll_intc])
-        fn = builder.module.get_or_insert_function(
+        fn = cgutils.get_or_insert_function(
+            builder.module,
             fnty, name="numba_get_PyUnicode_ExtendedCase")
         return builder.call(fn, [args[0]])
 

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -1,5 +1,5 @@
 from llvmlite import binding as ll
-from llvmlite.llvmpy import core as lc
+from llvmlite import ir
 
 from numba.core.codegen import BaseCPUCodegen, CodeLibrary
 from numba.core import utils
@@ -46,7 +46,7 @@ class JITCUDACodegen(BaseCPUCodegen):
         self._target_data = ll.create_target_data(self._data_layout)
 
     def _create_empty_module(self, name):
-        ir_module = lc.Module(name)
+        ir_module = ir.Module(name)
         ir_module.triple = CUDA_TRIPLE[utils.MACHINE_BITS]
         if self._data_layout:
             ir_module.data_layout = self._data_layout

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -14,7 +14,7 @@ from llvmlite import ir
 
 from .error import NvvmError, NvvmSupportError
 from .libs import get_libdevice, open_libdevice, open_cudalib
-from numba.core import config
+from numba.core import cgutils, config
 
 
 logger = logging.getLogger(__name__)
@@ -894,14 +894,13 @@ def _replace_llvm_memset_declaration(m):
 
 
 def set_cuda_kernel(lfunc):
-    from llvmlite.llvmpy.core import MetaData, MetaDataString, Constant, Type
-
     mod = lfunc.module
 
-    ops = lfunc, MetaDataString.get(mod, "kernel"), Constant.int(Type.int(), 1)
-    md = MetaData.get(mod, ops)
+    mdstr = ir.MetaDataString(mod, "kernel")
+    mdvalue = ir.Constant(ir.IntType(32), 1)
+    md = mod.add_metadata((lfunc, mdstr, mdvalue))
 
-    nmd = mod.get_or_insert_named_metadata('nvvm.annotations')
+    nmd = cgutils.get_or_insert_named_metadata(mod, 'nvvm.annotations')
     nmd.add(md)
 
 

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -2,8 +2,7 @@ from functools import reduce
 import operator
 import math
 
-from llvmlite.llvmpy.core import Type, InlineAsm
-import llvmlite.llvmpy.core as lc
+from llvmlite import ir
 import llvmlite.binding as ll
 
 from numba.core.imputils import Registry
@@ -199,8 +198,8 @@ def ptx_syncthreads(context, builder, sig, args):
     assert not args
     fname = 'llvm.nvvm.barrier0'
     lmod = builder.module
-    fnty = Type.function(Type.void(), ())
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.VoidType(), ())
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     builder.call(sync, ())
     return context.get_dummy_value()
 
@@ -209,8 +208,8 @@ def ptx_syncthreads(context, builder, sig, args):
 def ptx_syncthreads_count(context, builder, sig, args):
     fname = 'llvm.nvvm.barrier0.popc'
     lmod = builder.module
-    fnty = Type.function(Type.int(32), (Type.int(32),))
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(sync, args)
 
 
@@ -218,8 +217,8 @@ def ptx_syncthreads_count(context, builder, sig, args):
 def ptx_syncthreads_and(context, builder, sig, args):
     fname = 'llvm.nvvm.barrier0.and'
     lmod = builder.module
-    fnty = Type.function(Type.int(32), (Type.int(32),))
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(sync, args)
 
 
@@ -227,8 +226,8 @@ def ptx_syncthreads_and(context, builder, sig, args):
 def ptx_syncthreads_or(context, builder, sig, args):
     fname = 'llvm.nvvm.barrier0.or'
     lmod = builder.module
-    fnty = Type.function(Type.int(32), (Type.int(32),))
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(sync, args)
 
 
@@ -237,8 +236,8 @@ def ptx_threadfence_block(context, builder, sig, args):
     assert not args
     fname = 'llvm.nvvm.membar.cta'
     lmod = builder.module
-    fnty = Type.function(Type.void(), ())
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.VoidType(), ())
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     builder.call(sync, ())
     return context.get_dummy_value()
 
@@ -248,8 +247,8 @@ def ptx_threadfence_system(context, builder, sig, args):
     assert not args
     fname = 'llvm.nvvm.membar.sys'
     lmod = builder.module
-    fnty = Type.function(Type.void(), ())
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.VoidType(), ())
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     builder.call(sync, ())
     return context.get_dummy_value()
 
@@ -259,8 +258,8 @@ def ptx_threadfence_device(context, builder, sig, args):
     assert not args
     fname = 'llvm.nvvm.membar.gl'
     lmod = builder.module
-    fnty = Type.function(Type.void(), ())
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.VoidType(), ())
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     builder.call(sync, ())
     return context.get_dummy_value()
 
@@ -276,8 +275,8 @@ def ptx_syncwarp(context, builder, sig, args):
 def ptx_syncwarp_mask(context, builder, sig, args):
     fname = 'llvm.nvvm.bar.warp.sync'
     lmod = builder.module
-    fnty = Type.function(Type.void(), (Type.int(32),))
-    sync = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.VoidType(), (ir.IntType(32),))
+    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
     builder.call(sync, args)
     return context.get_dummy_value()
 
@@ -301,36 +300,37 @@ def ptx_shfl_sync_i32(context, builder, sig, args):
     mask, mode, value, index, clamp = args
     value_type = sig.args[2]
     if value_type in types.real_domain:
-        value = builder.bitcast(value, Type.int(value_type.bitwidth))
+        value = builder.bitcast(value, ir.IntType(value_type.bitwidth))
     fname = 'llvm.nvvm.shfl.sync.i32'
     lmod = builder.module
-    fnty = Type.function(
-        Type.struct((Type.int(32), Type.int(1))),
-        (Type.int(32), Type.int(32), Type.int(32), Type.int(32), Type.int(32))
+    fnty = ir.FunctionType(
+        ir.LiteralStructType((ir.IntType(32), ir.IntType(1))),
+                            (ir.IntType(32), ir.IntType(32), ir.IntType(32),
+                             ir.IntType(32), ir.IntType(32))
     )
-    func = lmod.get_or_insert_function(fnty, name=fname)
+    func = cgutils.get_or_insert_function(lmod, fnty, fname)
     if value_type.bitwidth == 32:
         ret = builder.call(func, (mask, mode, value, index, clamp))
         if value_type == types.float32:
             rv = builder.extract_value(ret, 0)
             pred = builder.extract_value(ret, 1)
-            fv = builder.bitcast(rv, Type.float())
+            fv = builder.bitcast(rv, ir.FloatType())
             ret = cgutils.make_anonymous_struct(builder, (fv, pred))
     else:
-        value1 = builder.trunc(value, Type.int(32))
+        value1 = builder.trunc(value, ir.IntType(32))
         value_lshr = builder.lshr(value, context.get_constant(types.i8, 32))
-        value2 = builder.trunc(value_lshr, Type.int(32))
+        value2 = builder.trunc(value_lshr, ir.IntType(32))
         ret1 = builder.call(func, (mask, mode, value1, index, clamp))
         ret2 = builder.call(func, (mask, mode, value2, index, clamp))
         rv1 = builder.extract_value(ret1, 0)
         rv2 = builder.extract_value(ret2, 0)
         pred = builder.extract_value(ret1, 1)
-        rv1_64 = builder.zext(rv1, Type.int(64))
-        rv2_64 = builder.zext(rv2, Type.int(64))
+        rv1_64 = builder.zext(rv1, ir.IntType(64))
+        rv2_64 = builder.zext(rv2, ir.IntType(64))
         rv_shl = builder.shl(rv2_64, context.get_constant(types.i8, 32))
         rv = builder.or_(rv_shl, rv1_64)
         if value_type == types.float64:
-            rv = builder.bitcast(rv, Type.double())
+            rv = builder.bitcast(rv, ir.DoubleType())
         ret = cgutils.make_anonymous_struct(builder, (rv, pred))
     return ret
 
@@ -339,9 +339,10 @@ def ptx_shfl_sync_i32(context, builder, sig, args):
 def ptx_vote_sync(context, builder, sig, args):
     fname = 'llvm.nvvm.vote.sync'
     lmod = builder.module
-    fnty = Type.function(Type.struct((Type.int(32), Type.int(1))),
-                         (Type.int(32), Type.int(32), Type.int(1)))
-    func = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.LiteralStructType((ir.IntType(32),
+                                                 ir.IntType(1))),
+                           (ir.IntType(32), ir.IntType(32), ir.IntType(1)))
+    func = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(func, args)
 
 
@@ -353,11 +354,11 @@ def ptx_match_any_sync(context, builder, sig, args):
     mask, value = args
     width = sig.args[1].bitwidth
     if sig.args[1] in types.real_domain:
-        value = builder.bitcast(value, Type.int(width))
+        value = builder.bitcast(value, ir.IntType(width))
     fname = 'llvm.nvvm.match.any.sync.i{}'.format(width)
     lmod = builder.module
-    fnty = Type.function(Type.int(32), (Type.int(32), Type.int(width)))
-    func = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32), ir.IntType(width)))
+    func = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(func, (mask, value))
 
 
@@ -369,12 +370,13 @@ def ptx_match_all_sync(context, builder, sig, args):
     mask, value = args
     width = sig.args[1].bitwidth
     if sig.args[1] in types.real_domain:
-        value = builder.bitcast(value, Type.int(width))
+        value = builder.bitcast(value, ir.IntType(width))
     fname = 'llvm.nvvm.match.all.sync.i{}'.format(width)
     lmod = builder.module
-    fnty = Type.function(Type.struct((Type.int(32), Type.int(1))),
-                         (Type.int(32), Type.int(width)))
-    func = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.LiteralStructType((ir.IntType(32),
+                                                 ir.IntType(1))),
+                           (ir.IntType(32), ir.IntType(width)))
+    func = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(func, (mask, value))
 
 
@@ -405,8 +407,8 @@ def ptx_cbrt(context, builder, sig, args):
     fname = cbrt_funcs[ty]
     fty = context.get_value_type(ty)
     lmod = builder.module
-    fnty = Type.function(fty, [fty])
-    fn = lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(fty, [fty])
+    fn = cgutils.get_or_insert_function(lmod, fnty, fname)
     return builder.call(fn, args)
 
 
@@ -415,8 +417,9 @@ def ptx_brev_u4(context, builder, sig, args):
     # FIXME the llvm.bitreverse.i32 intrinsic isn't supported by nvcc
     # return builder.bitreverse(args[0])
 
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(lc.Type.int(32), (lc.Type.int(32),)),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(ir.IntType(32), (ir.IntType(32),)),
         '__nv_brev')
     return builder.call(fn, args)
 
@@ -426,8 +429,9 @@ def ptx_brev_u8(context, builder, sig, args):
     # FIXME the llvm.bitreverse.i64 intrinsic isn't supported by nvcc
     # return builder.bitreverse(args[0])
 
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(lc.Type.int(64), (lc.Type.int(64),)),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(ir.IntType(64), (ir.IntType(64),)),
         '__nv_brevll')
     return builder.call(fn, args)
 
@@ -454,10 +458,11 @@ def ptx_selp(context, builder, sig, args):
 
 @lower(max, types.f4, types.f4)
 def ptx_max_f4(context, builder, sig, args):
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(
-            lc.Type.float(),
-            (lc.Type.float(), lc.Type.float())),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(
+            ir.FloatType(),
+            (ir.FloatType(), ir.FloatType())),
         '__nv_fmaxf')
     return builder.call(fn, args)
 
@@ -466,10 +471,11 @@ def ptx_max_f4(context, builder, sig, args):
 @lower(max, types.f4, types.f8)
 @lower(max, types.f8, types.f8)
 def ptx_max_f8(context, builder, sig, args):
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(
-            lc.Type.double(),
-            (lc.Type.double(), lc.Type.double())),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(
+            ir.DoubleType(),
+            (ir.DoubleType(), ir.DoubleType())),
         '__nv_fmax')
 
     return builder.call(fn, [
@@ -480,10 +486,11 @@ def ptx_max_f8(context, builder, sig, args):
 
 @lower(min, types.f4, types.f4)
 def ptx_min_f4(context, builder, sig, args):
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(
-            lc.Type.float(),
-            (lc.Type.float(), lc.Type.float())),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(
+            ir.FloatType(),
+            (ir.FloatType(), ir.FloatType())),
         '__nv_fminf')
     return builder.call(fn, args)
 
@@ -492,10 +499,11 @@ def ptx_min_f4(context, builder, sig, args):
 @lower(min, types.f4, types.f8)
 @lower(min, types.f8, types.f8)
 def ptx_min_f8(context, builder, sig, args):
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(
-            lc.Type.double(),
-            (lc.Type.double(), lc.Type.double())),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(
+            ir.DoubleType(),
+            (ir.DoubleType(), ir.DoubleType())),
         '__nv_fmin')
 
     return builder.call(fn, [
@@ -507,10 +515,11 @@ def ptx_min_f8(context, builder, sig, args):
 @lower(round, types.f4)
 @lower(round, types.f8)
 def ptx_round(context, builder, sig, args):
-    fn = builder.module.get_or_insert_function(
-        lc.Type.function(
-            lc.Type.int(64),
-            (lc.Type.double(),)),
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(
+            ir.IntType(64),
+            (ir.DoubleType(),)),
         '__nv_llrint')
     return builder.call(fn, [
         context.cast(builder, args[0], sig.args[0], types.double),
@@ -826,7 +835,7 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
         raise TypeError("unsupported type: %s" % dtype)
 
     lldtype = context.get_data_type(dtype)
-    laryty = Type.array(lldtype, elemcount)
+    laryty = ir.ArrayType(lldtype, elemcount)
 
     if addrspace == nvvm.ADDRSPACE_LOCAL:
         # Special case local address space allocation to use alloca
@@ -837,7 +846,8 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
         lmod = builder.module
 
         # Create global variable in the requested address space
-        gvmem = lmod.add_global_variable(laryty, symbol_name, addrspace)
+        gvmem = cgutils.add_global_variable(lmod, laryty, symbol_name,
+                                            addrspace)
         # Specify alignment to avoid misalignment bug
         align = context.get_abi_sizeof(lldtype)
         # Alignment is required to be a power of 2 for shared memory. If it is
@@ -845,7 +855,7 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
         gvmem.align = 1 << (align - 1 ).bit_length()
 
         if dynamic_smem:
-            gvmem.linkage = lc.LINKAGE_EXTERNAL
+            gvmem.linkage = 'external'
         else:
             ## Comment out the following line to workaround a NVVM bug
             ## which generates a invalid symbol name when the linkage
@@ -853,11 +863,11 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
             ## See _get_unique_smem_id()
             # gvmem.linkage = lc.LINKAGE_INTERNAL
 
-            gvmem.initializer = lc.Constant.undef(laryty)
+            gvmem.initializer = ir.Constant(laryty, ir.Undefined)
 
         # Convert to generic address-space
-        conv = nvvmutils.insert_addrspace_conv(lmod, Type.int(8), addrspace)
-        addrspaceptr = gvmem.bitcast(Type.pointer(Type.int(8), addrspace))
+        conv = nvvmutils.insert_addrspace_conv(lmod, ir.IntType(8), addrspace)
+        addrspaceptr = gvmem.bitcast(ir.PointerType(ir.IntType(8), addrspace))
         dataptr = builder.call(conv, [addrspaceptr])
 
     targetdata = _get_target_data(context)
@@ -879,11 +889,11 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
         # Unfortunately NVVM does not provide an intrinsic for the
         # %dynamic_smem_size register, so we must read it using inline
         # assembly.
-        get_dynshared_size = InlineAsm.get(Type.function(Type.int(), []),
-                                           "mov.u32 $0, %dynamic_smem_size;",
-                                           '=r', side_effect=True)
+        get_dynshared_size = ir.InlineAsm(ir.FunctionType(ir.IntType(32), []),
+                                          "mov.u32 $0, %dynamic_smem_size;",
+                                          '=r', side_effect=True)
         dynsmem_size = builder.zext(builder.call(get_dynshared_size, []),
-                                    Type.int(width=64))
+                                    ir.IntType(64))
         # Only 1-D dynamic shared memory is supported so the following is a
         # sufficient construction of the shape
         kitemsize = context.get_constant(types.intp, itemsize)

--- a/numba/cuda/libdeviceimpl.py
+++ b/numba/cuda/libdeviceimpl.py
@@ -1,4 +1,4 @@
-from llvmlite.llvmpy.core import Type
+from llvmlite import ir
 from numba.core import cgutils, types
 from numba.core.imputils import Registry
 from numba.cuda import libdevice, libdevicefuncs
@@ -12,8 +12,8 @@ def libdevice_implement(func, retty, nbargs):
         lmod = builder.module
         fretty = context.get_value_type(retty)
         fargtys = [context.get_value_type(arg.ty) for arg in nbargs]
-        fnty = Type.function(fretty, fargtys)
-        fn = lmod.get_or_insert_function(fnty, name=func)
+        fnty = ir.FunctionType(fretty, fargtys)
+        fn = cgutils.get_or_insert_function(lmod, fnty, func)
         return builder.call(fn, args)
 
     key = getattr(libdevice, func[5:])
@@ -38,8 +38,8 @@ def libdevice_implement_multiple_returns(func, retty, prototype_args):
 
         fretty = context.get_value_type(retty)
 
-        fnty = Type.function(fretty, fargtys)
-        fn = lmod.get_or_insert_function(fnty, name=func)
+        fnty = ir.FunctionType(fretty, fargtys)
+        fn = cgutils.get_or_insert_function(lmod, fnty, func)
 
         # For returned values that are returned through a pointer, we need to
         # allocate variables on the stack and pass a pointer to them.

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -176,8 +176,8 @@ def insert_addrspace_conv(lmod, elemtype, addrspace):
 def declare_string(builder, value):
     lmod = builder.basic_block.function.module
     cval = cgutils.make_bytearray(value.encode("utf-8") + b"\x00")
-    gl = lmod.add_global_variable(cval.type, name="_str",
-                                  addrspace=nvvm.ADDRSPACE_CONSTANT)
+    gl = cgutils.add_global_variable(lmod, cval.type, name="_str",
+                                     addrspace=nvvm.ADDRSPACE_CONSTANT)
     gl.linkage = 'internal'
     gl.global_constant = True
     gl.initializer = cval

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -1,16 +1,17 @@
 import itertools
-import llvmlite.llvmpy.core as lc
+from llvmlite import ir
+from numba.core import cgutils
 from .cudadrv import nvvm
 from .api import current_context
 
 
 def declare_atomic_cas_int(lmod, isize):
     fname = '___numba_atomic_i' + str(isize) + '_cas_hack'
-    fnty = lc.Type.function(lc.Type.int(isize),
-                            (lc.Type.pointer(lc.Type.int(isize)),
-                             lc.Type.int(isize),
-                             lc.Type.int(isize)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(isize),
+                           (ir.PointerType(ir.IntType(isize)),
+                            ir.IntType(isize),
+                            ir.IntType(isize)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def atomic_cmpxchg(builder, lmod, isize, ptr, cmp, val):
@@ -29,10 +30,9 @@ def atomic_cmpxchg(builder, lmod, isize, ptr, cmp, val):
 
 def declare_atomic_add_float32(lmod):
     fname = 'llvm.numba_nvvm.atomic.load.add.f32.p0f32'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float(),
-                                                              0),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType(), 0), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_add_float64(lmod):
@@ -40,127 +40,121 @@ def declare_atomic_add_float64(lmod):
         fname = 'llvm.numba_nvvm.atomic.load.add.f64.p0f64'
     else:
         fname = '___numba_atomic_double_add'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_sub_float32(lmod):
     fname = '___numba_atomic_float_sub'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float()),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, name=fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType()), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_sub_float64(lmod):
     fname = '___numba_atomic_double_sub'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_inc_int32(lmod):
     fname = 'llvm.nvvm.atomic.load.inc.32.p0i32'
-    fnty = lc.Type.function(lc.Type.int(32), (lc.Type.pointer(lc.Type.int(32)),
-                                              lc.Type.int(32)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(32),
+                           (ir.PointerType(ir.IntType(32)), ir.IntType(32)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_inc_int64(lmod):
     fname = '___numba_atomic_u64_inc'
-    fnty = lc.Type.function(lc.Type.int(64), (lc.Type.pointer(lc.Type.int(64)),
-                                              lc.Type.int(64)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(64),
+                           (ir.PointerType(ir.IntType(64)), ir.IntType(64)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_dec_int32(lmod):
     fname = 'llvm.nvvm.atomic.load.dec.32.p0i32'
-    fnty = lc.Type.function(lc.Type.int(32), (lc.Type.pointer(lc.Type.int(32)),
-                                              lc.Type.int(32)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(32),
+                           (ir.PointerType(ir.IntType(32)), ir.IntType(32)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_dec_int64(lmod):
     fname = '___numba_atomic_u64_dec'
-    fnty = lc.Type.function(lc.Type.int(64), (lc.Type.pointer(lc.Type.int(64)),
-                                              lc.Type.int(64)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(64),
+                           (ir.PointerType(ir.IntType(64)), ir.IntType(64)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_max_float32(lmod):
     fname = '___numba_atomic_float_max'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float()),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType()), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_max_float64(lmod):
     fname = '___numba_atomic_double_max'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_min_float32(lmod):
     fname = '___numba_atomic_float_min'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float()),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType()), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_min_float64(lmod):
     fname = '___numba_atomic_double_min'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_nanmax_float32(lmod):
     fname = '___numba_atomic_float_nanmax'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float()),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType()), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_nanmax_float64(lmod):
     fname = '___numba_atomic_double_nanmax'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_nanmin_float32(lmod):
     fname = '___numba_atomic_float_nanmin'
-    fnty = lc.Type.function(lc.Type.float(), (lc.Type.pointer(lc.Type.float()),
-                                              lc.Type.float()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.FloatType(),
+                           (ir.PointerType(ir.FloatType()), ir.FloatType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_atomic_nanmin_float64(lmod):
     fname = '___numba_atomic_double_nanmin'
-    fnty = lc.Type.function(lc.Type.double(),
-                            (lc.Type.pointer(lc.Type.double()),
-                             lc.Type.double()))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.DoubleType(),
+                           (ir.PointerType(ir.DoubleType()), ir.DoubleType()))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_cudaCGGetIntrinsicHandle(lmod):
     fname = 'cudaCGGetIntrinsicHandle'
-    fnty = lc.Type.function(lc.Type.int(64),
-                            (lc.Type.int(32),))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(64),
+                           (ir.IntType(32),))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def declare_cudaCGSynchronize(lmod):
     fname = 'cudaCGSynchronize'
-    fnty = lc.Type.function(lc.Type.int(32),
-                            (lc.Type.int(64), lc.Type.int(32)))
-    return lmod.get_or_insert_function(fnty, fname)
+    fnty = ir.FunctionType(ir.IntType(32),
+                           (ir.IntType(64), ir.IntType(32)))
+    return cgutils.get_or_insert_function(lmod, fnty, fname)
 
 
 def insert_addrspace_conv(lmod, elemtype, addrspace):
@@ -173,24 +167,23 @@ def insert_addrspace_conv(lmod, elemtype, addrspace):
     tyname = {'float': 'f32', 'double': 'f64'}.get(tyname, tyname)
     s2g_name_fmt = 'llvm.nvvm.ptr.' + addrspacename + '.to.gen.p0%s.p%d%s'
     s2g_name = s2g_name_fmt % (tyname, addrspace, tyname)
-    elem_ptr_ty = lc.Type.pointer(elemtype)
-    elem_ptr_ty_addrspace = lc.Type.pointer(elemtype, addrspace)
-    s2g_fnty = lc.Type.function(elem_ptr_ty,
-                                [elem_ptr_ty_addrspace])
-    return lmod.get_or_insert_function(s2g_fnty, s2g_name)
+    elem_ptr_ty = ir.PointerType(elemtype)
+    elem_ptr_ty_addrspace = ir.PointerType(elemtype, addrspace)
+    s2g_fnty = ir.FunctionType(elem_ptr_ty, [elem_ptr_ty_addrspace])
+    return cgutils.get_or_insert_function(lmod, s2g_fnty, s2g_name)
 
 
 def declare_string(builder, value):
     lmod = builder.basic_block.function.module
-    cval = lc.Constant.stringz(value)
+    cval = cgutils.make_bytearray(value.encode("utf-8") + b"\x00")
     gl = lmod.add_global_variable(cval.type, name="_str",
                                   addrspace=nvvm.ADDRSPACE_CONSTANT)
-    gl.linkage = lc.LINKAGE_INTERNAL
+    gl.linkage = 'internal'
     gl.global_constant = True
     gl.initializer = cval
 
-    charty = lc.Type.int(8)
-    constcharptrty = lc.Type.pointer(charty, nvvm.ADDRSPACE_CONSTANT)
+    charty = ir.IntType(8)
+    constcharptrty = ir.PointerType(charty, nvvm.ADDRSPACE_CONSTANT)
     charptr = builder.bitcast(gl, constcharptrty)
 
     conv = insert_addrspace_conv(lmod, charty, nvvm.ADDRSPACE_CONSTANT)
@@ -198,11 +191,11 @@ def declare_string(builder, value):
 
 
 def declare_vprint(lmod):
-    voidptrty = lc.Type.pointer(lc.Type.int(8))
+    voidptrty = ir.PointerType(ir.IntType(8))
     # NOTE: the second argument to vprintf() points to the variable-length
     # array of arguments (after the format)
-    vprintfty = lc.Type.function(lc.Type.int(), [voidptrty, voidptrty])
-    vprintf = lmod.get_or_insert_function(vprintfty, "vprintf")
+    vprintfty = ir.FunctionType(ir.IntType(32), [voidptrty, voidptrty])
+    vprintf = cgutils.get_or_insert_function(lmod, vprintfty, "vprintf")
     return vprintf
 
 
@@ -232,8 +225,8 @@ SREG_MAPPING = {
 
 def call_sreg(builder, name):
     module = builder.module
-    fnty = lc.Type.function(lc.Type.int(), ())
-    fn = module.get_or_insert_function(fnty, name=SREG_MAPPING[name])
+    fnty = ir.FunctionType(ir.IntType(32), ())
+    fn = cgutils.get_or_insert_function(module, fnty, SREG_MAPPING[name])
     return builder.call(fn, ())
 
 

--- a/numba/cuda/printimpl.py
+++ b/numba/cuda/printimpl.py
@@ -1,5 +1,5 @@
 from functools import singledispatch
-from llvmlite.llvmpy.core import Type
+from llvmlite import ir
 from numba.core import types, cgutils
 from numba.core.imputils import Registry
 from numba.cuda import nvvmutils
@@ -7,7 +7,7 @@ from numba.cuda import nvvmutils
 registry = Registry()
 lower = registry.lower
 
-voidptr = Type.pointer(Type.int(8))
+voidptr = ir.PointerType(ir.IntType(8))
 
 
 # NOTE: we don't use @lower here since print_item() doesn't return a LLVM value

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -192,7 +192,7 @@ class CUDATargetContext(BaseContext):
                     cas_hack = "___numba_atomic_i32_cas_hack"
                     casfn = ir.Function(wrapper_module, casfnty, name=cas_hack)
                     xchg = builder.call(casfn, [gv_exc, old, status.code])
-                    changed = builder.icmp('==', xchg, old)
+                    changed = builder.icmp_unsigned('==', xchg, old)
 
                 # If the xchange is successful, save the thread ID.
                 sreg = nvvmutils.SRegBuilder(builder)

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -191,7 +191,7 @@ class CUDATargetContext(BaseContext):
                                                          old.type])
 
                     cas_hack = "___numba_atomic_i32_cas_hack"
-                    casfn = wrapper_module.add_function(casfnty, name=cas_hack)
+                    casfn = ir.Function(wrapper_module, casfnty, name=cas_hack)
                     xchg = builder.call(casfn, [gv_exc, old, status.code])
                     changed = builder.icmp('==', xchg, old)
 

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -1,8 +1,6 @@
 import re
-from llvmlite.llvmpy.core import (Type, Builder, LINKAGE_INTERNAL, Constant,
-                                  ICMP_EQ)
-import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
+from llvmlite import ir
 
 from numba.core import (typing, types, dispatcher, debuginfo, itanium_mangler,
                         cgutils)
@@ -142,22 +140,23 @@ class CUDATargetContext(BaseContext):
         """
         arginfo = self.get_arg_packer(argtypes)
         argtys = list(arginfo.argument_types)
-        wrapfnty = Type.function(Type.void(), argtys)
+        wrapfnty = ir.FunctionType(ir.VoidType(), argtys)
         wrapper_module = self.create_module("cuda.kernel.wrapper")
-        fnty = Type.function(Type.int(),
-                             [self.call_conv.get_return_type(types.pyobject)]
-                             + argtys)
-        func = wrapper_module.add_function(fnty, name=fname)
+        fnty = ir.FunctionType(ir.IntType(32),
+                               [self.call_conv.get_return_type(types.pyobject)]
+                               + argtys)
+        func = ir.Function(wrapper_module, fnty, fname)
 
         prefixed = itanium_mangler.prepend_namespace(func.name, ns='cudapy')
-        wrapfn = wrapper_module.add_function(wrapfnty, name=prefixed)
-        builder = Builder(wrapfn.append_basic_block(''))
+        wrapfn = ir.Function(wrapper_module, wrapfnty, prefixed)
+        builder = ir.IRBuilder(wrapfn.append_basic_block(''))
 
         # Define error handling variables
         def define_error_gv(postfix):
-            gv = wrapper_module.add_global_variable(Type.int(),
-                                                    name=wrapfn.name + postfix)
-            gv.initializer = Constant.null(gv.type.pointee)
+            name = wrapfn.name + postfix
+            gv = cgutils.add_global_variable(wrapper_module, ir.IntType(32),
+                                             name)
+            gv.initializer = ir.Constant(gv.type.pointee, None)
             return gv
 
         gv_exc = define_error_gv("__errcode__")
@@ -178,7 +177,7 @@ class CUDATargetContext(BaseContext):
 
             with builder.if_then(builder.not_(status.is_python_exc)):
                 # User exception raised
-                old = Constant.null(gv_exc.type.pointee)
+                old = ir.Constant(gv_exc.type.pointee, None)
 
                 # Use atomic cmpxchg to prevent rewriting the error status
                 # Only the first error is recorded
@@ -188,13 +187,13 @@ class CUDATargetContext(BaseContext):
                                            'monotonic', 'monotonic')
                     changed = builder.extract_value(xchg, 1)
                 else:
-                    casfnty = lc.Type.function(old.type, [gv_exc.type, old.type,
-                                                          old.type])
+                    casfnty = ir.FunctionType(old.type, [gv_exc.type, old.type,
+                                                         old.type])
 
                     cas_hack = "___numba_atomic_i32_cas_hack"
                     casfn = wrapper_module.add_function(casfnty, name=cas_hack)
                     xchg = builder.call(casfn, [gv_exc, old, status.code])
-                    changed = builder.icmp(ICMP_EQ, xchg, old)
+                    changed = builder.icmp('==', xchg, old)
 
                 # If the xchange is successful, save the thread ID.
                 sreg = nvvmutils.SRegBuilder(builder)
@@ -227,12 +226,13 @@ class CUDATargetContext(BaseContext):
             self.get_constant(types.byte, i)
             for i in iter(arr.tobytes(order='A'))
         ]
-        constary = lc.Constant.array(Type.int(8), constvals)
+        constaryty = ir.ArrayType(ir.IntType(8), len(constvals))
+        constary = ir.Constant(constaryty, constvals)
 
         addrspace = nvvm.ADDRSPACE_CONSTANT
-        gv = lmod.add_global_variable(constary.type, name="_cudapy_cmem",
-                                      addrspace=addrspace)
-        gv.linkage = lc.LINKAGE_INTERNAL
+        gv = cgutils.add_global_variable(lmod, constary.type, "_cudapy_cmem",
+                                         addrspace=addrspace)
+        gv.linkage = 'internal'
         gv.global_constant = True
         gv.initializer = constary
 
@@ -242,8 +242,8 @@ class CUDATargetContext(BaseContext):
         gv.align = 2 ** (align - 1).bit_length()
 
         # Convert to generic address-space
-        conv = nvvmutils.insert_addrspace_conv(lmod, Type.int(8), addrspace)
-        addrspaceptr = gv.bitcast(Type.pointer(Type.int(8), addrspace))
+        conv = nvvmutils.insert_addrspace_conv(lmod, ir.IntType(8), addrspace)
+        addrspaceptr = gv.bitcast(ir.PointerType(ir.IntType(8), addrspace))
         genptr = builder.call(conv, [addrspaceptr])
 
         # Create array object
@@ -263,23 +263,22 @@ class CUDATargetContext(BaseContext):
         Unlike the parent version.  This returns a a pointer in the constant
         addrspace.
         """
-        text = Constant.stringz(string)
+        text = cgutils.make_bytearray(string.encode("utf-8") + b"\x00")
         name = '$'.join(["__conststring__",
                          itanium_mangler.mangle_identifier(string)])
         # Try to reuse existing global
         gv = mod.globals.get(name)
         if gv is None:
             # Not defined yet
-            gv = mod.add_global_variable(text.type, name=name,
-                                         addrspace=nvvm.ADDRSPACE_CONSTANT)
-            gv.linkage = LINKAGE_INTERNAL
+            gv = cgutils.add_global_variable(mod, text.type, name,
+                                             addrspace=nvvm.ADDRSPACE_CONSTANT)
+            gv.linkage = 'internal'
             gv.global_constant = True
             gv.initializer = text
 
         # Cast to a i8* pointer
         charty = gv.type.pointee.element
-        return Constant.bitcast(gv,
-                                charty.as_pointer(nvvm.ADDRSPACE_CONSTANT))
+        return gv.bitcast(charty.as_pointer(nvvm.ADDRSPACE_CONSTANT))
 
     def insert_string_const_addrspace(self, builder, string):
         """

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -1,4 +1,4 @@
-from llvmlite.llvmpy.core import Module, Type, Builder
+from llvmlite import ir
 from numba.cuda.cudadrv.nvvm import (llvm_to_ptx, set_cuda_kernel,
                                      fix_data_layout, get_arch_option,
                                      get_supported_ccs)
@@ -27,10 +27,10 @@ class TestNvvmDriver(unittest.TestCase):
         self.assertTrue('ave' in ptx)
 
     def test_nvvm_from_llvm(self):
-        m = Module("test_nvvm_from_llvm")
-        fty = Type.function(Type.void(), [Type.int()])
-        kernel = m.add_function(fty, name='mycudakernel')
-        bldr = Builder(kernel.append_basic_block('entry'))
+        m = ir.Module("test_nvvm_from_llvm")
+        fty = ir.FunctionType(ir.VoidType(), [ir.IntType(32)])
+        kernel = ir.Function(m, fty, name='mycudakernel')
+        bldr = ir.IRBuilder(kernel.append_basic_block('entry'))
         bldr.ret_void()
         set_cuda_kernel(kernel)
 

--- a/numba/cuda/tests/cudapy/test_const_string.py
+++ b/numba/cuda/tests/cudapy/test_const_string.py
@@ -26,7 +26,7 @@ class TestCudaConstString(unittest.TestCase):
         fnty = ir.FunctionType(ir.IntType(8).as_pointer(), [])
 
         # Using insert_const_string
-        fn = mod.add_function(fnty, name="test_insert_const_string")
+        fn = ir.Function(mod, fnty, "test_insert_const_string")
         builder = ir.IRBuilder(fn.append_basic_block())
         res = targetctx.insert_addrspace_conv(builder, gv0,
                                               addrspace=ADDRSPACE_CONSTANT)
@@ -37,7 +37,7 @@ class TestCudaConstString(unittest.TestCase):
         self.assertEqual(len(matches), 1)
 
         # Using insert_string_const_addrspace
-        fn = mod.add_function(fnty, name="test_insert_string_const_addrspace")
+        fn = ir.Function(mod, fnty, "test_insert_string_const_addrspace")
         builder = ir.IRBuilder(fn.append_basic_block())
         res = targetctx.insert_string_const_addrspace(builder, textstring)
         builder.ret(res)

--- a/numba/experimental/jitclass/base.py
+++ b/numba/experimental/jitclass/base.py
@@ -521,8 +521,7 @@ def imp_dtor(context, module, instance_type):
                                      [llvoidptr, llsize, llvoidptr])
 
     fname = "_Dtor.{0}".format(instance_type.name)
-    dtor_fn = module.get_or_insert_function(dtor_ftype,
-                                            name=fname)
+    dtor_fn = cgutils.get_or_insert_function(module, dtor_ftype, fname)
     if dtor_fn.is_declaration:
         # Define
         builder = llvmir.IRBuilder(dtor_fn.append_basic_block())

--- a/numba/misc/gdb_hook.py
+++ b/numba/misc/gdb_hook.py
@@ -103,30 +103,30 @@ def init_gdb_codegen(cgctx, builder, signature, args,
 
     # insert getpid, getpid is always successful, call without concern!
     fnty = ir.FunctionType(int32_t, tuple())
-    getpid = mod.get_or_insert_function(fnty, "getpid")
+    getpid = cgutils.get_or_insert_function(mod, fnty, "getpid")
 
     # insert snprintf
     # int snprintf(char *str, size_t size, const char *format, ...);
     fnty = ir.FunctionType(
         int32_t, (char_ptr, intp_t, char_ptr), var_arg=True)
-    snprintf = mod.get_or_insert_function(fnty, "snprintf")
+    snprintf = cgutils.get_or_insert_function(mod, fnty, "snprintf")
 
     # insert fork
     fnty = ir.FunctionType(int32_t, tuple())
-    fork = mod.get_or_insert_function(fnty, "fork")
+    fork = cgutils.get_or_insert_function(mod, fnty, "fork")
 
     # insert execl
     fnty = ir.FunctionType(int32_t, (char_ptr, char_ptr), var_arg=True)
-    execl = mod.get_or_insert_function(fnty, "execl")
+    execl = cgutils.get_or_insert_function(mod, fnty, "execl")
 
     # insert sleep
     fnty = ir.FunctionType(int32_t, (int32_t,))
-    sleep = mod.get_or_insert_function(fnty, "sleep")
+    sleep = cgutils.get_or_insert_function(mod, fnty, "sleep")
 
     # insert break point
     fnty = ir.FunctionType(ir.VoidType(), tuple())
-    breakpoint = mod.get_or_insert_function(fnty,
-                                            "numba_gdb_breakpoint")
+    breakpoint = cgutils.get_or_insert_function(mod, fnty,
+                                                "numba_gdb_breakpoint")
 
     # do the work
     parent_pid = builder.call(getpid, tuple())
@@ -210,8 +210,8 @@ def gen_bp_impl():
         def codegen(cgctx, builder, signature, args):
             mod = builder.module
             fnty = ir.FunctionType(ir.VoidType(), tuple())
-            breakpoint = mod.get_or_insert_function(fnty,
-                                                    "numba_gdb_breakpoint")
+            breakpoint = cgutils.get_or_insert_function(mod, fnty,
+                                                        "numba_gdb_breakpoint")
             builder.call(breakpoint, tuple())
             return cgctx.get_constant(types.none, None)
         return function_sig, codegen

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -2967,7 +2967,7 @@ def _np_round_float(context, builder, tp, val):
     llty = context.get_value_type(tp)
     module = builder.module
     fnty = lc.Type.function(llty, [llty])
-    fn = module.get_or_insert_function(fnty, name=_np_round_intrinsic(tp))
+    fn = cgutils.get_or_insert_function(module, fnty, _np_round_intrinsic(tp))
     return builder.call(fn, (val,))
 
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1581,8 +1581,8 @@ def _attempt_nocopy_reshape(context, builder, aryty, ary,
         ll_intp, ll_intp_star, ll_intp_star,
         # itemsize, is_f_order
         ll_intp, ll_intc])
-    fn = builder.module.get_or_insert_function(
-        fnty, name="numba_attempt_nocopy_reshape")
+    fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                        "numba_attempt_nocopy_reshape")
 
     nd = ll_intp(aryty.ndim)
     shape = cgutils.gep_inbounds(builder, ary._get_ptr_by_name('shape'), 0, 0)

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -345,7 +345,7 @@ def call_xxdot(context, builder, conjugate, dtype,
                            [ll_char, ll_char, intp_t,    # kind, conjugate, n
                             ll_void_p, ll_void_p, ll_void_p,  # a, b, out
                             ])
-    fn = builder.module.get_or_insert_function(fnty, name="numba_xxdot")
+    fn = cgutils.get_or_insert_function(builder.module, fnty, "numba_xxdot")
 
     kind = get_blas_kind(dtype)
     kind_val = ir.Constant(ll_char, ord(kind))
@@ -369,7 +369,7 @@ def call_xxgemv(context, builder, do_trans,
                             ll_void_p, ll_void_p, intp_t,     # alpha, a, lda
                             ll_void_p, ll_void_p, ll_void_p,  # x, beta, y
                             ])
-    fn = builder.module.get_or_insert_function(fnty, name="numba_xxgemv")
+    fn = cgutils.get_or_insert_function(builder.module, fnty, "numba_xxgemv")
 
     dtype = m_type.dtype
     alpha = make_constant_slot(context, builder, dtype, 1.0)
@@ -410,7 +410,7 @@ def call_xxgemm(context, builder,
                             ll_void_p, intp_t, ll_void_p,  # b, ldb, beta
                             ll_void_p, intp_t,             # c, ldc
                             ])
-    fn = builder.module.get_or_insert_function(fnty, name="numba_xxgemm")
+    fn = cgutils.get_or_insert_function(builder.module, fnty, "numba_xxgemm")
 
     m, k = x_shapes
     _k, n = y_shapes

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -95,7 +95,7 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
                         for ty in call_argtys]
         fnty = lc.Type.function(lc.Type.void(), call_argltys)
         # Note: the function isn't pure here (it writes to its pointer args)
-        fn = mod.get_or_insert_function(fnty, name=func_name)
+        fn = cgutils.get_or_insert_function(mod, fnty, func_name)
         builder.call(fn, call_args)
         retval = builder.load(call_args[0])
     else:

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -1,5 +1,5 @@
 from numba import jit, typeof
-from numba.core import types, serialize, sigutils
+from numba.core import cgutils, types, serialize, sigutils
 from numba.core.typing import npydecl
 from numba.core.typing.templates import AbstractTemplate, signature
 from numba.np.ufunc import _internal
@@ -38,8 +38,9 @@ def make_dufunc_kernel(_dufunc):
                 func_type = self.context.call_conv.get_function_type(
                     isig.return_type, isig.args)
             module = self.builder.block.function.module
-            entry_point = module.get_or_insert_function(
-                func_type, name=self.cres.fndesc.llvm_func_name)
+            entry_point = cgutils.get_or_insert_function(
+                module, func_type,
+                self.cres.fndesc.llvm_func_name)
             entry_point.attributes.add("alwaysinline")
 
             _, res = self.context.call_conv.call_function(

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -22,7 +22,7 @@ import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
 
 from numba.np.numpy_support import as_dtype
-from numba.core import types, config, errors
+from numba.core import types, cgutils, config, errors
 from numba.np.ufunc.wrappers import _wrapper_info
 from numba.np.ufunc import ufuncbuilder
 from numba.extending import overload
@@ -134,22 +134,22 @@ def build_gufunc_kernel(library, ctx, info, sig, inner_ndim):
 
     parallel_for_ty = lc.Type.function(lc.Type.void(),
                                        [byte_ptr_t] * 5 + [intp_t, ] * 3)
-    parallel_for = mod.get_or_insert_function(parallel_for_ty,
-                                              name='numba_parallel_for')
+    parallel_for = cgutils.get_or_insert_function(mod, parallel_for_ty,
+                                                  'numba_parallel_for')
 
     # Reference inner-function and link
     innerfunc_fnty = lc.Type.function(
         lc.Type.void(),
         [byte_ptr_ptr_t, intp_ptr_t, intp_ptr_t, byte_ptr_t],
     )
-    tmp_voidptr = mod.get_or_insert_function(
-        innerfunc_fnty, name=info.name,
-    )
+    tmp_voidptr = cgutils.get_or_insert_function(mod, innerfunc_fnty,
+                                                 info.name,)
     wrapperlib.add_linking_library(info.library)
 
-    get_num_threads = builder.module.get_or_insert_function(
+    get_num_threads = cgutils.get_or_insert_function(
+        builder.module,
         lc.Type.function(lc.Type.int(types.intp.bitwidth), []),
-        name="get_num_threads")
+        "get_num_threads")
 
     num_threads = builder.call(get_num_threads, [])
 

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import llvmlite.llvmpy.core as lc
 import llvmlite.binding as ll
+from llvmlite import ir
 
 from numba.np.numpy_support import as_dtype
 from numba.core import types, cgutils, config, errors
@@ -110,7 +111,7 @@ def build_gufunc_kernel(library, ctx, info, sig, inner_ndim):
     wrapperlib = ctx.codegen().create_library('parallelgufuncwrapper')
     mod = wrapperlib.create_ir_module('parallel.gufunc.wrapper')
     kernel_name = ".kernel.{}_{}".format(id(info.env), info.name)
-    lfunc = mod.add_function(fnty, name=kernel_name)
+    lfunc = ir.Function(mod, fnty, name=kernel_name)
 
     bb_entry = lfunc.append_basic_block('')
 

--- a/numba/np/ufunc/wrappers.py
+++ b/numba/np/ufunc/wrappers.py
@@ -525,7 +525,8 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
                                     ll_intp_ptr, ll_voidptr,
                                     ll_int, ll_int])
 
-    fn_array_new = mod.get_or_insert_function(fnty, name="numba_ndarray_new")
+    fn_array_new = cgutils.get_or_insert_function(mod, fnty,
+                                                  "numba_ndarray_new")
 
     # Convert each llarray into pyobject
     error_pointer = cgutils.alloca_once(builder, Type.int(1), name='error')

--- a/numba/np/ufunc/wrappers.py
+++ b/numba/np/ufunc/wrappers.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import numpy as np
 
 from llvmlite.llvmpy.core import Type, Builder, ICMP_EQ, Constant
+from llvmlite import ir
 
 from numba.core import types, cgutils
 from numba.core.compiler_lock import global_compiler_lock
@@ -161,10 +162,10 @@ def build_ufunc_wrapper(library, context, fname, signature, objmode, cres):
         func_type = context.call_conv.get_function_type(
             signature.return_type, signature.args)
 
-    func = wrapper_module.add_function(func_type, name=fname)
+    func = ir.Function(wrapper_module, func_type, name=fname)
     func.attributes.add("alwaysinline")
 
-    wrapper = wrapper_module.add_function(fnty, "__ufunc__." + func.name)
+    wrapper = ir.Function(wrapper_module, fnty, "__ufunc__." + func.name)
     arg_args, arg_dims, arg_steps, arg_data = wrapper.args
     arg_args.name = "args"
     arg_dims.name = "dims"
@@ -354,10 +355,10 @@ class _GufuncWrapper(object):
         func_type = self.call_conv.get_function_type(self.fndesc.restype,
                                                      self.fndesc.argtypes)
         fname = self.fndesc.llvm_func_name
-        func = wrapper_module.add_function(func_type, name=fname)
+        func = ir.Function(wrapper_module, func_type, name=fname)
 
         func.attributes.add("alwaysinline")
-        wrapper = wrapper_module.add_function(fnty, name)
+        wrapper = ir.Function(wrapper_module, fnty, name)
         # The use of weak_odr linkage avoids the function being dropped due
         # to the order in which the wrappers and the user function are linked.
         wrapper.linkage = 'weak_odr'

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -1531,15 +1531,17 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
     scheduling_fnty = lc.Type.function(
         intp_ptr_t, [uintp_t, sched_ptr_type, sched_ptr_type, uintp_t, sched_ptr_type, intp_t])
     if index_var_typ.signed:
-        do_scheduling = builder.module.get_or_insert_function(scheduling_fnty,
-                                                          name="do_scheduling_signed")
+        do_scheduling = cgutils.get_or_insert_function(builder.module,
+                                                       scheduling_fnty,
+                                                       "do_scheduling_signed")
     else:
-        do_scheduling = builder.module.get_or_insert_function(scheduling_fnty,
-                                                          name="do_scheduling_unsigned")
+        do_scheduling = cgutils.get_or_insert_function(builder.module,
+                                                       scheduling_fnty,
+                                                       "do_scheduling_unsigned")
 
-    get_num_threads = builder.module.get_or_insert_function(
-        lc.Type.function(lc.Type.int(types.intp.bitwidth), []),
-        name="get_num_threads")
+    get_num_threads = cgutils.get_or_insert_function(
+        builder.module, lc.Type.function(lc.Type.int(types.intp.bitwidth), []),
+        "get_num_threads")
 
     num_threads = builder.call(get_num_threads, [])
 
@@ -1758,7 +1760,7 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
     fnty = lc.Type.function(lc.Type.void(), [byte_ptr_ptr_t, intp_ptr_t,
                                              intp_ptr_t, byte_ptr_t])
 
-    fn = builder.module.get_or_insert_function(fnty, name=wrapper_name)
+    fn = cgutils.get_or_insert_function(builder.module, fnty, wrapper_name)
     context.active_code_library.add_linking_library(info.library)
 
     if config.DEBUG_ARRAY_OPT:

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -232,7 +232,7 @@ class _ModuleCompiler(object):
             name = entry.symbol
             llvm_func_name = self._mangle_method_symbol(name)
             fnty = self.exported_function_types[entry]
-            lfunc = llvm_module.add_function(fnty, name=llvm_func_name)
+            lfunc = ir.Function(llvm_module, fnty, llvm_func_name)
 
             method_name = self.context.insert_const_string(llvm_module, name)
             method_def_const = lc.Constant.struct((method_name,
@@ -297,7 +297,7 @@ class _ModuleCompiler(object):
             fnty = ir.FunctionType(lt._int32,
                                    [modobj.type, self.method_def_ptr,
                                     self.env_def_ptr, envgv_array.type])
-            fn = llvm_module.add_function(fnty, self.external_init_function)
+            fn = ir.Function(llvm_module, fnty, self.external_init_function)
             return builder.call(fn, [modobj, method_array, env_array,
                                      envgv_array])
         else:
@@ -392,7 +392,7 @@ class ModuleCompiler(_ModuleCompiler):
     def _emit_python_wrapper(self, llvm_module):
         # Figure out the Python C API module creation function, and
         # get a LLVM function for it.
-        create_module_fn = llvm_module.add_function(*self.module_create_definition)
+        create_module_fn = ir.Function(llvm_module, *self.module_create_definition)
         create_module_fn.linkage = lc.LINKAGE_EXTERNAL
 
         # Define a constant string for the module name.
@@ -434,7 +434,7 @@ class ModuleCompiler(_ModuleCompiler):
         mod_def.linkage = lc.LINKAGE_INTERNAL
 
         # Define the module initialization function.
-        mod_init_fn = llvm_module.add_function(*self.module_init_definition)
+        mod_init_fn = ir.Function(llvm_module, *self.module_init_definition)
         entry = mod_init_fn.append_basic_block('Entry')
         builder = lc.Builder(entry)
         pyapi = self.context.get_python_api(builder)

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -244,8 +244,9 @@ class _ModuleCompiler(object):
         sentinel = lc.Constant.struct([NULL, NULL, ZERO, NULL])
         method_defs.append(sentinel)
         method_array_init = lc.Constant.array(self.method_def_ty, method_defs)
-        method_array = llvm_module.add_global_variable(method_array_init.type,
-                                                       '.module_methods')
+        method_array = cgutils.add_global_variable(llvm_module,
+                                                   method_array_init.type,
+                                                   '.module_methods')
         method_array.initializer = method_array_init
         method_array.linkage = lc.LINKAGE_INTERNAL
         method_array_ptr = lc.Constant.gep(method_array, [ZERO, ZERO])
@@ -405,8 +406,9 @@ class ModuleCompiler(_ModuleCompiler):
              lc.Constant.null(lt._pyobject_head_p),         # m_copy
             )
         )
-        mod_def_base = llvm_module.add_global_variable(mod_def_base_init.type,
-                                                       '.module_def_base')
+        mod_def_base = cgutils.add_global_variable(llvm_module,
+                                                   mod_def_base_init.type,
+                                                   '.module_def_base')
         mod_def_base.initializer = mod_def_base_init
         mod_def_base.linkage = lc.LINKAGE_INTERNAL
 
@@ -426,8 +428,8 @@ class ModuleCompiler(_ModuleCompiler):
         )
 
         # Define a constant string for the module name.
-        mod_def = llvm_module.add_global_variable(mod_def_init.type,
-                                                  '.module_def')
+        mod_def = cgutils.add_global_variable(llvm_module, mod_def_init.type,
+                                              '.module_def')
         mod_def.initializer = mod_def_init
         mod_def.linkage = lc.LINKAGE_INTERNAL
 

--- a/numba/roc/codegen.py
+++ b/numba/roc/codegen.py
@@ -1,5 +1,4 @@
-from llvmlite import binding as ll
-from llvmlite.llvmpy import core as lc
+from llvmlite import ir, binding as ll
 from numba.core import utils
 from numba.core.codegen import BaseCPUCodegen, CodeLibrary
 from .hlc import DATALAYOUT, TRIPLE, hlc
@@ -34,7 +33,7 @@ class JITHSACodegen(BaseCPUCodegen):
         self._target_data = ll.create_target_data(self._data_layout)
 
     def _create_empty_module(self, name):
-        ir_module = lc.Module(name)
+        ir_module = ir.Module(name)
         ir_module.triple = TRIPLE
         return ir_module
 

--- a/numba/roc/hsaimpl.py
+++ b/numba/roc/hsaimpl.py
@@ -264,7 +264,8 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace):
         lmod = builder.module
 
         # Create global variable in the requested address-space
-        gvmem = lmod.add_global_variable(laryty, symbol_name, addrspace)
+        gvmem = cgutils.add_global_variable(lmod, laryty, symbol_name,
+                                            addrspace)
 
         if elemcount <= 0:
             raise ValueError("array length <= 0")

--- a/numba/roc/hsaimpl.py
+++ b/numba/roc/hsaimpl.py
@@ -56,7 +56,7 @@ def _declare_function(context, builder, name, sig, cargs,
     llargs = [context.get_value_type(t) for t in sig.args]
     fnty = Type.function(llretty, llargs)
     mangled = mangler(name, cargs)
-    fn = mod.get_or_insert_function(fnty, mangled)
+    fn = cgutils.get_or_insert_function(mod, fnty, mangled)
     fn.calling_convention = target.CC_SPIR_FUNC
     return fn
 
@@ -172,7 +172,7 @@ def activelanepermute_wavewidth_impl(context, builder, sig, args):
     name = "__hsail_activelanepermute_wavewidth_b{0}".format(bitwidth)
 
     fnty = Type.function(intbitwidth, [intbitwidth, i32, intbitwidth, i1])
-    fn = builder.module.get_or_insert_function(fnty, name=name)
+    fn = cgutils.get_or_insert_function(builder.module, fnty, name=name)
     fn.calling_convention = target.CC_SPIR_FUNC
 
     def cast(val):

--- a/numba/roc/target.py
+++ b/numba/roc/target.py
@@ -212,7 +212,7 @@ def set_hsa_kernel(fn):
     fn.calling_convention = CC_SPIR_KERNEL
 
     # Mark kernels
-    ocl_kernels = mod.get_or_insert_named_metadata("opencl.kernels")
+    ocl_kernels = cgutils.get_or_insert_named_metadata(mod, "opencl.kernels")
     ocl_kernels.add(lc.MetaData.get(mod, [fn,
                                           gen_arg_addrspace_md(fn),
                                           gen_arg_access_qual_md(fn),
@@ -224,11 +224,13 @@ def set_hsa_kernel(fn):
     make_constant = lambda x: lc.Constant.int(lc.Type.int(), x)
     spir_version_constant = [make_constant(x) for x in SPIR_VERSION]
 
-    spir_version = mod.get_or_insert_named_metadata("opencl.spir.version")
+    spir_version = cgutils.get_or_insert_named_metadata(mod,
+                                                        "opencl.spir.version")
     if not spir_version.operands:
         spir_version.add(lc.MetaData.get(mod, spir_version_constant))
 
-    ocl_version = mod.get_or_insert_named_metadata("opencl.ocl.version")
+    ocl_version = cgutils.get_or_insert_named_metadata(mod,
+                                                       "opencl.ocl.version")
     if not ocl_version.operands:
         ocl_version.add(lc.MetaData.get(mod, spir_version_constant))
 
@@ -240,7 +242,7 @@ def set_hsa_kernel(fn):
         #           "opencl.compiler.options"]cat
         #
         # for name in others:
-        #     nmd = mod.get_or_insert_named_metadata(name)
+        #     nmd = cgutils.get_or_insert_named_metadata(mod, name)
         #     if not nmd.operands:
         #         nmd.add(empty_md)
 

--- a/numba/roc/target.py
+++ b/numba/roc/target.py
@@ -139,10 +139,10 @@ class HSATargetContext(BaseContext):
                                 [self.call_conv.get_return_type(
                                     types.pyobject)] + argtys)
 
-        func = wrapper_module.add_function(fnty, name=func.name)
+        func = llvmir.Function(wrapper_module, fnty, func.name)
         func.calling_convention = CC_SPIR_FUNC
 
-        wrapper = wrapper_module.add_function(wrapperfnty, name=wrappername)
+        wrapper = llvmir.Function(wrapper_module, wrapperfnty, name=wrappername)
 
         builder = lc.Builder(wrapper.append_basic_block(''))
 

--- a/numba/tests/test_cgutils.py
+++ b/numba/tests/test_cgutils.py
@@ -31,8 +31,7 @@ class StructureTestCase(TestCase):
                                     * (ctypes.c_size_t,) * nargs)
         module = self.context.create_module("")
 
-        function = module.get_or_insert_function(llvm_fnty,
-                                                name=self.id())
+        function = cgutils.get_or_insert_function(module, llvm_fnty, self.id())
         assert function.is_declaration
         entry_block = function.append_basic_block('entry')
         builder = lc.Builder(entry_block)

--- a/numba/tests/test_compile_cache.py
+++ b/numba/tests/test_compile_cache.py
@@ -1,7 +1,7 @@
 import unittest
 from contextlib import contextmanager
 
-import llvmlite.llvmpy.core as lc
+from llvmlite import ir
 
 from numba.core import types, typing, callconv, cpu, cgutils
 
@@ -18,7 +18,7 @@ class TestCompileCache(unittest.TestCase):
         context = cpu.CPUContext(typing_context)
         lib = context.codegen().create_library('testing')
         with context.push_code_library(lib):
-            module = lc.Module("test_module")
+            module = ir.Module("test_module")
 
             sig = typing.signature(types.int32, types.int32)
             llvm_fnty = context.call_conv.get_function_type(sig.return_type,
@@ -28,7 +28,7 @@ class TestCompileCache(unittest.TestCase):
             args = context.call_conv.get_arguments(function)
             assert function.is_declaration
             entry_block = function.append_basic_block('entry')
-            builder = lc.Builder(entry_block)
+            builder = ir.IRBuilder(entry_block)
 
             yield context, builder, sig, args
 
@@ -67,7 +67,7 @@ class TestCompileCache(unittest.TestCase):
             args2 = context.call_conv.get_arguments(function2)
             assert function2.is_declaration
             entry_block2 = function2.append_basic_block('entry')
-            builder2 = lc.Builder(entry_block2)
+            builder2 = ir.IRBuilder(entry_block2)
 
             # Ensure that the same function with a different signature does not
             # reuse an entry from the cache in error

--- a/numba/tests/test_compile_cache.py
+++ b/numba/tests/test_compile_cache.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 import llvmlite.llvmpy.core as lc
 
-from numba.core import types, typing, callconv, cpu
+from numba.core import types, typing, callconv, cpu, cgutils
 
 
 class TestCompileCache(unittest.TestCase):
@@ -23,7 +23,8 @@ class TestCompileCache(unittest.TestCase):
             sig = typing.signature(types.int32, types.int32)
             llvm_fnty = context.call_conv.get_function_type(sig.return_type,
                                                             sig.args)
-            function = module.get_or_insert_function(llvm_fnty, name='test_fn')
+            function = cgutils.get_or_insert_function(module, llvm_fnty,
+                                                      'test_fn')
             args = context.call_conv.get_arguments(function)
             assert function.is_declaration
             entry_block = function.append_basic_block('entry')
@@ -61,8 +62,8 @@ class TestCompileCache(unittest.TestCase):
             sig2 = typing.signature(types.float64, types.float64)
             llvm_fnty2 = context.call_conv.get_function_type(sig2.return_type,
                                                             sig2.args)
-            function2 = builder.module.get_or_insert_function(llvm_fnty2,
-                                                            name='test_fn_2')
+            function2 = cgutils.get_or_insert_function(builder.module,
+                                                       llvm_fnty2, 'test_fn_2')
             args2 = context.call_conv.get_arguments(function2)
             assert function2.is_declaration
             entry_block2 = function2.append_basic_block('entry')

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -176,7 +176,8 @@ def _call_dict_free(context, builder, ptr):
         ir.VoidType(),
         [ll_dict_type],
     )
-    free = builder.module.get_or_insert_function(fnty, name='numba_dict_free')
+    free = cgutils.get_or_insert_function(builder.module, fnty,
+                                          'numba_dict_free')
     builder.call(free, [ptr])
 
 
@@ -190,7 +191,7 @@ def _imp_dtor(context, module):
         [llvoidptr, llsize, llvoidptr],
     )
     fname = '_numba_dict_dtor'
-    fn = module.get_or_insert_function(fnty, name=fname)
+    fn = cgutils.get_or_insert_function(module, fnty, fname)
 
     if fn.is_declaration:
         # Set linkage
@@ -225,8 +226,8 @@ def _dict_new_minsize(typingctx, keyty, valty):
             ll_status,
             [ll_dict_type.as_pointer(), ll_ssize_t, ll_ssize_t],
         )
-        fn = builder.module.get_or_insert_function(
-            fnty, name='numba_dict_new_minsize')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_new_minsize')
         # Determine sizeof key and value types
         ll_key = context.get_data_type(keyty.instance_type)
         ll_val = context.get_data_type(valty.instance_type)
@@ -333,8 +334,8 @@ def _dict_insert(typingctx, d, key, hashval, val):
         )
         [d, key, hashval, val] = args
         [td, tkey, thashval, tval] = sig.args
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_dict_insert')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_insert')
 
         dm_key = context.data_model_manager[tkey]
         dm_val = context.data_model_manager[tval]
@@ -379,8 +380,8 @@ def _dict_length(typingctx, d):
             ll_ssize_t,
             [ll_dict_type],
         )
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_dict_length')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_length')
         [d] = args
         [td] = sig.args
         dp = _container_get_data(context, builder, td, d)
@@ -406,7 +407,8 @@ def _dict_dump(typingctx, d):
         [td] = sig.args
         [d] = args
         dp = _container_get_data(context, builder, td, d)
-        fn = builder.module.get_or_insert_function(fnty, name='numba_dict_dump')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_dump')
 
         builder.call(fn, [dp])
 
@@ -429,8 +431,8 @@ def _dict_lookup(typingctx, d, key, hashval):
         )
         [td, tkey, thashval] = sig.args
         [d, key, hashval] = args
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_dict_lookup')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_lookup')
 
         dm_key = context.data_model_manager[tkey]
         dm_val = context.data_model_manager[td.value_type]
@@ -486,8 +488,8 @@ def _dict_popitem(typingctx, d):
         )
         [d] = args
         [td] = sig.args
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_dict_popitem')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_popitem')
 
         dm_key = context.data_model_manager[td.key_type]
         dm_val = context.data_model_manager[td.value_type]
@@ -536,8 +538,8 @@ def _dict_delitem(typingctx, d, hk, ix):
         [d, hk, ix] = args
         [td, thk, tix] = sig.args
 
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_dict_delitem')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_dict_delitem')
 
         dp = _container_get_data(context, builder, td, d)
         status = builder.call(fn, [dp, hk, ix])
@@ -946,7 +948,8 @@ def impl_iterable_getiter(context, builder, sig, args):
         [ll_dictiter_type, ll_dict_type],
     )
 
-    fn = builder.module.get_or_insert_function(fnty, name='numba_dict_iter')
+    fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                        'numba_dict_iter')
 
     proto = ctypes.CFUNCTYPE(ctypes.c_size_t)
     dictiter_sizeof = proto(_helperlib.c_helpers['dict_iter_sizeof'])
@@ -979,7 +982,7 @@ def impl_dict_getiter(context, builder, sig, args):
         [ll_dictiter_type, ll_dict_type],
     )
 
-    fn = builder.module.get_or_insert_function(fnty, name='numba_dict_iter')
+    fn = cgutils.get_or_insert_function(builder.module, fnty, 'numba_dict_iter')
 
     proto = ctypes.CFUNCTYPE(ctypes.c_size_t)
     dictiter_sizeof = proto(_helperlib.c_helpers['dict_iter_sizeof'])
@@ -1011,9 +1014,8 @@ def impl_iterator_iternext(context, builder, sig, args, result):
         ll_status,
         [ll_bytes, p2p_bytes, p2p_bytes]
     )
-    iternext = builder.module.get_or_insert_function(
-        iternext_fnty,
-        name='numba_dict_iter_next',
+    iternext = cgutils.get_or_insert_function(
+        builder.module, iternext_fnty, 'numba_dict_iter_next',
     )
     key_raw_ptr = cgutils.alloca_once(builder, ll_bytes)
     val_raw_ptr = cgutils.alloca_once(builder, ll_bytes)

--- a/numba/typed/listobject.py
+++ b/numba/typed/listobject.py
@@ -173,9 +173,10 @@ def _list_codegen_set_method_table(context, builder, lp, itemty):
         [ll_list_type, vtablety.as_pointer()]
     )
 
-    setmethod_fn = builder.module.get_or_insert_function(
+    setmethod_fn = cgutils.get_or_insert_function(
+        builder.module,
         setmethod_fnty,
-        name='numba_list_set_method_table')
+        'numba_list_set_method_table')
     vtable = cgutils.alloca_once(builder, vtablety, zfill=True)
 
     # install item incref/decref
@@ -229,7 +230,8 @@ def _call_list_free(context, builder, ptr):
         ir.VoidType(),
         [ll_list_type],
     )
-    free = builder.module.get_or_insert_function(fnty, name='numba_list_free')
+    free = cgutils.get_or_insert_function(builder.module, fnty,
+                                          'numba_list_free')
     builder.call(free, [ptr])
 
 
@@ -244,7 +246,7 @@ def _imp_dtor(context, module):
         [llvoidptr, llsize, llvoidptr],
     )
     fname = '_numba_list_dtor'
-    fn = module.get_or_insert_function(fnty, name=fname)
+    fn = cgutils.get_or_insert_function(module, fnty, fname)
 
     if fn.is_declaration:
         # Set linkage
@@ -321,7 +323,7 @@ def _list_new_codegen(context, builder, itemty, new_size, error_handler):
         ll_status,
         [ll_list_type.as_pointer(), ll_ssize_t, ll_ssize_t],
     )
-    fn = builder.module.get_or_insert_function(fnty, name='numba_list_new')
+    fn = cgutils.get_or_insert_function(builder.module, fnty, 'numba_list_new')
     # Determine sizeof item types
     ll_item = context.get_data_type(itemty)
     sz_item = context.get_abi_sizeof(ll_item)
@@ -424,7 +426,7 @@ def _list_length(typingctx, l):
             [ll_list_type],
         )
         fname = 'numba_list_size_address'
-        fn = builder.module.get_or_insert_function(fnty, name=fname)
+        fn = cgutils.get_or_insert_function(builder.module, fnty, fname)
         fn.attributes.add('alwaysinline')
         fn.attributes.add('readonly')
         fn.attributes.add('nounwind')
@@ -461,8 +463,8 @@ def _list_allocated(typingctx, l):
             ll_ssize_t,
             [ll_list_type],
         )
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_list_allocated')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_allocated')
         [l] = args
         [tl] = sig.args
         lp = _container_get_data(context, builder, tl, l)
@@ -496,8 +498,8 @@ def _list_is_mutable(typingctx, l):
             ll_status,
             [ll_list_type],
         )
-        fn = builder.module.get_or_insert_function(
-            fnty, name='numba_list_is_mutable')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_is_mutable')
         [l] = args
         [tl] = sig.args
         lp = _container_get_data(context, builder, tl, l)
@@ -541,8 +543,8 @@ def _list_set_is_mutable(typingctx, l, is_mutable):
             ir.VoidType(),
             [ll_list_type, cgutils.intp_t],
         )
-        fn = builder.module.get_or_insert_function(
-            fnty, name='numba_list_set_is_mutable')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_set_is_mutable')
         [l, i] = args
         [tl, ti] = sig.args
         lp = _container_get_data(context, builder, tl, l)
@@ -565,8 +567,8 @@ def _list_append(typingctx, l, item):
         )
         [l, item] = args
         [tl, titem] = sig.args
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_list_append')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_append')
 
         dm_item = context.data_model_manager[titem]
 
@@ -704,7 +706,7 @@ def _gen_getitem(borrowed):
                 [ll_list_type],
             )
             fname = 'numba_list_base_ptr'
-            fn = builder.module.get_or_insert_function(fnty, fname)
+            fn = cgutils.get_or_insert_function(builder.module, fnty, fname)
             fn.attributes.add('alwaysinline')
             fn.attributes.add('nounwind')
             fn.attributes.add('readonly')
@@ -803,8 +805,8 @@ def _list_setitem(typingctx, l, index, item):
         )
         [l, index, item] = args
         [tl, tindex, titem] = sig.args
-        fn = builder.module.get_or_insert_function(fnty,
-                                                   name='numba_list_setitem')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_setitem')
 
         dm_item = context.data_model_manager[titem]
         data_item = dm_item.as_data(builder, item)
@@ -940,8 +942,8 @@ def _list_delitem(typingctx, l, index):
         )
         [tl, tindex] = sig.args
         [l, index] = args
-        fn = builder.module.get_or_insert_function(
-            fnty, name='numba_list_delitem')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_delitem')
 
         lp = _container_get_data(context, builder, tl, l)
         status = builder.call(fn, [lp, index])
@@ -964,8 +966,8 @@ def _list_delete_slice(typingctx, l, start, stop, step):
         )
         [l, start, stop, step] = args
         [tl, tstart, tstop, tstep] = sig.args
-        fn = builder.module.get_or_insert_function(
-            fnty, name='numba_list_delete_slice')
+        fn = cgutils.get_or_insert_function(builder.module, fnty,
+                                            'numba_list_delete_slice')
 
         lp = _container_get_data(context, builder, tl, l)
         status = builder.call(

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -126,11 +126,9 @@ def _get_incref_decref(context, module, datamodel, container_element_type):
     fe_type = datamodel.fe_type
     data_ptr_ty = datamodel.get_data_type().as_pointer()
     refct_fnty = ir.FunctionType(ir.VoidType(), [data_ptr_ty])
-    incref_fn = module.get_or_insert_function(
-        refct_fnty,
-        name='.numba_{}.{}_incref'.format(
-            context.fndesc.mangled_name, container_element_type),
-    )
+    incref_fn = cgutils.get_or_insert_function(
+        module, refct_fnty, '.numba_{}.{}_incref'.format(
+            context.fndesc.mangled_name, container_element_type),)
 
     builder = ir.IRBuilder(incref_fn.append_basic_block())
     context.nrt.incref(
@@ -139,11 +137,9 @@ def _get_incref_decref(context, module, datamodel, container_element_type):
     )
     builder.ret_void()
 
-    decref_fn = module.get_or_insert_function(
-        refct_fnty,
-        name='.numba_{}.{}_decref'.format(
-            context.fndesc.mangled_name, container_element_type),
-    )
+    decref_fn = cgutils.get_or_insert_function(
+        module, refct_fnty, name='.numba_{}.{}_decref'.format(
+            context.fndesc.mangled_name, container_element_type),)
     builder = ir.IRBuilder(decref_fn.append_basic_block())
     context.nrt.decref(
         builder, fe_type,
@@ -177,19 +173,15 @@ def _get_equal(context, module, datamodel, container_element_type):
         intres = context.cast(builder, res, types.boolean, types.int32)
         context.call_conv.return_value(builder, intres)
 
-    wrapfn = module.get_or_insert_function(
-        wrapfnty,
-        name='.numba_{}.{}_equal.wrap'.format(
-            context.fndesc.mangled_name, container_element_type)
-    )
+    wrapfn = cgutils.get_or_insert_function(
+        module, wrapfnty, name='.numba_{}.{}_equal.wrap'.format(
+            context.fndesc.mangled_name, container_element_type))
     build_wrapper(wrapfn)
 
     equal_fnty = ir.FunctionType(ir.IntType(32), [data_ptr_ty, data_ptr_ty])
-    equal_fn = module.get_or_insert_function(
-        equal_fnty,
-        name='.numba_{}.{}_equal'.format(
-            context.fndesc.mangled_name, container_element_type),
-    )
+    equal_fn = cgutils.get_or_insert_function(
+        module, equal_fnty, name='.numba_{}.{}_equal'.format(
+            context.fndesc.mangled_name, container_element_type),)
     builder = Builder(equal_fn.append_basic_block())
     lhs = datamodel.load_from_data_pointer(builder, equal_fn.args[0])
     rhs = datamodel.load_from_data_pointer(builder, equal_fn.args[1])


### PR DESCRIPTION
This PR replaces all llvmpy API usage with llvmlite API usage in the CUDA target. I started this replacement work because I often want to do something based on existing code in the CUDA target, but I'm loathe to add new code using the compatibility layer, so I felt it would be better to make the entire CUDA target an exemplar of the right API. This spidered out of just the CUDA target because a lot of code is shared between the core and the CUDA target, so the changes are:

- Remove all llvmpy usage in the CUDA target.
- Replace all usages of the llvmpy `Module` class with the llvmlite `Module` class. I started by replacing only CUDA target modules with the llvmlite `Module` class, but since it passes through the core so much, with the possibility of a lack of test coverage for some basic functionality (simple mathematical operators, etc, might not be explicitly tested by the CUDA target, with the assumption that simple nopython mode things generally work) I thought the safest route was to make sure that no target uses an llvmpy `Module`.
- `cgutils` now has some extra methods to replace functionality that was in the llvmpy `Module` class - these functions are now called where the old `Module` method was used. I didn't replace `get_global_variable_named()` with anything in `cgutils` because it was used exactly once.

I'm marking this as medium effort because although it's quite a long PR, the majority of it is very mechanical substitutions.