### PR TITLE
Add support for np.rot90

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -487,6 +487,7 @@ The following top-level functions are supported:
 * :func:`numpy.roll` (only the 2 first arguments; second argument ``shift``
   must be an integer)
 * :func:`numpy.roots`
+* :func:`numpy.rot90` (only the 2 first arguments)
 * :func:`numpy.round_`
 * :func:`numpy.searchsorted` (only the 3 first arguments)
 * :func:`numpy.select` (only using homogeneous lists or tuples for the first

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -19,6 +19,7 @@ from numba.core import types, utils, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, carray, farray, is_contiguous,
                                     is_fortran)
 from numba.np.numpy_support import type_can_asarray, is_nonelike
+from numba.np.unsafe.ndarray import to_fixed_tuple
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic,
                                  lower_setattr_generic,
@@ -1583,16 +1584,9 @@ def numpy_rot90(arr, k=1):
         if k == 2:
             return np.flipud(np.fliplr(arr))
 
-        def axes_list_gen(i):
-            if i == 0:
-                return 1
-            if i == 1:
-                return 0
-            return i
-
-        axes_list = (1, 0)
-        for i in range(2, arr.ndim):
-            axes_list = tuple_setitem(axes_list, i, i)
+        axes_list = np.arange(arr.ndim)
+        axes_list[:2] = [1, 0]
+        axes_list = to_fixed_tuple(axes_list, arr.ndim)
 
         if k == 1:
             return np.transpose(np.fliplr(arr), axes_list)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -19,7 +19,6 @@ from numba.core import types, utils, typing, errors, cgutils, extending
 from numba.np.numpy_support import (as_dtype, carray, farray, is_contiguous,
                                     is_fortran)
 from numba.np.numpy_support import type_can_asarray, is_nonelike
-from numba.np.unsafe.ndarray import to_fixed_tuple
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic,
                                  lower_setattr_generic,

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1565,12 +1565,13 @@ def array_T(context, builder, typ, value):
 
 @overload(np.rot90)
 def numpy_rot90(arr, k=1):
-    # axes = (0, 1) using other axes needs axis support in flip
-
+    # supporting axes argument it needs to be included in np.flip
     if not isinstance(k, types.Integer):
         raise errors.TypingError('The second argument "k" must be an integer')
-    if not type_can_asarray(arr):
-        raise errors.TypingError('The first argument "arr" must be array-like')
+    if not isinstance(arr, types.Array):
+        raise errors.TypingError('The first argument "arr" must be an array')
+
+    const_arr_ndim = arr.ndim
 
     def impl(arr, k=1):
         arr = np.asarray(arr)
@@ -1586,7 +1587,7 @@ def numpy_rot90(arr, k=1):
 
         axes_list = np.arange(arr.ndim)
         axes_list[:2] = [1, 0]
-        axes_list = to_fixed_tuple(axes_list, arr.ndim)
+        axes_list = to_fixed_tuple(axes_list, const_arr_ndim)
 
         if k == 1:
             return np.transpose(np.fliplr(arr), axes_list)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1586,7 +1586,7 @@ def numpy_rot90(arr, k=1):
         elif k == 3:
             return np.fliplr(np.transpose(arr, axes_list))
         else:
-            assert 0  # unreachable
+            raise AssertionError  # unreachable
 
     return impl
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1574,11 +1574,10 @@ def numpy_rot90(arr, k=1):
     if arr.ndim < 2:
         raise ValueError('Input must be >= 1-d.')
 
-    axes_list = tuple([1, 0] + [*range(2, arr.ndim)])
+    axes_list = (1, 0, *range(2, arr.ndim))
 
     def impl(arr, k=1):
         arr = np.asarray(arr)
-
 
         k = k % 4
         if k == 0:

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1571,13 +1571,11 @@ def numpy_rot90(arr, k=1):
         raise errors.TypingError('The first argument "arr" must be an array')
 
     if arr.ndim < 2:
-        raise ValueError('Input must be >= 1-d.')
+        raise ValueError('Input must be >= 2-d.')
 
     axes_list = (1, 0, *range(2, arr.ndim))
 
     def impl(arr, k=1):
-        arr = np.asarray(arr)
-
         k = k % 4
         if k == 0:
             return arr[:]
@@ -1588,7 +1586,8 @@ def numpy_rot90(arr, k=1):
         elif k == 3:
             return np.fliplr(np.transpose(arr, axes_list))
         else:
-            assert 0 # unreachable
+            assert 0  # unreachable
+
     return impl
 
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2328,7 +2328,6 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         def a_variations():
             yield np.arange(10).reshape(5, 2)
             yield np.arange(20).reshape(5, 2, 2)
-            yield ([1, 2], [3, 4],)
 
         for a in a_variations():
             for k in range(-3, 13):
@@ -2339,11 +2338,11 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc("abc")
 
-        self.assertIn('The first argument "arr" must be array-like',
+        self.assertIn('The first argument "arr" must be an array',
                       str(raises.exception))
 
         with self.assertRaises(TypingError) as raises:
-            cfunc([[1, 2], [3, 4]], k="abc")
+            cfunc(np.arange(4).reshape(2, 2), k="abc")
 
         self.assertIn('The second argument "k" must be an integer',
                       str(raises.exception))

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -132,8 +132,10 @@ def flip(a):
 def rot90(a):
     return np.rot90(a)
 
+
 def rot90_k(a, k=1):
     return np.rot90(a, k)
+
 
 def array_split(a, indices, axis=0):
     return np.array_split(a, indices, axis=axis)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2376,7 +2376,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as raises:
             cfunc(np.arange(3))
 
-        self.assertIn("Input must be >= 1-d.", str(raises.exception))
+        self.assertIn("Input must be >= 2-d.", str(raises.exception))
 
     def _check_split(self, func):
         # Since np.split and np.array_split are very similar


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This PR is adds `np.rot90`, which is currently unimplemented according to #4074
The only problem is, that in numba `np.transpose` the axes argument needs to be a tuple. I am not able to create the tuple dynamically
