### PR TITLE
Make some `numba.core` modules flake8 compliant

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,23 +28,16 @@ exclude =
     numba/core/tracing.py
     numba/core/withcontexts.py
     numba/_version.py
-    numba/core/inline_closurecall.py
     numba/core/ir_utils.py
     numba/core/pylowering.py
     numba/parfors/parfor.py
     numba/misc/numba_entry.py
     numba/stencils/stencilparfor.py
-    numba/core/ir.py
     numba/core/itanium_mangler.py
-    numba/core/generators.py
     numba/misc/appdirs.py
-    numba/core/caching.py
-    numba/core/debuginfo.py
     numba/core/annotations/pretty_annotate.py
     numba/misc/dummyarray.py
-    numba/core/dataflow.py
     numba/core/pythonapi.py
-    numba/core/decorators.py
     numba/core/typeconv/typeconv.py
     numba/core/typeconv/rules.py
     numba/core/typeconv/castgraph.py
@@ -57,7 +50,6 @@ exclude =
     numba/core/types/common.py
     numba/core/types/iterators.py
     numba/core/types/scalars.py
-    numba/core/fastmathpass.py
     numba/cpython/setobj.py
     numba/core/options.py
     numba/cpython/printimpl.py
@@ -65,27 +57,21 @@ exclude =
     numba/cpython/tupleobj.py
     numba/cpython/mathimpl.py
     numba/core/registry.py
-    numba/core/imputils.py
     numba/cpython/builtins.py
-    numba/core/cpu.py
     numba/misc/quicksort.py
-    numba/core/callconv.py
     numba/cpython/randomimpl.py
     numba/np/npyimpl.py
     numba/cpython/slicing.py
     numba/cpython/numbers.py
     numba/cpython/listobj.py
     numba/core/removerefctpass.py
-    numba/core/boxing.py
     numba/misc/cffiimpl.py
     numba/np/linalg.py
     numba/cpython/rangeobj.py
     numba/np/npyfuncs.py
     numba/cpython/iterators.py
-    numba/core/codegen.py
     numba/np/polynomial.py
     numba/misc/mergesort.py
-    numba/core/base.py
     numba/np/npdatetime.py
     numba/pycc/cc.py
     numba/pycc/compiler.py
@@ -231,7 +217,6 @@ exclude =
     numba/core/typing/enumdecl.py
     numba/core/typing/cffi_utils.py
     numba/core/typing/npdatetime.py
-    numba/core/annotations/type_annotations.py
     numba/roc/mathdecl.py
     numba/roc/compiler.py
     numba/roc/hsadecl.py
@@ -278,10 +263,6 @@ exclude =
     numba/np/ufunc/array_exprs.py
     numba/np/ufunc/decorators.py
     numba/roc/servicelib/service.py
-    numba/core/datamodel/models.py
-    numba/core/datamodel/packer.py
-    numba/core/datamodel/testing.py
-    numba/core/datamodel/manager.py
 
 per-file-ignores =
     # Ignore star imports, unused imports, and "may be defined by star imports"

--- a/.flake8
+++ b/.flake8
@@ -31,7 +31,6 @@ exclude =
     numba/core/inline_closurecall.py
     numba/core/ir_utils.py
     numba/core/pylowering.py
-    numba/python_utils.py
     numba/parfors/parfor.py
     numba/misc/numba_entry.py
     numba/stencils/stencilparfor.py
@@ -50,7 +49,6 @@ exclude =
     numba/core/typeconv/rules.py
     numba/core/typeconv/castgraph.py
     numba/core/rewrites/registry.py
-    numba/core/rewrites/macros.py
     numba/core/rewrites/static_binop.py
     numba/core/rewrites/ir_print.py
     numba/core/types/abstract.py
@@ -103,10 +101,8 @@ exclude =
     numba/tests/test_inlining.py
     numba/tests/test_array_manipulation.py
     numba/tests/test_dummyarray.py
-    numba/tests/test_smart_array.py
     numba/tests/test_linalg.py
     numba/tests/test_threadsafety.py
-    numba/tests/test_utils.py
     numba/tests/cfunc_cache_usecases.py
     numba/tests/enum_usecases.py
     numba/tests/test_func_lifetime.py
@@ -132,7 +128,6 @@ exclude =
     numba/tests/test_intwidth.py
     numba/tests/test_remove_dead.py
     numba/tests/serialize_usecases.py
-    numba/tests/test_del.py
     numba/tests/test_gil.py
     numba/tests/cffi_usecases.py
     numba/tests/test_slices.py
@@ -178,7 +173,6 @@ exclude =
     numba/tests/test_stencils.py
     numba/tests/test_annotations.py
     numba/tests/cache_usecases.py
-    numba/tests/true_div_usecase.py
     numba/tests/test_dataflow.py
     numba/tests/test_tuples.py
     numba/tests/test_svml.py
@@ -274,7 +268,6 @@ exclude =
     numba/roc/hsadrv/driver.py
     numba/roc/hsadrv/devices.py
     numba/roc/hsadrv/devicearray.py
-    numba/testing/ddt.py
     numba/testing/loader.py
     numba/testing/notebook.py
     numba/testing/main.py

--- a/numba/core/annotations/pretty_annotate.py
+++ b/numba/core/annotations/pretty_annotate.py
@@ -5,7 +5,8 @@ This module implements code highlighting of numba function annotations.
 from warnings import warn
 
 warn("The pretty_annotate functionality is experimental and might change API",
-         FutureWarning)
+     FutureWarning)
+
 
 def hllines(code, style):
     try:
@@ -36,6 +37,7 @@ def htlines(code, style):
     res = highlight(code, pylex, hf)
     return res.splitlines()
 
+
 def get_ansi_template():
     try:
         from jinja2 import Template
@@ -60,8 +62,8 @@ def get_ansi_template():
                 {%- endif -%}
             {%- endfor -%}
     {%- endfor -%}
-    """)
-    return ansi_template
+                    """) #noqa: E501
+
 
 def get_html_template():
     try:
@@ -83,7 +85,7 @@ def get_html_template():
             /* override JupyterLab style */
             .annotation_table td {
                 text-align: left;
-                background-color: transparent; 
+                background-color: transparent;
                 padding: 1px;
             }
 
@@ -93,7 +95,7 @@ def get_html_template():
 
             .annotation_table code
             {
-                background-color: transparent; 
+                background-color: transparent;
                 white-space: normal;
             }
 
