### PR TITLE
Remove illegal "debug" kw argument

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -76,8 +76,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
     if sigutils.is_signature(func_or_sig):
         if config.ENABLE_CUDASIM:
             def jitwrapper(func):
-                return FakeCUDAKernel(func, device=device, fastmath=fastmath,
-                                      debug=debug)
+                return FakeCUDAKernel(func, device=device, fastmath=fastmath)
             return jitwrapper
 
         argtypes, restype = sigutils.normalize_signature(func_or_sig)

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -106,7 +106,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             if config.ENABLE_CUDASIM:
                 def autojitwrapper(func):
                     return FakeCUDAKernel(func, device=device,
-                                          fastmath=fastmath, debug=debug)
+                                          fastmath=fastmath)
             else:
                 def autojitwrapper(func):
                     return jit(func, device=device, debug=debug, opt=opt, **kws)
@@ -116,7 +116,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
         else:
             if config.ENABLE_CUDASIM:
                 return FakeCUDAKernel(func_or_sig, device=device,
-                                      fastmath=fastmath, debug=debug)
+                                      fastmath=fastmath)
             elif device:
                 return jitdevice(func_or_sig, debug=debug, opt=opt, **kws)
             else:

--- a/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
+++ b/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
@@ -1,6 +1,7 @@
 from numba import cuda
 import numpy as np
 from numba.cuda.testing import CUDATestCase
+from numba.tests.support import override_config
 import unittest
 
 
@@ -76,6 +77,13 @@ class TestCudaJitNoTypes(CUDATestCase):
 
         self.assertEqual(b[0], (a[0] + 1) + (2 + 1))
 
+    def test_jit_debug_simulator(self):
+        # Ensure that the jit decorator accepts the debug kwarg when the
+        # simulator is in use - see Issue #6615.
+        with override_config('ENABLE_CUDASIM', 1):
+            @cuda.jit(debug=True)
+            def f(x):
+                pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
+++ b/numba/cuda/tests/cudapy/test_cuda_jit_no_types.py
@@ -85,5 +85,6 @@ class TestCudaJitNoTypes(CUDATestCase):
             def f(x):
                 pass
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix for https://github.com/numba/numba/issues/6615

Removes illegal argument from call to  `FakeCUDAKernel`. Hard to trigger in test -- but currently these lines are untested and clearly illegal, as `FakeCUDAKernel` does not take the `debug` keyword.

With these lines removed, works with my test suite in with `NUMBA_ENABLE_CUDASIM` defined; otherwise doesn't work.

Relevant configuration in conftests.py:
```python
def pytest_configure(config):
    """
    Implement configuration options.
    * If "CUDA" is specified, make sure cuda simulator
      is turned on before collection if real cuda not available.

    * remove featureset cache if specified
    """
    cudasim = config.getoption("--cudasim")
    if cudasim:
        os.environ["NUMBA_ENABLE_CUDASIM"] = "1"
        config.option.cuda = "true"
        return
    cuda = config.getoption("--cuda")
    if cuda:
        check_cuda()


def check_cuda():
    """
    Check if CUDA simulator is necessary.

    Use CUDA simulator if CUDA not available.

    We have to call in subprocess because load of `cuda`
    module requires NUMBA_ENABLE_CUDASIM to be set first.
    """
    available = (
        subprocess.check_output(
            [
                "python",
                "-c",
                "from numba import cuda; print(cuda.is_available())",
            ]
        )
        .decode()
        .strip()
    )
    if available != "True":
        os.environ["NUMBA_ENABLE_CUDASIM"] = "1"
        print(f"Using CUDA Simulator (available: {available})")
    else:
        # make sure we use appropriate device
        from numba import cuda

        c_dev = cuda.get_current_device()
        cd_cc = c_dev.compute_capability
        assert cd_cc[0] >= 8 and (cd_cc[0] > 8 or cd_cc[1] >= 6)

```
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
