### PR TITLE
Add Github action to mark issues as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Mark stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: >
+            This issue is marked as stale as it has had no activity in the past
+            30 days. Please close this issue if no further response or action is
+            needed. Otherwise, please respond with any updates and confirm that
+            this issue still needs to be addressed.
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'good first issue,good second issue,feature_request,Blocked awaiting long term feature,Numba 1.0'
+          days-before-issue-stale: 30
+          days-before-issue-close: -1


### PR DESCRIPTION
This uses the [stale action](https://github.com/actions/stale).

The intended configuration is:

- At 1:30 every day, any issues that have been inactive for 30 days are:
  - Labelled stale, and
  - Have a comment posted explaining why they're stale and requesting an update or that the issue be closed.
- Labels pertaining to long-term items, feature requests, and good first / second issues do not get marked.
- Stale issues are never closed.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
