### PR TITLE
Fix issue with array analysis tests needing scipy.

### DIFF
--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -16,7 +16,8 @@ from numba.core import (
     registry,
     utils,
 )
-from numba.tests.support import TestCase, tag, skip_parfors_unsupported
+from numba.tests.support import (TestCase, tag, skip_parfors_unsupported,
+                                 skip_unless_scipy)
 from numba.parfors.array_analysis import EquivSet, ArrayAnalysis
 from numba.core.compiler import Compiler, Flags, PassManager
 from numba.core.ir_utils import remove_dead
@@ -625,6 +626,7 @@ class TestArrayAnalysis(TestCase):
                                        self.with_equiv('F', 'D'),],
                                idempotent=False)
 
+    @skip_unless_scipy
     def test_numpy_calls(self):
         def test_zeros(n):
             a = np.zeros(n)


### PR DESCRIPTION
This is needed since the implementation of `np.dot` is now an
overload and as a result it must be typed via compilation and if
SciPy is not present this will fail. Fix is to skip this test on
systems with no suitable SciPy.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
