### PR TITLE
Initial refactoring of parfor reduction lowering 

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -334,6 +334,29 @@ class BaseLower(object):
         if config.DEBUG_JIT:
             self.context.debug_print(self.builder, "DEBUGJIT: {0}".format(msg))
 
+    def print_variable(self, msg, varname):
+        """Helper to emit ``print(msg, varname)`` for debugging.
+
+        Parameters
+        ----------
+        msg : str
+            Literal string to be printed.
+        varname : str
+            A variable name whose value will be printed.
+        """
+        argtys = (
+            types.literal(msg),
+            self.fndesc.typemap[varname]
+        )
+        args = (
+            self.context.get_dummy_value(),
+            self.loadvar(varname),
+        )
+        sig = typing.signature(types.none, *argtys)
+
+        impl = self.context.get_function(print, sig)
+        impl(self.builder, args)
+
 
 class Lower(BaseLower):
     GeneratorLower = generators.GeneratorLower

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -23,6 +23,7 @@ from functools import reduce
 from collections import defaultdict, OrderedDict, namedtuple
 from contextlib import contextmanager
 import operator
+from dataclasses import make_dataclass
 
 import numba.core.ir
 from numba.core import types, typing, utils, errors, ir, analysis, postproc, rewrites, typeinfer, config, ir_utils
@@ -3488,6 +3489,14 @@ def get_parfor_outputs(parfor, parfor_params):
     outputs = list(set(outputs) & set(parfor_params))
     return sorted(outputs)
 
+
+_RedVarInfo = make_dataclass(
+    "_RedVarInfo",
+    ["init_val", "reduce_nodes", "redop"],
+    frozen=True,
+)
+
+
 def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=None,
         reduce_varnames=None, param_uses=None, param_nodes=None,
         var_to_param=None):
@@ -3562,7 +3571,11 @@ def get_parfor_reductions(func_ir, parfor, parfor_params, calltypes, reductions=
                 else:
                     init_val = None
                     redop = None
-                reductions[param_name] = (init_val, reduce_nodes, redop)
+                reductions[param_name] = _RedVarInfo(
+                    init_val=init_val,
+                    reduce_nodes=reduce_nodes,
+                    redop=redop,
+                )
 
     return reduce_varnames, reductions
 

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -548,7 +548,7 @@ def _emit_binop_reduce_call(binop, lowerer, thread_count, reduce_info):
 
 
 def _is_inplace_binop_and_rhs_is_init(inst, redvar_name):
-    """Is ``inst`` a inplace-binop and the RHS is the reduction init?
+    """Is ``inst`` an inplace-binop and the RHS is the reduction init?
     """
     if not isinstance(inst, ir.Assign):
         return False

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -419,6 +419,12 @@ def _lower_trivial_inplace_binops(parfor, lowerer, thread_count, reduce_info):
         if _fix_redvar_name_ssa_mismatch(parfor, lowerer, inst,
                                    reduce_info.redvar_name):
             break
+    if config.DEBUG_ARRAY_OPT_RUNTIME:
+        varname = reduce_info.redvar_name
+        lowerer.print_variable(
+            f"{parfor.loc}: parfor {fn.__name__} reduction {varname} =",
+            varname,
+        )
 
 
 def _lower_non_trivial_reduce(parfor, lowerer, thread_count, reduce_info):
@@ -443,6 +449,7 @@ def _lower_non_trivial_reduce(parfor, lowerer, thread_count, reduce_info):
                 )
                 lowerer.storevar(elem, init_name)
                 lowerer.lower_inst(inst)
+
             # Otherwise?
             else:
                 raise ParforsUnexpectedReduceNodeError(inst)
@@ -452,6 +459,12 @@ def _lower_non_trivial_reduce(parfor, lowerer, thread_count, reduce_info):
                                        reduce_info.redvar_name):
                 break
 
+    if config.DEBUG_ARRAY_OPT_RUNTIME:
+        varname = reduce_info.redvar_name
+        lowerer.print_variable(
+            f"{parfor.loc}: parfor non-trivial reduction {varname} =",
+            varname,
+        )
 
 def _lower_var_to_var_assign(lowerer, inst):
     """Lower Var->Var assignment.


### PR DESCRIPTION
Summary:
- Breakup long functions to highlight the logic structure
- Replace manually constructed Numba IR with jitted python code.

In the long run, we want to move parfor lowering outside of the `LoweringPass`. 