### PR TITLE
Numba gdb-python extension for printing

### DIFF
--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -403,6 +403,33 @@ debug info is available:
   * Other types are shown as a structure based on Numba's memory model
     representation of the type.
 
+Further, the Numba ``gdb`` printing extension can be loaded into ``gdb`` (if the
+``gdb`` has Python support) to permit the printing of variables as they would be
+in native Python. The extension does this by reinterpreting Numba's memory model
+representations as Python types. Information about the ``gdb`` installation that
+Numba is using, including the path to load the ``gdb`` printing extension, can
+be displayed by using the ``numba -g`` command. For best results ensure that the
+Python that ``gdb`` is using has a NumPy module accessible. An example output
+of the ``gdb`` information follows:
+
+.. code-block:: none
+  :emphasize-lines: 1
+
+    $ numba -g
+    GDB info:
+    --------------------------------------------------------------------------------
+    Binary location                               : <some path>/gdb
+    Print extension location                      : <some python path>/numba/misc/gdb_print_extension.py
+    Python version                                : 3.8
+    NumPy version                                 : 1.20.0
+    Numba printing extension supported            : True
+
+    To load the Numba gdb printing extension, execute the following from the gdb prompt:
+
+    source <some python path>/numba/misc/gdb_print_extension.py
+
+    --------------------------------------------------------------------------------
+
 Known issues:
 
 * Stepping depends heavily on optimization level. At full optimization
@@ -496,6 +523,55 @@ In the terminal:
     (gdb) bt
     #0  __main__::foo_241[abi:c8tJTC_2fWgEeGLSgydRTQUgiqKEZ6gEoDvQJmaQIA](long long) (a=123) at test1.py:8
     #1  0x00007ffff06439fa in cpython::__main__::foo_241[abi:c8tJTC_2fWgEeGLSgydRTQUgiqKEZ6gEoDvQJmaQIA](long long) ()
+
+
+Another example follows that makes use of the Numba ``gdb`` printing extension
+mentioned above, note the change in the print format once the extension is
+loaded with ``source`` :
+
+The Python source:
+
+.. code-block:: python
+  :linenos:
+
+    from numba import njit
+    import numpy as np
+
+    @njit(debug=True)
+    def foo(n):
+        x = np.arange(n)
+        y = (x[0], x[-1])
+        return x, y
+
+    foo(4)
+
+In the terminal:
+
+.. code-block:: none
+  :emphasize-lines: 1, 3, 4, 7, 12, 14, 16, 17, 20
+
+    $ NUMBA_OPT=0 NUMBA_EXTEND_VARIABLE_LIFETIMES=1 gdb -q python
+    Reading symbols from python...
+    (gdb) set breakpoint pending on
+    (gdb) break test2.py:8
+    No source file named test2.py.
+    Breakpoint 1 (test2.py:8) pending.
+    (gdb) run test2.py
+    Starting program: <path>/bin/python test2.py
+    ...
+    Breakpoint 1, __main__::foo_241[abi:c8tJTC_2fWgEeGLSgydRTQUgiqKEZ6gEoDvQJmaQIA](long long) (n=4) at test2.py:8
+    8           return x, y
+    (gdb) print x
+    $1 = {meminfo = 0x55555688f470 "\001", parent = 0x0, nitems = 4, itemsize = 8, data = 0x55555688f4a0, shape = {4}, strides = {8}}
+    (gdb) print y
+    $2 = {0, 3}
+    (gdb) source numba/misc/gdb_print_extension.py
+    (gdb) print x
+    $3 =
+    [0 1 2 3]
+    (gdb) print y
+    $4 = (0, 3)
+
 
 
 Globally override debug setting

--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -422,8 +422,12 @@ class DIBuilder(AbstractDIBuilder):
 
         for idx, (name, nbtype) in enumerate(argmap.items()):
             name = name.replace('.', '$')    # for gdb to work correctly
-            datamodel = self.cgctx.data_model_manager[nbtype]
-            lltype = self.cgctx.get_value_type(nbtype)
+            use_ty = nbtype
+            if isinstance(nbtype, types.Omitted):
+                resolver = self.cgctx.typing_context.resolve_value_type
+                use_ty = resolver(nbtype.value)
+            datamodel = self.cgctx.data_model_manager[use_ty]
+            lltype = self.cgctx.get_value_type(use_ty)
             size = self.cgctx.get_abi_sizeof(lltype)
             mdtype = self._var_type(lltype, size, datamodel=datamodel)
             md.append(mdtype)

--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -422,12 +422,8 @@ class DIBuilder(AbstractDIBuilder):
 
         for idx, (name, nbtype) in enumerate(argmap.items()):
             name = name.replace('.', '$')    # for gdb to work correctly
