### PR TITLE
CUDA: Support passing tuples to ufuncs

### DIFF
--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -90,16 +90,17 @@ class UFuncMechanism(object):
         Get all arguments in array form
         """
         for i, arg in enumerate(self.args):
-            if isinstance(arg, np.ndarray):
-                self.arrays[i] = arg
-            elif self.is_device_array(arg):
+            if self.is_device_array(arg):
                 self.arrays[i] = self.as_device_array(arg)
             elif isinstance(arg, (int, float, complex, np.number)):
                 # Is scalar
                 self.scalarpos.append(i)
             else:
-                raise TypeError("argument #%d has invalid type of %s" \
-                % (i + 1, type(arg) ))
+                array = np.asarray(arg)
+                if array.dtype == np.object:
+                    fmt = "argument #%d has invalid type of %s"
+                    raise TypeError(fmt % (i + 1, type(arg) ))
+                self.arrays[i] = array
 
     def _fill_argtypes(self):
         """
@@ -107,7 +108,7 @@ class UFuncMechanism(object):
         """
         for i, ary in enumerate(self.arrays):
             if ary is not None:
-                self.argtypes[i] = ary.dtype
+                self.argtypes[i] = np.asarray(ary).dtype
 
     def _resolve_signature(self):
         """Resolve signature.

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -96,11 +96,7 @@ class UFuncMechanism(object):
                 # Is scalar
                 self.scalarpos.append(i)
             else:
-                array = np.asarray(arg)
-                if array.dtype == np.object:
-                    fmt = "argument #%d has invalid type of %s"
-                    raise TypeError(fmt % (i + 1, type(arg) ))
-                self.arrays[i] = array
+                self.arrays[i] = np.asarray(arg)
 
     def _fill_argtypes(self):
         """


### PR DESCRIPTION
This PR adds support for use cases like the following to CUDA ufuncs created with `@vectorize`:

```python
from numba import vectorize, float64
import math

@vectorize([float64(float64)], target='cuda')
def cuda_cos(x):
    return math.cos(x)

print(cuda_cos((1.0, 2.0, 3.0)))
```

Passing tuples, namedtuples, tuples of arrays, and nesting of these is supported - tests are added to cover some of these cases.

It seems that this already worked for gufuncs, so some tests are added for the equivalent in gufuncs, but no functional change is made there.

Fixes #6563.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
