### PR TITLE
CUDA: Skip managed alloc tests on ARM

### DIFF
--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -146,8 +146,8 @@ def managed_array(shape, dtype=np.float_, strides=None, order='C', stream=0,
     Allocate a np.ndarray with a buffer that is managed.
     Similar to np.empty().
 
-    Managed memory is supported on Linux, and is considered experimental on
-    Windows.
+    Managed memory is supported on Linux / x86 and PowerPC, and is considered
+    experimental on Windows and Linux / AArch64.
 
     :param attach_global: A flag indicating whether to attach globally. Global
                           attachment implies that the memory is accessible from

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import platform
 import shutil
 import sys
 
@@ -97,6 +98,12 @@ def skip_without_nvdisasm(reason):
 def skip_with_nvdisasm(reason):
     nvdisasm_path = shutil.which('nvdisasm')
     return unittest.skipIf(nvdisasm_path is not None, reason)
+
+
+def skip_on_arm(reason):
+    cpu = platform.processor()
+    is_arm = cpu.startswith('arm') or cpu.startswith('aarch')
+    return unittest.skipIf(is_arm, reason)
 
 
 def cc_X_or_above(major, minor):

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -3,12 +3,13 @@ from ctypes import byref, c_size_t
 from numba.cuda.cudadrv.driver import device_memset, driver
 from numba import cuda
 from numba.cuda.testing import unittest, ContextResettingTestCase
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, skip_on_arm
 from numba.tests.support import linux_only
 
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 @linux_only
+@skip_on_arm
 class TestManagedAlloc(ContextResettingTestCase):
 
     def get_total_gpu_memory(self):

--- a/numba/cuda/tests/cudadrv/test_managed_alloc.py
+++ b/numba/cuda/tests/cudadrv/test_managed_alloc.py
@@ -9,7 +9,7 @@ from numba.tests.support import linux_only
 
 @skip_on_cudasim('CUDA Driver API unsupported in the simulator')
 @linux_only
-@skip_on_arm
+@skip_on_arm('Managed Alloc support is experimental/untested on ARM')
 class TestManagedAlloc(ContextResettingTestCase):
 
     def get_total_gpu_memory(self):


### PR DESCRIPTION
Managed allocation does work on AArch64, but the tests cause some problems on various different Tegra devices. Given the lack of AArch64 testing capability, for now we'll skip the tests on ARM and note that the support is considered "experimental".

Fixes #7180.