### PR TITLE
Update the docs and error message for errors when importing Numba.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,7 +45,6 @@ exclude =
     numba/core/dataflow.py
     numba/core/pythonapi.py
     numba/core/decorators.py
-    numba/core/typeconv/typeconv.py
     numba/core/typeconv/rules.py
     numba/core/typeconv/castgraph.py
     numba/core/rewrites/registry.py

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -3,6 +3,75 @@
 Frequently Asked Questions
 ==========================
 
+Installation
+============
+
+Numba could not be imported
+---------------------------
+
+If you are seeing an exception on importing Numba with an error message
+that starts with::
+
+    ImportError: Numba could not be imported.
+
+here are some common issues and things to try to fix it.
+
+#. Your installation has more than one version of Numba a given environment.
+
+   Common ways this occurs include:
+
+   * Installing Numba with conda and then installing again with pip.
+   * Installing Numba with pip and then updating to a new version with pip (pip
+     re-installations don't seem to always clean up very well).
+
+   To fix this the best approach is to create an entirely new environment and
+   install a single version of Numba in that environment using a package manager
+   of your choice.
+
+#. Your installation has Numba for Python version X but you are running with
+   Python version Y.
+
+   This occurs due to a variety of Python environment mixup/mismatch problems.
+   The most common mismatch comes from installing Numba into the
+   site-packages/environment of one version of Python by using a base or
+   system installation of Python that is a different version, this typically
+   happens through the use of the "wrong" ``pip`` binary. This will obviously
+   cause problems as the C-Extensions on which Numba relies are bound to
+   specific Python versions. A way to check if this likely the problem is to
+   see if the path to the python at::
+
+       python -c 'import sys; print(sys.executable)'
+
+   matches the path to your installation tool and/or matches the reported
+   installation location and if the Python versions match up across all of
+   these. Note that Python version ``X.Y.A`` is compatible with ``X.Y.B``.
+
+   To fix this the best approach is to create an entirely new environment and
+   ensure that the installation tool used to install Numba is the one from that
+   environment/the Python versions at install and run time match.
+
+#. Your core system libraries are too old.
+
+   This is a somewhat rare occurence, but there are occasions when a very old
+   (typically out of support) version of Linux is in use it doesn't have a
+   ``glibc`` library with sufficiently new versioned symbols for Numba's shared
+   libraries to resolve against. The fix for this is to update your OS system
+   libraries/update your OS.
+
+#. You are using an IDE e.g. Spyder.
+
+   There are some unknown issues in relation to installing Numba via IDEs, but
+   it would appear that these are likely variations of 1. or 2. with the same
+   suggested fixes. Also, try installation from outside of the IDE with the
+   command line.
+
+
+If you have an installation problem which is not one of the above problems,
+please do ask on `numba.discourse.group <https://numba.discourse.group/>`_ and
+if possible include the path where Numba is installed and also the output of::
+
+    python -c 'import sys; print(sys.executable)'
+
 
 Programming
 ===========

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -31,14 +31,14 @@ here are some common issues and things to try to fix it.
 #. Your installation has Numba for Python version X but you are running with
    Python version Y.
 
-   This occurs due to a variety of Python environment mixup/mismatch problems.
+   This occurs due to a variety of Python environment mix-up/mismatch problems.
    The most common mismatch comes from installing Numba into the
    site-packages/environment of one version of Python by using a base or
    system installation of Python that is a different version, this typically
    happens through the use of the "wrong" ``pip`` binary. This will obviously
    cause problems as the C-Extensions on which Numba relies are bound to
    specific Python versions. A way to check if this likely the problem is to
-   see if the path to the python at::
+   see if the path to the ``python`` binary at::
 
        python -c 'import sys; print(sys.executable)'
 
@@ -52,7 +52,7 @@ here are some common issues and things to try to fix it.
 
 #. Your core system libraries are too old.
 
-   This is a somewhat rare occurence, but there are occasions when a very old
+   This is a somewhat rare occurrence, but there are occasions when a very old
    (typically out of support) version of Linux is in use it doesn't have a
    ``glibc`` library with sufficiently new versioned symbols for Numba's shared
    libraries to resolve against. The fix for this is to update your OS system

--- a/numba/core/typeconv/typeconv.py
+++ b/numba/core/typeconv/typeconv.py
@@ -9,11 +9,10 @@ except ImportError as e:
     dashes = '-' * 80
     msg = (f"Numba could not be imported.\n{dashes}\nIf you are seeing this "
            "message and are undertaking Numba development work, you may need "
-           "to re-run:\n\n$ python setup.py build_ext --inplace\n\nAlso, "
-           f"please check the development set up guide:\n\n{dev_url}."
-           f"\n\n{dashes}\nIf you are not working on Numba development, the "
-           f"original error was: '{str(e)}'. For help, please visit:\n\n"
-           f"{user_url}\n")
+           "to rebuild Numba.\nPlease see the development set up guide:\n\n"
+           f"{dev_url}.\n\n{dashes}\nIf you are not working on Numba "
+           f"development, the original error was: '{str(e)}'.\nFor help, "
+           f"please visit:\n\n{user_url}\n")
     raise ImportError(msg)
 
 from numba.core.typeconv import castgraph, Conversion

