### PR TITLE
Do not run cache tests under typeguard.

### DIFF
--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -26,7 +26,7 @@ from numba.np.numpy_support import as_dtype
 from numba.core.caching import _UserWideCacheLocator
 from numba.core.dispatcher import Dispatcher
 from numba.tests.support import (skip_parfors_unsupported, needs_lapack,
-                                 SerialMixin)
+                                 SerialMixin, skip_if_typeguard)
 from numba.testing.main import _TIMEOUT as _RUNNER_TIMEOUT
 import llvmlite.binding as ll
 import unittest
@@ -1598,6 +1598,7 @@ class TestMultiprocessCache(BaseCacheTest):
         self.assertEqual(res, n * (n - 1) // 2)
 
 
+@skip_if_typeguard
 class TestCacheFileCollision(unittest.TestCase):
     _numba_parallel_test_ = False
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -21,6 +21,7 @@ from numba.tests.support import (
     temp_directory,
     override_config,
     run_in_new_process_in_cache_dir,
+    skip_if_typeguard,
 )
 from numba.core.errors import LoweringError
 import unittest
@@ -1162,6 +1163,7 @@ def _assert_cache_stats(cfunc, expect_hit, expect_misses):
         raise AssertionError("cache not used")
 
 
+@skip_if_typeguard
 class TestOverloadMethodCaching(TestCase):
     # Nested multiprocessing.Pool raises AssertionError:
     # "daemonic processes are not allowed to have children"
@@ -1759,6 +1761,7 @@ def with_objmode_cache_ov_example(x):
     pass
 
 
+@skip_if_typeguard
 class TestCachingOverloadObjmode(TestCase):
     """Test caching of the use of overload implementations that use
     `with objmode`


### PR DESCRIPTION
As title.

Fixes #7136
