### PR TITLE
Fix #7394 and #6550 & Added test & improved error message

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1068,9 +1068,11 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         # this doesn't work in objmode as it's effectively untyped
         if typed:
             len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
-            from numba.cpython.rangeobj import comprehension_iter_len
+            from numba.cpython.rangeobj import length_of_iterator
             stmts.append(_new_definition(func_ir, len_func_var,
-                                         ir.Global('comprehension_iter_len', comprehension_iter_len, loc=loc),
+                                         ir.Global('length_of_iterator',
+                                                   length_of_iterator,
+                                                   loc=loc),
                                          loc))
             size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
         else:

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -1068,10 +1068,10 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
         # this doesn't work in objmode as it's effectively untyped
         if typed:
             len_func_var = ir.Var(scope, mk_unique_var("len_func"), loc)
-            from numba.cpython.rangeobj import range_iter_len
+            from numba.cpython.rangeobj import comprehension_iter_len
             stmts.append(_new_definition(func_ir, len_func_var,
-                        ir.Global('range_iter_len', range_iter_len, loc=loc),
-                        loc))
+                                         ir.Global('comprehension_iter_len', comprehension_iter_len, loc=loc),
+                                         loc))
             size_val = ir.Expr.call(len_func_var, (iter_var,), (), loc=loc)
         else:
             raise GuardException

--- a/numba/cpython/rangeobj.py
+++ b/numba/cpython/rangeobj.py
@@ -181,7 +181,7 @@ def range_to_range(context, builder, fromty, toty, val):
     return cgutils.make_anonymous_struct(builder, items)
 
 @intrinsic
-def comprehension_iter_len(typingctx, val):
+def length_of_iterator(typingctx, val):
     """
     An implementation of len(iter) for internal use.
     Primary use is for array comprehensions (see inline_closurecall).

--- a/numba/cpython/rangeobj.py
+++ b/numba/cpython/rangeobj.py
@@ -7,7 +7,7 @@ import operator
 import llvmlite.llvmpy.core as lc
 
 from numba import prange
-from numba.core import types, cgutils
+from numba.core import types, cgutils, errors
 from numba.cpython.listobj import ListIterInstance
 from numba.np.arrayobj import make_array
 from numba.core.imputils import (lower_builtin, lower_cast,
@@ -181,9 +181,10 @@ def range_to_range(context, builder, fromty, toty, val):
     return cgutils.make_anonymous_struct(builder, items)
 
 @intrinsic
-def range_iter_len(typingctx, val):
+def comprehension_iter_len(typingctx, val):
     """
-    An implementation of len(range_iter) for internal use.
+    An implementation of len(iter) for internal use.
+    Primary use is for array comprehensions (see inline_closurecall).
     """
     if isinstance(val, types.RangeIteratorType):
         val_type = val.yield_type
@@ -213,7 +214,27 @@ def range_iter_len(typingctx, val):
             # array iterates along the outer dimension
             return impl_ret_untracked(context, builder, intp_t, shape[0])
         return signature(types.intp, val), codegen
+    elif isinstance(val, types.UniTupleIter):
+        def codegen(context, builder, sig, args):
+            (iterty,) = sig.args
+            tuplety = iterty.container
+            intp_t = context.get_value_type(types.intp)
+            count_const = intp_t(tuplety.count)
+            return impl_ret_untracked(context, builder, intp_t, count_const)
 
+        return signature(types.intp, val), codegen
+    elif isinstance(val, types.ListTypeIteratorType):
+        def codegen(context, builder, sig, args):
+            (value,) = args
+            intp_t = context.get_value_type(types.intp)
+            from numba.typed.listobject import ListIterInstance
+            iterobj = ListIterInstance(context, builder, sig.args[0], value)
+            return impl_ret_untracked(context, builder, intp_t, iterobj.size)
+        return signature(types.intp, val), codegen
+    else:
+        msg = ('Unsupported iterator found in array comprehension, try '
+               'preallocating the array and filling manually.')
+        raise errors.TypingError(msg)
 
 def make_range_attr(index, attribute):
     @intrinsic

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpy
 
 from numba.core.compiler import compile_isolated
-from numba import jit
+from numba import jit, typed
 from numba.core import types, utils
 from numba.core.errors import TypingError, LoweringError
 from numba.core.types.functions import _header_lead
@@ -407,6 +407,10 @@ class TestArrayComprehension(unittest.TestCase):
         self.check(array_comp, l)
         # with array iterator
         self.check(array_comp, np.array(l))
+        # with tuple iterator (issue #7394)
+        self.check(array_comp, tuple(l))
+        # with typed.List iterator (issue #6550)
+        self.check(array_comp, typed.List(l))
 
     def test_array_comp_with_dtype(self):
         def array_comp(n):

--- a/numba/tests/test_comprehension.py
+++ b/numba/tests/test_comprehension.py
@@ -370,6 +370,16 @@ class TestArrayComprehension(unittest.TestCase):
         self.assertIn(_header_lead, str(raises.exception))
         self.assertIn('array(undefined,', str(raises.exception))
 
+    def test_comp_unsupported_iter(self):
+        def comp_unsupported_iter():
+            val = zip([1, 2, 3], [4, 5, 6])
+            return np.array([a for a, b in val])
+        with self.assertRaises(TypingError) as raises:
+            self.check(comp_unsupported_iter)
+        self.assertIn(_header_lead, str(raises.exception))
+        self.assertIn('Unsupported iterator found in array comprehension',
+                      str(raises.exception))
+
     def test_no_array_comp(self):
         def no_array_comp1(n):
             l = [1,2,3,4]

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -9,7 +9,7 @@ from numba import jit, njit
 from numba.core import types, utils
 from numba.tests.support import tag
 
-from numba.cpython.rangeobj import comprehension_iter_len
+from numba.cpython.rangeobj import length_of_iterator
 def loop1(n):
     s = 0
     for i in range(n):
@@ -40,10 +40,10 @@ def range_len2(a, b):
 def range_len3(a, b, c):
     return len(range(a, b, c))
 def range_iter_len1(a):
-    return comprehension_iter_len(iter(range(a)))
+    return length_of_iterator(iter(range(a)))
 
 def range_iter_len2(a):
-    return comprehension_iter_len(iter(a))
+    return length_of_iterator(iter(a))
 
 def range_attrs(start, stop, step):
     r1 = range(start)

--- a/numba/tests/test_range.py
+++ b/numba/tests/test_range.py
@@ -9,7 +9,7 @@ from numba import jit, njit
 from numba.core import types, utils
 from numba.tests.support import tag
 
-from numba.cpython.rangeobj import range_iter_len
+from numba.cpython.rangeobj import comprehension_iter_len
 def loop1(n):
     s = 0
     for i in range(n):
@@ -40,10 +40,10 @@ def range_len2(a, b):
 def range_len3(a, b, c):
     return len(range(a, b, c))
 def range_iter_len1(a):
-    return range_iter_len(iter(range(a)))
+    return comprehension_iter_len(iter(range(a)))
 
 def range_iter_len2(a):
-    return range_iter_len(iter(a))
+    return comprehension_iter_len(iter(a))
 
 def range_attrs(start, stop, step):
     r1 = range(start)


### PR DESCRIPTION
also renames `range_iter_len` -> `comprehension_iter_len`

As discussed with @stuartarchibald, this adds the code he suggest in both the issues to (the renamed) `comprehension_iter_len` and gives a better error message. It might be worth considering to move `comprehension_iter_len` to another module, since it is now even less tightly coupled to the `rangeobj`.