### PR TITLE
Implement operator.contains for empty Tuples

### DIFF
--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -406,3 +406,9 @@ def tuple_index(tup, value):
         raise ValueError("tuple.index(x): x not in tuple")
 
     return tuple_index_impl
+
+
+@overload(operator.contains)
+def in_seq_empty_tuple(x, y):
+    if isinstance(x, types.Tuple) and not x.types:
+        return lambda x, y: False

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -282,7 +282,6 @@ class TestOperations(TestCase):
                "list(undefined)<iv=None>.")
         self.assertIn(msg, str(raises.exception))
 
-
     def test_in(self):
         pyfunc = in_usecase
         cr = compile_isolated(pyfunc,
@@ -290,6 +289,10 @@ class TestOperations(TestCase):
         tup = (4, 1, 5)
         for i in range(5):
             self.assertPreciseEqual(cr.entry_point(i, tup), pyfunc(i, tup))
+
+        # Test the empty case
+        cr = compile_isolated(pyfunc, [types.int64, types.Tuple([])])
+        self.assertPreciseEqual(cr.entry_point(1, ()), pyfunc(1, ()))
 
     def check_slice(self, pyfunc):
         tup = (4, 5, 6, 7)


### PR DESCRIPTION
This PR implements `x in ()`.