### PR TITLE
CUDA: Use relaxed strides checking to compute contiguity

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -306,3 +306,33 @@ In 0.54.0:
 - ``ptx`` and the inspection methods will always return a dict.
 - Support for indexing into the results of these methods using ``(cc,
   argtypes)`` will be removed.
+
+
+.. _deprecation-strict-strides:
+
+Deprecation of strict strides checking when computing contiguity
+================================================================
+
+The contiguity of device arrays (the ``'C_CONTIGUOUS'`` and ``'F_CONTIGUOUS'``
+elements of the flags of a device array) are computed using relaxed strides
+checking, which matches the default in NumPy since Version 1.12. A config
+variable, :envvar:`NUMBA_NPY_RELAXED_STRIDES_CHECKING`, is provided to force
+computation of these flags using strict strides checking.
+
+This flag is provided to work around any bugs that may be exposed by strict
+strides checking, and will be removed in future.
+
+Schedule
+--------
+
+In 0.54.0:
+
+- Relaxed strides checking will become the default.
+- Strict strides checking will be deprecated.
+
+In 0.55.0:
+
+- Strict strides checking will be removed, if no reports of bugs related to
+  relaxed strides checking in 0.54.0 onwards. This plan will be re-examined if
+  bugs related to relaxed strides checking are reported, but may not necessarily
+  change as a result.

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -332,7 +332,7 @@ In 0.54.0:
 
 In 0.55.0:
 
-- Strict strides checking will be removed, if no reports of bugs related to
-  relaxed strides checking in 0.54.0 onwards. This plan will be re-examined if
-  bugs related to relaxed strides checking are reported, but may not necessarily
-  change as a result.
+- Strict strides checking will be removed, if there are no reports of bugs
+  related to relaxed strides checking in 0.54.0 onwards. This plan will be
+  re-examined if bugs related to relaxed strides checking are reported, but may
+  not necessarily change as a result.

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -430,6 +430,20 @@ GPU support
    Setting this variable to 1 also includes the values of arguments to Driver
    API calls in the logs.
 
+.. envvar:: NUMBA_NPY_RELAXED_STRIDES_CHECKING
+
+   By default Numba device arrays compute their contiguity using relaxed strides
+   checking, which is the default mechanism used by NumPy since version 1.12
+   (see `NPY_RELAXED_STRIDES_CHECKING
+   <https://numpy.org/doc/stable/release/1.8.0-notes.html?highlight=numpy%20sum#npy-relaxed-strides-checking>`_).
+   Setting ``NUMBA_NPY_RELAXED_STRIDES_CHECKING=0`` reverts back to strict
+   strides checking. This option should not normally be needed, but is provided
+   in case it is needed to workaround latent bugs related to strict strides
+   checking.
+
+   Strict strides checking is deprecated and may be removed in future. See
+   :ref:`deprecation-strict-strides`.
+
 
 Threading Control
 -----------------

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -432,13 +432,14 @@ GPU support
 
 .. envvar:: NUMBA_NPY_RELAXED_STRIDES_CHECKING
 
-   By default Numba device arrays compute their contiguity using relaxed strides
+   By default arrays that inherit from ``numba.misc.dummyarray.Array` (e.g.
+   CUDA and ROCm device arrays) compute their contiguity using relaxed strides
    checking, which is the default mechanism used by NumPy since version 1.12
    (see `NPY_RELAXED_STRIDES_CHECKING
-   <https://numpy.org/doc/stable/release/1.8.0-notes.html?highlight=numpy%20sum#npy-relaxed-strides-checking>`_).
+   <https://numpy.org/doc/stable/release/1.8.0-notes.html#npy-relaxed-strides-checking>`_).
    Setting ``NUMBA_NPY_RELAXED_STRIDES_CHECKING=0`` reverts back to strict
    strides checking. This option should not normally be needed, but is provided
-   in case it is needed to workaround latent bugs related to strict strides
+   in case it is needed to work around latent bugs related to strict strides
    checking.
 
    Strict strides checking is deprecated and may be removed in future. See

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -432,7 +432,7 @@ GPU support
 
 .. envvar:: NUMBA_NPY_RELAXED_STRIDES_CHECKING
 
