### PR TITLE
Make `numpy.searchsorted` match NumPy when first argument is unsorted

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3740,8 +3740,29 @@ def np_bincount(a, weights=None, minlength=0):
 
 
 def _searchsorted(func):
-    def searchsorted_inner(a, v):
-        n = len(a)
+    def searchsorted_inner(a, v, v_last, lo, hi, n):
+        """Perform inner loop of searchsorted (i.e. a binary search).
+
+        This is loosely based on the NumPy implementation in [1]_.
+
+        Parameters
+        ----------
+        a: 1-D array_like
+            The input array.
+        v: array_like
+            The current value to insert into `a`.
+        v_last: array_like
+            The previous value inserted into `a`.
+        lo: int
+            The initial/previous "low" value of the binary search.
+        hi: int
+            The initial/previous "high" value of the binary search.
+        n: int
+            The length of `a`.
+
+
+        .. [1] https://github.com/numpy/numpy/blob/809e8d26b03f549fd0b812a17b8a166bcd966889/numpy/core/src/npysort/binsearch.cpp#L173
+        """  # noqa: E501
         if np.isnan(v):
             # Find the first nan (i.e. the last from the end of a,
             # since there shouldn't be many of them in practice)
@@ -3749,8 +3770,13 @@ def _searchsorted(func):
                 if not np.isnan(a[i - 1]):
                     return i
             return 0
-        lo = 0
-        hi = n
+
+        if v_last < v:
+            hi = n
+        else:
+            lo = 0
+            hi = hi + 1 if hi < n else n
+
         while hi > lo:
             mid = (lo + hi) >> 1
             if func(a[mid], (v)):
@@ -3782,24 +3808,36 @@ def searchsorted(a, v, side='left'):
     if isinstance(v, types.Array):
         # N-d array and output
         def searchsorted_impl(a, v, side='left'):
+            n = len(a)
+            lo = 0
+            hi = n
             out = np.empty(v.shape, np.intp)
+            v_last = v.flat[0]
             for view, outview in np.nditer((v, out)):
-                index = loop_impl(a, view.item())
-                outview.itemset(index)
+                lo = loop_impl(a, view.item(), v_last, lo, hi, n)
+                v_last = view.item()
+                outview.itemset(lo)
             return out
 
     elif isinstance(v, types.Sequence):
         # 1-d sequence and output
         def searchsorted_impl(a, v, side='left'):
+            n = len(a)
+            lo = 0
+            hi = n
             out = np.empty(len(v), np.intp)
+            v_last = v[0]
             for i in range(len(v)):
-                out[i] = loop_impl(a, v[i])
+                lo = loop_impl(a, v[i], v_last, lo, hi, n)
+                out[i] = lo
+                v_last = v[i]
             return out
     else:
         # Scalar value and output
         # Note: NaNs come last in Numpy-sorted arrays
         def searchsorted_impl(a, v, side='left'):
-            return loop_impl(a, v)
+            n = len(a)
+            return loop_impl(a, v, v, 0, n, n)
 
     return searchsorted_impl
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1109,6 +1109,16 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         )
         check(a, v)
 
+        a = np.array([9, 1, 4, 2, 0, 3, 7, 6, 8])
+        v = np.array(
+            [
+                [5, 10],
+                [10, 5],
+                [-1, 5],
+            ]
+        )
+        check(a, v)
+
     def test_digitize(self):
         pyfunc = digitize
         cfunc = jit(nopython=True)(pyfunc)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1098,12 +1098,13 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             cfunc([1,2], 1, side='right')
 
         # Test unordered values
-        a = np.array([0.29769574, 0.71649186, 0.20475563])
+        a = np.array([1, 2, 0])
         v = np.array(
             [
-                [0.18847123, 0.39659508],
-                [0.56220006, 0.57428752],
-                [0.86720994, 0.44522637],
+                [5, 4],
+                [6, 7],
+                [2, 1],
+                [0, 3],
             ]
         )
         check(a, v)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1097,6 +1097,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertTypingError():
             cfunc([1,2], 1, side='right')
 
+        # Test unordered values
+        a = np.array([0.29769574, 0.71649186, 0.20475563])
+        v = np.array(
+            [
+                [0.18847123, 0.39659508],
+                [0.56220006, 0.57428752],
+                [0.86720994, 0.44522637],
+            ]
+        )
+        check(a, v)
+
     def test_digitize(self):
         pyfunc = digitize
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
This PR makes Numba's `searchsorted` implementation match NumPy's when the first argument isn't sorted.

Here's an example of the discrepancy under the current Numba implementation:
```python
import numpy as np
import numba


@numba.njit
def numba_searchsorted(a, b):
    return np.searchsorted(a, b, "right")


a = np.array([0.29769574, 0.71649186, 0.20475563])
v = np.array(
    [
        [0.18847123, 0.39659508],
        [0.56220006, 0.57428752],
        [0.86720994, 0.44522637],
    ]
)

numba_searchsorted(a, v)
# array([[0, 1],
#        [1, 1],
#        [3, 1]])

np.searchsorted(a, v, side="right")
# array([[0, 1],
#        [3, 3],
#        [3, 1]])
```