### PR TITLE
CUDA: Deprecate `ptx` Attribute and Update Tests

### DIFF
--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -157,8 +157,8 @@ class _Kernel(serialize.ReduceMixin):
         '''
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve compiled machine code of the cuda function, use "
-            "`inpect_asm`."
+            "To retrieve the compiled machine code of the CUDA function, use "
+            "the `inpect_asm` method."
             , FutureWarning
         )
         return self._codelibrary.get_asm_str()
@@ -818,8 +818,8 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
     def ptx(self):
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve compiled machine code of the cuda function of certain"
-            "signature `sig`, use `inspect_asm(sig)`."
+            "To retrieve the compiled machine code of the CUDA function for a"
+            "given signature `sig`, use the method `inspect_asm(sig)`."
             , FutureWarning
         )
         return {sig: overload.ptx for sig, overload in self.overloads.items()}

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -8,7 +8,7 @@ import warnings
 from numba.core import config, serialize, sigutils, types, typing, utils
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
-from numba.core.errors import NumbaPerformanceWarning
+from numba.core.errors import NumbaPerformanceWarning, NumbaDeprecationWarning
 from numba.core.typing.typeof import Purpose, typeof
 
 from numba.cuda.api import get_current_device
@@ -159,7 +159,7 @@ class _Kernel(serialize.ReduceMixin):
             "Attribute `ptx` is deprecated and will be removed in the future. "
             "To retrieve the compiled machine code of the CUDA function, use "
             "the `inpect_asm` method."
-            , FutureWarning
+            , NumbaDeprecationWarning
         )
         return self._codelibrary.get_asm_str()
 
@@ -820,7 +820,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
             "Attribute `ptx` is deprecated and will be removed in the future. "
             "To retrieve the compiled machine code of the CUDA function for a"
             "given signature `sig`, use the method `inspect_asm(sig)`."
-            , FutureWarning
+            , NumbaDeprecationWarning
         )
         return {sig: overload.ptx for sig, overload in self.overloads.items()}
 

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -3,6 +3,7 @@ import os
 import sys
 import ctypes
 import functools
+import warnings
 
 from numba.core import config, serialize, sigutils, types, typing, utils
 from numba.core.compiler_lock import global_compiler_lock
@@ -154,6 +155,12 @@ class _Kernel(serialize.ReduceMixin):
         '''
         PTX code for this kernel.
         '''
+        warnings.warn(
+            "Attribute `ptx` is deprecated and will be removed in the future. "
+            "To retrieve compiled machine code of the cuda function, use "
+            "`inpect_asm`."
+            , FutureWarning
+        )
         return self._codelibrary.get_asm_str()
 
     @property
@@ -809,6 +816,12 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
     @property
     def ptx(self):
+        warnings.warn(
+            "Attribute `ptx` is deprecated and will be removed in the future. "
+            "To retrieve compiled machine code of the cuda function, use "
+            "`inpect_asm`."
+            , FutureWarning
+        )
         return {sig: overload.ptx for sig, overload in self.overloads.items()}
 
     def bind(self):

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -819,7 +819,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
     def ptx(self):
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve the compiled machine code of the CUDA function for a"
+            "To retrieve the compiled machine code of the CUDA function for a "
             "given signature `sig`, use the method `inspect_asm(sig)`."
             , NumbaDeprecationWarning
         )

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -158,7 +158,7 @@ class _Kernel(serialize.ReduceMixin):
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
             "To retrieve the compiled machine code of the CUDA function for a "
-            "given cuda compute compatibility `cc`, use the `inspect_asm(cc)` "
+            "given CUDA compute compatibility `cc`, use the `inspect_asm(cc)` "
             "method."
             , NumbaDeprecationWarning
         )

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -157,8 +157,9 @@ class _Kernel(serialize.ReduceMixin):
         '''
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve the compiled machine code of the CUDA function, use "
-            "the `inpect_asm` method."
+            "To retrieve the compiled machine code of the CUDA function for a "
+            "given cuda compute compatibility `cc`, use the `inspect_asm(cc)` "
+            "method."
             , NumbaDeprecationWarning
         )
         return self._codelibrary.get_asm_str()

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -818,8 +818,8 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
     def ptx(self):
         warnings.warn(
             "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve compiled machine code of the cuda function, use "
-            "`inpect_asm`."
+            "To retrieve compiled machine code of the cuda function of certain"
+            "signature `sig`, use `inspect_asm(sig)`."
             , FutureWarning
         )
         return {sig: overload.ptx for sig, overload in self.overloads.items()}

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -100,7 +100,7 @@ class TestCudaConstantMemory(CUDATestCase):
         if not ENABLE_CUDASIM:
             self.assertIn(
                 'ld.const.f64',
-                jcuconst.ptx[sig],
+                jcuconst.inspect_asm(sig),
                 "as we're adding to it, load as a double")
 
     def test_const_empty(self):
@@ -125,7 +125,7 @@ class TestCudaConstantMemory(CUDATestCase):
         if not ENABLE_CUDASIM:
             self.assertIn(
                 'ld.const.u32',
-                jcuconst2d.ptx[sig],
+                jcuconst2d.inspect_asm(sig),
                 "load the ints as ints")
 
     def test_const_array_3d(self):
@@ -146,7 +146,9 @@ class TestCudaConstantMemory(CUDATestCase):
                 complex_load = 'ld.const.f32'
                 description = 'load each half of the complex as f32'
 
-            self.assertIn(complex_load, jcuconst3d.ptx[sig], description)
+            self.assertIn(
+                complex_load, jcuconst3d.inspect_asm(sig), description
+            )
 
     def test_const_record_empty(self):
         jcuconstRecEmpty = cuda.jit('void(int64[:])')(cuconstRecEmpty)

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -1,6 +1,7 @@
 import numpy as np
 import threading
 import warnings
