### PR TITLE
Add support of np.swapaxes #4074

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -498,6 +498,7 @@ The following top-level functions are supported:
 * :func:`numpy.sort` (no optional arguments)
 * :func:`numpy.split`
 * :func:`numpy.stack`
+* :func:`numpy.swapaxes`
 * :func:`numpy.take` (only the 2 first arguments)
 * :func:`numpy.transpose`
 * :func:`numpy.trapz` (only the 3 first arguments)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5278,14 +5278,22 @@ def numpy_swapaxes(arr, axis1, axis2):
         raise errors.TypingError('The first argument "arr" must be an array')
 
     # create tuple list for transpose
-    axes_list = tuple(range(arr.ndim))
+    ndim = arr.ndim
+    axes_list = tuple(range(ndim))
 
     def impl(arr, axis1, axis2):
+        if axis1 >= ndim or abs(axis1) > ndim:
+            raise ValueError('The second argument "axis1" is out of bounds '
+                             'for array of given dimension')
+        if axis2 >= ndim or abs(axis2) > ndim:
+            raise ValueError('The third argument "axis2" is out of bounds '
+                             'for array of given dimension')
+
         # to ensure tuple_setitem support of negative values
         if axis1 < 0:
-            axis1 += arr.ndim
+            axis1 += ndim
         if axis2 < 0:
-            axis2 += arr.ndim
+            axis2 += ndim
 
         axes_tuple = tuple_setitem(axes_list, axis1, axis2)
         axes_tuple = tuple_setitem(axes_tuple, axis2, axis1)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1573,18 +1573,16 @@ def numpy_rot90(arr, k=1):
     if arr.ndim < 2:
         raise ValueError('Input must be >= 2-d.')
 
-    axes_list = (1, 0, *range(2, arr.ndim))
-
     def impl(arr, k=1):
         k = k % 4
         if k == 0:
             return arr[:]
         elif k == 1:
-            return np.transpose(np.fliplr(arr), axes_list)
+            return np.swapaxes(np.fliplr(arr), 0, 1)
         elif k == 2:
             return np.flipud(np.fliplr(arr))
         elif k == 3:
-            return np.fliplr(np.transpose(arr, axes_list))
+            return np.fliplr(np.swapaxes(arr, 0, 1))
         else:
             raise AssertionError  # unreachable
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5266,3 +5266,31 @@ def ol_bool(arr):
                        "is ambiguous. Use a.any() or a.all()")
                 raise ValueError(msg)
         return impl
+
+
+@overload(np.swapaxes)
+def numpy_swapaxes(arr, axis1, axis2):
+    if not isinstance(axis1, (int, types.Integer)):
+        raise errors.TypingError('The second argument "axis1" must be an '
+                                 'integer')
+    if not isinstance(axis2, (int, types.Integer)):
+        raise errors.TypingError('The third argument "axis2" must be an '
+                                 'integer')
+    if not isinstance(arr, types.Array):
+        raise errors.TypingError('The first argument "arr" must be an array')
+
+    # create tuple list for transpose
+    axes_list = tuple(range(arr.ndim))
+
+    def impl(arr, axis1, axis2):
+        # to ensure tuple_setitem support of negative values
+        if axis1 < 0:
+            axis1 += arr.ndim
+        if axis2 < 0:
+            axis2 += arr.ndim
+
+        axes_tuple = tuple_setitem(axes_list, axis1, axis2)
+        axes_tuple = tuple_setitem(axes_tuple, axis2, axis1)
+        return np.transpose(arr, axes_tuple)
+
+    return impl

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4097,6 +4097,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         self.assertIn('The third argument "axis2" is out of bounds for array'
                       ' of given dimension', str(raises.exception))
 
+
 class TestNPMachineParameters(TestCase):
     # tests np.finfo, np.iinfo, np.MachAr
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -353,6 +353,10 @@ def array_contains(a, key):
     return key in a
 
 
+def swapaxes(a, a1, a2):
+    return np.swapaxes(a, a1, a2)
+
+
 class TestNPFunctions(MemoryLeakMixin, TestCase):
     """
     Tests for various Numpy functions.
@@ -4039,6 +4043,47 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(TypingError) as e:
             cfunc(np.array([1, 2, 3, 4]), 'float32')
         self.assertIn("dtype must be a valid Numpy dtype", str(e.exception))
+
+    def test_swapaxes_basic(self):
+        pyfunc = swapaxes
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def a_variations():
+            yield np.arange(10)
+            yield np.arange(10).reshape(2, 5)
+            yield np.arange(60).reshape(5, 4, 3)
+
+        for a in a_variations():
+            for a1 in range(-a.ndim, a.ndim):
+                for a2 in range(-a.ndim, a.ndim):
+                    expected = pyfunc(a, a1, a2)
+                    got = cfunc(a, a1, a2)
+                    self.assertPreciseEqual(expected, got)
+
+    def test_swapaxes_exception(self):
+        pyfunc = swapaxes
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        with self.assertRaises(TypingError) as raises:
+            cfunc('abc', 0, 0)
+
+        self.assertIn('The first argument "arr" must be an array',
+                      str(raises.exception))
+
+        with self.assertRaises(TypingError) as raises:
+            cfunc(np.arange(4), 'abc', 0)
+
+        self.assertIn('The second argument "axis1" must be an integer',
+                      str(raises.exception))
+
+        with self.assertRaises(TypingError) as raises:
+            cfunc(np.arange(4), 0, 'abc')
+
+        self.assertIn('The third argument "axis2" must be an integer',
+                      str(raises.exception))
 
 
 class TestNPMachineParameters(TestCase):

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4085,6 +4085,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         self.assertIn('The third argument "axis2" must be an integer',
                       str(raises.exception))
 
+        with self.assertRaises(ValueError) as raises:
+            cfunc(np.arange(4), 1, 0)
+
+        self.assertIn('The second argument "axis1" is out of bounds for array'
+                      ' of given dimension', str(raises.exception))
+
+        with self.assertRaises(ValueError) as raises:
+            cfunc(np.arange(8).reshape(2, 4), 0, -3)
+
+        self.assertIn('The third argument "axis2" is out of bounds for array'
+                      ' of given dimension', str(raises.exception))
 
 class TestNPMachineParameters(TestCase):
     # tests np.finfo, np.iinfo, np.MachAr


### PR DESCRIPTION
This PR is adds `np.swapaxes`, which is currently unimplemented according to #4074 (or `np.swapaxis` which is the mis-spelling version). I had help by @stuartarchibald on discourse: (https://numba.discourse.group/t/how-to-use-types-integer-for-indexing-list/647)

This function can be used to simplify the implementation of `np.rot90` from #6822, which is also the first step of implementing full further arguments of it.