### PR TITLE
convert NamedTuple to NamedUniTuple when possible

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -393,7 +393,12 @@ class NamedUniTuple(_HomogeneousTuple, BaseNamedTuple):
 
 
 class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
-    def __new__(cls, types, clss):
+    def __new__(cls, types, clss, convert=True):
+        """
+        arg convert: whether allow NamedTuple convert to Uni, default True.
+        """
+        if not convert:
+            return object.__new__(NamedTuple)
 
         t = utils.unified_function_type(types, require_precise=True)
         if t is not None:
@@ -406,8 +411,7 @@ class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
         else:
             return object.__new__(NamedTuple)
 
-    def __init__(self, types, clss):
-        _HeterogeneousTuple.is_types_iterable(types)
+    def __init__(self, types, clss, convert=True):
         self.types = tuple(types)
         self.count = len(self.types)
         self.fields = tuple(clss._fields)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -400,7 +400,9 @@ class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
 
         _HeterogeneousTuple.is_types_iterable(types)
 
-        if types and all(t == types[0] for t in types[1:]):
+        all_literals = all(isinstance(ty, Literal) for ty in types) \
+            if types else False
+        if types and not all_literals and all(t == types[0] for t in types[1:]):
             return NamedUniTuple(dtype=types[0], count=len(types), clss=clss)
         else:
             return object.__new__(NamedTuple)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -400,9 +400,8 @@ class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
 
         _HeterogeneousTuple.is_types_iterable(types)
 
-        all_literals = all(isinstance(ty, Literal) for ty in types) \
-            if types else False
-        if types and not all_literals and all(t == types[0] for t in types[1:]):
+        if types and all(t == types[0] for t in types[1:])\
+                and not isinstance(clss, LiteralStrKeyDict.FakeNamedTuple):
             return NamedUniTuple(dtype=types[0], count=len(types), clss=clss)
         else:
             return object.__new__(NamedTuple)

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -393,13 +393,7 @@ class NamedUniTuple(_HomogeneousTuple, BaseNamedTuple):
 
 
 class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
-    def __new__(cls, types, clss, convert=True):
-        """
-        arg convert: whether allow NamedTuple convert to Uni, default True.
-        """
-        if not convert:
-            return object.__new__(NamedTuple)
-
+    def __new__(cls, types, clss):
         t = utils.unified_function_type(types, require_precise=True)
         if t is not None:
             return NamedUniTuple(dtype=t, count=len(types), clss=clss)
@@ -411,7 +405,7 @@ class NamedTuple(_HeterogeneousTuple, BaseNamedTuple):
         else:
             return object.__new__(NamedTuple)
 
-    def __init__(self, types, clss, convert=True):
+    def __init__(self, types, clss):
         self.types = tuple(types)
         self.count = len(self.types)
         self.fields = tuple(clss._fields)

--- a/numba/tests/test_dictobject.py
+++ b/numba/tests/test_dictobject.py
@@ -2277,7 +2277,7 @@ class TestLiteralStrKeyDict(MemoryLeakMixin, TestCase):
 
         @njit
         def foo():
-            a = {'a': {'b1': 10, 'b2': 'string'}}
+            a = {'a1': {'b1': 10, 'b2': 'string'}}
             bar(a)
 
         foo()

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -1087,8 +1087,7 @@ def build_map(context, builder, dict_type, item_types, items):
         unliteral_tys = [x for x in
                          dict_type.literal_value.values()]
         nbty = types.NamedTuple(unliteral_tys,
-                                dict_type.tuple_ty,
-                                False)
+                                dict_type.tuple_ty)
         values = [x[1] for x in items]
         # replace with make_tuple call?
         tup = context.get_constant_undef(nbty)

--- a/numba/typed/dictobject.py
+++ b/numba/typed/dictobject.py
@@ -1087,7 +1087,8 @@ def build_map(context, builder, dict_type, item_types, items):
         unliteral_tys = [x for x in
                          dict_type.literal_value.values()]
         nbty = types.NamedTuple(unliteral_tys,
-                                dict_type.tuple_ty)
+                                dict_type.tuple_ty,
+                                False)
         values = [x[1] for x in items]
         # replace with make_tuple call?
         tup = context.get_constant_undef(nbty)


### PR DESCRIPTION
fixes #8026 .

- [x] Add \_\_new\_\_ for `NamedTuple`, similar with \_\_new\_\_ for `Tuple`.
- [x] Add a test for #8026 .
- [x] Change `cls` to `clss`, to avoid duplicate names between positional args and kwargs.
- [x] forbid `LiteralDict.FakeNamedTuple` use NamedUniTuple
- [x] CI pass