### PR TITLE
Remove deprecations

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -302,26 +302,6 @@ the function accepts.
    this notice has been updated to retain support for passing signatures.
 
 
-Recommendations
----------------
-
-Any eagerly-compiled device functions should have their signature removed, e.g.:
-
-.. code-block:: python
-
-   @cuda.jit('int32(int32, int32)', device=True)
-   def f(x, y):
-       return x + y
-
-becomes:
-
-
-.. code-block:: python
-
-   @cuda.jit(device=True)
-   def f(x, y):
-       return x + y
-
 Schedule
 --------
 

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -264,8 +264,8 @@ with:
 Schedule
 --------
 
-- In Numba 0.54: ``inspect_ptx()`` will be deprecated.
-- In Numba 0.55: ``inspect_ptx()`` will be removed.
+- In Numba 0.54: ``inspect_ptx()`` was deprecated.
+- In Numba 0.55: ``inspect_ptx()`` was removed.
 
 
 Deprecation of eager compilation of CUDA device functions
@@ -274,7 +274,7 @@ Deprecation of eager compilation of CUDA device functions
 In future versions of Numba, the ``device`` kwarg to the ``@cuda.jit`` decorator
 will be obviated, and whether a device function or global kernel is compiled will
 be inferred from the context. With respect to kernel / device functions and lazy
-/ eager compilation, four cases are presently handled:
+/ eager compilation, four cases were handled:
 
 1. ``device=True``, eager compilation with a signature provided
 2. ``device=False``, eager compilation with a signature provided
@@ -288,10 +288,19 @@ device function, then a device function should be compiled.
 
 The first two cases cannot be differentiated in the absence of the ``device``
 kwarg - without it, it will not be clear from a signature alone whether a device
-function or global kernel should be compiled. In order to resolve this, support
-for eager compilation of device functions will be removed. Eager compilation
-with the ``@cuda.jit`` decorator will in future always imply the immediate
-compilation of a global kernel.
+function or global kernel should be compiled. In order to resolve this, device
+functions will no longer be eagerly compiled. When a signature is provided to a
+device function, it will only be used to enforce the types of arguments that
+the function accepts.
+
+.. note::
+
+   In previous releases this notice stated that support for providing
+   signatures to device functions would be removed completely - however, this
+   precludes the common use case of enforcing the types that can be passed to a
+   device function (and the automatic insertion of casts that it implies) so
+   this notice has been updated to retain support for passing signatures.
+
 
 Recommendations
 ---------------
@@ -318,7 +327,7 @@ Schedule
 
 - In Numba 0.54: Eager compilation of device functions will be deprecated.
 - In Numba 0.55: Eager compilation of device functions will be unsupported and
-  attempts to eagerly compile device functions will raise an error.
+  the provision of signatures for device functions will only enforce casting.
 
 
 .. _rocm_unmaintained:

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -226,33 +226,6 @@ compiled in :term:`object mode`.
 
 .. _deprecation-strict-strides:
 
-Deprecation of strict strides checking when computing contiguity
-================================================================
-
-The contiguity of device arrays (the ``'C_CONTIGUOUS'`` and ``'F_CONTIGUOUS'``
-elements of the flags of a device array) are computed using relaxed strides
-checking, which matches the default in NumPy since Version 1.12. A config
-variable, :envvar:`NUMBA_NPY_RELAXED_STRIDES_CHECKING`, is provided to force
-computation of these flags using strict strides checking.
-
-This flag is provided to work around any bugs that may be exposed by strict
-strides checking, and will be removed in future.
-
-Schedule
---------
-
-In 0.54.0:
-
-- Relaxed strides checking will become the default.
-- Strict strides checking will be deprecated.
-
-In 0.55.0:
-
-- Strict strides checking will be removed, if there are no reports of bugs
-  related to relaxed strides checking in 0.54.0 onwards. This plan will be
-  re-examined if bugs related to relaxed strides checking are reported, but may
-  not necessarily change as a result.
-
 
 Deprecation of the ``inspect_ptx()`` method
 ===========================================

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -224,26 +224,6 @@ supply the keyword argument ``forceobj=True`` to ensure the function is always
 compiled in :term:`object mode`.
 
 
