### PR TITLE
Made stencil compilation not fail for arrays of conflicting types.

### DIFF
--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -35,6 +35,15 @@ class StencilFuncLowerer(object):
 @register_jitable
 def raise_if_incompatible_array_sizes(a, *args):
     ashape = a.shape
+
+    # We need literal_unroll here because the stencil might take
+    # multiple input arrays with different types that are not compatible
+    # (e.g. values as float[:] and flags as bool[:])
+    # When more than three total arrays are given, the second and third
+    # are iterated over in the loop below. Without literal_unroll, their
+    # types have to match.
+    # An example failing signature without literal_unroll might be
+    # (float[:], float[:], bool[:]) (Just (float[:], bool[:]) wouldn't fail)
     for arg in literal_unroll(args):
         if a.ndim != arg.ndim:
             raise ValueError("Secondary stencil array does not have same number "

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -13,6 +13,7 @@ from numba.core.typing.templates import (CallableTemplate, signature,
                                          infer_global, AbstractTemplate)
 from numba.core.imputils import lower_builtin
 from numba.core.extending import register_jitable
+from numba.misc.special import literal_unroll
 import numba
 
 import operator
@@ -34,7 +35,7 @@ class StencilFuncLowerer(object):
 @register_jitable
 def raise_if_incompatible_array_sizes(a, *args):
     ashape = a.shape
-    for arg in args:
+    for arg in literal_unroll(args):
         if a.ndim != arg.ndim:
             raise ValueError("Secondary stencil array does not have same number "
                              " of dimensions as the first stencil input.")

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -57,6 +57,11 @@ def stencil_multiple_input_kernel_var(a, b, w):
                 b[0, 1] + b[1, 0] + b[0, -1] + b[-1, 0])
 
 
+@stencil
+def stencil_multiple_input_mixed_types_2d(a, b, f):
+    return a[0, 0] if f[0, 0] else b[0, 0]
+
+
 @stencil(standard_indexing=("b",))
 def stencil_with_standard_indexing_1d(a, b):
     return a[-1] * b[0] + a[0] * b[1]
@@ -360,6 +365,28 @@ class TestStencil(TestStencilBase):
             w = 0.25
             C = stencil_multiple_input_kernel_var(A, B, w)
             return C
+        self.check(test_impl_seq, test_seq, n)
+
+    @skip_unsupported
+    def test_stencil_mixed_types(self):
+        def test_impl_seq(n):
+            A = np.arange(n ** 2).reshape((n, n))
+            B = n ** 2 - np.arange(n ** 2).reshape((n, n))
+            S = np.eye(n, dtype=np.bool_)
+            O = np.zeros((n, n), dtype=A.dtype)
+            for i in range(0, n):
+                for j in range(0, n):
+                    O[i, j] = A[i, j] if S[i, j] else B[i, j]
+            return O
+
+        def test_seq(n):
+            A = np.arange(n ** 2).reshape((n, n))
+            B = n ** 2 - np.arange(n ** 2).reshape((n, n))
+            S = np.eye(n, dtype=np.bool_)
+            O = stencil_multiple_input_mixed_types_2d(A, B, S)
+            return O
+
+        n = 3
         self.check(test_impl_seq, test_seq, n)
 
     @skip_unsupported


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Based on a short bug report on [gitter](https://gitter.im/numba/numba?at=60959645c651cb6a001aa559).

Makes `raise_if_incompatible_array_sizes` use `literal_unroll` so that there is no problem when passed arrays 2 and 3 (e.g. `args[0]` and `args[1]`) are of type than can't be unified (i.e. `bool` and `int`).

I also added a test, but I am not completly sure if they are ok in the form they are.