@@ -210,7 +212,7 @@ def get_html_template():
 
 def reform_code(annotation):
     """
-    Extract the code from the Numba annotation datastructure. 
+    Extract the code from the Numba annotation datastructure.
 
     Pygments can only highlight full multi-line strings, the Numba
     annotation is list of single lines, with indentation removed.

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -228,7 +228,8 @@ class _InTreeCacheLocator(_SourceFileBackedLocatorMixin, _CacheLocator):
     def __init__(self, py_func, py_file):
         self._py_file = py_file
         self._lineno = py_func.__code__.co_firstlineno
-        self._cache_path = os.path.join(os.path.dirname(self._py_file), '__pycache__')
+        self._cache_path = os.path.join(os.path.dirname(self._py_file),
+                                        '__pycache__')
 
     def get_cache_path(self):
         return self._cache_path
@@ -735,4 +736,3 @@ def make_library_cache(prefix):
         _impl_class = CustomCodeLibraryCacheImpl
 
     return LibraryCache
-

--- a/numba/core/callconv.py
+++ b/numba/core/callconv.py
@@ -9,7 +9,7 @@ import itertools
 from llvmlite import ir
 
 from numba.core import types, cgutils
-from numba.core.base import PYOBJECT, GENERIC_POINTER
+from numba.core.base import GENERIC_POINTER
 
 
 TryStatus = namedtuple('TryStatus', ['in_try', 'excinfo'])
@@ -29,15 +29,18 @@ Status = namedtuple("Status",
                      "is_python_exc",
                      # If the function errored with a user exception
                      "is_user_exc",
-                     # The pointer to the exception info structure (for user exceptions)
+                     # The pointer to the exception info structure
+                     # (for user exceptions)
                      "excinfoptr",
                      ))
 
 int32_t = ir.IntType(32)
 errcode_t = int32_t
 
+
 def _const_int(code):
     return ir.Constant(errcode_t, code)
+
 
 RETCODE_OK = _const_int(0)
 RETCODE_EXC = _const_int(-1)
@@ -48,8 +51,6 @@ RETCODE_STOPIT = _const_int(-3)
 FIRST_USEREXC = 1
 
 RETCODE_USEREXC = _const_int(FIRST_USEREXC)
-
-
 
 
 class BaseCallConv(object):
@@ -317,6 +318,7 @@ class _MinimalCallHelper(object):
             msg = "unknown error %d in native function" % exc_id
             return SystemError, (msg,)
 
+
 # The structure type constructed by PythonAPI.serialize_uncached()
 # i.e a {i8* pickle_buf, i32 pickle_bufsz, i8* hash_buf}
 excinfo_t = ir.LiteralStructType([GENERIC_POINTER, int32_t, GENERIC_POINTER])
@@ -386,8 +388,8 @@ class CPUCallConv(BaseCallConv):
                         func_name=None):
         try_info = getattr(builder, '_in_try_block', False)
         self.set_static_user_exc(builder, exc, exc_args=exc_args,
-                                   loc=loc, func_name=func_name)
-        trystatus = self.check_try_status(builder)
+                                 loc=loc, func_name=func_name)
+        self.check_try_status(builder)
         if try_info:
             # This is a hack for old-style impl.
             # We will branch directly to the exception handler.
@@ -625,7 +627,7 @@ class NumpyErrorModel(ErrorModel):
 error_models = {
     'python': PythonErrorModel,
     'numpy': NumpyErrorModel,
-    }
+}
 
 
 def create_error_model(model_name, context):

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -1,4 +1,3 @@
-import sys
 import platform
 
 import llvmlite.binding as ll
@@ -7,16 +6,16 @@ from llvmlite import ir
 
 from numba import _dynfunc
 from numba.core.callwrapper import PyCallWrapper
-from numba.core.base import BaseContext, PYOBJECT
-from numba.core import utils, types, config, cgutils, callconv, codegen, externals, fastmathpass, intrinsics
+from numba.core.base import BaseContext
+from numba.core import (utils, types, config, cgutils, callconv, codegen,
+                        externals, fastmathpass, intrinsics)
 from numba.core.utils import cached_property
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.runtime import rtsys
 from numba.core.compiler_lock import global_compiler_lock
 import numba.core.entrypoints
-from numba.core.cpu_options import (ParallelOptions, FastMathOptions,
-                                    InlineOptions)
 from numba.np import ufunc_db
+
 
 # Keep those structures in sync with _dynfunc.c.
 
@@ -68,18 +67,19 @@ class CPUContext(BaseContext):
 
     def load_additional_registries(self):
         # Add implementations that work via import
-        from numba.cpython import (slicing, tupleobj, enumimpl, hashing, heapq,
-                                   iterators, numbers, rangeobj, unicode,
-                                   charseq)
-        from numba.core import optional
-        from numba.misc import gdb_hook, literal
-        from numba.np import linalg, polynomial, arraymath
-        from numba.typed import typeddict, dictimpl
-        from numba.typed import typedlist, listobject
-        from numba.experimental import jitclass, function_type
+        from numba.cpython import (slicing, tupleobj, enumimpl,  # noqa: F401
+                                   hashing, heapq, iterators,   # noqa: F401
+                                   numbers, rangeobj, unicode,  # noqa: F401
+                                   charseq)  # noqa: F401
+        from numba.core import optional  # noqa: F401
+        from numba.misc import gdb_hook, literal  # noqa: F401
+        from numba.np import linalg, polynomial, arraymath  # noqa: F401
+        from numba.typed import typeddict, dictimpl  # noqa: F401
+        from numba.typed import typedlist, listobject  # noqa: F401
+        from numba.experimental import jitclass, function_type  # noqa: F401
 
         try:
-            from numba.np import npdatetime
+            from numba.np import npdatetime  # noqa: F401
         except NotImplementedError:
             pass
 
@@ -164,7 +164,6 @@ class CPUContext(BaseContext):
 
         return dictobject.build_map(self, builder, dict_type, item_types, items)
 
-
     def post_lowering(self, mod, library):
         if self.fastmath:
             fastmathpass.rewrite_module(mod, self.fastmath)
@@ -180,7 +179,8 @@ class CPUContext(BaseContext):
                                release_gil=False):
         wrapper_module = self.create_module("wrapper")
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        wrapper_callee = ir.Function(wrapper_module, fnty, fndesc.llvm_func_name)
+        wrapper_callee = ir.Function(wrapper_module, fnty,
+                                     fndesc.llvm_func_name)
         builder = PyCallWrapper(self, wrapper_module, wrapper_callee,
                                 fndesc, env, call_helper=call_helper,
                                 release_gil=release_gil)
@@ -190,12 +190,14 @@ class CPUContext(BaseContext):
     def create_cfunc_wrapper(self, library, fndesc, env, call_helper):
         wrapper_module = self.create_module("cfunc_wrapper")
         fnty = self.call_conv.get_function_type(fndesc.restype, fndesc.argtypes)
-        wrapper_callee = ir.Function(wrapper_module, fnty, fndesc.llvm_func_name)
+        wrapper_callee = ir.Function(wrapper_module, fnty,
+                                     fndesc.llvm_func_name)
 
         ll_argtypes = [self.get_value_type(ty) for ty in fndesc.argtypes]
         ll_return_type = self.get_value_type(fndesc.restype)
         wrapty = ir.FunctionType(ll_return_type, ll_argtypes)
-        wrapfn = ir.Function(wrapper_module, wrapty, fndesc.llvm_cfunc_wrapper_name)
+        wrapfn = ir.Function(wrapper_module, wrapty,
+                             fndesc.llvm_cfunc_wrapper_name)
         builder = ir.IRBuilder(wrapfn.append_basic_block('entry'))
 
         status, out = self.call_conv.call_function(
@@ -231,8 +233,9 @@ class CPUContext(BaseContext):
             an execution environment (from _dynfunc)
         """
         # Code generation
-        baseptr = library.get_pointer_to_function(fndesc.llvm_func_name)
-        fnptr = library.get_pointer_to_function(fndesc.llvm_cpython_wrapper_name)
+        library.get_pointer_to_function(fndesc.llvm_func_name)
+        wrapper_name = fndesc.llvm_cpython_wrapper_name
+        fnptr = library.get_pointer_to_function(wrapper_name)
 
         # Note: we avoid reusing the original docstring to avoid encoding
         # issues on Python 2, see issue #1908
@@ -278,6 +281,7 @@ _options_mixin = include_default_options(
     "inline",
 )
 
+
 class CPUTargetOptions(_options_mixin, TargetOptions):
     def finalize(self, flags, options):
         if not flags.is_set("enable_pyobject"):
@@ -297,6 +301,7 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
         flags.enable_pyobject_looplift = True
 
         flags.inherit_if_not_set("fastmath")
+
 
 # ----------------------------------------------------------------------------
 # Internal

--- a/numba/core/dataflow.py
+++ b/numba/core/dataflow.py
@@ -1,6 +1,4 @@
-import collections
 from pprint import pprint
-import sys
 import warnings
 
 from numba.core.errors import UnsupportedError
@@ -40,7 +38,8 @@ class DataFlowAnalysis(object):
             ib = self.infos[ib.offset]
             incoming_blocks.append(ib)
             if (ib.offset, blk.offset) in self.edge_process:
-                edge_callbacks.append(self.edge_process[(ib.offset, blk.offset)])
+                offset = (ib.offset, blk.offset)
+                edge_callbacks.append(self.edge_process[offset])
 
             # Compute stack offset at block entry
             # The stack effect of our predecessors should be known
@@ -182,7 +181,7 @@ class DataFlowAnalysis(object):
             raise UnsupportedError(
                 msg,
                 loc=Loc(filename=self.bytecode.func_id.filename,
-                line=inst.lineno)
+                        line=inst.lineno)
             )
         value = info.pop()
         strvar = info.make_temp()
@@ -227,7 +226,8 @@ class DataFlowAnalysis(object):
         target = info.peek(index)
         appendvar = info.make_temp()
         res = info.make_temp()
-        info.append(inst, target=target, value=value, appendvar=appendvar, res=res)
+        info.append(inst, target=target, value=value, appendvar=appendvar,
+                    res=res)
 
     def op_BUILD_MAP(self, info, inst):
         dct = info.make_temp()
@@ -248,7 +248,7 @@ class DataFlowAnalysis(object):
         setitemvar = info.make_temp()
         res = info.make_temp()
         info.append(inst, target=target, key=key, value=value,
-                     setitemvar=setitemvar, res=res)
+                    setitemvar=setitemvar, res=res)
 
     def op_BUILD_SET(self, info, inst):
         count = inst.arg
@@ -340,13 +340,19 @@ class DataFlowAnalysis(object):
         pair = info.make_temp()
         indval = info.make_temp()
         pred = info.make_temp()
-        info.append(inst, iterator=iterator, pair=pair, indval=indval, pred=pred)
+        info.append(inst, iterator=iterator, pair=pair, indval=indval,
+                    pred=pred)
         info.push(indval)
-        # Setup for stack POP (twice) at loop exit (before processing instruction at jump target)
+
+        # Setup for stack POP (twice) at loop exit (before processing
+        # instruction at jump target)
         def pop_info(info):
             info.pop()
             info.pop()
