### PR TITLE
Support for scalar arguments in Np.ascontiguousarray 

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4331,26 +4331,28 @@ def array_ascontiguousarray(context, builder, sig, args):
     return _as_layout_array(context, builder, sig, args, output_layout='C')
 
 
-def _array_ascontiguous_scalar(a):
-    """common between ascontiguousarray and asfortranarray"""
-    if isinstance(a, (types.Number, types.Boolean, )):
-        dtype = a
-
+@overload(np.ascontiguousarray)
+def array_ascontiguousarray_scalar(a):
+    """
+    This is an implementation for scalar.
+    For arrays, see `array_ascontiguousarray`.
+    """
+    if isinstance(a, (types.Number, types.Boolean,)):
         def impl(a):
-            ary = np.empty((1, ), dtype=dtype)
-            ary[0] = a
-            return ary
+            return np.ascontiguousarray(np.array(a))
         return impl
 
 
-@overload(np.ascontiguousarray)
-def array_ascontiguousarray_scalar(a):
-    return _array_ascontiguous_scalar(a)
-
-
 @overload(np.asfortranarray)
-def array_asfortran_scalar(a):
-    return _array_ascontiguous_scalar(a)
+def array_asfortranarray_scalar(a):
+    """
+    This is an implementation for scalar.
+    For arrays, see `array_asfortranarray`.
+    """
+    if isinstance(a, (types.Number, types.Boolean,)):
+        def impl(a):
+            return np.asfortranarray(np.array(a))
+        return impl
 
 
 @lower_builtin("array.astype", types.Array, types.DTypeSpec)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4331,6 +4331,28 @@ def array_ascontiguousarray(context, builder, sig, args):
     return _as_layout_array(context, builder, sig, args, output_layout='C')
 
 
+def _array_ascontiguous_scalar(a):
+    """common between ascontiguousarray and asfortranarray"""
+    if isinstance(a, (types.Number, types.Boolean, )):
+        dtype = a
+
+        def impl(a):
+            ary = np.empty((1, ), dtype=dtype)
+            ary[0] = a
+            return ary
+        return impl
+
+
+@overload(np.ascontiguousarray)
+def array_ascontiguousarray_scalar(a):
+    return _array_ascontiguous_scalar(a)
+
+
+@overload(np.ascontiguousarray)
+def array_asfortran_scalar(a):
+    return _array_ascontiguous_scalar(a)
+
+
 @lower_builtin("array.astype", types.Array, types.DTypeSpec)
 @lower_builtin("array.astype", types.Array, types.StringLiteral)
 def array_astype(context, builder, sig, args):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4348,7 +4348,7 @@ def array_ascontiguousarray_scalar(a):
     return _array_ascontiguous_scalar(a)
 
 
-@overload(np.ascontiguousarray)
+@overload(np.asfortranarray)
 def array_asfortran_scalar(a):
     return _array_ascontiguous_scalar(a)
 

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -596,11 +596,22 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
     def test_np_copy(self):
         self.check_layout_dependent_func(np_copy)
 
+    def check_ascontiguousarray_scalar(self, pyfunc):
+        def check_scalar(x):
+            cres = compile_isolated(pyfunc, (typeof(x), ))
+            expected = pyfunc(x)
+            got = cres.entry_point(x)
+            self.assertPreciseEqual(expected, got)
+        for x in [42, 42.0, 42j, np.float32(42), np.float64(42), True]:
+            check_scalar(x)
+
     def test_np_asfortranarray(self):
         self.check_layout_dependent_func(np_asfortranarray)
+        self.check_ascontiguousarray_scalar(np_asfortranarray)
 
     def test_np_ascontiguousarray(self):
         self.check_layout_dependent_func(np_ascontiguousarray)
+        self.check_ascontiguousarray_scalar(np_ascontiguousarray)
 
     def check_np_frombuffer_allocated(self, pyfunc):
         def run(shape):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

## Reference an existing issue

#7353 

## Details

I have added a code to overload scalar arguments to `np.ascontiguousarray` and `np.asfortranarray`. Existing implementations use low level API `glue_lowering`, but I couldn't figure out how to modify the code to handle scalars. Hopefully mixing high level API (`overload`) and low level API is fine.