### PR TITLE
Move function unique ID to abi-tags

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -289,7 +289,7 @@ class BaseContext(object):
         Load target-specific registries.  Can be overridden by subclasses.
         """
 
-    def mangler(self, name, types, *, abi_tags=(), uid):
+    def mangler(self, name, types, *, abi_tags=(), uid=None):
         """
         Perform name mangling.
         """

--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -289,11 +289,11 @@ class BaseContext(object):
         Load target-specific registries.  Can be overridden by subclasses.
         """
 
-    def mangler(self, name, types, *, abi_tags=()):
+    def mangler(self, name, types, *, abi_tags=(), uid):
         """
         Perform name mangling.
         """
-        return funcdesc.default_mangler(name, types, abi_tags=abi_tags)
+        return funcdesc.default_mangler(name, types, abi_tags=abi_tags, uid=uid)
 
     def get_env_name(self, fndesc):
         """Get the environment name given a FunctionDescriptor.

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -307,12 +307,22 @@ class FunctionIdentity(serialize.ReduceMixin):
     (the two might be distinct, e.g. in the `@generated_jit` case).
     """
     _unique_ids = itertools.count(1)
+    _cache = {}
 
     @classmethod
     def from_function(cls, pyfunc):
         """
         Create the FunctionIdentity of the given function.
         """
+        if pyfunc in cls._cache:
+            obj = cls._cache[pyfunc]
+        else:
+            obj = cls._make_from_function(pyfunc)
+            cls._cache[pyfunc] = obj
+        return obj
+
+    @classmethod
+    def _make_from_function(cls, pyfunc):
         func = get_function_object(pyfunc)
         code = get_code_object(func)
         pysig = utils.pysignature(func)
@@ -346,6 +356,7 @@ class FunctionIdentity(serialize.ReduceMixin):
         # variables, so we make sure to disambiguate using an unique id.
         uid = next(cls._unique_ids)
         self.unique_name = '{}${}'.format(self.func_qualname, uid)
+        self.unique_id = uid
 
         return self
 

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -307,22 +307,12 @@ class FunctionIdentity(serialize.ReduceMixin):
     (the two might be distinct, e.g. in the `@generated_jit` case).
     """
     _unique_ids = itertools.count(1)
-    _cache = {}
 
     @classmethod
     def from_function(cls, pyfunc):
         """
         Create the FunctionIdentity of the given function.
         """
-        if pyfunc in cls._cache:
-            obj = cls._cache[pyfunc]
-        else:
-            obj = cls._make_from_function(pyfunc)
-            cls._cache[pyfunc] = obj
-        return obj
-
-    @classmethod
-    def _make_from_function(cls, pyfunc):
         func = get_function_object(pyfunc)
         code = get_code_object(func)
         pysig = utils.pysignature(func)

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -9,7 +9,7 @@ from numba.core import types, itanium_mangler
 from numba.core.utils import _dynamic_modname, _dynamic_module
 
 
-def default_mangler(name, argtypes, *, abi_tags=(), uid):
+def default_mangler(name, argtypes, *, abi_tags=(), uid=None):
     return itanium_mangler.mangle(name, argtypes, abi_tags=abi_tags, uid=uid)
 
 

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -33,7 +33,7 @@ class FunctionDescriptor(object):
     __slots__ = ('native', 'modname', 'qualname', 'doc', 'typemap',
                  'calltypes', 'args', 'kws', 'restype', 'argtypes',
                  'mangled_name', 'unique_name', 'env_name', 'global_dict',
-                 'inline', 'noalias', 'abi_tags')
+                 'inline', 'noalias', 'abi_tags', 'uid')
 
     def __init__(self, native, modname, qualname, unique_name, doc,
                  typemap, restype, calltypes, args, kws, mangler=None,
@@ -64,6 +64,7 @@ class FunctionDescriptor(object):
         # The mangled name *must* be unique, else the wrong function can
         # be chosen at link time.
         qualprefix = qualifying_prefix(self.modname, self.qualname)
+        self.uid = uid
         self.mangled_name = mangler(
             qualprefix, self.argtypes, abi_tags=abi_tags, uid=uid,
         )

--- a/numba/core/itanium_mangler.py
+++ b/numba/core/itanium_mangler.py
@@ -228,7 +228,7 @@ def mangle_c(ident, argtys):
     return PREFIX + mangle_identifier(ident) + mangle_args_c(argtys)
 
 
-def mangle(ident, argtys, *, abi_tags=(), uid):
+def mangle(ident, argtys, *, abi_tags=(), uid=None):
     """
     Mangle identifier with Numba type objects and abi-tags.
     """

--- a/numba/core/itanium_mangler.py
+++ b/numba/core/itanium_mangler.py
@@ -140,6 +140,7 @@ def mangle_identifier(ident, template_params='', *, abi_tags=(), uid=None):
     import re
     m = re.match(r"(.*)(\$\d+)$", ident)
     if m:
+        raise ValueError("unexpected")
         ident, ver = m.groups()
         if uid is not None:
             assert ver == f"${uid}"

--- a/numba/core/itanium_mangler.py
+++ b/numba/core/itanium_mangler.py
@@ -137,16 +137,9 @@ def mangle_identifier(ident, template_params='', *, abi_tags=(), uid=None):
 
     This treats '.' as '::' in C++.
     """
