### PR TITLE
- remove setuptools dependency

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.38.0dev0,<0.38
-    - importlib_metadata # [py<39]
+    - importlib_metadata # [py<38]
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
     # NOTE: ppc64le exclusion is temporary until packages are more generally
@@ -48,7 +48,7 @@ requirements:
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.38.0dev0,<0.38
-    - importlib_metadata # [py<39]
+    - importlib_metadata # [py<38]
   run_constrained:
     # If TBB is present it must be at least version 2021
     - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.38.0dev0,<0.38
+    - importlib_metadata # [py<39]
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
     # NOTE: ppc64le exclusion is temporary until packages are more generally
@@ -47,6 +48,7 @@ requirements:
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.38.0dev0,<0.38
+    - importlib_metadata # [py<39]
   run_constrained:
     # If TBB is present it must be at least version 2021
     - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -28,6 +28,7 @@ call activate %CONDA_ENV%
 @rem Install latest llvmlite build
 %CONDA_INSTALL% -c numba/label/dev llvmlite
 @rem Install dependencies for building the documentation
+if %PYTHON% LSS 3.8 (%CONDA_INSTALL% importlib_metadata)
 if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx sphinx_rtd_theme pygments)
 @rem Install dependencies for code coverage (codecov.io)
 if "%RUN_COVERAGE%" == "yes" (%PIP_INSTALL% codecov)

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -84,7 +84,7 @@ elif  [[ $(uname) == Darwin ]]; then
     # Install llvm-openmp and intel-openmp on OSX too
     $CONDA_INSTALL llvm-openmp intel-openmp
 fi
-
+if [ $PYTHON \< "3.8" ]; then $CONDA_INSTALL importlib_metadata; fi
 # `pip install` all the dependencies on Python 3.10
 if [[ "$PYTHON" == "3.10" ]] ; then
     $PIP_INSTALL -U pip

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -198,7 +198,7 @@ vary with target operating system and hardware. The following lists them all
 
 * Required run time:
 
-  * ``setuptools``
+  * ``importlib_metadata`` (for Python versions < 3.8)
   * ``numpy``
   * ``llvmlite``
 

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -21,7 +21,7 @@ def _entry_points_sequence():
     try:
         return raw_eps.select(group="numba_extensions", name="init")
     except AttributeError as e:
-        return (item for item in raw_eps.get("numba_extensions") if item.name=="init")
+        return (item for item in raw_eps.get("numba_extensions", ()) if item.name=="init")
 
 
 _already_initialized = False

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 _already_initialized = False
 logger = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ def init_all():
     # Must put this here to avoid extensions re-triggering initialization
     _already_initialized = True
 
-    for entry_point in iter_entry_points('numba_extensions', 'init'):
+    for entry_point in (item for item in entry_points().get('numba_extensions', []) if item.name == "init"):
         logger.debug('Loading extension: %s', entry_point)
         try:
             func = entry_point.load()

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -4,12 +4,12 @@ import warnings
 
 try:
     import importlib.metadata as importlib_metadata
-except ImportError as ex:
+except ImportError:
     try:
         import importlib_metadata
     except ImportError as ex:
         raise ImportError(
-            "backports.entry-points-selectable is required for Python version < 3.9, "
+            "importlib_metadata is required for Python version < 3.8, "
             "try:\n"
             "$ conda/pip install importlib.metadata"
         ) from ex
@@ -19,9 +19,9 @@ def _entry_points_sequence():
     raw_eps = importlib_metadata.entry_points()
     try:
         return raw_eps.select(group="numba_extensions", name="init")
-    except AttributeError as _:
-        return (item for item in raw_eps.get("numba_extensions", ())
-                                 if item.name == "init")
+    except AttributeError:
+        eps = raw_eps.get("numba_extensions", ())
+        return (item for item in eps if item.name == "init")
 
 
 _already_initialized = False

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -5,12 +5,12 @@ from numba.core.config import PYVERSION
 
 if PYVERSION < (3, 9):
     try:
