### PR TITLE
CUDA: Fix potential leaks when initialization fails

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -223,7 +223,10 @@ class Driver(object):
             self.is_initialized = True
             self.initialization_error = e
 
-    def initialize(self):
+    def ensure_initialized(self):
+        if self.is_initialized:
+            return
+
         # lazily initialize logger
         global _logger
         _logger = make_logger()
@@ -233,8 +236,9 @@ class Driver(object):
             _logger.info('init')
             self.cuInit(0)
         except CudaAPIError as e:
-            self.initialization_error = e
-            raise CudaSupportError("Error at driver init: \n%s:" % e)
+            description = f"{e.msg} ({e.code})"
+            self.initialization_error = description
+            raise CudaSupportError(f"Error at driver init: {description}")
         else:
             self.pid = _getpid()
 
@@ -259,8 +263,7 @@ class Driver(object):
 
     @property
     def is_available(self):
-        if not self.is_initialized:
-            self.initialize()
+        self.ensure_initialized()
         return self.initialization_error is None
 
     def __getattr__(self, fname):
@@ -272,9 +275,7 @@ class Driver(object):
         restype = proto[0]
         argtypes = proto[1:]
 
-        # Initialize driver
-        if not self.is_initialized:
-            self.initialize()
+        self.ensure_initialized()
 
         if self.initialization_error is not None:
             raise CudaSupportError("Error at driver init: \n%s:" %

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -221,7 +221,7 @@ class Driver(object):
             self.lib = find_driver()
         except CudaSupportError as e:
             self.is_initialized = True
-            self.initialization_error = e
+            self.initialization_error = e.msg
 
     def ensure_initialized(self):
         if self.is_initialized:

--- a/numba/cuda/device_init.py
+++ b/numba/cuda/device_init.py
@@ -69,7 +69,9 @@ def is_supported_version():
 
 
 def cuda_error():
-    """Returns None or an exception if the CUDA driver fails to initialize.
+    """Returns None if there was no error initializing the CUDA driver.
+    If there was an error initializing the driver, a string describing the
+    error is returned.
     """
     return driver.driver.initialization_error
 

--- a/numba/cuda/simulator/__init__.py
+++ b/numba/cuda/simulator/__init__.py
@@ -21,6 +21,7 @@ if config.ENABLE_CUDASIM:
     sys.modules['numba.cuda.cudadrv.driver'] = cudadrv.driver
     sys.modules['numba.cuda.cudadrv.runtime'] = cudadrv.runtime
     sys.modules['numba.cuda.cudadrv.drvapi'] = cudadrv.drvapi
+    sys.modules['numba.cuda.cudadrv.error'] = cudadrv.error
     sys.modules['numba.cuda.cudadrv.nvvm'] = cudadrv.nvvm
 
     from . import compiler

--- a/numba/cuda/simulator/cudadrv/__init__.py
+++ b/numba/cuda/simulator/cudadrv/__init__.py
@@ -1,1 +1,2 @@
-from numba.cuda.simulator.cudadrv import devicearray, devices, driver, drvapi, nvvm
+from numba.cuda.simulator.cudadrv import (devicearray, devices, driver, drvapi,
+                                          error, nvvm)

--- a/numba/cuda/simulator/cudadrv/driver.py
+++ b/numba/cuda/simulator/cudadrv/driver.py
@@ -38,6 +38,10 @@ class LinkerError(RuntimeError):
     pass
 
 
+class CudaAPIError(RuntimeError):
+    pass
+
+
 def launch_kernel(*args, **kwargs):
     msg = 'Launching kernels directly is not supported in the simulator'
     raise RuntimeError(msg)

--- a/numba/cuda/simulator/cudadrv/error.py
+++ b/numba/cuda/simulator/cudadrv/error.py
@@ -1,0 +1,2 @@
+class CudaSupportError(RuntimeError):
+    pass

--- a/numba/cuda/tests/cudadrv/test_init.py
+++ b/numba/cuda/tests/cudadrv/test_init.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 from numba import cuda
 from numba.cuda.cudadrv.driver import CudaAPIError, driver
 from numba.cuda.cudadrv.error import CudaSupportError
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
 
 
 # A mock of cuInit that always raises a CudaAPIError
@@ -50,6 +50,7 @@ def initialization_error_test(result_queue):
     result_queue.put((success, msg))
 
 
+@skip_on_cudasim('CUDA Simulator does not initialize driver')
 class TestInit(CUDATestCase):
     def _test_init_failure(self, target, expected):
         # Run the initialization failure test in a separate subprocess

--- a/numba/cuda/tests/cudadrv/test_init.py
+++ b/numba/cuda/tests/cudadrv/test_init.py
@@ -90,10 +90,10 @@ class TestInit(CUDATestCase):
         result_queue = ctx.Queue()
         proc = ctx.Process(target=target, args=(result_queue,))
         proc.start()
-        proc.join()
+        proc.join(30) # should complete within 30s
         success, msg = result_queue.get()
 
-        # Ensure the child process raised an except during initialization
+        # Ensure the child process raised an exception during initialization
         # before checking the message
         if not success:
             self.fail('CudaSupportError not raised')

--- a/numba/cuda/tests/cudadrv/test_init.py
+++ b/numba/cuda/tests/cudadrv/test_init.py
@@ -1,0 +1,86 @@
+import multiprocessing as mp
+
+from numba import cuda
+from numba.cuda.cudadrv.driver import CudaAPIError, driver
+from numba.cuda.cudadrv.error import CudaSupportError
+from numba.cuda.testing import unittest, CUDATestCase
+
+
+# A mock of cuInit that always raises a CudaAPIError
+def cuInit_raising(arg):
+    raise CudaAPIError(999, 'CUDA_ERROR_UNKNOWN')
+
+
+# Test code to run in a child that patches driver.cuInit to a variant that
+# always raises. We can't use mock.patch.object here because driver.cuInit is
+# not assigned until we attempt to initialize - mock.patch.object cannot locate
+# the non-existent original method, and so fails. Instead we patch
+# driver.cuInit with our raising version prior to any attempt to initialize.
+def cuInit_raising_test(result_queue):
+    driver.cuInit = cuInit_raising
+
+    success = False
+    msg = None
+
+    try:
+        # A CUDA operation that forces initialization of the device
+        cuda.device_array(1)
+    except CudaSupportError as e:
+        success = True
+        msg = e.msg
+
+    result_queue.put((success, msg))
+
+
+# Similar to cuInit_raising_test above, but for testing that the string
+# returned by cuda_error() is as expected.
+def initialization_error_test(result_queue):
+    driver.cuInit = cuInit_raising
+
+    success = False
+    msg = None
+
+    try:
+        # A CUDA operation that forces initialization of the device
+        cuda.device_array(1)
+    except CudaSupportError:
+        success = True
+        msg = cuda.cuda_error()
+
+    result_queue.put((success, msg))
+
+
+class TestInit(CUDATestCase):
+    def _test_init_failure(self, target, expected):
+        # Run the initialization failure test in a separate subprocess
+        ctx = mp.get_context('spawn')
+        result_queue = ctx.Queue()
+        proc = ctx.Process(target=target, args=(result_queue,))
+        proc.start()
+        proc.join()
+        success, msg = result_queue.get()
+
+        # Ensure the child process raised an except during initialization
+        # before checking the message
+        if not success:
+            self.fail('CudaSupportError not raised')
+
+        self.assertEqual(msg, expected)
+
+    def test_init_failure_raising(self):
+        expected = 'Error at driver init: CUDA_ERROR_UNKNOWN (999)'
+        self._test_init_failure(cuInit_raising_test, expected)
+
+    def test_init_failure_error(self):
+        expected = 'CUDA_ERROR_UNKNOWN (999)'
+        self._test_init_failure(initialization_error_test, expected)
+
+    def test_init_success(self):
+        # Here we assume that initialization is successful (because many bad
+        # things will happen with the test suite if it is not) and check that
+        # there is no error recorded.
+        self.assertIsNone(cuda.cuda_error())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When CUDA driver initialization fails, the driver singleton object persists holding on to an exception object that references calling
frames and potentially other objects. This can create a leak in the case where modules that attempt to initialize the driver and then fail are created and destroyed.

This change rectifies the issue by holding on to a string describing the error instead of the exception object. There are a couple of small related changes:

- `initialize()` is changed to `ensure_initialized()`, and the caller no longer needs to check whether it should be called - it can always call it when it needs to ensure that the driver is initialized.
- `cuda.cuda_error()` returns the error string instead of an exception object. Constructing an exception object here just to maintain the original behavior seems a bit convoluted; it's likely that any code using `cuda_error()` is checking whether its return value is `None` rather than looking for a specific instance of an exception class to see if an exception occurred.

Some initialization tests are added - for the failing cases we need to run in a subprocess to avoid interfering with the initialization of the driver in the process in which we're actually running tests. The failure of `cuInit(0)` is accomplished by a slightly unorthodox patching of `driver.cuInit`, which is needed because driver functions are added to the `Driver` object on-demand, so there is nothing for `mock.patch.object()` to replace at the time we need to set up the mock.