### PR TITLE
Implemented np.random.noncentral_chisquare for all size arguments

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -659,6 +659,7 @@ Distributions
 * :func:`numpy.random.beta`
 * :func:`numpy.random.binomial`
 * :func:`numpy.random.chisquare`
+* :func:`numpy.random.noncentral_chisquare`
 * :func:`numpy.random.dirichlet`
 * :func:`numpy.random.exponential`
 * :func:`numpy.random.f`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -659,7 +659,6 @@ Distributions
 * :func:`numpy.random.beta`
 * :func:`numpy.random.binomial`
 * :func:`numpy.random.chisquare`
-* :func:`numpy.random.noncentral_chisquare`
 * :func:`numpy.random.dirichlet`
 * :func:`numpy.random.exponential`
 * :func:`numpy.random.f`
@@ -673,6 +672,7 @@ Distributions
 * :func:`numpy.random.logseries`
 * :func:`numpy.random.multinomial`
 * :func:`numpy.random.negative_binomial`
+* :func:`numpy.random.noncentral_chisquare`
 * :func:`numpy.random.normal`
 * :func:`numpy.random.pareto`
 * :func:`numpy.random.poisson`

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -1595,7 +1595,8 @@ def noncentral_chisquare(df, nonc, size=None):
 
     @register_jitable
     def noncentral_chisquare_single(df, nonc):
-
+        # identical to numpy implementation 
+        
         if df <= 0:
             raise ValueError("df <= 0")
         if nonc < 0:
@@ -1608,6 +1609,7 @@ def noncentral_chisquare(df, nonc, size=None):
             chi2 = np.random.chisquare(df-1)
             n = np.random.standard_normal() + np.sqrt(nonc)
             return chi2 + n * n
+
         else:
             i = np.random.poisson(nonc/2.0)
             return np.random.chisquare(df + 2 * i)

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -1596,6 +1596,7 @@ def noncentral_chisquare(df, nonc, size=None):
     @register_jitable
     def noncentral_chisquare_single(df, nonc):
         # identical to numpy implementation from distributions.c
+        # https://github.com/numpy/numpy/blob/c65bc212ec1987caefba0ea7efe6a55803318de9/numpy/random/src/distributions/distributions.c
         
         if df <= 0:
             raise ValueError("df <= 0")

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -1596,7 +1596,7 @@ def noncentral_chisquare(df, nonc, size=None):
     @register_jitable
     def noncentral_chisquare_single(df, nonc):
         # identical to numpy implementation from distributions.c
-        # https://github.com/numpy/numpy/blob/c65bc212ec1987caefba0ea7efe6a55803318de9/numpy/random/src/distributions/distributions.c
+        # https://github.com/numpy/numpy/blob/c65bc212ec1987caefba0ea7efe6a55803318de9/numpy/random/src/distributions/distributions.c#L797
         
         if df <= 0:
             raise ValueError("df <= 0")

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -1595,7 +1595,7 @@ def noncentral_chisquare(df, nonc, size=None):
 
     @register_jitable
     def noncentral_chisquare_single(df, nonc):
-        # identical to numpy implementation 
+        # identical to numpy implementation from distributions.c
         
         if df <= 0:
             raise ValueError("df <= 0")
@@ -1605,7 +1605,7 @@ def noncentral_chisquare(df, nonc, size=None):
         if np.isnan(nonc):
             return np.nan
 
-        if df > 1:
+        if 1 < df:
             chi2 = np.random.chisquare(df-1)
             n = np.random.standard_normal() + np.sqrt(nonc)
             return chi2 + n * n

--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -1384,19 +1384,19 @@ class TestRandomNoncentralChiSquare(BaseTest):
 
     def _check_sample(self, size, sample):
 
-        """Check output structure"""
+        # Check output structure
         if size is not None:
             self.assertIsInstance(sample, np.ndarray)
             self.assertEqual(sample.dtype, np.float64)
             
-            if type(size) is int:
+            if isinstance(size, int):
                 self.assertEqual(sample.shape, (size,))
             else:
                 self.assertEqual(sample.shape, size)
         else:
              self.assertIsInstance(sample, float)
 
-        """Check statistical properties"""
+        # Check statistical properties
         for val in np.nditer(sample):
             self.assertGreaterEqual(val, 0)
 
@@ -1412,12 +1412,10 @@ class TestRandomNoncentralChiSquare(BaseTest):
             (100000, 1),
             (1, 10000),
         )
-        for input in inputs:
-            df, nonc = input
+        for df, nonc in inputs:
             res = cfunc(df, nonc)
             self._check_sample(None, res)
-            nonc = np.nan
-            res = cfunc(df, nonc) # test branch when nonc is nan
+            res = cfunc(df, np.nan) # test branch when nonc is nan
             self.assertTrue(np.isnan(res))
 
 
@@ -1435,12 +1433,10 @@ class TestRandomNoncentralChiSquare(BaseTest):
             (1, 10000),
         )
 
-        for input, size in itertools.product(inputs, sizes):
-            df, nonc = input
+        for (df, nonc), size in itertools.product(inputs, sizes):
             res = cfunc(df, nonc, size)
             self._check_sample(size, res)
-            nonc = np.nan
-            res = cfunc(df, nonc, size)
+            res = cfunc(df, np.nan, size) # test branch when nonc is nan
             self.assertTrue(np.isnan(res).all())
 
     def test_noncentral_chisquare_exceptions(self):

--- a/numba/tests/test_random.py
+++ b/numba/tests/test_random.py
@@ -1424,7 +1424,7 @@ class TestRandomNoncentralChiSquare(BaseTest):
         Test noncentral_chisquare(df, nonc, size)
         """
         cfunc = jit(nopython=True)(numpy_noncentral_chisquare)
-        sizes = (None, (10,), (10, 10))
+        sizes = (None, 10, (10,), (10, 10))
         inputs = (
             (0.5, 1),
             (1, 5),


### PR DESCRIPTION
This is an implementation of np.random.noncentral_chisquare that accepts size arguments. This implementation uses the same algorithm found in numpy's distributions.c. Part of #1335 - I have plans to knock out the other two functions shortly. 
