### PR TITLE
Added multiple axes support for np.expand_dims

### DIFF
--- a/docs/upcoming_changes/7604.improvement.rst
+++ b/docs/upcoming_changes/7604.improvement.rst
@@ -1,0 +1,5 @@
+Support multiple ``axis`` arguments in ``np.expand_dims``
+---------------------------------------------------------
+
+Users can now specify multiple axes in the form of a
+tuple of integers in a single call to ``np.expand_dims``.

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5986,99 +5986,76 @@ def impl_np_array(object, dtype=None):
     return impl
 
 
-def _normalize_axis(context, builder, func_name, ndim, axis):
-    zero = axis.type(0)
-    ll_ndim = axis.type(ndim)
-
-    # Normalize negative axis
-    is_neg_axis = builder.icmp_signed('<', axis, zero)
-    axis = builder.select(is_neg_axis, builder.add(axis, ll_ndim), axis)
-
-    # Check axis for bounds
-    axis_out_of_bounds = builder.or_(
-        builder.icmp_signed('<', axis, zero),
-        builder.icmp_signed('>=', axis, ll_ndim))
-    with builder.if_then(axis_out_of_bounds, likely=False):
-        msg = "%s(): axis out of bounds" % func_name
-        context.call_conv.return_user_exc(builder, IndexError, (msg,))
-
-    return axis
-
-
-def _insert_axis_in_shape(context, builder, orig_shape, ndim, axis):
-    """
-    Compute shape with the new axis inserted
-    e.g. given original shape (2, 3, 4) and axis=2,
-    the returned new shape is (2, 3, 1, 4).
-    """
-    assert len(orig_shape) == ndim - 1
-
-    ll_shty = ir.ArrayType(cgutils.intp_t, ndim)
-    shapes = cgutils.alloca_once(builder, ll_shty)
-
-    one = cgutils.intp_t(1)
-
-    # 1. copy original sizes at appropriate places
-    for dim in range(ndim - 1):
-        ll_dim = cgutils.intp_t(dim)
-        after_axis = builder.icmp_signed('>=', ll_dim, axis)
-        sh = orig_shape[dim]
-        idx = builder.select(after_axis,
-                             builder.add(ll_dim, one),
-                             ll_dim)
-        builder.store(sh, cgutils.gep_inbounds(builder, shapes, 0, idx))
-
-    # 2. insert new size (1) at axis dimension
-    builder.store(one, cgutils.gep_inbounds(builder, shapes, 0, axis))
-
-    return cgutils.unpack_tuple(builder, builder.load(shapes))
-
-
-def _insert_axis_in_strides(context, builder, orig_strides, ndim, axis):
-    """
-    Same as _insert_axis_in_shape(), but with a strides array.
-    """
-    assert len(orig_strides) == ndim - 1
-
-    ll_shty = ir.ArrayType(cgutils.intp_t, ndim)
-    strides = cgutils.alloca_once(builder, ll_shty)
-
-    one = cgutils.intp_t(1)
-    zero = cgutils.intp_t(0)
-
-    # 1. copy original strides at appropriate places
-    for dim in range(ndim - 1):
-        ll_dim = cgutils.intp_t(dim)
-        after_axis = builder.icmp_signed('>=', ll_dim, axis)
-        idx = builder.select(after_axis,
-                             builder.add(ll_dim, one),
-                             ll_dim)
-        builder.store(orig_strides[dim],
-                      cgutils.gep_inbounds(builder, strides, 0, idx))
-
-    # 2. insert new stride at axis dimension
-    # (the value is indifferent for a 1-sized dimension, we use 0)
-    builder.store(zero, cgutils.gep_inbounds(builder, strides, 0, axis))
-
-    return cgutils.unpack_tuple(builder, builder.load(strides))
-
-
-def expand_dims(context, builder, sig, args, axis):
+def expand_dims(context, builder, sig, args):
     """
     np.expand_dims() with the given axis.
     """
     retty = sig.return_type
     ndim = retty.ndim
     arrty = sig.args[0]