--- a/numba/core/typeconv/typeconv.py
+++ b/numba/core/typeconv/typeconv.py
@@ -3,18 +3,18 @@ try:
     # Numba, if it fails to import, provide some feedback
     from numba.core.typeconv import _typeconv
 except ImportError as e:
-    from numba.core.errors import feedback_details as reportme
-    import sys
-    url = "https://numba.pydata.org/numba-doc/latest/developer/contributing.html"
+    base_url = "https://numba.readthedocs.io/en/stable"
+    dev_url = f"{base_url}/developer/contributing.html"
+    user_url = f"{base_url}/user/faq.html#numba-could-not-be-imported"
     dashes = '-' * 80
-    msg = ("Numba could not be imported.\nIf you are seeing this message and "
-           "are undertaking Numba development work, you may need to re-run:\n\n"
-           "python setup.py build_ext --inplace\n\n(Also, please check the "
-           "development set up guide %s.)\n\nIf you are not working on Numba "
-           "development:\n%s\nThe original error was: '%s'\n" + dashes + "\nIf "
-           "possible please include the following in your error report:\n\n"
-           "sys.executable: %s\n")
-    raise ImportError(msg % (url, reportme, str(e), sys.executable))
+    msg = (f"Numba could not be imported.\n{dashes}\nIf you are seeing this "
+           "message and are undertaking Numba development work, you may need "
+           "to re-run:\n\n$ python setup.py build_ext --inplace\n\nAlso, "
+           f"please check the development set up guide:\n\n{dev_url}."
+           f"\n\n{dashes}\nIf you are not working on Numba development, the "
+           f"original error was: '{str(e)}'. For help, please visit:\n\n"
+           f"{user_url}\n")
+    raise ImportError(msg)
 
 from numba.core.typeconv import castgraph, Conversion
 from numba.core import types
@@ -23,11 +23,9 @@ from numba.core import types
 class TypeManager(object):
 
     # The character codes used by the C/C++ API (_typeconv.cpp)
-    _conversion_codes = {
-        Conversion.safe: ord("s"),
-        Conversion.unsafe: ord("u"),
-        Conversion.promote: ord("p"),
-        }
+    _conversion_codes = {Conversion.safe: ord("s"),
+                         Conversion.unsafe: ord("u"),
+                         Conversion.promote: ord("p"),}
 
     def __init__(self):
         self._ptr = _typeconv.new_type_manager()
@@ -129,4 +127,3 @@ class TypeCastingRules(object):
             self._tm.set_unsafe_convert(a, b)
         else:
             raise AssertionError(rel)
-


### PR DESCRIPTION
This updates the error message users see when the import of Numba
fails. It directs users to new documentation that outlines common
issues and has suggested fixes. This error is now considered
non-reportable as pretty much all occurences are due to one of the
few cases that are now documented. Should users have an issue that
is not covered, the docs direct them to the discourse forum to ask
for assistance.
