### PR TITLE
Fixing issue 7693

### DIFF
--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -896,6 +896,9 @@ class NestedArrayModel(ArrayModel):
         self._be_type = dmm.lookup(fe_type.dtype).get_data_type()
         super(NestedArrayModel, self).__init__(dmm, fe_type)
 
+    def get_data_type(self):
+        return ir.ArrayType(self._be_type, self._fe_type.nitems)
+
 
 @register_default(types.Optional)
 class OptionalModel(StructModel):

--- a/numba/core/datamodel/models.py
+++ b/numba/core/datamodel/models.py
@@ -896,9 +896,6 @@ class NestedArrayModel(ArrayModel):
         self._be_type = dmm.lookup(fe_type.dtype).get_data_type()
         super(NestedArrayModel, self).__init__(dmm, fe_type)
 
-    def get_data_type(self):
-        return ir.ArrayType(self._be_type, self._fe_type.nitems)
-
 
 @register_default(types.Optional)
 class OptionalModel(StructModel):

--- a/numba/cuda/simulator/kernel.py
+++ b/numba/cuda/simulator/kernel.py
@@ -148,6 +148,10 @@ class FakeCUDAKernel(object):
     def overloads(self):
         return FakeOverloadDict()
 
+    @property
+    def py_func(self):
+        return self.fn
+
 
 # Thread emulation
 

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -99,6 +99,8 @@ recordwith2darray = np.dtype([('i', np.int32),
 
 nested_array1_dtype = np.dtype([("array1", np.int16, (3,))], align=True)
 
+nested_array2_dtype = np.dtype([("array2", np.int16, (3, 2))], align=True)
+
 
 # Functions used for "full array" tests
 
@@ -170,6 +172,10 @@ def record_read_2d_array01(ary):
 
 def assign_array_to_nested(dest, src):
     dest['array1'] = src
+
+
+def assign_array_to_nested_2d(dest, src):
+    dest['array2'] = src
 
 
 class TestRecordDtype(CUDATestCase):
@@ -461,6 +467,19 @@ class TestNestedArrays(CUDATestCase):
         expected = np.zeros(2, dtype=nested_array1_dtype)
 
         pyfunc = assign_array_to_nested
+        kernel = cuda.jit(pyfunc)
+
+        kernel[1, 1](got[0], src)
+        pyfunc(expected[0], src)
+
+        np.testing.assert_array_equal(expected, got)
+
+    def test_assign_array_to_nested_2d(self):
+        src = (np.arange(6) + 1).astype(np.int16).reshape((3, 2))
+        got = np.zeros(2, dtype=nested_array2_dtype)
+        expected = np.zeros(2, dtype=nested_array2_dtype)
+
+        pyfunc = assign_array_to_nested_2d
         kernel = cuda.jit(pyfunc)
 
         kernel[1, 1](got[0], src)

--- a/numba/cuda/tests/cudapy/test_record_dtype.py
+++ b/numba/cuda/tests/cudapy/test_record_dtype.py
@@ -420,18 +420,22 @@ class TestNestedArrays(CUDATestCase):
         np.testing.assert_equal(res, nbval[0].j[1, 0])
 
     def test_setitem(self):
-        nbarr1 = np.recarray(2, dtype=recordwith2darray)
-        nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
-                             dtype=recordwith2darray)[0]
-        nbarr2 = np.recarray(2, dtype=recordwith2darray)
-        nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
-                             dtype=recordwith2darray)[0]
+        def gen():
+            nbarr1 = np.recarray(1, dtype=recordwith2darray)
+            nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
+                                 dtype=recordwith2darray)[0]
+            nbarr2 = np.recarray(1, dtype=recordwith2darray)
+            nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
+                                 dtype=recordwith2darray)[0]
+            return nbarr1[0], nbarr2[0]
         pyfunc = record_setitem_array
-        args = nbarr1[0], nbarr2[0]
-        arr_expected = pyfunc(*args)
+        pyargs = gen()
+        pyfunc(*pyargs)
+
         cfunc = cuda.jit(pyfunc)
-        arr_res = cfunc[1, 1](*args)
-        np.testing.assert_equal(arr_res, arr_expected)
+        cuargs = gen()
+        cfunc[1, 1](*cuargs)
+        np.testing.assert_equal(pyargs, cuargs)
 
     def test_getitem_idx(self):
         # Test __getitem__ with numerical index

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2601,11 +2601,12 @@ def record_setattr(context, builder, sig, args, attr):
 
     if isinstance(elemty, types.NestedArray):
         # TODO: assert both sides are arrays