-    import re
-    m = re.match(r"(.*)(\$\d+)$", ident)
-    if m:
-        raise ValueError("unexpected")
-        ident, ver = m.groups()
-        if uid is not None:
-            assert ver == f"${uid}"
-        abi_tags = (ver, *abi_tags)
-    elif uid is not None:
-        abi_tags = (f"${uid}", *abi_tags)
+    if uid is not None:
+        # Add uid to abi-tags
+        abi_tags = (f"v{uid}", *abi_tags)
     parts = [_len_encoded(_escape_string(x)) for x in ident.split('.')]
     enc_abi_tags = list(map(mangle_abi_tag, abi_tags))
     extras = template_params + ''.join(enc_abi_tags)

--- a/numba/core/itanium_mangler.py
+++ b/numba/core/itanium_mangler.py
@@ -129,7 +129,7 @@ def mangle_abi_tag(abi_tag: str) -> str:
     return "B" + _len_encoded(_escape_string(abi_tag))
 
 
-def mangle_identifier(ident, template_params='', *, abi_tags=()):
+def mangle_identifier(ident, template_params='', *, abi_tags=(), uid=None):
     """
     Mangle the identifier with optional template parameters and abi_tags.
 
@@ -141,7 +141,11 @@ def mangle_identifier(ident, template_params='', *, abi_tags=()):
     m = re.match(r"(.*)(\$\d+)$", ident)
     if m:
         ident, ver = m.groups()
+        if uid is not None:
+            assert ver == f"${uid}"
         abi_tags = (ver, *abi_tags)
+    elif uid is not None:
+        abi_tags = (f"${uid}", *abi_tags)
     parts = [_len_encoded(_escape_string(x)) for x in ident.split('.')]
     enc_abi_tags = list(map(mangle_abi_tag, abi_tags))
     extras = template_params + ''.join(enc_abi_tags)
@@ -223,12 +227,12 @@ def mangle_c(ident, argtys):
     return PREFIX + mangle_identifier(ident) + mangle_args_c(argtys)
 
 
-def mangle(ident, argtys, *, abi_tags=()):
+def mangle(ident, argtys, *, abi_tags=(), uid):
     """
     Mangle identifier with Numba type objects and abi-tags.
     """
     return ''.join([PREFIX,
-                    mangle_identifier(ident, abi_tags=abi_tags),
+                    mangle_identifier(ident, abi_tags=abi_tags, uid=uid),
                     mangle_args(argtys)])
 
 

--- a/numba/core/itanium_mangler.py
+++ b/numba/core/itanium_mangler.py
@@ -137,6 +137,11 @@ def mangle_identifier(ident, template_params='', *, abi_tags=()):
 
     This treats '.' as '::' in C++.
     """
+    import re
+    m = re.match(r"(.*)(\$\d+)$", ident)
+    if m:
+        ident, ver = m.groups()
+        abi_tags = (ver, *abi_tags)
     parts = [_len_encoded(_escape_string(x)) for x in ident.split('.')]
     enc_abi_tags = list(map(mangle_abi_tag, abi_tags))
     extras = template_params + ''.join(enc_abi_tags)

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1018,12 +1018,7 @@ class Lower(BaseLower):
         argvals = self.fold_call_args(
             fnty, signature, expr.args, expr.vararg, expr.kws,
         )