-            use_ty = nbtype
-            if isinstance(nbtype, types.Omitted):
-                resolver = self.cgctx.typing_context.resolve_value_type
-                use_ty = resolver(nbtype.value)
-            datamodel = self.cgctx.data_model_manager[use_ty]
-            lltype = self.cgctx.get_value_type(use_ty)
+            datamodel = self.cgctx.data_model_manager[nbtype]
+            lltype = self.cgctx.get_value_type(nbtype)
             size = self.cgctx.get_abi_sizeof(lltype)
             mdtype = self._var_type(lltype, size, datamodel=datamodel)
             md.append(mdtype)

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -97,6 +97,12 @@ class NumbaIRAssumptionWarning(NumbaPedanticWarning):
     Warning category for reporting an IR assumption violation.
     """
 
+
+class NumbaDebugInfoWarning(NumbaWarning):
+    """
+    Warning category for an issue with the emission of debug information.
+    """
+
 # These are needed in the color formatting of errors setup
 
 

--- a/numba/misc/gdb_print_extension.py
+++ b/numba/misc/gdb_print_extension.py
@@ -155,7 +155,10 @@ class NumbaUnicodeTypePrinter:
                 except UnicodeDecodeError as e:
                     buf = "ERROR: %s" % str(e)
             else:
-                buf = mem.decode('utf-8')
+                if isinstance(mem, memoryview):
+                    buf = bytes(mem).decode()
+                else:
+                    buf = mem.decode('utf-8')
         else:
             buf = str(data)
         return "'%s'" % buf

--- a/numba/misc/gdb_print_extension.py
+++ b/numba/misc/gdb_print_extension.py
@@ -65,13 +65,15 @@ class NumbaArrayPrinter:
                 field_dts = fields.split(',')
                 struct_entries = []
                 for f in field_dts:
-                    name, *dt_part = f.split('[')
+                    splitted = f.split('[')
+                    name = splitted[0]
+                    dt_part = splitted[1:]
                     if len(dt_part) > 1:
-                        raise TypeError(f'Unsupported sub-type: {f}')
+                        raise TypeError('Unsupported sub-type: %s' % f)
                     else:
                         dt_part = dt_part[0]
                         if "nestedarray" in dt_part:
-                            raise TypeError(f'Unsupported sub-type: {f}')
+                            raise TypeError('Unsupported sub-type: %s' % f)
                         dt_as_str = dt_part.split(';')[0].split('=')[1]
                         dtype = np.dtype(dt_as_str)
                     struct_entries.append((name, dtype))

--- a/numba/misc/gdb_print_extension.py
+++ b/numba/misc/gdb_print_extension.py
@@ -1,0 +1,166 @@
+"""gdb printing extension for Numba types.
+"""
+import re
+import sys
+_PYVERSION = sys.version_info[:2]
+
+try:
+    import gdb.printing
+    import gdb
+except ImportError:
+    raise ImportError("GDB python support is not available.")
+
+
+class NumbaArrayPrinter:
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            import numpy as np
+            HAVE_NUMPY = True
+        except ImportError:
+            HAVE_NUMPY = False
+
+        try:
+            NULL = 0x0
+
+            # raw data refs
+            nitems = int(self.val["nitems"])
+            data = self.val['data']
+            rshp = self.val["shape"]
+            itemsize = self.val["itemsize"]
+
+            # type information decode, simple type:
+            ty_str = str(self.val.type)
+            if HAVE_NUMPY and ('unaligned' in ty_str or 'Record' in ty_str):
+                ty_str = ty_str.lstrip('unaligned').strip()
+                matcher = re.compile(r"array\((Record.*), (.*), (.*)\)\ \(.*")
+                arr_info = [x.strip() for x in matcher.match(ty_str).groups()]
+                dtype_str, ndim_str, order_str = arr_info
+                field_dts = re.match(
+                    'Record\\((.*\\[.*\\])', dtype_str).groups()[0].split(',')
+                struct_entries = []
+                for f in field_dts:
+                    name, stuff = f.split('[')
+                    dt_as_str = stuff.split(';')[0].split('=')[1]
+                    if "unichr" in dt_as_str:
+                        raise ValueError
+                    else:
+                        dtype = np.dtype(dt_as_str)
+                    struct_entries.append((name, dtype))
+                    # The dtype is actually a record of some sort
+                dtype_str = struct_entries
+
+            else:  # simple type
+                matcher = re.compile(r"array\((.*),(.*),(.*)\)\ \(.*")
+                arr_info = [x.strip() for x in matcher.match(ty_str).groups()]
+                dtype_str, ndim_str, order_str = arr_info
+
+            # shape extraction
+            fields = rshp.type.fields()
+            lo, hi = fields[0].type.range()
+            shape = tuple([int(rshp[x]) for x in range(lo, hi + 1)])
+
+            # if data is not NULL
+            if data != NULL:
+                if HAVE_NUMPY:
+                    # TODO: Deal with order and non-contiguous data
+                    dtype_clazz = np.dtype(dtype_str)
+                    dtype = dtype_clazz  # .type
+                    this_proc = gdb.selected_inferior()
+                    mem = this_proc.read_memory(int(data), nitems * itemsize)
+                    new_arr = np.frombuffer(mem, dtype=dtype).reshape(shape)
+                    return str(new_arr)
+                # Catch all for no NumPy
+                return "array([...], dtype=%s, shape=%s)" % (dtype_str, shape)
+            else:
+                # Not yet initialized or NULLed out data
+                buf = list(["NULL/Uninitialized"])
+                return "array([" + ', '.join(buf) + "]" + ")"
+        except Exception as e:
+            return 'Failed to parse. %s' % e
+
+
+class NumbaComplexPrinter:
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return "%s+%sj" % (self.val['real'], self.val['imag'])
+
+
+class NumbaTuplePrinter:
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        buf = []
+        fields = self.val.type.fields()
+        for f in fields:
+            buf.append(str(self.val[f.name]))
+        return "(%s)" % ', '.join(buf)
+
+
+class NumbaUniTuplePrinter:
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        # unituples are arrays
+        fields = self.val.type.fields()
+        lo, hi = fields[0].type.range()
+        buf = []
+        for i in range(lo, hi + 1):
+            buf.append(str(self.val[i]))
+        return "(%s)" % ', '.join(buf)
+
+
+class NumbaUnicodeTypePrinter:
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        NULL = 0x0
+        data = self.val["data"]
+        nitems = self.val["length"]
+        kind = self.val["kind"]
+        if data != NULL:
+            # This needs sorting out, encoding is wrong
+            this_proc = gdb.selected_inferior()
+            mem = this_proc.read_memory(int(data), nitems * kind)
+            if _PYVERSION < (3, 0):
+                try:
+                    buf = unicode(mem, 'utf-8') # noqa F821
+                except UnicodeDecodeError as e:
+                    buf = "ERROR: %s" % str(e)
+            else:
+                buf = mem.decode('utf-8')
+        else:
+            buf = str(data)
+        return "'%s'" % buf
+
+
+def _create_printers():
+    printer = gdb.printing.RegexpCollectionPrettyPrinter("Numba")
+    printer.add_printer('Numba unaligned array printer', '^unaligned array\\(',
+                        NumbaArrayPrinter)
+    printer.add_printer('Numba array printer', '^array\\(', NumbaArrayPrinter)
+    printer.add_printer('Numba complex printer', '^complex[0-9]+\\ ',
+                        NumbaComplexPrinter)
+    printer.add_printer('Numba Tuple printer', '^Tuple\\(',
+                        NumbaTuplePrinter)
+    printer.add_printer('Numba UniTuple printer', '^UniTuple\\(',
+                        NumbaUniTuplePrinter)
+    printer.add_printer('Numba unicode_type printer', '^unicode_type\\s+\\(',
+                        NumbaUnicodeTypePrinter)
+    return printer
+
+
+# register the Numba pretty printers for the current object
+gdb.printing.register_pretty_printer(gdb.current_objfile(), _create_printers())

--- a/numba/misc/numba_entry.py
+++ b/numba/misc/numba_entry.py
@@ -5,6 +5,7 @@ import subprocess
 import json
 
 from .numba_sysinfo import display_sysinfo, get_sysinfo
+from .numba_gdbinfo import display_gdbinfo
 
 
 def make_parser():
@@ -25,6 +26,8 @@ def make_parser():
                         help='Output source annotation as html')
     parser.add_argument('-s', '--sysinfo', action="store_true",
                         help='Output system information for bug reporting')
+    parser.add_argument('-g', '--gdbinfo', action="store_true",
+                        help='Output system information about gdb')
     parser.add_argument('--sys-json', nargs=1,
                         help='Saves the system info dict as a json file')
     parser.add_argument('filename', nargs='?', help='Python source filename')
@@ -45,6 +48,12 @@ def main():
     if args.sysinfo:
         print("System info:")
         display_sysinfo()
+
+    if args.gdbinfo:
+        print("GDB info:")
+        display_gdbinfo()
+
+    if args.sysinfo or args.gdbinfo:
         sys.exit(0)
 
     if args.sys_json:

--- a/numba/misc/numba_gdbinfo.py
+++ b/numba/misc/numba_gdbinfo.py
@@ -1,84 +1,143 @@
 """Module for displaying information about Numba's gdb set up"""
