### PR TITLE
Fix #6001: typed.List ignores ctor arguments with JIT disabled

### DIFF
--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -20,7 +20,7 @@ from numba.core import types
 from numba.core.errors import TypingError
 from numba.tests.support import (TestCase, MemoryLeakMixin, override_config,
                                  forbid_codegen)
-from numba.typed import listobject
+from numba.typed import listobject, List
 
 
 class TestCreateAppendLength(MemoryLeakMixin, TestCase):
@@ -42,6 +42,14 @@ class TestCreateAppendLength(MemoryLeakMixin, TestCase):
             with forbid_codegen():
                 l = listobject.new_list(int32)
                 self.assertEqual(type(l), list)
+
+    def test_nonempty_list_create_no_jit(self):
+        # See Issue #6001: https://github.com/numba/numba/issues/6001
+        with override_config('DISABLE_JIT', True):
+            with forbid_codegen():
+                l = List([1, 2, 3])
+                self.assertEqual(type(l), list)
+                self.assertEqual(l, [1, 2, 3])
 
 
 class TestBool(MemoryLeakMixin, TestCase):

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -200,12 +200,15 @@ class List(MutableSequence, pt.Generic[T]):
     _legal_kwargs = ["lsttype", "meminfo", "allocated"]
 
     def __new__(cls,
+                *args,
                 lsttype=None,
                 meminfo=None,
                 allocated=DEFAULT_ALLOCATED,
                 **kwargs):
         if config.DISABLE_JIT:
-            return list.__new__(list)
+            pylist = list.__new__(list)
+            pylist.__init__(*args, **kwargs)
+            return pylist
         else:
             return object.__new__(cls)
 


### PR DESCRIPTION
When `List.__new__()` is called, the constructor arguments get swallowed by `lsttype`, which is the first argument (after the class) and is also a keyword argument. This doesn't matter when JIT is enabled, because `__new__()` returns an instance of `typed.List`, so the interpreter then calls `__init__()` on the result.

However, when JIT is disabled, `List.__new__()` returns an instance of `list`, and therefore the interpreter does not call `__init__()` on it at all - it is the responsibility of `__new__()` to initialize the returned object.

(See https://docs.python.org/3/reference/datamodel.html#object.__new__ for an explanation of the behaviour and requirements described).

To implement correct behaviour with JIT disabled, we need two changes:

- The non-keyword arguments need to be placed ahead of keyword arguments in the parameters to `List.__new__()` (`*args`).
- When JIT is disabled, in addition to creating a new `list`, we also explicitly call its `__init__()` method with our `args` and `kwargs`.

Fixes #6001.