### PR TITLE
CUDA: Provide stream in async_done result

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -1920,7 +1920,7 @@ class Stream(object):
     def async_done(self) -> asyncio.futures.Future:
         """
         Return an awaitable that resolves once all preceding stream operations
-        are complete.
+        are complete. The result of the awaitable is the current stream.
         """
         loop = asyncio.get_running_loop() if utils.PYVERSION >= (3, 7) \
             else asyncio.get_event_loop()
@@ -1930,7 +1930,7 @@ class Stream(object):
             if future.done():
                 return
             elif status == 0:
-                future.set_result(None)
+                future.set_result(self)
             else:
                 future.set_exception(Exception(f"Stream error {status}"))
 

--- a/numba/cuda/tests/cudadrv/test_streams.py
+++ b/numba/cuda/tests/cudadrv/test_streams.py
@@ -47,7 +47,8 @@ class TestCudaStream(CUDATestCase):
             h_src[:] = value_in
             d_ary = cuda.to_device(h_src, stream=stream)
             d_ary.copy_to_host(h_dst, stream=stream)
-            await stream.async_done()
+            done_result = await stream.async_done()
+            self.assertEqual(done_result, stream)
             return h_dst.mean()
 
         values_in = [1, 2, 3, 4]
@@ -59,7 +60,18 @@ class TestCudaStream(CUDATestCase):
     async def test_multiple_async_done(self):
         stream = cuda.stream()
         done_aws = [stream.async_done() for _ in range(4)]
-        await asyncio.gather(*done_aws)
+        done = await asyncio.gather(*done_aws)
+        for d in done:
+            self.assertEqual(d, stream)
+
+    @with_asyncio_loop
+    async def test_multiple_async_done_multiple_streams(self):
+        streams = [ cuda.stream() for _ in range(4)]
+        done_aws = [stream.async_done() for stream in streams]
+        done = await asyncio.gather(*done_aws)
+
+        # Ensure we got the four original streams in done
+        self.assertSetEqual(set(done), set(streams))
 
     @with_asyncio_loop
     async def test_cancelled_future(self):


### PR DESCRIPTION
It's awkward to await on a `Stream.async_done()` for the purpose of enqueuing something new onto the stream, because there is no way to tell which stream finished from the completed future - this forces the user to maintain a mapping between futures and streams.

This PR makes the result of the future be the stream on which operations completed, so that the user can obtain the stream from the completed future.