### PR TITLE
CUDA Dispatcher refactor 2: inherit from `dispatcher.Dispatcher`

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -56,7 +56,7 @@ This is similar to launch configuration in CUDA C/C++:
 Dispatcher objects also provide several utility methods for inspection and
 creating a specialized instance:
 
-.. autoclass:: numba.cuda.dispatcher.Dispatcher
+.. autoclass:: numba.cuda.dispatcher.CUDADispatcher
    :members: inspect_asm, inspect_llvm, inspect_sass, inspect_types,
              get_regs_per_thread, specialize, specialized, extensions, forall
 

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -269,20 +269,25 @@ _LowerResult = namedtuple("_LowerResult", [
 ])
 
 
-def compile_result(**kws):
-    keys = set(kws.keys())
+def sanitize_compile_result_entries(entries):
+    keys = set(entries.keys())
     fieldset = set(CR_FIELDS)
     badnames = keys - fieldset
     if badnames:
         raise NameError(*badnames)
     missing = fieldset - keys
     for k in missing:
-        kws[k] = None
+        entries[k] = None
     # Avoid keeping alive traceback variables
-    err = kws['typing_error']
+    err = entries['typing_error']
     if err is not None:
-        kws['typing_error'] = err.with_traceback(None)
-    return CompileResult(**kws)
+        entries['typing_error'] = err.with_traceback(None)
+    return entries
+
+
+def compile_result(**entries):
+    entries = sanitize_compile_result_entries(entries)
+    return CompileResult(**entries)
 
 
 def compile_isolated(func, args, return_type=None, flags=DEFAULT_FLAGS,

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -30,11 +30,11 @@ class CUDAFlags(Flags):
     )
 
 
-# The CUDACompileResult (CCR) has a specially-defined entry point equal to its id.
-# This is because the entry point is used as a key into a dict of overloads by
-# the base dispatcher. The id of the CCR is the only small and unique property
-# of a CompileResult in the CUDA target (cf. the CPU target, which uses its
-# entry_point, which is a pointer value).
+# The CUDACompileResult (CCR) has a specially-defined entry point equal to its
+# id.  This is because the entry point is used as a key into a dict of
+# overloads by the base dispatcher. The id of the CCR is the only small and
+# unique property of a CompileResult in the CUDA target (cf. the CPU target,
+# which uses its entry_point, which is a pointer value).
 #
 # This does feel a little hackish, and there are two ways in which this could
 # be improved:

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -29,11 +29,21 @@ class CUDAFlags(Flags):
     )
 
 
-# FIXME: Update this comment
-# We give the id of the overload (a CompileResult) because this is used
-# as a key into a dict of overloads, and this is the only small and
-# unique property of a CompileResult on CUDA (c.f. the CPU target,
-# which uses its entry_point, which is a pointer value).
+# The CUDACompileResult has a specially-defined entry point equal to its id.
+# This is because the entry point is used as a key into a dict of overloads by
+# the base dispatcher. The id of the CCR is the only small and unique property
+# of a CompileResult in the CUDA target (c.f. the CPU target, which uses its
+# entry_point, which is a pointer value).
+#
+# This does feel a little hackish, and there are two ways in which this could
+# be improved:
+#
+# 1. We could change the core of Numba so that each CompileResult has its own
+#    unique ID that can be used as a key - e.g. a count, similar to the way in
+#    which types have unique counts.
+# 2. At some future time when kernel launch uses a compiled function, the entry
+#    point will no longer need to be a synthetic value, but will instead be a
+#    pointer to the compiled function as in the CPU target.
 
 class CUDACompileResult(CompileResult):
     @property

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -30,10 +30,10 @@ class CUDAFlags(Flags):
     )
 
 
-# The CUDACompileResult has a specially-defined entry point equal to its id.
+# The CUDACompileResult (CCR) has a specially-defined entry point equal to its id.
 # This is because the entry point is used as a key into a dict of overloads by
 # the base dispatcher. The id of the CCR is the only small and unique property
-# of a CompileResult in the CUDA target (c.f. the CPU target, which uses its
+# of a CompileResult in the CUDA target (cf. the CPU target, which uses its
 # entry_point, which is a pointer value).
 #
 # This does feel a little hackish, and there are two ways in which this could

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -29,6 +29,12 @@ class CUDAFlags(Flags):
     )
 
 
