### PR TITLE
Increase the timeout on the SVML tests for loaded machines.

### DIFF
--- a/numba/tests/test_svml.py
+++ b/numba/tests/test_svml.py
@@ -240,8 +240,10 @@ class TestSVMLGeneration(TestCase):
             q = ctx.Queue()
             p = ctx.Process(target=type(self).mp_runner, args=[testname, q])
             p.start()
-            # timeout to avoid hanging and long enough to avoid bailing too early
-            term_or_timeout = p.join(timeout=10)
+            # timeout to avoid hanging and long enough to avoid bailing too
+            # early. Note: this was timeout=10 but that seemed to caused
+            # intermittent failures on heavily loaded machines.
+            term_or_timeout = p.join(timeout=30)
             exitcode = p.exitcode
             if term_or_timeout is None:
                 if exitcode is None:


### PR DESCRIPTION
As title. If a machine is under heavy load 10s might not be
enough.
