### PR TITLE
Remove cu{blas,sparse,rand,fft} from library checks

### DIFF
--- a/numba/cuda/cudadrv/libs.py
+++ b/numba/cuda/cudadrv/libs.py
@@ -81,7 +81,7 @@ def test(_platform=None, print_paths=True):
     failed = False
 
     # Checks for dynamic libraries
-    libs = 'cublas cusparse cufft curand nvvm cudart'.split()
+    libs = 'nvvm cudart'.split()
     for lib in libs:
         path = get_cudalib(lib, _platform)
         print('Finding {} from {}'.format(lib, _get_source_variable(lib)))

--- a/numba/cuda/tests/cudadrv/test_cuda_libraries.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_libraries.py
@@ -13,6 +13,10 @@ class TestLibraryDetection(unittest.TestCase):
         PyCulib (and potentially others) rely on Numba's library finding
         capacity to find and subsequently load these libraries.
         """
-        core_libs = ['nvvm', 'cublas', 'cusparse', 'cufft', 'curand']
+        core_libs = ['nvvm']
         for l in core_libs:
             self.assertNotEqual(find_lib(l), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
These libraries are not needed by Numba, and pyculib, which used them,
is deprecated / discontinued. There is therefore no point in checking
for these libraries.

Prior to this commit, the library check:

```
$ python -c "from numba import cuda; cuda.cudadrv.libs.test()"
```

gave (for example):

```
Finding cublas from System
	located at /usr/local/cuda/lib64/libcublas.so.11.2.2.29
	trying to open library...	ok
Finding cusparse from System
	located at /usr/local/cuda/lib64/libcusparse.so.11.3.1.29
	trying to open library...	ok
Finding cufft from System
	located at /usr/local/cuda/lib64/libcufft.so.10.4.0.29
	trying to open library...	ok
Finding curand from System
	located at /usr/local/cuda/lib64/libcurand.so.10.2.3.29
	trying to open library...	ok
Finding nvvm from System
	located at /usr/local/cuda/nvvm/lib64/libnvvm.so.4.0.0
	trying to open library...	ok
Finding cudart from System
	located at /usr/local/cuda/lib64/libcudart.so.11.2.29
	trying to open library...	ok
Finding cudadevrt from System
	located at /usr/local/cuda/lib64/libcudadevrt.a
Finding libdevice from System
	searching for compute_20...	ok
	searching for compute_30...	ok
	searching for compute_35...	ok
	searching for compute_50...	ok
```

Now it only prints:

```
Finding nvvm from System
	located at /usr/local/cuda/nvvm/lib64/libnvvm.so.4.0.0
	trying to open library...	ok
Finding cudart from System
	located at /usr/local/cuda/lib64/libcudart.so.11.2.29
	trying to open library...	ok
Finding cudadevrt from System
	located at /usr/local/cuda/lib64/libcudadevrt.a
Finding libdevice from System
	searching for compute_20...	ok
	searching for compute_30...	ok
	searching for compute_35...	ok
	searching for compute_50...	ok
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
