### PR TITLE
CUDA: Support `Enum/IntEnum` in Kernel

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -65,6 +65,7 @@ The following built-in types support are inherited from CPU nopython mode.
 * bool
 * None
 * tuple
+* Enum, IntEnum
 
 See :ref:`nopython built-in types <pysupported-builtin-types>`.
 

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -87,7 +87,7 @@ __all__ = """
     """.split() + types.__all__ + errors.__all__
 
 
-_min_llvmlite_version = (0, 39, 0)
+_min_llvmlite_version = (0, 38, 0)
 _min_llvm_version = (11, 0, 0)
 
 def _ensure_llvm():

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -87,7 +87,7 @@ __all__ = """
     """.split() + types.__all__ + errors.__all__
 
 
-_min_llvmlite_version = (0, 38, 0)
+_min_llvmlite_version = (0, 39, 0)
 _min_llvm_version = (11, 0, 0)
 
 def _ensure_llvm():

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -358,18 +358,6 @@ class _Kernel(serialize.ReduceMixin):
             kernelargs.append(ctypes.c_double(val.real))
             kernelargs.append(ctypes.c_double(val.imag))
 
-        elif isinstance(ty, types.EnumMember):
-            try:
-                self._prepare_args(
-                    ty.dtype, val.value, stream, retr, kernelargs
-                )
-            except Exception as e:
-                if isinstance(e, NotImplementedError):
-                    raise NotImplementedError(
-                        f"Unsupported value for Enum {val}"
-                    ) from e
-                raise
-
         elif isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
             kernelargs.append(ctypes.c_int64(val.view(np.int64)))
 
@@ -384,6 +372,14 @@ class _Kernel(serialize.ReduceMixin):
             assert len(ty) == len(val)
             for t, v in zip(ty, val):
                 self._prepare_args(t, v, stream, retr, kernelargs)
+
+        elif isinstance(ty, types.EnumMember):
+            try:
+                self._prepare_args(
+                    ty.dtype, val.value, stream, retr, kernelargs
+                )
+            except NotImplementedError:
+                raise NotImplementedError(ty, val)
 
         else:
             raise NotImplementedError(ty, val)

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -358,6 +358,18 @@ class _Kernel(serialize.ReduceMixin):
             kernelargs.append(ctypes.c_double(val.real))
             kernelargs.append(ctypes.c_double(val.imag))
 
+        elif isinstance(ty, types.EnumMember):
+            try:
+                self._prepare_args(
+                    ty.dtype, val.value, stream, retr, kernelargs
+                )
+            except Exception as e:
+                if isinstance(e, NotImplementedError):
+                    raise NotImplementedError(
+                        f"Unsupported value for Enum {val}"
+                    ) from e
+                raise
+
         elif isinstance(ty, (types.NPDatetime, types.NPTimedelta)):
             kernelargs.append(ctypes.c_int64(val.view(np.int64)))
 

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -20,11 +20,13 @@ from numba.cuda import codegen, nvvmutils
 class CUDATypingContext(typing.BaseContext):
     def load_additional_registries(self):
         from . import cudadecl, cudamath, libdevicedecl
+        from numba.core.typing import enumdecl
 
         self.install_registry(cudadecl.registry)
         self.install_registry(cudamath.registry)
         self.install_registry(cmathdecl.registry)
         self.install_registry(libdevicedecl.registry)
+        self.install_registry(enumdecl.registry)
 
     def resolve_value_type(self, val):
         # treat dispatcher object as another device function
@@ -88,7 +90,7 @@ class CUDATargetContext(BaseContext):
     def load_additional_registries(self):
         # side effect of import needed for numba.cpython.*, the builtins
         # registry is updated at import time.
-        from numba.cpython import numbers, tupleobj, slicing # noqa: F401
+        from numba.cpython import numbers, tupleobj, slicing, enumimpl # noqa: F401, E501
         from numba.cpython import rangeobj, iterators # noqa: F401
         from numba.cpython import unicode, charseq # noqa: F401
         from numba.cpython import cmathimpl

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -90,8 +90,8 @@ class CUDATargetContext(BaseContext):
     def load_additional_registries(self):
         # side effect of import needed for numba.cpython.*, the builtins
         # registry is updated at import time.
-        from numba.cpython import numbers, tupleobj, slicing, enumimpl # noqa: F401, E501
-        from numba.cpython import rangeobj, iterators # noqa: F401
+        from numba.cpython import numbers, tupleobj, slicing # noqa: F401
+        from numba.cpython import rangeobj, iterators, enumimpl # noqa: F401
         from numba.cpython import unicode, charseq # noqa: F401
         from numba.cpython import cmathimpl
         from numba.np import arrayobj # noqa: F401