-Deprecation of the target kwarg
-===============================
-There have been a number of users attempting to use the ``target`` keyword
-argument that's meant for internal use only. We are deprecating this argument,
-as alternative solutions are available to achieve the same behaviour.
-
-Recommendations
----------------
-Update the ``jit`` decorator as follows:
-
-* Change ``@numba.jit(..., target='cuda')`` to ``numba.cuda.jit(...)``.
-
-Schedule
---------
-This feature will be moved with respect to this schedule:
-
-* Deprecation warnings will be issued in 0.51.0.
-* The target kwarg will be removed in version 0.54.0.
-
-
 Removal of the role of compute capability for CUDA inspection methods
 =====================================================================
 

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -224,68 +224,6 @@ supply the keyword argument ``forceobj=True`` to ensure the function is always
 compiled in :term:`object mode`.
 
 
-Removal of the role of compute capability for CUDA inspection methods
-=====================================================================
-
-The following methods of the :class:`Dispatcher
-<numba.cuda.compiler.Dispatcher>` class:
-
-- :meth:`inspect_asm <numba.cuda.compiler.Dispatcher.inspect_asm>`
-- :meth:`inspect_llvm <numba.cuda.compiler.Dispatcher.inspect_llvm>`
-- :meth:`inspect_sass <numba.cuda.compiler.Dispatcher.inspect_sass>`
-
-accepted a kwarg called ``compute_capability``. This kwarg is now removed as it
-was problematic - in most cases the returned values erroneously pertained to
-the device in the current context, instead of the requested compute capability.
-
-These methods return a dict of variants, which was previously keyed by a
-``(compute_capability, argtypes)`` tuple. The dict is now only keyed by
-argument types, and items in the dict are for the device in the current
-context.
-
-For specialized Dispatchers (those whose kernels were eagerly compiled by
-providing a signature), the methods previously returned only one variant,
-instead of a dict of variants. For consistency with the CPU target and for
-support for multiple signatures to be added to the CUDA target, these methods
-now always return a dict.
-
-The :meth:`ptx <numba.cuda.compiler.Dispatcher.ptx>` property also returned one
-variant directly for specialized Dispatchers, and a dict for un-specialized
-Dispatchers. It now always returns a dict
-
-Recommendations
----------------
-
-Update calls to these methods such that:
-
-- They are always called when the device for which their output is required is
-  in the current CUDA context.
-- The ``compute_capability`` kwarg is not passed to them.
-- Any use of their results indexes into them using only a tuple of argument
-  types.
-- With specialized Dispatchers, ensure that the returned dict is indexed into
-  using the appropriate signature.
-
-Schedule
---------
-
-In 0.53.0:
-
-- The ``compute_capability`` kwarg was deprecated.
-- Returned values from the inspection methods supported indexing by
-  ``(compute_capability, argtypes)`` and ``argtypes``.
-- The inspection methods and ``ptx`` property of specialized dispatchers returned
-  their result for a single variant, rather than a dict, and produced a
-  warning.
-
-In 0.54.0:
-
-- The ``compute_capability`` kwarg has been removed.
-- ``ptx`` and the inspection methods always return a dict.
-- Support for indexing into the results of these methods using ``(cc,
-  argtypes)`` has been removed.
-
-
 .. _deprecation-strict-strides:
 
 Deprecation of strict strides checking when computing contiguity

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -310,30 +310,6 @@ Schedule
   the provision of signatures for device functions will only enforce casting.
 
 
