### PR TITLE
CUDA: Skip IPC tests on ARM

### DIFF
--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import platform
 import shutil
 import sys
 
@@ -97,6 +98,12 @@ def skip_without_nvdisasm(reason):
 def skip_with_nvdisasm(reason):
     nvdisasm_path = shutil.which('nvdisasm')
     return unittest.skipIf(nvdisasm_path is not None, reason)
+
+
+def skip_on_arm(reason):
+    cpu = platform.processor()
+    is_arm = cpu.startswith('arm') or cpu.startswith('aarch')
+    return unittest.skipIf(is_arm, reason)
 
 
 def cc_X_or_above(major, minor):

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -6,7 +6,8 @@ import pickle
 import numpy as np
 
 from numba import cuda
-from numba.cuda.testing import (skip_on_cudasim, skip_under_cuda_memcheck,
+from numba.cuda.testing import (skip_on_arm, skip_on_cudasim,
+                                skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
 import unittest
 
@@ -78,7 +79,9 @@ def ipc_array_test(ipcarr, result_queue):
 
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @skip_on_cudasim('Ipc not available in CUDASIM')
+@skip_on_arm('CUDA IPC not supported on ARM in Numba')
 class TestIpcMemory(ContextResettingTestCase):
+
     def test_ipc_handle(self):
         # prepare data for IPC
         arr = np.arange(10, dtype=np.intp)
@@ -227,6 +230,7 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
 
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @skip_on_cudasim('Ipc not available in CUDASIM')
+@skip_on_arm('CUDA IPC not supported on ARM in Numba')
 class TestIpcStaged(ContextResettingTestCase):
     def test_staged(self):
         # prepare data for IPC


### PR DESCRIPTION
These are unsupported on Tegra platforms (such as Jetson). There are some CUDA ARM systems that support IPC, but for now we will count these as not supported by Numba, and skip the tests regardless.

In the longer term (when we get to test Numba on CUDA ARM systems that support IPC) this should be re-visited, either by finding a more precise check for skipping the tests than just "Is the CPU architecture ARM?", or by moving the IPC implementation to use `cuMemCreate()` and obtaining shareable memory handles, which will be supported on Tegra.

Fixes #7178.

(cc @jeffhammond)
