### PR TITLE
CUDA: Warn when debug=True and opt=True

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -18,7 +18,8 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.core.compiler_machinery import (LoweringPass, PassManager,
                                            register_pass)
 from numba.core.dispatcher import OmittedArg
-from numba.core.errors import NumbaDeprecationWarning
+from numba.core.errors import (NumbaDeprecationWarning,
+                               NumbaInvalidConfigWarning)
 from numba.core.typed_passes import IRLegalization, NativeLowering
 from numba.core.typing.typeof import Purpose, typeof
 from warnings import warn
@@ -212,6 +213,12 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
     :return: (ptx, resty): The PTX code and inferred return type
     :rtype: tuple
     """
+    if debug and opt:
+        msg = ("debug=True with opt=True (the default) "
+               "is not supported by CUDA. This may result in a crash"
+               " - set debug=False or opt=False.")
+        warn(NumbaInvalidConfigWarning(msg))
+
     nvvm_options = {
         'debug': debug,
         'lineinfo': lineinfo,

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -1,6 +1,7 @@
 from warnings import warn
 from numba.core import types, config, sigutils
-from numba.core.errors import DeprecationError, NumbaDeprecationWarning
+from numba.core.errors import (DeprecationError, NumbaDeprecationWarning,
+                               NumbaInvalidConfigWarning)
 from .compiler import (compile_device, declare_device_function, Dispatcher,
                        compile_device_dispatcher)
 from .simulator.kernel import FakeCUDAKernel
@@ -44,8 +45,9 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
     :type link: list
     :param debug: If True, check for exceptions thrown when executing the
        kernel. Since this degrades performance, this should only be used for
-       debugging purposes.  Defaults to False.  (The default value can be
-       overridden by setting environment variable ``NUMBA_CUDA_DEBUGINFO=1``.)
+       debugging purposes. If set to True, then ``opt`` should be set to False.
+       Defaults to False.  (The default value can be overridden by setting
+       environment variable ``NUMBA_CUDA_DEBUGINFO=1``.)
     :param fastmath: When True, enables fastmath optimizations as outlined in
        the :ref:`CUDA Fast Math documentation <cuda-fast-math>`.
     :param max_registers: Request that the kernel is limited to using at most
@@ -80,6 +82,12 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
 
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     fastmath = kws.get('fastmath', False)
+
+    if debug and opt:
+        msg = ("debug=True with opt=True (the default) "
+               "is not supported by CUDA. This may result in a crash"
+               " - set debug=False or opt=False.")
+        warn(NumbaInvalidConfigWarning(msg))
 
     if sigutils.is_signature(func_or_sig):
         if config.ENABLE_CUDASIM:

--- a/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -38,7 +38,7 @@ class TestCudaDebugInfo(CUDATestCase):
         self._check(foo, sig=(types.int32[:],), expect=False)
 
     def test_debuginfo_in_asm(self):
-        @cuda.jit(debug=True)
+        @cuda.jit(debug=True, opt=False)
         def foo(x):
             x[0] = 1
 
@@ -47,7 +47,7 @@ class TestCudaDebugInfo(CUDATestCase):
     def test_environment_override(self):
         with override_config('CUDA_DEBUGINFO_DEFAULT', 1):
             # Using default value
-            @cuda.jit
+            @cuda.jit(opt=False)
             def foo(x):
                 x[0] = 1
 
@@ -116,7 +116,7 @@ class TestCudaDebugInfo(CUDATestCase):
         # This is condensed from this reproducer in Issue 5311:
         # https://github.com/numba/numba/issues/5311#issuecomment-674206587
 
-        @cuda.jit((types.int32[:], types.int32[:]), debug=True)
+        @cuda.jit((types.int32[:], types.int32[:]), debug=True, opt=False)
         def f(inp, outp):
             outp[0] = 1 if inp[0] in (2, 3) else 3
 
@@ -136,15 +136,15 @@ class TestCudaDebugInfo(CUDATestCase):
                 arr[i] = threadid()
 
     def _test_chained_device_function(self, kernel_debug, f1_debug, f2_debug):
-        @cuda.jit(device=True, debug=f2_debug)
+        @cuda.jit(device=True, debug=f2_debug, opt=False)
         def f2(x):
             return x + 1
 
-        @cuda.jit(device=True, debug=f1_debug)
+        @cuda.jit(device=True, debug=f1_debug, opt=False)
         def f1(x, y):
             return x - f2(y)
 
-        @cuda.jit((types.int32, types.int32), debug=kernel_debug)
+        @cuda.jit((types.int32, types.int32), debug=kernel_debug, opt=False)
         def kernel(x, y):
             f1(x, y)
 
@@ -168,15 +168,15 @@ class TestCudaDebugInfo(CUDATestCase):
     def _test_chained_device_function_two_calls(self, kernel_debug, f1_debug,
                                                 f2_debug):
 
-        @cuda.jit(device=True, debug=f2_debug)
+        @cuda.jit(device=True, debug=f2_debug, opt=False)
         def f2(x):
             return x + 1
 
-        @cuda.jit(device=True, debug=f1_debug)
+        @cuda.jit(device=True, debug=f1_debug, opt=False)
         def f1(x, y):
             return x - f2(y)
 
-        @cuda.jit(debug=kernel_debug)
+        @cuda.jit(debug=kernel_debug, opt=False)
         def kernel(x, y):
             f1(x, y)
             f2(x)
@@ -233,7 +233,7 @@ class TestCudaDebugInfo(CUDATestCase):
         # to ensure that the recursion visits all the way down the call tree
         # when fixing linkage of functions for debug.
         def three_device_fns(kernel_debug, leaf_debug):
-            @cuda.jit(device=True, debug=leaf_debug)
+            @cuda.jit(device=True, debug=leaf_debug, opt=False)
             def f3(x):
                 return x * x
 
@@ -245,7 +245,7 @@ class TestCudaDebugInfo(CUDATestCase):
             def f1(x, y):
                 return x - f2(y)
 
-            @cuda.jit(debug=kernel_debug)
+            @cuda.jit(debug=kernel_debug, opt=False)
             def kernel(x, y):
                 f1(x, y)
 

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import cuda
-from numba.cuda.testing import CUDATestCase, skip_on_cudasim
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.tests.support import linux_only, override_config
 from numba.core.errors import NumbaPerformanceWarning
 import warnings
@@ -107,3 +107,33 @@ class TestWarnings(CUDATestCase):
                 foo[1, N](ary, N)
 
         self.assertEqual(len(w), 0)
+
+    def test_warn_on_debug_and_opt(self):
+        with warnings.catch_warnings(record=True) as w:
+            cuda.jit(debug=True, opt=True)
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('not supported by CUDA', str(w[0].message))
+
+    def test_warn_on_debug_and_opt_default(self):
+        with warnings.catch_warnings(record=True) as w:
+            cuda.jit(debug=True)
+
+        self.assertEqual(len(w), 1)
+        self.assertIn('not supported by CUDA', str(w[0].message))
+
+    def test_no_warn_on_debug_and_no_opt(self):
+        with warnings.catch_warnings(record=True) as w:
+            cuda.jit(debug=True, opt=False)
+
+        self.assertEqual(len(w), 0)
+
+    def test_no_warn_with_no_debug_and_opt_kwargs(self):
+        with warnings.catch_warnings(record=True) as w:
+            cuda.jit()
+
+        self.assertEqual(len(w), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As per Issue #7214, using `debug=True` with `opt=True` can cause NVVM to crash (or the link can fail with an error message from ptxas). We can't easily stop the user from doing this by default as it might break a lot of existing code (particularly that which uses debug=True to force a check for exceptions) but we can warn them.

This commit adds a warning when `debug` and `opt` are both `True`, and some tests for most cases. The debuginfo tests are also updated so that they don't trigger the warning and make the test suite noisy. However, I chose not to "fix" the tests that check for a raised exception (e.g. in test_exception and test_fastmath) - I think the test suite should be emitting warnings there to highlight/remind about the fact that we need to split `debug=True` into at least two options (e.g. `debuginfo=True` and `exceptions=True`).

Fixes #7214.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->
