### PR TITLE
Remove use of `llvmlite.llvmpy`

### DIFF
--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -1183,3 +1183,12 @@ def is_nonelike(ty):
         isinstance(ty, types.NoneType) or
         isinstance(ty, types.Omitted)
     )
+
+
+def create_constant_array(ty, val):
+    """
+    Create an LLVM-constant of a fixed-length array from Python values.
+
+    The type provided is the type of the elements.
+    """
+    return ir.Constant(ir.ArrayType(ty, len(val)), val)

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -537,7 +537,7 @@ def for_range_slice(builder, start, stop, step, intp=None, inc=True):
     Parameters
     -------------
     builder : object
-        Builder object
+        IRBuilder object
     start : int
         The beginning value of the slice
     stop : int

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -11,7 +11,7 @@ import llvmlite.ir as llvmir
 
 from abc import abstractmethod, ABCMeta
 from numba.core import utils, config, cgutils
-from numba.core.passes import create_pass_manager_builder
+from numba.core.llvm_bindings import create_pass_manager_builder
 from numba.core.runtime.nrtopt import remove_redundant_nrt_refct
 from numba.core.runtime import rtsys
 from numba.core.compiler_lock import require_global_compiler_lock

--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -6,13 +6,12 @@ import ctypes
 import html
 import textwrap
 
-import llvmlite.llvmpy.core as lc
-import llvmlite.llvmpy.passes as lp
 import llvmlite.binding as ll
 import llvmlite.ir as llvmir
 
 from abc import abstractmethod, ABCMeta
 from numba.core import utils, config, cgutils
+from numba.core.passes import create_pass_manager_builder
 from numba.core.runtime.nrtopt import remove_redundant_nrt_refct
 from numba.core.runtime import rtsys
 from numba.core.compiler_lock import require_global_compiler_lock
@@ -1250,10 +1249,10 @@ class CPUCodegen(Codegen):
         loop_vectorize = kwargs.pop('loop_vectorize', config.LOOP_VECTORIZE)
         slp_vectorize = kwargs.pop('slp_vectorize', config.SLP_VECTORIZE)
 
-        pmb = lp.create_pass_manager_builder(opt=opt_level,
-                                             loop_vectorize=loop_vectorize,
-                                             slp_vectorize=slp_vectorize,
-                                             **kwargs)
+        pmb = create_pass_manager_builder(opt=opt_level,
+                                          loop_vectorize=loop_vectorize,
+                                          slp_vectorize=slp_vectorize,
+                                          **kwargs)
 
         return pmb
 

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -2,7 +2,6 @@ import sys
 import platform
 
 import llvmlite.binding as ll
-import llvmlite.llvmpy.core as lc
 from llvmlite import ir
 
 from numba import _dynfunc
@@ -338,7 +337,7 @@ def remove_null_refct_call(bb):
     pass
     ## Skipped for now
     # for inst in bb.instructions:
-    #     if isinstance(inst, lc.CallOrInvokeInstruction):
+    #     if isinstance(inst, ir.CallInstr):
     #         fname = inst.called_function.name
     #         if fname == "Py_IncRef" or fname == "Py_DecRef":
     #             arg = inst.args[0]
@@ -362,7 +361,7 @@ def remove_refct_pairs(bb):
 
         # Mark
         for inst in bb.instructions:
-            if isinstance(inst, lc.CallOrInvokeInstruction):
+            if isinstance(inst, ir.CallInstr):
                 fname = inst.called_function.name
                 if fname == "Py_IncRef":
                     arg = inst.operands[0]

--- a/numba/core/llvm_bindings.py
+++ b/numba/core/llvm_bindings.py
@@ -14,7 +14,11 @@ from llvmlite import binding as llvm
 
 
 def _inlining_threshold(optlevel, sizelevel=0):
-    # Refer http://llvm.org/docs/doxygen/html/InlineSimple_8cpp_source.html
+    """
+    Compute the inlining threshold for the desired optimisation level
+
+    Refer to http://llvm.org/docs/doxygen/html/InlineSimple_8cpp_source.html
+    """
     if optlevel > 2:
         return 275
 
@@ -31,6 +35,9 @@ def _inlining_threshold(optlevel, sizelevel=0):
 
 def create_pass_manager_builder(opt=2, loop_vectorize=False,
                                 slp_vectorize=False):
+    """
+    Create an LLVM pass manager with the desired optimisation level and options.
+    """
     pmb = llvm.create_pass_manager_builder()
     pmb.opt_level = opt
     pmb.loop_vectorize = loop_vectorize

--- a/numba/core/passes.py
+++ b/numba/core/passes.py
@@ -1,0 +1,39 @@
+"""
+Useful options to debug LLVM passes
+
+llvm.set_option("test", "-debug-pass=Details")
+llvm.set_option("test", "-debug-pass=Executions")
+llvm.set_option("test", "-debug-pass=Arguments")
+llvm.set_option("test", "-debug-pass=Structure")
+llvm.set_option("test", "-debug-only=loop-vectorize")
+llvm.set_option("test", "-help-hidden")
+
+"""
+
+from llvmlite import binding as llvm
+
+
+def _inlining_threshold(optlevel, sizelevel=0):
+    # Refer http://llvm.org/docs/doxygen/html/InlineSimple_8cpp_source.html
+    if optlevel > 2:
+        return 275
+
+    # -Os
+    if sizelevel == 1:
+        return 75
+
+    # -Oz
+    if sizelevel == 2:
+        return 25
+
+    return 225
+
+
+def create_pass_manager_builder(opt=2, loop_vectorize=False,
+                                slp_vectorize=False):
+    pmb = llvm.create_pass_manager_builder()
+    pmb.opt_level = opt
+    pmb.loop_vectorize = loop_vectorize
+    pmb.slp_vectorize = slp_vectorize
+    pmb.inlining_threshold = _inlining_threshold(opt)
+    return pmb

--- a/numba/core/pylowering.py
+++ b/numba/core/pylowering.py
@@ -7,8 +7,7 @@ import builtins
 import operator
 import inspect
 
-from llvmlite.llvmpy.core import Type, Constant
-import llvmlite.llvmpy.core as lc
+import llvmlite.ir
 
 from numba.core import types, utils, ir, generators, cgutils
 from numba.core.errors import (ForbiddenConstruct, LoweringError,
@@ -137,12 +136,12 @@ class PyLower(BaseLower):
 
         elif isinstance(inst, ir.Branch):
             cond = self.loadvar(inst.cond.name)
-            if cond.type == Type.int(1):
+            if cond.type == llvmlite.ir.IntType(1):
                 istrue = cond
             else:
                 istrue = self.pyapi.object_istrue(cond)
-            zero = lc.Constant.null(istrue.type)
-            pred = self.builder.icmp(lc.ICMP_NE, istrue, zero)
+            zero = llvmlite.ir.Constant(istrue.type, None)
+            pred = self.builder.icmp_unsigned('!=', istrue, zero)
             tr = self.blkmap[inst.truebr]
             fl = self.blkmap[inst.falsebr]
             self.builder.cbranch(pred, tr, fl)
@@ -375,7 +374,7 @@ class PyLower(BaseLower):
             # Check tuple size is as expected
             tup_size = self.pyapi.tuple_size(tup)
             expected_size = self.context.get_constant(types.intp, expr.count)
-            has_wrong_size = self.builder.icmp(lc.ICMP_NE,
+            has_wrong_size = self.builder.icmp_unsigned('!=',
                                                tup_size, expected_size)
             with cgutils.if_unlikely(self.builder, has_wrong_size):
                 self.return_exception(ValueError)
@@ -538,8 +537,8 @@ class PyLower(BaseLower):
         """
         Raise an exception if *num* is smaller than *ok_value*.
         """
-        ok = lc.Constant.int(num.type, ok_value)
-        pred = self.builder.icmp(lc.ICMP_SLT, num, ok)
+        ok = llvmlite.ir.Constant(num.type, ok_value)
+        pred = self.builder.icmp_signed('<', num, ok)
         with cgutils.if_unlikely(self.builder, pred):
             self.return_exception_raised()
 

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -5,8 +5,7 @@ import hashlib
 import sys
 
 from llvmlite import ir
-from llvmlite.llvmpy.core import Type, Constant
-import llvmlite.llvmpy.core as lc
+from llvmlite.ir import Constant
 
 import ctypes
 from numba import _helperlib
@@ -182,15 +181,15 @@ class PythonAPI(object):
         # Initialize types
         self.pyobj = self.context.get_argument_type(types.pyobject)
         self.pyobjptr = self.pyobj.as_pointer()
-        self.voidptr = Type.pointer(Type.int(8))
-        self.long = Type.int(ctypes.sizeof(ctypes.c_long) * 8)
+        self.voidptr = ir.PointerType(ir.IntType(8))
+        self.long = ir.IntType(ctypes.sizeof(ctypes.c_long) * 8)
         self.ulong = self.long
-        self.longlong = Type.int(ctypes.sizeof(ctypes.c_ulonglong) * 8)
+        self.longlong = ir.IntType(ctypes.sizeof(ctypes.c_ulonglong) * 8)
         self.ulonglong = self.longlong
-        self.double = Type.double()
+        self.double = ir.DoubleType()
         self.py_ssize_t = self.context.get_value_type(types.intp)
-        self.cstring = Type.pointer(Type.int(8))
-        self.gil_state = Type.int(_helperlib.py_gil_state_size * 8)
+        self.cstring = ir.PointerType(ir.IntType(8))
+        self.gil_state = ir.IntType(_helperlib.py_gil_state_size * 8)
         self.py_buffer_t = ir.ArrayType(ir.IntType(8), _helperlib.py_buffer_size)
         self.py_hash_t = self.py_ssize_t
         self.py_unicode_1byte_kind = _helperlib.py_unicode_1byte_kind
@@ -227,17 +226,17 @@ class PythonAPI(object):
     #
 
     def incref(self, obj):
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="Py_IncRef")
         self.builder.call(fn, [obj])
 
     def decref(self, obj):
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="Py_DecRef")
         self.builder.call(fn, [obj])
 
     def get_type(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="numba_py_type")
         return self.builder.call(fn, [obj])
 
@@ -246,27 +245,27 @@ class PythonAPI(object):
     #
 
     def parse_tuple_and_keywords(self, args, kws, fmt, keywords, *objs):
-        charptr = Type.pointer(Type.int(8))
-        charptrary = Type.pointer(charptr)
+        charptr = ir.PointerType(ir.IntType(8))
+        charptrary = ir.PointerType(charptr)
         argtypes = [self.pyobj, self.pyobj, charptr, charptrary]
-        fnty = Type.function(Type.int(), argtypes, var_arg=True)
+        fnty = ir.FunctionType(ir.IntType(32), argtypes, var_arg=True)
         fn = self._get_function(fnty, name="PyArg_ParseTupleAndKeywords")
         return self.builder.call(fn, [args, kws, fmt, keywords] + list(objs))
 
     def parse_tuple(self, args, fmt, *objs):
-        charptr = Type.pointer(Type.int(8))
+        charptr = ir.PointerType(ir.IntType(8))
         argtypes = [self.pyobj, charptr]
-        fnty = Type.function(Type.int(), argtypes, var_arg=True)
+        fnty = ir.FunctionType(ir.IntType(32), argtypes, var_arg=True)
         fn = self._get_function(fnty, name="PyArg_ParseTuple")
         return self.builder.call(fn, [args, fmt] + list(objs))
 
     def unpack_tuple(self, args, name, n_min, n_max, *objs):
-        charptr = Type.pointer(Type.int(8))
+        charptr = ir.PointerType(ir.IntType(8))
         argtypes = [self.pyobj, charptr, self.py_ssize_t, self.py_ssize_t]
-        fnty = Type.function(Type.int(), argtypes, var_arg=True)
+        fnty = ir.FunctionType(ir.IntType(32), argtypes, var_arg=True)
         fn = self._get_function(fnty, name="PyArg_UnpackTuple")
-        n_min = Constant.int(self.py_ssize_t, n_min)
-        n_max = Constant.int(self.py_ssize_t, n_max)
+        n_min = Constant(self.py_ssize_t, int(n_min))
+        n_max = Constant(self.py_ssize_t, int(n_max))
         if isinstance(name, str):
             name = self.context.insert_const_string(self.builder.module, name)
         return self.builder.call(fn, [args, name, n_min, n_max] + list(objs))
@@ -276,17 +275,17 @@ class PythonAPI(object):
     #
 
     def err_occurred(self):
-        fnty = Type.function(self.pyobj, ())
+        fnty = ir.FunctionType(self.pyobj, ())
         fn = self._get_function(fnty, name="PyErr_Occurred")
         return self.builder.call(fn, ())
 
     def err_clear(self):
-        fnty = Type.function(Type.void(), ())
+        fnty = ir.FunctionType(ir.VoidType(), ())
         fn = self._get_function(fnty, name="PyErr_Clear")
         return self.builder.call(fn, ())
 
     def err_set_string(self, exctype, msg):
-        fnty = Type.function(Type.void(), [self.pyobj, self.cstring])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj, self.cstring])
         fn = self._get_function(fnty, name="PyErr_SetString")
         if isinstance(exctype, str):
             exctype = self.get_c_object(exctype)
@@ -295,7 +294,7 @@ class PythonAPI(object):
         return self.builder.call(fn, (exctype, msg))
 
     def err_format(self, exctype, msg, *format_args):
-        fnty = Type.function(Type.void(), [self.pyobj, self.cstring], var_arg=True)
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj, self.cstring], var_arg=True)
         fn = self._get_function(fnty, name="PyErr_Format")
         if isinstance(exctype, str):
             exctype = self.get_c_object(exctype)
@@ -308,38 +307,38 @@ class PythonAPI(object):
         Raise an arbitrary exception (type or value or (type, args)
         or None - if reraising).  A reference to the argument is consumed.
         """
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="numba_do_raise")
         if exc is None:
             exc = self.make_none()
         return self.builder.call(fn, (exc,))
 
     def err_set_object(self, exctype, excval):
-        fnty = Type.function(Type.void(), [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyErr_SetObject")
         if isinstance(exctype, str):
             exctype = self.get_c_object(exctype)
         return self.builder.call(fn, (exctype, excval))
 
     def err_set_none(self, exctype):
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="PyErr_SetNone")
         if isinstance(exctype, str):
             exctype = self.get_c_object(exctype)
         return self.builder.call(fn, (exctype,))
 
     def err_write_unraisable(self, obj):
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="PyErr_WriteUnraisable")
         return self.builder.call(fn, (obj,))
 
     def err_fetch(self, pty, pval, ptb):
-        fnty = Type.function(Type.void(), [self.pyobjptr] * 3)
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobjptr] * 3)
         fn = self._get_function(fnty, name="PyErr_Fetch")
         return self.builder.call(fn, (pty, pval, ptb))
 
     def err_restore(self, ty, val, tb):
-        fnty = Type.function(Type.void(), [self.pyobj] * 3)
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj] * 3)
         fn = self._get_function(fnty, name="PyErr_Restore")
         return self.builder.call(fn, (ty, val, tb))
 
@@ -394,7 +393,7 @@ class PythonAPI(object):
         self.err_set_string("PyExc_NameError", cstr)
 
     def fatal_error(self, msg):
-        fnty = Type.function(Type.void(), [self.cstring])
+        fnty = ir.FunctionType(ir.VoidType(), [self.cstring])
         fn = self._get_function(fnty, name="Py_FatalError")
         fn.attributes.add("noreturn")
         cstr = self.context.insert_const_string(self.module, msg)
@@ -409,7 +408,7 @@ class PythonAPI(object):
 
         Returns a borrowed reference
         """
-        fnty = Type.function(self.pyobj, [self.pyobj, self.cstring])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.cstring])
         fn = self._get_function(fnty, name="PyDict_GetItemString")
         cstr = self.context.insert_const_string(self.module, name)
         return self.builder.call(fn, [dic, cstr])
@@ -419,30 +418,30 @@ class PythonAPI(object):
 
         Returns a borrowed reference
         """
-        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyDict_GetItem")
         return self.builder.call(fn, [dic, name])
 
     def dict_new(self, presize=0):
         if presize == 0:
-            fnty = Type.function(self.pyobj, ())
+            fnty = ir.FunctionType(self.pyobj, ())
             fn = self._get_function(fnty, name="PyDict_New")
             return self.builder.call(fn, ())
         else:
-            fnty = Type.function(self.pyobj, [self.py_ssize_t])
+            fnty = ir.FunctionType(self.pyobj, [self.py_ssize_t])
             fn = self._get_function(fnty, name="_PyDict_NewPresized")
             return self.builder.call(fn,
-                                     [Constant.int(self.py_ssize_t, presize)])
+                                     [Constant(self.py_ssize_t, int(presize))])
 
     def dict_setitem(self, dictobj, nameobj, valobj):
-        fnty = Type.function(Type.int(), (self.pyobj, self.pyobj,
-                                          self.pyobj))
+        fnty = ir.FunctionType(ir.IntType(32), (self.pyobj, self.pyobj,
+                                                self.pyobj))
         fn = self._get_function(fnty, name="PyDict_SetItem")
         return self.builder.call(fn, (dictobj, nameobj, valobj))
 
     def dict_setitem_string(self, dictobj, name, valobj):
-        fnty = Type.function(Type.int(), (self.pyobj, self.cstring,
-                                          self.pyobj))
+        fnty = ir.FunctionType(ir.IntType(32), (self.pyobj, self.cstring,
+                                                self.pyobj))
         fn = self._get_function(fnty, name="PyDict_SetItemString")
         cstr = self.context.insert_const_string(self.module, name)
         return self.builder.call(fn, (dictobj, cstr, valobj))
@@ -464,29 +463,29 @@ class PythonAPI(object):
     #
 
     def float_from_double(self, fval):
-        fnty = Type.function(self.pyobj, [self.double])
+        fnty = ir.FunctionType(self.pyobj, [self.double])
         fn = self._get_function(fnty, name="PyFloat_FromDouble")
         return self.builder.call(fn, [fval])
 
     def number_as_ssize_t(self, numobj):
-        fnty = Type.function(self.py_ssize_t, [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(self.py_ssize_t, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_AsSsize_t")
         # We don't want any clipping, so pass OverflowError as the 2nd arg
         exc_class = self.get_c_object("PyExc_OverflowError")
         return self.builder.call(fn, [numobj, exc_class])
 
     def number_long(self, numobj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_Long")
         return self.builder.call(fn, [numobj])
 
     def long_as_ulonglong(self, numobj):
-        fnty = Type.function(self.ulonglong, [self.pyobj])
+        fnty = ir.FunctionType(self.ulonglong, [self.pyobj])
         fn = self._get_function(fnty, name="PyLong_AsUnsignedLongLong")
         return self.builder.call(fn, [numobj])
 
     def long_as_longlong(self, numobj):
-        fnty = Type.function(self.ulonglong, [self.pyobj])
+        fnty = ir.FunctionType(self.ulonglong, [self.pyobj])
         fn = self._get_function(fnty, name="PyLong_AsLongLong")
         return self.builder.call(fn, [numobj])
 
@@ -495,13 +494,13 @@ class PythonAPI(object):
         Convert the given Python integer to a void*.  This is recommended
         over number_as_ssize_t as it isn't affected by signedness.
         """
