### PR TITLE
Fixes issue reported under #7217

### DIFF
--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -910,6 +910,17 @@ class MixedContainerUnroller(FunctionPass):
                 new_var_dict[name] = mk_unique_var(name)
             replace_var_names(loop_blocks, new_var_dict)
 
+            # Patch up the scope with the new variable names, this is horrible
+            new_var_table = get_name_var_table(loop_blocks)
+            for blk in loop_blocks.values():
+                scope = blk.scope
+                real_con = scope.localvars._con
+                for name, var in dict(scope.localvars._con).items():
+                    if name in new_var_dict:
+                        new_name = new_var_dict[name]
+                        del real_con[name]
+                        real_con[new_name] = new_var_table[new_name]
+
             # clobber the sentinel body and then stuff in the rest
             switch_ir.blocks[lbl] = deepcopy(loop_blocks[loop_start_lbl])
             remaining_keys = [y for y in loop_blocks.keys()]

--- a/numba/tests/test_mixed_tuple_unroller.py
+++ b/numba/tests/test_mixed_tuple_unroller.py
@@ -1818,6 +1818,19 @@ class TestMore(TestCase):
 
         self.assertEqual(foo(), foo.py_func())
 
+    def test_unroller_with_scope_update(self):
+        # See issue #7217
+        @njit
+        def foo():
+            i = 0
+            for _ in literal_unroll((1, 2)):
+                for i in range(1):
+                    i += 1
+            return i
+
+        foo()
+        self.assertEqual(foo(), foo.py_func())
+
 
 def capture(real_pass):
     """ Returns a compiler pass that captures the mutation state reported


### PR DESCRIPTION
This fixes the issue with ``literal_unroll`` reported in #7217.
Does not close the issue as there's potentially more than just
this problem with ``literal_unroll`` present.

This patch adds a fix to update the scope of blocks in the
versioned loop bodies with variables that have been versioned.
