### PR TITLE
Correct evaluation order in assert statement

### DIFF
--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -380,7 +380,7 @@ call_cfunc(Dispatcher *self, PyObject *cfunc, PyObject *args, PyObject *kws, PyO
     PyThreadState *tstate;
 
     assert(PyCFunction_Check(cfunc));
-    assert(PyCFunction_GET_FLAGS(cfunc) == METH_VARARGS | METH_KEYWORDS);
+    assert(PyCFunction_GET_FLAGS(cfunc) == (METH_VARARGS | METH_KEYWORDS));
     fn = (PyCFunctionWithKeywords) PyCFunction_GET_FUNCTION(cfunc);
     tstate = PyThreadState_GET();
 


### PR DESCRIPTION
This fixes the condition in the `assert` such that the `|` is evaluated before the `==`.