### PR TITLE
Declare minimum sphinx version required for docs as 4.

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -28,7 +28,7 @@ call activate %CONDA_ENV%
 @rem Install latest llvmlite build
 %CONDA_INSTALL% -c numba/label/dev llvmlite
 @rem Install dependencies for building the documentation
-if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx sphinx_rtd_theme pygments)
+if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx=4 sphinx_rtd_theme pygments)
 @rem Install dependencies for code coverage (codecov.io)
 if "%RUN_COVERAGE%" == "yes" (%PIP_INSTALL% codecov)
 @rem Install TBB

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -85,7 +85,7 @@ fi
 $CONDA_INSTALL -c numba/label/dev llvmlite
 
 # Install dependencies for building the documentation
-if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx=2.4.4 sphinx_rtd_theme pygments numpydoc; fi
+if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx=4 sphinx_rtd_theme pygments numpydoc; fi
 if [ "$BUILD_DOC" == "yes" ]; then $PIP_INSTALL rstcheck; fi
 # Install dependencies for code coverage (codecov.io)
 if [ "$RUN_COVERAGE" == "yes" ]; then $PIP_INSTALL codecov; fi

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -413,7 +413,8 @@ Main documentation
 This documentation is under the ``docs`` directory of the `Numba repository`_.
 It is built with `Sphinx <http://sphinx-doc.org/>`_ and
 `numpydoc <https://numpydoc.readthedocs.io/>`_, which are available using
-conda or pip; i.e. ``conda install sphinx numpydoc``.
+conda or pip; i.e. ``conda install sphinx=4 numpydoc`` (``sphinx`` version 4.0
+or greater is required).
 
 To build the documentation, you need the bootstrap theme::
 

--- a/docs/source/extending/low-level.rst
+++ b/docs/source/extending/low-level.rst
@@ -60,6 +60,7 @@ and typing *operations* (or *functions*) on known value types.
    ``numba.float64``).
 
 .. decorator:: as_numba_type.register
+   :noindex:
 
    Register the decorated function as a type inference function used by
    ``as_numba_type`` when trying to infer the Numba type of a Python type.

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -266,7 +266,7 @@ vary with target operating system and hardware. The following lists them all
 
 * To build the documentation:
 
-  * ``sphinx``
+  * ``sphinx`` - version 4.0 or greater required.
   * ``pygments``
   * ``sphinx_rtd_theme``
   * ``numpydoc``


### PR DESCRIPTION
As title. Patches up the build scripts to enforce and docs to note
this.
