### PR TITLE
install ipykernel as an optional dependency on CI

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -54,8 +54,8 @@ set -v
 # Install optional packages into activated env
 if [ "${VANILLA_INSTALL}" != "yes" ]; then
     # Scipy, CFFI, jinja2, IPython, ipython_genutils and pygments are optional dependencies, but exercised in the test suite
-    # pexpect is used to run the
-    $CONDA_INSTALL ${EXTRA_CHANNELS} cffi jinja2 ipython ipython_genutils pygments pexpect
+    # pexpect is used to run the gdb tests
+    $CONDA_INSTALL ${EXTRA_CHANNELS} cffi jinja2 ipython ipykernel ipython_genutils pygments pexpect
     # Only install scipy on 64bit, else it'll pull in NumPy, 32bit linux needs
     # to get scipy from pip
     if [[ "$CONDA_SUBDIR" != "linux-32" && "$BITS32" != "yes" ]] ; then
@@ -83,9 +83,6 @@ fi
 
 # Install latest llvmlite build
 $CONDA_INSTALL -c numba/label/dev llvmlite
-
-# Install latest ipykernel for testing
-$CONDA_INSTALL ipykernel
 
 # Install dependencies for building the documentation
 if [ "$BUILD_DOC" == "yes" ]; then $CONDA_INSTALL sphinx=2.4.4 docutils=0.17 sphinx_rtd_theme pygments numpydoc; fi


### PR DESCRIPTION
This is a followup from changes introduced in: https://github.com/numba/numba/pull/7345