### PR TITLE
Bump llvmlite dependency to 0.39.0dev0 for Numba 0.56.0dev0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Dependencies
 ============
 
 * Python versions: 3.7-3.10
-* llvmlite 0.38.*
+* llvmlite 0.39.*
 * NumPy >=1.18 (can build with 1.11 for ABI compatibility).
 
 Optionally:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - numpy
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.38.0dev0,<0.38
+    - llvmlite >=0.39.0dev0,<0.39
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
     # NOTE: ppc64le exclusion is temporary until packages are more generally
@@ -46,7 +46,7 @@ requirements:
     - numpy >=1.18
     - setuptools
     # On channel https://anaconda.org/numba/
-    - llvmlite >=0.38.0dev0,<0.38
+    - llvmlite >=0.39.0dev0,<0.39
   run_constrained:
     # If TBB is present it must be at least version 2021
     - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -87,7 +87,7 @@ __all__ = """
     """.split() + types.__all__ + errors.__all__
 
 
-_min_llvmlite_version = (0, 38, 0)
+_min_llvmlite_version = (0, 39, 0)
 _min_llvm_version = (11, 0, 0)
 
 def _ensure_llvm():

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ min_python_version = "3.7"
 max_python_version = "3.11"  # exclusive
 min_numpy_build_version = "1.11"
 min_numpy_run_version = "1.18"
-min_llvmlite_version = "0.38.0dev0"
-max_llvmlite_version = "0.39"
+min_llvmlite_version = "0.39.0dev0"
+max_llvmlite_version = "0.40"
 
 if sys.platform.startswith('linux'):
     # Patch for #2555 to make wheels without libpython


### PR DESCRIPTION
As title.