+from collections import namedtuple
+import os
+import re
+import shutil
+import subprocess
+from textwrap import dedent
+from numba import config
+
+# Container for the output of the gdb info data collection
+_fields = ('binary_loc, extension_loc, py_ver, np_ver, supported')
+_gdb_info = namedtuple('_gdb_info', _fields)
 
 
-def _run_cmd(cmdline, env):
-    """Runs cmdline (list of string args) in a subprocess with environment dict
-    env.
-    """
-    import subprocess
-    import threading
-    popen = subprocess.Popen(cmdline,
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
-                             env=env)
-    # finish in 10 seconds or kill it
-    timeout = threading.Timer(10, popen.kill)
-    try:
-        timeout.start()
-        out, err = popen.communicate()
-        if popen.returncode != 0:
-            raise AssertionError(
-                "process failed with code %s: stderr follows\n%s\n" %
-                (popen.returncode, err.decode()))
-        return out.decode(), err.decode()
-    finally:
-        timeout.cancel()
-    return None, None
+class _GDBTestWrapper():
+    """Wraps the gdb binary and has methods for checking what the gdb binary
+    has support for (Python and NumPy)."""
+
+    def __init__(self,):
+        gdb_binary = shutil.which(config.GDB_BINARY)
+        if gdb_binary is None:
+            msg = ("No valid binary could be found for gdb named: "
+                   f"{config.GDB_BINARY}")
+            raise ValueError(msg)
+        self._gdb_binary = gdb_binary
+
+    def _run_cmd(self, cmd=()):
+        gdb_call = [self.gdb_binary, '-q',]
+        for x in cmd:
+            gdb_call.append('-ex')
+            gdb_call.append(x)
+        gdb_call.extend(['-ex', 'q'])
+        return subprocess.run(gdb_call, capture_output=True, timeout=10,
+                              text=True)
+
+    @property
+    def gdb_binary(self):
+        return self._gdb_binary
+
+    @classmethod
+    def success(cls, status):
+        return status.returncode == 0
+
+    def check_launch(self):
+        """Checks that gdb will launch ok"""
+        return self._run_cmd()
+
+    def check_python(self):
+        cmd = ("python from __future__ import print_function; "
+               "import sys; print(sys.version_info[:2])")
+        return self._run_cmd((cmd,))
+
+    def check_numpy(self):
+        cmd = ("python from __future__ import print_function; "
+               "import types; import numpy; "
+               "print(isinstance(numpy, types.ModuleType))")
+        return self._run_cmd((cmd,))
+
+    def check_numpy_version(self):
+        cmd = ("python from __future__ import print_function; "
+               "import types; import numpy;"
+               "print(numpy.__version__)")
+        return self._run_cmd((cmd,))
 
 
-def display_gdbinfo(sep_pos=45):
+def collect_gdbinfo():
     """Prints information to stdout about the gdb setup that Numba has found"""
-    import os
-    import re
-    from textwrap import dedent
-    from numba import config
 
-    print('-' * 80)
-    fmt = f'%-{sep_pos}s : %-s'
+    # Check gdb exists
+    gdb_wrapper = _GDBTestWrapper()
 
+    # State flags:
+    gdb_has_python = False
+    gdb_has_numpy = False
+    gdb_python_version = 'No Python support'
+    gdb_python_numpy_version = "No NumPy support"
+
+    # Check gdb works
+    status = gdb_wrapper.check_launch()
+    if not gdb_wrapper.success(status):
+        msg = (f"gdb at '{gdb_wrapper.gdb_binary}' does not appear to work."
+               f"\nstdout: {status.stdout}\nstderr: {status.stderr}")
+        raise ValueError(msg)
+
+    # Got this far, so gdb works, start checking what it supports
+    status = gdb_wrapper.check_python()
+    if gdb_wrapper.success(status):
+        version_match = re.match(r'\((\d+),\s+(\d+)\)', status.stdout.strip())
+        if version_match is not None:
+            pymajor, pyminor = version_match.groups()
+            gdb_python_version = f"{pymajor}.{pyminor}"
+            gdb_has_python = True
+
+            status = gdb_wrapper.check_numpy()
+            if gdb_wrapper.success(status):
+                if "Traceback" not in status.stderr.strip():
+                    if status.stdout.strip() == 'True':
+                        gdb_has_numpy = True
+                        gdb_python_numpy_version = "Unknown"
+                        # NumPy is present find the version
+                        status = gdb_wrapper.check_numpy_version()
+                        if gdb_wrapper.success(status):
+                            if "Traceback" not in status.stderr.strip():
+                                gdb_python_numpy_version = status.stdout.strip()
+
+    # Work out what level of print-extension support is present in this gdb
+    if gdb_has_python:
+        if gdb_has_numpy:
+            print_ext_supported = "Full (Python and NumPy supported)"
+        else:
+            print_ext_supported = "Partial (Python only, no NumPy support)"
+    else:
+        print_ext_supported = "None"
+
+    # Work out print ext location
     print_ext_file = "gdb_print_extension.py"
     print_ext_path = os.path.join(os.path.dirname(__file__), print_ext_file)
 
-    gdb_call = [config.GDB_BINARY, "-q", "-ex",]
+    # return!
+    return _gdb_info(gdb_wrapper.gdb_binary, print_ext_path, gdb_python_version,
+                     gdb_python_numpy_version, print_ext_supported)
 
-    cmd = gdb_call + [("python from __future__ import print_function; "
-                       "import sys; print(sys.version_info[:2])"), "-ex", "q"]
-    stderr, stdout = _run_cmd(cmd, os.environ)
-    version_match = re.match(r'\((\d+),\s+(\d+)\)', stderr.strip())
-    if version_match is None:
-        gdb_python_version = 'No Python support'
-        gdb_python_numpy_version = None
-    else:
-        pymajor, pyminor = version_match.groups()
-        gdb_python_version = f"{pymajor}.{pyminor}"
 
-        cmd = gdb_call + [("python from __future__ import print_function; "
-                           "import types; import numpy; "
-                           "print(isinstance(numpy, types.ModuleType))"),
-                          "-ex", "q"]
-
-        stderr, stdout = _run_cmd(cmd, os.environ)
-        if stderr.strip() == 'True':
-            # NumPy is present find the version
-            cmd = gdb_call + [("python from __future__ import print_function; "
-                               "import types; import numpy;"
-                               "print(numpy.__version__)"),
-                              "-ex", "q"]
-            stderr, stdout = _run_cmd(cmd, os.environ)
-            gdb_python_numpy_version = stderr.strip()
-
+def display_gdbinfo(sep_pos=45):
+    """Displays the infomation collected by collect_gdbinfo.
+    """
+    gdb_info = collect_gdbinfo()
+    print('-' * 80)
+    fmt = f'%-{sep_pos}s : %-s'
     # Display the information
-    print(fmt % ("Binary location", config.GDB_BINARY))
-    print(fmt % ("Print extension location", print_ext_path))
-    print(fmt % ("Python version", gdb_python_version))
-    print(fmt % ("NumPy version", gdb_python_numpy_version))
-    print_ext_supported = gdb_python_numpy_version is not None
-    print(fmt % ("Numba printing extension supported", print_ext_supported))
+    print(fmt % ("Binary location", gdb_info.binary_loc))
+    print(fmt % ("Print extension location", gdb_info.extension_loc))
+    print(fmt % ("Python version", gdb_info.py_ver))
+    print(fmt % ("NumPy version", gdb_info.np_ver))
+    print(fmt % ("Numba printing extension support", gdb_info.supported))
 
     print("")
     print("To load the Numba gdb printing extension, execute the following "
           "from the gdb prompt:")
