### PR TITLE
Add constant lowering support for `SliceType`s

### DIFF
--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -1077,6 +1077,7 @@ class UniTupleIter(StructModel):
         super(UniTupleIter, self).__init__(dmm, fe_type, members)
 
 
+@register_default(types.misc.SliceLiteral)
 @register_default(types.SliceType)
 class SliceModel(StructModel):
     def __init__(self, dmm, fe_type):

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -334,6 +334,10 @@ class SliceLiteral(Literal, SliceType):
         members = 2 if value.step is None else 3
         SliceType.__init__(self, name=name, members=members)
 
+    @property
+    def key(self):
+        return self.name
+
 
 Literal.ctor_map[slice] = SliceLiteral
 

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -336,7 +336,8 @@ class SliceLiteral(Literal, SliceType):
 
     @property
     def key(self):
-        return self.name
+        sl = self.literal_value
+        return sl.start, sl.stop, sl.step
 
 
 Literal.ctor_map[slice] = SliceLiteral

--- a/numba/cpython/slicing.py
+++ b/numba/cpython/slicing.py
@@ -150,8 +150,13 @@ def get_defaults(context):
 
 @lower_builtin(slice, types.VarArg(types.Any))
 def slice_constructor_impl(context, builder, sig, args):
-    default_start_pos, default_start_neg, default_stop_pos, default_stop_neg, default_step = \
-        [context.get_constant(types.intp, x) for x in get_defaults(context)]
+    (
+        default_start_pos,
+        default_start_neg,
+        default_stop_pos,
+        default_stop_neg,
+        default_step,
+    ) = [context.get_constant(types.intp, x) for x in get_defaults(context)]
 
     slice_args = [None] * 3
 
@@ -239,8 +244,13 @@ def make_slice_from_constant(context, builder, ty, pyval):
     sli = context.make_helper(builder, ty)
     lty = context.get_value_type(types.intp)
 
-    default_start_pos, default_start_neg, default_stop_pos, default_stop_neg, default_step = \
-        [context.get_constant(types.intp, x) for x in get_defaults(context)]
+    (
+        default_start_pos,
+        default_start_neg,
+        default_stop_pos,
+        default_stop_neg,
+        default_step,
+    ) = [context.get_constant(types.intp, x) for x in get_defaults(context)]
 
     step = pyval.step
     if step is None:

--- a/numba/cpython/slicing.py
+++ b/numba/cpython/slicing.py
@@ -5,11 +5,11 @@ Implement slices and various slice computations.
 from itertools import zip_longest
 
 from llvmlite import ir
-
-from numba.core import types, typing, utils, cgutils
-from numba.core.imputils import (lower_builtin, lower_getattr,
-                                    iternext_impl, impl_ret_borrowed,
-                                    impl_ret_new_ref, impl_ret_untracked)
+from numba.core import cgutils, types, typing, utils
+from numba.core.imputils import (impl_ret_borrowed, impl_ret_new_ref,
+                                 impl_ret_untracked, iternext_impl,
+                                 lower_builtin, lower_cast, lower_constant,
+                                 lower_getattr)
 
 
 def fix_index(builder, idx, size):
@@ -232,4 +232,61 @@ def slice_indices(context, builder, sig, args):
         builder,
         sig.return_type,
         (sli.start, sli.stop, sli.step)
+    )
+
+
+def make_slice_from_constant(context, builder, ty, pyval):
+    sli = context.make_helper(builder, ty)
+    lty = context.get_value_type(types.intp)
+
+    default_start_pos, default_start_neg, default_stop_pos, default_stop_neg, default_step = \
+        [context.get_constant(types.intp, x) for x in get_defaults(context)]
+
+    step = pyval.step
+    if step is None:
+        step_is_neg = False
+        step = default_step
+    else:
+        step_is_neg = step < 0
+        step = lty(step)
+
+    start = pyval.start
+    if start is None:
+        if step_is_neg:
+            start = default_start_neg
+        else:
+            start = default_start_pos
+    else:
+        start = lty(start)
+
+    stop = pyval.stop
+    if stop is None:
+        if step_is_neg:
+            stop = default_stop_neg
+        else:
+            stop = default_stop_pos
+    else:
+        stop = lty(stop)
+
+    sli.start = start
+    sli.stop = stop
+    sli.step = step
+
+    return sli._getvalue()
+
+
+@lower_constant(types.SliceType)
+def constant_slice(context, builder, ty, pyval):
+    if isinstance(ty, types.Literal):
+        typ = ty.literal_type
+    else:
+        typ = ty
+
+    return make_slice_from_constant(context, builder, typ, pyval)
+
+
+@lower_cast(types.misc.SliceLiteral, types.SliceType)
+def cast_from_literal(context, builder, fromty, toty, val):
+    return make_slice_from_constant(
+        context, builder, toty, fromty.literal_value,
     )

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1399,6 +1399,17 @@ class TestParfors(TestParforsBase):
             self.check(test_impl, n)
             self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
 
