### PR TITLE
CUDA: Fix parallel testing for all testsuite submodules

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -349,6 +349,7 @@ def get_supported_ccs():
     except: # noqa: E722
         # The CUDA Runtime may not be present
         cudart_version_major = 0
+        cudart_version_minor = 0
 
     ctk_ver = f"{cudart_version_major}.{cudart_version_minor}"
     unsupported_ver = f"CUDA Toolkit {ctk_ver} is unsupported by Numba - " \

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -37,6 +37,20 @@ class ContextResettingTestCase(CUDATestCase):
         reset()
 
 
+def ensure_supported_ccs_initialized():
+    from numba.cuda import is_available as cuda_is_available
+    from numba.cuda.cudadrv import nvvm
+
+    if cuda_is_available():
+        # Ensure that cudart.so is loaded and the list of supported compute
+        # capabilities in the nvvm module is populated before a fork. This is
+        # needed because some compilation tests don't require a CUDA context,
+        # but do use NVVM, and it is required that libcudart.so should be
+        # loaded before a fork (note that the requirement is not explicitly
+        # documented).
+        nvvm.get_supported_ccs()
+
+
 def skip_on_cudasim(reason):
     """Skip this test if running on the CUDA simulator"""
     return unittest.skipIf(config.ENABLE_CUDASIM, reason)

--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -1,3 +1,4 @@
+from numba.cuda.testing import ensure_supported_ccs_initialized
 from numba.testing import unittest
 from numba.testing import load_testsuite
 from numba import cuda
@@ -7,15 +8,9 @@ from os.path import dirname, join
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()
     this_dir = dirname(__file__)
+    ensure_supported_ccs_initialized()
     suite.addTests(load_testsuite(loader, join(this_dir, 'nocuda')))
     if cuda.is_available():
-        # Ensure that cudart.so is loaded and the list of supported compute
-        # capabilities in the nvvm module is populated before a fork. This is
-        # needed because some compilation tests don't require a CUDA context,
-        # but do use NVVM to compile, and it is required that libcudart.so
-        # should be loaded before a fork (note that the requirement is not
-        # explicitly documented).
-        cuda.cudadrv.nvvm.get_supported_ccs()
         suite.addTests(load_testsuite(loader, join(this_dir, 'cudasim')))
         gpus = cuda.list_devices()
         if gpus and gpus[0].compute_capability >= (2, 0):

--- a/numba/cuda/tests/cudadrv/__init__.py
+++ b/numba/cuda/tests/cudadrv/__init__.py
@@ -1,6 +1,8 @@
+from numba.cuda.testing import ensure_supported_ccs_initialized
 from numba.testing import load_testsuite
 import os
 
 
 def load_tests(loader, tests, pattern):
+    ensure_supported_ccs_initialized()
     return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/cudapy/__init__.py
+++ b/numba/cuda/tests/cudapy/__init__.py
@@ -1,6 +1,8 @@
+from numba.cuda.testing import ensure_supported_ccs_initialized
 from numba.testing import load_testsuite
 import os
 
 
 def load_tests(loader, tests, pattern):
+    ensure_supported_ccs_initialized()
     return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/nocuda/__init__.py
+++ b/numba/cuda/tests/nocuda/__init__.py
@@ -1,6 +1,8 @@
+from numba.cuda.testing import ensure_supported_ccs_initialized
 from numba.testing import load_testsuite
 import os
 
 
 def load_tests(loader, tests, pattern):
+    ensure_supported_ccs_initialized()
     return load_testsuite(loader, os.path.dirname(__file__))

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -1,7 +1,6 @@
-from numba.cuda.compiler import compile_kernel
 from numba.cuda.cudadrv import nvvm
-from numba.cuda.testing import skip_on_cudasim, SerialMixin
-from numba.core import types, utils
+from numba.cuda.testing import skip_on_cudasim
+from numba.core import utils
 
 from llvmlite import ir
 from llvmlite import binding as llvm
@@ -19,21 +18,7 @@ missing_align = "call void @llvm.memset.p0i8.i64(" \
 @skip_on_cudasim('libNVVM not supported in simulator')
 @unittest.skipIf(utils.MACHINE_BITS == 32, "CUDA not support for 32-bit")
 @unittest.skipIf(not nvvm.is_available(), "No libNVVM")
-class TestNvvmWithoutCuda(SerialMixin, unittest.TestCase):
-    def test_nvvm_llvm_to_ptx(self):
-        """
-        A simple test to exercise nvvm.llvm_to_ptx()
-        to trigger issues with mismatch NVVM API.
-        """
-
-        def foo(x):
-            x[0] = 123
-
-        cukern = compile_kernel(foo, args=(types.int32[::1],), link=())
-        llvmir = cukern._codelibrary.get_llvm_str()
-        ptx = nvvm.llvm_to_ptx(llvmir)
-        self.assertIn("foo", ptx.decode('ascii'))
-
+class TestNvvmWithoutCuda(unittest.TestCase):
     def test_nvvm_memset_fixup_for_34(self):
         """
         Test llvm.memset changes in llvm7.


### PR DESCRIPTION
Running the testsuite in parallel for the `numba.cuda.tests` module works already, but running it in parallel for submodules, such as `numba.cuda.tests.cudapy` did not. This is because the `numba.cuda.tests.__init__.load_tests()` function ensured that the list of supported compute capabilities in `numba.cuda.cudadrv.nvvm` was initialized in the parent process, but the `load_tests()` function in its child modules did not.  This commit rectifies this issue by ensuring that it is initialized for each of the submodules that might want to use NVVM in a test that can be run in parallel (i.e. not a `CUDATestCase` requiring a context).

Some other issues were discovered and are fixed:

- In nvvm.py, if the CUDA runtime was not present, `cudart_version_minor` was not set, so formatting `ctk_ver` raised an exception, leading to confusing error messages. It is now set to 0 for an absent toolkit.
- `TestNvvmWithoutCuda` had the `SerialMixin`, which shouldn't be needed for a test that is not supposed to require a context. The mixin is now removed.
- `TestNvvmWithoutCuda.test_nvvm_llvm_to_ptx` actually does require a context, because it compiles a kernel (which will be linked and loaded, etc.)! This test just shouldn't be in a test class that is not supposed to require a context, and is probably left over from a time when binding (linking and loading) did not occur automatically (many years ago). Since there are better tests of `nvvm_to_ptx` in the `cudapy` tests, this test is removed.

Running the whole CUDA test suite or its submodules in parallel with the `-m` flag, e.g.:

```
python -m numba.runtests numba.cuda.tests.<module>
```

now works correctly for each of the modules:

- No submodule, just `numba.cuda.tests`
- `cudadrv`
- `cudapy`
- `nocuda`
- `cudasim`
- `doc_examples`

(verified manually)

Fixes #6703.

**Edit:**
Fixes #6910. (added by @sklam)
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
