### PR TITLE
Patch cloudpickle to not reset dynamic class each time it is unpickled

### DIFF
--- a/numba/cloudpickle/cloudpickle_fast.py
+++ b/numba/cloudpickle/cloudpickle_fast.py
@@ -36,6 +36,7 @@ from .cloudpickle import (
     parametrized_type_hint_getinitargs, _create_parametrized_type_hint,
     builtin_code_type,
     _make_dict_keys, _make_dict_values, _make_dict_items,
+    _DYNAMIC_CLASS_TRACKER_REUSING,
 )
 
 
@@ -460,6 +461,10 @@ def _function_setstate(obj, state):
 
 
 def _class_setstate(obj, state):
+    # Check if class is being reused and needs bypass setstate logic.
+    if obj in _DYNAMIC_CLASS_TRACKER_REUSING:
+        return obj
+
     state, slotstate = state
     registry = None
     for attrname, attr in state.items():

--- a/numba/tests/cloudpickle_main_class.py
+++ b/numba/tests/cloudpickle_main_class.py
@@ -1,0 +1,6 @@
+# Expected to run this module as __main__
+
+
+# Cloudpickle will think this is a dynamic class when this module is __main__
+class Klass:
+    classvar = None

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -212,6 +212,8 @@ class TestSerializationMisc(TestCase):
 class TestCloudPickleIssues(TestCase):
     """This testcase includes all issues specific to cloudpickle implementation.
     """
+    _numba_parallel_test_ = False
+
     def test_dynamic_class_reset_on_unpickle(self):
         # a dynamic class
         class Klass:

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -205,5 +205,32 @@ class TestSerializationMisc(TestCase):
         self.assertIs(got1, got2)
 
 
+
+class TestCloudPickleIssues(TestCase):
+    """This testcase includes all issues specific to cloudpickle implementation.
+    """
+    def test_dynamic_class_reset_on_unpickle(self):
+        from numba.cloudpickle import dumps, loads
+
+        # a dynamic class
+        class Klass:
+            classvar = None
+
+        def mutator():
+            Klass.classvar = 100
+
+        def check():
+            self.assertEqual(Klass.classvar, 100)
+
+        saved = dumps(Klass)
+        mutator()
+        check()
+        loads(saved)
+        check()
+        loads(saved)
+        check()
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -210,7 +210,7 @@ class TestSerializationMisc(TestCase):
 
 
 class TestCloudPickleIssues(TestCase):
-    """This testcase includes all issues specific to cloudpickle implementation.
+    """This test case includes issues specific to the cloudpickle implementation.
     """
     _numba_parallel_test_ = False
 


### PR DESCRIPTION
Fixes a problem with cloudpickle when dynamic class is unpickled and the class is reset to the state when it is pickled.

A short reproducer for the cloudpickle problem is available here:

```python
# Tested with cloudpickle 1.6.0
from cloudpickle import dumps, loads


class Klass:
    classvar = None

def mutator():
    Klass.classvar = 100

def check():
    print("checking....")
    print(f"   Klass.classvar [{hex(id(Klass))}] = {Klass.classvar}")


def failing_case():
    print("Klass", hex(id(Klass)))
    saved = dumps(Klass)
    mutator()
    check()
    loads(saved)
    check()
    loads(saved)
    check()



if __name__ == '__main__':
    failing_case()
```

Note, cloudpickle treats any class created in `__main__` as dynamic.

The patch makes cloudpickle remember whether a dynamic class is being reused. Reuse can come from the class being unpickled in the same process as it being pickled; or, a previously unpickled class is still around.

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->

Fixes https://github.com/numba/numba/issues/7356