+    _empty_tuple = tuple([-1] * ndim)
+
+    if isinstance(sig.args[1], types.Integer):
+        to_tuple = register_jitable(lambda axis: (axis,))
+    else:
+        to_tuple = register_jitable(lambda axis: axis)
+
+    @register_jitable
+    def normalize_axis(axis, ndim):
+        for i in range(len(axis)):
+            # In case of negative axes, we wrap them around
+            if axis[i] < 0:
+                axis = tuple_setitem(axis, i, axis[i] + ndim)
+
+            # Check for out of bound axes
+            if axis[i] < 0 or axis[i] >= ndim:
+                raise IndexError("axis out of bounds")
+        return axis
+
+    @register_jitable
+    def _build_shape_stride_tuples(_curr_tuple, ndim, axis, value):
+        axis = to_tuple(axis)
+        axis = normalize_axis(axis, ndim)
+        # 1. Initialize new tuple with -1
+        res = _empty_tuple
+
+        # 2. Replace the new tuple with given value using
+        # their index array i.e. axis
+        for i in axis:
+            if res[i] == value:
+                raise ValueError("An axis is being repeated")
+            res = tuple_setitem(res, i, value)
+
+        # 3. Incrementally put original tuple values into
+        # indices that are -1
+        idx = 0
+        for i in range(ndim):
+            if res[i] == -1:
+                res = tuple_setitem(res, i, _curr_tuple[idx])
+                idx = idx + 1
+
+        return res
 
     arr = make_array(arrty)(context, builder, value=args[0])
     ret = make_array(retty)(context, builder)
+    temp_ty = types.UniTuple(types.intp, count=sig.args[0].ndim)
 
-    shapes = cgutils.unpack_tuple(builder, arr.shape)
-    strides = cgutils.unpack_tuple(builder, arr.strides)
+    ndim_const = context.get_constant(types.intp, ndim)
+    zero = context.get_constant(types.intp, 0)
+    one = context.get_constant(types.intp, 1)
 
-    new_shapes = _insert_axis_in_shape(context, builder, shapes, ndim, axis)
-    new_strides = _insert_axis_in_strides(context, builder, strides, ndim, axis)
+    fnty = context.typing_context.resolve_value_type(_build_shape_stride_tuples)
+    sig = fnty.get_call_type(
+        context.typing_context,
+        (temp_ty, types.intp, sig.args[1], types.intp),
+        {}
+    )
+    new_shapes = context.get_function(fnty, sig)(
+        builder, (arr.shape, ndim_const, args[1], one)
+    )
+    new_strides = context.get_function(fnty, sig)(
+        builder, (arr.strides, ndim_const, args[1], zero)
+    )
 
     populate_array(ret,
                    data=arr.data,
@@ -6094,15 +6071,25 @@ def expand_dims(context, builder, sig, args, axis):
 @intrinsic
 def np_expand_dims(typingctx, a, axis):
     layout = a.layout if a.ndim <= 1 else 'A'
-    ret = a.copy(ndim=a.ndim + 1, layout=layout)
+
+    if isinstance(axis, types.UniTuple) and axis.count:
+        ret = a.copy(ndim=a.ndim + axis.count, layout=layout)
+    elif isinstance(axis, types.Integer):
+        ret = a.copy(ndim=a.ndim + 1, layout=layout)
+    else:
+        # An empty tuple
+        ret = a.copy(ndim=a.ndim, layout=layout)
     sig = ret(a, axis)
 
     def codegen(context, builder, sig, args):
-        axis = context.cast(builder, args[1], sig.args[1], types.intp)
-        axis = _normalize_axis(context, builder, "np.expand_dims",
-                               sig.return_type.ndim, axis)
+        axes_types = sig.args[1]
+        if (isinstance(axes_types, (types.UniTuple, types.Tuple))
+                and not axes_types.count):
+            # An empty tuple
+            return impl_ret_borrowed(context, builder,
+                                     sig.return_type, args[0])
 
-        ret = expand_dims(context, builder, sig, args, axis)
+        ret = expand_dims(context, builder, sig, args)
         return impl_ret_borrowed(context, builder, sig.return_type, ret)
 
     return sig, codegen
@@ -6114,8 +6101,13 @@ def impl_np_expand_dims(a, axis):
         msg = f'First argument "a" must be an array. Got {a}'
         raise errors.TypingError(msg)
 
-    if not isinstance(axis, types.Integer):
-        msg = f'Argument "axis" must be an integer. Got {axis}'
+    # Either an integer or a Tuple with all integer elements or an empty Tuple
+    if not isinstance(axis, types.Integer)\
+        and not (isinstance(axis, types.UniTuple)
+                 and isinstance(axis.dtype, types.Integer) and axis.count)\
+            and not (isinstance(axis, types.Tuple) and not axis.count):
+        msg = ('Argument "axis" must be an integer or tuple of integers.'
+               f' Got {axis}')
         raise errors.TypingError(msg)
 
     def impl(a, axis):
@@ -6162,8 +6154,9 @@ def _atleast_nd_transform(min_ndim, axes):
                 axis = cgutils.intp_t(axes[i])
                 newarrty = arrty.copy(ndim=arrty.ndim + 1)
                 arr = expand_dims(context, builder,
-                                  typing.signature(newarrty, arrty), (arr,),
-                                  axis)
+                                  typing.signature(newarrty, arrty,
+                                                   types.intp),
+                                  (arr, axis))
                 arrty = newarrty
 
         return arr
