### PR TITLE
Enhancing docs about PRNG seeding

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,7 +585,7 @@ Initialization
 .. warning::
    Calling :func:`numpy.random.seed` from non-Numba code (or from :term:`object mode`
    code) will seed the NumPy random generator, not the Numba random generator.
-   To poperly seed the Numba random generator, see example below.
+   To properly seed the Numba random generator, see example below.
 
 .. code-block:: python
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -583,7 +583,7 @@ Initialization
 * :func:`numpy.random.seed`: with an integer argument only
 
 .. warning::
-   Calling :func:`numpy.random.seed` from non-Numba code (or from :term:`object mode`
+   Calling :func:`numpy.random.seed` from interpreted code (including from :term:`object mode`
    code) will seed the NumPy random generator, not the Numba random generator.
    To properly seed the Numba random generator, see example below.
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,7 +585,7 @@ Initialization
 .. warning::
    Calling :func:`numpy.random.seed` from interpreted code (including from :term:`object mode`
    code) will seed the NumPy random generator, not the Numba random generator.
-   To properly seed the Numba random generator, see example below.
+   To seed the Numba random generator, see the example below.
 
 .. code-block:: python
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -582,6 +582,42 @@ Initialization
 
 * :func:`numpy.random.seed`: with an integer argument only
 
+.. warning::
+   Calling :func:`numpy.random.seed` from non-Numba code (or from :term:`object mode`
+   code) will seed the NumPy random generator, not the Numba random generator.
+   To poperly seed the Numba random generator, see example below.
+
+.. code-block:: python
+
+  from numba import njit
+  import numpy as np
+
+  @njit
+  def seed(a):
+      np.random.seed(a)
+
+  @njit
+  def rand():
+      return np.random.rand()
+
+
+  # Uncorrect seeding
+  np.random.seed(1234)
+  print(rand())
+
+  np.random.seed(1234)
+  print(rand())
+
+  # Correct seeding
+  seed(1234)
+  print(rand())
+
+  seed(1234)
+  print(rand())
+
+
+
+
 Simple random data
 ''''''''''''''''''
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -601,7 +601,7 @@ Initialization
       return np.random.rand()
 
 
-  # Uncorrect seeding
+  # Incorrect seeding
   np.random.seed(1234)
   print(rand())
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1156,9 +1156,39 @@ startup with entropy drawn from the operating system.
 * :func:`random.vonmisesvariate`
 * :func:`random.weibullvariate`
 
-.. note::
+.. warning::
    Calling :func:`random.seed` from non-Numba code (or from :term:`object mode`
    code) will seed the Python random generator, not the Numba random generator.
+   To poperly seed the Numba random generator, see example below.
+
+.. code-block:: python
+
+  from numba import njit
+  import random
+
+  @njit
+  def seed(a):
+      random.seed(a)
+
+  @njit
+  def rand():
+      return random.random()
+
+
+  # Uncorrect seeding
+  random.seed(1234)
+  print(rand())
+
+  random.seed(1234)
+  print(rand())
+
+  # Correct seeding
+  seed(1234)
+  print(rand())
+
+  seed(1234)
+  print(rand())
+
 
 .. note::
    Since version 0.28.0, the generator is thread-safe and fork-safe.  Each

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1159,7 +1159,7 @@ startup with entropy drawn from the operating system.
 .. warning::
    Calling :func:`random.seed` from non-Numba code (or from :term:`object mode`
    code) will seed the Python random generator, not the Numba random generator.
-   To poperly seed the Numba random generator, see example below.
+   To properly seed the Numba random generator, see example below.
 
 .. code-block:: python
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1175,7 +1175,7 @@ startup with entropy drawn from the operating system.
       return random.random()
 
 
-  # Uncorrect seeding
+  # Incorrect seeding
   random.seed(1234)
   print(rand())
 

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -1159,7 +1159,7 @@ startup with entropy drawn from the operating system.
 .. warning::
    Calling :func:`random.seed` from non-Numba code (or from :term:`object mode`
    code) will seed the Python random generator, not the Numba random generator.
-   To properly seed the Numba random generator, see example below.
+   To seed the Numba random generator, see the example below.
 
 .. code-block:: python
 


### PR DESCRIPTION
Hello,

This PR directly follows my [proposition](https://github.com/numba/numba/issues/6002#issuecomment-850429729) in #6002.

The goal was to enhance the current documentation to be more clear about PRNG seeding. A note was already present for the Python `random` module but not the the NumPy one.

It took the liberty to add a minimal working example in both cases, as well as labelling it as a *warning* to have more impact.

I will gladly accept any comment or suggestion from your side.

Thanks :-)

# Updated doc.
## Python
![python_seed](https://user-images.githubusercontent.com/27275099/120037603-2e0cf200-c002-11eb-9263-3532e96d4896.png)

## NumPy
![numpy_seed](https://user-images.githubusercontent.com/27275099/120037613-31a07900-c002-11eb-80c3-5be6b1f838d4.png)

