### PR TITLE
Fix CUDA @``intrinsic`` use

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -29,6 +29,7 @@ from .cudadrv import nvvm, driver
 from .errors import missing_launch_config_msg, normalize_kernel_dimensions
 from .api import get_current_device
 from .args import wrap_arg
+from .descriptor import cuda_target
 
 
 def _nvvm_options_type(x):
@@ -852,6 +853,8 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
     # cases.
     _fold_args = False
 
+    targetdescr = cuda_target
+
     def __init__(self, py_func, sigs, targetoptions):
         self.py_func = py_func
         self.sigs = []
@@ -870,9 +873,7 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         self.targetoptions['extensions'] = \
             list(self.targetoptions.get('extensions', []))
 
-        from .descriptor import cuda_target
-
-        self.typingctx = cuda_target.typing_context
+        self.typingctx = self.targetdescr.typing_context
 
         self._tm = default_type_manager
 

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -3,11 +3,15 @@ def initialize_all():
     import numba.cuda.models  # noqa: F401
 
     from numba import cuda
+    from numba.cuda.compiler import Dispatcher
     from numba.core import decorators
-    from numba.core.extending_hardware import hardware_registry
+    from numba.core.extending_hardware import (hardware_registry,
+                                               dispatcher_registry)
 
     def cuda_jit_device(*args, **kwargs):
         kwargs['device'] = True
         return cuda.jit(*args, **kwargs)
 
-    decorators.jit_registry[hardware_registry["cuda"]] = cuda_jit_device
+    cuda_hw = hardware_registry["cuda"]
+    decorators.jit_registry[cuda_hw] = cuda_jit_device
+    dispatcher_registry[cuda_hw] = Dispatcher

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -11,7 +11,6 @@ from numba.core.typing import cmathdecl
 
 from .cudadrv import nvvm
 from numba.cuda import codegen, nvvmutils
-from .decorators import jitdevice
 from numba.cpython import cmathimpl
 
 
@@ -39,6 +38,7 @@ class CUDATypingContext(typing.BaseContext):
                     raise ValueError('using cpu function on device '
                                      'but its compilation is disabled')
                 opt = val.targetoptions.get('opt', True)
+                from .decorators import jitdevice
                 jd = jitdevice(val, debug=val.targetoptions.get('debug'),
                                opt=opt)
                 # cache the device function for future use and to avoid


### PR DESCRIPTION
As title. The CUDA dispatcher needs a target description as the
`@intrinsic` function templates query it.

Fixes #6970

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
