### PR TITLE
`IntEnumMember` support for  `np.empty`, `np.zeros`, and `np.ones`

### DIFF
--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -455,7 +455,7 @@ def parse_shape(shape):
     if isinstance(shape, types.Integer):
         ndim = 1
     elif isinstance(shape, (types.Tuple, types.UniTuple)):
-        if all(isinstance(s, types.Integer) for s in shape):
+        if all(isinstance(s, (types.Integer, types.IntEnumMember)) for s in shape):
             ndim = len(shape)
     return ndim
 

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -455,7 +455,8 @@ def parse_shape(shape):
     if isinstance(shape, types.Integer):
         ndim = 1
     elif isinstance(shape, (types.Tuple, types.UniTuple)):
-        if all(isinstance(s, (types.Integer, types.IntEnumMember)) for s in shape):
+        int_tys = (types.Integer, types.IntEnumMember)
+        if all(isinstance(s, int_tys) for s in shape):
             ndim = len(shape)
     return ndim
 

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -162,6 +162,19 @@ class TestIntEnum(BaseEnumTest, TestCase):
         for member in IntEnumWithNegatives:
             self.assertPreciseEqual(pyfun(member), cfunc(member))
 
+    def test_int_shape_cast(self):
+        def pyfun_empty(x):
+            return np.empty((x, x), dtype='int64').fill(-1)
+        def pyfun_zeros(x):
+            return np.zeros((x, x), dtype='int64')
+        def pyfun_ones(x):
+            return np.ones((x, x), dtype='int64')
+        for pyfun in [pyfun_empty, pyfun_zeros, pyfun_ones]:
+            cfunc = jit(nopython=True)(pyfun)
+            for member in IntEnumWithNegatives:
+                if member >= 0:
+                    self.assertPreciseEqual(pyfun(member), cfunc(member))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds `IntEnumMember` support for `np.empty`, `np.zeros`, and `np.ones`.

Closes [issue 6631](https://github.com/numba/numba/issues/6631), as well as the implicitly-casted version of the code in question:
```python
import numba
from enum import IntEnum
import numpy as np
from numba import njit

class Matrix(IntEnum):
    r = 4
    c = 4

@njit
def test():
    return np.zeros((Matrix.r, Matrix.c), dtype='int64')

z = test()
print(z, z.dtype)
```

Is there a more general solution to this problem that would allow support for IntEnumMember in other places, or a good way to automate its inclusions throughout the codebase?