### PR TITLE
don't post to python announce on the first RC

### DIFF
--- a/.github/ISSUE_TEMPLATE/first_rc_checklist.md
+++ b/.github/ISSUE_TEMPLATE/first_rc_checklist.md
@@ -27,7 +27,6 @@ labels: task
 * [ ] Review, merge and check execution of release notebook.
 * [ ] Send RC announcement email / post announcement to discourse group.
 * [ ] Post link to Twitter.
-* [ ] Post link to python-announce-list@python.org.
 
 ### Post Release:
 


### PR DESCRIPTION
So as not to spam with many RC announcements.

