### PR TITLE
Make *var work for randn for parfors.

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2265,7 +2265,9 @@ class ArrayAnalysis(object):
                 expr.args = args[1:]
             return result
 
-    def _analyze_op_call_builtins_len(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_builtins_len(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         # python 3 version of len()
         require(len(args) == 1)
         var = args[0]
@@ -2324,7 +2326,9 @@ class ArrayAnalysis(object):
             loc=loc,
         )
 
-    def _analyze_op_call_numpy_empty(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_empty(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         return self._analyze_numpy_create_array(
             scope, equiv_set, loc, args, kws
         )
@@ -2336,17 +2340,23 @@ class ArrayAnalysis(object):
             scope, equiv_set, loc, args, kws
         )
 
-    def _analyze_op_call_numpy_zeros(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_zeros(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         return self._analyze_numpy_create_array(
             scope, equiv_set, loc, args, kws
         )
 
-    def _analyze_op_call_numpy_ones(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_ones(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         return self._analyze_numpy_create_array(
             scope, equiv_set, loc, args, kws
         )
 
-    def _analyze_op_call_numpy_eye(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_eye(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         if len(args) > 0:
             N = args[0]
         elif "N" in kws:
@@ -2369,7 +2379,9 @@ class ArrayAnalysis(object):
         N = args[0]
         return ArrayAnalysis.AnalyzeResult(shape=(N, N))
 
-    def _analyze_op_call_numpy_diag(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_diag(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         # We can only reason about the output shape when the input is 1D or
         # square 2D.
         assert len(args) > 0
@@ -2402,7 +2414,9 @@ class ArrayAnalysis(object):
             return ArrayAnalysis.AnalyzeResult(shape=var)
         return None
 
-    def _analyze_op_call_numpy_ravel(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_ravel(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         assert len(args) == 1
         var = args[0]
         typ = self.typemap[var.name]
@@ -2418,7 +2432,9 @@ class ArrayAnalysis(object):
         # TODO: handle multi-D input arrays (calc array size)
         return None
 
-    def _analyze_op_call_numpy_copy(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_copy(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         return self._analyze_numpy_array_like(scope, equiv_set, args, kws)
 
     def _analyze_op_call_numpy_empty_like(
@@ -2446,7 +2462,9 @@ class ArrayAnalysis(object):
     ):
         return self._analyze_numpy_array_like(scope, equiv_set, args, kws)
 
-    def _analyze_op_call_numpy_reshape(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_reshape(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         n = len(args)
         assert n > 1
         if n == 2:
@@ -2772,7 +2790,9 @@ class ArrayAnalysis(object):
             pre=sum(asserts, [])
         )
 
-    def _analyze_op_call_numpy_stack(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_stack(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         assert len(args) > 0
         loc = args[0].loc
         seq, op = find_build_sequence(self.func_ir, args[0])
@@ -2798,7 +2818,9 @@ class ArrayAnalysis(object):
         new_shape = list(shape[0:axis]) + [n] + list(shape[axis:])
         return ArrayAnalysis.AnalyzeResult(shape=tuple(new_shape), pre=asserts)
 
-    def _analyze_op_call_numpy_vstack(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_vstack(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         assert len(args) == 1
         seq, op = find_build_sequence(self.func_ir, args[0])
         n = len(seq)
@@ -2815,7 +2837,9 @@ class ArrayAnalysis(object):
                 scope, equiv_set, loc, args, kws, varargs
             )
 
-    def _analyze_op_call_numpy_hstack(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_hstack(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         assert len(args) == 1
         seq, op = find_build_sequence(self.func_ir, args[0])
         n = len(seq)
@@ -2830,7 +2854,9 @@ class ArrayAnalysis(object):
             scope, equiv_set, loc, args, kws, varargs
         )
 
-    def _analyze_op_call_numpy_dstack(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_dstack(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         assert len(args) == 1
         seq, op = find_build_sequence(self.func_ir, args[0])
         n = len(seq)
@@ -2856,11 +2882,15 @@ class ArrayAnalysis(object):
                 scope, equiv_set, loc, args, kws, varargs
             )
 
-    def _analyze_op_call_numpy_cumsum(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_cumsum(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         # TODO
         return None
 
-    def _analyze_op_call_numpy_cumprod(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_cumprod(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         # TODO
         return None
 
@@ -2875,7 +2905,9 @@ class ArrayAnalysis(object):
             num = kws["num"]
         return ArrayAnalysis.AnalyzeResult(shape=(num,))
 
-    def _analyze_op_call_numpy_dot(self, scope, equiv_set, loc, args, kws, varargs):
+    def _analyze_op_call_numpy_dot(
+        self, scope, equiv_set, loc, args, kws, varargs
+    ):
         n = len(args)
         assert n >= 2
         loc = args[0].loc

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -3193,7 +3193,8 @@ class ArrayAnalysis(object):
         elif isinstance(typ, types.Number):
             return typ
         else:
-            dprint(1, "Unhandled case in _get_typ_part:", typ, i)
+            if config.DEBUG_ARRAY_OPT >= 1:
+                print(1, "Unhandled case in _get_typ_part:", typ, i)
             return types.intp
 
     def _gen_shape_call(self, equiv_set, var, ndims, shape, post, typ):

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -3194,7 +3194,7 @@ class ArrayAnalysis(object):
             return typ
         else:
             if config.DEBUG_ARRAY_OPT >= 1:
-                print(1, "Unhandled case in _get_typ_part:", typ, i)
+                print("Unhandled case in _get_typ_part:", typ, i)
             return types.intp
 
     def _gen_shape_call(self, equiv_set, var, ndims, shape, post, typ):

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3010,6 +3010,7 @@ def _remove_size_arg(call_name, expr):
         # these calls have only a "size" argument or list of ints
         # so remove all args
         expr.args = []
+        expr.vararg = None
 
     if call_name in random_3arg_sizelast:
         # normal, uniform, ... have 3 args, last one is size

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -1055,7 +1055,7 @@ class TestArrayAnalysisInterface(TestCase):
             if fname.startswith('_analyze_op_call_'):
                 aoc[fname] = getattr(ArrayAnalysis, fname)
         # check interface
-        def iface_stub(self, scope, equiv_set, loc, args, kws):
+        def iface_stub(self, scope, equiv_set, loc, args, kws, varargs):
             pass
         expected = utils.pysignature(iface_stub)
         for k, v in aoc.items():

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1027,6 +1027,15 @@ class TestParforNumPy(TestParforsBase):
         n = 10
         self.check(test_impl, (n,n))
 
+    def test_stararg_mix(self):
+        def test_impl(n, r):
+            A = np.random.randn(r, *n)
+            B = np.sum(A)
+            return B - B
+
+        n = 10
+        self.check(test_impl, (n,n), n)
+
     def test_min(self):
         def test_impl1(A):
             return A.min()

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1018,6 +1018,18 @@ class TestParforNumPy(TestParforsBase):
         self.assertEqual(parfor_output, py_output)
         self.assertEqual(countParfors(test_impl, (types.int64, )), 0)
 
+    def test_stararg(self):
+        def test_impl(n):
+            A = np.random.randn(*n)
+            return 3
+
+        n = 10
+        cpfunc = self.compile_parallel(test_impl, (numba.typeof((n,n)),))
+        parfor_output = cpfunc.entry_point((n,n))
+        py_output = test_impl((n,n))
+        self.assertEqual(parfor_output, py_output)
+        self.assertEqual(countParfors(test_impl, (types.int64, types.int64)), 1)
+
     def test_min(self):
         def test_impl1(A):
             return A.min()

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1024,11 +1024,7 @@ class TestParforNumPy(TestParforsBase):
             return 3
 
         n = 10
-        cpfunc = self.compile_parallel(test_impl, (numba.typeof((n,n)),))
-        parfor_output = cpfunc.entry_point((n,n))
-        py_output = test_impl((n,n))
-        self.assertEqual(parfor_output, py_output)
-        self.assertEqual(countParfors(test_impl, (types.int64, types.int64)), 1)
+        self.check(test_impl, (n,n))
 
     def test_min(self):
         def test_impl1(A):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1026,7 +1026,7 @@ class TestParforNumPy(TestParforsBase):
             return B - B
 
         n = 10
-        self.check(test_impl, (n,n))
+        self.check(test_impl, (n, n))
 
     def test_stararg_mix(self):
         def test_impl(n, r):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1020,6 +1020,7 @@ class TestParforNumPy(TestParforsBase):
 
     def test_stararg(self):
         def test_impl(n):
+            np.random.seed(0)
             A = np.random.randn(*n)
             B = np.sum(A)
             return B - B

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1021,7 +1021,8 @@ class TestParforNumPy(TestParforsBase):
     def test_stararg(self):
         def test_impl(n):
             A = np.random.randn(*n)
-            return 3
+            B = np.sum(A)
+            return B - B
 
         n = 10
         self.check(test_impl, (n,n))

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1036,7 +1036,7 @@ class TestParforNumPy(TestParforsBase):
             return B - B
 
         n = 10
-        self.check(test_impl, (n,n), n)
+        self.check(test_impl, (n, n), n)
 
     def test_min(self):
         def test_impl1(A):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1030,6 +1030,7 @@ class TestParforNumPy(TestParforsBase):
 
     def test_stararg_mix(self):
         def test_impl(n, r):
+            np.random.seed(0)
             A = np.random.randn(r, *n)
             B = np.sum(A)
             return B - B


### PR DESCRIPTION
Sometimes, the shape of an output is inferred from its varargs and not the regular args.  Randn is one such example.  Randn gets converted to parfor but the varargs also need to be cleared along with args so that randn gets a single-item within each loop iteration.

I included another related fix here where a UniTuple(int32 x 2) was coming in as an argument but the size variable created was int64 and this led to 32-64-bit assignment problems.  I've passed the typ to the code that extracts sizes as individual variables so that the type created there can match the input type.

This is not based on any pending issue but something I ran across.