### PR TITLE
Add support for `array.resize`

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1989,9 +1989,11 @@ def array_resize(context, builder, sig, args):
     for dimension_size in shapes:
         prod = builder.mul(prod, dimension_size)
     builder.store(prod, new_size)
-    array_data = builder.alloca(context.get_value_type(retty.dtype).as_pointer())
+    array_dtype = context.get_value_type(retty.dtype)
+    array_data = builder.alloca(array_dtype.as_pointer())
     builder.store(ary.data, array_data)
-    with builder.if_then(builder.icmp_signed('>', builder.load(new_size), ary.nitems)):
+    with builder.if_then(builder.icmp_signed('>',
+                         builder.load(new_size), ary.nitems)):
         new_ary = _empty_nd_impl(context, builder, retty, shapes)
         _zero_fill_array(context, builder, new_ary)
         cgutils.memcpy(builder, new_ary.data, ary.data, ary.nitems)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1984,8 +1984,9 @@ def array_resize(context, builder, sig, args):
     strides_array = cgutils.pack_array(builder, strides, ty=intp_t)
     builder.store(strides_array, newstrides)
 
-    new_size = builder.alloca(ir.IntType(64))
-    prod = ir.Constant(ir.IntType(64), 1)
+    shape_int_type = context.get_value_type(shapety.dtype)
+    new_size = builder.alloca(shape_int_type)
+    prod = ir.Constant(shape_int_type, 1)
     for dimension_size in shapes:
         prod = builder.mul(prod, dimension_size)
     builder.store(prod, new_size)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4735,7 +4735,7 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         for ndim, order in itertools.product(ndims, orders):
             random_shape = tuple(np.random.randint(1, 10, size=ndim).tolist())
-            random_list = np.random.randint(-1000, 1000, size=random_shape).tolist()
+            random_list = np.random.randint(-10, 10, size=random_shape).tolist()
             random_array = np.asarray(random_list, order=order)
             random_array_copy = random_array.copy()
 

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4761,7 +4761,9 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         curr_dim = ndim
         while curr_dim <= max_dim:
             for _new_shape in new_shapes:
-                new_shape = _new_shape + tuple(np.random.randint(1, 5) for _ in range(max_dim - curr_dim))
+                new_shape = _new_shape + tuple(np.random.randint(1, 5)
+                                               for _ in range(
+                                               max_dim - curr_dim))
                 py_res = random_array_copy.copy()
                 py_res.resize(new_shape)
                 c_res = cfunc(random_array.copy(), new_shape)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4757,6 +4757,19 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                     self.assertEqual(py_res.shape, c_res.shape)
                 curr_dim -= 1
 
+        max_dim = 4
+        curr_dim = ndim
+        while curr_dim <= max_dim:
+            for _new_shape in new_shapes:
+                new_shape = _new_shape + tuple(np.random.randint(1, 5) for _ in range(max_dim - curr_dim))
+                py_res = random_array_copy.copy()
+                py_res.resize(new_shape)
+                c_res = cfunc(random_array.copy(), new_shape)
+                assert (py_res == c_res).all()
+                assert py_res.shape == c_res.shape
+
+            curr_dim += 1
+
 
 class TestNPMachineParameters(TestCase):
     # tests np.finfo, np.iinfo, np.MachAr

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -4731,10 +4731,12 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         cfunc = jit(nopython=True)(pyfunc)
 
         ndims = (1, 2, 3, 4)
+        orders = ('F', 'C')
 
-        for ndim in ndims:
+        for ndim, order in itertools.product(ndims, orders):
             random_shape = tuple(np.random.randint(1, 10, size=ndim).tolist())
-            random_array = np.random.randint(-1000, 1000, size=random_shape)
+            random_list = np.random.randint(-1000, 1000, size=random_shape).tolist()
+            random_array = np.asarray(random_list, order=order)
             random_array_copy = random_array.copy()
 
             min_dim = 1


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes #8015 

I have added initial support `array.resize` for numpy arrays in Numba. I have taken inspiration from `reshape` implementation. I have considered 3 cases,

1. New size of array is less than or equal to the original size of array - Then there is no need to allocation extra amount of data. Just fill the shape and strides (according to order of the input array).
2. New size of arrays is greater than the size of the original size of array - Here, other than filling the shape and strides according to the new shape, we have to allocate new block of memory and then fill the extra values with zero.

I have currently implemented and tested the first case. Will update the PR for the second case as well.

Please let me know if you have any other approach in mind. Will be happy to implement that as well. Thanks.
