### PR TITLE
CUDA: Support IPC on Windows

### DIFF
--- a/docs/source/cuda/ipc.rst
+++ b/docs/source/cuda/ipc.rst
@@ -7,9 +7,6 @@ Sharing CUDA Memory
 Sharing between process
 =======================
 
-.. warning:: This feature is limited to Linux only.
-
-
 Export device array to another process
 --------------------------------------
 

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -40,7 +40,6 @@ from numba.cuda.envvars import get_numba_envvar
 
 VERBOSE_JIT_LOG = int(get_numba_envvar('VERBOSE_CU_JIT_LOG', 1))
 MIN_REQUIRED_CC = (2, 0)
-SUPPORTS_IPC = sys.platform.startswith('linux')
 
 
 _py_decref = ctypes.pythonapi.Py_DecRef
@@ -1164,8 +1163,6 @@ class Context(object):
         """
         Returns a *IpcHandle* from a GPU allocation.
         """
-        if not SUPPORTS_IPC:
-            raise OSError('OS does not support CUDA IPC')
         return self.memory_manager.get_ipc_handle(memory)
 
     def open_ipc_handle(self, handle, size):

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -9,7 +9,6 @@ import numpy as np
 from numba import cuda
 from numba.cuda.testing import (skip_on_cudasim, skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
-from numba.tests.support import linux_only
 import unittest
 
 linux = sys.platform.startswith('linux')

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -1,4 +1,3 @@
-import sys
 import multiprocessing as mp
 import itertools
 import traceback
@@ -11,7 +10,6 @@ from numba.cuda.testing import (skip_on_cudasim, skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
 import unittest
 
-linux = sys.platform.startswith('linux')
 has_mp_get_context = hasattr(mp, 'get_context')
 
 

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -81,7 +81,6 @@ def ipc_array_test(ipcarr, result_queue):
     result_queue.put((succ, out))
 
 
-@linux_only
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
@@ -190,18 +189,6 @@ class TestIpcMemory(ContextResettingTestCase):
                 self.check_ipc_array(index, foreign)
 
 
-@unittest.skipIf(linux, 'Only on OS other than Linux')
-@skip_on_cudasim('Ipc not available in CUDASIM')
-class TestIpcNotSupported(ContextResettingTestCase):
-    def test_unsupported(self):
-        arr = np.arange(10, dtype=np.intp)
-        devarr = cuda.to_device(arr)
-        with self.assertRaises(OSError) as raises:
-            devarr.get_ipc_handle()
-        errmsg = str(raises.exception)
-        self.assertIn('OS does not support CUDA IPC', errmsg)
-
-
 def staged_ipc_handle_test(handle, device_num, result_queue):
     def the_work():
         with cuda.gpus[device_num]:
@@ -244,7 +231,6 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
     result_queue.put((succ, out))
 
 
-@linux_only
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')


### PR DESCRIPTION
As of CUDA 9.2, IPC is supported on Windows, so we can remove the restriction in Numba.

Note that another PR (#6795) removes support for CUDA 9.0 and 9.1, and I have not duplicated the removal in this PR, on the assumption that #6795 will get merged too.