-        dptr = cgutils.get_record_member(builder, target, offset,
-                                     context.get_data_type(elemty))
+        arr_model = context.data_model_manager[elemty]
+        be_arr_ty = ir.ArrayType(arr_model._be_type, arr_model._fe_type.nitems)
+        dptr = cgutils.get_record_member(builder, target, offset, be_arr_ty)
 
         dataval_ptr = context.data_model_manager[elemty].get(builder, val, 'data')
-        dataval_ptr = builder.bitcast(dataval_ptr, context.get_data_type(elemty).as_pointer())
+        dataval_ptr = builder.bitcast(dataval_ptr, be_arr_ty.as_pointer())
         align = None if typ.aligned else 1
         dataval = builder.load(dataval_ptr)
         builder.store(dataval, dptr, align=align)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2600,7 +2600,6 @@ def record_setattr(context, builder, sig, args, attr):
     elemty = typ.typeof(attr)
 
     if isinstance(elemty, types.NestedArray):
-        # TODO: assert both sides are arrays
         arr_model = context.data_model_manager[elemty]
         be_arr_ty = ir.ArrayType(arr_model._be_type, arr_model._fe_type.nitems)
         dptr = cgutils.get_record_member(builder, target, offset, be_arr_ty)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2605,7 +2605,7 @@ def record_setattr(context, builder, sig, args, attr):
         be_arr_ty = ir.ArrayType(arr_model._be_type, arr_model._fe_type.nitems)
         dptr = cgutils.get_record_member(builder, target, offset, be_arr_ty)
 
-        dataval_ptr = context.data_model_manager[elemty].get(builder, val, 'data')
+        dataval_ptr = arr_model.get(builder, val, 'data')
         dataval_ptr = builder.bitcast(dataval_ptr, be_arr_ty.as_pointer())
         align = None if typ.aligned else 1
         dataval = builder.load(dataval_ptr)

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1514,18 +1514,22 @@ class TestNestedArrays(TestCase):
             np.testing.assert_equal(arr_res, arr_expected)
 
     def test_setitem(self):
-        nbarr1 = np.recarray(2, dtype=recordwith2darray)
-        nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
-                             dtype=recordwith2darray)[0]
-        nbarr2 = np.recarray(2, dtype=recordwith2darray)
-        nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
-                             dtype=recordwith2darray)[0]
+        def gen():
+            nbarr1 = np.recarray(1, dtype=recordwith2darray)
+            nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
+                                 dtype=recordwith2darray)[0]
+            nbarr2 = np.recarray(1, dtype=recordwith2darray)
+            nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
+                                 dtype=recordwith2darray)[0]
+            return nbarr1[0], nbarr2[0]
         pyfunc = record_setitem_array
-        args = nbarr1[0], nbarr2[0]
-        arr_expected = pyfunc(*args)
-        cfunc = self.get_cfunc(pyfunc, tuple((typeof(arg) for arg in args)))
-        arr_res = cfunc(*args)
-        np.testing.assert_equal(arr_res, arr_expected)
+        pyargs = gen()
+        pyfunc(*pyargs)
+
+        nbargs = gen()
+        cfunc = self.get_cfunc(pyfunc, tuple((typeof(arg) for arg in nbargs)))
+        cfunc(*nbargs)
+        np.testing.assert_equal(pyargs, nbargs)
 
     def test_getitem_idx(self):
         # Test __getitem__ with numerical index

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -240,6 +240,10 @@ def recarray_write_array_of_nestedarray_broadcast(ary):
     return ary
 
 
+def record_setitem_array(rec_source, rec_dest):
+    rec_dest['j'] = rec_source['j']
+
+
 def recarray_write_array_of_nestedarray(ary):
     ary.j[:, :, :] = np.ones((2, 3, 2), dtype=np.float64)
     return ary
@@ -1494,6 +1498,23 @@ class TestNestedArrays(TestCase):
             cfunc = self.get_cfunc(pyfunc, (ty,))
             arr_res = cfunc(nbarr)
             np.testing.assert_equal(arr_res, arr_expected)
