### PR TITLE
Update FAQ to include details about using debug-only option

### DIFF
--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -188,6 +188,12 @@ add the following lines:
 This tells LLVM to print debug information from the **loop-vectorize**
 pass to stderr.  Each function entry looks like:
 
+
+.. note::
+   Using ``--debug-only`` requires LLVM to be build with assertions enabled to
+   work. Use the build of llvmlite in the `Numba channel <https://anaconda.org/numba/llvmlite>`_
+   which is linked against LLVM with assertions enabled.
+
 .. code-block:: text
 
     LV: Checking a loop in "<low-level symbol name>" from <function name>


### PR DESCRIPTION
Fix #7358. This PR includes an info section to use llvmlite from numba channel in order for `debug-only` to work.

Edit: example
![image](https://user-images.githubusercontent.com/2712115/166266759-babf70b4-0b48-423d-95cf-f966cd31f7e6.png)

