### PR TITLE
Move Azure builds to OSX 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
     matrix:
       py37_np118:
         PYTHON: '3.7'

--- a/buildscripts/incremental/MacOSX10.10.sdk.checksum
+++ b/buildscripts/incremental/MacOSX10.10.sdk.checksum
@@ -1,0 +1,1 @@
+ea40a3b9dc48cd3593628490f2738b89282f00ab  ./MacOSX10.10.sdk.tar.xz

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -16,8 +16,8 @@ fi
 if [[ $(uname) == "Darwin" ]]; then
     # The following is suggested in https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html?highlight=SDK#macos-sdk
     wget -q https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
-    shasum -c ./MacOSX10.10.sdk.checksum
-    tar -xf MacOSX10.10.sdk.tar.xz
+    shasum -c ./buildscripts/incremental/MacOSX10.10.sdk.checksum
+    tar -xf ./MacOSX10.10.sdk.tar.xz
     export SDKROOT=`pwd`/MacOSX10.10.sdk
 fi
 python setup.py build_ext -q --inplace --debug $EXTRA_BUILD_EXT_FLAGS --verbose

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source activate $CONDA_ENV
+source  activate
+conda activate $CONDA_ENV
 
 # Make sure any error below is reported as such
 set -v -e
@@ -12,7 +13,13 @@ else
     EXTRA_BUILD_EXT_FLAGS=""
 fi
 
-python setup.py build_ext -q --inplace --debug $EXTRA_BUILD_EXT_FLAGS
+if [[ $(uname) == "Darwin" ]]; then
+    # The following is suggested in https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html?highlight=SDK#macos-sdk
+    wget -q https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
+    tar -xf MacOSX10.10.sdk.tar.xz
+    export SDKROOT=`pwd`/MacOSX10.10.sdk
+fi
+python setup.py build_ext -q --inplace --debug $EXTRA_BUILD_EXT_FLAGS --verbose
 # (note we don't install to avoid problems with extra long Windows paths
 #  during distutils-dependent tests -- e.g. test_pycc)
 

--- a/buildscripts/incremental/build.sh
+++ b/buildscripts/incremental/build.sh
@@ -16,6 +16,7 @@ fi
 if [[ $(uname) == "Darwin" ]]; then
     # The following is suggested in https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html?highlight=SDK#macos-sdk
     wget -q https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.10.sdk.tar.xz
+    shasum -c ./MacOSX10.10.sdk.checksum
     tar -xf MacOSX10.10.sdk.tar.xz
     export SDKROOT=`pwd`/MacOSX10.10.sdk
 fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -86,6 +86,11 @@ if [[ "$archstr" == 'ppc64le' ]]; then
     TEST_NPROCS=16
 fi
 
+# setup SDKROOT on Mac
+if [[ $(uname) == "Darwin" ]]; then
+    export SDKROOT=`pwd`/MacOSX10.10.sdk
+fi
+
 # First check that the test discovery works
 python -m numba.tests.test_runtests
 


### PR DESCRIPTION
Closes https://github.com/numba/numba/pull/7639

Azure moved minimal OSX support to 10.15, but anaconda compiler needs the MacOSX10.10 SDK to work. 