### PR TITLE
Implement floordiv reduction in parfors.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -3611,9 +3611,10 @@ def get_reduction_init(nodes):
     if acc_expr.fn == operator.iadd or acc_expr.fn == operator.isub:
         return 0, acc_expr.fn
     if (  acc_expr.fn == operator.imul
-       or acc_expr.fn == operator.itruediv
-       or acc_expr.fn == operator.ifloordiv ):
+       or acc_expr.fn == operator.itruediv ):
         return 1, acc_expr.fn
+    if acc_expr.fn == operator.ifloordiv:
+        return np.iinfo(np.int64).max, acc_expr.fn
     return None, None
 
 def supported_reduction(x, func_ir):


### PR DESCRIPTION
assume
``x_init // x0 // x1 // x2 // ... // xn``
can be computed as
``floor((max_i64 // x0 // x1 // x2 // ... // xn) * (x_init / max_i64))``

However, there may be numerical problems:

```python

from numba import njit, prange
import numpy as np


@njit(parallel=True)
def foo(x, ys):
    for i in prange(ys.size):
        x //= ys[i]
    return x


ys = np.array([5, 3, 2, 1, 5, 1, 8, 1, 1, 5, 4, 1, 8, 3, 1, 1, 2, 2, 2, 7, 6, 7, 1, 7, 4, 7, 1])
init = 9999 * np.prod(ys)
res = foo(init, ys)
print("res = ", res)
exp = foo.py_func(init, ys)
print("exp = ", exp)
assert res == exp
```
The above will fail with:

```
res =  9998
exp =  9999
Traceback (most recent call last):
  File "/Users/siu/dev/numba/chk.py", line 36, in <module>
    assert res == exp
AssertionError
```