### PR TITLE
cross-referenced Array type in docs

### DIFF
--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -77,8 +77,9 @@ Arrays
 ------
 
 The easy way to declare :class:`~numba.types.Array` types is to subscript an elementary type
-according to the number of dimensions.  For example a 1-dimension
-single-precision array::
+according to the number of dimensions. 
+
+For example a 1-dimension single-precision array::
 
    >>> numba.float32[:]
    array(float32, 1d, A)

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -76,7 +76,7 @@ complex128              c16              double-precision complex number
 Arrays
 ------
 
-The easy way to declare array types is to subscript an elementary type
+The easy way to declare :class:`~numba.types.Array` types is to subscript an elementary type
 according to the number of dimensions.  For example a 1-dimension
 single-precision array::
 

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -76,8 +76,8 @@ complex128              c16              double-precision complex number
 Arrays
 ------
 
-The easy way to declare :class:`~numba.types.Array` types is to subscript an elementary type
-according to the number of dimensions. 
+The easy way to declare :class:`~numba.types.Array` types is to subscript an
+elementary type according to the number of dimensions. 
 
 For example a 1-dimension single-precision array::
 

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -77,9 +77,8 @@ Arrays
 ------
 
 The easy way to declare :class:`~numba.types.Array` types is to subscript an
-elementary type according to the number of dimensions. 
-
-For example a 1-dimension single-precision array::
+elementary type according to the number of dimensions. For example a 
+1-dimension single-precision array::
 
    >>> numba.float32[:]
    array(float32, 1d, A)


### PR DESCRIPTION
Updated Array explanation to contain a reference to Array class definition.

![image](https://user-images.githubusercontent.com/20266953/111707032-5c838980-8869-11eb-8059-ad3c88e4d3ea.png)
