### PR TITLE
[WIP][QUESTIONS] An attempt to extend Enum support

### DIFF
--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -285,17 +285,6 @@ class ProxyModel(DataModel):
         return self._proxied_model.from_return(builder, value)
 
 
-@register_default(types.EnumMember)
-@register_default(types.IntEnumMember)
-class EnumModel(ProxyModel):
-    """
-    Enum members are represented exactly like their values.
-    """
-    def __init__(self, dmm, fe_type):
-        super(EnumModel, self).__init__(dmm, fe_type)
-        self._proxied_model = dmm.lookup(fe_type.dtype)
-
-
 @register_default(types.Opaque)
 @register_default(types.PyObject)
 @register_default(types.RawPointer)
@@ -713,6 +702,21 @@ class StructModel(CompositeModel):
 
     def inner_models(self):
         return self._models
+
+
+@register_default(types.IntEnumMember)
+@register_default(types.EnumMember)
+class EnumModel(StructModel):
+    """
+    Enum members are structures with a value field and a name field.
+    """
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('name', fe_type.ntype),
+            ('value', fe_type.dtype),
+        ]
+        self._valuemodel = dmm.lookup(fe_type.dtype)
+        super(EnumModel, self).__init__(dmm, fe_type, members)
 
 
 @register_default(types.Complex)
@@ -1374,4 +1378,3 @@ class StructRefModel(StructModel):
             ("meminfo", types.MemInfoPointer(dtype)),
         ]
         super().__init__(dmm, fe_typ, members)
-

--- a/numba/core/types/scalars.py
+++ b/numba/core/types/scalars.py
@@ -3,6 +3,7 @@ import enum
 import numpy as np
 
 from .abstract import Dummy, Hashable, Literal, Number, Type
+from .misc import UnicodeType
 from functools import total_ordering
 from numba.core import utils
 from numba.core.typeconv import Conversion
@@ -192,6 +193,7 @@ class EnumClass(Dummy):
     Type class for Enum classes.
     """
     basename = "Enum class"
+    ntype = UnicodeType('unicode_type') # Type for the name field
 
     def __init__(self, cls, dtype):
         assert isinstance(cls, type)
@@ -233,6 +235,7 @@ class EnumMember(Type):
     """
     basename = "Enum"
     class_type_class = EnumClass
+    ntype = EnumClass.ntype
 
     def __init__(self, cls, dtype):
         assert isinstance(cls, type)

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -931,6 +931,8 @@ class Int(AbstractTemplate):
             return signature(arg, arg)
         if isinstance(arg, (types.Float, types.Boolean)):
             return signature(types.intp, arg)
+        if isinstance(arg, types.IntEnumMember):
+            return signature(types.intp, arg) #Needed for explicit casting
 
 
 @infer_global(float)

--- a/numba/core/typing/enumdecl.py
+++ b/numba/core/typing/enumdecl.py
@@ -19,6 +19,9 @@ class EnumAttribute(AttributeTemplate):
     def resolve_value(self, ty):
         return ty.dtype
 
+    def resolve_name(self, ty):
+        return ty.ntype
+
 
 @infer_getattr
 class EnumClassAttribute(AttributeTemplate):

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -495,6 +495,8 @@ class NpArray(CallableTemplate):
                 dtype = parse_dtype(dtype)
                 if dtype is None:
                     return
+            if isinstance(dtype, types.IntEnumMember):
+                dtype = dtype.dtype
             return types.Array(dtype, ndim, 'C')
 
         return typer

--- a/numba/cpython/enumimpl.py
+++ b/numba/cpython/enumimpl.py
@@ -5,16 +5,27 @@ import operator
 
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic, lower_cast,
-                                 lower_constant, impl_ret_untracked)
-from numba.core import types
+                                 lower_constant, impl_ret_untracked,
+                                 impl_ret_borrowed)
+from numba.core import types, cgutils
+from numba.core.extending import overload_method
+
+
+def _get_member_name(builder, member):
+    return builder.extract_value(member, 0)
+
+
+def _get_member_value(builder, member):
+    return builder.extract_value(member, 1)
 
 
 @lower_builtin(operator.eq, types.EnumMember, types.EnumMember)
 def enum_eq(context, builder, sig, args):
     tu, tv = sig.args
     u, v = args
