### PR TITLE
`numba.typed.typeddict.Dict.get` uses `castedkey` to avoid returning default value even if the key is present

### DIFF
--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -1112,6 +1112,15 @@ class TestTypedDict(MemoryLeakMixin, TestCase):
         val = consumer(d)
         self.assertEqual(val, 1.23)
 
+    def test_gh7908(self):
+        d = Dict.empty(
+            key_type=types.Tuple([types.uint32,
+                                  types.uint32]),
+            value_type=int64)
+
+        d[(1, 1)] = 12345
+        self.assertEqual(d[(1, 1)], d.get((1, 1)))
+
     def check_stringify(self, strfn, prefix=False):
         nbd = Dict.empty(int32, int32)
         d = {}

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -738,7 +738,7 @@ def impl_get(dct, key, default=None):
 
     def impl(dct, key, default=None):
         castedkey = _cast(key, keyty)
-        ix, val = _dict_lookup(dct, key, hash(castedkey))
+        ix, val = _dict_lookup(dct, castedkey, hash(castedkey))
         if ix > DKIX.EMPTY:
             return val
         return default


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes https://github.com/numba/numba/issues/7908

cc: @guilhermeleobas @stuartarchibald @MarcMassar
