### PR TITLE
Don't embed current thread count into parallel=True functions so that they can be cacheable.

### DIFF
--- a/numba/np/ufunc/gufunc_scheduler.cpp
+++ b/numba/np/ufunc/gufunc_scheduler.cpp
@@ -326,6 +326,20 @@ std::vector<RangeActual> create_schedule(const RangeActual &full_space, uintp nu
     }
 }
 
+void print_rangeactual_vector(const std::vector<RangeActual> &rav) {
+    for(uintp i = 0; i < rav.size(); ++i) {
+        printf("sched[%d] = ", (int)i);
+        uintp j;
+        for(j = 0; j < rav[i].start.size(); ++j) {
+            printf("%d ", (int)rav[i].start[j]);
+        }
+        for(j = 0; j < rav[i].end.size(); ++j) {
+            printf("%d ", (int)rav[i].end[j]);
+        }
+        printf("\n");
+    }
+}
+
 /*
     num_dim (D) is the number of dimensions of the iteration space.
     starts is the range-start of each of those dimensions, inclusive.
@@ -350,6 +364,9 @@ extern "C" void do_scheduling_signed(uintp num_dim, intp *starts, intp *ends, ui
 
     RangeActual full_space(num_dim, starts, ends);
     std::vector<RangeActual> ret = create_schedule(full_space, num_threads);
+    if (debug) {
+        print_rangeactual_vector(ret);
+    }
     flatten_schedule(ret, sched);
 }
 
@@ -369,5 +386,8 @@ extern "C" void do_scheduling_unsigned(uintp num_dim, intp *starts, intp *ends, 
 
     RangeActual full_space(num_dim, starts, ends);
     std::vector<RangeActual> ret = create_schedule(full_space, num_threads);
+    if (debug) {
+        print_rangeactual_vector(ret);
+    }
     flatten_schedule(ret, sched);
 }

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from numba.core import types, ir, cgutils
+from numba.core import types, ir
 from numba.core.ir_utils import mk_unique_var
 from numba.core.typing import signature
 

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -32,10 +32,6 @@ class ParforLoweringBuilder:
     def _calltypes(self):
         return self._lowerer.fndesc.calltypes
 
-    @property
-    def builder(self):
-        return self._lowerer.builder
-
     def bind_global_function(self, fobj, ftype, args, kws={}):
         """Binds a global function to a variable.
 

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -51,7 +51,6 @@ class ParforLoweringBuilder:
         -------
         callable: _CallableNode
         """
-        print("bind_global_function:", fobj, ftype, args)
         loc = self._loc
         varname = f"{fobj.__name__}_func"
         gvname = f"{fobj.__name__}"

--- a/numba/parfors/parfor_lowering_utils.py
+++ b/numba/parfors/parfor_lowering_utils.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from numba.core import types, ir
+from numba.core import types, ir, cgutils
 from numba.core.ir_utils import mk_unique_var
 from numba.core.typing import signature
 
@@ -32,6 +32,10 @@ class ParforLoweringBuilder:
     def _calltypes(self):
         return self._lowerer.fndesc.calltypes
 
+    @property
+    def builder(self):
+        return self._lowerer.builder
+
     def bind_global_function(self, fobj, ftype, args, kws={}):
         """Binds a global function to a variable.
 
@@ -47,6 +51,7 @@ class ParforLoweringBuilder:
         -------
         callable: _CallableNode
         """
+        print("bind_global_function:", fobj, ftype, args)
         loc = self._loc
         varname = f"{fobj.__name__}_func"
         gvname = f"{fobj.__name__}"


### PR DESCRIPTION
Resolves #7518 

Move the printing of the parfor schedule into the C code in debug mode.

Use the dynamic thread count when constructing the schedule so that the parallel=True function can be correctly cacheable.
