### PR TITLE
Update Omitted Type to use Hashable Values as Keys for Caching

### DIFF
--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -5,7 +5,7 @@ import weakref
 
 import numpy as np
 
-from numba.core.utils import cached_property
+from numba.core.utils import cached_property, get_hashable_key
 
 # Types are added to a global registry (_typecache) in order to assign
 # them unique integer codes for fast matching in _dispatcher.c.
@@ -424,12 +424,7 @@ class Literal(Type):
         self._literal_value = value
         # We want to support constants of non-hashable values, therefore
         # fall back on the value's id() if necessary.
-        try:
-            hash(value)
-        except TypeError:
-            self._key = id(value)
-        else:
-            self._key = value
+        self._key = get_hashable_key(value)
 
     @property
     def literal_value(self):

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -87,11 +87,19 @@ class Omitted(Opaque):
 
     def __init__(self, value):
         self._value = value
+        # Because id(value) may not match when loading from disk,
+        # just return the value if we can hash it.
+        # See discussion in gh #6957
+        self._value_key = (
+            value
+            if hasattr(value, "__hash__") and value.__hash__ is not None
+            else id(value)
+        )
         super(Omitted, self).__init__("omitted(default=%r)" % (value,))
 
     @property
     def key(self):
-        return type(self._value), id(self._value)
+        return type(self._value), self._value_key
 
     @property
     def value(self):

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -3,6 +3,7 @@ from numba.core.types.common import (Dummy, IterableType, Opaque,
                                      SimpleIteratorType)
 from numba.core.typeconv import Conversion
 from numba.core.errors import TypingError, LiteralTypingError
+from numba.core.ir import UndefinedType
 
 
 class PyObject(Dummy):
@@ -92,7 +93,7 @@ class Omitted(Opaque):
         # See discussion in gh #6957
         self._value_key = (
             value
-            if hasattr(value, "__hash__") and value.__hash__ is not None
+            if not isinstance(value, UndefinedType) and hasattr(value, "__hash__") and value.__hash__ is not None
             else id(value)
         )
         super(Omitted, self).__init__("omitted(default=%r)" % (value,))

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -91,11 +91,11 @@ class Omitted(Opaque):
         # Because id(value) may not match when loading from disk,
         # just return the value if we can hash it.
         # See discussion in gh #6957
-        self._value_key = (
-            value
-            if not isinstance(value, UndefinedType) and hasattr(value, "__hash__") and value.__hash__ is not None
-            else id(value)
-        )
+        try:
+            hash(value)
+            self._value_key = value
+        except Exception:
+            self._value_key = id(value)
         super(Omitted, self).__init__("omitted(default=%r)" % (value,))
 
     @property

