### PR TITLE
Fix issue #6895 - walrus operator

### DIFF
--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -572,12 +572,17 @@ class Interpreter(object):
 
                 # iterate over RHS operands and replace them iff they
                 # are in replaced_var dict
-                if (isinstance(inst.value, ir.Expr)
-                        and inst.value.op == "binop"):
-                    for k in ('lhs', 'rhs'):
-                        v = inst.value._kws.get(k)
-                        if v.name in replaced_var:
-                            inst.value._kws[k] = replaced_var[v.name]
+                if isinstance(inst.value, ir.Expr):
+                    for k, v in inst.value._kws.items():
+                        if isinstance(v, (tuple, list)):
+                            l = list(v)
+                            for i, e in enumerate(l):
+                                if e.name in replaced_var:
+                                    l[i] = replaced_var[e.name]
+                            inst.value._kws[k] = type(v)(l)
+                        elif isinstance(v, ir.Var):
+                            if v.name in replaced_var:
+                                inst.value._kws[k] = replaced_var[v.name]
 
                 # eliminate temporary variables that are assigned to user
                 # variables right after creation. E.g.:

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -569,6 +569,16 @@ class Interpreter(object):
                     inst.value.value = replaced_var[inst.value.value.name]
                     new_body.append(inst)
                     continue
+
+                # iterate over RHS operands and replace them iff they
+                # are in replaced_var dict
+                if (isinstance(inst.value, ir.Expr)
+                        and inst.value.op == "binop"):
+                    for k in ('lhs', 'rhs'):
+                        v = inst.value._kws.get(k)
+                        if v.name in replaced_var:
+                            inst.value._kws[k] = replaced_var[v.name]
+
                 # eliminate temporary variables that are assigned to user
                 # variables right after creation. E.g.:
                 # $1 = f(); a = $1 -> a = f()

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -535,9 +535,7 @@ class Interpreter(object):
         self._inject_call(eh.exception_check, 'exception_check',
                           '$exception_check')
 
-
-    from typing import Dict
-    def replace_dead_vars(self, replaced_var: Dict[str, ir.Var], value):
+    def replace_dead_vars(self, replaced_var, value):
         if isinstance(value, ir.Var):
             if value.name in replaced_var:
                 return replaced_var[value.name]
@@ -550,8 +548,6 @@ class Interpreter(object):
                 value[k] = self.replace_dead_vars(replaced_var, v)
         else:
             return value
-        #     raise ValueError(type(value))
-
 
     def _remove_unused_temporaries(self):
         """

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -63,6 +63,10 @@ skip_py38_or_later = unittest.skipIf(
     utils.PYVERSION >= (3, 8),
     "unsupported on py3.8 or later"
 )
+skip_unless_py38_or_later = unittest.skipIf(
+    utils.PYVERSION < (3, 8),
+    "unsupported on py3.7 or earlier"
+)
 skip_tryexcept_unsupported = unittest.skipIf(
     utils.PYVERSION < (3, 7),
     "try-except unsupported on py3.6 or earlier"
@@ -107,6 +111,7 @@ skip_ppc64le_issue6465 = unittest.skipIf(platform.machine() == 'ppc64le',
 skip_unless_py37_or_later = lambda reason: \
     unittest.skipIf(utils.PYVERSION < (3, 7),
     reason)
+
 
 try:
     import scipy.linalg.cython_lapack


### PR DESCRIPTION
As title. This PR fix a bug (reported in #6895) whereas code using the walrus operator would fail in Numba 0.53:

```python
from numba import jit
import numpy as np


@jit
def bugged(array, i):
    #i = cuda.grid(1)
    if i < array.shape[0]:
        if (value_used_for_more_complex_computation := array[i]) < 4.:
            array[i] = 1.  # this should work


if __name__ == '__main__':
    array = np.zeros((10), int)
    try:
        bugged(array, 1)
    except Exception as E:
        print(E)
    print(array)
```

The interpreter will create a temporary variable `$20binary_subscr.2` for the expression `array[i]` that later will be assigned to `value`. When doing the copy propagation optimization and deleting the temporary variable `$20binary_subscr.2`, numba must replace its uses with `value`