### PR TITLE
Add runtests option to gitdiff on the common ancestor

### DIFF
--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -198,10 +198,18 @@ class NumbaTestProgram(unittest.main):
         parser.add_argument('-j', '--slice', dest='useslice', nargs='?',
                             type=str, const="None",
                             help='Slice the test sequence')
-        parser.add_argument('-g', '--gitdiff', dest='gitdiff',
-                            action='store_true',
+
+        def git_diff_str(x):
+            if x != 'ancestor':
+                raise ValueError("invalid option for --gitdiff")
+            return x
+
+        parser.add_argument('-g', '--gitdiff', dest='gitdiff', type=git_diff_str,
+                            default=False, nargs='?',
                             help=('Run tests from changes made against '
-                                  'origin/master as identified by `git diff`'))
+                                  'origin/master as identified by `git diff`. '
+                                  'If set to "ancestor", the diff compares '
+                                  'against the common ancestor.'))
         return parser
 
     def _handle_tags(self, argv, tagstr):
@@ -266,8 +274,11 @@ class NumbaTestProgram(unittest.main):
             self.test = _choose_random_tests(self.test, self.random_select,
                                              self.random_seed)
 
-        if self.gitdiff:
-            self.test = _choose_gitdiff_tests(self.test)
+        if self.gitdiff is not False:
+            self.test = _choose_gitdiff_tests(
+                self.test,
+                use_common_ancestor=(self.gitdiff == 'ancestor'),
+            )
 
         if self.verbosity <= 0:
             # We aren't interested in informational messages / warnings when
@@ -379,14 +390,18 @@ def _flatten_suite(test):
     return tests
 
 
-def _choose_gitdiff_tests(tests):
+def _choose_gitdiff_tests(tests, *, use_common_ancestor=False):
     try:
         from git import Repo
     except ImportError:
         raise ValueError("gitpython needed for git functionality")
     repo = Repo('.')
     path = os.path.join('numba', 'tests')
-    target = 'origin/master..HEAD'
+    if use_common_ancestor:
+        print(f"Git diff by common ancestor")
+        target = 'origin/master...HEAD'
+    else:
+        target = 'origin/master..HEAD'
     gdiff_paths = repo.git.diff(target, path, name_only=True).split()
     # normalise the paths as they are unix style from repo.git.diff
     gdiff_paths = [os.path.normpath(x) for x in gdiff_paths]

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -116,6 +116,23 @@ class TestCase(unittest.TestCase):
         # The tests must be equivalent
         self.assertEqual(sorted(full), sorted(sliced))
 
+    def test_gitdiff(self):
+        # Check for git
+        try:
+            subprocess.call("git", stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except FileNotFoundError as e:
+            self.skipTest("no git available")
+
+        # default
+        outs = self.get_testsuite_listing(['-g'])
+        self.assertNotIn("Git diff by common ancestor", outs)
+        # using ancestor
+        outs = self.get_testsuite_listing(['-g=ancestor'])
+        self.assertIn("Git diff by common ancestor", outs)
+        # misspelled ancestor
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.get_testsuite_listing(['-g=ancest'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -10,9 +10,14 @@ class TestCase(unittest.TestCase):
     Therefore, the logic used here shouldn't use numba.testing, but only the
     upstream unittest, and run the numba test suite only in a subprocess."""
 
-    def get_testsuite_listing(self, args):
+    def get_testsuite_listing(self, args, *, subp_kwargs=None):
+        """
+        Use `subp_kwargs` to pass extra argument to `subprocess.check_output`.
+        """
+        subp_kwargs = subp_kwargs or {}
         cmd = [sys.executable, '-m', 'numba.runtests', '-l'] + list(args)
-        lines = subprocess.check_output(cmd).decode('UTF-8').splitlines()
+        out_bytes = subprocess.check_output(cmd, **subp_kwargs)
+        lines = out_bytes.decode('UTF-8').splitlines()
         lines = [line for line in lines if line.strip()]
         return lines
 
@@ -119,7 +124,9 @@ class TestCase(unittest.TestCase):
     def test_gitdiff(self):
         # Check for git
         try:
-            subprocess.call("git", stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.call("git",
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL)
         except FileNotFoundError as e:
             self.skipTest("no git available")
 
@@ -130,8 +137,9 @@ class TestCase(unittest.TestCase):
         outs = self.get_testsuite_listing(['-g=ancestor'])
         self.assertIn("Git diff by common ancestor", outs)
         # misspelled ancestor
+        subp_kwargs = dict(stderr=subprocess.DEVNULL)
         with self.assertRaises(subprocess.CalledProcessError):
-            self.get_testsuite_listing(['-g=ancest'])
+            self.get_testsuite_listing(['-g=ancest'], subp_kwargs=subp_kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Example:

```python
python -m numba.runtests -g=ancestor
```

This allows us to test PR HEAD against its first splitting point from main branch. Useful for testing just the changes in the PR instead of including all new additions to the mainline.