### PR TITLE
Move the type annotation pass to post legalization.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -173,7 +173,6 @@ exclude =
     numba/tests/test_profiler.py
     numba/tests/test_numpyadapt.py
     numba/tests/test_stencils.py
-    numba/tests/test_annotations.py
     numba/tests/cache_usecases.py
     numba/tests/true_div_usecase.py
     numba/tests/test_dataflow.py

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -558,7 +558,8 @@ class DefaultPassBuilder(object):
                     "ensure features that are in use are in a valid form")
         pm.add_pass(IRLegalization,
                     "ensure IR is legal prior to lowering")
-
+        # Annotate only once legalized
+        pm.add_pass(AnnotateTypes, "annotate types")
         # lower
         pm.add_pass(NativeLowering, "native lowering")
         pm.add_pass(NoPythonBackend, "nopython mode backend")
@@ -572,7 +573,6 @@ class DefaultPassBuilder(object):
         pm = PassManager(name)
         # typing
         pm.add_pass(NopythonTypeInference, "nopython frontend")
-        pm.add_pass(AnnotateTypes, "annotate types")
 
         # strip phis
         pm.add_pass(PreLowerStripPhis, "remove phis nodes")
@@ -657,8 +657,8 @@ class DefaultPassBuilder(object):
         # convert any remaining closures into functions
         pm.add_pass(MakeFunctionToJitFunction,
                     "convert make_function into JIT functions")
-        pm.add_pass(AnnotateTypes, "annotate types")
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        pm.add_pass(AnnotateTypes, "annotate types")
         pm.add_pass(ObjectModeBackEnd, "object mode backend")
         pm.finalize()
         return pm

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -173,23 +173,23 @@ class PartialTypeInference(BaseTypeInference):
     _raise_errors = False
 
 
-@register_pass(mutates_CFG=True, analysis_only=False)
+@register_pass(mutates_CFG=False, analysis_only=False)
 class AnnotateTypes(AnalysisPass):
     _name = "annotate_types"
 
     def __init__(self):
         AnalysisPass.__init__(self)
 
+    def get_analysis_usage(self, AU):
+        AU.add_required(IRLegalization)
+
     def run_pass(self, state):
         """
         Create type annotation after type inference
         """