-    print(f"\nsource {print_ext_path}\n")
+    print(f"\nsource {gdb_info.extension_loc}\n")
     print('-' * 80)
     warn = """
     =============================================================

--- a/numba/misc/numba_gdbinfo.py
+++ b/numba/misc/numba_gdbinfo.py
@@ -1,0 +1,93 @@
+"""Module for displaying information about Numba's gdb set up"""
+
+
+def _run_cmd(cmdline, env):
+    """Runs cmdline (list of string args) in a subprocess with environment dict
+    env.
+    """
+    import subprocess
+    import threading
+    popen = subprocess.Popen(cmdline,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             env=env)
+    # finish in 10 seconds or kill it
+    timeout = threading.Timer(10, popen.kill)
+    try:
+        timeout.start()
+        out, err = popen.communicate()
+        if popen.returncode != 0:
+            raise AssertionError(
+                "process failed with code %s: stderr follows\n%s\n" %
+                (popen.returncode, err.decode()))
+        return out.decode(), err.decode()
+    finally:
+        timeout.cancel()
+    return None, None
+
+
+def display_gdbinfo(sep_pos=45):
+    """Prints information to stdout about the gdb setup that Numba has found"""
+    import os
+    import re
+    from textwrap import dedent
+    from numba import config
+
+    print('-' * 80)
+    fmt = f'%-{sep_pos}s : %-s'
+
+    print_ext_file = "gdb_print_extension.py"
+    print_ext_path = os.path.join(os.path.dirname(__file__), print_ext_file)
+
+    gdb_call = [config.GDB_BINARY, "-q", "-ex",]
+
+    cmd = gdb_call + [("python from __future__ import print_function; "
+                       "import sys; print(sys.version_info[:2])"), "-ex", "q"]
+    stderr, stdout = _run_cmd(cmd, os.environ)
+    version_match = re.match(r'\((\d+),\s+(\d+)\)', stderr.strip())
+    if version_match is None:
+        gdb_python_version = 'No Python support'
+        gdb_python_numpy_version = None
+    else:
+        pymajor, pyminor = version_match.groups()
+        gdb_python_version = f"{pymajor}.{pyminor}"
+
+        cmd = gdb_call + [("python from __future__ import print_function; "
+                           "import types; import numpy; "
+                           "print(isinstance(numpy, types.ModuleType))"),
+                          "-ex", "q"]
+
+        stderr, stdout = _run_cmd(cmd, os.environ)
+        if stderr.strip() == 'True':
+            # NumPy is present find the version
+            cmd = gdb_call + [("python from __future__ import print_function; "
+                               "import types; import numpy;"
+                               "print(numpy.__version__)"),
+                              "-ex", "q"]
+            stderr, stdout = _run_cmd(cmd, os.environ)
+            gdb_python_numpy_version = stderr.strip()
+
+    # Display the information
+    print(fmt % ("Binary location", config.GDB_BINARY))
+    print(fmt % ("Print extension location", print_ext_path))
+    print(fmt % ("Python version", gdb_python_version))
+    print(fmt % ("NumPy version", gdb_python_numpy_version))
+    print_ext_supported = gdb_python_numpy_version is not None
+    print(fmt % ("Numba printing extension supported", print_ext_supported))
+
+    print("")
+    print("To load the Numba gdb printing extension, execute the following "
+          "from the gdb prompt:")
+    print(f"\nsource {print_ext_path}\n")
+    print('-' * 80)
+    warn = """
+    =============================================================
+    IMPORTANT: Before sharing you should remove any information
+    in the above that you wish to keep private e.g. paths.
+    =============================================================
+    """
+    print(dedent(warn))
+
+
+if __name__ == '__main__':
+    display_gdbinfo()

--- a/numba/tests/gdb/test_array_arg.py
+++ b/numba/tests/gdb/test_array_arg.py
@@ -40,9 +40,9 @@ class Test(TestCase):
         driver.check_hit_breakpoint(2)
         driver.stack_list_variables(1)
         # 'z' should be populated
-        expect = (r'\{name="z",value="\{meminfo = 0x[0-9a-f]+.*, '
-                  r'parent = 0x[0-9a-f]+.*, nitems = 5, itemsize = 8, '
-                  r'data = 0x[0-9a-f]+.*, shape = \{5\}, strides = \{8\}\}"\}')
+        expect = (r'^.*\{name="z",value="\{meminfo = 0x[0-9a-f]+ .*, '
+                  r'parent = 0x0, nitems = 5, itemsize = 8, '
+                  r'data = 0x[0-9a-f]+, shape = \{5\}, strides = \{8\}\}.*$')
         driver.assert_regex_output(expect)
         driver.quit()
 

--- a/numba/tests/gdb/test_pretty_print.py
+++ b/numba/tests/gdb/test_pretty_print.py
@@ -30,7 +30,7 @@ class Test(TestCase):
         foo()
 
         extension = os.path.join('numba', 'misc', 'gdb_print_extension.py')
-        driver = GdbMIDriver(__file__, init_cmds=['-x', extension], debug=True)
+        driver = GdbMIDriver(__file__, init_cmds=['-x', extension], debug=False)
         driver.set_breakpoint(line=28)
         driver.run()
         driver.check_hit_breakpoint(1)

--- a/numba/tests/gdb/test_pretty_print.py
+++ b/numba/tests/gdb/test_pretty_print.py
@@ -1,0 +1,52 @@
+# NOTE: This test is sensitive to line numbers as it checks breakpoints
+from numba import njit
+import numpy as np
+from numba.tests.gdb_support import GdbMIDriver
+from numba.tests.support import TestCase, needs_subprocess
+import os
+import unittest
+
+
+@needs_subprocess
+class Test(TestCase):
+
+    def test(self):
+        @njit(debug=True)
+        def foo():
+            a = 1.234
+            b = (1, 2, 3)
+            c = ('a', b, 4)
+            d = np.arange(5.)
+            e = np.array([[1, 3j], [2, 4j]])
+            f = "Some string" + "           L-Padded string".lstrip()
+            g = 11 + 22j
+            return a, b, c, d, e, f, g
+
+        foo()
+
+        extension = os.path.join('numba', 'misc', 'gdb_print_extension.py')
+        driver = GdbMIDriver(__file__, init_cmds=['-x', extension])
+        driver.set_breakpoint(line=23)
+        driver.run()
+        driver.check_hit_breakpoint(1)
+
+        # Ideally the function would be run to get the string repr of locals
+        # but not everything appears in DWARF e.g. string literals. Further, str
+        # on NumPy arrays seems to vary a bit in output. Therefore a regex based
+        # match is used.
+        expect = (r'[\{name="a",value="1.234"\},'
+                  r'\{name="b",value="\(1, 2, 3\)"\},'
+                  r'\{name="c",value="\(0x0, \(1, 2, 3\), 4)"\},'
+                  r'\{name="d",value="\[\s+0. 1. 2. 3. 4.\]"\},'
+                  # NOTE: output for variable e is split over these 2 lines
+                  r'\{name="e,value="\[\[\s+1.+0.j\s+0.+3.j\]\\\n'
+                  r'\s+\[\s+2.+0.j\s+0.+4.j\]\]"\},'
+                  r'{name="f",value="\'Some stringL-Padded string\'"},'
+                  r'{name="g",value="11+22j"}]')
+        driver.stack_list_variables(1)
+        driver.assert_regex_output(expect)
+        driver.quit()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/gdb/test_pretty_print.py
+++ b/numba/tests/gdb/test_pretty_print.py
@@ -5,13 +5,14 @@ from numba.tests.gdb_support import GdbMIDriver
 from numba.tests.support import TestCase, needs_subprocess
 import os
 import unittest
+import re
 
 
 @needs_subprocess
 class Test(TestCase):
 
     def test(self):
-        rdt = np.dtype([("x", np.int16, (2,)), ("y", np.float64)], align=True)
+        rdt_a = np.dtype([("x", np.int16), ("y", np.float64)], align=True)
 
         @njit(debug=True)
         def foo():
@@ -23,24 +24,43 @@ class Test(TestCase):
             f = "Some string" + "           L-Padded string".lstrip()
             g = 11 + 22j
             h = np.arange(24).reshape((4, 6))[::2, ::3]
-            i = np.zeros(6, dtype=rdt)
+            i = np.zeros(2, dtype=rdt_a)
             return a, b, c, d, e, f, g, h, i
 
         foo()
 
         extension = os.path.join('numba', 'misc', 'gdb_print_extension.py')
         driver = GdbMIDriver(__file__, init_cmds=['-x', extension], debug=True)
