### PR TITLE
Don't convert setitems that have dimension mismatches to parfors.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1779,7 +1779,7 @@ class ConvertSetItemPass:
                                 sliced_dims = 0
 
                             # Only create a parfor for this setitem if we know the
-                            # shape of the output and numbers of dimensions set is
+                            # shape of the output and number of dimensions set is
                             # equal to the number of dimensions on the right side.
                             if (shape is not None and
                                 (not isinstance(value_typ, types.npytypes.Array) or

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1763,7 +1763,27 @@ class ConvertSetItemPass:
                         else:
                             # Handle A[:] = x
                             shape = equiv_set.get_shape(instr)
-                            if shape is not None:
+                            # Don't converted broadcasted setitems into parfors.
+                            if isinstance(index_typ, types.BaseTuple):
+                                # The sliced dims are those in the index that
+                                # are made of slices.  Count the numbers of slices
+                                # in the index tuple.
+                                sliced_dims = len(list(filter(
+                                    lambda x: isinstance(x, types.misc.SliceType),
+                                    index_typ.types)))
+                            elif isinstance(index_typ, types.misc.SliceType):
+                                # For singular indices there can be a bare slice
+                                # and if so there is one dimension being set.
+                                sliced_dims = 1
+                            else:
+                                sliced_dims = 0
+
+                            # Only create a parfor for this setitem if we know the
+                            # shape of the output and numbers of dimensions set is
+                            # equal to the number of dimensions on the right side.
+                            if (shape is not None and
+                                (not isinstance(value_typ, types.npytypes.Array) or
+                                 sliced_dims == value_typ.ndim)):
                                 new_instr = self._setitem_to_parfor(equiv_set,
                                         loc, target, index, value, shape=shape)
                                 self.rewritten.append(

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3569,6 +3569,26 @@ class TestPrangeBasic(TestPrangeBase):
         self.prange_tester(test_impl, True)
         self.prange_tester(test_impl, False)
 
+    def test_prange30(self):
+        # issue7675: broadcast setitem
+        def test_impl(x, par, numthreads):
+            n_par = par.shape[0]
+            n_x = len(x)
+            result = np.zeros((n_par, n_x), dtype=np.float64)
+            chunklen = (len(x) + numthreads - 1) // numthreads
+
+            for i in range(numthreads):
+                start = i * chunklen
+                stop = (i + 1) * chunklen
+                result[:, start:stop] = x[start:stop] * par[:]
+
+            return result
+
+        x = np.array(np.arange(0, 6, 1.0))
+        par = np.array([1.0, 2.0, 3.0])
+
+        self.prange_tester(test_impl, x, par, 2)
+
 
 @skip_parfors_unsupported
 class TestPrangeSpecific(TestPrangeBase):


### PR DESCRIPTION
Resolves #7675 

