### PR TITLE
CUDA: Deprecate support for CC < 5.3 and CTK < 10.2

### DIFF
--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -41,7 +41,7 @@ Numba supports CUDA-enabled GPUs with Compute Capability 3.0 or greater.
 Support for devices with Compute Capability less than 5.3 is deprecated, and
 will be removed in the next Numba release (0.56).
 
-Devices with Compute Capability 5.3 or greater include:
+Devices with Compute Capability 5.3 or greater include (but are not limited to):
 
 - Embedded platforms: NVIDIA Jetson Nano, TX1, TX2, Xavier NX, AGX Xavier.
 - Desktop / Server GPUs: All GPUs with Pascal microarchitecture or later. E.g.

--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -37,24 +37,39 @@ Requirements
 Supported GPUs
 --------------
 
-Numba supports CUDA-enabled GPU with compute capability 3.0 or above with an
-up-to-data Nvidia driver.
+Numba supports CUDA-enabled GPUs with Compute Capability 3.0 or greater.
+Support for devices with Compute Capability less than 5.3 is deprecated, and
+will be removed in the next Numba release (0.56).
+
+Devices with Compute Capability 5.3 or greater include:
+
+- Embedded platforms: NVIDIA Jetson Nano, TX1, TX2, Xavier NX, AGX Xavier.
+- Desktop / Server GPUs: All GPUs with Pascal microarchitecture or later. E.g.
+  GTX 10 / 16 series, RTX 20 / 30 series, Quadro P / V / RTX series, RTX A series.
+- Laptop GPUs: All GPUs with Pascal microarchitecture or later. E.g. MX series,
+  Quadro P / T series (mobile), RTX 20 / 30 series (mobile), RTX A series (mobile).
 
 Software
 --------
 
-Numba aims to support CUDA Toolkit versions released within the last 3 years. At
-the present time, you will need the CUDA toolkit version 9.2 or later installed.
+Numba aims to support CUDA Toolkit versions released within the last 3 years.
+An NVIDIA driver sufficient for the toolkit version is also required.
+Presently:
 
-CUDA is supported on 64-bit Linux and Windows. 32-bit platforms, and macOS are
-unsupported.
+* 9.2 is the minimum required toolkit version.
+* Support for versions less than 10.2 is deprecated, and will be removed in the
+  next Numba release (0.56).
+* 11.2 or later is recommended, as it uses an NVVM version based on LLVM 7 (as
+  opposed to 3.4 in earlier releases).
+
+CUDA is supported on 64-bit Linux and Windows.
 
 If you are using Conda, you can install the CUDA toolkit with::
 
    $ conda install cudatoolkit
 
 If you are not using Conda or if you want to use a different version of CUDA
-toolkit, the following describe how Numba searches for a CUDA toolkit
+toolkit, the following describes how Numba searches for a CUDA toolkit
 installation.
 
 .. _cuda-bindings:

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -328,3 +328,27 @@ Schedule
 
 - In Numba 0.55: ``add_user_function()`` will be deprecated.
 - In Numba 0.56: ``add_user_function()`` will be removed.
+
+
+Deprecation of CUDA Toolkits < 10.2 and devices with CC < 5.3
+=============================================================
+
+Support for:
+
+- Devices with Compute Capability < 5.3, and
+- CUDA toolkits less than 10.2
+
+is deprecated and will be removed in future.
+
+Recommendations
+---------------
+
+- For devices of Compute Capability 3.0 - 5.2, Numba 0.55.1 or earlier will be
+  required.
+- CUDA toolkit 10.2 or later (ideally 11.2 or later) should be installed.
+
+Schedule
+--------
+
+- In Numba 0.55.1: support for CC < 5.3 and CUDA toolkits < 10.2 are deprecated.
+- In Numba 0.56: support for CC < 5.3 and CUDA toolkits < 10.2 will be removed.

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -14,7 +14,9 @@ Our supported platforms are:
 * Windows 7 and later (32-bit and 64-bit)
 * OS X 10.9 and later (64-bit and unofficial support on M1/Arm64)
 * \*BSD (unofficial support only)
-* NVIDIA GPUs of compute capability 3.0 and later
+* NVIDIA GPUs of compute capability 5.3 and later
+
+  * Compute capabilities 3.0 - 5.2 are supported, but deprecated.
 * ARMv7 (32-bit little-endian, such as Raspberry Pi 2 and 3)
 * ARMv8 (64-bit little-endian, such as the NVIDIA Jetson)
 
@@ -263,12 +265,11 @@ Checking your installation
 You should be able to import Numba from the Python prompt::
 
     $ python
