### PR TITLE
Fix #7065: Add expected exception messages for NumPy 1.20 to tests

### DIFF
--- a/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_array_slicing.py
@@ -291,7 +291,9 @@ class CudaArraySetting(CUDATestCase):
             container=[
                 "Can't assign 3-D array to 1-D self",  # device
                 "could not broadcast input array from shape (2,3) "
-                "into shape (35)",  # simulator
+                "into shape (35)",  # simulator, NP < 1.20
+                "could not broadcast input array from shape (2,3) "
+                "into shape (35,)",  # simulator, NP >= 1.20
             ])
 
     def test_incompatible_shape(self):
@@ -306,7 +308,9 @@ class CudaArraySetting(CUDATestCase):
                 "Can't copy sequence with size 2 to array axis 0 with "
                 "dimension 5",  # device
                 "cannot copy sequence with size 2 to array axis with "
-                "dimension 5",  # simulator
+                "dimension 5",  # simulator, NP < 1.20
+                "could not broadcast input array from shape (2,) into "
+                "shape (5,)",   # simulator, NP >= 1.20
             ])
 
     @skip_on_cudasim('cudasim does not use streams and operates synchronously')


### PR DESCRIPTION
The exception messages generated in `test_incompatible_highdim` and
`test_incompatible_shape` vary slightly in NumPy 1.20, so these
variants are added to the list of expected messages.

Fixes #7065.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