-.. _rocm_unmaintained:
-
-Dropping support for the ROCm target
-====================================
-
-The `ROCm <https://rocmdocs.amd.com/en/latest/index.html>`_ target has not been
-maintained for a number of years. It's known to be not far from working but has
-essentially bit-rotted in a number of areas. Numba 0.54 includes a new API for
-describing targets and both the CPU and CUDA targets have been ported to use
-this. Due to lack of maintenance, support and user base, the ROCm target is
-not being ported to this API, is being moved to an "unmaintained" status and
-will reside outside of the Numba package. Should there be sufficient interest
-and support for this target in future its status will be reconsidered.
-
-Schedule
---------
-
-In 0.54.0:
-
-- The ``ROCm`` target is officially unmaintained and the target source code has
-  been moved out of the Numba main repository and into a `separate repository
-  <https://github.com/numba/numba-rocm>`_.
-
-
 Deprecation of ``numba.core.base.BaseContext.add_user_function()``
 ==================================================================
 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -490,21 +490,6 @@ GPU support
    <https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html>`_
    for an explanation of the legacy and per-thread default streams.
 
-.. envvar:: NUMBA_NPY_RELAXED_STRIDES_CHECKING
-
-   By default arrays that inherit from ``numba.misc.dummyarray.Array`` (e.g.
-   CUDA device arrays) compute their contiguity using relaxed strides checking,
-   which is the default mechanism used by NumPy since version 1.12
-   (see `NPY_RELAXED_STRIDES_CHECKING
-   <https://numpy.org/doc/stable/release/1.8.0-notes.html#npy-relaxed-strides-checking>`_).
-   Setting ``NUMBA_NPY_RELAXED_STRIDES_CHECKING=0`` reverts back to strict
-   strides checking. This option should not normally be needed, but is provided
-   in case it is needed to work around latent bugs related to strict strides
-   checking.
-
-   Strict strides checking is deprecated and may be removed in future. See
-   :ref:`deprecation-strict-strides`.
-
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 
    Enable warnings if the grid size is too small relative to the number of

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -385,12 +385,6 @@ class _EnvReloader(object):
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv(
             "NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
 
-        # Compute contiguity of device arrays using the relaxed strides
-        # checking algorithm.
-        NPY_RELAXED_STRIDES_CHECKING = _readenv(
-            "NUMBA_NPY_RELAXED_STRIDES_CHECKING",
-            int, 1)
-
         # HSA Configs
 
         # Disable HSA support

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -385,11 +385,6 @@ class _EnvReloader(object):
         CUDA_PER_THREAD_DEFAULT_STREAM = _readenv(
             "NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM", int, 0)
 
-        # HSA Configs
-
-        # Disable HSA support
-        DISABLE_HSA = _readenv("NUMBA_DISABLE_HSA", int, 0)
-
         # The default number of threads to use.
         NUMBA_DEFAULT_NUM_THREADS = max(
             1,

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -41,10 +41,6 @@ def jit(signature_or_function=None, locals={}, cache=False,
         Mapping of local variable names to Numba types. Used to override the
         types deduced by Numba's type inference engine.
 
-    target (deprecated): str
-        Specifies the target platform to compile for. Valid targets are cpu,
-        gpu, npyufunc, and cuda. Defaults to cpu.
-
     pipeline_class: type numba.compiler.CompilerBase
             The compiler pipeline type for customizing the compilation stages.
 
@@ -106,7 +102,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
     --------
     The function can be used in the following ways:
 
-    1) jit(signatures, target='cpu', **targetoptions) -> jit(function)
+    1) jit(signatures, **targetoptions) -> jit(function)
 
         Equivalent to:
 
@@ -127,7 +123,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
             def bar(x, y):
                 return x + y
 
-    2) jit(function, target='cpu', **targetoptions) -> dispatcher
+    2) jit(function, **targetoptions) -> dispatcher
 
         Create a dispatcher function object that specializes at call site.
 
@@ -137,7 +133,7 @@ def jit(signature_or_function=None, locals={}, cache=False,
             def foo(x, y):
                 return x + y
 
-            @jit(target='cpu', nopython=True)
+            @jit(nopython=True)
             def bar(x, y):
                 return x + y
 
@@ -148,14 +144,11 @@ def jit(signature_or_function=None, locals={}, cache=False,
         raise DeprecationError(_msg_deprecated_signature_arg.format('restype'))
     if options.get('nopython', False) and options.get('forceobj', False):
         raise ValueError("Only one of 'nopython' or 'forceobj' can be True.")
-    if 'target' in options:
-        target = options.pop('target')
-        warnings.warn("The 'target' keyword argument is deprecated.", NumbaDeprecationWarning)
-    else:
-        if "_target" in options:
-            # Set the "target_backend" option if "_target" is defined.
-            options['target_backend'] = options['_target']
-        target = options.pop('_target', 'cpu')
+
+    if "_target" in options:
+        # Set the "target_backend" option if "_target" is defined.
+        options['target_backend'] = options['_target']
+    target = options.pop('_target', 'cpu')
 
     options['boundscheck'] = boundscheck
 
@@ -230,7 +223,7 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
     return wrapper
 
 
-def generated_jit(function=None, target='cpu', cache=False,
+def generated_jit(function=None, cache=False,
                   pipeline_class=None, **options):
     """
     This decorator allows flexible type-based compilation
@@ -241,7 +234,7 @@ def generated_jit(function=None, target='cpu', cache=False,
     dispatcher_args = {}
     if pipeline_class is not None:
         dispatcher_args['pipeline_class'] = pipeline_class
-    wrapper = _jit(sigs=None, locals={}, target=target, cache=cache,
+    wrapper = _jit(sigs=None, locals={}, target='cpu', cache=cache,
                    targetoptions=options, impl_kind='generated',
                    **dispatcher_args)
     if function is not None:


### PR DESCRIPTION
This PR removes deprecation notices for things removed in 0.54 (and also removed things that were claimed to be removed in 0.54), and also updates the notes on items deprecated / removed in 0.55.

Fixes #7530, as it updates the relevant deprecation notice.