### PR TITLE
Add attribute lower_extension to CPUContext

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -65,6 +65,10 @@ class CPUContext(BaseContext):
 
         # Add lower_extension attribute
         self.lower_extensions = {}
+        from numba.parfors.parfor_lowering import _lower_parfor_parallel
+        from numba.parfors.parfor import Parfor
+        # Specify how to lower Parfor nodes using the lower_extensions
+        self.lower_extensions[Parfor] = _lower_parfor_parallel
 
     def load_additional_registries(self):
         # Add target specific implementations

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -63,6 +63,9 @@ class CPUContext(BaseContext):
         import numba.typed.dictimpl
         import numba.experimental.function_type
 
+        # Add lower_extension attribute
+        self.lower_extensions = {}
+
     def load_additional_registries(self):
         # Add target specific implementations
         from numba.np import npyimpl

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -267,10 +267,6 @@ class BaseLower(object):
             self.context.debug_print(self.builder, "DEBUGJIT: {0}".format(msg))
 
 
-# Dictionary mapping instruction class to its lowering function.
-lower_extensions = {}
-
-
 class Lower(BaseLower):
     GeneratorLower = generators.GeneratorLower
 
@@ -438,10 +434,11 @@ class Lower(BaseLower):
             self.lower_static_try_raise(inst)
 
         else:
-            for _class, func in lower_extensions.items():
-                if isinstance(inst, _class):
-                    func(self, inst)
-                    return
+            if hasattr(self.context, "lower_extensions"):
+                for _class, func in self.context.lower_extensions.items():
+                    if isinstance(inst, _class):
+                        func(self, inst)
+                        return
             raise NotImplementedError(type(inst))
 
     def lower_setitem(self, target_var, index_var, value_var, signature):

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -289,6 +289,13 @@ class ParforPass(FunctionPass):
         """
         Convert data-parallel computations into Parfor nodes
         """
+        # Register lowerer for Parfor Node
+        from numba.parfors.parfor_lowering import _lower_parfor_parallel
+        if hasattr(state.targetctx, "lower_extensions"):
+            state.targetctx.lower_extensions[Parfor] = _lower_parfor_parallel
+        else:
+            raise AttributeError("target_context has no attribute 'lower_extensions'")
+
         # Ensure we have an IR and type information.
         assert state.func_ir
         parfor_pass = _parfor_ParforPass(state.func_ir,

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -294,7 +294,8 @@ class ParforPass(FunctionPass):
         if hasattr(state.targetctx, "lower_extensions"):
             state.targetctx.lower_extensions[Parfor] = _lower_parfor_parallel
         else:
-            raise AttributeError("target_context has no attribute 'lower_extensions'")
+            raise AttributeError("target_context has no attribute "
+                                 "'lower_extensions'")
 
         # Ensure we have an IR and type information.
         assert state.func_ir

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -289,14 +289,6 @@ class ParforPass(FunctionPass):
         """
         Convert data-parallel computations into Parfor nodes
         """
-        # Register lowerer for Parfor Node
-        from numba.parfors.parfor_lowering import _lower_parfor_parallel
-        if hasattr(state.targetctx, "lower_extensions"):
-            state.targetctx.lower_extensions[Parfor] = _lower_parfor_parallel
-        else:
-            raise AttributeError("target_context has no attribute "
-                                 "'lower_extensions'")
-
         # Ensure we have an IR and type information.
         assert state.func_ir
         parfor_pass = _parfor_ParforPass(state.func_ir,

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -482,9 +482,6 @@ def _lower_parfor_parallel(lowerer, parfor):
     if config.DEBUG_ARRAY_OPT:
         print("_lower_parfor_parallel done")
 
-# A work-around to prevent circular imports
-lowering.lower_extensions[parfor.Parfor] = _lower_parfor_parallel
-
 
 def _create_shape_signature(
         get_shape_classes,


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
This PR makes the global `lower_extensions` a part of CPUContext. For Numba IR extension nodes, the pass that adds the extension node can register the method to lower it with the target context.