### PR TITLE
gh #7131 Support for astype with literal strings

### DIFF
--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -405,7 +405,6 @@ class BoundFunction(Callable, Opaque):
         literal_e = None
         nonliteral_e = None
         out = None
-
         choice = [True, False] if template.prefer_literal else [False, True]
         for uselit in choice:
             if uselit:
@@ -442,7 +441,10 @@ class BoundFunction(Callable, Opaque):
                                 raise exc
                         nonliteral_e = exc
                     else:
-                        break
+                        # If out returns None don't break as we may need to use
+                        # a literal.
+                        if out is not None:
+                            break
 
         if out is None and (nonliteral_e is not None or literal_e is not None):
             header = "- Resolution failure for {} arguments:\n{}\n"

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4146,6 +4146,7 @@ def array_ascontiguousarray(context, builder, sig, args):
 
 
 @lower_builtin("array.astype", types.Array, types.DTypeSpec)
+@lower_builtin("array.astype", types.Array, types.StringLiteral)
 def array_astype(context, builder, sig, args):
     arytype = sig.args[0]
     ary = make_array(arytype)(context, builder, value=args[0])

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -471,6 +471,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         check(arr, np.int32)
         check(arr, np.float32)
         check(arr, np.complex128)
+        check(arr, "float32")
 
         # F-contiguous
         arr = np.arange(24, dtype=np.int8).reshape((3, 8)).T


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Adds support for Array.astype with string literal type names. This required two changes:
  1. Adding a lower_builtin for string literals.
  2. Fixes a bug in `get_call_type` where the literal option would never be tried if the unliteral version was preferred and returned None.

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->
Closes #7131