-        from numba.core.bytecode import FunctionIdentity
-        pyfunc = fnty.dispatcher_type.dispatcher.py_func
-        func_id = FunctionIdentity.from_function(pyfunc)
-        uid = func_id.unique_id
-
-        qualprefix = fnty.overloads[signature.args]
+        qualprefix, uid = fnty.overloads[signature.args]
         mangler = self.context.mangler or default_mangler
         abi_tags = self.fndesc.abi_tags
         mangled_name = mangler(qualprefix, signature.args, abi_tags=abi_tags,

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1018,11 +1018,11 @@ class Lower(BaseLower):
         argvals = self.fold_call_args(
             fnty, signature, expr.args, expr.vararg, expr.kws,
         )
-        qualprefix, uid = fnty.overloads[signature.args]
+        rec_ov = fnty.get_overloads(signature.args)
         mangler = self.context.mangler or default_mangler
         abi_tags = self.fndesc.abi_tags
-        mangled_name = mangler(qualprefix, signature.args, abi_tags=abi_tags,
-                               uid=uid)
+        mangled_name = mangler(rec_ov.qualname, signature.args,
+                               abi_tags=abi_tags, uid=rec_ov.uid)
         # special case self recursion
         if self.builder.function.name.startswith(mangled_name):
             res = self.context.call_internal(

--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1018,10 +1018,16 @@ class Lower(BaseLower):
         argvals = self.fold_call_args(
             fnty, signature, expr.args, expr.vararg, expr.kws,
         )
+        from numba.core.bytecode import FunctionIdentity
+        pyfunc = fnty.dispatcher_type.dispatcher.py_func
+        func_id = FunctionIdentity.from_function(pyfunc)
+        uid = func_id.unique_id
+
         qualprefix = fnty.overloads[signature.args]
         mangler = self.context.mangler or default_mangler
         abi_tags = self.fndesc.abi_tags
-        mangled_name = mangler(qualprefix, signature.args, abi_tags=abi_tags)
+        mangled_name = mangler(qualprefix, signature.args, abi_tags=abi_tags,
+                               uid=uid)
         # special case self recursion
         if self.builder.function.name.startswith(mangled_name):
             res = self.context.call_internal(

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -1533,12 +1533,12 @@ https://numba.readthedocs.io/en/stable/user/troubleshoot.html#my-code-has-an-unt
                                                          pos_args, kw_args)
                 fndesc = disp.overloads[args].fndesc
                 qual = qualifying_prefix(fndesc.modname, fndesc.qualname)
-                fnty.overloads[args] = qual, fndesc.uid
+                fnty.add_overloads(args, qual, fndesc.uid)
                 return sig
 
             fnid = frame.func_id
             qual = qualifying_prefix(fnid.modname, fnid.func_qualname)
-            fnty.overloads[args] = qual, fnid.unique_id
+            fnty.add_overloads(args, qual, fnid.unique_id)
             # Resume propagation in parent frame
             return_type = frame.typeinfer.return_types_from_partial()
             # No known return type

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -1533,12 +1533,12 @@ https://numba.readthedocs.io/en/stable/user/troubleshoot.html#my-code-has-an-unt
                                                          pos_args, kw_args)
                 fndesc = disp.overloads[args].fndesc
                 fnty.overloads[args] = qualifying_prefix(fndesc.modname,
-                                                         fndesc.unique_name)
+                                                         fndesc.qualname)
                 return sig
 
             fnid = frame.func_id
             fnty.overloads[args] = qualifying_prefix(fnid.modname,
-                                                     fnid.unique_name)
+                                                     fnid.func_qualname)
             # Resume propagation in parent frame
             return_type = frame.typeinfer.return_types_from_partial()
             # No known return type

--- a/numba/core/typeinfer.py
+++ b/numba/core/typeinfer.py
@@ -1532,13 +1532,13 @@ https://numba.readthedocs.io/en/stable/user/troubleshoot.html#my-code-has-an-unt
                 sig = self.context.resolve_function_type(fnty.dispatcher_type,
                                                          pos_args, kw_args)
                 fndesc = disp.overloads[args].fndesc
-                fnty.overloads[args] = qualifying_prefix(fndesc.modname,
-                                                         fndesc.qualname)
+                qual = qualifying_prefix(fndesc.modname, fndesc.qualname)
+                fnty.overloads[args] = qual, fndesc.uid
                 return sig
 
             fnid = frame.func_id
-            fnty.overloads[args] = qualifying_prefix(fnid.modname,
-                                                     fnid.func_qualname)
+            qual = qualifying_prefix(fnid.modname, fnid.func_qualname)
+            fnty.overloads[args] = qual, fnid.unique_id
             # Resume propagation in parent frame
             return_type = frame.typeinfer.return_types_from_partial()
             # No known return type

--- a/numba/core/types/functions.py
+++ b/numba/core/types/functions.py
@@ -702,6 +702,9 @@ class NumberClass(Callable, DTypeSpec, Opaque):
         return self.instance_type
 
 
