### PR TITLE
CUDA: Fix and deprecate `inspect_ptx()`, fix NVVM option setup for device functions

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -25,7 +25,7 @@ from warnings import warn
 import numba
 from .cudadrv.devices import get_context
 from .cudadrv.libs import get_cudalib
-from .cudadrv import nvvm, driver
+from .cudadrv import driver
 from .errors import missing_launch_config_msg, normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
@@ -260,8 +260,13 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
         Returns the `CompileResult`.
         """
         if args not in self._compileinfos:
+            nvvm_options = {
+                'opt': 3 if self.opt else 0,
+                'debug': self.debug,
+            }
+
             cres = compile_cuda(self.py_func, None, args, debug=self.debug,
-                                inline=self.inline)
+                                inline=self.inline, nvvm_options=nvvm_options)
             first_definition = not self._compileinfos
             self._compileinfos[args] = cres
             libs = [cres.library]
@@ -290,12 +295,8 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
         -------
         llvmir : str
         """
-        # Force a compilation to occur if none has yet - this can be needed if
-        # the user attempts to inspect LLVM IR or PTX before the function has
-        # been called for the given arguments from a jitted kernel.
-        self.compile(args)
-        cres = self._compileinfos[args]
-        return "\n\n".join([str(mod) for mod in cres.library.modules])
+        modules = self.compile(args).library.modules
+        return "\n\n".join([str(mod) for mod in modules])
 
     def inspect_ptx(self, args, nvvm_options={}):
         """Returns the PTX compiled for *args* for the currently active GPU
@@ -309,15 +310,15 @@ class DeviceFunctionTemplate(serialize.ReduceMixin):
         -------
         ptx : bytes
         """
-        llvmir = self.inspect_llvm(args)
-        # Make PTX
-        cuctx = get_context()
-        device = cuctx.device
-        cc = device.compute_capability
-        arch = nvvm.get_arch_option(*cc)
-        opt = 3 if self.opt else 0
-        ptx = nvvm.llvm_to_ptx(llvmir, opt=opt, arch=arch, **nvvm_options)
-        return ptx
+        msg = ('inspect_ptx for device functions is deprecated. Use '
+               'compile_ptx instead.')
+        warn(msg, category=NumbaDeprecationWarning)
+
+        if nvvm_options:
+            msg = ('nvvm_options are ignored. Use compile_ptx if you want to '
+                   'set NVVM options.')
+            warn(msg, category=NumbaDeprecationWarning)
+        return self.compile(args).library.get_asm_str().encode()
 
 
 def compile_device_template(pyfunc, debug=False, inline=False, opt=True):

--- a/numba/cuda/tests/cudapy/test_inspect.py
+++ b/numba/cuda/tests/cudapy/test_inspect.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from io import StringIO
 from numba import cuda, float32, float64, int32, intp
@@ -203,6 +204,49 @@ class TestInspect(CUDATestCase):
 
         msg = 'ptx will always return a dict in future'
         self.assertIn(msg, str(warns.warnings[0]))
+
+    def test_inspect_ptx(self):
+        # Ensure that inspect_ptx works - see issue #6950
+        @cuda.jit(device=True)
+        def use_power(x):
+            return x ** 3
+
+        ptx = use_power.inspect_ptx((int32,)).decode()
+
+        # A simple sanity check - look for multiplications used to implement
+        # `x ** 3` as `x * x * x`.
+        self.assertIn('mul.wide.s32', ptx)
+        self.assertIn('mul.lo.s64', ptx)
+
+    def test_inspect_ptx_deprecation(self):
+        # Make sure we warn the user that inspect_ptx is deprecated and tell
+        # them to use compile_ptx instead.
+        @cuda.jit(device=True)
+        def use_power(x):
+            return x ** 3
+
+        with warnings.catch_warnings(record=True) as w:
+            use_power.inspect_ptx((int32,))
+
+        self.assertEqual(w[0].category, NumbaDeprecationWarning)
+        self.assertIn('Use compile_ptx instead', str(w[0].message))
+
+    def test_inspect_ptx_nvvm_options_deprecation(self):
+        # Ensure that we warn the user of the deprecation of inspect_ptx and
+        # that nvvm_options are ignored if they pass nvvm_options to
+        # inspect_ptx.
+        @cuda.jit(device=True)
+        def use_power(x):
+            return x ** 3
+
+        with warnings.catch_warnings(record=True) as w:
+            nvvm_options = {'opt': 0}
+            use_power.inspect_ptx((int32,), nvvm_options=nvvm_options)
+
+        self.assertEqual(w[0].category, NumbaDeprecationWarning)
+        self.assertIn('Use compile_ptx instead', str(w[0].message))
+        self.assertEqual(w[1].category, NumbaDeprecationWarning)
+        self.assertIn('nvvm_options are ignored', str(w[1].message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes issues with device functions:

- `inspect_ptx` was broken by PR #6735 (commit 11a7397). The device  function should use the code library to obtain the PTX instead of attempting to compile directly itself.
- Optimization and debug options were not passed to NVVM when compiling device functions. These options are now set up and passed to `compile_cuda` when a device function is compiled.

This commit also deprecates the use of `inspect_ptx` - the preferred API for compiling Python to PTX is to use the `compile_ptx` function instead. The `inspect_ptx()` method had a couple of issues:

- Allowing it to receive a dict of options for NVVM enabled it to produce different PTX to what might actually have been compiled so far, as highlighted by the fact that optimization and debug flags failed to be passed to NVVM for the `compile()` method, but not in the `inspect_ptx()` method.
- The NVVM options dict kwarg was unsafely initialized anyway (`nvvm_options={}`) - See issue #5811.
- It returned encoded bytes, which differs from similar APIs (e.g. `inspect_llvm()`, and the Dispatcher's `inspect_asm()`, which return `str` instead.

As there is no easy way to correctly and consistently pass NVVM options through `inspect_ptx()`, a warning is emitted stating that these are ignored if a user passes any options in.

Some tests are also added, to ensure that it works correctly, and warns the user appropriately.

Fixes #6950.