### PR TITLE
Add size_t and ssize_t types

### DIFF
--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -65,6 +65,8 @@ intc                    --               C int-sized integer
 uintc                   --               C int-sized unsigned integer
 intp                    --               pointer-sized integer
 uintp                   --               pointer-sized unsigned integer
+ssize_t                 --               C ssize_t
+size_t                  --               C size_t
 
 float32                 f4               single-precision floating-point number
 float64, double         f8               double-precision floating-point number

--- a/numba/core/types/__init__.py
+++ b/numba/core/types/__init__.py
@@ -47,9 +47,9 @@ int64 = Integer('int64')
 intp = int32 if utils.MACHINE_BITS == 32 else int64
 uintp = uint32 if utils.MACHINE_BITS == 32 else uint64
 intc = int32 if struct.calcsize('i') == 4 else int64
-uintc = uint32 if struct.calcsize('i') == 4 else uint64
+uintc = uint32 if struct.calcsize('I') == 4 else uint64
 ssize_t = int32 if struct.calcsize('n') == 4 else int64
-size_t = uint32 if struct.calcsize('n') == 4 else uint64
+size_t = uint32 if struct.calcsize('N') == 4 else uint64
 
 float32 = Float('float32')
 float64 = Float('float64')

--- a/numba/core/types/__init__.py
+++ b/numba/core/types/__init__.py
@@ -48,6 +48,8 @@ intp = int32 if utils.MACHINE_BITS == 32 else int64
 uintp = uint32 if utils.MACHINE_BITS == 32 else uint64
 intc = int32 if struct.calcsize('i') == 4 else int64
 uintc = uint32 if struct.calcsize('i') == 4 else uint64
+ssize_t = int32 if struct.calcsize('n') == 4 else int64
+size_t = uint32 if struct.calcsize('n') == 4 else uint64
 
 float32 = Float('float32')
 float64 = Float('float64')
@@ -129,6 +131,8 @@ intp
 uintp
 intc
 uintc
+ssize_t
+size_t
 boolean
 float32
 float64

--- a/numba/tests/test_ctypes.py
+++ b/numba/tests/test_ctypes.py
@@ -20,8 +20,8 @@ class TestCTypesTypes(TestCase):
         check(c_double, types.float64)
         check(c_int, types.intc)
         check(c_uint16, types.uint16)
-        check(c_size_t, types.uintp)
-        check(c_ssize_t, types.intp)
+        check(c_size_t, types.size_t)
+        check(c_ssize_t, types.ssize_t)
 
         check(c_void_p, types.voidptr)
         check(POINTER(c_float), types.CPointer(types.float32))


### PR DESCRIPTION
These are mainly for use with `cfunc`, to match the defined signature of
a C API. In flat-memory ABIs these are the same as uintptr_t and
intptr_t, but's not guaranteed to hold forever. More practically, having
these names will make code clearer, as it will match the C names for the
interface being implemented, and make it clear that a parameter is
holding a size/count rather than a bit-cast pointer.