--- a/numba/cuda/tests/cudapy/test_enums.py
+++ b/numba/cuda/tests/cudapy/test_enums.py
@@ -1,0 +1,116 @@
+"""
+Test cases adapted from numba/tests/test_enums.py
+"""
+
+import numpy as np
+
+from numba import int8, int16, int32
+from numba import cuda, vectorize
+from numba.tests.support import TestCase
+from numba.tests.enum_usecases import (
+    Color,
+    Shape,
+    Planet,
+    RequestError,
+    IntEnumWithNegatives
+)
+
+
+class EnumTest(TestCase):
+
+    pairs = [
+        (Color.red, Color.red),
+        (Color.red, Color.green),
+        (Planet.EARTH, Planet.EARTH),
+        (Planet.VENUS, Planet.MARS),
+        (Shape.circle, IntEnumWithNegatives.two) # IntEnum, same value
+    ]
+
+    def test_compare(self):
+        @cuda.jit
+        def f(a, b, out):
+            out[0] = a == b
+            out[1] = a != b
+            out[2] = a is b
+            out[3] = a is not b
+
+        arr = np.zeros((4,), dtype=np.bool_)
+        for a, b in self.pairs:
+            f[1, 1](a, b, arr)
+            self.assertPreciseEqual(arr, np.array([
+                a == b, a != b, a is b, a is not b
+            ]))
+
+    def test_getattr_getitem(self):
+        @cuda.jit
+        def f(out):
+            # Lookup of a enum member on its class
+            out[0] = Color.red == Color.green
+            out[1] = Color['red'] == Color['green']
+
+        arr = np.zeros((2,), dtype=np.bool_)
+        f[1, 1](arr)
+        self.assertPreciseEqual(arr, np.array([
+            Color.red == Color.green, Color['red'] == Color['green']
+        ]))
+
+    def test_return_from_device_func(self):
+        @cuda.jit
+        def helper(pred):
+            return Color.red if pred else Color.green
+
+        @cuda.jit
+        def f(pred, out):
+            out[0] = helper(pred) == Color.red
+            out[1] = helper(not pred) == Color.green
+
+        arr = np.zeros((2,), dtype=np.bool_)
+        f[1, 1](True, arr)
+        self.assertPreciseEqual(arr, np.array([
+            Color.red == Color.red, Color.green == Color.green
+        ]))
+
+    def test_int_coerse(self):
+        @cuda.jit
+        def f(out):
+            # Implicit coercion of intenums to ints
+            out[0] = Shape.square - RequestError.not_found
+            out[1] = int32(Shape.circle > IntEnumWithNegatives.one)
+
+        arr = np.zeros((2,), dtype=np.int32)
+        f[1, 1](arr)
+        self.assertPreciseEqual(arr, np.array([
+            Shape.square - RequestError.not_found,
+            Shape.circle > IntEnumWithNegatives.one
+        ], dtype=arr.dtype))
+
+    def test_int_cast(self):
+        @cuda.jit
+        def f(x, out0, out1, out2):
+            # Explicit coercion of intenums to ints
+            out0[0] = x > int16(RequestError.internal_error)
+            out1[0] = x - int32(RequestError.not_found)
+            out2[0] = x + int8(Shape.circle)
+
+        arr0 = np.zeros((1,), dtype=np.int16)
+        arr1 = np.zeros((1,), dtype=np.int32)
+        arr2 = np.zeros((1,), dtype=np.int8)
+        x = np.int8(10)
+
+        f[1, 1](x, arr0, arr1, arr2)
+        self.assertEqual(arr0[0], x > np.int16(RequestError.internal_error))
+        self.assertEqual(arr1[0], x - np.int32(RequestError.not_found))
+        self.assertEqual(arr2[0], x + np.int8(Shape.circle))
+
+    def test_vectorize(self):
+        def f(x):
+            if x != RequestError.not_found:
+                return RequestError['internal_error']
+            else:
+                return RequestError.dummy
+
+        cuda_func = vectorize("int64(int64)", target='cuda')(f)
+        arr = np.array([2, 404, 500, 404])
+        expected = np.array([f(x) for x in arr])
+        got = cuda_func(arr)
+        self.assertPreciseEqual(expected, got)

--- a/numba/cuda/tests/cudapy/test_enums.py
+++ b/numba/cuda/tests/cudapy/test_enums.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from numba import int8, int16, int32
 from numba import cuda, vectorize
