### PR TITLE
CUDA: Run doctests as part of numba.cuda.tests and fix test_cg

### DIFF
--- a/numba/cuda/tests/__init__.py
+++ b/numba/cuda/tests/__init__.py
@@ -16,6 +16,7 @@ def load_tests(loader, tests, pattern):
         if gpus and gpus[0].compute_capability >= (2, 0):
             suite.addTests(load_testsuite(loader, join(this_dir, 'cudadrv')))
             suite.addTests(load_testsuite(loader, join(this_dir, 'cudapy')))
+            suite.addTests(load_testsuite(loader, join(this_dir, 'doc_examples')))
         else:
             print("skipped CUDA tests because GPU CC < 2.0")
     else:

--- a/numba/cuda/tests/doc_examples/test_cg.py
+++ b/numba/cuda/tests/doc_examples/test_cg.py
@@ -9,10 +9,12 @@ from numba.cuda.testing import CUDATestCase, skip_on_cudasim
 class TestCooperativeGroups(CUDATestCase):
     def test_ex_grid_sync(self):
         # magictoken.ex_grid_sync_kernel.begin
-        from numba import cuda, int32, void
+        from numba import cuda, int32
         import numpy as np
 
-        @cuda.jit(void(int32[:,::1]))
+        sig = (int32[:,::1],)
+
+        @cuda.jit(sig)
         def sequential_rows(M):
             col = cuda.grid(1)
             g = cuda.cg.this_grid()
@@ -41,7 +43,7 @@ class TestCooperativeGroups(CUDATestCase):
 
         # Skip this test if the grid size used in the example is too large for
         # a cooperative launch on the current GPU
-        mb = sequential_rows.definition.max_cooperative_grid_blocks(blockdim)
+        mb = sequential_rows.overloads[sig].max_cooperative_grid_blocks(blockdim)
         if mb < griddim:
             self.skipTest('Device does not support a large enough coop grid')
 

--- a/numba/cuda/tests/doc_examples/test_cg.py
+++ b/numba/cuda/tests/doc_examples/test_cg.py
@@ -2,9 +2,12 @@
 # "magictoken" is used for markers as beginning and ending of example text.
 
 import unittest
-from numba.cuda.testing import CUDATestCase, skip_on_cudasim
+from numba.cuda.testing import (CUDATestCase, skip_on_cudasim,
+                                skip_if_cudadevrt_missing, skip_unless_cc_60)
 
 
+@skip_if_cudadevrt_missing
+@skip_unless_cc_60
 @skip_on_cudasim("cudasim doesn't support cuda import at non-top-level")
 class TestCooperativeGroups(CUDATestCase):
     def test_ex_grid_sync(self):


### PR DESCRIPTION
Whilst reviewing #7330 I noticed that the CUDA doctests don't get run as part of `numba.cuda.tests`, and even worse, `test_cg` was broken (it used an old, removed API)!

This commit adds the `doc_example` module to those loaded as part of `numba.cuda.tests`, and fixes `test_cg`.