-   By default arrays that inherit from ``numba.misc.dummyarray.Array` (e.g.
+   By default arrays that inherit from ``numba.misc.dummyarray.Array`` (e.g.
    CUDA and ROCm device arrays) compute their contiguity using relaxed strides
    checking, which is the default mechanism used by NumPy since version 1.12
    (see `NPY_RELAXED_STRIDES_CHECKING

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -337,6 +337,12 @@ class _EnvReloader(object):
         CUDA_ARRAY_INTERFACE_SYNC = _readenv("NUMBA_CUDA_ARRAY_INTERFACE_SYNC",
                                              int, 1)
 
+        # Compute contiguity of device arrays using the relaxed strides
+        # checking algorithm.
+        NPY_RELAXED_STRIDES_CHECKING = _readenv(
+            "NUMBA_NPY_RELAXED_STRIDES_CHECKING",
+            int, 1)
+
         # HSA Configs
 
         # Disable HSA support

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -1,8 +1,10 @@
+import itertools
 import numpy as np
 from numba.cuda.cudadrv import devicearray
 from numba import cuda
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
+from numba.tests.support import override_config
 
 
 class TestCudaNDArray(CUDATestCase):
@@ -279,33 +281,6 @@ class TestCudaNDArray(CUDATestCase):
         self.assertTrue(np.all(d.copy_to_host() == a_f))
 
     def test_devicearray_broadcast_host_copy(self):
-        try:
-            broadcast_to = np.broadcast_to
-        except AttributeError:
-            # numpy<1.10 doesn't have broadcast_to. The following implements
-            # a limited broadcast_to that only works along already existing
-            # dimensions of length 1.
-            def broadcast_to(arr, new_shape):
-                new_strides = []
-                for new_length, length, stride in zip(
-                    new_shape, arr.shape, arr.strides
-                ):
-                    if length == 1 and new_length > 1:
-                        new_strides.append(0)
-                    elif new_length == length:
-                        new_strides.append(stride)
-                    else:
-                        raise ValueError(
-                            "cannot broadcast shape {} to shape {}"
-                            .format(arr.shape, new_shape)
-                        )
-                return np.ndarray(
-                    buffer=np.squeeze(arr),
-                    dtype=arr.dtype,
-                    shape=new_shape,
-                    strides=tuple(new_strides),
-                )
-
         broadsize = 4
         coreshape = (2, 3)
         coresize = np.prod(coreshape)
@@ -314,8 +289,8 @@ class TestCudaNDArray(CUDATestCase):
         for dim in range(len(coreshape)):
             newindex = (slice(None),) * dim + (np.newaxis,)
             broadshape = coreshape[:dim] + (broadsize,) + coreshape[dim:]
-            broad_c = broadcast_to(core_c[newindex], broadshape)
-            broad_f = broadcast_to(core_f[newindex], broadshape)
+            broad_c = np.broadcast_to(core_c[newindex], broadshape)
+            broad_f = np.broadcast_to(core_f[newindex], broadshape)
             dbroad_c = cuda.to_device(broad_c)
             dbroad_f = cuda.to_device(broad_f)
             np.testing.assert_array_equal(dbroad_c.copy_to_host(), broad_c)
@@ -342,6 +317,47 @@ class TestCudaNDArray(CUDATestCase):
         self.assertEqual(
             devicearray.errmsg_contiguous_buffer,
             str(e.exception))
