### PR TITLE
CUDA: Convert some intrinsics to use `@intrinsic`

### DIFF
--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -16,20 +16,6 @@ register_global = registry.register_global
 register_number_classes(register_global)
 
 
-class GridFunction(CallableTemplate):
-    def generic(self):
-        def typer(ndim):
-            val = ndim.literal_value
-            if val == 1:
-                restype = types.int32
-            elif val in (2, 3):
-                restype = types.UniTuple(types.int32, val)
-            else:
-                raise ValueError('argument can only be 1, 2, 3')
-            return signature(restype, types.int32)
-        return typer
-
-
 class Cuda_array_decl(CallableTemplate):
     def generic(self):
         def typer(shape, dtype):

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -30,11 +30,6 @@ class GridFunction(CallableTemplate):
         return typer
 
 
-@register
-class Cuda_gridsize(GridFunction):
-    key = cuda.gridsize
-
-
 class Cuda_array_decl(CallableTemplate):
     def generic(self):
         def typer(shape, dtype):
@@ -470,9 +465,6 @@ class CudaAtomicTemplate(AttributeTemplate):
 @register_attr
 class CudaModuleTemplate(AttributeTemplate):
     key = types.Module(cuda)
-
-    def resolve_gridsize(self, mod):
-        return types.Function(Cuda_gridsize)
 
     def resolve_cg(self, mod):
         return types.Module(cuda.cg)

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -31,11 +31,6 @@ class GridFunction(CallableTemplate):
 
 
 @register
-class Cuda_grid(GridFunction):
-    key = cuda.grid
-
-
-@register
 class Cuda_gridsize(GridFunction):
     key = cuda.gridsize
 
@@ -475,9 +470,6 @@ class CudaAtomicTemplate(AttributeTemplate):
 @register_attr
 class CudaModuleTemplate(AttributeTemplate):
     key = types.Module(cuda)
-
-    def resolve_grid(self, mod):
-        return types.Function(Cuda_grid)
 
     def resolve_gridsize(self, mod):
         return types.Function(Cuda_gridsize)

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -443,9 +443,6 @@ class CudaModuleTemplate(AttributeTemplate):
     def resolve_gridDim(self, mod):
         return dim3
 
-    def resolve_warpsize(self, mod):
-        return types.int32
-
     def resolve_laneid(self, mod):
         return types.int32
 

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -75,30 +75,6 @@ class Cuda_const_array_like(CallableTemplate):
 
 
 @register
-class Cuda_syncthreads(ConcreteTemplate):
-    key = cuda.syncthreads
-    cases = [signature(types.none)]
-
-
-@register
-class Cuda_syncthreads_count(ConcreteTemplate):
-    key = cuda.syncthreads_count
-    cases = [signature(types.i4, types.i4)]
-
-
-@register
-class Cuda_syncthreads_and(ConcreteTemplate):
-    key = cuda.syncthreads_and
-    cases = [signature(types.i4, types.i4)]
-
-
-@register
-class Cuda_syncthreads_or(ConcreteTemplate):
-    key = cuda.syncthreads_or
-    cases = [signature(types.i4, types.i4)]
-
-
-@register
 class Cuda_threadfence_device(ConcreteTemplate):
     key = cuda.threadfence
     cases = [signature(types.none)]
@@ -507,18 +483,6 @@ class CudaModuleTemplate(AttributeTemplate):
 
     def resolve_cbrt(self, mod):
         return types.Function(Cuda_cbrt)
-
-    def resolve_syncthreads(self, mod):
-        return types.Function(Cuda_syncthreads)
-
-    def resolve_syncthreads_count(self, mod):
-        return types.Function(Cuda_syncthreads_count)
-
-    def resolve_syncthreads_and(self, mod):
-        return types.Function(Cuda_syncthreads_and)
-
-    def resolve_syncthreads_or(self, mod):
-        return types.Function(Cuda_syncthreads_or)
 
     def resolve_threadfence(self, mod):
         return types.Function(Cuda_threadfence_device)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -51,11 +51,6 @@ def cuda_laneid(context, builder, sig, args):
     return nvvmutils.call_sreg(builder, 'laneid')
 
 
