### PR TITLE
Avoid issue with DI gen for arrayexprs.

### DIFF
--- a/numba/tests/gdb/test_array_arg.py
+++ b/numba/tests/gdb/test_array_arg.py
@@ -12,7 +12,7 @@ class Test(TestCase):
     def test(self):
         @njit(debug=True)
         def foo(x):
-            z = 7 + x # break here
+            z = np.ones_like(x) # break here
             return x, z
 
         tmp = np.ones(5)

--- a/numba/tests/test_gdb_dwarf.py
+++ b/numba/tests/test_gdb_dwarf.py
@@ -26,7 +26,7 @@ class TestGDBDwarf(TestCase):
     def test_basic(self):
         self._subprocess_test_runner('test_basic')
 
-    def test_array(self):
+    def test_array_arg(self):
         self._subprocess_test_runner('test_array_arg')
 
     def test_conditional_breakpoint(self):


### PR DESCRIPTION
As title. Alters a test looking for breakpoints on lines that uses
arrayexprs to not use arrayexprs as #7752 leads to the arrayexpr
referencing the source line repeatedly.

Fixes #7787

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
