### PR TITLE
Update postproc to general multiple del nodes if a variable is assigned multiple times in the same basic block

### DIFF
--- a/numba/core/postproc.py
+++ b/numba/core/postproc.py
@@ -195,6 +195,11 @@ class PostProcessor(object):
                 # used here but not afterwards
                 delete_pts.append((stmt, dead_set))
                 internal_dead_set -= dead_set
+                # Readd the variable to the dead set after any
+                # assignments in case a variable is assigned
+                # to multiple times
+                if isinstance(stmt, ir.Assign):
+                    internal_dead_set.add(stmt.target.name)
 
             # rewrite body and insert dels
             body = []


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

In Bodo we assign to a variable multiple times to support "inplace" updates. For example a sort with `inplace=True` is accomplished by reassigning to the same IR variable after a sort is finished. This change fixes a memory leak that was deteced in Numba 0.54 because only 1 del is generated.

I'll add a reproducer with a Numba pipeline extension shortly.

<!-- You can link to an existing issue using the github syntax #<issue number>  -->
