### PR TITLE
Split legalization pass to consider IR and features separately.

### DIFF
--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -30,7 +30,7 @@ from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
                                      InlineOverloads, PreLowerStripPhis,
                                      NativeLowering,
                                      NoPythonSupportedFeatureValidation,
-                                     ObjModeSupportedFeatureValidation)
+                                     )
 
 from numba.core.object_mode_passes import (ObjectModeFrontEnd,
                                            ObjectModeBackEnd)
@@ -651,8 +651,6 @@ class DefaultPassBuilder(object):
         pm.add_pass(MakeFunctionToJitFunction,
                     "convert make_function into JIT functions")
         pm.add_pass(AnnotateTypes, "annotate types")
-        pm.add_pass(ObjModeSupportedFeatureValidation,
-                    "ensure features that are in use are in a valid form")
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
         pm.add_pass(ObjectModeBackEnd, "object mode backend")
         pm.finalize()

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -28,7 +28,9 @@ from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
                                      ParforPass, DumpParforDiagnostics,
                                      IRLegalization, NoPythonBackend,
                                      InlineOverloads, PreLowerStripPhis,
-                                     NativeLowering)
+                                     NativeLowering,
+                                     NoPythonSupportedFeatureValidation,
+                                     ObjModeSupportedFeatureValidation)
 
 from numba.core.object_mode_passes import (ObjectModeFrontEnd,
                                            ObjectModeBackEnd)
@@ -547,6 +549,8 @@ class DefaultPassBuilder(object):
     def define_nopython_lowering_pipeline(state, name='nopython_lowering'):
         pm = PassManager(name)
         # legalise
+        pm.add_pass(NoPythonSupportedFeatureValidation,
+                    "ensure features that are in use are in a valid form")
         pm.add_pass(IRLegalization,
                     "ensure IR is legal prior to lowering")
 
@@ -647,6 +651,8 @@ class DefaultPassBuilder(object):
         pm.add_pass(MakeFunctionToJitFunction,
                     "convert make_function into JIT functions")
         pm.add_pass(AnnotateTypes, "annotate types")
+        pm.add_pass(ObjModeSupportedFeatureValidation,
+                    "ensure features that are in use are in a valid form")
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
         pm.add_pass(ObjectModeBackEnd, "object mode backend")
         pm.finalize()

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -441,28 +441,13 @@ class NoPythonSupportedFeatureValidation(AnalysisPass):
     """NoPython Mode check: Validates the IR to ensure that features in use are
     in a form that is supported"""
 
-    _name = "no_python_supported_feature_validation"
+    _name = "nopython_supported_feature_validation"
 
     def __init__(self):
         AnalysisPass.__init__(self)
 
     def run_pass(self, state):
         raise_on_unsupported_feature(state.func_ir, state.typemap)
-        warn_deprecated(state.func_ir, state.typemap)
-        return False
-
-
-@register_pass(mutates_CFG=False, analysis_only=True)
-class ObjModeSupportedFeatureValidation(AnalysisPass):
-    """Object mode check: Validates the IR to ensure that features in use are
-    in a form that is supported"""
-
-    _name = "obj_mode_supported_feature_validation"
-
-    def __init__(self):
-        AnalysisPass.__init__(self)
-
-    def run_pass(self, state):
         warn_deprecated(state.func_ir, state.typemap)
         return False
 

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -437,6 +437,37 @@ class NativeLowering(LoweringPass):
 
 
 @register_pass(mutates_CFG=False, analysis_only=True)
+class NoPythonSupportedFeatureValidation(AnalysisPass):
+    """NoPython Mode check: Validates the IR to ensure that features in use are
+    in a form that is supported"""
+
+    _name = "no_python_supported_feature_validation"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        raise_on_unsupported_feature(state.func_ir, state.typemap)
+        warn_deprecated(state.func_ir, state.typemap)
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
+class ObjModeSupportedFeatureValidation(AnalysisPass):
+    """Object mode check: Validates the IR to ensure that features in use are
+    in a form that is supported"""
+
+    _name = "obj_mode_supported_feature_validation"
+
+    def __init__(self):
+        AnalysisPass.__init__(self)
+
+    def run_pass(self, state):
+        warn_deprecated(state.func_ir, state.typemap)
+        return False
+
+
+@register_pass(mutates_CFG=False, analysis_only=True)
 class IRLegalization(AnalysisPass):
 
     _name = "ir_legalization"
@@ -445,8 +476,6 @@ class IRLegalization(AnalysisPass):
         AnalysisPass.__init__(self)
 
     def run_pass(self, state):
-        raise_on_unsupported_feature(state.func_ir, state.typemap)
-        warn_deprecated(state.func_ir, state.typemap)
         # NOTE: this function call must go last, it checks and fixes invalid IR!
         check_and_legalize_ir(state.func_ir)
         return True

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -1083,6 +1083,20 @@ class TestLiftObj(MemoryLeak, TestCase):
              r"as a (<class ')?numba.typed.typedlist.List('>)?"),
         )
 
+    def test_objmode_use_of_view(self):
+        # See issue #7158, npm functionality should only be validated if in
+        # npm.
+        @njit
+        def foo(x):
+            with numba.objmode(y="int64[::1]"):
+                y = x.view("int64")
+            return y
+
+        a = np.ones(1, np.int64).view('float64')
+        expected = foo.py_func(a)
+        got = foo(a)
+        self.assertPreciseEqual(expected, got)
+
 
 def case_inner_pyfunc(x):
     return x / 10


### PR DESCRIPTION
This splits out legalization into:
* IR legalization
* Feature legalization for nopython mode and object mode.

It puts these into separate compiler passes and adds them to the
standard pipelines.

Adds test based on original reproducer.

Fixes #7158
