### PR TITLE
Defensive copy IR when doing obj looplift.

### DIFF
--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -721,7 +721,9 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
                                        lifted_from=lifted_from)
 
         # compile with rewrites off, IR shouldn't be mutated irreparably
-        norw_cres = compile_local(func_ir.copy(), norw_flags)
+        # deepcopy to create defense against mutation
+        norw_ir_copy = copy.deepcopy(func_ir)
+        norw_cres = compile_local(norw_ir_copy, norw_flags)
 
         # try and compile with rewrites on if no_rewrites was not set in the
         # original flags, IR might get broken but we've got a CompileResult
@@ -732,7 +734,7 @@ def compile_ir(typingctx, targetctx, func_ir, args, return_type, flags,
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", errors.NumbaWarning)
                 try:
-                    rw_cres = compile_local(func_ir.copy(), flags)
+                    rw_cres = compile_local(copy.deepcopy(func_ir), flags)
                 except Exception:
                     pass
         # if the rewrite variant of compilation worked, use it, else use

--- a/numba/tests/test_looplifting.py
+++ b/numba/tests/test_looplifting.py
@@ -599,6 +599,22 @@ class TestLoopLiftingInAction(MemoryLeakMixin, TestCase):
         [lifted] = foo.overloads[foo.signatures[0]].lifted
         self.assertEqual(len(lifted.nopython_signatures), 1)
 
+    def test_lift_forceobj_issue_7215(self):
+        from numba import jit
+
+        @jit(forceobj=True)
+        def foo(d):
+            res = {}
+            for k, v in d.items():
+                res[k] = v
+                if v:
+                    pass
+            return res
+
+        x = {1: 1, 2: 2}
+        got = foo(x)
+        self.assertEqual(x, got)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title. This isolates the mutations made in the various
attempts to compile the looplift IR.

Fixes #7215
