### PR TITLE
Updates the gdb configuration to accept a binary name or a path.

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -156,11 +156,13 @@ These variables influence what is printed out during compilation of
 
 .. envvar:: NUMBA_GDB_BINARY
 
-   Set the ``gdb`` binary for use in Numba's ``gdb`` support, this takes the
-   form  of a path and full name of the binary, for example:
-   ``/path/from/root/to/binary/name_of_gdb_binary`` This is to permit
-   the use of a ``gdb`` from a non-default location with a non-default name. If
-   not set ``gdb`` is assumed to reside at ``/usr/bin/gdb``.
+   Set the ``gdb`` binary for use in Numba's ``gdb`` support. This takes one of
+   two forms: 1) a path and full name of the binary to explicitly express
+   which binary to use 2) just the name of the binary and the current path will
+   be searched using the standard path resolution rules. For example:
+   ``/path/from/root/to/binary/name_of_gdb_binary`` or
+   ``custom_gdb_binary_name``. This is to permit the use of a ``gdb`` from a
+   non-default location with a non-default name. The default value is ``gdb``.
 
 .. envvar:: NUMBA_DEBUG_TYPEINFER
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -2,6 +2,7 @@ import platform
 import sys
 import os
 import re
+import shutil
 import warnings
 
 # YAML needed to use file based Numba config
@@ -465,7 +466,11 @@ class _EnvReloader(object):
                                              int, 0)
 
         # gdb binary location
