### PR TITLE
Add axis option to norm computation

### DIFF
--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2309,7 +2309,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     m = a.shape[-2]
 
                     if a.size == 0:
-                        return np.zeros(1, dtype=a.dtype)
+                        return np.zeros(1, dtype=np_ret_type)
 
                     if axis not in (0, 1):
                         raise ValueError("Invalid axis for array.")
@@ -2317,7 +2317,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     if ord == np.inf and axis == 0:
                         # max of abs across rows
                         # max(abs(a), axis=0)
-                        axis_nrms = np.zeros(n)
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] = max(abs(a[i, j]), axis_nrms[j])
@@ -2326,7 +2326,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == np.inf and axis == 1:
                         # max of abs across columns
                         # max(abs(a), axis=1)
-                        axis_nrms = np.zeros(m)
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
                             for j in range(n):
                                 axis_nrms[i] = max(abs(a[i, j]), axis_nrms[i])
@@ -2335,7 +2335,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == -np.inf and axis == 0:
                         # min of abs across rows
                         # min(abs(a), axis=0)
-                        axis_nrms = np.full(n, max_val)
+                        axis_nrms = np.full(n, max_val, dtype=np_ret_type)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] = min(abs(a[i, j]), axis_nrms[j])
@@ -2344,7 +2344,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == -np.inf and axis == 1:
                         # min of abs across columns
                         # min(abs(a), axis=1)
-                        axis_nrms = np.full(m, max_val)
+                        axis_nrms = np.full(m, max_val, dtype=np_ret_type)
                         for i in range(m):
                             for j in range(n):
                                 axis_nrms[i] = min(abs(a[i, j]), axis_nrms[i])
@@ -2353,7 +2353,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == 1 and axis == 0:
                         # sum of abs across rows
                         # sum(abs(a), axis=0)
-                        axis_nrms = np.zeros(n)
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] += abs(a[i, j])
@@ -2362,7 +2362,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == 1 and axis == 1:
                         # sum of abs across columns
                         # sum(abs(a), axis=1)
-                        axis_nrms = np.zeros(m)
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
                             for j in range(n):
                                 axis_nrms[i] += abs(a[i, j])
@@ -2371,7 +2371,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == -1 and axis == 0:
                         # min of sum of abs across rows
                         # min(sum(abs(a)), axis=0)
-                        axis_nrms = np.full(n, max_val)
+                        axis_nrms = np.full(n, max_val, dtype=np_ret_type)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] += abs(a[i, j])
@@ -2380,30 +2380,30 @@ def _get_norm_impl(a, ord_flag, axis):
                     elif ord == -1 and axis == 1:
                         # sum of abs across columns
                         # sum(abs(a), axis=1)
-                        axis_nrms = np.zeros(m)
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
                             for j in range(n):
                                 axis_nrms[i] += abs(a[i, j])
                         return axis_nrms
 
                     elif ord == 2 and axis == 0:
-                        # L2 norm across cols
-                        # sqrt(sum(a ** 2), axis=0)
-                        axis_nrms = np.zeros(m)
-                        for i in range(m):
-                            for j in range(n):
-                                axis_nrms[i] += a[i, j] ** 2
-                            axis_nrms[i] = np.sqrt(axis_nrms[i])
-                        return axis_nrms
-
-                    elif ord == 2 and axis == 1:
                         # L2 norm across rows
-                        # sqrt(sum(a ** 2), axis=1)
-                        axis_nrms = np.zeros(n)
+                        # sqrt(sum(a ** 2), axis=0)
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] += a[i, j] ** 2
-                            axis_nrms[j] = np.sqrt(axis_nrms[j])
+                            axis_nrms[j] = axis_nrms[j] ** 0.5
+                        return axis_nrms
+
+                    elif ord == 2 and axis == 1:
+                        # L2 norm across columns
+                        # sqrt(sum(a ** 2), axis=1)
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
+                        for i in range(m):
+                            for j in range(n):
+                                axis_nrms[i] += a[i, j] ** 2
+                            axis_nrms[i] = axis_nrms[i] ** 0.5
                         return axis_nrms
 
                     else:

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2275,15 +2275,14 @@ def _get_norm_impl(a, ord_flag, axis):
                     # Compute the norm along a specific axis
                     m = a.shape[-2]
                     n = a.shape[-1]