-from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.tests.enum_usecases import (
     Color,
     Shape,
@@ -102,6 +102,7 @@ class EnumTest(CUDATestCase):
         self.assertEqual(arr1[0], x - np.int32(RequestError.not_found))
         self.assertEqual(arr2[0], x + np.int8(Shape.circle))
 
+    @skip_on_cudasim("ufuncs are unsupported on simulator.")
     def test_vectorize(self):
         def f(x):
             if x != RequestError.not_found:

--- a/numba/cuda/tests/cudapy/test_enums.py
+++ b/numba/cuda/tests/cudapy/test_enums.py
@@ -33,7 +33,7 @@ class EnumTest(CUDATestCase):
             out[2] = a is b
             out[3] = a is not b
 
-        cuda_f = cuda.jit()(f)
+        cuda_f = cuda.jit(f)
         for a, b in self.pairs:
             got = np.zeros((4,), dtype=np.bool_)
             expected = got.copy()
@@ -47,7 +47,7 @@ class EnumTest(CUDATestCase):
             out[0] = Color.red == Color.green
             out[1] = Color['red'] == Color['green']
 
-        cuda_f = cuda.jit()(f)
+        cuda_f = cuda.jit(f)
         got = np.zeros((2,), dtype=np.bool_)
         expected = got.copy()
         cuda_f[1, 1](got)
@@ -78,7 +78,7 @@ class EnumTest(CUDATestCase):
             else:
                 out[0] = x + Shape.circle
 
-        cuda_f = cuda.jit()(f)
+        cuda_f = cuda.jit(f)
         for x in [300, 450, 550]:
             got = np.zeros((1,), dtype=np.int32)
             expected = got.copy()
@@ -94,7 +94,7 @@ class EnumTest(CUDATestCase):
             else:
                 out[0] = x + int8(Shape.circle)
 
-        cuda_f = cuda.jit()(f)
+        cuda_f = cuda.jit(f)
         for x in [300, 450, 550]:
             got = np.zeros((1,), dtype=np.int32)
             expected = got.copy()

--- a/numba/cuda/tests/cudapy/test_enums.py
+++ b/numba/cuda/tests/cudapy/test_enums.py
@@ -36,10 +36,10 @@ class EnumTest(CUDATestCase):
         cuda_f = cuda.jit()(f)
         for a, b in self.pairs:
             got = np.zeros((4,), dtype=np.bool_)
-            expect = got.copy()
+            expected = got.copy()
             cuda_f[1, 1](a, b, got)
-            f(a, b, expect)
-            self.assertPreciseEqual(expect, got)
+            f(a, b, expected)
+            self.assertPreciseEqual(expected, got)
 
     def test_getattr_getitem(self):
         def f(out):
@@ -49,10 +49,10 @@ class EnumTest(CUDATestCase):
 
         cuda_f = cuda.jit()(f)
         got = np.zeros((2,), dtype=np.bool_)
-        expect = got.copy()
+        expected = got.copy()
         cuda_f[1, 1](got)
-        f(expect)
-        self.assertPreciseEqual(expect, got)
+        f(expected)
+        self.assertPreciseEqual(expected, got)
 
     def test_return_from_device_func(self):
         @cuda.jit(device=True)
@@ -81,10 +81,10 @@ class EnumTest(CUDATestCase):
         cuda_f = cuda.jit()(f)
         for x in [300, 450, 550]:
             got = np.zeros((1,), dtype=np.int32)
-            expect = got.copy()
+            expected = got.copy()
             cuda_f[1, 1](x, got)
-            f(x, expect)
-            self.assertPreciseEqual(expect, got)
+            f(x, expected)
+            self.assertPreciseEqual(expected, got)
 
     def test_int_cast(self):
         def f(x, out):
@@ -97,10 +97,10 @@ class EnumTest(CUDATestCase):
         cuda_f = cuda.jit()(f)
         for x in [300, 450, 550]:
             got = np.zeros((1,), dtype=np.int32)
-            expect = got.copy()
+            expected = got.copy()
             cuda_f[1, 1](x, got)
-            f(x, expect)
-            self.assertEqual(expect, got)
+            f(x, expected)
+            self.assertEqual(expected, got)
 
     @skip_on_cudasim("ufuncs are unsupported on simulator.")
     def test_vectorize(self):

--- a/numba/cuda/tests/cudapy/test_enums.py
+++ b/numba/cuda/tests/cudapy/test_enums.py
@@ -5,7 +5,7 @@ Test cases adapted from numba/tests/test_enums.py
 import numpy as np
 
 from numba import int8, int16, int32
-from numba import cuda, vectorize
+from numba import cuda, vectorize, njit
 from numba.cuda.testing import unittest, CUDATestCase, skip_on_cudasim
 from numba.tests.enum_usecases import (
     Color,
@@ -55,20 +55,15 @@ class EnumTest(CUDATestCase):
         self.assertPreciseEqual(expected, got)
 
     def test_return_from_device_func(self):
+        @njit
         def inner(pred):
             return Color.red if pred else Color.green
 
-        def _make_test_func(inner, jitter):
-            inner = jitter(inner)
+        def f(pred, out):
+            out[0] = inner(pred) == Color.red
+            out[1] = inner(not pred) == Color.green
 
-            def f(pred, out):
-                out[0] = inner(pred) == Color.red
-                out[1] = inner(not pred) == Color.green
-            return jitter(f)
-
-        f = _make_test_func(inner, lambda x:x)
-        cuda_f = _make_test_func(inner, cuda.jit())
-
+        cuda_f = cuda.jit(f)
         got = np.zeros((2,), dtype=np.bool_)
         expected = got.copy()
         f(True, expected)

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -350,6 +350,8 @@ class UFuncMechanism(object):
 
 
 def to_dtype(ty):
+    if isinstance(ty, types.EnumMember):
+        ty = ty.dtype
     return np.dtype(str(ty))
 
 


### PR DESCRIPTION
This PR adds support to `Enum/IntEnum` to kernel. Tested cases include: compares, use as constants, explicit/implict convert to ints and vectorize.