+            X = np.ones((211, 3))
+
+            def test_impl(X):
+                y = 0
+                for i in numba.prange(X.shape[0]):
+                    y += X[i, ts].sum()
+                return y
+
+            self.check(test_impl, X)
+            self.assertEqual(countNonParforArrayAccesses(test_impl, (types.float64[:, :],)), 0)
+
     @skip_parfors_unsupported
     @disabled_test # Test itself is problematic, see #3155
     def test_parfor_hoist_setitem(self):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1384,33 +1384,6 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
 
     @skip_parfors_unsupported
-    def test_parfor_array_access_lower_slice(self):
-        for ts in [slice(1, 3, None), slice(2, None, None), slice(None, 2, -1),
-                   slice(None, None, None), slice(None, None, -2)]:
-
-            def test_impl(n):
-                X = np.ones((n, 3))
-                y = 0
-                for i in numba.prange(n):
-                    y += X[i, ts].sum()
-                return y
-
-            n = 211
-            self.check(test_impl, n)
-            self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
-
-            X = np.ones((211, 3))
-
-            def test_impl(X):
-                y = 0
-                for i in numba.prange(X.shape[0]):
-                    y += X[i, ts].sum()
-                return y
-
-            self.check(test_impl, X)
-            self.assertEqual(countNonParforArrayAccesses(test_impl, (types.float64[:, :],)), 0)
-
-    @skip_parfors_unsupported
     @disabled_test # Test itself is problematic, see #3155
     def test_parfor_hoist_setitem(self):
         # Make sure that read of out is not hoisted.
@@ -3459,6 +3432,32 @@ class TestParforsSlice(TestParforsBase):
             return result
 
         self.check(test_impl)
+
+    @skip_parfors_unsupported
+    def test_parfor_array_access_lower_slice(self):
+        for ts in [slice(1, 3, None), slice(2, None, None), slice(None, 2, -1),
+                   slice(None, None, None), slice(None, None, -2)]:
+
+            def test_impl(n):
+                X = np.ones((n, 3))
+                y = 0
+                for i in numba.prange(n):
+                    y += X[i, ts].sum()
+                return y
+
+            n = 211
+            self.check(test_impl, n)
+
+            X = np.ones((211, 3))
+
+            def test_impl(X):
+                y = 0
+                for i in numba.prange(X.shape[0]):
+                    y += X[i, ts].sum()
+                return y
+
+            self.check(test_impl, X)
+
 
 
 class TestParforsOptions(TestParforsBase):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1384,6 +1384,22 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
 
     @skip_parfors_unsupported
+    def test_parfor_array_access_lower_slice(self):
+        for ts in [slice(1, 3, None), slice(2, None, None), slice(None, 2, -1),
+                   slice(None, None, None), slice(None, None, -2)]:
+
+            def test_impl(n):
+                X = np.ones((n, 3))
+                y = 0
+                for i in numba.prange(n):
+                    y += X[i, ts].sum()
+                return y
+
+            n = 211
+            self.check(test_impl, n)
+            self.assertEqual(countNonParforArrayAccesses(test_impl, (types.intp,)), 0)
+
+    @skip_parfors_unsupported
     @disabled_test # Test itself is problematic, see #3155
     def test_parfor_hoist_setitem(self):
         # Make sure that read of out is not hoisted.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3439,16 +3439,16 @@ class TestParforsSlice(TestParforsBase):
                    slice(None, None, None), slice(None, None, -2)]:
 
             def test_impl(n):
-                X = np.ones((n, 3))
+                X = np.arange(n * 4).reshape((n, 4))
                 y = 0
                 for i in numba.prange(n):
                     y += X[i, ts].sum()
                 return y
 
-            n = 211
+            n = 10
             self.check(test_impl, n)
 
-            X = np.ones((211, 3))
+            X = np.arange(n * 4).reshape((n, 4))
 
             def test_impl(X):
                 y = 0

--- a/numba/tests/test_slices.py
+++ b/numba/tests/test_slices.py
@@ -185,22 +185,27 @@ class TestSlices(MemoryLeakMixin, TestCase):
             str(e.exception)
         )
 
-    def test_slice_constant_lowering(self):
-        for ts in [slice(1, 3, None), slice(2, None, None), slice(None, 2, -1),
-                   slice(None, None, None), slice(None, None, -2)]:
-            test_tuple = (1, 2, 3, 4)
+    def test_slice_from_constant(self):
+        test_tuple = (1, 2, 3, 4)
+
+        for ts in itertools.product(
+            [None, 1, 2, 3], [None, 1, 2, 3], [None, 1, 2, -1, -2]
+        ):
+            ts = slice(*ts)
 
             @jit(nopython=True)
             def test_fn():
                 return test_tuple[ts]
 
-            assert test_fn() == test_tuple[ts]
+            self.assertEqual(test_fn(), test_fn.py_func())
 
     def test_literal_slice_distinct(self):
         sl1 = types.misc.SliceLiteral(slice(1, None, None))
         sl2 = types.misc.SliceLiteral(slice(None, None, None))
+        sl3 = types.misc.SliceLiteral(slice(1, None, None))
 
-        assert sl1 != sl2
+        self.assertNotEqual(sl1, sl2)
+        self.assertEqual(sl1, sl3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds constant lowering support for `SliceType`s.

The approach used here is largely taken from existing implementations throughout the codebase (and some guess work), so someone will need to tell me if there's a newer/more preferable way to do this.

Closes #6744.