-                    a_c = array_prepare(a)
                     if axis == 0:
                         nrm_axis = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
-                            nrm_axis[j] = _oneD_norm_2(a_c[:, j])
+                            nrm_axis[j] = _oneD_norm_2(a[:, j])
                     elif axis == 1:
                         nrm_axis = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
-                            nrm_axis[i] = _oneD_norm_2(a_c[i, :])
+                            nrm_axis[i] = _oneD_norm_2(a[i, :])
                     else:
                         raise ValueError("Invalid axis for array.")
                     return nrm_axis

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2253,10 +2253,6 @@ def _get_norm_impl(a, ord_flag, axis):
     elif a.ndim == 2:
         # 2D cases
 
-        if not np_support.is_nonelike(axis) \
-            or not isinstance(axis, (types.Integer, int)):
-            raise ValueError("Invalid axis for array.")
-
         # handle "ord" being "None"
         if ord_flag in (None, types.none):
             # Force `a` to be C-order, so that we can take a contiguous
@@ -2292,7 +2288,7 @@ def _get_norm_impl(a, ord_flag, axis):
                         else:
                             raise ValueError("Invalid axis for array.")
                     return nrm_axis
-            else:
+            elif np_support.is_nonelike(axis):
                 def twoD_impl(a, ord=None, axis=None):
                     n = a.size
                     if n == 0:
@@ -2300,6 +2296,8 @@ def _get_norm_impl(a, ord_flag, axis):
                         return 0.0
                     a_c = array_prepare(a)
                     return _oneD_norm_2(a_c.reshape(n))
+            else:
+                raise ValueError("Invaldi axis for array.")
         else:
             # max value for this dtype
             max_val = np.finfo(np_ret_type.type).max
@@ -2374,7 +2372,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     else:
                         # replicate numpy error
                         raise ValueError("Invalid norm order for matrices.")
-            else:
+            elif np_support.is_nonelike(axis):
                 def twoD_impl(a, ord=None, axis=None):
                     n = a.shape[-1]
                     m = a.shape[-2]
@@ -2444,6 +2442,8 @@ def _get_norm_impl(a, ord_flag, axis):
                     else:
                         # replicate numpy error
                         raise ValueError("Invalid norm order for matrices.")
+            else:
+                raise ValueError("Invalid axis for array.")
         return twoD_impl
     else:
         assert 0  # unreachable

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2253,7 +2253,7 @@ def _get_norm_impl(a, ord_flag, axis):
     elif a.ndim == 2:
         # 2D cases
 
-        if axis < 0 or axis >= 2:
+        if axis != None and axis not in (0, 1):
             raise ValueError("Invalid axis for 2d array.")
 
         # handle "ord" being "None"

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2183,7 +2183,7 @@ def _get_norm_impl(a, ord_flag, axis):
 
         # The specified axis index can't be greater than the number of
         # dimensions of the array.
-        if axis != None:
+        if axis not in (None, types.none):
             raise ValueError("Invalid axis for array.")
 
         # handle "ord" being "None", must be done separately
@@ -2253,7 +2253,7 @@ def _get_norm_impl(a, ord_flag, axis):
     elif a.ndim == 2:
         # 2D cases
 
-        if axis != None and axis not in (0, 1):
+        if axis not in (0, 1, None, types.none):
             raise ValueError("Invalid axis for array.")
 
         # handle "ord" being "None"
@@ -2374,7 +2374,6 @@ def _get_norm_impl(a, ord_flag, axis):
 
 @overload(np.linalg.norm)
 def norm_impl(a, ord=None, axis=None):
