### PR TITLE
Added overload methods for Numpy's ufunc.reduce

### DIFF
--- a/numba/core/runtime/nrt.h
+++ b/numba/core/runtime/nrt.h
@@ -269,4 +269,6 @@ VISIBILITY_HIDDEN const NRT_api_functions* NRT_get_api(void);
  */
 VISIBILITY_HIDDEN NRT_ExternalAllocator* _nrt_get_sample_external_allocator(void);
 
+PyObject * NRT_adapt_ndarray_to_python_acqref(arystruct_t* arystruct, PyTypeObject *retty,
+                            int ndim, int writeable, PyArray_Descr *descr)
 #endif /* NUMBA_NRT_H_ */

--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -344,10 +344,12 @@ dufunc_reduce(PyDUFuncObject * self, PyObject * args, PyObject *kws)
 }
 
 static PyObject *
-dufunc_reduce_direct(PyDUFuncObject * self, PyObject * args, int axis)
-{
-  PyObject *kwargs = Py_BuildValue("{s:L}", "axis", axis);
-  return dufunc_reduce(self, args, kwargs);
+dufunc_reduce_direct(PyDUFuncObject * self, arystruct_t * args, int axis, PyTypeObject *retty,  PyArray_Descr *descr)
+{   
+    PyObject * res = NRT_adapt_ndarray_to_python_acqref(args, retty, 2, 1, descr);
+    PyObject *kwargs = Py_BuildValue("{s:L}", "axis", axis);
+    // The code segfaults on the following call.
+    return dufunc_reduce(self, res, kwargs);
 }
 
 static PyObject *

--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -344,10 +344,9 @@ dufunc_reduce(PyDUFuncObject * self, PyObject * args, PyObject *kws)
 }
 
 static PyObject *
-dufunc_reduce_direct(PyDUFuncObject * self, int axis, PyObject * args)
+dufunc_reduce_direct(PyDUFuncObject * self, PyObject * args, int axis)
 {
   PyObject *kwargs = Py_BuildValue("{s:L}", "axis", axis);
-// The code segfaults on the following call.
   return dufunc_reduce(self, args, kwargs);
 }
 

--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -344,6 +344,29 @@ init_ufunc_dispatch(void)
     return result;
 }
 
