### PR TITLE
Force text-align:left when using Annotate

### DIFF
--- a/numba/core/annotations/pretty_annotate.py
+++ b/numba/core/annotations/pretty_annotate.py
@@ -72,6 +72,7 @@ def get_html_template():
     <html>
     <head>
         <style>
+
             .annotation_table {
                 color: #000000;
                 font-family: monospace;
@@ -165,7 +166,7 @@ def get_html_template():
             <table class="annotation_table tex2jax_ignore">
                 {%- for num, line, hl, hc in func_data[func_key]['pygments_lines'] -%}
                     {%- if func_data[func_key]['ir_lines'][num] %}
-                        <tr><td class="{{func_data[func_key]['python_tags'][num]}}">
+                        <tr><td style="text-align:left;" class="{{func_data[func_key]['python_tags'][num]}}">
                             <details>
                                 <summary>
                                     <code>
@@ -191,7 +192,7 @@ def get_html_template():
                                 </details>
                         </td></tr>
                     {% else -%}
-                        <tr><td style=" padding-left: 22px;" class="{{func_data[func_key]['python_tags'][num]}}">
+                        <tr><td style="text-align:left; padding-left: 22px;" class="{{func_data[func_key]['python_tags'][num]}}">
                             <code>
                                 {{num}}:
                                 {{'&nbsp;'*func_data[func_key]['python_indent'][num]}}{{hl}}

--- a/numba/core/annotations/pretty_annotate.py
+++ b/numba/core/annotations/pretty_annotate.py
@@ -178,7 +178,7 @@ def get_html_template():
                                     <tbody>
                                         {%- for ir_line, ir_line_type in func_data[func_key]['ir_lines'][num] %}
                                             <tr class="ir_code">
-                                                <td><code>
+                                                <td style="text-align: left;"><code>
                                                 &nbsp;
                                                 {{- '&nbsp;'*func_data[func_key]['python_indent'][num]}}
                                                 {{ '&nbsp;'*func_data[func_key]['ir_indent'][num][loop.index0]}}{{ir_line|e -}}


### PR DESCRIPTION
This is a simple fix for https://github.com/numba/numba/issues/4064

Before:
![image](https://user-images.githubusercontent.com/2712115/112696461-9a357300-8e64-11eb-9414-f3a242e3dbaa.png)

Result after fix:
![image](https://user-images.githubusercontent.com/2712115/112697418-3c098f80-8e66-11eb-9dfe-f8f4eda215fc.png)