-        driver.set_breakpoint(line=27)
+        driver.set_breakpoint(line=28)
         driver.run()
         driver.check_hit_breakpoint(1)
 
         # Ideally the function would be run to get the string repr of locals
-        # but not everything appears in DWARF e.g. string literals. Further, str
-        # on NumPy arrays seems to vary a bit in output. Therefore a regex based
+        # but not everything appears in DWARF e.g. string literals. Further,
+        # str on NumPy arrays seems to vary a bit in output. Therefore a custom
         # match is used.
-        #expect = ('TODO')
+
         driver.stack_list_variables(1)
-        #driver.assert_regex_output(expect)
+        output = driver._captured.after.decode('UTF-8')
+        done_str = output.splitlines()[0]
+        pat = r'^\^done,variables=\[\{(.*)\}\]$'
+        lcls_strs = re.match(pat, done_str).groups()[0].split('},{')
+        lcls = {k: v for k, v in [re.match(r'name="(.*)",value="(.*)"',
+                x).groups() for x in lcls_strs]}
+        expected = dict()
+        expected['a'] = r'1\.234'
+        expected['b'] = r'\(1, 2, 3\)'
+        expected['c'] = r'\(0x0, \(1, 2, 3\), 4\)'
+        expected['d'] = r'\\n\[0. 1. 2. 3. 4.\]'
+        expected['e'] = r'\\n\[\[1.\+0.j 0.\+3.j\]\\n \[2.\+0.j 0.\+4.j\]\]'
+        expected['f'] = "'Some stringL-Padded string'"
+        expected['g'] = r"11\+22j"
+        expected['h'] = r'\\n\[\[ 0  3\]\\n \[12 15\]\]'
+        expected['i'] = r'\\n\[\(0, 0.\) \(0, 0.\)\]'
+
+        for k, v in expected.items():
+            self.assertRegex(lcls[k], v)
+
         driver.quit()
 
 

--- a/numba/tests/gdb_support.py
+++ b/numba/tests/gdb_support.py
@@ -183,29 +183,3 @@ class GdbMIDriver(object):
         g = m.groups()
         assert len(g) == 1, "Invalid number of match groups found"
         return g[0].replace('"', '').split(',')
-
-
-def _gdb_has_python():
-    if _HAVE_PEXPECT and _HAVE_GDB:
-        driver = GdbMIDriver(__file__, debug=False,)
-        has_python = driver.supports_python()
-        driver.quit()
-        return has_python
-    else:
-        return False
-
-
-def _gdb_has_numpy():
-    if _HAVE_PEXPECT and _HAVE_GDB:
-        driver = GdbMIDriver(__file__, debug=False,)
-        has_numpy = driver.supports_numpy()
-        driver.quit()
-        return has_numpy
-    else:
-        return False
-
-
-_msg = "functioning gdb present, but it does not python"
-skip_unless_gdb_has_python = unittest.skipUnless(_gdb_has_python(), _msg)
-_msg = "functioning gdb present and has Python, but it does not have NumPy"
-skip_unless_gdb_has_numpy = unittest.skipUnless(_gdb_has_numpy(), _msg)

--- a/numba/tests/gdb_support.py
+++ b/numba/tests/gdb_support.py
@@ -94,7 +94,8 @@ class GdbMIDriver(object):
         regex."""
         output = self._captured.after
         decoded = output.decode('utf-8')
-        found = re.search(expected, decoded)
+        done_str = decoded.splitlines()[0]
+        found = re.match(expected, done_str)
         assert found, f'decoded={decoded}\nexpected={expected})'
 
     def _run_command(self, command, expect=''):

--- a/numba/tests/gdb_support.py
+++ b/numba/tests/gdb_support.py
@@ -70,7 +70,10 @@ class GdbMIDriver(object):
            (and by extension Python support) False otherwise"""
         if not self.supports_python():
             return False
-        self.interpreter_exec('console', 'python import numpy; print numpy')
+        # Some gdb's have python 2!
+        cmd = ('python from __future__ import print_function;'
+               'import numpy; print(numpy)')
+        self.interpreter_exec('console', cmd)
         return "module \'numpy\' from" in self._captured.before.decode()
 
     def _captured_expect(self, expect):
@@ -165,7 +168,7 @@ class GdbMIDriver(object):
         if command is None:
             raise ValueError("command cannot be None")
         cmd = f'-interpreter-exec {interpreter} "{command}"'
-        self._run_command(cmd, expect=r'\^done.*\r\n') #NOTE no `,` after done
+        self._run_command(cmd, expect=r'\^(done|error).*\r\n') #NOTE no `,`
 
     def _list_features_raw(self):
         cmd = '-list-features'

--- a/numba/tests/gdb_support.py
+++ b/numba/tests/gdb_support.py
@@ -205,5 +205,7 @@ def _gdb_has_numpy():
         return False
 
 
+_msg = "functioning gdb present, but it does not python"
 skip_unless_gdb_has_python = unittest.skipUnless(_gdb_has_python(), _msg)
+_msg = "functioning gdb present and has Python, but it does not have NumPy"
 skip_unless_gdb_has_numpy = unittest.skipUnless(_gdb_has_numpy(), _msg)

--- a/numba/tests/gdb_support.py
+++ b/numba/tests/gdb_support.py
@@ -186,17 +186,23 @@ class GdbMIDriver(object):
 
 
 def _gdb_has_python():
-    driver = GdbMIDriver(__file__, debug=False,)
-    has_python = driver.supports_python()
-    driver.quit()
-    return has_python
+    if _HAVE_PEXPECT and _HAVE_GDB:
+        driver = GdbMIDriver(__file__, debug=False,)
+        has_python = driver.supports_python()
+        driver.quit()
+        return has_python
+    else:
+        return False
 
 
 def _gdb_has_numpy():
-    driver = GdbMIDriver(__file__, debug=False,)
-    has_numpy = driver.supports_numpy()
-    driver.quit()
-    return has_numpy
+    if _HAVE_PEXPECT and _HAVE_GDB:
+        driver = GdbMIDriver(__file__, debug=False,)
+        has_numpy = driver.supports_numpy()
+        driver.quit()
+        return has_numpy
+    else:
+        return False
 
 
 skip_unless_gdb_has_python = unittest.skipUnless(_gdb_has_python(), _msg)

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -125,7 +125,8 @@ class TestGDBCLIInfo(TestCase):
         self._patches = []
 
         mock_init = lambda self: None
-        mock.patch.object(_GDBTestWrapper, '__init__', mock_init)
+        self._patches.append(mock.patch.object(_GDBTestWrapper, '__init__',
+                                               mock_init))
 
         bpath = 'numba.misc.numba_gdbinfo._GDBTestWrapper.gdb_binary'
         self._patches.append(mock.patch(bpath, 'PATH_TO_GDB'))

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -5,11 +5,17 @@ import subprocess
 import sys
 import threading
 import json
+from subprocess import CompletedProcess
 from tempfile import TemporaryDirectory
+from unittest import mock
 
 import unittest
 from numba.tests.support import TestCase
 import numba.misc.numba_sysinfo as nsi
+from numba.tests.gdb_support import needs_gdb
+from numba.misc.numba_gdbinfo import collect_gdbinfo
+# Going to mock parts of this in testing
+from numba.misc.numba_gdbinfo import _GDBTestWrapper
 
 
 def run_cmd(cmdline, env=os.environ, timeout=60):