-        self.edge_process[(info.block.offset, inst.get_jump_target())] = pop_info
+
+        offset = info.block.offset
+        target = inst.get_jump_target()
+        self.edge_process[(offset, target)] = pop_info
 
     def op_CALL_FUNCTION(self, info, inst):
         narg = inst.arg
@@ -729,7 +735,7 @@ class DataFlowAnalysis(object):
         info.append(inst)
 
     def op_POP_BLOCK(self, info, inst):
-        block = self.pop_syntax_block(info)
+        self.pop_syntax_block(info)
         info.append(inst)
 
     def op_RAISE_VARARGS(self, info, inst):
@@ -754,8 +760,9 @@ class DataFlowAnalysis(object):
         if inst.arg & 0x1:
             defaults = info.pop()
         res = info.make_temp()
-        info.append(inst, name=name, code=code, closure=closure, annotations=annotations,
-                    kwdefaults=kwdefaults, defaults=defaults, res=res)
+        info.append(inst, name=name, code=code, closure=closure,
+                    annotations=annotations, kwdefaults=kwdefaults,
+                    defaults=defaults, res=res)
         info.push(res)
 
     def op_MAKE_CLOSURE(self, info, inst):

--- a/numba/core/datamodel/manager.py
+++ b/numba/core/datamodel/manager.py
@@ -44,4 +44,3 @@ class DataModelManager(object):
         dmm = DataModelManager()
         dmm._handlers = self._handlers.copy()
         return dmm
-

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -749,7 +749,6 @@ class UnionModel(StructModel):
         super(UnionModel, self).__init__(dmm, fe_type, members)
 
 
-
 @register_default(types.Pair)
 class PairModel(StructModel):
     def __init__(self, dmm, fe_type):
@@ -797,7 +796,7 @@ class ListIterModel(StructModel):
             # original list object)
             ('meminfo', types.MemInfoPointer(payload_type)),
             ('index', types.EphemeralPointer(types.intp)),
-            ]
+        ]
         super(ListIterModel, self).__init__(dmm, fe_type, members)
 
 
@@ -833,6 +832,7 @@ class SetPayloadModel(StructModel):
         ]
         super(SetPayloadModel, self).__init__(dmm, fe_type, members)
 
+
 @register_default(types.Set)
 class SetModel(StructModel):
     def __init__(self, dmm, fe_type):
@@ -845,6 +845,7 @@ class SetModel(StructModel):
         ]
         super(SetModel, self).__init__(dmm, fe_type, members)
 
+
 @register_default(types.SetIter)
 class SetIterModel(StructModel):
     def __init__(self, dmm, fe_type):
@@ -855,7 +856,7 @@ class SetIterModel(StructModel):
             ('meminfo', types.MemInfoPointer(payload_type)),
             # The index into the entries table
             ('index', types.EphemeralPointer(types.intp)),
-            ]
+        ]
         super(SetIterModel, self).__init__(dmm, fe_type, members)
 
 
@@ -925,6 +926,7 @@ class OptionalModel(StructModel):
             valid = get_valid(value)
             data = self.get(builder, value, "data")
             return builder.select(valid, data, ir.Constant(data.type, None))
+
         def get_valid(value):
             return self.get(builder, value, "valid")
 
@@ -1044,7 +1046,6 @@ class CContiguousFlatIter(StructModel):
     def __init__(self, dmm, fe_type, need_indices):
         assert fe_type.array_type.layout == 'C'
         array_type = fe_type.array_type
