### PR TITLE
Fix `inline_closurecall` may not be imported

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -1738,6 +1738,7 @@ def get_ir_of_code(glbls, fcode):
     rewrites.rewrite_registry.apply('before-inference', state)
     # call inline pass to handle cases like stencils and comprehensions
     swapped = {} # TODO: get this from diagnostics store
+    import numba.core.inline_closurecall
     inline_pass = numba.core.inline_closurecall.InlineClosureCallPass(
         ir, numba.core.cpu.ParallelOptions(False), swapped)
     inline_pass.run()


### PR DESCRIPTION
Mainline is failing because of this.

See error log at https://dev.azure.com/numba/numba/_build/results?buildId=9107&view=logs&jobId=0b09a2a2-0f6e-53e2-0b1f-738b2a0d11e7&j=0b09a2a2-0f6e-53e2-0b1f-738b2a0d11e7&t=e50a781e-75f1-573d-4144-a4055b22df26

This is likely caused by drifting in test slices that finally reveal the problem because the test is py3.9 only.