### PR TITLE
Fix linspace to use np.divide and clamp to stop.

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4074,11 +4074,13 @@ def numpy_linspace_3(context, builder, sig, args):
         div = num - 1
         if div > 0:
             delta = stop - start
-            step = delta / div
+            step = np.divide(delta, div)
             for i in range(0, num):
                 arr[i] = start + (i * step)
         else:
             arr[0] = start
+        if num > 1:
+            arr[-1] = stop
         return arr
 
     res = context.compile_internal(builder, linspace, sig, args)

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -1241,7 +1241,7 @@ class TestLinspace(BaseTest):
             return np.linspace(n, m)
         self.check_outputs(pyfunc,
                            [(0, 4), (1, 100), (-3.5, 2.5), (-3j, 2+3j),
-                            (2, 1), (1+0.5j, 1.5j)], exact=False)
+                            (2, 1), (1+0.5j, 1.5j)])
 
     def test_linspace_3(self):
         def pyfunc(n, m, p):
@@ -1249,8 +1249,7 @@ class TestLinspace(BaseTest):
         self.check_outputs(pyfunc,
                            [(0, 4, 9), (1, 4, 3), (-3.5, 2.5, 8),
                             (-3j, 2+3j, 7), (2, 1, 0),
-                            (1+0.5j, 1.5j, 5), (1, 1e100, 1)],
-                           exact=False)
+                            (1+0.5j, 1.5j, 5), (1, 1e100, 1)])
 
     def test_linspace_accuracy(self):
         # Checking linspace reasonably replicates NumPy's algorithm


### PR DESCRIPTION
As title. This improves the match to NumPy and as a result the
tests can be more strict.

Fixes #7366