+# FIXME: Update this comment
+# We give the id of the overload (a CompileResult) because this is used
+# as a key into a dict of overloads, and this is the only small and
+# unique property of a CompileResult on CUDA (c.f. the CPU target,
+# which uses its entry_point, which is a pointer value).
+
 class CUDACompileResult(CompileResult):
     @property
     def entry_point(self):

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -99,15 +99,15 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['fastmath'] = fastmath
             targetoptions['device'] = device
             targetoptions['extensions'] = extensions
+
             disp = Dispatcher(func, targetoptions=targetoptions)
-            # TODO: Support multiple signatures by compiling in a loop over
-            # signatures.
+
             if device:
                 disp.compile_device(argtypes)
-                disp._specialized = True
             else:
                 disp.compile(argtypes)
-                disp._specialized = True
+
+            disp._specialized = True
             disp.disable_compile()
 
             return disp

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -2,7 +2,7 @@ from warnings import warn
 from numba.core import types, config, sigutils
 from numba.core.errors import DeprecationError, NumbaInvalidConfigWarning
 from numba.cuda.compiler import declare_device_function
-from numba.cuda.dispatcher import Dispatcher
+from numba.cuda.dispatcher import CUDADispatcher
 from numba.cuda.simulator.kernel import FakeCUDAKernel
 
 
@@ -100,7 +100,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['device'] = device
             targetoptions['extensions'] = extensions
 
-            disp = Dispatcher(func, targetoptions=targetoptions)
+            disp = CUDADispatcher(func, targetoptions=targetoptions)
 
             if device:
                 disp.compile_device(argtypes)
@@ -138,7 +138,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                 targetoptions['fastmath'] = fastmath
                 targetoptions['device'] = device
                 targetoptions['extensions'] = extensions
-                return Dispatcher(func_or_sig, targetoptions=targetoptions)
+                return CUDADispatcher(func_or_sig, targetoptions=targetoptions)
 
 
 def declare_device(name, sig):

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -69,6 +69,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
 
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     fastmath = kws.get('fastmath', False)
+    extensions = kws.get('extensions', [])
 
     if debug and opt:
         msg = ("debug=True with opt=True (the default) "
@@ -97,7 +98,10 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['opt'] = opt
             targetoptions['fastmath'] = fastmath
             targetoptions['device'] = device
+            targetoptions['extensions'] = extensions
             disp = Dispatcher(func, targetoptions=targetoptions)
+            # TODO: Support multiple signatures by compiling in a loop over
+            # signatures.
             if device:
                 disp.compile_device(argtypes)
                 disp._specialized = True
@@ -133,6 +137,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                 targetoptions['link'] = link
                 targetoptions['fastmath'] = fastmath
                 targetoptions['device'] = device
+                targetoptions['extensions'] = extensions
                 return Dispatcher(func_or_sig, targetoptions=targetoptions)
 
 

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -97,7 +97,16 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
             targetoptions['opt'] = opt
             targetoptions['fastmath'] = fastmath
             targetoptions['device'] = device
-            return Dispatcher(func, [func_or_sig], targetoptions=targetoptions)
+            disp = Dispatcher(func, targetoptions=targetoptions)
+            if device:
+                disp.compile_device(argtypes)
+                disp._specialized = True
+            else:
+                disp.compile(argtypes)
+                disp._specialized = True
+            disp.disable_compile()
+
+            return disp
 
         return _jit
     else:
@@ -124,9 +133,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                 targetoptions['link'] = link
                 targetoptions['fastmath'] = fastmath
                 targetoptions['device'] = device
-                sigs = None
-                return Dispatcher(func_or_sig, sigs,
-                                  targetoptions=targetoptions)
+                return Dispatcher(func_or_sig, targetoptions=targetoptions)
 
 
 def declare_device(name, sig):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -50,6 +50,14 @@ class _Kernel(serialize.ReduceMixin):
         # target with slight modifications.
         self.objectmode = False
 
+        # The finalizer constructed by _DispatcherBase._make_finalizer also
+        # expects overloads to be a CompileResult. It uses the entry_point to
+        # remove a CompileResult from a target context. However, since we never
+        # insert kernels into a target context (there is no need because they
+        # cannot be called by other functions, only through the dispatcher) it
+        # suffices to pretend we have an entry point of None.
+        self.entry_point = None
+
         self.py_func = py_func
         self.argtypes = argtypes
         self.debug = debug
@@ -484,13 +492,6 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
         # If we produced specialized dispatchers, we cache them for each set of
         # argument types
         self.specializations = {}
-
-    def _make_finalizer(self):
-        # Dummy finalizer whilst _DispatcherBase assumes the existence of a
-        # finalizer
-        def finalizer():
-            pass
-        return finalizer
 
     @property
     def _numba_type_(self):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -481,7 +481,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                          pipeline_class=pipeline_class)
         self._type = self._numba_type_
 
