### PR TITLE
Address guvectorize too slow for cuda target

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -470,8 +470,7 @@ GPU support
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 
    Enable warnings if the grid size is too small relative to the number of
-   steraming multiprocessors (SM). If the block size is too small an inefficient
-   schedule will result and performance will suffer. This option is on by default (1).
+   steraming multiprocessors (SM). This option is on by default (1).
 
    The heuristic checked is whether gridsize < 2 * (number of SMs). NOTE: The absence of
    a warning does not imply a good gridsize relative to the number of SMs. Disabling

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -470,12 +470,12 @@ GPU support
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 
    Enable warnings if the grid size is too small relative to the number of
-   steraming multiprocessors (SM). This option is on by default (1).
+   streaming multiprocessors (SM). This option is on by default (default  value is 1).
 
-   The heuristic checked is whether gridsize < 2 * (number of SMs). NOTE: The absence of
+   The heuristic checked is whether ``gridsize < 2 * (number of SMs)``. NOTE: The absence of
    a warning does not imply a good gridsize relative to the number of SMs. Disabling
-   this warning will reduce the number of CUDA API calls, as the heuristic needs to
-   check the number of SMs for the device in the current context.
+   this warning will reduce the number of CUDA API calls (during JIT compilation), as the
+   heuristic needs to check the number of SMs for the device in the current context.
 
 
 Threading Control

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -469,9 +469,14 @@ GPU support
 
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 
-   Enable warnings if the block size is too small relative to the number of
+   Enable warnings if the grid size is too small relative to the number of
    steraming multiprocessors (SM). If the block size is too small an inefficient
-   schedule will result and performance will suffer.
+   schedule will result and performance will suffer. This option is on by default (1).
+
+   The heuristic checked is whether gridsize < 2 * (number of SMs). NOTE: The absence of
+   a warning does not imply a good gridsize relative to the number of SMs. Disabling
+   this warning will reduce the number of CUDA API calls, as the heuristic needs to
+   check the number of SMs for the device in the current context.
 
 
 Threading Control

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -467,6 +467,12 @@ GPU support
    Strict strides checking is deprecated and may be removed in future. See
    :ref:`deprecation-strict-strides`.
 
+.. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
+
+   Enable warnings if the block size is too small relative to the number of
+   steraming multiprocessors (SM). If the block size is too small an inefficient
+   schedule will result and performance will suffer.
+
 
 Threading Control
 -----------------

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -470,12 +470,13 @@ GPU support
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 
    Enable warnings if the grid size is too small relative to the number of
-   streaming multiprocessors (SM). This option is on by default (default  value is 1).
+   streaming multiprocessors (SM). This option is on by default (default value is 1).
 
    The heuristic checked is whether ``gridsize < 2 * (number of SMs)``. NOTE: The absence of
    a warning does not imply a good gridsize relative to the number of SMs. Disabling
    this warning will reduce the number of CUDA API calls (during JIT compilation), as the
-   heuristic needs to check the number of SMs for the device in the current context.
+   heuristic needs to check the number of SMs available on the device in the
+   current context.
 
 
 Threading Control

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -154,6 +154,11 @@ class _EnvReloader(object):
             "NUMBA_ALWAYS_WARN_UNINIT_VAR", int, 0,
         )
 
+        # whether to warn about kernels where the block size will
+        # result in a inefficient mapping to GPUs. On by default.
+        LOW_OCCUPANCY_WARNINGS = _readenv(
+            "NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS", int, 1)
+
         # Debug flag to control compiler debug print
         DEBUG = _readenv("NUMBA_DEBUG", int, 0)
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -155,8 +155,8 @@ class _EnvReloader(object):
         )
 
         # Whether to warn about kernel launches where the grid size will