-    # TODO: axis=None???
     ensure_lapack()
 
     _check_linalg_1_or_2d_matrix(a, "norm")

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2403,25 +2403,27 @@ def _get_norm_impl(a, ord_flag, axis):
                             axis_nrms[i] = _oneD_norm_2(a[i, :])
                         return axis_nrms
 
-                    # elif ord == -2 and axis == 0:
-                    #     # min SV across rows
-                    #     axis_nrms = np.zeros(n, dtype=np_ret_type)
-                    #     for j in range(n):
-                    #         tmp = np.zeros((m, 1), dtype=np_ret_type)
-                    #         for i in range(m):
-                    #             tmp[i] = a[i, j]
-                    #         axis_nrms[j] = _compute_singular_values(tmp)[-1]
-                    #     return axis_nrms
+                    elif ord == -2 and axis == 0:
+                        # inverse root sum of squared coefs across rows
+                        # sum(abs(a)**(-2))**(-1/2)
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
+                        for j in range(n):
+                            tmp = 0.
+                            for i in range(m):
+                                tmp += 1 / pow(abs(a[i, j]), 2)
+                            axis_nrms[j] = 1 / pow(tmp, 0.5)
+                        return axis_nrms
 
-                    # elif ord == -2 and axis == 1:
-                    #     # min SV across columns
-                    #     axis_nrms = np.zeros(m, dtype=np_ret_type)
-                    #     for i in range(m):
-                    #         tmp = np.zeros((n, 1), dtype=np_ret_type)
-                    #         for j in range(n):
-                    #             tmp[j] = a[i, j]
-                    #         axis_nrms[i] = _compute_singular_values(tmp)[-1]
-                    #     return axis_nrms
+                    elif ord == -2 and axis == 1:
+                        # inverse root sum of squared coefs across columns
+                        # sum(abs(a)**(-2))**(-1/2)
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
+                        for i in range(m):
+                            tmp = 0.
+                            for j in range(n):
+                                tmp += 1 / pow(abs(a[i, j]), 2)
+                            axis_nrms[i] = 1 / pow(tmp, 0.5)
+                        return axis_nrms
 
                     else:
                         # replicate numpy error

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2403,6 +2403,26 @@ def _get_norm_impl(a, ord_flag, axis):
                             axis_nrms[i] = _oneD_norm_2(a[i, :])
                         return axis_nrms
 
+                    elif ord == -2 and axis == 0:
+                        # min SV across rows
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
+                        for j in range(n):
+                            tmp = np.zeros((m, 1), dtype=np_ret_type)
+                            for i in range(m):
+                                tmp[i] = a[i, j]
+                            axis_nrms[j] = _compute_singular_values(tmp)[-1]
+                        return axis_nrms
+
+                    elif ord == -2 and axis == 1:
+                        # min SV across columns
+                        axis_nrms = np.zeros(m, dtype=np_ret_type)
+                        for i in range(m):
+                            tmp = np.zeros((n, 1), dtype=np_ret_type)
+                            for j in range(n):
+                                tmp[j] = a[i, j]
+                            axis_nrms[i] = _compute_singular_values(tmp)[-1]
+                        return axis_nrms
+
                     else:
                         # replicate numpy error
                         raise ValueError("Invalid norm order for matrices.")

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2391,9 +2391,7 @@ def _get_norm_impl(a, ord_flag, axis):
                         # sqrt(sum(a ** 2), axis=0)
                         axis_nrms = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
-                            for i in range(m):
-                                axis_nrms[j] += a[i, j] ** 2
-                            axis_nrms[j] = axis_nrms[j] ** 0.5
+                            axis_nrms[j] = _oneD_norm_2(a[:, j])
                         return axis_nrms
 
                     elif ord == 2 and axis == 1:
@@ -2401,9 +2399,7 @@ def _get_norm_impl(a, ord_flag, axis):
                         # sqrt(sum(a ** 2), axis=1)
                         axis_nrms = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