@@ -32,7 +38,7 @@ def run_cmd(cmdline, env=os.environ, timeout=60):
     return None, None
 
 
-class TestCLi(TestCase):
+class TestCLI(TestCase):
 
     def test_as_module_exit_code(self):
         cmdline = [sys.executable, "-m", "numba"]
@@ -41,12 +47,12 @@ class TestCLi(TestCase):
 
         self.assertIn("process failed with code 1", str(raises.exception))
 
-    def test_as_module(self):
+    def test_sysinfo_from_module(self):
         cmdline = [sys.executable, "-m", "numba", "-s"]
         o, _ = run_cmd(cmdline)
         self.assertIn("System info", o)
 
-    def test_json_sysinfo(self):
+    def test_json_sysinfo_from_module(self):
         with TemporaryDirectory() as d:
             path = os.path.join(d, "test_json_sysinfo.json")
             cmdline = [sys.executable, "-m", "numba", "--sys-json", path]
@@ -98,6 +104,134 @@ class TestCLi(TestCase):
                 for k in keys:
                     with self.subTest(k=k):
                         self.assertIsInstance(info[k], t)
+
+    @needs_gdb
+    def test_gdb_status_from_module(self):
+        # Check that the `python -m numba -g` works ok
+        cmdline = [sys.executable, "-m", "numba", "-g"]
+        o, _ = run_cmd(cmdline)
+        self.assertIn("GDB info", o)
+        # It's not known a priori whether the extension is supported, this just
+        # checks that the last logical item in the output is printed.
+        self.assertIn("Numba printing extension supported", o)
+
+
+class TestGDBCLIInfo(TestCase):
+
+    def setUp(self):
+        # Mock the entire class, to report valid things,
+        # then override bits of it locally to check failures etc.
+
+        self._patches = []
+
+        mock_init = lambda self: None
+        mock.patch.object(_GDBTestWrapper, '__init__', mock_init)
+
+        bpath = 'numba.misc.numba_gdbinfo._GDBTestWrapper.gdb_binary'
+        self._patches.append(mock.patch(bpath, 'PATH_TO_GDB'))
+
+        def _patch(fnstr, func):
+            self._patches.append(mock.patch.object(_GDBTestWrapper, fnstr,
+                                                   func))
+
+        def mock_check_launch(self):
+            return CompletedProcess('COMMAND STRING', 0)
+
+        _patch('check_launch', mock_check_launch)
+
+        # NOTE: The Python and NumPy versions are set to something unsupported!
+        def mock_check_python(self):
+            return CompletedProcess('COMMAND STRING', 0,
+                                    stdout='(3, 2)',
+                                    stderr='')
+
+        _patch('check_python', mock_check_python)
+
+        def mock_check_numpy(self):
+            return CompletedProcess('COMMAND STRING', 0, stdout='True',
+                                    stderr='')
+
+        _patch('check_numpy', mock_check_numpy)
+
+        def mock_check_numpy_version(self):
+            return CompletedProcess('COMMAND STRING', 0, stdout='1.15',
+                                    stderr='')
+
+        _patch('check_numpy_version', mock_check_numpy_version)
+
+        # start the patching
+        for p in self._patches:
+            p.start()
+
+    def tearDown(self):
+        # stop the patching
+        for p in self._patches:
+            p.stop()
+
+    def test_valid(self):
+        collected = collect_gdbinfo()
+        self.assertEqual(collected.binary_loc, 'PATH_TO_GDB')
+        extp = os.path.exists(os.path.abspath(collected.extension_loc))
+        self.assertTrue(extp)
+        self.assertEqual(collected.py_ver, '3.2')
+        self.assertEqual(collected.np_ver, '1.15')
+        self.assertIn('Full', collected.supported)
+
+    def test_invalid_binary(self):
+
+        def mock_fn(self):
+            return CompletedProcess('INVALID_BINARY', 1)
+
+        with mock.patch.object(_GDBTestWrapper, 'check_launch', mock_fn):
+            with self.assertRaises(ValueError) as raises:
+                collect_gdbinfo()
+            self.assertRegex(str(raises.exception),
+                             'gdb at.*does not appear to work.')
+
+    def test_no_python(self):
+        def mock_fn(self):
+            return CompletedProcess('NO PYTHON', 1)
+
+        with mock.patch.object(_GDBTestWrapper, 'check_python', mock_fn):
+            collected = collect_gdbinfo()
+            self.assertEqual(collected.py_ver, 'No Python support')
+            self.assertEqual(collected.supported, 'None')
+
+    def test_unparsable_python_version(self):
+        def mock_fn(self):
+            return CompletedProcess('NO PYTHON', 0, stdout='(NOT A VERSION)')
+
+        with mock.patch.object(_GDBTestWrapper, 'check_python', mock_fn):
+            collected = collect_gdbinfo()
+            self.assertEqual(collected.py_ver, 'No Python support')
+
+    def test_no_numpy(self):
+        def mock_fn(self):
+            return CompletedProcess('NO NUMPY', 1)
+
+        with mock.patch.object(_GDBTestWrapper, 'check_numpy', mock_fn):
+            collected = collect_gdbinfo()
+            self.assertEqual(collected.np_ver, 'No NumPy support')
+            self.assertEqual(collected.py_ver, '3.2')
+            self.assertIn('Partial', collected.supported)
+
+    def test_no_numpy_version(self):
+        def mock_fn(self):
+            return CompletedProcess('NO NUMPY VERSION', 1)
+
+        with mock.patch.object(_GDBTestWrapper, 'check_numpy_version', mock_fn):
+            collected = collect_gdbinfo()
+            self.assertEqual(collected.np_ver, 'Unknown')
+
+    def test_traceback_in_numpy_version(self):
+        def mock_fn(self):
+            return CompletedProcess('NO NUMPY VERSION', 0,
+                                    stdout='(NOT A VERSION)',
+                                    stderr='Traceback')
+
+        with mock.patch.object(_GDBTestWrapper, 'check_numpy_version', mock_fn):
+            collected = collect_gdbinfo()
+            self.assertEqual(collected.np_ver, 'Unknown')
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -113,7 +113,7 @@ class TestCLI(TestCase):
         self.assertIn("GDB info", o)
         # It's not known a priori whether the extension is supported, this just
         # checks that the last logical item in the output is printed.
-        self.assertIn("Numba printing extension supported", o)
+        self.assertIn("Numba printing extension support", o)
 
 
 class TestGDBCLIInfo(TestCase):

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -144,6 +144,19 @@ class TestDebugInfoEmission(TestCase):
                                     test_name=test_name,
                                     envvars=self._NUMBA_OPT_0_ENV)
 
+    def _get_metadata_map(self, metadata):
+        """Gets the map of DI label to md, e.g.
+        '!33' -> '!{!"branch_weights", i32 1, i32 99}'
+        """
+        metadata_definition_map = dict()
+        meta_definition_split = re.compile(r'(![0-9]+) = (.*)')
+        for line in metadata:
+            matched = meta_definition_split.match(line)
+            if matched:
+                dbg_val, info = matched.groups()
+                metadata_definition_map[dbg_val] = info
+        return metadata_definition_map
+
     def test_DW_LANG(self):
 
         @njit(debug=True)
@@ -236,13 +249,7 @@ class TestDebugInfoEmission(TestCase):
         pysrc, pysrc_line_start = inspect.getsourcelines(foo)
 
         # build a map of dbg reference to DI* information