+
+    def test_devicearray_relaxed_strides(self):
+        # From the reproducer in Issue #6824.
+
+        with override_config('NPY_RELAXED_STRIDES_CHECKING', 1):
+            # Construct a device array that is contiguous even though
+            # the strides for the first axis (800) are not equal to
+            # the strides * size (10 * 8 = 80) for the previous axis,
+            # because the first axis size is 1.
+            arr = devicearray.DeviceNDArray((1, 10), (800, 8), np.float64)
+
+            # Ensure we still believe the array to be contiguous.
+            self.assertTrue(arr.flags['C_CONTIGUOUS'])
+            self.assertTrue(arr.flags['F_CONTIGUOUS'])
+
+    def test_devicearray_strict_strides(self):
+        # From the reproducer in Issue #6824.
+
+        with override_config('NPY_RELAXED_STRIDES_CHECKING', 0):
+            # Construct a device array that is not contiguous because
+            # the strides for the first axis (800) are not equal to
+            # the strides * size (10 * 8 = 80) for the previous axis.
+            arr = devicearray.DeviceNDArray((1, 10), (800, 8), np.float64)
+
+            # Ensure we still believe the array to be contiguous.
+            self.assertFalse(arr.flags['C_CONTIGUOUS'])
+            self.assertFalse(arr.flags['F_CONTIGUOUS'])
+
+    def test_c_f_contiguity_matches_numpy(self):
+        # From the reproducer in Issue #4943.
+
+        shapes = ((1, 4), (4, 1))
+        orders = ('C', 'F')
+        with override_config('NPY_RELAXED_STRIDES_CHECKING', 1):
+            for shape, order in itertools.product(shapes, orders):
+                arr = np.ndarray(shape, order=order)
+                d_arr = cuda.to_device(arr)
+                self.assertEqual(arr.flags['C_CONTIGUOUS'],
+                                 d_arr.flags['C_CONTIGUOUS'])
+                self.assertEqual(arr.flags['F_CONTIGUOUS'],
+                                 d_arr.flags['F_CONTIGUOUS'])
 
     @skip_on_cudasim('Typing not done in the simulator')
     def test_devicearray_typing_order_simple_c(self):

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -329,7 +329,8 @@ class TestCudaNDArray(CUDATestCase):
             # because the first axis size is 1.
             arr = devicearray.DeviceNDArray((1, 10), (800, 8), np.float64)
 
-            # Ensure we still believe the array to be contiguous.
+            # Ensure we still believe the array to be contiguous because
+            # strides checking is relaxed.
             self.assertTrue(arr.flags['C_CONTIGUOUS'])
             self.assertTrue(arr.flags['F_CONTIGUOUS'])
 
@@ -343,7 +344,8 @@ class TestCudaNDArray(CUDATestCase):
             # the strides * size (10 * 8 = 80) for the previous axis.
             arr = devicearray.DeviceNDArray((1, 10), (800, 8), np.float64)
 
-            # Ensure we still believe the array to be contiguous.
+            # Ensure we don't believe the array to be contiguous becase strides
+            # checking is strict.
             self.assertFalse(arr.flags['C_CONTIGUOUS'])
             self.assertFalse(arr.flags['F_CONTIGUOUS'])
 

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -318,6 +318,7 @@ class TestCudaNDArray(CUDATestCase):
             devicearray.errmsg_contiguous_buffer,
             str(e.exception))
 
+    @skip_on_cudasim('DeviceNDArray class not present in simulator')
     def test_devicearray_relaxed_strides(self):
         # From the reproducer in Issue #6824.
 
@@ -332,6 +333,7 @@ class TestCudaNDArray(CUDATestCase):
             self.assertTrue(arr.flags['C_CONTIGUOUS'])
             self.assertTrue(arr.flags['F_CONTIGUOUS'])
 
+    @skip_on_cudasim('DeviceNDArray class not present in simulator')
     def test_devicearray_strict_strides(self):
         # From the reproducer in Issue #6824.
 

--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -7,6 +7,7 @@ import ctypes
 import numpy as np
 
 from numba import _helperlib
+from numba.core import config
 
 
 Extent = namedtuple("Extent", ["begin", "end"])
@@ -164,7 +165,47 @@ class Array(object):
         self.itemsize = itemsize
         self.size = functools.reduce(operator.mul, self.shape, 1)
         self.extent = self._compute_extent()
