### PR TITLE
fix order of handling and casting

### DIFF
--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -223,12 +223,12 @@ class TestGetitem(MemoryLeakMixin, TestCase):
                   ):
             self.assertEqual(foo((t(0))), 0)
 
-    def test_list_getitem_different_sized_int_index(self):
+    def test_list_getitem_different_sized_uint_index(self):
         # Checks that the index type cast and ext/trunc to the
         # type of the length is correct, both wraparound and
         # direct index is tested via -1/0.
 
-        for ty in types.integer_domain:
+        for ty in types.unsigned_domain:
             @njit
             def foo():
                 l = listobject.new_list(int32)
@@ -236,6 +236,20 @@ class TestGetitem(MemoryLeakMixin, TestCase):
                 return l[ty(0)]
 
             self.assertEqual(foo(), 7)
+
+    def test_list_getitem_different_sized_int_index(self):
+        # Checks that the index type cast and ext/trunc to the
+        # type of the length is correct, both wraparound and
+        # direct index is tested via -1/0.
+
+        for ty in types.signed_domain:
+            @njit
+            def foo():
+                l = listobject.new_list(int32)
+                l.append(7)
+                return l[ty(0)], l[ty(-1)]
+
+            self.assertEqual(foo(), (7, 7))
 
 
 class TestGetitemSlice(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_listobject.py
+++ b/numba/tests/test_listobject.py
@@ -233,9 +233,9 @@ class TestGetitem(MemoryLeakMixin, TestCase):
             def foo():
                 l = listobject.new_list(int32)
                 l.append(7)
-                return l[ty(0)], l[ty(-1)]
+                return l[ty(0)]
 
-            self.assertEqual(foo(), (7, 7))
+            self.assertEqual(foo(), 7)
 
 
 class TestGetitemSlice(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from numba import config
 from numba import njit
-from numba import int32, float32, prange
+from numba import int32, float32, prange, uint8
 from numba.core import types
 from numba import typeof
 from numba.typed import List, Dict
@@ -1439,6 +1439,22 @@ class TestImmutable(MemoryLeakMixin, TestCase):
                     "list is immutable",
                     str(raises.exception),
                 )
+
+
+class TestGetItemIndexType(MemoryLeakMixin, TestCase):
+
+    def test_indexing_with_uint8(self):
+        """ Test for reproducer at https://github.com/numba/numba/issues/7250
+        """
+        @njit
+        def foo():
+            l = List.empty_list(uint8)
+            for i in range(129):
+                l.append(uint8(i))
+            a = uint8(128)
+            return l[a]
+
+        self.assertEqual(foo(), 128)
 
 
 class TestListFromIter(MemoryLeakMixin, TestCase):

--- a/numba/typed/listobject.py
+++ b/numba/typed/listobject.py
@@ -764,9 +764,9 @@ def impl_getitem(l, index):
     if index in index_types:
         if IS_NOT_NONE:
             def integer_non_none_impl(l, index):
-                index = handle_index(l, index)
                 castedindex = _cast(index, indexty)
-                status, item = _list_getitem(l, castedindex)
+                handledindex = handle_index(l, castedindex)
+                status, item = _list_getitem(l, handledindex)
                 if status == ListStatus.LIST_OK:
                     return _nonoptional(item)
                 else:


### PR DESCRIPTION
Must cast first and handle later, not the other way around!



Fixes #7250