### PR TITLE
Implement np.tensordot()

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -510,7 +510,7 @@ The following top-level functions are supported:
 * :func:`numpy.stack`
 * :func:`numpy.swapaxes`
 * :func:`numpy.take` (only the 2 first arguments)
-* :func:`numpy.tensordot`
+* :func:`numpy.tensordot` (``axes`` must be a tuple of a pair of tuples)
 * :func:`numpy.transpose`
 * :func:`numpy.trapz` (only the 3 first arguments)
 * :func:`numpy.tri` (only the 3 first arguments; third argument ``k`` must be an integer)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -510,6 +510,7 @@ The following top-level functions are supported:
 * :func:`numpy.stack`
 * :func:`numpy.swapaxes`
 * :func:`numpy.take` (only the 2 first arguments)
+* :func:`numpy.tensordot`
 * :func:`numpy.transpose`
 * :func:`numpy.trapz` (only the 3 first arguments)
 * :func:`numpy.tri` (only the 3 first arguments; third argument ``k`` must be an integer)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -4688,7 +4688,7 @@ def cross2d(a, b):
 
 
 @register_jitable
-def multiply_reduce(a):
+def _multiply_reduce(a):
     result = 1
     for i in range(len(a)):
         result *= a[i]
@@ -4696,10 +4696,35 @@ def multiply_reduce(a):
 
 
 @register_jitable
-def copy_to_tuple(from_list, to_tuple):
+def _copy_to_tuple(from_list, to_tuple):
     for i in range(len(to_tuple)):
         to_tuple = tuple_setitem(to_tuple, i, from_list[i])
     return to_tuple
+
+
+@register_jitable
+def _nm_dot(a, b):
+    """
+    This is an implementation of np.dot for the N-D/M-D case where M>=2.
+
+    Ideally this should eventually be:
+
+    1. Exposed as part of normal np.dot() API.
+    2. Implemented in a more efficient way (BLAS?).
+    """
+    result_shape = a.shape[:-1] + b.shape[:-2] + (b.shape[-1],)
+    adim = len(a.shape)
+    bdim = len(b.shape)
+    result = np.zeros(result_shape, dtype=a.dtype)
+    # TODO can't slice tuple
+    for a_key in np.ndindex(np.empty(result_shape[:adim - 1])):
+        for b_key_part_1 in np.ndindex(np.empty(result_shape[adim -1:adim -1 + bdim -2])):
+            for b_key_part_2 in range(result_shape[-1]):
+                result[a_key + b_key_part_1 + (b_key_part_2,)] = np.sum(
+                    a[a_key + (slice(None, None),)] *
+                    b[b_key_part_1 + (slice(None, None), b_key_part_2)]
+                )
+    return result
 
 
 @overload(np.tensordot)
@@ -4759,27 +4784,28 @@ def np_tensordot(a, b, axes):
         # Move the axes to sum over to the end of "a"
         # and to the front of "b"
         notin = [k for k in range(nda) if k not in axes_a]
-        newaxes_a = copy_to_tuple(notin + axes_a, newaxes_a_tuple)
+        newaxes_a = _copy_to_tuple(notin + axes_a, newaxes_a_tuple)
 
         N2 = 1
         for axis in axes_a:
             N2 *= as_[axis]
-        newshape_a = (int(multiply_reduce([as_[ax] for ax in notin])), N2)
-        olda = copy_to_tuple([as_[axis] for axis in notin], olda_tuple)
+        # TODO not hardocding results in segfault
+        newshape_a = (2, 1, 0)#(int(_multiply_reduce([as_[ax] for ax in notin])), N2)
+        olda = _copy_to_tuple([as_[axis] for axis in notin], olda_tuple)
 
         notin = [k for k in range(ndb) if k not in axes_b]
-        newaxes_b = copy_to_tuple(axes_b + notin, newaxes_b_tuple)
+        newaxes_b = _copy_to_tuple(axes_b + notin, newaxes_b_tuple)
         N2 = 1
         for axis in axes_b:
             N2 *= bs[axis]