-        fnty = Type.function(self.voidptr, [self.pyobj])
+        fnty = ir.FunctionType(self.voidptr, [self.pyobj])
         fn = self._get_function(fnty, name="PyLong_AsVoidPtr")
         return self.builder.call(fn, [numobj])
 
     def _long_from_native_int(self, ival, func_name, native_int_type,
                               signed):
-        fnty = Type.function(self.pyobj, [native_int_type])
+        fnty = ir.FunctionType(self.pyobj, [native_int_type])
         fn = self._get_function(fnty, name=func_name)
         resptr = cgutils.alloca_once(self.builder, self.pyobj)
         fn = self._get_function(fnty, name=func_name)
@@ -511,7 +510,7 @@ class PythonAPI(object):
 
     def long_from_long(self, ival):
         func_name = "PyLong_FromLong"
-        fnty = Type.function(self.pyobj, [self.long])
+        fnty = ir.FunctionType(self.pyobj, [self.long])
         fn = self._get_function(fnty, name=func_name)
         return self.builder.call(fn, [ival])
 
@@ -556,7 +555,7 @@ class PythonAPI(object):
             raise OverflowError("integer too big (%d bits)" % (bits))
 
     def _get_number_operator(self, name):
-        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_%s" % name)
         return fn
 
@@ -603,33 +602,33 @@ class PythonAPI(object):
         return self._call_number_operator("Xor", lhs, rhs, inplace=inplace)
 
     def number_power(self, lhs, rhs, inplace=False):
