### PR TITLE
fix: preserve decorated function's type annotations

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 import inspect
 import logging
+import typing
 
 from numba.core.errors import DeprecationError, NumbaDeprecationWarning
 from numba.stencils.stencil import stencil
@@ -23,8 +24,13 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
+JittedFuncType = typing.TypeVar("JittedFuncType",
+                                bound=typing.Callable[..., typing.Any])
+
+
 def jit(signature_or_function=None, locals={}, cache=False,
-        pipeline_class=None, boundscheck=None, **options):
+        pipeline_class=None, boundscheck=None, **options
+    ) -> typing.Callable[[JittedFuncType], JittedFuncType]:
     """
     This decorator is used to compile a Python function into native code.
 
@@ -188,12 +194,14 @@ def jit(signature_or_function=None, locals={}, cache=False,
         return wrapper
 
 
-def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
+def _jit(
+         sigs, locals, target, cache, targetoptions, **dispatcher_args
+    ) -> typing.Callable[[JittedFuncType], JittedFuncType]:
 
     from numba.core.target_extension import resolve_dispatcher_from_str
     dispatcher = resolve_dispatcher_from_str(target)
 
-    def wrapper(func):
+    def wrapper(func: JittedFuncType) -> JittedFuncType:
         if extending.is_jitted(func):
             raise TypeError(
                 "A jit decorator was called on an already jitted function "

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -24,13 +24,8 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-JittedFuncType = typing.TypeVar("JittedFuncType",
-                                bound=typing.Callable[..., typing.Any])
-
-
-def jit(signature_or_function=None, locals={}, cache=False,
-        pipeline_class=None, boundscheck=None, **options
-    ) -> typing.Callable[[JittedFuncType], JittedFuncType]:
+def jit(signature_or_function=None, locals={}, cache=False, pipeline_class=None,
+        boundscheck=None, **options):
     """
     This decorator is used to compile a Python function into native code.
 
@@ -194,14 +189,12 @@ def jit(signature_or_function=None, locals={}, cache=False,
         return wrapper
 
 
-def _jit(
-         sigs, locals, target, cache, targetoptions, **dispatcher_args
-    ) -> typing.Callable[[JittedFuncType], JittedFuncType]:
+def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
 
     from numba.core.target_extension import resolve_dispatcher_from_str
     dispatcher = resolve_dispatcher_from_str(target)
 
-    def wrapper(func: JittedFuncType) -> JittedFuncType:
+    def wrapper(func):
         if extending.is_jitted(func):
             raise TypeError(
                 "A jit decorator was called on an already jitted function "
@@ -322,3 +315,20 @@ def jit_module(**kwargs):
             _logger.debug("Auto decorating function {} from module {} with jit "
                           "and options: {}".format(obj, module.__name__, kwargs))
             module.__dict__[name] = jit(obj, **kwargs)
+
+
+if typing.TYPE_CHECKING:
+    JittedFuncType = typing.TypeVar("JittedFuncType",
+                                    bound=typing.Callable[..., typing.Any])
+    
+    original_jit = jit
+    original_njit = njit
+
+    def jit(signature_or_function=None, locals={}, cache=False,
+        pipeline_class=None, boundscheck=None, **options
+    ) -> typing.Callable[[JittedFuncType], JittedFuncType]:
+        return original_jit(signature_or_function, locals, cache,
+                            pipeline_class, boundscheck, **options)
+    
+    def njit(*args, **kws) -> typing.Callable[[JittedFuncType], JittedFuncType]:
+        return original_njit(*args, **kws)

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -24,8 +24,8 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jit(signature_or_function=None, locals={}, cache=False, pipeline_class=None,
-        boundscheck=None, **options):
+def jit(signature_or_function=None, locals={}, cache=False,
+        pipeline_class=None, boundscheck=None, **options):
     """
     This decorator is used to compile a Python function into native code.
 


### PR DESCRIPTION
This PR introduces type annotations to the `@jit` decorator in order to preserve decorated functions' type annotations and avoid some problems with `mypy`.

~Closes #7424 .~

**EDIT:** I tried to apply these same changes in the installed library I'm using in my virtualenv... and it's not working as intended (`mypy` keeps complaining about missing types, I'm not sure if it's because I "hide" the type annotations under the `if typing.TYPE_CHECKING:` guard).

So I would say it's still a work in progress.