### PR TITLE
Make aliasing work for tuple (re)construction.

### DIFF
--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -816,6 +816,10 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
             if isinstance(instr, ir.Assign):
                 expr = instr.value
                 lhs = instr.target.name
+                lhstype = None
+                if lhs in typemap:
+                    lhstype = typemap[lhs]
+
                 # only mutable types can alias
                 if is_immutable_type(lhs, typemap):
                     continue
@@ -851,6 +855,12 @@ def find_potential_aliases(blocks, args, typemap, func_ir, alias_map=None,
                         _add_alias(lhs, expr.args[0].name, alias_map, arg_aliases)
                     if isinstance(fmod, ir.Var) and fname in np_alias_funcs:
                         _add_alias(lhs, fmod.name, alias_map, arg_aliases)
+                    if isinstance(lhstype, types.containers.BaseTuple):
+                        for used_var in expr.args:
+                            _add_alias(lhs, used_var.name, alias_map, arg_aliases)
+                        for used_var in expr.kws:
+                            assert(isinstance(used_var[1], ir.Var))
+                            _add_alias(lhs, used_var[1].name, alias_map, arg_aliases)
 
     # copy to avoid changing size during iteration
     old_alias_map = copy.deepcopy(alias_map)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1786,6 +1786,19 @@ class TestParfors(TestParforsBase):
         x = TestNamedTuple3(y=np.zeros(10))
         self.check(test_impl, x, check_arg_equality=[comparer])
 
+    def test_namedtuple4(self):
+        # issue7135
+        def test_impl(dat):
+            n, = dat.x.shape
+            for i in numba.prange(n):
+                dat.x[i] = -1
+
+        x = np.ones(10)
+        Data = namedtuple("Data", ["x"])
+        dat = Data(x)
+
+        self.check(test_impl, dat)
+
     def test_inplace_binop(self):
         def test_impl(a, b):
             b += a


### PR DESCRIPTION
Resolves #7135 

Previously, aliasing only worked when extracting something from a tuple.  In issue 7135, a tuple is passed to a parfor and because it is a tuple, we extract the individual parts and reconstruct the tuple within the gufunc since tuples can't be passed explicitly to gufuncs.  When the tuple is reconstructed, we need the elements that go into the tuple to alias with the tuple so that when elements are subsequently extracted that everything aliases and so the original arguments are known to be live and so that liveness propagates to the tuple and then elements extracted from it.  In short, this PR stops dead code removal from thinking that writes into parts of a reconstructed tuple are dead.