-                            for j in range(n):
-                                axis_nrms[i] += a[i, j] ** 2
-                            axis_nrms[i] = axis_nrms[i] ** 0.5
+                            axis_nrms[i] = _oneD_norm_2(a[i, :])
                         return axis_nrms
 
                     else:

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2279,12 +2279,13 @@ def _get_norm_impl(a, ord_flag, axis):
                 def twoD_impl(a, ord=None, axis=None):
                     # Compute the norm along a specific axis
                     a_c = array_prepare(a)
-                    nrm_axis = np.zeros(a_c.shape[axis])
-                    for idx in range(a_c.shape[axis]):
+                    # Trick: a_c.shape[0] if axis = 1, a_c.shape[1] if axis = 0
+                    nrm_axis = np.zeros(a_c.shape[1 - axis])
+                    for idx in range(len(nrm_axis)):
                         if axis == 0:
-                            nrm_axis[idx] = _oneD_norm_2(a_c[idx])
-                        elif axis == 1:
                             nrm_axis[idx] = _oneD_norm_2(a_c[:, idx])
+                        elif axis == 1:
+                            nrm_axis[idx] = _oneD_norm_2(a_c[idx])
                         else:
                             raise ValueError("Invalid axis for array.")
                     return nrm_axis

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2278,16 +2278,19 @@ def _get_norm_impl(a, ord_flag, axis):
             if isinstance(axis, (types.Integer, int)):
                 def twoD_impl(a, ord=None, axis=None):
                     # Compute the norm along a specific axis
+                    m = a.shape[-2]
+                    n = a.shape[-1]
                     a_c = array_prepare(a)
-                    # Trick: a_c.shape[0] if axis = 1, a_c.shape[1] if axis = 0
-                    nrm_axis = np.zeros(a_c.shape[1 - axis])
-                    for idx in range(len(nrm_axis)):
-                        if axis == 0:
-                            nrm_axis[idx] = _oneD_norm_2(a_c[:, idx])
-                        elif axis == 1:
-                            nrm_axis[idx] = _oneD_norm_2(a_c[idx])
-                        else:
-                            raise ValueError("Invalid axis for array.")
+                    if axis == 0:
+                        nrm_axis = np.zeros(n, dtype=np_ret_type)
+                        for j in range(n):
+                            nrm_axis[j] = _oneD_norm_2(a_c[:, j])
+                    elif axis == 1:
+                        nrm_axis = np.zeros(m, dtype=np_ret_type)
+                        for i in range(m):
+                            nrm_axis[i] = _oneD_norm_2(a_c[i, :])
+                    else:
+                        raise ValueError("Invalid axis for array.")
                     return nrm_axis
             elif np_support.is_nonelike(axis):
                 def twoD_impl(a, ord=None, axis=None):

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2403,25 +2403,25 @@ def _get_norm_impl(a, ord_flag, axis):
                             axis_nrms[i] = _oneD_norm_2(a[i, :])
                         return axis_nrms
 
-                    elif ord == -2 and axis == 0:
-                        # min SV across rows
-                        axis_nrms = np.zeros(n, dtype=np_ret_type)
-                        for j in range(n):
-                            tmp = np.zeros((m, 1), dtype=np_ret_type)
-                            for i in range(m):
-                                tmp[i] = a[i, j]
-                            axis_nrms[j] = _compute_singular_values(tmp)[-1]
-                        return axis_nrms
+                    # elif ord == -2 and axis == 0:
+                    #     # min SV across rows
+                    #     axis_nrms = np.zeros(n, dtype=np_ret_type)
+                    #     for j in range(n):
+                    #         tmp = np.zeros((m, 1), dtype=np_ret_type)
+                    #         for i in range(m):
+                    #             tmp[i] = a[i, j]
+                    #         axis_nrms[j] = _compute_singular_values(tmp)[-1]
+                    #     return axis_nrms
 
