### PR TITLE
Replace deprecated call to cuDeviceComputeCapability

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -472,11 +472,8 @@ class Device(object):
         self.attributes = {}
 
         # Read compute capability
-        cc_major = c_int()
-        cc_minor = c_int()
-        driver.cuDeviceComputeCapability(byref(cc_major), byref(cc_minor),
-                                         self.id)
-        self.compute_capability = (cc_major.value, cc_minor.value)
+        self.compute_capability = (self.COMPUTE_CAPABILITY_MAJOR,
+                                   self.COMPUTE_CAPABILITY_MINOR)
 
         # Read name
         bufsz = 128


### PR DESCRIPTION
Use device properties to get the major and minor compute capability values instead.

As identified on Gitter: https://gitter.im/numba/numba?at=60c11e241477ff6954ad9b51

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
