### PR TITLE
Prevent use of varargs in closure calls.

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -696,6 +696,9 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
     """
     if call_expr.op == 'call':
         args = list(call_expr.args)
+        if call_expr.vararg:
+            msg = "Calling a closure with *args is unsupported."
+            raise errors.UnsupportedError(msg, call_expr.loc)
     elif call_expr.op == 'getattr':
         args = [call_expr.value]
     elif ir_utils.is_operator_or_getitem(call_expr):

--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -364,7 +364,7 @@ class TestInlinedClosure(TestCase):
             return inner2(inner, x)
 
         def outer20(x):
-            #""" Test calling numpy in closure """
+            """ Test calling numpy in closure """
             z = x + 1
 
             def inner(x):
@@ -372,12 +372,19 @@ class TestInlinedClosure(TestCase):
             return inner(x)
 
         def outer21(x):
-            #""" Test calling numpy import as in closure """
+            """ Test calling numpy import as in closure """
             z = x + 1
 
             def inner(x):
                 return x + np.cos(z)
             return inner(x)
+
+        def outer22():
+            """Test to ensure that unsupported *args raises correctly"""
+            def bar(a, b):
+                pass
+            x = 1, 2
+            bar(*x)
 
         # functions to test that are expected to pass
         f = [outer1, outer2, outer5, outer6, outer7, outer8,
@@ -423,6 +430,12 @@ class TestInlinedClosure(TestCase):
             cfunc = jit(nopython=True)(outer18)
             cfunc(var)
         msg = "The use of yield in a closure is unsupported."
+        self.assertIn(msg, str(raises.exception))
+
+        with self.assertRaises(UnsupportedError) as raises:
+            cfunc = jit(nopython=True)(outer22)
+            cfunc()
+        msg = "Calling a closure with *args is unsupported."
         self.assertIn(msg, str(raises.exception))
 
 


### PR DESCRIPTION
As title. This isn't supported by the closure inliner.

Makes #6894 a feature request not a bug.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
