### PR TITLE
Fix `ir_utils._max_label` being updated incorrectly

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -374,14 +374,14 @@ class InlineWorker(object):
         callee_blocks = callee_ir.blocks
 
         # 1. relabel callee_ir by adding an offset
-        max_label = max(ir_utils._max_label, max(caller_ir.blocks.keys()))
+        max_label = max(ir_utils._the_max_label.next(), max(caller_ir.blocks.keys()))
         callee_blocks = add_offset_to_labels(callee_blocks, max_label + 1)
         callee_blocks = simplify_CFG(callee_blocks)
         callee_ir.blocks = callee_blocks
         min_label = min(callee_blocks.keys())
         max_label = max(callee_blocks.keys())
         #    reset globals in ir_utils before we use it
-        ir_utils._max_label = max_label
+        ir_utils._the_max_label.update(max_label)
         self.debug_print("After relabel")
         _debug_dump(callee_ir)
 
@@ -579,14 +579,14 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     callee_blocks = callee_ir.blocks
 
     # 1. relabel callee_ir by adding an offset
-    max_label = max(ir_utils._max_label, max(func_ir.blocks.keys()))
+    max_label = max(ir_utils._the_max_label.next(), max(func_ir.blocks.keys()))
     callee_blocks = add_offset_to_labels(callee_blocks, max_label + 1)
     callee_blocks = simplify_CFG(callee_blocks)
     callee_ir.blocks = callee_blocks
     min_label = min(callee_blocks.keys())
     max_label = max(callee_blocks.keys())
     #    reset globals in ir_utils before we use it
-    ir_utils._max_label = max_label
+    ir_utils._the_max_label.update(max_label)
     debug_print("After relabel")
     _debug_dump(callee_ir)
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -36,7 +36,19 @@ def mk_unique_var(prefix):
     return var
 
 
-_max_label = 0
+class _MaxLabel:
+    def __init__(self, value=0):
+        self._value = value
+
+    def next(self):
+        self._value += 1
+        return self._value
+
+    def update(self, newval):
+        self._value = max(newval, self._value)
+
+
+_the_max_label = _MaxLabel()
 
 
 def get_unused_var_name(prefix, var_table):
@@ -52,9 +64,7 @@ def get_unused_var_name(prefix, var_table):
 
 
 def next_label():
-    global _max_label
-    _max_label += 1
-    return _max_label
+    return _the_max_label.next()
 
 
 def mk_alloc(typemap, calltypes, lhs, size_var, dtype, scope, loc, lhs_typ):
@@ -1662,10 +1672,9 @@ def compile_to_numba_ir(mk_func, glbls, typingctx=None, targetctx=None,
     remove_dels(f_ir.blocks)
 
     # relabel by adding an offset
-    global _max_label
-    f_ir.blocks = add_offset_to_labels(f_ir.blocks, _max_label + 1)
+    f_ir.blocks = add_offset_to_labels(f_ir.blocks, _the_max_label.next())
     max_label = max(f_ir.blocks.keys())
-    _max_label = max_label
+    _the_max_label.update(max_label)
 
     # rename all variables to avoid conflict
     var_table = get_name_var_table(f_ir.blocks)

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -49,6 +49,7 @@ class _MaxLabel:
 
 
 _the_max_label = _MaxLabel()
+del _MaxLabel
 
 
 def get_unused_var_name(prefix, var_table):

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1571,7 +1571,7 @@ class ParforPassStates:
             self.typingctx, self.func_ir, self.typemap, self.calltypes,
         )
 
-        ir_utils._max_label = max(func_ir.blocks.keys())
+        ir_utils._the_max_label.update(max(func_ir.blocks.keys()))
         self.flags = flags
         self.metadata = metadata
         if "parfors" not in metadata:
@@ -2781,9 +2781,9 @@ class ParforPass(ParforPassStates):
     def _pre_run(self):
         # run array analysis, a pre-requisite for parfor translation
         self.array_analysis.run(self.func_ir.blocks)
