### PR TITLE
Fix pickling error when module cannot be imported

### DIFF
--- a/numba/cloudpickle/cloudpickle.py
+++ b/numba/cloudpickle/cloudpickle.py
@@ -220,7 +220,7 @@ def _lookup_module_and_qualname(obj, name=None):
         # types.ModuleType. The other possibility is that module was removed
         # from sys.modules after obj was created/imported. But this case is not
         # supported, as the standard pickle does not support it either.
-        del obj.__module__
+        obj.__module__ = None
         return None
 
     try:

--- a/numba/cloudpickle/cloudpickle.py
+++ b/numba/cloudpickle/cloudpickle.py
@@ -203,6 +203,10 @@ def _lookup_module_and_qualname(obj, name=None):
 
     module_name = _whichmodule(obj, name)
 
+    if module_name not in sys.modules:
+        del obj.__module__
+        return None
+
     if module_name is None:
         # In this case, obj.__module__ is None AND obj was not found in any
         # imported module. obj is thus treated as dynamic.

--- a/numba/cloudpickle/cloudpickle.py
+++ b/numba/cloudpickle/cloudpickle.py
@@ -220,7 +220,6 @@ def _lookup_module_and_qualname(obj, name=None):
         # types.ModuleType. The other possibility is that module was removed
         # from sys.modules after obj was created/imported. But this case is not
         # supported, as the standard pickle does not support it either.
-        obj.__module__ = None
         return None
 
     try:

--- a/numba/cloudpickle/cloudpickle.py
+++ b/numba/cloudpickle/cloudpickle.py
@@ -203,10 +203,6 @@ def _lookup_module_and_qualname(obj, name=None):
 
     module_name = _whichmodule(obj, name)
 
-    if module_name not in sys.modules:
-        del obj.__module__
-        return None
-
     if module_name is None:
         # In this case, obj.__module__ is None AND obj was not found in any
         # imported module. obj is thus treated as dynamic.
@@ -224,6 +220,7 @@ def _lookup_module_and_qualname(obj, name=None):
         # types.ModuleType. The other possibility is that module was removed
         # from sys.modules after obj was created/imported. But this case is not
         # supported, as the standard pickle does not support it either.
+        del obj.__module__
         return None
 
     try:

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -87,7 +87,7 @@ class FunctionDescriptor(object):
         """
         Return the module in which this function is supposed to exist.
         This may be a dummy module if the function was dynamically
-        generated. Raise exception if the module can't be found.
+        generated or the module can't be found.
         """
         if self.modname == _dynamic_modname:
             return _dynamic_module

--- a/numba/core/funcdesc.py
+++ b/numba/core/funcdesc.py
@@ -96,9 +96,7 @@ class FunctionDescriptor(object):
                 # ensure module exist
                 return importlib.import_module(self.modname)
             except ImportError:
