### PR TITLE
Add more flexible compare-and-swap

### DIFF
--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -419,8 +419,8 @@ class Cuda_atomic_compare_and_swap(AbstractTemplate):
 
 
 @register
-class Cuda_atomic_cas_element(AbstractTemplate):
-    key = cuda.atomic.cas_element
+class Cuda_atomic_cas(AbstractTemplate):
+    key = cuda.atomic.cas
 
     def generic(self, args, kws):
         assert not kws
@@ -521,8 +521,8 @@ class CudaAtomicTemplate(AttributeTemplate):
     def resolve_compare_and_swap(self, mod):
         return types.Function(Cuda_atomic_compare_and_swap)
 
-    def resolve_cas_element(self, mod):
-        return types.Function(Cuda_atomic_cas_element)
+    def resolve_cas(self, mod):
+        return types.Function(Cuda_atomic_cas)
 
 
 @register_attr

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -419,6 +419,19 @@ class Cuda_atomic_compare_and_swap(AbstractTemplate):
 
 
 @register
+class Cuda_atomic_cas_element(AbstractTemplate):
+    key = cuda.atomic.cas_element
+
+    def generic(self, args, kws):
+        assert not kws
+        ary, idx, old, val = args
+        dty = ary.dtype
+
+        if dty in integer_numba_types and ary.ndim == 1:
+            return signature(dty, ary, types.intp, dty, dty)
+
+
+@register
 class Cuda_nanosleep(ConcreteTemplate):
     key = cuda.nanosleep
 
@@ -505,6 +518,9 @@ class CudaAtomicTemplate(AttributeTemplate):
 
     def resolve_compare_and_swap(self, mod):
         return types.Function(Cuda_atomic_compare_and_swap)
+
+    def resolve_cas_element(self, mod):
+        return types.Function(Cuda_atomic_cas_element)
 
 
 @register_attr

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -429,6 +429,8 @@ class Cuda_atomic_cas_element(AbstractTemplate):
 
         if dty in integer_numba_types and ary.ndim == 1:
             return signature(dty, ary, types.intp, dty, dty)
+        elif ary.ndim > 1:
+            return signature(dty, ary, idx, dty, dty)
 
 
 @register

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -962,10 +962,10 @@ def ptx_atomic_cas_tuple(context, builder, sig, args):
                         'with %s array' % dtype)
 
 
-@lower(stubs.atomic.cas_element, types.Array, types.intp, types.Any, types.Any)
-@lower(stubs.atomic.cas_element, types.Array, types.Tuple, types.Any, types.Any)
-@lower(stubs.atomic.cas_element, types.Array, types.UniTuple, types.Any, types.Any)  # noqa E501
-def ptx_atomic_cas_element_tuple(context, builder, sig, args):
+@lower(stubs.atomic.cas, types.Array, types.intp, types.Any, types.Any)
+@lower(stubs.atomic.cas, types.Array, types.Tuple, types.Any, types.Any)
+@lower(stubs.atomic.cas, types.Array, types.UniTuple, types.Any, types.Any)  # noqa E501
+def ptx_atomic_cas(context, builder, sig, args):
 
     aryty, indty, oldty, valty = sig.args
     ary, inds, old, val = args
@@ -982,8 +982,7 @@ def ptx_atomic_cas_element_tuple(context, builder, sig, args):
         bitwidth = aryty.dtype.bitwidth
         return nvvmutils.atomic_cmpxchg(builder, lmod, bitwidth, ptr, old, val)
     else:
-        raise TypeError('Unimplemented atomic cas_element '
-                        'with %s array' % aryty.dtype)
+        raise TypeError('Unimplemented atomic cas with %s array' % aryty.dtype)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -963,6 +963,8 @@ def ptx_atomic_cas_tuple(context, builder, sig, args):
 
 
 @lower(stubs.atomic.cas_element, types.Array, types.intp, types.Any, types.Any)
