### PR TITLE
Document that AOT-compiled functions do not check arg types

### DIFF
--- a/docs/source/user/pycc.rst
+++ b/docs/source/user/pycc.rst
@@ -39,7 +39,7 @@ Limitations
    several different signatures under different names).
 
 #. Exported functions do not check the types of the arguments that are passed
-   to them; the callee is expected to provide arguments of the correct type.
+   to them; the caller is expected to provide arguments of the correct type.
 
 #. AOT compilation produces generic code for your CPU's architectural family
    (for example "x86-64"), while JIT compilation produces code optimized

--- a/docs/source/user/pycc.rst
+++ b/docs/source/user/pycc.rst
@@ -38,6 +38,9 @@ Limitations
 #. Each exported function can have only one signature (but you can export
    several different signatures under different names).
 
+#. Exported functions do not check the types of the arguments that are passed
+   to them; the callee is expected to provide arguments of the correct type.
+
 #. AOT compilation produces generic code for your CPU's architectural family
    (for example "x86-64"), while JIT compilation produces code optimized
    for your particular CPU model.


### PR DESCRIPTION
This explicitly documents the limitation described in #7725, that AOT-compiled functions don't check their argument types.