### PR TITLE
Fix cross_iter_dep check.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -530,7 +530,6 @@ class Parfor(ir.Expr, ir.Stmt):
             pattern,
             flags,
             *,  #only specify the options below by keyword
-            unanalyzable_body=False,
             no_sequential_lowering=False,
             races=set()):
         super(Parfor, self).__init__(
@@ -558,7 +557,6 @@ class Parfor(ir.Expr, ir.Stmt):
         # sequential lowering option
         self.no_sequential_lowering = no_sequential_lowering
         self.races = races
-        self.unanalyzable_body = unanalyzable_body
         if config.DEBUG_ARRAY_OPT_STATS:
             fmt = 'Parallel for-loop #{} is produced from pattern \'{}\' at {}'
             print(fmt.format(
@@ -2558,20 +2556,6 @@ class ConvertLoopPass:
                         first_body_label = min(loop_body.keys())
                         loop_body[first_body_label].body = header_body + loop_body[first_body_label].body
 
-                    # See if there are any calls that take arrays that might generate dependencies.
-                    # Those dependencies might be safe for one parfor but not safe for fusion.
-                    def call_with_array(typemap, loop_body):
-                        for block in loop_body.values():
-                            for inst in block.body:
-                                if (isinstance(inst, ir.Assign)
-                                    and isinstance(inst.value, ir.Expr)
-                                    and inst.value.op == "call"
-                                    and any([isinstance(typemap[x.name], types.npytypes.Array) for x in inst.value.args])):
-                                    if config.DEBUG_ARRAY_OPT >= 3:
-                                        print("Found array passed to unanalyzable call in prange/pndindex.")
-                                    return True
-                        return False
-
                     index_var_map = {v: index_var for v in loop_index_vars}
                     replace_vars(loop_body, index_var_map)
                     if unsigned_index:
@@ -2579,13 +2563,11 @@ class ConvertLoopPass:
                         # optimizations (see #2846)
                         self._replace_loop_access_indices(
                             loop_body, loop_index_vars, index_var)
-                    ubody = call_with_array(pass_states.typemap, loop_body)
                     parfor = Parfor(loops, init_block, loop_body, loc,
                                     orig_index_var if mask_indices else index_var,
                                     equiv_set,
                                     ("prange", loop_kind, loop_replacing),
-                                    pass_states.flags, races=races,
-                                    unanalyzable_body=ubody)
+                                    pass_states.flags, races=races)
 
                     blocks[loop.header].body = [parfor]
                     # We have to insert the header_body after the parfor because in
@@ -3988,10 +3970,7 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata):
 
     # TODO: make sure parfor1's reduction output is not used in parfor2
     # only data parallel loops
-    if (has_cross_iter_dep(parfor1) or
-        has_cross_iter_dep(parfor2) or
-        parfor1.unanalyzable_body or
-        parfor2.unanalyzable_body):
+    if has_cross_iter_dep(parfor1) or has_cross_iter_dep(parfor2):
         dprint("try_fuse: parfor cross iteration dependency found")
         msg = ("- fusion failed: cross iteration dependency found "
                 "between loops #%s and #%s")
@@ -4091,7 +4070,7 @@ def has_cross_iter_dep(parfor):
     # the parfor index is used in any expression since the expression could
     # be used for indexing arrays
     # TODO: make it more accurate using ud-chains
-    indices = {l.index_variable for l in parfor.loop_nests}
+    indices = {l.index_variable.name for l in parfor.loop_nests}
     for b in parfor.loop_body.values():
         for stmt in b.body:
             # GetItem/SetItem nodes are fine since can't have expression inside
@@ -4103,8 +4082,9 @@ def has_cross_iter_dep(parfor):
                 op = stmt.value.op
                 if op in ['build_tuple', 'getitem', 'static_getitem']:
                     continue
+            stmt_vars = [x.name for x in stmt.list_vars()]
             # other statements can have potential violations
-            if not indices.isdisjoint(stmt.list_vars()):
+            if not indices.isdisjoint(stmt_vars):
                 dprint("has_cross_iter_dep found", indices, stmt)
                 return True
     return False

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2860,13 +2860,19 @@ class ParforPass(ParforPassStates):
             maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap,
                                                             up_direction=False)
             dprint_func_ir(self.func_ir, "after maximize fusion down")