-        GDB_BINARY = _readenv("NUMBA_GDB_BINARY", str, '/usr/bin/gdb')
+        def which_gdb(path_or_bin):
+            gdb = shutil.which(path_or_bin)
+            return gdb if gdb is not None else path_or_bin
+
+        GDB_BINARY = _readenv("NUMBA_GDB_BINARY", which_gdb, 'gdb')
 
         # CUDA Memory management
         CUDA_MEMORY_MANAGER = _readenv("NUMBA_CUDA_MEMORY_MANAGER", str,

--- a/numba/misc/numba_gdbinfo.py
+++ b/numba/misc/numba_gdbinfo.py
@@ -2,7 +2,6 @@
 from collections import namedtuple
 import os
 import re
-import shutil
 import subprocess
 from textwrap import dedent
 from numba import config
@@ -17,7 +16,7 @@ class _GDBTestWrapper():
     has support for (Python and NumPy)."""
 
     def __init__(self,):
-        gdb_binary = shutil.which(config.GDB_BINARY)
+        gdb_binary = config.GDB_BINARY
         if gdb_binary is None:
             msg = ("No valid binary could be found for gdb named: "
                    f"{config.GDB_BINARY}")
@@ -66,42 +65,52 @@ class _GDBTestWrapper():
 def collect_gdbinfo():
     """Prints information to stdout about the gdb setup that Numba has found"""
 
-    # Check gdb exists
-    gdb_wrapper = _GDBTestWrapper()
-
     # State flags:
+    gdb_state = None
     gdb_has_python = False
     gdb_has_numpy = False
     gdb_python_version = 'No Python support'
     gdb_python_numpy_version = "No NumPy support"
 
-    # Check gdb works
-    status = gdb_wrapper.check_launch()
-    if not gdb_wrapper.success(status):
-        msg = (f"gdb at '{gdb_wrapper.gdb_binary}' does not appear to work."
-               f"\nstdout: {status.stdout}\nstderr: {status.stderr}")
-        raise ValueError(msg)
+    # There are so many ways for gdb to not be working as expected. Surround
+    # the "is it working" tests with try/except and if there's an exception
+    # store it for processing later.
+    try:
+        # Check gdb exists
+        gdb_wrapper = _GDBTestWrapper()
 
-    # Got this far, so gdb works, start checking what it supports
-    status = gdb_wrapper.check_python()
-    if gdb_wrapper.success(status):
-        version_match = re.match(r'\((\d+),\s+(\d+)\)', status.stdout.strip())
-        if version_match is not None:
-            pymajor, pyminor = version_match.groups()
-            gdb_python_version = f"{pymajor}.{pyminor}"
-            gdb_has_python = True
+        # Check gdb works
+        status = gdb_wrapper.check_launch()
+        if not gdb_wrapper.success(status):
+            msg = (f"gdb at '{gdb_wrapper.gdb_binary}' does not appear to work."
+                   f"\nstdout: {status.stdout}\nstderr: {status.stderr}")
+            raise ValueError(msg)
+        gdb_state = gdb_wrapper.gdb_binary
+    except Exception as e:
+        gdb_state = f"Testing gdb binary failed. Reported Error: {e}"
+    else:
+        # Got this far, so gdb works, start checking what it supports
+        status = gdb_wrapper.check_python()
+        if gdb_wrapper.success(status):
+            version_match = re.match(r'\((\d+),\s+(\d+)\)',
+                                     status.stdout.strip())
+            if version_match is not None:
+                pymajor, pyminor = version_match.groups()
+                gdb_python_version = f"{pymajor}.{pyminor}"
+                gdb_has_python = True
 
-            status = gdb_wrapper.check_numpy()
-            if gdb_wrapper.success(status):
-                if "Traceback" not in status.stderr.strip():
-                    if status.stdout.strip() == 'True':
-                        gdb_has_numpy = True
-                        gdb_python_numpy_version = "Unknown"
-                        # NumPy is present find the version
-                        status = gdb_wrapper.check_numpy_version()
-                        if gdb_wrapper.success(status):
-                            if "Traceback" not in status.stderr.strip():
-                                gdb_python_numpy_version = status.stdout.strip()
+                status = gdb_wrapper.check_numpy()
+                if gdb_wrapper.success(status):
+                    if "Traceback" not in status.stderr.strip():
+                        if status.stdout.strip() == 'True':
+                            gdb_has_numpy = True
+                            gdb_python_numpy_version = "Unknown"
+                            # NumPy is present find the version
+                            status = gdb_wrapper.check_numpy_version()
+                            if gdb_wrapper.success(status):
+                                if "Traceback" not in status.stderr.strip():
+                                    gdb_python_numpy_version = \
+                                        status.stdout.strip()
 
     # Work out what level of print-extension support is present in this gdb
     if gdb_has_python:
@@ -117,7 +126,7 @@ def collect_gdbinfo():
     print_ext_path = os.path.join(os.path.dirname(__file__), print_ext_file)
 
     # return!
-    return _gdb_info(gdb_wrapper.gdb_binary, print_ext_path, gdb_python_version,
+    return _gdb_info(gdb_state, print_ext_path, gdb_python_version,
                      gdb_python_numpy_version, print_ext_supported)
 
 

--- a/numba/tests/gdb/test_pretty_print.py
+++ b/numba/tests/gdb/test_pretty_print.py
@@ -1,13 +1,14 @@
 # NOTE: This test is sensitive to line numbers as it checks breakpoints
 from numba import njit
 import numpy as np
-from numba.tests.gdb_support import GdbMIDriver
+from numba.tests.gdb_support import GdbMIDriver, needs_gdb_py3
 from numba.tests.support import TestCase, needs_subprocess
-import os
+from numba.misc.numba_gdbinfo import collect_gdbinfo
 import unittest
 import re
 
 
+@needs_gdb_py3
 @needs_subprocess
 class Test(TestCase):
 
@@ -29,9 +30,9 @@ class Test(TestCase):
 
         foo()
 
-        extension = os.path.join('numba', 'misc', 'gdb_print_extension.py')
+        extension = collect_gdbinfo().extension_loc
         driver = GdbMIDriver(__file__, init_cmds=['-x', extension], debug=False)
-        driver.set_breakpoint(line=28)
+        driver.set_breakpoint(line=29)
         driver.run()
         driver.check_hit_breakpoint(1)
 

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -184,10 +184,10 @@ class TestGDBCLIInfo(TestCase):
             return CompletedProcess('INVALID_BINARY', 1)
 
         with mock.patch.object(_GDBTestWrapper, 'check_launch', mock_fn):
-            with self.assertRaises(ValueError) as raises:
-                collect_gdbinfo()
-            self.assertRegex(str(raises.exception),
-                             'gdb at.*does not appear to work.')
+            info = collect_gdbinfo()
+            self.assertIn("Testing gdb binary failed.", info.binary_loc)
+            self.assertIn("gdb at 'PATH_TO_GDB' does not appear to work",
+                          info.binary_loc)
 
     def test_no_python(self):
         def mock_fn(self):

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 import unittest
-from numba.tests.support import TestCase
+from numba.tests.support import TestCase, linux_only
 import numba.misc.numba_sysinfo as nsi
 from numba.tests.gdb_support import needs_gdb
 from numba.misc.numba_gdbinfo import collect_gdbinfo
@@ -235,6 +235,7 @@ class TestGDBCLIInfo(TestCase):
             self.assertEqual(collected.np_ver, 'Unknown')
 
 
+@linux_only
 class TestGDBCLIInfoBrokenGdbs(TestCase):
     # In these tests, it's necessary to actually run the entry point in an env
     # with the env var set as it's in part testing the processing of the

--- a/numba/tests/test_cli.py
+++ b/numba/tests/test_cli.py
@@ -235,5 +235,46 @@ class TestGDBCLIInfo(TestCase):
             self.assertEqual(collected.np_ver, 'Unknown')
 
 
+class TestGDBCLIInfoBrokenGdbs(TestCase):
+    # In these tests, it's necessary to actually run the entry point in an env
+    # with the env var set as it's in part testing the processing of the
+    # handling of consumption of variables by numba.core.config.
+
+    def test_cannot_find_gdb_from_name(self):
+        # Tests that supplying an invalid gdb binary name is handled ok
+        env = os.environ.copy()
+        env['NUMBA_GDB_BINARY'] = 'THIS_IS_NOT_A_VALID_GDB_BINARY_NAME'
+        cmdline = [sys.executable, "-m", "numba", "-g"]
+        stdout, stderr = run_cmd(cmdline, env=env)
+        self.assertIn("Testing gdb binary failed", stdout)
+        self.assertIn("No such file or directory", stdout)
+        self.assertIn("'THIS_IS_NOT_A_VALID_GDB_BINARY_NAME'", stdout)
+
+    def test_cannot_find_gdb_from_path(self):
+        # Tests that an invalid path is handled ok
+        env = os.environ.copy()
+        with TemporaryDirectory() as d:
+            # This wont exist as a path...
+            path = os.path.join(d, 'CANNOT_EXIST')
+            env['NUMBA_GDB_BINARY'] = path
+            cmdline = [sys.executable, "-m", "numba", "-g"]
+            stdout, stderr = run_cmd(cmdline, env=env)
+            self.assertIn("Testing gdb binary failed", stdout)
+            self.assertIn("No such file or directory", stdout)
+            self.assertIn(path, stdout)
+
+    def test_nonsense_gdb_binary(self):
+        # Tests that a nonsense binary specified as gdb it picked up ok
+        env = os.environ.copy()
+        env['NUMBA_GDB_BINARY'] = 'python' # 'python' isn't gdb!
+        cmdline = [sys.executable, "-m", "numba", "-g"]
+        stdout, stderr = run_cmd(cmdline, env=env)
+        self.assertIn("Testing gdb binary failed", stdout)
+        # NOTE: should 'python' ever add support for the same flags as the gdb
+        # commands used in the infomation gathering code in `numba_gdbinfo`
+        # this test will fail, it's reasonably unlikely.
+        self.assertIn("Unknown option", stdout)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title. Adjusts tests to accommodate and adds more tests for
various nonsensical cases. Also adds a requirement of gdb with
Python 3 support for the gdb printing extension tests, largely
to increase reliability.

Fixes #7792
Fixes #7791

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
