### PR TITLE
CUDA: Explicitly specify objmode + looplifting for jit functions in cuda.random

### DIFF
--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -1,7 +1,7 @@
 import math
 
-from numba import (cuda, float32, float64, uint32, int64, uint64, from_dtype,
-                   jit)
+from numba import (config, cuda, float32, float64, uint32, int64, uint64,
+                   from_dtype, jit)
 
 import numpy as np
 
@@ -33,8 +33,16 @@ xoroshiro128p_dtype = np.dtype([('s0', np.uint64), ('s1', np.uint64)],
                                align=True)
 xoroshiro128p_type = from_dtype(xoroshiro128p_dtype)
 
+# When cudasim is enabled, Fake CUDA arrays are passed to some of the
+# @jit-decorated functions. This causes a fallback to object mode and the
+# emission of a warning at present - this is visible in the test suite with
+# cudasim, but also fallback-by-default will not be permitted in future. In
+# order to avoid the warning / future error, we explicitly specify that
+# object mode with loop lifting is acceptable when using the simulator.
+forceobj = looplift = config.ENABLE_CUDASIM
 
-@jit
+
+@jit(forceobj=forceobj, looplift=looplift)
 def init_xoroshiro128p_state(states, index, seed):
     '''Use SplitMix64 to generate an xoroshiro128p state from 64-bit seed.
 
@@ -60,7 +68,7 @@ def init_xoroshiro128p_state(states, index, seed):
     states[index]['s1'] = z
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def rotl(x, k):
     '''Left rotate x by k bits.'''
     x = uint64(x)
@@ -68,7 +76,7 @@ def rotl(x, k):
     return (x << k) | (x >> uint32(64 - k))
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_next(states, index):
     '''Return the next random uint64 and advance the RNG in states[index].
 
@@ -90,7 +98,7 @@ def xoroshiro128p_next(states, index):
     return result
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_jump(states, index):
     '''Advance the RNG in ``states[index]`` by 2**64 steps.
 
@@ -117,21 +125,21 @@ def xoroshiro128p_jump(states, index):
     states[index]['s1'] = s1
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def uint64_to_unit_float64(x):
     '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
     x = uint64(x)
     return (x >> uint32(11)) * (float64(1) / (uint64(1) << uint32(53)))
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def uint64_to_unit_float32(x):
     '''Convert uint64 to float32 value in the range [0.0, 1.0)'''
     x = uint64(x)
     return float32(uint64_to_unit_float64(x))
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_uniform_float32(states, index):
     '''Return a float32 in range [0.0, 1.0) and advance ``states[index]``.
 
@@ -145,7 +153,7 @@ def xoroshiro128p_uniform_float32(states, index):
     return uint64_to_unit_float32(xoroshiro128p_next(states, index))
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_uniform_float64(states, index):
     '''Return a float64 in range [0.0, 1.0) and advance ``states[index]``.
 
@@ -163,7 +171,7 @@ TWO_PI_FLOAT32 = np.float32(2 * math.pi)
 TWO_PI_FLOAT64 = np.float64(2 * math.pi)
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_normal_float32(states, index):
     '''Return a normally distributed float32 and advance ``states[index]``.
 
@@ -188,7 +196,7 @@ def xoroshiro128p_normal_float32(states, index):
     return z0
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def xoroshiro128p_normal_float64(states, index):
     '''Return a normally distributed float32 and advance ``states[index]``.
 
@@ -213,7 +221,7 @@ def xoroshiro128p_normal_float64(states, index):
     return z0
 
 
-@jit
+@jit(forceobj=forceobj, looplift=looplift)
 def init_xoroshiro128p_states_cpu(states, seed, subsequence_start):
     n = states.shape[0]
     seed = uint64(seed)

--- a/numba/cuda/random.py
+++ b/numba/cuda/random.py
@@ -39,10 +39,10 @@ xoroshiro128p_type = from_dtype(xoroshiro128p_dtype)
 # cudasim, but also fallback-by-default will not be permitted in future. In
 # order to avoid the warning / future error, we explicitly specify that
 # object mode with loop lifting is acceptable when using the simulator.
-forceobj = looplift = config.ENABLE_CUDASIM
+_forceobj = _looplift = config.ENABLE_CUDASIM
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def init_xoroshiro128p_state(states, index, seed):
     '''Use SplitMix64 to generate an xoroshiro128p state from 64-bit seed.
 
@@ -68,7 +68,7 @@ def init_xoroshiro128p_state(states, index, seed):
     states[index]['s1'] = z
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def rotl(x, k):
     '''Left rotate x by k bits.'''
     x = uint64(x)
@@ -76,7 +76,7 @@ def rotl(x, k):
     return (x << k) | (x >> uint32(64 - k))
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_next(states, index):
     '''Return the next random uint64 and advance the RNG in states[index].
 
@@ -98,7 +98,7 @@ def xoroshiro128p_next(states, index):
     return result
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_jump(states, index):
     '''Advance the RNG in ``states[index]`` by 2**64 steps.
 
@@ -125,21 +125,21 @@ def xoroshiro128p_jump(states, index):
     states[index]['s1'] = s1
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def uint64_to_unit_float64(x):
     '''Convert uint64 to float64 value in the range [0.0, 1.0)'''
     x = uint64(x)
     return (x >> uint32(11)) * (float64(1) / (uint64(1) << uint32(53)))
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def uint64_to_unit_float32(x):
     '''Convert uint64 to float32 value in the range [0.0, 1.0)'''
     x = uint64(x)
     return float32(uint64_to_unit_float64(x))
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_uniform_float32(states, index):
     '''Return a float32 in range [0.0, 1.0) and advance ``states[index]``.
 
@@ -153,7 +153,7 @@ def xoroshiro128p_uniform_float32(states, index):
     return uint64_to_unit_float32(xoroshiro128p_next(states, index))
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_uniform_float64(states, index):
     '''Return a float64 in range [0.0, 1.0) and advance ``states[index]``.
 
@@ -171,7 +171,7 @@ TWO_PI_FLOAT32 = np.float32(2 * math.pi)
 TWO_PI_FLOAT64 = np.float64(2 * math.pi)
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_normal_float32(states, index):
     '''Return a normally distributed float32 and advance ``states[index]``.
 
@@ -196,7 +196,7 @@ def xoroshiro128p_normal_float32(states, index):
     return z0
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def xoroshiro128p_normal_float64(states, index):
     '''Return a normally distributed float32 and advance ``states[index]``.
 
@@ -221,7 +221,7 @@ def xoroshiro128p_normal_float64(states, index):
     return z0
 
 
-@jit(forceobj=forceobj, looplift=looplift)
+@jit(forceobj=_forceobj, looplift=_looplift)
 def init_xoroshiro128p_states_cpu(states, seed, subsequence_start):
     n = states.shape[0]
     seed = uint64(seed)


### PR DESCRIPTION
Using the `@jit` decorator alone results in warnings being emitted when using the `cuda.random` functions with the simulator enabled, because Fake CUDA Arrays are passed to jitted functions. Since these can't be typed or unboxed, a fallback to object mode with looplifting is needed.

To avoid the warning, we explicitly specify that object mode with looplifting should be used when the simulator is enabled.

Fixes #4809.