### PR TITLE
FEAT: add np.moveaxis support

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -498,6 +498,8 @@ The following top-level functions are supported:
 * :func:`numpy.reshape` (no order argument; 'C' order only)
 * :func:`numpy.roll` (only the 2 first arguments; second argument ``shift``
   must be an integer)
+* :func:`numpy.moveaxis` (if the ``source`` is an integer then
+  ``destination``, too, must be an integer and vice versa.)
 * :func:`numpy.roots`
 * :func:`numpy.rot90` (only the 2 first arguments)
 * :func:`numpy.round_`


### PR DESCRIPTION
Closes: https://github.com/numba/numba/issues/7369

This PR adds support for `np.moveaxis`. I've modified the following files:

- added `moveaxis` implementation to `arraymath.py`
- added an entry in the documentation of `numpysupported.rst`
- added unit tests for `moveaxis` matching the unit tests currently used by numpy (with exception of one variant that passed in a `range` iterable into `moveaxis`, which numba doesn't support)

I did not check for full coverage of the unit tests; hence, some paths that lead to raising the correct exception may not be covered.