+from contextlib import contextmanager
 
 from numba import cuda, float32, float64, int32, int64, void
 from numba.core.errors import NumbaDeprecationWarning
@@ -291,6 +292,14 @@ class TestDispatcher(CUDATestCase):
         self.assertEqual("Add two integers, device version", add_device.__doc__)
 
 
+@contextmanager
+def deprecation_warning_catcher():
+    with warnings.catch_warnings(record=True) as w:
+        ignore_internal_warnings()
+        warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        yield w
+
+
 @skip_on_cudasim('Dispatcher objects not used in the simulator')
 class TestDispatcherDeprecation(CUDATestCase):
     def check_warning(self, warnings, expected_str, category):
@@ -303,29 +312,29 @@ class TestDispatcherDeprecation(CUDATestCase):
         def f(x):
             x[0] = 42
 
-        with warnings.catch_warnings(record=True) as w:
-            ignore_internal_warnings()
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        msg = "Attribute `ptx` is deprecated and will be removed in the "
+        "future. "
 
-            msg = "Attribute `ptx` is deprecated and will be removed in the "
-            "future. "
-
-            # Kernel code path
-            with self.subTest(name="DispatcherOnCudaKernel"):
-                dispatcher = cuda.jit(f)
-                dispatcher.ptx
-                self.check_warning(w, msg, NumbaDeprecationWarning)
-                w.clear()
-            with self.subTest(name="KernelObjectOnCudaKernel"):
-                kernel = dispatcher.compile((float32[::1],))
-                kernel.ptx
-                self.check_warning(w, msg, NumbaDeprecationWarning)
-                w.clear()
-            # Device function code path
-            with self.subTest(name="DispatcherOnDeviceFunction"):
-                device_f_dispatcher = cuda.jit(f, device=True)
-                device_f_dispatcher.ptx
-                self.check_warning(w, msg, NumbaDeprecationWarning)
+        # Kernel code path
+        with self.subTest(
+            name="DispatcherOnCudaKernel"
+        ), deprecation_warning_catcher() as w:
+            dispatcher = cuda.jit(f)
+            dispatcher.ptx
+            self.check_warning(w, msg, NumbaDeprecationWarning)
+        with self.subTest(
+            name="KernelObjectOnCudaKernel"
+        ), deprecation_warning_catcher() as w:
+            kernel = dispatcher.compile((float32[::1],))
+            kernel.ptx
+            self.check_warning(w, msg, NumbaDeprecationWarning)
+        # Device function code path
+        with self.subTest(
+            name="DispatcherOnDeviceFunction"
+        ), deprecation_warning_catcher() as w:
+            device_f_dispatcher = cuda.jit(f, device=True)
+            device_f_dispatcher.ptx
+            self.check_warning(w, msg, NumbaDeprecationWarning)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -301,8 +301,9 @@ class TestDispatcherDeprecation(CUDATestCase):
     def test_ptx_deprecation(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", category=NumbaDeprecationWarning)
-            def f():
-                x = 42
+
+            def f(x):
+                x[0] = 42
             # Kernel code path
             dispatcher = cuda.jit(f)
             dispatcher.ptx
@@ -315,6 +316,7 @@ class TestDispatcherDeprecation(CUDATestCase):
             msg = "Attribute `ptx` is deprecated and will be removed in the "
             "future. "
             self.check_warning(w, msg, NumbaDeprecationWarning)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -35,7 +35,7 @@ class TestCudaLocalMem(CUDATestCase):
     def test_local_array(self):
         sig = (int32[:], int32[:])
         jculocal = cuda.jit(sig)(culocal)
-        self.assertTrue('.local' in jculocal.ptx[sig])
+        self.assertTrue('.local' in jculocal.inspect_asm(sig))
         A = np.arange(1000, dtype='int32')
         B = np.zeros_like(A)
         jculocal[1, 1](A, B)

--- a/numba/cuda/tests/cudapy/test_sync.py
+++ b/numba/cuda/tests/cudapy/test_sync.py
@@ -186,7 +186,7 @@ class TestCudaSync(CUDATestCase):
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
         if not ENABLE_CUDASIM:
-            self.assertIn("membar.gl;", compiled.ptx[sig])
+            self.assertIn("membar.gl;", compiled.inspect_asm(sig))
 
     def test_threadfence_block_codegen(self):
         # Does not test runtime behavior, just the code generation.
@@ -196,7 +196,7 @@ class TestCudaSync(CUDATestCase):
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
         if not ENABLE_CUDASIM:
-            self.assertIn("membar.cta;", compiled.ptx[sig])
+            self.assertIn("membar.cta;", compiled.inspect_asm(sig))
 
     def test_threadfence_system_codegen(self):
         # Does not test runtime behavior, just the code generation.
@@ -206,7 +206,7 @@ class TestCudaSync(CUDATestCase):
         compiled[1, 1](ary)
         self.assertEqual(123 + 321, ary[0])
         if not ENABLE_CUDASIM:
-            self.assertIn("membar.sys;", compiled.ptx[sig])
+            self.assertIn("membar.sys;", compiled.inspect_asm(sig))
 
     def test_syncthreads_count(self):
         compiled = cuda.jit("void(int32[:], int32[:])")(use_syncthreads_count)


### PR DESCRIPTION
After speaking with @gmarkall , `ptx` attribute is supposed to be removed as part of effort in https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-the-inspect-ptx-method, but was missed. This PR adds deprecation warning to `ptx` attribute and updates all usages in tests.

Part of #7849