### PR TITLE
Initialize NUMBA_DEFAULT_NUM_THREADS with a batch scheduler aware value

### DIFF
--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -268,10 +268,10 @@ API Reference
 
 .. py:data:: numba.config.NUMBA_DEFAULT_NUM_THREADS
 
-   The number of CPU cores on the system (as determined by
-   ``multiprocessing.cpu_count()``). This is the default value for
-   :obj:`numba.config.NUMBA_NUM_THREADS` unless the
-   :envvar:`NUMBA_NUM_THREADS` environment variable is set.
+   The number of usable CPU cores on the system (as determined by either
+   ``len(os.sched_getaffinity(0))`` or ``multiprocessing.cpu_count()``).
+   This is the default value for :obj:`numba.config.NUMBA_NUM_THREADS` unless
+   the :envvar:`NUMBA_NUM_THREADS` environment variable is set.
 
 .. autofunction:: numba.set_num_threads
 

--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -268,8 +268,9 @@ API Reference
 
 .. py:data:: numba.config.NUMBA_DEFAULT_NUM_THREADS
 
-   The number of usable CPU cores on the system (as determined by either
-   ``len(os.sched_getaffinity(0))`` or ``multiprocessing.cpu_count()``).
+   The number of usable CPU cores on the system (as determined by
+   ``len(os.sched_getaffinity(0))``, if supported by the OS, or
+   ``multiprocessing.cpu_count()`` if not).
    This is the default value for :obj:`numba.config.NUMBA_NUM_THREADS` unless
    the :envvar:`NUMBA_NUM_THREADS` environment variable is set.
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -367,7 +367,12 @@ class _EnvReloader(object):
         DISABLE_HSA = _readenv("NUMBA_DISABLE_HSA", int, 0)
 
         # The default number of threads to use.
-        NUMBA_DEFAULT_NUM_THREADS = max(1, multiprocessing.cpu_count())
+        NUMBA_DEFAULT_NUM_THREADS = max(
+            1,
+            len(os.sched_getaffinity(0))
+            if hasattr(os, "sched_getaffinity")
+            else multiprocessing.cpu_count(),
+        )
 
         # Numba thread pool size (defaults to number of CPUs on the system).
         _NUMBA_NUM_THREADS = _readenv("NUMBA_NUM_THREADS", int,


### PR DESCRIPTION
This PR updates the value of `NUMBA_DEFAULT_NUM_THREADS` to use a batch-scheduler aware number of CPU cores  through `len(os.sched_getaffinity(0))` when available.

closes  #7086


<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
