### PR TITLE
F2PY Support

### DIFF
--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -126,7 +126,7 @@ The function ``get_f2py_function_address`` obtains the address of a
 C function in a F2PY extension module. The address can be used to
 access the C function via a :func:`ctypes.CFUNCTYPE` callback, thus
 allowing use of the C function inside a Numba jitted function. For
-example, call scipy.interpolate.dfitpack.splev::
+example, call ``scipy.interpolate.dfitpack.splev``::
 
     import numba as nb
     import numpy as np

--- a/docs/source/extending/high-level.rst
+++ b/docs/source/extending/high-level.rst
@@ -137,7 +137,7 @@ example, call scipy.interpolate.dfitpack.splev::
     dble_p=ctypes.POINTER(ctypes.c_double)
     int_p =ctypes.POINTER(ctypes.c_longlong)
 
-    #Calling siganture
+    #Calling signature
     functype = ctypes.CFUNCTYPE(ctypes.c_void_p,
                                 dble_p,int_p,dble_p,int_p,dble_p,dble_p,int_p,int_p,int_p)
 

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -563,7 +563,7 @@ import_cython_function(const char *module_name, const char *function_name)
     }
     /* 2.7+ => Cython exports a PyCapsule */
     capsule_name = PyCapsule_GetName(cobj);
