### PR TITLE
Show GPU UUIDs in cuda.detect() output

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -495,6 +495,7 @@ def detect():
         attrs += [('Compute Capability', '%d.%d' % cc)]
         attrs += [('PCI Device ID', dev.PCI_DEVICE_ID)]
         attrs += [('PCI Bus ID', dev.PCI_BUS_ID)]
+        attrs += [('UUID', dev.uuid)]
         attrs += [('Watchdog', 'Enabled' if kernel_timeout else 'Disabled')]
         if os.name == "nt":
             attrs += [('Compute Mode', 'TCC' if tcc else 'WDDM')]


### PR DESCRIPTION
Now that we can get GPU UUIDs, it's helpful to display them in the output of `cuda.detect()`. For example, on my system:

```
$ python -c "from numba import cuda; cuda.detect()"
Found 2 CUDA devices
id 0      b'Quadro RTX 8000'                              [SUPPORTED]
                      Compute Capability: 7.5
                           PCI Device ID: 0
                              PCI Bus ID: 21
                                    UUID: GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643
                                Watchdog: Enabled
             FP32/FP64 Performance Ratio: 32
id 1      b'Quadro RTX 8000'                              [SUPPORTED]
                      Compute Capability: 7.5
                           PCI Device ID: 0
                              PCI Bus ID: 45
                                    UUID: GPU-499943e5-f155-f631-f44c-a61ca5995fd2
                                Watchdog: Disabled
             FP32/FP64 Performance Ratio: 32
Summary:
	2/2 devices are supported
```

This is handy for MIG usage, where the UUID of the device is sometimes used in the `CUDA_VISIBLE_DEVICES` environment variable to select which GPU to use (See https://docs.nvidia.com/datacenter/tesla/mig-user-guide/index.html#cuda-visible-devices)