-            self.fuse_parfors(self.array_analysis, self.func_ir, self.typemap)
+            self.fuse_parfors(self.array_analysis,
+                              self.func_ir.blocks,
+                              self.func_ir,
+                              self.typemap)
             dprint_func_ir(self.func_ir, "after first fuse")
             # push non-parfors up
             maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap)
             dprint_func_ir(self.func_ir, "after maximize fusion up")
             # try fuse again after maximize
-            self.fuse_parfors(self.array_analysis, self.func_ir, self.typemap)
+            self.fuse_parfors(self.array_analysis,
+                              self.func_ir.blocks,
+                              self.func_ir,
+                              self.typemap)
             dprint_func_ir(self.func_ir, "after fusion")
             # remove dead code after fusion to remove extra arrays and variables
             simplify(self.func_ir, self.typemap, self.calltypes, self.metadata["parfors"])
@@ -2958,8 +2964,7 @@ class ParforPass(ParforPassStates):
         """
         return _mk_parfor_loops(self.typemap, size_vars, scope, loc)
 
-    def fuse_parfors(self, array_analysis, func_ir, typemap):
-        blocks = func_ir.blocks
+    def fuse_parfors(self, array_analysis, blocks, func_ir, typemap):
         for label, block in blocks.items():
             equiv_set = array_analysis.get_equiv_set(label)
             fusion_happened = True

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2989,7 +2989,6 @@ class ParforPass(ParforPassStates):
                             fusion_happened = True
                             self.diagnostics.fusion_info[stmt.id].extend([next_stmt.id])
                             new_body.append(fused_node)
-                            func_ir._definitions = build_definitions(blocks)
                             self.fuse_recursive_parfor(fused_node, equiv_set, func_ir, typemap)
                             i += 2
                             continue
@@ -3975,6 +3974,7 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata, func_ir, typemap):
             report = FusionReport(parfor1.id, parfor2.id, msg % i)
             return None, report
 
+    func_ir._definitions = build_definitions(func_ir.blocks)
     # TODO: make sure parfor1's reduction output is not used in parfor2
     # only data parallel loops
     p1_cross_dep, p1_ip, p1_ia, p1_non_ia = has_cross_iter_dep(parfor1, func_ir, typemap)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3971,10 +3971,9 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata, func_ir, typemap):
     # TODO: make sure parfor1's reduction output is not used in parfor2
     # only data parallel loops
     func_ir._definitions = build_definitions(func_ir.blocks)
-    p1_cross_dep, p1_ip, p1_ia, p1_non_ia = has_cross_iter_dep(p1, func_ir, typemap)
-    dprint("p1_cross_dep:", p1_cross_dep)
+    p1_cross_dep, p1_ip, p1_ia, p1_non_ia = has_cross_iter_dep(parfor1, func_ir, typemap)
     if not p1_cross_dep:
-        p2_cross_dep = has_cross_iter_dep(p2, func_ir, typemap, p1_ip, p1_ia, p1_non_ia)[0]
+        p2_cross_dep = has_cross_iter_dep(parfor2, func_ir, typemap, p1_ip, p1_ia, p1_non_ia)[0]
     else:
         p2_cross_dep = True
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2860,13 +2860,13 @@ class ParforPass(ParforPassStates):
             maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap,
                                                             up_direction=False)
             dprint_func_ir(self.func_ir, "after maximize fusion down")
-            self.fuse_parfors(self.array_analysis, self.func_ir.blocks, self.func_ir, self.typemap)
+            self.fuse_parfors(self.array_analysis, self.func_ir, self.typemap)
             dprint_func_ir(self.func_ir, "after first fuse")
             # push non-parfors up
             maximize_fusion(self.func_ir, self.func_ir.blocks, self.typemap)
             dprint_func_ir(self.func_ir, "after maximize fusion up")
             # try fuse again after maximize
-            self.fuse_parfors(self.array_analysis, self.func_ir.blocks, self.func_ir, self.typemap)
+            self.fuse_parfors(self.array_analysis, self.func_ir, self.typemap)
             dprint_func_ir(self.func_ir, "after fusion")
             # remove dead code after fusion to remove extra arrays and variables
             simplify(self.func_ir, self.typemap, self.calltypes, self.metadata["parfors"])
@@ -2958,7 +2958,8 @@ class ParforPass(ParforPassStates):
         """
         return _mk_parfor_loops(self.typemap, size_vars, scope, loc)
 