-        self.flags = self._compute_layout()
+        if config.NPY_RELAXED_STRIDES_CHECKING:
+            self.flags = self._relaxed_compute_layout()
+        else:
+            self.flags = self._compute_layout()
+
+    def _relaxed_compute_layout(self):
+        # The logic here is based on that in _UpdateContiguousFlags from
+        # numpy/core/src/multiarray/flagsobject.c in NumPy v1.19.1 (commit
+        # 13661ac70).
+
+        # Records have no dims, and we can treat them as contiguous
+        if not self.dims:
+            return {'C_CONTIGUOUS': True, 'F_CONTIGUOUS': True}
+
+        # If this is a broadcast array then it is not contiguous
+        if any([dim.stride == 0 for dim in self.dims]):
+            return {'C_CONTIGUOUS': False, 'F_CONTIGUOUS': False}
+
+        flags = {'C_CONTIGUOUS': True, 'F_CONTIGUOUS': True}
+
+        # Check C contiguity
+        sd = self.itemsize
+        for dim in reversed(self.dims):
+            if dim.size == 0:
+                # Contiguous by definition
+                return {'C_CONTIGUOUS': True, 'F_CONTIGUOUS': True}
+            if dim.size != 1:
+                if dim.stride != sd:
+                    flags['C_CONTIGUOUS'] = False
+                sd *= dim.size
+
+        # Check F contiguity
+        sd = self.itemsize
+        for dim in self.dims:
+            if dim.size != 1:
+                if dim.stride != sd:
+                    flags['F_CONTIGUOUS'] = False
+                    return flags
+                sd *= dim.size
+
+        return flags
 
     def _compute_layout(self):
         flags = {}

--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -174,6 +174,7 @@ class Array(object):
         # The logic here is based on that in _UpdateContiguousFlags from
         # numpy/core/src/multiarray/flagsobject.c in NumPy v1.19.1 (commit
         # 13661ac70).
+        # https://github.com/numpy/numpy/blob/maintenance/1.19.x/numpy/core/src/multiarray/flagsobject.c#L123-L191
 
         # Records have no dims, and we can treat them as contiguous
         if not self.dims:

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -154,6 +154,13 @@ class TestSlicing(unittest.TestCase):
             self.assertEqual(got.shape, expect.shape)
             self.assertEqual(got.strides, expect.strides)
 
+    def test_issue_2766(self):
+        z = np.empty((1, 2, 3))
+        z = np.transpose(z, axes=(2, 0, 1))
+        arr = Array.from_desc(0, z.shape, z.strides, z.itemsize)
+        self.assertEqual(z.flags['C_CONTIGUOUS'], arr.flags['C_CONTIGUOUS'])
+        self.assertEqual(z.flags['F_CONTIGUOUS'], arr.flags['F_CONTIGUOUS'])
+
 
 class TestReshape(unittest.TestCase):
     def test_reshape_2d2d(self):


### PR DESCRIPTION
Since NumPy 1.8, a relaxed strides check has been available for computing the contiguity of arrays (and the relaxed check is the default starting from 1.12). The relaxed check permits additional conditions for arrays to be considered contiguous:

- All 0-size arrays are considered contiguous, even if they are multidimensional.
- Strides for an axis are ignored if its shape is 1 when checking contiguity.

Examples of shapes and strides that would now be considered contiguous:

- Shape: (1, 10), Strides: (800, 80): because the first axis has size 1.
- Shape: (1, 0, 2), Strides (64, 16, 8): because the second axis has size 0.

This PR makes relaxed strides checking the default when computing the C- and F-contiguity of device arrays, and enables more use cases. For example, from the reproducer in Issue #6824:

```python
import dask.array as da
import numpy as np
from numba import guvectorize

x = da.arange(10000, dtype=np.float64).reshape(100, 100).rechunk((1, 10))
f = np.ascontiguousarray(x.blocks[0, 0])
```

`f` is an array that is only contiguous under relaxed strides checking, and prior to this commit could not be transferred to a device array.

Since this may expose latent bugs (the switch in NumPy exposed some issues between versions 1.10.0 and 1.10.2, for example), a config variable, `NPY_RELAXED_STRIDES_CHECKING` is provided to restore the old, strict checking. This is provided on a temporary basis in case any bugs need to be worked out, and will be removed in 0.55 in the current deprecation schedule.

Fixes #6824.
Fixes #4943.
Fixes #2766.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
