### PR TITLE
Add support for arrayanalysis of tuple args.

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -1325,6 +1325,12 @@ class ArrayAnalysis(object):
                     shape = gvalue
                 elif isinstance(gvalue, int):
                     shape = (gvalue,)
+            elif isinstance(inst.value, ir.Arg):
+                if (
+                    isinstance(typ, types.containers.UniTuple)
+                    and isinstance(typ.dtype, types.Integer)
+                ):
+                    shape = inst.value
 
             if isinstance(shape, ir.Const):
                 if isinstance(shape.value, tuple):
@@ -3128,9 +3134,14 @@ class ArrayAnalysis(object):
         # attr call: A_sh_attr = getattr(A, shape)
         if isinstance(shape, ir.Var):
             shape = equiv_set.get_shape(shape)
+
         # already a tuple variable that contains size
         if isinstance(shape, ir.Var):
             attr_var = shape
+            shape_attr_call = None
+            shape = None
+        elif isinstance(shape, ir.Arg):
+            attr_var = var
             shape_attr_call = None
             shape = None
         else:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1850,6 +1850,13 @@ class TestParfors(TestParforsBase):
         x = np.ones((2, 2, 2, 2, 2, 15))
         self.check(test_impl, x)
 
+    def test_tuple_arg(self):
+        def test_impl(x, sz):
+            for i in numba.pndindex(sz):
+                x[i] = 1
+            return x
+        sz = (10,10)
+        self.check(test_impl, np.empty(sz), sz)
 
 @skip_parfors_unsupported
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):


### PR DESCRIPTION
Previously, if a tuple of integers were passed in and then used in a pndindex, the parfor pass would fail because the tuple of dimension sizes didn't have an entry in array analysis.  This PR adds integer tuple arguments to array analysis whereas previously only integer tuple variables were supported.