### PR TITLE
Testhound/host array performance warning

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -478,6 +478,11 @@ GPU support
    heuristic needs to check the number of SMs available on the device in the
    current context.
 
+.. envvar:: CUDA_WARN_ON_HOST_MEMORY_LAUNCH
+
+   Enable warnings if a kernel is launched with host memory which forces a copy to and
+   from the device. This option is on by default (default value is 1).
+
 
 Threading Control
 -----------------

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -478,7 +478,7 @@ GPU support
    heuristic needs to check the number of SMs available on the device in the
    current context.
 
-.. envvar:: CUDA_WARN_ON_HOST_MEMORY_LAUNCH
+.. envvar:: CUDA_WARN_ON_IMPLICIT_COPY
 
    Enable warnings if a kernel is launched with host memory which forces a copy to and
    from the device. This option is on by default (default value is 1).

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -310,6 +310,12 @@ class _EnvReloader(object):
 
         # CUDA Configs
 
+        # Whether to warn about kernel launches where a host array
+        # is used a parameter, forcing a copy to and from the device.
+        # On by default.
+        CUDA_WARN_ON_HOST_MEMORY_LAUNCH = _readenv(
+            "NUMBA_CUDA_WARN_ON_HOST_MEMORY_LAUNCH", int, 1)
+
         # Force CUDA compute capability to a specific version
         FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _parse_cc, None)
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -311,7 +311,7 @@ class _EnvReloader(object):
         # CUDA Configs
 
         # Whether to warn about kernel launches where a host array
-        # is used a parameter, forcing a copy to and from the device.
+        # is used as a parameter, forcing a copy to and from the device.
         # On by default.
         CUDA_WARN_ON_IMPLICIT_COPY = _readenv(
             "NUMBA_CUDA_WARN_ON_IMPLICIT_COPY", int, 1)

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -313,8 +313,8 @@ class _EnvReloader(object):
         # Whether to warn about kernel launches where a host array
         # is used a parameter, forcing a copy to and from the device.
         # On by default.
