### PR TITLE
Fix regression #7355: cannot set items in structured array data types 

### DIFF
--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -452,9 +452,8 @@ class Array(Buffer):
             layout = self.layout
         if readonly is None:
             readonly = not self.mutable
-        cls = type(self)
-        return cls(dtype=dtype, ndim=ndim, layout=layout, readonly=readonly,
-                   aligned=self.aligned)
+        return Array(dtype=dtype, ndim=ndim, layout=layout, readonly=readonly,
+                     aligned=self.aligned)
 
     @property
     def key(self):

--- a/numba/tests/test_ndarray_subclasses.py
+++ b/numba/tests/test_ndarray_subclasses.py
@@ -89,6 +89,11 @@ class MyArrayType(types.Array):
         super().__init__(dtype, ndim, layout, readonly=readonly,
                          aligned=aligned, name=name)
 
+    def copy(self, *args, **kwargs):
+        # This is here to future-proof.
+        # The test here never uses this.
+        raise NotImplementedError
+
     # Tell Numba typing how to combine MyArrayType with other ndarray types.
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         if method == "__call__":

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -315,6 +315,10 @@ def set_field4(rec):
     return rec
 
 
+def set_field_slice(arr):
+    arr['k'][:] = 0.0
+
+
 recordtype = np.dtype([('a', np.float64),
                        ('b', np.int16),
                        ('c', np.complex64),
@@ -862,6 +866,10 @@ class TestRecordDtype(unittest.TestCase):
         self.assertEqual(cfunc(rec), pyfunc(rec))
 
         pyfunc = record_read_second_arr
+        cfunc = self.get_cfunc(pyfunc, (nbrecord,))
+        self.assertEqual(cfunc(rec), pyfunc(rec))
+
+        pyfunc = set_field_slice
         cfunc = self.get_cfunc(pyfunc, (nbrecord,))
         self.assertEqual(cfunc(rec), pyfunc(rec))
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -317,6 +317,7 @@ def set_field4(rec):
 
 def set_field_slice(arr):
     arr['k'][:] = 0.0
+    return arr
 
 
 recordtype = np.dtype([('a', np.float64),
@@ -871,7 +872,7 @@ class TestRecordDtype(unittest.TestCase):
 
         pyfunc = set_field_slice
         cfunc = self.get_cfunc(pyfunc, (nbrecord,))
-        self.assertEqual(cfunc(rec), pyfunc(rec))
+        np.testing.assert_array_equal(cfunc(rec), pyfunc(rec))
 
     def test_structure_dtype_with_titles(self):
         # the following is the definition of int4 vector type from pyopencl


### PR DESCRIPTION
This is a minimal fix for #7355 and does not replace #7359. We need a minimal fix for 0.54.1

**Edit, adding details:**

This is the easiest fix because:

- making the base `Array.copy()` return a covariant type is the reason of the regression for `nestedarray`.
- The new _array subclass_ feature can override `copy()` to specialize accordingly.
- Requiring `copy()` is less invasive and _array subclass_ support is new and experimental.

This change will require _array subclass_ to override `copy()`.