### PR TITLE
CUDA: Deprecate eager compilation of device functions

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -375,3 +375,56 @@ Schedule
 
 - In Numba 0.54: ``inspect_ptx()`` will be deprecated.
 - In Numba 0.55: ``inspect_ptx()`` will be removed.
+
+
+Deprecation of eager compilation of CUDA device functions
+=========================================================
+
+In future versions of Numba, the ``device`` kwarg to the ``@cuda.jit`` decorator
+will be obviated, and whether a device function or global kernel is compiled will
+be inferred from the context. With respect to kernel / device functions and lazy
+/ eager compilation, four cases are presently handled:
+
+1. ``device=True``, eager compilation with a signature provided
+2. ``device=False``, eager compilation with a signature provided
+3. ``device=True``, lazy compilation with no signature
+4. ``device=False``, lazy compilation with no signature
+
+The latter two cases can be differentiated without the ``device`` kwarg, because
+it can be inferred from the calling context - if the call is from the host, then
+a global kernel should be compiled, and if the call is from a kernel or another
+device function, then a device function should be compiled.
+
+The first two cases cannot be differentiated in the absence of the ``device``
+kwarg - without it, it will not be clear from a signature alone whether a device
+function or global kernel should be compiled. In order to resolve, this, support
+for eager compilation of device functions will be removed. Eager compilation
+with the ``@cuda.jit`` decorator will in future always imply the immediate
+compilation of a global kernel.
+
+Recommendations
+---------------
+
+Any eagerly-compiled device functions should have their signature removed, e.g.:
+
+.. code-block:: python
+
+   @cuda.jit('int32(int32, int32)', device=True)
+   def f(x, y):
+       return x + y
+
+becomes:
+
+
+.. code-block:: python
+
+   @cuda.jit(device=True)
+   def f(x, y):
+       return x + y
+
+Schedule
+--------
+
+- In Numba 0.54: Eager compilation of device functions will be deprecated.
+- In Numba 0.55: Eager compilation of device functions will be unsupported and
+  attempts to eagerly compile device functions will raise an error.

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -397,7 +397,7 @@ device function, then a device function should be compiled.
 
 The first two cases cannot be differentiated in the absence of the ``device``
 kwarg - without it, it will not be clear from a signature alone whether a device
-function or global kernel should be compiled. In order to resolve, this, support
+function or global kernel should be compiled. In order to resolve this, support
 for eager compilation of device functions will be removed. Eager compilation
 with the ``@cuda.jit`` decorator will in future always imply the immediate
 compilation of a global kernel.

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,5 +1,6 @@
+from warnings import warn
 from numba.core import types, config, sigutils
-from numba.core.errors import DeprecationError
+from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from .compiler import (compile_device, declare_device_function, Dispatcher,
                        compile_device_dispatcher)
 from .simulator.kernel import FakeCUDAKernel
@@ -104,6 +105,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                                   debug=debug)
 
         if device:
+            msg = ("Eager compilation of device functions is deprecated")
+            warn(NumbaDeprecationWarning(msg))
             return device_jit
         else:
             return kernel_jit

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -105,7 +105,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                                   debug=debug)
 
         if device:
-            msg = ("Eager compilation of device functions is deprecated")
+            msg = ("Eager compilation of device functions is deprecated "
+                   "(this occurs when a signature is provided)")
             warn(NumbaDeprecationWarning(msg))
             return device_jit
         else:

--- a/numba/cuda/tests/cudapy/test_device_func.py
+++ b/numba/cuda/tests/cudapy/test_device_func.py
@@ -2,6 +2,7 @@ import re
 import types
 
 import numpy as np
+import warnings
 
 from numba.cuda.testing import unittest, skip_on_cudasim, CUDATestCase
 from numba import cuda, jit, int32
@@ -139,6 +140,15 @@ class TestDeviceFunc(CUDATestCase):
         llvm = foo.inspect_llvm(args)
         # Check that the compiled function name is in the LLVM.
         self.assertIn(fname, llvm)
+
+    @skip_on_cudasim('not supported in cudasim')
+    def test_deprecated_eager_device(self):
+        with warnings.catch_warnings(record=True) as w:
+            cuda.jit('int32(int32)', device=True)
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('Eager compilation of device functions is deprecated',
+                      str(w[0].message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In future versions of Numba, the `device` kwarg to the `@cuda.jit` decorator will be obviated, and whether a device function or global kernel is compiled will be inferred from the context. With respect to kernel / device functions and lazy / eager compilation, four cases are presently handled:

1. `device=True`, eager compilation with a signature provided
2. `device=False`, eager compilation with a signature provided
3. `device=True`, lazy compilation with no signature
4. `device=False`, lazy compilation with no signature

The latter two cases can be differentiated without the `device` kwarg, because it can be inferred from the calling context - if the call is from the host, then a global kernel should be compiled, and if the call is from a kernel or another device function, then a device function should be compiled.

The first two cases cannot be differentiated in the absence of the `device` kwarg - without it, it will not be clear from a signature alone whether a device function or global kernel should be compiled. In order to resolve, this, support for eager compilation of device functions will be removed. Eager compilation with the `@cuda.jit` decorator will in future always imply the immediate
compilation of a global kernel.

This PR is made for Numba 0.54, in order to prepare for the changes in #7107 for 0.55.