### PR TITLE
Fix #7507. catch `NotImplementedError ` in `.get_function()` 

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -560,7 +560,7 @@ class BaseContext(object):
             # It's a type instance => try to find a definition for the type class
             try:
                 return self.get_function(type(fn), sig)
-            except errors.NumbaNotImplementedError:
+            except NotImplementedError:
                 # Raise exception for the type instance, for a better error message
                 pass
 

--- a/numba/tests/test_practical_lowering_issues.py
+++ b/numba/tests/test_practical_lowering_issues.py
@@ -12,6 +12,11 @@ from numba.core.compiler_machinery import register_pass, FunctionPass
 from numba.tests.support import MemoryLeakMixin, TestCase
 
 
+def issue7507_lround(a):
+    """Dummy function used in test"""
+    pass
+
+
 class TestLowering(MemoryLeakMixin, TestCase):
     def test_issue4156_loop_vars_leak(self):
         """Test issues with zero-filling of refct'ed variables inside loops.
@@ -175,3 +180,33 @@ class TestLowering(MemoryLeakMixin, TestCase):
         got = foo(arr)
         expect = foo.py_func(arr)
         self.assertEqual(got, expect)
+
+    def test_issue7507(self):
+        """
+        Test a problem with BaseContext.get_function() because of changes
+        related to the new style error handling.
+        """
+        from numba.core.typing.templates import AbstractTemplate, infer_global
+        from numba.core.imputils import lower_builtin
+
+        @infer_global(issue7507_lround)
+        class lroundTemplate(AbstractTemplate):
+            key = issue7507_lround
+
+            def generic(self, args, kws):
+                signature = types.int64(types.float64)
+
+                # insert a new builtin during the compilation process
+                @lower_builtin(issue7507_lround, types.float64)
+                def codegen(context, builder, sig, args):
+                    # Simply truncate with the cast to integer.
+                    return context.cast(builder, args[0], sig.args[0],
+                                        sig.return_type)
+
+                return signature
+
+        @njit('int64(float64)')
+        def foo(a):
+            return issue7507_lround(a)
+
+        self.assertEqual(foo(3.4), 3)


### PR DESCRIPTION
Exception handler should be catching `NotImplementedError` instead.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->
