### PR TITLE
CUDA Docs: include example calling slow matmul

### DIFF
--- a/docs/source/cuda/examples.rst
+++ b/docs/source/cuda/examples.rst
@@ -27,6 +27,15 @@ Here is a naïve implementation of matrix multiplication using a CUDA kernel:
    :dedent: 8
    :linenos:
 
+An example usage of this function is as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_run_matmul.begin
+   :end-before: magictoken.ex_run_matmul.end
+   :dedent: 8
+   :linenos:
 
 This implementation is straightforward and intuitive but performs poorly,
 because the same matrix elements will be loaded multiple times from device
@@ -56,7 +65,7 @@ It synchronizes again after the computation to ensure all threads
 have finished with the data in shared memory before overwriting it
 in the next loop iteration.
 
-An example usage of this function is as follows:
+An example usage of the ``fast_matmul`` function is as follows:
 
 .. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
    :language: python

--- a/numba/cuda/tests/doc_examples/test_matmul.py
+++ b/numba/cuda/tests/doc_examples/test_matmul.py
@@ -49,6 +49,26 @@ class TestMatMul(CUDATestCase):
                 C[i, j] = tmp
         # magictoken.ex_matmul.end
 
+        # magictoken.ex_run_matmul.begin
+        x_h = np.arange(16).reshape([4, 4])
+        y_h = np.ones([4, 4])
+        z_h = np.zeros([4, 4])
+
+        x_d = cuda.to_device(x_h)
+        y_d = cuda.to_device(y_h)
+        z_d = cuda.to_device(z_h)
+
+        threadsperblock = (16, 16)
+        blockspergrid_x = math.ceil(z_h.shape[0] / threadsperblock[0])
+        blockspergrid_y = math.ceil(z_h.shape[1] / threadsperblock[1])
+        blockspergrid = (blockspergrid_x, blockspergrid_y)
+
+        matmul[blockspergrid, threadsperblock](x_d, y_d, z_d)
+        z_h = z_d.copy_to_host()
+        print(z_h)
+        print(x_h @ y_h)
+        # magictoken.ex_run_matmul.end
+
         # magictoken.ex_fast_matmul.begin
         # Controls threads per block and shared memory usage.
         # The computation will be done on blocks of TPBxTPB elements.


### PR DESCRIPTION
The CUDA matrix multiplcation example lacked an example of how to call the naive matrix multiplication kernel (there was only an example of a call of the shared-memory optimized version - identified in https://github.com/numba/numba/issues/7679#issuecomment-998830327). This is a little unhelpful for someone encountering the example for the first time. This PR adds an example calling the naive matrix multiplication kernel prior to discussing optimizations.