-                    elif ord == -2 and axis == 1:
-                        # min SV across columns
-                        axis_nrms = np.zeros(m, dtype=np_ret_type)
-                        for i in range(m):
-                            tmp = np.zeros((n, 1), dtype=np_ret_type)
-                            for j in range(n):
-                                tmp[j] = a[i, j]
-                            axis_nrms[i] = _compute_singular_values(tmp)[-1]
-                        return axis_nrms
+                    # elif ord == -2 and axis == 1:
+                    #     # min SV across columns
+                    #     axis_nrms = np.zeros(m, dtype=np_ret_type)
+                    #     for i in range(m):
+                    #         tmp = np.zeros((n, 1), dtype=np_ret_type)
+                    #         for j in range(n):
+                    #             tmp[j] = a[i, j]
+                    #         axis_nrms[i] = _compute_singular_values(tmp)[-1]
+                    #     return axis_nrms
 
                     else:
                         # replicate numpy error

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2367,21 +2367,25 @@ def _get_norm_impl(a, ord_flag, axis):
                         return axis_nrms
 
                     elif ord == -1 and axis == 0:
-                        # min of sum of abs across rows
-                        # min(sum(abs(a)), axis=0)
-                        axis_nrms = np.full(n, max_val, dtype=np_ret_type)
+                        # inverse sum of inverse abs across rows
+                        # sum(abs(a)**(-1))**(-1)
+                        axis_nrms = np.zeros(n, dtype=np_ret_type)
                         for j in range(n):
+                            tmp = 0.
                             for i in range(m):
-                                axis_nrms[j] += abs(a[i, j])
+                                tmp += 1 / abs(a[i, j])
+                            axis_nrms[j] = 1 / tmp
                         return axis_nrms
 
                     elif ord == -1 and axis == 1:
-                        # sum of abs across columns
-                        # sum(abs(a), axis=1)
+                        # inverse sum of inverse abs across columns
+                        # sum(abs(a)**(-1))**(-1)
                         axis_nrms = np.zeros(m, dtype=np_ret_type)
                         for i in range(m):
+                            tmp = 0.
                             for j in range(n):
-                                axis_nrms[i] += abs(a[i, j])
+                                tmp += 1 / abs(a[i, j])
+                            axis_nrms[i] = 1 / tmp
                         return axis_nrms
 
                     elif ord == 2 and axis == 0:

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2309,45 +2309,81 @@ def _get_norm_impl(a, ord_flag, axis):
                     m = a.shape[-2]
 
                     if a.size == 0:
-                        return 0.0
+                        return np.zeros(1, dtype=a.dtype)
 
                     if axis not in (0, 1):
                         raise ValueError("Invalid axis for array.")
 
                     if ord == np.inf and axis == 0:
-                        # max of abs across columns
-                        # max(abs(a), axis=0)
-                        axis_nrms = np.zeros(m)
-                        for i in range(m):
-                            for j in range(n):
-                                axis_nrms[i] = max(abs(a[i, j]), axis_nrms[i])
-                        return axis_nrms
-
-                    elif ord == np.inf and axis == 1:
                         # max of abs across rows
-                        # max(abs(a), axis=1)
+                        # max(abs(a), axis=0)
                         axis_nrms = np.zeros(n)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] = max(abs(a[i, j]), axis_nrms[j])
                         return axis_nrms
 
+                    elif ord == np.inf and axis == 1:
+                        # max of abs across columns
+                        # max(abs(a), axis=1)
+                        axis_nrms = np.zeros(m)
+                        for i in range(m):
+                            for j in range(n):
+                                axis_nrms[i] = max(abs(a[i, j]), axis_nrms[i])
+                        return axis_nrms
+
+                    elif ord == -np.inf and axis == 0:
+                        # min of abs across rows
+                        # min(abs(a), axis=0)
+                        axis_nrms = np.full(n, max_val)
+                        for j in range(n):
+                            for i in range(m):
+                                axis_nrms[j] = min(abs(a[i, j]), axis_nrms[j])
+                        return axis_nrms
+
+                    elif ord == -np.inf and axis == 1:
+                        # min of abs across columns
+                        # min(abs(a), axis=1)
+                        axis_nrms = np.full(m, max_val)
+                        for i in range(m):
+                            for j in range(n):
+                                axis_nrms[i] = min(abs(a[i, j]), axis_nrms[i])
+                        return axis_nrms
+
                     elif ord == 1 and axis == 0:
