### PR TITLE
DOC: remove incorrect warning in np.random reference

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -654,7 +654,7 @@ Permutations
 Distributions
 '''''''''''''
 
-.. warning:: The `size` argument is not supported in the following functions.
+The following functions support all arguments. 
 
 * :func:`numpy.random.beta`
 * :func:`numpy.random.binomial`


### PR DESCRIPTION
Currently, the np.random reference states that none of the functions accept size arguments in nopython mode. However, all of the current implementations accept all of the possible size arguments. See:

```python
from numba import njit
import numpy as np

@njit
def nb_triangular(l, m, r, size):
    return np.random.triangular(l, m, r, size)

@njit
def nb_poisson(lam, size):
    return np.random.poisson(lam, size)

size = (3, 3, 10)

nb_triangular(0, 1, 2, size)

nb_poisson(1, size)

```

This PR changes the warning to state that Numba's np.random implementations accept all arguments. 