### PR TITLE
Ensure the NRT is initialized prior to use in external NRT tests.

### DIFF
--- a/docs/source/developer/numba-runtime.rst
+++ b/docs/source/developer/numba-runtime.rst
@@ -176,6 +176,19 @@ Here is an example that uses the ``nrt_external.h``:
       return mi;
   }
 
+It is important to ensure that the NRT is initialized prior to making calls to
+it, calling ``numba.core.runtime.nrt.rtsys.initialize(context)`` from Python
+will have the desired effect. Similarly the code snippet:
+
+.. code-block:: Python
+
+  from numba.core import typing, cpu
+  typingctx = typing.Context()
+  cpu.CPUContext(typingctx, 'cpu')
+
+will achieve the same specifically for Numba's CPU target (the default). Failure
+to initialize the NRT will result in access violations as function pointers for
+various internal atomic operations will be missing in the ``NRT_MemSys`` struct.
 
 Future Plan
 ===========

--- a/docs/source/developer/numba-runtime.rst
+++ b/docs/source/developer/numba-runtime.rst
@@ -182,9 +182,8 @@ will have the desired effect. Similarly the code snippet:
 
 .. code-block:: Python
 
-  from numba.core import typing, cpu
-  typingctx = typing.Context()
-  cpu.CPUContext(typingctx, 'cpu')
+  from numba.core.registry import cpu_target # Get the CPU target singleton
+  cpu_target.target_context # Access the target_context property to initialize
 
 will achieve the same specifically for Numba's CPU target (the default). Failure
 to initialize the NRT will result in access violations as function pointers for

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -7,7 +7,7 @@ import re
 import numpy as np
 
 from numba import njit
-from numba.core import typing, types
+from numba.core import types
 from numba.core.compiler import compile_isolated, Flags
 from numba.core.runtime import (
     rtsys,

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -25,7 +25,7 @@ from numba.core.unsafe.nrt import NRT_get_api
 
 from numba.tests.support import (MemoryLeakMixin, TestCase, temp_directory,
                                  import_dynamic)
-from numba.core import cpu
+from numba.core.registry import cpu_target
 import unittest
 
 enable_nrt_flags = Flags()
@@ -82,7 +82,7 @@ class TestNrtMemInfo(unittest.TestCase):
         # Reset the Dummy class
         Dummy.alive = 0
         # initialize the NRT (in case the tests are run in isolation)
-        cpu.CPUContext(typing.Context())
+        cpu_target.target_context
 
     def test_meminfo_refct_1(self):
         d = Dummy()
@@ -557,7 +557,7 @@ class TestNrtExternalCFFI(MemoryLeakMixin, TestCase):
     def setUp(self):
         # initialize the NRT (in case the tests are run in isolation)
         super(TestNrtExternalCFFI, self).setUp()
-        cpu.CPUContext(typing.Context())
+        cpu_target.target_context
 
     def compile_cffi_module(self, name, source, cdef):
         from cffi import FFI

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -554,6 +554,10 @@ br i1 %.294, label %B42, label %B160
 class TestNrtExternalCFFI(MemoryLeakMixin, TestCase):
     """Testing the use of externally compiled C code that use NRT
     """
+    def setUp(self):
+        # initialize the NRT (in case the tests are run in isolation)
+        super(TestNrtExternalCFFI, self).setUp()
+        cpu.CPUContext(typing.Context())
 
     def compile_cffi_module(self, name, source, cdef):
         from cffi import FFI


### PR DESCRIPTION
As title. Also updates the docs to remind users of the NRT
external API that the NRT must be initialized prior to use.

Fixes #7385