-        from backports.entry_points_selectable import entry_points
+        from importlib.metadata import entry_points
     except ImportError as ex:
         raise ImportError(
             "backports.entry-points-selectable is required for Python version < 3.9, "
             "try:\n"
-            "$ conda/pip install backports.entry-points-selectable"
+            "$ conda/pip install importlib.metadata"
         ) from ex
 else:
     from importlib.metadata import entry_points

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -46,7 +46,7 @@ def init_all():
             func = entry_point.load()
             func()
         except Exception as e:
-            msg = (f"Numba extension module '{entry_point.module}' "
+            msg = (f"Numba extension module '{entry_point}' "
                    f"failed to load due to '{type(e).__name__}({str(e)})'.")
             warnings.warn(msg, stacklevel=2)
             logger.debug('Extension loading failed for: %s', entry_point)

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -1,27 +1,27 @@
 import logging
 import warnings
 
-from numba.core.config import PYVERSION
 
-if PYVERSION < (3, 9):
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError as ex:
     try:
         import importlib_metadata
-
     except ImportError as ex:
         raise ImportError(
             "backports.entry-points-selectable is required for Python version < 3.9, "
             "try:\n"
             "$ conda/pip install importlib.metadata"
         ) from ex
-else:
-    import importlib.metadata as importlib_metadata
+
 
 def _entry_points_sequence():
     raw_eps = importlib_metadata.entry_points()
     try:
         return raw_eps.select(group="numba_extensions", name="init")
-    except AttributeError as e:
-        return (item for item in raw_eps.get("numba_extensions", ()) if item.name=="init")
+    except AttributeError as _:
+        return (item for item in raw_eps.get("numba_extensions", ())
+                                 if item.name == "init")
 
 
 _already_initialized = False

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -5,7 +5,7 @@ from numba.core.config import PYVERSION
 
 if PYVERSION < (3, 9):
     try:
-        from importlib_metadata import entry_points
+        import importlib_metadata
 
     except ImportError as ex:
         raise ImportError(
@@ -14,10 +14,10 @@ if PYVERSION < (3, 9):
             "$ conda/pip install importlib.metadata"
         ) from ex
 else:
-    from importlib.metadata import entry_points
+    import importlib.metadata as importlib_metadata
 
 def _entry_points_sequence():
-    raw_eps = entry_points()
+    raw_eps = importlib_metadata.entry_points()
     try:
         return raw_eps.select(group="numba_extensions", name="init")
     except AttributeError as e:

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -21,7 +21,7 @@ def _entry_points_sequence():
     try:
         return raw_eps.select(group="numba_extensions", name="init")
     except AttributeError as e:
-        return (item for item in eps.get("numba_extensions") if item.name=="init")
+        return (item for item in raw_eps.get("numba_extensions") if item.name=="init")
 
 
 _already_initialized = False

--- a/numba/core/entrypoints.py
+++ b/numba/core/entrypoints.py
@@ -46,7 +46,7 @@ def init_all():
             func = entry_point.load()
             func()
         except Exception as e:
-            msg = (f"Numba extension module '{entry_point}' "
+            msg = (f"Numba extension '{entry_point.value}' "
                    f"failed to load due to '{type(e).__name__}({str(e)})'.")
             warnings.warn(msg, stacklevel=2)
             logger.debug('Extension loading failed for: %s', entry_point)

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -118,7 +118,7 @@ class TestEntrypoints(TestCase):
                 with warnings.catch_warnings(record=True) as w:
                     entrypoints.init_all()
 
-                bad_str = "Numba extension module '_test_numba_bad_extension'"
+                bad_str = "Numba extension '_test_numba_bad_extension:init_func'"
                 for x in w:
                     if bad_str in str(x):
                         break

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -50,7 +50,8 @@ class TestEntrypoints(TestCase):
         for fake_ep in [mockOfEntryPoint(), {'numba_extensions': (my_entrypoint,)}]:
             try:
                 # will remove this module at the end of the test
-                sys.modules[mod.__name__] = mock.Mock(__name__='_test_numba_extension')
+                mod = mock.Mock(__name__='_test_numba_extension')
+                sys.modules[mod.__name__] = mod
 
                 with mock.patch.object(
                     importlib_metadata,

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -50,8 +50,8 @@ class TestEntrypoints(TestCase):
         #   https://github.com/pandas-dev/pandas/pull/27488
 
         for fake_ep in [mockOfEntryPoint(),
-                       {'numba_extensions':
-                        (my_entrypoint,)}]:
+                        {'numba_extensions':
+                         (my_entrypoint,)}]:
             try:
                 # will remove this module at the end of the test
                 mod = mock.Mock(__name__='_test_numba_extension')

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import threading
 
-from numba import config, njit
+from numba import njit
 from numba.tests.support import TestCase
 from numba.testing.main import _TIMEOUT as _RUNNER_TIMEOUT
 

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -113,7 +113,7 @@ class TestEntrypoints(TestCase):
                 'entry_points',
                 return_value={'numba_extensions': (my_entrypoint,)},
             ), warnings.catch_warnings(record=True) as w:
-                    entrypoints.init_all()
+                entrypoints.init_all()
             bad_str = "Numba extension '_test_numba_bad_extension:init_func'"
             for x in w:
                 if bad_str in str(x):

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -105,29 +105,23 @@ class TestEntrypoints(TestCase):
                 'numba_extensions',
             )
 
