### PR TITLE
Refactor threading layer priority tests to not use stdout/stderr

### DIFF
--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -530,7 +530,7 @@ class TestThreadingLayerPriority(ThreadLayerTestHelper):
     def each_env_var(self, env_var: str):
         """Test setting priority via env var NUMBA_THREADING_LAYER_PRIORITY.
         """
-        env = dict()
+        env = os.environ.copy()
         env['NUMBA_THREADING_LAYER'] = 'default'
         env['NUMBA_THREADING_LAYER_PRIORITY'] = env_var
 

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -10,6 +10,7 @@ import os
 import random
 import subprocess
 import sys
+import textwrap
 import threading
 import unittest
 
@@ -528,37 +529,34 @@ class TestThreadingLayerPriority(ThreadLayerTestHelper):
 
     def each_env_var(self, env_var: str):
         """Test setting priority via env var NUMBA_THREADING_LAYER_PRIORITY.
-
-        :return: threading_layer_priority, stderr
-            (containing ``@threading_layer@``)
         """
-        env = os.environ.copy()
+        env = dict()
         env['NUMBA_THREADING_LAYER'] = 'default'
         env['NUMBA_THREADING_LAYER_PRIORITY'] = env_var
 
         code = f"""
-import numba
+                import numba
 
-# trigger threading layer decision
-# hence catching invalid THREADING_LAYER_PRIORITY
-@numba.jit(
-    'float64[::1](float64[::1], float64[::1])',
-    nopython=True,
-    parallel=True,
-)
-def plus(x, y):
-    return x + y
+                # trigger threading layer decision
+                # hence catching invalid THREADING_LAYER_PRIORITY
+                @numba.jit(
+                    'float64[::1](float64[::1], float64[::1])',
+                    nopython=True,
+                    parallel=True,
+                )
+                def plus(x, y):
+                    return x + y
 
-captured_envvar = list("{env_var}".split())
-assert numba.config.THREADING_LAYER_PRIORITY == captured_envvar, \
-    "priority mismatch"
-assert numba.threading_layer() == captured_envvar[0],\
-    "selected backend mismatch"
-"""
+                captured_envvar = list("{env_var}".split())
+                assert numba.config.THREADING_LAYER_PRIORITY == \
+                    captured_envvar, "priority mismatch"
+                assert numba.threading_layer() == captured_envvar[0],\
+                    "selected backend mismatch"
+                """
         cmd = [
             sys.executable,
             '-c',
-            code,
+            textwrap.dedent(code),
         ]
         self.run_cmd(cmd, env=env)
 

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -562,12 +562,16 @@ assert numba.threading_layer() == captured_envvar[0],\
         ]
         self.run_cmd(cmd, env=env)
 
+    @skip_no_omp
+    @skip_no_tbb
     def test_valid_env_var(self):
         default = ['tbb', 'omp', 'workqueue']
         for p in itertools.permutations(default):
             env_var = ' '.join(p)
             self.each_env_var(env_var)
 
+    @skip_no_omp
+    @skip_no_tbb
     def test_invalid_env_var(self):
         env_var = 'tbb omp workqueue notvalidhere'
         with self.assertRaises(AssertionError) as raises:

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -615,16 +615,13 @@ class TestMiscBackendIssues(ThreadLayerTestHelper):
 
             x = np.ones(2**20, np.float32)
             foo(*([x]*8))
-            print("@%s@" % threading_layer())
+            assert threading_layer() == "omp", "omp not found"
         """
         cmdline = [sys.executable, '-c', runme]
         env = os.environ.copy()
         env['NUMBA_THREADING_LAYER'] = "omp"
         env['OMP_STACKSIZE'] = "100K"
-        out, err = self.run_cmd(cmdline, env=env)
-        if self._DEBUG:
-            print(out, err)
-        self.assertIn("@omp@", out)
+        self.run_cmd(cmdline, env=env)
 
     @skip_no_tbb
     def test_single_thread_tbb(self):
@@ -643,16 +640,13 @@ class TestMiscBackendIssues(ThreadLayerTestHelper):
                 return acc
 
             foo(100)
-            print("@%s@" % threading_layer())
+            assert threading_layer() == "tbb", "tbb not found"
         """
         cmdline = [sys.executable, '-c', runme]
         env = os.environ.copy()
         env['NUMBA_THREADING_LAYER'] = "tbb"
         env['NUMBA_NUM_THREADS'] = "1"
-        out, err = self.run_cmd(cmdline, env=env)
-        if self._DEBUG:
-            print(out, err)
-        self.assertIn("@tbb@", out)
+        self.run_cmd(cmdline, env=env)
 
     def test_workqueue_aborts_on_nested_parallelism(self):
         """


### PR DESCRIPTION
As title, this prevents output from e.g diagnostics being able to
influence the outcome of the tests.

Fixes #7458