-@lower_attr(types.Module(cuda), 'warpsize')
-def cuda_warpsize(context, builder, sig, args):
-    return nvvmutils.call_sreg(builder, 'warpsize')
-
-
 @lower_attr(dim3, 'x')
 def dim3_x(context, builder, sig, args):
     return builder.extract_value(args, 0)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -91,17 +91,6 @@ def ptx_sync_group(context, builder, sig, args):
 
 # -----------------------------------------------------------------------------
 
-@lower(cuda.grid, types.int32)
-def cuda_grid(context, builder, sig, args):
-    restype = sig.return_type
-    if restype == types.int32:
-        return nvvmutils.get_global_id(builder, dim=1)
-    elif isinstance(restype, types.UniTuple):
-        ids = nvvmutils.get_global_id(builder, dim=restype.count)
-        return cgutils.pack_array(builder, ids)
-    else:
-        raise ValueError('Unexpected return type %s from cuda.grid' % restype)
-
 
 def _nthreads_for_dim(builder, dim):
     ntid = nvvmutils.call_sreg(builder, f"ntid.{dim}")

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -153,44 +153,6 @@ def ptx_lmem_alloc_array(context, builder, sig, args):
                           can_dynsized=False)
 
 
-@lower(stubs.syncthreads)
-def ptx_syncthreads(context, builder, sig, args):
-    assert not args
-    fname = 'llvm.nvvm.barrier0'
-    lmod = builder.module
-    fnty = ir.FunctionType(ir.VoidType(), ())
-    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
-    builder.call(sync, ())
-    return context.get_dummy_value()
-
-
-@lower(stubs.syncthreads_count, types.i4)
-def ptx_syncthreads_count(context, builder, sig, args):
-    fname = 'llvm.nvvm.barrier0.popc'
-    lmod = builder.module
-    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
-    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
-    return builder.call(sync, args)
-
-
-@lower(stubs.syncthreads_and, types.i4)
-def ptx_syncthreads_and(context, builder, sig, args):
-    fname = 'llvm.nvvm.barrier0.and'
-    lmod = builder.module
-    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
-    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
-    return builder.call(sync, args)
-
-
-@lower(stubs.syncthreads_or, types.i4)
-def ptx_syncthreads_or(context, builder, sig, args):
-    fname = 'llvm.nvvm.barrier0.or'
-    lmod = builder.module
-    fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
-    sync = cgutils.get_or_insert_function(lmod, fnty, fname)
-    return builder.call(sync, args)
-
-
 @lower(stubs.threadfence_block)
 def ptx_threadfence_block(context, builder, sig, args):
     assert not args

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -91,35 +91,6 @@ def ptx_sync_group(context, builder, sig, args):
 
 # -----------------------------------------------------------------------------
 
-
-def _nthreads_for_dim(builder, dim):
-    ntid = nvvmutils.call_sreg(builder, f"ntid.{dim}")
-    nctaid = nvvmutils.call_sreg(builder, f"nctaid.{dim}")
-    return builder.mul(ntid, nctaid)
-
-
-@lower(cuda.gridsize, types.int32)
-def cuda_gridsize(context, builder, sig, args):
-    restype = sig.return_type
-    nx = _nthreads_for_dim(builder, 'x')
-
-    if restype == types.int32:
-        return nx
-    elif isinstance(restype, types.UniTuple):
-        ny = _nthreads_for_dim(builder, 'y')
-
-        if restype.count == 2:
-            return cgutils.pack_array(builder, (nx, ny))
-        elif restype.count == 3:
-            nz = _nthreads_for_dim(builder, 'z')
-            return cgutils.pack_array(builder, (nx, ny, nz))
-
-    # Fallthrough to here indicates unexpected return type or tuple length
-    raise ValueError('Unexpected return type %s of cuda.gridsize' % restype)
-
-
-# -----------------------------------------------------------------------------
-
 @lower(cuda.const.array_like, types.Array)
 def cuda_const_array_like(context, builder, sig, args):
     # This is a no-op because CUDATargetContext.make_constant_array already

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -2,11 +2,12 @@
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     warpsize, syncthreads, syncthreads_count, syncwarp,
                     syncthreads_and, syncthreads_or, shared, local,
