### PR TITLE
CUDA: Add support for activemask(), lanemask_lt(), and nanosleep()

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -399,6 +399,19 @@ the GPU compute capability is below 7.x.
     all have the same value, otherwise it is 0. And pred is a boolean of whether
     or not all threads in the mask warp have the same warp.
 
+.. function:: numba.cuda.activemask()
+
+    Returns a 32-bit integer mask of all currently active threads in the
+    calling warp. The Nth bit is set if the Nth lane in the warp is active when
+    activemask() is called. Inactive threads are represented by 0 bits in the
+    returned mask. Threads which have exited the kernel are always marked as
+    inactive.
+
+.. function:: numba.cuda.lanemask_lt()
+
+    Returns a 32-bit integer mask of all lanes (including inactive ones) with
+    ID less than the current lane.
+
 
 Integer Intrinsics
 ~~~~~~~~~~~~~~~~~~
@@ -449,6 +462,7 @@ precision parts of the CUDA Toolkit documentation.
    ``cbrt`` and ``cbrtf`` in the C api. Supports float32, and float64 arguments
    only.
 
+
 Control Flow Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -464,3 +478,12 @@ semantics, please refer to the `relevant CUDA Toolkit documentation
 
     Select between two expressions, depending on the value of the first
     argument. Similar to LLVM's ``select`` instruction.
+
+
+Timer Intrinsics
+~~~~~~~~~~~~~~~~
+
+.. function:: numba.cuda.nanosleep(ns)
+
+    Suspends the thread for a sleep duration approximately close to the delay
+    ``ns``, specified in nanoseconds.

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -206,6 +206,18 @@ class Cuda_match_all_sync(ConcreteTemplate):
 
 
 @register
+class Cuda_activemask(ConcreteTemplate):
+    key = cuda.activemask
+    cases = [signature(types.int32)]
+
+
+@register
+class Cuda_lanemask_lt(ConcreteTemplate):
+    key = cuda.lanemask_lt
+    cases = [signature(types.int32)]
+
+
+@register
 class Cuda_popc(ConcreteTemplate):
     """
     Supported types from `llvm.popc`
@@ -369,6 +381,13 @@ class Cuda_atomic_compare_and_swap(AbstractTemplate):
 
         if dty in integer_numba_types and ary.ndim == 1:
             return signature(dty, ary, dty, dty)
+
+
+@register
+class Cuda_nanosleep(ConcreteTemplate):
+    key = cuda.nanosleep
+
+    cases = [signature(types.void, types.uint32)]
 
 
 @register_attr
@@ -541,8 +560,17 @@ class CudaModuleTemplate(AttributeTemplate):
     def resolve_match_all_sync(self, mod):
         return types.Function(Cuda_match_all_sync)
 
+    def resolve_activemask(self, mod):
+        return types.Function(Cuda_activemask)
+
+    def resolve_lanemask_lt(self, mod):
+        return types.Function(Cuda_lanemask_lt)
+
     def resolve_selp(self, mod):
         return types.Function(Cuda_selp)
+
+    def resolve_nanosleep(self, mod):
+        return types.Function(Cuda_nanosleep)
 
     def resolve_atomic(self, mod):
         return types.Module(cuda.atomic)

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -208,13 +208,13 @@ class Cuda_match_all_sync(ConcreteTemplate):
 @register
 class Cuda_activemask(ConcreteTemplate):
     key = cuda.activemask
-    cases = [signature(types.int32)]
+    cases = [signature(types.uint32)]
 
 
 @register
 class Cuda_lanemask_lt(ConcreteTemplate):
     key = cuda.lanemask_lt
-    cases = [signature(types.int32)]
+    cases = [signature(types.uint32)]
 
 
 @register

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -380,6 +380,21 @@ def ptx_match_all_sync(context, builder, sig, args):
     return builder.call(func, (mask, value))
 
 
+@lower(stubs.activemask)
+def ptx_activemask(context, builder, sig, args):
+    activemask = ir.InlineAsm(ir.FunctionType(ir.IntType(32), []),
+                              "activemask.b32 $0;", '=r', side_effect=True)
+    return builder.call(activemask, [])
+
+
+@lower(stubs.lanemask_lt)
+def ptx_lanemask_lt(context, builder, sig, args):
+    activemask = ir.InlineAsm(ir.FunctionType(ir.IntType(32), []),
+                              "mov.u32 $0, %lanemask_lt;", '=r',
+                              side_effect=True)
+    return builder.call(activemask, [])
+
+
 @lower(stubs.popc, types.Any)
 def ptx_popc(context, builder, sig, args):
     return builder.ctpop(args[0])
@@ -810,6 +825,16 @@ def ptx_atomic_cas_tuple(context, builder, sig, args):
     else:
         raise TypeError('Unimplemented atomic compare_and_swap '
                         'with %s array' % dtype)
+
+
+# -----------------------------------------------------------------------------
+
+@lower(stubs.nanosleep, types.uint32)
+def ptx_nanosleep(context, builder, sig, args):
+    nanosleep = ir.InlineAsm(ir.FunctionType(ir.VoidType(), [ir.IntType(32)]),
+                             "nanosleep.u32 $0;", 'r', side_effect=True)
+    ns = args[0]
+    builder.call(nanosleep, [ns])
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -6,7 +6,7 @@ from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
                     threadfence, selp, popc, brev, clz, ffs, fma, cbrt,
-                    cg)
+                    cg, activemask, lanemask_lt, nanosleep)
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -309,6 +309,29 @@ class match_all_sync(Stub):
     _description_ = '<match_all_sync()>'
 
 
+class activemask(Stub):
+    '''
+    activemask()
+
+    Returns a 32-bit integer mask of all currently active threads in the
+    calling warp. The Nth bit is set if the Nth lane in the warp is active when
+    activemask() is called. Inactive threads are represented by 0 bits in the
+    returned mask. Threads which have exited the kernel are always marked as
+    inactive.
+    '''
+    _description_ = '<activemask()>'
+
+
+class lanemask_lt(Stub):
+    '''
+    lanemask_lt()
+
+    Returns a 32-bit integer mask of all lanes (including inactive ones) with
+    ID less than the current lane.
+    '''
+    _description_ = '<lanemask_lt()>'
+
+
 # -------------------------------------------------------------------------------
 # memory fences
 
@@ -552,3 +575,16 @@ class atomic(Stub):
 
         Returns the current value as if it is loaded atomically.
         """
+
+
+#-------------------------------------------------------------------------------
+# timers
+
+class nanosleep(Stub):
+    '''
+    nanosleep(ns)
+
+    Suspends the thread for a sleep duration approximately close to the delay
+    `ns`, specified in nanoseconds.
+    '''
+    _description_ = '<nansleep()>'


### PR DESCRIPTION
These are added to facilitate the implementation of warp-aggregated atomics (see e.g. [1]) and mutexes with exponential back-off (see e.g. [2]).

[1] https://developer.nvidia.com/blog/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/
[2] https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#scheduling-example

Fixes #6906.