### PR TITLE
Clamp numpy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Dependencies
 
 * Python versions: 3.7-3.9
 * llvmlite 0.37.*
-* NumPy >=1.17,<=1.20 (can build with 1.11 for ABI compatibility).
+* NumPy >=1.17,<1.21 (can build with 1.11 for ABI compatibility).
 
 Optionally:
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Dependencies
 
 * Python versions: 3.7-3.9
 * llvmlite 0.37.*
-* NumPy >=1.17 (can build with 1.11 for ABI compatibility).
+* NumPy >=1.17,<=1.20 (can build with 1.11 for ABI compatibility).
 
 Optionally:
 

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - tbb-devel >=2021       # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
   run:
     - python >=3.6
-    - numpy >=1.17
+    - numpy >=1.17,<1.21
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.37.0rc1,<0.38

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,8 +5,8 @@ Installation
 Compatibility
 -------------
 
-Numba is compatible with Python 3.7 or later, and Numpy versions from 1.17 to
-1.20.
+Numba is compatible with Python 3.7 or later, and Numpy versions from 1.17 up
+to but excluding 1.21.
 
 Our supported platforms are:
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,7 +5,8 @@ Installation
 Compatibility
 -------------
 
-Numba is compatible with Python 3.7 or later, and Numpy versions 1.17 or later.
+Numba is compatible with Python 3.7 or later, and Numpy versions from 1.17 to
+1.20.
 
 Our supported platforms are:
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -5,7 +5,7 @@ Installation
 Compatibility
 -------------
 
-Numba is compatible with Python 3.7 or later, and Numpy versions from 1.17 up
+Numba is compatible with Python 3.7 or later, and NumPy versions from 1.17 up
 to but excluding 1.21.
 
 Our supported platforms are:

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -134,6 +134,8 @@ def _ensure_critical_deps():
 
     if numpy_version < (1, 17):
         raise ImportError("Numba needs NumPy 1.17 or greater")
+    elif numpy_version > (1, 20):
+        raise ImportError("Numba needs NumPy 1.20 or less")
 
     try:
         import scipy

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ min_python_version = "3.7"
 max_python_version = "3.10"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.17"
+max_numpy_run_version = "1.20"
 min_llvmlite_version = "0.37.0rc1"
 max_llvmlite_version = "0.38"
 
@@ -359,7 +360,7 @@ packages = find_packages(include=["numba", "numba.*"])
 build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
-    'numpy >={}'.format(min_numpy_run_version),
+    'numpy >={},<={}'.format(min_numpy_run_version, max_numpy_run_version),
     'setuptools',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ min_python_version = "3.7"
 max_python_version = "3.10"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.17"
-max_numpy_run_version = "1.20"
+max_numpy_run_version = "1.21"
 min_llvmlite_version = "0.37.0rc1"
 max_llvmlite_version = "0.38"
 
@@ -360,7 +360,7 @@ packages = find_packages(include=["numba", "numba.*"])
 build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
-    'numpy >={},<={}'.format(min_numpy_run_version, max_numpy_run_version),
+    'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
     'setuptools',
 ]
 


### PR DESCRIPTION
As discussed during the developer meeting, we will clamp NumPy to a maximum compatible version for released versions. This implements that.