### PR TITLE
Allow arbitrary walk-back in reduction nodes to find inplace_binop.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3570,7 +3570,7 @@ def get_reduction_init(nodes):
     # there could be multiple extra assignments after the reduce node
     # See: test_reduction_var_reuse
     cur_index = 1
-    acc_expr = nodes[cur_index].value
+    acc_expr = nodes[-cur_index].value
     while isinstance(acc_expr, ir.Var):
         require(len(nodes) >= cur_index + 1)
         require(nodes[-(cur_index + 1)].target.name == nodes[-cur_index].value.name)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3569,14 +3569,7 @@ def get_reduction_init(nodes):
     require(len(nodes) >= 1)
     # there could be multiple extra assignments after the reduce node
     # See: test_reduction_var_reuse
-    cur_index = 1
-    acc_expr = nodes[-cur_index].value
-    while isinstance(acc_expr, ir.Var):
-        require(len(nodes) >= cur_index + 1)
-        require(nodes[-(cur_index + 1)].target.name == nodes[-cur_index].value.name)
-        cur_index += 1
-        acc_expr = nodes[-cur_index].value
-
+    acc_expr = list(filter(lambda x: isinstance(x.value, ir.Expr), nodes))[-1].value
     require(isinstance(acc_expr, ir.Expr) and acc_expr.op=='inplace_binop')
     if acc_expr.fn == operator.iadd or acc_expr.fn == operator.isub:
         return 0, acc_expr.fn

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3566,15 +3566,17 @@ def get_reduction_init(nodes):
     Get initial value for known reductions.
     Currently, only += and *= are supported.
     """
-    require(len(nodes) >=1)
-    # there could be an extra assignment after the reduce node
+    require(len(nodes) >= 1)
+    # there could be multiple extra assignments after the reduce node
     # See: test_reduction_var_reuse
-    if isinstance(nodes[-1].value, ir.Var):
-        require(len(nodes) >=2)
-        require(nodes[-2].target.name == nodes[-1].value.name)
-        acc_expr = nodes[-2].value
-    else:
-        acc_expr = nodes[-1].value
+    cur_index = 1
+    acc_expr = nodes[cur_index].value
+    while isinstance(acc_expr, ir.Var):
+        require(len(nodes) >= cur_index + 1)
+        require(nodes[-(cur_index + 1)].target.name == nodes[-cur_index].value.name)
+        cur_index += 1
+        acc_expr = nodes[-cur_index].value
+
     require(isinstance(acc_expr, ir.Expr) and acc_expr.op=='inplace_binop')
     if acc_expr.fn == operator.iadd or acc_expr.fn == operator.isub:
         return 0, acc_expr.fn

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1574,6 +1574,20 @@ class TestParfors(TestParforsBase):
             return s
         self.check(test_impl, np.ones(10), np.ones(10).astype('bool'))
 
+    def test_if_not_else_reduction(self):
+        # issue #7344
+        def test_impl(A, cond):
+            s = 1
+            t = 10
+            for i in prange(A.shape[0]):
+                if cond[i]:
+                    s += 1
+                    t += 1
+                else:
+                    s += 2
+            return s + t
+        self.check(test_impl, np.ones(10), np.ones(10).astype('bool'))
+
     def test_two_d_array_reduction_reuse(self):
         def test_impl(n):
             shp = (13, 17)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1564,6 +1564,16 @@ class TestParfors(TestParforsBase):
             return acc
         self.check(test_impl, 16)
 
+    def test_non_identity_initial(self):
+        # issue #7344
+        def test_impl(A, cond):
+            s = 1
+            for i in prange(A.shape[0]):
+                if cond[i]:
+                    s += 1
+            return s
+        self.check(test_impl, np.ones(10), np.ones(10).astype('bool'))
+
     def test_two_d_array_reduction_reuse(self):
         def test_impl(n):
             shp = (13, 17)


### PR DESCRIPTION
Resolves #7344 

Previously, there could only be one extra assignment after the inplace_binop node for a reduction before the assignment to the reduction variable.  In this issue, there was an additional assignment.  The solution is to start at the enf with the reduction variable and walk backwards through the reduce nodes so long as they are all assignments and link with each other until we get to inplace_binop.