### PR TITLE
Pyston compatibility for the test suite

### DIFF
--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -226,7 +226,10 @@ class TestTracemalloc(unittest.TestCase):
     """
 
     def measure_memory_diff(self, func):
-        import tracemalloc
+        try:
+            import tracemalloc
+        except ImportError:
+            self.skipTest("tracemalloc not available")
         tracemalloc.start()
         try:
             before = tracemalloc.take_snapshot()

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -210,7 +210,7 @@ class TestCC(BasePYCCTest):
         self.assertTrue(os.path.basename(f).startswith('pycc_test_simple.'), f)
         if sys.platform.startswith('linux'):
             self.assertTrue(f.endswith('.so'), f)
-            self.assertIn('.cpython', f)
+            self.assertIn(find_pyext_ending(), f)
 
     def test_compile(self):
         with self.check_cc_compiled(self._test_module.cc) as lib:


### PR DESCRIPTION
numba already works on Pyston, but there were two small snags in the test suite that caused the tests to not pass.