-        CUDA_WARN_ON_HOST_MEMORY_LAUNCH = _readenv(
-            "NUMBA_CUDA_WARN_ON_HOST_MEMORY_LAUNCH", int, 1)
+        CUDA_WARN_ON_IMPLICIT_COPY = _readenv(
+            "NUMBA_CUDA_WARN_ON_IMPLICIT_COPY", int, 1)
 
         # Force CUDA compute capability to a specific version
         FORCE_CUDA_CC = _readenv("NUMBA_FORCE_CUDA_CC", _parse_cc, None)

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -117,7 +117,8 @@ def to_device(obj, stream=0, copy=True, to=None):
         hary = d_ary.copy_to_host(stream=stream)
     """
     if to is None:
-        to, new = devicearray.auto_device(obj, stream=stream, copy=copy)
+        to, new = devicearray.auto_device(obj, stream=stream, copy=copy,
+                                          user_explicit=True)
         return to
     if copy:
         to.copy_to_device(obj, stream=stream)

--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -783,9 +783,9 @@ def auto_device(obj, stream=0, copy=True):
                 if (
                     not isinstance(obj, DeviceNDArray)
                     and isinstance(obj, np.ndarray)
-                    ):
-                    msg = ("Host array used in CUDA kernel will incur copy overhead"
-                       "to/from device.")
+                ):
+                    msg = ("Host array used in CUDA kernel will incur copy "
+                           "overhead to/from device.")
                     warn(NumbaPerformanceWarning(msg))
             devobj.copy_to_device(obj, stream=stream)
         return devobj, True

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -30,11 +30,11 @@ class CUDATestCase(SerialMixin, TestCase):
         # Disable warnings about low gpu utilization in the test suite
         config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
         # Disable warnings about host arrays in the test suite
-        config.CUDA_WARN_ON_HOST_MEMORY_LAUNCH = 0
+        config.CUDA_WARN_ON_IMPLICIT_COPY = 0
 
     def tearDown(self):
         config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
-        config.CUDA_WARN_ON_HOST_MEMORY_LAUNCH = \
+        config.CUDA_WARN_ON_IMPLICIT_COPY = \
             self._warn_on_host_memory_launch
 
 

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -25,7 +25,7 @@ class CUDATestCase(SerialMixin, TestCase):
 
     def setUp(self):
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
-        self._warn_on_host_memory_launch = config.CUDA_LOW_OCCUPANCY_WARNINGS
+        self._warn_on_implicit_copy = config.CUDA_WARN_ON_IMPLICIT_COPY
 
         # Disable warnings about low gpu utilization in the test suite
         config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
@@ -35,7 +35,7 @@ class CUDATestCase(SerialMixin, TestCase):
     def tearDown(self):
         config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
         config.CUDA_WARN_ON_IMPLICIT_COPY = \
-            self._warn_on_host_memory_launch
+            self._warn_on_implicit_copy
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -25,11 +25,17 @@ class CUDATestCase(SerialMixin, TestCase):
 
     def setUp(self):
         self._low_occupancy_warnings = config.CUDA_LOW_OCCUPANCY_WARNINGS
+        self._warn_on_host_memory_launch = config.CUDA_LOW_OCCUPANCY_WARNINGS
+
         # Disable warnings about low gpu utilization in the test suite
         config.CUDA_LOW_OCCUPANCY_WARNINGS = 0
+        # Disable warnings about host arrays in the test suite
+        config.CUDA_WARN_ON_HOST_MEMORY_LAUNCH = 0
 
     def tearDown(self):
         config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
+        config.CUDA_WARN_ON_HOST_MEMORY_LAUNCH = \
+            self._warn_on_host_memory_launch
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -34,8 +34,7 @@ class CUDATestCase(SerialMixin, TestCase):
 
     def tearDown(self):
         config.CUDA_LOW_OCCUPANCY_WARNINGS = self._low_occupancy_warnings
-        config.CUDA_WARN_ON_IMPLICIT_COPY = \
-            self._warn_on_implicit_copy
+        config.CUDA_WARN_ON_IMPLICIT_COPY = self._warn_on_implicit_copy
 
 
 class ContextResettingTestCase(CUDATestCase):

--- a/numba/cuda/tests/cudapy/test_multithreads.py
+++ b/numba/cuda/tests/cudapy/test_multithreads.py
@@ -27,7 +27,7 @@ def check_concurrent_compiling():
         foo[1, 1](x)
         return x
 
-    arrays = [np.arange(10) for i in range(10)]
+    arrays = [cuda.to_device(np.arange(10)) for i in range(10)]
     expected = np.arange(10)
     expected[0] += 1
     with ThreadPoolExecutor(max_workers=4) as e:

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numba import cuda
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim
-from numba.tests.support import override_config
+from numba.tests.support import linux_only, override_config
 from numba.core.errors import NumbaPerformanceWarning
 import warnings
 
@@ -79,6 +79,7 @@ class TestWarnings(CUDATestCase):
 
         self.assertEqual(len(w), 0)
 
+    @linux_only
     def test_nowarn_on_managed_array(self):
         @cuda.jit
         def foo(r, x):

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -39,7 +39,7 @@ class TestWarnings(CUDATestCase):
 
         N = 10
         arr_f32 = np.zeros(N, dtype=np.float32)
-        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+        with override_config('CUDA_WARN_ON_IMPLICIT_COPY', 1):
             with warnings.catch_warnings(record=True) as w:
                 foo[1, N](arr_f32, N)
 
@@ -56,7 +56,7 @@ class TestWarnings(CUDATestCase):
         N = 10
         ary = cuda.pinned_array(N, dtype=np.float32)
 
-        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+        with override_config('CUDA_WARN_ON_IMPLICIT_COPY', 1):
             with warnings.catch_warnings(record=True) as w:
                 foo[1, N](ary, N)
 
@@ -73,7 +73,7 @@ class TestWarnings(CUDATestCase):
         N = 10
         ary = cuda.mapped_array(N, dtype=np.float32)
 
-        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+        with override_config('CUDA_WARN_ON_IMPLICIT_COPY', 1):
             with warnings.catch_warnings(record=True) as w:
                 foo[1, N](ary, N)
 
@@ -87,7 +87,7 @@ class TestWarnings(CUDATestCase):
         N = 10
         ary = cuda.managed_array(N, dtype=np.float32)
 
-        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+        with override_config('CUDA_WARN_ON_IMPLICIT_COPY', 1):
             with warnings.catch_warnings(record=True) as w:
                 foo[1, N](ary, N)
 
@@ -101,7 +101,7 @@ class TestWarnings(CUDATestCase):
         N = 10
         ary = cuda.device_array(N, dtype=np.float32)
 
-        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+        with override_config('CUDA_WARN_ON_IMPLICIT_COPY', 1):
             with warnings.catch_warnings(record=True) as w:
                 foo[1, N](ary, N)
 

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numba import cuda
 from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 from numba.tests.support import override_config
@@ -28,5 +29,80 @@ class TestWarnings(CUDATestCase):
         with override_config('CUDA_LOW_OCCUPANCY_WARNINGS', 1):
             with warnings.catch_warnings(record=True) as w:
                 kernel[256, 256]()
+
+        self.assertEqual(len(w), 0)
+
+    def test_warn_on_host_array(self):
+        @cuda.jit
+        def foo(r, x):
+            r[0] = x + 1
+
+        N = 10
+        arr_f32 = np.zeros(N, dtype=np.float32)
+        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+            with warnings.catch_warnings(record=True) as w:
+                foo[1, N](arr_f32, N)
+
+        self.assertEqual(w[0].category, NumbaPerformanceWarning)
+        self.assertIn('Host array used in CUDA kernel will incur',
+                      str(w[0].message))
+        self.assertIn('copy overhead', str(w[0].message))
+
+    def test_pinned_warn_on_host_array(self):
+        @cuda.jit
+        def foo(r, x):
+            r[0] = x + 1
+
+        N = 10
+        ary = cuda.pinned_array(N, dtype=np.float32)
+
+        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+            with warnings.catch_warnings(record=True) as w:
+                foo[1, N](ary, N)
+
+        self.assertEqual(w[0].category, NumbaPerformanceWarning)
+        self.assertIn('Host array used in CUDA kernel will incur',
+                      str(w[0].message))
+        self.assertIn('copy overhead', str(w[0].message))
+
+    def test_nowarn_on_mapped_array(self):
+        @cuda.jit
+        def foo(r, x):
+            r[0] = x + 1
+
+        N = 10
+        ary = cuda.mapped_array(N, dtype=np.float32)
+
+        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+            with warnings.catch_warnings(record=True) as w:
+                foo[1, N](ary, N)
+
+        self.assertEqual(len(w), 0)
+
+    def test_nowarn_on_managed_array(self):
+        @cuda.jit
+        def foo(r, x):
+            r[0] = x + 1
+
+        N = 10
+        ary = cuda.managed_array(N, dtype=np.float32)
+
+        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+            with warnings.catch_warnings(record=True) as w:
+                foo[1, N](ary, N)
+
+        self.assertEqual(len(w), 0)
+
+    def test_nowarn_on_device_array(self):
+        @cuda.jit
+        def foo(r, x):
+            r[0] = x + 1
+
+        N = 10
+        ary = cuda.device_array(N, dtype=np.float32)
+
+        with override_config('CUDA_WARN_ON_HOST_MEMORY_LAUNCH', 1):
+            with warnings.catch_warnings(record=True) as w:
+                foo[1, N](ary, N)
 
         self.assertEqual(len(w), 0)


### PR DESCRIPTION
This pull request addresses: https://github.com/numba/numba/issues/6904 (Produce a NumbaPerformanceWarning whenever a kernel is called on a host array).

The PR adds a new environment variable NUMBA_CUDA_WARN_ON_HOST_MEMORY_LAUNCH that determines whether a warning will be emitted.