-                        # sum of abs across cols
+                        # sum of abs across rows
                         # sum(abs(a), axis=0)
+                        axis_nrms = np.zeros(n)
+                        for j in range(n):
+                            for i in range(m):
+                                axis_nrms[j] += abs(a[i, j])
+                        return axis_nrms
+
+                    elif ord == 1 and axis == 1:
+                        # sum of abs across columns
+                        # sum(abs(a), axis=1)
                         axis_nrms = np.zeros(m)
                         for i in range(m):
                             for j in range(n):
                                 axis_nrms[i] += abs(a[i, j])
                         return axis_nrms
 
-                    elif ord == 1 and axis == 1:
-                        # sum of abs across rows
-                        # sum(abs(a), axis=1)
-                        axis_nrms = np.zeros(n)
+                    elif ord == -1 and axis == 0:
+                        # min of sum of abs across rows
+                        # min(sum(abs(a)), axis=0)
+                        axis_nrms = np.full(n, max_val)
                         for j in range(n):
                             for i in range(m):
                                 axis_nrms[j] += abs(a[i, j])
+                        return axis_nrms
+
+                    elif ord == -1 and axis == 1:
+                        # sum of abs across columns
+                        # sum(abs(a), axis=1)
+                        axis_nrms = np.zeros(m)
+                        for i in range(m):
+                            for j in range(n):
+                                axis_nrms[i] += abs(a[i, j])
                         return axis_nrms
 
                     elif ord == 2 and axis == 0:

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2184,7 +2184,7 @@ def _get_norm_impl(a, ord_flag, axis):
         # The specified axis index can't be greater than the number of
         # dimensions of the array.
         if axis != None:
-            raise ValueError("Invalid axis for 1d array.")
+            raise ValueError("Invalid axis for array.")
 
         # handle "ord" being "None", must be done separately
         if ord_flag in (None, types.none):
@@ -2254,7 +2254,7 @@ def _get_norm_impl(a, ord_flag, axis):
         # 2D cases
 
         if axis != None and axis not in (0, 1):
-            raise ValueError("Invalid axis for 2d array.")
+            raise ValueError("Invalid axis for array.")
 
         # handle "ord" being "None"
         if ord_flag in (None, types.none):

--- a/numba/np/linalg.py
+++ b/numba/np/linalg.py
@@ -2181,11 +2181,6 @@ def _get_norm_impl(a, ord_flag, axis):
     if a.ndim == 1:
         # 1D cases
 
-        # For 1d arrays, axis must always be None since there is only one
-        # possible axis along with a norm can be computed.
-        if not np_support.is_nonelike(axis):
-            raise ValueError("Invalid axis for array.")
-
         # handle "ord" being "None", must be done separately
         if ord_flag in (None, types.none):
             def oneD_impl(a, ord=None, axis=None):
@@ -2301,7 +2296,7 @@ def _get_norm_impl(a, ord_flag, axis):
                     a_c = array_prepare(a)
                     return _oneD_norm_2(a_c.reshape(n))
             else:
-                raise ValueError("Invaldi axis for array.")
+                raise ValueError("Invalid axis for array.")
         else:
             # max value for this dtype
             max_val = np.finfo(np_ret_type.type).max

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2133,8 +2133,6 @@ class TestLinalgNorm(TestLinalgSystems):
         # standard 2D input
         for size, dtype, order, nrm_type, arr_axis in \
                 product(sizes, self.dtypes, 'FC', nrm_types, arr_axes):
