### PR TITLE
use correct variable name in closure

### DIFF
--- a/numba/core/transforms.py
+++ b/numba/core/transforms.py
@@ -530,7 +530,7 @@ def find_setupwiths(blocks):
 
     def previously_occurred(start, known_ranges):
         for a, b in known_ranges:
-            if s >= a and s < b:
+            if start >= a and start < b:
                 return True
         return False
 


### PR DESCRIPTION
The argument name in the closure is `start` but `s` is used instead. The
only reason this works is because `s` is defined in the same scope that
also defines the closure. This fixes that.This fixes that.

