### PR TITLE
CUDA: Fold the device dispatcher into the kernel dispatcher

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1231,6 +1231,10 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         for _, defn in self.overloads.items():
             defn.inspect_types(file=file)
 
+    def inspect_ptx(self, args):
+        # XXX: Need to warn here
+        return self.compile_device(args).library.get_asm_str().encode()
+
     @property
     def ptx(self):
         return {sig: overload.ptx for sig, overload in self.overloads.items()}

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -18,6 +18,7 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.core.compiler_machinery import (LoweringPass, PassManager,
                                            register_pass)
 from numba.core.dispatcher import OmittedArg
+from numba.core.errors import NumbaDeprecationWarning
 from numba.core.typed_passes import IRLegalization, NativeLowering
 from numba.core.typing.typeof import Purpose, typeof
 from warnings import warn
@@ -1231,8 +1232,17 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         for _, defn in self.overloads.items():
             defn.inspect_types(file=file)
 
-    def inspect_ptx(self, args):
+    def inspect_ptx(self, args, nvvm_options={}):
         # XXX: Need to warn here
+        msg = ('inspect_ptx for device functions is deprecated. Use '
+               'compile_ptx instead.')
+        warn(msg, category=NumbaDeprecationWarning)
+
+        if nvvm_options:
+            msg = ('nvvm_options are ignored. Use compile_ptx if you want to '
+                   'set NVVM options.')
+            warn(msg, category=NumbaDeprecationWarning)
+
         return self.compile_device(args).library.get_asm_str().encode()
 
     @property

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -956,6 +956,9 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         typingctx = cuda_target.typing_context
         typingctx.insert_user_function(dispatcher, function_template)
 