-            if nrm_type == -2 and arr_axis is not None:
-                continue
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
             check(a, ord=nrm_type, axis=arr_axis)

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2127,7 +2127,7 @@ class TestLinalgNorm(TestLinalgSystems):
         # test: column vector, tall, wide, square, row vector
         # prime sizes
         sizes = [(7, 1), (11, 5), (5, 11), (3, 3), (1, 7)]
-        nrm_types = [None, np.inf, -np.inf, 1, 2] # -1, -2
+        nrm_types = [None, np.inf, -np.inf, 1, -1, 2] # -2
         arr_axes = [None, 0, 1]
 
         # standard 2D input

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2132,7 +2132,7 @@ class TestLinalgNorm(TestLinalgSystems):
 
         # standard 2D input
         for size, dtype, order, nrm_type, arr_axis in \
-                product(sizes, self.dtypes, 'C', nrm_types, arr_axes):
+                product(sizes, self.dtypes, 'FC', nrm_types, arr_axes):
             print(size, nrm_type, order, arr_axis)
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
@@ -2143,7 +2143,7 @@ class TestLinalgNorm(TestLinalgSystems):
         nrm_types = [None]
         arr_axes = [None]
         for dtype, nrm_type, order, arr_axis in \
-                product(self.dtypes, nrm_types, 'C', arr_axes):
+                product(self.dtypes, nrm_types, 'FC', arr_axes):
             a = self.specific_sample_matrix((17, 13), dtype, order)
             print("next session:", size, nrm_type, order, arr_axis)
             # contig for C order

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2127,12 +2127,13 @@ class TestLinalgNorm(TestLinalgSystems):
         # test: column vector, tall, wide, square, row vector
         # prime sizes
         sizes = [(7, 1), (11, 5), (5, 11), (3, 3), (1, 7)]
-        nrm_types = [None, np.inf, -np.inf, 1, -1, 2, -2]
+        nrm_types = [None, np.inf, -np.inf, 1, 2] # -1, -2
         arr_axes = [None, 0, 1]
 
         # standard 2D input
         for size, dtype, order, nrm_type, arr_axis in \
-                product(sizes, self.dtypes, 'FC', nrm_types, arr_axes):
+                product(sizes, self.dtypes, 'C', nrm_types, arr_axes):
+            print(size, nrm_type, order, arr_axis)
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
             check(a, ord=nrm_type, axis=arr_axis)
@@ -2140,17 +2141,19 @@ class TestLinalgNorm(TestLinalgSystems):
         # check 2D slices work for the case where xnrm2 is called from
         # BLAS (ord=None) to make sure it is working ok.
         nrm_types = [None]
+        arr_axes = [None]
         for dtype, nrm_type, order, arr_axis in \
-                product(self.dtypes, nrm_types, 'FC', arr_axes):
+                product(self.dtypes, nrm_types, 'C', arr_axes):
             a = self.specific_sample_matrix((17, 13), dtype, order)
+            print("next session:", size, nrm_type, order, arr_axis)
             # contig for C order
-            check(a[:3], ord=nrm_type, axes=arr_axis)
+            check(a[:3], ord=nrm_type, axis=arr_axis)
 
             # contig for Fortran order
-            check(a[:, 3:], ord=nrm_type, axes=arr_axis)
+            check(a[:, 3:], ord=nrm_type, axis=arr_axis)
 
             # contig for neither order
-            check(a[1, 4::3], ord=nrm_type, axes=arr_axis)
+            check(a[1, 4::3], ord=nrm_type, axis=arr_axis)
 
         # check that numba returns zero for empty arrays. Numpy returns zero
         # for most norm types and raises ValueError for +/-np.inf.
@@ -2184,13 +2187,9 @@ class TestLinalgNorm(TestLinalgSystems):
         self.assert_invalid_norm_kind(cfunc, (np.array([[1., 2.], [3., 4.]],
                                                        dtype=np.float64), 6))
 
