### PR TITLE
developer contributing docs - llvm, sqlite3, sphinx-rtd-theme, and make html

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -418,7 +418,7 @@ conda or pip; i.e. ``conda install sphinx numpydoc``.
 
 To build the documentation, you need the rtd theme::
 
-   $ conda install sphinx-rtd-theme
+   $ conda install sphinx_rtd_theme
 
 You can edit the source files under ``docs/source/``, after which you can
 build and check the documentation under ``docs/``::

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -416,9 +416,9 @@ It is built with `Sphinx <http://sphinx-doc.org/>`_ and
 `numpydoc <https://numpydoc.readthedocs.io/>`_, which are available using
 conda or pip; i.e. ``conda install sphinx numpydoc``.
 
-To build the documentation, you need the bootstrap and rtd themes::
+To build the documentation, you need the rtd theme::
 
-   $ conda install sphinx_bootstrap_theme sphinx-rtd-theme
+   $ conda install sphinx-rtd-theme
 
 You can edit the source files under ``docs/source/``, after which you can
 build and check the documentation under ``docs/``::

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -421,12 +421,12 @@ It is built with `Sphinx <http://sphinx-doc.org/>`_ and
 `numpydoc <https://numpydoc.readthedocs.io/>`_, which are available using
 conda or pip; i.e. ``conda install sphinx numpydoc``.
 
-To build the documentation, you need the bootstrap theme::
+To build the documentation, you need the bootstrap and rtd themes::
 
-   $ pip install sphinx_bootstrap_theme
+   $ pip install sphinx_bootstrap_theme sphinx-rtd-theme
 
 You can edit the source files under ``docs/source/``, after which you can
-build and check the documentation::
+build and check the documentation under ``docs/``::
 
    $ make html
    $ open _build/html/index.html

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -264,7 +264,7 @@ you commit changes. You can skip this check with ``git commit --no-verify``.
 .. note::
    To use these pre-commit hooks on Windows, it may be necessary to copy
    ``sqlite3.dll`` from ``C:\Users\<USER>\anaconda3\Library\bin`` to
-   ``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH (`source <https:// stackoverflow.com/a/55642416/13697228>`_).
+   ``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH (`source <https://stackoverflow.com/a/55642416/13697228>`_).
 
 Numba has started the process of using `type hints <https://www.python.org/dev/peps/pep-0484/>`_ in its code base. This
 will be a gradual process of extending the number of files that use type hints, as well as going from voluntary to

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -261,11 +261,6 @@ and then running::
 from the root of the Numba repository. Now ``flake8`` will be run each time
 you commit changes. You can skip this check with ``git commit --no-verify``.
 
-.. note::
-   To use these pre-commit hooks on Windows, it may be necessary to copy
-   ``sqlite3.dll`` from ``C:\Users\<USER>\anaconda3\Library\bin`` to
-   ``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH (`source <https://stackoverflow.com/a/55642416/13697228>`_).
-
 Numba has started the process of using `type hints <https://www.python.org/dev/peps/pep-0484/>`_ in its code base. This
 will be a gradual process of extending the number of files that use type hints, as well as going from voluntary to
 mandatory type hints for new features. `Mypy <http://mypy-lang.org/>`_ is used for automated static checking.

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -423,7 +423,7 @@ conda or pip; i.e. ``conda install sphinx numpydoc``.
 
 To build the documentation, you need the bootstrap and rtd themes::
 
-   $ pip install sphinx_bootstrap_theme sphinx-rtd-theme
+   $ conda install sphinx_bootstrap_theme sphinx-rtd-theme
 
 You can edit the source files under ``docs/source/``, after which you can
 build and check the documentation under ``docs/``::

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -262,9 +262,9 @@ from the root of the Numba repository. Now ``flake8`` will be run each time
 you commit changes. You can skip this check with ``git commit --no-verify``.
 
 .. note::
-  To use these pre-commit hooks on Windows, it may be necessary to copy
-``sqlite3.dll`` from ``C:\Users\<USER>\anaconda3\Library\bin`` to
-``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH. (`source <https://stackoverflow.com/a/55642416/13697228>`_).
+   To use these pre-commit hooks on Windows, it may be necessary to copy
+   ``sqlite3.dll`` from ``C:\Users\<USER>\anaconda3\Library\bin`` to
+   ``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH (`source <https:// stackoverflow.com/a/55642416/13697228>`_).
 
 Numba has started the process of using `type hints <https://www.python.org/dev/peps/pep-0484/>`_ in its code base. This
 will be a gradual process of extending the number of files that use type hints, as well as going from voluntary to

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -91,10 +91,11 @@ recommend you use `conda <http://conda.pydata.org/miniconda.html>`_ to
 create a dedicated development environment and install precompiled versions
 of those dependencies there.
 
-First add the Anaconda Cloud ``numba`` channel so as to get development builds
-of the llvmlite library::
+First add the Anaconda Cloud ``numba`` and ``numba/label/ci_llvmlite_0.38``
+channels so as to get development builds of the llvmlite library::
 
    $ conda config --add channels numba
+   $ conda config --add channels numba/label/ci_llvmlite_0.38
 
 Then create an environment with the right dependencies::
 
@@ -118,7 +119,7 @@ Once the environment is activated, you have a dedicated Python with the
 required dependencies::
 
     $ python
-    Python 3.8.5 (default, Sep  4 2020, 07:30:14) 
+    Python 3.8.5 (default, Sep  4 2020, 07:30:14)
     [GCC 7.3.0] :: Anaconda, Inc. on linux
     Type "help", "copyright", "credits" or "license" for more information.
 
@@ -259,6 +260,11 @@ and then running::
 
 from the root of the Numba repository. Now ``flake8`` will be run each time
 you commit changes. You can skip this check with ``git commit --no-verify``.
+
+.. note::
+  To use these pre-commit hooks on Windows, it may be necessary to copy
+``sqlite3.dll`` from ``C:\Users\<USER>\anaconda3\Library\bin`` to
+``C:\Users\<USER>\anaconda3\DLLs`` or modify your PATH. (`source <https://stackoverflow.com/a/55642416/13697228>`_).
 
 Numba has started the process of using `type hints <https://www.python.org/dev/peps/pep-0484/>`_ in its code base. This
 will be a gradual process of extending the number of files that use type hints, as well as going from voluntary to


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Here's a summary:
- There seems to be an issue in the docs related to the channel used for llvm
- There seems to be a Windows-specific bug where conda can't find sqlite3.dll when trying to commit using the pre-commit hooks, so I added some instructions for overcoming that issue.
- The docs can't build because it `sphinx-rtd-theme` isn't installed, so I added that to the pip install
- I added instructions that `make html` is run under `docs` (should be obvious to anyone familiar with make, seeing as there is no MAKEFILE under `docs/source`, but saves someone the extra step)

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->
#7362 #7354