--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -4,6 +4,7 @@ from numba.core.types.common import (Dummy, IterableType, Opaque,
 from numba.core.typeconv import Conversion
 from numba.core.errors import TypingError, LiteralTypingError
 from numba.core.ir import UndefinedType
+from numba.core.utils import get_hashable_key
 
 
 class PyObject(Dummy):
@@ -88,14 +89,9 @@ class Omitted(Opaque):
 
     def __init__(self, value):
         self._value = value
-        # Because id(value) may not match when loading from disk,
-        # just return the value if we can hash it.
-        # See discussion in gh #6957
-        try:
-            hash(value)
-            self._value_key = value
-        except Exception:
-            self._value_key = id(value)
+        # Use helper function to support both hashable and non-hashable
+        # values. See discussion in gh #6957.
+        self._value_key = get_hashable_key(value)
         super(Omitted, self).__init__("omitted(default=%r)" % (value,))
 
     @property

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -636,3 +636,19 @@ class _RedirectSubpackage(ModuleType):
     def __reduce__(self):
         args = (self.__old_module_states, self.__new_module)
         return _RedirectSubpackage, args
+
+
+def get_hashable_key(value):
+    """
+        Given a value, returns a key that can be used
+        as a hash. If the value is hashable, we return
+        the value, otherwise we return id(value).
+
+        See discussion in gh #6957
+    """
+    try:
+        hash(value)
+    except TypeError:
+        return id(value)
+    else:
+        return value

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -48,70 +48,72 @@ class TestCaching(SerialMixin, TestCase):
     def test_dict_cache(self):
         self.run_test(check_dict_cache)
 
-
-def omitted_child_test_wrapper(result_queue, second_call):
-
-    @njit(cache=True)
-    def test(num=1000):
-        return num
-
-    try:
-        output = test()
-        # If we have a second call, we should have a cache hit.
-        # Otherwise, we expect a cache miss.
-        if second_call:
-            assert test._cache_hits[test.signatures[0]] == 1, \
-                "Cache did not hit as expected"
-            assert test._cache_misses[test.signatures[0]] == 0, \
-                "Cache has an unexpected miss"
-        else:
-            assert test._cache_misses[test.signatures[0]] == 1, \
-                "Cache did not miss as expected"
-            assert test._cache_hits[test.signatures[0]] == 0, \
-                "Cache has an unexpected hit"
-        success = True
-    # Catch anything raised so it can be propagated
-    except: # noqa: E722
-        output = traceback.format_exc()
-        success = False
-    result_queue.put((success, output))
-
-
-class TestDiskCaching(SerialMixin, TestCase):
-    """
-        Tests that caching works when loadingvalues from disk.
-    """
     def test_omitted(self):
 
         # Test in a new directory
         cache_dir = temp_directory(self.__class__.__name__)
-        with override_config("CACHE_DIR", cache_dir):
-            ctx = mp.get_context()
-            result_queue = ctx.Queue()
-            proc = ctx.Process(
-                target=omitted_child_test_wrapper, args=(result_queue, False)
-            )
-            proc.start()
-            proc.join()
-            success, output = result_queue.get()
+        ctx = mp.get_context()
+        result_queue = ctx.Queue()
+        proc = ctx.Process(
+            target=omitted_child_test_wrapper,
+            args=(result_queue, cache_dir, False),
+        )
+        proc.start()
+        proc.join()
+        success, output = result_queue.get()
 
-            # Ensure the child process is completed before checking its output
-            if not success:
-                self.fail(output)
+        # Ensure the child process is completed before checking its output
+        if not success:
+            self.fail(output)
 
-            assert output == 1000, \
-                "Omitted function returned an incorrect output"
+        self.assertEqual(
+            output,
+            1000,
+            "Omitted function returned an incorrect output"
+        )
 
-            proc = ctx.Process(
-                target=omitted_child_test_wrapper, args=(result_queue, True)
-            )
-            proc.start()
-            proc.join()
-            success, output = result_queue.get()
+        proc = ctx.Process(
+            target=omitted_child_test_wrapper,
+            args=(result_queue, cache_dir, True)
+        )
+        proc.start()
+        proc.join()
+        success, output = result_queue.get()
 
-            # Ensure the child process is completed before checking its output
-            if not success:
-                self.fail(output)
+        # Ensure the child process is completed before checking its output
+        if not success:
+            self.fail(output)
 
-            assert output == 1000, \
-                "Omitted function returned an incorrect output"
+        self.assertEqual(
+            output,
+            1000,
+            "Omitted function returned an incorrect output"
+        )
+
+
+def omitted_child_test_wrapper(result_queue, cache_dir, second_call):
+    with override_config("CACHE_DIR", cache_dir):
+        @njit(cache=True)
+        def test(num=1000):
+            return num
+
+        try:
+            output = test()
+            # If we have a second call, we should have a cache hit.
+            # Otherwise, we expect a cache miss.
+            if second_call:
+                assert test._cache_hits[test.signatures[0]] == 1, \
+                    "Cache did not hit as expected"
+                assert test._cache_misses[test.signatures[0]] == 0, \
+                    "Cache has an unexpected miss"
+            else:
+                assert test._cache_misses[test.signatures[0]] == 1, \
+                    "Cache did not miss as expected"
+                assert test._cache_hits[test.signatures[0]] == 0, \
+                    "Cache has an unexpected hit"
+            success = True
+        # Catch anything raised so it can be propagated
+        except: # noqa: E722
+            output = traceback.format_exc()
+            success = False
+        result_queue.put((success, output))

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,8 +1,12 @@
+import multiprocessing as mp
+import traceback
 from numba import njit
 from numba.tests.support import (
     TestCase,
     SerialMixin,
-    run_in_new_process_caching
+    override_config,
+    run_in_new_process_caching,
+    temp_directory,
 )
 
 
@@ -43,3 +47,71 @@ class TestCaching(SerialMixin, TestCase):
 
     def test_dict_cache(self):
         self.run_test(check_dict_cache)
+
+
+def omitted_child_test_wrapper(result_queue, second_call):
+
+    @njit(cache=True)
+    def test(num=1000):
+        return num
+
+    try:
+        output = test()
+        # If we have a second call, we should have a cache hit.
+        # Otherwise, we expect a cache miss.
+        if second_call:
+            assert test._cache_hits[test.signatures[0]] == 1, \
+                "Cache did not hit as expected"
+            assert test._cache_misses[test.signatures[0]] == 0, \
+                "Cache has an unexpected miss"
+        else:
+            assert test._cache_misses[test.signatures[0]] == 1, \
+                "Cache did not miss as expected"
+            assert test._cache_hits[test.signatures[0]] == 0, \
+                "Cache has an unexpected hit"
+        success = True
+    # Catch anything raised so it can be propagated
+    except: # noqa: E722
+        output = traceback.format_exc()
+        success = False
+    result_queue.put((success, output))
+
+
+class TestDiskCaching(SerialMixin, TestCase):
+    """
+        Tests that caching works when loadingvalues from disk.
+    """
+    def test_omitted(self):
+
+        # Test in a new directory
+        cache_dir = temp_directory(self.__class__.__name__)
+        with override_config("CACHE_DIR", cache_dir):
+            ctx = mp.get_context()
+            result_queue = ctx.Queue()
+            proc = ctx.Process(
+                target=omitted_child_test_wrapper, args=(result_queue, False)
+            )
+            proc.start()
+            proc.join()
+            success, output = result_queue.get()
+
+            # Ensure the child process is completed before checking its output
+            if not success:
+                self.fail(output)
+
+            assert output == 1000, \
+                "Omitted function returned an incorrect output"
+
+            proc = ctx.Process(
+                target=omitted_child_test_wrapper, args=(result_queue, True)
+            )
+            proc.start()
+            proc.join()
+            success, output = result_queue.get()
+
+            # Ensure the child process is completed before checking its output
+            if not success:
+                self.fail(output)
+
+            assert output == 1000, \
+                "Omitted function returned an incorrect output"


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes #6957.

Changes Omitted arguments to use a different key for hashable and non-hashable types. For hashable types, this enables loading cache from disk even if id no longer matches.