+@lower(stubs.atomic.cas_element, types.Array, types.Tuple, types.Any, types.Any)
+@lower(stubs.atomic.cas_element, types.Array, types.UniTuple, types.Any, types.Any)  # noqa E501
 def ptx_atomic_cas_element_tuple(context, builder, sig, args):
 
     aryty, indty, oldty, valty = sig.args

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -733,7 +733,7 @@ lower(math.degrees, types.f4)(gen_deg_rad(_rad2deg))
 lower(math.degrees, types.f8)(gen_deg_rad(_rad2deg))
 
 
-def _normalize_indices(context, builder, indty, inds):
+def _normalize_indices(context, builder, aryty, indty, valty, inds):
     """
     Convert integer indices into tuple of intp
     """
@@ -744,6 +744,15 @@ def _normalize_indices(context, builder, indty, inds):
         indices = cgutils.unpack_tuple(builder, inds, count=len(indty))
     indices = [context.cast(builder, i, t, types.intp)
                for t, i in zip(indty, indices)]
+
+    dtype = aryty.dtype
+    if dtype != valty:
+        raise TypeError("expect %s but got %s" % (dtype, valty))
+
+    if aryty.ndim != len(indty):
+        raise TypeError("indexing %d-D array with %d-D index" %
+                        (aryty.ndim, len(indty)))
+
     return indty, indices
 
 
@@ -752,22 +761,15 @@ def _atomic_dispatcher(dispatch_fn):
         # The common argument handling code
         aryty, indty, valty = sig.args
         ary, inds, val = args
-        dtype = aryty.dtype
 
-        indty, indices = _normalize_indices(context, builder, indty, inds)
-
-        if dtype != valty:
-            raise TypeError("expect %s but got %s" % (dtype, valty))
-
-        if aryty.ndim != len(indty):
-            raise TypeError("indexing %d-D array with %d-D index" %
-                            (aryty.ndim, len(indty)))
+        indty, indices = _normalize_indices(context, builder, aryty, indty,
+                                            valty, inds)
 
         lary = context.make_array(aryty)(context, builder, ary)
         ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices,
                                        wraparound=True)
         # dispatcher to implementation base on dtype
-        return dispatch_fn(context, builder, dtype, ptr, val)
+        return dispatch_fn(context, builder, aryty.dtype, ptr, val)
     return imp
 
 
@@ -965,16 +967,9 @@ def ptx_atomic_cas_element_tuple(context, builder, sig, args):
 
     aryty, indty, oldty, valty = sig.args
     ary, inds, old, val = args
-    dtype = aryty.dtype
 
-    indty, indices = _normalize_indices(context, builder, indty, inds)
-
-    if dtype != valty:
-        raise TypeError("expect %s but got %s" % (dtype, valty))
-
-    if aryty.ndim != len(indty):
-        raise TypeError("indexing %d-D array with %d-D index" %
-                        (aryty.ndim, len(indty)))
+    indty, indices = _normalize_indices(context, builder, aryty, indty,
+                                        valty, inds)
 
     lary = context.make_array(aryty)(context, builder, ary)
     ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices,
@@ -986,7 +981,7 @@ def ptx_atomic_cas_element_tuple(context, builder, sig, args):
         return nvvmutils.atomic_cmpxchg(builder, lmod, bitwidth, ptr, old, val)
     else:
         raise TypeError('Unimplemented atomic cas_element '
-                        'with %s array' % dtype)
+                        'with %s array' % aryty.dtype)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -125,6 +125,7 @@ xorlock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
 caslock = threading.Lock()
+caseltlock = threading.Lock()
 inclock = threading.Lock()
 declock = threading.Lock()
 exchlock = threading.Lock()
@@ -212,6 +213,14 @@ class FakeCUDAAtomic(object):
     def compare_and_swap(self, array, old, val):
         with caslock:
             index = (0,) * array.ndim
+            loaded = array[index]
+            if loaded == old:
+                array[index] = val
+            return loaded
+
+    def cas_element(self, array,idx, old, val):
+        with caseltlock:
+            index = (idx,) * array.ndim
             loaded = array[index]
             if loaded == old:
                 array[index] = val

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -218,7 +218,7 @@ class FakeCUDAAtomic(object):
                 array[index] = val
             return loaded
 
