### PR TITLE
Ignore .ycm_extra_conf.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 htmlcov/
 .idea/
 .vscode/
+.ycm_extra_conf.py
 .mypy_cache/
 .ipynb_checkpoints/
 __pycache__/


### PR DESCRIPTION
Users of [YouCompleteMe](https://github.com/ycm-core/YouCompleteMe) might want to add a `.ycm_extra_conf.py` to the root of their local repo (for example, to help clangd find the Python includes), but we probably don't want to have a version committed to the Numba repo. This PR ignores that file for the convenience of those users - I note there are also ignores for `.idea` and `.vscode`, and this aligns with ignoring those too.