-    def fuse_parfors(self, array_analysis, blocks, func_ir, typemap):
+    def fuse_parfors(self, array_analysis, func_ir, typemap):
+        blocks = func_ir.blocks
         for label, block in blocks.items():
             equiv_set = array_analysis.get_equiv_set(label)
             fusion_happened = True
@@ -2983,6 +2984,7 @@ class ParforPass(ParforPassStates):
                             fusion_happened = True
                             self.diagnostics.fusion_info[stmt.id].extend([next_stmt.id])
                             new_body.append(fused_node)
+                            func_ir._definitions = build_definitions(blocks)
                             self.fuse_recursive_parfor(fused_node, equiv_set, func_ir, typemap)
                             i += 2
                             continue
@@ -3970,7 +3972,6 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata, func_ir, typemap):
 
     # TODO: make sure parfor1's reduction output is not used in parfor2
     # only data parallel loops
-    func_ir._definitions = build_definitions(func_ir.blocks)
     p1_cross_dep, p1_ip, p1_ia, p1_non_ia = has_cross_iter_dep(parfor1, func_ir, typemap)
     if not p1_cross_dep:
         p2_cross_dep = has_cross_iter_dep(parfor2, func_ir, typemap, p1_ip, p1_ia, p1_non_ia)[0]
@@ -4072,13 +4073,48 @@ def remove_duplicate_definitions(blocks, nameset):
     return
 
 
-def has_cross_iter_dep(parfor, func_ir, typemap, index_positions=None, indexed_arrays=None, non_indexed_arrays=None):
-    # we conservatively assume there is cross iteration dependency when
-    # the parfor index is used in any expression since the expression could
-    # be used for indexing arrays
+def has_cross_iter_dep(
+        parfor,
+        func_ir,
+        typemap,
+        index_positions=None,
+        indexed_arrays=None,
+        non_indexed_arrays=None):
+    # We should assume there is cross iteration dependency unless we can
+    # prove otherwise.  Return True if there is a cross-iter dependency
+    # that should prevent fusion, False if fusion is okay.
+
     # TODO: make it more accurate using ud-chains
+
+    # Get the index variable used by this parfor.
+    # This will hold other variables with equivalent value, e.g., a = index_var
     indices = {l.index_variable.name for l in parfor.loop_nests}
+    # This set will store variables that are (potentially recursively)
+    # defined in relation to an index variable, e.g., a = index_var + 1.
+    # A getitem that uses an index variable from this set will be considered
+    # as potentially having a cross-iter dependency and so won't fuse.
     derived_from_indices = set()
+    # For the first parfor considered for fusion, the later 3 args will be None
+    # and initialized to empty.  For the second parfor, the strutures from the
+    # previous parfor is passed in so that cross-parfor violations of the
+    # below comments can prevent fusion.
+    #
+    # index_positions keeps track of which index positions have had an index
+    # variable used for them and which ones haven't for each possible array
+    # dimensionality.  After the first array access is seen, if subsequent
+    # ones use a parfor index for a different dimension then we conservatively
+    # say that we can't fuse.  For example, if a 2D array is accessed with
+    # a[parfor_index, 0] then index_positions[2] will be (True, False) and
+    # if a[0, parfor_index] happens later which is (False, True) then this
+    # conflicts with the previous value and will prevent fusion.
+    #
+    # indexed_arrays records arrays that are accessed with at least one
+    # parfor index.  If such an array is later accessed with indices that
+    # don't include a parfor index then conservatively assume we can't fuse.
+    #
+    # non_indexed_arrays holds arrays that are indexed without a parfor index.
+    # If an array first accessed without a parfor index is later indexed
+    # with one then conservatively assume we can't fuse.
     if index_positions is None:
         index_positions = {}
     if indexed_arrays is None:
@@ -4087,51 +4123,83 @@ def has_cross_iter_dep(parfor, func_ir, typemap, index_positions=None, indexed_a
         non_indexed_arrays = set()
 
     def add_check_position(new_position, array_accessed):
-        """Returns True if there is a reason to prevent fusion."""
+        """Returns True if there is a reason to prevent fusion based
+           on the rules described above.
+           new_position will be a list or tuples of boolean that
+           says whether the index in that spot is a parfor index
+           or not.  array_accessed is the array on which the access
+           is occurring."""
+
+        # Convert list indices to tuple for generality.
         if isinstance(new_position, list):
             new_position = tuple(new_position)
+
+        # If none of the indices are based on a parfor index.
         if True not in new_position:
+            # See if this array has been accessed before with a
+            # a parfor index and if so say that we can't fuse.
             if array_accessed in indexed_arrays:
                 return True
             else:
+                # Either array is already in non_indexed arrays or we
+                # will add it.  Either way, this index usage can fuse.
                 non_indexed_arrays.add(array_accessed)
                 return False
+
+        # Fallthrough for cases where one of the indices is a parfor index.
+        # If this array previous accessed without a parfor index then
+        # conservatively say we can't fuse.
         if array_accessed in non_indexed_arrays:
             return True
 
         npsize = len(new_position)
+        # See if we have not seen a npsize dimensioned array accessed before.
         if npsize not in index_positions:
+            # If not then add current set of parfor/non-parfor indices and
+            # indicate it is safe as it is the first usage.
             index_positions[npsize] = new_position
             return False
 
+        # Here we have a subsequent access to a npsize-dimensioned array.
+        # Make sure we see the same combination of parfor/non-parfor index
+        # indices that we've seen before.  If not then return True saying
+        # that we can't fuse.
         return index_positions[npsize] != new_position
 
     def check_index(stmt_index, array_accessed):
-        """Returns True if there is a reason to prevent fusion."""
+        """Looks at the indices of a getitem or setitem to see if there
+           is a reason that they would prevent fusion.
+           Returns True if fusion should be prohibited, False otherwise.
+        """
         if isinstance(stmt_index, ir.Var):
             # If the array is 2+ dimensions then the index should be a tuple.
             if isinstance(typemap[stmt_index.name], types.BaseTuple):
+                # Get how the index tuple is constructed.
                 fbs_res = guard(find_build_sequence, func_ir, stmt_index)
                 if fbs_res is not None:
                     ind_seq, ind_op = fbs_res
-                    # If all the parts of the tuple are parfor indices
-                    # or not derived from indices it is okay.
+                    # If any indices are derived from an index is used then
+                    # return True to say we can't fuse.
                     if (all([x.name in indices or
                         x.name not in derived_from_indices for x in ind_seq])):
+                        # Get position in index tuple where parfor indices used.
                         new_index_positions = [x.name in indices for x in ind_seq]
                         # Make sure that we aren't accessing a given array with
                         # different indices in a different order.
                         if add_check_position(new_index_positions, array_accessed):
                             return True
                     else:
+                        # index derived from a parfor index used so no fusion
                         return True
                 else:
                     # Don't know how the index tuple is built so
                     # have to assume fusion can't happen.
                     return True
             else:
-                # Should be for 1D array getitems.
+                # Should be for 1D arrays.
                 if stmt_index.name in indices:
+                    # Array indexed by a parfor index variable.
+                    # Make sure this 1D access consistent with prior ones.
                     if add_check_position((True,), array_accessed):
                         return True
                 elif stmt_index.name in derived_from_indices:
@@ -4139,39 +4207,59 @@ def has_cross_iter_dep(parfor, func_ir, typemap, index_positions=None, indexed_a
                     # from an index then no fusion.
                     return True
                 else:
+                    # Some kind of index that isn't a parfor index or
+                    # one derived from one, e.g., a constant.  Make sure
+                    # this is consistent with prior accessed of this array.
                     if add_check_position((False,), array_accessed):
                         return True
         else:
+            # We don't know how to handle non-Var indices so no fusion.
             return True
+
+        # No reason to reject so indicate safe for fusion.
         return False
 
+    # Iterate through all the statements in the parfor.
     for b in parfor.loop_body.values():
         for stmt in b.body:
-            # GetItem/SetItem nodes are fine since can't have expression inside
-            # and only simple indices are possible
+            # Make sure SetItem accesses are fusion safe.
             if isinstance(stmt, (ir.SetItem, ir.StaticSetItem)):
+                # Check index safety with prior array accesses.
                 if check_index(stmt.index, stmt.target.name):
                     return True, index_positions, indexed_arrays, non_indexed_arrays
+                # Fusion safe so go to next statement.
                 continue
-            # tuples are immutable so no expression on parfor possible
             if isinstance(stmt, ir.Assign):
+                # If stmt of form a = parfor_index then add "a" to set of
+                # parfor indices.
                 if isinstance(stmt.value, ir.Var):
                     if stmt.value.name in indices:
                         indices.add(stmt.target.name)
                         continue
                 elif isinstance(stmt.value, ir.Expr):
                     op = stmt.value.op
+                    # Make sure getitem accesses are fusion safe.
                     if op in ['getitem', 'static_getitem']:
-                        if not check_index(stmt.value.index, stmt.value.value.name):
-                            continue
-
-                        return True, index_positions, indexed_arrays, non_indexed_arrays
+                        # Check index safety with prior array accesses.
+                        if check_index(stmt.value.index, stmt.value.value.name):
+                            return True, index_positions, indexed_arrays, non_indexed_arrays
+                        # Fusion safe so go to next statement.
+                        continue
                     if op == 'call':
+                        # If there is a call in the parfor body that takes some
+                        # array parameter then we have no way to analyze what
+                        # that call is doing so presume it is unsafe for fusion.
                         if (any([isinstance(typemap[x.name], types.npytypes.Array)
                             for x in stmt.value.list_vars()])):
                             return True, index_positions, indexed_arrays, non_indexed_arrays
 
+                    # Get the vars used by this non-setitem/getitem statement.
                     rhs_vars = [x.name for x in stmt.value.list_vars()]
+                    # If a parfor index is used as part of this statement or
+                    # something previous determined to be derived from a parfor
+                    # index then add the target variable to the set of variable
+                    # variables that are derived from parfors and so should
+                    # prevent fusion if used as an index.
                     if (not indices.isdisjoint(rhs_vars) or
                         not derived_from_indices.isdisjoint(rhs_vars)):
                         derived_from_indices.add(stmt.target.name)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -4246,7 +4246,9 @@ def has_cross_iter_dep(
 
         # All branches above should cover all the cases and each should
         # return so we should never get here.
-        assert 0
+        raise errors.InternalError("Some code path in the parfor fusion "
+                                   "cross-iteration dependency checker "
+                                   "check_index didn't return a result.")
 
     # Iterate through all the statements in the parfor.
     for b in parfor.loop_body.values():

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1974,7 +1974,7 @@ class TestParfors(TestParforsBase):
 
         size = 4
         u = np.zeros((size, size))
-        cptypes = (numba.float64[:,:], types.int64)
+        cptypes = (numba.float64[:, ::1], types.int64)
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, u, size)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2011,7 +2011,7 @@ class TestParfors(TestParforsBase):
         size = 10
         a = np.zeros((size, size))
         b = np.zeros((size, size))
-        cptypes = (numba.float64[:,:], numba.float64[:,:], types.int64)
+        cptypes = (numba.float64[:, ::1], numba.float64[:, ::1], types.int64)
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, a, b, size)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1992,7 +1992,7 @@ class TestParfors(TestParforsBase):
 
         size = 4
         u = np.zeros((size, size))
-        cptypes = (numba.float64[:,:], types.int64)
+        cptypes = (numba.float64[:, ::1], types.int64)
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, u, size)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2032,7 +2032,7 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, a, size)
 