-        dtype = array_type.dtype
         ndim = array_type.ndim
         members = [('array', array_type),
                    ('stride', types.intp),
@@ -1061,10 +1062,11 @@ class FlatIter(StructModel):
         array_type = fe_type.array_type
         dtype = array_type.dtype
         ndim = array_type.ndim
-        members = [('array', array_type),
-                   ('pointers', types.EphemeralArray(types.CPointer(dtype), ndim)),
-                   ('indices', types.EphemeralArray(types.intp, ndim)),
-                   ('exhausted', types.EphemeralPointer(types.boolean)),
+        members = [
+            ('array', array_type),
+            ('pointers', types.EphemeralArray(types.CPointer(dtype), ndim)),
+            ('indices', types.EphemeralArray(types.intp, ndim)),
+            ('exhausted', types.EphemeralPointer(types.boolean)),
         ]
         super(FlatIter, self).__init__(dmm, fe_type, members)
 
@@ -1226,12 +1228,14 @@ def handle_numpy_flat_type(dmm, ty):
     else:
         return FlatIter(dmm, ty)
 
+
 @register_default(types.NumpyNdEnumerateType)
 def handle_numpy_ndenumerate_type(dmm, ty):
     if ty.array_type.layout == 'C':
         return CContiguousFlatIter(dmm, ty, need_indices=True)
     else:
         return FlatIter(dmm, ty)
+
 
 @register_default(types.BoundFunction)
 def handle_bound_function(dmm, ty):
@@ -1258,7 +1262,8 @@ class NdIter(StructModel):
             member_name = 'index%d' % i
             if kind == 'flat':
                 # A single index into the flattened array
-                members.append((member_name, types.EphemeralPointer(types.intp)))
+                members.append((member_name,
+                                types.EphemeralPointer(types.intp)))
             elif kind in ('scalar', 'indexed', '0d'):
                 # Nothing required
                 pass
@@ -1374,4 +1379,3 @@ class StructRefModel(StructModel):
             ("meminfo", types.MemInfoPointer(dtype)),
         ]
         super().__init__(dmm, fe_typ, members)
-

--- a/numba/core/datamodel/packer.py
+++ b/numba/core/datamodel/packer.py
@@ -3,7 +3,6 @@ from collections import deque
 from numba.core import types, cgutils
 
 
-
 class DataPacker(object):
     """
     A helper to pack a number of typed arguments into a data structure.
@@ -36,7 +35,8 @@ class DataPacker(object):
         res = []
         for i, i_formal in enumerate(self._pack_map):
             elem_ptr = cgutils.gep_inbounds(builder, ptr, 0, i)
-            val = self._models[i_formal].load_from_data_pointer(builder, elem_ptr)
+            val = self._models[i_formal].load_from_data_pointer(builder,
+                                                                elem_ptr)
             if formal_list is None:
                 res.append((self._fe_types[i_formal], val))
             else:
@@ -156,6 +156,7 @@ _APPEND_NEXT_VALUE = 2
 _APPEND_EMPTY_TUPLE = 3
 _POP = 4
 
+
 class _Unflattener(object):
     """
     An object used to unflatten nested sequences after a given pattern
@@ -172,6 +173,7 @@ class _Unflattener(object):
         (an iterable of nested sequences).
         """
         code = []
+
         def rec(iterable):
             for i in iterable:
                 if isinstance(i, (tuple, list)):

--- a/numba/core/datamodel/testing.py
+++ b/numba/core/datamodel/testing.py
@@ -126,9 +126,9 @@ class NotSupportAsDataMixin(object):
 
         undef_value = ir.Constant(self.datamodel.get_value_type(), None)
         with self.assertRaises(NotImplementedError):
-            data = self.datamodel.as_data(builder, undef_value)
+            self.datamodel.as_data(builder, undef_value)
         with self.assertRaises(NotImplementedError):
-            rev_data = self.datamodel.from_data(builder, undef_value)
+            self.datamodel.from_data(builder, undef_value)
 
 
 class DataModelTester_SupportAsDataMixin(DataModelTester,

--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -147,7 +147,8 @@ class DIBuilder(AbstractDIBuilder):
         function.attributes.add('noinline')
 
     def finalize(self):
-        dbgcu = cgutils.get_or_insert_named_metadata(self.module, self.DBG_CU_NAME)
+        dbgcu = cgutils.get_or_insert_named_metadata(self.module,
+                                                     self.DBG_CU_NAME)
         dbgcu.add(self.dicompileunit)
         self._set_module_flags()
 
@@ -159,7 +160,8 @@ class DIBuilder(AbstractDIBuilder):
         """Set the module flags metadata
         """
         module = self.module
-        mflags = cgutils.get_or_insert_named_metadata(module, 'llvm.module.flags')
+        mflags = cgutils.get_or_insert_named_metadata(module,
+                                                      'llvm.module.flags')
         # Set *require* behavior to warning
         # See http://llvm.org/docs/LangRef.html#module-flags-metadata
         require_warning_behavior = self._const_int(2)
@@ -314,7 +316,7 @@ class NvvmDIBuilder(DIBuilder):
     def _di_compile_unit(self):
         filepair = self._filepair()
         empty = self.module.add_metadata([self._const_int(0)])
-        sp_metadata = self.module.add_metadata(self.subprograms)
+        self.module.add_metadata(self.subprograms)
         return self.module.add_metadata([
             self._const_int(self.DI_Compile_unit),         # tag
             filepair,                   # source directory and file pair

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -3,16 +3,14 @@ Define @jit and related decorators.
 """
 
 
-import sys
 import warnings
 import inspect
 import logging
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
-from numba.stencils.stencil import stencil
-from numba.core import config, extending, sigutils, registry
-from numba.core.extending_hardware import (JitDecorator, hardware_registry,
-                                           dispatcher_registry,
+from numba.stencils.stencil import stencil  # noqa: F401
+from numba.core import config, extending, sigutils
+from numba.core.extending_hardware import (hardware_registry,
                                            resolve_dispatcher_from_str)
 from numba.core.registry import TargetRegistry
 
@@ -156,7 +154,8 @@ def jit(signature_or_function=None, locals={}, cache=False,
         raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
     if 'target' in options:
         target = options.pop('target')
-        warnings.warn("The 'target' keyword argument is deprecated.", NumbaDeprecationWarning)
+        warnings.warn("The 'target' keyword argument is deprecated.",
+                      NumbaDeprecationWarning)
     else:
         target = options.pop('_target', 'cpu')
 
@@ -193,6 +192,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
 
 # Register the cpu token as using `jit` as the jitter
 jit_registry[hardware_registry['cpu']] = jit
+
 
 def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
 
@@ -288,7 +288,8 @@ def cfunc(sig, locals={}, cache=False, pipeline_class=None, **options):
         additional_args = {}
         if pipeline_class is not None:
             additional_args['pipeline_class'] = pipeline_class
-        res = CFunc(func, sig, locals=locals, options=options, **additional_args)
+        res = CFunc(func, sig, locals=locals, options=options,
+                    **additional_args)
         if cache:
             res.enable_caching()
         res.compile()
@@ -317,5 +318,6 @@ def jit_module(**kwargs):
     for name, obj in module.__dict__.items():
         if inspect.isfunction(obj) and inspect.getmodule(obj) == module:
             _logger.debug("Auto decorating function {} from module {} with jit "
-                          "and options: {}".format(obj, module.__name__, kwargs))
+                          "and options: {}".format(obj, module.__name__,
+                                                   kwargs))
             module.__dict__[name] = jit(obj, **kwargs)

--- a/numba/core/fastmathpass.py
+++ b/numba/core/fastmathpass.py
@@ -41,4 +41,3 @@ def rewrite_module(mod, options):
     flags = options.flags
     FastFloatBinOpVisitor(flags).visit(mod)
     FastFloatCallVisitor(flags).visit(mod)
-

--- a/numba/core/imputils.py
+++ b/numba/core/imputils.py
@@ -5,11 +5,9 @@ Utilities to simplify the boilerplate for native lowering.
 
 import collections
 import contextlib
-import inspect
-import functools
 from enum import Enum
 
-from numba.core import typing, types, utils, cgutils
+from numba.core import typing, types, cgutils
 from numba.core.typing.templates import BaseRegistryLoader
 
 
@@ -155,6 +153,7 @@ def _decorate_getattr(impl, ty, attr):
     res.attr = attr
     return res
 
+
 def _decorate_setattr(impl, ty, attr):
     real_impl = impl
 
@@ -179,10 +178,11 @@ def fix_returning_optional(context, builder, sig, status, retval):
         with builder.if_then(builder.not_(status.is_none)):
             optional_value = context.make_optional_value(
                 builder, value_type, retval,
-                )
+            )
             builder.store(optional_value, retvalptr)
         retval = builder.load(retvalptr)
     return retval
+
 
 def user_function(fndesc, libs):
     """
@@ -297,6 +297,7 @@ class _IternextResult(object):
         """
         return self._pairobj.first
 
+
 class RefType(Enum):
     """
     Enumerate the reference type
@@ -313,6 +314,7 @@ class RefType(Enum):
     An untracked reference
     """
     UNTRACKED = 3
+
 
 def iternext_impl(ref_type=None):
     """
@@ -334,7 +336,7 @@ def iternext_impl(ref_type=None):
             pair_type = sig.return_type
             pairobj = context.make_helper(builder, pair_type)
             func(context, builder, sig, args,
-                _IternextResult(context, builder, pairobj))
+                 _IternextResult(context, builder, pairobj))
             if ref_type == RefType.NEW:
                 impl_ret = impl_ret_new_ref
             elif ref_type == RefType.BORROWED:
@@ -343,8 +345,7 @@ def iternext_impl(ref_type=None):
                 impl_ret = impl_ret_untracked
             else:
                 raise ValueError("Unknown ref_type encountered")
-            return impl_ret(context, builder,
-                                    pair_type, pairobj._getvalue())
+            return impl_ret(context, builder, pair_type, pairobj._getvalue())
         return wrapper
     return outer
 

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -2,8 +2,7 @@ import types as pytypes  # avoid confusion with numba.types
 import copy
 import ctypes
 import numba.core.analysis
-from numba.core import utils, types, typing, errors, ir, rewrites, config, ir_utils
-from numba import prange
+from numba.core import types, typing, errors, ir, rewrites, config, ir_utils
 from numba.parfors.parfor import internal_prange
 from numba.core.ir_utils import (
     mk_unique_var,
@@ -25,7 +24,7 @@ from numba.core.ir_utils import (
     simplify_CFG,
     canonicalize_array_math,
     dead_code_elimination,
-    )
+)
 
 from numba.core.analysis import (
     compute_cfg_from_blocks,
@@ -80,24 +79,24 @@ class InlineClosureCallPass(object):
             label, block = work_list.pop()
             for i, instr in enumerate(block.body):
                 if isinstance(instr, ir.Assign):
-                    lhs = instr.target
                     expr = instr.value
                     if isinstance(expr, ir.Expr) and expr.op == 'call':
                         call_name = guard(find_callname, self.func_ir, expr)
-                        func_def = guard(get_definition, self.func_ir, expr.func)
+                        func_def = guard(get_definition, self.func_ir,
+                                         expr.func)
 
                         if guard(self._inline_reduction,
                                  work_list, block, i, expr, call_name):
                             modified = True
                             break # because block structure changed
 
-                        if guard(self._inline_closure,
-                                work_list, block, i, func_def):
+                        if guard(self._inline_closure, work_list, block, i,
+                                 func_def):
                             modified = True
                             break # because block structure changed
 
-                        if guard(self._inline_stencil,
-                                instr, call_name, func_def):
+                        if guard(self._inline_stencil, instr, call_name,
+                                 func_def):
                             modified = True
 
         if enable_inline_arraycall:
@@ -112,11 +111,11 @@ class InlineClosureCallPass(object):
             sized_loops = [(k, len(loops[k].body)) for k in loops.keys()]
             visited = []
             # We go over all loops, bigger loops first (outer first)
-            for k, s in sorted(sized_loops, key=lambda tup: tup[1], reverse=True):
+            for k, s in sorted(sized_loops, key=lambda t: t[1], reverse=True):
                 visited.append(k)
-                if guard(_inline_arraycall, self.func_ir, cfg, visited, loops[k],
-                         self.swapped, self.parallel_options.comprehension,
-                         self.typed):
+                if guard(_inline_arraycall, self.func_ir, cfg, visited,
+                         loops[k], self.swapped,
+                         self.parallel_options.comprehension, self.typed):
                     modified = True
             if modified:
                 _fix_nested_array(self.func_ir)
@@ -150,6 +149,7 @@ class InlineClosureCallPass(object):
                             "two arguments are required (optional initial "
                             "value can also be specified)")
         check_reduce_func(self.func_ir, expr.args[0])
+
         def reduce_func(f, A, v=None):
             it = iter(A)
             if v is not None:
@@ -157,12 +157,12 @@ class InlineClosureCallPass(object):
             else:
                 s = next(it)
             for a in it:
-               s = f(s, a)
+                s = f(s, a)
             return s
         inline_closure_call(self.func_ir,
-                        self.func_ir.func_id.func.__globals__,
-                        block, i, reduce_func, work_list=work_list,
-                        callee_validator=callee_ir_validator)
+                            self.func_ir.func_id.func.__globals__, block, i,
+                            reduce_func, work_list=work_list,
+                            callee_validator=callee_ir_validator)
         return True
 
     def _inline_stencil(self, instr, call_name, func_def):
@@ -173,8 +173,8 @@ class InlineClosureCallPass(object):
         # alive by adding them to the actual kernel call as extra
         # keyword arguments, which is ignored anyway.
         if (isinstance(func_def, ir.Global) and
-            func_def.name == 'stencil' and
-            isinstance(func_def.value, StencilFunc)):
+                func_def.name == 'stencil' and
+                isinstance(func_def.value, StencilFunc)):
             if expr.kws:
                 expr.kws += func_def.value.kws
             else:
@@ -187,23 +187,24 @@ class InlineClosureCallPass(object):
         self._processed_stencils.append(expr)
         if not len(expr.args) == 1:
             raise ValueError("As a minimum Stencil requires"
-                " a kernel as an argument")
+                             " a kernel as an argument")
         stencil_def = guard(get_definition, self.func_ir, expr.args[0])
         require(isinstance(stencil_def, ir.Expr) and
                 stencil_def.op == "make_function")
         kernel_ir = get_ir_of_code(self.func_ir.func_id.func.__globals__,
-                stencil_def.code)
+                                   stencil_def.code)
         options = dict(expr.kws)
         if 'neighborhood' in options:
             fixed = guard(self._fix_stencil_neighborhood, options)
             if not fixed:
-               raise ValueError("stencil neighborhood option should be a tuple"
-                        " with constant structure such as ((-w, w),)")
+                raise ValueError("stencil neighborhood option should be a tuple"
+                                 " with constant structure such as ((-w, w),)")
         if 'index_offsets' in options:
             fixed = guard(self._fix_stencil_index_offsets, options)
             if not fixed:
-               raise ValueError("stencil index_offsets option should be a tuple"
-                        " with constant structure such as (offset, )")
+                msg = ("stencil index_offsets option should be a "
+                       "tuple with constant structure such as (offset, )")
+                raise ValueError(msg)
         sf = StencilFunc(kernel_ir, 'constant', options)
         sf.kws = expr.kws # hack to keep variables live
         sf_global = ir.Global('stencil', sf, expr.loc)
@@ -246,6 +247,7 @@ class InlineClosureCallPass(object):
                             callee_validator=callee_ir_validator)
         return True
 
+
 def check_reduce_func(func_ir, func_var):
     """Checks the function at func_var in func_ir to make sure it's amenable
     for inlining. Returns the function itself"""
@@ -260,10 +262,10 @@ def check_reduce_func(func_ir, func_var):
         # pull out the python function for inlining
         reduce_func = reduce_func.value.py_func
     elif not (hasattr(reduce_func, 'code')
-            or hasattr(reduce_func, '__code__')):
+              or hasattr(reduce_func, '__code__')):
         raise ValueError("Invalid reduction function")
     f_code = (reduce_func.code if hasattr(reduce_func, 'code')
-                                    else reduce_func.__code__)
+              else reduce_func.__code__)
     if not f_code.co_argcount == 2:
         raise TypeError("Reduction function should take 2 arguments")
     return reduce_func
@@ -334,7 +336,6 @@ class InlineWorker(object):
         self._permit_update_type_and_call_maps = not all(pair_is_none)
         self.typemap = typemap
         self.calltypes = calltypes
-
 
     def inline_ir(self, caller_ir, block, i, callee_ir, callee_freevars,
                   arg_typs=None):
@@ -468,11 +469,11 @@ class InlineWorker(object):
         Run the compiler frontend's untyped passes over the given Python
         function, and return the function's canonical Numba IR.
 
-        Disable SSA transformation by default, since the call site won't be in SSA
-        form and self.inline_ir depends on this being the case.
+        Disable SSA transformation by default, since the call site won't be in
+        SSA form and self.inline_ir depends on this being the case.
         """
         from numba.core.compiler import StateDict, _CompileStatus
-        from numba.core.untyped_passes import ExtractByteCode, WithLifting
+        from numba.core.untyped_passes import ExtractByteCode
         from numba.core import bytecode
         from numba.parfors.parfor import ParforDiagnostics
         state = StateDict()
@@ -522,8 +523,11 @@ class InlineWorker(object):
         # callee's typing may require SSA
         callee_ir = reconstruct_ssa(callee_ir)
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
-        f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                self.typingctx, self.targetctx, callee_ir, arg_typs, None)
+        pass_result = typed_passes.type_inference_stage(self.typingctx,
+                                                        self.targetctx,
+                                                        callee_ir, arg_typs,
+                                                        None)
+        f_typemap, f_return_type, f_calltypes, _ = pass_result
         callee_ir = PreLowerStripPhis()._strip_phi_nodes(callee_ir)
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         canonicalize_array_math(callee_ir, f_typemap,
@@ -563,7 +567,10 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     debug_print("Found closure call: ", instr, " with callee = ", callee)
     # support both function object and make_function Expr
     callee_code = callee.code if hasattr(callee, 'code') else callee.__code__
-    callee_closure = callee.closure if hasattr(callee, 'closure') else callee.__closure__
+    if hasattr(callee, 'closure'):
+        callee_closure = callee.closure
+    else:
+        callee_closure = callee.__closure__
     # first, get the IR of the callee
     if isinstance(callee, pytypes.FunctionType):
         from numba.core import compiler
@@ -590,7 +597,8 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     debug_print("After relabel")
     _debug_dump(callee_ir)
 
-    # 2. rename all local variables in callee_ir with new locals created in func_ir
+    # 2. rename all local variables in callee_ir with new locals created in
+    # func_ir
     callee_scopes = _get_all_scopes(callee_blocks)
     debug_print("callee_scopes = ", callee_scopes)
     #    one function should only have one local scope
@@ -636,12 +644,17 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         numba.core.analysis.dead_branch_prune(callee_ir, arg_typs)
         try:
-            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                    typingctx, targetctx, callee_ir, arg_typs, None)
-        except Exception as e:
-            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                    typingctx, targetctx, callee_ir, arg_typs, None)
-            pass
+            pass_result = typed_passes.type_inference_stage(typingctx,
+                                                            targetctx,
+                                                            callee_ir,
+                                                            arg_typs, None)
+        except Exception:
+            pass_result = typed_passes.type_inference_stage(typingctx,
+                                                            targetctx,
+                                                            callee_ir,
+                                                            arg_typs, None)
+
+        f_typemap, f_return_type, f_calltypes, _ = pass_result
         canonicalize_array_math(callee_ir, f_typemap,
                                 f_calltypes, typingctx)
         # remove argument entries like arg.a from typemap