-    Python 3.8.1 (default, Jan 8  2020, 16:15:59)
-    [Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
+    Python 3.10.2 | packaged by conda-forge | (main, Jan 14 2022, 08:02:09) [GCC 9.4.0] on linux
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import numba
     >>> numba.__version__
-    '0.48.0'
+    '0.55.1'
 
 You can also try executing the ``numba --sysinfo`` (or ``numba -s`` for short)
 command to report information about your system capabilities. See :ref:`cli` for
@@ -280,36 +281,41 @@ further information.
     System info:
     --------------------------------------------------------------------------------
     __Time Stamp__
-    2018-08-28 15:46:24.631054
+    Report started (local time)                   : 2022-01-18 10:35:08.981319
 
     __Hardware Information__
-    Machine                             : x86_64
-    CPU Name                            : haswell
-    CPU Features                        :
-    aes avx avx2 bmi bmi2 cmov cx16 f16c fma fsgsbase lzcnt mmx movbe pclmul popcnt
-    rdrnd sse sse2 sse3 sse4.1 sse4.2 ssse3 xsave xsaveopt
+    Machine                                       : x86_64
+    CPU Name                                      : skylake-avx512
+    CPU Count                                     : 12
+    CPU Features                                  :
+    64bit adx aes avx avx2 avx512bw avx512cd avx512dq avx512f avx512vl bmi bmi2
+    clflushopt clwb cmov cx16 cx8 f16c fma fsgsbase fxsr invpcid lzcnt mmx
+    movbe pclmul pku popcnt prfchw rdrnd rdseed rtm sahf sse sse2 sse3 sse4.1
+    sse4.2 ssse3 xsave xsavec xsaveopt xsaves
 
     __OS Information__
-    Platform                            : Darwin-17.6.0-x86_64-i386-64bit
-    Release                             : 17.6.0
-    System Name                         : Darwin
-    Version                             : Darwin Kernel Version 17.6.0: Tue May  8 15:22:16 PDT 2018; root:xnu-4570.61.1~1/RELEASE_X86_64
-    OS specific info                    : 10.13.5   x86_64
+    Platform Name                                 : Linux-5.4.0-94-generic-x86_64-with-glibc2.31
+    Platform Release                              : 5.4.0-94-generic
+    OS Name                                       : Linux
+    OS Version                                    : #106-Ubuntu SMP Thu Jan 6 23:58:14 UTC 2022
 
     __Python Information__
-    Python Compiler                     : GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)
-    Python Implementation               : CPython
-    Python Version                      : 2.7.15
-    Python Locale                       : en_US UTF-8
+    Python Compiler                               : GCC 9.4.0
+    Python Implementation                         : CPython
+    Python Version                                : 3.10.2
+    Python Locale                                 : en_GB.UTF-8
 
     __LLVM information__
-    LLVM version                        : 6.0.0
+    LLVM Version                                  : 11.1.0
 
     __CUDA Information__
     Found 1 CUDA devices
-    id 0         GeForce GT 750M                              [SUPPORTED]
-                          compute capability: 3.0
-                               pci device id: 0
-                                  pci bus id: 1
+    id 0      b'Quadro RTX 8000'                              [SUPPORTED]
+                          Compute Capability: 7.5
+                               PCI Device ID: 0
+                                  PCI Bus ID: 21
+                                        UUID: GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643
+                                    Watchdog: Enabled
+                 FP32/FP64 Performance Ratio: 32
 
 (output truncated due to length)

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -475,8 +475,11 @@ def detect():
         if os.name == "nt":
             attrs += [('Compute Mode', 'TCC' if tcc else 'WDDM')]
         attrs += [('FP32/FP64 Performance Ratio', fp32_to_fp64_ratio)]
-        if cc < (2, 0):
-            support = '[NOT SUPPORTED: CC < 2.0]'
+        if cc < (3, 0):
+            support = '[NOT SUPPORTED: CC < 3.0]'
+        elif cc < (5, 3):
+            support = '[SUPPORTED  (DEPRECATED)]'
+            supported_count += 1
         else:
             support = '[SUPPORTED]'
             supported_count += 1

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -478,7 +478,7 @@ def detect():
         if cc < (3, 0):
             support = '[NOT SUPPORTED: CC < 3.0]'
         elif cc < (5, 3):
-            support = '[SUPPORTED  (DEPRECATED)]'
+            support = '[SUPPORTED (DEPRECATED)]'
             supported_count += 1
         else:
             support = '[SUPPORTED]'


### PR DESCRIPTION
This deprecates support for:

- Compute capabilities less than 5.3
- CUDA toolkits less than 10.2

in preparation for removing support for them in Numba 0.56. This is in accordance with supporting 3 year's worth of toolkits (9.2 is almost 4 years old now), and all hardware released in the last 6 years is still supported.

I've also updated the Numba sysinfo example so it looks similar to what a user might see today (rather than referencing outdated versions of things) and added a small note to `cuda.detect()` to show supported but deprecated devices, and to correctly identify devices with CC < 3.0 as unsupported.