### PR TITLE
use np.asarray to convert arg to array

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -791,6 +791,8 @@ def np_all(a):
 @overload(np.any)
 @overload_method(types.Array, "any")
 def np_any(a):
+    if not type_can_asarray(a):
+        raise errors.TypingError('The argument "a" must be array-like')
     def flat_any(a):
         a = np.asarray(a)
         for v in np.nditer(a):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -779,6 +779,7 @@ def array_argmax(context, builder, sig, args):
 @overload_method(types.Array, "all")
 def np_all(a):
     def flat_all(a):
+        a = np.asarray(a)
         for v in np.nditer(a):
             if not v.item():
                 return False
@@ -791,6 +792,7 @@ def np_all(a):
 @overload_method(types.Array, "any")
 def np_any(a):
     def flat_any(a):
+        a = np.asarray(a)
         for v in np.nditer(a):
             if v.item():
                 return True


### PR DESCRIPTION

used `np.asarray` to convert arg to array

closes #7101 