-    if (PyCapsule_IsValid(cobj,capsule_name)!=0) {
+    if (PyCapsule_IsValid(cobj, capsule_name) != 0) {
         res = PyCapsule_GetPointer(cobj, capsule_name);
     }
     Py_DECREF(cobj);

--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -593,7 +593,7 @@ import_f2py_function(const char *module_name, const char *function_name)
         PyErr_Clear();
         PyErr_Format(PyExc_ValueError,
                      "No _cpointer attribute found in function '%s' of '%s'",
-                     function_name,module_name);
+                     function_name, module_name);
         return NULL;
     }
     /* f2py exports PyCapsule */

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -229,6 +229,7 @@ static PyMethodDef ext_methods[] = {
     { "rnd_set_state", (PyCFunction) _numba_rnd_set_state, METH_VARARGS, NULL },
     { "rnd_shuffle", (PyCFunction) _numba_rnd_shuffle, METH_O, NULL },
     { "_import_cython_function", (PyCFunction) _numba_import_cython_function, METH_VARARGS, NULL },
+    { "_import_f2py_function", (PyCFunction) _numba_import_f2py_function, METH_VARARGS, NULL },
     { NULL },
 };
 

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -17,7 +17,7 @@ from numba.core.imputils import (  # noqa: F401
 from numba.core.datamodel import models   # noqa: F401
 from numba.core.datamodel import register_default as register_model  # noqa: F401, E501
 from numba.core.pythonapi import box, unbox, reflect, NativeValue  # noqa: F401
-from numba._helperlib import _import_cython_function  # noqa: F401
+from numba._helperlib import _import_cython_function,_import_f2py_function  # noqa: F401
 from numba.core.serialize import ReduceMixin
 
 

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -463,6 +463,23 @@ def get_cython_function_address(module_name, function_name):
     """
     return _import_cython_function(module_name, function_name)
 
+def get_f2py_function_address(module_name, function_name):
+    """
+    Get the address of a f2py function.
+
+    Args
+    ----
+    module_name:
+        Name of the f2py module
+    function_name:
+        Name of the f2py function
+
+    Returns
+    -------
+    A Python int containing the address of the function
+
+    """
+    return _import_f2py_function(module_name, function_name)
 
 def include_path():
     """Returns the C include directory path.

--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -17,7 +17,8 @@ from numba.core.imputils import (  # noqa: F401
 from numba.core.datamodel import models   # noqa: F401
 from numba.core.datamodel import register_default as register_model  # noqa: F401, E501
 from numba.core.pythonapi import box, unbox, reflect, NativeValue  # noqa: F401
-from numba._helperlib import _import_cython_function,_import_f2py_function  # noqa: F401
+from numba._helperlib import _import_cython_function # noqa: F401
+from numba._helperlib import _import_f2py_function
 from numba.core.serialize import ReduceMixin
 
 
@@ -463,6 +464,7 @@ def get_cython_function_address(module_name, function_name):
     """
     return _import_cython_function(module_name, function_name)
 
+
 def get_f2py_function_address(module_name, function_name):
     """
     Get the address of a f2py function.
@@ -480,6 +482,7 @@ def get_f2py_function_address(module_name, function_name):
 
     """
     return _import_f2py_function(module_name, function_name)
+
 
 def include_path():
     """Returns the C include directory path.

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -66,9 +66,9 @@ def stack_empty(shape,dtype,order="C"):
     """
     arr_ptr = intr_stack_empty_alloc(shape,dtype)
     if order == "C":
-        return carray(arr_ptr,shape)
+        return carray(arr_ptr, shape)
     elif order == "F":
-        return farray(arr_ptr,shape)
+        return farray(arr_ptr, shape)
     else:
         raise errors.UnsupportedError(
             "order must be one of 'C', 'F'")

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -43,7 +43,7 @@ def intr_stack_empty_alloc(typingctx,shape,dtype):
         for i in range(len(shape)):
             size *= shape[i].literal_value
 
-        sig = types.CPointer(dtype.dtype)(typeof(shape).instance_type,dtype)
+        sig = types.CPointer(dtype.dtype)(typeof(shape).instance_type, dtype)
     else:
         raise errors.TypingError(
             "Shape must be IntegerLiteral " +

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -38,8 +38,8 @@ def intr_stack_empty_alloc(typingctx,shape,dtype):
         size = shape.literal_value
         sig = types.CPointer(dtype.dtype)(types.int64,dtype)
 
-    elif isinstance(shape,(types.containers.Tuple,
-                           types.containers.UniTuple)):
+    elif isinstance(shape, (types.containers.Tuple,
+                            types.containers.UniTuple)):
         for i in range(len(shape)):
             size *= shape[i].literal_value
 

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -51,7 +51,7 @@ def intr_stack_empty_alloc(typingctx,shape,dtype):
 
     def impl(context, builder, signature, args):
         ty = context.get_value_type(dtype.dtype)
-        ptr = cgutils.alloca_once(builder, ty,size=size)
+        ptr = cgutils.alloca_once(builder, ty, size=size)
         return ptr
     return sig, impl
 

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -36,7 +36,7 @@ def intr_stack_empty_alloc(typingctx,shape,dtype):
     size = 1
     if isinstance(shape,types.scalars.IntegerLiteral):
         size = shape.literal_value
-        sig = types.CPointer(dtype.dtype)(types.int64,dtype)
+        sig = types.CPointer(dtype.dtype)(types.int64, dtype)
 
     elif isinstance(shape, (types.containers.Tuple,
                             types.containers.UniTuple)):

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -32,7 +32,7 @@ def ptr_to_val(typingctx, data):
 
 
 @intrinsic
-def intr_stack_empty_alloc(typingctx,shape,dtype):
+def intr_stack_empty_alloc(typingctx, shape, dtype):
     size = 1
     if isinstance(shape,types.scalars.IntegerLiteral):
         size = shape.literal_value

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -14,8 +14,8 @@ def val_to_ptr(typingctx, data):
     def impl(context, builder, signature, args):
         ptr = cgutils.alloca_once_value(builder,args[0])
         return ptr
-    sig = types.CPointer((typeof(data).instance_type)
-                         (typeof(data).instance_type))
+    sig = types.CPointer(typeof(data).instance_type)(typeof(
+        data).instance_type)
     return sig, impl
 
 

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -64,7 +64,7 @@ def stack_empty(shape,dtype,order="C"):
     Please note: - Arrays allocated on the stack can't be returned.
                  - Stack size is limited
     """
-    arr_ptr = intr_stack_empty_alloc(shape,dtype)
+    arr_ptr = intr_stack_empty_alloc(shape, dtype)
     if order == "C":
         return carray(arr_ptr, shape)
     elif order == "F":

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -1,0 +1,75 @@
+#Workaround using stack-allocated arrays, 
+#faster than heap-allocated arrays.
+#Workaround for ctypes byref
+from numba import types,typeof,carray,farray,njit
+from numba.extending import intrinsic
+from numba.core import cgutils,errors
+
+@intrinsic
+def val_to_ptr(typingctx, data):
+    """
+    Get the value, pointed to by a pointer
+    """
+    def impl(context, builder, signature, args):
+        ptr = cgutils.alloca_once_value(builder,args[0])
+        return ptr
+    sig = types.CPointer(typeof(data).instance_type)\
+        (typeof(data).instance_type)
+    return sig, impl
+
+
+@intrinsic
+def ptr_to_val(typingctx, data):
+    """
+    Get a pointer to a given value
+    """
+    def impl(context, builder, signature, args):
+        val = builder.load(args[0])
+        return val
+    sig = data.dtype(types.CPointer(data.dtype))
+    return sig, impl
+
+
+@intrinsic
+def intr_stack_empty_alloc(typingctx,shape,dtype):
+    size=1
+    if isinstance(shape,types.scalars.IntegerLiteral):
+        size=shape.literal_value
+        sig = types.CPointer(dtype.dtype)\
+              (types.int64,dtype)
+            
+    elif isinstance(shape,(types.containers.Tuple,
+                           types.containers.UniTuple)):
+        for i in range(len(shape)):
+            size*=shape[i].literal_value
+        
+        sig = types.CPointer(dtype.dtype)\
+              (typeof(shape).instance_type,dtype)
+    else:
+        raise errors.TypingError(
+            "Shape must be IntegerLiteral "+ \
+            "or a tuple of IntegerLiterals")
+    
+    def impl(context, builder, signature, args):
+        ty=context.get_value_type(dtype.dtype)
+        ptr = cgutils.alloca_once(builder, ty,size=size)
+        return ptr
+    return sig, impl
+
+
+#inline always, stack memory can't be returned
+@njit(inline="always")
+def stack_empty(shape,dtype,order="C"):
+    """
+    Allocate an array on the stack.
+    Please note: - Arrays allocated on the stack can't be returned.
+                 - Stack size is limited
+    """
+    arr_ptr=intr_stack_empty_alloc(shape,dtype)
+    if order =="C":
+        return carray(arr_ptr,shape)
+    elif order == "F":
+        return farray(arr_ptr,shape)
+    else:
+        raise errors.UnsupportedError(
+            "order must be one of 'C', 'F'")

--- a/numba/cpython/unsafe/stack_arr.py
+++ b/numba/cpython/unsafe/stack_arr.py
@@ -1,9 +1,10 @@
-#Workaround using stack-allocated arrays, 
+#Workaround using stack-allocated arrays,
 #faster than heap-allocated arrays.
 #Workaround for ctypes byref
 from numba import types,typeof,carray,farray,njit
 from numba.extending import intrinsic
 from numba.core import cgutils,errors
+
 
 @intrinsic
 def val_to_ptr(typingctx, data):
@@ -13,8 +14,8 @@ def val_to_ptr(typingctx, data):
     def impl(context, builder, signature, args):
         ptr = cgutils.alloca_once_value(builder,args[0])
         return ptr
-    sig = types.CPointer(typeof(data).instance_type)\
-        (typeof(data).instance_type)
+    sig = types.CPointer((typeof(data).instance_type)
+                         (typeof(data).instance_type))
     return sig, impl
 
 
@@ -32,26 +33,24 @@ def ptr_to_val(typingctx, data):
 
 @intrinsic
 def intr_stack_empty_alloc(typingctx,shape,dtype):
-    size=1
+    size = 1
     if isinstance(shape,types.scalars.IntegerLiteral):
-        size=shape.literal_value
-        sig = types.CPointer(dtype.dtype)\
-              (types.int64,dtype)
-            
+        size = shape.literal_value
+        sig = types.CPointer(dtype.dtype)(types.int64,dtype)
+
     elif isinstance(shape,(types.containers.Tuple,
                            types.containers.UniTuple)):
         for i in range(len(shape)):
-            size*=shape[i].literal_value
-        
-        sig = types.CPointer(dtype.dtype)\
-              (typeof(shape).instance_type,dtype)
+            size *= shape[i].literal_value
+
+        sig = types.CPointer(dtype.dtype)(typeof(shape).instance_type,dtype)
     else:
         raise errors.TypingError(
-            "Shape must be IntegerLiteral "+ \
+            "Shape must be IntegerLiteral " +
             "or a tuple of IntegerLiterals")
-    
+
     def impl(context, builder, signature, args):
-        ty=context.get_value_type(dtype.dtype)
+        ty = context.get_value_type(dtype.dtype)
         ptr = cgutils.alloca_once(builder, ty,size=size)
         return ptr
     return sig, impl
@@ -65,8 +64,8 @@ def stack_empty(shape,dtype,order="C"):
     Please note: - Arrays allocated on the stack can't be returned.
                  - Stack size is limited
     """
-    arr_ptr=intr_stack_empty_alloc(shape,dtype)
-    if order =="C":
+    arr_ptr = intr_stack_empty_alloc(shape,dtype)
+    if order == "C":
         return carray(arr_ptr,shape)
     elif order == "F":
         return farray(arr_ptr,shape)

--- a/numba/np/unsafe/stack.py
+++ b/numba/np/unsafe/stack.py
@@ -1,0 +1,117 @@
+"""Implementation of Stack-allocated arrays
+Please note that stack memory is limited and can't be returned.
+There is no further check! If you try to return a stack array and
+the function isn't inlined, you get an array object which points to
+unallocated memory.
+
+Purpose:
+  - Small temporary arrays which are not retuned (faster allocation)
+  - Small temporary arrays needed to wrap a C/Fortran function
+"""
+from numba import types,typeof,carray,farray,njit
+from numba.extending import intrinsic
+from numba.core import cgutils,errors
+from numba.core.typing.npydecl import parse_dtype
+
+
+@intrinsic
+def val_to_ptr(typingctx, data):
+    """
+    Get a pointer of type typeof(value) to a value
+    Python scalars are immuteable. Internally a stack-array is allocated
+    and the given value is copied into it. To get a Python scalar ptr_to_val
+    has to be called.
+    This pointer is only valid within a function and can't be returned.
+    """
+    def impl(context, builder, signature, args):
+        ptr = cgutils.alloca_once_value(builder, args[0])
+        return ptr
+    sig = types.CPointer(typeof(data).instance_type)(typeof(
+        data).instance_type)
+    return sig, impl
+
+
+@intrinsic
+def ptr_to_val(typingctx, data):
+    """
+    Get the first value, where a pointer points to
+    """
+    def impl(context, builder, signature, args):
+        val = builder.load(args[0])
+        return val
+    sig = data.dtype(types.CPointer(data.dtype))
+    return sig, impl
+
+
+@intrinsic
+def intr_stack_empty_alloc(typingctx, shape, dtype):
+    """
+    Allocates memory on the stack
+    """
+    size = 1
+    val_type = parse_dtype(dtype)
+
+    if isinstance(shape, types.scalars.IntegerLiteral):
+        size = shape.literal_value
+        sig = types.CPointer(val_type)(types.int64,dtype)
+
+    elif isinstance(shape,(types.containers.Tuple)):
+        for i in range(len(shape)):
+            if isinstance(shape[i], types.scalars.IntegerLiteral):
+                size *= shape[i].literal_value
+            else:
+                raise errors.LiteralTypingError(
+                    "Shape " + str(i) + " is not a Integer Literal")
+
+        sig = types.CPointer(val_type)(typeof(shape).instance_type,dtype)
+    else:
+        raise errors.TypingError(
+            "Shape must be IntegerLiteral " +
+            "or a tuple of IntegerLiterals")
+
+    def impl(context, builder, signature, args):
+        ty = context.get_value_type(val_type)
+        ptr = cgutils.alloca_once(builder, ty,size=size)
+        return ptr
+    return sig, impl
+
+
+#inline always, stack memory can't be returned
+@njit(inline="always")
+def empty(shape, dtype, order="C"):
+    """
+    Allocate an empty array on the stack.
+    Please note: - Arrays allocated on the stack can't be returned.
+                 - Stack size is limited
+    """
+    arr_ptr = intr_stack_empty_alloc(shape, dtype)
+    if order == "C":
+        return carray(arr_ptr, shape)
+    elif order == "F":
+        return farray(arr_ptr, shape)
+    else:
+        raise errors.UnsupportedError(
+            "order must be one of 'C', 'F'")
+
+
+#inline always, stack memory can't be returned
+@njit(inline="always")
+def zeros(shape, dtype, order="C"):
+    """
+    Allocate an array filled with zeros on the stack.
+    Please note: - Arrays allocated on the stack can't be returned.
+                 - Stack size is limited
+    """
+    arr_ptr = intr_stack_empty_alloc(shape, dtype)
+    if order == "C":
+        arr = carray(arr_ptr, shape)
+        arr[:] = 0
+        return arr
+    elif order == "F":
+        arr = farray(arr_ptr, shape)
+        arr[:] = 0
+        return arr
+    else:
+        raise errors.UnsupportedError(
+            "order must be one of 'C', 'F'")
+

--- a/numba/np/unsafe/stack.py
+++ b/numba/np/unsafe/stack.py
@@ -114,4 +114,3 @@ def zeros(shape, dtype, order="C"):
     else:
         raise errors.UnsupportedError(
             "order must be one of 'C', 'F'")
-

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1613,8 +1613,8 @@ class TestImportF2PYFunction(unittest.TestCase):
             e_arr = val_to_ptr(int64(e))
             ier_arr = val_to_ptr(int64(0))
 
-            SPLEV(t.ctypes,n_arr,c.ctypes,k_arr,x.ctypes,
-                  y.ctypes,m_arr,e_arr,ier_arr)
+            SPLEV(t.ctypes, n_arr, c.ctypes, k_arr, x.ctypes,
+                  y.ctypes, m_arr, e_arr, ier_arr)
 
             return y
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1642,7 +1642,7 @@ class TestImportF2PYFunction(unittest.TestCase):
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
     def test_missing_function(self):
         with self.assertRaises(ValueError) as raises:
-            get_cython_function_address(
+            get_f2py_function_address(
                 "scipy.interpolate.dfitpack", "foo"
             )
         msg = ("module 'scipy.interpolate.dfitpack' has no attribute 'foo'")

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1585,7 +1585,7 @@ class TestImportCythonFunction(unittest.TestCase):
         self.assertEqual(msg, str(raises.exception))
  
 
- class TestImportF2PYFunction(unittest.TestCase):
+class TestImportF2PYFunction(unittest.TestCase):
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
     def test_getting_function(self):
         addr = get_f2py_function_address(

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1595,8 +1595,8 @@ class TestImportF2PYFunction(unittest.TestCase):
         dble_p = ctypes.POINTER(ctypes.c_double)
         int_p = ctypes.POINTER(ctypes.c_longlong)
 
-        functype = ctypes.CFUNCTYPE(ctypes.c_void_p,dble_p,int_p,dble_p,int_p,
-                                    dble_p,dble_p,int_p,int_p,int_p)
+        functype = ctypes.CFUNCTYPE(ctypes.c_void_p, dble_p, int_p, dble_p, int_p,
+                                    dble_p, dble_p, int_p, int_p, int_p)
         SPLEV = functype(addr)
 
         from numba.cpython.unsafe.stack_arr import val_to_ptr

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -6,7 +6,6 @@ import multiprocessing
 import ctypes
 import warnings
 from distutils.version import LooseVersion
-import re
 
 import numpy as np
 
@@ -69,7 +68,7 @@ try:
     else:
         import scipy.special.cython_special as sc
         from scipy import interpolate
-        from numba.cpython.unsafe.stack_arr import val_to_ptr
+        from numba.np.unsafe.stack import val_to_ptr
         from numba import int64
 except ImportError:
     sc = None

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1621,7 +1621,7 @@ class TestImportF2PYFunction(unittest.TestCase):
         x, dx = np.linspace(10, 100, 200, retstep=True)
         y = np.sin(x)
 
-        coeff_1 = interpolate.splrep(x,y, k=3)
+        coeff_1 = interpolate.splrep(x, y, k=3)
 
         x2 = np.linspace(0,110,1000)
         np.random.shuffle(x2)

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1618,7 +1618,7 @@ class TestImportF2PYFunction(unittest.TestCase):
 
             return y
 
-        x, dx = np.linspace(10,100,200, retstep=True)
+        x, dx = np.linspace(10, 100, 200, retstep=True)
         y = np.sin(x)
 
         coeff_1 = interpolate.splrep(x,y, k=3)

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1604,8 +1604,8 @@ class TestImportF2PYFunction(unittest.TestCase):
 
         @njit('float64[::1](float64[::1],float64[::1],int64,' +
               'float64[::1],int64)')
-        def splev_wrapped(t,c,k,x,e):
-            y = np.empty(x.shape[0],dtype=np.float64)
+        def splev_wrapped(t, c, k, x, e):
+            y = np.empty(x.shape[0], dtype=np.float64)
 
             n_arr = val_to_ptr(int64(t.shape[0]))
             k_arr = val_to_ptr(int64(k))

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1602,8 +1602,8 @@ class TestImportF2PYFunction(unittest.TestCase):
         from numba.cpython.unsafe.stack_arr import val_to_ptr
         from numba import int64
 
-        @njit('float64[::1](float64[::1],float64[::1],int64,' +
-              'float64[::1],int64)')
+        @njit('float64[::1](float64[::1], float64[::1], int64,' +
+              'float64[::1], int64)')
         def splev_wrapped(t, c, k, x, e):
             y = np.empty(x.shape[0], dtype=np.float64)
 

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1592,41 +1592,41 @@ class TestImportF2PYFunction(unittest.TestCase):
         addr = get_f2py_function_address(
             "scipy.interpolate.dfitpack", "splev"
         )
-        dble_p=ctypes.POINTER(ctypes.c_double)
-        int_p =ctypes.POINTER(ctypes.c_longlong)
+        dble_p = ctypes.POINTER(ctypes.c_double)
+        int_p = ctypes.POINTER(ctypes.c_longlong)
 
-        functype = ctypes.CFUNCTYPE(ctypes.c_void_p,
-                   dble_p,int_p,dble_p,int_p,dble_p,dble_p,int_p,int_p,int_p)
+        functype = ctypes.CFUNCTYPE(ctypes.c_void_p,dble_p,int_p,dble_p,int_p,
+                                    dble_p,dble_p,int_p,int_p,int_p)
         SPLEV = functype(addr)
 
-        from numba.cpython.unsafe.stack_arr import val_to_ptr,ptr_to_val
+        from numba.cpython.unsafe.stack_arr import val_to_ptr
         from numba import int64
 
-        @njit('float64[::1](float64[::1],float64[::1],int64,' + 
-                                      'float64[::1],int64)')
+        @njit('float64[::1](float64[::1],float64[::1],int64,' +
+              'float64[::1],int64)')
         def splev_wrapped(t,c,k,x,e):
-            y=np.empty(x.shape[0],dtype=np.float64)
+            y = np.empty(x.shape[0],dtype=np.float64)
 
-            n_arr=val_to_ptr(int64(t.shape[0]))
-            k_arr=val_to_ptr(int64(k))
-            m_arr=val_to_ptr(int64(x.shape[0]))
-            e_arr=val_to_ptr(int64(e))
-            ier_arr=val_to_ptr(int64(0))
+            n_arr = val_to_ptr(int64(t.shape[0]))
+            k_arr = val_to_ptr(int64(k))
+            m_arr = val_to_ptr(int64(x.shape[0]))
+            e_arr = val_to_ptr(int64(e))
+            ier_arr = val_to_ptr(int64(0))
 
             SPLEV(t.ctypes,n_arr,c.ctypes,k_arr,x.ctypes,
-                y.ctypes,m_arr,e_arr,ier_arr)
+                  y.ctypes,m_arr,e_arr,ier_arr)
 
             return y
-        
+
         x, dx = np.linspace(10,100,200, retstep=True)
         y = np.sin(x)
 
         coeff_1 = interpolate.splrep(x,y, k=3)
 
-        x2 = np.linspace(0,110,1000) 
+        x2 = np.linspace(0,110,1000)
         np.random.shuffle(x2)
-        isclose=np.allclose(interpolate.splev(x2, coeff_1), 
-            splev_wrapped(coeff_1[0],coeff_1[1],coeff_1[2],x2,0))
+        isclose = np.allclose(interpolate.splev(x2, coeff_1), splev_wrapped(
+                              coeff_1[0],coeff_1[1],coeff_1[2],x2,0))
         self.assertEqual(isclose,True)
 
     def test_missing_module(self):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -44,6 +44,7 @@ from numba.extending import (
     _Intrinsic,
     register_jitable,
     get_cython_function_address,
+    get_f2py_function_address,
     is_jitted,
     overload_classmethod,
 )
@@ -1582,6 +1583,48 @@ class TestImportCythonFunction(unittest.TestCase):
             "'scipy.special.cython_special'"
         )
         self.assertEqual(msg, str(raises.exception))
+ 
+
+ class TestImportF2PYFunction(unittest.TestCase):
+    @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
+    def test_getting_function(self):
+        addr = get_f2py_function_address(
+            "scipy.interpolate.dfitpack", "splev"
+        )
+        dble_p=ctypes.POINTER(ctypes.c_double)
+        int_p =ctypes.POINTER(ctypes.c_longlong)
+
+        functype = ctypes.CFUNCTYPE(ctypes.c_void_p,
+                   dble_p,int_p,dble_p,int_p,dble_p,dble_p,int_p,int_p,int_p)
+        SPLEV = functype(addr)
+        
+        from numba.cpython.unsafe.stack_arr import val_to_ptr,ptr_to_val
+        @njit('float64[::1](float64[::1],float64[::1],int64,' + 
+                                      'float64[::1],int64)')
+        def splev_wrapped(t,c,k,x,e):
+            y=np.empty(x.shape[0],dtype=np.float64)
+            
+            n_arr=val_to_ptr(nb.int64(t.shape[0]))
+            k_arr=val_to_ptr(nb.int64(k))
+            m_arr=val_to_ptr(nb.int64(x.shape[0]))
+            e_arr=val_to_ptr(nb.int64(e))
+            ier_arr=val_to_ptr(nb.int64(0))
+            
+            SPLEV(t.ctypes,n_arr,c.ctypes,k_arr,x.ctypes,
+                y.ctypes,m_arr,e_arr,ier_arr)
+            
+            return y
+        
+        x, dx = np.linspace(10,100,200, retstep=True)
+        y = np.sin(x)
+
+        coeff_1 = interpolate.splrep(x,y, k=3)
+
+        x2 = np.linspace(0,110,1000) 
+        np.random.shuffle(x2)
+
+        self.assertEqual(interpolate.splev(x2, coeff_1), 
+            splev_wrapped(coeff_1[0],coeff_1[1],coeff_1[2],x2,0))
 
 
 @overload_method(

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1623,7 +1623,7 @@ class TestImportF2PYFunction(unittest.TestCase):
 
         coeff_1 = interpolate.splrep(x, y, k=3)
 
-        x2 = np.linspace(0,110,1000)
+        x2 = np.linspace(0, 110, 1000)
         np.random.shuffle(x2)
         isclose = np.allclose(interpolate.splev(x2, coeff_1), splev_wrapped(
                               coeff_1[0],coeff_1[1],coeff_1[2],x2,0))

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1626,7 +1626,7 @@ class TestImportF2PYFunction(unittest.TestCase):
         x2 = np.linspace(0, 110, 1000)
         np.random.shuffle(x2)
         isclose = np.allclose(interpolate.splev(x2, coeff_1), splev_wrapped(
-                              coeff_1[0],coeff_1[1],coeff_1[2],x2,0))
+                              coeff_1[0], coeff_1[1], coeff_1[2], x2, 0))
         self.assertEqual(isclose,True)
 
     def test_missing_module(self):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1598,26 +1598,24 @@ class TestImportF2PYFunction(unittest.TestCase):
         functype = ctypes.CFUNCTYPE(ctypes.c_void_p,
                    dble_p,int_p,dble_p,int_p,dble_p,dble_p,int_p,int_p,int_p)
         SPLEV = functype(addr)
-        
+
         from numba.cpython.unsafe.stack_arr import val_to_ptr,ptr_to_val
         from numba import int64
-        from numpy import empty,linspace,sin,random
-        import numpy as np
-        
+
         @njit('float64[::1](float64[::1],float64[::1],int64,' + 
                                       'float64[::1],int64)')
         def splev_wrapped(t,c,k,x,e):
             y=np.empty(x.shape[0],dtype=np.float64)
-            
+
             n_arr=val_to_ptr(int64(t.shape[0]))
             k_arr=val_to_ptr(int64(k))
             m_arr=val_to_ptr(int64(x.shape[0]))
             e_arr=val_to_ptr(int64(e))
             ier_arr=val_to_ptr(int64(0))
-            
+
             SPLEV(t.ctypes,n_arr,c.ctypes,k_arr,x.ctypes,
                 y.ctypes,m_arr,e_arr,ier_arr)
-            
+
             return y
         
         x, dx = np.linspace(10,100,200, retstep=True)
@@ -1627,9 +1625,9 @@ class TestImportF2PYFunction(unittest.TestCase):
 
         x2 = np.linspace(0,110,1000) 
         np.random.shuffle(x2)
-
-        self.assertEqual(interpolate.splev(x2, coeff_1), 
+        isclose=np.allclose(interpolate.splev(x2, coeff_1), 
             splev_wrapped(coeff_1[0],coeff_1[1],coeff_1[2],x2,0))
+        self.assertEqual(isclose,True)
 
     def test_missing_module(self):
         with self.assertRaises(ImportError) as raises:
@@ -1641,7 +1639,7 @@ class TestImportF2PYFunction(unittest.TestCase):
 
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")
     def test_missing_function(self):
-        with self.assertRaises(ValueError) as raises:
+        with self.assertRaises(AttributeError) as raises:
             get_f2py_function_address(
                 "scipy.interpolate.dfitpack", "foo"
             )


### PR DESCRIPTION
Especially in scipy quite a lot functions are wrapped using f2py. Fortran functions which are wrapped using f2py always have an [_cpointer ](https://numpy.org/devdocs/f2py/python-usage.html)` attribute.

This pull request adds a new function `get_f2py_function_address`, which should work in the same way as `get_cython_function_address`.

Fix for #7818 and #7824 .