+
+NUMBA_EXPORT_FUNC(PyObject)
+dufunc_reduce_direct(int *curr_ufunc,PyObject arr,int axis)
+{   
+    int result = 0;
+    PyMethodDef * crnt = PyUFunc_Type.tp_methods;
+    const char * crnt_name = NULL;
+    PyCFunctionWithKeywords curr_ufunc_reduce;
+    for (; crnt->ml_name != NULL; crnt++) {
+        crnt_name = crnt->ml_name;
+        if(crnt_name[0]=='r'){
+            if (strncmp(crnt_name, "reduce", 7) == 0) {
+                curr_ufunc_reduce =
+                    (PyCFunctionWithKeywords)crnt->ml_meth;
+            }
+        }
+    }
+
+    result = (curr_ufunc_reduce != NULL);
+    
+    return curr_ufunc_reduce((PyObject*)curr_ufunc)(arr, axis);
+}
+
 static PyObject *
 dufunc_reduce(PyDUFuncObject * self, PyObject * args, PyObject *kws)
 {

--- a/numba/np/ufunc/_internal.h
+++ b/numba/np/ufunc/_internal.h
@@ -11,6 +11,8 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/ndarrayobject.h"
 #include "numpy/ufuncobject.h"
+#include "../../_arraystruct.h"
+#include "../../../numba/core/runtime/nrt.h"
 
 extern PyObject *ufunc_fromfunc(PyObject *NPY_UNUSED(dummy), PyObject *args);
 
@@ -23,7 +25,7 @@ typedef struct {
 } PyDUFuncObject;
 
 NUMBA_EXPORT_FUNC(static PyObject *)
-dufunc_reduce_direct(PyDUFuncObject * self, PyObject * args, int axis);
+dufunc_reduce_direct(PyDUFuncObject * self, arystruct_t * args, int axis, PyTypeObject *retty,  PyArray_Descr *descr);
 
 int PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                                 PyObject *args, PyObject *kwds,

--- a/numba/np/ufunc/_internal.h
+++ b/numba/np/ufunc/_internal.h
@@ -5,12 +5,25 @@
 
 #include "../../_pymodule.h"
 #include <structmember.h>
+#include "../../cext/cext.h"
+#include "Python.h"
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/ndarrayobject.h"
 #include "numpy/ufuncobject.h"
 
 extern PyObject *ufunc_fromfunc(PyObject *NPY_UNUSED(dummy), PyObject *args);
+
+typedef struct {
+  PyObject_HEAD
+  PyObject      * dispatcher;
+  PyUFuncObject * ufunc;
+  PyObject      * keepalive;
+  int             frozen;
+} PyDUFuncObject;
+
+NUMBA_EXPORT_FUNC(static PyObject *)
+dufunc_reduce_direct(PyDUFuncObject * self, int axis, PyObject * args);
 
 int PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                                 PyObject *args, PyObject *kwds,

--- a/numba/np/ufunc/_internal.h
+++ b/numba/np/ufunc/_internal.h
@@ -23,7 +23,7 @@ typedef struct {
 } PyDUFuncObject;
 
 NUMBA_EXPORT_FUNC(static PyObject *)
-dufunc_reduce_direct(PyDUFuncObject * self, int axis, PyObject * args);
+dufunc_reduce_direct(PyDUFuncObject * self, PyObject * args, int axis);
 
 int PyUFunc_GeneralizedFunction(PyUFuncObject *ufunc,
                                 PyObject *args, PyObject *kwds,

--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -339,20 +339,19 @@ def intr_reduce(typcontext, ft, argst, axist):
         f_ir, args_ir, axis_ir = args
 
         ret_ir_type = context.get_value_type(signature.return_type)
-        # args_ir_type = context.get_value_type(types.pyobject)
-        # kws_ir_type = context.get_value_type(types.pyobject)
+
         args_ir_type = args_ir.type
         axis_ir_type = axis_ir.type
 
         fnty = ir.FunctionType(
             ret_ir_type,
-            [f_ir.type, axis_ir_type, args_ir_type]
+            [f_ir.type, args_ir_type, axis_ir_type]
         )
 
         fn = cgutils.get_or_insert_function(
             builder.module, fnty,  "dufunc_reduce_direct"
         )
-        return builder.call(fn, [f_ir, axis_ir, args_ir])
+        return builder.call(fn, [f_ir, args_ir, axis_ir])
 
     return sig, codegen
 

--- a/numba/tests/npyufunc/test_ufunc.py
+++ b/numba/tests/npyufunc/test_ufunc.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numba import float32, jit, njit
+from numba import float32, jit, njit, vectorize
 from numba.np.ufunc import Vectorize
 from numba.core.errors import TypingError
 from numba.tests.support import TestCase
@@ -139,6 +139,19 @@ class TestUFuncs(TestCase):
 
         msg = "expected array(float64, 1d, C), got None"
         self.assertIn(msg, str(raises.exception))
+
+    def test_reduce(self):
+
+        @vectorize
+        def add_twice(x, y):
+            return 2 * x + 2 * y
+
+        @njit
+        def test_fn(x, axis):
+            return add_twice.reduce(x, axis)
+
+        a = np.arange(2 * 3).reshape((2, 3))
+        self.assertPreciseEqual(test_fn(a, 1), np.sum(a, axis=1))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->
Resolves #6313 #2751

This PR aims to implement the `numpy.ufunc.METHOD` as a callable inside `njit`-ed functions so that we can do stuff like: 

```python
import numba as nb
import numpy as np

@nb.njit
def add_twice(x, y):
    return 2*x + 2*y

custom_vectorize = nb.vectorize([], identity=None, target="cpu")
vec_add = custom_vectorize(add_twice)

@nb.njit
def test_fn(x, axis):
    return vec_add.reduce(x, axis) 

print(test_fn(np.ones((10, 20)), 0))
```