### PR TITLE
Change compile unit language in DWARF to C++

### DIFF
--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -216,7 +216,7 @@ class DIBuilder(AbstractDIBuilder):
 
     def _di_compile_unit(self):
         return self.module.add_debug_info('DICompileUnit', {
-            'language': ir.DIToken('DW_LANG_Python'),
+            'language': ir.DIToken('DW_LANG_C_plus_plus'),
             'file': self.difile,
             'producer': 'Numba',
             'runtimeVersion': 0,


### PR DESCRIPTION
Change DWARF language to `DW_LANG_C_plus_plus`.
It helps GDB to understand C++ mangled functions.

Code
```python
from numba import njit

@njit(debug=True)
def foo(a):
    b = a + 1
    print (b)

foo(123)
```
Run with breakpoints:
```bush
gdb --pyargs python br_chk.py
(gdb) break ...
(gdb) run
Stop or not?
```

&nbsp; | DW_LANG_Python | DW_LANG_C_plus_plus
-- | -- | --
`break   njit-basic.py:foo$241` | &nbsp; | +
`break foo$241` | + | +
`break   __main__::foo$241` | + | +
`break   njit-basic.py:__main__::foo$241` | &nbsp; | +

Get function info:
```bash
(gdb) info function foo
```

&nbsp; | DW_LANG_C_plus_plus | DW_LANG_Python
-- | -- | --
`info func foo` | `void   __main__::foo$241(long long);` | `void _ZN8__main__7foo$241Ex(void);`

@vlad-perevezentsev 