### PR TITLE
Add trailing slashes to dir paths in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,9 @@
 
 # Owners of specific parts of the code, will be requested to review if a PR
 # touches code in the matched pattern
-/numba/cuda @gmarkall
-/numba/parfors @DrTodd13
-/numba/stencils @DrTodd13
+/numba/cuda/ @gmarkall
+/numba/parfors/ @DrTodd13
+/numba/stencils/ @DrTodd13
 
 # ------------------------------------------------------------------------------
 # Information for contributors


### PR DESCRIPTION
Hopefully this resolves the issue of reviews not being requested for CUDA (and presumably parfors / stencils - cc @DrTodd13)