### PR TITLE
Fix `@overload_glue` performance regression.

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -272,6 +272,7 @@ _options_mixin = include_default_options(
     "fastmath",
     "error_model",
     "inline",
+    "forceinline",
     # Add "target_backend" as a accepted option for the CPU in @jit(...)
     "target_backend",
 )
@@ -300,6 +301,8 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
 
         # Add "target_backend" as a option that inherits from the caller
         flags.inherit_if_not_set("target_backend")
+
+        flags.inherit_if_not_set("forceinline")
 
 # ----------------------------------------------------------------------------
 # Internal

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -88,6 +88,7 @@ class DefaultOptions:
     fastmath = _mapping("fastmath")
     error_model = _mapping("error_model")
     inline = _mapping("inline")
+    forceinline = _mapping("forceinline")
 
     target_backend = _mapping("target_backend")
 

--- a/numba/core/overload_glue.py
+++ b/numba/core/overload_glue.py
@@ -128,7 +128,8 @@ class _OverloadWrapper(object):
     def _build(self):
         from numba.core.extending import overload, intrinsic
 
-        @overload(self._function, strict=False)
+        @overload(self._function, strict=False,
+                  jit_options={'forceinline': True})
         def ol_generated(*ol_args, **ol_kwargs):
 
             def body(tyctx):


### PR DESCRIPTION
The code generated by `@overload_glue` is too involved for LLVM
to inline by default, this patch forces inlining to end up with
generated code similar to that prior to `overload_glue` where IR
was directly injected at the call site.
