### PR TITLE
CUDA: Support for `@overload`

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -232,7 +232,7 @@ def compile_ptx_for_current_device(pyfunc, args, debug=False, device=False,
                        fastmath=fastmath, cc=cc, opt=True)
 
 
-class DeviceFunctionTemplate(serialize.ReduceMixin):
+class DeviceDispatcher(serialize.ReduceMixin):
     """Unmaterialized device function
     """
     def __init__(self, pyfunc, debug, inline, opt):
@@ -249,7 +249,43 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
 
     @classmethod
     def _rebuild(cls, py_func, debug, inline):
-        return compile_device_template(py_func, debug=debug, inline=inline)
+        return compile_device_dispatcher(py_func, debug=debug, inline=inline)
+
+    def get_call_template(self, args, kws):
+        # Copied and simplified from _DispatcherBase.get_call_template.
+        """
+        Get a typing.ConcreteTemplate for this dispatcher and the given
+        *args* and *kws* types.  This allows to resolve the return type.
+
+        A (template, pysig, args, kws) tuple is returned.
+        """
+        # Ensure an overload is available
+        self.compile(tuple(args))
+
+        # Create function type for typing
+        func_name = self.py_func.__name__
+        name = "CallTemplate({0})".format(func_name)
+
+        # The `key` isn't really used except for diagnosis here,
+        # so avoid keeping a reference to `cfunc`.
+        call_template = typing.make_concrete_template(
+            name, key=func_name, signatures=self.nopython_signatures)
+        pysig = utils.pysignature(self.py_func)
+
+        return call_template, pysig, args, kws
+
+    @property
+    def nopython_signatures(self):
+        # All _compileinfos are for nopython mode, because there is only
+        # nopython mode in CUDA
+        return [info.signature for info in self._compileinfos.values()]
+
+    def get_overload(self, sig):
+        # NOTE: This dispatcher seems to be used as the key for the dict of
+        # implementations elsewhere in Numba, so we return this dispatcher
+        # instead of a compiled entry point as in
+        # _DispatcherBase.get_overload().
+        return self
 
     def compile(self, args):
         """Compile the function for the given argument types.
@@ -320,20 +356,19 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
         return ptx
 
 
-def compile_device_template(pyfunc, debug=False, inline=False, opt=True):
-    """Create a DeviceFunctionTemplate object and register the object to
-    the CUDA typing context.
+def compile_device_dispatcher(pyfunc, debug=False, inline=False, opt=True):
+    """Create a DeviceDispatcher and register it to the CUDA typing context.
     """
     from .descriptor import cuda_target
 
-    dft = DeviceFunctionTemplate(pyfunc, debug=debug, inline=inline, opt=opt)
+    dispatcher = DeviceDispatcher(pyfunc, debug=debug, inline=inline, opt=opt)
 
     class device_function_template(AbstractTemplate):
-        key = dft
+        key = dispatcher
 
         def generic(self, args, kws):
             assert not kws
-            return dft.compile(args).signature
+            return dispatcher.compile(args).signature
 
         def get_template_info(cls):
             basepath = os.path.dirname(os.path.dirname(numba.__file__))
@@ -351,8 +386,8 @@ def compile_device_template(pyfunc, debug=False, inline=False, opt=True):
             return info
 
     typingctx = cuda_target.typingctx
-    typingctx.insert_user_function(dft, device_function_template)
-    return dft
+    typingctx.insert_user_function(dispatcher, device_function_template)
+    return dispatcher
 
 
 def compile_device(pyfunc, return_type, args, inline=True, debug=False):

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,7 +1,7 @@
 from numba.core import types, config, sigutils
 from numba.core.errors import DeprecationError
 from .compiler import (compile_device, declare_device_function, Dispatcher,
-                       compile_device_template)
+                       compile_device_dispatcher)
 from .simulator.kernel import FakeCUDAKernel
 
 
@@ -10,13 +10,16 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jitdevice(func, link=[], debug=None, inline=False, opt=True):
+def jitdevice(func, link=[], debug=None, inline=False, opt=True,
+              no_cpython_wrapper=None):
     """Wrapper for device-jit.
     """
+    # We ignore  the no_cpython_wrapper kwarg - it is passed by the callee when
+    # using overloads, but there is never a CPython wrapper for CUDA anyway.
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     if link:
         raise ValueError("link keyword invalid for device function")
-    return compile_device_template(func, debug=debug, inline=inline, opt=opt)
+    return compile_device_dispatcher(func, debug=debug, inline=inline, opt=opt)
 
 
 def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -1,12 +1,13 @@
-def init_jit():
-    from numba.cuda.compiler import Dispatcher
-    return Dispatcher
-
-
 def initialize_all():
     # Import models to register them with the data model manager
     import numba.cuda.models  # noqa: F401
 
