### PR TITLE
[CI TEST] Revert "Fix linspace to use np.divide and clamp to stop."

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4172,13 +4172,11 @@ def numpy_linspace_3(context, builder, sig, args):
         div = num - 1
         if div > 0:
             delta = stop - start
-            step = np.divide(delta, div)
+            step = delta / div
             for i in range(0, num):
                 arr[i] = start + (i * step)
         else:
             arr[0] = start
-        if num > 1:
-            arr[-1] = stop
         return arr
 
     res = context.compile_internal(builder, linspace, sig, args)

--- a/numba/tests/test_dyn_array.py
+++ b/numba/tests/test_dyn_array.py
@@ -1241,7 +1241,7 @@ class TestLinspace(BaseTest):
             return np.linspace(n, m)
         self.check_outputs(pyfunc,
                            [(0, 4), (1, 100), (-3.5, 2.5), (-3j, 2+3j),
-                            (2, 1), (1+0.5j, 1.5j)])
+                            (2, 1), (1+0.5j, 1.5j)], exact=False)
 
     def test_linspace_3(self):
         def pyfunc(n, m, p):
@@ -1249,7 +1249,8 @@ class TestLinspace(BaseTest):
         self.check_outputs(pyfunc,
                            [(0, 4, 9), (1, 4, 3), (-3.5, 2.5, 8),
                             (-3j, 2+3j, 7), (2, 1, 0),
-                            (1+0.5j, 1.5j, 5), (1, 1e100, 1)])
+                            (1+0.5j, 1.5j, 5), (1, 1e100, 1)],
+                           exact=False)
 
     def test_linspace_accuracy(self):
         # Checking linspace reasonably replicates NumPy's algorithm


### PR DESCRIPTION
This reverts commit c10cb3e2993af80a95827792d3acb42ed8c99eb4.



