### PR TITLE
Prepend the inlined function name to inlined variables.

### DIFF
--- a/numba/tests/test_copy_propagate.py
+++ b/numba/tests/test_copy_propagate.py
@@ -10,7 +10,7 @@ from numba.core.annotations import type_annotations
 from numba.core.ir_utils import (copy_propagate, apply_copy_propagate,
                             get_name_var_table)
 from numba.core.typed_passes import type_inference_stage
-from numba.tests.test_ir_inlining import InlineTestPipeline
+from numba.tests.support import IRPreservingTestPipeline
 import numpy as np
 import unittest
 
@@ -124,7 +124,7 @@ class TestCopyPropagate(unittest.TestCase):
             b = a + 3
             return b
 
-        j_func = njit(pipeline_class=InlineTestPipeline)(test_impl)
+        j_func = njit(pipeline_class=IRPreservingTestPipeline)(test_impl)
         self.assertEqual(test_impl(5), j_func(5))
 
         # make sure b is the target of the expression assignment, not a temporary

--- a/numba/tests/test_ir_inlining.py
+++ b/numba/tests/test_ir_inlining.py
@@ -7,8 +7,8 @@ import operator
 from itertools import product
 import numpy as np
 
-from numba import njit, typeof, literally
-from numba.core import types, ir, ir_utils, cgutils
+from numba import njit, typeof, literally, prange
+from numba.core import types, ir, ir_utils, cgutils, errors
 from numba.core.extending import (
     overload,
     overload_method,
@@ -25,29 +25,11 @@ from numba.core.extending import (
 from numba.core.datamodel.models import OpaqueModel
 from numba.core.cpu import InlineOptions
 from numba.core.compiler import DefaultPassBuilder, CompilerBase
-from numba.core.typed_passes import IRLegalization, InlineOverloads
-from numba.core.untyped_passes import PreserveIR
+from numba.core.typed_passes import InlineOverloads
 from numba.core.typing import signature
 from numba.tests.support import (TestCase, unittest, skip_py38_or_later,
-                                 MemoryLeakMixin)
-
-
-class InlineTestPipeline(CompilerBase):
-    """ Same as the standard pipeline, but preserves the func_ir into the
-    metadata store"""
-
-    def define_pipelines(self):
-        pipeline = DefaultPassBuilder.define_nopython_pipeline(
-            self.state, "inliner_custom_pipe")
-        # mangle the default pipeline and inject DCE and IR preservation ahead
-        # of legalisation
-
-        # TODO: add a way to not do this! un-finalizing is not a good idea
-        pipeline._finalized = False
-        pipeline.add_pass_after(PreserveIR, IRLegalization)
-
-        pipeline.finalize()
-        return [pipeline]
+                                 MemoryLeakMixin, IRPreservingTestPipeline,
+                                 skip_parfors_unsupported)
 
 
 # this global has the same name as the global in inlining_usecases.py, it
@@ -101,7 +83,7 @@ class InliningBase(TestCase):
             assert isinstance(k, str)
             assert isinstance(v, bool)
 
-        j_func = njit(pipeline_class=InlineTestPipeline)(test_impl)
+        j_func = njit(pipeline_class=IRPreservingTestPipeline)(test_impl)
 
         # check they produce the same answer first!
         self.assertEqual(test_impl(*args), j_func(*args))
@@ -489,6 +471,43 @@ class TestFunctionInlining(MemoryLeakMixin, InliningBase):
 
         self.check(impl, inline_expect={'foo': True, 'boz': True,
                                         'fortran': True}, block_count=37)
+
+    def test_inline_renaming_scheme(self):
+        # See #7380, this checks that inlined variables have a name derived from
+        # the function they were defined in.
+
+        @njit(inline="always")
+        def bar(z):
+            x = 5
+            y = 10
+            return x + y + z
+
+        @njit(pipeline_class=IRPreservingTestPipeline)
+        def foo(a, b):
+            return bar(a), bar(b)
+
+        self.assertEqual(foo(10, 20), (25, 35))
+
+        # check IR. Look for the `x = 5`... there should be
+        # Two lots of `const(int, 5)`, one for each inline
+        # The LHS of the assignment will have a name like:
+        # TestFunctionInlining_test_inline_renaming_scheme__locals__bar_v2.x
+        # Ensure that this is the case!
+        func_ir = foo.overloads[foo.signatures[0]].metadata['preserved_ir']
+        store = []
+        for blk in func_ir.blocks.values():
+            for stmt in blk.body:
+                if isinstance(stmt, ir.Assign):
+                    if isinstance(stmt.value, ir.Const):
+                        if stmt.value.value == 5:
+                            store.append(stmt)
+
+        self.assertEqual(len(store), 2)
+        for i in store:
+            name = i.target.name
+            basename = self.id().lstrip(self.__module__)
+            regex = rf'{basename}__locals__bar_v[0-9]+.x'
+            self.assertRegex(name, regex)
 
 
 class TestRegisterJitableInlining(MemoryLeakMixin, InliningBase):
@@ -1059,7 +1078,7 @@ class TestOverloadMethsAttrsInlining(InliningBase):
 
     def check_method(self, test_impl, args, expected, block_count,
                      expects_inlined=True):
-        j_func = njit(pipeline_class=InlineTestPipeline)(test_impl)
+        j_func = njit(pipeline_class=IRPreservingTestPipeline)(test_impl)
         # check they produce the same answer first!
         self.assertEqual(j_func(*args), expected)
 
@@ -1081,7 +1100,7 @@ class TestOverloadMethsAttrsInlining(InliningBase):
 
     def check_getattr(self, test_impl, args, expected, block_count,
                       expects_inlined=True):
-        j_func = njit(pipeline_class=InlineTestPipeline)(test_impl)
+        j_func = njit(pipeline_class=IRPreservingTestPipeline)(test_impl)
         # check they produce the same answer first!
         self.assertEqual(j_func(*args), expected)
 
@@ -1454,6 +1473,43 @@ class TestInlineMiscIssues(TestCase):
             return bar(z), bar(z)
 
         self.assertEqual(foo(10), (11.3, 11.3))
+
+    @skip_parfors_unsupported
+    def test_issue7380(self):
+        # This checks that inlining a function containing a loop into another
+        # loop where the induction variable in boths loops is the same doesn't
+        # end up with a name collision. Parfors can detect this so it is used.
+        # See: https://github.com/numba/numba/issues/7380
+
+        # Check Numba inlined function passes
+
+        @njit(inline="always")
+        def bar(x):
+            for i in range(x.size):
+                x[i] += 1
+
+        @njit(parallel=True)
+        def foo(a):
+            for i in prange(a.shape[0]):
+                bar(a[i])
+
+        a = np.ones((10, 10))
+        foo(a) # run
+        # check mutation of data is correct
+        self.assertPreciseEqual(a, 2 * np.ones_like(a))
+
+        # Check manually inlined equivalent function fails
+        @njit(parallel=True)
+        def foo_bad(a):
+            for i in prange(a.shape[0]):
+                x = a[i]
+                for i in range(x.size):
+                    x[i] += 1
+
+        with self.assertRaises(errors.UnsupportedRewriteError) as e:
+            foo_bad(a)
+
+        self.assertIn("Overwrite of parallel loop index", str(e.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As title.

Fixes #7380
Fixes #7365
