### PR TITLE
Add dbg_optnone and dbg_extend_lifetimes flags

### DIFF
--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -443,7 +443,9 @@ JIT options for debug
 * ``_dbg_optnone`` (bool). Set to ``True`` to disable all LLVM optimization passes 
   on the function. Defaults to ``False``. See :envvar:`NUMBA_OPT` for a global setting
   to disable optimization.
-* ``_dbg_extend_lifetimes`` (bool). Set to ``True`` to extend the lifetime of objects such that they more closely follow the semantics of Python. Automatically set to ``True`` when 
+* ``_dbg_extend_lifetimes`` (bool). Set to ``True`` to extend the lifetime of
+  objects such that they more closely follow the semantics of Python.
+  Automatically set to ``True`` when 
   ``debug=True``; otherwise, defaults to ``False``. Users can explicitly set this option 
   to ``False`` to retain the normal execution semantics of compiled code.
   See :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` for a global option to extend object 

--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -443,10 +443,9 @@ JIT options for debug
 * ``_dbg_optnone`` (bool). Set to ``True`` to disable all LLVM optimization passes 
   on the function. Defaults to ``False``. See :envvar:`NUMBA_OPT` for a global setting
   to disable optimization.
-* ``_dbg_extend_lifetimes`` (bool). Set to ``True`` to extend object lifetimes to match 
-  closer to Python semantic for the function. Automatically set to ``True`` when 
+* ``_dbg_extend_lifetimes`` (bool). Set to ``True`` to extend the lifetime of objects such that they more closely follow the semantics of Python. Automatically set to ``True`` when 
   ``debug=True``; otherwise, defaults to ``False``. Users can explicitly set this option 
-  to ``False`` to retain  semantic of normal execution of compiled code.
+  to ``False`` to retain the normal execution semantics of compiled code.
   See :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` for a global option to extend object 
   lifetimes.
 

--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -443,8 +443,8 @@ JIT options for debug
 * ``_dbg_optnone`` (bool). Set to ``True`` to disable all LLVM optimization passes 
   on the function. Defaults to ``False``. See :envvar:`NUMBA_OPT` for a global setting
   to disable optimization.