-        # assert 1D input raises for invalid axis kwarg
-        self.assert_invalid_array_axis(cfunc, (np.array([1., 2., 3.],
-                                                        dtype=np.float64), 1))
-
         # assert 2D input raises for invalid axis kwarg
         self.assert_invalid_array_axis(cfunc, (np.array([[1., 2.], [3., 4.]],
-                                                        dtype=np.float64), 2))
+                                                        dtype=np.float64), None, 2))
 
 
 class TestLinalgCond(TestLinalgBase):

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -607,7 +607,7 @@ class TestLinalgBase(TestCase):
 
     def assert_invalid_array_axis(self, cfunc, args):
         """
-        For use in norm() and cond() tests.
+        For use in norm() tests.
         """
         msg = "Invalid axis for array."
         self.assert_error(cfunc, args, msg, ValueError)
@@ -2274,14 +2274,6 @@ class TestLinalgCond(TestLinalgBase):
         # assert raises for an invalid norm kind kwarg
         self.assert_invalid_norm_kind(cfunc, (np.array([[1., 2.], [3., 4.]],
                                                        dtype=np.float64), 6))
-
-        # assert 1D input raises for invalid axis kwarg
-        self.assert_invalid_array_axis(cfunc, (np.array([1., 2., 3.],
-                                                        dtype=np.float64), 1))
-
-        # assert 2D input raises for invalid axis kwarg
-        self.assert_invalid_array_axis(cfunc, (np.array([[1., 2.], [3., 4.]],
-                                                        dtype=np.float64), 2))
 
 
 class TestLinalgMatrixRank(TestLinalgSystems):

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2133,8 +2133,8 @@ class TestLinalgNorm(TestLinalgSystems):
         # standard 2D input
         for size, dtype, order, nrm_type, arr_axis in \
                 product(sizes, self.dtypes, 'FC', nrm_types, arr_axes):
-            if nrm_type == -2 and arr_axis:
-                pass
+            if nrm_type == -2 and arr_axis is not None:
+                continue
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
             check(a, ord=nrm_type, axis=arr_axis)

--- a/numba/tests/test_linalg.py
+++ b/numba/tests/test_linalg.py
@@ -2127,13 +2127,14 @@ class TestLinalgNorm(TestLinalgSystems):
         # test: column vector, tall, wide, square, row vector
         # prime sizes
         sizes = [(7, 1), (11, 5), (5, 11), (3, 3), (1, 7)]
-        nrm_types = [None, np.inf, -np.inf, 1, -1, 2] # -2
+        nrm_types = [None, np.inf, -np.inf, 1, -1, 2, -2]
         arr_axes = [None, 0, 1]
 
         # standard 2D input
         for size, dtype, order, nrm_type, arr_axis in \
                 product(sizes, self.dtypes, 'FC', nrm_types, arr_axes):
-            print(size, nrm_type, order, arr_axis)
+            if nrm_type == -2 and arr_axis:
+                pass
             # check a full rank matrix
             a = self.specific_sample_matrix(size, dtype, order)
             check(a, ord=nrm_type, axis=arr_axis)
@@ -2145,7 +2146,6 @@ class TestLinalgNorm(TestLinalgSystems):
         for dtype, nrm_type, order, arr_axis in \
                 product(self.dtypes, nrm_types, 'FC', arr_axes):
             a = self.specific_sample_matrix((17, 13), dtype, order)
-            print("next session:", size, nrm_type, order, arr_axis)
             # contig for C order
             check(a[:3], ord=nrm_type, axis=arr_axis)
 


### PR DESCRIPTION
The goal of this PR is to add the axis option to the `np.linalg.norm` function in NoPython mode. 

Some issues request the support of this feature: #2181 #2558 #3116

Roadmap: 
- [x] Implement axis option for `ord=None`
- [x] Implement axis option for other orders
- [x] Add unit tests