-    def test_prange_parfor_index_tuple1(self):
+    def test_prange_parfor_index_const_tuple_fusion(self):
         # Testing if accessing a tuple with prange index
         # and later with a constant will not prevent fusion.
         def test_impl(a, c, size):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2002,7 +2002,7 @@ class TestParfors(TestParforsBase):
         def test_impl(a, b, size):
             for i in numba.prange(size):
                 for j in range(size):
-                    a[i,j] = b[i, j] + 1
+                    a[i, j] = b[i, j] + 1
             for i in numba.prange(size):
                 for j in range(size):
                     b[j, i] = 3

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2035,13 +2035,13 @@ class TestParfors(TestParforsBase):
     def test_prange_parfor_index_const_tuple_fusion(self):
         # Testing if accessing a tuple with prange index
         # and later with a constant will not prevent fusion.
-        def test_impl(a, c, size):
-            b = 0
+        def test_impl(a, tup, size):
+            acc = 0
             for i in numba.prange(size):
-                a[i] = i + c[i]
+                a[i] = i + tup[i]
             for i in numba.prange(size):
-                b += a[i] + c[1]
-            return b
+                acc += a[i] + tup[1]
+            return acc
 
         size = 10
         a = np.zeros(size)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2006,7 +2006,7 @@ class TestParfors(TestParforsBase):
             for i in numba.prange(size):
                 for j in range(size):
                     b[j,i] = 3
-            return a + b[0,0]
+            return a[0,0] + b[0,0]
 
         size = 10
         a = np.zeros((size, size))

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2032,6 +2032,26 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, a, size)
 
