### PR TITLE
lru cache for configure call

### DIFF
--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -513,6 +513,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
     def _numba_type_(self):
         return cuda_types.CUDADispatcher(self)
 
+    @functools.lru_cache(maxsize=128)
     def configure(self, griddim, blockdim, stream=0, sharedmem=0):
         griddim, blockdim = normalize_kernel_dimensions(griddim, blockdim)
         return _LaunchConfiguration(self, griddim, blockdim, stream, sharedmem)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Use `lru_cache` for `Dispatcher.configure` to avoid creating new `_LaunchConfiguration` instances at every `__getitem__` call.
For a simple kernel like
```py
@cuda.jit
def func_cuda(a, b=0.):
    for i in range(cuda.grid(1), a.shape[0], cuda.gridsize(1)):
        a[i]+= b
```

The invocation of `func_cuda[4,256](a_g, b=1.)` changes from 70 us to 40 us per invocation with the lru_cache.
