### PR TITLE
BUG: Fastcall fix ufunc methods (NumPy 1.21 support)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 19
+  TEST_COUNT: 22
 
 jobs:
 # Mac and Linux use the same template with different matrixes
@@ -90,32 +90,47 @@ jobs:
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 11
+      py37_np121:
+        PYTHON: '3.7'
+        NUMPY: '1.21'
+        CONDA_ENV: azure_ci
+        TEST_START_INDEX: 12
       py38_np118:
         PYTHON: '3.8'
         NUMPY: '1.18'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 12
+        TEST_START_INDEX: 13
       py38_np119_typeguard:
         PYTHON: '3.8'
         NUMPY: '1.19'
         CONDA_ENV: azure_ci
         RUN_TYPEGUARD: yes
-        TEST_START_INDEX: 13
+        TEST_START_INDEX: 14
       py38_np120:
         PYTHON: '3.8'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 14
+        TEST_START_INDEX: 15
+      py38_np121:
+        PYTHON: '3.8'
+        NUMPY: '1.21'
+        CONDA_ENV: azure_ci
+        TEST_START_INDEX: 16
       py39_np119:
         PYTHON: '3.9'
         NUMPY: '1.19'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 15
+        TEST_START_INDEX: 17
       py39_np120:
         PYTHON: '3.9'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 16
+        TEST_START_INDEX: 18
+      py39_np121:
+        PYTHON: '3.9'
+        NUMPY: '1.21'
+        CONDA_ENV: azure_ci
+        TEST_START_INDEX: 19
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -12,12 +12,12 @@ jobs:
         PYTHON: '3.9'
         NUMPY: '1.20'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 17
+        TEST_START_INDEX: 20
       py37_np117:
         PYTHON: '3.7'
         NUMPY: '1.17'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 18
+        TEST_START_INDEX: 21
 
   steps:
     - task: CondaEnvironment@1

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -40,7 +40,7 @@ conda list
 # NOTE: pyyaml is used to ensure that the Azure CI config is valid
 # NOTE: 32 bit linux... do not install NumPy, there's no conda package for >1.15
 # so it has to come from pip later
-if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then
+if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" || "$NUMPY" == "1.21" ]]; then
     conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON pip gitpython pyyaml
 else
     conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON numpy=$NUMPY pip gitpython pyyaml
@@ -76,7 +76,7 @@ elif  [[ $(uname) == Darwin ]]; then
 fi
 
 # If on 32bit linux, now pip install NumPy and SciPy (no conda package)
-if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]] ; then
+if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" || "$NUMPY" == "1.21" ]] ; then
     $PIP_INSTALL numpy==$NUMPY scipy
 fi
 

--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -276,6 +276,7 @@ static PyMemberDef dufunc_members[] = {
  */
 
 static struct _ufunc_dispatch {
+    /* Note that the following may also hold `_PyCFunctionFastWithKeywords` */
     PyCFunctionWithKeywords ufunc_reduce;
     PyCFunctionWithKeywords ufunc_accumulate;
     PyCFunctionWithKeywords ufunc_reduceat;
@@ -286,7 +287,7 @@ static struct _ufunc_dispatch {
 } ufunc_dispatch;
 
 static int
-init_ufunc_dispatch(void)
+init_ufunc_dispatch(int *numpy_uses_fastcall)
 {
     int result = 0;
     PyMethodDef * crnt = PyUFunc_Type.tp_methods;
@@ -329,6 +330,16 @@ init_ufunc_dispatch(void)
             result = -1; /* Unknown method */
         }
         if (result < 0) break;
+
+        /* Check whether NumPy uses fastcall (ufunc.at never uses it) */
+        if (!strncmp(crnt_name, "at", 3)) {
+            if (*numpy_uses_fastcall == -1) {
+                *numpy_uses_fastcall = crnt->ml_flags & METH_FASTCALL;
+            }
+            else if (*numpy_uses_fastcall != (crnt->ml_flags & METH_FASTCALL)) {
+                return -1;
+            }
+        }
     }
     if (result == 0) {
         /* Sanity check. */
@@ -343,6 +354,7 @@ init_ufunc_dispatch(void)
     }
     return result;
 }
+
 
 static PyObject *
 dufunc_reduce(PyDUFuncObject * self, PyObject * args, PyObject *kws)
@@ -367,6 +379,47 @@ dufunc_outer(PyDUFuncObject * self, PyObject * args, PyObject *kws)
 {
     return ufunc_dispatch.ufunc_outer((PyObject*)self->ufunc, args, kws);
 }
