### PR TITLE
Permit any string as a key in literalstrkeydict type.

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from collections.abc import Iterable
 from types import MappingProxyType
 
@@ -766,13 +765,22 @@ class LiteralStrKeyDict(Literal, ConstSized, Hashable):
     namedtuple with dict semantics).
     """
 
+    class FakeNamedTuple(object):
+        # This is namedtuple-like and is a workaround for #6518 and #7416.
+        # This has the couple of namedtuple properties that are used by Numba's
+        # internals but avoids use of an actual namedtuple as it cannot have
+        # numeric field names, i.e. `namedtuple('foo', '0 1')` is invalid.
+        def __init__(self, name, keys):
+            self.__name__ = name
+            self._fields = tuple(keys)
+
     mutable = False
 
     def __init__(self, literal_value, value_index=None):
         self._literal_init(literal_value)
         self.value_index = value_index
         strkeys = [x.literal_value for x in literal_value.keys()]
-        self.tuple_ty = namedtuple("_ntclazz", " ".join(strkeys))
+        self.tuple_ty = self.FakeNamedTuple("_ntclazz", strkeys)
         tys = [x for x in literal_value.values()]
         self.types = tuple(tys)
         self.count = len(self.types)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from collections.abc import Sequence as pySequence
 from types import MappingProxyType
 
 from .abstract import (
@@ -765,7 +766,7 @@ class LiteralStrKeyDict(Literal, ConstSized, Hashable):
     namedtuple with dict semantics).
     """
 
-    class FakeNamedTuple(object):
+    class FakeNamedTuple(pySequence):
         # This is namedtuple-like and is a workaround for #6518 and #7416.
         # This has the couple of namedtuple properties that are used by Numba's
         # internals but avoids use of an actual namedtuple as it cannot have
@@ -773,6 +774,13 @@ class LiteralStrKeyDict(Literal, ConstSized, Hashable):
         def __init__(self, name, keys):
             self.__name__ = name
             self._fields = tuple(keys)
+            super(LiteralStrKeyDict.FakeNamedTuple, self).__init__()
+
+        def __len__(self):
+            return len(self._fields)
+
+        def __getitem__(self, key):
+            return self._fields[key]
 
     mutable = False
 

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -2247,6 +2247,26 @@ class TestLiteralStrKeyDict(MemoryLeakMixin, TestCase):
 
         foo()
 
+    def test_uncommon_identifiers(self):
+        # Tests uncommon identifiers like numerical values and operators in
+        # the key fields. See #6518 and #7416.
+
+        # Numerical values in keys
+        @njit
+        def foo():
+            d = {'0': np.ones(5), '1': 4}
+            return len(d)
+
+        self.assertPreciseEqual(foo(), foo.py_func())
+
+        # operators in keys
+        @njit
+        def bar():
+            d = {'+': np.ones(5), 'x--': 4}
+            return len(d)
+
+        self.assertPreciseEqual(bar(), bar.py_func())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title.

Fixes #7416
Fixes #6518
