### PR TITLE
Make numba.types.Optional __str__ less verbose.

### DIFF
--- a/numba/core/types/misc.py
+++ b/numba/core/types/misc.py
@@ -218,9 +218,6 @@ class Optional(Type):
         name = "OptionalType(%s)" % self.type
         super(Optional, self).__init__(name)
 
-    def __str__(self):
-        return "%s i.e. the type '%s or None'" % (self.name, self.type)
-
     @property
     def key(self):
         return self.type


### PR DESCRIPTION
As title. Whilst well intentioned, the verbose string repr makes
it harder to debug issues with Optional types.
