### PR TITLE
Fix `__eq__` for Flags and cpu_options classes

### DIFF
--- a/numba/core/cpu_options.py
+++ b/numba/core/cpu_options.py
@@ -44,11 +44,18 @@ class FastMathOptions(object):
     def __repr__(self):
         return f"FastMathOptions({self.flags})"
 
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.flags == other.flags
+        return NotImplemented
+
 
 class ParallelOptions(object):
     """
     Options for controlling auto parallelization.
     """
+    __slots__ = ("enabled", "comprehension", "reduction", "inplace_binop",
+                 "setitem", "numpy", "stencil", "fusion", "prange")
 
     def __init__(self, value):
         if isinstance(value, bool):
@@ -87,6 +94,16 @@ class ParallelOptions(object):
         else:
             msg = "Expect parallel option to be either a bool or a dict"
             raise ValueError(msg)
+
+    def _get_values(self):
+        """Get values as dictionary.
+        """
+        return {k: getattr(self, k) for k in self.__slots__}
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self._get_values() == other._get_values()
+        return NotImplemented
 
 
 class InlineOptions(object):
@@ -137,3 +154,8 @@ class InlineOptions(object):
         The raw value
         """
         return self._inline
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self.value == other.value
+        return NotImplemented

--- a/numba/core/targetconfig.py
+++ b/numba/core/targetconfig.py
@@ -147,13 +147,6 @@ class TargetConfig(metaclass=_MetaTargetConfig):
         else:
             return NotImplemented
 
-    def __ne__(self, other):
-        eq = self.__eq__(other)
-        if eq is NotImplemented:
-            return NotImplemented
-        else:
-            return eq
-
     def values(self):
         """Returns a dict of all the values
         """

--- a/numba/stencils/stencilparfor.py
+++ b/numba/stencils/stencilparfor.py
@@ -666,7 +666,8 @@ def get_stencil_ir(sf, typingctx, args, scope, loc, input_dict, typemap,
         raise ValueError("Cannot use the reserved word 'out' in stencil kernels.")
 
     # get typed IR with a dummy pipeline (similar to test_parfors.py)
-    targetctx = CPUContext(typingctx)
+    from numba.core.registry import cpu_target
+    targetctx = cpu_target.target_context
     with cpu_target.nested_context(typingctx, targetctx):
         tp = DummyPipeline(typingctx, targetctx, args, stencil_func_ir)
 


### PR DESCRIPTION
Fixes #7079

- Removed `Flags.__ne__` because it is invalid and unneeded.
- Added `__eq__` on classes in `cpu_options.py`