-        metadata_definition_map = dict()
-        meta_definition_split = re.compile(r'(![0-9]+) = (.*)')
-        for line in metadata:
-            matched = meta_definition_split.match(line)
-            if matched:
-                dbg_val, info = matched.groups()
-                metadata_definition_map[dbg_val] = info
+        metadata_definition_map = self._get_metadata_map(metadata)
 
         # Pull out metadata entries referred to by the llvm line end !dbg
         # check they match the python source, the +2 is for the @njit decorator
@@ -482,13 +489,7 @@ class TestDebugInfoEmission(TestCase):
                 return a
 
             metadata = self._get_metadata(foo, sig=())
-            metadata_definition_map = dict()
-            meta_definition_split = re.compile(r'(![0-9]+) = (.*)')
-            for line in metadata:
-                matched = meta_definition_split.match(line)
-                if matched:
-                    dbg_val, info = matched.groups()
-                    metadata_definition_map[dbg_val] = info
+            metadata_definition_map = self._get_metadata_map(metadata)
 
             for k, v in metadata_definition_map.items():
                 if 'DILocalVariable(name: "a"' in v:
@@ -523,13 +524,7 @@ class TestDebugInfoEmission(TestCase):
             return a
 
         metadata = self._get_metadata(foo, sig=())
-        metadata_definition_map = dict()
-        meta_definition_split = re.compile(r'(![0-9]+) = (.*)')
-        for line in metadata:
-            matched = meta_definition_split.match(line)
-            if matched:
-                dbg_val, info = matched.groups()
-                metadata_definition_map[dbg_val] = info
+        metadata_definition_map = self._get_metadata_map(metadata)
 
         for k, v in metadata_definition_map.items():
             if 'DILocalVariable(name: "a"' in v:
@@ -594,6 +589,52 @@ class TestDebugInfoEmission(TestCase):
             base_type_marker = base_type_matches[0]
             data_type = metadata_definition_map[base_type_marker]
             self.assertRegex(data_type, expected[field])
+
+    def test_omitted_arg(self):
+        # See issue 7726
+        @njit(debug=True)
+        def foo(missing=None):
+            pass
+
+        # check that it will actually compile (verifies DI emission is ok)
+        with override_config('DEBUGINFO_DEFAULT', 1):
+            foo()
+
+        metadata = self._get_metadata(foo, sig=(types.Omitted(None),))
+        metadata_definition_map = self._get_metadata_map(metadata)
+
+        # Find DISubroutineType
+        tmp_disubr = []
+        for md in metadata:
+            if "DISubroutineType" in md:
+                tmp_disubr.append(md)
+        self.assertEqual(len(tmp_disubr), 1)
+        disubr = tmp_disubr.pop()
+
+        disubr_matched = re.match(r'.*!DISubroutineType\(types: ([!0-9]+)\)$',
+                                  disubr)
+        self.assertIsNotNone(disubr_matched)
+        disubr_groups = disubr_matched.groups()
+        self.assertEqual(len(disubr_groups), 1)
+        disubr_meta = disubr_groups[0]
+
+        # Find the types in the DISubroutineType arg list
+        disubr_types = metadata_definition_map[disubr_meta]
+        disubr_types_matched = re.match(r'!{(.*)}', disubr_types)
+        self.assertIsNotNone(disubr_matched)
+        disubr_types_groups = disubr_types_matched.groups()
+        self.assertEqual(len(disubr_types_groups), 1)
+
+        # fetch out and assert the last argument type, should be void *
+        md_fn_arg = [x.strip() for x in disubr_types_groups[0].split(',')][-1]
+        arg_ty = metadata_definition_map[md_fn_arg]
+        ptr_size = types.intp.bitwidth
+        self.assertRegex(arg_ty, r'!DIDerivedType\(tag: DW_TAG_pointer_type, '
+                                 rf'baseType: ![0-9]+, size: {ptr_size}\)')
+        md_base_ty = re.match(r'.*baseType: (![0-9]+),.*', arg_ty).groups()[0]
+        base_ty = metadata_definition_map[md_base_ty]
+        self.assertEqual(base_ty, ('!DIBasicType(name: "i8", size: 8, '
+                                   'encoding: DW_ATE_unsigned)'))
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -17,13 +17,6 @@ class TestGDBDwarf(TestCase):
     # reuse of the existing subprocess_test_runner harness.
     _NUMBA_OPT_0_ENV = {'NUMBA_OPT': '0'}
 
-    def _gdb_has_python():
-        """Returns True if gdb has Python support, False otherwise"""
-        driver = GdbMIDriver(__file__, debug=False,)
-        has_python = driver.supports_python()
-        driver.quit()
-        return has_python
-
     def _gdb_has_numpy(self):
         """Returns True if gdb has NumPy support, False otherwise"""
         driver = GdbMIDriver(__file__, debug=False,)

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -61,8 +61,7 @@ class TestGDBPrettyPrinterLogic(TestCase):
     # representation of Numba array and dtypes as it parses these
     # representations and recreates NumPy array/dtypes based on them!
 
-    @classmethod
-    def setUpClass(self):
+    def setUp(self):
         # Patch sys.modules with mock gdb modules such that the
         # numba.misc.gdb_print_extension can import ok, the rest of the gdb
         # classes etc are implemented later
@@ -88,8 +87,7 @@ class TestGDBPrettyPrinterLogic(TestCase):
         si = SelectedInferior()
         gdb.configure_mock(**{'selected_inferior': lambda :si})
 
-    @classmethod
-    def tearDownClass(self):
+    def tearDown(self):
         # drop the sys.modules patch
         self.patched_sys.stop()
 

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -1,6 +1,8 @@
 """Tests for gdb interacting with the DWARF numba generates"""
 from numba.tests.support import TestCase, linux_only
-from numba.tests.gdb_support import needs_gdb, skip_unless_pexpect
+from numba.tests.gdb_support import (needs_gdb, skip_unless_pexpect,
+                                     skip_unless_gdb_has_numpy)
+
 import unittest
 
 
@@ -34,6 +36,10 @@ class TestGDBDwarf(TestCase):
 
     def test_break_on_symbol(self):
         self._subprocess_test_runner('test_break_on_symbol')
+
+    @skip_unless_gdb_has_numpy
+    def test_test_pretty_print(self):
+        self._subprocess_test_runner('test_pretty_print')
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -1,7 +1,11 @@
 """Tests for gdb interacting with the DWARF numba generates"""
 from numba.tests.support import TestCase, linux_only
 from numba.tests.gdb_support import needs_gdb, skip_unless_pexpect, GdbMIDriver
-
+from unittest.mock import patch, Mock
+from numba.core import datamodel
+import numpy as np
+from numba import typeof
+import ctypes as ct
 import unittest
 
 
@@ -43,12 +47,213 @@ class TestGDBDwarf(TestCase):
     def test_break_on_symbol(self):
         self._subprocess_test_runner('test_break_on_symbol')
 
-    def test_test_pretty_print(self):
+    def test_pretty_print(self):
         if not self._gdb_has_numpy():
             _msg = "Cannot find gdb with NumPy support"
             self.skipTest(_msg)
 
         self._subprocess_test_runner('test_pretty_print')
