### PR TITLE
Ddof support for nanvar nanstd

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -401,9 +401,9 @@ The following reduction functions are supported:
 * :func:`numpy.nanquantile` (only the 2 first arguments, requires NumPy >= 1.15,
   complex dtypes unsupported)
 * :func:`numpy.nanprod` (only the first argument)
-* :func:`numpy.nanstd` (only the first argument)
+* :func:`numpy.nanstd` (only the first argument and ddof)
 * :func:`numpy.nansum` (only the first argument)
-* :func:`numpy.nanvar` (only the first argument)
+* :func:`numpy.nanvar` (only the first argument and ddof)
 * :func:`numpy.percentile` (only the 2 first arguments, requires NumPy >= 1.10,
   complex dtypes unsupported)
 * :func:`numpy.quantile` (only the 2 first arguments, requires NumPy >= 1.15,

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1039,6 +1039,7 @@ def np_nanvar(a, ddof=0):
 
     return nanvar_impl
 
+
 @overload(np.nanstd)
 def np_nanstd(a, ddof=0):
     if not isinstance(a, types.Array):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1039,6 +1039,16 @@ def np_nanvar(a, ddof=0):
 
     return nanvar_impl
 
+@overload(np.nanstd)
+def np_nanstd(a, ddof=0):
+    if not isinstance(a, types.Array):
+        return
+
+    def nanstd_impl(a, ddof=0):
+        return np.nanvar(a, ddof) ** 0.5
+
+    return nanstd_impl
+
 
 @overload(np.nansum)
 def np_nansum(a):

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -1003,7 +1003,7 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         reduction_funcs_rspace = [array_argmin, array_argmin_global,
                                   array_argmax, array_argmax_global]
 
-        reduction_funcs += [array_nanmean, array_nanstd, array_nanvar]
+        reduction_funcs += [array_nanmean, array_nanstd_basic, array_nanvar_basic]
         reduction_funcs += [array_nanprod]
 
         dtypes_to_test = [np.int32, np.float32, np.bool_, np.complex64]

--- a/numba/tests/test_array_reductions.py
+++ b/numba/tests/test_array_reductions.py
@@ -110,11 +110,17 @@ def array_nansum(arr):
 def array_nanprod(arr):
     return np.nanprod(arr)
 
-def array_nanstd(arr):
+def array_nanstd_basic(arr):
     return np.nanstd(arr)
 
-def array_nanvar(arr):
+def array_nanstd_ddof(arr, ddof=0):
+    return np.nanstd(arr, ddof=ddof)
+
+def array_nanvar_basic(arr):
     return np.nanvar(arr)
+
+def array_nanvar_ddof(arr, ddof=0):
+    return np.nanvar(arr, ddof=ddof)
 
 def array_nanmedian_global(arr):
     return np.nanmedian(arr)
@@ -290,10 +296,16 @@ class TestArrayReductions(MemoryLeakMixin, TestCase):
         self.check_reduction_basic(array_nanprod)
 
     def test_nanstd_basic(self):
-        self.check_reduction_basic(array_nanstd)
+        self.check_reduction_basic(array_nanstd_basic)
 
     def test_nanvar_basic(self):
-        self.check_reduction_basic(array_nanvar, prec='double')
+        self.check_reduction_basic(array_nanvar_basic, prec='double')
+
+    def test_nanstd_ddof(self):
+        self.check_ddof(array_nanstd_ddof)
+
+    def test_nanvar_ddof(self):
+        self.check_ddof(array_nanvar_ddof)
 
     def check_median_basic(self, pyfunc, array_variations):
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
Added support for `ddof` argument for `np.nanvar` and `np.nanstd` . Moved `compute_sum_of_square_diffs` out of `nanvar_impl` and decorated with @register_jittable

closes #6611 