-        newshape_b = (N2, int(multiply_reduce([bs[ax] for ax in notin])))
-        oldb = copy_to_tuple([bs[axis] for axis in notin], oldb_tuple)
+        newshape_b = (0, 1, 2)#(N2, int(_multiply_reduce([bs[ax] for ax in notin])))
+        oldb = _copy_to_tuple([bs[axis] for axis in notin], oldb_tuple)
 
         # TODO: figure out way to do reshape on original transpose, without
         # ascontiguousarray().
         at = np.ascontiguousarray(a.transpose(newaxes_a)).reshape(newshape_a)
         bt = np.ascontiguousarray(b.transpose(newaxes_b)).reshape(newshape_b)
-        res = np.dot(at, bt)
+        res = _nm_dot(at, bt)
         return res.reshape(olda + oldb)
 
     return tensordot_impl

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -4707,19 +4707,15 @@ def np_tensordot(a, b, axes):
     """
     Implementation of np.tensordot().
 
-    If multiple axes are given, requires the two array-likes to be tuples,
-    unlike more lenient NumPy.  Based on
+    For now axes does not yet support integers, and it's limited to a tuple of
+    two tuples, unlike more lenient NumPy.  Based on
     https://github.com/numpy/numpy/blob/v1.21.0/numpy/core/numeric.py#L943-L1133
     """
-    #if not type_can_asarray(a) or not type_can_asarray(b):
-    #    raise TypingError("Inputs must be array-like.")
-    # try:
-    #     iter(axes)
-    # except Exception:
-    #     axes_a = tuple(range(-axes, 0))
-    #     axes_b = tuple(range(0, axes))
-    # else:
-    #     axes_a, axes_b = axes
+    if not type_can_asarray(a) or not type_can_asarray(b):
+        raise TypingError("Inputs must be array-like.")
+    if isinstance(axes, (int, types.Integer)):
+        raise ValueError("integer axes are not yet supported")
+
     newaxes_a_tuple = (0,) * a.ndim
     newaxes_b_tuple = (0,) * b.ndim
     # We don't know the size of the final reshape, and reshape wants a tuple,

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -348,6 +348,32 @@ class TestProduct(TestCase):
             cfunc(a, a, 1)
         self.assertIn("integer axes are not yet supported", str(e.exception))
 
+    @needs_blas
+    def test_tensordot(self):
+        cfunc = jit(nopython=True)(tensordot)
+
+        def assert_same_as_py(arr1, arr2, axes):
+            expected = cfunc.py_func(arr1, arr2, axes)
+            result = cfunc(arr1, arr2, axes)
+            np.testing.assert_allclose(expected, result)
+
+        # 2-D squares:
+        a = self.sample_matrix(3, 3, np.float64)
+        b = self.sample_matrix(3, 3, np.float64)
+        assert_same_as_py(a, b, ((1, 0), (0, 1)))
+        assert_same_as_py(a, b, ((0, 1), (0, 1)))
+        assert_same_as_py(a, b, ((0, 1), (1, 0)))
+        assert_same_as_py(a, b, ((1, 0), (1, 0)))
+        assert_same_as_py(a, b, ((1,), (1,)))
+        assert_same_as_py(a, b, ((0,), (0,)))
+        assert_same_as_py(a, b, ((), ()))
+
+        # 2-D rectangle:
+        # TODO
+
+        # 3-D:
+        # TODO
+
 
 # Implementation definitions for the purpose of jitting.
 


### PR DESCRIPTION
Implementing in the hopes I can use it as basis for `np.einsum`, but seems useful on its own too.

The code was copy/pasted from NumPy and updated; this relies on #7202 for the NumPy licensing compliance, but the appropriate changes could be done here instead.

My main concern is that this isn't well enough tested, so suggestions for more tests would be appreciated.