+
+
+class TestGDBPrettyPrinterLogic(TestCase):
+    # Tests the logic in numba.misc.gdb_print_extension.NumbaArrayPrinter
+    # it's quite involved and susceptible to changes to the string
+    # representation of Numba array and dtypes as it parses these
+    # representations and recreates NumPy array/dtypes based on them!
+
+    @classmethod
+    def setUpClass(self):
+        # Patch sys.modules with mock gdb modules such that the
+        # numba.misc.gdb_print_extension can import ok, the rest of the gdb
+        # classes etc are implemented later
+
+        mock_modules = {'gdb': Mock(),
+                        'gdb.printing': Mock()}
+        self.patched_sys = patch.dict('sys.modules', mock_modules)
+        self.patched_sys.start()
+
+        # Now sys.modules has a gdb in it, patch the gdb.selected_inferior.
+        # This function should return a process wrapping object that has a
+        # read_memory method that can read a memory region from a given address
+        # in the process' address space.
+
+        import gdb
+
+        class SelectedInferior():
+
+            def read_memory(self, data, extent):
+                buf = (ct.c_char * extent).from_address(data)
+                return buf.raw # this is bytes
+
+        si = SelectedInferior()
+        gdb.configure_mock(**{'selected_inferior': lambda :si})
+
+    @classmethod
+    def tearDownClass(self):
+        # drop the sys.modules patch
+        self.patched_sys.stop()
+
+    def get_gdb_repr(self, array):
+        # Returns the gdb repr of an array as reconstructed via the
+        # gdb_print_extension (should be the same as NumPy!).
+
+        # This is the module being tested, it uses gdb and gdb.printing, both
+        # of which are mocked in self.setUp()
+        from numba.misc import gdb_print_extension
+
+        # The following classes are ducks for the gdb classes (which are not
+        # easily/guaranteed importable from the test suite). They implement the
+        # absolute bare minimum necessary to test the gdb_print_extension.
+
+        class DISubrange():
+            def __init__(self, lo, hi):
+                self._lo = lo
+                self._hi = hi
+
+            @property
+            def type(self):
+                return self
+
+            def range(self):
+                return self._lo, self._hi
+
+        class DW_TAG_array_type():
+            def __init__(self, lo, hi):
+                self._lo, self._hi = lo, hi
+
+            def fields(self):
+                return [DISubrange(self._lo, self._hi),]
+
+        class DIDerivedType_tuple():
+            def __init__(self, the_tuple):
+                self._type = DW_TAG_array_type(0, len(the_tuple) - 1)
+                self._tuple = the_tuple
+
+            @property
+            def type(self):
+                return self._type
+
+            def __getitem__(self, item):
+                return self._tuple[item]
+
+        class DICompositeType_Array():
+            def __init__(self, arr, type_str):
+                self._arr = arr
+                self._type_str = type_str
+
+            def __getitem__(self, item):
+                return getattr(self, item)
+
+            @property
+            def data(self):
+                return self._arr.ctypes.data
+
+            @property
+            def itemsize(self):
+                return self._arr.itemsize
+
+            @property
+            def shape(self):
+                return DIDerivedType_tuple(self._arr.shape)
+
+            @property
+            def strides(self):
+                return DIDerivedType_tuple(self._arr.strides)
+
+            @property
+            def type(self):
+                return self._type_str
+
+        # The type string encoded into the DWARF is the string repr of the Numba
+        # type followed by the LLVM repr of the data model in brackets.
+        dmm = datamodel.default_manager
+        array_model = datamodel.models.ArrayModel(dmm, typeof(array))
+        data_type = array_model.get_data_type()
+        type_str = f"{typeof(array)} ({data_type.structure_repr()})"
+        fake_gdb_arr = DICompositeType_Array(array, type_str)
+
+        printer = gdb_print_extension.NumbaArrayPrinter(fake_gdb_arr)
+
+        return printer.to_string().strip() # strip, there's new lines
+
+    def check(self, array):
+        gdb_printed = self.get_gdb_repr(array)
+        self.assertEqual(str(gdb_printed), str(array))
+
+    def test_np_array_printer_simple_numeric_types(self):
+        # Tests printer over a selection of basic types
+        n = 4
+        m = 3
+
+        for dt in (np.int8, np.uint16, np.int64, np.float32, np.complex128):
+            arr = np.arange(m * n, dtype=dt).reshape(m, n)
+            self.check(arr)
+
+    def test_np_array_printer_simple_numeric_types_strided(self):
+        # Tests printer over randomized strided arrays
+        n_tests = 30
+        np.random.seed(0)
+
+        for _ in range(n_tests):
+
+            shape = np.random.randint(1, high=6, size=np.random.randint(1, 5))
+            tmp = np.arange(np.prod(shape)).reshape(shape)
+
+            slices = []
+            for x in shape:
+                start = np.random.randint(0, x)
+                # x + 3 is to ensure that sometimes the stop is beyond the
+                # end of the size in a given dimension
+                stop = np.random.randint(start + 1, max(start + 1, x + 3))
+                step = np.random.randint(1, 3) # step as 1, 2
+                strd = slice(start, stop, step)
+                slices.append(strd)
+
+            arr = tmp[tuple(slices)]
+            self.check(arr)
+
+    def test_np_array_printer_simple_structured_dtype(self):
+        # Tests printer over a selection of basic types
+        n = 4
+        m = 3
+
+        aligned = np.dtype([("x", np.int16), ("y", np.float64)], align=True)
+        unaligned = np.dtype([("x", np.int16), ("y", np.float64)], align=False)
+
+        for dt in (aligned, unaligned):
+            arr = np.empty(m * n, dtype=dt).reshape(m, n)
+            arr['x'] = np.arange(m * n, dtype=dt['x']).reshape(m, n)
+            arr['y'] = 100 * np.arange(m * n, dtype=dt['y']).reshape(m, n)
+            self.check(arr)
+
+    def test_np_array_printer_chr_array(self):
+        # Test unichr array
+        arr = np.array(['abcde'])
+        self.check(arr)
+
+    def test_np_array_printer_unichr_structured_dtype(self):
+        # Not supported yet
+        n = 4
+        m = 3
+
+        dt = np.dtype([("x", '<U5'), ("y", np.float64)], align=True)
+        arr = np.zeros(m * n, dtype=dt).reshape(m, n)
+        rep = self.get_gdb_repr(arr)
+        self.assertIn("array[Exception:", rep)
+        self.assertIn("Unsupported sub-type", rep)
+        self.assertIn("[unichr x 5]", rep)
+
+    def test_np_array_printer_nested_array_structured_dtype(self):
+        # Not supported yet
+        n = 4
+        m = 3
+
+        dt = np.dtype([("x", np.int16, (2,)), ("y", np.float64)], align=True)
+        arr = np.zeros(m * n, dtype=dt).reshape(m, n)
+        rep = self.get_gdb_repr(arr)
+        self.assertIn("array[Exception:", rep)
+        self.assertIn("Unsupported sub-type", rep)
+        self.assertIn("nestedarray(int16", rep)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -194,7 +194,7 @@ class TestGDBPrettyPrinterLogic(TestCase):
 
         for _ in range(n_tests):
 
-            shape = np.random.randint(1, high=6, size=np.random.randint(1, 5))
+            shape = np.random.randint(1, high=12, size=np.random.randint(1, 5))
             tmp = np.arange(np.prod(shape)).reshape(shape)
 
             slices = []


### PR DESCRIPTION
This adds support for printing Numba types as their python
equivalents from gdb by using its python extension.

It includes fixes from https://github.com/numba/numba/pull/7729 and https://github.com/numba/numba/pull/7744

Pythonic printing support is added for:
* Numeric scalars
* Strings
* Tuples
* NumPy arrays of primitive numeric types, and very basic record/structured dtypes.

Also:
* docs - the documentation for gdb needs is updated to reflect these changes
* `numba -g` has been added to provide a simple way of displaying the location of the gdb printing extension file along with gdb configuration information.