### PR TITLE
Add option to extend variable lifetimes to the end of their block.

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -125,6 +125,13 @@ These variables influence what is printed out during compilation of
    for each compiled function.
    Default value equals to the value of `NUMBA_ENABLE_PROFILING`.
 
+.. envvar:: NUMBA_EXTEND_VARIABLE_LIFETIMES
+
+    If set to non-zero, extend the lifetime of variables to the end of the block
+    in which their lifetime ends. This is particularly useful in conjunction
+    with `NUMBA_DEBUGINFO` as it helps with introspection of values. Default is
+    zero.
+
 .. envvar:: NUMBA_GDB_BINARY
 
    Set the ``gdb`` binary for use in Numba's ``gdb`` support, this takes the

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -417,6 +417,9 @@ class _EnvReloader(object):
         DEBUGINFO_DEFAULT = _readenv("NUMBA_DEBUGINFO", int, ENABLE_PROFILING)
         CUDA_DEBUGINFO_DEFAULT = _readenv("NUMBA_CUDA_DEBUGINFO", int, 0)
 
+        EXTEND_VARIABLE_LIFETIMES = _readenv("NUMBA_EXTEND_VARIABLE_LIFETIMES",
+                                             int, 0)
+
         # gdb binary location
         GDB_BINARY = _readenv("NUMBA_GDB_BINARY", str, '/usr/bin/gdb')
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2212,7 +2212,7 @@ def check_and_legalize_ir(func_ir):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    post_proc.run(True)
+    post_proc.run(True, extend_lifetimes=config.EXTEND_VARIABLE_LIFETIMES)
 
 
 def convert_code_obj_to_function(code_obj, caller_ir):

--- a/numba/core/postproc.py
+++ b/numba/core/postproc.py
@@ -67,7 +67,7 @@ class PostProcessor(object):
     def __init__(self, func_ir):
         self.func_ir = func_ir
 
-    def run(self, emit_dels=False):
+    def run(self, emit_dels=False, extend_lifetimes=False):
         """
         Run the following passes over Numba IR:
         - canonicalize the CFG
@@ -94,7 +94,7 @@ class PostProcessor(object):
         # Emit del nodes, do this last as the generator info parsing generates
         # and then strips dels as part of its analysis.
         if emit_dels:
-            self._insert_var_dels()
+            self._insert_var_dels(extend_lifetimes=extend_lifetimes)
 
     def _populate_generator_info(self):
         """
@@ -154,7 +154,7 @@ class PostProcessor(object):
         gi.state_vars = sorted(st)
         self.remove_dels()
 
-    def _insert_var_dels(self):
+    def _insert_var_dels(self, extend_lifetimes=False):
         """
         Insert del statements for each variable.
         Returns a 2-tuple of (variable definition map, variable deletion map)
@@ -172,9 +172,11 @@ class PostProcessor(object):
         branch and return) are deleted by the successors or the caller.
         """
         vlt = self.func_ir.variable_lifetime
-        self._patch_var_dels(vlt.deadmaps.internal, vlt.deadmaps.escaping)
+        self._patch_var_dels(vlt.deadmaps.internal, vlt.deadmaps.escaping,
+                             extend_lifetimes=extend_lifetimes)
 
-    def _patch_var_dels(self, internal_dead_map, escaping_dead_map):
+    def _patch_var_dels(self, internal_dead_map, escaping_dead_map,
+                        extend_lifetimes=False):
         """
         Insert delete in each block
         """
@@ -199,15 +201,28 @@ class PostProcessor(object):
             # rewrite body and insert dels
             body = []
             lastloc = ir_block.loc
+            del_store = []
             for stmt, delete_set in reversed(delete_pts):
-                lastloc = stmt.loc
+                # If using extended lifetimes then the Dels are all put at the
+                # block end just ahead of the terminator, so associate their
+                # location with the terminator.
+                if extend_lifetimes:
+                    lastloc = ir_block.body[-1].loc
+                else:
+                    lastloc = stmt.loc
                 # Ignore dels (assuming no user inserted deletes)
                 if not isinstance(stmt, ir.Del):
                     body.append(stmt)
                 # note: the reverse sort is not necessary for correctness
                 #       it is just to minimize changes to test for now
                 for var_name in sorted(delete_set, reverse=True):
-                    body.append(ir.Del(var_name, loc=lastloc))
+                    delnode = ir.Del(var_name, loc=lastloc)
+                    if extend_lifetimes:
+                        del_store.append(delnode)
+                    else:
+                        body.append(delnode)
+            if extend_lifetimes:
+                body.extend(del_store)
             body.append(ir_block.body[-1])  # terminator
             ir_block.body = body
 


### PR DESCRIPTION
This:
* Adds a new env var ``NUMBA_EXTEND_VARIABLE_LIFETIMES`` which when
  set extends the lifetime of variables to the end of the block in
  which their lifetime ends.
* Fixes up the Dels and their location information in the case of
  the above being set.
* Wires the above into the post processor call in the legalizer. The
  legalizer is the only place which should change the variable life
  times as it is the last thing that is executed in the pipeline
  before lowering. Changing the lifetimes in general will break
  optimisation passes that rely on lifetime analysis via Del nodes.

Fixes #7420