@@ -713,6 +726,7 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
         normal_handler = lambda index, param, default: default
         default_handler = lambda index, param, default: ir.Const(default, loc)
         # Throw error for stararg
+
         # TODO: handle stararg
         def stararg_handler(index, param, default):
             raise NotImplementedError(
@@ -751,9 +765,8 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
                               x in default_tuple.items]
                 args = args + const_vals
             else:
-                raise NotImplementedError(
-                    "Unsupported defaults to make_function: {}".format(
-                        defaults))
+                msg = "Unsupported defaults to make_function: {}"
+                raise NotImplementedError(msg.format(callee_defaults))
         return args
 
 
@@ -824,8 +837,11 @@ def _replace_returns(blocks, target, return_label):
                 for cast in casts:
                     if cast.target.name == stmt.value.name:
                         cast.value = cast.value.value
-            elif isinstance(stmt, ir.Assign) and isinstance(stmt.value, ir.Expr) and stmt.value.op == 'cast':
+            elif (isinstance(stmt, ir.Assign)
+                    and isinstance(stmt.value, ir.Expr)
+                    and stmt.value.op == 'cast'):
                 casts.append(stmt)
+
 
 def _add_definitions(func_ir, block):
     """
@@ -836,6 +852,7 @@ def _add_definitions(func_ir, block):
     for stmt in assigns:
         definitions[stmt.target.name].append(stmt.value)
 
+
 def _find_arraycall(func_ir, block):
     """Look for statement like "x = numpy.array(y)" or "x[..] = y"
     immediately after the closure call that creates list y (the i-th
@@ -843,7 +860,6 @@ def _find_arraycall(func_ir, block):
     raise GuardException.
     """
     array_var = None
-    array_call_index = None
     list_var_dead_after_array_call = False
     list_var = None
 
@@ -858,10 +874,10 @@ def _find_arraycall(func_ir, block):
             pass
         elif isinstance(instr, ir.Assign):
             # Found array_var = array(list_var)
-            lhs  = instr.target
+            lhs = instr.target
             expr = instr.value
             if (guard(find_callname, func_ir, expr) == ('array', 'numpy') and
-                isinstance(expr.args[0], ir.Var)):
+                    isinstance(expr.args[0], ir.Var)):
                 list_var = expr.args[0]
                 array_var = lhs
                 array_stmt_index = i
@@ -893,7 +909,8 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     debug_print = _make_debug_print("find_iter_range")
     range_iter_def = get_definition(func_ir, range_iter_var)
     debug_print("range_iter_var = ", range_iter_var, " def = ", range_iter_def)
-    require(isinstance(range_iter_def, ir.Expr) and range_iter_def.op == 'getiter')
+    require(isinstance(range_iter_def, ir.Expr)
+            and range_iter_def.op == 'getiter')
     range_var = range_iter_def.value
     range_def = get_definition(func_ir, range_var)
     debug_print("range_var = ", range_var, " range_def = ", range_def)
@@ -902,7 +919,8 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     func_def = get_definition(func_ir, func_var)
     debug_print("func_var = ", func_var, " func_def = ", func_def)
     require(isinstance(func_def, ir.Global) and
-            (func_def.value == range or func_def.value == numba.misc.special.prange))
+            (func_def.value == range
+             or func_def.value == numba.misc.special.prange))
     nargs = len(range_def.args)
     swapping = [('"array comprehension"', 'closure of'), range_def.func.loc]
     if nargs == 1:
@@ -917,32 +935,40 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     else:
         raise GuardException
 
+
 def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
                       typed=False):
-    """Look for array(list) call in the exit block of a given loop, and turn list operations into
-    array operations in the loop if the following conditions are met:
+    """Look for array(list) call in the exit block of a given loop, and turn
+    list operations into array operations in the loop if the following
+    conditions are met:
+
       1. The exit block contains an array call on the list;
       2. The list variable is no longer live after array call;
       3. The list is created in the loop entry block;
-      4. The loop is created from an range iterator whose length is known prior to the loop;
-      5. There is only one list_append operation on the list variable in the loop body;
-      6. The block that contains list_append dominates the loop head, which ensures list
-         length is the same as loop length;
-    If any condition check fails, no modification will be made to the incoming IR.
+      4. The loop is created from an range iterator whose length is known prior
+         to the loop;
+      5. There is only one list_append operation on the list variable in the
+         loop body;
+      6. The block that contains list_append dominates the loop head, which
+         ensures list length is the same as loop length;
+
+    If any condition check fails, no modification will be made to the incoming
+    IR.
     """
     debug_print = _make_debug_print("inline_arraycall")
     # There should only be one loop exit
     require(len(loop.exits) == 1)
     exit_block = next(iter(loop.exits))
-    list_var, array_call_index, array_kws = _find_arraycall(func_ir, func_ir.blocks[exit_block])
+    list_var, array_call_index, array_kws = \
+        _find_arraycall(func_ir, func_ir.blocks[exit_block])
 
     # check if dtype is present in array call
     dtype_def = None
     dtype_mod_def = None
     if 'dtype' in array_kws:
         require(isinstance(array_kws['dtype'], ir.Var))
-        # We require that dtype argument to be a constant of getattr Expr, and we'll
-        # remember its definition for later use.
+        # We require that dtype argument to be a constant of getattr Expr, and
+        # we'll remember its definition for later use.
         dtype_def = get_definition(func_ir, array_kws['dtype'])
         require(isinstance(dtype_def, ir.Expr) and dtype_def.op == 'getattr')
         dtype_mod_def = get_definition(func_ir, dtype_def.value)
@@ -952,30 +978,32 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     if isinstance(list_var_def, ir.Expr) and list_var_def.op == 'cast':
         list_var_def = get_definition(func_ir, list_var_def.value)
     # Check if the definition is a build_list
-    require(isinstance(list_var_def, ir.Expr) and list_var_def.op ==  'build_list')
+    require(isinstance(list_var_def, ir.Expr)
+            and list_var_def.op == 'build_list')
     # The build_list must be empty
     require(len(list_var_def.items) == 0)
 
-    # Look for list_append in "last" block in loop body, which should be a block that is
-    # a post-dominator of the loop header.
+    # Look for list_append in "last" block in loop body, which should be a
+    # block that is a post-dominator of the loop header.
     list_append_stmts = []
     for label in loop.body:
         # We have to consider blocks of this loop, but not sub-loops.
-        # To achieve this, we require the set of "in_loops" of "label" to be visited loops.
+        # To achieve this, we require the set of "in_loops" of "label" to be
+        # visited loops.
         in_visited_loops = [l.header in visited for l in cfg.in_loops(label)]
         if not all(in_visited_loops):
             continue
         block = func_ir.blocks[label]
         debug_print("check loop body block ", label)
         for stmt in block.find_insts(ir.Assign):
-            lhs = stmt.target
             expr = stmt.value
             if isinstance(expr, ir.Expr) and expr.op == 'call':
                 func_def = get_definition(func_ir, expr.func)
                 if isinstance(func_def, ir.Expr) and func_def.op == 'getattr' \
-                  and func_def.attr == 'append':
+                        and func_def.attr == 'append':
                     list_def = get_definition(func_ir, func_def.value)
-                    debug_print("list_def = ", list_def, list_def is list_var_def)
+                    debug_print("list_def = ", list_def,
+                                list_def is list_var_def)
                     if list_def is list_var_def:
                         # found matching append call
                         list_append_stmts.append((label, block, stmt))
@@ -1009,8 +1037,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
 
     # Require only one iterator in loop header
     require(len(iter_vars) == 1 and len(iter_first_vars) == 1)
-    iter_var = iter_vars[0] # variable that holds the iterator object
-    iter_first_var = iter_first_vars[0] # variable that holds the value out of iterator
+    iter_var = iter_vars[0] # holds the iterator object
+    iter_first_var = iter_first_vars[0] # holds the value out of iterator
 
     # Final requirement: only one loop entry, and we're going to modify it by:
     # 1. replacing the list definition with an array definition;
@@ -1022,6 +1050,7 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     loc = loop_entry.loc
     stmts = []
     removed = []
+
     def is_removed(val, removed):
         if isinstance(val, ir.Var):
             for x in removed:
@@ -1031,24 +1060,28 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     # Skip list construction and skip terminator, add the rest to stmts
     for i in range(len(loop_entry.body) - 1):
         stmt = loop_entry.body[i]
-        if isinstance(stmt, ir.Assign) and (stmt.value is list_def or is_removed(stmt.value, removed)):
+        if isinstance(stmt, ir.Assign) and (stmt.value is list_def
+                                            or is_removed(stmt.value, removed)):
             removed.append(stmt.target)
         else:
             stmts.append(stmt)
     debug_print("removed variables: ", removed)
 
     # Define an index_var to index the array.
-    # If the range happens to be single step ranges like range(n), or range(m, n),
-    # then the index_var correlates to iterator index; otherwise we'll have to
-    # define a new counter.
+    # If the range happens to be single step ranges like range(n), or range(m,
+    # n), then the index_var correlates to iterator index; otherwise we'll have
+    # to define a new counter.
     range_def = guard(_find_iter_range, func_ir, iter_var, swapped)
     index_var = ir.Var(scope, mk_unique_var("index"), loc)
     if range_def and range_def[0] == 0:
         # iterator starts with 0, index_var can just be iter_first_var
         index_var = iter_first_var
     else:
-        # index_var = -1 # starting the index with -1 since it will incremented in loop header
-        stmts.append(_new_definition(func_ir, index_var, ir.Const(value=-1, loc=loc), loc))
+        # index_var = -1 # starting the index with -1 since it will incremented
+        # in loop header
+        m1 = ir.Const(value=-1, loc=loc)
+        new_defn = _new_definition(func_ir, index_var, m1)
+        stmts.append(new_defn, loc)
 
     # Insert statement to get the size of the loop iterator
     size_var = ir.Var(scope, mk_unique_var("size"), loc)
@@ -1057,7 +1090,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         if start == 0:
             size_val = stop
         else:
-            size_val = ir.Expr.binop(fn=operator.sub, lhs=stop, rhs=start, loc=loc)
+            size_val = ir.Expr.binop(fn=operator.sub, lhs=stop, rhs=start,
+                                     loc=loc)
         # we can parallelize this loop if enable_prange = True, by changing
         # range function from range, to prange.
         if enable_prange and isinstance(range_func_def, ir.Global):
@@ -1070,12 +1104,11 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
             from numba.cpython.rangeobj import range_iter_len
             stmts.append(_new_definition(func_ir, len_func_var,
-                        ir.Global('range_iter_len', range_iter_len, loc=loc),
-                        loc))
+                         ir.Global('range_iter_len', range_iter_len, loc=loc),
+                         loc))
             size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
         else:
             raise GuardException