-                    const, grid, gridsize, atomic, shfl_sync_intrinsic,
+                    const, gridsize, atomic, shfl_sync_intrinsic,
                     vote_sync_intrinsic, match_any_sync, match_all_sync,
                     threadfence_block, threadfence_system,
                     threadfence, selp, popc, brev, clz, ffs, fma, cbrt,
                     cg, activemask, lanemask_lt, nanosleep)
+from .intrinsics import grid
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -2,12 +2,11 @@
 from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
                     warpsize, syncthreads, syncthreads_count, syncwarp,
                     syncthreads_and, syncthreads_or, shared, local,
-                    const, gridsize, atomic, shfl_sync_intrinsic,
-                    vote_sync_intrinsic, match_any_sync, match_all_sync,
-                    threadfence_block, threadfence_system,
-                    threadfence, selp, popc, brev, clz, ffs, fma, cbrt,
-                    cg, activemask, lanemask_lt, nanosleep)
-from .intrinsics import grid
+                    const, atomic, shfl_sync_intrinsic, vote_sync_intrinsic,
+                    match_any_sync, match_all_sync, threadfence_block,
+                    threadfence_system, threadfence, selp, popc, brev, clz,
+                    ffs, fma, cbrt, cg, activemask, lanemask_lt, nanosleep)
+from .intrinsics import grid, gridsize
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -1,12 +1,12 @@
 # Re export
