### PR TITLE
Small caching refactor to support target cache implementations

### DIFF
--- a/numba/core/base.py
+++ b/numba/core/base.py
@@ -948,7 +948,7 @@ class BaseContext(object):
         res = imputils.fix_returning_optional(self, builder, sig, status, res)
         return res
 
-    def get_executable(self, func, fndesc):
+    def get_executable(self, func, fndesc, env):
         raise NotImplementedError
 
     def get_python_api(self, builder):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -27,18 +27,6 @@ from numba.core import config, compiler
 from numba.core.serialize import dumps
 
 
-def _get_codegen(obj):
-    """
-    Returns the Codegen associated with the given object.
-    """
-    if isinstance(obj, CodeLibrary):
-        return obj.codegen
-    elif isinstance(obj, CompileResult):
-        return obj.target_context.codegen()
-    else:
-        raise TypeError(type(obj))
-
-
 def _cache_log(msg, *args):
     if config.DEBUG_CACHE:
         msg = msg % args
@@ -668,7 +656,7 @@ class Cache(_Cache):
         if not self._impl.check_cachable(data):
             return
         self._impl.locator.ensure_cache_path()
-        key = self._index_key(sig, _get_codegen(data))
+        key = self._index_key(sig, data.codegen)
         data = self._impl.reduce(data)
         self._cache_file.save(key, data)
 

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -31,9 +31,7 @@ def _get_codegen(obj):
     """
     Returns the Codegen associated with the given object.
     """
-    if isinstance(obj, BaseContext):
-        return obj.codegen()
-    elif isinstance(obj, CodeLibrary):
+    if isinstance(obj, CodeLibrary):
         return obj.codegen
     elif isinstance(obj, CompileResult):
         return obj.target_context.codegen()
@@ -651,7 +649,7 @@ class Cache(_Cache):
     def _load_overload(self, sig, target_context):
         if not self._enabled:
             return
-        key = self._index_key(sig, _get_codegen(target_context))
+        key = self._index_key(sig, target_context.codegen())
         data = self._cache_file.load(key)
         if data is not None:
             data = self._impl.rebuild(target_context, data)

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -308,7 +308,7 @@ class _IPythonCacheLocator(_CacheLocator):
         return self
 
 
-class _CacheImpl(metaclass=ABCMeta):
+class CacheImpl(metaclass=ABCMeta):
     """
     Provides the core machinery for caching.
     - implement how to serialize and deserialize the data in the cache.
@@ -377,7 +377,7 @@ class _CacheImpl(metaclass=ABCMeta):
         pass
 
 
-class CompileResultCacheImpl(_CacheImpl):
+class CompileResultCacheImpl(CacheImpl):
     """
     Implements the logic to cache CompileResult objects.
     """
@@ -413,7 +413,7 @@ class CompileResultCacheImpl(_CacheImpl):
         return True
 
 
-class CodeLibraryCacheImpl(_CacheImpl):
+class CodeLibraryCacheImpl(CacheImpl):
     """
     Implements the logic to cache CodeLibrary objects.
     """
@@ -588,7 +588,7 @@ class Cache(_Cache):
 
     Note:
     This contains the driver logic only.  The core logic is provided
-    by a subclass of ``_CacheImpl`` specified as *_impl_class* in the subclass.
+    by a subclass of ``CacheImpl`` specified as *_impl_class* in the subclass.
     """
 
     # The following class variables must be overridden by subclass.

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -255,6 +255,10 @@ class CompileResult(namedtuple("_CompileResult", CR_FIELDS)):
 
         return cr
 
+    @property
+    def codegen(self):
+        return self.target_context.codegen()
+
     def dump(self, tab=''):
         print(f'{tab}DUMP {type(self).__name__} {self.entry_point}')
         self.signature.dump(tab=tab + '  ')


### PR DESCRIPTION
This PR refactors the caching implementation such that a target can implement its own cache without modifying the core of Numba. These changes are derived from the experience of writing #7944. There is no functional change. The changes include:

- Fix the arguments to `BaseContext.get_executable()` - if a target context forgets to implement `get_executable()`, then a call to it fails because the default implementation was missing the `env` argument.
- Removal of the `_get_codegen()` function `caching.py` - the design of this function forces it to be updated for every target. To replace it, `_load_overload()` and `_save_overload()` use a method/property on the objects they handle to get the codegen instead. This required adding the `codegen` property to `CompileResult`.
- making `_CacheImpl` public - a target might want its own cache implementation, so it shouldn't really be private in `caching.py`.

A PR based on this one that adds caching for CUDA by only making changes in the `numba.cuda` module will follow, but this is ready for review as-is.