-    from numba.core.extending_hardware import dispatcher_registry
-    dispatcher_registry.ondemand['gpu'] = init_jit
-    dispatcher_registry.ondemand['cuda'] = init_jit
+    from numba import cuda
+    from numba.core import decorators
+    from numba.core.extending_hardware import hardware_registry
+
+    def cuda_jit_device(*args, **kwargs):
+        kwargs['device'] = True
+        return cuda.jit(*args, **kwargs)
+
+    decorators.jit_registry[hardware_registry["cuda"]] = cuda_jit_device

--- a/numba/cuda/tests/cudapy/test_overload.py
+++ b/numba/cuda/tests/cudapy/test_overload.py
@@ -1,0 +1,345 @@
+from numba import cuda
+from numba.core.extending import overload
+from numba.cuda.testing import (CUDATestCase, captured_cuda_stdout,
+                                skip_on_cudasim, unittest)
+
+
+def generic_func_1():
+    pass
+
+
+def cuda_func_1():
+    pass
+
+
+def generic_func_2():
+    pass
+
+
+def cuda_func_2():
+    pass
+
+
+def generic_calls_generic():
+    pass
+
+
+def generic_calls_cuda():
+    pass
+
+
+def cuda_calls_generic():
+    pass
+
+
+def cuda_calls_cuda():
+    pass
+
+
+def hardware_overloaded():
+    pass
+
+
+def generic_calls_hardware_overloaded():
+    pass
+
+
+def cuda_calls_hardware_overloaded():
+    pass
+
+
+def hardware_overloaded_calls_hardware_overloaded():
+    pass
+
+
+@overload(generic_func_1, hardware='generic')
+def ol_generic_func_1():
+    def impl():
+        print("Generic function 1")
+    return impl
+
+
+@overload(cuda_func_1, hardware='cuda')
+def ol_cuda_func_1():
+    def impl():
+        print("CUDA function 1")
+    return impl
+
+
+@overload(generic_func_2, hardware='generic')
+def ol_generic_func_2():
+    def impl():
+        print("Generic function 2")
+    return impl
+
+
+@overload(cuda_func_2, hardware='cuda')
+def ol_cuda_func():
+    def impl():
+        print("CUDA function 2")
+    return impl
+
+
+@overload(generic_calls_generic, hardware='generic')
+def ol_generic_calls_generic():
+    def impl():
+        print("Generic calls generic")
+        generic_func_1()
+    return impl
+
+
+@overload(generic_calls_cuda, hardware='generic')
+def ol_generic_calls_cuda():
+    def impl():
+        print("Generic calls CUDA")
+        cuda_func_1()
+    return impl
+
+
+@overload(cuda_calls_generic, hardware='cuda')
+def ol_cuda_calls_generic():
+    def impl():
+        print("CUDA calls generic")
+        generic_func_1()
+    return impl
+
+
+@overload(cuda_calls_cuda, hardware='cuda')
+def ol_cuda_calls_cuda():
+    def impl():
+        print("CUDA calls CUDA")
+        cuda_func_1()
+    return impl
+
+
+@overload(hardware_overloaded, hardware='generic')
+def ol_hardware_overloaded_generic():
+    def impl():
+        print("Generic hardware overloaded function")
+    return impl
+
+
+@overload(hardware_overloaded, hardware='cuda')
+def ol_hardware_overloaded_cuda():
+    def impl():
+        print("CUDA hardware overloaded function")
+    return impl
+
+
+@overload(generic_calls_hardware_overloaded, hardware='generic')
+def ol_generic_calls_hardware_overloaded():
+    def impl():
+        print("Generic calls hardware overloaded")
+        hardware_overloaded()
+    return impl
+
+
+@overload(cuda_calls_hardware_overloaded, hardware='cuda')
+def ol_cuda_calls_hardware_overloaded():
+    def impl():
+        print("CUDA calls hardware overloaded")
+        hardware_overloaded()
+    return impl
+
+
+@overload(hardware_overloaded_calls_hardware_overloaded, hardware='generic')
+def ol_generic_calls_hardware_overloaded_generic():
+    def impl():
+        print("Generic hardware overloaded calls hardware overloaded")
+        hardware_overloaded()
+    return impl
+
+
+@overload(hardware_overloaded_calls_hardware_overloaded, hardware='cuda')
+def ol_generic_calls_hardware_overloaded_cuda():
+    def impl():
+        print("CUDA hardware overloaded calls hardware overloaded")
+        hardware_overloaded()
+    return impl
+
+
+@skip_on_cudasim('Overloading not supported in cudasim')
+class TestOverload(CUDATestCase):
+    def test_generic(self):
+        @cuda.jit
+        def call_kernel():
+            generic_func_1()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn('Generic function 1', out)
+        self.assertNotIn('Generic function 2', out)
+        self.assertNotIn('CUDA', out)
+
+    def test_cuda(self):
+        @cuda.jit
+        def call_kernel():
+            cuda_func_1()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn('CUDA function 1', out)
+        self.assertNotIn('CUDA function 2', out)
+        self.assertNotIn('Generic', out)
+
+    def test_generic_and_cuda(self):
+        @cuda.jit
+        def call_kernel():
+            generic_func_1()
+            cuda_func_1()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn('Generic function 1', out)
+        self.assertIn('CUDA function 1', out)
+        self.assertNotIn('2', out)
+
+    def test_call_two_generic_calls(self):
+        @cuda.jit
+        def call_kernel():
+            generic_func_1()
+            generic_func_2()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn('Generic function 1', out)
+        self.assertIn('Generic function 2', out)
+
+    def test_call_two_cuda_calls(self):
+        @cuda.jit
+        def call_kernel():
+            cuda_func_1()
+            cuda_func_2()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn('CUDA function 1', out)
+        self.assertIn('CUDA function 2', out)
+
+    def test_generic_calls_generic(self):
+        @cuda.jit
+        def call_kernel():
+            generic_calls_generic()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("Generic calls generic", out)
+        self.assertIn("Generic function 1", out)
+        self.assertNotIn("CUDA", out)
+
+    def test_generic_calls_cuda(self):
+        @cuda.jit
+        def call_kernel():
+            generic_calls_cuda()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("Generic calls CUDA", out)
+        self.assertIn("CUDA function 1", out)
+
+    def test_cuda_calls_generic(self):
+        @cuda.jit
+        def call_kernel():
+            cuda_calls_generic()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("CUDA calls generic", out)
+        self.assertIn("Generic function 1", out)
+
+    def test_cuda_calls_cuda(self):
+        @cuda.jit
+        def call_kernel():
+            cuda_calls_cuda()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("CUDA calls CUDA", out)
+        self.assertIn("CUDA function 1", out)
+        self.assertNotIn("Generic", out)
+
+    def test_call_hardware_overloaded(self):
+        @cuda.jit
+        def call_kernel():
+            hardware_overloaded()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("CUDA hardware overloaded function", out)
+        self.assertNotIn("Generic hardware overloaded function", out)
+
+    def test_generic_calls_hardware_overloaded(self):
+        @cuda.jit
+        def call_kernel():
+            generic_calls_hardware_overloaded()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("Generic calls hardware overloaded", out)
+        self.assertIn("CUDA hardware overloaded function", out)
+        self.assertNotIn("Generic hardware overloaded function", out)
+
+    def test_cuda_calls_hardware_overloaded(self):
+        @cuda.jit
+        def call_kernel():
+            cuda_calls_hardware_overloaded()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("CUDA calls hardware overloaded", out)
+        self.assertIn("CUDA hardware overloaded function", out)
+        self.assertNotIn("Generic hardware overloaded function", out)
+
+    def test_hardware_overloaded_calls_hardware_overloaded(self):
+        @cuda.jit
+        def call_kernel():
+            hardware_overloaded_calls_hardware_overloaded()
+
+        with captured_cuda_stdout() as stdout:
+            call_kernel[1, 1]()
+            cuda.synchronize()
+
+        out = stdout.getvalue()
+        self.assertIn("CUDA hardware overloaded calls hardware overloaded", out)
+        self.assertIn("CUDA hardware overloaded function", out)
+        self.assertNotIn("Generic", out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Joint work with @stuartarchibald.

The implementation consists of:

- Addition of `get_call_template`, `nopython_signatures`, and   `get_overload` to the class that is now `DeviceDispatcher`. These are needed by the overload infrastructure, and are inspired by the equivalents in `_DispatcherBase`.
- Registration of a CUDA `jit` decorator. The registration with `dispatcher_register` is removed and replaced with this new registration, because it did nothing (it was for the `target` kwarg to the `numba.jit` decorator, which is deprecated). The `jit` decorator for overloads is a bit special in that it always adds the `device=True` kwarg to the regular `jit` decorator, because overloads will always be device functions.
- Addition of a `no_cpython_wrapper` kwarg to `jitdevice`, which is needed because the overload infrastructure passes it. No action is required regardless of its value, because there is no CPython wrapper in the CUDA target.

A refactoring is also made: `DeviceFunctionTemplate` is renamed to `DeviceDispatcher`, as it reflects more closely what it is - it is
analagous to the `Dispatcher` class used for kernels, and the `DeviceFunction` class is more analagous to the `_Kernel` class. Eventually `Dispatcher` will subsume these classes as we move towards a more "modern" dispatcher implementation in the CUDA target.

Tests are added; these are all skipped on the simulator because overloading doesn't really exist as a concept without compilation.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
