### PR TITLE
Fix unicode encoding error in debug metadata in llvmlite.

### DIFF
--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -15,8 +15,13 @@ from numba.core import cgutils
 def _escape_unicode(x):
     """Escape unicode chars used in LLVM debug metadata.
     """
-    # We will simply replace them with '?' for now.
-    return x.encode('ascii', 'replace').decode()
+    def repl(x):
+        # GDB uses \NNN where NNN is octal representation of the character.
+        s = chr(x)
+        return s if s.isascii() else r'\{:03o}'.format(x)
+    utf8chars = x.encode()
+    out = ''.join(map(repl, utf8chars))
+    return out
 
 
 @contextmanager

--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -10,6 +10,15 @@ from contextlib import contextmanager
 from llvmlite import ir
 from numba.core import cgutils
 
+
+
+def _escape_unicode(x):
+    """Escape unicode chars used in LLVM debug metadata.
+    """
+    # We will simply replace them with '?' for now.
+    return x.encode('ascii', 'replace').decode()
+
+
 @contextmanager
 def suspend_emission(builder):
     """Suspends the emission of debug_metadata for the duration of the context
@@ -137,7 +146,7 @@ class DIBuilder(AbstractDIBuilder):
         mdtype = self._var_type(lltype, size)
         name = name.replace('.', '$')    # for gdb to work correctly
         mdlocalvar = m.add_debug_info('DILocalVariable', {
-            'name': name,
+            'name': _escape_unicode(name),
             'arg': 0,
             'scope': self.subprograms[-1],
             'file': self.difile,
@@ -243,7 +252,7 @@ class DIBuilder(AbstractDIBuilder):
 
     def _di_subprogram(self, name, linkagename, line):
         return self.module.add_debug_info('DISubprogram', {
-            'name': name,
+            'name': _escape_unicode(name),
             'linkageName': linkagename,
             'scope': self.difile,
             'file': self.difile,

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -7,6 +7,7 @@ import sys
 from numba.tests.support import TestCase, override_config
 from numba import jit, njit
 from numba.core import types
+from numba.core.debuginfo import _escape_unicode
 import unittest
 import llvmlite.binding as llvm
 
@@ -281,6 +282,12 @@ class TestDebugInfoEmission(TestCase):
         self.assertIn('OK', status.stderr)
         self.assertTrue('FAIL' not in status.stderr)
         self.assertTrue('ERROR' not in status.stderr)
+
+
+class TestDebugInfoMisc(TestCase):
+    def test_escape_unicode(self):
+        self.assertEqual(_escape_unicode("apple"), "apple")
+        self.assertEqual(_escape_unicode("appl©"), r"appl\302\251")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Unicode characters in symbol names are replaced with '?'. Not sure if gdb will allow looking up unicode symbol names.

The original issue can be demonstrated by running: `NUMBA_DEBUGINFO=1 python runtests.py numba.tests.test_unicode_names.TestUnicodeNames`