### PR TITLE
Refactor hardware extension API to refer to "target" instead.

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -53,8 +53,8 @@ from numba import experimental
 import numba.core.withcontexts
 from numba.core.withcontexts import objmode_context as objmode
 
-# Initialize hardware
-import numba.core.extending_hardware
+# Initialize target extensions
+import numba.core.target_extension
 
 # Initialize typed containers
 import numba.typed

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -234,9 +234,9 @@ class BaseContext(object):
 
         self.address_size = utils.MACHINE_BITS
         self.typing_context = typing_context
-        from numba.core.extending_hardware import hardware_registry
+        from numba.core.target_extension import target_registry
         self.target_name = target
-        self.target = hardware_registry[target]
+        self.target = target_registry[target]
 
         # A mapping of installed registries to their loaders
         self._registries = {}

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -11,12 +11,6 @@ import logging
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
 from numba.core import config, extending, sigutils, registry
-from numba.core.target_extension import (JitDecorator, target_registry,
-                                         dispatcher_registry,
-                                         resolve_dispatcher_from_str)
-from numba.core.registry import DelayedRegistry
-
-jit_registry = DelayedRegistry()
 
 _logger = logging.getLogger(__name__)
 
@@ -191,11 +185,9 @@ def jit(signature_or_function=None, locals={}, cache=False,
         return wrapper
 
 
-# Register the cpu token as using `jit` as the jitter
-jit_registry[target_registry['cpu']] = jit
-
 def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
 
+    from numba.core.target_extension import resolve_dispatcher_from_str
     dispatcher = resolve_dispatcher_from_str(target)
 
     def wrapper(func):

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -11,12 +11,12 @@ import logging
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
 from numba.core import config, extending, sigutils, registry
-from numba.core.extending_hardware import (JitDecorator, hardware_registry,
-                                           dispatcher_registry,
-                                           resolve_dispatcher_from_str)
-from numba.core.registry import TargetRegistry
+from numba.core.target_extension import (JitDecorator, target_registry,
+                                         dispatcher_registry,
+                                         resolve_dispatcher_from_str)
+from numba.core.registry import DelayedRegistry
 
-jit_registry = TargetRegistry()
+jit_registry = DelayedRegistry()
 
 _logger = logging.getLogger(__name__)
 
@@ -192,7 +192,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
 
 
 # Register the cpu token as using `jit` as the jitter
-jit_registry[hardware_registry['cpu']] = jit
+jit_registry[target_registry['cpu']] = jit
 
 def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
 

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -112,8 +112,8 @@ def overload(func, jit_options={}, strict=True, inline='never',
     allow for more control (e.g. disabling non-literal types).
 
     **kwargs prescribes additional arguments passed through to the overload
-    template. The only accepted key at present is 'hardware' which is a string
-    corresponding to the hardware that this overload should target.
+    template. The only accepted key at present is 'target' which is a string
+    corresponding to the target that this overload should be bound against.
     """
     from numba.core.typing.templates import make_overload_template, infer_global
 
@@ -121,7 +121,7 @@ def overload(func, jit_options={}, strict=True, inline='never',
     opts = _overload_default_jit_options.copy()
     opts.update(jit_options)  # let user options override
 
-    # TODO: abort now if the kwarg 'hardware' relates to unregistered hardware,
+    # TODO: abort now if the kwarg 'target' relates to an unregistered target,
     # this requires sorting out the circular imports first.
 
     def decorate(overload_func):

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -418,12 +418,12 @@ class Expr(Inst):
         return cls(op=op, loc=loc, fn=fn, value=value)
 
     @classmethod
-    def call(cls, func, args, kws, loc, vararg=None, hardware=None):
+    def call(cls, func, args, kws, loc, vararg=None, target=None):
         assert isinstance(func, Var)
         assert isinstance(loc, Loc)
         op = 'call'
         return cls(op=op, loc=loc, func=func, args=args, kws=kws,
-                   vararg=vararg, hardware=hardware)
+                   vararg=vararg, target=target)
 
     @classmethod
     def build_tuple(cls, items, loc):

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -980,10 +980,9 @@ class Lower(BaseLower):
             argvals = self.fold_call_args(
                 fnty, signature, expr.args, expr.vararg, expr.kws,
             )
-        tname = expr.hardware
+        tname = expr.target
         if tname is not None:
-            from numba.core.extending_hardware import \
-                resolve_dispatcher_from_str
+            from numba.core.target_extension import resolve_dispatcher_from_str
             disp = resolve_dispatcher_from_str(tname)
             hw_ctx = disp.targetdescr.target_context
             impl = hw_ctx.get_function(fnty, signature)

--- a/numba/core/registry.py
+++ b/numba/core/registry.py
@@ -73,30 +73,30 @@ class CPUDispatcher(dispatcher.Dispatcher):
     targetdescr = cpu_target
 
 
-class TargetRegistry(utils.UniqueDict):
+class DelayedRegistry(utils.UniqueDict):
     """
-    A registry of API implementations for various backends.
+    A unique dictionary but with deferred initialisation of the values.
 
     Attributes
     ----------
     ondemand:
 
-        A dictionary of target-name -> function, where function is executed
-        the first time a target is used.  It is used for deferred
-        initialization for some targets (e.g. gpu).
+        A dictionary of key -> value, where value is executed
+        the first time it is is used.  It is used for part of a deferred
+        initialization strategy.
     """
     def __init__(self, *args, **kws):
         self.ondemand = utils.UniqueDict()
         self.key_type = kws.pop('key_type', None)
         self.value_type = kws.pop('value_type', None)
         self._type_check = self.key_type or self.value_type
-        super(TargetRegistry, self).__init__(*args, **kws)
+        super(DelayedRegistry, self).__init__(*args, **kws)
 
     def __getitem__(self, item):
         if item in self.ondemand:
             self[item] = self.ondemand[item]()
             del self.ondemand[item]
-        return super(TargetRegistry, self).__getitem__(item)
+        return super(DelayedRegistry, self).__getitem__(item)
 
     def __setitem__(self, key, value):
         if self._type_check:
@@ -109,4 +109,4 @@ class TargetRegistry(utils.UniqueDict):
                 check(key, self.key_type)
             if self.value_type is not None:
                 check(value, self.value_type)
-        return super(TargetRegistry, self).__setitem__(key, value)
+        return super(DelayedRegistry, self).__setitem__(key, value)

--- a/numba/core/target_extension.py
+++ b/numba/core/target_extension.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from numba.core.registry import DelayedRegistry, CPUDispatcher
-
+from numba.core.decorators import jit
 from threading import local as tls
+
 
 _active_context = tls()
 _active_context_default = 'cpu'
@@ -19,7 +20,11 @@ class _TargetRegistry(DelayedRegistry):
             raise ValueError(msg.format(item, known)) from None
 
 
+# Registry mapping target name strings to Target classes
 target_registry = _TargetRegistry()
+
+# Registry mapping Target classes the @jit decorator for that target
+jit_registry = DelayedRegistry()
 
 
 class target_override(object):
@@ -131,4 +136,9 @@ target_registry['ROCm'] = ROCm
 target_registry['npyufunc'] = NPyUfunc
 
 dispatcher_registry = DelayedRegistry(key_type=Target)
-dispatcher_registry[target_registry['cpu']] = CPUDispatcher
+
+
+# Register the cpu target token with its dispatcher and jit
+cpu_target = target_registry['cpu']
+dispatcher_registry[cpu_target] = CPUDispatcher
+jit_registry[cpu_target] = jit

--- a/numba/core/target_extension.py
+++ b/numba/core/target_extension.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from numba.core.registry import TargetRegistry, CPUDispatcher
+from numba.core.registry import DelayedRegistry, CPUDispatcher
 
 from threading import local as tls
 
@@ -7,7 +7,7 @@ _active_context = tls()
 _active_context_default = 'cpu'
 
 
-class HardwareRegistry(TargetRegistry):
+class _TargetRegistry(DelayedRegistry):
 
     def __getitem__(self, item):
         try:
@@ -15,14 +15,16 @@ class HardwareRegistry(TargetRegistry):
         except KeyError:
             msg = "No target is registered against '{}', known targets:\n{}"
             known = '\n'.join([f"{k: <{10}} -> {v}"
-                               for k, v in hardware_registry.items()])
+                               for k, v in target_registry.items()])
             raise ValueError(msg.format(item, known)) from None
 
 
-hardware_registry = HardwareRegistry()
+target_registry = _TargetRegistry()
 
 
-class hardware_target(object):
+class target_override(object):
+    """Context manager to temporarily override the current target with that
+       prescribed."""
     def __init__(self, name):
         self._orig_target = getattr(_active_context, 'target',
                                     _active_context_default)
@@ -50,9 +52,9 @@ def get_local_target(context):
     if len(context.callstack._stack) > 0:
         target = context.callstack[0].target
     else:
-        target = hardware_registry.get(current_target(), None)
+        target = target_registry.get(current_target(), None)
     if target is None:
-        msg = ("The hardware target found is not registered."
+        msg = ("The target found is not registered."
                "Given target was {}.")
         raise ValueError(msg.format(target))
     else:
@@ -61,11 +63,11 @@ def get_local_target(context):
 
 def resolve_target_str(target_str):
     """Resolves a target specified as a string to its Target class."""
-    return hardware_registry[target_str]
+    return target_registry[target_str]
 
 
 def resolve_dispatcher_from_str(target_str):
-    """Returns the dispatcher associated with a target hardware string"""
+    """Returns the dispatcher associated with a target string"""
     target_hw = resolve_target_str(target_str)
     return dispatcher_registry[target_hw]
 
@@ -78,7 +80,7 @@ class JitDecorator(ABC):
 
 
 class Target(ABC):
-    """ Implements a hardware/pseudo-hardware target """
+    """ Implements a target """
 
     @classmethod
     def inherits_from(cls, other):
@@ -87,46 +89,46 @@ class Target(ABC):
 
 
 class Generic(Target):
-    """Mark the hardware target as generic, i.e. suitable for compilation on
-    any target. All hardware must inherit from this.
+    """Mark the target as generic, i.e. suitable for compilation on
+    any target. All must inherit from this.
     """
 
 
 class CPU(Generic):
-    """Mark the hardware target as CPU.
+    """Mark the target as CPU.
     """
 
 
 class GPU(Generic):
-    """Mark the hardware target as GPU, i.e. suitable for compilation on a GPU
+    """Mark the target as GPU, i.e. suitable for compilation on a GPU
     target.
     """
 
 
 class CUDA(GPU):
-    """Mark the hardware target as CUDA.
+    """Mark the target as CUDA.
     """
 
 
 class ROCm(GPU):
-    """Mark the hardware target as ROCm.
+    """Mark the target as ROCm.
     """
 
 
 class NPyUfunc(Target):
-    """Mark the hardware target as a ufunc
+    """Mark the target as a ufunc
     """
 
 
-hardware_registry['generic'] = Generic
-hardware_registry['CPU'] = CPU
-hardware_registry['cpu'] = CPU
-hardware_registry['GPU'] = GPU
-hardware_registry['gpu'] = GPU
-hardware_registry['CUDA'] = CUDA
-hardware_registry['cuda'] = CUDA
-hardware_registry['ROCm'] = ROCm
-hardware_registry['npyufunc'] = NPyUfunc
+target_registry['generic'] = Generic
+target_registry['CPU'] = CPU
+target_registry['cpu'] = CPU
+target_registry['GPU'] = GPU
+target_registry['gpu'] = GPU
+target_registry['CUDA'] = CUDA
+target_registry['cuda'] = CUDA
+target_registry['ROCm'] = ROCm
+target_registry['npyufunc'] = NPyUfunc
 
-dispatcher_registry = TargetRegistry(key_type=Target)
-dispatcher_registry[hardware_registry['cpu']] = CPUDispatcher
+dispatcher_registry = DelayedRegistry(key_type=Target)
+dispatcher_registry[target_registry['cpu']] = CPUDispatcher

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -701,19 +701,20 @@ class _OverloadFunctionTemplate(AbstractTemplate):
 
     def _get_jit_decorator(self):
         """Gets a jit decorator suitable for the current target"""
-        from numba.core import decorators
-        from numba import jit
+
         jitter_str = self.metadata.get('target', None)
         if jitter_str is None:
+            from numba import jit
             # There is no target requested, use default, this preserves
             # original behaviour
             jitter = lambda *args, **kwargs: jit(*args, nopython=True, **kwargs)
         else:
             from numba.core.target_extension import (target_registry,
-                                                     get_local_target)
+                                                     get_local_target,
+                                                     jit_registry)
 
             # target has been requested, see what it is...
-            jitter = decorators.jit_registry.get(jitter_str, None)
+            jitter = jit_registry.get(jitter_str, None)
 
             if jitter is None:
                 # No JIT known for target string, see if something is
@@ -731,7 +732,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
                 if not issubclass(target_hw, target_class):
                     msg = "No overloads exist for the requested target: {}."
 
-                jitter = decorators.jit_registry[target_hw]
+                jitter = jit_registry[target_hw]
 
         if jitter is None:
             raise ValueError("Cannot find a suitable jit decorator")

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -677,7 +677,7 @@ class _OverloadFunctionTemplate(AbstractTemplate):
                                                 'iinfo': iinfo}
         else:
             sig = disp_type.get_call_type(self.context, new_args, kws)
-            if sig is None: # can't resolve for this hardware
+            if sig is None: # can't resolve for this target
                 return None
             self._compiled_overloads[sig.args] = disp_type.get_overload(sig)
         return sig
@@ -703,33 +703,33 @@ class _OverloadFunctionTemplate(AbstractTemplate):
         """Gets a jit decorator suitable for the current target"""
         from numba.core import decorators
         from numba import jit
-        jitter_str = self.metadata.get('hardware', None)
+        jitter_str = self.metadata.get('target', None)
         if jitter_str is None:
-            # There is no hardware requested, use default, this preserves
+            # There is no target requested, use default, this preserves
             # original behaviour
             jitter = lambda *args, **kwargs: jit(*args, nopython=True, **kwargs)
         else:
-            from numba.core.extending_hardware import (hardware_registry,
-                                                       get_local_target)
+            from numba.core.target_extension import (target_registry,
+                                                     get_local_target)
 
-            # Hardware has been requested, see what it is...
+            # target has been requested, see what it is...
             jitter = decorators.jit_registry.get(jitter_str, None)
 
             if jitter is None:
-                # No JIT known for hardware string, see if something is
+                # No JIT known for target string, see if something is
                 # registered for the string and report if not.
-                hardware_class = hardware_registry.get(jitter_str, None)
-                if hardware_class is None:
-                    msg = ("Unknown hardware target '{}', has it been ",
+                target_class = target_registry.get(jitter_str, None)
+                if target_class is None:
+                    msg = ("Unknown target '{}', has it been ",
                            "registered?")
                     raise ValueError(msg.format(jitter_str))
 
                 target_hw = get_local_target(self.context)
 
-                # check that the requested hardware is in the hierarchy for the
+                # check that the requested target is in the hierarchy for the
                 # current frame's target.
-                if not issubclass(target_hw, hardware_class):
-                    msg = "No overloads exist for the requested hardware: {}."
+                if not issubclass(target_hw, target_class):
+                    msg = "No overloads exist for the requested target: {}."
 
                 jitter = decorators.jit_registry[target_hw]
 
@@ -885,13 +885,13 @@ class _IntrinsicTemplate(AbstractTemplate):
         """
         Type the intrinsic by the arguments.
         """
-        from numba.core.extending_hardware import (get_local_target,
-                                                   resolve_target_str,
-                                                   dispatcher_registry)
+        from numba.core.target_extension import (get_local_target,
+                                                 resolve_target_str,
+                                                 dispatcher_registry)
         from numba.core.imputils import builtin_registry
 
         cache_key = self.context, args, tuple(kws.items())
-        hwstr = self.metadata.get('hardware', 'generic')
+        hwstr = self.metadata.get('target', 'generic')
         # Get the class for the target declared by the function
         hw_clazz = resolve_target_str(hwstr)
         # get the local target

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -5,13 +5,13 @@ def initialize_all():
     from numba import cuda
     from numba.cuda.compiler import Dispatcher
     from numba.core import decorators
-    from numba.core.extending_hardware import (hardware_registry,
-                                               dispatcher_registry)
+    from numba.core.target_extension import (target_registry,
+                                             dispatcher_registry)
 
     def cuda_jit_device(*args, **kwargs):
         kwargs['device'] = True
         return cuda.jit(*args, **kwargs)
 
-    cuda_hw = hardware_registry["cuda"]
+    cuda_hw = target_registry["cuda"]
     decorators.jit_registry[cuda_hw] = cuda_jit_device
     dispatcher_registry[cuda_hw] = Dispatcher

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -12,6 +12,6 @@ def initialize_all():
         kwargs['device'] = True
         return cuda.jit(*args, **kwargs)
 
-    cuda_hw = target_registry["cuda"]
-    jit_registry[cuda_hw] = cuda_jit_device
-    dispatcher_registry[cuda_hw] = Dispatcher
+    cuda_target = target_registry["cuda"]
+    jit_registry[cuda_target] = cuda_jit_device
+    dispatcher_registry[cuda_target] = Dispatcher

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -4,14 +4,14 @@ def initialize_all():
 
     from numba import cuda
     from numba.cuda.compiler import Dispatcher
-    from numba.core import decorators
     from numba.core.target_extension import (target_registry,
-                                             dispatcher_registry)
+                                             dispatcher_registry,
+                                             jit_registry)
 
     def cuda_jit_device(*args, **kwargs):
         kwargs['device'] = True
         return cuda.jit(*args, **kwargs)
 
     cuda_hw = target_registry["cuda"]
-    decorators.jit_registry[cuda_hw] = cuda_jit_device
+    jit_registry[cuda_hw] = cuda_jit_device
     dispatcher_registry[cuda_hw] = Dispatcher

--- a/numba/cuda/tests/cudapy/test_overload.py
+++ b/numba/cuda/tests/cudapy/test_overload.py
@@ -39,19 +39,19 @@ def cuda_calls_cuda():
     pass
 
 
-def hardware_overloaded():
+def target_overloaded():
     pass
 
 
-def generic_calls_hardware_overloaded():
+def generic_calls_target_overloaded():
     pass
 
 
-def cuda_calls_hardware_overloaded():
+def cuda_calls_target_overloaded():
     pass
 
 
-def hardware_overloaded_calls_hardware_overloaded():
+def target_overloaded_calls_target_overloaded():
     pass
 
 
@@ -68,45 +68,45 @@ GENERIC_CALLS_GENERIC = 11
 GENERIC_CALLS_CUDA = 13
 CUDA_CALLS_GENERIC = 17
 CUDA_CALLS_CUDA = 19
-GENERIC_HARDWARE_OL = 23
-CUDA_HARDWARE_OL = 29
-GENERIC_CALLS_HARDWARE_OL = 31
-CUDA_CALLS_HARDWARE_OL = 37
-GENERIC_HARDWARE_OL_CALLS_HARDWARE_OL = 41
-CUDA_HARDWARE_OL_CALLS_HARDWARE_OL = 43
+GENERIC_TARGET_OL = 23
+CUDA_TARGET_OL = 29
+GENERIC_CALLS_TARGET_OL = 31
+CUDA_CALLS_TARGET_OL = 37
+GENERIC_TARGET_OL_CALLS_TARGET_OL = 41
+CUDA_TARGET_OL_CALLS_TARGET_OL = 43
 
 
 # Overload implementations
 
-@overload(generic_func_1, hardware='generic')
+@overload(generic_func_1, target='generic')
 def ol_generic_func_1(x):
     def impl(x):
         x[0] *= GENERIC_FUNCTION_1
     return impl
 
 
-@overload(cuda_func_1, hardware='cuda')
+@overload(cuda_func_1, target='cuda')
 def ol_cuda_func_1(x):
     def impl(x):
         x[0] *= CUDA_FUNCTION_1
     return impl
 
 
-@overload(generic_func_2, hardware='generic')
+@overload(generic_func_2, target='generic')
 def ol_generic_func_2(x):
     def impl(x):
         x[0] *= GENERIC_FUNCTION_2
     return impl
 
 
-@overload(cuda_func_2, hardware='cuda')
+@overload(cuda_func_2, target='cuda')
 def ol_cuda_func(x):
     def impl(x):
         x[0] *= CUDA_FUNCTION_2
     return impl
 
 
-@overload(generic_calls_generic, hardware='generic')
+@overload(generic_calls_generic, target='generic')
 def ol_generic_calls_generic(x):
     def impl(x):
         x[0] *= GENERIC_CALLS_GENERIC
@@ -114,7 +114,7 @@ def ol_generic_calls_generic(x):
     return impl
 
 
-@overload(generic_calls_cuda, hardware='generic')
+@overload(generic_calls_cuda, target='generic')
 def ol_generic_calls_cuda(x):
     def impl(x):
         x[0] *= GENERIC_CALLS_CUDA
@@ -122,7 +122,7 @@ def ol_generic_calls_cuda(x):
     return impl
 
 
-@overload(cuda_calls_generic, hardware='cuda')
+@overload(cuda_calls_generic, target='cuda')
 def ol_cuda_calls_generic(x):
     def impl(x):
         x[0] *= CUDA_CALLS_GENERIC
@@ -130,7 +130,7 @@ def ol_cuda_calls_generic(x):
     return impl
 
 
-@overload(cuda_calls_cuda, hardware='cuda')
+@overload(cuda_calls_cuda, target='cuda')
 def ol_cuda_calls_cuda(x):
     def impl(x):
         x[0] *= CUDA_CALLS_CUDA
@@ -138,49 +138,49 @@ def ol_cuda_calls_cuda(x):
     return impl
 
 
-@overload(hardware_overloaded, hardware='generic')
-def ol_hardware_overloaded_generic(x):
+@overload(target_overloaded, target='generic')
+def ol_target_overloaded_generic(x):
     def impl(x):
-        x[0] *= GENERIC_HARDWARE_OL
+        x[0] *= GENERIC_TARGET_OL
     return impl
 
 
-@overload(hardware_overloaded, hardware='cuda')
-def ol_hardware_overloaded_cuda(x):
+@overload(target_overloaded, target='cuda')
+def ol_target_overloaded_cuda(x):
     def impl(x):
-        x[0] *= CUDA_HARDWARE_OL
+        x[0] *= CUDA_TARGET_OL
     return impl
 
 
-@overload(generic_calls_hardware_overloaded, hardware='generic')
-def ol_generic_calls_hardware_overloaded(x):
+@overload(generic_calls_target_overloaded, target='generic')
+def ol_generic_calls_target_overloaded(x):
     def impl(x):
-        x[0] *= GENERIC_CALLS_HARDWARE_OL
-        hardware_overloaded(x)
+        x[0] *= GENERIC_CALLS_TARGET_OL
+        target_overloaded(x)
     return impl
 
 
-@overload(cuda_calls_hardware_overloaded, hardware='cuda')
-def ol_cuda_calls_hardware_overloaded(x):
+@overload(cuda_calls_target_overloaded, target='cuda')
+def ol_cuda_calls_target_overloaded(x):
     def impl(x):
-        x[0] *= CUDA_CALLS_HARDWARE_OL
-        hardware_overloaded(x)
+        x[0] *= CUDA_CALLS_TARGET_OL
+        target_overloaded(x)
     return impl
 
 
-@overload(hardware_overloaded_calls_hardware_overloaded, hardware='generic')
-def ol_generic_calls_hardware_overloaded_generic(x):
+@overload(target_overloaded_calls_target_overloaded, target='generic')
+def ol_generic_calls_target_overloaded_generic(x):
     def impl(x):
-        x[0] *= GENERIC_HARDWARE_OL_CALLS_HARDWARE_OL
-        hardware_overloaded(x)
+        x[0] *= GENERIC_TARGET_OL_CALLS_TARGET_OL
+        target_overloaded(x)
     return impl
 
 
-@overload(hardware_overloaded_calls_hardware_overloaded, hardware='cuda')
-def ol_generic_calls_hardware_overloaded_cuda(x):
+@overload(target_overloaded_calls_target_overloaded, target='cuda')
+def ol_generic_calls_target_overloaded_cuda(x):
     def impl(x):
-        x[0] *= CUDA_HARDWARE_OL_CALLS_HARDWARE_OL
-        hardware_overloaded(x)
+        x[0] *= CUDA_TARGET_OL_CALLS_TARGET_OL
+        target_overloaded(x)
     return impl
 
 
@@ -262,37 +262,37 @@ class TestOverload(CUDATestCase):
         expected = CUDA_CALLS_CUDA * CUDA_FUNCTION_1
         self.check_overload(kernel, expected)
 
-    def test_call_hardware_overloaded(self):
+    def test_call_target_overloaded(self):
         def kernel(x):
-            hardware_overloaded(x)
+            target_overloaded(x)
 
-        expected = CUDA_HARDWARE_OL
+        expected = CUDA_TARGET_OL
         self.check_overload(kernel, expected)
 
-    def test_generic_calls_hardware_overloaded(self):
+    def test_generic_calls_target_overloaded(self):
         def kernel(x):
-            generic_calls_hardware_overloaded(x)
+            generic_calls_target_overloaded(x)
 
-        expected = GENERIC_CALLS_HARDWARE_OL * CUDA_HARDWARE_OL
+        expected = GENERIC_CALLS_TARGET_OL * CUDA_TARGET_OL
         self.check_overload(kernel, expected)
 
-    def test_cuda_calls_hardware_overloaded(self):
+    def test_cuda_calls_target_overloaded(self):
         def kernel(x):
-            cuda_calls_hardware_overloaded(x)
+            cuda_calls_target_overloaded(x)
 
-        expected = CUDA_CALLS_HARDWARE_OL * CUDA_HARDWARE_OL
+        expected = CUDA_CALLS_TARGET_OL * CUDA_TARGET_OL
         self.check_overload(kernel, expected)
 
-    def test_hardware_overloaded_calls_hardware_overloaded(self):
+    def test_target_overloaded_calls_target_overloaded(self):
         def kernel(x):
-            hardware_overloaded_calls_hardware_overloaded(x)
+            target_overloaded_calls_target_overloaded(x)
 
         # Check the CUDA overloads are used on CUDA
-        expected = CUDA_HARDWARE_OL_CALLS_HARDWARE_OL * CUDA_HARDWARE_OL
+        expected = CUDA_TARGET_OL_CALLS_TARGET_OL * CUDA_TARGET_OL
         self.check_overload(kernel, expected)
 
         # Also check that the CPU overloads are used on the CPU
-        expected = GENERIC_HARDWARE_OL_CALLS_HARDWARE_OL * GENERIC_HARDWARE_OL
+        expected = GENERIC_TARGET_OL_CALLS_TARGET_OL * GENERIC_TARGET_OL
         self.check_overload_cpu(kernel, expected)
 
 

--- a/numba/np/ufunc/decorators.py
+++ b/numba/np/ufunc/decorators.py
@@ -3,7 +3,7 @@ import inspect
 from numba.np.ufunc import _internal
 from numba.np.ufunc.parallel import ParallelUFuncBuilder, ParallelGUFuncBuilder
 
-from numba.core.registry import TargetRegistry
+from numba.core.registry import DelayedRegistry
 from numba.np.ufunc import dufunc
 from numba.np.ufunc import gufunc
 
@@ -28,8 +28,8 @@ class _BaseVectorize(object):
 
 
 class Vectorize(_BaseVectorize):
-    target_registry = TargetRegistry({'cpu': dufunc.DUFunc,
-                                      'parallel': ParallelUFuncBuilder,})
+    target_registry = DelayedRegistry({'cpu': dufunc.DUFunc,
+                                       'parallel': ParallelUFuncBuilder,})
 
     def __new__(cls, func, **kws):
         identity = cls.get_identity(kws)
@@ -39,8 +39,8 @@ class Vectorize(_BaseVectorize):
 
 
 class GUVectorize(_BaseVectorize):
-    target_registry = TargetRegistry({'cpu': gufunc.GUFunc,
-                                      'parallel': ParallelGUFuncBuilder,})
+    target_registry = DelayedRegistry({'cpu': gufunc.GUFunc,
+                                       'parallel': ParallelGUFuncBuilder,})
 
     def __new__(cls, func, signature, **kws):
         identity = cls.get_identity(kws)

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -8,7 +8,7 @@ from numba.core.decorators import jit
 from numba.core.descriptors import TargetDescriptor
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.registry import cpu_target
-from numba.core.extending_hardware import dispatcher_registry, hardware_registry
+from numba.core.target_extension import dispatcher_registry, target_registry
 from numba.core import utils, types, serialize, compiler, sigutils
 from numba.np.numpy_support import as_dtype
 from numba.np.ufunc import _internal
@@ -159,7 +159,7 @@ class UFuncDispatcher(serialize.ReduceMixin):
                 return cres
 
 
-dispatcher_registry[hardware_registry['npyufunc']] = UFuncDispatcher
+dispatcher_registry[target_registry['npyufunc']] = UFuncDispatcher
 
 
 # Utility functions

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -8,7 +8,7 @@ from numba.core.errors import TypingError
 from numba.tests.support import TestCase, tag
 from .serialize_usecases import *
 import unittest
-from numba.core.extending_hardware import resolve_dispatcher_from_str
+from numba.core.target_extension import resolve_dispatcher_from_str
 
 
 class TestDispatcherPickling(TestCase):

--- a/numba/tests/test_target_extension.py
+++ b/numba/tests/test_target_extension.py
@@ -17,6 +17,7 @@ from numba.core.target_extension import (
     JitDecorator,
     target_registry,
     dispatcher_registry,
+    jit_registry,
     target_override,
     GPU,
     resolve_dispatcher_from_str,
@@ -28,7 +29,7 @@ from numba.core import cpu, typing, cgutils
 from numba.core.base import BaseContext
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.utils import cached_property
-from numba.core import callconv, decorators
+from numba.core import callconv
 from numba.core.codegen import CPUCodegen, JITCodeLibrary
 from numba.core.callwrapper import PyCallWrapper
 from numba.core.imputils import RegistryLoader, Registry
@@ -363,7 +364,7 @@ class djit(JitDecorator):
 
 # add it to the decorator registry, this is so e.g. @overload can look up a
 # JIT function to do the compilation work.
-decorators.jit_registry[target_registry["dpu"]] = djit
+jit_registry[target_registry["dpu"]] = djit
 
 # The DPU target "knows" nothing, add in some primitives for basic things...
 


### PR DESCRIPTION
As title. This is a largely mechanical refactor. It changes the
new hardware extension API to refer to "target" instead of
"hardware". This is because the "hardware" is often actually
synthetic and "target" better describes this.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
