### PR TITLE
Add get_impl_key as abstract method to types.Callable

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -541,8 +541,7 @@ class BaseContext(object):
         """
         assert sig is not None
         sig = sig.as_function()
-        if isinstance(fn, (types.Function, types.BoundFunction,
-                           types.Dispatcher)):
+        if isinstance(fn, types.Callable):
             key = fn.get_impl_key(sig)
             overloads = self._defns[key]
         else:

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -278,6 +278,12 @@ class Callable(Type):
         Returns a tuple of (list of signatures, parameterized)
         """
 
+    @abstractmethod
+    def get_impl_key(self, sig):
+        """
+        Returns the impl key for the given signature
+        """
+
 
 class DTypeSpec(Type):
     """

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -679,6 +679,9 @@ class NamedTupleClass(Callable, Opaque):
     def get_call_signatures(self):
         return (), True
 
+    def get_impl_key(self, sig):
+        return type(self)
+
     @property
     def key(self):
         return self.instance_class

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -701,6 +701,9 @@ class NumberClass(Callable, DTypeSpec, Opaque):
     def get_call_signatures(self):
         return (), True
 
+    def get_impl_key(self, sig):
+        return type(self)
+
     @property
     def key(self):
         return self.instance_type

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -295,6 +295,9 @@ class ExceptionClass(Callable, Phantom):
         return_type = ExceptionInstance(self.exc_class)
         return [typing.signature(return_type)], False
 
+    def get_impl_key(self, sig):
+        return type(self)
+
     @property
     def key(self):
         return self.exc_class
@@ -427,6 +430,9 @@ class ClassType(Callable, Opaque):
     def get_call_signatures(self):
         return (), True
 
+    def get_impl_key(self, sig):
+        return type(self)
+
     @property
     def methods(self):
         return {k: v.py_func for k, v in self.jit_methods.items()}
@@ -514,6 +520,9 @@ class ContextManager(Callable, Phantom):
 
         posargs = list(args) + [v for k, v in sorted(kws.items())]
         return typing.signature(self, *posargs)
+
+    def get_impl_key(self, sig):
+        return type(self)
 
 
 class UnicodeType(IterableType, Hashable):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -15,6 +15,7 @@ from numba.core import types, errors, typing, compiler, cgutils
 from numba.core.typed_passes import type_inference_stage
 from numba.core.registry import cpu_target
 from numba.core.compiler import compile_isolated
+from numba.core.imputils import lower_constant
 from numba.tests.support import (
     TestCase,
     captured_stdout,
@@ -490,6 +491,71 @@ class MkFuncTyping(AbstractTemplate):
 
 def mk_func_test_impl():
     mk_func_input(lambda a: a)
+
+
+# -----------------------------------------------------------------------
+# Define a types derived from types.Callable and overloads for them
+
+
+class MyClass(object):
+    pass
+
+
+class CallableTypeRef(types.Callable):
+
+    def __init__(self, instance_type):
+        self.instance_type = instance_type
+        self.sig_to_impl_key = {}
+        self.compiled_templates = []
+        super(CallableTypeRef, self).__init__('callable_type_ref'
+                                              '[{}]'.format(self.instance_type))
+
+    def get_call_type(self, context, args, kws):
+
+        # >>> self == callable_type_ref[<class '__main__.MyClass'>]
+        # type(self) == <class '__main__.CallableTypeRef'>
+        res_sig = None
+        for template in context._functions[type(self)]:
+            try:
+                res_sig = template.apply(args, kws)
+            except Exception:
+                pass  # for simplicity assume args must match exactly
+            else:
+                compiled_ovlds = getattr(template, '_compiled_overloads', {})
+                if args in compiled_ovlds:
+                    self.sig_to_impl_key[res_sig] = compiled_ovlds[args]
+                    self.compiled_templates.append(template)
+                    break
+
+        return res_sig
+
+    def get_call_signatures(self):
+        sigs = list(self.sig_to_impl_key.keys())
+        return sigs, True
+
+    def get_impl_key(self, sig):
+        return self.sig_to_impl_key[sig]
+
+
+@register_model(CallableTypeRef)
+class CallableTypeModel(models.OpaqueModel):
+    def __init__(self, dmm, fe_type):
+
+        models.OpaqueModel.__init__(self, dmm, fe_type)
+
+
+@typeof_impl.register(CallableTypeRef)
+def typeof_callable_typeref(val, c):
+    return val
+
+
+@lower_constant(CallableTypeRef)
+def constant_callable_typeref(context, builder, ty, pyval):
+    return context.get_dummy_value()
+
+
+def get_callable_typeref(instance_type):
+    return CallableTypeRef(instance_type)
 
 
 # -----------------------------------------------------------------------
@@ -1152,6 +1218,33 @@ class TestHighLevelExtending(TestCase):
             "Unknown attribute 'array_alloc' of",
             str(raises.exception),
         )
+
+    def test_overload_callable_typeref(self):
+
+        @overload(CallableTypeRef)
+        def callable_type_call_ovld1(x):
+            if isinstance(x, types.Integer):
+                def impl(x):
+                    return 42.5 + x
+                return impl
+
+        @overload(CallableTypeRef)
+        def callable_type_call_ovld2(x):
+            if isinstance(x, (types.UnicodeType, types.StringLiteral)):
+                def impl(x):
+                    return '42.5' + x
+
+                return impl
+
+        typeref_type = get_callable_typeref(MyClass)
+
+        @njit
+        def foo(a, b):
+            return typeref_type(a), typeref_type(b)
+
+        args = (4, '4')
+        expected = (42.5 + args[0], '42.5' + args[1])
+        self.assertPreciseEqual(foo(*args), expected)
 
 
 def _assert_cache_stats(cfunc, expect_hit, expect_misses):


### PR DESCRIPTION
This PR adds abstract method get_impl_key to types.Callable
that allows it's subclasses to work with @overload decorator
and find existing implementation during lowering.

Fixes #7111