### PR TITLE
Allow converting NumPy datetimes to int

### DIFF
--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -964,7 +964,7 @@ class Int(AbstractTemplate):
             if arg.unit == 'ns':
                 return signature(types.int64, arg)
             else:
-                raise errors.NumbaTypeError(f"Only datetime64[ns] can be converted, but got {arg.unit}")
+                raise errors.NumbaTypeError(f"Only datetime64[ns] can be converted, but got datetime64[{arg.unit}]")
         if isinstance(arg, types.NPTimedelta):
             return signature(types.int64, arg)
 

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -796,7 +796,7 @@ class NumberClassAttribute(AttributeTemplate):
 
     def resolve___call__(self, classty):
         """
-        Resolve a number class's constructor (e.g. calling int(...))
+        Resolve a NumPy number class's constructor (e.g. calling numpy.int32(...))
         """
         ty = classty.instance_type
 
@@ -841,7 +841,7 @@ class TypeRefAttribute(AttributeTemplate):
 
     def resolve___call__(self, classty):
         """
-        Resolve a number class's constructor (e.g. calling int(...))
+        Resolve a core number's constructor (e.g. calling int(...))
 
         Note:
 
@@ -960,6 +960,13 @@ class Int(AbstractTemplate):
             return signature(arg, arg)
         if isinstance(arg, (types.Float, types.Boolean)):
             return signature(types.intp, arg)
+        if isinstance(arg, types.NPDatetime):
+            if arg.unit == 'ns':
+                return signature(types.int64, arg)
+            else:
+                raise errors.NumbaTypeError(f"Only datetime64[ns] can be converted, but got {arg.unit}")
+        if isinstance(arg, types.NPTimedelta):
+            return signature(types.int64, arg)
 
 
 @infer_global(float)

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -576,6 +576,27 @@ class TestTimedeltaArithmeticNoPython(TestTimedeltaArithmetic):
 
     jitargs = dict(nopython=True)
 
+    def test_int_cast(self):
+        f = self.jit(int_cast_usecase)
+        def check(a):
+            self.assertPreciseEqual(f(a), int(a))
+
+        for (delta, unit) in ((3, 'ns'), (-4, 'ns'), (30000, 'ns'),
+                        (-40000000, 'ns'), (1, 'Y')):
+            check(TD(delta, unit).astype('timedelta64[ns]'))
+
+        for time in ('2014', '2016', '2000', '2014-02', '2014-03', '2014-04',
+                     '2016-02', '2000-12-31', '2014-01-16', '2014-01-05',
+                     '2014-01-07', '2014-01-06', '2014-02-02', '2014-02-27',
+                     '2014-02-16', '2014-03-01', '2000-01-01T01:02:03.002Z',
+                     '2000-01-01T01:02:03Z'):
+            check(DT(time).astype('datetime64[ns]'))
+
+        with self.assertRaises(TypingError, msg=('Only datetime64[ns] can be ' +
+                                                 'converted, but got ' +
+                                                 'datetime64[y]')):
+            f(DT('2014'))
+
 
 class TestDatetimeArithmetic(TestCase):
 

--- a/numba/tests/test_npdatetime.py
+++ b/numba/tests/test_npdatetime.py
@@ -85,6 +85,9 @@ def min_usecase(x, y):
 def max_usecase(x, y):
     return max(x, y)
 
+def int_cast_usecase(x):
+    return int(x)
+
 def make_add_constant(const):
     def add_constant(x):
         return x + const


### PR DESCRIPTION
Add support for `int(numpy.datetime64)` and `int(numpy.timedelta64)`.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