-        # add back in dels.
-        post_proc = postproc.PostProcessor(state.func_ir)
-        post_proc.run(emit_dels=True)
-
+        func_ir = state.func_ir.copy()
         state.type_annotation = type_annotations.TypeAnnotation(
-            func_ir=state.func_ir.copy(),
+            func_ir=func_ir,
             typemap=state.typemap,
             calltypes=state.calltypes,
             lifted=state.lifted,
@@ -206,8 +206,6 @@ class AnnotateTypes(AnalysisPass):
             with open(config.HTML, 'w') as fout:
                 state.type_annotation.html_annotate(fout)
 
-        # now remove dels
-        post_proc.remove_dels()
         return False
 
 
@@ -260,8 +258,8 @@ class PreParforPass(FunctionPass):
         assert state.func_ir
         preparfor_pass = _parfor_PreParforPass(
             state.func_ir,
-            state.type_annotation.typemap,
-            state.type_annotation.calltypes,
+            state.typemap,
+            state.calltypes,
             state.typingctx,
             state.targetctx,
             state.flags.auto_parallel,
@@ -296,8 +294,8 @@ class ParforPass(FunctionPass):
         # Ensure we have an IR and type information.
         assert state.func_ir
         parfor_pass = _parfor_ParforPass(state.func_ir,
-                                         state.type_annotation.typemap,
-                                         state.type_annotation.calltypes,
+                                         state.typemap,
+                                         state.calltypes,
                                          state.return_type,
                                          state.typingctx,
                                          state.targetctx,
@@ -569,7 +567,7 @@ class InlineOverloads(FunctionPass):
                 del state.func_ir.blocks[dead]
             # clean up blocks
             dead_code_elimination(state.func_ir,
-                                  typemap=state.type_annotation.typemap)
+                                  typemap=state.typemap)
             # clean up unconditional branches that appear due to inlined
             # functions introducing blocks
             state.func_ir.blocks = simplify_CFG(state.func_ir.blocks)
@@ -582,7 +580,7 @@ class InlineOverloads(FunctionPass):
         return True
 
     def _get_attr_info(self, state, expr):
-        recv_type = state.type_annotation.typemap[expr.value.name]
+        recv_type = state.typemap[expr.value.name]
         recv_type = types.unliteral(recv_type)
         matched = state.typingctx.find_matching_getattr_template(
             recv_type, expr.attr,
@@ -610,7 +608,7 @@ class InlineOverloads(FunctionPass):
             if expr.op == 'call':
                 # check this is a known and typed function
                 try:
-                    func_ty = state.type_annotation.typemap[expr.func.name]
+                    func_ty = state.typemap[expr.func.name]
                 except KeyError:
                     # e.g. Calls to CUDA Intrinsic have no mapped type
                     # so KeyError
@@ -643,7 +641,7 @@ class InlineOverloads(FunctionPass):
         if func_ty is None:
             return None
 
-        sig = state.type_annotation.calltypes[expr]
+        sig = state.calltypes[expr]
         if not sig:
             return None
 
@@ -717,8 +715,8 @@ class InlineOverloads(FunctionPass):
         if not inline_type.is_always_inline:
             from numba.core.typing.templates import _inline_info
             caller_inline_info = _inline_info(state.func_ir,
-                                              state.type_annotation.typemap,
-                                              state.type_annotation.calltypes,
+                                              state.typemap,
+                                              state.calltypes,
                                               sig)
 
             # must be a cost-model function, run the function

--- a/numba/tests/test_annotations.py
+++ b/numba/tests/test_annotations.py
@@ -4,6 +4,8 @@ from io import StringIO
 import numba
 from numba.core.compiler import compile_isolated, Flags
 from numba.core import types
+from numba import njit
+from numba.tests.support import override_config, TestCase
 import unittest
 
 try:
@@ -18,7 +20,7 @@ except ImportError:
 
 
 @unittest.skipIf(jinja2 is None, "please install the 'jinja2' package")
-class TestAnnotation(unittest.TestCase):
+class TestAnnotation(TestCase):
 
     def test_exercise_code_path(self):
         """
@@ -143,41 +145,106 @@ class TestAnnotation(unittest.TestCase):
 
         foo(1, 2)
         # Exercise the method
-        obj = foo.inspect_types(pretty=True)
+        foo.inspect_types(pretty=True)
 
         # Exercise but supply a not None file kwarg, this is invalid
         with self.assertRaises(ValueError) as raises:
-            obj = foo.inspect_types(pretty=True, file='should be None')
-        self.assertIn('`file` must be None if `pretty=True`', str(raises.exception))
+            foo.inspect_types(pretty=True, file='should be None')
+        self.assertIn('`file` must be None if `pretty=True`',
+                      str(raises.exception))
 
 
 class TestTypeAnnotation(unittest.TestCase):
+
+    def findpatloc(self, lines, pat):
+        for i, ln in enumerate(lines):
+            if pat in ln:
+                return i
+        raise ValueError("can't find {!r}".format(pat))
+
+    def getlines(self, func):
+        strbuf = StringIO()
+        func.inspect_types(strbuf)
+        return strbuf.getvalue().splitlines()
+
     def test_delete(self):
         @numba.njit
         def foo(appleorange, berrycherry):
             return appleorange + berrycherry
 
         foo(1, 2)
-        # Exercise the method
-        strbuf = StringIO()
-        foo.inspect_types(strbuf)
+
+        lines = self.getlines(foo)
+
         # Ensure deletion show up after their use
-        lines = strbuf.getvalue().splitlines()
+        sa = self.findpatloc(lines, 'appleorange = arg(0, name=appleorange)')
+        sb = self.findpatloc(lines, 'berrycherry = arg(1, name=berrycherry)')
 
-        def findpatloc(pat):
-            for i, ln in enumerate(lines):
-                if pat in ln:
-                    return i
-            raise ValueError("can't find {!r}".format(pat))
-
-        sa = findpatloc('appleorange = arg(0, name=appleorange)')
-        sb = findpatloc('berrycherry = arg(1, name=berrycherry)')
-
-        ea = findpatloc('del appleorange')
-        eb = findpatloc('del berrycherry')
+        ea = self.findpatloc(lines, 'del appleorange')
+        eb = self.findpatloc(lines, 'del berrycherry')
 
         self.assertLess(sa, ea)
         self.assertLess(sb, eb)
+
+    def _lifetimes_impl(self, extend):
+        with override_config('EXTEND_VARIABLE_LIFETIMES', extend):
+            @njit
+            def foo(a):
+                b = a
+                return b
+            x = 10
+            b = foo(x)
+            self.assertEqual(b, x)
+
+        lines = self.getlines(foo)
+
+        sa = self.findpatloc(lines, 'a = arg(0, name=a)')
+        sb = self.findpatloc(lines, 'b = a')
+
+        cast_ret = self.findpatloc(lines, 'cast(value=b)')
+
+        dela = self.findpatloc(lines, 'del a')
+        delb = self.findpatloc(lines, 'del b')
+
+        return sa, sb, cast_ret, dela, delb
+
+    def test_delete_standard_lifetimes(self):
+        # without extended lifetimes, dels occur as soon as dead
+        #
+        # label 0
+        #   a = arg(0, name=a)  :: int64
+        #   b = a  :: int64
+        #   del a
+        #   $8return_value.2 = cast(value=b)  :: int64
+        #   del b
+        #   return $8return_value.2
+
+        sa, sb, cast_ret, dela, delb = self._lifetimes_impl(extend=0)
+
+        self.assertLess(sa, dela)
+        self.assertLess(sb, delb)
+        # del a is before cast and del b is after
+        self.assertLess(dela, cast_ret)
+        self.assertGreater(delb, cast_ret)
+
+    def test_delete_extended_lifetimes(self):
+        # with extended lifetimes, dels are last in block:
+        #
+        # label 0
+        #   a = arg(0, name=a)  :: int64
+        #   b = a  :: int64
+        #   $8return_value.2 = cast(value=b)  :: int64
+        #   del a
+        #   del b
+        #   return $8return_value.2
+
+        sa, sb, cast_ret, dela, delb = self._lifetimes_impl(extend=1)
+
+        self.assertLess(sa, dela)
+        self.assertLess(sb, delb)
+        # dels are after the cast
+        self.assertGreater(dela, cast_ret)
+        self.assertGreater(delb, cast_ret)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_array_analysis.py
+++ b/numba/tests/test_array_analysis.py
@@ -98,8 +98,7 @@ class ArrayAnalysisPass(FunctionPass):
 
     def run_pass(self, state):
         state.array_analysis = ArrayAnalysis(state.typingctx, state.func_ir,
-                                             state.type_annotation.typemap,
-                                             state.type_annotation.calltypes)
+                                             state.typemap, state.calltypes)
         state.array_analysis.run(state.func_ir.blocks)
         post_proc = postproc.PostProcessor(state.func_ir)
         post_proc.run()
@@ -151,7 +150,6 @@ class ArrayAnalysisTester(Compiler):
                     "inline calls to locally defined closures")
         # typing
         pm.add_pass(NopythonTypeInference, "nopython frontend")
-        pm.add_pass(AnnotateTypes, "annotate types")
 
         if not state.flags.no_rewrites:
             pm.add_pass(NopythonRewrites, "nopython rewrites")
@@ -163,6 +161,7 @@ class ArrayAnalysisTester(Compiler):
             pm.add_pass(ArrayAnalysisPass, "idempotence array analysis")
         # legalise
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
+        pm.add_pass(AnnotateTypes, "annotate types")
 
         # partial compile
         pm.finalize()

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -56,8 +56,7 @@ class InlineTestPass(FunctionPass):
             if guard(find_callname,state.func_ir, stmt.value) is not None:
                 inline_closure_call(state.func_ir, {}, block, i, lambda: None,
                                     state.typingctx, state.targetctx, (),
-                                    state.type_annotation.typemap,
-                                    state.type_annotation.calltypes)
+                                    state.typemap, state.calltypes)
                 break
         # also fix up the IR
         post_proc = postproc.PostProcessor(state.func_ir)
@@ -82,7 +81,6 @@ def gen_pipeline(state, test_pass):
                     "inline calls to locally defined closures")
         # typing
         pm.add_pass(NopythonTypeInference, "nopython frontend")
-        pm.add_pass(AnnotateTypes, "annotate types")
 
         if state.flags.auto_parallel.enabled:
             pm.add_pass(PreParforPass, "Preprocessing for parfors")
@@ -95,7 +93,7 @@ def gen_pipeline(state, test_pass):
 
         # legalise
         pm.add_pass(IRLegalization, "ensure IR is legal prior to lowering")
-
+        pm.add_pass(AnnotateTypes, "annotate types")
         pm.add_pass(PreserveIR, "preserve IR")
 
         # lower
@@ -261,8 +259,8 @@ class TestInlining(TestCase):
                             is not None):
                         inline_closure_call(state.func_ir, {}, block, i,
                             foo.py_func, state.typingctx, state.targetctx,
-                            (state.type_annotation.typemap[stmt.value.args[0].name],),
-                            state.type_annotation.typemap, state.calltypes)
+                            (state.typemap[stmt.value.args[0].name],),
+                             state.typemap, state.calltypes)
                         break
                 return True
 

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -76,16 +76,7 @@ class TestRemoveDead(unittest.TestCase):
             typingctx.refresh()
             targetctx.refresh()
             args = (types.int64, types.int64, types.int64)
-            typemap, return_type, calltypes, _ = type_inference_stage(typingctx, targetctx, test_ir, args, None)
-            type_annotation = type_annotations.TypeAnnotation(
-                func_ir=test_ir,
-                typemap=typemap,
-                calltypes=calltypes,
-                lifted=(),
-                lifted_from=None,
-                args=args,
-                return_type=return_type,
-                html_output=config.HTML)
+            typemap, _, calltypes, _ = type_inference_stage(typingctx, targetctx, test_ir, args, None)
             remove_dels(test_ir.blocks)
             in_cps, out_cps = copy_propagate(test_ir.blocks, typemap)
             apply_copy_propagate(test_ir.blocks, in_cps, get_name_var_table(test_ir.blocks), typemap, calltypes)
@@ -255,8 +246,8 @@ class TestRemoveDead(unittest.TestCase):
             def run_pass(self, state):
                 parfor_pass = numba.parfors.parfor.ParforPass(
                     state.func_ir,
-                    state.type_annotation.typemap,
-                    state.type_annotation.calltypes,
+                    state.typemap,
+                    state.calltypes,
                     state.return_type,
                     state.typingctx,
                     state.flags.auto_parallel,
@@ -270,7 +261,7 @@ class TestRemoveDead(unittest.TestCase):
                 remove_dead(state.func_ir.blocks,
                             state.func_ir.arg_names,
                             state.func_ir,
-                            state.type_annotation.typemap)
+                            state.typemap)
                 numba.parfors.parfor.get_parfor_params(state.func_ir.blocks,
                                                 parfor_pass.options.fusion,
                                                 parfor_pass.nested_fusion_info)
@@ -297,7 +288,6 @@ class TestRemoveDead(unittest.TestCase):
                             "inline calls to locally defined closures")
                 # typing
                 pm.add_pass(NopythonTypeInference, "nopython frontend")
-                pm.add_pass(AnnotateTypes, "annotate types")
 
                 # lower
                 pm.add_pass(NativeLowering, "native lowering")


### PR DESCRIPTION
This PR moves the type annotation pass to run after legalization,
this is so as to pick up the variable lifetimes correctly. The
`AnnotateTypes` pass now depends on the `IRLegalization` pass. The
rest of the changes are fixes to change use of members of the type
annotations object (e.g. `typemap`) to the same member on the
pipeline `state` object.

<!--
