### PR TITLE
Move minimum LLVM version to 11.

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -86,7 +86,7 @@ __all__ = """
 
 
 _min_llvmlite_version = (0, 33, 0)
-_min_llvm_version = (9, 0, 0)
+_min_llvm_version = (11, 0, 0)
 
 def _ensure_llvm():
     """


### PR DESCRIPTION
Since Aarch64 is now fixed for LLVM 11 this can be moved.