-        # underutilize the GPU due to low occupancy. On by default.
-        LOW_OCCUPANCY_WARNINGS = _readenv(
+        # under utilize the GPU due to low occupancy. On by default.
+        CUDA_LOW_OCCUPANCY_WARNINGS = _readenv(
             "NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS", int, 1)
 
         # Debug flag to control compiler debug print

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -154,8 +154,8 @@ class _EnvReloader(object):
             "NUMBA_ALWAYS_WARN_UNINIT_VAR", int, 0,
         )
 
-        # whether to warn about kernels where the block size will
-        # result in a inefficient mapping to GPUs. On by default.
+        # Whether to warn about kernel launches where the grid size will
+        # underutilize the GPU due to low occupancy. On by default.
         LOW_OCCUPANCY_WARNINGS = _readenv(
             "NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS", int, 1)
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -787,13 +787,13 @@ class _KernelConfiguration:
         self.stream = stream
         self.sharedmem = sharedmem
 
-        if config.LOW_OCCUPANCY_WARNINGS:
+        if config.CUDA_LOW_OCCUPANCY_WARNINGS:
             ctx = get_context()
             smcount = ctx.device.MULTIPROCESSOR_COUNT
             grid_size = griddim[0] * griddim[1] * griddim[2]
             if grid_size < 2 * smcount:
                 msg = ("Grid size ({grid}) < 2 * SM count ({sm}) "
-                       "will likely result in GPU underutilization due"
+                       "will likely result in GPU under utilization due"
                        "to low occupancy.")
                 msg = msg.format(grid=grid_size, sm=2 * smcount)
                 warn(NumbaPerformanceWarning(msg))

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -787,15 +787,16 @@ class _KernelConfiguration:
         self.stream = stream
         self.sharedmem = sharedmem
 