+
+
+    def test_setitem(self):
+        nbarr1 = np.recarray(2, dtype=recordwith2darray)
+        nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
+                            dtype=recordwith2darray)[0]
+        nbarr2 = np.recarray(2, dtype=recordwith2darray)
+        nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
+                            dtype=recordwith2darray)[0]
+
+        pyfunc = record_setitem_array
+        args = nbarr1[0], nbarr2[0]
+        arr_expected = pyfunc(*args)
+        cfunc = self.get_cfunc(pyfunc, tuple((typeof(arg) for arg in args)))
+        arr_res = cfunc(*args)
+        np.testing.assert_equal(arr_res, arr_expected)
+
 
     def test_getitem_idx(self):
         # Test __getitem__ with numerical index

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -411,6 +411,11 @@ def assign_array_to_nested(dest):
     dest['array1'] = tmp
 
 
+def assign_array_to_nested_2d(dest):
+    tmp = (np.arange(6) + 1).astype(np.int16).reshape((3, 2))
+    dest['array2'] = tmp
+
+
 recordtype = np.dtype([('a', np.float64),
                        ('b', np.int16),
                        ('c', np.complex64),
@@ -439,6 +444,8 @@ recordwith4darray = np.dtype([('o', np.int64),
                               ('q', 'U10'),])
 
 nested_array1_dtype = np.dtype([("array1", np.int16, (3,))], align=True)
+
+nested_array2_dtype = np.dtype([("array2", np.int16, (3, 2))], align=True)
 
 
 class TestRecordDtypeMakeCStruct(unittest.TestCase):
@@ -1655,6 +1662,16 @@ class TestNestedArrays(TestCase):
         cfunc = njit(assign_array_to_nested)
         cfunc(got[0])
         assign_array_to_nested(expected[0])
+
+        np.testing.assert_array_equal(expected, got)
+
+    def test_assign_array_to_nested_2d(self):
+        got = np.zeros(2, dtype=nested_array2_dtype)
+        expected = np.zeros(2, dtype=nested_array2_dtype)
+
+        cfunc = njit(assign_array_to_nested_2d)
+        cfunc(got[0])
+        assign_array_to_nested_2d(expected[0])
 
         np.testing.assert_array_equal(expected, got)
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1506,22 +1506,19 @@ class TestNestedArrays(TestCase):
             arr_res = cfunc(nbarr)
             np.testing.assert_equal(arr_res, arr_expected)
 
-
     def test_setitem(self):
         nbarr1 = np.recarray(2, dtype=recordwith2darray)
         nbarr1[0] = np.array([(1, ((1, 2), (4, 5), (2, 3)))],
-                            dtype=recordwith2darray)[0]
+                             dtype=recordwith2darray)[0]
         nbarr2 = np.recarray(2, dtype=recordwith2darray)
         nbarr2[0] = np.array([(10, ((10, 20), (40, 50), (20, 30)))],
-                            dtype=recordwith2darray)[0]
-
+                             dtype=recordwith2darray)[0]
         pyfunc = record_setitem_array
         args = nbarr1[0], nbarr2[0]
         arr_expected = pyfunc(*args)
         cfunc = self.get_cfunc(pyfunc, tuple((typeof(arg) for arg in args)))
         arr_res = cfunc(*args)
         np.testing.assert_equal(arr_res, arr_expected)
-
 
     def test_getitem_idx(self):
         # Test __getitem__ with numerical index

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1531,6 +1531,17 @@ class TestNestedArrays(TestCase):
         cfunc(*nbargs)
         np.testing.assert_equal(pyargs, nbargs)
 
+    def test_setitem_whole_array_error(self):
+        # Ensure we raise a suitable error when attempting to assign an
+        # array to a whole array's worth of nested arrays.
+        nbarr1 = np.recarray(1, dtype=recordwith2darray)
+        nbarr2 = np.recarray(1, dtype=recordwith2darray)
+        args = (nbarr1, nbarr2)
+        pyfunc = record_setitem_array
+        errmsg = "unsupported array index type"
+        with self.assertRaisesRegex(TypingError, errmsg):
+            self.get_cfunc(pyfunc, tuple((typeof(arg) for arg in args)))
+
     def test_getitem_idx(self):
         # Test __getitem__ with numerical index
 


### PR DESCRIPTION
Fixes the lowering of setitem of a nestedarray into the nestedarray field of a record. Changes to the generated LLVM IR in those cases, to prevent the metadata (strides, etc) of the source being copied into the data buffer of the destination array. 

fixes #7693 