### PR TITLE
Docs: Add DALI to list of CAI-supporting libraries

### DIFF
--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -513,6 +513,14 @@ The following Python libraries have adopted the CUDA Array Interface:
 - `ArrayViews <https://github.com/xnd-project/arrayviews>`_
 - `JAX <https://jax.readthedocs.io/en/latest/index.html>`_
 - `PyCUDA <https://documen.tician.de/pycuda/tutorial.html#interoperability-with-other-libraries-using-the-cuda-array-interface>`_
+- `DALI: the NVIDIA Data Loading Library (DALI) <https://github.com/NVIDIA/DALI>`_ :
+
+    - `TensorGPU objects
+      <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_
+      expose the CUDA Array Interface.
+    - `External Source objects
+      <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/supported_ops.html#nvidia.dali.fn.external_source>`_
+      consume objects exporting the CUDA Array Interface.
 - The RAPIDS stack:
 
     - `cuDF <https://rapidsai.github.io/projects/cudf/en/0.11.0/10min-cudf-cupy.html>`_

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -516,10 +516,10 @@ The following Python libraries have adopted the CUDA Array Interface:
 - `DALI: the NVIDIA Data Loading Library <https://github.com/NVIDIA/DALI>`_ :
 
     - `TensorGPU objects
-      <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_
+      <https://docs.nvidia.com/deeplearning/dali/user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_
       expose the CUDA Array Interface.
     - `The External Source operator
-      <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/supported_ops.html#nvidia.dali.fn.external_source>`_
+      <https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops.html#nvidia.dali.fn.external_source>`_
       consumes objects exporting the CUDA Array Interface.
 - The RAPIDS stack:
 

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -518,9 +518,9 @@ The following Python libraries have adopted the CUDA Array Interface:
     - `TensorGPU objects
       <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_
       expose the CUDA Array Interface.
-    - `External Source objects
+    - `The External Source operator
       <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/supported_ops.html#nvidia.dali.fn.external_source>`_
-      consume objects exporting the CUDA Array Interface.
+      consumes objects exporting the CUDA Array Interface.
 - The RAPIDS stack:
 
     - `cuDF <https://rapidsai.github.io/projects/cudf/en/0.11.0/10min-cudf-cupy.html>`_

--- a/docs/source/cuda/cuda_array_interface.rst
+++ b/docs/source/cuda/cuda_array_interface.rst
@@ -513,7 +513,7 @@ The following Python libraries have adopted the CUDA Array Interface:
 - `ArrayViews <https://github.com/xnd-project/arrayviews>`_
 - `JAX <https://jax.readthedocs.io/en/latest/index.html>`_
 - `PyCUDA <https://documen.tician.de/pycuda/tutorial.html#interoperability-with-other-libraries-using-the-cuda-array-interface>`_
-- `DALI: the NVIDIA Data Loading Library (DALI) <https://github.com/NVIDIA/DALI>`_ :
+- `DALI: the NVIDIA Data Loading Library <https://github.com/NVIDIA/DALI>`_ :
 
     - `TensorGPU objects
       <https://docs.nvidia.com/deeplearning/dali/master-user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_


### PR DESCRIPTION
As title. cc @klecki.

Fixes #7015.