### PR TITLE
modified ipython locator conditions for when ipython points to /tmp

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -307,7 +307,7 @@ class _IPythonCacheLocator(_CacheLocator):
 
     @classmethod
     def from_function(cls, py_func, py_file):
-        if not py_file.startswith("<ipython-"):
+        if not py_file.startswith("<ipython-") and "ipykernel" not in py_file:
             return
         self = cls(py_func, py_file)
         try:


### PR DESCRIPTION
Recently on a fresh jupyter/ipython installation on Ubuntu 20 + python 3.8.10, I found that numba wouldn't work w/ njit(cache=True). Usually when running:

```python
import inspect
from numba import njit

def foo():
    return 1

print(inspect.getfile(foo))

njit_foo = njit(cache=True)(foo)
print(njit_foo())
```
You would get something like 
```
<ipython-input-X-XXXXXXXXX>
1
```
For for some reason (maybe a different version of jupyter) on this fresh install it pointed to the /tmp directory like this
```
/tmp/ipykernel_53800/2759104420.py
1
```

This fix just proceeds with the ipython locator if "ipykernel" is in the function's file path.

For reference `jupyter --version` looks like this:
```
jupyter core     : 4.6.3
jupyter-notebook : 6.4.3
qtconsole        : 5.1.1
ipython          : 7.27.0
ipykernel        : 6.3.1
jupyter client   : 7.0.2
jupyter lab      : not installed
nbconvert        : 6.1.0
ipywidgets       : 7.6.3
nbformat         : 5.1.3
traitlets        : 4.3.3
```

I believe this fixes issue #7345