### PR TITLE
Update URLs in error messages to refer to RTD docs.

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -1282,7 +1282,7 @@ class CPUCodegen(Codegen):
             raise RuntimeError(
                 "LLVM will produce incorrect floating-point code "
                 "in the current locale %s.\nPlease read "
-                "https://numba.pydata.org/numba-doc/latest/user/faq.html#llvm-locale-bug "
+                "https://numba.readthedocs.io/en/stable/user/faq.html#llvm-locale-bug "
                 "for more information."
                 % (loc,))
         raise AssertionError("Unexpected IR:\n%s\n" % (ir_out,))

--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -364,9 +364,9 @@ please file a feature request at:
 https://github.com/numba/numba/issues/new?template=feature_request.md
 
 To see Python/NumPy features supported by the latest release of Numba visit:
-https://numba.pydata.org/numba-doc/latest/reference/pysupported.html
+https://numba.readthedocs.io/en/stable/reference/pysupported.html
 and
-https://numba.pydata.org/numba-doc/latest/reference/numpysupported.html
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html
 """
 
 constant_inference_info = """
@@ -375,7 +375,7 @@ a constant. This could well be a current limitation in Numba's internals,
 however please first check that your code is valid for compilation,
 particularly with respect to string interpolation (not supported!) and
 the requirement of compile time constants as arguments to exceptions:
-https://numba.pydata.org/numba-doc/latest/reference/pysupported.html?highlight=exceptions#constructs
+https://numba.readthedocs.io/en/stable/reference/pysupported.html?highlight=exceptions#constructs
 
 If the code is valid and the unsupported functionality is important to you
 please file a feature request at:
@@ -389,12 +389,12 @@ This is not usually a problem with Numba itself but instead often caused by
 the use of unsupported features or an issue in resolving types.
 
 To see Python/NumPy features supported by the latest release of Numba visit:
-https://numba.pydata.org/numba-doc/latest/reference/pysupported.html
+https://numba.readthedocs.io/en/stable/reference/pysupported.html
 and
-https://numba.pydata.org/numba-doc/latest/reference/numpysupported.html
+https://numba.readthedocs.io/en/stable/reference/numpysupported.html
 
 For more information about typing errors and how to debug them visit:
-https://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-doesn-t-compile
+https://numba.readthedocs.io/en/stable/user/troubleshoot.html#my-code-doesn-t-compile
 
 If you think your code should work with Numba, please report the error message
 and traceback, along with a minimal reproducer at:

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2124,9 +2124,9 @@ def raise_on_unsupported_feature(func_ir, typemap):
                "in a function is unsupported (strange things happen!), use "
                "numba.gdb_breakpoint() to create additional breakpoints "
                "instead.\n\nRelevant documentation is available here:\n"
-               "https://numba.pydata.org/numba-doc/latest/user/troubleshoot.html"
-               "/troubleshoot.html#using-numba-s-direct-gdb-bindings-in-"
-               "nopython-mode\n\nConflicting calls found at:\n %s")
+               "https://numba.readthedocs.io/en/stable/user/troubleshoot.html"
+               "#using-numba-s-direct-gdb-bindings-in-nopython-mode\n\n"
+               "Conflicting calls found at:\n %s")
         buf = '\n'.join([x.strformat() for x in gdb_calls])
         raise UnsupportedError(msg % buf)
 
@@ -2142,7 +2142,7 @@ def warn_deprecated(func_ir, typemap):
                 arg = name.split('.')[1]
                 fname = func_ir.func_id.func_qualname
                 tyname = 'list' if isinstance(ty, types.List) else 'set'