-        # The following properties are for specialization of CUDADisptachers. A
+        # The following properties are for specialization of CUDADispatchers. A
         # specialized CUDADispatcher is one that is compiled for exactly one
         # set of argument types, and bypasses some argument type checking for
         # faster kernel launches.

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -466,7 +466,8 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
                  pipeline_class=CUDACompiler):
         # TODO: Check if this fixes the cuda docstring jit issue
 
-        super().__init__(py_func, pipeline_class=pipeline_class)
+        super().__init__(py_func, targetoptions=targetoptions,
+                         pipeline_class=pipeline_class)
 
         # CUDA-specific stuff - hopefully some of it can be removed ASAP
 

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -469,27 +469,10 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
         # CUDA-specific stuff - hopefully some of it can be removed ASAP
 
         self._specialized = False
-        self.link = targetoptions.pop('link', (),)
-        #self._can_compile = True
         self._type = self._numba_type_
 
         # Specializations for given sets of argument types
         self.specializations = {}
-
-        # defensive copy
-        self.targetoptions['extensions'] = \
-            list(self.targetoptions.get('extensions', []))
-
-        #if sigs:
-        #    if len(sigs) > 1:
-        #        raise TypeError("Only one signature supported at present")
-        #    if targetoptions.get('device'):
-        #        argtypes, restype = sigutils.normalize_signature(sigs[0])
-        #        self.compile_device(argtypes)
-        #    else:
-        #        self.compile(sigs[0])
-
-        #    self._can_compile = False
 
     def _make_finalizer(self):
         # Dummy finalizer whilst _DispatcherBase assumes the existence of a
@@ -620,7 +603,6 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
             return specialization
 
         targetoptions = self.targetoptions
-        targetoptions['link'] = self.link
         specialization = Dispatcher(self.py_func, targetoptions=targetoptions)
         specialization.compile(argtypes)
         specialization.disable_compile()
@@ -730,7 +712,7 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
         if kernel is None:
             if not self._can_compile:
                 raise RuntimeError("Compilation disabled")