-        fnty = Type.function(self.pyobj, [self.pyobj] * 3)
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj] * 3)
         fname = "PyNumber_InPlacePower" if inplace else "PyNumber_Power"
         fn = self._get_function(fnty, fname)
         return self.builder.call(fn, [lhs, rhs, self.borrow_none()])
 
     def number_negative(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_Negative")
         return self.builder.call(fn, (obj,))
 
     def number_positive(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_Positive")
         return self.builder.call(fn, (obj,))
 
     def number_float(self, val):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_Float")
         return self.builder.call(fn, [val])
 
     def number_invert(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyNumber_Invert")
         return self.builder.call(fn, (obj,))
 
     def float_as_double(self, fobj):
-        fnty = Type.function(self.double, [self.pyobj])
+        fnty = ir.FunctionType(self.double, [self.pyobj])
         fn = self._get_function(fnty, name="PyFloat_AsDouble")
         return self.builder.call(fn, [fobj])
 
@@ -641,22 +640,22 @@ class PythonAPI(object):
         return self.bool_from_long(longval)
 
     def bool_from_long(self, ival):
-        fnty = Type.function(self.pyobj, [self.long])
+        fnty = ir.FunctionType(self.pyobj, [self.long])
         fn = self._get_function(fnty, name="PyBool_FromLong")
         return self.builder.call(fn, [ival])
 
     def complex_from_doubles(self, realval, imagval):
-        fnty = Type.function(self.pyobj, [Type.double(), Type.double()])
+        fnty = ir.FunctionType(self.pyobj, [ir.DoubleType(), ir.DoubleType()])
         fn = self._get_function(fnty, name="PyComplex_FromDoubles")
         return self.builder.call(fn, [realval, imagval])
 
     def complex_real_as_double(self, cobj):
-        fnty = Type.function(Type.double(), [self.pyobj])
+        fnty = ir.FunctionType(ir.DoubleType(), [self.pyobj])
         fn = self._get_function(fnty, name="PyComplex_RealAsDouble")
         return self.builder.call(fn, [cobj])
 
     def complex_imag_as_double(self, cobj):
-        fnty = Type.function(Type.double(), [self.pyobj])
+        fnty = ir.FunctionType(ir.DoubleType(), [self.pyobj])
         fn = self._get_function(fnty, name="PyComplex_ImagAsDouble")
         return self.builder.call(fn, [cobj])
 
@@ -674,8 +673,8 @@ class PythonAPI(object):
         pstart = cgutils.alloca_once(self.builder, self.py_ssize_t)
         pstop = cgutils.alloca_once(self.builder, self.py_ssize_t)
         pstep = cgutils.alloca_once(self.builder, self.py_ssize_t)
-        fnty = Type.function(Type.int(),
-                             [self.pyobj] + [self.py_ssize_t.as_pointer()] * 3)
+        fnty = ir.FunctionType(ir.IntType(32),
+                               [self.pyobj] + [self.py_ssize_t.as_pointer()] * 3)
         fn = self._get_function(fnty, name="numba_unpack_slice")
         res = self.builder.call(fn, (obj, pstart, pstop, pstep))
         start = self.builder.load(pstart)
@@ -688,28 +687,28 @@ class PythonAPI(object):
     #
 
     def sequence_getslice(self, obj, start, stop):
-        fnty = Type.function(self.pyobj, [self.pyobj, self.py_ssize_t,
-                                          self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.py_ssize_t,
+                                            self.py_ssize_t])
         fn = self._get_function(fnty, name="PySequence_GetSlice")
         return self.builder.call(fn, (obj, start, stop))
 
     def sequence_tuple(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PySequence_Tuple")
         return self.builder.call(fn, [obj])
 
     def list_new(self, szval):
-        fnty = Type.function(self.pyobj, [self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.py_ssize_t])
         fn = self._get_function(fnty, name="PyList_New")
         return self.builder.call(fn, [szval])
 
     def list_size(self, lst):
-        fnty = Type.function(self.py_ssize_t, [self.pyobj])
+        fnty = ir.FunctionType(self.py_ssize_t, [self.pyobj])
         fn = self._get_function(fnty, name="PyList_Size")
         return self.builder.call(fn, [lst])
 
     def list_append(self, lst, val):
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyList_Append")
         return self.builder.call(fn, [lst, val])
 
@@ -717,8 +716,8 @@ class PythonAPI(object):
         """
         Warning: Steals reference to ``val``
         """
-        fnty = Type.function(Type.int(), [self.pyobj, self.py_ssize_t,
-                                          self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.py_ssize_t,
+                                                self.pyobj])
         fn = self._get_function(fnty, name="PyList_SetItem")
         return self.builder.call(fn, [lst, idx, val])
 
@@ -726,7 +725,7 @@ class PythonAPI(object):
         """
         Returns a borrowed reference.
         """
-        fnty = Type.function(self.pyobj, [self.pyobj, self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.py_ssize_t])
         fn = self._get_function(fnty, name="PyList_GetItem")
         if isinstance(idx, int):
             idx = self.context.get_constant(types.intp, idx)
@@ -735,8 +734,8 @@ class PythonAPI(object):
     def list_setslice(self, lst, start, stop, obj):
         if obj is None:
             obj = self.get_null_object()
-        fnty = Type.function(Type.int(), [self.pyobj, self.py_ssize_t,
-                                          self.py_ssize_t, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.py_ssize_t,
+                                                self.py_ssize_t, self.pyobj])
         fn = self._get_function(fnty, name="PyList_SetSlice")
         return self.builder.call(fn, (lst, start, stop, obj))
 
@@ -749,13 +748,13 @@ class PythonAPI(object):
         """
         Borrow reference
         """
-        fnty = Type.function(self.pyobj, [self.pyobj, self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.py_ssize_t])
         fn = self._get_function(fnty, name="PyTuple_GetItem")
         idx = self.context.get_constant(types.intp, idx)
         return self.builder.call(fn, [tup, idx])
 
     def tuple_pack(self, items):
-        fnty = Type.function(self.pyobj, [self.py_ssize_t], var_arg=True)
+        fnty = ir.FunctionType(self.pyobj, [self.py_ssize_t], var_arg=True)
         fn = self._get_function(fnty, name="PyTuple_Pack")
         n = self.context.get_constant(types.intp, len(items))
         args = [n]
@@ -763,12 +762,12 @@ class PythonAPI(object):
         return self.builder.call(fn, args)
 
     def tuple_size(self, tup):
-        fnty = Type.function(self.py_ssize_t, [self.pyobj])
+        fnty = ir.FunctionType(self.py_ssize_t, [self.pyobj])
         fn = self._get_function(fnty, name="PyTuple_Size")
         return self.builder.call(fn, [tup])
 
     def tuple_new(self, count):
-        fnty = Type.function(self.pyobj, [Type.int()])
+        fnty = ir.FunctionType(self.pyobj, [ir.IntType(32)])
         fn = self._get_function(fnty, name='PyTuple_New')
         return self.builder.call(fn, [self.context.get_constant(types.int32,
                                                                 count)])
@@ -777,7 +776,7 @@ class PythonAPI(object):
         """
         Steals a reference to `item`.
         """
-        fnty = Type.function(Type.int(), [self.pyobj, Type.int(), self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, ir.IntType(32), self.pyobj])
         setitem_fn = self._get_function(fnty, name='PyTuple_SetItem')
         index = self.context.get_constant(types.int32, index)
         self.builder.call(setitem_fn, [tuple_val, index, item])
@@ -789,34 +788,34 @@ class PythonAPI(object):
     def set_new(self, iterable=None):
         if iterable is None:
             iterable = self.get_null_object()
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PySet_New")
         return self.builder.call(fn, [iterable])
 
     def set_add(self, set, value):
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PySet_Add")
         return self.builder.call(fn, [set, value])
 
     def set_clear(self, set):
-        fnty = Type.function(Type.int(), [self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj])
         fn = self._get_function(fnty, name="PySet_Clear")
         return self.builder.call(fn, [set])
 
     def set_size(self, set):
-        fnty = Type.function(self.py_ssize_t, [self.pyobj])
+        fnty = ir.FunctionType(self.py_ssize_t, [self.pyobj])
         fn = self._get_function(fnty, name="PySet_Size")
         return self.builder.call(fn, [set])
 
     def set_update(self, set, iterable):
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="_PySet_Update")
         return self.builder.call(fn, [set, iterable])
 
     def set_next_entry(self, set, posptr, keyptr, hashptr):
-        fnty = Type.function(Type.int(),
-                             [self.pyobj, self.py_ssize_t.as_pointer(),
-                              self.pyobj.as_pointer(), self.py_hash_t.as_pointer()])
+        fnty = ir.FunctionType(ir.IntType(32),
+                               [self.pyobj, self.py_ssize_t.as_pointer(),
+                                self.pyobj.as_pointer(), self.py_hash_t.as_pointer()])
         fn = self._get_function(fnty, name="_PySet_NextEntry")
         return self.builder.call(fn, (set, posptr, keyptr, hashptr))
 
@@ -827,7 +826,7 @@ class PythonAPI(object):
         hashptr = cgutils.alloca_once(builder, self.py_hash_t, name="hashptr")
         keyptr = cgutils.alloca_once(builder, self.pyobj, name="keyptr")
         posptr = cgutils.alloca_once_value(builder,
-                                           ir.Constant(self.py_ssize_t, 0),
+                                           Constant(self.py_ssize_t, 0),
                                            name="posptr")
 
         bb_body = builder.append_basic_block("bb_body")
@@ -856,8 +855,8 @@ class PythonAPI(object):
         Ensure the GIL is acquired.
         The returned value must be consumed by gil_release().
         """
-        gilptrty = Type.pointer(self.gil_state)
-        fnty = Type.function(Type.void(), [gilptrty])
+        gilptrty = ir.PointerType(self.gil_state)
+        fnty = ir.FunctionType(ir.VoidType(), [gilptrty])
         fn = self._get_function(fnty, "numba_gil_ensure")
         gilptr = cgutils.alloca_once(self.builder, self.gil_state)
         self.builder.call(fn, [gilptr])
@@ -868,8 +867,8 @@ class PythonAPI(object):
         Release the acquired GIL by gil_ensure().
         Must be paired with a gil_ensure().
         """
-        gilptrty = Type.pointer(self.gil_state)
-        fnty = Type.function(Type.void(), [gilptrty])
+        gilptrty = ir.PointerType(self.gil_state)
+        fnty = ir.FunctionType(ir.VoidType(), [gilptrty])
         fn = self._get_function(fnty, "numba_gil_release")
         return self.builder.call(fn, [gil])
 
@@ -878,7 +877,7 @@ class PythonAPI(object):
         Release the GIL and return the former thread state
         (an opaque non-NULL pointer).
         """
-        fnty = Type.function(self.voidptr, [])
+        fnty = ir.FunctionType(self.voidptr, [])
         fn = self._get_function(fnty, name="PyEval_SaveThread")
         return self.builder.call(fn, [])
 
@@ -886,7 +885,7 @@ class PythonAPI(object):
         """
         Restore the given thread state by reacquiring the GIL.
         """
-        fnty = Type.function(Type.void(), [self.voidptr])
+        fnty = ir.FunctionType(ir.VoidType(), [self.voidptr])
         fn = self._get_function(fnty, name="PyEval_RestoreThread")
         self.builder.call(fn, [thread_state])
 
@@ -896,17 +895,17 @@ class PythonAPI(object):
     #
 
     def object_get_private_data(self, obj):
-        fnty = Type.function(self.voidptr, [self.pyobj])
+        fnty = ir.FunctionType(self.voidptr, [self.pyobj])
         fn = self._get_function(fnty, name="numba_get_pyobject_private_data")
         return self.builder.call(fn, (obj,))
 
     def object_set_private_data(self, obj, ptr):
-        fnty = Type.function(Type.void(), [self.pyobj, self.voidptr])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj, self.voidptr])
         fn = self._get_function(fnty, name="numba_set_pyobject_private_data")
         return self.builder.call(fn, (obj, ptr))
 
     def object_reset_private_data(self, obj):
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="numba_reset_pyobject_private_data")
         return self.builder.call(fn, (obj,))
 
@@ -916,12 +915,12 @@ class PythonAPI(object):
     #
 
     def import_module_noblock(self, modname):
-        fnty = Type.function(self.pyobj, [self.cstring])
+        fnty = ir.FunctionType(self.pyobj, [self.cstring])
         fn = self._get_function(fnty, name="PyImport_ImportModuleNoBlock")
         return self.builder.call(fn, [modname])
 
     def call_function_objargs(self, callee, objargs):
-        fnty = Type.function(self.pyobj, [self.pyobj], var_arg=True)
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj], var_arg=True)
         fn = self._get_function(fnty, name="PyObject_CallFunctionObjArgs")
         args = [callee] + list(objargs)
         args.append(self.context.get_constant_null(types.pyobject))
@@ -929,7 +928,7 @@ class PythonAPI(object):
 
     def call_method(self, callee, method, objargs=()):
         cname = self.context.insert_const_string(self.module, method)
-        fnty = Type.function(self.pyobj, [self.pyobj, self.cstring, self.cstring],
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.cstring, self.cstring],
                              var_arg=True)
         fn = self._get_function(fnty, name="PyObject_CallMethod")
         fmt = 'O' * len(objargs)
@@ -945,24 +944,24 @@ class PythonAPI(object):
             args = self.get_null_object()
         if kws is None:
             kws = self.get_null_object()
-        fnty = Type.function(self.pyobj, [self.pyobj] * 3)
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj] * 3)
         fn = self._get_function(fnty, name="PyObject_Call")
         return self.builder.call(fn, (callee, args, kws))
 
     def object_type(self, obj):
         """Emit a call to ``PyObject_Type(obj)`` to get the type of ``obj``.
         """
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_Type")
         return self.builder.call(fn, (obj,))
 
     def object_istrue(self, obj):
-        fnty = Type.function(Type.int(), [self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_IsTrue")
         return self.builder.call(fn, [obj])
 
     def object_not(self, obj):
-        fnty = Type.function(Type.int(), [self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_Not")
         return self.builder.call(fn, [obj])
 
@@ -974,31 +973,31 @@ class PythonAPI(object):
         ops = ['<', '<=', '==', '!=', '>', '>=']
         if opstr in ops:
             opid = ops.index(opstr)
-            fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj, Type.int()])
+            fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj, ir.IntType(32)])
             fn = self._get_function(fnty, name="PyObject_RichCompare")
             lopid = self.context.get_constant(types.int32, opid)
             return self.builder.call(fn, (lhs, rhs, lopid))
         elif opstr == 'is':
-            bitflag = self.builder.icmp(lc.ICMP_EQ, lhs, rhs)
+            bitflag = self.builder.icmp_unsigned('==', lhs, rhs)
             return self.bool_from_bool(bitflag)
         elif opstr == 'is not':
-            bitflag = self.builder.icmp(lc.ICMP_NE, lhs, rhs)
+            bitflag = self.builder.icmp_unsigned('!=', lhs, rhs)
             return self.bool_from_bool(bitflag)
         elif opstr in ('in', 'not in'):
-            fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
+            fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj])
             fn = self._get_function(fnty, name="PySequence_Contains")
             status = self.builder.call(fn, (rhs, lhs))
             negone = self.context.get_constant(types.int32, -1)
-            is_good = self.builder.icmp(lc.ICMP_NE, status, negone)
+            is_good = self.builder.icmp_unsigned('!=', status, negone)
             # Stack allocate output and initialize to Null
             outptr = cgutils.alloca_once_value(self.builder,
-                                               Constant.null(self.pyobj))
+                                               Constant(self.pyobj, None))
             # If PySequence_Contains returns non-error value
             with cgutils.if_likely(self.builder, is_good):
                 if opstr == 'not in':
                     status = self.builder.not_(status)
                 # Store the status as a boolean object
-                truncated = self.builder.trunc(status, Type.int(1))
+                truncated = self.builder.trunc(status, ir.IntType(1))
                 self.builder.store(self.bool_from_bool(truncated),
                                    outptr)
 
@@ -1008,34 +1007,34 @@ class PythonAPI(object):
                 op=opstr))
 
     def iter_next(self, iterobj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyIter_Next")
         return self.builder.call(fn, [iterobj])
 
     def object_getiter(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_GetIter")
         return self.builder.call(fn, [obj])
 
     def object_getattr_string(self, obj, attr):
         cstr = self.context.insert_const_string(self.module, attr)
-        fnty = Type.function(self.pyobj, [self.pyobj, self.cstring])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.cstring])
         fn = self._get_function(fnty, name="PyObject_GetAttrString")
         return self.builder.call(fn, [obj, cstr])
 
     def object_getattr(self, obj, attr):
-        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_GetAttr")
         return self.builder.call(fn, [obj, attr])
 
     def object_setattr_string(self, obj, attr, val):
         cstr = self.context.insert_const_string(self.module, attr)
-        fnty = Type.function(Type.int(), [self.pyobj, self.cstring, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.cstring, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_SetAttrString")
         return self.builder.call(fn, [obj, cstr, val])
 
     def object_setattr(self, obj, attr, val):
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_SetAttr")
         return self.builder.call(fn, [obj, attr, val])
 
@@ -1053,7 +1052,7 @@ class PythonAPI(object):
         """
         Return obj[key]
         """
-        fnty = Type.function(self.pyobj, [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_GetItem")
         return self.builder.call(fn, (obj, key))
 
@@ -1061,7 +1060,7 @@ class PythonAPI(object):
         """
         obj[key] = val
         """
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_SetItem")
         return self.builder.call(fn, (obj, key, val))
 
@@ -1069,12 +1068,12 @@ class PythonAPI(object):
         """
         del obj[key]
         """
-        fnty = Type.function(Type.int(), [self.pyobj, self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.pyobj])
         fn = self._get_function(fnty, name="PyObject_DelItem")
         return self.builder.call(fn, (obj, key))
 
     def string_as_string(self, strobj):
-        fnty = Type.function(self.cstring, [self.pyobj])
+        fnty = ir.FunctionType(self.cstring, [self.pyobj])
         fname = "PyUnicode_AsUTF8"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [strobj])
@@ -1088,14 +1087,14 @@ class PythonAPI(object):
         """
 
         p_length = cgutils.alloca_once(self.builder, self.py_ssize_t)
-        fnty = Type.function(self.cstring, [self.pyobj,
+        fnty = ir.FunctionType(self.cstring, [self.pyobj,
                                             self.py_ssize_t.as_pointer()])
         fname = "PyUnicode_AsUTF8AndSize"
         fn = self._get_function(fnty, name=fname)
 
         buffer = self.builder.call(fn, [strobj, p_length])
         ok = self.builder.icmp_unsigned('!=',
-                                        ir.Constant(buffer.type, None),
+                                        Constant(buffer.type, None),
                                         buffer)
         return (ok, buffer, self.builder.load(p_length))
 
@@ -1109,58 +1108,58 @@ class PythonAPI(object):
         The ``hash`` is a long/uint64_t (py_hash_t) of the Unicode constant hash
         """
         p_length = cgutils.alloca_once(self.builder, self.py_ssize_t)
-        p_kind = cgutils.alloca_once(self.builder, Type.int())
-        p_ascii = cgutils.alloca_once(self.builder, Type.int())
+        p_kind = cgutils.alloca_once(self.builder, ir.IntType(32))
+        p_ascii = cgutils.alloca_once(self.builder, ir.IntType(32))
         p_hash = cgutils.alloca_once(self.builder, self.py_hash_t)
-        fnty = Type.function(self.cstring, [self.pyobj,
-                                            self.py_ssize_t.as_pointer(),
-                                            Type.int().as_pointer(),
-                                            Type.int().as_pointer(),
-                                            self.py_hash_t.as_pointer()])
+        fnty = ir.FunctionType(self.cstring, [self.pyobj,
+                                              self.py_ssize_t.as_pointer(),
+                                              ir.IntType(32).as_pointer(),
+                                              ir.IntType(32).as_pointer(),
+                                              self.py_hash_t.as_pointer()])
         fname = "numba_extract_unicode"
         fn = self._get_function(fnty, name=fname)
 
         buffer = self.builder.call(
             fn, [strobj, p_length, p_kind, p_ascii, p_hash])
         ok = self.builder.icmp_unsigned('!=',
-                                        ir.Constant(buffer.type, None),
+                                        Constant(buffer.type, None),
                                         buffer)
         return (ok, buffer, self.builder.load(p_length),
                 self.builder.load(p_kind), self.builder.load(p_ascii),
                 self.builder.load(p_hash))
 
     def string_from_string_and_size(self, string, size):
-        fnty = Type.function(self.pyobj, [self.cstring, self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.cstring, self.py_ssize_t])
         fname = "PyString_FromStringAndSize"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [string, size])
 
     def string_from_string(self, string):
-        fnty = Type.function(self.pyobj, [self.cstring])
+        fnty = ir.FunctionType(self.pyobj, [self.cstring])
         fname = "PyUnicode_FromString"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [string])
 
     def string_from_kind_and_data(self, kind, string, size):
-        fnty = Type.function(self.pyobj, [Type.int(), self.cstring, self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [ir.IntType(32), self.cstring, self.py_ssize_t])
         fname = "PyUnicode_FromKindAndData"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [kind, string, size])
 
     def bytes_from_string_and_size(self, string, size):
-        fnty = Type.function(self.pyobj, [self.cstring, self.py_ssize_t])
+        fnty = ir.FunctionType(self.pyobj, [self.cstring, self.py_ssize_t])
         fname = "PyBytes_FromStringAndSize"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [string, size])
 
     def object_hash(self, obj):
-        fnty = Type.function(self.py_hash_t, [self.pyobj,])
+        fnty = ir.FunctionType(self.py_hash_t, [self.pyobj, ])
         fname = "PyObject_Hash"
         fn = self._get_function(fnty, name=fname)
         return self.builder.call(fn, [obj,])
 
     def object_str(self, obj):
-        fnty = Type.function(self.pyobj, [self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [self.pyobj])
         fn = self._get_function(fnty, name="PyObject_Str")
         return self.builder.call(fn, [obj])
 
@@ -1173,7 +1172,7 @@ class PythonAPI(object):
         return self.get_c_object("_Py_NoneStruct")
 
     def sys_write_stdout(self, fmt, *args):
-        fnty = Type.function(Type.void(), [self.cstring], var_arg=True)
+        fnty = ir.FunctionType(ir.VoidType(), [self.cstring], var_arg=True)
         fn = self._get_function(fnty, name="PySys_FormatStdout")
         return self.builder.call(fn, (fmt,) + args)
 
@@ -1181,7 +1180,7 @@ class PythonAPI(object):
         """
         Dump a Python object on C stderr.  For debugging purposes.
         """
-        fnty = Type.function(Type.void(), [self.pyobj])
+        fnty = ir.FunctionType(ir.VoidType(), [self.pyobj])
         fn = self._get_function(fnty, name="_PyObject_Dump")
         return self.builder.call(fn, (obj,))
 
@@ -1196,10 +1195,10 @@ class PythonAPI(object):
         # Embed the Python type of the array (maybe subclass) in the LLVM IR.
         serial_aryty_pytype = self.unserialize(self.serialize_object(aryty.box_type))
 
-        fnty = Type.function(self.pyobj,
-                             [self.voidptr, self.pyobj, intty, intty, self.pyobj])
+        fnty = ir.FunctionType(self.pyobj,
+                               [self.voidptr, self.pyobj, intty, intty, self.pyobj])
         fn = self._get_function(fnty, name="NRT_adapt_ndarray_to_python_acqref")
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
 
         ndim = self.context.get_constant(types.int32, aryty.ndim)
         writable = self.context.get_constant(types.int32, int(aryty.mutable))
@@ -1225,8 +1224,8 @@ class PythonAPI(object):
             fnty,
             "NRT_meminfo_new_from_pyobject",
             )
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
-        fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
+        fn.args[1].add_attribute('nocapture')
         fn.return_value.add_attribute("noalias")
         return self.builder.call(fn, [data, pyobj])
 
@@ -1260,19 +1259,19 @@ class PythonAPI(object):
 
     def nrt_adapt_ndarray_from_python(self, ary, ptr):
         assert self.context.enable_nrt
-        fnty = Type.function(Type.int(), [self.pyobj, self.voidptr])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.voidptr])
         fn = self._get_function(fnty, name="NRT_adapt_ndarray_from_python")
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
-        fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
+        fn.args[1].add_attribute('nocapture')
         return self.builder.call(fn, (ary, ptr))
 
     def nrt_adapt_buffer_from_python(self, buf, ptr):
         assert self.context.enable_nrt
-        fnty = Type.function(Type.void(), [Type.pointer(self.py_buffer_t),
-                                           self.voidptr])
+        fnty = ir.FunctionType(ir.VoidType(), [ir.PointerType(self.py_buffer_t),
+                                               self.voidptr])
         fn = self._get_function(fnty, name="NRT_adapt_buffer_from_python")
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
-        fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
+        fn.args[1].add_attribute('nocapture')
         return self.builder.call(fn, (buf, ptr))
 
     # ------ utils -----
@@ -1289,7 +1288,7 @@ class PythonAPI(object):
         """
         # Treat the buffer as an opaque array of bytes
         ptr = cgutils.alloca_once_value(self.builder,
-                                        lc.Constant.null(self.py_buffer_t))
+                                        Constant(self.py_buffer_t, None))
         return ptr
 
     @contextlib.contextmanager
@@ -1310,7 +1309,7 @@ class PythonAPI(object):
         self.sys_write_stdout(fmt)
 
     def get_null_object(self):
-        return Constant.null(self.pyobj)
+        return Constant(self.pyobj, None)
 
     def return_none(self):
         none = self.make_none()
@@ -1331,7 +1330,7 @@ class PythonAPI(object):
         Unserialize some data.  *structptr* should be a pointer to
         a {i8* data, i32 length} structure.
         """
-        fnty = Type.function(self.pyobj,
+        fnty = ir.FunctionType(self.pyobj,
                              (self.voidptr, ir.IntType(32), self.voidptr))
         fn = self._get_function(fnty, name="numba_unpickle")
         ptr = self.builder.extract_value(self.builder.load(structptr), 0)
@@ -1358,9 +1357,9 @@ class PythonAPI(object):
             self.module, f"{name}.sha1", hashed,
         )
         # Then populate the structure constant
-        struct = ir.Constant.literal_struct([
+        struct = Constant.literal_struct([
             arr.bitcast(self.voidptr),
-            ir.Constant(ir.IntType(32), arr.type.pointee.count),
+            Constant(ir.IntType(32), arr.type.pointee.count),
             hasharr.bitcast(self.voidptr),
             ])
         return struct
@@ -1436,7 +1435,7 @@ class PythonAPI(object):
         Extract the generator structure pointer from a generator *obj*
         (a _dynfunc.Generator instance).
         """
-        gen_ptr_ty = Type.pointer(self.context.get_data_type(typ))
+        gen_ptr_ty = ir.PointerType(self.context.get_data_type(typ))
         value = self.context.get_generator_state(self.builder, obj, gen_ptr_ty)
         return NativeValue(value)
 
@@ -1454,25 +1453,25 @@ class PythonAPI(object):
         gendesc = self.context.get_generator_desc(typ)
 
         # This is the PyCFunctionWithKeywords generated by PyCallWrapper
-        genfnty = Type.function(self.pyobj, [self.pyobj, self.pyobj, self.pyobj])
+        genfnty = ir.FunctionType(self.pyobj, [self.pyobj, self.pyobj, self.pyobj])
         genfn = self._get_function(genfnty, name=gendesc.llvm_cpython_wrapper_name)
 
         # This is the raw finalizer generated by _lower_generator_finalize_func()
-        finalizerty = Type.function(Type.void(), [self.voidptr])
+        finalizerty = ir.FunctionType(ir.VoidType(), [self.voidptr])
         if typ.has_finalizer:
             finalizer = self._get_function(finalizerty, name=gendesc.llvm_finalizer_name)
         else:
-            finalizer = Constant.null(Type.pointer(finalizerty))
+            finalizer = Constant(ir.PointerType(finalizerty), None)
 
         # PyObject *numba_make_generator(state_size, initial_state, nextfunc, finalizer, env)
-        fnty = Type.function(self.pyobj, [self.py_ssize_t,
-                                          self.voidptr,
-                                          Type.pointer(genfnty),
-                                          Type.pointer(finalizerty),
-                                          self.voidptr])
+        fnty = ir.FunctionType(self.pyobj, [self.py_ssize_t,
+                                            self.voidptr,
+                                            ir.PointerType(genfnty),
+                                            ir.PointerType(finalizerty),
+                                            self.voidptr])
         fn = self._get_function(fnty, name="numba_make_generator")
 
-        state_size = ir.Constant(self.py_ssize_t, gen_struct_size)
+        state_size = Constant(self.py_ssize_t, gen_struct_size)
         initial_state = self.builder.bitcast(val, self.voidptr)
         if env is None:
             env = self.get_null_object()
@@ -1483,67 +1482,67 @@ class PythonAPI(object):
 
     def numba_array_adaptor(self, ary, ptr):
         assert not self.context.enable_nrt
-        fnty = Type.function(Type.int(), [self.pyobj, self.voidptr])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, self.voidptr])
         fn = self._get_function(fnty, name="numba_adapt_ndarray")
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
-        fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
+        fn.args[1].add_attribute('nocapture')
         return self.builder.call(fn, (ary, ptr))
 
     def numba_buffer_adaptor(self, buf, ptr):
-        fnty = Type.function(Type.void(),
+        fnty = ir.FunctionType(ir.VoidType(),
                              [ir.PointerType(self.py_buffer_t), self.voidptr])
         fn = self._get_function(fnty, name="numba_adapt_buffer")
-        fn.args[0].add_attribute(lc.ATTR_NO_CAPTURE)
-        fn.args[1].add_attribute(lc.ATTR_NO_CAPTURE)
+        fn.args[0].add_attribute('nocapture')
+        fn.args[1].add_attribute('nocapture')
         return self.builder.call(fn, (buf, ptr))
 
     def complex_adaptor(self, cobj, cmplx):
-        fnty = Type.function(Type.int(), [self.pyobj, cmplx.type])
+        fnty = ir.FunctionType(ir.IntType(32), [self.pyobj, cmplx.type])
         fn = self._get_function(fnty, name="numba_complex_adaptor")
         return self.builder.call(fn, [cobj, cmplx])
 
     def extract_record_data(self, obj, pbuf):
-        fnty = Type.function(self.voidptr,
-                             [self.pyobj, ir.PointerType(self.py_buffer_t)])
+        fnty = ir.FunctionType(self.voidptr,
+                               [self.pyobj, ir.PointerType(self.py_buffer_t)])
         fn = self._get_function(fnty, name="numba_extract_record_data")
         return self.builder.call(fn, [obj, pbuf])
 
     def get_buffer(self, obj, pbuf):
-        fnty = Type.function(Type.int(),
-                             [self.pyobj, ir.PointerType(self.py_buffer_t)])
+        fnty = ir.FunctionType(ir.IntType(32),
+                               [self.pyobj, ir.PointerType(self.py_buffer_t)])
         fn = self._get_function(fnty, name="numba_get_buffer")
         return self.builder.call(fn, [obj, pbuf])
 
     def release_buffer(self, pbuf):
-        fnty = Type.function(Type.void(), [ir.PointerType(self.py_buffer_t)])
+        fnty = ir.FunctionType(ir.VoidType(), [ir.PointerType(self.py_buffer_t)])
         fn = self._get_function(fnty, name="numba_release_buffer")
         return self.builder.call(fn, [pbuf])
 
     def extract_np_datetime(self, obj):
-        fnty = Type.function(Type.int(64), [self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(64), [self.pyobj])
         fn = self._get_function(fnty, name="numba_extract_np_datetime")
         return self.builder.call(fn, [obj])
 
     def extract_np_timedelta(self, obj):
-        fnty = Type.function(Type.int(64), [self.pyobj])
+        fnty = ir.FunctionType(ir.IntType(64), [self.pyobj])
         fn = self._get_function(fnty, name="numba_extract_np_timedelta")
         return self.builder.call(fn, [obj])
 
     def create_np_datetime(self, val, unit_code):
-        unit_code = Constant.int(Type.int(), unit_code)
-        fnty = Type.function(self.pyobj, [Type.int(64), Type.int()])
+        unit_code = Constant(ir.IntType(32), int(unit_code))
+        fnty = ir.FunctionType(self.pyobj, [ir.IntType(64), ir.IntType(32)])
         fn = self._get_function(fnty, name="numba_create_np_datetime")
         return self.builder.call(fn, [val, unit_code])
 
     def create_np_timedelta(self, val, unit_code):
-        unit_code = Constant.int(Type.int(), unit_code)
-        fnty = Type.function(self.pyobj, [Type.int(64), Type.int()])
+        unit_code = Constant(ir.IntType(32), int(unit_code))
+        fnty = ir.FunctionType(self.pyobj, [ir.IntType(64), ir.IntType(32)])
         fn = self._get_function(fnty, name="numba_create_np_timedelta")
         return self.builder.call(fn, [val, unit_code])
 
     def recreate_record(self, pdata, size, dtype, env_manager):
-        fnty = Type.function(self.pyobj, [Type.pointer(Type.int(8)),
-                                          Type.int(), self.pyobj])
+        fnty = ir.FunctionType(self.pyobj, [ir.PointerType(ir.IntType(8)),
+                                            ir.IntType(32), self.pyobj])
         fn = self._get_function(fnty, name="numba_recreate_record")
         dtypeaddr = env_manager.read_const(env_manager.add_const(dtype))
         return self.builder.call(fn, [pdata, size, dtypeaddr])

--- a/numba/core/pythonapi.py
+++ b/numba/core/pythonapi.py
@@ -1088,7 +1088,7 @@ class PythonAPI(object):
 
         p_length = cgutils.alloca_once(self.builder, self.py_ssize_t)
         fnty = ir.FunctionType(self.cstring, [self.pyobj,
-                                            self.py_ssize_t.as_pointer()])
+                                              self.py_ssize_t.as_pointer()])
         fname = "PyUnicode_AsUTF8AndSize"
         fn = self._get_function(fnty, name=fname)
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -6,8 +6,6 @@ import operator
 import warnings
 
 from llvmlite import ir
-from llvmlite.llvmpy.core import Type, Constant
-import llvmlite.llvmpy.core as lc
 
 from numba.core.imputils import (lower_builtin, lower_getattr,
                                  lower_getattr_generic, lower_cast,
@@ -244,7 +242,7 @@ def round_impl_unary(context, builder, sig, args):
     fltty = sig.args[0]
     llty = context.get_value_type(fltty)
     module = builder.module
-    fnty = Type.function(llty, [llty])
+    fnty = ir.FunctionType(llty, [llty])
     fn = cgutils.get_or_insert_function(module, fnty, _round_intrinsic(fltty))
     res = builder.call(fn, args)
     # unary round() returns an int

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -6,9 +6,6 @@ Implement the cmath module functions.
 import cmath
 import math
 
-import llvmlite.llvmpy.core as lc
-from llvmlite.llvmpy.core import Type
-
 from numba.core.imputils import Registry, impl_ret_untracked
 from numba.core import types, cgutils
 from numba.core.typing import signature

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -10,7 +10,6 @@ import warnings
 from collections import namedtuple
 
 import llvmlite.binding as ll
-import llvmlite.llvmpy.core as lc
 from llvmlite import ir
 
 from numba.core.extending import (
@@ -128,7 +127,7 @@ def _Py_HashDouble(v):
 def _fpext(tyctx, val):
     def impl(cgctx, builder, signature, args):
         val = args[0]
-        return builder.fpext(val, lc.Type.double())
+        return builder.fpext(val, ir.DoubleType())
     sig = types.float64(types.float32)
     return sig, impl
 

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -173,15 +173,11 @@ def unary_math_extern(fn, f32extern, f64extern, int_restype=False):
 
 
 unary_math_intr(math.fabs, 'llvm.fabs')
-#unary_math_intr(math.sqrt, lc.INTR_SQRT)
 exp_impl = unary_math_intr(math.exp, 'llvm.exp')
 log_impl = unary_math_intr(math.log, 'llvm.log')
 log10_impl = unary_math_intr(math.log10, 'llvm.log10')
 sin_impl = unary_math_intr(math.sin, 'llvm.sin')
 cos_impl = unary_math_intr(math.cos, 'llvm.cos')
-#unary_math_intr(math.floor, 'llvm.floor')
-#unary_math_intr(math.ceil, lc.INTR_CEIL)
-#unary_math_intr(math.trunc, lc.INTR_TRUNC)
 
 log1p_impl = unary_math_extern(math.log1p, "log1pf", "log1p")
 expm1_impl = unary_math_extern(math.expm1, "expm1f", "expm1")

--- a/numba/cpython/mathimpl.py
+++ b/numba/cpython/mathimpl.py
@@ -7,8 +7,8 @@ import operator
 import sys
 import numpy as np
 
-import llvmlite.llvmpy.core as lc
-from llvmlite.llvmpy.core import Type
+import llvmlite.ir
+from llvmlite.ir import Constant
 
 from numba.core.imputils import Registry, impl_ret_untracked
 from numba import typeof
@@ -47,10 +47,10 @@ def is_inf(builder, val):
     """
     Return a condition testing whether *val* is an infinite.
     """
-    pos_inf = lc.Constant.real(val.type, float("+inf"))
-    neg_inf = lc.Constant.real(val.type, float("-inf"))
-    isposinf = builder.fcmp(lc.FCMP_OEQ, val, pos_inf)
-    isneginf = builder.fcmp(lc.FCMP_OEQ, val, neg_inf)
+    pos_inf = Constant(val.type, float("+inf"))
+    neg_inf = Constant(val.type, float("-inf"))
+    isposinf = builder.fcmp_ordered('==', val, pos_inf)
+    isneginf = builder.fcmp_ordered('==', val, neg_inf)
     return builder.or_(isposinf, isneginf)
 
 def is_finite(builder, val):
@@ -65,43 +65,43 @@ def f64_as_int64(builder, val):
     """
     Bitcast a double into a 64-bit integer.
     """
-    assert val.type == Type.double()
-    return builder.bitcast(val, Type.int(64))
+    assert val.type == llvmlite.ir.DoubleType()
+    return builder.bitcast(val, llvmlite.ir.IntType(64))
 
 def int64_as_f64(builder, val):
     """
     Bitcast a 64-bit integer into a double.
     """
-    assert val.type == Type.int(64)
-    return builder.bitcast(val, Type.double())
+    assert val.type == llvmlite.ir.IntType(64)
+    return builder.bitcast(val, llvmlite.ir.DoubleType())
 
 def f32_as_int32(builder, val):
     """
     Bitcast a float into a 32-bit integer.
     """
-    assert val.type == Type.float()
-    return builder.bitcast(val, Type.int(32))
+    assert val.type == llvmlite.ir.FloatType()
+    return builder.bitcast(val, llvmlite.ir.IntType(32))
 
 def int32_as_f32(builder, val):
     """
     Bitcast a 32-bit integer into a float.
     """
-    assert val.type == Type.int(32)
-    return builder.bitcast(val, Type.float())
+    assert val.type == llvmlite.ir.IntType(32)
+    return builder.bitcast(val, llvmlite.ir.FloatType())
 
 def negate_real(builder, val):
     """
     Negate real number *val*, with proper handling of zeros.
     """
     # The negative zero forces LLVM to handle signed zeros properly.
-    return builder.fsub(lc.Constant.real(val.type, -0.0), val)
+    return builder.fsub(Constant(val.type, -0.0), val)
 
 def call_fp_intrinsic(builder, name, args):
     """
     Call a LLVM intrinsic floating-point operation.
     """
     mod = builder.module
-    intr = lc.Function.intrinsic(mod, name, [a.type for a in args])
+    intr = mod.declare_intrinsic(name, [a.type for a in args])
     return builder.call(intr, args)
 
 
@@ -158,7 +158,7 @@ def unary_math_extern(fn, f32extern, f64extern, int_restype=False):
             types.float32: f32extern,
             types.float64: f64extern,
             }[input_type]
-        fnty = Type.function(lty, [lty])
+        fnty = llvmlite.ir.FunctionType(lty, [lty])
         fn = cgutils.insert_pure_function(builder.module, fnty, name=func_name)
         res = builder.call(fn, (val,))
         res = context.cast(builder, res, input_type, sig.return_type)
@@ -172,14 +172,14 @@ def unary_math_extern(fn, f32extern, f64extern, int_restype=False):
     return float_impl
 
 
-unary_math_intr(math.fabs, lc.INTR_FABS)
+unary_math_intr(math.fabs, 'llvm.fabs')
 #unary_math_intr(math.sqrt, lc.INTR_SQRT)
-exp_impl = unary_math_intr(math.exp, lc.INTR_EXP)
-log_impl = unary_math_intr(math.log, lc.INTR_LOG)
-log10_impl = unary_math_intr(math.log10, lc.INTR_LOG10)
-sin_impl = unary_math_intr(math.sin, lc.INTR_SIN)
-cos_impl = unary_math_intr(math.cos, lc.INTR_COS)
-#unary_math_intr(math.floor, lc.INTR_FLOOR)
+exp_impl = unary_math_intr(math.exp, 'llvm.exp')
+log_impl = unary_math_intr(math.log, 'llvm.log')
+log10_impl = unary_math_intr(math.log10, 'llvm.log10')
+sin_impl = unary_math_intr(math.sin, 'llvm.sin')
+cos_impl = unary_math_intr(math.cos, 'llvm.cos')
+#unary_math_intr(math.floor, 'llvm.floor')
 #unary_math_intr(math.ceil, lc.INTR_CEIL)
 #unary_math_intr(math.trunc, lc.INTR_TRUNC)
 
@@ -251,7 +251,7 @@ def isfinite_int_impl(context, builder, sig, args):
 def copysign_float_impl(context, builder, sig, args):
     lty = args[0].type
     mod = builder.module
-    fn = cgutils.get_or_insert_function(mod, lc.Type.function(lty, (lty, lty)),
+    fn = cgutils.get_or_insert_function(mod, llvmlite.ir.FunctionType(lty, (lty, lty)),
                                         'llvm.copysign.%s' % lty.intrinsic_name)
     res = builder.call(fn, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -266,7 +266,7 @@ def frexp_impl(context, builder, sig, args):
     fltty = context.get_data_type(sig.args[0])
     intty = context.get_data_type(sig.return_type[1])
     expptr = cgutils.alloca_once(builder, intty, name='exp')
-    fnty = Type.function(fltty, (fltty, Type.pointer(intty)))
+    fnty = llvmlite.ir.FunctionType(fltty, (fltty, llvmlite.ir.PointerType(intty)))
     fname = {
         "float": "numba_frexpf",
         "double": "numba_frexp",
@@ -281,7 +281,7 @@ def frexp_impl(context, builder, sig, args):
 def ldexp_impl(context, builder, sig, args):
     val, exp = args
     fltty, intty = map(context.get_data_type, sig.args)
-    fnty = Type.function(fltty, (fltty, intty))
+    fnty = llvmlite.ir.FunctionType(fltty, (fltty, intty))
     fname = {
         "float": "numba_ldexpf",
         "double": "numba_ldexp",
@@ -297,16 +297,16 @@ def ldexp_impl(context, builder, sig, args):
 @lower(math.atan2, types.int64, types.int64)
 def atan2_s64_impl(context, builder, sig, args):
     [y, x] = args
-    y = builder.sitofp(y, Type.double())
-    x = builder.sitofp(x, Type.double())
+    y = builder.sitofp(y, llvmlite.ir.DoubleType())
+    x = builder.sitofp(x, llvmlite.ir.DoubleType())
     fsig = signature(types.float64, types.float64, types.float64)
     return atan2_float_impl(context, builder, fsig, (y, x))
 
 @lower(math.atan2, types.uint64, types.uint64)
 def atan2_u64_impl(context, builder, sig, args):
     [y, x] = args
-    y = builder.uitofp(y, Type.double())
-    x = builder.uitofp(x, Type.double())
+    y = builder.uitofp(y, llvmlite.ir.DoubleType())
+    x = builder.uitofp(x, llvmlite.ir.DoubleType())
     fsig = signature(types.float64, types.float64, types.float64)
     return atan2_float_impl(context, builder, fsig, (y, x))
 
@@ -320,7 +320,7 @@ def atan2_float_impl(context, builder, sig, args):
         types.float32: "atan2f",
         types.float64: "atan2"
         }[ty]
-    fnty = Type.function(lty, (lty, lty))
+    fnty = llvmlite.ir.FunctionType(lty, (lty, lty))
     fn = cgutils.insert_pure_function(builder.module, fnty, name=func_name)
     res = builder.call(fn, args)
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -332,8 +332,8 @@ def atan2_float_impl(context, builder, sig, args):
 @lower(math.hypot, types.int64, types.int64)
 def hypot_s64_impl(context, builder, sig, args):
     [x, y] = args
-    y = builder.sitofp(y, Type.double())
-    x = builder.sitofp(x, Type.double())
+    y = builder.sitofp(y, llvmlite.ir.DoubleType())
+    x = builder.sitofp(x, llvmlite.ir.DoubleType())
     fsig = signature(types.float64, types.float64, types.float64)
     res = hypot_float_impl(context, builder, fsig, (x, y))
     return impl_ret_untracked(context, builder, sig.return_type, res)
@@ -342,8 +342,8 @@ def hypot_s64_impl(context, builder, sig, args):
 @lower(math.hypot, types.uint64, types.uint64)
 def hypot_u64_impl(context, builder, sig, args):
     [x, y] = args
-    y = builder.sitofp(y, Type.double())
-    x = builder.sitofp(x, Type.double())
+    y = builder.sitofp(y, llvmlite.ir.DoubleType())
+    x = builder.sitofp(x, llvmlite.ir.DoubleType())
     fsig = signature(types.float64, types.float64, types.float64)
     res = hypot_float_impl(context, builder, fsig, (x, y))
     return impl_ret_untracked(context, builder, sig.return_type, res)

--- a/numba/cpython/printimpl.py
+++ b/numba/cpython/printimpl.py
@@ -1,7 +1,6 @@
 """
 This file implements print functionality for the CPU.
 """
-from llvmlite.llvmpy.core import Type
 from numba.core import types, typing, cgutils
 from numba.core.imputils import Registry, impl_ret_untracked
 

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -2,8 +2,6 @@
 Implementation of tuple objects
 """
 
-from llvmlite import ir
-import llvmlite.llvmpy.core as lc
 import operator
 
 from numba.core.imputils import (lower_builtin, lower_getattr_generic,
@@ -169,7 +167,7 @@ def iternext_unituple(context, builder, sig, args, result):
     idx = builder.load(idxptr)
     count = context.get_constant(types.intp, tupiterty.container.count)
 
-    is_valid = builder.icmp(lc.ICMP_SLT, idx, count)
+    is_valid = builder.icmp_signed('<', idx, count)
     result.set_valid(is_valid)
 
     with builder.if_then(is_valid):

--- a/numba/cpython/unicode_support.py
+++ b/numba/cpython/unicode_support.py
@@ -6,8 +6,9 @@ same name in CPython.
 """
 from collections import namedtuple
 from enum import IntEnum
+
+import llvmlite.ir
 import numpy as np
-import llvmlite.llvmpy.core as lc
 
 from numba.core import types, cgutils
 from numba.core.imputils import (impl_ret_untracked)
@@ -95,7 +96,7 @@ def _gettyperecord_impl(typingctx, codepoint):
         ll_uchar_ptr = ll_uchar.as_pointer()
         ll_ushort = context.get_value_type(types.ushort)
         ll_ushort_ptr = ll_ushort.as_pointer()
-        fnty = lc.Type.function(ll_void, [
+        fnty = llvmlite.ir.FunctionType(ll_void, [
             ll_Py_UCS4,    # code
             ll_intc_ptr,   # upper
             ll_intc_ptr,   # lower
@@ -164,7 +165,7 @@ def _PyUnicode_ExtendedCase(typingctx, index):
     def details(context, builder, signature, args):
         ll_Py_UCS4 = context.get_value_type(_Py_UCS4)
         ll_intc = context.get_value_type(types.intc)
-        fnty = lc.Type.function(ll_Py_UCS4, [ll_intc])
+        fnty = llvmlite.ir.FunctionType(ll_Py_UCS4, [ll_intc])
         fn = cgutils.get_or_insert_function(
             builder.module,
             fnty, name="numba_get_PyUnicode_ExtendedCase")

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -9,9 +9,8 @@ from enum import IntEnum
 from functools import partial
 import operator
 
+import llvmlite.ir
 import numpy as np
-
-import llvmlite.llvmpy.core as lc
 
 from numba import generated_jit
 from numba.core import types, cgutils
@@ -3159,7 +3158,7 @@ def _np_round_intrinsic(tp):
 def _np_round_float(context, builder, tp, val):
     llty = context.get_value_type(tp)
     module = builder.module
-    fnty = lc.Type.function(llty, [llty])
+    fnty = llvmlite.ir.FunctionType(llty, [llty])
     fn = cgutils.get_or_insert_function(module, fnty, _np_round_intrinsic(tp))
     return builder.call(fn, (val,))
 

--- a/numba/np/npdatetime.py
+++ b/numba/np/npdatetime.py
@@ -9,7 +9,7 @@ import llvmlite.ir
 from llvmlite.ir import Constant
 
 from numba.core import types, cgutils
-from numba.core.base import create_constant_array
+from numba.core.cgutils import create_constant_array
 from numba.core.imputils import (lower_builtin, lower_constant,
                                  impl_ret_untracked, lower_cast)
 from numba.np import npdatetime_helpers, numpy_support, npyfuncs

--- a/numba/np/npdatetime.py
+++ b/numba/np/npdatetime.py
@@ -5,10 +5,11 @@ Implementation of operations on numpy timedelta64.
 import numpy as np
 import operator
 
-from llvmlite.llvmpy.core import Type, Constant
-import llvmlite.llvmpy.core as lc
+import llvmlite.ir
+from llvmlite.ir import Constant
 
 from numba.core import types, cgutils
+from numba.core.base import create_constant_array
 from numba.core.imputils import (lower_builtin, lower_constant,
                                  impl_ret_untracked, lower_cast)
 from numba.np import npdatetime_helpers, numpy_support, npyfuncs
@@ -17,8 +18,8 @@ from numba.core.config import IS_32BITS
 from numba.core.errors import LoweringError
 
 # datetime64 and timedelta64 use the same internal representation
-DATETIME64 = TIMEDELTA64 = Type.int(64)
-NAT = Constant.int(TIMEDELTA64, npdatetime_helpers.NAT)
+DATETIME64 = TIMEDELTA64 = llvmlite.ir.IntType(64)
+NAT = Constant(TIMEDELTA64, npdatetime_helpers.NAT)
 
 TIMEDELTA_BINOP_SIG = (types.NPTimedelta,) * 2
 
@@ -27,21 +28,21 @@ def scale_by_constant(builder, val, factor):
     """
     Multiply *val* by the constant *factor*.
     """
-    return builder.mul(val, Constant.int(TIMEDELTA64, factor))
+    return builder.mul(val, Constant(TIMEDELTA64, factor))
 
 
 def unscale_by_constant(builder, val, factor):
     """
     Divide *val* by the constant *factor*.
     """
-    return builder.sdiv(val, Constant.int(TIMEDELTA64, factor))
+    return builder.sdiv(val, Constant(TIMEDELTA64, factor))
 
 
 def add_constant(builder, val, const):
     """
     Add constant *const* to *val*.
     """
-    return builder.add(val, Constant.int(TIMEDELTA64, const))
+    return builder.add(val, Constant(TIMEDELTA64, const))
 
 
 def scale_timedelta(context, builder, val, srcty, destty):
@@ -88,7 +89,7 @@ def alloc_boolean_result(builder, name='ret'):
     """
     Allocate an uninitialized boolean result slot.
     """
-    ret = cgutils.alloca_once(builder, Type.int(1), name=name)
+    ret = cgutils.alloca_once(builder, llvmlite.ir.IntType(1), name=name)
     return ret
 
 
@@ -96,7 +97,7 @@ def is_not_nat(builder, val):
     """
     Return a predicate which is true if *val* is not NaT.
     """
-    return builder.icmp(lc.ICMP_NE, val, NAT)
+    return builder.icmp_unsigned('!=', val, NAT)
 
 
 def are_not_nat(builder, vals):
@@ -110,18 +111,17 @@ def are_not_nat(builder, vals):
     return pred
 
 
-def make_constant_array(vals):
-    consts = [Constant.int(TIMEDELTA64, v) for v in vals]
-    return Constant.array(TIMEDELTA64, consts)
-
-
-normal_year_months = make_constant_array([31, 28, 31, 30, 31, 30,
-                                          31, 31, 30, 31, 30, 31])
-leap_year_months = make_constant_array([31, 29, 31, 30, 31, 30,
-                                        31, 31, 30, 31, 30, 31])
-normal_year_months_acc = make_constant_array(
+normal_year_months = create_constant_array(
+    TIMEDELTA64,
+    [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+leap_year_months = create_constant_array(
+    TIMEDELTA64,
+    [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+normal_year_months_acc = create_constant_array(
+    TIMEDELTA64,
     [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334])
-leap_year_months_acc = make_constant_array(
+leap_year_months_acc = create_constant_array(
+    TIMEDELTA64,
     [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335])
 
 
@@ -164,18 +164,18 @@ def timedelta_sign_impl(context, builder, sig, args):
     """
     val, = args
     ret = alloc_timedelta_result(builder)
-    zero = Constant.int(TIMEDELTA64, 0)
-    with builder.if_else(builder.icmp(lc.ICMP_SGT, val, zero)
+    zero = Constant(TIMEDELTA64, 0)
+    with builder.if_else(builder.icmp_signed('>', val, zero)
                          ) as (gt_zero, le_zero):
         with gt_zero:
-            builder.store(Constant.int(TIMEDELTA64, 1), ret)
+            builder.store(Constant(TIMEDELTA64, 1), ret)
         with le_zero:
-            with builder.if_else(builder.icmp(lc.ICMP_EQ, val, zero)
+            with builder.if_else(builder.icmp_unsigned('==', val, zero)
                                  ) as (eq_zero, lt_zero):
                 with eq_zero:
-                    builder.store(Constant.int(TIMEDELTA64, 0), ret)
+                    builder.store(Constant(TIMEDELTA64, 0), ret)
                 with lt_zero:
-                    builder.store(Constant.int(TIMEDELTA64, -1), ret)
+                    builder.store(Constant(TIMEDELTA64, -1), ret)
     res = builder.load(ret)
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
@@ -286,7 +286,7 @@ def timedelta_over_timedelta(context, builder, sig, args):
     not_nan = are_not_nat(builder, [va, vb])
     ll_ret_type = context.get_value_type(sig.return_type)
     ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
-    builder.store(Constant.real(ll_ret_type, float('nan')), ret)
+    builder.store(Constant(ll_ret_type, float('nan')), ret)
     with cgutils.if_likely(builder, not_nan):
         va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
         va = builder.sitofp(va, ll_ret_type)
@@ -308,8 +308,8 @@ if numpy_support.numpy_version >= (1, 16):
         ll_ret_type = context.get_value_type(sig.return_type)
         not_nan = are_not_nat(builder, [va, vb])
         ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
-        zero = Constant.int(ll_ret_type, 0)
-        one = Constant.int(ll_ret_type, 1)
+        zero = Constant(ll_ret_type, 0)
+        one = Constant(ll_ret_type, 1)
         builder.store(zero, ret)
         with cgutils.if_likely(builder, not_nan):
             va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
@@ -349,7 +349,7 @@ if numpy_support.numpy_version >= (1, 16):
         ll_ret_type = context.get_value_type(sig.return_type)
         ret = alloc_timedelta_result(builder)
         builder.store(NAT, ret)
-        zero = Constant.int(ll_ret_type, 0)
+        zero = Constant(ll_ret_type, 0)
         with cgutils.if_likely(builder, not_nan):
             va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
             # is the denominator zero or NaT?
@@ -387,15 +387,15 @@ def _create_timedelta_comparison_impl(ll_op, default_value):
                     # Cannot normalize units => the values are unequal (except if NaT)
                     builder.store(default_value, ret)
                 else:
-                    builder.store(builder.icmp(ll_op, norm_a, norm_b), ret)
+                    builder.store(builder.icmp_unsigned(ll_op, norm_a, norm_b), ret)
             with otherwise:
                 if numpy_support.numpy_version < (1, 16):
                     # No scaling when comparing NaTs
-                    builder.store(builder.icmp(ll_op, va, vb), ret)
+                    builder.store(builder.icmp_unsigned(ll_op, va, vb), ret)
                 else:
                     # NumPy >= 1.16 switched to NaT ==/>=/>/</<= NaT being
                     # False and NaT != <anything, including NaT> being True
-                    if ll_op == lc.ICMP_NE:
+                    if ll_op == '!=':
                         builder.store(cgutils.true_bit, ret)
                     else:
                         builder.store(cgutils.false_bit, ret)
@@ -414,13 +414,13 @@ def _create_timedelta_ordering_impl(ll_op):
             with then:
                 norm_a, norm_b = normalize_timedeltas(
                     context, builder, va, vb, ta, tb)
-                builder.store(builder.icmp(ll_op, norm_a, norm_b), ret)
+                builder.store(builder.icmp_signed(ll_op, norm_a, norm_b), ret)
             with otherwise:
                 if numpy_support.numpy_version < (1, 16):
                     # No scaling when comparing NaT with something else
                     # (i.e. NaT is <= everything else, since it's the smallest
                     #  int64 value)
-                    builder.store(builder.icmp(ll_op, va, vb), ret)
+                    builder.store(builder.icmp_signed(ll_op, va, vb), ret)
                 else:
                     # NumPy >= 1.16 switched to NaT >=/>/</<= NaT being False
                     builder.store(cgutils.false_bit, ret)
@@ -431,13 +431,13 @@ def _create_timedelta_ordering_impl(ll_op):
 
 
 timedelta_eq_timedelta_impl = _create_timedelta_comparison_impl(
-    lc.ICMP_EQ, cgutils.false_bit)
+    '==', cgutils.false_bit)
 timedelta_ne_timedelta_impl = _create_timedelta_comparison_impl(
-    lc.ICMP_NE, cgutils.true_bit)
-timedelta_lt_timedelta_impl = _create_timedelta_ordering_impl(lc.ICMP_SLT)
-timedelta_le_timedelta_impl = _create_timedelta_ordering_impl(lc.ICMP_SLE)
-timedelta_gt_timedelta_impl = _create_timedelta_ordering_impl(lc.ICMP_SGT)
-timedelta_ge_timedelta_impl = _create_timedelta_ordering_impl(lc.ICMP_SGE)
+    '!=', cgutils.true_bit)
+timedelta_lt_timedelta_impl = _create_timedelta_ordering_impl('<')
+timedelta_le_timedelta_impl = _create_timedelta_ordering_impl('<=')
+timedelta_gt_timedelta_impl = _create_timedelta_ordering_impl('>')
+timedelta_ge_timedelta_impl = _create_timedelta_ordering_impl('>=')
 
 for op_, func in [(operator.eq, timedelta_eq_timedelta_impl),
                   (operator.ne, timedelta_ne_timedelta_impl),
@@ -455,13 +455,13 @@ def is_leap_year(builder, year_val):
     Return a predicate indicating whether *year_val* (offset by 1970) is a
     leap year.
     """
-    actual_year = builder.add(year_val, Constant.int(DATETIME64, 1970))
+    actual_year = builder.add(year_val, Constant(DATETIME64, 1970))
     multiple_of_4 = cgutils.is_null(
-        builder, builder.and_(actual_year, Constant.int(DATETIME64, 3)))
+        builder, builder.and_(actual_year, Constant(DATETIME64, 3)))
     not_multiple_of_100 = cgutils.is_not_null(
-        builder, builder.srem(actual_year, Constant.int(DATETIME64, 100)))
+        builder, builder.srem(actual_year, Constant(DATETIME64, 100)))
     multiple_of_400 = cgutils.is_null(
-        builder, builder.srem(actual_year, Constant.int(DATETIME64, 400)))
+        builder, builder.srem(actual_year, Constant(DATETIME64, 400)))
     return builder.and_(multiple_of_4,
                         builder.or_(not_multiple_of_100, multiple_of_400))
 
@@ -676,14 +676,14 @@ def _create_datetime_comparison_impl(ll_op):
                     builder, va, unit_a, ret_unit)
                 norm_b = convert_datetime_for_arith(
                     builder, vb, unit_b, ret_unit)
-                ret_val = builder.icmp(ll_op, norm_a, norm_b)
+                ret_val = builder.icmp_signed(ll_op, norm_a, norm_b)
                 builder.store(ret_val, ret)
             with otherwise:
                 if numpy_support.numpy_version < (1, 16):
                     # No scaling when comparing NaTs
-                    ret_val = builder.icmp(ll_op, va, vb)
+                    ret_val = builder.icmp_signed(ll_op, va, vb)
                 else:
-                    if ll_op == lc.ICMP_NE:
+                    if ll_op == '!=':
                         ret_val = cgutils.true_bit
                     else:
                         ret_val = cgutils.false_bit
@@ -694,12 +694,12 @@ def _create_datetime_comparison_impl(ll_op):
     return impl
 
 
-datetime_eq_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_EQ)
-datetime_ne_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_NE)
-datetime_lt_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_SLT)
-datetime_le_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_SLE)
-datetime_gt_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_SGT)
-datetime_ge_datetime_impl = _create_datetime_comparison_impl(lc.ICMP_SGE)
+datetime_eq_datetime_impl = _create_datetime_comparison_impl('==')
+datetime_ne_datetime_impl = _create_datetime_comparison_impl('!=')
+datetime_lt_datetime_impl = _create_datetime_comparison_impl('<')
+datetime_le_datetime_impl = _create_datetime_comparison_impl('<=')
+datetime_gt_datetime_impl = _create_datetime_comparison_impl('>')
+datetime_ge_datetime_impl = _create_datetime_comparison_impl('>=')
 
 for op, func in [(operator.eq, datetime_eq_datetime_impl),
                  (operator.ne, datetime_ne_datetime_impl),
@@ -720,7 +720,7 @@ def _gen_datetime_max_impl(NAT_DOMINATES):
         in1, in2 = args
         in1_not_nat = is_not_nat(builder, in1)
         in2_not_nat = is_not_nat(builder, in2)
-        in1_ge_in2 = builder.icmp(lc.ICMP_SGE, in1, in2)
+        in1_ge_in2 = builder.icmp_signed('>=', in1, in2)
         res = builder.select(in1_ge_in2, in1, in2)
         if NAT_DOMINATES and numpy_support.numpy_version >= (1, 18):
             # NaT now dominates, like NaN
@@ -741,7 +741,7 @@ def _gen_datetime_min_impl(NAT_DOMINATES):
         in1, in2 = args
         in1_not_nat = is_not_nat(builder, in1)
         in2_not_nat = is_not_nat(builder, in2)
-        in1_le_in2 = builder.icmp(lc.ICMP_SLE, in1, in2)
+        in1_le_in2 = builder.icmp_signed('<=', in1, in2)
         res = builder.select(in1_le_in2, in1, in2)
         if NAT_DOMINATES and numpy_support.numpy_version >= (1, 18):
             # NaT now dominates, like NaN
@@ -762,7 +762,7 @@ def _gen_timedelta_max_impl(NAT_DOMINATES):
         in1, in2 = args
         in1_not_nat = is_not_nat(builder, in1)
         in2_not_nat = is_not_nat(builder, in2)
-        in1_ge_in2 = builder.icmp(lc.ICMP_SGE, in1, in2)
+        in1_ge_in2 = builder.icmp_signed('>=', in1, in2)
         res = builder.select(in1_ge_in2, in1, in2)
         if NAT_DOMINATES and numpy_support.numpy_version >= (1, 18):
             # NaT now dominates, like NaN
@@ -783,7 +783,7 @@ def _gen_timedelta_min_impl(NAT_DOMINATES):
         in1, in2 = args
         in1_not_nat = is_not_nat(builder, in1)
         in2_not_nat = is_not_nat(builder, in2)
-        in1_le_in2 = builder.icmp(lc.ICMP_SLE, in1, in2)
+        in1_le_in2 = builder.icmp_signed('<=', in1, in2)
         res = builder.select(in1_le_in2, in1, in2)
         if NAT_DOMINATES and numpy_support.numpy_version >= (1, 18):
             # NaT now dominates, like NaN

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -6,9 +6,9 @@ Python builtins
 
 
 import math
-import numpy as np
 
-from llvmlite.llvmpy import core as lc
+import llvmlite.ir
+import numpy as np
 
 from numba.core.imputils import impl_ret_untracked
 from numba.core import typing, types, errors, lowering, cgutils
@@ -51,7 +51,7 @@ def _call_func_by_name_with_cast(context, builder, sig, args,
     # helper function facilitates that.
     mod = builder.module
     lty = context.get_argument_type(ty)
-    fnty = lc.Type.function(lty, [lty]*len(sig.args))
+    fnty = llvmlite.ir.FunctionType(lty, [lty]*len(sig.args))
     fn = cgutils.insert_pure_function(mod, fnty, name=func_name)
     cast_args = [context.cast(builder, arg, argty, ty)
                  for arg, argty in zip(args, sig.args) ]
@@ -95,7 +95,7 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
         call_argtys = [ty] + list(sig.args)
         call_argltys = [context.get_value_type(ty).as_pointer()
                         for ty in call_argtys]
-        fnty = lc.Type.function(lc.Type.void(), call_argltys)
+        fnty = llvmlite.ir.FunctionType(llvmlite.ir.VoidType(), call_argltys)
         # Note: the function isn't pure here (it writes to its pointer args)
         fn = cgutils.get_or_insert_function(mod, fnty, func_name)
         builder.call(fn, call_args)
@@ -103,7 +103,7 @@ def _dispatch_func_by_name_type(context, builder, sig, args, table, user_name):
     else:
         argtypes = [context.get_argument_type(aty) for aty in sig.args]
         restype = context.get_argument_type(sig.return_type)
-        fnty = lc.Type.function(restype, argtypes)
+        fnty = llvmlite.ir.FunctionType(restype, argtypes)
         fn = cgutils.insert_pure_function(mod, fnty, name=func_name)
         retval = context.call_external_function(builder, fn, sig.args, args)
     return retval
@@ -132,9 +132,9 @@ def np_int_sdiv_impl(context, builder, sig, args):
     ZERO = context.get_constant(ty, 0)
     MINUS_ONE = context.get_constant(ty, -1)
     MIN_INT = context.get_constant(ty, 1 << (den.type.width-1))
-    den_is_zero = builder.icmp(lc.ICMP_EQ, ZERO, den)
-    den_is_minus_one = builder.icmp(lc.ICMP_EQ, MINUS_ONE, den)
-    num_is_min_int = builder.icmp(lc.ICMP_EQ, MIN_INT, num)
+    den_is_zero = builder.icmp_unsigned('==', ZERO, den)
+    den_is_minus_one = builder.icmp_unsigned('==', MINUS_ONE, den)
+    num_is_min_int = builder.icmp_unsigned('==', MIN_INT, num)
     could_cause_sigfpe = builder.and_(den_is_minus_one, num_is_min_int)
     force_zero = builder.or_(den_is_zero, could_cause_sigfpe)
     with builder.if_else(force_zero, likely=False) as (then, otherwise):
@@ -144,10 +144,10 @@ def np_int_sdiv_impl(context, builder, sig, args):
             bb_otherwise = builder.basic_block
             div = builder.sdiv(num, den)
             mod = builder.srem(num, den)
-            num_gt_zero = builder.icmp(lc.ICMP_SGT, num, ZERO)
-            den_gt_zero = builder.icmp(lc.ICMP_SGT, den, ZERO)
+            num_gt_zero = builder.icmp_signed('>', num, ZERO)
+            den_gt_zero = builder.icmp_signed('>', den, ZERO)
             not_same_sign = builder.xor(num_gt_zero, den_gt_zero)
-            mod_not_zero = builder.icmp(lc.ICMP_NE, mod, ZERO)
+            mod_not_zero = builder.icmp_unsigned('!=', mod, ZERO)
             needs_fixing = builder.and_(not_same_sign, mod_not_zero)
             fix_value = builder.select(needs_fixing, MINUS_ONE, ZERO)
             result_otherwise = builder.add(div, fix_value)
@@ -167,15 +167,15 @@ def np_int_srem_impl(context, builder, sig, args):
     ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
-    den_not_zero = builder.icmp(lc.ICMP_NE, ZERO, den)
+    den_not_zero = builder.icmp_unsigned('!=', ZERO, den)
     bb_no_if = builder.basic_block
     with cgutils.if_unlikely(builder, den_not_zero):
         bb_if = builder.basic_block
         mod = builder.srem(num,den)
-        num_gt_zero = builder.icmp(lc.ICMP_SGT, num, ZERO)
-        den_gt_zero = builder.icmp(lc.ICMP_SGT, den, ZERO)
+        num_gt_zero = builder.icmp_signed('>', num, ZERO)
+        den_gt_zero = builder.icmp_signed('>', den, ZERO)
         not_same_sign = builder.xor(num_gt_zero, den_gt_zero)
-        mod_not_zero = builder.icmp(lc.ICMP_NE, mod, ZERO)
+        mod_not_zero = builder.icmp_unsigned('!=', mod, ZERO)
         needs_fixing = builder.and_(not_same_sign, mod_not_zero)
         fix_value = builder.select(needs_fixing, den, ZERO)
         final_mod = builder.add(fix_value, mod)
@@ -200,7 +200,7 @@ def np_int_udiv_impl(context, builder, sig, args):
     ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
-    div_by_zero = builder.icmp(lc.ICMP_EQ, ZERO, den)
+    div_by_zero = builder.icmp_unsigned('==', ZERO, den)
     with builder.if_else(div_by_zero, likely=False) as (then, otherwise):
         with then:
             # division by zero
@@ -224,7 +224,7 @@ def np_int_urem_impl(context, builder, sig, args):
     ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
-    den_not_zero = builder.icmp(lc.ICMP_NE, ZERO, den)
+    den_not_zero = builder.icmp_unsigned('!=', ZERO, den)
     bb_no_if = builder.basic_block
     with cgutils.if_unlikely(builder, den_not_zero):
         bb_if = builder.basic_block
@@ -264,9 +264,9 @@ def np_real_mod_impl(context, builder, sig, args):
 
     ZERO = context.get_constant(ty, 0.0)
     res = builder.frem(in1, in2)
-    res_ne_zero = builder.fcmp(lc.FCMP_ONE, res, ZERO)
-    den_lt_zero = builder.fcmp(lc.FCMP_OLT, in2, ZERO)
-    res_lt_zero = builder.fcmp(lc.FCMP_OLT, res, ZERO)
+    res_ne_zero = builder.fcmp_ordered('!=', res, ZERO)
+    den_lt_zero = builder.fcmp_ordered('<', in2, ZERO)
+    res_lt_zero = builder.fcmp_ordered('<', res, ZERO)
     needs_fixing = builder.and_(res_ne_zero,
                                 builder.xor(den_lt_zero, res_lt_zero))
     fix_value = builder.select(needs_fixing, in2, ZERO)
@@ -280,9 +280,9 @@ def np_real_fmod_impl(context, builder, sig, args):
 
 
 def _fabs(context, builder, arg):
-    ZERO = lc.Constant.real(arg.type, 0.0)
+    ZERO = llvmlite.ir.Constant(arg.type, 0.0)
     arg_negated = builder.fsub(ZERO, arg)
-    arg_is_negative = builder.fcmp(lc.FCMP_OLT, arg, ZERO)
+    arg_is_negative = builder.fcmp_ordered('<', arg, ZERO)
     return builder.select(arg_is_negative, arg_negated, arg)
 
 
@@ -305,18 +305,18 @@ def np_complex_div_impl(context, builder, sig, args):
     assert all([i.type==ftype for i in [in1r, in1i, in2r, in2i]]), "mismatched types"
     out = context.make_helper(builder, sig.return_type)
 
-    ZERO = lc.Constant.real(ftype, 0.0)
-    ONE = lc.Constant.real(ftype, 1.0)
+    ZERO = llvmlite.ir.Constant(ftype, 0.0)
+    ONE = llvmlite.ir.Constant(ftype, 1.0)
 
     # if abs(denominator.real) >= abs(denominator.imag)
     in2r_abs = _fabs(context, builder, in2r)
     in2i_abs = _fabs(context, builder, in2i)
-    in2r_abs_ge_in2i_abs = builder.fcmp(lc.FCMP_OGE, in2r_abs, in2i_abs)
+    in2r_abs_ge_in2i_abs = builder.fcmp_ordered('>=', in2r_abs, in2i_abs)
     with builder.if_else(in2r_abs_ge_in2i_abs) as (then, otherwise):
         with then:
             # if abs(denominator.real) == 0 and abs(denominator.imag) == 0
-            in2r_is_zero = builder.fcmp(lc.FCMP_OEQ, in2r_abs, ZERO)
-            in2i_is_zero = builder.fcmp(lc.FCMP_OEQ, in2i_abs, ZERO)
+            in2r_is_zero = builder.fcmp_ordered('==', in2r_abs, ZERO)
+            in2i_is_zero = builder.fcmp_ordered('==', in2i_abs, ZERO)
             in2_is_zero = builder.and_(in2r_is_zero, in2i_is_zero)
             with builder.if_else(in2_is_zero) as (inn_then, inn_otherwise):
                 with inn_then:
@@ -442,14 +442,14 @@ def np_complex_floor_div_impl(context, builder, sig, args):
     ftype = in1r.type
     assert all([i.type==ftype for i in [in1r, in1i, in2r, in2i]]), "mismatched types"
 
-    ZERO = lc.Constant.real(ftype, 0.0)
+    ZERO = llvmlite.ir.Constant(ftype, 0.0)
 
     out = context.make_helper(builder, sig.return_type)
     out.imag = ZERO
 
     in2r_abs = _fabs(context, builder, in2r)
     in2i_abs = _fabs(context, builder, in2i)
-    in2r_abs_ge_in2i_abs = builder.fcmp(lc.FCMP_OGE, in2r_abs, in2i_abs)
+    in2r_abs_ge_in2i_abs = builder.fcmp_ordered('>=', in2r_abs, in2i_abs)
 
     with builder.if_else(in2r_abs_ge_in2i_abs) as (then, otherwise):
         with then:
@@ -832,7 +832,7 @@ def np_complex_reciprocal_impl(context, builder, sig, args):
     in1i = in1.imag
     in1r_abs = _fabs(context, builder, in1r)
     in1i_abs = _fabs(context, builder, in1i)
-    in1i_abs_le_in1r_abs = builder.fcmp(lc.FCMP_OLE, in1i_abs, in1r_abs)
+    in1i_abs_le_in1r_abs = builder.fcmp_ordered('<=', in1i_abs, in1r_abs)
 
     with builder.if_else(in1i_abs_le_in1r_abs) as (then, otherwise):
         with then:
@@ -1143,10 +1143,10 @@ def np_complex_ge_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_gt_yr = builder.fcmp(lc.FCMP_OGT, xr, yr)
-    no_nan_xi_yi = builder.fcmp(lc.FCMP_ORD, xi, yi)
-    xr_eq_yr = builder.fcmp(lc.FCMP_OEQ, xr, yr)
-    xi_ge_yi = builder.fcmp(lc.FCMP_OGE, xi, yi)
+    xr_gt_yr = builder.fcmp_ordered('>', xr, yr)
+    no_nan_xi_yi = builder.fcmp_ordered('ord', xi, yi)
+    xr_eq_yr = builder.fcmp_ordered('==', xr, yr)
+    xi_ge_yi = builder.fcmp_ordered('>=', xi, yi)
     first_term = builder.and_(xr_gt_yr, no_nan_xi_yi)
     second_term = builder.and_(xr_eq_yr, xi_ge_yi)
     return builder.or_(first_term, second_term)
@@ -1164,10 +1164,10 @@ def np_complex_le_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_lt_yr = builder.fcmp(lc.FCMP_OLT, xr, yr)
-    no_nan_xi_yi = builder.fcmp(lc.FCMP_ORD, xi, yi)
-    xr_eq_yr = builder.fcmp(lc.FCMP_OEQ, xr, yr)
-    xi_le_yi = builder.fcmp(lc.FCMP_OLE, xi, yi)
+    xr_lt_yr = builder.fcmp_ordered('<', xr, yr)
+    no_nan_xi_yi = builder.fcmp_ordered('ord', xi, yi)
+    xr_eq_yr = builder.fcmp_ordered('==', xr, yr)
+    xi_le_yi = builder.fcmp_ordered('<=', xi, yi)
     first_term = builder.and_(xr_lt_yr, no_nan_xi_yi)
     second_term = builder.and_(xr_eq_yr, xi_le_yi)
     return builder.or_(first_term, second_term)
@@ -1185,10 +1185,10 @@ def np_complex_gt_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_gt_yr = builder.fcmp(lc.FCMP_OGT, xr, yr)
-    no_nan_xi_yi = builder.fcmp(lc.FCMP_ORD, xi, yi)
-    xr_eq_yr = builder.fcmp(lc.FCMP_OEQ, xr, yr)
-    xi_gt_yi = builder.fcmp(lc.FCMP_OGT, xi, yi)
+    xr_gt_yr = builder.fcmp_ordered('>', xr, yr)
+    no_nan_xi_yi = builder.fcmp_ordered('ord', xi, yi)
+    xr_eq_yr = builder.fcmp_ordered('==', xr, yr)
+    xi_gt_yi = builder.fcmp_ordered('>', xi, yi)
     first_term = builder.and_(xr_gt_yr, no_nan_xi_yi)
     second_term = builder.and_(xr_eq_yr, xi_gt_yi)
     return builder.or_(first_term, second_term)
@@ -1206,10 +1206,10 @@ def np_complex_lt_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_lt_yr = builder.fcmp(lc.FCMP_OLT, xr, yr)
-    no_nan_xi_yi = builder.fcmp(lc.FCMP_ORD, xi, yi)
-    xr_eq_yr = builder.fcmp(lc.FCMP_OEQ, xr, yr)
-    xi_lt_yi = builder.fcmp(lc.FCMP_OLT, xi, yi)
+    xr_lt_yr = builder.fcmp_ordered('<', xr, yr)
+    no_nan_xi_yi = builder.fcmp_ordered('ord', xi, yi)
+    xr_eq_yr = builder.fcmp_ordered('==', xr, yr)
+    xi_lt_yi = builder.fcmp_ordered('<', xi, yi)
     first_term = builder.and_(xr_lt_yr, no_nan_xi_yi)
     second_term = builder.and_(xr_eq_yr, xi_lt_yi)
     return builder.or_(first_term, second_term)
@@ -1227,8 +1227,8 @@ def np_complex_eq_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_eq_yr = builder.fcmp(lc.FCMP_OEQ, xr, yr)
-    xi_eq_yi = builder.fcmp(lc.FCMP_OEQ, xi, yi)
+    xr_eq_yr = builder.fcmp_ordered('==', xr, yr)
+    xi_eq_yi = builder.fcmp_ordered('==', xi, yi)
     return builder.and_(xr_eq_yr, xi_eq_yi)
 
 
@@ -1244,8 +1244,8 @@ def np_complex_ne_impl(context, builder, sig, args):
     yr = in2.real
     yi = in2.imag
 
-    xr_ne_yr = builder.fcmp(lc.FCMP_UNE, xr, yr)
-    xi_ne_yi = builder.fcmp(lc.FCMP_UNE, xi, yi)
+    xr_ne_yr = builder.fcmp_unordered('!=', xr, yr)
+    xi_ne_yi = builder.fcmp_unordered('!=', xi, yi)
     return builder.or_(xr_ne_yr, xi_ne_yi)
 
 
@@ -1327,14 +1327,14 @@ def np_complex_logical_not_impl(context, builder, sig, args):
 def np_int_smax_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
     arg1, arg2 = args
-    arg1_sge_arg2 = builder.icmp(lc.ICMP_SGE, arg1, arg2)
+    arg1_sge_arg2 = builder.icmp_signed('>=', arg1, arg2)
     return builder.select(arg1_sge_arg2, arg1, arg2)
 
 
 def np_int_umax_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
     arg1, arg2 = args
-    arg1_uge_arg2 = builder.icmp(lc.ICMP_UGE, arg1, arg2)
+    arg1_uge_arg2 = builder.icmp_unsigned('>=', arg1, arg2)
     return builder.select(arg1_uge_arg2, arg1, arg2)
 
 
@@ -1343,11 +1343,11 @@ def np_real_maximum_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     arg1, arg2 = args
-    arg1_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg1)
-    any_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg2)
+    arg1_nan = builder.fcmp_unordered('uno', arg1, arg1)
+    any_nan = builder.fcmp_unordered('uno', arg1, arg2)
     nan_result = builder.select(arg1_nan, arg1, arg2)
 
-    arg1_ge_arg2 = builder.fcmp(lc.FCMP_OGE, arg1, arg2)
+    arg1_ge_arg2 = builder.fcmp_ordered('>=', arg1, arg2)
     non_nan_result = builder.select(arg1_ge_arg2, arg1, arg2)
 
     return builder.select(any_nan, nan_result, non_nan_result)
@@ -1358,11 +1358,11 @@ def np_real_fmax_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     arg1, arg2 = args
-    arg2_nan = builder.fcmp(lc.FCMP_UNO, arg2, arg2)
-    any_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg2)
+    arg2_nan = builder.fcmp_unordered('uno', arg2, arg2)
+    any_nan = builder.fcmp_unordered('uno', arg1, arg2)
     nan_result = builder.select(arg2_nan, arg1, arg2)
 
-    arg1_ge_arg2 = builder.fcmp(lc.FCMP_OGE, arg1, arg2)
+    arg1_ge_arg2 = builder.fcmp_ordered('>=', arg1, arg2)
     non_nan_result = builder.select(arg1_ge_arg2, arg1, arg2)
 
     return builder.select(any_nan, nan_result, non_nan_result)
@@ -1414,14 +1414,14 @@ def np_complex_fmax_impl(context, builder, sig, args):
 def np_int_smin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
     arg1, arg2 = args
-    arg1_sle_arg2 = builder.icmp(lc.ICMP_SLE, arg1, arg2)
+    arg1_sle_arg2 = builder.icmp_signed('<=', arg1, arg2)
     return builder.select(arg1_sle_arg2, arg1, arg2)
 
 
 def np_int_umin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
     arg1, arg2 = args
-    arg1_ule_arg2 = builder.icmp(lc.ICMP_ULE, arg1, arg2)
+    arg1_ule_arg2 = builder.icmp_unsigned('<=', arg1, arg2)
     return builder.select(arg1_ule_arg2, arg1, arg2)
 
 
@@ -1430,11 +1430,11 @@ def np_real_minimum_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     arg1, arg2 = args
-    arg1_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg1)
-    any_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg2)
+    arg1_nan = builder.fcmp_unordered('uno', arg1, arg1)
+    any_nan = builder.fcmp_unordered('uno', arg1, arg2)
     nan_result = builder.select(arg1_nan, arg1, arg2)
 
-    arg1_le_arg2 = builder.fcmp(lc.FCMP_OLE, arg1, arg2)
+    arg1_le_arg2 = builder.fcmp_ordered('<=', arg1, arg2)
     non_nan_result = builder.select(arg1_le_arg2, arg1, arg2)
 
     return builder.select(any_nan, nan_result, non_nan_result)
@@ -1445,11 +1445,11 @@ def np_real_fmin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 2)
 
     arg1, arg2 = args
-    arg1_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg1)
-    any_nan = builder.fcmp(lc.FCMP_UNO, arg1, arg2)
+    arg1_nan = builder.fcmp_unordered('uno', arg1, arg1)
+    any_nan = builder.fcmp_unordered('uno', arg1, arg2)
     nan_result = builder.select(arg1_nan, arg2, arg1)
 
-    arg1_le_arg2 = builder.fcmp(lc.FCMP_OLE, arg1, arg2)
+    arg1_le_arg2 = builder.fcmp_ordered('<=', arg1, arg2)
     non_nan_result = builder.select(arg1_le_arg2, arg1, arg2)
 
     return builder.select(any_nan, nan_result, non_nan_result)

--- a/numba/np/npyimpl.py
+++ b/numba/np/npyimpl.py
@@ -8,7 +8,7 @@ import sys
 import itertools
 from collections import namedtuple
 
-from llvmlite.llvmpy import core as lc
+import llvmlite.ir as ir
 
 import numpy as np
 import operator
@@ -71,9 +71,9 @@ class _ScalarHelper(object):
         self.val = val
         self.base_type = ty
         intpty = ctxt.get_value_type(types.intp)
-        self.shape = [lc.Constant.int(intpty, 1)]
+        self.shape = [ir.Constant(intpty, 1)]
 
-        lty = ctxt.get_data_type(ty) if ty != types.boolean else lc.Type.int(1)
+        lty = ctxt.get_data_type(ty) if ty != types.boolean else ir.IntType(1)
         self._ptr = cgutils.alloca_once(bld, lty)
 
     def create_iter_indices(self):
@@ -95,14 +95,14 @@ class _ArrayIndexingHelper(namedtuple('_ArrayIndexingHelper',
     def update_indices(self, loop_indices, name):
         bld = self.array.builder
         intpty = self.array.context.get_value_type(types.intp)
-        ONE = lc.Constant.int(lc.Type.int(intpty.width), 1)
+        ONE = ir.Constant(ir.IntType(intpty.width), 1)
 
         # we are only interested in as many inner dimensions as dimensions
         # the indexed array has (the outer dimensions are broadcast, so
         # ignoring the outer indices produces the desired result.
         indices = loop_indices[len(loop_indices) - len(self.indices):]
         for src, dst, dim in zip(indices, self.indices, self.array.shape):
-            cond = bld.icmp(lc.ICMP_UGT, dim, ONE)
+            cond = bld.icmp_unsigned('>', dim, ONE)
             with bld.if_then(cond):
                 bld.store(src, dst)
 
@@ -127,11 +127,11 @@ class _ArrayHelper(namedtuple('_ArrayHelper', ('context', 'builder',
     """
     def create_iter_indices(self):
         intpty = self.context.get_value_type(types.intp)
-        ZERO = lc.Constant.int(lc.Type.int(intpty.width), 0)
+        ZERO = ir.Constant(ir.IntType(intpty.width), 0)
 
         indices = []
         for i in range(self.ndim):
-            x = cgutils.alloca_once(self.builder, lc.Type.int(intpty.width))
+            x = cgutils.alloca_once(self.builder, ir.IntType(intpty.width))
             self.builder.store(ZERO, x)
             indices.append(x)
         return _ArrayIndexingHelper(self, indices)
@@ -269,7 +269,7 @@ def _build_array(context, builder, array_ty, input_types, inputs):
             builder, _broadcast_onto, _broadcast_onto_sig,
             [arg_ndim, src_shape, dest_ndim, dest_shape])
         with cgutils.if_unlikely(builder,
-                                 builder.icmp(lc.ICMP_SLT, arg_result, ONE)):
+                                 builder.icmp_signed('<', arg_result, ONE)):
             msg = "unable to broadcast argument %d to output array" % (
                 arg_number,)
 
@@ -361,7 +361,7 @@ def numpy_ufunc_kernel(context, builder, sig, args, ufunc, kernel_class):
             else:
                 output = _prepare_argument(
                     context, builder,
-                    lc.Constant.null(context.get_value_type(ret_ty)), ret_ty)
+                    ir.Constant(context.get_value_type(ret_ty), None), ret_ty)
             arguments.append(output)
         elif context.enable_nrt:
             # Incref the output

--- a/numba/np/ufunc/wrappers.py
+++ b/numba/np/ufunc/wrappers.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import numpy as np
 
-from llvmlite.llvmpy.core import Type, Builder, ICMP_EQ, Constant
+from llvmlite.ir import Constant, IRBuilder
 from llvmlite import ir
 
 from numba.core import types, cgutils
@@ -144,14 +144,14 @@ def build_ufunc_wrapper(library, context, fname, signature, objmode, cres):
     (library, env, name)
     """
     assert isinstance(fname, str)
-    byte_t = Type.int(8)
-    byte_ptr_t = Type.pointer(byte_t)
-    byte_ptr_ptr_t = Type.pointer(byte_ptr_t)
+    byte_t = ir.IntType(8)
+    byte_ptr_t = ir.PointerType(byte_t)
+    byte_ptr_ptr_t = ir.PointerType(byte_ptr_t)
     intp_t = context.get_value_type(types.intp)
-    intp_ptr_t = Type.pointer(intp_t)
+    intp_ptr_t = ir.PointerType(intp_t)
 
-    fnty = Type.function(Type.void(), [byte_ptr_ptr_t, intp_ptr_t,
-                                       intp_ptr_t, byte_ptr_t])
+    fnty = ir.FunctionType(ir.VoidType(), [byte_ptr_ptr_t, intp_ptr_t,
+                                           intp_ptr_t, byte_ptr_t])
 
     wrapperlib = context.codegen().create_library('ufunc_wrapper')
     wrapper_module = wrapperlib.create_ir_module('')
@@ -172,7 +172,7 @@ def build_ufunc_wrapper(library, context, fname, signature, objmode, cres):
     arg_steps.name = "steps"
     arg_data.name = "data"
 
-    builder = Builder(wrapper.append_basic_block("entry"))
+    builder = IRBuilder(wrapper.append_basic_block("entry"))
 
     # Prepare Environment
     envname = context.get_env_name(cres.fndesc)
@@ -260,7 +260,8 @@ class UArrayArg(object):
         self.abisize = self.context.get_constant(types.intp, sizeof)
         offseted_step = self.builder.gep(steps, [offset])
         self.step = self.builder.load(offseted_step)
-        self.is_unit_strided = builder.icmp(ICMP_EQ, self.abisize, self.step)
+        self.is_unit_strided = builder.icmp_unsigned('==',
+                                                     self.abisize, self.step)
         self.builder = builder
 
     def load_direct(self, byteoffset):
@@ -331,14 +332,14 @@ class _GufuncWrapper(object):
         return self.cres.environment
 
     def _wrapper_function_type(self):
-        byte_t = Type.int(8)
-        byte_ptr_t = Type.pointer(byte_t)
-        byte_ptr_ptr_t = Type.pointer(byte_ptr_t)
+        byte_t = ir.IntType(8)
+        byte_ptr_t = ir.PointerType(byte_t)
+        byte_ptr_ptr_t = ir.PointerType(byte_ptr_t)
         intp_t = self.context.get_value_type(types.intp)
-        intp_ptr_t = Type.pointer(intp_t)
+        intp_ptr_t = ir.PointerType(intp_t)
 
-        fnty = Type.function(Type.void(), [byte_ptr_ptr_t, intp_ptr_t,
-                                           intp_ptr_t, byte_ptr_t])
+        fnty = ir.FunctionType(ir.VoidType(), [byte_ptr_ptr_t, intp_ptr_t,
+                                               intp_ptr_t, byte_ptr_t])
         return fnty
 
     def _build_wrapper(self, library, name):
@@ -368,7 +369,7 @@ class _GufuncWrapper(object):
         arg_steps.name = "steps"
         arg_data.name = "data"
 
-        builder = Builder(wrapper.append_basic_block("entry"))
+        builder = IRBuilder(wrapper.append_basic_block("entry"))
         loopcount = builder.load(arg_dims, name="loopcount")
         pyapi = self.context.get_python_api(builder)
 
@@ -519,18 +520,18 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
 
     ll_int = context.get_value_type(types.int32)
     ll_intp = context.get_value_type(types.intp)
-    ll_intp_ptr = Type.pointer(ll_intp)
+    ll_intp_ptr = ir.PointerType(ll_intp)
     ll_voidptr = context.get_value_type(types.voidptr)
     ll_pyobj = context.get_value_type(types.pyobject)
-    fnty = Type.function(ll_pyobj, [ll_int, ll_intp_ptr,
-                                    ll_intp_ptr, ll_voidptr,
-                                    ll_int, ll_int])
+    fnty = ir.FunctionType(ll_pyobj, [ll_int, ll_intp_ptr,
+                                      ll_intp_ptr, ll_voidptr,
+                                      ll_int, ll_int])
 
     fn_array_new = cgutils.get_or_insert_function(mod, fnty,
                                                   "numba_ndarray_new")
 
     # Convert each llarray into pyobject
-    error_pointer = cgutils.alloca_once(builder, Type.int(1), name='error')
+    error_pointer = cgutils.alloca_once(builder, ir.IntType(1), name='error')
     builder.store(cgutils.true_bit, error_pointer)
 
     # The PyObject* arguments to the kernel function
@@ -548,10 +549,10 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
             arycls = context.make_array(argty)
             array = arycls(context, builder, value=arg)
 
-            zero = Constant.int(ll_int, 0)
+            zero = Constant(ll_int, 0)
 
             # Extract members of the llarray
-            nd = Constant.int(ll_int, argty.ndim)
+            nd = Constant(ll_int, argty.ndim)
             dims = builder.gep(array._get_ptr_by_name('shape'), [zero, zero])
             strides = builder.gep(array._get_ptr_by_name('strides'),
                                   [zero, zero])
@@ -559,8 +560,8 @@ def _prepare_call_to_object_mode(context, builder, pyapi, func,
             dtype = np.dtype(str(argty.dtype))
 
             # Prepare other info for reconstruction of the PyArray
-            type_num = Constant.int(ll_int, dtype.num)
-            itemsize = Constant.int(ll_int, dtype.itemsize)
+            type_num = Constant(ll_int, dtype.num)
+            itemsize = Constant(ll_int, dtype.itemsize)
 
             # Call helper to reconstruct PyArray objects
             obj = builder.call(fn_array_new, [nd, dims, strides, data,

--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -27,7 +27,6 @@ from numba.core.analysis import compute_cfg_from_blocks
 from numba.core.typing import npydecl, signature
 import copy
 from numba.core.extending import intrinsic, register_jitable
-import llvmlite.llvmpy.core as lc
 import llvmlite
 from numba.np.unsafe.ndarray import to_fixed_tuple
 
@@ -189,7 +188,7 @@ def assert_equiv(typingctx, *val):
             bshapes = unpack_shapes(b, bty)
             assert len(ashapes) == len(bshapes)
             for (m, n) in zip(ashapes, bshapes):
-                m_eq_n = builder.icmp(lc.ICMP_EQ, m, n)
+                m_eq_n = builder.icmp_unsigned('==', m, n)
                 with builder.if_else(m_eq_n) as (then, orelse):
                     with then:
                         pass

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -1653,7 +1653,8 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
                                                        "do_scheduling_unsigned")
 
     get_num_threads = cgutils.get_or_insert_function(
-        builder.module, llvmlite.ir.FunctionType(llvmlite.ir.IntType(types.intp.bitwidth), []),
+        builder.module,
+        llvmlite.ir.FunctionType(llvmlite.ir.IntType(types.intp.bitwidth), []),
         "get_num_threads")
 
     num_threads = builder.call(get_num_threads, [])
@@ -1743,8 +1744,9 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
             builder.store(builder.bitcast(ary.data, byte_ptr_t), dst)
         elif isinstance(aty, types.ArrayCompatible):
             if var in races:
-                typ = context.get_data_type(
-                    aty.dtype) if aty.dtype != types.boolean else llvmlite.ir.IntType(1)
+                typ = (context.get_data_type(aty.dtype)
+                       if aty.dtype != types.boolean
+                       else llvmlite.ir.IntType(1))
 
                 rv_arg = cgutils.alloca_once(builder, typ)
                 builder.store(arg, rv_arg)
@@ -1761,14 +1763,16 @@ def call_parallel_gufunc(lowerer, cres, gu_signature, outer_sig, expr_args, expr
         else:
             if i < num_inps:
                 # Scalar input, need to store the value in an array of size 1
-                typ = context.get_data_type(
-                    aty) if not isinstance(aty, types.Boolean) else llvmlite.ir.IntType(1)
+                typ = (context.get_data_type(aty)
+                       if not isinstance(aty, types.Boolean)
+                       else llvmlite.ir.IntType(1))
                 ptr = cgutils.alloca_once(builder, typ)
                 builder.store(arg, ptr)
             else:
                 # Scalar output, must allocate
-                typ = context.get_data_type(
-                    aty) if not isinstance(aty, types.Boolean) else llvmlite.ir.IntType(1)
+                typ = (context.get_data_type(aty)
+                       if not isinstance(aty, types.Boolean)
+                       else llvmlite.ir.IntType(1))
                 ptr = cgutils.alloca_once(builder, typ)
             builder.store(builder.bitcast(ptr, byte_ptr_t), dst)
 

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -8,7 +8,7 @@ from llvmlite import ir
 from llvmlite.binding import Linkage
 
 from numba.pycc import llvm_types as lt
-from numba.core.base import create_constant_array
+from numba.core.cgutils import create_constant_array
 from numba.core.compiler import compile_extra, Flags
 from numba.core.compiler_lock import global_compiler_lock
 
@@ -339,10 +339,12 @@ class ModuleCompiler(_ModuleCompiler):
     #:   PyObject* m_copy;
     #: } PyModuleDef_Base;
     module_def_base_ty = ir.LiteralStructType(
-        (lt._pyobject_head,
-         m_init_ty,
-         lt._llvm_py_ssize_t,
-         lt._pyobject_head_p))
+        (
+            lt._pyobject_head,
+            m_init_ty,
+            lt._llvm_py_ssize_t,
+            lt._pyobject_head_p
+        ))
 
     #: This struct holds all information that is needed to create a module object.
     #: typedef struct PyModuleDef{
@@ -357,15 +359,17 @@ class ModuleCompiler(_ModuleCompiler):
     #:   freefunc m_free;
     #: }PyModuleDef;
     module_def_ty = ir.LiteralStructType(
-        (module_def_base_ty,
-         _char_star,
-         _char_star,
-         lt._llvm_py_ssize_t,
-         _ModuleCompiler.method_def_ptr,
-         inquiry_ty,
-         traverseproc_ty,
-         inquiry_ty,
-         freefunc_ty))
+        (
+            module_def_base_ty,
+            _char_star,
+            _char_star,
+            lt._llvm_py_ssize_t,
+            _ModuleCompiler.method_def_ptr,
+            inquiry_ty,
+            traverseproc_ty,
+            inquiry_ty,
+            freefunc_ty
+        ))
 
     @property
     def module_create_definition(self):

--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -6,9 +6,9 @@ import sys
 
 from llvmlite import ir
 from llvmlite.binding import Linkage
-import llvmlite.llvmpy.core as lc
 
 from numba.pycc import llvm_types as lt
+from numba.core.base import create_constant_array
 from numba.core.compiler import compile_extra, Flags
 from numba.core.compiler_lock import global_compiler_lock
 
@@ -21,10 +21,10 @@ logger = logging.getLogger(__name__)
 
 __all__ = ['Compiler']
 
-NULL = lc.Constant.null(lt._void_star)
-ZERO = lc.Constant.int(lt._int32, 0)
-ONE = lc.Constant.int(lt._int32, 1)
-METH_VARARGS_AND_KEYWORDS = lc.Constant.int(lt._int32, 1|2)
+NULL = ir.Constant(lt._void_star, None)
+ZERO = ir.Constant(lt._int32, 0)
+ONE = ir.Constant(lt._int32, 1)
+METH_VARARGS_AND_KEYWORDS = ir.Constant(lt._int32, 1|2)
 
 
 def get_header():
@@ -93,15 +93,15 @@ class _ModuleCompiler(object):
     #:                                    describe the args expected by the C func */
     #:     const char  *ml_doc;        /* The __doc__ attribute, or NULL */
     #: };
-    method_def_ty = lc.Type.struct((lt._int8_star,
-                                    lt._void_star,
-                                    lt._int32,
-                                    lt._int8_star))
+    method_def_ty = ir.LiteralStructType((lt._int8_star,
+                                          lt._void_star,
+                                          lt._int32,
+                                          lt._int8_star))
 
-    method_def_ptr = lc.Type.pointer(method_def_ty)
+    method_def_ptr = ir.PointerType(method_def_ty)
     # The structure type constructed by PythonAPI.serialize_uncached()
-    env_def_ty = lc.Type.struct((lt._void_star, lt._int32, lt._void_star))
-    env_def_ptr = lc.Type.pointer(env_def_ty)
+    env_def_ty = ir.LiteralStructType((lt._void_star, lt._int32, lt._void_star))
+    env_def_ptr = ir.PointerType(env_def_ty)
 
     def __init__(self, export_entries, module_name, use_nrt=False,
                  **aot_options):
@@ -160,11 +160,11 @@ class _ModuleCompiler(object):
             llvm_func = cres.library.get_function(func_name)
 
             if self.export_python_wrap:
-                llvm_func.linkage = lc.LINKAGE_INTERNAL
+                llvm_func.linkage = 'internal'
                 wrappername = cres.fndesc.llvm_cpython_wrapper_name
                 wrapper = cres.library.get_function(wrappername)
                 wrapper.name = self._mangle_method_symbol(entry.symbol)
-                wrapper.linkage = lc.LINKAGE_EXTERNAL
+                wrapper.linkage = 'external'
                 fnty = cres.target_context.call_conv.get_function_type(
                     cres.fndesc.restype, cres.fndesc.argtypes)
                 self.exported_function_types[entry] = fnty
@@ -235,21 +235,22 @@ class _ModuleCompiler(object):
             lfunc = ir.Function(llvm_module, fnty, llvm_func_name)
 
             method_name = self.context.insert_const_string(llvm_module, name)
-            method_def_const = lc.Constant.struct((method_name,
-                                                   lc.Constant.bitcast(lfunc, lt._void_star),
-                                                   METH_VARARGS_AND_KEYWORDS,
-                                                   NULL))
+            method_def_const = ir.Constant.literal_struct(
+                (method_name,
+                 ir.Constant.bitcast(lfunc, lt._void_star),
+                 METH_VARARGS_AND_KEYWORDS,
+                 NULL))
             method_defs.append(method_def_const)
 
-        sentinel = lc.Constant.struct([NULL, NULL, ZERO, NULL])
+        sentinel = ir.Constant.literal_struct([NULL, NULL, ZERO, NULL])
         method_defs.append(sentinel)
-        method_array_init = lc.Constant.array(self.method_def_ty, method_defs)
+        method_array_init = create_constant_array(self.method_def_ty, method_defs)
         method_array = cgutils.add_global_variable(llvm_module,
                                                    method_array_init.type,
                                                    '.module_methods')
         method_array.initializer = method_array_init
-        method_array.linkage = lc.LINKAGE_INTERNAL
-        method_array_ptr = lc.Constant.gep(method_array, [ZERO, ZERO])
+        method_array.linkage = 'internal'
+        method_array_ptr = ir.Constant.gep(method_array, [ZERO, ZERO])
         return method_array_ptr
 
     def _emit_environment_array(self, llvm_module, builder, pyapi):
@@ -264,7 +265,7 @@ class _ModuleCompiler(object):
             # Constants may be unhashable so avoid trying to cache them
             env_def = pyapi.serialize_uncached(env.consts)
             env_defs.append(env_def)
-        env_defs_init = lc.Constant.array(self.env_def_ty, env_defs)
+        env_defs_init = create_constant_array(self.env_def_ty, env_defs)
         gv = self.context.insert_unique_const(llvm_module,
                                               '.module_environments',
                                               env_defs_init)
@@ -282,7 +283,7 @@ class _ModuleCompiler(object):
             envgv = gv.bitcast(lt._void_star)
             env_setters.append(envgv)
 
-        env_setters_init = lc.Constant.array(lt._void_star, env_setters)
+        env_setters_init = create_constant_array(lt._void_star, env_setters)
         gv = self.context.insert_unique_const(llvm_module,
                                               '.module_envgvs',
                                               env_setters_init)
@@ -306,7 +307,7 @@ class _ModuleCompiler(object):
 
 class ModuleCompiler(_ModuleCompiler):
 
-    _ptr_fun = lambda ret, *args: lc.Type.pointer(lc.Type.function(ret, args))
+    _ptr_fun = lambda ret, *args: ir.PointerType(ir.FunctionType(ret, args))
 
     #: typedef int (*visitproc)(PyObject *, void *);
     visitproc_ty = _ptr_fun(lt._int8,
@@ -337,10 +338,11 @@ class ModuleCompiler(_ModuleCompiler):
     #:   Py_ssize_t m_index;
     #:   PyObject* m_copy;
     #: } PyModuleDef_Base;
-    module_def_base_ty = lc.Type.struct((lt._pyobject_head,
-                                         m_init_ty,
-                                         lt._llvm_py_ssize_t,
-                                         lt._pyobject_head_p))
+    module_def_base_ty = ir.LiteralStructType(
+        (lt._pyobject_head,
+         m_init_ty,
+         lt._llvm_py_ssize_t,
+         lt._pyobject_head_p))
 
     #: This struct holds all information that is needed to create a module object.
     #: typedef struct PyModuleDef{
@@ -354,15 +356,16 @@ class ModuleCompiler(_ModuleCompiler):
     #:   inquiry m_clear;
     #:   freefunc m_free;
     #: }PyModuleDef;
-    module_def_ty = lc.Type.struct((module_def_base_ty,
-                                    _char_star,
-                                    _char_star,
-                                    lt._llvm_py_ssize_t,
-                                    _ModuleCompiler.method_def_ptr,
-                                    inquiry_ty,
-                                    traverseproc_ty,
-                                    inquiry_ty,
-                                    freefunc_ty))
+    module_def_ty = ir.LiteralStructType(
+        (module_def_base_ty,
+         _char_star,
+         _char_star,
+         lt._llvm_py_ssize_t,
+         _ModuleCompiler.method_def_ptr,
+         inquiry_ty,
+         traverseproc_ty,
+         inquiry_ty,
+         freefunc_ty))
 
     @property
     def module_create_definition(self):
@@ -370,9 +373,9 @@ class ModuleCompiler(_ModuleCompiler):
         Return the signature and name of the Python C API function to
         initialize the module.
         """
-        signature = lc.Type.function(lt._pyobject_head_p,
-                                     (lc.Type.pointer(self.module_def_ty),
-                                      lt._int32))
+        signature = ir.FunctionType(lt._pyobject_head_p,
+                                    (ir.PointerType(self.module_def_ty),
+                                     lt._int32))
 
         name = "PyModule_Create2"
         if lt._trace_refs_:
@@ -385,7 +388,7 @@ class ModuleCompiler(_ModuleCompiler):
         """
         Return the name and signature of the module's initialization function.
         """
-        signature = lc.Type.function(lt._pyobject_head_p, ())
+        signature = ir.FunctionType(lt._pyobject_head_p, ())
 
         return signature, "PyInit_" + self.module_name
 
@@ -393,37 +396,37 @@ class ModuleCompiler(_ModuleCompiler):
         # Figure out the Python C API module creation function, and
         # get a LLVM function for it.
         create_module_fn = ir.Function(llvm_module, *self.module_create_definition)
-        create_module_fn.linkage = lc.LINKAGE_EXTERNAL
+        create_module_fn.linkage = 'external'
 
         # Define a constant string for the module name.
         mod_name_const = self.context.insert_const_string(llvm_module,
                                                           self.module_name)
 
-        mod_def_base_init = lc.Constant.struct(
+        mod_def_base_init = ir.Constant.literal_struct(
             (lt._pyobject_head_init,                        # PyObject_HEAD
-             lc.Constant.null(self.m_init_ty),              # m_init
-             lc.Constant.null(lt._llvm_py_ssize_t),         # m_index
-             lc.Constant.null(lt._pyobject_head_p),         # m_copy
+             ir.Constant(self.m_init_ty, None),             # m_init
+             ir.Constant(lt._llvm_py_ssize_t, None),        # m_index
+             ir.Constant(lt._pyobject_head_p, None),        # m_copy
             )
         )
         mod_def_base = cgutils.add_global_variable(llvm_module,
                                                    mod_def_base_init.type,
                                                    '.module_def_base')
         mod_def_base.initializer = mod_def_base_init
-        mod_def_base.linkage = lc.LINKAGE_INTERNAL
+        mod_def_base.linkage = 'internal'
 
         method_array = self._emit_method_array(llvm_module)
 
-        mod_def_init = lc.Constant.struct(
+        mod_def_init = ir.Constant.literal_struct(
             (mod_def_base_init,                              # m_base
              mod_name_const,                                 # m_name
-             lc.Constant.null(self._char_star),              # m_doc
-             lc.Constant.int(lt._llvm_py_ssize_t, -1),       # m_size
+             ir.Constant(self._char_star, None),             # m_doc
+             ir.Constant(lt._llvm_py_ssize_t, -1),           # m_size
              method_array,                                   # m_methods
-             lc.Constant.null(self.inquiry_ty),              # m_reload
-             lc.Constant.null(self.traverseproc_ty),         # m_traverse
-             lc.Constant.null(self.inquiry_ty),              # m_clear
-             lc.Constant.null(self.freefunc_ty)              # m_free
+             ir.Constant(self.inquiry_ty, None),             # m_reload
+             ir.Constant(self.traverseproc_ty, None),        # m_traverse
+             ir.Constant(self.inquiry_ty, None),             # m_clear
+             ir.Constant(self.freefunc_ty, None)             # m_free
             )
         )
 
@@ -431,17 +434,17 @@ class ModuleCompiler(_ModuleCompiler):
         mod_def = cgutils.add_global_variable(llvm_module, mod_def_init.type,
                                               '.module_def')
         mod_def.initializer = mod_def_init
-        mod_def.linkage = lc.LINKAGE_INTERNAL
+        mod_def.linkage = 'internal'
 
         # Define the module initialization function.
         mod_init_fn = ir.Function(llvm_module, *self.module_init_definition)
         entry = mod_init_fn.append_basic_block('Entry')
-        builder = lc.Builder(entry)
+        builder = ir.IRBuilder(entry)
         pyapi = self.context.get_python_api(builder)
 
         mod = builder.call(create_module_fn,
                            (mod_def,
-                            lc.Constant.int(lt._int32, sys.api_version)))
+                            ir.Constant(lt._int32, sys.api_version)))
 
         # Test if module has been created correctly.
         # (XXX for some reason comparing with the NULL constant fails llvm
@@ -456,7 +459,7 @@ class ModuleCompiler(_ModuleCompiler):
         if ret is not None:
             with builder.if_then(cgutils.is_not_null(builder, ret)):
                 # Init function errored out
-                builder.ret(lc.Constant.null(mod.type))
+                builder.ret(ir.Constant(mod.type, None))
 
         builder.ret(mod)
 

--- a/numba/pycc/llvm_types.py
+++ b/numba/pycc/llvm_types.py
@@ -1,36 +1,37 @@
 import sys
 import ctypes
 import struct as struct_
-from llvmlite.llvmpy.core import Type, Constant
+import llvmlite.ir
+from llvmlite.ir import Constant
 
 _trace_refs_ = hasattr(sys, 'getobjects')
 _plat_bits = struct_.calcsize('@P') * 8
 
-_int8 = Type.int(8)
-_int32 = Type.int(32)
+_int8 = llvmlite.ir.IntType(8)
+_int32 = llvmlite.ir.IntType(32)
 
-_void_star = Type.pointer(_int8)
+_void_star = llvmlite.ir.PointerType(_int8)
 
 _int8_star = _void_star
 
 _sizeof_py_ssize_t = ctypes.sizeof(getattr(ctypes, 'c_size_t'))
-_llvm_py_ssize_t = Type.int(_sizeof_py_ssize_t * 8)
+_llvm_py_ssize_t = llvmlite.ir.IntType(_sizeof_py_ssize_t * 8)
 
 if _trace_refs_:
-    _pyobject_head = Type.struct([_void_star, _void_star,
-                                  _llvm_py_ssize_t, _void_star])
-    _pyobject_head_init = Constant.struct([
-        Constant.null(_void_star),            # _ob_next
-        Constant.null(_void_star),            # _ob_prev
-        Constant.int(_llvm_py_ssize_t, 1),    # ob_refcnt
-        Constant.null(_void_star),            # ob_type
+    _pyobject_head = llvmlite.ir.LiteralStructType([_void_star, _void_star,
+                                                    _llvm_py_ssize_t, _void_star])
+    _pyobject_head_init = Constant.literal_struct([
+        Constant(_void_star, None),            # _ob_next
+        Constant(_void_star, None),            # _ob_prev
+        Constant(_llvm_py_ssize_t, 1),         # ob_refcnt
+        Constant(_void_star, None),            # ob_type
         ])
 
 else:
-    _pyobject_head = Type.struct([_llvm_py_ssize_t, _void_star])
-    _pyobject_head_init = Constant.struct([
-        Constant.int(_llvm_py_ssize_t, 1),    # ob_refcnt
-        Constant.null(_void_star),            # ob_type
+    _pyobject_head = llvmlite.ir.LiteralStructType([_llvm_py_ssize_t, _void_star])
+    _pyobject_head_init = Constant.literal_struct([
+        Constant(_llvm_py_ssize_t, 1),    # ob_refcnt
+        Constant(_void_star, None),       # ob_type
         ])
 
-_pyobject_head_p = Type.pointer(_pyobject_head)
+_pyobject_head_p = llvmlite.ir.PointerType(_pyobject_head)

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -1200,7 +1200,9 @@ class TestOperatorMixedTypes(TestCase):
             for x, y in itertools.product(things, things):
                 expected = func.py_func(x, y)
                 got = func(x, y)
-                self.assertEqual(expected, got)
+                message = ("%s %s %s does not match between Python and Numba"
+                           % (x, opstr, y))
+                self.assertEqual(expected, got, message)
 
 
 class TestIsinstanceBuiltin(TestCase):

--- a/numba/tests/test_cgutils.py
+++ b/numba/tests/test_cgutils.py
@@ -3,7 +3,7 @@ import ctypes
 import struct
 import sys
 
-import llvmlite.llvmpy.core as lc
+import llvmlite.ir as ir
 import numpy as np
 
 import unittest
@@ -12,10 +12,10 @@ from numba.core.compiler_lock import global_compiler_lock
 from numba.tests.support import TestCase
 
 
-machine_int = lc.Type.int(types.intp.bitwidth)
+machine_int = ir.IntType(types.intp.bitwidth)
 
 def machine_const(n):
-    return lc.Constant.int(machine_int, n)
+    return ir.Constant(machine_int, n)
 
 
 class StructureTestCase(TestCase):
@@ -26,7 +26,7 @@ class StructureTestCase(TestCase):
 
     @contextlib.contextmanager
     def compile_function(self, nargs):
-        llvm_fnty = lc.Type.function(machine_int, [machine_int] * nargs)
+        llvm_fnty = ir.FunctionType(machine_int, [machine_int] * nargs)
         ctypes_fnty = ctypes.CFUNCTYPE(ctypes.c_size_t,
                                     * (ctypes.c_size_t,) * nargs)
         module = self.context.create_module("")
@@ -34,7 +34,7 @@ class StructureTestCase(TestCase):
         function = cgutils.get_or_insert_function(module, llvm_fnty, self.id())
         assert function.is_declaration
         entry_block = function.append_basic_block('entry')
-        builder = lc.Builder(entry_block)
+        builder = ir.IRBuilder(entry_block)
 
         first = [True]
 
@@ -70,12 +70,12 @@ class StructureTestCase(TestCase):
         with self.compile_function(1) as (context, builder, args, call):
             inst = struct_class(context, builder)
             sptr = builder.add(args[0], machine_const(offset))
-            sptr = builder.inttoptr(sptr, lc.Type.pointer(inst._type))
+            sptr = builder.inttoptr(sptr, ir.PointerType(inst._type))
             inst = struct_class(context, builder, ref=sptr)
 
             yield context, builder, args, inst
 
-            builder.ret(lc.Constant.int(machine_int, 0))
+            builder.ret(ir.Constant(machine_int, 0))
         call(self.get_bytearray_addr(buf))
 
     @contextlib.contextmanager
@@ -102,8 +102,8 @@ class StructureTestCase(TestCase):
         fmt = "=iH"
         with self.run_simple_struct_test(S, fmt, (0x12345678, 0xABCD)) \
             as (context, builder, inst):
-            inst.a = lc.Constant.int(lc.Type.int(32), 0x12345678)
-            inst.b = lc.Constant.int(lc.Type.int(16), 0xABCD)
+            inst.a = ir.Constant(ir.IntType(32), 0x12345678)
+            inst.b = ir.Constant(ir.IntType(16), 0xABCD)
 
     def test_float_fields(self):
         class S(cgutils.Structure):
@@ -113,8 +113,8 @@ class StructureTestCase(TestCase):
         fmt = "=df"
         with self.run_simple_struct_test(S, fmt, (1.23, 4.56)) \
             as (context, builder, inst):
-            inst.a = lc.Constant.real(lc.Type.double(), 1.23)
-            inst.b = lc.Constant.real(lc.Type.float(), 4.56)
+            inst.a = ir.Constant(ir.DoubleType(), 1.23)
+            inst.b = ir.Constant(ir.FloatType(), 4.56)
 
 
 if __name__ == '__main__':

--- a/numba/typed/typedobjectutils.py
+++ b/numba/typed/typedobjectutils.py
@@ -4,7 +4,6 @@ import operator
 import warnings
 
 from llvmlite import ir
-from llvmlite.llvmpy.core import Builder
 
 from numba.core import types, cgutils
 from numba.core import typing
@@ -161,7 +160,7 @@ def _get_equal(context, module, datamodel, container_element_type):
     argtypes = [fe_type, fe_type]
 
     def build_wrapper(fn):
-        builder = Builder(fn.append_basic_block())
+        builder = ir.IRBuilder(fn.append_basic_block())
         args = context.call_conv.decode_arguments(builder, argtypes, fn)
 
         sig = typing.signature(types.boolean, fe_type, fe_type)
@@ -182,7 +181,7 @@ def _get_equal(context, module, datamodel, container_element_type):
     equal_fn = cgutils.get_or_insert_function(
         module, equal_fnty, name='.numba_{}.{}_equal'.format(
             context.fndesc.mangled_name, container_element_type),)
-    builder = Builder(equal_fn.append_basic_block())
+    builder = ir.IRBuilder(equal_fn.append_basic_block())
     lhs = datamodel.load_from_data_pointer(builder, equal_fn.args[0])
     rhs = datamodel.load_from_data_pointer(builder, equal_fn.args[1])
 


### PR DESCRIPTION
This replaces usage of:

- `llvmlite.llvmpy.Builder`, which is a wrapper around `llvmlite.ir.IRBuilder` adding two additional methods. These methods have been inlined.
- `llvmlite.llvmpy.Type`, which wraps several classes in `llvmlite.ir.types`
- `llvmlite.llvmpy.Constant`, which is a wrapper around `llvmlite.ir.Constant`
- `llvmlite.llvmpy.CallOrInvokeInstruction`, which is an alias for `llvmlite.ir.InvokeInstr`
- The constants in `llvmlite.llvmpy` for intrinsics and linkages were replaced with literals