+_RecursiveCallOverloads = namedtuple("_RecursiveCallOverloads", "qualname,uid")
+
+
 class RecursiveCall(Opaque):
     """
     Recursive call to a Dispatcher.
@@ -717,9 +720,25 @@ class RecursiveCall(Opaque):
         if self._overloads is None:
             self._overloads = {}
 
-    @property
-    def overloads(self):
-        return self._overloads
+    def add_overloads(self, args, qualname, uid):
+        """Add an overload of the function.
+
+        Parameters
+        ----------
+        args :
+            argument types
+        qualname :
+            function qualifying name
+        uid :
+            unique id
+        """
+        self._overloads[args] = _RecursiveCallOverloads(qualname, uid)
+
+    def get_overloads(self, args):
+        """Get the qualifying name and unique id for the overload given the
+        argument types.
+        """
+        return self._overloads[args]
 
     @property
     def key(self):

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -126,8 +126,9 @@ class CUDATargetContext(BaseContext):
     def call_conv(self):
         return CUDACallConv(self)
 
-    def mangler(self, name, argtypes, *, abi_tags=()):
-        return itanium_mangler.mangle(name, argtypes, abi_tags=abi_tags)
+    def mangler(self, name, argtypes, *, abi_tags=(), uid):
+        return itanium_mangler.mangle(name, argtypes, abi_tags=abi_tags,
+                                      uid=uid)
 
     def prepare_cuda_kernel(self, codelib, fndesc, debug,
                             nvvm_options, filename, linenum,

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -126,7 +126,7 @@ class CUDATargetContext(BaseContext):
     def call_conv(self):
         return CUDACallConv(self)
 
-    def mangler(self, name, argtypes, *, abi_tags=(), uid):
+    def mangler(self, name, argtypes, *, abi_tags=(), uid=None):
         return itanium_mangler.mangle(name, argtypes, abi_tags=abi_tags,
                                       uid=uid)
 

--- a/numba/tests/gdb/test_break_on_symbol.py
+++ b/numba/tests/gdb/test_break_on_symbol.py
@@ -18,7 +18,7 @@ class Test(TestCase):
         foo(120)
         sz = types.intp.bitwidth
         driver = GdbMIDriver(__file__)
-        driver.set_breakpoint(symbol="__main__::foo_241")
+        driver.set_breakpoint(symbol="__main__::foo")
         driver.run() # will hit cpython symbol match
         driver.check_hit_breakpoint(number=1)
         driver.cont() # will hit njit symbol match

--- a/numba/tests/gdb/test_break_on_symbol_version.py
+++ b/numba/tests/gdb/test_break_on_symbol_version.py
@@ -1,0 +1,65 @@
+# NOTE: This test is sensitive to line numbers as it checks breakpoints
+from numba import njit
+from numba.tests.gdb_support import GdbMIDriver
+from numba.tests.support import TestCase, needs_subprocess
+import unittest
+
+
+def foo_factory(n):
+    @njit(debug=True)
+    def foo(x):
+        z = 7 + n
+        return x, z
+
+    return foo
+
+
+foo1, foo2, foo3 = [foo_factory(x) for x in range(3)]
+
+
+@njit(debug=True)
+def call_foo():
+    a = foo1(10)
+    b = foo2(20)
+    c = foo3(30)
+    return a, b, c
+
+
+@needs_subprocess
+class Test(TestCase):
+
+    def test(self):
+        call_foo()
+        driver = GdbMIDriver(__file__)
+        # A specific foo, the first one, it has uid=2
+        vsym = "__main__::foo_factory::_3clocals_3e::foo[abi:v2]"
+        driver.set_breakpoint(symbol=vsym)
+        driver.run()
+        driver.check_hit_breakpoint(number=1)
+        driver.assert_regex_output(r'^.*foo\[abi:v2\].*line="11"')
+        driver.stack_list_arguments(2)
+        expect = ('[frame={level="0",args=[{name="x",type="Literal[int](10)",'
+                  'value="10"}]}]')
+        driver.assert_output(expect)
+        # Now break on any foo
+        driver.set_breakpoint(symbol="foo")
+        driver.cont()
+        driver.check_hit_breakpoint(number=2)
+        driver.assert_regex_output(r'^.*foo\[abi:v3\].*line="11"')
+        driver.stack_list_arguments(2)
+        expect = ('[frame={level="0",args=[{name="x",type="Literal[int](20)",'
+                  'value="20"}]}]')
+        driver.assert_output(expect)
+        # and again, hit the third foo
+        driver.cont()
+        driver.check_hit_breakpoint(number=2)
+        driver.assert_regex_output(r'^.*foo\[abi:v4\].*line="11"')
+        driver.stack_list_arguments(2)
+        expect = ('[frame={level="0",args=[{name="x",type="Literal[int](30)",'
+                  'value="30"}]}]')
+        driver.assert_output(expect)
+        driver.quit()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -35,6 +35,9 @@ class TestGDBDwarf(TestCase):
     def test_break_on_symbol(self):
         self._subprocess_test_runner('test_break_on_symbol')
 
+    def test_break_on_symbol_version(self):
+        self._subprocess_test_runner('test_break_on_symbol_version')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add unique-id to `FunctionIdentity` and `FunctionDescriptor` classes.
- `RecursionCall` class API is improved. 
- Mangler function now takes an optional `uid` argument for the unique id.