### PR TITLE
Speed up import time by not importing `unittest` or `multiprocessing` until it is needed

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -17,7 +17,6 @@ del generate_version_info
 
 
 from numba.core import config
-from numba.testing import _runtests as runtests
 from numba.core import types, errors
 
 # Re-export typeof
@@ -60,8 +59,11 @@ import numba.core.target_extension
 import numba.typed
 
 # Keep this for backward compatibility.
-test = runtests.main
-
+def test(argv, **kwds):
+    # To speed up the import time, avoid importing `unittest` and other test
+    # dependencies unless the user is actually trying to run tests.
+    from numba.testing import _runtests as runtests
+    return runtests.main(argv, **kwds)
 
 __all__ = """
     cfunc


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This also avoids importing `multiprocessing` for the trivial `cpu_count()` function that [just wraps](https://github.com/python/cpython/blob/bb3e0c240bc60fe08d332ff5955d54197f79751c/Lib/multiprocessing/context.py#L41-L47) `os.cpu_count()` in a way that isn't useful.

This reduces the import time by 7% on my machine (measured with `py -3.8 -S -Ximporttime -c "import numba"`, either by comparing before and after, or subtracting the components due to these imports). Here is the graph before this patch:

![image](https://user-images.githubusercontent.com/425260/130062351-97b213d1-4ab9-48ba-9477-f20cd1761853.png)

The two large pale-blue elements are the ones eliminated by this PR.
The next-lowest hanging fruit is #4927, which would contribute substantially to reducing the remaining import time.