-
 
     stmts.append(_new_definition(func_ir, size_var, size_val, loc))
 
@@ -1090,26 +1123,34 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         # when dtype is present, we'll call empty with dtype
         dtype_mod_var = ir.Var(scope, mk_unique_var("dtype_mod"), loc)
         dtype_var = ir.Var(scope, mk_unique_var("dtype"), loc)
-        stmts.append(_new_definition(func_ir, dtype_mod_var, dtype_mod_def, loc))
+        stmts.append(_new_definition(func_ir, dtype_mod_var, dtype_mod_def,
+                                     loc))
         stmts.append(_new_definition(func_ir, dtype_var,
-                         ir.Expr.getattr(dtype_mod_var, dtype_def.attr, loc), loc))
-        stmts.append(_new_definition(func_ir, empty_func,
-                         ir.Global('empty', np.empty, loc=loc), loc))
+                                     ir.Expr.getattr(dtype_mod_var,
+                                                     dtype_def.attr, loc),
+                                     loc))
+        stmts.append(_new_definition(func_ir, empty_func, ir.Global('empty',
+                                                                    np.empty,
+                                                                    loc=loc),
+                                     loc))
         array_kws = [('dtype', dtype_var)]
     else:
         # this doesn't work in objmode as it's effectively untyped
         if typed:
             # otherwise we'll call unsafe_empty_inferred
             stmts.append(_new_definition(func_ir, empty_func,
-                            ir.Global('unsafe_empty_inferred',
-                                unsafe_empty_inferred, loc=loc), loc))
+                                         ir.Global('unsafe_empty_inferred',
+                                                   unsafe_empty_inferred,
+                                                   loc=loc), loc))
             array_kws = []
         else:
             raise GuardException
 
     # array_var = empty_func(size_tuple_var)
     stmts.append(_new_definition(func_ir, array_var,
-                 ir.Expr.call(empty_func, (size_tuple_var,), list(array_kws), loc=loc), loc))
+                                 ir.Expr.call(empty_func, (size_tuple_var,),
+                                              list(array_kws), loc=loc),
+                                 loc))
 
     # Add back removed just in case they are used by something else
     for var in removed:
