### PR TITLE
Enhance Flags mangling/demangling

### DIFF
--- a/numba/core/targetconfig.py
+++ b/numba/core/targetconfig.py
@@ -2,6 +2,7 @@
 This module contains utils for manipulating target configurations such as
 compiler flags.
 """
+import re
 import zlib
 import base64
 
@@ -268,13 +269,20 @@ class TargetConfig(metaclass=_MetaTargetConfig):
                     args.append(v)
         return args
 
-    def _make_compression_dictionary(self) -> bytes:
+    @classmethod
+    def _make_compression_dictionary(cls) -> bytes:
         """Returns a ``bytes`` object suitable for use as a dictionary for
         compression.
         """
         buf = []
-        buf.append(self.__class__.__name__)
-        for k, opt in self.options.items():
+        # include package name
+        buf.append("numba")
+        # include class name
+        buf.append(cls.__class__.__name__)
+        # include common values
+        buf.extend(["True", "False"])
+        # include all options name and their default value
+        for k, opt in cls.options.items():
             buf.append(k)
             buf.append(str(opt.default))
         return ''.join(buf).encode()
@@ -292,13 +300,19 @@ class TargetConfig(metaclass=_MetaTargetConfig):
         buf.append(comp.flush())
         return base64.b64encode(b''.join(buf)).decode()
 
-    def demangle(self, mangled: str) -> str:
+    @classmethod
+    def demangle(cls, mangled: str) -> str:
         """Returns the demangled result from ``.get_mangle_string()``
         """
-        raw = base64.b64decode(mangled)
-
-        zdict = self._make_compression_dictionary()
-        dc = zlib.decompressobj(zdict=zdict, **self._ZLIB_CONFIG)
+        # unescape _XX sequence
+        def repl(x):
+            return chr(int('0x' + x.group(0)[1:], 16))
+        unescaped = re.sub(r"_[a-zA-Z0-9][a-zA-Z0-9]", repl, mangled)
+        # decode base64
+        raw = base64.b64decode(unescaped)
+        # decompress
+        zdict = cls._make_compression_dictionary()
+        dc = zlib.decompressobj(zdict=zdict, **cls._ZLIB_CONFIG)
         buf = []
         while raw:
             buf.append(dc.decompress(raw))

--- a/numba/tests/test_compiler_flags.py
+++ b/numba/tests/test_compiler_flags.py
@@ -1,7 +1,11 @@
+import re
+
 from numba import njit
 from numba.core.extending import overload
 from numba.core.targetconfig import ConfigStack
 from numba.core.compiler import Flags, DEFAULT_FLAGS
+from numba.core import types
+from numba.core.funcdesc import default_mangler
 
 from numba.tests.support import TestCase, unittest
 
@@ -78,6 +82,29 @@ class TestFlagMangling(TestCase):
         demangled = flags.demangle(flags.get_mangle_string()).decode()
         # There should be no pointer value in the demangled string.
         self.assertNotIn("0x", demangled)
+
+    def test_demangling_from_mangled_symbols(self):
+        """Test demangling of flags from mangled symbol"""
+        # Use default mangler to mangle the string
+        fname = 'foo'
+        argtypes = types.int32,
+        flags = Flags()
+        flags.nrt = True
+        flags.target_backend = "myhardware"
+        name = default_mangler(
+            fname, argtypes, abi_tags=[flags.get_mangle_string()],
+        )
+        # Find the ABI-tag. Starts with "B"
+        prefix = "_Z3fooB"
+        # Find the length of the ABI-tag
+        m = re.match("[0-9]+", name[len(prefix):])
+        size = m.group(0)
+        # Extract the ABI tag
+        base = len(prefix) + len(size)
+        abi_mangled = name[base:base + int(size)]
+        # Demangle and check
+        demangled = Flags.demangle(abi_mangled).decode()
+        self.assertEqual(demangled, flags.summary())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## changes
demangle:
- to deal with `_` escaped string
- to become a classmethod

mangling:
- include more values into the zdict for shorter output

## To manually demangle Numba symbol and extract the compilation flags:

1. mangled symbol `_ZN5numba7cpython7unicode11integer_str12_3clocals_3e9impl_2425B40c8tJTIeFCjyCbUFRqqOAK_2f6h0phxApbQBAA_3dEi` (probably from debugger)
2.  use `c++filt` to demangle:
     ```bash
     % c++filt -n _ZN5numba7cpython7unicode11integer_str12_3clocals_3e9impl_2425B40c8tJTIeFCjyCbUFRqqOAK_2f6h0phxApbQBAA_3dEi
     numba::cpython::unicode::integer_str::_3clocals_3e::impl_2425[abi:c8tJTIeFCjyCbUFRqqOAK_2f6h0phxApbQBAA_3d](int)
3. extract the part in `[abi:...]`
4. put it through:
```python
>>> from numba.core.compiler import Flags
>>> Flags.demangle("c8tJTIeFCjyCbUFRqqOAK_2f6h0phxApbQBAA_3d")
b'Flags(enable_looplift=True, enable_pyobject_looplift=True, no_cpython_wrapper=True)'
```