### PR TITLE
CUDA: Implement support for PTDS globally

### DIFF
--- a/docs/source/cuda-reference/host.rst
+++ b/docs/source/cuda-reference/host.rst
@@ -179,6 +179,13 @@ transfers and kernel execution. For further details on streams, see the `CUDA C
 Programming Guide Streams section
 <http://docs.nvidia.com/cuda/cuda-c-programming-guide/#streams>`_.
 
+Numba defaults to using the legacy default stream as the default stream. The
+per-thread default stream can be made the default stream by setting the
+environment variable ``NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`` to ``1`` (see the
+:ref:`CUDA Environment Variables section <numba-envvars-gpu-support>`).
+Regardless of this setting, the objects representing the legacy and per-thread
+default streams can be constructed using the functions below.
+
 Streams are instances of :class:`numba.cuda.cudadrv.driver.Stream`:
 
 .. autoclass:: numba.cuda.cudadrv.driver.Stream

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -452,6 +452,15 @@ GPU support
    indicating that verbose messaging is enabled. This should not need to be
    modified under normal circumstances.
 
+.. envvar:: NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM
+
+   When set to 1, the default stream is the per-thread default stream. When set
+   to 0, the default stream is the legacy default stream. This defaults to 0,
+   for the legacy default stream, and may default to 1 in a future release of
+   Numba. See `Stream Synchronization Behavior
+   <https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html>`_
+   for an explanation of the legacy and per-thread default streams.
+
 .. envvar:: NUMBA_NPY_RELAXED_STRIDES_CHECKING
 
    By default arrays that inherit from ``numba.misc.dummyarray.Array`` (e.g.

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -456,7 +456,7 @@ GPU support
 
    When set to 1, the default stream is the per-thread default stream. When set
    to 0, the default stream is the legacy default stream. This defaults to 0,
-   for the legacy default stream, and may default to 1 in a future release of
+   for the legacy default stream. It may default to 1 in a future release of
    Numba. See `Stream Synchronization Behavior
    <https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html>`_
    for an explanation of the legacy and per-thread default streams.

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -347,6 +347,10 @@ class _EnvReloader(object):
         # Whether to generate verbose log messages when JIT linking
         CUDA_VERBOSE_JIT_LOG = _readenv("NUMBA_CUDA_VERBOSE_JIT_LOG", int, 1)
 
+        # Whether the default stream is the per-thread default stream
+        CUDA_PER_THREAD_DEFAULT_STREAM = _readenv(
+            "NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
+
         # Compute contiguity of device arrays using the relaxed strides
         # checking algorithm.
         NPY_RELAXED_STRIDES_CHECKING = _readenv(

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -309,17 +309,16 @@ class Driver(object):
         return functools.wraps(libfn)(wrapper)
 
     def _find_api(self, fname):
-        # Try version 2
-        try:
-            return getattr(self.lib, fname + "_v2")
-        except AttributeError:
-            pass
+        if config.CUDA_PER_THREAD_DEFAULT_STREAM:
+            variants = ('_v2_ptds', '_v2_ptsz', '_ptds', '_ptsz', '_v2', '')
+        else:
+            variants = ('_v2', '')
 
-        # Try regular
-        try:
-            return getattr(self.lib, fname)
-        except AttributeError:
-            pass
+        for variant in variants:
+            try:
+                return getattr(self.lib, f'{fname}{variant}')
+            except AttributeError:
+                pass
 
         # Not found.
         # Delay missing function error to use

--- a/numba/cuda/tests/cudadrv/test_ptds.py
+++ b/numba/cuda/tests/cudadrv/test_ptds.py
@@ -1,27 +1,52 @@
+import multiprocessing as mp
+import logging
+import traceback
+from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim
+
 
 def child_test():
-    from numba import cuda, float32, void
-    from time import perf_counter
+    from numba import cuda, int32, void
+    from numba.core import config
+    import io
     import numpy as np
     import threading
 
+    # Enable PTDS before we make any CUDA driver calls.  Enabling it first
+    # ensures that PTDS APIs are used because the CUDA driver looks up API
+    # functions on first use and memoizes them.
+    config.CUDA_PER_THREAD_DEFAULT_STREAM = 1
+
+    # Set up log capture for the Driver API so we can see what API calls were
+    # used.
+    logbuf = io.StringIO()
+    handler = logging.StreamHandler(logbuf)
+    cudadrv_logger = logging.getLogger('numba.cuda.cudadrv.driver')
+    cudadrv_logger.addHandler(handler)
+    cudadrv_logger.setLevel(logging.DEBUG)
+
+    # Set up data for our test, and copy over to the device
     N = 2 ** 16
     N_THREADS = 10
     N_ADDITIONS = 4096
 
+    # Seed the RNG for repeatability
     np.random.seed(1)
-    x = np.random.random(N).astype(np.float32)
+    x = np.random.randint(low=0, high=1000, size=N, dtype=np.int32)
     r = np.zeros_like(x)
 
+    # One input and output array for each thread
     xs = [cuda.to_device(x) for _ in range(N_THREADS)]
     rs = [cuda.to_device(r) for _ in range(N_THREADS)]
 
+    # Compute the grid size and get the [per-thread] default stream
     n_threads = 256
     n_blocks = N // n_threads
     stream = cuda.default_stream()
 
-
-    @cuda.jit(void(float32[::1], float32[::1]))
+    # A simple multiplication-by-addition kernel. What it does exactly is not
+    # too important; only that we have a kernel that does something.
+    @cuda.jit(void(int32[::1], int32[::1]))
     def f(r, x):
         i = cuda.grid(1)
 
@@ -32,42 +57,86 @@ def child_test():
         for j in range(N_ADDITIONS):
             r[i] += x[i]
 
-
+    # This function will be used to launch the kernel from each thread on its
+    # own unique data.
     def kernel_thread(n):
         f[n_blocks, n_threads, stream](rs[n], xs[n])
 
+    # Create threads
+    threads = [threading.Thread(target=kernel_thread, args=(i,))
+               for i in range(N_THREADS)]
 
-    def main():
-        print("Creating threads")
-        threads = [threading.Thread(target=kernel_thread, args=(i,))
-                   for i in range(N_THREADS)]
+    # Start all threads
+    for thread in threads:
+        thread.start()
 
-        print("Starting threads")
-        start = perf_counter()
+    # Wait for all threads to finish, to ensure that we don't synchronize with
+    # the device until all kernels are scheduled.
+    for thread in threads:
+        thread.join()
 
-        for thread in threads:
-            thread.start()
+    # Synchronize with the device
+    cuda.synchronize()
 
-        print("Waiting for threads to finish")
-        for thread in threads:
-            thread.join()
+    # Check output is as expected
+    expected = x * N_ADDITIONS
+    for i in range(N_THREADS):
+        np.testing.assert_equal(rs[i].copy_to_host(), expected)
 
-        print("Synchronizing with device")
-        cuda.synchronize()
-
-        end = perf_counter()
-        print(f"Elapsed time: {end - start}")
-
-        print("Checking output")
-        expected = x * N_ADDITIONS
-
-        for i in range(N_THREADS):
-            print(f"Checking output {i}")
-            # Lower than usual tolerance because our method of accumulation is not
-            # particularly accurate
-            rtol = 1.0e-4
-            np.testing.assert_allclose(rs[i].copy_to_host(), expected, rtol=rtol)
-
-        print("Done!")
+    # Return the driver log output to the calling process for checking
+    handler.flush()
+    return logbuf.getvalue()
 
 
+def child_test_wrapper(result_queue):
+    try:
+        output = child_test()
+        success = True
+    # Catch anything raised so it can be propagated
+    except: # noqa: E722
+        output = traceback.format_exc()
+        success = False
+
+    result_queue.put((success, output))
+
+
+@skip_on_cudasim('Streams not supported on the simulator')
+class TestPTDS(CUDATestCase):
+    def test_ptds(self):
+        # Run a test with PTDS enabled in a child process
+        ctx = mp.get_context('spawn')
+        result_queue = ctx.Queue()
+        proc = ctx.Process(target=child_test_wrapper, args=(result_queue,))
+        proc.start()
+        proc.join()
+        success, output = result_queue.get()
+
+        # Ensure the child process ran to completion before checking its output
+        if not success:
+            self.fail(output)
+
+        # Functions with a per-thread default stream variant that we expect to
+        # see in the output
+        ptds_functions = ('cuMemcpyHtoD_v2_ptds', 'cuLaunchKernel_ptsz',
+                          'cuMemcpyDtoH_v2_ptds')
+
+        for fn in ptds_functions:
+            with self.subTest(fn=fn, expected=True):
+                self.assertIn(fn, output)
+
+        # Non-PTDS versions of the functions that we should not see in the
+        # output:
+        legacy_functions = ('cuMemcpyHtoD_v2', 'cuLaunchKernel',
+                            'cuMemcpyDtoH_v2')
+
+        for fn in legacy_functions:
+            with self.subTest(fn=fn, expected=False):
+                # Ensure we only spot these function names appearing without a
+                # _ptds or _ptsz suffix by checking including the end of the
+                # line in the log
+                fn_at_end = f'{fn}\n'
+                self.assertNotIn(fn_at_end, output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudadrv/test_ptds.py
+++ b/numba/cuda/tests/cudadrv/test_ptds.py
@@ -1,0 +1,73 @@
+
+def child_test():
+    from numba import cuda, float32, void
+    from time import perf_counter
+    import numpy as np
+    import threading
+
+    N = 2 ** 16
+    N_THREADS = 10
+    N_ADDITIONS = 4096
+
+    np.random.seed(1)
+    x = np.random.random(N).astype(np.float32)
+    r = np.zeros_like(x)
+
+    xs = [cuda.to_device(x) for _ in range(N_THREADS)]
+    rs = [cuda.to_device(r) for _ in range(N_THREADS)]
+
+    n_threads = 256
+    n_blocks = N // n_threads
+    stream = cuda.default_stream()
+
+
+    @cuda.jit(void(float32[::1], float32[::1]))
+    def f(r, x):
+        i = cuda.grid(1)
+
+        if i > len(r):
+            return
+
+        # Accumulate x into r
+        for j in range(N_ADDITIONS):
+            r[i] += x[i]
+
+
+    def kernel_thread(n):
+        f[n_blocks, n_threads, stream](rs[n], xs[n])
+
+
+    def main():
+        print("Creating threads")
+        threads = [threading.Thread(target=kernel_thread, args=(i,))
+                   for i in range(N_THREADS)]
+
+        print("Starting threads")
+        start = perf_counter()
+
+        for thread in threads:
+            thread.start()
+
+        print("Waiting for threads to finish")
+        for thread in threads:
+            thread.join()
+
+        print("Synchronizing with device")
+        cuda.synchronize()
+
+        end = perf_counter()
+        print(f"Elapsed time: {end - start}")
+
+        print("Checking output")
+        expected = x * N_ADDITIONS
+
+        for i in range(N_THREADS):
+            print(f"Checking output {i}")
+            # Lower than usual tolerance because our method of accumulation is not
+            # particularly accurate
+            rtol = 1.0e-4
+            np.testing.assert_allclose(rs[i].copy_to_host(), expected, rtol=rtol)
+
+        print("Done!")
+
+

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -10,8 +10,6 @@ from numba.cuda.testing import (skip_on_cudasim, skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
 import unittest
 
-has_mp_get_context = hasattr(mp, 'get_context')
-
 
 def core_ipc_handle_test(the_work, result_queue):
     try:
@@ -79,7 +77,6 @@ def ipc_array_test(ipcarr, result_queue):
 
 
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
-@unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcMemory(ContextResettingTestCase):
     def test_ipc_handle(self):
@@ -229,7 +226,6 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
 
 
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
-@unittest.skipUnless(has_mp_get_context, "requires multiprocessing.get_context")
 @skip_on_cudasim('Ipc not available in CUDASIM')
 class TestIpcStaged(ContextResettingTestCase):
     def test_staged(self):


### PR DESCRIPTION
This PR adds support for using the per-thread default stream by default - a config variable, `CUDA_PER_THREAD_DEFAULT_STREAM`, is added, which is used to control whether the default stream is legacy or per-thread. Presently the default is the legacy default stream - once this implementation is proven in use, we could consider making per-thread the default in future.

All tests pass for me locally with the legacy and per-thread default stream, run with:

```
$ python -m numba.runtests numba.cuda.tests -vf -m
```

and

```
$ NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM=1 python -m numba.runtests numba.cuda.tests -vf -m
```

respectively.  Additionally, a test program:

```python
from numba import cuda, float32, void
from time import perf_counter
import numpy as np
import threading

N = 2 ** 16
N_THREADS = 10
N_ADDITIONS = 4096

np.random.seed(1)
x = np.random.random(N).astype(np.float32)
r = np.zeros_like(x)

xs = [cuda.to_device(x) for _ in range(N_THREADS)]
rs = [cuda.to_device(r) for _ in range(N_THREADS)]

n_threads = 256
n_blocks = N // n_threads
stream = cuda.default_stream()


@cuda.jit(void(float32[::1], float32[::1]))
def f(r, x):
    i = cuda.grid(1)

    if i > len(r):
        return

    # Accumulate x into r
    for j in range(N_ADDITIONS):
        r[i] += x[i]


def kernel_thread(n):
    f[n_blocks, n_threads, stream](rs[n], xs[n])


def main():
    print("Creating threads")
    threads = [threading.Thread(target=kernel_thread, args=(i,))
               for i in range(N_THREADS)]

    print("Starting threads")
    start = perf_counter()

    for thread in threads:
        thread.start()

    print("Waiting for threads to finish")
    for thread in threads:
        thread.join()

    print("Synchronizing with device")
    cuda.synchronize()

    end = perf_counter()
    print(f"Elapsed time: {end - start}")

    print("Checking output")
    expected = x * N_ADDITIONS

    for i in range(N_THREADS):
        print(f"Checking output {i}")
        # Lower than usual tolerance because our method of accumulation is not
        # particularly accurate
        rtol = 1.0e-4
        np.testing.assert_allclose(rs[i].copy_to_host(), expected, rtol=rtol)

    print("Done!")


if __name__ == '__main__':
    main()
```

can be shown to correctly use the legacy default stream or the per-thread default stream depending on the setting of the config variable, using Nsight Systems to record the streams of the kernel launches. With the legacy default stream set:

![image](https://user-images.githubusercontent.com/535640/114943795-73080b00-9e3e-11eb-8516-3cedb9c53c4c.png)

With the per-thread default stream set:

![image](https://user-images.githubusercontent.com/535640/114943775-6d122a00-9e3e-11eb-8862-5d402e27a6e3.png)

**EDIT** (Test added in commit 8577d9b). **Original question:** *However, I'm struggling to thing of a fully automated / programmatic way of testing this. Any thoughts on this, anyone?*

Fixes #5137.