+    uval, vval = _get_member_value(builder, u), _get_member_value(builder, v)
     res = context.generic_compare(builder, operator.eq,
-                                  (tu.dtype, tv.dtype), (u, v))
+                                  (tu.dtype, tv.dtype), (uval, vval))
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
@@ -22,9 +33,10 @@ def enum_eq(context, builder, sig, args):
 def enum_is(context, builder, sig, args):
     tu, tv = sig.args
     u, v = args
+    uval, vval = _get_member_value(builder, u), _get_member_value(builder, v)
     if tu == tv:
         res = context.generic_compare(builder, operator.eq,
-                                      (tu.dtype, tv.dtype), (u, v))
+                                      (tu.dtype, tv.dtype), (uval, vval))
     else:
         res = context.get_constant(sig.return_type, False)
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -34,14 +46,31 @@ def enum_is(context, builder, sig, args):
 def enum_ne(context, builder, sig, args):
     tu, tv = sig.args
     u, v = args
+    uval, vval = _get_member_value(builder, u), _get_member_value(builder, v)
     res = context.generic_compare(builder, operator.ne,
-                                  (tu.dtype, tv.dtype), (u, v))
+                                  (tu.dtype, tv.dtype), (uval, vval))
     return impl_ret_untracked(context, builder, sig.return_type, res)
+
+
+@lower_getattr(types.EnumMember, 'name')
+def enum_name(context, builder, ty, val):
+    res = _get_member_name(builder, val)
+    return impl_ret_borrowed(context, builder, ty.ntype, res)
 
 
 @lower_getattr(types.EnumMember, 'value')
 def enum_value(context, builder, ty, val):
-    return val
+    res = _get_member_value(builder, val)
+    return impl_ret_borrowed(context, builder, ty.dtype, res)
+
+
+@overload_method(types.EnumMember, '__hash__')
+def enum_hash(val):
+    return lambda val: hash(val.name)
+
+@overload_method(types.IntEnumMember, '__hash__')
+def intenum_hash(val):
+    return lambda val: hash(val.value)
 
 
 @lower_cast(types.IntEnumMember, types.Integer)
@@ -49,7 +78,8 @@ def int_enum_to_int(context, builder, fromty, toty, val):
     """
     Convert an IntEnum member to its raw integer value.
     """
-    return context.cast(builder, val, fromty.dtype, toty)
+    value = _get_member_value(builder, val)
+    return context.cast(builder, value, fromty.dtype, toty)
 
 
 @lower_constant(types.EnumMember)
@@ -57,7 +87,13 @@ def enum_constant(context, builder, ty, pyval):
     """
     Return a LLVM constant representing enum member *pyval*.
     """
-    return context.get_constant_generic(builder, ty.dtype, pyval.value)
+    consts = [
+        context.get_constant_generic(builder, ty.ntype, pyval.name),
+        context.get_constant_generic(builder, ty.dtype, pyval.value)
+    ]
+    return impl_ret_borrowed(
+        context, builder, ty, cgutils.pack_struct(builder, consts),
+    )
 
 
 @lower_getattr_generic(types.EnumClass)
@@ -66,7 +102,7 @@ def enum_class_getattr(context, builder, ty, val, attr):
     Return an enum member by attribute name.
     """
     member = getattr(ty.instance_class, attr)
-    return context.get_constant_generic(builder, ty.dtype, member.value)
+    return enum_constant(context, builder, ty, member)
 
 
 @lower_builtin('static_getitem', types.EnumClass, types.StringLiteral)
@@ -76,5 +112,4 @@ def enum_class_getitem(context, builder, sig, args):
     """
     enum_cls_typ, idx = sig.args
     member = enum_cls_typ.instance_class[idx.literal_value]
-    return context.get_constant_generic(builder, enum_cls_typ.dtype,
-                                        member.value)
+    return enum_constant(context, builder, enum_cls_typ, member)

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -142,7 +142,7 @@ def as_dtype(nbtype):
         return np.dtype('%s%d' % (letter, nbtype.count))
     if isinstance(nbtype, types.Record):
         return as_struct_dtype(nbtype)