-        num_blocks = griddim[0] * griddim[1] * griddim[2]
-        ctx = get_context()
-        smcount = ctx.device.MULTIPROCESSOR_COUNT
-
-        if (config.LOW_OCCUPANCY_WARNINGS) and (num_blocks < 2 * smcount):
-            msg = ("Number of blocks ({blocks}) that are  < 2 * SM ({sm}) "
-                   "will generate inefficient kernel code.")
-            msg = msg.format(blocks=num_blocks, sm=2 * smcount)
-            warn(NumbaPerformanceWarning(msg))
+        if config.LOW_OCCUPANCY_WARNINGS:
+            ctx = get_context()
+            smcount = ctx.device.MULTIPROCESSOR_COUNT
+            grid_size = griddim[0] * griddim[1] * griddim[2]
+            if grid_size < 2 * smcount:
+                msg = ("Grid size ({grid}) < 2 * SM count ({sm}) "
+                       "will likely result in GPU underutilization due"
+                       "to low occupancy.")
+                msg = msg.format(grid=grid_size, sm=2 * smcount)
+                warn(NumbaPerformanceWarning(msg))
 
     def __call__(self, *args):
         return self.dispatcher.call(args, self.griddim, self.blockdim,

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -791,7 +791,7 @@ class _KernelConfiguration:
         ctx = get_context()
         smcount = ctx.device.MULTIPROCESSOR_COUNT
 
-        if num_blocks < 2 * smcount:
+        if (config.LOW_OCCUPANCY_WARNINGS) and (num_blocks < 2 * smcount):
             msg = ("Number of blocks ({blocks}) that are  < 2 * SM ({sm}) "
                    "will generate inefficient kernel code.")
             msg = msg.format(blocks=num_blocks, sm=2 * smcount)

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -29,6 +29,7 @@ from .cudadrv import nvvm, driver
 from .errors import missing_launch_config_msg, normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
+from numba.cuda.cudadrv.driver import driver
 
 
 def _nvvm_options_type(x):
@@ -785,6 +786,21 @@ class _KernelConfiguration:
         self.blockdim = blockdim
         self.stream = stream
         self.sharedmem = sharedmem
+
+        num_blocks = griddim[0] * griddim[1] * griddim[2]
+        ctx = get_context()
+        smcount = ctx.device.MULTIPROCESSOR_COUNT
+
+        print (griddim)
+        print (blockdim)
+        print (smcount)
+
+        if num_blocks < 2 * smcount:
+            msg = ("Number of blocks ({blocks}) that are  < 2 * SM ({sm}) "
+                  "will generate inefficient kernel code.")
+            msg = msg.format(blocks=num_blocks, sm=2 * smcount)
+            #warn(msg, category=RuntimeWarning)
+            warn(msg)
 
     def __call__(self, *args):
         return self.dispatcher.call(args, self.griddim, self.blockdim,

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -29,7 +29,7 @@ from .cudadrv import nvvm, driver
 from .errors import missing_launch_config_msg, normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
-from numba.cuda.cudadrv.driver import driver
+from numba.core.errors import NumbaPerformanceWarning
 
 
 def _nvvm_options_type(x):
@@ -791,16 +791,11 @@ class _KernelConfiguration:
         ctx = get_context()
         smcount = ctx.device.MULTIPROCESSOR_COUNT
 
-        print (griddim)
-        print (blockdim)
-        print (smcount)
-
         if num_blocks < 2 * smcount:
             msg = ("Number of blocks ({blocks}) that are  < 2 * SM ({sm}) "
-                  "will generate inefficient kernel code.")
+                   "will generate inefficient kernel code.")
             msg = msg.format(blocks=num_blocks, sm=2 * smcount)
-            #warn(msg, category=RuntimeWarning)
-            warn(msg)
+            warn(NumbaPerformanceWarning(msg))
 
     def __call__(self, *args):
         return self.dispatcher.call(args, self.griddim, self.blockdim,

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -22,6 +22,11 @@ class CUDATestCase(SerialMixin, TestCase):
     the context and destroy resources used by a normal CUDATestCase if any of
     its tests are run between tests from a CUDATestCase.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._low_occupancy_warnings = config.LOW_OCCUPANCY_WARNINGS
+
     def setUp(self):
         self._low_occupancy_warnings = config.LOW_OCCUPANCY_WARNINGS
         # Disable warnings about low gpu utilization for test suite

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -23,8 +23,12 @@ class CUDATestCase(SerialMixin, TestCase):
     its tests are run between tests from a CUDATestCase.
     """
     def setUp(self):
+        self._low_occupancy_warnings = config.LOW_OCCUPANCY_WARNINGS
         # Disable warnings about low gpu utilization for test suite
         config.LOW_OCCUPANCY_WARNINGS = 0
+
+    def tearDown(self):
+        config.LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -25,15 +25,15 @@ class CUDATestCase(SerialMixin, TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._low_occupancy_warnings = config.LOW_OCCUPANCY_WARNINGS
+        self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
 
     def setUp(self):
-        self._low_occupancy_warnings = config.LOW_OCCUPANCY_WARNINGS
-        # Disable warnings about low gpu utilization for test suite
-        config.LOW_OCCUPANCY_WARNINGS = 0
+        self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
+        # Disable warnings about low gpu utilization in the test suite
+        config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
 
     def tearDown(self):
-        config.LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
+        config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -22,6 +22,9 @@ class CUDATestCase(SerialMixin, TestCase):
     the context and destroy resources used by a normal CUDATestCase if any of
     its tests are run between tests from a CUDATestCase.
     """
+    def setUp(self):
+        # Disable warnings about low gpu utilization for test suite
+        config.LOW_OCCUPANCY_WARNINGS = 0
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -23,21 +23,8 @@ class CUDATestCase(SerialMixin, TestCase):
     its tests are run between tests from a CUDATestCase.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        # If the test class defines a setUp method, we need to run both
-        # CUDATestCase.setUp (to disable low occupancy warnings) and its setUp
-        if cls is not CUDATestCase and cls.setUp is not CUDATestCase.setUp:
-            cls_setUp = cls.setUp
-
-            def setUp_both(self, *args, **kwargs):
-                # Call our setUp first so that low occupancy warnings are
-                # disabled before anything else happens
-                CUDATestCase.setUp(self)
-                return cls_setUp(self, *args, **kwargs)
-            cls.setUp = setUp_both
-
     def setUp(self):
+        super().setUp()
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
         # Disable warnings about low gpu utilization in the test suite
         config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -39,8 +39,6 @@ class ContextResettingTestCase(CUDATestCase):
     to be internal implementation details (such as the state of allocations and
     deallocations, etc.).
     """
-    def setUp(self):
-        super().setUp()
 
     def tearDown(self):
         super().tearDown()

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -24,7 +24,6 @@ class CUDATestCase(SerialMixin, TestCase):
     """
 
     def setUp(self):
-        super().setUp()
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
         # Disable warnings about low gpu utilization in the test suite
         config.CUDA_LOW_OCCUPANCY_WARNINGS = 0

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -23,10 +23,6 @@ class CUDATestCase(SerialMixin, TestCase):
     its tests are run between tests from a CUDATestCase.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
-
     @classmethod
     def setUpClass(cls):
         # If the test class defines a setUp method, we need to run both

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -27,6 +27,20 @@ class CUDATestCase(SerialMixin, TestCase):
         super().__init__(*args, **kwargs)
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
 
+    @classmethod
+    def setUpClass(cls):
+        # If the test class defines a setUp method, we need to run both
+        # CUDATestCase.setUp (to disable low occupancy warnings) and its setUp
+        if cls is not CUDATestCase and cls.setUp is not CUDATestCase.setUp:
+            cls_setUp = cls.setUp
+
+            def setUp_both(self, *args, **kwargs):
+                # Call our setUp first so that low occupancy warnings are
+                # disabled before anything else happens
+                CUDATestCase.setUp(self)
+                return cls_setUp(self, *args, **kwargs)
+            cls.setUp = setUp_both
+
     def setUp(self):
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
         # Disable warnings about low gpu utilization in the test suite

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -39,8 +39,11 @@ class ContextResettingTestCase(CUDATestCase):
     to be internal implementation details (such as the state of allocations and
     deallocations, etc.).
     """
+    def setUp(self):
+        super().setUp()
 
     def tearDown(self):
+        super().tearDown()
         from numba.cuda.cudadrv.devices import reset
         reset()
 

--- a/numba/cuda/tests/cudadrv/test_context_stack.py
+++ b/numba/cuda/tests/cudadrv/test_context_stack.py
@@ -9,6 +9,7 @@ from numba.cuda.cudadrv import driver
 
 class TestContextStack(CUDATestCase):
     def setUp(self):
+        super().setUp()
         # Reset before testing
         cuda.close()
 
@@ -28,6 +29,7 @@ class TestContextStack(CUDATestCase):
 class TestContextAPI(CUDATestCase):
 
     def tearDown(self):
+        super().tearDown()
         cuda.close()
 
     def test_context_memory(self):
@@ -73,6 +75,7 @@ class TestContextAPI(CUDATestCase):
 @skip_on_cudasim('CUDA HW required')
 class Test3rdPartyContext(CUDATestCase):
     def tearDown(self):
+        super().tearDown()
         cuda.close()
 
     def test_attached_primary(self, extra_work=lambda: None):

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -13,6 +13,7 @@ class TestCudaDeviceRecord(CUDATestCase):
     Tests the DeviceRecord class with np.void host types.
     """
     def setUp(self):
+        super().setUp()
         self._create_data(np.zeros)
 
     def _create_data(self, array_ctor):
@@ -85,6 +86,7 @@ class TestCudaDeviceRecordWithRecord(TestCudaDeviceRecord):
     Tests the DeviceRecord class with np.record host types
     """
     def setUp(self):
+        super().setUp()
         self._create_data(np.recarray)
 
 

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -86,7 +86,7 @@ class TestCudaDeviceRecordWithRecord(TestCudaDeviceRecord):
     Tests the DeviceRecord class with np.record host types
     """
     def setUp(self):
-        CUDATestCase.setUp()
+        CUDATestCase.setUp(self)
         self._create_data(np.recarray)
 
 

--- a/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_devicerecord.py
@@ -86,7 +86,7 @@ class TestCudaDeviceRecordWithRecord(TestCudaDeviceRecord):
     Tests the DeviceRecord class with np.record host types
     """
     def setUp(self):
-        super().setUp()
+        CUDATestCase.setUp()
         self._create_data(np.recarray)
 
 

--- a/numba/cuda/tests/cudadrv/test_cuda_driver.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_driver.py
@@ -62,6 +62,7 @@ ptx2 = '''
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 class TestCudaDriver(CUDATestCase):
     def setUp(self):
+        super().setUp()
         self.assertTrue(len(devices.gpus) > 0)
         self.context = devices.get_context()
         device = self.context.device
@@ -72,6 +73,7 @@ class TestCudaDriver(CUDATestCase):
             self.ptx = ptx1
 
     def tearDown(self):
+        super().tearDown()
         del self.context
 
     def test_cuda_driver_basic(self):

--- a/numba/cuda/tests/cudadrv/test_cuda_memory.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_memory.py
@@ -10,6 +10,7 @@ from numba.cuda.testing import skip_on_cudasim
 @skip_on_cudasim('CUDA Memory API unsupported in the simulator')
 class TestCudaMemory(ContextResettingTestCase):
     def setUp(self):
+        super().setUp()
         self.context = devices.get_context()
 
     def tearDown(self):
@@ -97,6 +98,7 @@ class TestCudaMemory(ContextResettingTestCase):
 
 class TestCudaMemoryFunctions(ContextResettingTestCase):
     def setUp(self):
+        super().setUp()
         self.context = devices.get_context()
 
     def tearDown(self):

--- a/numba/cuda/tests/cudadrv/test_emm_plugins.py
+++ b/numba/cuda/tests/cudadrv/test_emm_plugins.py
@@ -105,11 +105,13 @@ class TestDeviceOnlyEMMPlugin(CUDATestCase):
     """
 
     def setUp(self):
+        super().setUp()
         # Always start afresh with a new context and memory manager
         cuda.close()
         cuda.set_memory_manager(DeviceOnlyEMMPlugin)
 
     def tearDown(self):
+        super().tearDown()
         # Unset the memory manager for subsequent tests
         cuda.close()
         cuda.cudadrv.driver._memory_manager = None

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -458,6 +458,7 @@ def atomic_compare_and_swap(res, old, ary, fill_val):
 
 class TestCudaAtomics(CUDATestCase):
     def setUp(self):
+        super().setUp()
         np.random.seed(0)
 
     def test_atomic_add(self):

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -200,7 +200,7 @@ class TestCUDAGufunc(CUDATestCase):
         b = np.random.rand(1024 * 1024 * 32).astype('float32')
         dist = np.zeros(a.shape[0]).astype('float32')
 
-        with override_config('LOW_OCCUPANCY_WARNINGS', 1):
+        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always', NumbaPerformanceWarning)
                 numba_dist_cuda(a, b, dist)
@@ -223,7 +223,7 @@ class TestCUDAGufunc(CUDATestCase):
             reshape((1024 * 1024, 128))
         dist = np.zeros_like(a)
 
-        with override_config('LOW_OCCUPANCY_WARNINGS', 1):
+        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter('always', NumbaPerformanceWarning)
                 numba_dist_cuda2(a, b, dist)

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -6,6 +6,9 @@ from numba import guvectorize
 from numba import cuda
 from numba.cuda.testing import skip_on_cudasim, CUDATestCase
 import unittest
+import warnings
+from numba.tests.support import ignore_internal_warnings
+from numba.core.errors import NumbaPerformanceWarning
 
 
 def _get_matmulcore_gufunc(dtype=float32, max_blocksize=None):
@@ -182,6 +185,27 @@ class TestCUDAGufunc(CUDATestCase):
         B = np.zeros_like(A)
         copy2d(A, out=B)
         self.assertTrue(np.allclose(A, B))
+
+    def test_inefficient_guvectorize(self):
+        @guvectorize(['void(float32[:], float32[:], float32[:])'],
+                     '(n),(n)->(n)', target='cuda')
+        def numba_dist_cuda(a, b, dist):
+            len = a.shape[0]
+            for i in range(len):
+                dist[i] = a[i] * b[i]
+
+        a = np.random.rand(1024 * 1024 * 32).astype('float32')
+        b = np.random.rand(1024 * 1024 * 32).astype('float32')
+        dist = np.zeros(a.shape[0]).astype('float32')
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaPerformanceWarning)
+            ignore_internal_warnings()
+            numba_dist_cuda(a, b, dist)
+            self.assertEqual(w[0].category, NumbaPerformanceWarning)
+            self.assertIn('Number of blocks', str(w[0].message))
+            self.assertIn('will generate inefficient kernel code',
+                          str(w[0].message))
 
     def test_nopython_flag(self):
 

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -106,6 +106,7 @@ class TestRecordDtype(CUDATestCase):
         self.samplerec2darr = np.recarray(1, dtype=recordwith2darray)[0]
 
     def setUp(self):
+        super().setUp()
         self._createSampleArrays()
 
         ary = self.sample1d

--- a/numba/cuda/tests/cudapy/test_retrieve_autoconverted_arrays.py
+++ b/numba/cuda/tests/cudapy/test_retrieve_autoconverted_arrays.py
@@ -32,6 +32,7 @@ recordtype = np.dtype(
 
 class TestRetrieveAutoconvertedArrays(CUDATestCase):
     def setUp(self):
+        super().setUp()
         self.set_array_to_three = cuda.jit(set_array_to_three)
         self.set_array_to_three_nocopy = nocopy(cuda.jit(set_array_to_three))
         self.set_record_to_three = cuda.jit(set_record_to_three)

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -1,4 +1,3 @@
-import numpy as np
 from numba import cuda
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 from numba.tests.support import override_config
@@ -6,49 +5,28 @@ from numba.core.errors import NumbaPerformanceWarning
 import warnings
 
 
-def numba_dist_cuda(a, b, dist):
-    len = a.shape[0]
-    for i in range(len):
-        dist[i] = a[i] * b[i]
-
-
-def numba_dist_cuda2(a, b, dist):
-    len = a.shape[0]
-    len2 = a.shape[1]
-    for i in range(len):
-        for j in range(len2):
-            dist[i, j] = a[i, j] * b[i, j]
-
-
-@skip_on_cudasim('Large data set causes slow execution in the simulator')
-class TestCUDAWarnings(CUDATestCase):
-    def test_inefficient_kernel(self):
-        a = np.random.rand(1024 * 1024 * 32).astype('float32')
-        b = np.random.rand(1024 * 1024 * 32).astype('float32')
-        dist = np.zeros(a.shape[0]).astype('float32')
-
-        sig = 'void(float32[:], float32[:], float32[:])'
-        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always', NumbaPerformanceWarning)
-                cuda_func = cuda.jit(sig)(numba_dist_cuda)
-                cuda_func[1,1](a, b, dist)
-                self.assertEqual(w[0].category, NumbaPerformanceWarning)
-                self.assertIn('Grid size', str(w[0].message))
-                self.assertIn('2 * SM count', str(w[0].message))
-
-    def test_efficient_kernel(self):
-        a = np.random.rand(1024 * 1024 * 128).astype('float32').\
-            reshape((1024 * 1024, 128))
-        b = np.random.rand(1024 * 1024 * 128).astype('float32').\
-            reshape((1024 * 1024, 128))
-        dist = np.zeros_like(a)
-
-        sig = 'void(float32[:, :], float32[:, :], float32[:, :])'
+@skip_on_cudasim('cudasim does not raise performance warnings')
+class TestWarnings(CUDATestCase):
+    def test_inefficient_launch_configuration(self):
+        @cuda.jit
+        def kernel():
+            pass
 
         with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
             with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always', NumbaPerformanceWarning)
-                cuda_func = cuda.jit(sig)(numba_dist_cuda2)
-                cuda_func[256,256](a, b, dist)
-                self.assertEqual(len(w), 0)
+                kernel[1, 1]()
+
+        self.assertEqual(w[0].category, NumbaPerformanceWarning)
+        self.assertIn('Grid size', str(w[0].message))
+        self.assertIn('2 * SM count', str(w[0].message))
+
+    def test_efficient_launch_configuration(self):
+        @cuda.jit
+        def kernel():
+            pass
+
+        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
+            with warnings.catch_warnings(record=True) as w:
+                kernel[256, 256]()
+
+        self.assertEqual(len(w), 0)

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -1,0 +1,54 @@
+import numpy as np
+from numba import cuda
+from numba.cuda.testing import CUDATestCase, skip_on_cudasim
+from numba.tests.support import override_config
+from numba.core.errors import NumbaPerformanceWarning
+import warnings
+
+
+def numba_dist_cuda(a, b, dist):
+    len = a.shape[0]
+    for i in range(len):
+        dist[i] = a[i] * b[i]
+
+
+def numba_dist_cuda2(a, b, dist):
+    len = a.shape[0]
+    len2 = a.shape[1]
+    for i in range(len):
+        for j in range(len2):
+            dist[i, j] = a[i, j] * b[i, j]
+
+
+@skip_on_cudasim('Large data set causes slow execution in the simulator')
+class TestCUDAWarnings(CUDATestCase):
+    def test_inefficient_kernel(self):
+        a = np.random.rand(1024 * 1024 * 32).astype('float32')
+        b = np.random.rand(1024 * 1024 * 32).astype('float32')
+        dist = np.zeros(a.shape[0]).astype('float32')
+
+        sig = 'void(float32[:], float32[:], float32[:])'
+        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always', NumbaPerformanceWarning)
+                cuda_func = cuda.jit(sig)(numba_dist_cuda)
+                cuda_func[1,1](a, b, dist)
+                self.assertEqual(w[0].category, NumbaPerformanceWarning)
+                self.assertIn('Grid size', str(w[0].message))
+                self.assertIn('2 * SM count', str(w[0].message))
+
+    def test_efficient_kernel(self):
+        a = np.random.rand(1024 * 1024 * 128).astype('float32').\
+            reshape((1024 * 1024, 128))
+        b = np.random.rand(1024 * 1024 * 128).astype('float32').\
+            reshape((1024 * 1024, 128))
+        dist = np.zeros_like(a)
+
+        sig = 'void(float32[:, :], float32[:, :], float32[:, :])'
+
+        with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always', NumbaPerformanceWarning)
+                cuda_func = cuda.jit(sig)(numba_dist_cuda2)
+                cuda_func[256,256](a, b, dist)
+                self.assertEqual(len(w), 0)

--- a/numba/tests/test_config.py
+++ b/numba/tests/test_config.py
@@ -23,6 +23,7 @@ class TestConfig(TestCase):
     def setUp(self):
         # use support.temp_directory, it can do the clean up
         self.tmppath = temp_directory('config_tmp')
+        self.maxDiff = 2500
         super(TestConfig, self).setUp()
 
     def mock_cfg_location(self):


### PR DESCRIPTION
This pull request address: https://github.com/numba/numba/issues/6159. It addresses the issues by detecting when the blocksize for a kernel would be < 2 * Number of SM's. I also added a environment variable called NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS that is enabled by default. I had to modify the the class CUDATestCase to disable the warning as many of the test cases trigger this warning.