+
+
+/*
+ * The following are the vectorcall versions of the above, since NumPy
+ * uses the FASTCALL/Vectorcall protocol starting with version 1.21.
+ * The only NumPy versions supporting vectorcall use Python 3.7 or higher.
+ */
+static PyObject *
+dufunc_reduce_fast(PyDUFuncObject * self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    return ((_PyCFunctionFastWithKeywords)ufunc_dispatch.ufunc_reduce)(
+            (PyObject*)self->ufunc, args, len_args, kwnames);
+}
+
+static PyObject *
+dufunc_reduceat_fast(PyDUFuncObject * self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    return ((_PyCFunctionFastWithKeywords)ufunc_dispatch.ufunc_reduceat)(
+            (PyObject*)self->ufunc, args, len_args, kwnames);
+}
+
+
+static PyObject *
+dufunc_accumulate_fast(PyDUFuncObject * self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    return ((_PyCFunctionFastWithKeywords)ufunc_dispatch.ufunc_accumulate)(
+            (PyObject*)self->ufunc, args, len_args, kwnames);
+}
+
+
+static PyObject *
+dufunc_outer_fast(PyDUFuncObject * self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    return ((_PyCFunctionFastWithKeywords)ufunc_dispatch.ufunc_outer)(
+            (PyObject*)self->ufunc, args, len_args, kwnames);
+}
+
 
 #if NPY_API_VERSION >= 0x00000008
 static PyObject *
@@ -568,6 +621,41 @@ static struct PyMethodDef dufunc_methods[] = {
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 
+
+/*
+ * If Python is new enough, NumPy may use fastcall.  In that case we have to
+ * also use fastcall for simplicity and speed.
+ */
+static struct PyMethodDef dufunc_methods_fast[] = {
+    {"reduce",
+        (PyCFunction)dufunc_reduce_fast,
+        METH_FASTCALL | METH_KEYWORDS, NULL },
+    {"accumulate",
+        (PyCFunction)dufunc_accumulate_fast,
+        METH_FASTCALL | METH_KEYWORDS, NULL },
+    {"reduceat",
+        (PyCFunction)dufunc_reduceat_fast,
+        METH_FASTCALL | METH_KEYWORDS, NULL },
+    {"outer",
+        (PyCFunction)dufunc_outer_fast,
+        METH_FASTCALL | METH_KEYWORDS, NULL},
+#if NPY_API_VERSION >= 0x00000008
+    {"at",
+        (PyCFunction)dufunc_at,
+        METH_VARARGS, NULL},
+#endif
+    {"_compile_for_args",
+        (PyCFunction)dufunc__compile_for_args,
+        METH_VARARGS | METH_KEYWORDS,
+        "Abstract method: subclasses should overload _compile_for_args() to compile the ufunc at the given arguments' types."},
+    {"_add_loop",
+        (PyCFunction)dufunc__add_loop,
+        METH_VARARGS,
+        NULL},
+    {NULL, NULL, 0, NULL}           /* sentinel */
+};
+
+
 static PyObject *
 dufunc_getfrozen(PyDUFuncObject * self, void * closure)
 {
@@ -681,8 +769,15 @@ MOD_INIT(_internal)
         return MOD_ERROR_VAL;
 
     PyDUFunc_Type.tp_new = PyType_GenericNew;
-    if (init_ufunc_dispatch() <= 0)
+
+    int numpy_uses_fastcall = -1;
+    if (init_ufunc_dispatch(&numpy_uses_fastcall) <= 0)
         return MOD_ERROR_VAL;
+
+    if (numpy_uses_fastcall) {
+        PyDUFunc_Type.tp_methods = dufunc_methods_fast;
+    }
+
     if (PyType_Ready(&PyDUFunc_Type) < 0)
         return MOD_ERROR_VAL;
     Py_INCREF(&PyDUFunc_Type);


### PR DESCRIPTION
This is a start to support NumPy 1.21 use of FASTCALL methods
in ufuncs.  There are probably better ways to achieve this support.

NumPy further uses `tp_vectorcall_offset` on newer versions.  This
PR does not add support for this (meaning that a DUfunc will be
unnecessarily slow on NumPy >=1.21 when kwargs are used).

Closes gh-7423

---

This is a start to close the NumPy 1.21 issues.  I am not extremely happy with this dance of duplicating the wrapper functions, but I did not have a better idea.
(Sorry, this is not really tested, yet aside from the fact that it compiles, so I may abuse CI to see if it actually is correct...)

I am sure there will be fix-ups necessary, please don't hesitate to just push/overwrite the changes here directly.