### PR TITLE
Move to using windows-2019 images in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,4 +120,4 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: vs2017-win2016
+    vmImage: windows-2019


### PR DESCRIPTION
As title. The 2016 images are EOL Jan 2022.