-            kernel = _Kernel(self.py_func, argtypes, link=self.link,
+            kernel = _Kernel(self.py_func, argtypes,
                              **self.targetoptions)
             # Inspired by _DispatcherBase.add_overload, but differs slightly
             # because we're inserting a _Kernel object instead of a compiled

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -731,13 +731,16 @@ class Dispatcher(_DispatcherBase, serialize.ReduceMixin):
 
             return call_template, pysig, args, kws
 
-    def get_overload(self, sig):
-        # We give the id of the overload (a CompileResult) because this is used
-        # as a key into a dict of overloads, and this is the only small and
-        # unique property of a CompileResult on CUDA (c.f. the CPU target,
-        # which uses its entry_point, which is a pointer value).
-        args, return_type = sigutils.normalize_signature(sig)
-        return id(self.overloads[args])
+#    def get_overload(self, sig):
+#        # We give the id of the overload (a CompileResult) because this is used
+#        # as a key into a dict of overloads, and this is the only small and
+#        # unique property of a CompileResult on CUDA (c.f. the CPU target,
+#        # which uses its entry_point, which is a pointer value).
+#        args, return_type = sigutils.normalize_signature(sig)
+#        return id(self.overloads[args])
+
+    def __repr__(self):
+        return f"numba.cuda.dispatcher.Dispatcher({self.py_func})"
 
     def compile_device(self, args):
         """Compile the device function for the given argument types.
@@ -763,7 +766,8 @@ class Dispatcher(_DispatcherBase, serialize.ReduceMixin):
 
             # The inserted function uses the id of the CompileResult as a key,
             # consistent with get_overload() above.
-            cres.target_context.insert_user_function(id(cres), cres.fndesc,
+            cres.target_context.insert_user_function(cres.entry_point,
+                                                     cres.fndesc,
                                                      [cres.library])
         else:
             cres = self.overloads[args]

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -600,9 +600,6 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
         self.specializations[cc, argtypes] = specialization
         return specialization
 
-    def disable_compile(self, val=True):
-        self._can_compile = not val
-
     @property
     def specialized(self):
         """
@@ -631,6 +628,9 @@ class Dispatcher(uber_Dispatcher, serialize.ReduceMixin):
 
     def get_call_template(self, args, kws):
         # Copied and simplified from _DispatcherBase.get_call_template.
+        #
+        # This seems to have some necessary differences to the _DispatcherBase
+        # version to force casts where necessay? XXX
         """
         Get a typing.ConcreteTemplate for this dispatcher and the given
         *args* and *kws* types.  This allows resolution of the return type.

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -731,14 +731,7 @@ class Dispatcher(_DispatcherBase, serialize.ReduceMixin):
 
             return call_template, pysig, args, kws
 
-#    def get_overload(self, sig):
-#        # We give the id of the overload (a CompileResult) because this is used
-#        # as a key into a dict of overloads, and this is the only small and
-#        # unique property of a CompileResult on CUDA (c.f. the CPU target,
-#        # which uses its entry_point, which is a pointer value).
-#        args, return_type = sigutils.normalize_signature(sig)
-#        return id(self.overloads[args])
-
+    # XXX: Delete this and call the class CUDADispatcher
     def __repr__(self):
         return f"numba.cuda.dispatcher.Dispatcher({self.py_func})"
 
@@ -764,8 +757,6 @@ class Dispatcher(_DispatcherBase, serialize.ReduceMixin):
                                 inline=inline, nvvm_options=nvvm_options)
             self.overloads[args] = cres
 
-            # The inserted function uses the id of the CompileResult as a key,
-            # consistent with get_overload() above.
             cres.target_context.insert_user_function(cres.entry_point,
                                                      cres.fndesc,
                                                      [cres.library])

--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -3,7 +3,7 @@ def initialize_all():
     import numba.cuda.models  # noqa: F401
 
     from numba import cuda
-    from numba.cuda.dispatcher import Dispatcher
+    from numba.cuda.dispatcher import CUDADispatcher
     from numba.core.target_extension import (target_registry,
                                              dispatcher_registry,
                                              jit_registry)
@@ -14,4 +14,4 @@ def initialize_all():
 
     cuda_target = target_registry["cuda"]
     jit_registry[cuda_target] = cuda_jit_device
-    dispatcher_registry[cuda_target] = Dispatcher
+    dispatcher_registry[cuda_target] = CUDADispatcher

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -3,7 +3,7 @@ import llvmlite.binding as ll
 from llvmlite import ir
 
 from numba.core import typing, types, debuginfo, itanium_mangler, cgutils
-from numba.core.dispatcher import Dispatcher as uber_Dispatcher
+from numba.core.dispatcher import Dispatcher
 from numba.core.utils import cached_property
 from numba.core.base import BaseContext
 from numba.core.callconv import MinimalCallConv
@@ -28,8 +28,8 @@ class CUDATypingContext(typing.BaseContext):
 
     def resolve_value_type(self, val):
         # treat other dispatcher object as another device function
-        from numba.cuda.dispatcher import Dispatcher as CUDADispatcher
-        if (isinstance(val, uber_Dispatcher) and not
+        from numba.cuda.dispatcher import CUDADispatcher
+        if (isinstance(val, Dispatcher) and not
                 isinstance(val, CUDADispatcher)):
             try:
                 # use cached device function

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -42,8 +42,7 @@ class CUDATypingContext(typing.BaseContext):
                 targetoptions['device'] = True
                 targetoptions['debug'] = targetoptions.get('debug', False)
                 targetoptions['opt'] = targetoptions.get('opt', True)
-                sigs = None
-                disp = CUDADispatcher(val.py_func, sigs, targetoptions)
+                disp = CUDADispatcher(val.py_func, targetoptions)
                 # cache the device function for future use and to avoid
                 # duplicated copy of the same function.
                 val.__dispatcher = disp

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -42,7 +42,7 @@ class CUDATypingContext(typing.BaseContext):
                 targetoptions['opt'] = targetoptions.get('opt', True)
                 sigs = None
                 from numba.cuda.dispatcher import Dispatcher
-                disp = Dispatcher(val, sigs, targetoptions)
+                disp = Dispatcher(val.py_func, sigs, targetoptions)
                 # cache the device function for future use and to avoid
                 # duplicated copy of the same function.
                 val.__dispatcher = disp

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -272,6 +272,21 @@ class TestDispatcher(CUDATestCase):
         self.assertIsInstance(regs_per_thread, int)
         self.assertGreater(regs_per_thread, 0)
 
+    def test_dispatcher_docstring(self):
+        # Ensure that CUDA-jitting a function preserves its docstring. See
+        # Issue #5902: https://github.com/numba/numba/issues/5902
+
+        @cuda.jit
+        def add_kernel(a, b):
+            """Add two integers, kernel version"""
+
+        @cuda.jit(device=True)
+        def add_device(a, b):
+            """Add two integers, device version"""
+
+        self.assertEqual("Add two integers, kernel version", add_kernel.__doc__)
+        self.assertEqual("Add two integers, device version", add_device.__doc__)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_errors.py
+++ b/numba/cuda/tests/cudapy/test_errors.py
@@ -71,9 +71,7 @@ class TestJitErrors(CUDATestCase):
         with self.assertRaises(TypingError) as raises:
             kernel_func[1, 1]()
         excstr = str(raises.exception)
-        self.assertIn("resolving callee type: "
-                      "type(numba.cuda.dispatcher.Dispatcher",
-                      excstr)
+        self.assertIn("resolving callee type: type(CUDADispatcher", excstr)
         self.assertIn("NameError: name 'floor' is not defined", excstr)
 
 

--- a/numba/cuda/tests/cudapy/test_errors.py
+++ b/numba/cuda/tests/cudapy/test_errors.py
@@ -72,7 +72,7 @@ class TestJitErrors(CUDATestCase):
             kernel_func[1, 1]()
         excstr = str(raises.exception)
         self.assertIn("resolving callee type: "
-                      "type(<numba.cuda.dispatcher.Dispatcher object",
+                      "type(numba.cuda.dispatcher.Dispatcher",
                       excstr)
         self.assertIn("NameError: name 'floor' is not defined", excstr)
 


### PR DESCRIPTION
(Note: based on #7814 - it should be easier to tell the differences once that is merged - in the meantime [this comparison](https://github.com/gmarkall/numba/compare/dispatcher-refactor-20220204...gmarkall:cuda-dispatcher-base-20220204) shows the changes unique to this PR)

The main accomplishment of this PR is to make the CUDA dispatcher inherit from `numba.core.dispatcher.Dispatcher` and reuse as much of its logic as possible, rather than duplicating it (and also to serve as a base for implementing on-disk caching, AOT compilation, better support for the high-level extension API, etc.). 

This necessitates a set of individual changes that accompany the main change:

- Creation of a `CUDACompileResult`, which reports its entry point as its `id` - this is because certain functions expect compile results to have entry points - however, this isn't true for CUDA because you can't enter a CUDA kernel through the C-layer dispatcher. Using the `id` gives each CUDA compile result a unique identifier.
- A small change to `compile_result` to factor out sanitizing the entries that go into the compile result, so that this logic can be shared between the core and the CUDA target.
- Changes to `numba.cuda.decorators` so it is responsible for handling signatures and compilation - the CUDA dispatcher no longer needs to be aware of signatures, and this behaviour mirrors the CPU target. CUDA still only supports one signature, but this can now be more easily changed in future.
- Fixes to the setup of the `extensions` target option, so that the CUDA dispatcher no longer needs to make a strange "defensive copy".
- Two additions to `_Kernel` so that they have the `objectmode` and `entry_point` properties, as if they were compile results - this is because overloads are expected to be compile results by some of the core dispatcher logic.
- Some refactors to `ForAll` that make the terminology more representative (but no functional change).
- Fix a very strange "how did it ever work"-style bug in `resolve_value_type`, where it was wrapping a CPU dispatcher in a CUDA dispatcher instead of wrapping the Python function in a CUDA dispatcher when calling an `@njit` function from a `@cuda.jit` function.
- Add test of docstrings for CUDA dispatchers (#5209).

Fixes #7741.

## Description prior to editing, kept for reference:

Fixes #5902.

To do:

- [X] Resolve the issue with `_make_finalizer` - possibly one of:
  - be certain that a dummy finalizer is fine, 
  - remove the finalization altogether if it's no longer needed (perhaps this is an old Python / Python 2 remnant)
  - implement a custom non-dummy finalizer
  - make `_Kernel` pretend to be a `CompileResult` a bit more by giving it an `entry_point`.
- [X] Add a test that #5902 is fixed (I have only manually verified it so far).

