### PR TITLE
Fix CI failure when gitpython is missing.

### DIFF
--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -4,6 +4,13 @@ import subprocess
 from numba import cuda
 import unittest
 
+try:
+    import git  # from gitpython package
+except ImportError:
+    has_gitpython = False
+else:
+    has_gitpython = True
+
 
 class TestCase(unittest.TestCase):
     """These test cases are meant to test the Numba test infrastructure itself.
@@ -121,6 +128,7 @@ class TestCase(unittest.TestCase):
         # The tests must be equivalent
         self.assertEqual(sorted(full), sorted(sliced))
 
+    @unittest.skipUnless(has_gitpython, "Requires gitpython")
     def test_gitdiff(self):
         # Check for git
         try:


### PR DESCRIPTION
Skip test when `import git` fails indicating that gitpython package is not available thus we cannot run gitdiff

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
