### PR TITLE
[Docs] [Very Minor] Make `numba.jit` boundscheck doc line consistent

### DIFF
--- a/docs/source/reference/jit-compilation.rst
+++ b/docs/source/reference/jit-compilation.rst
@@ -97,7 +97,7 @@ JIT functions
 
    .. _jit-decorator-boundscheck:
 
-   If True, ``boundscheck`` enables bounds checking for array indices. Out of
+   If true, *boundscheck* enables bounds checking for array indices. Out of
    bounds accesses will raise IndexError. The default is to not do bounds
    checking. If bounds checking is disabled, out of bounds accesses can
    produce garbage results or segfaults. However, enabling bounds checking


### PR DESCRIPTION
The rest of the docs for `jit` above on this same page use italicized paramater names instead of code block. Similar story with the boolean at the start, the rest of the page uses lowercase word.

Very minor nitpicky stuff, but hopefully an improvement nevertheless.