+        name = getattr(py_func, '__name__', 'unknown')
+        self.__name__ = f"{name} <CUDA device function>".format(name)
+
     def get_call_template(self, args, kws):
         # Copied and simplified from _DispatcherBase.get_call_template.
         """

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1216,7 +1216,14 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
 
         '''
         if signature is not None:
-            return self.overloads[signature].inspect_llvm()
+            overload = self.overloads[signature]
+            if isinstance(overload, _Kernel):
+                # Overload is a kernel
+                return overload.inspect_llvm()
+            else:
+                # Overload is a device function
+                modules = overload.library.modules
+                return "\n\n".join([str(mod) for mod in modules])
         else:
             return {sig: overload.inspect_llvm()
                     for sig, overload in self.overloads.items()}

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -407,6 +407,9 @@ def compile_ptx_for_current_device(pyfunc, args, debug=False, lineinfo=False,
 
 def compile_device(pyfunc, return_type, args, inline=True, debug=False,
                    lineinfo=False):
+    msg = ("Eager compilation of device functions is deprecated. Use "
+           "compile_ptx to get PTX code for a device function if needed.")
+    warn(NumbaDeprecationWarning(msg))
     return DeviceFunction(pyfunc, return_type, args, inline=True, debug=False,
                           lineinfo=False)
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -246,165 +246,6 @@ def compile_ptx_for_current_device(pyfunc, args, debug=False, lineinfo=False,
                        device=device, fastmath=fastmath, cc=cc, opt=True)
 
 
-#class DeviceDispatcher(serialize.ReduceMixin):
-#    """Unmaterialized device function
-#    """
-#    def __init__(self, pyfunc, debug, inline, opt):
-#        self.py_func = pyfunc
-#        self.debug = debug
-#        self.inline = inline
-#        self.opt = opt
-#        self.overloads = {}
-#        name = getattr(pyfunc, '__name__', 'unknown')
-#        self.__name__ = f"{name} <CUDA device function>".format(name)
-#
-#    def _reduce_states(self):
-#        return dict(py_func=self.py_func, debug=self.debug, inline=self.inline)
-#
-#    @classmethod
-#    def _rebuild(cls, py_func, debug, inline):
-#        return compile_device_dispatcher(py_func, debug=debug, inline=inline)
-#
-#    def get_call_template(self, args, kws):
-#        # Copied and simplified from _DispatcherBase.get_call_template.
-#        """
-#        Get a typing.ConcreteTemplate for this dispatcher and the given
-#        *args* and *kws* types.  This allows to resolve the return type.
-#
-#        A (template, pysig, args, kws) tuple is returned.
-#        """
-#        # Ensure an overload is available
-#        self.compile(tuple(args))
-#
-#        # Create function type for typing
-#        func_name = self.py_func.__name__
-#        name = "CallTemplate({0})".format(func_name)
-#
-#        # The `key` isn't really used except for diagnosis here,
-#        # so avoid keeping a reference to `cfunc`.
-#        call_template = typing.make_concrete_template(
-#            name, key=func_name, signatures=self.nopython_signatures)
-#        pysig = utils.pysignature(self.py_func)
-#
-#        return call_template, pysig, args, kws
-#
-#    @property
-#    def nopython_signatures(self):
-#        # All overloads are for nopython mode, because there is only
-#        # nopython mode in CUDA
-#        return [info.signature for info in self.overloads.values()]
-#
-#    def get_overload(self, sig):
-#        # NOTE: This dispatcher seems to be used as the key for the dict of
-#        # implementations elsewhere in Numba, so we return this dispatcher
-#        # instead of a compiled entry point as in
-#        # _DispatcherBase.get_overload().
-#        return self
-#
-#    def compile(self, args):
-#        """Compile the function for the given argument types.
-#
-#        Each signature is compiled once by caching the compiled function inside
-#        this object.
-#
-#        Returns the `CompileResult`.
-#        """
-#        if args not in self.overloads:
-#            nvvm_options = {
-#                'opt': 3 if self.opt else 0,
-#                'debug': self.debug,
-#            }
-#
-#            cres = compile_cuda(self.py_func, None, args, debug=self.debug,
-#                                inline=self.inline, nvvm_options=nvvm_options)
-#            first_definition = not self.overloads
-#            self.overloads[args] = cres
-#            libs = [cres.library]
-#
-#            if first_definition:
-#                # First definition
-#                cres.target_context.insert_user_function(self, cres.fndesc,
-#                                                         libs)
-#            else:
-#                cres.target_context.add_user_function(self, cres.fndesc, libs)
-#
-#        else:
-#            cres = self.overloads[args]
-#
-#        return cres
-#
-#    def inspect_llvm(self, args):
-#        """Returns the LLVM-IR text compiled for *args*.
-#
-#        Parameters
-#        ----------
-#        args: tuple[Type]
-#            Argument types.
-#
-#        Returns
-#        -------
-#        llvmir : str
-#        """
-#        modules = self.compile(args).library.modules
-#        return "\n\n".join([str(mod) for mod in modules])
-#
-#    def inspect_ptx(self, args, nvvm_options={}):
-#        """Returns the PTX compiled for *args* for the currently active GPU
-#
-#        Parameters
-#        ----------
-#        args: tuple[Type]
-#            Argument types.
-#
-#        Returns
-#        -------
-#        ptx : bytes
-#        """
-#        msg = ('inspect_ptx for device functions is deprecated. Use '
-#               'compile_ptx instead.')
-#        warn(msg, category=NumbaDeprecationWarning)
-#
-#        if nvvm_options:
-#            msg = ('nvvm_options are ignored. Use compile_ptx if you want to '
-#                   'set NVVM options.')
-#            warn(msg, category=NumbaDeprecationWarning)
-#        return self.compile(args).library.get_asm_str().encode()
-#
-#
-#def compile_device_dispatcher(pyfunc, debug=False, inline=False, opt=True):
-#    """Create a DeviceDispatcher and register it to the CUDA typing context.
-#    """
-#    from .descriptor import cuda_target
-#
-#    dispatcher = DeviceDispatcher(pyfunc, debug=debug, inline=inline, opt=opt)
-#
-#    class device_function_template(AbstractTemplate):
-#        key = dispatcher
-#
-#        def generic(self, args, kws):
-#            assert not kws
-#            return dispatcher.compile(args).signature
-#
-#        def get_template_info(cls):
-#            basepath = os.path.dirname(os.path.dirname(numba.__file__))
-#            code, firstlineno = inspect.getsourcelines(pyfunc)
-#            path = inspect.getsourcefile(pyfunc)
-#            sig = str(utils.pysignature(pyfunc))
-#            info = {
-#                'kind': "overload",
-#                'name': getattr(cls.key, '__name__', "unknown"),
-#                'sig': sig,
-#                'filename': utils.safe_relpath(path, start=basepath),
-#                'lines': (firstlineno, firstlineno + len(code) - 1),
-#                'docstring': pyfunc.__doc__
-#            }
-#            return info
-#
-#    typingctx = cuda_target.typing_context
-#    typingctx.insert_user_function(dispatcher, device_function_template)
-#    return dispatcher
-
-
 def compile_device(pyfunc, return_type, args, inline=True, debug=False,
                    lineinfo=False):
     msg = ("Eager compilation of device functions is deprecated. Use "
@@ -1151,7 +992,6 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
         specialized for the given signature.
         '''
         argtypes, return_type = sigutils.normalize_signature(sig)
-        #assert return_type is None or return_type == types.none
         if self.specialized:
             return next(iter(self.overloads.values()))
         else:
@@ -1276,7 +1116,6 @@ class Dispatcher(_dispatcher.Dispatcher, serialize.ReduceMixin):
             defn.inspect_types(file=file)
 
     def inspect_ptx(self, args, nvvm_options={}):
-        # XXX: Need to warn here
         msg = ('inspect_ptx for device functions is deprecated. Use '
                'compile_ptx instead.')
         warn(msg, category=NumbaDeprecationWarning)

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,6 +1,6 @@
 from numba.core import config, sigutils
 from numba.core.errors import DeprecationError
-from .compiler import declare_device_function, Dispatcher
+from .compiler import compile_device, declare_device_function, Dispatcher
 from .simulator.kernel import FakeCUDAKernel
 
 
@@ -98,14 +98,14 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['fastmath'] = fastmath
             return Dispatcher(func, [func_or_sig], targetoptions=targetoptions)
 
-        #def device_jit(func):
-        #    return compile_device(func, restype, argtypes, inline=inline,
-        #                          debug=debug)
+        def device_jit(func):
+            return compile_device(func, restype, argtypes, inline=inline,
+                                  debug=debug)
 
-        #if device:
-        #    return device_jit
-        #else:
-        return kernel_jit
+        if device:
+            return device_jit
+        else:
+            return kernel_jit
     else:
         if func_or_sig is None:
             if config.ENABLE_CUDASIM:

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,7 +1,6 @@
-from numba.core import types, config, sigutils
+from numba.core import config, sigutils
 from numba.core.errors import DeprecationError
-from .compiler import (compile_device, declare_device_function, Dispatcher,
-                       compile_device_dispatcher)
+from .compiler import declare_device_function, Dispatcher
 from .simulator.kernel import FakeCUDAKernel
 
 
@@ -10,16 +9,16 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jitdevice(func, link=[], debug=None, inline=False, opt=True,
-              no_cpython_wrapper=None):
-    """Wrapper for device-jit.
-    """
-    # We ignore  the no_cpython_wrapper kwarg - it is passed by the callee when
-    # using overloads, but there is never a CPython wrapper for CUDA anyway.
-    debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
-    if link:
-        raise ValueError("link keyword invalid for device function")
-    return compile_device_dispatcher(func, debug=debug, inline=inline, opt=opt)
+#def jitdevice(func, link=[], debug=None, inline=False, opt=True,
+#              no_cpython_wrapper=None):
+#    """Wrapper for device-jit.
+#    """
+#    # We ignore  the no_cpython_wrapper kwarg - it is passed by the callee when
+#    # using overloads, but there is never a CPython wrapper for CUDA anyway.
+#    debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
+#    if link:
+#        raise ValueError("link keyword invalid for device function")
+#    return compile_device_dispatcher(func, debug=debug, inline=inline, opt=opt)
 
 
 def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
@@ -88,8 +87,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
 
         argtypes, restype = sigutils.normalize_signature(func_or_sig)
 
-        if restype and not device and restype != types.void:
-            raise TypeError("CUDA kernel must have void return type.")
+        #if restype and not device and restype != types.void:
+        #    raise TypeError("CUDA kernel must have void return type.")
 
         def kernel_jit(func):
             targetoptions = kws.copy()
@@ -99,14 +98,14 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['fastmath'] = fastmath
             return Dispatcher(func, [func_or_sig], targetoptions=targetoptions)
 
-        def device_jit(func):
-            return compile_device(func, restype, argtypes, inline=inline,
-                                  debug=debug)
+        #def device_jit(func):
+        #    return compile_device(func, restype, argtypes, inline=inline,
+        #                          debug=debug)
 
-        if device:
-            return device_jit
-        else:
-            return kernel_jit
+        #if device:
+        #    return device_jit
+        #else:
+        return kernel_jit
     else:
         if func_or_sig is None:
             if config.ENABLE_CUDASIM:
@@ -123,8 +122,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             if config.ENABLE_CUDASIM:
                 return FakeCUDAKernel(func_or_sig, device=device,
                                       fastmath=fastmath)
-            elif device:
-                return jitdevice(func_or_sig, debug=debug, opt=opt, **kws)
+            #elif device:
+            #    return jitdevice(func_or_sig, debug=debug, opt=opt, **kws)
             else:
                 targetoptions = kws.copy()
                 targetoptions['debug'] = debug

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -9,18 +9,6 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-#def jitdevice(func, link=[], debug=None, inline=False, opt=True,
-#              no_cpython_wrapper=None):
-#    """Wrapper for device-jit.
-#    """
-#    # We ignore  the no_cpython_wrapper kwarg - it is passed by the callee when
-#    # using overloads, but there is never a CPython wrapper for CUDA anyway.
-#    debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
-#    if link:
-#        raise ValueError("link keyword invalid for device function")
-#    return compile_device_dispatcher(func, debug=debug, inline=inline, opt=opt)
-
-
 def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
         opt=True, **kws):
     """
@@ -87,9 +75,6 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
 
         argtypes, restype = sigutils.normalize_signature(func_or_sig)
 
-        #if restype and not device and restype != types.void:
-        #    raise TypeError("CUDA kernel must have void return type.")
-
         def kernel_jit(func):
             targetoptions = kws.copy()
             targetoptions['debug'] = debug
@@ -122,8 +107,6 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             if config.ENABLE_CUDASIM:
                 return FakeCUDAKernel(func_or_sig, device=device,
                                       fastmath=fastmath)
-            #elif device:
-            #    return jitdevice(func_or_sig, debug=debug, opt=opt, **kws)
             else:
                 targetoptions = kws.copy()
                 targetoptions['debug'] = debug

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -8,7 +8,7 @@ from numba.cuda.testing import unittest, CUDATestCase
 class TestCudaArrayArg(CUDATestCase):
     def test_array_ary(self):
 
-        @cuda.jit('double(double[:],int64)', device=True, inline=True)
+        @cuda.jit(device=True, inline=True)
         def device_function(a, c):
             return a[c]
 

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -64,7 +64,7 @@ class TestBlackScholes(CUDATestCase):
             black_scholes(callResultNumpy, putResultNumpy, stockPrice,
                           optionStrike, optionYears, RISKFREE, VOLATILITY)
 
-        @cuda.jit(double(double), device=True, inline=True)
+        @cuda.jit(device=True, inline=True)
         def cnd_cuda(d):
             K = 1.0 / (1.0 + 0.2316419 * math.fabs(d))
             ret_val = (RSQRT2PI * math.exp(-0.5 * d * d) *

--- a/numba/cuda/tests/cudapy/test_complex.py
+++ b/numba/cuda/tests/cudapy/test_complex.py
@@ -27,7 +27,7 @@ def compile_scalar_func(pyfunc, argtypes, restype):
     # First compile a scalar device function
     assert not any(isinstance(tp, types.Array) for tp in argtypes)
     assert not isinstance(restype, types.Array)
-    device_func = cuda.jit(restype(*argtypes), device=True)(pyfunc)
+    device_func = cuda.jit(pyfunc)
 
     kernel_types = [types.Array(tp, 1, "C")
                     for tp in [restype] + list(argtypes)]

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -35,7 +35,7 @@ class TestDeviceFunc(CUDATestCase):
         def add2f(a, b):
             return a + b
 
-        @cuda.jit("float32(float32, float32)", device=True)
+        @cuda.jit(device=True)
         def indirect(a, b):
             return add2f(a, b)
 
@@ -113,7 +113,7 @@ class TestDeviceFunc(CUDATestCase):
             return x + y
 
         args = (int32, int32)
-        cres = foo.compile(args)
+        cres = foo.compile_device(args)
 
         fname = cres.fndesc.mangled_name
         # Verify that the function name has "foo" in it as in the python name

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -130,7 +130,7 @@ class TestDeviceFunc(CUDATestCase):
             return x + y
 
         args = (int32, int32)
-        cres = foo.compile(args)
+        cres = foo.compile_device(args)
 
         fname = cres.fndesc.mangled_name
         # Verify that the function name has "foo" in it as in the python name

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -12,7 +12,7 @@ class TestDeviceFunc(CUDATestCase):
 
     def test_use_add2f(self):
 
-        @cuda.jit("float32(float32, float32)", device=True)
+        @cuda.jit(device=True)
         def add2f(a, b):
             return a + b
 
@@ -31,7 +31,7 @@ class TestDeviceFunc(CUDATestCase):
 
     def test_indirect_add2f(self):
 
-        @cuda.jit("float32(float32, float32)", device=True)
+        @cuda.jit(device=True)
         def add2f(a, b):
             return a + b
 

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -138,7 +138,7 @@ class TestFastMathOption(CUDATestCase):
 
     def test_device(self):
         # fastmath option is ignored for device function
-        @cuda.jit("float32(float32, float32)", device=True)
+        @cuda.jit(device=True)
         def foo(a, b):
             return a / b
 

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -137,7 +137,9 @@ class TestFastMathOption(CUDATestCase):
             self.fail("Divide in fastmath should not throw ZeroDivisionError")
 
     def test_device(self):
-        # fastmath option is ignored for device function
+        # Device functions inherit the fastmath flag from the calling kernel -
+        # the presence or absence of fastmath flag on the called function is
+        # ignored.
         @cuda.jit(device=True)
         def foo(a, b):
             return a / b

--- a/numba/cuda/tests/cudapy/test_fastmath.py
+++ b/numba/cuda/tests/cudapy/test_fastmath.py
@@ -140,7 +140,7 @@ class TestFastMathOption(CUDATestCase):
         # Device functions inherit the fastmath flag from the calling kernel -
         # the presence or absence of fastmath flag on the called function is
         # ignored.
-        @cuda.jit(device=True)
+        @cuda.jit("float32(float32, float32)", device=True)
         def foo(a, b):
             return a / b
 

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -15,7 +15,7 @@ SM_SIZE = tpb, tpb
 class TestCudaLaplace(CUDATestCase):
     def test_laplace_small(self):
 
-        @cuda.jit(float64(float64, float64), device=True, inline=True)
+        @cuda.jit(device=True, inline=True)
         def get_max(a, b):
             if a > b:
                 return a

--- a/numba/cuda/tests/cudapy/test_mandel.py
+++ b/numba/cuda/tests/cudapy/test_mandel.py
@@ -2,8 +2,6 @@ from numba import cuda
 from numba.cuda.testing import unittest
 
 
-@unittest.skip('Compile device function for specific signature should use '
-               'compile_ptx')
 class TestCudaMandel(unittest.TestCase):
     def test_mandel(self):
         """Just make sure we can compile this

--- a/numba/cuda/tests/cudapy/test_mandel.py
+++ b/numba/cuda/tests/cudapy/test_mandel.py
@@ -2,6 +2,8 @@ from numba import cuda
 from numba.cuda.testing import unittest
 
 
+@unittest.skip('Compile device function for specific signature should use '
+               'compile_ptx')
 class TestCudaMandel(unittest.TestCase):
     def test_mandel(self):
         """Just make sure we can compile this

--- a/numba/cuda/tests/cudapy/test_slicing.py
+++ b/numba/cuda/tests/cudapy/test_slicing.py
@@ -16,7 +16,7 @@ def copy(inp, out):
 class TestCudaSlicing(CUDATestCase):
     def test_slice_as_arg(self):
         global cufoo
-        cufoo = cuda.jit("void(int32[:], int32[:])", device=True)(foo)
+        cufoo = cuda.jit(device=True)(foo)
         cucopy = cuda.jit("void(int32[:,:], int32[:,:])")(copy)
 
         inp = np.arange(100, dtype=np.int32).reshape(10, 10)

--- a/numba/cuda/tests/cudapy/test_vectorize_device.py
+++ b/numba/cuda/tests/cudapy/test_vectorize_device.py
@@ -9,7 +9,7 @@ import unittest
 class TestCudaVectorizeDeviceCall(CUDATestCase):
     def test_cuda_vectorize_device_call(self):
 
-        @cuda.jit(float32(float32, float32, float32), device=True)
+        @cuda.jit
         def cu_device_fn(x, y, z):
             return x ** y / z
 

--- a/numba/cuda/vectorizers.py
+++ b/numba/cuda/vectorizers.py
@@ -49,7 +49,7 @@ def __gufunc_{name}({args}):
 
 class CUDAGUFuncVectorize(deviceufunc.DeviceGUFuncVectorize):
     def __init__(self, func, sig, **kwargs):
-        super().__init__(func, sig)
+        super().__init__(func, sig, **kwargs)
         self.dispatcher = cuda.jit(func)
 
     def build_ufunc(self):


### PR DESCRIPTION
This PR removes the separate dispatcher for device functions (`DeviceDispatcher`) and uses the `Dispatcher` class for all CUDA functions requiring dispatch. With this change, `device=True` generally has no effect - all CUDA jitted functions are treated the same, and can be called from the host or from kernels. 

There is one exception to this - eager compilation of device functions still goes through a slightly different route, through the `compile_device()` function to create a `DeviceFunction()` instance - this is kept for now because it is needed to support the use case where someone is using Numba to compile Python to PTX device functions. However, a deprecation warning is added that advises the use of `compile_ptx()` so that it is possible in future for the `device` keyword to be completely redundant.

This PR is functionally complete but needs some tidying up and documentation adding - the main reason for making it now is to request a CUDA buildfarm run before assuming that no major changes are required - @esc / @stuartarchibald could this have a run please?

I also noticed various cases where `fastmath` behaviour is not as expected - I'll add xfailing tests along with the other tidy-ups.