@@ -1130,10 +1171,9 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             block_id = terminator.truebr
             blk = func_ir.blocks[block_id]
             loc = blk.loc
-            blk.body.insert(0, _new_definition(func_ir, index_var,
-                ir.Expr.binop(fn=operator.sub, lhs=iter_first_var,
-                                      rhs=range_def[0], loc=loc),
-                loc))
+            binop = ir.Expr.binop(fn=operator.sub, lhs=iter_first_var,
+                                  rhs=range_def[0], loc=loc),
+            blk.body.insert(0, _new_definition(func_ir, index_var, binop, loc))
     else:
         # Insert index_var increment to the end of loop header
         loc = loop_header.loc
@@ -1146,7 +1186,9 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
                      ir.Const(value=1,loc=loc), loc))
         # next_index_var = index_var + 1
         stmts.append(_new_definition(func_ir, next_index_var,
-                     ir.Expr.binop(fn=operator.add, lhs=index_var, rhs=one, loc=loc), loc))
+                                     ir.Expr.binop(fn=operator.add,
+                                                   lhs=index_var, rhs=one,
+                                                   loc=loc), loc))
         # index_var = next_index_var
         stmts.append(_new_definition(func_ir, index_var, next_index_var, loc))
         stmts.append(terminator)
@@ -1157,7 +1199,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         if append_block.body[i] is append_stmt:
             debug_print("Replace append with SetItem")
             append_block.body[i] = ir.SetItem(target=array_var, index=index_var,
-                                              value=append_stmt.value.args[0], loc=append_stmt.loc)
+                                              value=append_stmt.value.args[0],
+                                              loc=append_stmt.loc)
 
     # replace array call, by changing "a = array(b)" to "a = b"
     stmt = func_ir.blocks[exit_block].body[array_call_index]
@@ -1232,10 +1275,14 @@ def _fix_nested_array(func_ir):
                                 var_def = get_definition(func_ir, var.name)
                                 if isinstance(var_def, ir.Const):
                                     loc = var.loc
-                                    new_var = ir.Var(scope, mk_unique_var("new_var"), loc)
+                                    new_var = ir.Var(scope,
+                                                     mk_unique_var("new_var"),
+                                                     loc)
                                     new_const = ir.Const(var_def.value, loc)
                                     new_vardef = _new_definition(func_ir,
-                                                    new_var, new_const, loc)
+                                                                 new_var,
+                                                                 new_const,
+                                                                 loc)
                                     new_body = []
                                     new_body.extend(body[:i])
                                     new_body.append(new_vardef)
@@ -1251,9 +1298,12 @@ def _fix_nested_array(func_ir):
     def fix_array_assign(stmt):
         """For assignment like lhs[idx] = rhs, where both lhs and rhs are arrays, do the
         following:
-        1. find the definition of rhs, which has to be a call to numba.unsafe.ndarray.empty_inferred
-        2. find the source array creation for lhs, insert an extra dimension of size of b.
-        3. replace the definition of rhs = numba.unsafe.ndarray.empty_inferred(...) with rhs = lhs[idx]
+        1. find the definition of rhs, which has to be a call to
+           numba.unsafe.ndarray.empty_inferred
+        2. find the source array creation for lhs, insert an extra dimension of
+           size of b.
+        3. replace the definition of rhs =
+           numba.unsafe.ndarray.empty_inferred(...) with rhs = lhs[idx]
         """
         require(isinstance(stmt, ir.SetItem))
         require(isinstance(stmt.value, ir.Var))
@@ -1274,11 +1324,13 @@ def _fix_nested_array(func_ir):
         dim_def = get_definition(func_ir, rhs_def.args[0])
         require(isinstance(dim_def, ir.Expr) and dim_def.op == 'build_tuple')
         debug_print("dim_def = ", dim_def)
-        extra_dims = [ get_definition(func_ir, x, lhs_only=True) for x in dim_def.items ]
+        extra_dims = [ get_definition(func_ir, x, lhs_only=True)
+                       for x in dim_def.items ]
         debug_print("extra_dims = ", extra_dims)
         # Expand size tuple when creating lhs_def with extra_dims
         size_tuple_def = get_definition(func_ir, lhs_def.args[0])
-        require(isinstance(size_tuple_def, ir.Expr) and size_tuple_def.op == 'build_tuple')
+        require(isinstance(size_tuple_def, ir.Expr)
+                and size_tuple_def.op == 'build_tuple')
         debug_print("size_tuple_def = ", size_tuple_def)
         extra_dims = fix_dependencies(size_tuple_def, extra_dims)
         size_tuple_def.items += extra_dims
@@ -1300,9 +1352,11 @@ def _fix_nested_array(func_ir):
             if guard(fix_array_assign, stmt):
                 block.body.remove(stmt)
 
+
 def _new_definition(func_ir, var, value, loc):
     func_ir._definitions[var.name] = [value]
     return ir.Assign(value=value, target=var, loc=loc)
+
 
 @rewrites.register_rewrite('after-inference')
 class RewriteArrayOfConsts(rewrites.Rewrite):
@@ -1328,9 +1382,9 @@ class RewriteArrayOfConsts(rewrites.Rewrite):
 
 
 def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
-    """Look for array(list) call where list is a constant list created by build_list,
-    and turn them into direct array creation and initialization, if the following
-    conditions are met:
+    """Look for array(list) call where list is a constant list created by
+    build_list, and turn them into direct array creation and initialization, if
+    the following conditions are met:
       1. The build_list call immediate precedes the array call;
       2. The list variable is no longer live after array call;
     If any condition check fails, no modification will be made.
@@ -1349,8 +1403,8 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         require(callname and callname[1] == 'numpy' and callname[0] == 'array')
         require(expr.args[0].name in list_vars)
         ret_type = calltypes[expr].return_type
-        require(isinstance(ret_type, types.ArrayCompatible) and
-                           ret_type.ndim == 1)
+        require(isinstance(ret_type, types.ArrayCompatible)
+                and ret_type.ndim == 1)
         loc = expr.loc
         list_var = expr.args[0]
         # Get the type of the array to be created.
@@ -1368,10 +1422,12 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         size_tuple_typ = types.UniTuple(size_typ, 1)
         typemap[size_var.name] = size_typ
         typemap[size_tuple_var.name] = size_tuple_typ
-        stmts.append(_new_definition(func_ir, size_var,
-                 ir.Const(size, loc=loc), loc))
+        stmts.append(_new_definition(func_ir, size_var, ir.Const(size,
+                                                                 loc=loc),
+                                     loc))
         stmts.append(_new_definition(func_ir, size_tuple_var,
-                 ir.Expr.build_tuple(items=[size_var], loc=loc), loc))
+                                     ir.Expr.build_tuple(items=[size_var],
+                                                         loc=loc), loc))
 
         # The general approach is to create an empty array and then fill
         # the elements in one-by-one from their specificiation.
@@ -1382,12 +1438,15 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         # Create a variable to hold the numpy empty function.
         empty_func = ir.Var(scope, mk_unique_var("empty_func"), loc)
         fnty = get_np_ufunc_typ(np.empty)
-        sig = context.resolve_function_type(fnty, (size_typ,), {'dtype':nptype})
+        # XXX: Does this do anything?
+        context.resolve_function_type(fnty, (size_typ,), {'dtype':nptype})
 
         typemap[empty_func.name] = fnty
 
-        stmts.append(_new_definition(func_ir, empty_func,
-                         ir.Global('empty', np.empty, loc=loc), loc))
+        stmts.append(_new_definition(func_ir, empty_func, ir.Global('empty',
+                                                                    np.empty,
+                                                                    loc=loc),
+                                     loc))
 
         # We pass two arguments to empty, first the size tuple and second
         # the dtype of the new array.  Here, we created typ_var which is
@@ -1420,8 +1479,8 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
             index_var = ir.Var(scope, mk_unique_var("index"), loc)
             index_typ = types.intp
             typemap[index_var.name] = index_typ