-from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid,
-                    warpsize, syncthreads, syncthreads_count, syncwarp,
-                    syncthreads_and, syncthreads_or, shared, local,
-                    const, atomic, shfl_sync_intrinsic, vote_sync_intrinsic,
-                    match_any_sync, match_all_sync, threadfence_block,
-                    threadfence_system, threadfence, selp, popc, brev, clz,
-                    ffs, fma, cbrt, cg, activemask, lanemask_lt, nanosleep)
-from .intrinsics import grid, gridsize
+from .stubs import (threadIdx, blockIdx, blockDim, gridDim, laneid, warpsize,
+                    syncwarp, shared, local, const, atomic,
+                    shfl_sync_intrinsic, vote_sync_intrinsic, match_any_sync,
+                    match_all_sync, threadfence_block, threadfence_system,
+                    threadfence, selp, popc, brev, clz, ffs, fma, cbrt, cg,
+                    activemask, lanemask_lt, nanosleep)
+from .intrinsics import (grid, gridsize, syncthreads, syncthreads_and,
+                         syncthreads_count, syncthreads_or)
 from .cudadrv.error import CudaSupportError
 from numba.cuda.cudadrv.driver import (BaseCUDAMemoryManager,
                                        HostOnlyCUDAMemoryManager,

--- a/numba/cuda/extending.py
+++ b/numba/cuda/extending.py
@@ -1,0 +1,7 @@
+"""
+Added for symmetry with the core API
+"""
+
+from numba.core.extending import intrinsic as _intrinsic
+
+intrinsic = _intrinsic(target='cuda')

--- a/numba/cuda/extending.py
+++ b/numba/cuda/extending.py
@@ -4,4 +4,4 @@ Added for symmetry with the core API
 
 from numba.core.extending import intrinsic as _intrinsic
 
-intrinsic = _intrinsic(target='cuda')
+intrinsic = _intrinsic(hardware='cuda')

--- a/numba/cuda/intrinsics.py
+++ b/numba/cuda/intrinsics.py
@@ -5,6 +5,18 @@ from numba.cuda import nvvmutils
 from numba.cuda.extending import intrinsic
 
 
+def _type_grid_function(ndim):
+    val = ndim.literal_value
+    if val == 1:
+        restype = types.int32
+    elif val in (2, 3):
+        restype = types.UniTuple(types.int32, val)
+    else:
+        raise ValueError('argument can only be 1, 2, 3')
+
+    return signature(restype, types.int32)
+
+
 @intrinsic
 def grid(typingctx, ndim):
     '''grid(ndim)
@@ -25,15 +37,7 @@ def grid(typingctx, ndim):
     if not isinstance(ndim, types.IntegerLiteral):
         return None
 
-    val = ndim.literal_value
-    if val == 1:
-        restype = types.int32
-    elif val in (2, 3):
-        restype = types.UniTuple(types.int32, val)
-    else:
-        raise ValueError('argument can only be 1, 2, 3')
-
-    sig = signature(restype, types.int32)
+    sig = _type_grid_function(ndim)
 
     def codegen(context, builder, sig, args):
         restype = sig.return_type
@@ -42,5 +46,50 @@ def grid(typingctx, ndim):
         elif isinstance(restype, types.UniTuple):
             ids = nvvmutils.get_global_id(builder, dim=restype.count)
             return cgutils.pack_array(builder, ids)
+
+    return sig, codegen
+
+
+@intrinsic
+def gridsize(typingctx, ndim):
+    '''gridsize(ndim)
+
+    Return the absolute size (or shape) in threads of the entire grid of
+    blocks. *ndim* should correspond to the number of dimensions declared when
+    instantiating the kernel. If *ndim* is 1, a single integer is returned.
+    If *ndim* is 2 or 3, a tuple of the given number of integers is returned.
+
+    Computation of the first integer is as follows::
+
+        cuda.blockDim.x * cuda.gridDim.x
+
+    and is similar for the other two indices, but using the ``y`` and ``z``
+    attributes.
+    '''
+
+    if not isinstance(ndim, types.IntegerLiteral):
+        return None
+
+    sig = _type_grid_function(ndim)
+
+    def _nthreads_for_dim(builder, dim):
+        ntid = nvvmutils.call_sreg(builder, f"ntid.{dim}")
+        nctaid = nvvmutils.call_sreg(builder, f"nctaid.{dim}")
+        return builder.mul(ntid, nctaid)
+
+    def codegen(context, builder, sig, args):
+        restype = sig.return_type
+        nx = _nthreads_for_dim(builder, 'x')
+
+        if restype == types.int32:
+            return nx
+        elif isinstance(restype, types.UniTuple):
+            ny = _nthreads_for_dim(builder, 'y')
+
+            if restype.count == 2:
+                return cgutils.pack_array(builder, (nx, ny))
+            elif restype.count == 3:
+                nz = _nthreads_for_dim(builder, 'z')
+                return cgutils.pack_array(builder, (nx, ny, nz))
 
     return sig, codegen

--- a/numba/cuda/intrinsics.py
+++ b/numba/cuda/intrinsics.py
@@ -1,0 +1,46 @@
+from numba import types
+from numba.core import cgutils
+from numba.core.typing import signature
+from numba.cuda import nvvmutils
+from numba.cuda.extending import intrinsic
+
+
+@intrinsic
+def grid(typingctx, ndim):
+    '''grid(ndim)
+
+    Return the absolute position of the current thread in the entire grid of
+    blocks.  *ndim* should correspond to the number of dimensions declared when
+    instantiating the kernel. If *ndim* is 1, a single integer is returned.
+    If *ndim* is 2 or 3, a tuple of the given number of integers is returned.
+
+    Computation of the first integer is as follows::
+
+        cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
+
+    and is similar for the other two indices, but using the ``y`` and ``z``
+    attributes.
+    '''
+
+    if not isinstance(ndim, types.IntegerLiteral):
+        return None
+
+    val = ndim.literal_value
+    if val == 1:
+        restype = types.int32
+    elif val in (2, 3):
+        restype = types.UniTuple(types.int32, val)
+    else:
+        raise ValueError('argument can only be 1, 2, 3')
+
+    sig = signature(restype, types.int32)
+
+    def codegen(context, builder, sig, args):
+        restype = sig.return_type
+        if restype == types.int32:
+            return nvvmutils.get_global_id(builder, dim=1)
+        elif isinstance(restype, types.UniTuple):
+            ids = nvvmutils.get_global_id(builder, dim=restype.count)
+            return cgutils.pack_array(builder, ids)
+
+    return sig, codegen

--- a/numba/cuda/intrinsics.py
+++ b/numba/cuda/intrinsics.py
@@ -133,16 +133,11 @@ def _syncthreads_predicate(typingctx, predicate, fname):
     if predicate.bitwidth > 32:
         return None
 
-    sig = signature(types.i4, predicate)
+    sig = signature(types.i4, types.i4)
 
     def codegen(context, builder, sig, args):
         fnty = ir.FunctionType(ir.IntType(32), (ir.IntType(32),))
         sync = cgutils.get_or_insert_function(builder.module, fnty, fname)
-
-        # Cast predicate if necessary
-        if sig.args[0].bitwidth < 32:
-            args = [context.cast(builder, args[0], sig.args[0], types.int32)]
-
         return builder.call(sync, args)
 
     return sig, codegen

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -102,24 +102,6 @@ class laneid(Stub):
     _description_ = '<laneid>'
 
 
-class grid(Stub):
-    '''grid(ndim)
-
-    Return the absolute position of the current thread in the entire grid of
-    blocks.  *ndim* should correspond to the number of dimensions declared when
-    instantiating the kernel. If *ndim* is 1, a single integer is returned.
-    If *ndim* is 2 or 3, a tuple of the given number of integers is returned.
-
-    Computation of the first integer is as follows::
-
-        cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
-
-    and is similar for the other two indices, but using the ``y`` and ``z``
-    attributes.
-    '''
-    _description_ = '<grid(ndim)>'
-
-
 class gridsize(Stub):
     '''gridsize(ndim)
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -174,49 +174,6 @@ class cg(Stub):
             '''
 
 
-#-------------------------------------------------------------------------------
-# syncthreads
-
-class syncthreads(Stub):
-    '''
-    Synchronize all threads in the same thread block.  This function implements
-    the same pattern as barriers in traditional multi-threaded programming: this
-    function waits until all threads in the block call it, at which point it
-    returns control to all its callers.
-    '''
-    _description_ = '<syncthreads()>'
-
-
-class syncthreads_count(Stub):
-    '''
-    syncthreads_count(predictate)
-
-    An extension to numba.cuda.syncthreads where the return value is a count
-    of the threads where predicate is true.
-    '''
-    _description_ = '<syncthreads_count()>'
-
-
-class syncthreads_and(Stub):
-    '''
-    syncthreads_and(predictate)
-
-    An extension to numba.cuda.syncthreads where 1 is returned if predicate is
-    true for all threads or 0 otherwise.
-    '''
-    _description_ = '<syncthreads_and()>'
-
-
-class syncthreads_or(Stub):
-    '''
-    syncthreads_or(predictate)
-
-    An extension to numba.cuda.syncthreads where 1 is returned if predicate is
-    true for any thread or 0 otherwise.
-    '''
-    _description_ = '<syncthreads_or()>'
-
-
 # -------------------------------------------------------------------------------
 # warp level operations
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -102,24 +102,6 @@ class laneid(Stub):
     _description_ = '<laneid>'
 
 
-class gridsize(Stub):
-    '''gridsize(ndim)
-
-    Return the absolute size (or shape) in threads of the entire grid of
-    blocks. *ndim* should correspond to the number of dimensions declared when
-    instantiating the kernel. If *ndim* is 1, a single integer is returned.
-    If *ndim* is 2 or 3, a tuple of the given number of integers is returned.
-
-    Computation of the first integer is as follows::
-
-        cuda.blockDim.x * cuda.gridDim.x
-
-    and is similar for the other two indices, but using the ``y`` and ``z``
-    attributes.
-    '''
-    _description_ = '<gridsize(ndim)>'
-
-
 #-------------------------------------------------------------------------------
 # Array creation
 

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -221,6 +221,7 @@ class TestCudaSync(CUDATestCase):
     def test_syncthreads_count_upcast(self):
         self._test_syncthreads_count(np.int16)
 
+    @skip_on_cudasim('Simulator is not rigorous about type checking')
     def test_syncthreads_count_downcast(self):
         with self.assertRaises(TypingError) as raises:
             self._test_syncthreads_count(np.int64)
@@ -244,6 +245,7 @@ class TestCudaSync(CUDATestCase):
     def test_syncthreads_and_upcast(self):
         self._test_syncthreads_and(np.int16)
 
+    @skip_on_cudasim('Simulator is not rigorous about type checking')
     def test_syncthreads_and_downcast(self):
         with self.assertRaises(TypingError) as raises:
             self._test_syncthreads_and(np.int64)
@@ -267,6 +269,7 @@ class TestCudaSync(CUDATestCase):
     def test_syncthreads_or_upcast(self):
         self._test_syncthreads_or(np.int16)
 
+    @skip_on_cudasim('Simulator is not rigorous about type checking')
     def test_syncthreads_or_downcast(self):
         with self.assertRaises(TypingError) as raises:
             self._test_syncthreads_or(np.int64)

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -2,6 +2,7 @@ import numpy as np
 from numba import cuda, int32, float32
 from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
 from numba.core.config import ENABLE_CUDASIM
+from numba.core.errors import TypingError
 
 
 def useless_syncthreads(ary):
@@ -205,19 +206,31 @@ class TestCudaSync(CUDATestCase):
         if not ENABLE_CUDASIM:
             self.assertIn("membar.sys;", compiled.ptx)
 
-    def test_syncthreads_count(self):
-        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_count)
-        ary_in = np.ones(72, dtype=np.int32)
+    def _test_syncthreads_count(self, in_dtype):
+        compiled = cuda.jit(use_syncthreads_count)
+        ary_in = np.ones(72, dtype=in_dtype)
         ary_out = np.zeros(72, dtype=np.int32)
         ary_in[31] = 0
         ary_in[42] = 0
         compiled[1, 72](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 70))
 
-    def test_syncthreads_and(self):
-        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_and)
+    def test_syncthreads_count(self):
+        self._test_syncthreads_count(np.int32)
+
+    def test_syncthreads_count_upcast(self):
+        self._test_syncthreads_count(np.int16)
+
+    def test_syncthreads_count_downcast(self):
+        with self.assertRaises(TypingError) as raises:
+            self._test_syncthreads_count(np.int64)
+
+        self.assertIn("With argument(s): '(int64)'", str(raises.exception))
+
+    def _test_syncthreads_and(self, in_dtype):
+        compiled = cuda.jit(use_syncthreads_and)
         nelem = 100
-        ary_in = np.ones(nelem, dtype=np.int32)
+        ary_in = np.ones(nelem, dtype=in_dtype)
         ary_out = np.zeros(nelem, dtype=np.int32)
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 1))
@@ -225,16 +238,40 @@ class TestCudaSync(CUDATestCase):
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 0))
 
-    def test_syncthreads_or(self):
-        compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_or)
+    def test_syncthreads_and(self):
+        self._test_syncthreads_and(np.int32)
+
+    def test_syncthreads_and_upcast(self):
+        self._test_syncthreads_and(np.int16)
+
+    def test_syncthreads_and_downcast(self):
+        with self.assertRaises(TypingError) as raises:
+            self._test_syncthreads_and(np.int64)
+
+        self.assertIn("With argument(s): '(int64)'", str(raises.exception))
+
+    def _test_syncthreads_or(self, in_dtype):
+        compiled = cuda.jit(use_syncthreads_or)
         nelem = 100
-        ary_in = np.zeros(nelem, dtype=np.int32)
+        ary_in = np.zeros(nelem, dtype=in_dtype)
         ary_out = np.zeros(nelem, dtype=np.int32)
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 0))
         ary_in[31] = 1
         compiled[1, nelem](ary_in, ary_out)
         self.assertTrue(np.all(ary_out == 1))
+
+    def test_syncthreads_or(self):
+        self._test_syncthreads_or(np.int32)
+
+    def test_syncthreads_or_upcast(self):
+        self._test_syncthreads_or(np.int16)
+
+    def test_syncthreads_or_downcast(self):
+        with self.assertRaises(TypingError) as raises:
+            self._test_syncthreads_or(np.int64)
+
+        self.assertIn("With argument(s): '(int64)'", str(raises.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR converts `grid`, `gridsize`, and `syncthreads[_*]`, from implementations built on a stub, typing, and lowering, to implementations using the `@intrinsic` decorator.

Some additional tests are added to ensure that the casting behaviour for syncthreads functions that accept a predicate is as expected - for predicates narrower than 32 bits we would like them to be cast up - for predicates wider than 32 bits we'd like to present an error so that the predicate isn't truncated.

I plan to convert more of the implementations and add specific tests of the decorator, but this PR is for initial feedback before I proceed with translating too many - once this is approved I will continue with the rest of the translations.