### PR TITLE
Avoid recompiling inlined overload impl

### DIFF
--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -635,6 +635,11 @@ class _OverloadFunctionTemplate(AbstractTemplate):
             # situations that will succeed. For context see #5887.
             resolve = disp_type.dispatcher.get_call_template
             template, pysig, folded_args, kws = resolve(new_args, kws)
+
+            # avoid recompiling the implementation if info already available
+            if folded_args in self._inline_overloads:
+                return self._inline_overloads[folded_args]['iinfo'].signature
+
             ir = inline_worker.run_untyped_passes(
                 disp_type.dispatcher.py_func, enable_ssa=True
             )


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
We use `inline="always"` for most of our overloads, and found that implementations being compiled over and over again during typing is a major compilation time bottleneck. Avoiding recompilation by this PR saves around 40% of total compilation time in my testing.