### PR TITLE
Fix LLVM IR parsing error on use of np.bool_ in globals

### DIFF
--- a/numba/cpython/numbers.py
+++ b/numba/cpython/numbers.py
@@ -1333,6 +1333,12 @@ def constant_complex(context, builder, ty, pyval):
 @lower_constant(types.Float)
 @lower_constant(types.Boolean)
 def constant_integer(context, builder, ty, pyval):
+    # See https://github.com/numba/numba/issues/6979
+    # llvmlite ir.IntType specialises the formatting of the constant for a
+    # cpython bool. A NumPy np.bool_ is not a cpython bool so force it to be one
+    # so that the constant renders correctly!
+    if isinstance(pyval, np.bool_):
+        pyval = bool(pyval)
     lty = context.get_value_type(ty)
     return lty(pyval)
 

--- a/numba/tests/test_globals.py
+++ b/numba/tests/test_globals.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numba import jit, njit
+from numba.extending import register_jitable
 from numba.tests import usecases
 import unittest
 
@@ -104,7 +105,12 @@ _glbl_np_bool_T = np.bool_(True)
 _glbl_np_bool_F = np.bool_(False)
 
 
+@register_jitable # consumer function
+def _sink(*args):
+    pass
+
 def global_npy_bool():
+    _sink(_glbl_np_bool_T, _glbl_np_bool_F)
     return _glbl_np_bool_T, _glbl_np_bool_F
 
 

--- a/numba/tests/test_globals.py
+++ b/numba/tests/test_globals.py
@@ -100,6 +100,14 @@ def global_npy_int_tuple():
     return tup_npy_ints[0] + tup_npy_ints[1]
 
 
+_glbl_np_bool_T = np.bool_(True)
+_glbl_np_bool_F = np.bool_(False)
+
+
+def global_npy_bool():
+    return _glbl_np_bool_T, _glbl_np_bool_F
+
+
 class TestGlobals(unittest.TestCase):
 
     def check_global_ndarray(self, **jitargs):
@@ -216,6 +224,13 @@ class TestGlobals(unittest.TestCase):
 
     def test_global_npy_int_tuple(self):
         pyfunc = global_npy_int_tuple
+        jitfunc = njit(pyfunc)
+        self.assertEqual(pyfunc(), jitfunc())
+
+    def test_global_npy_bool(self):
+        # Test global NumPy bool
+        # See issue https://github.com/numba/numba/issues/6979
+        pyfunc = global_npy_bool
         jitfunc = njit(pyfunc)
         self.assertEqual(pyfunc(), jitfunc())
 


### PR DESCRIPTION
As title.

Fixes #6979

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