@@ -6248,6 +6241,25 @@ def _do_concatenate(context, builder, axis,
         ret_data = cgutils.pointer_add(builder, ret_data, offset)
 
     return ret
+
+
+def _normalize_axis(context, builder, func_name, ndim, axis):
+    zero = axis.type(0)
+    ll_ndim = axis.type(ndim)
+
+    # Normalize negative axis
+    is_neg_axis = builder.icmp_signed('<', axis, zero)
+    axis = builder.select(is_neg_axis, builder.add(axis, ll_ndim), axis)
+
+    # Check axis for bounds
+    axis_out_of_bounds = builder.or_(
+        builder.icmp_signed('<', axis, zero),
+        builder.icmp_signed('>=', axis, ll_ndim))
+    with builder.if_then(axis_out_of_bounds, likely=False):
+        msg = "%s(): axis out of bounds" % func_name
+        context.call_conv.return_user_exc(builder, IndexError, (msg,))
+
+    return axis
 
 
 def _np_concatenate(context, builder, arrtys, arrs, retty, axis):
@@ -6467,8 +6479,8 @@ def np_column_stack(typingctx, tup):
                 # Convert 1d array to 2d column array: np.expand_dims(a, 1)
                 assert arrty.ndim == 1
                 newty = arrty.copy(ndim=2)
-                expand_sig = typing.signature(newty, arrty)
-                newarr = expand_dims(context, builder, expand_sig, (arr,), axis)
+                expand_sig = typing.signature(newty, arrty, types.intp)
+                newarr = expand_dims(context, builder, expand_sig, (arr, axis))
 
                 arrtys.append(newty)
                 arrs.append(newarr)
@@ -6630,8 +6642,8 @@ def _np_dstack(typingctx, tup):
                                          axis)
 
             axis = context.get_constant(types.intp, 0)
-            expand_sig = typing.signature(retty, stack_retty)
-            return expand_dims(context, builder, expand_sig, (stack_ret,), axis)
+            expand_sig = typing.signature(retty, stack_retty, types.intp)
+            return expand_dims(context, builder, expand_sig, (stack_ret, axis))
 
         elif ndim == 2:
             # np.stack(arrays, axis=2)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -6032,7 +6032,7 @@ def expand_dims(context, builder, sig, args):
         for i in range(ndim):
             if res[i] == -1:
                 res = tuple_setitem(res, i, _curr_tuple[idx])