-* ``_dbg_extend_lifetimes`` (bool). Set to ``True` to extend object lifetimes to match 
-  closer to Python semantic for the function. Automatically set to ``True` when 
+* ``_dbg_extend_lifetimes`` (bool). Set to ``True`` to extend object lifetimes to match 
+  closer to Python semantic for the function. Automatically set to ``True`` when 
   ``debug=True``; otherwise, defaults to ``False``. Users can explicitly set this option 
   to ``False`` to retain  semantic of normal execution of compiled code.
   See :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` for a global option to extend object 

--- a/docs/source/user/troubleshoot.rst
+++ b/docs/source/user/troubleshoot.rst
@@ -407,8 +407,11 @@ Known issues:
 
 * Stepping depends heavily on optimization level. At full optimization
   (equivalent to O3), most of the variables are optimized out. It is often
-  beneficial to use the environment variable :envvar:`NUMBA_OPT` to adjust the
-  optimization level and :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` to extend
+  beneficial to use the jit option ``_dbg_optnone=True`` 
+  or the environment variable :envvar:`NUMBA_OPT` to adjust the 
+  optimization level and the jit option ``_dbg_extend_lifetimes=True`` 
+  (which is on by default if ``debug=True``) or
+  :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` to extend
   the lifetime of variables to the end of their scope so as to get a debugging
   experience closer to the semantics of Python execution.
 
@@ -432,6 +435,20 @@ Internal details:
   ``x``, ``x.1`` and ``x.2``.)
 
 * When debug is enabled, inlining of functions at LLVM IR level is disabled.
+
+JIT options for debug
+---------------------
+
+* ``debug`` (bool). Set to ``True`` to enable debug info. Defaults to ``False``.
+* ``_dbg_optnone`` (bool). Set to ``True`` to disable all LLVM optimization passes 
+  on the function. Defaults to ``False``. See :envvar:`NUMBA_OPT` for a global setting
+  to disable optimization.
+* ``_dbg_extend_lifetimes`` (bool). Set to ``True` to extend object lifetimes to match 
+  closer to Python semantic for the function. Automatically set to ``True` when 
+  ``debug=True``; otherwise, defaults to ``False``. Users can explicitly set this option 
+  to ``False`` to retain  semantic of normal execution of compiled code.
+  See :envvar:`NUMBA_EXTEND_VARIABLE_LIFETIMES` for a global option to extend object 
+  lifetimes.
 
 Example debug usage
 -------------------

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -431,7 +431,8 @@ class BaseContext(object):
         fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)
         self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes, noalias=fndesc.noalias)
         if fndesc.inline:
-            fn.attributes.add('alwaysinline')
+            if 'noinline' not in fn.attributes:
+                fn.attributes.add('alwaysinline')
         return fn
 
     def declare_external_function(self, module, fndesc):

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -431,8 +431,10 @@ class BaseContext(object):
         fn = cgutils.get_or_insert_function(module, fnty, fndesc.mangled_name)
         self.call_conv.decorate_function(fn, fndesc.args, fndesc.argtypes, noalias=fndesc.noalias)
         if fndesc.inline:
-            if 'noinline' not in fn.attributes:
-                fn.attributes.add('alwaysinline')
+            fn.attributes.add('alwaysinline')
+            # alwaysinline overrides optnone
+            fn.attributes.discard('noinline')
+            fn.attributes.discard('optnone')
         return fn
 
     def declare_external_function(self, module, fndesc):

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -143,6 +143,12 @@ detail""",
         doc="backend"
     )
 
+    dbg_extend_lifetimes = Option(
+        type=bool,
+        default=False,
+        doc="Extend variable lifetime for debugging",
+    )
+
 
 DEFAULT_FLAGS = Flags()
 DEFAULT_FLAGS.nrt = True

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -149,6 +149,12 @@ detail""",
         doc="Extend variable lifetime for debugging",
     )
 
+    dbg_optnone = Option(
+        type=bool,
+        default=False,
+        doc="Disable opt for debug. Put optnone attribute in LLVM Function."
+    )
+
 
 DEFAULT_FLAGS = Flags()
 DEFAULT_FLAGS.nrt = True

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -87,7 +87,7 @@ class Flags(TargetConfig):
     forceinline = Option(
         type=bool,
         default=False,
-        doc="TODO",
+        doc="Force inlining of the function. Overrides dbg_optnone.",
     )
     no_cpython_wrapper = Option(
         type=bool,
@@ -147,13 +147,15 @@ detail""",
     dbg_extend_lifetimes = Option(
         type=bool,
         default=False,
-        doc="Extend variable lifetime for debugging",
+        doc=("Extend variable lifetime for debugging. "
+             "This automatically turns on with debug=True."),
     )
 
     dbg_optnone = Option(
         type=bool,
         default=False,
-        doc="Disable opt for debug. Put optnone attribute in LLVM Function."
+        doc=("Disable optimization for debug. "
+             "Equivalent to adding optnone attribute in the LLVM Function.")
     )
 
 

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -87,7 +87,7 @@ class Flags(TargetConfig):
     forceinline = Option(
         type=bool,
         default=False,
-        doc="Force inlining of the function. Overrides dbg_optnone.",
+        doc="Force inlining of the function. Overrides _dbg_optnone.",
     )
     no_cpython_wrapper = Option(
         type=bool,

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -296,8 +296,6 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
             if not flags.is_set("dbg_extend_lifetimes"):
                 # auto turn on extend-lifetimes if debuginfo is on.
                 flags.dbg_extend_lifetimes = True
-            if not flags.is_set("dbg_optnone"):
-                flags.dbg_optnone = True
 
         if not flags.is_set("boundscheck"):
             flags.boundscheck = flags.debuginfo
@@ -312,6 +310,10 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
         flags.inherit_if_not_set("target_backend")
 
         flags.inherit_if_not_set("forceinline")
+
+        if flags.forceinline:
+            # forceinline turns off optnone, just like clang.
+            flags.optnone = False
 
 # ----------------------------------------------------------------------------
 # Internal

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -294,6 +294,7 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
 
         if flags.debuginfo:
             if not flags.is_set("dbg_extend_lifetimes"):
+                # auto turn on extend-lifetimes if debuginfo is on.
                 flags.dbg_extend_lifetimes = True
             if not flags.is_set("dbg_optnone"):
                 flags.dbg_optnone = True

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -294,7 +294,8 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
 
         if flags.debuginfo:
             if not flags.is_set("dbg_extend_lifetimes"):
-                # auto turn on extend-lifetimes if debuginfo is on.
+                # auto turn on extend-lifetimes if debuginfo is on and
+                # dbg_extend_lifetimes is not set
                 flags.dbg_extend_lifetimes = True
 
         if not flags.is_set("boundscheck"):

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -274,7 +274,8 @@ _options_mixin = include_default_options(
     "inline",
     # Add "target_backend" as a accepted option for the CPU in @jit(...)
     "target_backend",
-    "dbg_extend_lifetimes"
+    "dbg_extend_lifetimes",
+    "dbg_optnone",
 )
 
 class CPUTargetOptions(_options_mixin, TargetOptions):
@@ -290,8 +291,11 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
         if not flags.is_set("debuginfo"):
             flags.debuginfo = config.DEBUGINFO_DEFAULT
 
-        if flags.debuginfo and not flags.is_set("dbg_extend_lifetimes"):
-            flags.dbg_extend_lifetimes = True
+        if flags.debuginfo:
+            if not flags.is_set("dbg_extend_lifetimes"):
+                flags.dbg_extend_lifetimes = True
+            if not flags.is_set("dbg_optnone"):
+                flags.dbg_optnone = True
 
         if not flags.is_set("boundscheck"):
             flags.boundscheck = flags.debuginfo

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -275,8 +275,8 @@ _options_mixin = include_default_options(
     "forceinline",
     # Add "target_backend" as a accepted option for the CPU in @jit(...)
     "target_backend",
-    "dbg_extend_lifetimes",
-    "dbg_optnone",
+    "_dbg_extend_lifetimes",
+    "_dbg_optnone",
 )
 
 class CPUTargetOptions(_options_mixin, TargetOptions):

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -274,6 +274,7 @@ _options_mixin = include_default_options(
     "inline",
     # Add "target_backend" as a accepted option for the CPU in @jit(...)
     "target_backend",
+    "dbg_extend_lifetimes"
 )
 
 class CPUTargetOptions(_options_mixin, TargetOptions):
@@ -288,6 +289,9 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
 
         if not flags.is_set("debuginfo"):
             flags.debuginfo = config.DEBUGINFO_DEFAULT
+
+        if flags.debuginfo and not flags.is_set("dbg_extend_lifetimes"):
+            flags.dbg_extend_lifetimes = True
 
         if not flags.is_set("boundscheck"):
             flags.boundscheck = flags.debuginfo

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -292,11 +292,14 @@ class CPUTargetOptions(_options_mixin, TargetOptions):
         if not flags.is_set("debuginfo"):
             flags.debuginfo = config.DEBUGINFO_DEFAULT
 
-        if flags.debuginfo:
-            if not flags.is_set("dbg_extend_lifetimes"):
+        if not flags.is_set("dbg_extend_lifetimes"):
+            if flags.debuginfo:
                 # auto turn on extend-lifetimes if debuginfo is on and
                 # dbg_extend_lifetimes is not set
                 flags.dbg_extend_lifetimes = True
+            else:
+                # set flag using env-var config
+                flags.dbg_extend_lifetimes = config.EXTEND_VARIABLE_LIFETIMES
 
         if not flags.is_set("boundscheck"):
             flags.boundscheck = flags.debuginfo

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -16,7 +16,8 @@ from numba.core.typing.templates import signature
 from numba.core.analysis import (compute_live_map, compute_use_defs,
                             compute_cfg_from_blocks)
 from numba.core.errors import (TypingError, UnsupportedError,
-                               NumbaPendingDeprecationWarning)
+                               NumbaPendingDeprecationWarning,
+                               CompilerError)
 
 import copy
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -7,22 +7,16 @@ import numpy
 
 import types as pytypes
 import collections
-import operator
 import warnings
-
-from llvmlite import ir as lir
 
 import numba
 from numba.core.extending import _Intrinsic
-from numba.core import types, utils, typing, ir, analysis, postproc, rewrites, config, cgutils
-from numba.core.typing.templates import (signature, infer_global,
-                                         AbstractTemplate)
-from numba.core.imputils import impl_ret_untracked
+from numba.core import types, typing, ir, analysis, postproc, rewrites, config
+from numba.core.typing.templates import signature
 from numba.core.analysis import (compute_live_map, compute_use_defs,
                             compute_cfg_from_blocks)
 from numba.core.errors import (TypingError, UnsupportedError,
-                               NumbaPendingDeprecationWarning, NumbaWarning,
-                               feedback_details, CompilerError)
+                               NumbaPendingDeprecationWarning)
 
 import copy
 
@@ -2204,7 +2198,7 @@ def legalize_single_scope(blocks):
     return len({blk.scope for blk in blocks.values()}) == 1
 
 
-def check_and_legalize_ir(func_ir):
+def check_and_legalize_ir(func_ir, flags: "numba.core.compiler.Flags"):
     """
     This checks that the IR presented is legal
     """
@@ -2212,7 +2206,8 @@ def check_and_legalize_ir(func_ir):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    post_proc.run(True, extend_lifetimes=config.EXTEND_VARIABLE_LIFETIMES)
+    print("flags.dbg_extend_lifetimes", flags.dbg_extend_lifetimes)
+    post_proc.run(True, extend_lifetimes=flags.dbg_extend_lifetimes)
 
 
 def convert_code_obj_to_function(code_obj, caller_ir):

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2218,12 +2218,7 @@ def check_and_legalize_ir(func_ir, flags: "numba.core.compiler.Flags"):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    if flags.is_set("dbg_extend_lifetimes"):
-        # function level setting take precedence over env-var config
-        ext_life = flags.dbg_extend_lifetimes
-    else:
-        ext_life = bool(config.EXTEND_VARIABLE_LIFETIMES)
-    post_proc.run(True, extend_lifetimes=ext_life)
+    post_proc.run(True, extend_lifetimes=flags.dbg_extend_lifetimes)
 
 def convert_code_obj_to_function(code_obj, caller_ir):
     """

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2217,8 +2217,8 @@ def check_and_legalize_ir(func_ir, flags: "numba.core.compiler.Flags"):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    print("flags.dbg_extend_lifetimes", flags.dbg_extend_lifetimes)
-    post_proc.run(True, extend_lifetimes=flags.dbg_extend_lifetimes)
+    ext_life = flags.dbg_extend_lifetimes or config.EXTEND_VARIABLE_LIFETIMES
+    post_proc.run(True, extend_lifetimes=ext_life)
 
 
 def convert_code_obj_to_function(code_obj, caller_ir):

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2218,7 +2218,7 @@ def check_and_legalize_ir(func_ir, flags: "numba.core.compiler.Flags"):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    ext_life = flags.dbg_extend_lifetimes or config.EXTEND_VARIABLE_LIFETIMES
+    ext_life = flags.dbg_extend_lifetimes or bool(config.EXTEND_VARIABLE_LIFETIMES)
     post_proc.run(True, extend_lifetimes=ext_life)
 
 

--- a/numba/core/ir_utils.py
+++ b/numba/core/ir_utils.py
@@ -2218,9 +2218,12 @@ def check_and_legalize_ir(func_ir, flags: "numba.core.compiler.Flags"):
     enforce_no_dels(func_ir)
     # postprocess and emit ir.Dels
     post_proc = postproc.PostProcessor(func_ir)
-    ext_life = flags.dbg_extend_lifetimes or bool(config.EXTEND_VARIABLE_LIFETIMES)
+    if flags.is_set("dbg_extend_lifetimes"):
+        # function level setting take precedence over env-var config
+        ext_life = flags.dbg_extend_lifetimes
+    else:
+        ext_life = bool(config.EXTEND_VARIABLE_LIFETIMES)
     post_proc.run(True, extend_lifetimes=ext_life)
-
 
 def convert_code_obj_to_function(code_obj, caller_ir):
     """

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -305,6 +305,11 @@ class BaseLower(object):
     def setup_function(self, fndesc):
         # Setup function
         self.function = self.context.declare_function(self.module, fndesc)
+        print("self.flags.dbg_optnone", self.flags.dbg_optnone)
+        if self.flags.dbg_optnone:
+            self.function.attributes.add("optnone")
+            print(self.function)
+
         self.entry_block = self.function.append_basic_block('entry')
         self.builder = Builder(self.entry_block)
         self.call_helper = self.call_conv.init_call_helper(self.builder)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -309,8 +309,8 @@ class BaseLower(object):
             attrset = self.function.attributes
             attrset.add("optnone")
             # optnone requires noinline unless it has alwaysinline
-            if "alwaysinline" not in attrset:
-                attrset.add("noinline")
+            attrset.discard("alwaysinline")
+            attrset.add("noinline")
         self.entry_block = self.function.append_basic_block('entry')
         self.builder = Builder(self.entry_block)
         self.call_helper = self.call_conv.init_call_helper(self.builder)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -307,10 +307,9 @@ class BaseLower(object):
         self.function = self.context.declare_function(self.module, fndesc)
         if self.flags.dbg_optnone:
             attrset = self.function.attributes
-            attrset.add("optnone")
-            # optnone requires noinline unless it has alwaysinline
-            attrset.discard("alwaysinline")
-            attrset.add("noinline")
+            if "alwaysinline" not in attrset:
+                attrset.add("optnone")
+                attrset.add("noinline")
         self.entry_block = self.function.append_basic_block('entry')
         self.builder = Builder(self.entry_block)
         self.call_helper = self.call_conv.init_call_helper(self.builder)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -305,11 +305,12 @@ class BaseLower(object):
     def setup_function(self, fndesc):
         # Setup function
         self.function = self.context.declare_function(self.module, fndesc)
-        print("self.flags.dbg_optnone", self.flags.dbg_optnone)
         if self.flags.dbg_optnone:
-            self.function.attributes.add("optnone")
-            print(self.function)
-
+            attrset = self.function.attributes
+            attrset.add("optnone")
+            # optnone requires noinline unless it has alwaysinline
+            if "alwaysinline" not in attrset:
+                attrset.add("noinline")
         self.entry_block = self.function.append_basic_block('entry')
         self.builder = Builder(self.entry_block)
         self.call_helper = self.call_conv.init_call_helper(self.builder)

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -91,6 +91,8 @@ class DefaultOptions:
 
     target_backend = _mapping("target_backend")
 
+    dbg_extend_lifetimes = _mapping("dbg_extend_lifetimes")
+
 
 def include_default_options(*args):
     """Returns a mixin class with a subset of the options

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -92,6 +92,7 @@ class DefaultOptions:
     target_backend = _mapping("target_backend")
 
     dbg_extend_lifetimes = _mapping("dbg_extend_lifetimes")
+    dbg_optnone = _mapping("dbg_optnone")
 
 
 def include_default_options(*args):

--- a/numba/core/options.py
+++ b/numba/core/options.py
@@ -92,8 +92,8 @@ class DefaultOptions:
 
     target_backend = _mapping("target_backend")
 
-    dbg_extend_lifetimes = _mapping("dbg_extend_lifetimes")
-    dbg_optnone = _mapping("dbg_optnone")
+    _dbg_extend_lifetimes = _mapping("dbg_extend_lifetimes")
+    _dbg_optnone = _mapping("dbg_optnone")
 
 
 def include_default_options(*args):

--- a/numba/core/postproc.py
+++ b/numba/core/postproc.py
@@ -64,7 +64,7 @@ class PostProcessor(object):
     A post-processor for Numba IR.
     """
 
-    def __init__(self, func_ir: ir.FunctionIR):
+    def __init__(self, func_ir):
         self.func_ir = func_ir
 
     def run(self, emit_dels: bool = False, extend_lifetimes: bool = False):

--- a/numba/core/postproc.py
+++ b/numba/core/postproc.py
@@ -64,10 +64,10 @@ class PostProcessor(object):
     A post-processor for Numba IR.
     """
 
-    def __init__(self, func_ir):
+    def __init__(self, func_ir: ir.FunctionIR):
         self.func_ir = func_ir
 
-    def run(self, emit_dels=False, extend_lifetimes=False):
+    def run(self, emit_dels: bool = False, extend_lifetimes: bool = False):
         """
         Run the following passes over Numba IR:
         - canonicalize the CFG

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -462,7 +462,7 @@ class IRLegalization(AnalysisPass):
 
     def run_pass(self, state):
         # NOTE: this function call must go last, it checks and fixes invalid IR!
-        check_and_legalize_ir(state.func_ir)
+        check_and_legalize_ir(state.func_ir, flags=state.flags)
         return True
 
 

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -157,6 +157,18 @@ class TestDebugInfoEmission(TestCase):
                 metadata_definition_map[dbg_val] = info
         return metadata_definition_map
 
+    def _get_lines_from_debuginfo(self, metadata):
+        # Get the lines contained in the debug info
+        md_def_map = self._get_metadata_map(metadata)
+
+        lines = set()
+        for md in md_def_map.values():
+            m = re.match(r"!DILocation\(line: (\d+),", md)
+            if m:
+                ln = int(m.group(1))
+                lines.add(ln)
+        return lines
+
     def test_DW_LANG(self):
 
         @njit(debug=True)
@@ -592,14 +604,8 @@ class TestDebugInfoEmission(TestCase):
 
     def test_debug_optnone(self):
         def get_debug_lines(fn):
-            # Get the lines contained in the debug info
-            mdlist = self._get_metadata(fn, fn.signatures[0])
-            lines = set()
-            for md in mdlist:
-                m = re.match(r"!\d+ = !DILocation\(line: (\d+),", md)
-                if m:
-                    ln = int(m.group(1))
-                    lines.add(ln)
+            metadata = self._get_metadata(fn, fn.signatures[0])
+            lines = self._get_lines_from_debuginfo(metadata)
             return lines
 
         def get_func_attrs(fn):

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -604,7 +604,7 @@ class TestDebugInfoEmission(TestCase):
             return c
 
         foo_debug = njit(debug=True)(foo)
-        foo_debug_optnone = njit(debug=True, dbg_optnone=True)(foo)
+        foo_debug_optnone = njit(debug=True, _dbg_optnone=True)(foo)
 
         expected = foo()
         test_list = [foo_debug, foo_debug_optnone]


### PR DESCRIPTION
- Adds `dbg_optnone` to disable optimization on specific functions for better debugging experience.
- Adds `dbg_extend_lifetimes` to extend value lifetimes for better debugging.