### PR TITLE
CUDA Python 11.6 support

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     # scipy 1.0 or later
     - scipy >=1.0
     # CUDA Python 11.6 or later
-    - cuda-python >= 11.6
+    - cuda-python >=11.6
 
 test:
   requires:

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -56,6 +56,8 @@ requirements:
     - cudatoolkit >=9.2
     # scipy 1.0 or later
     - scipy >=1.0
+    # CUDA Python 11.6 or later
+    - cuda-python >= 11.6
 
 test:
   requires:

--- a/docs/source/cuda/bindings.rst
+++ b/docs/source/cuda/bindings.rst
@@ -4,12 +4,7 @@ CUDA Bindings
 Numba supports two bindings to the CUDA Driver APIs: its own internal bindings
 based on ctypes, and the official `NVIDIA CUDA Python bindings
 <https://nvidia.github.io/cuda-python/>`_. Functionality is equivalent between
-the two bindings, with two exceptions:
-
-* the NVIDIA bindings presently do not support Per-Thread Default Streams
-  (PTDS), and an exception will be raised on import if PTDS is enabled along
-  with the NVIDIA bindings.
-* The profiling APIs are not available with the NVIDIA bindings.
+the two bindings.
 
 The internal bindings are used by default. If the NVIDIA bindings are installed,
 then they can be used by setting the environment variable
@@ -17,15 +12,32 @@ then they can be used by setting the environment variable
 Numba has been imported, the selected binding cannot be changed.
 
 
+Per-Thread Default Streams
+--------------------------
+
+Responsibility for handling Per-Thread Default Streams (PTDS) is delegated to
+the NVIDIA bindings when they are in use. To use PTDS with the NVIDIA bindings,
+set the environment variable ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` to
+``1`` instead of Numba's environmnent variable
+:envvar:`NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`.
+
+.. seealso::
+
+   The `Default Stream section
+   <https://nvidia.github.io/cuda-python/release/11.6.0-notes.html#default-stream>`_
+   in the NVIDIA Bindings documentation.
+
+
 Roadmap
 -------
 
+In Numba 0.56, the NVIDIA Bindings will be used by default, if they are
+installed.
+
 In future versions of Numba:
 
-- The NVIDIA Bindings will be used by default, if they are installed.
 - The internal bindings will be deprecated.
 - The internal bindings will be removed.
 
-It is expected that the NVIDIA bindings will be the default in Numba 0.56; at
-present, no specific release is planned for the deprecation or removal of the
-internal bindings.
+At present, no specific release is planned for the deprecation or removal of
+the internal bindings.

--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -64,10 +64,12 @@ CUDA Bindings
 
 Numba supports interacting with the CUDA Driver API via the `NVIDIA CUDA Python
 bindings <https://nvidia.github.io/cuda-python/>`_ and its own ctypes-based
-binding. The ctypes-based binding is presently the default as Per-Thread
-Default Streams and the profiler APIs are not supported with the NVIDIA
-bindings, but otherwise functionality is equivalent between the two. You can
-install the NVIDIA bindings with::
+bindings. Functionality is equivalent between the two bindings. The
+ctypes-based bindings are presently the default, but the NVIDIA bindings will
+be used by default (if they are available in the environment) in a future Numba
+release.
+
+You can install the NVIDIA bindings with::
 
    $ conda install nvidia::cuda-python
 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -490,7 +490,7 @@ GPU support
    for an explanation of the legacy and per-thread default streams.
 
    This variable only takes effect when using Numba's internal CUDA bindings;
-   when using the NVIDIA bindings, use the variable
+   when using the NVIDIA bindings, use the environment variable
    ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` instead.
 
    .. seealso::

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -485,10 +485,19 @@ GPU support
 
    When set to 1, the default stream is the per-thread default stream. When set
    to 0, the default stream is the legacy default stream. This defaults to 0,
-   for the legacy default stream. It may default to 1 in a future release of
-   Numba. See `Stream Synchronization Behavior
+   for the legacy default stream. See `Stream Synchronization Behavior
    <https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html>`_
    for an explanation of the legacy and per-thread default streams.