-    def cas_element(self, array, idx, old, val):
+    def cas(self, array, idx, old, val):
         with caseltlock:
             index = (idx,) * array.ndim
             loaded = array[index]

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -218,7 +218,7 @@ class FakeCUDAAtomic(object):
                 array[index] = val
             return loaded
 
-    def cas_element(self, array,idx, old, val):
+    def cas_element(self, array, idx, old, val):
         with caseltlock:
             index = (idx,) * array.ndim
             loaded = array[index]

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -580,7 +580,7 @@ class atomic(Stub):
     class cas_element(Stub):
         """cas_element(ary, idx, old, val)
 
-        Conditionally assign ``val`` to the element ary[idx] of an 1D array
+        Conditionally assign ``val`` to the element ary[idx] of a 1D array
         ``ary`` if the current value of ary[idx] matches ``old``.
 
         Returns the current value as if it is loaded atomically.

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -577,6 +577,15 @@ class atomic(Stub):
         Returns the current value as if it is loaded atomically.
         """
 
+    class cas_element(Stub):
+        """cas_element(ary, idx, old, val)
+
+        Conditionally assign ``val`` to the element ary[idx] of an 1D array
+        ``ary`` if the current value of ary[idx] matches ``old``.
+
+        Returns the current value as if it is loaded atomically.
+        """
+
 
 #-------------------------------------------------------------------------------
 # timers

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -577,8 +577,8 @@ class atomic(Stub):
         Returns the current value as if it is loaded atomically.
         """
 
-    class cas_element(Stub):
-        """cas_element(ary, idx, old, val)
+    class cas(Stub):
+        """cas(ary, idx, old, val)
 
         Conditionally assign ``val`` to the element ary[idx] of a 1D array
         ``ary`` if the current value of ary[idx] matches ``old``.

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -465,6 +465,7 @@ def atomic_cas_element(res, old, ary, fill_val):
 
 def check_cas(n, fill, unfill, dtype, cas_func):
     res = [fill] * (n // 2) + [unfill] * (n // 2)
+    np.random.seed(1)
     np.random.shuffle(res)
     res = np.asarray(res, dtype=dtype)
     out = np.zeros_like(res)

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -456,6 +456,13 @@ def atomic_compare_and_swap(res, old, ary, fill_val):
         old[gid] = out
 
 
+def atomic_cas_element(res, old, ary, fill_val):
+    gid = cuda.grid(1)
+    if gid < res.size:
+        out = cuda.atomic.cas_element(res, gid, fill_val, ary[gid])
+        old[gid] = out
+
+
 class TestCudaAtomics(CUDATestCase):
     def setUp(self):
         super().setUp()
@@ -1296,6 +1303,48 @@ class TestCudaAtomics(CUDATestCase):
         runfill = np.random.randint(1, 25, dtype=np.uint64)
         self.check_compare_and_swap(n=100, fill=rfill, unfill=runfill,
                                     dtype=np.uint64)
+
+    def check_cas_element(self, n, fill, unfill, dtype):
+        res = [fill] * (n // 2) + [unfill] * (n // 2)
+        np.random.shuffle(res)
+        res = np.asarray(res, dtype=dtype)
+        out = np.zeros_like(res)
+        ary = np.random.randint(1, 10, size=res.size).astype(res.dtype)
+
+        fill_mask = res == fill
+        unfill_mask = res == unfill
+
+        expect_res = np.zeros_like(res)
+        expect_res[fill_mask] = ary[fill_mask]
+        expect_res[unfill_mask] = unfill
+
+        expect_out = np.zeros_like(out)
+        expect_out[fill_mask] = res[fill_mask]
+        expect_out[unfill_mask] = unfill
+
+        cuda_func = cuda.jit(atomic_cas_element)
+        cuda_func[10, 10](res, out, ary, fill)
+
+        np.testing.assert_array_equal(expect_res, res)
+        np.testing.assert_array_equal(expect_out, out)
+
+    def test_atomic_cas_element(self):
+        self.check_cas_element(n=100, fill=-99, unfill=-1, dtype=np.int32)
+
+    def test_atomic_cas_element2(self):
+        self.check_cas_element(n=100, fill=-45, unfill=-1, dtype=np.int64)
+
+    def test_atomic_cas_element3(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint32)
+        runfill = np.random.randint(1, 25, dtype=np.uint32)
+        self.check_cas_element(n=100, fill=rfill, unfill=runfill,
+                               dtype=np.uint32)
+
+    def test_atomic_cas_element4(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint64)
+        runfill = np.random.randint(1, 25, dtype=np.uint64)
+        self.check_cas_element(n=100, fill=rfill, unfill=runfill,
+                               dtype=np.uint64)
 
     # Tests that the atomic add, min, and max operations return the old value -
     # in the simulator, they did not (see Issue #5458). The max and min have

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -456,10 +456,10 @@ def atomic_compare_and_swap(res, old, ary, fill_val):
         old[gid] = out
 
 
-def atomic_cas_element(res, old, ary, fill_val):
+def atomic_cas(res, old, ary, fill_val):
     gid = cuda.grid(1)
     if gid < res.size:
-        out = cuda.atomic.cas_element(res, gid, fill_val, ary[gid])
+        out = cuda.atomic.cas(res, gid, fill_val, ary[gid])
         old[gid] = out
 
 
@@ -1308,25 +1308,25 @@ class TestCudaAtomics(CUDATestCase):
         check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint64,
                   cas_func=atomic_compare_and_swap)
 
-    def test_atomic_cas_element(self):
+    def test_atomic_cas(self):
         check_cas(n=100, fill=-99, unfill=-1, dtype=np.int32,
-                  cas_func=atomic_cas_element)
+                  cas_func=atomic_cas)
 
-    def test_atomic_cas_element2(self):
+    def test_atomic_cas2(self):
         check_cas(n=100, fill=-45, unfill=-1, dtype=np.int64,
-                  cas_func=atomic_cas_element)
+                  cas_func=atomic_cas)
 
-    def test_atomic_cas_element3(self):
+    def test_atomic_cas3(self):
         rfill = np.random.randint(50, 500, dtype=np.uint32)
         runfill = np.random.randint(1, 25, dtype=np.uint32)
         check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint32,
-                  cas_func=atomic_cas_element)
+                  cas_func=atomic_cas)
 
-    def test_atomic_cas_element4(self):
+    def test_atomic_cas4(self):
         rfill = np.random.randint(50, 500, dtype=np.uint64)
         runfill = np.random.randint(1, 25, dtype=np.uint64)
         check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint64,
-                  cas_func=atomic_cas_element)
+                  cas_func=atomic_cas)
 
     # Tests that the atomic add, min, and max operations return the old value -
     # in the simulator, they did not (see Issue #5458). The max and min have


### PR DESCRIPTION
fixes: #6702

This PR adds `cas_element` as described in #6702. I refactored the test code to remove some initial redundancies (I started to condense even more, before I realized `pytest.parametrize` was not available). I also lightly refactored the impl code to move the index validations to  `_normalize_indices` in 567dc9c4ba7d8516bd7296e4b764de133ba86b48. It's hard to do much more given how the args vary. But it required passing a few more parameters, so things are a bit of a wash. Happy to remove that commit if it is not desired. 

cc @gmarkall This was mostly just cargo-cult pattern matching on my part, so any comments or guidance about anything I missed is very welcome. 

As an aside, would it be appropriate to consider deprecating `compare_and_swap` for removal in the future, given that it is duplicative of `cas_element`? A cursory search only seems to return a [handful of actual instances of use](https://github.com/search?q=%22atomic.compare_and_swap%22++language%3APython&type=Code&ref=advsearch&l=Python&l=) in all of GitHub.  
