### PR TITLE
CUDA: Fix OOB in test_kernel_arg

### DIFF
--- a/numba/cuda/tests/cudapy/test_cuda_array_interface.py
+++ b/numba/cuda/tests/cudapy/test_cuda_array_interface.py
@@ -59,7 +59,10 @@ class TestCudaArrayInterface(ContextResettingTestCase):
 
         @cuda.jit
         def mutate(arr, val):
-            arr[cuda.grid(1)] += val
+            i = cuda.grid(1)
+            if i >= len(arr):
+                return
+            arr[i] += val
 
         val = 7
         mutate.forall(wrapped.size)(wrapped, val)


### PR DESCRIPTION
Kernels launched with `forall` must bounds-check, but this kernel did not.

Fixes #7284.