-                idx = idx + 1
+                idx += 1
 
         return res
 
@@ -6045,7 +6045,7 @@ def expand_dims(context, builder, sig, args):
     one = context.get_constant(types.intp, 1)
 
     fnty = context.typing_context.resolve_value_type(_build_shape_stride_tuples)
-    sig = fnty.get_call_type(
+    fsig = fnty.get_call_type(
         context.typing_context,
         (temp_ty, types.intp, sig.args[1], types.intp),
         {}

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -6047,99 +6047,76 @@ def impl_np_array(object, dtype=None):
     return impl
 
 
-def _normalize_axis(context, builder, func_name, ndim, axis):
-    zero = axis.type(0)
-    ll_ndim = axis.type(ndim)
-
-    # Normalize negative axis
-    is_neg_axis = builder.icmp_signed('<', axis, zero)
-    axis = builder.select(is_neg_axis, builder.add(axis, ll_ndim), axis)
-
-    # Check axis for bounds
-    axis_out_of_bounds = builder.or_(
-        builder.icmp_signed('<', axis, zero),
-        builder.icmp_signed('>=', axis, ll_ndim))
-    with builder.if_then(axis_out_of_bounds, likely=False):
-        msg = "%s(): axis out of bounds" % func_name
-        context.call_conv.return_user_exc(builder, IndexError, (msg,))
-
-    return axis
-
-
-def _insert_axis_in_shape(context, builder, orig_shape, ndim, axis):
-    """
-    Compute shape with the new axis inserted
-    e.g. given original shape (2, 3, 4) and axis=2,
-    the returned new shape is (2, 3, 1, 4).
-    """
-    assert len(orig_shape) == ndim - 1
-
-    ll_shty = ir.ArrayType(cgutils.intp_t, ndim)
-    shapes = cgutils.alloca_once(builder, ll_shty)
-
-    one = cgutils.intp_t(1)
-
-    # 1. copy original sizes at appropriate places
-    for dim in range(ndim - 1):
-        ll_dim = cgutils.intp_t(dim)
-        after_axis = builder.icmp_signed('>=', ll_dim, axis)
-        sh = orig_shape[dim]
-        idx = builder.select(after_axis,
-                             builder.add(ll_dim, one),
-                             ll_dim)
-        builder.store(sh, cgutils.gep_inbounds(builder, shapes, 0, idx))
-
-    # 2. insert new size (1) at axis dimension
-    builder.store(one, cgutils.gep_inbounds(builder, shapes, 0, axis))
-
-    return cgutils.unpack_tuple(builder, builder.load(shapes))
-
-
-def _insert_axis_in_strides(context, builder, orig_strides, ndim, axis):
-    """
-    Same as _insert_axis_in_shape(), but with a strides array.
-    """
-    assert len(orig_strides) == ndim - 1
-
-    ll_shty = ir.ArrayType(cgutils.intp_t, ndim)
-    strides = cgutils.alloca_once(builder, ll_shty)
-
-    one = cgutils.intp_t(1)
-    zero = cgutils.intp_t(0)
-
-    # 1. copy original strides at appropriate places
-    for dim in range(ndim - 1):
-        ll_dim = cgutils.intp_t(dim)
-        after_axis = builder.icmp_signed('>=', ll_dim, axis)
-        idx = builder.select(after_axis,
-                             builder.add(ll_dim, one),
-                             ll_dim)
-        builder.store(orig_strides[dim],
-                      cgutils.gep_inbounds(builder, strides, 0, idx))
-
-    # 2. insert new stride at axis dimension
-    # (the value is indifferent for a 1-sized dimension, we use 0)
-    builder.store(zero, cgutils.gep_inbounds(builder, strides, 0, axis))
-
-    return cgutils.unpack_tuple(builder, builder.load(strides))
-
-
-def expand_dims(context, builder, sig, args, axis):
+def expand_dims(context, builder, sig, args):
     """
     np.expand_dims() with the given axis.
     """
     retty = sig.return_type
     ndim = retty.ndim
     arrty = sig.args[0]
+    _empty_tuple = tuple([-1] * ndim)
+
+    if isinstance(sig.args[1], types.Integer):
+        to_tuple = register_jitable(lambda axis: (axis,))
+    else:
+        to_tuple = register_jitable(lambda axis: axis)
+
+    @register_jitable
+    def normalize_axis(axis, ndim):
+        for i in range(len(axis)):
+            # In case of negative axes, we wrap them around
+            if axis[i] < 0:
+                axis = tuple_setitem(axis, i, axis[i] + ndim)
+
+            # Check for out of bound axes
+            if axis[i] < 0 or axis[i] >= ndim:
+                raise IndexError("axis out of bounds")
+        return axis
+
+    @register_jitable
+    def _build_shape_stride_tuples(_curr_tuple, ndim, axis, value):
+        axis = to_tuple(axis)
+        axis = normalize_axis(axis, ndim)
+        # 1. Initialize new tuple with -1
+        res = _empty_tuple
+
+        # 2. Replace the new tuple with given value using
+        # their index array i.e. axis
+        for i in axis:
+            if res[i] == value:
+                raise ValueError("An axis is being repeated")
+            res = tuple_setitem(res, i, value)
+
+        # 3. Incrementally put original tuple values into
+        # indices that are -1
+        idx = 0
+        for i in range(ndim):
+            if res[i] == -1:
+                res = tuple_setitem(res, i, _curr_tuple[idx])
+                idx = idx + 1
+
+        return res
 
     arr = make_array(arrty)(context, builder, value=args[0])
     ret = make_array(retty)(context, builder)
+    temp_ty = types.UniTuple(types.intp, count=sig.args[0].ndim)
 
-    shapes = cgutils.unpack_tuple(builder, arr.shape)
-    strides = cgutils.unpack_tuple(builder, arr.strides)
+    ndim_const = context.get_constant(types.intp, ndim)
+    zero = context.get_constant(types.intp, 0)
+    one = context.get_constant(types.intp, 1)
 
-    new_shapes = _insert_axis_in_shape(context, builder, shapes, ndim, axis)
-    new_strides = _insert_axis_in_strides(context, builder, strides, ndim, axis)
+    fnty = context.typing_context.resolve_value_type(_build_shape_stride_tuples)
+    sig = fnty.get_call_type(
+        context.typing_context,
+        (temp_ty, types.intp, sig.args[1], types.intp),
+        {}
+    )
+    new_shapes = context.get_function(fnty, sig)(
+        builder, (arr.shape, ndim_const, args[1], one)
+    )
+    new_strides = context.get_function(fnty, sig)(
+        builder, (arr.strides, ndim_const, args[1], zero)
+    )
 
     populate_array(ret,
                    data=arr.data,
@@ -6155,15 +6132,25 @@ def expand_dims(context, builder, sig, args, axis):
 @intrinsic
 def np_expand_dims(typingctx, a, axis):
     layout = a.layout if a.ndim <= 1 else 'A'
-    ret = a.copy(ndim=a.ndim + 1, layout=layout)
+
+    if isinstance(axis, types.UniTuple) and axis.count:
+        ret = a.copy(ndim=a.ndim + axis.count, layout=layout)
+    elif isinstance(axis, types.Integer):
+        ret = a.copy(ndim=a.ndim + 1, layout=layout)
+    else:
+        # An empty tuple
+        ret = a.copy(ndim=a.ndim, layout=layout)
     sig = ret(a, axis)
 
     def codegen(context, builder, sig, args):
-        axis = context.cast(builder, args[1], sig.args[1], types.intp)
-        axis = _normalize_axis(context, builder, "np.expand_dims",
-                               sig.return_type.ndim, axis)
+        axes_types = sig.args[1]
+        if (isinstance(axes_types, (types.UniTuple, types.Tuple))
+                and not axes_types.count):
+            # An empty tuple
+            return impl_ret_borrowed(context, builder,
+                                     sig.return_type, args[0])
 
-        ret = expand_dims(context, builder, sig, args, axis)
+        ret = expand_dims(context, builder, sig, args)
         return impl_ret_borrowed(context, builder, sig.return_type, ret)
 
     return sig, codegen
@@ -6175,8 +6162,13 @@ def impl_np_expand_dims(a, axis):
         msg = f'First argument "a" must be an array. Got {a}'
         raise errors.TypingError(msg)
 
-    if not isinstance(axis, types.Integer):
-        msg = f'Argument "axis" must be an integer. Got {axis}'
+    # Either an integer or a Tuple with all integer elements or an empty Tuple
+    if not isinstance(axis, types.Integer)\
+        and not (isinstance(axis, types.UniTuple)
+                 and isinstance(axis.dtype, types.Integer) and axis.count)\
+            and not (isinstance(axis, types.Tuple) and not axis.count):
+        msg = ('Argument "axis" must be an integer or tuple of integers.'
+               f' Got {axis}')
         raise errors.TypingError(msg)
 
     def impl(a, axis):
@@ -6223,8 +6215,9 @@ def _atleast_nd_transform(min_ndim, axes):
                 axis = cgutils.intp_t(axes[i])
                 newarrty = arrty.copy(ndim=arrty.ndim + 1)
                 arr = expand_dims(context, builder,
-                                  typing.signature(newarrty, arrty), (arr,),
-                                  axis)
+                                  typing.signature(newarrty, arrty,
+                                                   types.intp),
+                                  (arr, axis))
                 arrty = newarrty
 
         return arr
@@ -6309,6 +6302,25 @@ def _do_concatenate(context, builder, axis,
         ret_data = cgutils.pointer_add(builder, ret_data, offset)
 
     return ret
+
+
+def _normalize_axis(context, builder, func_name, ndim, axis):
+    zero = axis.type(0)
+    ll_ndim = axis.type(ndim)
+
+    # Normalize negative axis
+    is_neg_axis = builder.icmp_signed('<', axis, zero)
+    axis = builder.select(is_neg_axis, builder.add(axis, ll_ndim), axis)
+
+    # Check axis for bounds
+    axis_out_of_bounds = builder.or_(
+        builder.icmp_signed('<', axis, zero),
+        builder.icmp_signed('>=', axis, ll_ndim))
+    with builder.if_then(axis_out_of_bounds, likely=False):
+        msg = "%s(): axis out of bounds" % func_name
+        context.call_conv.return_user_exc(builder, IndexError, (msg,))
+
+    return axis
 
 
 def _np_concatenate(context, builder, arrtys, arrs, retty, axis):
@@ -6528,8 +6540,8 @@ def np_column_stack(typingctx, tup):
                 # Convert 1d array to 2d column array: np.expand_dims(a, 1)
                 assert arrty.ndim == 1
                 newty = arrty.copy(ndim=2)
-                expand_sig = typing.signature(newty, arrty)
-                newarr = expand_dims(context, builder, expand_sig, (arr,), axis)
+                expand_sig = typing.signature(newty, arrty, types.intp)
+                newarr = expand_dims(context, builder, expand_sig, (arr, axis))
 
                 arrtys.append(newty)
                 arrs.append(newarr)
@@ -6692,8 +6704,8 @@ def _np_dstack(typingctx, tup):
                                          axis)
 
             axis = context.get_constant(types.intp, 0)
-            expand_sig = typing.signature(retty, stack_retty)
-            return expand_dims(context, builder, expand_sig, (stack_ret,), axis)
+            expand_sig = typing.signature(retty, stack_retty, types.intp)
+            return expand_dims(context, builder, expand_sig, (stack_ret, axis))
 
         elif ndim == 2:
             # np.stack(arrays, axis=2)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -6111,10 +6111,10 @@ def expand_dims(context, builder, sig, args):
         (temp_ty, types.intp, sig.args[1], types.intp),
         {}
     )
-    new_shapes = context.get_function(fnty, sig)(
+    new_shapes = context.get_function(fnty, fsig)(
         builder, (arr.shape, ndim_const, args[1], one)
     )
-    new_strides = context.get_function(fnty, sig)(
+    new_strides = context.get_function(fnty, fsig)(
         builder, (arr.strides, ndim_const, args[1], zero)
     )
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -6093,7 +6093,7 @@ def expand_dims(context, builder, sig, args):
         for i in range(ndim):
             if res[i] == -1:
                 res = tuple_setitem(res, i, _curr_tuple[idx])
-                idx = idx + 1
+                idx += 1
 
         return res
 
@@ -6106,7 +6106,7 @@ def expand_dims(context, builder, sig, args):
     one = context.get_constant(types.intp, 1)
 
     fnty = context.typing_context.resolve_value_type(_build_shape_stride_tuples)
-    sig = fnty.get_call_type(
+    fsig = fnty.get_call_type(
         context.typing_context,
         (temp_ty, types.intp, sig.args[1], types.intp),
         {}

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -463,19 +463,28 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         # 1d
         arr = np.arange(5)
         check_all_axes(arr)
+        check(arr, (1, 2))
+        check(arr, ())
         # 3d (C, F, A)
         arr = np.arange(24).reshape((2, 3, 4))
         check_all_axes(arr)
         check_all_axes(arr.T)
         check_all_axes(arr[::-1])
+        check(arr, (1, 3))
         # 0d
         arr = np.array(42)
         check_all_axes(arr)
+        # 7d (C, F, A)
+        arr = np.arange(720).reshape((1, 2, 3, 4, 5, 6))
+        check(arr, (1, 2, 3, 4, 5, 6))
+        check(arr.T, (5, -6))
+        check(arr[::-1], (1, 3, 4, -2, -4))
 
     def test_expand_dims_exceptions(self):
+        self.disable_leak_check()
         pyfunc = expand_dims
         cfunc = jit(nopython=True)(pyfunc)
-        arr = np.arange(5)
+        arr = np.arange(20).reshape((4, 5))
 
         with self.assertTypingError() as raises:
             cfunc('hello', 3)
@@ -483,8 +492,16 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
         with self.assertTypingError() as raises:
             cfunc(arr, 'hello')
-        self.assertIn('Argument "axis" must be an integer', str(raises.exception))
+        self.assertIn('Argument "axis" must be an integer or tuple of integers',
+                      str(raises.exception))
 
+        with self.assertRaises(ValueError) as raises:
+            cfunc(arr, (1, 1))
+        self.assertIn('repeated axis', str(raises.exception))
+
+        with self.assertRaises(IndexError) as raises:
+            cfunc(arr, (4,))
+        self.assertIn('axis out of bounds', str(raises.exception))
 
     def check_atleast_nd(self, pyfunc, cfunc):
         def check_result(got, expected):

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -497,7 +497,7 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
 
         with self.assertRaises(ValueError) as raises:
             cfunc(arr, (1, 1))
-        self.assertIn('repeated axis', str(raises.exception))
+        self.assertIn('An axis is being repeated', str(raises.exception))
 
         with self.assertRaises(IndexError) as raises:
             cfunc(arr, (4,))


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR adds support for passing multiple axes as a tuple to `np.expand_dims()`.

```python
import numpy as np
import numba

orig_shape = (3,4,5)
orig = np.random.normal(size=orig_shape)
new_order_tuple = (1, 3)

ref = np.expand_dims(orig, new_order_tuple)

@numba.njit
def expand_dims_fn(x, new_order):
    return np.expand_dims(x, new_order)

res = expand_dims_fn(orig, new_order_tuple)

print(ref.shape) # (3, 1, 4, 1, 5)
print(res.shape) # (3, 1, 4, 1, 5)
```
