### PR TITLE
Inconsistent behavior of reshape between numpy and numba/cuda device array

### DIFF
--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -326,6 +326,15 @@ class Array(object):
             else:
                 knownsize *= dim
 
+        # compute the missing dimension
+        if unknownidx >= 0:
+            if knownsize == 0 or self.size % knownsize != 0:
+                raise ValueError("cannot infer valid shape for unknown dimension")
+            else:
+                newdims = newdims[0:unknownidx] \
+                        + tuple((self.size // knownsize,)) \
+                        + newdims[unknownidx + 1:]
+
         newsize = functools.reduce(operator.mul, newdims, 1)
 
         if order == 'A':

--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -314,6 +314,18 @@ class Array(object):
         if order not in 'CFA':
             raise ValueError('order not C|F|A')
 
+        # check for exactly one instance of -1 in newdims
+        unknownidx = -1
+        knownsize = 1
+        for i, dim in enumerate(newdims):
+            if dim < 0:
+                if unknownidx == -1:
+                    unknownidx = i
+                else:
+                    raise ValueError("can only specify one unknown dimension")
+            else:
+                knownsize *= dim
+
         newsize = functools.reduce(operator.mul, newdims, 1)
 
         if order == 'A':

--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -315,6 +315,7 @@ class Array(object):
             raise ValueError('order not C|F|A')
 
         # check for exactly one instance of -1 in newdims
+        # https://github.com/numpy/numpy/blob/623bc1fae1d47df24e7f1e29321d0c0ba2771ce0/numpy/core/src/multiarray/shape.c#L470-L515   # noqa: E501
         unknownidx = -1
         knownsize = 1
         for i, dim in enumerate(newdims):

--- a/numba/misc/dummyarray.py
+++ b/numba/misc/dummyarray.py
@@ -332,7 +332,7 @@ class Array(object):
                 raise ValueError("cannot infer valid shape for unknown dimension")
             else:
                 newdims = newdims[0:unknownidx] \
-                        + tuple((self.size // knownsize,)) \
+                        + (self.size // knownsize,) \
                         + newdims[unknownidx + 1:]
 
         newsize = functools.reduce(operator.mul, newdims, 1)

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -208,6 +208,51 @@ class TestReshape(unittest.TestCase):
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)
 
+    def test_reshape_infer2d2d(self):
+        nparr = np.empty((4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        expect = nparr.reshape(5, 4)
+        got = arr.reshape(-1, 4)[0]
+        self.assertEqual(got.shape, expect.shape)
+        self.assertEqual(got.strides, expect.strides)
+
+    def test_reshape_infer2d1d(self):
+        nparr = np.empty((4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        expect = nparr.reshape(5 * 4)
+        got = arr.reshape(-1)[0]
+        self.assertEqual(got.shape, expect.shape)
+        self.assertEqual(got.strides, expect.strides)
+
+    def test_reshape_infer3d3d(self):
+        nparr = np.empty((3, 4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        expect = nparr.reshape(5, 3, 4)
+        got = arr.reshape(5, -1, 4)[0]
+        self.assertEqual(got.shape, expect.shape)
+        self.assertEqual(got.strides, expect.strides)
+
+    def test_reshape_infer3d2d(self):
+        nparr = np.empty((3, 4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        expect = nparr.reshape(3, 4 * 5)
+        got = arr.reshape(3, -1)[0]
+        self.assertEqual(got.shape, expect.shape)
+        self.assertEqual(got.strides, expect.strides)
+
+    def test_reshape_infer3d1d(self):
+        nparr = np.empty((3, 4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+        expect = nparr.reshape(3 * 4 * 5)
+        got = arr.reshape(-1)[0]
+        self.assertEqual(got.shape, expect.shape)
+        self.assertEqual(got.strides, expect.strides)
+
 
 class TestSqueeze(unittest.TestCase):
     def test_squeeze(self):

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -221,7 +221,7 @@ class TestReshape(unittest.TestCase):
         nparr = np.empty((4, 5))
         arr = Array.from_desc(0, nparr.shape, nparr.strides,
                               nparr.dtype.itemsize)
-        expect = nparr.reshape(5 * 4)
+        expect = nparr.reshape(-1)
         got = arr.reshape(-1)[0]
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -212,7 +212,7 @@ class TestReshape(unittest.TestCase):
         nparr = np.empty((4, 5))
         arr = Array.from_desc(0, nparr.shape, nparr.strides,
                               nparr.dtype.itemsize)
-        expect = nparr.reshape(5, 4)
+        expect = nparr.reshape(-1, 4)
         got = arr.reshape(-1, 4)[0]
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)
@@ -230,7 +230,7 @@ class TestReshape(unittest.TestCase):
         nparr = np.empty((3, 4, 5))
         arr = Array.from_desc(0, nparr.shape, nparr.strides,
                               nparr.dtype.itemsize)
-        expect = nparr.reshape(5, 3, 4)
+        expect = nparr.reshape(5, -1, 4)
         got = arr.reshape(5, -1, 4)[0]
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)
@@ -239,7 +239,7 @@ class TestReshape(unittest.TestCase):
         nparr = np.empty((3, 4, 5))
         arr = Array.from_desc(0, nparr.shape, nparr.strides,
                               nparr.dtype.itemsize)
-        expect = nparr.reshape(3, 4 * 5)
+        expect = nparr.reshape(3, -1)
         got = arr.reshape(3, -1)[0]
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)
@@ -248,7 +248,7 @@ class TestReshape(unittest.TestCase):
         nparr = np.empty((3, 4, 5))
         arr = Array.from_desc(0, nparr.shape, nparr.strides,
                               nparr.dtype.itemsize)
-        expect = nparr.reshape(3 * 4 * 5)
+        expect = nparr.reshape(-1)
         got = arr.reshape(-1)[0]
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)

--- a/numba/tests/test_dummyarray.py
+++ b/numba/tests/test_dummyarray.py
@@ -253,6 +253,24 @@ class TestReshape(unittest.TestCase):
         self.assertEqual(got.shape, expect.shape)
         self.assertEqual(got.strides, expect.strides)
 
+    def test_reshape_infer_two_unknowns(self):
+        nparr = np.empty((3, 4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+
+        with self.assertRaises(ValueError) as raises:
+            arr.reshape(-1, -1, 3)
+        self.assertIn('can only specify one unknown dimension', str(raises.exception))
+
+    def test_reshape_infer_invalid_shape(self):
+        nparr = np.empty((3, 4, 5))
+        arr = Array.from_desc(0, nparr.shape, nparr.strides,
+                              nparr.dtype.itemsize)
+
+        with self.assertRaises(ValueError) as raises:
+            arr.reshape(-1, 7)
+        self.assertIn('cannot infer valid shape for unknown dimension', str(raises.exception))
+
 
 class TestSqueeze(unittest.TestCase):
     def test_squeeze(self):


### PR DESCRIPTION
 <!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Fixes #6930. 

A branch is added to check for a single `-1` instance, or an unknown dimension, in the `newdims`. If there is an unknown dimension, the computation is done to work out the missing dimension. Finally, `newdims` is updated with `-1` replaced with the computed dimension at the appropriate index to reflect this.

Unknown dimension inference based off of [numpy's implementation](https://github.com/numpy/numpy/blob/623bc1fae1d47df24e7f1e29321d0c0ba2771ce0/numpy/core/src/multiarray/shape.c#L470-L515).