### PR TITLE
Add support for axis keyword arg to numpy.argmax()

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -274,7 +274,6 @@ The following methods of Numpy arrays are supported in their basic form
 
 * :meth:`~numpy.ndarray.all`
 * :meth:`~numpy.ndarray.any`
-* :meth:`~numpy.ndarray.argmax`
 * :meth:`~numpy.ndarray.argmin`
 * :meth:`~numpy.ndarray.conj`
 * :meth:`~numpy.ndarray.conjugate`
@@ -297,6 +296,7 @@ Other methods
 
 The following methods of Numpy arrays are supported:
 
+* :meth:`~numpy.ndarray.argmax` (``axis`` keyword argument supported).
 * :meth:`~numpy.ndarray.argsort` (``kind`` key word argument supported for
   values ``'quicksort'`` and ``'mergesort'``)
 * :meth:`~numpy.ndarray.astype` (only the 1-argument form)
@@ -335,6 +335,8 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.view` (only the 1-argument form)
 * :meth:`~numpy.ndarray.__contains__` 
 
+Where applicable, the corresponding top-level Numpy functions (such as
+:func:`numpy.argmax`) are similarly supported.
 
 .. warning::
    Sorting may be slightly slower than Numpy's implementation.

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -335,7 +335,7 @@ The following methods of Numpy arrays are supported:
 * :meth:`~numpy.ndarray.view` (only the 1-argument form)
 * :meth:`~numpy.ndarray.__contains__` 
 
-Where applicable, the corresponding top-level Numpy functions (such as
+Where applicable, the corresponding top-level NumPy functions (such as
 :func:`numpy.argmax`) are similarly supported.
 
 .. warning::

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1303,7 +1303,7 @@ def simplify_CFG(blocks):
 
 
 arr_math = ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-            'cumsum', 'cumprod', 'argmin', 'argsort',
+            'cumsum', 'cumprod', 'argmax', 'argmin', 'argsort',
             'nonzero', 'ravel']
 
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1303,7 +1303,7 @@ def simplify_CFG(blocks):
 
 
 arr_math = ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-            'cumsum', 'cumprod', 'argmin', 'argmax', 'argsort',
+            'cumsum', 'cumprod', 'argmin', 'argsort',
             'nonzero', 'ravel']
 
 

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -777,7 +777,6 @@ for fName in ["var", "std"]:
 
 # Functions that return an index (intp)
 install_array_method("argmin", generic_index)
-install_array_method("argmax", generic_index)
 
 
 @infer_global(operator.eq)

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -387,7 +387,7 @@ def _numpy_redirect(fname):
     infer_global(numpy_function, types.Function(cls))
 
 for func in ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-             'cumsum', 'cumprod', 'argmin', 'argmax', 'argsort',
+             'cumsum', 'cumprod', 'argmin', 'argsort',
              'nonzero', 'ravel']:
     _numpy_redirect(func)
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -824,7 +824,7 @@ def array_argmax(arr, axis=None):
             assert transposed_arr.size % m == 0
             out = np.empty(transposed_arr.size // m, retty)
             for i in range(out.size):
-                out[i] = flatten_impl(raveled[i*m:(i+1) * m])
+                out[i] = flatten_impl(raveled[i * m:(i + 1) * m])
 
             # Reshape based on axis we didn't flatten over:
             return out.reshape(transposed_arr.shape[:-1])

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -772,7 +772,7 @@ def array_argmax_impl_generic(arry):
 
 @overload(np.argmax)
 @overload_method(types.Array, "argmax")
-def array_argmax(arr):
+def array_argmax(arr, axis=None):
     if isinstance(arr.dtype, (types.NPDatetime, types.NPTimedelta)):
         flatten_impl = array_argmax_impl_datetime
     elif isinstance(arr.dtype, types.Float):
@@ -780,11 +780,21 @@ def array_argmax(arr):
     else:
         flatten_impl = array_argmax_impl_generic
 
-    def array_argmax_impl(arr):
-        return flatten_impl(arr)
+    if is_nonelike(axis):
+        def array_argmax_impl(arr, axis=None):
+            return flatten_impl(arr)
+    else:
+        def array_argmax_impl(arr, axis=None):
+            if axis < 0:
+                axis = arr.ndim + axis
+            # TODO interpolate
+            length = len(arr)
+            out = np.empty(length, arr.dtype)
+            for i in range(length):
+                out[i] = flatten_impl(arr)
+            return out
 
     return array_argmax_impl
-
 
 
 @overload(np.all)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -783,10 +783,6 @@ def array_argmax(arr, axis=None):
     if is_nonelike(axis):
         def array_argmax_impl(arr, axis=None):
             return flatten_impl(arr)
-    #elif axis.ndim == 1:
-    #    def array_argmax_impl(arr, axis=None):
-    #        if axis != 0: raise ValueError("...")
-    #        return flatten_impl(arr)
     else:
         retty = arr.dtype
 
@@ -797,6 +793,13 @@ def array_argmax(arr, axis=None):
                 raise ValueError("More than 3 dimensions are not supported.")
             if axis < 0:
                 axis = arr.ndim + axis
+
+            if axis < 0 or axis >= arr.ndim:
+                raise ValueError("Axis is out of bounds")
+
+            # Short circuit 1-dimensional arrays:
+            if arr.ndim == 1:
+                return flatten_impl(arr)
 
             # Make chosen axis the last axis:
             if arr.ndim == 2:

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -791,10 +791,6 @@ def array_argmax(arr, axis=None):
         tuple_buffer = tuple(range(arr.ndim))
 
         def array_argmax_impl(arr, axis=None):
-            if arr.ndim > 3:
-                # Transposing currently only works with literals, so can't
-                # calculate new axis order for arbitrary array dimensions.
-                raise ValueError("More than 3 dimensions are not supported.")
             if axis < 0:
                 axis = arr.ndim + axis
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -784,6 +784,7 @@ def array_argmax(arr, axis=None):
         def array_argmax_impl(arr, axis=None):
             return flatten_impl(arr)
     else:
+        _check_is_integer(axis, "axis")
         retty = arr.dtype
 
         def array_argmax_impl(arr, axis=None):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -795,7 +795,7 @@ def array_argmax(arr, axis=None):
                 axis = arr.ndim + axis
 
             if axis < 0 or axis >= arr.ndim:
-                raise ValueError("Axis is out of bounds")
+                raise ValueError("axis is out of bounds")
 
             # Short circuit 1-dimensional arrays:
             if arr.ndim == 1:

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -938,6 +938,23 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             for a in a_variations():
                 check(a)
 
+    def test_argmax_axis(self):
+        arr = np.arange(24).reshape(2, 3, 4) + 10
+        arr[0,1,1] += 100
+        arr[1,0,0] += 100
+
+        py_functions = [
+            lambda a, _axis=axis: np.argmax(a, axis=_axis)
+            for axis in [0, 1, 2, -1]
+        ]
+        c_functions = [
+            jit(nopython=True)(pyfunc) for pyfunc in py_functions
+        ]
+        self.assertPreciseEqual(
+            [pyfunc(arr) for pyfunc in py_functions],
+            [cfunc(arr) for cfunc in c_functions]
+        )
+
     @classmethod
     def install_generated_tests(cls):
         # These form a testing product where each of the combinations are tested

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -980,6 +980,15 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         assert_raises(arr2d, -3)
         assert_raises(arr2d, 2)
 
+    def test_argmax_method_axis(self):
+        arr2d = np.arange(6).reshape(2, 3)
+
+        def argmax(arr):
+            return arr2d.argmax(axis=0)
+
+        self.assertPreciseEqual(argmax(arr2d),
+                                jit(nopython=True)(argmax)(arr2d))
+
     @classmethod
     def install_generated_tests(cls):
         # These form a testing product where each of the combinations are tested

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -945,15 +945,14 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
 
         py_functions = [
             lambda a, _axis=axis: np.argmax(a, axis=_axis)
-            for axis in [0, 1, 2, -1]
+            for axis in [0, 1, 2, -1, -2, -3]
         ]
         c_functions = [
             jit(nopython=True)(pyfunc) for pyfunc in py_functions
         ]
-        self.assertPreciseEqual(
-            [pyfunc(arr) for pyfunc in py_functions],
-            [cfunc(arr) for cfunc in c_functions]
-        )
+        for (pyfunc, cfunc) in zip(py_functions, c_functions):
+            self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+        # TODO out of range axis tests
 
     @classmethod
     def install_generated_tests(cls):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -970,9 +970,9 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             return np.argmax(arr, axis)
 
         def assert_raises(arr, axis):
-            with self.assertRaises(ValueError):
-                np.argmax(arr, axis)
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "axis.*out of bounds"):
+                jitargmax.py_func(arr, axis)
+            with self.assertRaisesRegex(ValueError, "axis.*out of bounds"):
                 jitargmax(arr, axis)
 
         assert_raises(arr1d, 1)

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -944,16 +944,16 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         arr2d[0,1] += 100
 
         arr4d = np.arange(120).reshape(2, 3, 4, 5) + 10
-        arr4d[0,1,1,2] += 100
-        arr4d[1,0,0,0] += 100
+        arr4d[0, 1, 1, 2] += 100
+        arr4d[1, 0, 0, 0] -= 51
 
         for arr in [arr1d, arr2d, arr4d]:
-            axises = list(range(arr.ndim)) + [
+            axes = list(range(arr.ndim)) + [
                 -(i+1) for i in range(arr.ndim)
             ]
             py_functions = [
                 lambda a, _axis=axis: np.argmax(a, axis=_axis)
-                for axis in axises
+                for axis in axes
             ]
             c_functions = [
                 jit(nopython=True)(pyfunc) for pyfunc in py_functions

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -980,6 +980,17 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         assert_raises(arr2d, -3)
         assert_raises(arr2d, 2)
 
+    def test_argmax_axis_must_be_integer(self):
+        arr = np.arange(6)
+
+        @jit(nopython=True)
+        def jitargmax(arr, axis):
+            return np.argmax(arr, axis)
+
+        with self.assertTypingError() as e:
+            jitargmax(arr, "foo")
+        self.assertIn("axis must be an integer", str(e.exception))
+
     def test_argmax_method_axis(self):
         arr2d = np.arange(6).reshape(2, 3)
 

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -938,16 +938,16 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             for a in a_variations():
                 check(a)
 
-    def test_argmax_axis_1d_2d_3d(self):
+    def test_argmax_axis_1d_2d_4d(self):
         arr1d = np.array([0, 20, 3, 4])
         arr2d = np.arange(6).reshape(2, 3)
         arr2d[0,1] += 100
 
-        arr3d = np.arange(24).reshape(2, 3, 4) + 10
-        arr3d[0,1,1] += 100
-        arr3d[1,0,0] += 100
+        arr4d = np.arange(120).reshape(2, 3, 4, 5) + 10
+        arr4d[0,1,1,2] += 100
+        arr4d[1,0,0,0] += 100
 
-        for arr in [arr1d, arr2d, arr3d]:
+        for arr in [arr1d, arr2d, arr4d]:
             axises = list(range(arr.ndim)) + [
                 -(i+1) for i in range(arr.ndim)
             ]

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -958,8 +958,8 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
             c_functions = [
                 jit(nopython=True)(pyfunc) for pyfunc in py_functions
             ]
-            for (pyfunc, cfunc) in zip(py_functions, c_functions):
-                self.assertPreciseEqual(pyfunc(arr), cfunc(arr))
+            for cfunc in c_functions:
+                self.assertPreciseEqual(cfunc.py_func(arr), cfunc(arr))
 
     def test_argmax_axis_out_of_range(self):
         arr1d = np.arange(6)


### PR DESCRIPTION
This adds support for the `axis` keyword argument to `np.argmax` and `np.ndarray.argmax`.

~I could not get arbitrary dimensions working, because `np.transpose()` only works (as far as I can tell) with literals. Suggestions are welcome.~