### PR TITLE
CUDA fixes for Windows

### DIFF
--- a/docs/source/cuda/ipc.rst
+++ b/docs/source/cuda/ipc.rst
@@ -7,6 +7,10 @@ Sharing CUDA Memory
 Sharing between process
 =======================
 
+Sharing between processes is implemented using the Legacy CUDA IPC API
+(functions whose names begin with ``cuIpc``), and is supported only on Linux.
+
+
 Export device array to another process
 --------------------------------------
 

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -32,12 +32,11 @@ def disassemble_cubin(cubin):
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         except FileNotFoundError as e:
-            if e.filename == 'nvdisasm':
-                msg = ("nvdisasm is required for SASS inspection, and has not "
-                       "been found.\n\nYou may need to install the CUDA "
-                       "toolkit and ensure that it is available on your "
-                       "PATH.\n")
-                raise RuntimeError(msg)
+            msg = ("nvdisasm is required for SASS inspection, and has not "
+                   "been found.\n\nYou may need to install the CUDA "
+                   "toolkit and ensure that it is available on your "
+                   "PATH.\n")
+            raise RuntimeError(msg) from e
         return cp.stdout.decode('utf-8')
     finally:
         if fd is not None:

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -47,6 +47,7 @@ if USE_NV_BINDING:
     CU_STREAM_DEFAULT = 0
 
 MIN_REQUIRED_CC = (3, 0)
+SUPPORTS_IPC = sys.platform.startswith('linux')
 
 
 _py_decref = ctypes.pythonapi.Py_DecRef
@@ -1372,8 +1373,10 @@ class Context(object):
 
     def get_ipc_handle(self, memory):
         """
-        Returns a *IpcHandle* from a GPU allocation.
+        Returns an *IpcHandle* from a GPU allocation.
         """
+        if not SUPPORTS_IPC:
+            raise OSError('OS does not support CUDA IPC')
         return self.memory_manager.get_ipc_handle(memory)
 
     def open_ipc_handle(self, handle, size):

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -10,6 +10,7 @@ from numba.cuda.cudadrv import driver
 from numba.cuda.testing import (skip_on_arm, skip_on_cudasim,
                                 skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
+from numba.tests.support import linux_only
 import unittest
 
 
@@ -78,6 +79,7 @@ def ipc_array_test(ipcarr, result_queue):
     result_queue.put((succ, out))
 
 
+@linux_only
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @skip_on_cudasim('Ipc not available in CUDASIM')
 @skip_on_arm('CUDA IPC not supported on ARM in Numba')
@@ -236,6 +238,7 @@ def staged_ipc_array_test(ipcarr, device_num, result_queue):
     result_queue.put((succ, out))
 
 
+@linux_only
 @skip_under_cuda_memcheck('Hangs cuda-memcheck')
 @skip_on_cudasim('Ipc not available in CUDASIM')
 @skip_on_arm('CUDA IPC not supported on ARM in Numba')

--- a/numba/cuda/tests/cudapy/test_ipc.py
+++ b/numba/cuda/tests/cudapy/test_ipc.py
@@ -10,7 +10,7 @@ from numba.cuda.cudadrv import driver
 from numba.cuda.testing import (skip_on_arm, skip_on_cudasim,
                                 skip_under_cuda_memcheck,
                                 ContextResettingTestCase, ForeignArray)
-from numba.tests.support import linux_only
+from numba.tests.support import linux_only, windows_only
 import unittest
 
 
@@ -296,6 +296,18 @@ class TestIpcStaged(ContextResettingTestCase):
                 self.fail(out)
             else:
                 np.testing.assert_equal(arr, out)
+
+
+@windows_only
+@skip_on_cudasim('Ipc not available in CUDASIM')
+class TestIpcNotSupported(ContextResettingTestCase):
+    def test_unsupported(self):
+        arr = np.arange(10, dtype=np.intp)
+        devarr = cuda.to_device(arr)
+        with self.assertRaises(OSError) as raises:
+            devarr.get_ipc_handle()
+        errmsg = str(raises.exception)
+        self.assertIn('OS does not support CUDA IPC', errmsg)
 
 
 if __name__ == '__main__':

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -83,6 +83,9 @@ skip_unless_scipy = unittest.skipIf(scipy is None, _msg)
 _lnx_reason = 'linux only test'
 linux_only = unittest.skipIf(not sys.platform.startswith('linux'), _lnx_reason)
 
+_win_reason = 'Windows-only test'
+windows_only = unittest.skipIf(not sys.platform.startswith('win'), _win_reason)
+
 _is_armv7l = platform.machine() == 'armv7l'
 
 disabled_test = unittest.skipIf(True, 'Test disabled')


### PR DESCRIPTION
This fixes a couple of issues on Windows:

- IPC is not actually supported on Windows, there was just a small range of drivers where it appeared to work in some circumstances. Because it is not properly supported, we limit its support back to just Linux again - this includes skipping the tests, erroring if an attempt to use IPC on non-Linux is used, and updating the documentation.
- Sometimes on Windows if `nvdisasm` is not found, the `FileNotFoundError`'s filename is blank. There doesn't appear to be any value in checking for `nvdisasm` in the name, and when it's not found it resulted in incorrect logic, so I just removed the check for the filename.

One issue is still outstanding on Windows with recent drivers (tests of printing functionality, #8005), which will be fixed in a separate PR.