### PR TITLE
CUDA: Fix linking with PTX when compiling lazily

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -107,7 +107,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                                           fastmath=fastmath)
             else:
                 def autojitwrapper(func):
-                    return jit(func, device=device, debug=debug, opt=opt, **kws)
+                    return jit(func, device=device, debug=debug, opt=opt,
+                               link=link, **kws)
 
             return autojitwrapper
         # func_or_sig is a function

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -66,7 +66,6 @@ class TestLinker(CUDATestCase):
         linker = Linker.new()
         del linker
 
-    @require_context
     def test_linking(self):
         global bar  # must be a global; other it is recognized as a freevar
         bar = cuda.declare_device('bar', 'int32(int32)')
@@ -85,7 +84,6 @@ class TestLinker(CUDATestCase):
 
         self.assertTrue(A[0] == 123 + 2 * 321)
 
-    @require_context
     def test_try_to_link_nonexistent(self):
         with self.assertRaises(LinkerError) as e:
             @cuda.jit('void(int32[::1])', link=['nonexistent.a'])
@@ -93,7 +91,6 @@ class TestLinker(CUDATestCase):
                 x[0] = 0
         self.assertIn('nonexistent.a not found', e.exception.args)
 
-    @require_context
     def test_set_registers_no_max(self):
         """Ensure that the jitted kernel used in the test_set_registers_* tests
         uses more than 57 registers - this ensures that test_set_registers_*
@@ -103,19 +100,16 @@ class TestLinker(CUDATestCase):
         compiled = compiled.specialize(np.empty(32), *range(6))
         self.assertGreater(compiled.get_regs_per_thread(), 57)
 
-    @require_context
     def test_set_registers_57(self):
         compiled = cuda.jit(max_registers=57)(func_with_lots_of_registers)
         compiled = compiled.specialize(np.empty(32), *range(6))
         self.assertLessEqual(compiled.get_regs_per_thread(), 57)
 
-    @require_context
     def test_set_registers_38(self):
         compiled = cuda.jit(max_registers=38)(func_with_lots_of_registers)
         compiled = compiled.specialize(np.empty(32), *range(6))
         self.assertLessEqual(compiled.get_regs_per_thread(), 38)
 
-    @require_context
     def test_set_registers_eager(self):
         sig = void(float64[::1], int64, int64, int64, int64, int64, int64)
         compiled = cuda.jit(sig, max_registers=38)(func_with_lots_of_registers)

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -66,7 +66,7 @@ class TestLinker(CUDATestCase):
         linker = Linker.new()
         del linker
 
-    def _test_linking(self, eager=False):
+    def _test_linking(self, eager):
         global bar  # must be a global; other it is recognized as a freevar
         bar = cuda.declare_device('bar', 'int32(int32)')
 


### PR DESCRIPTION
When no signature was provided, the `link` kwarg was accidentally dropped in the wrapper function calling `jit` inside the decorator.

Also includes the removal of some un-needed decorators in the linker test.

Fixes #7607.