### PR TITLE
Link ELF obj as DSO for radare2 disassembly CFG

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -838,16 +838,18 @@ class CPUCodeLibrary(CodeLibrary):
         self._sentry_cache_disable_inspection()
         return _CFG(self, name, py_func, **kwargs)
 
-    def get_disasm_cfg(self):
+    def get_disasm_cfg(self, mangled_name):
         """
-        Get the CFG of the disassembly of the ELF object
+        Get the CFG of the disassembly of the ELF object at symbol mangled_name.
 
         Requires python package: r2pipe
         Requires radare2 binary on $PATH.
         Notebook rendering requires python package: graphviz
+        Optionally requires a compiler toolchain (via pycc) to link the ELF to
+        get better disassembly results.
         """
         elf = self._get_compiled_object()
-        return disassemble_elf_to_cfg(elf)
+        return disassemble_elf_to_cfg(elf, mangled_name)
 
     @classmethod
     def _dump_elf(cls, buf):

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -672,7 +672,7 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         if signature is not None:
             cres = self.overloads[signature]
             lib = cres.library
-            return lib.get_disasm_cfg()
+            return lib.get_disasm_cfg(cres.fndesc.mangled_name)
 
         return dict((sig, self.inspect_disasm_cfg(sig))
                     for sig in self.signatures)

--- a/numba/misc/inspection.py
+++ b/numba/misc/inspection.py
@@ -1,12 +1,17 @@
 """Miscellaneous inspection tools
 """
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+import os
+import warnings
+
+from numba.core.errors import NumbaWarning
 
 
-def disassemble_elf_to_cfg(elf):
+def disassemble_elf_to_cfg(elf, mangled_symbol):
     """
-    Gets the CFG of the disassembly of an ELF object, elf, and renders it
-    appropriately depending on the execution environment (terminal/notebook).
+    Gets the CFG of the disassembly of an ELF object, elf, at mangled name,
+    mangled_symbol, and renders it appropriately depending on the execution
+    environment (terminal/notebook).
     """
     try:
         import r2pipe
@@ -14,20 +19,56 @@ def disassemble_elf_to_cfg(elf):
         raise RuntimeError("r2pipe package needed for disasm CFG")
 
     def get_rendering(cmd=None):
+        from numba.pycc.platform import Toolchain # import local, circular ref
         if cmd is None:
             raise ValueError("No command given")
 
-        with NamedTemporaryFile(delete=False) as f:
-            f.write(elf)
-            f.flush()  # force write, radare2 needs a binary blob on disk
+        with TemporaryDirectory() as tmpdir:
+            # Write ELF as a temporary file in the temporary dir, do not delete!
+            with NamedTemporaryFile(delete=False, dir=tmpdir) as f:
+                f.write(elf)
+                f.flush()  # force write, radare2 needs a binary blob on disk
+
+            # Now try and link the ELF, this helps radare2 _a lot_
+            linked = False
+            try:
+                raw_dso_name = f'{os.path.basename(f.name)}.so'
+                linked_dso = os.path.join(tmpdir, raw_dso_name)
+                tc = Toolchain()
+                tc.link_shared(linked_dso, (f.name,))
+                obj_to_analyse = linked_dso
+                linked = True
+            except Exception as e:
+                # link failed, mention it to user, radare2 will still be able to
+                # analyse the object, but things like dwarf won't appear in the
+                # asm as comments.
+                msg = ('Linking the ELF object with the distutils toolchain '
+                       f'failed with: {e}. Disassembly will still work but '
+                       'might be less accurate and will not use DWARF '
+                       'information.')
+                warnings.warn(NumbaWarning(msg))
+                obj_to_analyse = f.name
 
             # catch if r2pipe can actually talk to radare2
             try:
-                flags = ['-e io.cache=true',  # fix relocations in disassembly
+                flags = ['-2', # close stderr to hide warnings
+                         '-e io.cache=true', # fix relocations in disassembly
                          '-e scr.color=1',  # 16 bit ANSI colour terminal
+                         '-e asm.dwarf=true', # DWARF decode
+                         '-e scr.utf8=true', # UTF8 output looks better
                          ]
-                r = r2pipe.open(f.name, flags=flags)
-                data = r.cmd('af;%s' % cmd)
+                r = r2pipe.open(obj_to_analyse, flags=flags)
+                r.cmd('aaaaaa') # analyse as much as possible
+                # If the elf is linked then it's necessary to seek as the
+                # DSO ctor/dtor is at the default position
+                if linked:
+                    # switch off demangle, the seek is on a mangled symbol
+                    r.cmd('e bin.demangle=false')
+                    # seek to the mangled symbol address
+                    r.cmd(f's `is~ {mangled_symbol}[1]`')
+                    # switch demangling back on for output purposes
+                    r.cmd('e bin.demangle=true')
+                data = r.cmd('%s' % cmd) # print graph
                 r.quit()
             except Exception as e:
                 if "radare2 in PATH" in str(e):


### PR DESCRIPTION
This improves the amount of analysis r2 can do and also lets
DWARF info be used in the disassembly CFG output.
