### PR TITLE
Support fortran loop ordering for ufunc generation

### DIFF
--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -383,7 +383,17 @@ def numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel_class):
     # assume outputs are all the same size, which numpy requires
 
     loopshape = outputs[0].shape
-    with cgutils.loop_nest(builder, loopshape, intp=intpty) as loop_indices:
+
+    input_layouts = [inp.layout for inp in inputs if isinstance(inp, _ArrayHelper)]
+    num_c_layout = len([x for x in input_layouts if x == 'C'])
+    num_f_layout = len([x for x in input_layouts if x == 'F'])
+
+    if num_f_layout > num_c_layout:
+        order = 'F'
+    else:
+        order = 'C'
+
+    with cgutils.loop_nest(builder, loopshape, intp=intpty, order=order) as loop_indices:
         vals_in = []
         for i, (index, arg) in enumerate(zip(indices, inputs)):
             index.update_indices(loop_indices, i)

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -384,10 +384,16 @@ def numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel_class):
 
     loopshape = outputs[0].shape
 
-    input_layouts = [inp.layout for inp in inputs if isinstance(inp, _ArrayHelper)]
+    # count the number of C and F layout arrays, respectively
+    input_layouts = [inp.layout for inp in inputs
+                     if isinstance(inp, _ArrayHelper)]
     num_c_layout = len([x for x in input_layouts if x == 'C'])
     num_f_layout = len([x for x in input_layouts if x == 'F'])
 
+    # Only choose F iteration order if more arrays are in F layout.
+    # Default to C order otherwise.
+    # This is a best effort for performance. NumPy has more fancy logic that
+    # uses array iterators in non-trivial cases.
     if num_f_layout > num_c_layout:
         order = 'F'
     else:


### PR DESCRIPTION
Numba currently generates C ordered loop for ufunc only. This adds the support for F ordered loop generation when arrayexpr inputs are mostly F ordered.

Consider the case:

```python
import numpy as np
from numba import njit


# Make horribly strided arrays
num_columns = 50
num_rows = 100_000
inp_data_2d = np.random.rand(num_rows, num_columns)
inp_data_1d = (inp_data_2d)[:,0]
print(inp_data_2d.strides)
print(inp_data_1d.strides)


def compute(data2d, data1d):
    out = (data2d.transpose() * data1d)
    return out


@njit
def jit_compute(data2d, data1d):
    out = (data2d.transpose() * data1d)
    return out

# warm up
expect = compute(inp_data_2d, inp_data_1d)
got = jit_compute(inp_data_2d, inp_data_1d)
np.testing.assert_array_equal(expect, got)

%timeit -n 10 compute(inp_data_2d, inp_data_1d)
%timeit -n 10 jit_compute(inp_data_2d, inp_data_1d)
```

Without this patch, Numba is 10x slower than NumPy.

Relates to issue in https://github.com/numba/numba/issues/7611