### PR TITLE
Moved typedlist __iter__ into njit code instead of just __getitem__

### DIFF
--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -94,6 +94,12 @@ def _getitem(l, i):
 
 
 @njit
+def _iter(l):
+    for i in range(len(l)):
+        yield l[i]
+
+
+@njit
 def _contains(l, item):
     return item in l
 
@@ -369,8 +375,10 @@ class List(MutableSequence, pt.Generic[T]):
             return _getitem(self, i)
 
     def __iter__(self) -> pt.Iterator[T]:
-        for i in range(len(self)):
-            yield self[i]
+        if not self._typed:
+            return iter([])
+        else:
+            return _iter(self)
 
     def __contains__(self, item: T) -> bool:  # type: ignore[override]
         return _contains(self, item)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->


This is a very small change rewriting `typed.List.__iter__` to use a new function `_iter` that implements the entire loop in `njit` code, creating a speed-up of 30x (probably because of less calls across the compilation boundaries).

I didn't create new unittest because I assume that typed List is already well tested and I am not changing any user facing behaviour/adding new features.