### PR TITLE
Improve flake8 compliance and code style (1)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/_version.py
     numba/core/inline_closurecall.py
     numba/core/ir_utils.py
     numba/core/pylowering.py

--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/core/ir_utils.py
     numba/core/pylowering.py
     numba/python_utils.py
     numba/parfors/parfor.py

--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/core/inline_closurecall.py
     numba/core/ir_utils.py
     numba/core/pylowering.py
     numba/python_utils.py

--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/core/pylowering.py
     numba/python_utils.py
     numba/parfors/parfor.py
     numba/misc/numba_entry.py

--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,7 @@ exclude =
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
     # numba/stencils/stencil.py
-    numba/core/transforms.py
+    # numba/core/transforms.py
     numba/core/tracing.py
     numba/core/withcontexts.py
     numba/_version.py

--- a/.flake8
+++ b/.flake8
@@ -22,8 +22,7 @@ exclude =
     __init__.py
     # Ignore vendored files
     numba/cloudpickle/*
-    # Grandfather in existing failing files.  This list should shrink over time
-    numba/python_utils.py
+    # Grandfather in existing failing files. This list should shrink over time
     numba/parfors/parfor.py
     numba/misc/numba_entry.py
     numba/stencils/stencilparfor.py

--- a/.flake8
+++ b/.flake8
@@ -23,9 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    # numba/stencils/stencil.py
-    # numba/core/transforms.py
-    numba/core/tracing.py
     numba/core/withcontexts.py
     numba/_version.py
     numba/core/inline_closurecall.py

--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,7 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/stencils/stencil.py
+    # numba/stencils/stencil.py
     numba/core/transforms.py
     numba/core/tracing.py
     numba/core/withcontexts.py

--- a/.flake8
+++ b/.flake8
@@ -23,7 +23,6 @@ exclude =
     # Ignore vendored files
     numba/cloudpickle/*
     # Grandfather in existing failing files.  This list should shrink over time
-    numba/core/withcontexts.py
     numba/_version.py
     numba/core/inline_closurecall.py
     numba/core/ir_utils.py

--- a/numba/_version.py
+++ b/numba/_version.py
@@ -113,7 +113,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose=False):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
         print("likely tags: %s" % ",".join(sorted(tags)))
     for ref in sorted(tags):
@@ -143,13 +143,13 @@ def git_parse_vcs_describe(git_describe, tag_prefix, verbose=False):
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" not in git_describe:  # just HEX
-        return "0+untagged.g"+git_describe+dirty_suffix, dirty
+        return "0+untagged.g" + git_describe + dirty_suffix, dirty
 
     # just TAG-NUM-gHEX
     mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
     if not mo:
         # unparseable. Maybe git-describe is misbehaving?
-        return "0+unparseable"+dirty_suffix, dirty
+        return "0+unparseable" + dirty_suffix, dirty
 
     # tag
     full_tag = mo.group(1)

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1071,9 +1071,9 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     debug_print("removed variables: ", removed)
 
     # Define an index_var to index the array.
-    # If the range happens to be single step ranges like range(n), or range(m,
-    # n), then the index_var correlates to iterator index; otherwise we'll have
-    # to define a new counter.
+    # If the range happens to be single step ranges like range(n), or 
+    # range(m, n), then the index_var correlates to iterator index; otherwise
+    # we'll have to define a new counter.
     range_def = guard(_find_iter_range, func_ir, iter_var, swapped)
     index_var = ir.Var(scope, mk_unique_var("index"), loc)
     if range_def and range_def[0] == 0:

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -2,8 +2,7 @@ import types as pytypes  # avoid confusion with numba.types
 import copy
 import ctypes
 import numba.core.analysis
-from numba.core import utils, types, typing, errors, ir, rewrites, config, ir_utils
-from numba import prange
+from numba.core import types, typing, errors, ir, rewrites, config, ir_utils
 from numba.parfors.parfor import internal_prange
 from numba.core.ir_utils import (
     mk_unique_var,
@@ -25,7 +24,7 @@ from numba.core.ir_utils import (
     simplify_CFG,
     canonicalize_array_math,
     dead_code_elimination,
-    )
+)
 
 from numba.core.analysis import (
     compute_cfg_from_blocks,
@@ -80,24 +79,24 @@ class InlineClosureCallPass(object):
             label, block = work_list.pop()
             for i, instr in enumerate(block.body):
                 if isinstance(instr, ir.Assign):
-                    lhs = instr.target
                     expr = instr.value
                     if isinstance(expr, ir.Expr) and expr.op == 'call':
                         call_name = guard(find_callname, self.func_ir, expr)
-                        func_def = guard(get_definition, self.func_ir, expr.func)
+                        func_def = guard(get_definition, self.func_ir,
+                                         expr.func)
 
                         if guard(self._inline_reduction,
                                  work_list, block, i, expr, call_name):
                             modified = True
                             break # because block structure changed
 
-                        if guard(self._inline_closure,
-                                work_list, block, i, func_def):
+                        if guard(self._inline_closure, work_list, block, i,
+                                 func_def):
                             modified = True
                             break # because block structure changed
 
-                        if guard(self._inline_stencil,
-                                instr, call_name, func_def):
+                        if guard(self._inline_stencil, instr, call_name,
+                                 func_def):
                             modified = True
 
         if enable_inline_arraycall:
@@ -112,11 +111,11 @@ class InlineClosureCallPass(object):
             sized_loops = [(k, len(loops[k].body)) for k in loops.keys()]
             visited = []
             # We go over all loops, bigger loops first (outer first)
-            for k, s in sorted(sized_loops, key=lambda tup: tup[1], reverse=True):
+            for k, s in sorted(sized_loops, key=lambda t: t[1], reverse=True):
                 visited.append(k)
-                if guard(_inline_arraycall, self.func_ir, cfg, visited, loops[k],
-                         self.swapped, self.parallel_options.comprehension,
-                         self.typed):
+                if guard(_inline_arraycall, self.func_ir, cfg, visited,
+                         loops[k], self.swapped,
+                         self.parallel_options.comprehension, self.typed):
                     modified = True
             if modified:
                 _fix_nested_array(self.func_ir)
@@ -150,6 +149,7 @@ class InlineClosureCallPass(object):
                             "two arguments are required (optional initial "
                             "value can also be specified)")
         check_reduce_func(self.func_ir, expr.args[0])
+
         def reduce_func(f, A, v=None):
             it = iter(A)
             if v is not None:
@@ -157,12 +157,12 @@ class InlineClosureCallPass(object):
             else:
                 s = next(it)
             for a in it:
-               s = f(s, a)
+                s = f(s, a)
             return s
         inline_closure_call(self.func_ir,
-                        self.func_ir.func_id.func.__globals__,
-                        block, i, reduce_func, work_list=work_list,
-                        callee_validator=callee_ir_validator)
+                            self.func_ir.func_id.func.__globals__, block, i,
+                            reduce_func, work_list=work_list,
+                            callee_validator=callee_ir_validator)
         return True
 
     def _inline_stencil(self, instr, call_name, func_def):
@@ -173,8 +173,8 @@ class InlineClosureCallPass(object):
         # alive by adding them to the actual kernel call as extra
         # keyword arguments, which is ignored anyway.
         if (isinstance(func_def, ir.Global) and
-            func_def.name == 'stencil' and
-            isinstance(func_def.value, StencilFunc)):
+                func_def.name == 'stencil' and
+                isinstance(func_def.value, StencilFunc)):
             if expr.kws:
                 expr.kws += func_def.value.kws
             else:
@@ -187,23 +187,24 @@ class InlineClosureCallPass(object):
         self._processed_stencils.append(expr)
         if not len(expr.args) == 1:
             raise ValueError("As a minimum Stencil requires"
-                " a kernel as an argument")
+                             " a kernel as an argument")
         stencil_def = guard(get_definition, self.func_ir, expr.args[0])
         require(isinstance(stencil_def, ir.Expr) and
                 stencil_def.op == "make_function")
         kernel_ir = get_ir_of_code(self.func_ir.func_id.func.__globals__,
-                stencil_def.code)
+                                   stencil_def.code)
         options = dict(expr.kws)
         if 'neighborhood' in options:
             fixed = guard(self._fix_stencil_neighborhood, options)
             if not fixed:
-               raise ValueError("stencil neighborhood option should be a tuple"
-                        " with constant structure such as ((-w, w),)")
+                raise ValueError("stencil neighborhood option should be a tuple"
+                                 " with constant structure such as ((-w, w),)")
         if 'index_offsets' in options:
             fixed = guard(self._fix_stencil_index_offsets, options)
             if not fixed:
-               raise ValueError("stencil index_offsets option should be a tuple"
-                        " with constant structure such as (offset, )")
+                msg = ("stencil index_offsets option should be a "
+                       "tuple with constant structure such as (offset, )")
+                raise ValueError(msg)
         sf = StencilFunc(kernel_ir, 'constant', options)
         sf.kws = expr.kws # hack to keep variables live
         sf_global = ir.Global('stencil', sf, expr.loc)
@@ -246,6 +247,7 @@ class InlineClosureCallPass(object):
                             callee_validator=callee_ir_validator)
         return True
 
+
 def check_reduce_func(func_ir, func_var):
     """Checks the function at func_var in func_ir to make sure it's amenable
     for inlining. Returns the function itself"""
@@ -260,10 +262,10 @@ def check_reduce_func(func_ir, func_var):
         # pull out the python function for inlining
         reduce_func = reduce_func.value.py_func
     elif not (hasattr(reduce_func, 'code')
-            or hasattr(reduce_func, '__code__')):
+              or hasattr(reduce_func, '__code__')):
         raise ValueError("Invalid reduction function")
     f_code = (reduce_func.code if hasattr(reduce_func, 'code')
-                                    else reduce_func.__code__)
+              else reduce_func.__code__)
     if not f_code.co_argcount == 2:
         raise TypeError("Reduction function should take 2 arguments")
     return reduce_func
@@ -335,7 +337,6 @@ class InlineWorker(object):
         self.typemap = typemap
         self.calltypes = calltypes
 
-
     def inline_ir(self, caller_ir, block, i, callee_ir, callee_freevars,
                   arg_typs=None):
         """ Inlines the callee_ir in the caller_ir at statement index i of block
@@ -374,7 +375,10 @@ class InlineWorker(object):
         callee_blocks = callee_ir.blocks
 
         # 1. relabel callee_ir by adding an offset
-        max_label = max(ir_utils._the_max_label.next(), max(caller_ir.blocks.keys()))
+        max_label = max(
+            ir_utils._the_max_label.next(),
+            max(caller_ir.blocks.keys()),
+        )
         callee_blocks = add_offset_to_labels(callee_blocks, max_label + 1)
         callee_blocks = simplify_CFG(callee_blocks)
         callee_ir.blocks = callee_blocks
@@ -468,11 +472,11 @@ class InlineWorker(object):
         Run the compiler frontend's untyped passes over the given Python
         function, and return the function's canonical Numba IR.
 
-        Disable SSA transformation by default, since the call site won't be in SSA
-        form and self.inline_ir depends on this being the case.
+        Disable SSA transformation by default, since the call site won't be in
+        SSA form and self.inline_ir depends on this being the case.
         """
         from numba.core.compiler import StateDict, _CompileStatus
-        from numba.core.untyped_passes import ExtractByteCode, WithLifting
+        from numba.core.untyped_passes import ExtractByteCode
         from numba.core import bytecode
         from numba.parfors.parfor import ParforDiagnostics
         state = StateDict()
@@ -522,8 +526,11 @@ class InlineWorker(object):
         # callee's typing may require SSA
         callee_ir = reconstruct_ssa(callee_ir)
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
-        f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                self.typingctx, self.targetctx, callee_ir, arg_typs, None)
+        pass_result = typed_passes.type_inference_stage(self.typingctx,
+                                                        self.targetctx,
+                                                        callee_ir, arg_typs,
+                                                        None)
+        f_typemap, f_return_type, f_calltypes, _ = pass_result
         callee_ir = PreLowerStripPhis()._strip_phi_nodes(callee_ir)
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         canonicalize_array_math(callee_ir, f_typemap,
@@ -563,7 +570,10 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     debug_print("Found closure call: ", instr, " with callee = ", callee)
     # support both function object and make_function Expr
     callee_code = callee.code if hasattr(callee, 'code') else callee.__code__
-    callee_closure = callee.closure if hasattr(callee, 'closure') else callee.__closure__
+    if hasattr(callee, 'closure'):
+        callee_closure = callee.closure
+    else:
+        callee_closure = callee.__closure__
     # first, get the IR of the callee
     if isinstance(callee, pytypes.FunctionType):
         from numba.core import compiler
@@ -590,7 +600,8 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     debug_print("After relabel")
     _debug_dump(callee_ir)
 
-    # 2. rename all local variables in callee_ir with new locals created in func_ir
+    # 2. rename all local variables in callee_ir with new locals created in
+    # func_ir
     callee_scopes = _get_all_scopes(callee_blocks)
     debug_print("callee_scopes = ", callee_scopes)
     #    one function should only have one local scope
@@ -636,12 +647,17 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
         callee_ir._definitions = ir_utils.build_definitions(callee_ir.blocks)
         numba.core.analysis.dead_branch_prune(callee_ir, arg_typs)
         try:
-            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                    typingctx, targetctx, callee_ir, arg_typs, None)
-        except Exception as e:
-            f_typemap, f_return_type, f_calltypes, _ = typed_passes.type_inference_stage(
-                    typingctx, targetctx, callee_ir, arg_typs, None)
-            pass
+            pass_result = typed_passes.type_inference_stage(typingctx,
+                                                            targetctx,
+                                                            callee_ir,
+                                                            arg_typs, None)
+        except Exception:
+            pass_result = typed_passes.type_inference_stage(typingctx,
+                                                            targetctx,
+                                                            callee_ir,
+                                                            arg_typs, None)
+
+        f_typemap, f_return_type, f_calltypes, _ = pass_result
         canonicalize_array_math(callee_ir, f_typemap,
                                 f_calltypes, typingctx)
         # remove argument entries like arg.a from typemap
@@ -713,6 +729,7 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
         normal_handler = lambda index, param, default: default
         default_handler = lambda index, param, default: ir.Const(default, loc)
         # Throw error for stararg
+
         # TODO: handle stararg
         def stararg_handler(index, param, default):
             raise NotImplementedError(
@@ -751,9 +768,8 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
                               x in default_tuple.items]
                 args = args + const_vals
             else:
-                raise NotImplementedError(
-                    "Unsupported defaults to make_function: {}".format(
-                        defaults))
+                msg = "Unsupported defaults to make_function: {}"
+                raise NotImplementedError(msg.format(callee_defaults))
         return args
 
 
@@ -824,8 +840,11 @@ def _replace_returns(blocks, target, return_label):
                 for cast in casts:
                     if cast.target.name == stmt.value.name:
                         cast.value = cast.value.value
-            elif isinstance(stmt, ir.Assign) and isinstance(stmt.value, ir.Expr) and stmt.value.op == 'cast':
+            elif (isinstance(stmt, ir.Assign)
+                    and isinstance(stmt.value, ir.Expr)
+                    and stmt.value.op == 'cast'):
                 casts.append(stmt)
+
 
 def _add_definitions(func_ir, block):
     """
@@ -836,6 +855,7 @@ def _add_definitions(func_ir, block):
     for stmt in assigns:
         definitions[stmt.target.name].append(stmt.value)
 
+
 def _find_arraycall(func_ir, block):
     """Look for statement like "x = numpy.array(y)" or "x[..] = y"
     immediately after the closure call that creates list y (the i-th
@@ -843,7 +863,6 @@ def _find_arraycall(func_ir, block):
     raise GuardException.
     """
     array_var = None
-    array_call_index = None
     list_var_dead_after_array_call = False
     list_var = None
 
@@ -858,10 +877,10 @@ def _find_arraycall(func_ir, block):
             pass
         elif isinstance(instr, ir.Assign):
             # Found array_var = array(list_var)
-            lhs  = instr.target
+            lhs = instr.target
             expr = instr.value
             if (guard(find_callname, func_ir, expr) == ('array', 'numpy') and
-                isinstance(expr.args[0], ir.Var)):
+                    isinstance(expr.args[0], ir.Var)):
                 list_var = expr.args[0]
                 array_var = lhs
                 array_stmt_index = i
@@ -893,7 +912,8 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     debug_print = _make_debug_print("find_iter_range")
     range_iter_def = get_definition(func_ir, range_iter_var)
     debug_print("range_iter_var = ", range_iter_var, " def = ", range_iter_def)
-    require(isinstance(range_iter_def, ir.Expr) and range_iter_def.op == 'getiter')
+    require(isinstance(range_iter_def, ir.Expr)
+            and range_iter_def.op == 'getiter')
     range_var = range_iter_def.value
     range_def = get_definition(func_ir, range_var)
     debug_print("range_var = ", range_var, " range_def = ", range_def)
@@ -902,7 +922,8 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     func_def = get_definition(func_ir, func_var)
     debug_print("func_var = ", func_var, " func_def = ", func_def)
     require(isinstance(func_def, ir.Global) and
-            (func_def.value == range or func_def.value == numba.misc.special.prange))
+            (func_def.value == range
+             or func_def.value == numba.misc.special.prange))
     nargs = len(range_def.args)
     swapping = [('"array comprehension"', 'closure of'), range_def.func.loc]
     if nargs == 1:
@@ -917,32 +938,40 @@ def _find_iter_range(func_ir, range_iter_var, swapped):
     else:
         raise GuardException
 
+
 def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
                       typed=False):
-    """Look for array(list) call in the exit block of a given loop, and turn list operations into
-    array operations in the loop if the following conditions are met:
+    """Look for array(list) call in the exit block of a given loop, and turn
+    list operations into array operations in the loop if the following
+    conditions are met:
+
       1. The exit block contains an array call on the list;
       2. The list variable is no longer live after array call;
       3. The list is created in the loop entry block;
-      4. The loop is created from an range iterator whose length is known prior to the loop;
-      5. There is only one list_append operation on the list variable in the loop body;
-      6. The block that contains list_append dominates the loop head, which ensures list
-         length is the same as loop length;
-    If any condition check fails, no modification will be made to the incoming IR.
+      4. The loop is created from an range iterator whose length is known prior
+         to the loop;
+      5. There is only one list_append operation on the list variable in the
+         loop body;
+      6. The block that contains list_append dominates the loop head, which
+         ensures list length is the same as loop length;
+
+    If any condition check fails, no modification will be made to the incoming
+    IR.
     """
     debug_print = _make_debug_print("inline_arraycall")
     # There should only be one loop exit
     require(len(loop.exits) == 1)
     exit_block = next(iter(loop.exits))
-    list_var, array_call_index, array_kws = _find_arraycall(func_ir, func_ir.blocks[exit_block])
+    list_var, array_call_index, array_kws = \
+        _find_arraycall(func_ir, func_ir.blocks[exit_block])
 
     # check if dtype is present in array call
     dtype_def = None
     dtype_mod_def = None
     if 'dtype' in array_kws:
         require(isinstance(array_kws['dtype'], ir.Var))
-        # We require that dtype argument to be a constant of getattr Expr, and we'll
-        # remember its definition for later use.
+        # We require that dtype argument to be a constant of getattr Expr, and
+        # we'll remember its definition for later use.
         dtype_def = get_definition(func_ir, array_kws['dtype'])
         require(isinstance(dtype_def, ir.Expr) and dtype_def.op == 'getattr')
         dtype_mod_def = get_definition(func_ir, dtype_def.value)
@@ -952,30 +981,32 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     if isinstance(list_var_def, ir.Expr) and list_var_def.op == 'cast':
         list_var_def = get_definition(func_ir, list_var_def.value)
     # Check if the definition is a build_list
-    require(isinstance(list_var_def, ir.Expr) and list_var_def.op ==  'build_list')
+    require(isinstance(list_var_def, ir.Expr)
+            and list_var_def.op == 'build_list')
     # The build_list must be empty
     require(len(list_var_def.items) == 0)
 
-    # Look for list_append in "last" block in loop body, which should be a block that is
-    # a post-dominator of the loop header.
+    # Look for list_append in "last" block in loop body, which should be a
+    # block that is a post-dominator of the loop header.
     list_append_stmts = []
     for label in loop.body:
         # We have to consider blocks of this loop, but not sub-loops.
-        # To achieve this, we require the set of "in_loops" of "label" to be visited loops.
+        # To achieve this, we require the set of "in_loops" of "label" to be
+        # visited loops.
         in_visited_loops = [l.header in visited for l in cfg.in_loops(label)]
         if not all(in_visited_loops):
             continue
         block = func_ir.blocks[label]
         debug_print("check loop body block ", label)
         for stmt in block.find_insts(ir.Assign):
-            lhs = stmt.target
             expr = stmt.value
             if isinstance(expr, ir.Expr) and expr.op == 'call':
                 func_def = get_definition(func_ir, expr.func)
                 if isinstance(func_def, ir.Expr) and func_def.op == 'getattr' \
-                  and func_def.attr == 'append':
+                        and func_def.attr == 'append':
                     list_def = get_definition(func_ir, func_def.value)
-                    debug_print("list_def = ", list_def, list_def is list_var_def)
+                    debug_print("list_def = ", list_def,
+                                list_def is list_var_def)
                     if list_def is list_var_def:
                         # found matching append call
                         list_append_stmts.append((label, block, stmt))
@@ -1009,8 +1040,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
 
     # Require only one iterator in loop header
     require(len(iter_vars) == 1 and len(iter_first_vars) == 1)
-    iter_var = iter_vars[0] # variable that holds the iterator object
-    iter_first_var = iter_first_vars[0] # variable that holds the value out of iterator
+    iter_var = iter_vars[0] # holds the iterator object
+    iter_first_var = iter_first_vars[0] # holds the value out of iterator
 
     # Final requirement: only one loop entry, and we're going to modify it by:
     # 1. replacing the list definition with an array definition;
@@ -1022,6 +1053,7 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     loc = loop_entry.loc
     stmts = []
     removed = []
+
     def is_removed(val, removed):
         if isinstance(val, ir.Var):
             for x in removed:
@@ -1031,24 +1063,28 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
     # Skip list construction and skip terminator, add the rest to stmts
     for i in range(len(loop_entry.body) - 1):
         stmt = loop_entry.body[i]
-        if isinstance(stmt, ir.Assign) and (stmt.value is list_def or is_removed(stmt.value, removed)):
+        if isinstance(stmt, ir.Assign) and (stmt.value is list_def
+                                            or is_removed(stmt.value, removed)):
             removed.append(stmt.target)
         else:
             stmts.append(stmt)
     debug_print("removed variables: ", removed)
 
     # Define an index_var to index the array.
-    # If the range happens to be single step ranges like range(n), or range(m, n),
-    # then the index_var correlates to iterator index; otherwise we'll have to
-    # define a new counter.
+    # If the range happens to be single step ranges like range(n), or range(m,
+    # n), then the index_var correlates to iterator index; otherwise we'll have
+    # to define a new counter.
     range_def = guard(_find_iter_range, func_ir, iter_var, swapped)
     index_var = ir.Var(scope, mk_unique_var("index"), loc)
     if range_def and range_def[0] == 0:
         # iterator starts with 0, index_var can just be iter_first_var
         index_var = iter_first_var
     else:
-        # index_var = -1 # starting the index with -1 since it will incremented in loop header
-        stmts.append(_new_definition(func_ir, index_var, ir.Const(value=-1, loc=loc), loc))
+        # index_var = -1 # starting the index with -1 since it will incremented
+        # in loop header
+        m1 = ir.Const(value=-1, loc=loc)
+        new_defn = _new_definition(func_ir, index_var, m1)
+        stmts.append(new_defn, loc)
 
     # Insert statement to get the size of the loop iterator
     size_var = ir.Var(scope, mk_unique_var("size"), loc)
@@ -1057,7 +1093,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         if start == 0:
             size_val = stop
         else:
-            size_val = ir.Expr.binop(fn=operator.sub, lhs=stop, rhs=start, loc=loc)
+            size_val = ir.Expr.binop(fn=operator.sub, lhs=stop, rhs=start,
+                                     loc=loc)
         # we can parallelize this loop if enable_prange = True, by changing
         # range function from range, to prange.
         if enable_prange and isinstance(range_func_def, ir.Global):
@@ -1070,12 +1107,11 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
             from numba.cpython.rangeobj import range_iter_len
             stmts.append(_new_definition(func_ir, len_func_var,
-                        ir.Global('range_iter_len', range_iter_len, loc=loc),
-                        loc))
+                         ir.Global('range_iter_len', range_iter_len, loc=loc),
+                         loc))
             size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
         else:
             raise GuardException
-
 
     stmts.append(_new_definition(func_ir, size_var, size_val, loc))
 
@@ -1090,26 +1126,34 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         # when dtype is present, we'll call empty with dtype
         dtype_mod_var = ir.Var(scope, mk_unique_var("dtype_mod"), loc)
         dtype_var = ir.Var(scope, mk_unique_var("dtype"), loc)
-        stmts.append(_new_definition(func_ir, dtype_mod_var, dtype_mod_def, loc))
+        stmts.append(_new_definition(func_ir, dtype_mod_var, dtype_mod_def,
+                                     loc))
         stmts.append(_new_definition(func_ir, dtype_var,
-                         ir.Expr.getattr(dtype_mod_var, dtype_def.attr, loc), loc))
-        stmts.append(_new_definition(func_ir, empty_func,
-                         ir.Global('empty', np.empty, loc=loc), loc))
+                                     ir.Expr.getattr(dtype_mod_var,
+                                                     dtype_def.attr, loc),
+                                     loc))
+        stmts.append(_new_definition(func_ir, empty_func, ir.Global('empty',
+                                                                    np.empty,
+                                                                    loc=loc),
+                                     loc))
         array_kws = [('dtype', dtype_var)]
     else:
         # this doesn't work in objmode as it's effectively untyped
         if typed:
             # otherwise we'll call unsafe_empty_inferred
             stmts.append(_new_definition(func_ir, empty_func,
-                            ir.Global('unsafe_empty_inferred',
-                                unsafe_empty_inferred, loc=loc), loc))
+                                         ir.Global('unsafe_empty_inferred',
+                                                   unsafe_empty_inferred,
+                                                   loc=loc), loc))
             array_kws = []
         else:
             raise GuardException
 
     # array_var = empty_func(size_tuple_var)
     stmts.append(_new_definition(func_ir, array_var,
-                 ir.Expr.call(empty_func, (size_tuple_var,), list(array_kws), loc=loc), loc))
+                                 ir.Expr.call(empty_func, (size_tuple_var,),
+                                              list(array_kws), loc=loc),
+                                 loc))
 
     # Add back removed just in case they are used by something else
     for var in removed:
@@ -1130,10 +1174,9 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             block_id = terminator.truebr
             blk = func_ir.blocks[block_id]
             loc = blk.loc
-            blk.body.insert(0, _new_definition(func_ir, index_var,
-                ir.Expr.binop(fn=operator.sub, lhs=iter_first_var,
-                                      rhs=range_def[0], loc=loc),
-                loc))
+            binop = ir.Expr.binop(fn=operator.sub, lhs=iter_first_var,
+                                  rhs=range_def[0], loc=loc),
+            blk.body.insert(0, _new_definition(func_ir, index_var, binop, loc))
     else:
         # Insert index_var increment to the end of loop header
         loc = loop_header.loc
@@ -1146,7 +1189,9 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
                      ir.Const(value=1,loc=loc), loc))
         # next_index_var = index_var + 1
         stmts.append(_new_definition(func_ir, next_index_var,
-                     ir.Expr.binop(fn=operator.add, lhs=index_var, rhs=one, loc=loc), loc))
+                                     ir.Expr.binop(fn=operator.add,
+                                                   lhs=index_var, rhs=one,
+                                                   loc=loc), loc))
         # index_var = next_index_var
         stmts.append(_new_definition(func_ir, index_var, next_index_var, loc))
         stmts.append(terminator)
@@ -1157,7 +1202,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         if append_block.body[i] is append_stmt:
             debug_print("Replace append with SetItem")
             append_block.body[i] = ir.SetItem(target=array_var, index=index_var,
-                                              value=append_stmt.value.args[0], loc=append_stmt.loc)
+                                              value=append_stmt.value.args[0],
+                                              loc=append_stmt.loc)
 
     # replace array call, by changing "a = array(b)" to "a = b"
     stmt = func_ir.blocks[exit_block].body[array_call_index]
@@ -1232,10 +1278,14 @@ def _fix_nested_array(func_ir):
                                 var_def = get_definition(func_ir, var.name)
                                 if isinstance(var_def, ir.Const):
                                     loc = var.loc
-                                    new_var = ir.Var(scope, mk_unique_var("new_var"), loc)
+                                    new_var = ir.Var(scope,
+                                                     mk_unique_var("new_var"),
+                                                     loc)
                                     new_const = ir.Const(var_def.value, loc)
                                     new_vardef = _new_definition(func_ir,
-                                                    new_var, new_const, loc)
+                                                                 new_var,
+                                                                 new_const,
+                                                                 loc)
                                     new_body = []
                                     new_body.extend(body[:i])
                                     new_body.append(new_vardef)
@@ -1251,9 +1301,12 @@ def _fix_nested_array(func_ir):
     def fix_array_assign(stmt):
         """For assignment like lhs[idx] = rhs, where both lhs and rhs are arrays, do the
         following:
-        1. find the definition of rhs, which has to be a call to numba.unsafe.ndarray.empty_inferred
-        2. find the source array creation for lhs, insert an extra dimension of size of b.
-        3. replace the definition of rhs = numba.unsafe.ndarray.empty_inferred(...) with rhs = lhs[idx]
+        1. find the definition of rhs, which has to be a call to
+           numba.unsafe.ndarray.empty_inferred
+        2. find the source array creation for lhs, insert an extra dimension of
+           size of b.
+        3. replace the definition of rhs =
+           numba.unsafe.ndarray.empty_inferred(...) with rhs = lhs[idx]
         """
         require(isinstance(stmt, ir.SetItem))
         require(isinstance(stmt.value, ir.Var))
@@ -1274,11 +1327,13 @@ def _fix_nested_array(func_ir):
         dim_def = get_definition(func_ir, rhs_def.args[0])
         require(isinstance(dim_def, ir.Expr) and dim_def.op == 'build_tuple')
         debug_print("dim_def = ", dim_def)
-        extra_dims = [ get_definition(func_ir, x, lhs_only=True) for x in dim_def.items ]
+        extra_dims = [ get_definition(func_ir, x, lhs_only=True)
+                       for x in dim_def.items ]
         debug_print("extra_dims = ", extra_dims)
         # Expand size tuple when creating lhs_def with extra_dims
         size_tuple_def = get_definition(func_ir, lhs_def.args[0])
-        require(isinstance(size_tuple_def, ir.Expr) and size_tuple_def.op == 'build_tuple')
+        require(isinstance(size_tuple_def, ir.Expr)
+                and size_tuple_def.op == 'build_tuple')
         debug_print("size_tuple_def = ", size_tuple_def)
         extra_dims = fix_dependencies(size_tuple_def, extra_dims)
         size_tuple_def.items += extra_dims
@@ -1300,9 +1355,11 @@ def _fix_nested_array(func_ir):
             if guard(fix_array_assign, stmt):
                 block.body.remove(stmt)
 
+
 def _new_definition(func_ir, var, value, loc):
     func_ir._definitions[var.name] = [value]
     return ir.Assign(value=value, target=var, loc=loc)
+
 
 @rewrites.register_rewrite('after-inference')
 class RewriteArrayOfConsts(rewrites.Rewrite):
@@ -1328,9 +1385,9 @@ class RewriteArrayOfConsts(rewrites.Rewrite):
 
 
 def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
-    """Look for array(list) call where list is a constant list created by build_list,
-    and turn them into direct array creation and initialization, if the following
-    conditions are met:
+    """Look for array(list) call where list is a constant list created by
+    build_list, and turn them into direct array creation and initialization, if
+    the following conditions are met:
       1. The build_list call immediate precedes the array call;
       2. The list variable is no longer live after array call;
     If any condition check fails, no modification will be made.
@@ -1349,8 +1406,8 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         require(callname and callname[1] == 'numpy' and callname[0] == 'array')
         require(expr.args[0].name in list_vars)
         ret_type = calltypes[expr].return_type
-        require(isinstance(ret_type, types.ArrayCompatible) and
-                           ret_type.ndim == 1)
+        require(isinstance(ret_type, types.ArrayCompatible)
+                and ret_type.ndim == 1)
         loc = expr.loc
         list_var = expr.args[0]
         # Get the type of the array to be created.
@@ -1368,10 +1425,12 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         size_tuple_typ = types.UniTuple(size_typ, 1)
         typemap[size_var.name] = size_typ
         typemap[size_tuple_var.name] = size_tuple_typ
-        stmts.append(_new_definition(func_ir, size_var,
-                 ir.Const(size, loc=loc), loc))
+        stmts.append(_new_definition(func_ir, size_var, ir.Const(size,
+                                                                 loc=loc),
+                                     loc))
         stmts.append(_new_definition(func_ir, size_tuple_var,
-                 ir.Expr.build_tuple(items=[size_var], loc=loc), loc))
+                                     ir.Expr.build_tuple(items=[size_var],
+                                                         loc=loc), loc))
 
         # The general approach is to create an empty array and then fill
         # the elements in one-by-one from their specificiation.
@@ -1382,12 +1441,15 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
         # Create a variable to hold the numpy empty function.
         empty_func = ir.Var(scope, mk_unique_var("empty_func"), loc)
         fnty = get_np_ufunc_typ(np.empty)
-        sig = context.resolve_function_type(fnty, (size_typ,), {'dtype':nptype})
+        # XXX: Does this do anything?
+        context.resolve_function_type(fnty, (size_typ,), {'dtype':nptype})
 
         typemap[empty_func.name] = fnty
 
-        stmts.append(_new_definition(func_ir, empty_func,
-                         ir.Global('empty', np.empty, loc=loc), loc))
+        stmts.append(_new_definition(func_ir, empty_func, ir.Global('empty',
+                                                                    np.empty,
+                                                                    loc=loc),
+                                     loc))
 
         # We pass two arguments to empty, first the size tuple and second
         # the dtype of the new array.  Here, we created typ_var which is
@@ -1420,8 +1482,8 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
             index_var = ir.Var(scope, mk_unique_var("index"), loc)
             index_typ = types.intp
             typemap[index_var.name] = index_typ
-            stmts.append(_new_definition(func_ir, index_var,
-                    ir.Const(i, loc), loc))
+            stmts.append(_new_definition(func_ir, index_var, ir.Const(i, loc),
+                                         loc))
             setitem = ir.SetItem(array_var, index_var, seq[i], loc)
             calltypes[setitem] = typing.signature(types.none, array_typ,
                                                   index_typ, dtype)
@@ -1441,13 +1503,14 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
             # list_vars keep track of the variable created from the latest
             # build_list instruction, as well as its synonyms.
             self.list_vars = []
-            # dead_vars keep track of those in list_vars that are considered dead.
+            # dead_vars keep track of those in list_vars that are considered
+            # dead.
             self.dead_vars = []
             # list_items keep track of the elements used in build_list.
             self.list_items = []
             self.stmts = []
-            # dels keep track of the deletion of list_items, which will need to be
-            # moved after array initialization.
+            # dels keep track of the deletion of list_items, which will need to
+            # be moved after array initialization.
             self.dels = []
             # tracks if a modification has taken place
             self.modified = False
@@ -1487,7 +1550,6 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
                     state.stmts.append(inst)
                     continue
                 elif expr.op == 'call' and expr in calltypes:
-                    arr_var = inst.target
                     if guard(inline_array, inst.target, expr,
                              state.stmts, state.list_vars, state.dels):
                         state.modified = True
@@ -1510,10 +1572,10 @@ def _inline_const_arraycall(block, func_ir, context, typemap, calltypes):
                     # will also be empty when we reach this point.
                     body = []
                     for inst in state.stmts:
-                        if ((isinstance(inst, ir.Assign) and
-                             inst.target.name in state.dead_vars) or
-                             (isinstance(inst, ir.Del) and
-                             inst.value in state.dead_vars)):
+                        if ((isinstance(inst, ir.Assign)
+                             and inst.target.name in state.dead_vars)
+                            or (isinstance(inst, ir.Del) and
+                                inst.value in state.dead_vars)):
                             continue
                         body.append(inst)
                     state.stmts = body

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1083,8 +1083,8 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         # index_var = -1 # starting the index with -1 since it will incremented
         # in loop header
         m1 = ir.Const(value=-1, loc=loc)
-        new_defn = _new_definition(func_ir, index_var, m1)
-        stmts.append(new_defn, loc)
+        new_defn = _new_definition(func_ir, index_var, m1, loc)
+        stmts.append(new_defn)
 
     # Insert statement to get the size of the loop iterator
     size_var = ir.Var(scope, mk_unique_var("size"), loc)

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1174,9 +1174,20 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             block_id = terminator.truebr
             blk = func_ir.blocks[block_id]
             loc = blk.loc
-            binop = ir.Expr.binop(fn=operator.sub, lhs=iter_first_var,
-                                  rhs=range_def[0], loc=loc),
-            blk.body.insert(0, _new_definition(func_ir, index_var, binop, loc))
+            blk.body.insert(
+                0,
+                _new_definition(
+                    func_ir,
+                    index_var,
+                    ir.Expr.binop(
+                        fn=operator.sub,
+                        lhs=iter_first_var,
+                        rhs=range_def[0],
+                        loc=loc,
+                    ),
+                    loc,
+                ),
+            )
     else:
         # Insert index_var increment to the end of loop header
         loc = loop_header.loc

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -7,16 +7,22 @@ import numpy
 
 import types as pytypes
 import collections
+import operator
 import warnings
+
+from llvmlite import ir as lir
 
 import numba
 from numba.core.extending import _Intrinsic
-from numba.core import types, typing, ir, analysis, postproc, rewrites, config
-from numba.core.typing.templates import signature
+from numba.core import types, utils, typing, ir, analysis, postproc, rewrites, config, cgutils
+from numba.core.typing.templates import (signature, infer_global,
+                                         AbstractTemplate)
+from numba.core.imputils import impl_ret_untracked
 from numba.core.analysis import (compute_live_map, compute_use_defs,
                                  compute_cfg_from_blocks)
-from numba.core.errors import (TypingError, UnsupportedError,
-                               NumbaPendingDeprecationWarning, CompilerError)
+from numba.core.errors import (TypingError, UnsupportedError, NumbaWarning,
+                               NumbaPendingDeprecationWarning, CompilerError,
+                               feedback_details)
 
 import copy
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2124,8 +2124,8 @@ def raise_on_unsupported_feature(func_ir, typemap):
                 "Tuple '{}' length must be smaller than 1000.\nLarge tuples "
                 "lead to the generation of a prohibitively large LLVM IR which "
                 "causes excessive memory pressure and large compile times.\nAs "
-                "an alternative, the use of a 'list' is recommended in place of"
-                " a 'tuple' as lists do not suffer from this problem.".format(
+                "an alternative, the use of a 'list' is recommended in place "
+                "of a 'tuple' as lists do not suffer from this problem.".format(
                     arg_name,
                 )
             )

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -478,7 +478,13 @@ def add_offset_to_labels(blocks, offset):
     new_blocks = {}
     for l, b in blocks.items():
         # some parfor last blocks might be empty
-        term = b.body[-1] if b.body else None
+        term = None
+        if b.body:
+            term = b.body[-1]
+            for inst in b.body:
+                for T, f in add_offset_to_labels_extensions.items():
+                    if isinstance(inst, T):
+                        f_max = f(inst, offset)
         if isinstance(term, ir.Jump):
             b.body[-1] = ir.Jump(term.target + offset, term.loc)
         if isinstance(term, ir.Branch):

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -7,22 +7,16 @@ import numpy
 
 import types as pytypes
 import collections
-import operator
 import warnings
-
-from llvmlite import ir as lir
 
 import numba
 from numba.core.extending import _Intrinsic
-from numba.core import types, utils, typing, ir, analysis, postproc, rewrites, config, cgutils
-from numba.core.typing.templates import (signature, infer_global,
-                                         AbstractTemplate)
-from numba.core.imputils import impl_ret_untracked
+from numba.core import types, typing, ir, analysis, postproc, rewrites, config
+from numba.core.typing.templates import signature
 from numba.core.analysis import (compute_live_map, compute_use_defs,
                                  compute_cfg_from_blocks)
-from numba.core.errors import (TypingError, UnsupportedError, NumbaWarning,
-                               NumbaPendingDeprecationWarning, CompilerError,
-                               feedback_details)
+from numba.core.errors import (TypingError, UnsupportedError,
+                               NumbaPendingDeprecationWarning, CompilerError)
 
 import copy
 
@@ -484,7 +478,8 @@ def add_offset_to_labels(blocks, offset):
             for inst in b.body:
                 for T, f in add_offset_to_labels_extensions.items():
                     if isinstance(inst, T):
-                        f_max = f(inst, offset)
+                        # Although f_max is unused, this is required for parfor.
+                        f_max = f(inst, offset)  # noqa: F841
         if isinstance(term, ir.Jump):
             b.body[-1] = ir.Jump(term.target + offset, term.loc)
         if isinstance(term, ir.Branch):

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -7,7 +7,7 @@ import builtins
 import operator
 import inspect
 
-from llvmlite.llvmpy.core import Type, Constant
+from llvmlite.llvmpy.core import Type
 import llvmlite.llvmpy.core as lc
 
 from numba.core import types, utils, ir, generators, cgutils
@@ -62,6 +62,7 @@ PYTHON_COMPAREOPMAP = {
     operator.is_not: 'is not',
     operator.contains: 'in'
 }
+
 
 class PyLower(BaseLower):
 
@@ -208,7 +209,9 @@ class PyLower(BaseLower):
                 typobj = self.pyapi.get_type(obj)
                 is_omitted = self.builder.icmp_unsigned('==', typobj,
                                                         self._omitted_typobj)
-                with self.builder.if_else(is_omitted, likely=False) as (omitted, present):
+                with self.builder.if_else(
+                        is_omitted, likely=False
+                ) as (omitted, present):
                     with present:
                         self.incref(obj)
                         self.builder.store(obj, slot)
@@ -351,7 +354,11 @@ class PyLower(BaseLower):
                     # Make the tuple valid by inserting None as dummy
                     # iteration "result" (it will be ignored).
                     self.pyapi.tuple_setitem(pair, 0, self.pyapi.make_none())
-            self.pyapi.tuple_setitem(pair, 1, self.pyapi.bool_from_bool(is_valid))
+            self.pyapi.tuple_setitem(
+                pair,
+                1,
+                self.pyapi.bool_from_bool(is_valid),
+            )
             return pair
         elif expr.op == 'pair_first':
             pair = self.loadvar(expr.value.name)
@@ -451,8 +458,10 @@ class PyLower(BaseLower):
             bbelse = self.builder.basic_block
 
             with self.builder.if_then(obj_is_null):
-                mod = self.pyapi.dict_getitem(moddict,
-                                          self._freeze_string("__builtins__"))
+                mod = self.pyapi.dict_getitem(
+                    moddict,
+                    self._freeze_string("__builtins__"),
+                )
                 builtin = self.builtin_lookup(mod, name)
                 bbif = self.builder.basic_block
 

--- a/numba/core/transforms.py
+++ b/numba/core/transforms.py
@@ -61,8 +61,12 @@ def _extract_loop_lifting_candidates(cfg, blocks):
     candidates = []
     for loop in find_top_level_loops(cfg):
         _logger.debug("top-level loop: %s", loop)
-        if (same_exit_point(loop) and one_entry(loop) and cannot_yield(loop) and
-            cfg.entry_point() not in loop.entries):
+        if (
+            same_exit_point(loop)
+            and one_entry(loop)
+            and cannot_yield(loop)
+            and cfg.entry_point() not in loop.entries
+        ):
             candidates.append(loop)
             _logger.debug("add candidate: %s", loop)
     return candidates
@@ -112,7 +116,7 @@ def _loop_lift_get_candidate_infos(cfg, blocks, livemap):
         an_exit = next(iter(loop.exits))  # anyone of the exit block
         if len(loop.exits) > 1:
             # Pre-Py3.8 may have multiple exits
-            [(returnto, _)] = cfg.successors(an_exit)  # requirement checked earlier
+            [(returnto, _)] = cfg.successors(an_exit)  # req checked earlier
         else:
             # Post-Py3.8 DO NOT have multiple exits
             returnto = an_exit
@@ -200,9 +204,13 @@ def _loop_lift_modify_blocks(func_ir, loopinfo, blocks,
                             typingctx, targetctx, flags, locals)
 
     # modify for calling into liftedloop
-    callblock = _loop_lift_modify_call_block(liftedloop, blocks[loopinfo.callfrom],
-                                             loopinfo.inputs, loopinfo.outputs,
-                                             loopinfo.returnto)
+    callblock = _loop_lift_modify_call_block(
+        liftedloop,
+        blocks[loopinfo.callfrom],
+        loopinfo.inputs,
+        loopinfo.outputs,
+        loopinfo.returnto,
+    )
     # remove blocks
     for k in loopblockkeys:
         del blocks[k]
@@ -220,8 +228,11 @@ def loop_lifting(func_ir, typingctx, targetctx, flags, locals):
     """
     blocks = func_ir.blocks.copy()
     cfg = compute_cfg_from_blocks(blocks)
-    loopinfos = _loop_lift_get_candidate_infos(cfg, blocks,
-                                               func_ir.variable_lifetime.livemap)
+    loopinfos = _loop_lift_get_candidate_infos(
+        cfg,
+        blocks,
+        func_ir.variable_lifetime.livemap,
+    )
     loops = []
     if loopinfos:
         _logger.debug('loop lifting this IR with %d candidates:\n%s',
@@ -407,7 +418,7 @@ def _get_with_contextmanager(func_ir, blocks, blk_start):
             raise errors.CompilerError(
                 "Undefined variable used as context manager",
                 loc=blocks[blk_start].loc,
-                )
+            )
 
         if ctxobj is None:
             raise errors.CompilerError(_illegal_cm_msg, loc=dfn.loc)
@@ -423,13 +434,13 @@ def _get_with_contextmanager(func_ir, blocks, blk_start):
                 raise errors.CompilerError(
                     "Unsupported context manager in use",
                     loc=blocks[blk_start].loc,
-                    )
+                )
             return ctxobj, extra
     # No contextmanager found?
     raise errors.CompilerError(
         "malformed with-context usage",
         loc=blocks[blk_start].loc,
-        )
+    )
 
 
 def _legalize_with_head(blk):
@@ -444,12 +455,12 @@ def _legalize_with_head(blk):
         raise errors.CompilerError(
             "with's head-block must have exactly 1 ENTER_WITH",
             loc=blk.loc,
-            )
+        )
     if counters.pop(ir.Jump) != 1:
         raise errors.CompilerError(
             "with's head-block must have exactly 1 JUMP",
             loc=blk.loc,
-            )
+        )
     # Can have any number of del
     counters.pop(ir.Del, None)
     # There MUST NOT be any other statements
@@ -457,7 +468,7 @@ def _legalize_with_head(blk):
         raise errors.CompilerError(
             "illegal statements in with's head-block",
             loc=blk.loc,
-            )
+        )
 
 
 def _cfg_nodes_in_region(cfg, region_begin, region_end):
@@ -542,7 +553,7 @@ def find_setupwiths(blocks):
                 raise errors.CompilerError(
                     'unsupported controlflow due to return/raise '
                     'statements inside with block'
-                    )
+                )
             assert s in blocks, 'starting offset is not a label'
             known_ranges.append((s, e))
 

--- a/numba/core/withcontexts.py
+++ b/numba/core/withcontexts.py
@@ -89,7 +89,7 @@ class _CallContextType(WithContext):
             callfrom=blk_start,
             returnto=blk_end,
             body_block_ids=set(body_blocks),
-            )
+        )
 
         lifted_blks = {k: blocks[k] for k in body_blocks}
         _mutate_with_block_callee(lifted_blks, blk_start, blk_end,
@@ -101,13 +101,13 @@ class _CallContextType(WithContext):
             arg_names=tuple(inputs),
             arg_count=len(inputs),
             force_non_generator=True,
-            )
+        )
 
         dispatcher = dispatcher_factory(lifted_ir)
 
         newblk = _mutate_with_block_caller(
             dispatcher, blocks, blk_start, blk_end, inputs, outputs,
-            )
+        )
 
         blocks[blk_start] = newblk
         _clear_blocks(blocks, body_blocks)
@@ -201,14 +201,14 @@ class _ObjModeContextType(WithContext):
         if args:
             raise errors.CompilerError(
                 "objectmode context doesn't take any positional arguments",
-                )
+            )
         typeanns = {}
 
         def report_error(varname, msg, loc):
             raise errors.CompilerError(
-                    f"Error handling objmode argument {varname!r}. {msg}",
-                    loc=loc,
-                )
+                f"Error handling objmode argument {varname!r}. {msg}",
+                loc=loc,
+            )
 
         for k, v in kwargs.items():
             if isinstance(v, ir.Const) and isinstance(v.value, str):
@@ -277,7 +277,7 @@ class _ObjModeContextType(WithContext):
                 "Objmode context failed.",
                 f"Argument {name!r} is declared as "
                 f"an unsupported type: {typ}.",
-                f"Reflected types are not supported.",
+                "Reflected types are not supported.",
             ]
             raise errors.CompilerError(" ".join(msgbuf), loc=loc)
 
@@ -319,7 +319,7 @@ class _ObjModeContextType(WithContext):
             callfrom=blk_start,
             returnto=blk_end,
             body_block_ids=set(body_blocks),
-            )
+        )
 
         # Determine types in the output tuple
         def strip_var_ver(x):
@@ -359,14 +359,14 @@ class _ObjModeContextType(WithContext):
             arg_names=tuple(inputs),
             arg_count=len(inputs),
             force_non_generator=True,
-            )
+        )
 
         dispatcher = dispatcher_factory(lifted_ir, objectmode=True,
                                         output_types=outtup)
 
         newblk = _mutate_with_block_caller(
             dispatcher, blocks, blk_start, blk_end, inputs, outputs,
-            )
+        )
 
         blocks[blk_start] = newblk
         _clear_blocks(blocks, body_blocks)
@@ -424,7 +424,7 @@ def _mutate_with_block_caller(dispatcher, blocks, blk_start, blk_end,
         label_next=blk_end,
         inputs=inputs,
         outputs=outputs,
-        )
+    )
     return newblock
 
 
@@ -450,7 +450,7 @@ def _mutate_with_block_callee(blocks, blk_start, blk_end, inputs, outputs):
         block=ir.Block(scope=scope, loc=loc),
         inputs=inputs,
         label_next=head_blk,
-        )
+    )
     blocks[blk_end] = ir_utils.fill_callee_epilogue(
         block=ir.Block(scope=scope, loc=loc),
         outputs=outputs,

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -5,6 +5,7 @@
 
 import copy
 
+import numpy as np  # noqa: F401 Unused import but is needed.
 from llvmlite import ir as lir
 
 from numba.core import types, typing, utils, ir, config, ir_utils, registry

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -5,7 +5,7 @@
 
 import copy
 
-import numpy as np  # noqa: F401 Unused import but is needed.
+import numpy as np  # noqa: F401 Used only in dynamic code generation.
 from llvmlite import ir as lir
 
 from numba.core import types, typing, utils, ir, config, ir_utils, registry

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -469,7 +469,7 @@ class StencilFunc(object):
         )
         if isinstance(return_type, types.npytypes.Array):
             raise ValueError(
-                "Stencil kernel must return a scalar and not a numpy array."
+                "Stencil kernel must return a scalar and not a NumPy array."
             )
 
         real_ret = types.npytypes.Array(

--- a/numba/stencils/stencil.py
+++ b/numba/stencils/stencil.py
@@ -5,12 +5,10 @@
 
 import copy
 
-import numpy as np
 from llvmlite import ir as lir
 
 from numba.core import types, typing, utils, ir, config, ir_utils, registry
-from numba.core.typing.templates import (CallableTemplate, signature,
-                                         infer_global, AbstractTemplate)
+from numba.core.typing.templates import AbstractTemplate, signature
 from numba.core.imputils import lower_builtin
 from numba.core.extending import register_jitable
 from numba.misc.special import literal_unroll
@@ -307,7 +305,6 @@ class StencilFunc(object):
                             )
                     else:
                         index_vars = []
-                        sum_results = []
                         s_index_name = ir_utils.mk_unique_var("stencil_index")
                         s_index_var = ir.Var(scope, s_index_name, loc)
                         const_index_vars = []


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Beginning a campaign to reduce the list of "grandfathered" files in the `flake8` config, starting with `stencil.py`. Since this is probably going to be a big task and take a while, I figured I'd best get some opinions before continuing.

I've reduced `numba/stencils/stencil.py` to only throwing 4 errors:
```
numba\stencils\stencil.py:8:1: F401 'numpy as np' imported but unused
numba\stencils\stencil.py:12:1: F401 'numba.core.typing.templates.CallableTemplate' imported but unused
numba\stencils\stencil.py:12:1: F401 'numba.core.typing.templates.infer_global' imported but unused
numba\stencils\stencil.py:309:25: F841 local variable 'sum_results' is assigned to but never used
```
Before removing all 4, I thought best to check with someone more familiar with the codebase that such imports aren't needed for e.g. side-effect reasons, although I can see nothing obvious.

If you look at the changes I've made, you'll find the style I've used is heavily influenced by [Black](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html), although I've deviated in places where it seemed appropriate - and before someone points out such a deviation, I made the changes by hand which is why the style hasn't been implemented everywhere. But I do wonder how you'd feel about adding something like Black, which includes an autoformatter, in order to tidy up the code style? It would likely throw lots of errors at first, but I'd be relatively happy to focus effort there (as well as in updating older styles) as part of this.

More than anything, I could also do with some general consensus/agreement before I begin on stylistic choices. Things like `%` versus `.format()` string formatting, and whether or not to include parentheses when unpacking tuples, and other such small changes - I don't want to make lots of changes, only to find that someone either a) has major disagreement or, even worse, b) had written using one specific style with good reason!

And finally, in order to track what I've done, I intend to modify and remove a few files per PR to make them more manageable for reviewers.
