### PR TITLE
Clarify conversions to numeric types

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -923,7 +923,7 @@ The following built-in functions are supported:
 * :func:`filter`
 * :class:`float`
 * :func:`hash` (see :ref:`pysupported-hashing` below)
-* :class:`int`: only the one-argument form
+* :class:`int`: only the one-argument form, and only for numeric type conversions (Integer, Float and Boolean), string parsing is not supported yet
 * :func:`iter`: only the one-argument form
 * :func:`len`
 * :func:`min`

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -921,9 +921,9 @@ The following built-in functions are supported:
 * :func:`divmod`
 * :func:`enumerate`
 * :func:`filter`
-* :class:`float`
+* :class:`float`: only for numeric type conversions (Integer, Real)
 * :func:`hash` (see :ref:`pysupported-hashing` below)
-* :class:`int`: only the one-argument form, and only for numeric type conversions (Integer, Float and Boolean), string parsing is not supported yet
+* :class:`int`: only the one-argument form, and only for numeric type conversions (Integer, Float and Boolean)
 * :func:`iter`: only the one-argument form
 * :func:`len`
 * :func:`min`


### PR DESCRIPTION
The current documentation for `int` support is `only the one-argument form`, but it actually is more restricted than that.

The second argument of the `int` constructor is the base, used only for setting a custom base when converting from `str`, `bytes` or `bytearray`, so just saying it supports one argument only might be interpreted, like I did, as "no custom base is supported", where actually it just supports `Integer`, `Float` or `Boolean` as implemented [here](https://github.com/numba/numba/blob/master/numba/core/typing/builtins.py#L930-L933).

This uses a single argument but fails:
```python
@njit
def foo(val):
    return int(val)

foo('123') # No implementation of function Function(<class 'int'>) found for signature: >>> int(unicode_type)
```


The [python docs](https://docs.python.org/3/library/functions.html#int) also defines the support for casting objects into `int`s, but since passing an object as an argument require using object mode, it works correctly using the python apis, so I don't think it needs to be mentioned here. In object mode string conversions also work correctly:

```python
@jit(forceobj=True)
def foo(val):
    return int(val)

class A:
    def __int__(self):
        return 4

foo(A())
foo('123')
```

The same restriction applies for `float`, but it has a clearer error message:
```python
@njit
def foo(val):
    return float(val)
foo('123')
```
```
No implementation of function Function(<class 'float'>) found for signature:
 
 >>> float(unicode_type)
 
There are 2 candidate implementations:
  - Of which 2 did not match due to:
  Overload in function 'Float.generic': File: numba/core/typing/builtins.py: Line 939.
    With argument(s): '(unicode_type)':
   Rejected as the implementation raised a specific error:
     TypeError: float() only support for numbers <=========== The int error message does not have this line
```

I would add that error message on the `int` generic copy [this error](https://github.com/numba/numba/blob/master/numba/core/typing/builtins.py#L945) as a fallback [here](https://github.com/numba/numba/blob/master/numba/core/typing/builtins.py#L934), but I don't know where to test it. I may open another PR for that.