### PR TITLE
Allocate new memory in the stack to save array transpose value insteading of sharing memory with original array, this fix numba#6949 .

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1004,7 +1004,7 @@ class Lower(BaseLower):
             return self.lower_binop(resty, expr, expr.fn)
         elif expr.op == 'inplace_binop':
             lty = self.typeof(expr.lhs.name)
-            if lty.mutable and self.fndesc.noalias:
+            if lty.mutable:
                 return self.lower_binop(resty, expr, expr.fn)
             else:
                 # inplace operators on non-mutable types reuse the same

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1004,7 +1004,7 @@ class Lower(BaseLower):
             return self.lower_binop(resty, expr, expr.fn)
         elif expr.op == 'inplace_binop':
             lty = self.typeof(expr.lhs.name)
-            if lty.mutable:
+            if lty.mutable and self.fndesc.noalias:
                 return self.lower_binop(resty, expr, expr.fn)
             else:
                 # inplace operators on non-mutable types reuse the same

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1551,8 +1551,11 @@ def array_T(context, builder, typ, value):
         ret = make_array(typ)(context, builder)
         shapes = cgutils.unpack_tuple(builder, ary.shape, typ.ndim)
         strides = cgutils.unpack_tuple(builder, ary.strides, typ.ndim)
+        llvm_type = context.get_value_type(typ.dtype)
+        data_ptr = builder.alloca(llvm_type, ary.nitems)
+        cgutils.memcpy(builder, data_ptr, ary.data, ary.nitems)
         populate_array(ret,
-                       data=ary.data,
+                       data=data_ptr,
                        shape=cgutils.pack_array(builder, shapes[::-1]),
                        strides=cgutils.pack_array(builder, strides[::-1]),
                        itemsize=ary.itemsize,


### PR DESCRIPTION

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
The result of array inpalce binop(such as+=`) is ircorrect since the array transpose data are sharing memory with original array, which cased the transposed array data changed during the inplace binop calculation. For example (provided in #6949):
```
@jit 
def self_addition(x):
    x += x.T
    return x

x = np.array([[1,2],[3,4]])

self_addition(x)
> array([[2, 5],[8, 8]])
```
In this case, `x` will be temporarily changed to `[[2,5], [3,4]]` since the first row will be calculated first when matrix addition is performed. Therefore, `x.T` will be `[[2,3], [5,4]]`  (the correct value is `[[1,3], [2,4]]`) when the second row is calculated. Therefore, numba should allocate new memory in the stack to save array transpose data insteading of sharing memory with original array.

