### PR TITLE
Use `omp_set_max_active_levels()` instead of `omp_set_nested()`

### DIFF
--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -26,9 +26,9 @@ There are three threading layers available and they are named as follows:
 * ``workqueue`` -A simple built-in work-sharing task scheduler.
 
 In practice, the only threading layer guaranteed to be present is ``workqueue``.
-The ``omp`` layer requires the presence of a suitable OpenMP runtime library.
-The ``tbb`` layer requires the presence of Intel's TBB libraries, these can be
-obtained via the conda command::
+The ``omp`` layer requires the presence of a suitable (3.0 or greater) OpenMP
+runtime library.  The ``tbb`` layer requires the presence of Intel's TBB
+libraries, these can be obtained via the conda command::
 
     $ conda install tbb
 

--- a/numba/np/ufunc/omppool.cpp
+++ b/numba/np/ufunc/omppool.cpp
@@ -224,8 +224,21 @@ static void launch_threads(int count)
     if(count < 1)
         return;
     omp_set_num_threads(count);
-    omp_set_nested(0x1); // enable nesting, control depth with OMP env var
     _INIT_NUM_THREADS = count;
+
+    // Enable up to 32 levels of nested parallelism, or whatever the
+    // implementation supports. From the OpenMP 3.0 spec, p.127:
+    //
+    //     "If the number of parallel levels requested exceeds the number of
+    //     levels of parallelism supported by the implementation, the value of
+    //     the max-active-levels-var ICV will be set to the number of parallel
+    //     levels support by the implementation."
+    //
+    // (https://www.openmp.org/wp-content/uploads/spec30.pdf)
+    //
+    // 32 levels is likely to be far in excess of any practical use case, and
+    // therefore should not present any real-world limitation.
+    omp_set_max_active_levels(32);
 }
 
 static void synchronize(void)


### PR DESCRIPTION
`omp_set_nested()` is deprecated and often results in a warning on recent installations. Following the discussion in Issue #5275, this commit changes the call to `omp_set_max_active_levels()`. Ideally we'd set it to the maximum supported nesting level, but we can't determine what that is; the function `omp_get_supported_active_levels()` was only added in OpenMP 5.0, which is quite recent and was not supported by some implementations until very recently (e.g. it was added to GNU OpenMP in mid-2020). We arbitrarily set the nesting level to 32, which is far greater than any real requirement, and the implementation will limit the nesting levels to the supported number as per the spec if it is less than 32.

Fixes #5275.