### PR TITLE
Use normal list constructor in List.__new__()

### DIFF
--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -206,9 +206,7 @@ class List(MutableSequence, pt.Generic[T]):
                 allocated=DEFAULT_ALLOCATED,
                 **kwargs):
         if config.DISABLE_JIT:
-            pylist = list.__new__(list)
-            pylist.__init__(*args, **kwargs)
-            return pylist
+            return list(*args, **kwargs)
         else:
             return object.__new__(cls)
 


### PR DESCRIPTION
Calling `list.__new__()` without arguments and then `list.__init__()` with arguments on the resulting object is not guaranteed to work - the fact that `list.__new__()` doesn't refer to its arguments (and therefore doesn't strictly require them to be the same as the arguments to `__init__()`) is an implementation detail.

It is safer to just call `list(*args, **kwargs)` instead.

With thanks to @eric-wieser (ref: https://github.com/numba/numba/pull/7251#discussion_r677856531)