+            from numba.core import entrypoints
+            # Allow reinitialization
+            entrypoints._already_initialized = False
             with mock.patch.object(
                 importlib_metadata,
                 'entry_points',
                 return_value={'numba_extensions': (my_entrypoint,)},
-            ):
-
-                from numba.core import entrypoints
-                # Allow reinitialization
-                entrypoints._already_initialized = False
-
-                with warnings.catch_warnings(record=True) as w:
+            ), warnings.catch_warnings(record=True) as w:
                     entrypoints.init_all()
-
-                bad_str = "Numba extension '_test_numba_bad_extension:init_func'"
-                for x in w:
-                    if bad_str in str(x):
-                        break
-                else:
-                    raise ValueError("Expected warning message not found")
-
-                # was our init function called?
-                self.assertEqual(counters['init'], 1)
-
+            bad_str = "Numba extension '_test_numba_bad_extension:init_func'"
+            for x in w:
+                if bad_str in str(x):
+                    break
+            else:
+                raise ValueError("Expected warning message not found")
+            # was our init function called?
+            self.assertEqual(counters['init'], 1)
         finally:
             # remove fake module
             if mod.__name__ in sys.modules:

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -1,15 +1,21 @@
 import sys
+from unittest import mock
+
 import types
 import warnings
 import unittest
 import os
 import subprocess
 import threading
-import pkg_resources
 
-from numba import njit
+from numba import config, njit
 from numba.tests.support import TestCase
 from numba.testing.main import _TIMEOUT as _RUNNER_TIMEOUT
+
+if config.PYVERSION < (3, 9):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
 
 _TEST_TIMEOUT = _RUNNER_TIMEOUT - 60.
 
@@ -31,45 +37,35 @@ class TestEntrypoints(TestCase):
         # loosely based on Pandas test from:
         #   https://github.com/pandas-dev/pandas/pull/27488
 
-        # FIXME: Python 2 workaround because nonlocal doesn't exist
-        counters = {'init': 0}
-
-        def init_function():
-            counters['init'] += 1
-
-        mod = types.ModuleType("_test_numba_extension")
-        mod.init_func = init_function
+        mod = mock.Mock(__name__='_test_numba_extension')
 
         try:
             # will remove this module at the end of the test
             sys.modules[mod.__name__] = mod
 
