### PR TITLE
bump llvmlite dependency to 0.38.0dev0 for Numba 0.55.0dev0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Dependencies
 ============
 
 * Python versions: 3.7-3.9
-* llvmlite 0.37.*
+* llvmlite 0.38.*
 * NumPy >=1.17 (can build with 1.11 for ABI compatibility).
 
 Optionally:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.37.0dev0,<0.37
+    - llvmlite >=0.38.0dev0,<0.39
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
     # NOTE: ppc64le exclusion is temporary until packages are more generally
@@ -46,7 +46,7 @@ requirements:
     - numpy >=1.17
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.37.0dev0,<0.37
+    - llvmlite >=0.38.0dev0,<0.39
   run_constrained:
     # If TBB is present it must be at least version 2021
     - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.38.0dev0,<0.39
+    - llvmlite >=0.38.0dev0,<0.38
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
     # NOTE: ppc64le exclusion is temporary until packages are more generally
@@ -46,7 +46,7 @@ requirements:
     - numpy >=1.17
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.38.0dev0,<0.39
+    - llvmlite >=0.38.0dev0,<0.38
   run_constrained:
     # If TBB is present it must be at least version 2021
     - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -85,7 +85,7 @@ __all__ = """
     """.split() + types.__all__ + errors.__all__
 
 
-_min_llvmlite_version = (0, 37, 0)
+_min_llvmlite_version = (0, 38, 0)
 _min_llvm_version = (11, 0, 0)
 
 def _ensure_llvm():

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ min_python_version = "3.7"
 max_python_version = "3.10"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.17"
-min_llvmlite_version = "0.37.0.dev0"
-max_llvmlite_version = "0.38"
+min_llvmlite_version = "0.38.0dev0"
+max_llvmlite_version = "0.39"
 
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython


### PR DESCRIPTION
As required by https://github.com/numba/numba/issues/7164

Note: do not merge until a first llvmlite 0.38.0dev0 becomes available, else CI will fail.