-                raise ModuleNotFoundError(
-                    f"can't compile {self.qualname}: "
-                    f"import of module {self.modname} failed") from None
+                return _dynamic_module
 
     def lookup_function(self):
         """

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -25,7 +25,7 @@ def f(x):
         exec(compiled, objs)
 
         compiled_f = njit(objs['f'])
-        assert compliled_f(3) == 3
+        assert compiled_f(3) == 3
 
 
 class TestFuncDescMangledName(unittest.TestCase):

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -25,10 +25,7 @@ def f(x):
         exec(compiled, objs)
 
         compiled_f = njit(objs['f'])
-        with self.assertRaises(ModuleNotFoundError) as raises:
-            compiled_f(0)
-        msg = "can't compile f: import of module mypackage failed"
-        self.assertIn(msg, str(raises.exception))
+        assert compliled_f(3) == 3
 
 
 class TestFuncDescMangledName(unittest.TestCase):

--- a/numba/tests/test_funcdesc.py
+++ b/numba/tests/test_funcdesc.py
@@ -25,7 +25,7 @@ def f(x):
         exec(compiled, objs)
 
         compiled_f = njit(objs['f'])
-        assert compiled_f(3) == 3
+        self.assertEqual(compiled_f(3), 3)
 
 
 class TestFuncDescMangledName(unittest.TestCase):

--- a/numba/tests/test_unpickle_without_module.py
+++ b/numba/tests/test_unpickle_without_module.py
@@ -1,0 +1,45 @@
+import unittest
+import pickle
+import sys
+import tempfile
+from pathlib import Path
+
+
+class TestUnpickleDeletedModule(unittest.TestCase):
+    def test_loading_pickle_with_no_module(self):
+        """Create a module that uses Numba, import a function from it.
+        Then delete the module and pickle the function. The function
+        should load from the pickle without a problem.
+
+        Note - This is a simplified version of how Numba might be used
+        on a distributed system using e.g. dask distributed. With the
+        pickle being sent to the worker but not the original module.
+        """
+
+        # Source code for temporary module we will make
+        source = "\n".join(["from numba import vectorize",
+                            "@vectorize(['float64(float64)'])",
+                            "def inc1(x):",
+                            "    return x + 1"])
+
+        # Create a temporary directory and add it to path.
+        modname = "tmp_module"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sys.path.append(tmp_dir)
+
+            # Create tmp_module.py in there with our source code above.
+            filename = Path(f"{tmp_dir}/{modname}.py")
+            f = open(filename, "a")
+            f.write(source)
+            f.close()
+
+            # Import the temporary module before file is deleted
+            from tmp_module import inc1
+
+        # Remove from imported libraries
+        del sys.modules[modname]
+
+        # Pickle function and assert that it loads correctly
+        pkl = pickle.dumps(inc1)
+        f = pickle.loads(pkl)
+        assert f(2) == 3

--- a/numba/tests/test_unpickle_without_module.py
+++ b/numba/tests/test_unpickle_without_module.py
@@ -46,4 +46,4 @@ class TestUnpickleDeletedModule(unittest.TestCase):
         # Pickle function and assert that it loads correctly
         pkl = pickle.dumps(inc1)
         f = pickle.loads(pkl)
-        assert f(2) == 3
+        self.assertEqual(f(2), 3)

--- a/numba/tests/test_unpickle_without_module.py
+++ b/numba/tests/test_unpickle_without_module.py
@@ -17,10 +17,14 @@ class TestUnpickleDeletedModule(unittest.TestCase):
         """
 
         # Source code for temporary module we will make
-        source = "\n".join(["from numba import vectorize",
-                            "@vectorize(['float64(float64)'])",
-                            "def inc1(x):",
-                            "    return x + 1"])
+        source = "\n".join(
+            [
+                "from numba import vectorize",
+                "@vectorize(['float64(float64)'])",
+                "def inc1(x):",
+                "    return x + 1",
+            ]
+        )
 
         # Create a temporary directory and add it to path.
         modname = "tmp_module"


### PR DESCRIPTION
The [change to using cloudpickle ](https://github.com/numba/numba/pull/6977) also changed the behaviour when unpickling a function from a module that cannot be imported. Previously Numba used the _rebuild_function in serialize.py, which handled the ImportErrors like this

```
def _rebuild_function(code_reduced, globals, name, cell_values, defaults):
    """
    Rebuild a function from its _reduce_function() results.
    """
    if cell_values:
        cells = tuple(_make_cell(v) for v in cell_values)
    else:
        cells = ()
    code = _rebuild_code(*code_reduced)
    modname = globals['__name__']
    try:
        _rebuild_module(modname)
    except ImportError:
        # If the module can't be found, avoid passing it (it would produce
        # errors when lowering).
        del globals['__name__']
    return FunctionType(code, globals, name, defaults, cells)
```

This PR attempts to reimplement this behaviour within cloudpickle. 

Below is a minimal example to show the issue. The real life context for wanting this feature is deploying the code using dask distributed, where the pickled function is sent to worker nodes but the original module is not. 

```
import pickle
import sys
import os


source = """
from numba import vectorize

@vectorize(["float64(float64)"])
def inc1(x):
    return x + 1
"""

modname = "example"
filename = f"{modname}.py"
f = open(filename, "a")
f.write(source)
f.close()

from example import inc1

os.remove(filename)
del sys.modules[modname]
pkl = pickle.dumps(inc1)

f = pickle.loads(pkl)
print(f(2))
```

I'm not very familiar with the Numba source code, so please let me know if you think there is a better way to implement this feature. If it seems ok, I'm happy to make a unit test for it.