+    def test_prange_parfor_index_tuple1(self):
+        # Testing if accessing a tuple with prange index
+        # and later with a constant will not prevent fusion.
+        def test_impl(a, c, size):
+            b = 0
+            for i in numba.prange(size):
+                a[i] = i + c[i]
+            for i in numba.prange(size):
+                b += a[i] + c[1]
+            return b
+
+        size = 10
+        a = np.zeros(size)
+        b = tuple(a)
+        cptypes = (numba.float64[:],
+                   types.containers.UniTuple(types.int64, size),
+                   types.int64)
+        self.assertEqual(countParfors(test_impl, cptypes), 1)
+        self.check(test_impl, a, b, size)
+
     def test_prange_non_parfor_index_then_opposite(self):
         # Testing if accessing an array first without a parfor index then
         # with will prevent fusion.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2023,7 +2023,7 @@ class TestParfors(TestParforsBase):
 
         size = 10
         a = np.zeros(size)
-        cptypes = (numba.float64[:], types.int64))
+        cptypes = (numba.float64[:], types.int64)
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, a, size)
 
@@ -2042,7 +2042,7 @@ class TestParfors(TestParforsBase):
         size = 10
         a = np.zeros(size)
         b = np.zeros(size)
-        cptypes = (numba.float64[:], numba.float64[:], types.int64))
+        cptypes = (numba.float64[:], numba.float64[:], types.int64)
         self.assertEqual(countParfors(test_impl, cptypes), 2)
         self.check(test_impl, a, b, size)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2006,7 +2006,7 @@ class TestParfors(TestParforsBase):
             for i in numba.prange(size):
                 for j in range(size):
                     b[j, i] = 3
-            return a[0,0] + b[0,0]
+            return a[0, 0] + b[0, 0]
 
         size = 10
         a = np.zeros((size, size))

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1990,6 +1990,22 @@ class TestParfors(TestParforsBase):
         self.assertEqual(countParfors(test_impl, (types.int64,)), 3)
         self.check(test_impl, 4)
 
+    def test_prange_reverse_order1(self):
+        def test_impl():
+            size = 10
+            a = np.zeros((size,size))
+            b = np.zeros((size,size))
+            for i in numba.prange(size):
+                for j in range(size):
+                    a[i,j] = b[i,j] + 1
+            for i in numba.prange(size):
+                for j in range(size):
+                    b[j,i] = 3
+            return a
+
+        self.assertEqual(countParfors(test_impl, ()), 3)
+        self.check(test_impl)
+
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -1973,8 +1973,23 @@ class TestParfors(TestParforsBase):
                 issue7854_proc(u, i, 1, size)
             return u
 
-        self.check(test_impl, 4)
         self.assertEqual(countParfors(test_impl, (types.int64,)), 3)
+        self.check(test_impl, 4)
+
+    def test_prange_unknown_call2(self):
+        def test_impl(size):
+            u = np.zeros((size,size))
+            for i in numba.prange(1, size-1):
+                for j in range((i + 1)%2 +1, size-1, 2):
+                    u[i, j] = u[i, j+1] + u[i, j-1] + u[i+1,j ] + u[i-1, j] + 1
+            for i in numba.prange(1, size-1):
+                for j in range(i%2 +1, size-1, 2):
+                    u[i, j] = u[i, j+1] + u[i, j-1] + u[i+1,j ] + u[i-1, j] + 1
+            return u
+
+        self.assertEqual(countParfors(test_impl, (types.int64,)), 3)
+        self.check(test_impl, 4)
+
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2047,8 +2047,8 @@ class TestParfors(TestParforsBase):
         a = np.zeros(size)
         b = tuple(a)
         cptypes = (numba.float64[:],
-                   types.containers.UniTuple(types.int64, size),
-                   types.int64)
+                   types.containers.UniTuple(types.float64, size),
+                   types.intp)
         self.assertEqual(countParfors(test_impl, cptypes), 1)
         self.check(test_impl, a, b, size)
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2005,7 +2005,7 @@ class TestParfors(TestParforsBase):
                     a[i,j] = b[i, j] + 1
             for i in numba.prange(size):
                 for j in range(size):
-                    b[j,i] = 3
+                    b[j, i] = 3
             return a[0,0] + b[0,0]
 
         size = 10


### PR DESCRIPTION
Resolves #7854 

Cross iteration dependency check wasn't working with the disjointness test working on ir.Var instead of variable names.  I changed to using names instead.