### PR TITLE
Add __hash__ for IntEnum

### DIFF
--- a/numba/cpython/enumimpl.py
+++ b/numba/cpython/enumimpl.py
@@ -80,6 +80,7 @@ def enum_class_getitem(context, builder, sig, args):
     return context.get_constant_generic(builder, enum_cls_typ.dtype,
                                         member.value)
 
+
 @overload_method(types.IntEnumMember, '__hash__')
 def intenum_hash(val):
     # uses the hash of the value, for IntEnums this will be int.__hash__

--- a/numba/cpython/enumimpl.py
+++ b/numba/cpython/enumimpl.py
@@ -7,6 +7,7 @@ from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic, lower_cast,
                                  lower_constant, impl_ret_untracked)
 from numba.core import types
+from numba.extending import overload_method
 
 
 @lower_builtin(operator.eq, types.EnumMember, types.EnumMember)
@@ -78,3 +79,10 @@ def enum_class_getitem(context, builder, sig, args):
     member = enum_cls_typ.instance_class[idx.literal_value]
     return context.get_constant_generic(builder, enum_cls_typ.dtype,
                                         member.value)
+
+@overload_method(types.IntEnumMember, '__hash__')
+def intenum_hash(val):
+    # uses the hash of the value, for IntEnums this will be int.__hash__
+    def hash_impl(val):
+        return hash(val.value)
+    return hash_impl

--- a/numba/cpython/enumimpl.py
+++ b/numba/cpython/enumimpl.py
@@ -7,7 +7,7 @@ from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic, lower_cast,
                                  lower_constant, impl_ret_untracked)
 from numba.core import types
-from numba.extending import overload_method
+from numba.core.extending import overload_method
 
 
 @lower_builtin(operator.eq, types.EnumMember, types.EnumMember)

--- a/numba/tests/enum_usecases.py
+++ b/numba/tests/enum_usecases.py
@@ -44,3 +44,12 @@ class RequestError(IntEnum):
     not_found = 404
     internal_error = 500
 
+class IntEnumWithNegatives(IntEnum):
+    # Used for testing of hash, need to make sure -1 -> -2 to comply with CPy
+    one = 1
+    two = 2
+    too = 2
+    three = 3
+    negone = -1
+    negtwo = -2
+    negthree = -3

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -8,7 +8,8 @@ import unittest
 from numba import jit, vectorize
 
 from numba.tests.support import TestCase
-from .enum_usecases import Color, Shape, Shake, Planet, RequestError
+from .enum_usecases import Color, Shape, Shake, Planet, RequestError, \
+                           IntEnumWithNegatives
 
 
 def compare_usecase(a, b):
@@ -139,6 +140,13 @@ class TestIntEnum(BaseEnumTest, TestCase):
         arg = np.array([2, 404, 500, 404])
         sol = np.array([vectorize_usecase(i) for i in arg], dtype=arg.dtype)
         self.assertPreciseEqual(sol, cfunc(arg))
+
+    def test_hash(self):
+        def pyfun(x):
+            return hash(x)
+        cfunc = jit(nopython=True)(pyfun)
+        for member in IntEnumWithNegatives:
+            self.assertPreciseEqual(pyfun(member), cfunc(member))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi  :-)

Partially solving #5911

This patch adds `__hash__` capability for IntEnums. I think this would be a nice addition, because I like to use enums as keys for the typed `Dict`, since there is less risk of introducing typos. 

I have been using this inside my own code for a while, but I had mistakenly thought that the hashes I created are different from the CPython hashes.
Today I realised that the CPython hash for an IntEnum is in fact simply `int.__hash__ (value)` so I think this could move into numba.

Is it frowned upon to use the extension API for internals? 

Cheers!
