### PR TITLE
CUDA: Fix `ffs`

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -409,22 +409,23 @@ documentation
 <https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__INT.html>`_.
 
 
-.. function:: numba.cuda.popc
+.. function:: numba.cuda.popc(x)
 
-   Returns the number of set bits in the given value.
+   Returns the number of bits set in ``x``.
 
-.. function:: numba.cuda.brev
+.. function:: numba.cuda.brev(x)
 
-   Reverses the bit pattern of an integer value, for example 0b10110110
-   becomes 0b01101101.
+   Returns the reverse of the bit pattern of ``x``. For example, ``0b10110110``
+   becomes ``0b01101101``.
 
-.. function:: numba.cuda.clz
+.. function:: numba.cuda.clz(x)
 
-   Counts the number of leading zeros in a value.
+   Returns the number of leading zeros in ``x``.
 
-.. function:: numba.cuda.ffs
+.. function:: numba.cuda.ffs(x)
 
-   Find the position of the least significant bit set to 1 in an integer.
+   Returns the position of the first (least significant) bit set to 1 in ``x``,
+   where the least significant bit position is 1. ``ffs(0)`` returns 0.
 
 
 Floating Point Intrinsics

--- a/docs/source/cuda/simulator.rst
+++ b/docs/source/cuda/simulator.rst
@@ -96,6 +96,8 @@ Some limitations of the simulator include:
   is, testing equality, less than, greater than, and basic mathematical 
   operations are supported, but many other operations, such as the in-place 
   operators and bit operators are not.
+* The :func:`ffs() <numba.cuda.ffs>` function only works correctly for values
+  that can be represented using 32-bit integers.
 
 Obviously, the speed of the simulator is also much lower than that of a real
 device. It may be necessary to reduce the size of input data and the size of the

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -283,14 +283,14 @@ class Cuda_ffs(ConcreteTemplate):
     """
     key = cuda.ffs
     cases = [
-        signature(types.int8, types.int8),
-        signature(types.int16, types.int16),
-        signature(types.int32, types.int32),
-        signature(types.int64, types.int64),
-        signature(types.uint8, types.uint8),
-        signature(types.uint16, types.uint16),
+        signature(types.uint32, types.int8),
+        signature(types.uint32, types.int16),
+        signature(types.uint32, types.int32),
+        signature(types.uint32, types.int64),
+        signature(types.uint32, types.uint8),
+        signature(types.uint32, types.uint16),
         signature(types.uint32, types.uint32),
-        signature(types.uint64, types.uint64),
+        signature(types.uint32, types.uint64),
     ]
 
 

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -443,11 +443,24 @@ def ptx_clz(context, builder, sig, args):
         context.get_constant(types.boolean, 0))
 
 
-@lower(stubs.ffs, types.Any)
-def ptx_ffs(context, builder, sig, args):
-    return builder.cttz(
-        args[0],
-        context.get_constant(types.boolean, 0))
+@lower(stubs.ffs, types.i4)
+@lower(stubs.ffs, types.u4)
+def ptx_ffs_32(context, builder, sig, args):
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(ir.IntType(32), (ir.IntType(32),)),
+        '__nv_ffs')
+    return builder.call(fn, args)
+
+
+@lower(stubs.ffs, types.i8)
+@lower(stubs.ffs, types.u8)
+def ptx_ffs_64(context, builder, sig, args):
+    fn = cgutils.get_or_insert_function(
+        builder.module,
+        ir.FunctionType(ir.IntType(32), (ir.IntType(64),)),
+        '__nv_ffsll')
+    return builder.call(fn, args)
 
 
 @lower(stubs.selp, types.Any, types.Any, types.Any)

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -315,8 +315,14 @@ class FakeCUDAModule(object):
         return len(s) - len(s.lstrip('0'))
 
     def ffs(self, val):
+        # The algorithm is:
+        # 1. Count the number of trailing zeros.
+        # 2. Add 1, because the LSB is numbered 1 rather than 0, and so on.
+        # 3. If we've counted 32 zeros (resulting in 33), there were no bits
+        #    set so we need to return zero.
         s = '{:032b}'.format(val)
-        return len(s) - len(s.rstrip('0'))
+        r = (len(s) - len(s.rstrip('0')) + 1) % 33
+        return r
 
     def selp(self, a, b, c):
         return b if a else c

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -338,34 +338,35 @@ class threadfence(Stub):
 
 class popc(Stub):
     """
-    popc(val)
+    popc(x)
 
-    Returns the number of set bits in the given value.
+    Returns the number of set bits in x.
     """
 
 
 class brev(Stub):
     """
-    brev(val)
+    brev(x)
 
-    Reverse the bitpattern of an integer value; for example 0b10110110
+    Returns the reverse of the bit pattern of x. For example, 0b10110110
     becomes 0b01101101.
     """
 
 
 class clz(Stub):
     """
-    clz(val)
+    clz(x)
 
-    Counts the number of leading zeros in a value.
+    Returns the number of leading zeros in z.
     """
 
 
 class ffs(Stub):
     """
-    ffs(val)
+    ffs(x)
 
-    Find the position of the least significant bit set to 1 in an integer.
+    Returns the position of the first (least significant) bit set to 1 in x,
+    where the least significant bit position is 1. ffs(0) returns 0.
     """
 
 

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -363,12 +363,16 @@ class TestCudaIntrinsic(CUDATestCase):
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
         self.assertEquals(ary[0], 21)
+        compiled[1, 1](ary, 0x80000000)
+        self.assertEquals(ary[0], 32)
 
     def test_ffs_u4(self):
         compiled = cuda.jit("void(int32[:], uint32)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
         self.assertEquals(ary[0], 21)
+        compiled[1, 1](ary, 0x80000000)
+        self.assertEquals(ary[0], 32)
 
     def test_ffs_i4_1s(self):
         compiled = cuda.jit("void(int32[:], int32)")(simple_ffs)
@@ -388,6 +392,8 @@ class TestCudaIntrinsic(CUDATestCase):
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x000000000010000)
         self.assertEquals(ary[0], 17)
+        compiled[1, 1](ary, 0x100000000)
+        self.assertEquals(ary[0], 33)
 
     def test_simple_laneid(self):
         compiled = cuda.jit("void(int32[:])")(simple_laneid)

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -362,32 +362,32 @@ class TestCudaIntrinsic(CUDATestCase):
         compiled = cuda.jit("void(int32[:], int32)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
-        self.assertEquals(ary[0], 20)
+        self.assertEquals(ary[0], 21)
 
     def test_ffs_u4(self):
         compiled = cuda.jit("void(int32[:], uint32)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x00100000)
-        self.assertEquals(ary[0], 20)
+        self.assertEquals(ary[0], 21)
 
     def test_ffs_i4_1s(self):
         compiled = cuda.jit("void(int32[:], int32)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0xFFFFFFFF)
-        self.assertEquals(ary[0], 0)
+        self.assertEquals(ary[0], 1)
 
     def test_ffs_i4_0s(self):
         compiled = cuda.jit("void(int32[:], int32)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x0)
-        self.assertEquals(ary[0], 32, "CUDA semantics")
+        self.assertEquals(ary[0], 0)
 
     @skip_on_cudasim('only get given a Python "int", assumes 32 bits')
     def test_ffs_i8(self):
         compiled = cuda.jit("void(int32[:], int64)")(simple_ffs)
         ary = np.zeros(1, dtype=np.int32)
         compiled[1, 1](ary, 0x000000000010000)
-        self.assertEquals(ary[0], 16)
+        self.assertEquals(ary[0], 17)
 
     def test_simple_laneid(self):
         compiled = cuda.jit("void(int32[:])")(simple_laneid)


### PR DESCRIPTION
The `ffs` intrinsic produced results that were off-by-1 compared to `__ffs()` in CUDA C (and in general compared with `ffs()` implementations in C libraries). This commit fixes the implementation by making use of the libdevice implementations `__nv_ffs` and `__nv_ffsll` for 32- and 64-bit operands respectively. Since these always return a 32-bit integer between 0 and 32 (0 for no bit set), the typing of the function is modified to always return a `uint32`.

Tests are updated accordingly.

The documentation is updated to clarify the index of the least significant bit, and the result of calling `ffs(0)`. Documentation for
other bit manipulation instructions is tidied up and made consistent with the documentation for `ffs`.

Fixes #6919.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
