### PR TITLE
Copy prange loop header to after the parfor.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2568,7 +2568,13 @@ class ConvertLoopPass:
                                     ("prange", loop_kind, loop_replacing),
                                     pass_states.flags, races=races)
 
-                    blocks[loop.header].body = [parfor, ir.Jump(list(loop.exits)[0], loc)]
+                    blocks[loop.header].body = [parfor]
+                    # We have to insert the header_body after the parfor because in
+                    # a Numba loop this will be executed one more time before the
+                    # branch and may contain instructions such as variable renamings
+                    # that are relied upon later.
+                    blocks[loop.header].body.extend(header_body)
+                    blocks[loop.header].body.append(ir.Jump(list(loop.exits)[0], loc))
                     self.rewritten.append(dict(
                         old_loop=loop,
                         new=parfor,

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2570,7 +2570,7 @@ class ConvertLoopPass:
 
                     blocks[loop.header].body = [parfor]
                     # We have to insert the header_body after the parfor because in
-                    # a Numba loop this will be executed one more time before the
+                    # a Numba loop this will be executed one more times before the
                     # branch and may contain instructions such as variable renamings
                     # that are relied upon later.
                     blocks[loop.header].body.extend(header_body)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3562,7 +3562,7 @@ class TestPrangeBasic(TestPrangeBase):
                 for i in range(1):
                     result += 1
             else:
-                for i in range(1000000):
+                for i in range(1):
                     result -= 3
             return result
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3524,7 +3524,7 @@ class TestPrangeBasic(TestPrangeBase):
                            scheduler_type='unsigned',
                            check_fastmath=True)
 
-    def test_prange_28(self):
+    def test_prange28(self):
         # issue7105: label conflict in nested parfor
         def test_impl(x, y):
             out = np.zeros(len(y))
@@ -3553,6 +3553,21 @@ class TestPrangeBasic(TestPrangeBase):
 
         self.prange_tester(test_impl, X, Y, scheduler_type='unsigned',
                            check_fastmath=True, check_fastmath_result=True)
+
+    def test_prange29(self):
+        # issue7630: SSA renaming in prange header
+        def test_impl(flag):
+            result = 0
+            if flag:
+                for i in range(1000000):
+                    result += 1
+            else:
+                for i in range(1000000):
+                    result -= 3
+            return result
+
+        self.prange_tester(test_impl, True)
+        self.prange_tester(test_impl, False)
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3559,7 +3559,7 @@ class TestPrangeBasic(TestPrangeBase):
         def test_impl(flag):
             result = 0
             if flag:
-                for i in range(1000000):
+                for i in range(1):
                     result += 1
             else:
                 for i in range(1000000):


### PR DESCRIPTION
Resolves #7630 

Numba can insert statements with side-effects into the prange loop header and expect those to be executed after the last loop iteration for correctness.  We copy the loop header after the parfor here then for correctness.