### PR TITLE
Retain non-modified index tuple components.

### DIFF
--- a/numba/parfors/array_analysis.py
+++ b/numba/parfors/array_analysis.py
@@ -2056,6 +2056,7 @@ class ArrayAnalysis(object):
         var_shape = equiv_set._get_shape(var)
         if isinstance(ind_typ, types.SliceType):
             seq_typs = (ind_typ,)
+            seq = (ind_var,)
         else:
             require(isinstance(ind_typ, types.BaseTuple))
             seq, op = find_build_sequence(self.func_ir, ind_var)
@@ -2077,7 +2078,10 @@ class ArrayAnalysis(object):
         shape_list = []
         index_var_list = []
         replace_index = False
-        for (typ, size, dsize) in zip(seq_typs, ind_shape, var_shape):
+        for (typ, size, dsize, orig_ind) in zip(seq_typs,
+                                                ind_shape,
+                                                var_shape,
+                                                seq):
             # Convert the given dimension of the get/setitem index expr.
             shape_part, index_var_part = to_shape(typ, size, dsize)
             shape_list.append(shape_part)
@@ -2090,7 +2094,7 @@ class ArrayAnalysis(object):
                 replace_index = True
                 index_var_list.append(index_var_part)
             else:
-                index_var_list.append(size)
+                index_var_list.append(orig_ind)
 
         # If at least one of the dimensions required a new slice variable
         # then we'll need to replace the build_tuple for this get/setitem.

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2001,6 +2001,19 @@ class TestParfors(TestParforsBase):
         arr = np.arange(10, dtype=np.int64)
         self.check(test_impl, arr)
 
+    def test_setitem_2d_one_replaced(self):
+        # issue7843
+        def test_impl(x):
+            count = 0
+            for n in range(x.shape[0]):
+                # Useless "if" necessary to trigger bug.
+                if n:
+                    n
+                x[count, :] = 1
+                count += 1
+            return x
+
+        self.check(test_impl, np.zeros((3, 1)))
 
 @skip_parfors_unsupported
 class TestParforsLeaks(MemoryLeakMixin, TestParforsBase):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -609,16 +609,22 @@ def _count_non_parfor_array_accesses_inner(f_ir, blocks, typemap, parfor_indices
                     f_ir, parfor_blocks, typemap, parfor_indices)
 
             # getitem
-            if (is_getitem(stmt) and isinstance(typemap[stmt.value.value.name],
+            elif (is_getitem(stmt) and isinstance(typemap[stmt.value.value.name],
                         types.ArrayCompatible) and not _uses_indices(
                         f_ir, index_var_of_get_setitem(stmt), parfor_indices)):
                 ret_count += 1
 
             # setitem
-            if (is_setitem(stmt) and isinstance(typemap[stmt.target.name],
+            elif (is_setitem(stmt) and isinstance(typemap[stmt.target.name],
                     types.ArrayCompatible) and not _uses_indices(
                     f_ir, index_var_of_get_setitem(stmt), parfor_indices)):
                 ret_count += 1
+
+            # find parfor_index aliases
+            elif (isinstance(stmt, ir.Assign) and
+                  isinstance(stmt.value, ir.Var) and
+                  stmt.value.name in parfor_indices):
+                parfor_indices.add(stmt.target.name)
 
     return ret_count
 


### PR DESCRIPTION
Resolves #7843

If an index tuple needs to be partially reconstructed by array analysis, then for the unmodified parts, use the original variables used in the tuple.