### PR TITLE
Patch for support numba-dppy `with device_context`

### DIFF
--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -742,7 +742,14 @@ class _MemoMixin:
         self._recent.append(self)
 
 
-class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
+import abc
+
+class DispatcherMeta(abc.ABCMeta):
+    def __instancecheck__(self, other):
+        return type(type(other)) == DispatcherMeta
+
+
+class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase, metaclass=DispatcherMeta):
     """
     Implementation of user-facing dispatcher objects (i.e. created using
     the @jit decorator).
@@ -994,6 +1001,9 @@ class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
         if not self._can_compile and len(self.overloads) == 1:
             cres = tuple(self.overloads.values())[0]
             return types.FunctionType(cres.signature)
+
+    def get_compiled(self):
+        return self
 
 
 class LiftedCode(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):

--- a/numba/core/registry.py
+++ b/numba/core/registry.py
@@ -2,6 +2,7 @@ import contextlib
 
 from numba.core.descriptors import TargetDescriptor
 from numba.core import utils, typing, dispatcher, cpu
+from numba.core.compiler_lock import global_compiler_lock
 
 # -----------------------------------------------------------------------------
 # Default CPU target descriptors
@@ -26,16 +27,19 @@ class CPUTarget(TargetDescriptor):
     _nested = _NestedContext()
 
     @utils.cached_property
+    @global_compiler_lock
     def _toplevel_target_context(self):
         # Lazily-initialized top-level target context, for all threads
         return cpu.CPUContext(self.typing_context)
 
     @utils.cached_property
+    @global_compiler_lock
     def _toplevel_typing_context(self):
         # Lazily-initialized top-level typing context, for all threads
         return typing.Context()
 
     @property
+    @global_compiler_lock
     def target_context(self):
         """
         The target context for CPU targets.
@@ -47,6 +51,7 @@ class CPUTarget(TargetDescriptor):
             return self._toplevel_target_context
 
     @property
+    @global_compiler_lock
     def typing_context(self):
         """
         The typing context for CPU targets.
@@ -57,6 +62,7 @@ class CPUTarget(TargetDescriptor):
         else:
             return self._toplevel_typing_context
 
+    @global_compiler_lock
     def nested_context(self, typing_context, target_context):
         """
         A context manager temporarily replacing the contexts with the

--- a/numba/core/typing/context.py
+++ b/numba/core/typing/context.py
@@ -234,6 +234,14 @@ class BaseContext(object):
         if functy is not None:
             func = functy
 
+        from numba.core.registry import CPUDispatcher
+        if isinstance(func, CPUDispatcher) and func is not CPUDispatcher:
+        # if we are here it's numba-dppy case and we got TargetDispatcher, so get compiled version
+            func = func.get_compiled()
+            functy = self._lookup_global(func)
+            if functy is not None:
+               func = functy
+
         if isinstance(func, types.Type):
             # If it's a type, it may support a __call__ method
             func_type = self.resolve_getattr(func, "__call__")

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -398,6 +398,8 @@ class TestDispatcher(BaseTest):
         def foo(x):
             return x + 1
 
+        foo = foo.get_compiled()
+
         self.assertEqual(foo(1), 2)
 
         # get serialization memo

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -249,6 +249,8 @@ class TestTracemalloc(unittest.TestCase):
             """
             return np.empty(N, dtype)
 
+        alloc_nrt_memory = alloc_nrt_memory.get_compiled()
+
         def keep_memory():
             return alloc_nrt_memory()
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -803,8 +803,8 @@ class TestRecordDtype(unittest.TestCase):
         self.assertIn('Array', transformed)
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
-        # Length is usually 50 - 5 chars tolerance as above.
-        self.assertLess(len(transformed), 50)
+        # Length is usually 60 - 5 chars tolerance as above.
+        self.assertLess(len(transformed), 60)
 
     def test_record_two_arrays(self):
         """

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -135,9 +135,9 @@ class TestDispatcherPickling(TestCase):
 
         Note that "same function" is intentionally under-specified.
         """
-        func = closure(5)
+        func = closure(5).get_compiled()
         pickled = pickle.dumps(func)
-        func2 = closure(6)
+        func2 = closure(6).get_compiled()
         pickled2 = pickle.dumps(func2)
 
         f = pickle.loads(pickled)
@@ -152,7 +152,7 @@ class TestDispatcherPickling(TestCase):
         self.assertEqual(h(2, 3), 11)
 
         # Now make sure the original object doesn't exist when deserializing
-        func = closure(7)
+        func = closure(7).get_compiled()
         func(42, 43)
         pickled = pickle.dumps(func)
         del func


### PR DESCRIPTION
This modifications make jit() decorator use TargetDispatcher from numba-dppy.
Changes made in IntelPython/numba#57 by @AlexanderKalistratov and @1e-to.

Patch to fix SDC integration testing (IntelPython/numba#203)

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This is an initial patch from IntelPython/numba for support numba-dppy `with context`.
Code is from https://github.com/IntelPython/numba/pull/96.
History:
1. @reazulhoque created comment and set the goal here: https://github.com/IntelPython/numba/pull/96#issuecomment-775311261
2. @sklam created https://github.com/numba/numba/pull/6770 and alternative more flexible version https://github.com/numba/numba/pull/6870
3. @diptorupd created issue for review and adopt @sklam PRs in numba-dppy: https://github.com/IntelPython/numba-dppy/issues/271
4. @PokhodenkoSA created numba-dppy patch for using solution from https://github.com/numba/numba/pull/6870: https://github.com/IntelPython/numba-dppy/pull/278
Some problems with @sklam solution:
- Context does not apply to nested functions calls.
5. @sklam created solution based on https://github.com/numba/numba/pull/6814, https://github.com/numba/numba/pull/6762 and https://github.com/numba/numba/pull/6870 with introducing "legalization pass that scan for invalid target in callees" for checking nested functions calls: https://github.com/sklam/numba/blob/demo/extendtarget_demo_1/demo.md
- Contains an issue in Case 4.
- Numba tests fails on `demo` branch.

I have created this PR for sharing initial PR code which represents our initial goal. Also I have shared history of solutions we have tried to replace initial PR.

This PR is for discussion and transforming it to something appropriate for upstreaming to numba/numba.