### PR TITLE
Fix #7751: Use original filename for array exprs

### DIFF
--- a/numba/np/ufunc/array_exprs.py
+++ b/numba/np/ufunc/array_exprs.py
@@ -333,7 +333,7 @@ def _lower_array_expr(lowerer, expr):
     '''Lower an array expression built by RewriteArrayExprs.
     '''
     expr_name = "__numba_array_expr_%s" % (hex(hash(expr)).replace("-", "_"))
-    expr_filename = f"__numba_array_expr_synthetic_module_{expr.loc.filename}"
+    expr_filename = expr.loc.filename
     expr_var_list = expr.list_vars()
     # The expression may use a given variable several times, but we
     # should only create one parameter for it.


### PR DESCRIPTION
Using a synthetic filename causes an issue for coverage, which cannot find the synthetic file when generating a report.

This commit restores the use of the original filename for array expressions in order to resolve the issue.

@stuartarchibald I'm not sure about whether this is correct - it fixes coverage, but I couldn't work out from the PR which added the synthetic filename (#7177) why the synthetic filename is used. What are your thoughts here?

Fixes #7751.