### PR TITLE
Don't report start, stop, step parfor vars for insert_dels.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3772,15 +3772,16 @@ def parfor_insert_dels(parfor, curr_dead_set):
     dead_map = compute_dead_maps(cfg, blocks, live_map, usedefs.defmap)
 
     # treat loop variables and size variables as live
-    loop_vars = {
-        l.start.name for l in parfor.loop_nests if isinstance(
-            l.start, ir.Var)}
-    loop_vars |= {
-        l.stop.name for l in parfor.loop_nests if isinstance(
-            l.stop, ir.Var)}
-    loop_vars |= {
-        l.step.name for l in parfor.loop_nests if isinstance(
-            l.step, ir.Var)}
+    loop_vars = set()
+    #loop_vars |= {
+    #    l.start.name for l in parfor.loop_nests if isinstance(
+    #        l.start, ir.Var)}
+    #loop_vars |= {
+    #    l.stop.name for l in parfor.loop_nests if isinstance(
+    #        l.stop, ir.Var)}
+    #loop_vars |= {
+    #    l.step.name for l in parfor.loop_nests if isinstance(
+    #        l.step, ir.Var)}
     loop_vars |= {l.index_variable.name for l in parfor.loop_nests}
     # for var_list in parfor.array_analysis.array_size_vars.values():
     #    loop_vars |= {v.name for v in var_list if isinstance(v, ir.Var)}

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2828,6 +2828,16 @@ class TestParforsMisc(TestParforsBase):
             return buf
         self.check(test_impl)
 
+    def test_issue7523_generator(self):
+        def test_impl():
+            temp = np.empty(1)
+            for j in range(1):
+                temp[j] = 1
+            yield temp
+
+        cfunc = njit(parallel=True)(test_impl)
+        self.assertEqual(list(test_impl()), list(cfunc()))
+
 
 @skip_parfors_unsupported
 class TestParforsDiagnostics(TestParforsBase):


### PR DESCRIPTION
This is a work in progress at this point.  When the code to inserts dels is run, if parfors report their start, stop, and step variables in their loop nests as having dels added then the code outside the parfor won't add them.  The parfor doesn't, shouldn't, and can't add dels for variables used in the loop nests start, stop, and step inside the parfor so the outside parfor code has to do it.  Parfors was previously reporting such variables as having had dels added which meant the outside code didn't do it which results in strange downstream errors.