-    if isinstance(nbtype, types.EnumMember):
+    if isinstance(nbtype, types.IntEnumMember):
         return as_dtype(nbtype.dtype)
     if isinstance(nbtype, types.npytypes.DType):
         return as_dtype(nbtype.dtype)


### PR DESCRIPTION
Hi everyone :-)

*While this was once meant to be a real PR, I see it a bit more as a learning opportunity now. So there is absolutely no urgency here. I opened this primarily for archival purposes and to maybe learn a thing or two.*

A while back I had a go at improving the Enum support, triggered by [#5911](https://github.com/numba/numba/issues/5911), but eventually I got stuck.
After reading [this post](https://numba.discourse.group/t/intenum-from-int/625/5) on Discourse I thought it would be a good idea to share what I have come up with so far (this PR would not fix the reported issue there, but maybe it could help someone to pick up the task of implementing a solution.)

## Context

Currently numba deals with Enum fields based on their `value` alone. This cannot fully reflect CPython behaviour, where the member `name` is used for hashing.
Since I needed the hashing capabilities and thought that the name field would be needed to achieve this, I started to turn EnumMembers into Structures with a field each for their name and value.

When I started this work I was unaware that IntEnums (which are sufficient for myself) behave distinctly different since their members are first and foremost integers. As such they use the `int.__hash__` function on their `value`, such that my original [hack](https://github.com/numba/numba/issues/5911#issuecomment-649457131) is actually perfectly acceptable, and extending Enums in general would not be necessary to make this work.

I doubt that adding hashing capabilities for generic Enums justifies complicating the very simple existing implementation to this extent, therefore I will open a proper PR for the IntEnum hashing.

This is maybe more of a resource for the future if extending the capabilities of Enums becomes necessary.

## What this PR tries to achieve

- Extend (Int)Enums so that their value and name are available in jitted code.
- Allow explicit casting of the newly extended IntEnums
- Add hashing of Enums (name based) and IntEnums (value based)
- Block array creation from generic Enums without explicit casting (see below)
- Don't break existing functionality :laughing: 

## Questions / Known issues / Plea for comments

- This is the first time I tried to dig a little deeper into Numba, and I am sure there are some heinous crimes (reference counting :see_no_evil:) hidden in my code.
I would appreciate if someone could share some criticism so that I (and hopefully others) can learn something for the future :slightly_smiling_face: 

- If one were to adopt these changes, should the Enum type move into a different `core/types` submodule since it is no longer strictly scalar?

- What would be needed to implement arithmetic operations and comparisons (maybe general ufuncs) between arrays and IntEnums? The associated tests fail. Operations between IntEnums and scalars from inside arrays seem to work (probably thanks to implicit casting)

- Returning the IntEnums from a vectorized function (without implicit or explicit casting) fails with a segfault (I simplified the associated test, since it contained a comparison that I know to be wonky at this point.)

## Observed existing issues

While working on this patch I noticed that numba currently allows creating arrays of generic Enum members. This is possible because they are lowered as scalar values. So if the datatype is supported by numpy it will happily create an array.

In CPython this actually does not work quite the same; since the enum members are generic Python objects, numpy creates an object array, which for example does not allow arithmetic operations, even if all the Enum values are themselves numbers (so you could argue that numba has a _better_ support :stuck_out_tongue: ).

The culprit is located [here](https://github.com/numba/numba/blob/bb2ec93fe107339d752bb03bde49f505fa2ed02c/numba/np/numpy_support.py#L145-L146).

Does this warrant a separate issue or would you like to keep this as it is currently working? (This PR assumes it shouldn't be possible, but I am aware that breaking things is always risky business.)

```python
from enum import Enum
from numba import njit
import numpy as np

class E(Enum):
    MEMBER = 1

def f(x):
    return np.array((x, x))
fjit = njit(f)

print(f(E.MEMBER).dtype)  # --> object
print(fjit(E.MEMBER).dtype)  # --> int64
```

Cheers
Hannes

/cc @nelson2005