### PR TITLE
Fix iterators in CUDA

### DIFF
--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -86,7 +86,7 @@ class CUDATargetContext(BaseContext):
         # side effect of import needed for numba.cpython.*, the builtins
         # registry is updated at import time.
         from numba.cpython import numbers, tupleobj, slicing # noqa: F401
-        from numba.cpython import rangeobj, unicode # noqa: F401
+        from numba.cpython import rangeobj, iterators, unicode # noqa: F401
         from numba.cpython import cmathimpl
         from numba.np import arrayobj # noqa: F401
         from numba.np import npdatetime # noqa: F401

--- a/numba/cuda/tests/cudapy/test_iterators.py
+++ b/numba/cuda/tests/cudapy/test_iterators.py
@@ -1,0 +1,99 @@
+from numba import cuda
+from numba.cuda.testing import unittest, CUDATestCase
+
+import numpy as np
+
+
+class TestIterators(CUDATestCase):
+
+    def test_enumerate(self):
+        @cuda.jit
+        def enumerator(x, error):
+            count = 0
+
+            for i, v in enumerate(x):
+                if count != i:
+                    error[0] = 1
+                if v != x[i]:
+                    error[0] = 2
+
+                count += 1
+
+            if count != len(x):
+                error[0] = 3
+
+        x = np.asarray((10, 9, 8, 7, 6))
+        error = np.zeros(1, dtype=np.int32)
+
+        enumerator[1, 1](x, error)
+        self.assertEqual(error[0], 0)
+
+    def _test_twoarg_function(self, f):
+        x = np.asarray((10, 9, 8, 7, 6))
+        y = np.asarray((1, 2, 3, 4, 5))
+        error = np.zeros(1, dtype=np.int32)
+
+        f[1, 1](x, y, error)
+        self.assertEqual(error[0], 0)
+
+    def test_zip(self):
+        @cuda.jit
+        def zipper(x, y, error):
+            i = 0
+
+            for xv, yv in zip(x, y):
+                if xv != x[i]:
+                    error[0] = 1
+                if yv != y[i]:
+                    error[0] = 2
+
+                i += 1
+
+            if i != len(x):
+                error[0] = 3
+
+        self._test_twoarg_function(zipper)
+
+    def test_enumerate_zip(self):
+        @cuda.jit
+        def enumerator_zipper(x, y, error):
+            count = 0
+
+            for i, (xv, yv) in enumerate(zip(x, y)):
+                if i != count:
+                    error[0] = 1
+                if xv != x[i]:
+                    error[0] = 2
+                if yv != y[i]:
+                    error[0] = 3
+
+                count += 1
+
+            if count != len(x):
+                error[0] = 4
+
+        self._test_twoarg_function(enumerator_zipper)
+
+    def test_zip_enumerate(self):
+        @cuda.jit
+        def zipper_enumerator(x, y, error):
+            count = 0
+
+            for (i, xv), yv in zip(enumerate(x), y):
+                if i != count:
+                    error[0] = 1
+                if xv != x[i]:
+                    error[0] = 2
+                if yv != y[i]:
+                    error[0] = 3
+
+                count += 1
+
+            if count != len(x):
+                error[0] = 4
+
+        self._test_twoarg_function(zipper_enumerator)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The recent refactoring to remove side-effects on import missed registering typing and lowering for iterators with CUDA. This PR adds the registration of them and appropriate tests.