-            # We are registering an entry point using the "numba" package
-            # ("distribution" in pkg_resources-speak) itself, though these are
-            # normally registered by other packages.
-            dist = "numba"
-            entrypoints = pkg_resources.get_entry_map(dist)
-            my_entrypoint = pkg_resources.EntryPoint(
-                "init",  # name of entry point
-                mod.__name__,  # module with entry point object
-                attrs=['init_func'],  # name of entry point object
-                dist=pkg_resources.get_distribution(dist)
+            my_entrypoint = importlib_metadata.EntryPoint(
+                'init', '_test_numba_extension:init_func', 'numba_extensions',
             )
-            entrypoints.setdefault('numba_extensions',
-                                   {})['init'] = my_entrypoint
 
-            from numba.core import entrypoints
-            # Allow reinitialization
-            entrypoints._already_initialized = False
+            with mock.patch.object(
+                importlib_metadata,
+                'entry_points',
+                return_value={'numba_extensions': (my_entrypoint,)},
+            ):
 
-            entrypoints.init_all()
+                from numba.core import entrypoints
 
-            # was our init function called?
-            self.assertEqual(counters['init'], 1)
+                # Allow reinitialization
+                entrypoints._already_initialized = False
 
-            # ensure we do not initialize twice
-            entrypoints.init_all()
-            self.assertEqual(counters['init'], 1)
+                entrypoints.init_all()
+
+                # was our init function called?
+                mod.init_func.assert_called_once()
+
+                # ensure we do not initialize twice
+                entrypoints.init_all()
+                mod.init_func.assert_called_once()
         finally:
             # remove fake module
             if mod.__name__ in sys.modules:
@@ -93,36 +89,34 @@ class TestEntrypoints(TestCase):
             # will remove this module at the end of the test
             sys.modules[mod.__name__] = mod
 
-            # We are registering an entry point using the "numba" package
-            # ("distribution" in pkg_resources-speak) itself, though these are
-            # normally registered by other packages.
-            dist = "numba"
-            entrypoints = pkg_resources.get_entry_map(dist)
-            my_entrypoint = pkg_resources.EntryPoint(
-                "init",  # name of entry point
-                mod.__name__,  # module with entry point object
-                attrs=['init_func'],  # name of entry point object
-                dist=pkg_resources.get_distribution(dist)
+            my_entrypoint = importlib_metadata.EntryPoint(
+                'init',
+                '_test_numba_bad_extension:init_func',
+                'numba_extensions',
             )
-            entrypoints.setdefault('numba_extensions',
-                                   {})['init'] = my_entrypoint
 
-            from numba.core import entrypoints
-            # Allow reinitialization
-            entrypoints._already_initialized = False
+            with mock.patch.object(
+                importlib_metadata,
+                'entry_points',
+                return_value={'numba_extensions': (my_entrypoint,)},
+            ):
 
-            with warnings.catch_warnings(record=True) as w:
-                entrypoints.init_all()
+                from numba.core import entrypoints
+                # Allow reinitialization
+                entrypoints._already_initialized = False
 
-            bad_str = "Numba extension module '_test_numba_bad_extension'"
-            for x in w:
-                if bad_str in str(x):
-                    break
-            else:
-                raise ValueError("Expected warning message not found")
+                with warnings.catch_warnings(record=True) as w:
+                    entrypoints.init_all()
 
-            # was our init function called?
-            self.assertEqual(counters['init'], 1)
+                bad_str = "Numba extension module '_test_numba_bad_extension'"
+                for x in w:
+                    if bad_str in str(x):
+                        break
+                else:
+                    raise ValueError("Expected warning message not found")
+
+                # was our init function called?
+                self.assertEqual(counters['init'], 1)
 
         finally:
             # remove fake module
@@ -188,26 +182,23 @@ class TestEntrypoints(TestCase):
             # will remove this module at the end of the test
             sys.modules[mod.__name__] = mod
 
-            # We are registering an entry point using the "numba" package
-            # ("distribution" in pkg_resources-speak) itself, though these are
-            # normally registered by other packages.
-            dist = "numba"
-            entrypoints = pkg_resources.get_entry_map(dist)
-            my_entrypoint = pkg_resources.EntryPoint(
-                "init",  # name of entry point
-                mod.__name__,  # module with entry point object
-                attrs=['init_func'],  # name of entry point object
-                dist=pkg_resources.get_distribution(dist)
+            my_entrypoint = importlib_metadata.EntryPoint(
+                'init',
+                '_test_numba_init_sequence:init_func',
+                'numba_extensions',
             )
-            entrypoints.setdefault('numba_extensions',
-                                   {})['init'] = my_entrypoint
 
-            @njit
-            def foo(x):
-                return x
+            with mock.patch.object(
+                importlib_metadata,
+                'entry_points',
+                return_value={'numba_extensions': (my_entrypoint,)},
+            ):
+                @njit
+                def foo(x):
+                    return x
 
-            ival = _DummyClass(10)
-            foo(ival)
+                ival = _DummyClass(10)
+                foo(ival)
         finally:
             # remove fake module
             if mod.__name__ in sys.modules:

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -27,14 +27,16 @@ class _DummyClass(object):
     def __repr__(self):
         return '_DummyClass(%f, %f)' % self.value
 
+
 my_entrypoint = importlib_metadata.EntryPoint(
     'init', '_test_numba_extension:init_func', 'numba_extensions',
 )
 
+
 class mockOfEntryPoint(object):
     def select(self, group, name):
-        assert group=="numba_extensions"
-        assert name=="init"
+        assert group == "numba_extensions"
+        assert name == "init"
         yield my_entrypoint
 
 
@@ -47,7 +49,9 @@ class TestEntrypoints(TestCase):
         # loosely based on Pandas test from:
         #   https://github.com/pandas-dev/pandas/pull/27488
 
-        for fake_ep in [mockOfEntryPoint(), {'numba_extensions': (my_entrypoint,)}]:
+        for fake_ep in [mockOfEntryPoint(),
+                       {'numba_extensions':
+                        (my_entrypoint,)}]:
             try:
                 # will remove this module at the end of the test
                 mod = mock.Mock(__name__='_test_numba_extension')

--- a/numba/tests/test_entrypoints.py
+++ b/numba/tests/test_entrypoints.py
@@ -12,10 +12,10 @@ from numba import config, njit
 from numba.tests.support import TestCase
 from numba.testing.main import _TIMEOUT as _RUNNER_TIMEOUT
 
-if config.PYVERSION < (3, 9):
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
     import importlib_metadata
-else:
-    from importlib import metadata as importlib_metadata
 
 _TEST_TIMEOUT = _RUNNER_TIMEOUT - 60.
 

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'setuptools',
+    'backports.entry-points-selectable; python_version < "3.9"'
 ]
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'importlib_metadata; python_version < "3.9"'
+    'importlib_metadata; python_version < "3.8"'
 ]
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'backports.entry-points-selectable; python_version < "3.9"'
+    'importlib-metadata >= 3.6; python_version < "3.9"'
 ]
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'importlib-metadata >= 3.6; python_version < "3.9"'
+    'importlib-metadata; python_version < "3.9"'
 ]
 
 metadata = dict(

--- a/setup.py
+++ b/setup.py
@@ -360,7 +360,7 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'importlib-metadata; python_version < "3.9"'
+    'importlib_metadata; python_version < "3.9"'
 ]
 
 metadata = dict(


### PR DESCRIPTION
similar to https://github.com/numba/llvmlite/pull/801#issuecomment-1000445283, this is an effort to remove usage / dependency of setuptools.

The motivation is that it makes it easier to use tools like pyoxidizer, replaces a library dependency with a builtin depenency, decreases import latency and reduces overall dependancies.

also like the mentioned pull request, not a killer feauture not a bug fix, but it is expected to speedup import times.

At some point i noticed the PR [fix/4927-slow-import](https://github.com/numba/numba/pull/5209) and used the developoments from there.

This is not a successfull simplification. A dependency of a backport and two implementations how to find the entrypoints have been added. On  the other side the dependancy of setuptools and 1 implementation got removed.

If this yields improvements on importtime, it propably is still be worth it, especially for python 3.8 and newer. Also for me personaly droping setuptools as a requirement is a big plus as packages tend to use it if it is there, which ocationally causes issues...

I used input from: https://github.com/python/importlib_metadata/issues/298
And again, the original PR from @svrakitin.

These code changes would need to be touched when suport for 3.7 and 3.8 gets removed.

Unfortunately I was unable to test it with real extensions.