### PR TITLE
Fix nrt debug print

### DIFF
--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -176,6 +176,9 @@ class _EnvReloader(object):
         # (up to and including IR generation)
         DEBUG_FRONTEND = _readenv("NUMBA_DEBUG_FRONTEND", int, 0)
 
+        # Enable debug prints in nrtdynmod
+        DEBUG_NRT = _readenv("NUMBA_DEBUG_NRT", int, 0)
+
         # How many recently deserialized functions to retain regardless
         # of external references
         FUNCTION_CACHE_SIZE = _readenv("NUMBA_FUNCTION_CACHE_SIZE", int, 128)

--- a/numba/core/runtime/nrtdynmod.py
+++ b/numba/core/runtime/nrtdynmod.py
@@ -8,7 +8,7 @@ from numba.core import types, cgutils
 from llvmlite import ir, binding
 
 # Flag to enable debug print in NRT_incref and NRT_decref
-_debug_print = False
+_debug_print = True
 
 _word_type = ir.IntType(MACHINE_BITS)
 _pointer_type = ir.PointerType(ir.IntType(8))
@@ -54,10 +54,11 @@ def _define_nrt_incref(module, atomic_incr):
     with cgutils.if_unlikely(builder, is_null):
         builder.ret_void()
 
+    word_ptr = builder.bitcast(ptr, atomic_incr.args[0].type)
     if _debug_print:
-        cgutils.printf(builder, "*** NRT_Incref %zu [%p]\n", builder.load(ptr),
+        cgutils.printf(builder, "*** NRT_Incref %zu [%p]\n", builder.load(word_ptr),
                        ptr)
-    builder.call(atomic_incr, [builder.bitcast(ptr, atomic_incr.args[0].type)])
+    builder.call(atomic_incr, [word_ptr])
     builder.ret_void()
 
 
@@ -79,17 +80,20 @@ def _define_nrt_decref(module, atomic_decr):
     with cgutils.if_unlikely(builder, is_null):
         builder.ret_void()
 
-    if _debug_print:
-        cgutils.printf(builder, "*** NRT_Decref %zu [%p]\n", builder.load(ptr),
-                       ptr)
 
     # For memory fence usage, see https://llvm.org/docs/Atomics.html
 
     # A release fence is used before the relevant write operation.
     # No-op on x86.  On POWER, it lowers to lwsync.
     builder.fence("release")
+
+    word_ptr = builder.bitcast(ptr, atomic_decr.args[0].type)
+
+    if _debug_print:
+        cgutils.printf(builder, "*** NRT_Decref %zu [%p]\n", builder.load(word_ptr),
+                       ptr)
     newrefct = builder.call(atomic_decr,
-                            [builder.bitcast(ptr, atomic_decr.args[0].type)])
+                            [word_ptr])
 
     refct_eq_0 = builder.icmp_unsigned("==", newrefct,
                                        ir.Constant(newrefct.type, 0))

--- a/numba/core/runtime/nrtdynmod.py
+++ b/numba/core/runtime/nrtdynmod.py
@@ -3,14 +3,12 @@ Dynamically generate the NRT module
 """
 
 
-from numba.core.config import MACHINE_BITS
+from numba.core import config
 from numba.core import types, cgutils
 from llvmlite import ir, binding
 
-# Flag to enable debug print in NRT_incref and NRT_decref
-_debug_print = True
 
-_word_type = ir.IntType(MACHINE_BITS)
+_word_type = ir.IntType(config.MACHINE_BITS)
 _pointer_type = ir.PointerType(ir.IntType(8))
 
 _meminfo_struct_type = ir.LiteralStructType([
@@ -55,7 +53,7 @@ def _define_nrt_incref(module, atomic_incr):
         builder.ret_void()
 
     word_ptr = builder.bitcast(ptr, atomic_incr.args[0].type)
-    if _debug_print:
+    if config.DEBUG_NRT:
         cgutils.printf(builder, "*** NRT_Incref %zu [%p]\n", builder.load(word_ptr),
                        ptr)
     builder.call(atomic_incr, [word_ptr])
@@ -89,7 +87,7 @@ def _define_nrt_decref(module, atomic_decr):
 
     word_ptr = builder.bitcast(ptr, atomic_decr.args[0].type)
 
-    if _debug_print:
+    if config.DEBUG_NRT:
         cgutils.printf(builder, "*** NRT_Decref %zu [%p]\n", builder.load(word_ptr),
                        ptr)
     newrefct = builder.call(atomic_decr,


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR is a byproduct of me trying to fix generators. Without this PR I get output like this

```
*** NRT_Decref 140720103881220 [000002C1CB230770]
*** NRT_Incref 29778180 [000002C1CB230770] 
*** NRT_Decref 140720103881221 [000002C1CB230770] 
```

This is because the call to `printf` was essentially

```C
printf("*** NRT_Decref %zu [%p]\n", *ptr, ptr)
```
The problem here is that the type of `ptr` is `int8*`., meaning the a value of type `int8` was passed to `printf` when it expected a value of type `uint64`. This is undefined behaviour and apparently didn't break for others. I now changed it to be:

```C
printf("*** NRT_Decref %zu [%p]\n", *((uint64*) ptr), ptr)
```

which does work correctly for me.

At request of @gmarkall I also added a config variable 'NUMBA_DEBUG_NRT' to replace the global `_debug_print` in `nrtdynmod`

