### PR TITLE
fixed llvmir usage in create_module method

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1129,7 +1129,7 @@ class BaseContext(object):
     def create_module(self, name):
         """Create a LLVM module
         """
-        return ir.Module(name)
+        return llvmir.Module(name)
 
     @property
     def active_code_library(self):

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1130,7 +1130,7 @@ class BaseContext(object):
         """Create a LLVM module
         
         The default implementation in BaseContext always raises a
-        ``NotImplementedError`` exception. SubClass should implement 
+        ``NotImplementedError`` exception. Subclass should implement 
         this method.
         """
         raise NotImplementedError

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1128,8 +1128,12 @@ class BaseContext(object):
 
     def create_module(self, name):
         """Create a LLVM module
+        
+        The default implementation in BaseContext always raises a
+        ``NotImplementedError`` exception. SubClass should implement 
+        this method.
         """
-        return llvmir.Module(name)
+        raise NotImplementedError
 
     @property
     def active_code_library(self):

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -1130,7 +1130,7 @@ class BaseContext(object):
         """Create a LLVM module
         
         The default implementation in BaseContext always raises a
-        ``NotImplementedError`` exception. Subclass should implement 
+        ``NotImplementedError`` exception. Subclasses should implement 
         this method.
         """
         raise NotImplementedError


### PR DESCRIPTION
fixes #7022 

using llvmir instead of ir in `create_module` method of BaseContext