### PR TITLE
Resolve issue where nan was being assigned to int type numpy array

### DIFF
--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -1375,9 +1375,9 @@ class TestCudaAtomics(CUDATestCase):
     # Tests for atomic nanmin/nanmax
 
     # nanmax tests
-    def check_atomic_nanmax(self, dtype, lo, hi):
+    def check_atomic_nanmax(self, dtype, lo, hi, init_val):
         vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)
-        vals[1::2] = np.nan
+        vals[1::2] = init_val
         res = np.zeros(1, dtype=vals.dtype)
         cuda_func = cuda.jit(atomic_nanmax)
         cuda_func[32, 32](res, vals)
@@ -1385,24 +1385,30 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_equal(res, gold)
 
     def test_atomic_nanmax_int32(self):
-        self.check_atomic_nanmax(dtype=np.int32, lo=-65535, hi=65535)
+        self.check_atomic_nanmax(dtype=np.int32, lo=-65535, hi=65535,
+                                 init_val=0)
 
     def test_atomic_nanmax_uint32(self):
-        self.check_atomic_nanmax(dtype=np.uint32, lo=0, hi=65535)
+        self.check_atomic_nanmax(dtype=np.uint32, lo=0, hi=65535,
+                                 init_val=0)
 
     @skip_unless_cc_32
     def test_atomic_nanmax_int64(self):
-        self.check_atomic_nanmax(dtype=np.int64, lo=-65535, hi=65535)
+        self.check_atomic_nanmax(dtype=np.int64, lo=-65535, hi=65535,
+                                 init_val=0)
 
     @skip_unless_cc_32
     def test_atomic_nanmax_uint64(self):
-        self.check_atomic_nanmax(dtype=np.uint64, lo=0, hi=65535)
+        self.check_atomic_nanmax(dtype=np.uint64, lo=0, hi=65535,
+                                 init_val=0)
 
     def test_atomic_nanmax_float32(self):
-        self.check_atomic_nanmax(dtype=np.float32, lo=-65535, hi=65535)
+        self.check_atomic_nanmax(dtype=np.float32, lo=-65535, hi=65535,
+                                 init_val=np.nan)
 
     def test_atomic_nanmax_double(self):
-        self.check_atomic_nanmax(dtype=np.float64, lo=-65535, hi=65535)
+        self.check_atomic_nanmax(dtype=np.float64, lo=-65535, hi=65535,
+                                 init_val=np.nan)
 
     def test_atomic_nanmax_double_shared(self):
         vals = np.random.randint(0, 32, size=32).astype(np.float64)
@@ -1427,9 +1433,9 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_equal(res, gold)
 
     # nanmin tests
-    def check_atomic_nanmin(self, dtype, lo, hi):
+    def check_atomic_nanmin(self, dtype, lo, hi, init_val):
         vals = np.random.randint(lo, hi, size=(32, 32)).astype(dtype)
-        vals[1::2] = np.nan
+        vals[1::2] = init_val
         res = np.array([65535], dtype=vals.dtype)
         cuda_func = cuda.jit(atomic_nanmin)
         cuda_func[32, 32](res, vals)
@@ -1438,24 +1444,30 @@ class TestCudaAtomics(CUDATestCase):
         np.testing.assert_equal(res, gold)
 
     def test_atomic_nanmin_int32(self):
-        self.check_atomic_nanmin(dtype=np.int32, lo=-65535, hi=65535)
+        self.check_atomic_nanmin(dtype=np.int32, lo=-65535, hi=65535,
+                                 init_val=0)
 
     def test_atomic_nanmin_uint32(self):
-        self.check_atomic_nanmin(dtype=np.uint32, lo=0, hi=65535)
+        self.check_atomic_nanmin(dtype=np.uint32, lo=0, hi=65535,
+                                 init_val=0)
 
     @skip_unless_cc_32
     def test_atomic_nanmin_int64(self):
-        self.check_atomic_nanmin(dtype=np.int64, lo=-65535, hi=65535)
+        self.check_atomic_nanmin(dtype=np.int64, lo=-65535, hi=65535,
+                                 init_val=0)
 
     @skip_unless_cc_32
     def test_atomic_nanmin_uint64(self):
-        self.check_atomic_nanmin(dtype=np.uint64, lo=0, hi=65535)
+        self.check_atomic_nanmin(dtype=np.uint64, lo=0, hi=65535,
+                                 init_val=0)
 
     def test_atomic_nanmin_float(self):
-        self.check_atomic_nanmin(dtype=np.float32, lo=-65535, hi=65535)
+        self.check_atomic_nanmin(dtype=np.float32, lo=-65535, hi=65535,
+                                 init_val=np.nan)
 
     def test_atomic_nanmin_double(self):
-        self.check_atomic_nanmin(dtype=np.float64, lo=-65535, hi=65535)
+        self.check_atomic_nanmin(dtype=np.float64, lo=-65535, hi=65535,
+                                 init_val=np.nan)
 
     def test_atomic_nanmin_double_shared(self):
         vals = np.random.randint(0, 32, size=32).astype(np.float64)


### PR DESCRIPTION
This PR addresses issue https://github.com/numba/numba/issues/6965 where some atomic test cases are failing with Numpy 1.20. The PR adds a new initializer value to the test cases so that either np.nan (for float types) or zero (for integer types) can be passed to correctly initialize a slice of the numpy array.