-            stmts.append(_new_definition(func_ir, index_var,
-                    ir.Const(i, loc), loc))
+            stmts.append(_new_definition(func_ir, index_var, ir.Const(i, loc),
+                                         loc))
             setitem = ir.SetItem(array_var, index_var, seq[i], loc)
             calltypes[setitem] = typing.signature(types.none, array_typ,
                                                   index_typ, dtype)
@@ -1441,13 +1500,14 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
             # list_vars keep track of the variable created from the latest
             # build_list instruction, as well as its synonyms.
             self.list_vars = []
-            # dead_vars keep track of those in list_vars that are considered dead.
+            # dead_vars keep track of those in list_vars that are considered
+            # dead.
             self.dead_vars = []
             # list_items keep track of the elements used in build_list.
             self.list_items = []
             self.stmts = []
-            # dels keep track of the deletion of list_items, which will need to be
-            # moved after array initialization.
+            # dels keep track of the deletion of list_items, which will need to
+            # be moved after array initialization.
             self.dels = []
             # tracks if a modification has taken place
             self.modified = False
@@ -1487,7 +1547,6 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
                     state.stmts.append(inst)
                     continue
                 elif expr.op == 'call' and expr in calltypes:
-                    arr_var = inst.target
                     if guard(inline_array, inst.target, expr,
                              state.stmts, state.list_vars, state.dels):
                         state.modified = True
@@ -1510,10 +1569,10 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
                     # will also be empty when we reach this point.
                     body = []
                     for inst in state.stmts:
-                        if ((isinstance(inst, ir.Assign) and
-                             inst.target.name in state.dead_vars) or
-                             (isinstance(inst, ir.Del) and
-                             inst.value in state.dead_vars)):
+                        if ((isinstance(inst, ir.Assign)
+                             and inst.target.name in state.dead_vars)
+                            or (isinstance(inst, ir.Del) and
+                                inst.value in state.dead_vars)):
                             continue
                         body.append(inst)
                     state.stmts = body

--- a/numba/core/ir.py
+++ b/numba/core/ir.py
@@ -12,8 +12,7 @@ from functools import total_ordering
 from io import StringIO
 
 from numba.core import errors, config
-from numba.core.utils import (BINOPS_TO_OPERATORS, INPLACE_BINOPS_TO_OPERATORS,
-                              UNARY_BUITINS_TO_OPERATORS, OPERATORS_TO_BUILTINS)
+from numba.core.utils import (UNARY_BUITINS_TO_OPERATORS, OPERATORS_TO_BUILTINS)
 from numba.core.errors import (NotDefinedError, RedefinedError,
                                VerificationError, ConstantInferenceError)
 from numba.core import consts
@@ -43,10 +42,14 @@ class Loc(object):
 
     def __eq__(self, other):
         # equivalence is solely based on filename, line and col
-        if type(self) is not type(other): return False
-        if self.filename != other.filename: return False
-        if self.line != other.line: return False
-        if self.col != other.col: return False
+        if type(self) is not type(other):
+            return False
+        if self.filename != other.filename:
+            return False
+        if self.line != other.line:
+            return False
+        if self.col != other.col:
+            return False
         return True
 
     def __ne__(self, other):
@@ -107,7 +110,6 @@ class Loc(object):
             path = os.path.abspath(self.filename)
         return path
 
-
     def strformat(self, nlines_up=2):
 
         lines = self.get_lines()
@@ -135,7 +137,6 @@ class Loc(object):
                         index = idx
                         break
                 use_line = use_line + index
-
 
         ret = [] # accumulates output
         if lines and use_line:
@@ -169,7 +170,7 @@ class Loc(object):
                 if fn_name:
                     ret.append(fn_name)
                     spaces = count_spaces(x)
-                    ret.append(' '*(4 + spaces) + '<source elided>\n')
+                    ret.append(' ' * (4 + spaces) + '<source elided>\n')
 
             if selected:
                 ret.extend(selected[:-1])
@@ -177,13 +178,13 @@ class Loc(object):
 
                 # point at the problem with a caret
                 spaces = count_spaces(selected[-1])
-                ret.append(' '*(spaces) + _termcolor.indicate("^"))
+                ret.append(' ' * (spaces) + _termcolor.indicate("^"))
 
         # if in the REPL source may not be available
         if not ret:
             ret = "<source missing, REPL/exec in use?>"
 
-        err = _termcolor.filename('\nFile "%s", line %d:')+'\n%s'
+        err = _termcolor.filename('\nFile "%s", line %d:') + '\n%s'
         tmp = err % (self._get_path(), use_line, _termcolor.code(''.join(ret)))
         return tmp
 
@@ -544,7 +545,8 @@ class Expr(Inst):
         """
         assert isinstance(loc, Loc)
         op = 'make_function'
-        return cls(op=op, name=name, code=code, closure=closure, defaults=defaults, loc=loc)
+        return cls(op=op, name=name, code=code, closure=closure,
+                   defaults=defaults, loc=loc)
 
     @classmethod
     def null(cls, loc):
@@ -575,7 +577,8 @@ class Expr(Inst):
     def __repr__(self):
         if self.op == 'call':
             args = ', '.join(str(a) for a in self.args)
-            pres_order = self._kws.items() if config.DIFF_IR == 0 else sorted(self._kws.items())
+            pres_order = (self._kws.items() if config.DIFF_IR == 0
+                          else sorted(self._kws.items()))
             kws = ', '.join('%s=%s' % (k, v) for k, v in pres_order)
             vararg = '*%s' % (self.vararg,) if self.vararg is not None else ''
             arglist = ', '.join(filter(None, [args, vararg, kws]))
@@ -587,7 +590,8 @@ class Expr(Inst):
             fn = OPERATORS_TO_BUILTINS.get(self.fn, self.fn)
             return '%s %s %s' % (lhs, fn, rhs)
         else:
-            pres_order = self._kws.items() if config.DIFF_IR == 0 else sorted(self._kws.items())
+            pres_order = (self._kws.items() if config.DIFF_IR == 0
+                          else sorted(self._kws.items()))
             args = ('%s=%s' % (k, v) for k, v in pres_order)
             return '%s(%s)' % (self.op, ', '.join(args))
 
@@ -748,7 +752,8 @@ class StaticRaise(Terminator):
             return "<static> raise %s" % (self.exc_class,)
         else:
             return "<static> raise %s(%s)" % (self.exc_class,
-                                     ", ".join(map(repr, self.exc_args)))
+                                              ", ".join(map(repr,
+                                                            self.exc_args)))
 
     def get_targets(self):
         return []
@@ -788,7 +793,8 @@ class StaticTryRaise(Stmt):
             return "static_try_raise %s" % (self.exc_class,)
         else:
             return "static_try_raise %s(%s)" % (self.exc_class,
-                                     ", ".join(map(repr, self.exc_args)))
+                                                ", ".join(map(repr,
+                                                              self.exc_args)))
 
 
 class Return(Terminator):
@@ -1010,7 +1016,6 @@ class FreeVar(EqualityCheckMixin, AbstractRHS):
                        loc=self.loc)
 
 
-
 class Var(EqualityCheckMixin, AbstractRHS):
     """
     Attributes
@@ -1155,6 +1160,7 @@ class Scope(EqualityCheckMixin):
         Gets all known versions of a given name
         """
         vers = set()
+
         def walk(thename):
             redefs = self.var_redefinitions.get(thename, None)
             if redefs:
@@ -1514,7 +1520,6 @@ class FunctionIR(object):
 
         raise ValueError("Could not find an assignee for %s" % rhs_value)
 
-
     def dump(self, file=None):
         nofile = file is None
         # Avoid early bind of sys.stdout as default value
@@ -1526,7 +1531,7 @@ class FunctionIR(object):
             text = file.getvalue()
             if config.HIGHLIGHT_DUMPS:
                 try:
-                    import pygments
+                    import pygments  # noqa: F401
                 except ImportError:
                     msg = "Please install pygments to see highlighted dumps"
                     raise ValueError(msg)
@@ -1540,7 +1545,6 @@ class FunctionIR(object):
             else:
                 print(text)
 
-
     def dump_to_string(self):
         with StringIO() as sb:
             self.dump(file=sb)
@@ -1551,7 +1555,8 @@ class FunctionIR(object):
         gi = self.generator_info
         print("generator state variables:", sorted(gi.state_vars), file=file)
         for index, yp in sorted(gi.yield_points.items()):
-            print("yield point #%d: live variables = %s, weak live variables = %s"
+            print("yield point #%d: live variables = %s, "
+                  "weak live variables = %s"
                   % (index, sorted(yp.live_vars), sorted(yp.weak_live_vars)),
                   file=file)
 


### PR DESCRIPTION
This makes some files in `numba.core` flake8 compliant, but before I could finish them all it got to the point where I've spent a bit too much time on this. The remainder can be addressed later.

This PR also removes some non-existent files from the ignore list.