### PR TITLE
Fix unicode operator.eq handling of Optional types.

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -451,11 +451,27 @@ def unicode_len(s):
 def unicode_eq(a, b):
     if not (a.is_internal and b.is_internal):
         return
+    if isinstance(a, types.Optional):
+        check_a = a.type
+    else:
+        check_a = a
+    if isinstance(b, types.Optional):
+        check_b = b.type
+    else:
+        check_b = b
     accept = (types.UnicodeType, types.StringLiteral, types.UnicodeCharSeq)
-    a_unicode = isinstance(a, accept)
-    b_unicode = isinstance(b, accept)
+    a_unicode = isinstance(check_a, accept)
+    b_unicode = isinstance(check_b, accept)
     if a_unicode and b_unicode:
         def eq_impl(a, b):
+            # handle Optionals at runtime
+            a_none = a is None
+            b_none = b is None
+            if a_none or b_none:
+                if a_none and b_none:
+                    return True
+                else:
+                    return False
             # the str() is for UnicodeCharSeq, it's a nop else
             a = str(a)
             b = str(b)

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -446,6 +446,28 @@ class TestUnicode(BaseTest):
                 self.assertEqual(pyfunc(1, b),
                                  cfunc(1, b), '%s, %s' % (1, b))
 
+    def test_eq_optional(self):
+        # See issue #7474
+        @njit
+        def foo(pred1, pred2):
+            if pred1 > 0:
+                resolved1 = 'concrete'
+            else:
+                resolved1 = None
+            if pred2 < 0:
+                resolved2 = 'concrete'
+            else:
+                resolved2 = None
+
+            # resolved* are Optionals
+            if resolved1 == resolved2:
+                return 10
+            else:
+                return 20
+
+        for (p1, p2) in product(*((-1, 1),) * 2):
+            self.assertEqual(foo(p1, p2), foo.py_func(p1, p2))
+
     def _check_ordering_op(self, usecase):
         pyfunc = usecase
         cfunc = njit(pyfunc)


### PR DESCRIPTION
As title. This makes it such that the unicode `operator.eq`
implementation checks for Optional types and handles them at
runtime if they are present.

Fixes #7474