+
+   This variable only takes effect when using Numba's internal CUDA bindings;
+   when using the NVIDIA bindings, use the variable
+   ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` instead.
+
+   .. seealso::
+
+      The `Default Stream section
+      <https://nvidia.github.io/cuda-python/release/11.6.0-notes.html#default-stream>`_
+      in the NVIDIA Bindings documentation.
 
 .. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -247,7 +247,7 @@ vary with target operating system and hardware. The following lists them all
   * ``typeguard`` - used by ``runtests.py`` for
     :ref:`runtime type-checking <type_anno_check>`.
   * ``cuda-python`` - The NVIDIA CUDA Python bindings. See :ref:`cuda-bindings`.
-    Numba is tested with Version 11.5 of the bindings.
+    Numba requires Version 11.6 or greater.
 
 * To build the documentation:
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -135,7 +135,11 @@ class _EnvReloader(object):
                 CUDA_USE_NVIDIA_BINDING = False
 
             if CUDA_PER_THREAD_DEFAULT_STREAM:  # noqa: F821
-                warnings.warn("PTDS is not supported with CUDA Python")
+                warnings.warn("PTDS support is handled by CUDA Python when "
+                              "using the NVIDIA binding. Please set the "
+                              "environment variable "
+                              "CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM to 1 "
+                              "instead.")
 
     def process_environ(self, environ):
         def _readenv(name, ctor, default):

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -349,7 +349,10 @@ class Driver(object):
         return safe_call
 
     def _find_api(self, fname):
-        if config.CUDA_PER_THREAD_DEFAULT_STREAM:
+        # We use alternatively-named functions for PTDS with the Numba ctypes
+        # binding. For the NVidia binding, it handles linking to the correct
+        # variant.
+        if config.CUDA_PER_THREAD_DEFAULT_STREAM and not USE_NV_BINDING:
             variants = ('_v2_ptds', '_v2_ptsz', '_ptds', '_ptsz', '_v2', '')
         else:
             variants = ('_v2', '')

--- a/numba/cuda/testing.py
+++ b/numba/cuda/testing.py
@@ -130,11 +130,8 @@ def skip_unless_cc_60(fn):
     return unittest.skipUnless(cc_X_or_above(6, 0), "requires cc >= 6.0")(fn)
 
 
-def xfail_with_cuda_python(fn):
-    if driver.USE_NV_BINDING:
-        return unittest.expectedFailure(fn)
-    else:
-        return fn
+def skip_with_cuda_python(reason):
+    return unittest.skipIf(driver.USE_NV_BINDING, reason)
 
 
 def cudadevrt_missing():

--- a/numba/cuda/tests/cudadrv/test_profiler.py
+++ b/numba/cuda/tests/cudadrv/test_profiler.py
@@ -1,11 +1,10 @@
 import unittest
 from numba.cuda.testing import ContextResettingTestCase
 from numba import cuda
-from numba.cuda.testing import skip_on_cudasim, xfail_with_cuda_python
+from numba.cuda.testing import skip_on_cudasim
 
 
 @skip_on_cudasim('CUDA Profiler unsupported in the simulator')
-@xfail_with_cuda_python
 class TestProfiler(ContextResettingTestCase):
     def test_profiling(self):
         with cuda.profiling():

--- a/numba/cuda/tests/cudadrv/test_ptds.py
+++ b/numba/cuda/tests/cudadrv/test_ptds.py
@@ -2,7 +2,7 @@ import multiprocessing as mp
 import logging
 import traceback
 from numba.cuda.testing import unittest, CUDATestCase
-from numba.cuda.testing import skip_on_cudasim, xfail_with_cuda_python
+from numba.cuda.testing import skip_on_cudasim, skip_with_cuda_python
 
 
 def child_test():
@@ -102,7 +102,7 @@ def child_test_wrapper(result_queue):
 
 @skip_on_cudasim('Streams not supported on the simulator')
 class TestPTDS(CUDATestCase):
-    @xfail_with_cuda_python
+    @skip_with_cuda_python('Function names unchanged for PTDS with NV Binding')
     def test_ptds(self):
         # Run a test with PTDS enabled in a child process
         ctx = mp.get_context('spawn')


### PR DESCRIPTION
CUDA Python now supports the profiler APIs (as of 11.6), so the xfail needs removing.

Description to be updated once this PR is ready for review

gpuci run tests