### PR TITLE
Add support for casting from int enums

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -804,7 +804,7 @@ class NumberClassAttribute(AttributeTemplate):
                 sig = fnty.get_call_type(self.context, (val, types.DType(ty)),
                                          {})
                 return sig.return_type
-            elif isinstance(val, (types.Number, types.Boolean)):
+            elif isinstance(val, (types.Number, types.Boolean, types.IntEnumMember)):
                  # Scalar constructor, e.g. np.int32(42)
                  return ty
             elif isinstance(val, (types.NPDatetime, types.NPTimedelta)):

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -5,7 +5,7 @@ Tests for enum support.
 
 import numpy as np
 import unittest
-from numba import jit, vectorize
+from numba import jit, vectorize, int32
 
 from numba.tests.support import TestCase
 from .enum_usecases import Color, Shape, Shake, Planet, RequestError, \
@@ -49,6 +49,13 @@ def int_coerce_usecase(x):
         return x - RequestError.not_found
     else:
         return x + Shape.circle
+
+def int_cast_usecase(x):
+    # Implicit coercion of intenums to ints
+    if x > RequestError.internal_error:
+        return x - RequestError.not_found
+    else:
+        return x + int32 (Shape.circle)
 
 
 def vectorize_usecase(x):
@@ -130,6 +137,13 @@ class TestIntEnum(BaseEnumTest, TestCase):
 
     def test_int_coerce(self):
         pyfunc = int_coerce_usecase
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for arg in [300, 450, 550]:
+            self.assertPreciseEqual(pyfunc(arg), cfunc(arg))
+
+    def test_int_cast(self):
+        pyfunc = int_cast_usecase
         cfunc = jit(nopython=True)(pyfunc)
 
         for arg in [300, 450, 550]:

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -5,7 +5,7 @@ Tests for enum support.
 
 import numpy as np
 import unittest
-from numba import jit, vectorize, int32
+from numba import jit, vectorize, int8, int16, int32
 
 from numba.tests.support import TestCase
 from .enum_usecases import Color, Shape, Shake, Planet, RequestError, \
@@ -51,11 +51,11 @@ def int_coerce_usecase(x):
         return x + Shape.circle
 
 def int_cast_usecase(x):
-    # Implicit coercion of intenums to ints
-    if x > RequestError.internal_error:
-        return x - RequestError.not_found
+    # Explicit coercion of intenums to ints
+    if x > int16(RequestError.internal_error):
+        return x - int32(RequestError.not_found)
     else:
-        return x + int32 (Shape.circle)
+        return x + int8(Shape.circle)
 
 
 def vectorize_usecase(x):


### PR DESCRIPTION
This PR fixes a enum to int cast problem documented in this issue: https://github.com/numba/numba/issues/7573 and introduced here: https://github.com/numba/numba/commit/f2311d20934a883dde3a2050ff947ff0f5d07977.

Fixes #7573