### PR TITLE
Fix `NUMBA_DUMP_ANNOTATION` with `NUMBA_EXTEND_VARIABLE_LIFETIMES`

### DIFF
--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -186,7 +186,7 @@ class AnnotateTypes(AnalysisPass):
         """
         # add back in dels.
         post_proc = postproc.PostProcessor(state.func_ir)
-        post_proc.run(emit_dels=True)
+        post_proc.run(emit_dels=True, extend_lifetimes=config.EXTEND_VARIABLE_LIFETIMES)
 
         state.type_annotation = type_annotations.TypeAnnotation(
             func_ir=state.func_ir.copy(),


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

## Reference an existing issue
<!-- You can link to an existing issue using the github syntax #<issue number>  -->

This PR fixes how `NUMBA_DUMP_ANNOTATION=1` and `NUMBA_EXTEND_VARIABLE_LIFETIMES=1` works together.

Source code `chk_annotate.py`:
```python
from numba import njit

@njit
def func(a):
  b = a
  return b

b = func(10)
```
Before:
```bash
$ NUMBA_DUMP_ANNOTATION=1 NUMBA_EXTEND_VARIABLE_LIFETIMES=1 python chk_annotate.py
-----------------------------------ANNOTATION-----------------------------------
# File: /.../chk_annotate.py
# --- LINE 3 --- 

@njit

# --- LINE 4 --- 

def func(a):

  # --- LINE 5 --- 
  # label 0
  #   a = arg(0, name=a)  :: int64
  #   b = a  :: int64
  #   del a

  b = a

  # --- LINE 6 --- 
  #   $8return_value.2 = cast(value=b)  :: int64
  #   del b
  #   return $8return_value.2

  return b
```

After:
```bash
$ NUMBA_DUMP_ANNOTATION=1 NUMBA_EXTEND_VARIABLE_LIFETIMES=1 python chk_annotate.py
-----------------------------------ANNOTATION-----------------------------------
# File: /.../chk_annotate.py
# --- LINE 3 --- 

@njit

# --- LINE 4 --- 

def func(a):

  # --- LINE 5 --- 
  # label 0
  #   a = arg(0, name=a)  :: int64
  #   b = a  :: int64

  b = a

  # --- LINE 6 --- 
  #   $8return_value.2 = cast(value=b)  :: int64
  #   del a
  #   del b
  #   return $8return_value.2

  return b

```
