### PR TITLE
CUDA: Remove catch of NotImplementedError in target.py

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -77,11 +77,7 @@ class CPUContext(BaseContext):
         from numba.typed import typeddict, dictimpl
         from numba.typed import typedlist, listobject
         from numba.experimental import jitclass, function_type
-
-        try:
-            from numba.np import npdatetime
-        except NotImplementedError:
-            pass
+        from numba.np import npdatetime
 
         # Add target specific implementations
         from numba.np import npyimpl

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -89,10 +89,7 @@ class CUDATargetContext(BaseContext):
         from numba.cpython import rangeobj # noqa: F401
         from numba.cpython import cmathimpl
         from numba.np import arrayobj # noqa: F401
-        try:
-            from numba.np import npdatetime # noqa: F401
-        except NotImplementedError:
-            pass
+        from numba.np import npdatetime # noqa: F401
         from . import cudaimpl, printimpl, libdeviceimpl, mathimpl
         self.install_registry(cudaimpl.registry)
         self.install_registry(printimpl.registry)


### PR DESCRIPTION
Maybe this is more of a question than a PR, but I saw it added in #6948 and I'm not sure what it does. Removing it seems not to cause a problem - all tests still seem to pass without it.

