### PR TITLE
Fix issues with locating/parsing source during DebugInfo emission.

### DIFF
--- a/numba/core/errors.py
+++ b/numba/core/errors.py
@@ -97,6 +97,12 @@ class NumbaIRAssumptionWarning(NumbaPedanticWarning):
     Warning category for reporting an IR assumption violation.
     """
 
+
+class NumbaDebugInfoWarning(NumbaWarning):
+    """
+    Warning category for an issue with the emission of debug information.
+    """
+
 # These are needed in the color formatting of errors setup
 
 

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -3,12 +3,16 @@ import inspect
 import re
 import numpy as np
 import math
+from textwrap import dedent
+import unittest
+import warnings
 
-from numba.tests.support import TestCase, override_config, needs_subprocess
+from numba.tests.support import (TestCase, override_config, needs_subprocess,
+                                 ignore_internal_warnings)
 from numba import jit, njit
 from numba.core import types, utils
 from numba.core.datamodel import default_manager
-import unittest
+from numba.core.errors import NumbaDebugInfoWarning
 import llvmlite.binding as llvm
 
 #NOTE: These tests are potentially sensitive to changes in SSA or lowering
@@ -594,6 +598,50 @@ class TestDebugInfoEmission(TestCase):
             base_type_marker = base_type_matches[0]
             data_type = metadata_definition_map[base_type_marker]
             self.assertRegex(data_type, expected[field])
+
+    def test_missing_source(self):
+        strsrc = """
+        def foo():
+            return 1
+        """
+        l = dict()
+        exec(dedent(strsrc), {}, l)
+        foo = njit(debug=True)(l['foo'])
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaDebugInfoWarning)
+            ignore_internal_warnings()
+            foo()
+
+        self.assertEqual(len(w), 1)
+        found = w[0]
+        self.assertEqual(found.category, NumbaDebugInfoWarning)
+        msg = str(found.message)
+        # make sure the warning contains the right message
+        self.assertIn('Could not find source for function', msg)
+        # and refers to the offending function
+        self.assertIn(str(foo.py_func), msg)
+
+    def test_unparsable_indented_source(self):
+
+        @njit(debug=True)
+        def foo():
+# NOTE: THIS COMMENT MUST START AT COLUMN 0 FOR THIS SAMPLE CODE TO BE VALID # noqa: E115, E501
+            return 1
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', NumbaDebugInfoWarning)
+            ignore_internal_warnings()
+            foo()
+
+        self.assertEqual(len(w), 1)
+        found = w[0]
+        self.assertEqual(found.category, NumbaDebugInfoWarning)
+        msg = str(found.message)
+        # make sure the warning contains the right message
+        self.assertIn('Could not parse the source for function', msg)
+        # and refers to the offending function
+        self.assertIn(str(foo.py_func), msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This works around issues with source that cannot be parsed when
looking for a line containing `def` so as to get the correct line
info for use in DebugInfo emission. It adds tests for this and
also the case where the function source is simply unobtainable.

Fixes #7730