-                url = ("https://numba.pydata.org/numba-doc/latest/reference/"
+                url = ("https://numba.readthedocs.io/en/stable/reference/"
                        "deprecation.html#deprecation-of-reflection-for-list-and"
                        "-set-types")
                 msg = ("\nEncountered the use of a type that is scheduled for "

--- a/numba/core/object_mode_passes.py
+++ b/numba/core/object_mode_passes.py
@@ -151,7 +151,7 @@ class ObjectModeBackEnd(LoweringPass):
             warnings.warn(errors.NumbaWarning(warn_msg,
                                               state.func_ir.loc))
 
-            url = ("https://numba.pydata.org/numba-doc/latest/reference/"
+            url = ("https://numba.readthedocs.io/en/stable/reference/"
                    "deprecation.html#deprecation-of-object-mode-fall-"
                    "back-behaviour-when-using-jit")
             msg = ("\nFall-back from the nopython compilation path to the "

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -320,7 +320,7 @@ class ParforPass(FunctionPass):
             # parfor calls the compiler chain again with a string
             if not (config.DISABLE_PERFORMANCE_WARNINGS or
                     state.func_ir.loc.filename == '<string>'):
-                url = ("https://numba.pydata.org/numba-doc/latest/user/"
+                url = ("https://numba.readthedocs.io/en/stable/user/"
                        "parallel.html#diagnostics")
                 msg = ("\nThe keyword argument 'parallel=True' was specified "
                        "but no transformation for parallel execution was "

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -1155,7 +1155,7 @@ precise type that can be inferred from the other variables. Whilst sometimes
 the type of empty lists can be inferred, this is not always the case, see this
 documentation for help:
 
-https://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#my-code-has-an-untyped-list-problem
+https://numba.readthedocs.io/en/stable/user/troubleshoot.html#my-code-has-an-untyped-list-problem
 """
             if offender is not None:
                 # This block deals with imprecise lists

--- a/numba/cuda/errors.py
+++ b/numba/cuda/errors.py
@@ -17,8 +17,8 @@ class CudaLoweringError(LoweringError):
     pass
 
 
-_launch_help_url = ("https://numba.pydata.org/numba-doc/"
-                    "latest/cuda/kernels.html#kernel-invocation")
+_launch_help_url = ("https://numba.readthedocs.io/en/stable/cuda/"
+                    "kernels.html#kernel-invocation")
 missing_launch_config_msg = """
 Kernel launch configuration was not specified. Use the syntax:
 

--- a/numba/misc/gdb_hook.py
+++ b/numba/misc/gdb_hook.py
@@ -30,7 +30,7 @@ def _confirm_gdb(need_ptrace_attach=True):
     if not (os.path.exists(gdbloc) and os.path.isfile(gdbloc)):
         msg = ('Is gdb present? Location specified (%s) does not exist. The gdb'
                ' binary location can be set using Numba configuration, see: '
-               'https://numba.pydata.org/numba-doc/latest/reference/envvars.html'  # noqa: E501
+               'https://numba.readthedocs.io/en/stable/reference/envvars.html'  # noqa: E501
                )
         raise RuntimeError(msg % config.GDB_BINARY)
     # Is Yama being used as a kernel security module and if so is ptrace_scope

--- a/numba/tests/test_deprecations.py
+++ b/numba/tests/test_deprecations.py
@@ -11,7 +11,7 @@ class TestDeprecation(unittest.TestCase):
         self.assertEqual(len(warnings), 1)
         self.assertEqual(warnings[0].category, category)
         self.assertIn(expected_str, str(warnings[0].message))
-        self.assertIn("https://numba.pydata.org", str(warnings[0].message))
+        self.assertIn("https://numba.readthedocs.io", str(warnings[0].message))
 
     def test_jitfallback(self):
         # tests that @jit falling back to object mode raises a
@@ -52,7 +52,7 @@ class TestDeprecation(unittest.TestCase):
                 self.assertIn(msg, warn_msg)
                 msg = ("\'reflected %s\' found for argument" % container)
                 self.assertIn(msg, warn_msg)
-                self.assertIn("https://numba.pydata.org", warn_msg)
+                self.assertIn("https://numba.readthedocs.io", warn_msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As title. This replaces references to documentation at
numba.pydata.org with numba.readthedocs.io. It also fixes URLs
that were invalid.
