### PR TITLE
CUDA: NumPy and string dtypes for local and shared arrays

### DIFF
--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from numba import cuda, int32, complex128
-from numba.cuda.testing import unittest, CUDATestCase
+from numba import cuda, int32, complex128, void
+from numba.core.errors import TypingError
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 
 
 def culocal(A, B):
@@ -57,6 +58,56 @@ class TestCudaLocalMem(CUDATestCase):
         B = np.zeros_like(A)
         jculocalcomplex[1, 1](A, B)
         self.assertTrue(np.all(A == B))
+
+    def check_dtype(self, f):
+        # Find the typing of the dtype argument to cuda.local.array
+        annotation = next(iter(f.overloads.values()))._type_annotation
+        l_dtype = annotation.typemap['l'].dtype
+        # Ensure that the typing is correct
+        self.assertEqual(l_dtype, int32)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_numba_dtype(self):
+        # Check that Numba types can be used as the dtype of a local array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            l = cuda.local.array(10, dtype=int32)
+            l[0] = x[0]
+            x[0] = l[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_numpy_dtype(self):
+        # Check that NumPy types can be used as the dtype of a local array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            l = cuda.local.array(10, dtype=np.int32)
+            l[0] = x[0]
+            x[0] = l[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_string_dtype(self):
+        # Check that strings can be used to specify the dtype of a local array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            l = cuda.local.array(10, dtype='int32')
+            l[0] = x[0]
+            x[0] = l[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_invalid_string_dtype(self):
+        # Check that strings of invalid dtypes cause a typing error
+        with self.assertRaises(TypingError):
+            @cuda.jit(void(int32[::1]))
+            def f(x):
+                l = cuda.local.array(10, dtype='int33')
+                l[0] = x[0]
+                x[0] = l[0]
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -102,7 +102,8 @@ class TestCudaLocalMem(CUDATestCase):
     @skip_on_cudasim("Can't check typing in simulator")
     def test_invalid_string_dtype(self):
         # Check that strings of invalid dtypes cause a typing error
-        with self.assertRaises(TypingError):
+        re = ".*Invalid NumPy dtype specified: 'int33'.*"
+        with self.assertRaisesRegex(TypingError, re):
             @cuda.jit(void(int32[::1]))
             def f(x):
                 l = cuda.local.array(10, dtype='int33')

--- a/numba/cuda/tests/cudapy/test_sm_creation.py
+++ b/numba/cuda/tests/cudapy/test_sm_creation.py
@@ -182,7 +182,8 @@ class TestSharedMemoryCreation(CUDATestCase):
     @skip_on_cudasim("Can't check typing in simulator")
     def test_invalid_string_dtype(self):
         # Check that strings of invalid dtypes cause a typing error
-        with self.assertRaises(TypingError):
+        re = ".*Invalid NumPy dtype specified: 'int33'.*"
+        with self.assertRaisesRegex(TypingError, re):
             @cuda.jit(void(int32[::1]))
             def f(x):
                 s = cuda.shared.array(10, dtype='int33')

--- a/numba/cuda/tests/cudapy/test_sm_creation.py
+++ b/numba/cuda/tests/cudapy/test_sm_creation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import cuda, float32, int32
+from numba import cuda, float32, int32, void
 from numba.core.errors import TypingError
 from numba.cuda.testing import unittest, CUDATestCase
 from numba.cuda.testing import skip_on_cudasim
@@ -138,6 +138,56 @@ class TestSharedMemoryCreation(CUDATestCase):
                       ">>> array(shape=Tuple(Literal[int](1), int32), "
                       "dtype=class(float32))",
                       str(raises.exception))
+
+    def check_dtype(self, f):
+        # Find the typing of the dtype argument to cuda.shared.array
+        annotation = next(iter(f.overloads.values()))._type_annotation
+        l_dtype = annotation.typemap['s'].dtype
+        # Ensure that the typing is correct
+        self.assertEqual(l_dtype, int32)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_numba_dtype(self):
+        # Check that Numba types can be used as the dtype of a shared array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            s = cuda.shared.array(10, dtype=int32)
+            s[0] = x[0]
+            x[0] = s[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_numpy_dtype(self):
+        # Check that NumPy types can be used as the dtype of a shared array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            s = cuda.shared.array(10, dtype=np.int32)
+            s[0] = x[0]
+            x[0] = s[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_string_dtype(self):
+        # Check that strings can be used to specify the dtype of a shared array
+        @cuda.jit(void(int32[::1]))
+        def f(x):
+            s = cuda.shared.array(10, dtype='int32')
+            s[0] = x[0]
+            x[0] = s[0]
+
+        self.check_dtype(f)
+
+    @skip_on_cudasim("Can't check typing in simulator")
+    def test_invalid_string_dtype(self):
+        # Check that strings of invalid dtypes cause a typing error
+        with self.assertRaises(TypingError):
+            @cuda.jit(void(int32[::1]))
+            def f(x):
+                s = cuda.shared.array(10, dtype='int33')
+                s[0] = x[0]
+                x[0] = s[0]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue #5901 identified that at some point local arrays would only accept Numba types for their dtype. It appears that they now accept NumPy and string dtypes.

Since this now seems to work, this commit adds tests for passing string and NumPy types as dtypes to both local and shared array constructors.

Fixes #5901.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
