### PR TITLE
Use correct CUDA driver library on WSL

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -108,7 +108,10 @@ def find_driver():
     else:
         # Assume to be *nix like
         dlloader = ctypes.CDLL
-        dldir = ['/usr/lib', '/usr/lib64']
+        # Check for WSL lib location first, as on a WSL system, this contains
+        # the correct library - /usr/lib[64] may also contain a version of
+        # the library that won't work correctly.
+        dldir = ['/usr/lib/wsl/lib', '/usr/lib', '/usr/lib64']
         dlnames = ['libcuda.so', 'libcuda.so.1']
 
     if envpath:


### PR DESCRIPTION
Using the wrong libcuda.so on WSL can result in `CUDA_ERROR_NO_DEVICE` being returned on the call to `cuInit()`. The correct library location seems to be `/usr/lib/wsl/lib`. This PR adds this folder ahead of the usual library paths for the CUDA driver, so that on WSL systems it is detected ahead of the other libraries.

Fixes #7104.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