-        # NOTE: Prepare _max_label. See #6102
-        ir_utils._max_label = max(ir_utils._max_label,
-                                  ir_utils.find_max_label(self.func_ir.blocks))
+        # NOTE: Prepare _the_max_label. See #6102
+        ir_utils._the_max_label.update(
+            ir_utils.find_max_label(self.func_ir.blocks))
 
     def run(self):
         """run parfor conversion pass: replace Numpy calls
@@ -3255,8 +3255,7 @@ def _find_func_var(typemap, func, avail_vars, loc):
 
 
 def lower_parfor_sequential(typingctx, func_ir, typemap, calltypes, metadata):
-    ir_utils._max_label = max(ir_utils._max_label,
-                              ir_utils.find_max_label(func_ir.blocks))
+    ir_utils._the_max_label.update(ir_utils.find_max_label(func_ir.blocks))
     parfor_found = False
     new_blocks = {}
     scope = next(iter(func_ir.blocks.values())).scope

--- a/numba/stencils/stencilparfor.py
+++ b/numba/stencils/stencilparfor.py
@@ -692,7 +692,7 @@ def get_stencil_ir(sf, typingctx, args, scope, loc, input_dict, typemap,
                                                         ir_utils.next_label())
     min_label = min(stencil_blocks.keys())
     max_label = max(stencil_blocks.keys())
-    ir_utils._max_label = max_label
+    ir_utils._the_max_label.update(max_label)
 
     if config.DEBUG_ARRAY_OPT >= 1:
         print("Initial stencil_blocks")

--- a/numba/tests/parfors_max_label_error.py
+++ b/numba/tests/parfors_max_label_error.py
@@ -49,6 +49,7 @@ class MyCustomTarget(BasicRetarget):
 
 retarget = MyCustomTarget()
 
+
 # ------------ Functions being tested ------------
 @njit
 def f(a):

--- a/numba/tests/parfors_max_label_error.py
+++ b/numba/tests/parfors_max_label_error.py
@@ -4,7 +4,7 @@ correctly. As a result of the error, inline_closurecall will incorrectly
 overwrite an existing label, resulting in code that creates an effect-free
 infinite loop, which is an undefined behavior to LLVM. LLVM will then assume
 the function can never execute and an alternative code path will be taken
-despite of the value of any conditional branch that is guarding the alternative
+in spite of the value of any conditional branch that is guarding the alternative
 code path.
 """
 import numpy as np

--- a/numba/tests/parfors_max_label_error.py
+++ b/numba/tests/parfors_max_label_error.py
@@ -1,0 +1,67 @@
+"""
+This is a test for an error with ir_utils._max_label not being updated
+correctly. As a result of the error, inline_closurecall will incorrectly
+overwrite an existing label, resulting in code that creates an effect-free
+infinite loop, which is an undefined behavior to LLVM. LLVM will then assume
+the function can never execute and an alternative code path will be taken
+despite of the value of any conditional branch that is guarding the alternative
+code path.
+"""
+import numpy as np
+
+from numba import njit
+from numba.core.dispatcher import TargetConfig
+from numba.core.target_extension import (
+    dispatcher_registry,
+    CPUDispatcher,
+    CPU,
+    target_registry,
+)
+from numba.core.retarget import BasicRetarget
+
+# ------------ A "CustomCPU" target ------------
+
+
+class CustomCPU(CPU):
+    pass
+
+
+class CustomCPUDispatcher(CPUDispatcher):
+    pass
+
+
+target_registry["CustomCPU"] = CustomCPU
+dispatcher_registry[target_registry["CustomCPU"]] = CustomCPUDispatcher
+
+
+# ------------ For switching target ------------
+
+
+class MyCustomTarget(BasicRetarget):
+    @property
+    def output_target(self):
+        return "CustomCPU"
+
+    def compile_retarget(self, cpu_disp):
+        kernel = njit(_target="CustomCPU", parallel=True)(cpu_disp.py_func)
+        return kernel
+
+
+retarget = MyCustomTarget()
+
+# ------------ Functions being tested ------------
+@njit
+def f(a):
+    return np.arange(a.size)
+
+
+def main():
+    a = np.ones(20)
+    with TargetConfig.switch_target(retarget):
+        r = f(a)
+    np.testing.assert_equal(r, f.py_func(a))
+    print("TEST PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -19,6 +19,7 @@ import operator
 from collections import defaultdict, namedtuple
 import copy
 from itertools import cycle, chain
+import subprocess as subp
 
 import numba.parfors.parfor
 from numba import njit, prange, set_num_threads, get_num_threads, typeof
@@ -3947,6 +3948,17 @@ class TestParforsMisc(TestParforsBase):
             find_maxima_3D_jit(args),
             find_maxima_3D_jit.py_func(args),
         )
+
+    @skip_parfors_unsupported
+    def test_issue_due_to_max_label(self):
+        # Run the actual test in a new process since it can only reproduce in
+        # a fresh state.
+        out = subp.check_output(
+            [sys.executable, '-m', 'numba.tests.parfors_max_label_error'],
+            timeout=30,
+            stderr=subp.STDOUT, # redirect stderr to stdout
+        )
+        self.assertIn("TEST PASSED", out.decode())
 
 
 @skip_parfors_unsupported


### PR DESCRIPTION
Fixes #7155.

This patch changes `ir_utils._max_label` into an instance of `_MaxLabel` so it is easier to enforce the correct update logic. It also means that we no longer need to use `global _max_label` to update it.

**Additional notes**

As demonstrate by this patch,  #7155 is not caused by the retargeting support or any of the recent work to make target-specific overload. It is just unfortunate that the bug is revealed in a case that make use of the retargeting support. I'm also unsure if we really should keep the included testcase, which is not representative of the problem but just a coincident that it revealed the problem. It is likely overly difficult to create a minimal reproducer for the problem.