### PR TITLE
Support for Numpy BitGenerators PR#1 - Core Generator Support

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,7 +585,7 @@ Modules
 
 Generator Objects
 '''''''''''''''''
-Numba supports ``numpy.random.Generator()`` objects. Users can now pass
+Numba supports ``numpy.random.Generator()`` objects. As of version 0.56, users can pass
 individual Numpy ``Generator`` objects into Numba functions and use their
 methods inside the functions. The same algorithms are used as Numpy for
 random number generation hence maintaining parity between the random
@@ -598,8 +598,8 @@ execution logic.
 .. note::
   Numpy's ``Generator`` objects rely on ``BitGenerator`` to manage state
   and generate the random bits, which are then transformed into random
-  values from useful distributions. Numba ``unbox``es the ``Generator`` objects
-  and maintians a reference to the underlying ``BitGenerator`` objects using Numpy's
+  values from useful distributions. Numba will ``unbox`` the ``Generator`` objects
+  and will maintain a reference to the underlying ``BitGenerator`` objects using Numpy's
   ``ctypes`` interface bindings. Hence ``Generator`` objects can cross the JIT boundary
   and their functions be used within Numba-Jit code. Note that since only references
   to ``BitGenerator`` objects are maintained, any change to the state of a particular

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -586,20 +586,20 @@ Modules
 Generator Objects
 '''''''''''''''''
 Numba supports :py:class:`numpy.random.Generator()` objects. As of version 0.56, users can pass
-individual Numpy :py:class:`Generator` objects into Numba functions and use their
-methods inside the functions. The same algorithms are used as Numpy for
+individual NumPy :py:class:`Generator` objects into Numba functions and use their
+methods inside the functions. The same algorithms are used as NumPy for
 random number generation hence maintaining parity between the random
-number generated using Numpy and Numba under identical arguments 
-(also the same documentation notes as Numpy :py:class:`Generator` methods apply).
+number generated using NumPy and Numba under identical arguments 
+(also the same documentation notes as NumPy :py:class:`Generator` methods apply).
 The current Numba support for :py:class:`Generator` is not thread-safe, hence we
 do not recommend using :py:class:`Generator` methods in methods with parallel
 execution logic.
 
 .. note::
-  Numpy's :py:class:`Generator` objects rely on :py:class:`BitGenerator` to manage state
+  NumPy's :py:class:`Generator` objects rely on :py:class:`BitGenerator` to manage state
   and generate the random bits, which are then transformed into random
   values from useful distributions. Numba will ``unbox`` the :py:class:`Generator` objects
-  and will maintain a reference to the underlying :py:class:`BitGenerator` objects using Numpy's
+  and will maintain a reference to the underlying :py:class:`BitGenerator` objects using NumPy's
   ``ctypes`` interface bindings. Hence :py:class:`Generator` objects can cross the JIT boundary
   and their functions be used within Numba-Jit code. Note that since only references
   to :py:class:`BitGenerator` objects are maintained, any change to the state of a particular

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,39 +585,32 @@ Modules
 
 Generator Objects
 '''''''''''''''''
-Numba supports ``numpy.random.Generator()`` objects and their respective
-methods. Numpy's ``Generator`` objects rely on ``BitGenerator`` to manage state
-and generate the random bits, which are then transformed into random
-values from useful distributions. Numba ``unbox``es the ``Generator`` objects
-and maintians a reference to the underlying ``BitGenerator`` objects using Numpy's
-``ctypes`` interface bindings. Hence ``Generator`` objects can cross the JIT boundary
-and their functions be used within Numba-Jit code. Note that since only references
-to ``BitGenerator`` objects are maintained, any change to the state of a particular
-``Generator`` object outside Numba code would affect the state of ``Generator``
-inside the Numba code.
+Numba supports ``numpy.random.Generator()`` objects. Users can now pass
+individual Numpy ``Generator`` objects into Numba functions and use their
+methods inside the functions. The same algorithms are used as Numpy for
+random number generation hence maintaining parity between the random
+number generated using Numpy and Numba under identical arguments 
+(also the same documentation notes as Numpy ``Generator`` methods apply).
+The current Numba support for ``Generator`` is not thread-safe, hence we
+do not recommend using ``Generator`` methods in methods with parallel
+execution logic.
 
-.. code-block:: python
+.. note::
+  Numpy's ``Generator`` objects rely on ``BitGenerator`` to manage state
+  and generate the random bits, which are then transformed into random
+  values from useful distributions. Numba ``unbox``es the ``Generator`` objects
+  and maintians a reference to the underlying ``BitGenerator`` objects using Numpy's
+  ``ctypes`` interface bindings. Hence ``Generator`` objects can cross the JIT boundary
+  and their functions be used within Numba-Jit code. Note that since only references
+  to ``BitGenerator`` objects are maintained, any change to the state of a particular
+  ``Generator`` object outside Numba code would affect the state of ``Generator``
+  inside the Numba code.
 
-  import numpy as np
-  import numba
-
-  x = np.random.default_rng(1)
-  y = np.random.default_rng(1)
-
-  size = 10
-
-  def do_stuff(gen):
-      return gen.random(size=int(size/2))
-
-  print(x.random(size=size))
-  # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145
-  #  0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
-
-  print(do_stuff(y))
-  # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145]
-
-  print(y.random(size=int(size/2)))
-  # [0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
+.. literalinclude:: ../../../numba/tests/doc_examples/test_numpy_generators.py
+   :language: python
+   :start-after: magictoken.npgen_usage.begin
+   :end-before: magictoken.npgen_usage.end
+   :dedent: 8
 
 The following ``Generator`` methods are supported:
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,15 +585,15 @@ Modules
 
 Generator Objects
 '''''''''''''''''
-Numba supports `numpy.random.Generator()` objects and their respective
-methods. Numpy's `Generator` objects rely on `BitGenerator` to manage state
+Numba supports ``numpy.random.Generator()`` objects and their respective
+methods. Numpy's ``Generator`` objects rely on ``BitGenerator`` to manage state
 and generate the random bits, which are then transformed into random
-values from useful distributions. Numba `unbox`es the `Generator` objects
-and maintians a reference to the underlying `BitGenerator` objects using Numpy's
-`ctypes` interface bindings. Hence `Generator` objects can cross the JIT boundary
+values from useful distributions. Numba ``unbox``es the ``Generator`` objects
+and maintians a reference to the underlying ``BitGenerator`` objects using Numpy's
+``ctypes`` interface bindings. Hence ``Generator`` objects can cross the JIT boundary
 and their functions be used within Numba-Jit code. Note that since only references
-to `BitGenerator` objects are maintained, any change to the state of a particular
-`Generator` object outside Numba code would affect the state of `Generator`
+to ``BitGenerator`` objects are maintained, any change to the state of a particular
+``Generator`` object outside Numba code would affect the state of ``Generator``
 inside the Numba code.
 
 .. code-block:: python
@@ -619,7 +619,7 @@ inside the Numba code.
   print(y.random(size=int(size/2)))
   # [0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
 
-The following `Generator` methods are supported:
+The following ``Generator`` methods are supported:
 
 * :func:`numpy.random.Generator().random()`
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -585,25 +585,25 @@ Modules
 
 Generator Objects
 '''''''''''''''''
-Numba supports ``numpy.random.Generator()`` objects. As of version 0.56, users can pass
-individual Numpy ``Generator`` objects into Numba functions and use their
+Numba supports :py:class:`numpy.random.Generator()` objects. As of version 0.56, users can pass
+individual Numpy :py:class:`Generator` objects into Numba functions and use their
 methods inside the functions. The same algorithms are used as Numpy for
 random number generation hence maintaining parity between the random
 number generated using Numpy and Numba under identical arguments 
-(also the same documentation notes as Numpy ``Generator`` methods apply).
-The current Numba support for ``Generator`` is not thread-safe, hence we
-do not recommend using ``Generator`` methods in methods with parallel
+(also the same documentation notes as Numpy :py:class:`Generator` methods apply).
+The current Numba support for :py:class:`Generator` is not thread-safe, hence we
+do not recommend using :py:class:`Generator` methods in methods with parallel
 execution logic.
 
 .. note::
-  Numpy's ``Generator`` objects rely on ``BitGenerator`` to manage state
+  Numpy's :py:class:`Generator` objects rely on :py:class:`BitGenerator` to manage state
   and generate the random bits, which are then transformed into random
-  values from useful distributions. Numba will ``unbox`` the ``Generator`` objects
-  and will maintain a reference to the underlying ``BitGenerator`` objects using Numpy's
-  ``ctypes`` interface bindings. Hence ``Generator`` objects can cross the JIT boundary
+  values from useful distributions. Numba will ``unbox`` the :py:class:`Generator` objects
+  and will maintain a reference to the underlying :py:class:`BitGenerator` objects using Numpy's
+  ``ctypes`` interface bindings. Hence :py:class:`Generator` objects can cross the JIT boundary
   and their functions be used within Numba-Jit code. Note that since only references
-  to ``BitGenerator`` objects are maintained, any change to the state of a particular
-  ``Generator`` object outside Numba code would affect the state of ``Generator``
+  to :py:class:`BitGenerator` objects are maintained, any change to the state of a particular
+  :py:class:`Generator` object outside Numba code would affect the state of :py:class:`Generator`
   inside the Numba code.
 
 .. literalinclude:: ../../../numba/tests/doc_examples/test_numpy_generators.py
@@ -612,7 +612,7 @@ execution logic.
    :end-before: magictoken.npgen_usage.end
    :dedent: 8
 
-The following ``Generator`` methods are supported:
+The following :py:class:`Generator` methods are supported:
 
 * :func:`numpy.random.Generator().random()`
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -584,7 +584,7 @@ Modules
 ----------
 
 Generator Objects
-''''''''''''
+'''''''''''''''''
 Numba supports `numpy.random.Generator()` objects and their respective
 methods. Numpy's `Generator` objects rely on `BitGenerator` to manage state
 and generate the random bits, which are then transformed into random
@@ -595,6 +595,8 @@ and their functions be used within Numba-Jit code. Note that since only referenc
 to `BitGenerator` objects are maintained, any change to the state of a particular
 `Generator` object outside Numba code would affect the state of `Generator`
 inside the Numba code.
+
+.. code-block:: python
 
   import numpy as np
   import numba
@@ -622,7 +624,8 @@ The following `Generator` methods are supported:
 * :func:`numpy.random.Generator().random()`
 
 RandomState and legacy Random number generation
-''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''
+
 Numba supports top-level functions from the
 `numpy.random <http://docs.scipy.org/doc/numpy/reference/routines.random.html>`_
 module, but does not allow you to create individual RandomState instances.

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1260,7 +1260,6 @@ def unbox_numpy_random_generator(typ, obj, c):
         where deletion happens in Python runtime without NRT being awareness of it. 
     """
     is_error_ptr = cgutils.alloca_once_value(c.builder, cgutils.false_bit)
-    fail_obj = c.context.get_constant_null(typ)
 
     with ExitStack() as stack:
         struct_ptr = cgutils.create_struct_proxy(typ)(c.context, c.builder)

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1199,7 +1199,7 @@ def unbox_numpy_random_generator(typ, obj, c):
 
 
 @box(types.NumPyRandomGeneratorType)
-def box_numpy_random_bitgenerator(typ, val, c):
+def box_numpy_random_generator(typ, val, c):
     inst = c.context.make_helper(c.builder, typ, val)
     obj = inst.parent
     res = cgutils.alloca_once_value(c.builder, obj)

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1216,6 +1216,8 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
             # args tuple for that.
             extra_refs.append(ct_voidptr_ty)
             args = c.pyapi.tuple_pack([interface_next_fn, ct_voidptr_ty])
+            with early_exit_if_null(c.builder, stack, args):
+                handle_failure()
             extra_refs.append(ct_voidptr_ty)
 
             # Call ctypes.cast()

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1200,6 +1200,10 @@ def unbox_numpy_random_generator(typ, obj, c):
     bit_gen_inst = c.pyapi.object_getattr_string(obj, 'bit_generator')
     unboxed = c.unbox(_bit_gen_type, bit_gen_inst).value
     struct_ptr.bit_generator = unboxed
+    blank_ptr = cgutils.alloca_once(c.builder, ir.IntType(8))
+    struct_ptr.meminfo = c.pyapi.nrt_meminfo_new_from_pyobject(
+        blank_ptr, obj
+    )
     struct_ptr.parent = obj
     return NativeValue(struct_ptr._getvalue())
 

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1107,6 +1107,7 @@ def box_LiteralStrKeyDict(typ, val, c):
     return box_unsupported(typ, val, c)
 
 
+# Original implementation at: https://github.com/numba/numba/issues/4499#issuecomment-1063138477
 @unbox(types.NumPyRandomBitGeneratorType)
 def unbox_numpy_random_bitgenerator(typ, obj, c):
     # The bit_generator instance has a `.ctypes` attr which is a namedtuple
@@ -1200,3 +1201,8 @@ def unbox_numpy_random_generator(typ, obj, c):
     unboxed = c.unbox(_bit_gen_type, bit_gen_inst).value
     struct_ptr.bit_generator = unboxed
     return NativeValue(struct_ptr._getvalue())
+
+# @box(types.NumPyRandomGeneratorType)
+# def box_numpy_random_bitgenerator(typ, val, c):
+#     cls_obj = c.pyapi.unserialize(c.pyapi.serialize_object(typ.instance_class))
+#     return c.pyapi.nrt_meminfo_as_pyobject(val)

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1106,6 +1106,7 @@ def unbox_typeref(typ, val, c):
 def box_LiteralStrKeyDict(typ, val, c):
     return box_unsupported(typ, val, c)
 
+import sys
 
 # Original implementation at: https://github.com/numba/numba/issues/4499#issuecomment-1063138477
 @unbox(types.NumPyRandomBitGeneratorType)
@@ -1173,9 +1174,25 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
         setattr(struct_ptr, f'fnptr_{name}',
                 c.unbox(types.uintp, interface_next_fn_casted_value).value)
 
+        c.pyapi.decref(ct_voidptr_ty)
+        c.pyapi.decref(ct_voidptr_ty)
+
+        c.pyapi.decref(interface_next_fn)
+        c.pyapi.decref(interface_next_fn)
+
+        c.pyapi.decref(interface_next_fn_casted_value)
+
     wire_in_fnptrs('next_double')
     wire_in_fnptrs('next_uint64')
     wire_in_fnptrs('next_uint32')
+
+    c.pyapi.decref(ctypes_module)
+    c.pyapi.decref(ctypes_binding)
+    c.pyapi.decref(interface_state)
+    c.pyapi.decref(interface_state_address)
+    c.pyapi.decref(interface_state_value)
+    c.pyapi.decref(ct_cast)
+    c.pyapi.decref(ct_voidptr_ty)
 
     return NativeValue(struct_ptr._getvalue())
 
@@ -1194,6 +1211,7 @@ def unbox_numpy_random_generator(typ, obj, c):
         obj,   # the python object, the call to nrt_meminfo_new_from_pyobject
                # will py_incref
     )
+    c.pyapi.decref(bit_gen_inst)
     is_py_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
     return NativeValue(struct_ptr._getvalue(), is_error=is_py_error)
 

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1120,7 +1120,6 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
 
     struct_ptr = cgutils.create_struct_proxy(typ)(c.context, c.builder)
     struct_ptr.parent = obj
-    # c.pyapi.incref(obj)  # ? need to hold ref to the underlying python obj
 
     # Get the .ctypes attr
     ctypes_binding = c.pyapi.object_getattr_string(obj, 'ctypes')
@@ -1177,7 +1176,7 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
     wire_in_fnptrs('next_uint64')
     wire_in_fnptrs('next_uint32')
 
-    # This is the same as the `state` member but its the bit_generator address,
+    # This is the same as the `state` member but it's the bit_generator address,
     # it's probably never needed.
     interface_bit_generator = c.pyapi.object_getattr_string(
         ctypes_binding, 'bit_generator')

--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1194,7 +1194,8 @@ def unbox_numpy_random_bitgenerator(typ, obj, c):
     c.pyapi.decref(ct_cast)
     c.pyapi.decref(ct_voidptr_ty)
 
-    return NativeValue(struct_ptr._getvalue())
+    is_py_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
+    return NativeValue(struct_ptr._getvalue(), is_error=is_py_error)
 
 _bit_gen_type = types.NumPyRandomBitGeneratorType('bit_generator')
 

--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -73,6 +73,7 @@ class CPUContext(BaseContext):
         from numba.core import optional
         from numba.misc import gdb_hook, literal
         from numba.np import linalg, polynomial, arraymath, arrayobj
+        from numba.np.random import generator_core, generator_methods
         from numba.typed import typeddict, dictimpl
         from numba.typed import typedlist, listobject
         from numba.experimental import jitclass, function_type

--- a/numba/core/types/__init__.py
+++ b/numba/core/types/__init__.py
@@ -25,6 +25,8 @@ py2_string_type = Opaque('str')
 unicode_type = UnicodeType('unicode_type')
 string = unicode_type
 unknown = Dummy('unknown')
+npy_rng = NumPyRandomGeneratorType('rng')
+npy_bitgen = NumPyRandomBitGeneratorType('bitgen')
 
 code_type = Opaque('code')
 pyfunc_type = Opaque('pyfunc')

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -590,3 +590,14 @@ class NestedArray(Array):
     @property
     def key(self):
         return self.dtype, self.shape
+
+class NumPyRandomBitGeneratorType(Type):
+    def __init__(self, *args, **kwargs):
+        super(NumPyRandomBitGeneratorType, self).__init__(*args, **kwargs)
+        self.name = 'NumPyRandomBitGeneratorType'
+
+
+class NumPyRandomGeneratorType(Type):
+    def __init__(self, *args, **kwargs):
+        super(NumPyRandomGeneratorType, self).__init__(*args, **kwargs)
+        self.name = 'NumPyRandomGeneratorType'

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -591,6 +591,7 @@ class NestedArray(Array):
     def key(self):
         return self.dtype, self.shape
 
+
 class NumPyRandomBitGeneratorType(Type):
     def __init__(self, *args, **kwargs):
         super(NumPyRandomBitGeneratorType, self).__init__(*args, **kwargs)

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -7,15 +7,15 @@ import numpy as np
 
 from numba.core import types, utils, errors
 from numba.np import numpy_support
-
+from numba.np.numpy_support import numpy_version
 # terminal color markup
 _termcolor = errors.termcolor()
 
 # Note that the BitGenerator class exists in _bit_generator.pxd in
 # NumPy 1.18 (has underscore) and then bit_generator.pxd in NumPy 1.19
-try:
+if numpy_version < (1, 19):
     from numpy.random._bit_generator import BitGenerator
-except ImportError:
+else:
     from numpy.random.bit_generator import BitGenerator
 
 

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -11,6 +11,12 @@ from numba.np import numpy_support
 # terminal color markup
 _termcolor = errors.termcolor()
 
+# https://github.com/numba/numba/pull/7900#issuecomment-1065026619
+try:
+    from numpy.random._bit_generator import BitGenerator
+except ImportError:
+    from numpy.random.bit_generator import BitGenerator
+
 
 class Purpose(enum.Enum):
     # Value being typed is used as an argument
@@ -265,3 +271,13 @@ def _typeof_nb_type(val, c):
         return types.NumberClass(val)
     else:
         return types.TypeRef(val)
+
+
+@typeof_impl.register(BitGenerator)
+def typeof_numpy_random_bitgen(val, c):
+    return types.NumPyRandomBitGeneratorType(val)
+
+
+@typeof_impl.register(np.random.Generator)
+def typeof_random_generator(val, c):
+    return types.NumPyRandomGeneratorType(val)

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -11,7 +11,8 @@ from numba.np import numpy_support
 # terminal color markup
 _termcolor = errors.termcolor()
 
-# https://github.com/numba/numba/pull/7900#issuecomment-1065026619
+# Note that the BitGenerator class exists in _bit_generator.pxd in
+# NumPy 1.18 (has underscore) and then bit_generator.pxd in NumPy 1.19
 try:
     from numpy.random._bit_generator import BitGenerator
 except ImportError:

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -51,8 +51,10 @@ make_attribute_wrapper(
     'bit_generator')
 
 
-# Generate the overloads for "next_(some type)" functions
 def _generate_next_binding(overloadable_function, return_type):
+    """
+        Generate the overloads for "next_(some type)" functions.
+    """
     @intrinsic
     def intrin_NumPyRandomBitGeneratorType_next_ty(tyctx, inst):
         sig = return_type(inst)

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -33,6 +33,7 @@ class NumPyRandomGeneratorTypeModel(models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
             ('bit_generator', _bit_gen_type),
+            ('meminfo', types.MemInfoPointer(types.voidptr)),
             ('parent', types.pyobject)
         ]
         super(

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -1,0 +1,113 @@
+
+from llvmlite import ir
+from numba.core import cgutils, types
+from numba.core.extending import (intrinsic, make_attribute_wrapper, models,
+                                  overload, register_jitable,
+                                  register_model)
+from numba.core.imputils import Registry
+
+registry = Registry('generator_core')
+
+
+@register_model(types.NumPyRandomBitGeneratorType)
+class NumPyRngBitGeneratorModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('parent', types.pyobject),
+            ('state_address', types.uintp),
+            ('state', types.uintp),
+            ('fnptr_next_uint64', types.uintp),
+            ('fnptr_next_uint32', types.uintp),
+            ('fnptr_next_double', types.uintp),
+            ('bit_generator', types.uintp),
+        ]
+        super(NumPyRngBitGeneratorModel, self).__init__(dmm, fe_type, members)
+
+
+_bit_gen_type = types.NumPyRandomBitGeneratorType('bit_generator')
+
+
+@register_model(types.NumPyRandomGeneratorType)
+class NumPyRandomGeneratorTypeModel(models.StructModel):
+    def __init__(self, dmm, fe_type):
+        members = [
+            ('bit_generator', _bit_gen_type),
+        ]
+        super(
+            NumPyRandomGeneratorTypeModel,
+            self).__init__(
+            dmm,
+            fe_type,
+            members)
+
+
+# The Generator instances have a bit_generator attr
+make_attribute_wrapper(
+    types.NumPyRandomGeneratorType,
+    'bit_generator',
+    'bit_generator')
+
+
+# Generate the overloads for "next_(some type)" functions
+def generate_next_binding(overloadable_function, return_type):
+    @intrinsic
+    def intrin_NumPyRandomBitGeneratorType_next_ty(tyctx, inst):
+        sig = return_type(inst)
+
+        def codegen(cgctx, builder, sig, llargs):
+            name = overloadable_function.__name__
+            struct_ptr = cgutils.create_struct_proxy(inst)(cgctx, builder,
+                                                           value=llargs[0])
+
+            # Get the 'state' and 'fnptr_next_(type)' members of the struct
+            state = struct_ptr.state
+            next_double_addr = getattr(struct_ptr, f'fnptr_{name}')
+
+            # LLVM IR types needed
+            ll_void_ptr_t = cgctx.get_value_type(types.voidptr)
+            ll_return_t = cgctx.get_value_type(return_type)
+            ll_uintp_t = cgctx.get_value_type(types.uintp)
+
+            # Convert the stored Generator function address to a pointer
+            next_fn_fnptr = builder.inttoptr(
+                next_double_addr, ll_void_ptr_t)
+            # Add the function to the module
+            fnty = ir.FunctionType(ll_return_t, (ll_uintp_t,))
+            next_fn = cgutils.get_or_insert_function(
+                builder.module, fnty, name)
+            # Bit cast the function pointer to the function type
+            hack = builder.bitcast(next_fn_fnptr, next_fn.type)
+            # call it with the "state" address as the arg
+            ret = builder.call(hack, (state,))
+            return ret
+        return sig, codegen
+
+    @overload(overloadable_function)
+    def ol_next_ty(bitgen):
+        if isinstance(bitgen, types.NumPyRandomBitGeneratorType):
+            def impl(bitgen):
+                return intrin_NumPyRandomBitGeneratorType_next_ty(bitgen)
+            return impl
+
+
+# Some function stubs for "next(some type)", these will be overloaded
+def next_double(bitgen):
+    return bitgen.ctypes.next_double(bitgen.ctypes.state)
+
+
+def next_uint32(bitgen):
+    return bitgen.ctypes.next_uint32(bitgen.ctypes.state)
+
+
+def next_uint64(bitgen):
+    return bitgen.ctypes.next_uint64(bitgen.ctypes.state)
+
+
+generate_next_binding(next_double, types.double)
+generate_next_binding(next_uint32, types.uint32)
+generate_next_binding(next_uint64, types.uint64)
+
+
+@register_jitable
+def next_float(bitgen):
+    return (next_uint32(bitgen) >> 9) * (1.0 / 8388608.0)

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -33,6 +33,7 @@ class NumPyRandomGeneratorTypeModel(models.StructModel):
     def __init__(self, dmm, fe_type):
         members = [
             ('bit_generator', _bit_gen_type),
+            ('parent', types.pyobject)
         ]
         super(
             NumPyRandomGeneratorTypeModel,

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -7,6 +7,7 @@ from numba.core import cgutils, types
 from numba.core.extending import (intrinsic, make_attribute_wrapper, models,
                                   overload, register_jitable,
                                   register_model)
+from numba.np.numpy_support import numpy_version
 
 
 @register_model(types.NumPyRandomBitGeneratorType)
@@ -108,6 +109,11 @@ _generate_next_binding(next_uint32, types.uint32)
 _generate_next_binding(next_uint64, types.uint64)
 
 
-@register_jitable
-def next_float(bitgen):
-    return (next_uint32(bitgen) >> 9) * (1.0 / 8388608.0)
+if numpy_version >= (1, 22):
+    @register_jitable
+    def next_float(bitgen):
+        return (next_uint32(bitgen) >> 8) * (1.0 / 16777216.0)
+else:
+    @register_jitable
+    def next_float(bitgen):
+        return (next_uint32(bitgen) >> 9) * (1.0 / 8388608.0)

--- a/numba/np/random/generator_core.py
+++ b/numba/np/random/generator_core.py
@@ -113,6 +113,7 @@ _generate_next_binding(next_uint32, types.uint32)
 _generate_next_binding(next_uint64, types.uint64)
 
 
+# This is for keeping parity with: https://github.com/numpy/numpy/pull/20314
 if numpy_version >= (1, 22):
     @register_jitable
     def next_float(bitgen):

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -12,11 +12,14 @@ from numba.core.errors import TypingError
 from numba.core.types.containers import Tuple, UniTuple
 
 
-# Most of the standard NumPy distributions only support either
-# np.float32 or np.float64 as dtype arguments. This is a helper
-# function that helps Numba select the proper underlying
-# implementation according to provided dtype.
 def _get_proper_func(func_32, func_64, dtype, dist_name="the given"):
+    """
+        Most of the standard NumPy distributions that accept dtype argument
+        only support either np.float32 or np.float64 as dtypes.
+
+        This is a helper function that helps Numba select the proper underlying
+        implementation according to provided dtype.
+    """
     if isinstance(dtype, types.Omitted):
         dtype = dtype.value
 

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -1,0 +1,58 @@
+import numpy as np
+from numba.core import types
+from numba.core.extending import overload_method
+from numba.core.imputils import Registry
+from numba.np.numpy_support import as_dtype, from_dtype
+from numba.np.random.generator_core import next_float, next_double
+
+
+registry = Registry('generator_methods')
+
+
+# Most of the standard Numpy distributions only support either
+# np.float32 or np.float64 as dtype arguments. This is a helper
+# function that helps Numba select the proper underlying
+# implementation according to provided dtype.
+def get_proper_func(func_32, func_64, dtype, dist_name="the given"):
+    if isinstance(dtype, types.Omitted):
+        dtype = dtype.value
+
+    if not isinstance(dtype, types.Type):
+        dt = np.dtype(dtype)
+        nb_dt = from_dtype(dt)
+        np_dt = dtype
+    else:
+        nb_dt = dtype
+        np_dt = as_dtype(nb_dt)
+
+    np_dt = np.dtype(np_dt)
+
+    if np_dt == np.float32:
+        next_func = func_32
+    elif np_dt == np.float64:
+        next_func = func_64
+    else:
+        raise TypeError(f"Unsupported dtype {np_dt} for\
+        {dist_name} distribution")
+
+    return next_func, nb_dt
+
+
+# Overload the Generator().random()
+@overload_method(types.NumPyRandomGeneratorType, 'random')
+def NumPyRandomGeneratorType_random(inst, size=None, dtype=np.float64):
+    dist_func, nb_dt = get_proper_func(next_float, next_double, dtype, "random")
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if isinstance(size, (types.NoneType,)) or size is None:
+        def impl(inst, size=None, dtype=np.float64):
+            return nb_dt(dist_func(inst.bit_generator))
+        return impl
+    else:
+        def impl(inst, size=None, dtype=np.float64):
+            out = np.empty(size, dtype=dtype)
+            for i in np.ndindex(size):
+                out[i] = dist_func(inst.bit_generator)
+            return out
+        return impl

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -8,7 +8,8 @@ from numba.core.extending import overload_method
 from numba.np.numpy_support import as_dtype, from_dtype
 from numba.np.random.generator_core import next_float, next_double
 from numba.np.numpy_support import is_nonelike
-from numba.errors import TypingError
+from numba.core.errors import TypingError
+from numba.core.types.containers import Tuple, UniTuple
 
 
 # Most of the standard NumPy distributions only support either
@@ -34,8 +35,9 @@ def _get_proper_func(func_32, func_64, dtype, dist_name="the given"):
     elif np_dt == np.float64:
         next_func = func_64
     else:
-        raise TypingError(f"Unsupported dtype {np_dt} for\
-        {dist_name} distribution")
+        raise TypingError(
+            f"Unsupported dtype {np_dt} for {dist_name} distribution"
+        )
 
     return next_func, nb_dt
 
@@ -53,6 +55,13 @@ def NumPyRandomGeneratorType_random(inst, size=None, dtype=np.float64):
             return nb_dt(dist_func(inst.bit_generator))
         return impl
     else:
+        assert any([isinstance(size, UniTuple) and
+                   isinstance(size.dtype, types.Integer),
+                   isinstance(size, Tuple) and size.count == 0,
+                   isinstance(size, types.Integer)
+                   ]), "Size argument either of None,"\
+            + " an integer, an empty tuple or a tuple of integers"
+
         def impl(inst, size=None, dtype=np.float64):
             out = np.empty(size, dtype=dtype)
             for i in np.ndindex(size):

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -1,19 +1,21 @@
+"""
+Implementation of method overloads for Generator objects.
+"""
+
 import numpy as np
 from numba.core import types
 from numba.core.extending import overload_method
-from numba.core.imputils import Registry
 from numba.np.numpy_support import as_dtype, from_dtype
 from numba.np.random.generator_core import next_float, next_double
+from numba.np.numpy_support import is_nonelike
+from numba.errors import TypingError
 
 
-registry = Registry('generator_methods')
-
-
-# Most of the standard Numpy distributions only support either
+# Most of the standard NumPy distributions only support either
 # np.float32 or np.float64 as dtype arguments. This is a helper
 # function that helps Numba select the proper underlying
 # implementation according to provided dtype.
-def get_proper_func(func_32, func_64, dtype, dist_name="the given"):
+def _get_proper_func(func_32, func_64, dtype, dist_name="the given"):
     if isinstance(dtype, types.Omitted):
         dtype = dtype.value
 
@@ -32,7 +34,7 @@ def get_proper_func(func_32, func_64, dtype, dist_name="the given"):
     elif np_dt == np.float64:
         next_func = func_64
     else:
-        raise TypeError(f"Unsupported dtype {np_dt} for\
+        raise TypingError(f"Unsupported dtype {np_dt} for\
         {dist_name} distribution")
 
     return next_func, nb_dt
@@ -41,11 +43,12 @@ def get_proper_func(func_32, func_64, dtype, dist_name="the given"):
 # Overload the Generator().random()
 @overload_method(types.NumPyRandomGeneratorType, 'random')
 def NumPyRandomGeneratorType_random(inst, size=None, dtype=np.float64):
-    dist_func, nb_dt = get_proper_func(next_float, next_double, dtype, "random")
+    dist_func, nb_dt = _get_proper_func(next_float, next_double,
+                                        dtype, "random")
     if isinstance(size, types.Omitted):
         size = size.value
 
-    if isinstance(size, (types.NoneType,)) or size is None:
+    if is_nonelike(size):
         def impl(inst, size=None, dtype=np.float64):
             return nb_dt(dist_func(inst.bit_generator))
         return impl

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -58,8 +58,8 @@ def NumPyRandomGeneratorType_random(inst, size=None, dtype=np.float64):
         assert any([isinstance(size, UniTuple) and
                    isinstance(size.dtype, types.Integer),
                    isinstance(size, Tuple) and size.count == 0,
-                   isinstance(size, types.Integer)
-                   ]), "Size argument either of None,"\
+                   isinstance(size, types.Integer)]
+                   ), "Size argument either of None,"\
             + " an integer, an empty tuple or a tuple of integers"
 
         def impl(inst, size=None, dtype=np.float64):

--- a/numba/tests/doc_examples/test_numpy_generators.py
+++ b/numba/tests/doc_examples/test_numpy_generators.py
@@ -1,0 +1,37 @@
+# "magictoken" is used for markers as beginning and ending of example text.
+
+import unittest
+import numpy as np
+import numba
+
+
+class NumpyGeneratorUsageTest(unittest.TestCase):
+
+    def test_numpy_gen_usage(self):
+        # magictoken.npgen_usage.begin
+        x = np.random.default_rng(1)
+        y = np.random.default_rng(1)
+
+        size = 10
+
+        @numba.njit
+        def do_stuff(gen):
+            return gen.random(size=int(size / 2))
+
+        original = x.random(size=size)
+        # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145
+        #  0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
+
+        numba_res = do_stuff(y)
+        # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145]
+
+        after_numba = y.random(size=int(size / 2))
+        # [0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
+
+        # magictoken.npgen_usage.end
+        self.assertEqual(original,
+                         np.concatenate(numba_res, after_numba))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/doc_examples/test_numpy_generators.py
+++ b/numba/tests/doc_examples/test_numpy_generators.py
@@ -22,15 +22,16 @@ class NumpyGeneratorUsageTest(unittest.TestCase):
         # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145
         #  0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
 
-        numba_res = do_stuff(y)
+        numba_func_res = do_stuff(y)
         # [0.51182162 0.9504637  0.14415961 0.94864945 0.31183145]
 
         after_numba = y.random(size=int(size / 2))
         # [0.42332645 0.82770259 0.40919914 0.54959369 0.02755911]
 
         # magictoken.npgen_usage.end
-        self.assertEqual(original,
-                         np.concatenate(numba_res, after_numba))
+        numba_res = np.concatenate((numba_func_res, after_numba))
+        for _np_res, _nb_res in zip(original, numba_res):
+            self.assertEqual(_np_res, _nb_res)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -84,6 +84,12 @@ class TestRandomGenerators(TestCase):
 
         self.assertPreciseEqual(numba_res, numpy_res)
 
+    def test_npgen_boxing_unboxing(self):
+        rng_instance = np.random.default_rng()
+        numba_func = numba.njit(lambda x: x)
+        self.assertEqual(rng_instance, numba_func(rng_instance))
+        self.assertEqual(id(rng_instance), id(numba_func(rng_instance)))
+
     def test_bitgen_funcs(self):
         self._test_bitgen_func_parity("next_uint32", next_uint32)
         self._test_bitgen_func_parity("next_uint64", next_uint64)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from numba import types
 from numba.tests.support import TestCase
-from numba.np.random.generator_methods import get_proper_func
+from numba.np.random.generator_methods import _get_proper_func
 from numpy.random import MT19937, Generator
 from numpy.testing import assert_equal, assert_array_equal, assert_raises
 
@@ -15,35 +15,35 @@ def test_proper_func_provider():
     def test_64bit_func():
         return 64
 
-    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
-                                 np.float64)[0](), 64)
-    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
-                                 np.float32)[0](), 32)
-    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
-                                 types.float64)[0](), 64)
-    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
-                                 types.float32)[0](), 32)
+    assert_equal(_get_proper_func(test_32bit_func, test_64bit_func,
+                                  np.float64)[0](), 64)
+    assert_equal(_get_proper_func(test_32bit_func, test_64bit_func,
+                                  np.float32)[0](), 32)
+    assert_equal(_get_proper_func(test_32bit_func, test_64bit_func,
+                                  types.float64)[0](), 64)
+    assert_equal(_get_proper_func(test_32bit_func, test_64bit_func,
+                                  types.float32)[0](), 32)
 
     # With any other datatype it should return a TypeError
     with assert_raises(TypeError):
-        get_proper_func(test_32bit_func, test_64bit_func, np.int32)
+        _get_proper_func(test_32bit_func, test_64bit_func, np.int32)
 
 
 class TestRandomGenerators(TestCase):
     def check_numpy_parity(self, distribution_func,
-                           bitgen_instance=None, seed=1,
+                           bitgen_type=None, seed=1,
                            test_sizes=None, test_dtypes=None):
 
         distribution_func = numba.njit(distribution_func)
-        if bitgen_instance is None:
+        if bitgen_type is None:
             numba_rng_instance = np.random.default_rng(seed=seed)
             numpy_rng_instance = np.random.default_rng(seed=seed)
         else:
-            numba_rng_instance = Generator(bitgen_instance(seed))
-            numpy_rng_instance = Generator(bitgen_instance(seed))
+            numba_rng_instance = Generator(bitgen_type(seed))
+            numpy_rng_instance = Generator(bitgen_type(seed))
 
         if test_sizes is None:
-            test_sizes = [None, (), (100,), (10,20,30)]
+            test_sizes = [None, (), (100,), (10, 20, 30)]
         if test_dtypes is None:
             test_dtypes = [np.float32, np.float64]
 
@@ -72,8 +72,8 @@ class TestRandomGenerators(TestCase):
         # Provide single values so this test would run exactly once
         self.check_numpy_parity(dist_func, test_sizes=[100],
                                 test_dtypes=[np.float64])
-        self.check_numpy_parity(dist_func, bitgen_instance=MT19937)
+        self.check_numpy_parity(dist_func, bitgen_type=MT19937)
 
         dist_func = lambda x, size, dtype:x.random(size=size, dtype=dtype)
         self.check_numpy_parity(dist_func)
-        self.check_numpy_parity(dist_func, bitgen_instance=MT19937)
+        self.check_numpy_parity(dist_func, bitgen_type=MT19937)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -95,6 +95,15 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self._test_bitgen_func_parity("next_uint64", next_uint64)
         self._test_bitgen_func_parity("next_double", next_double)
 
+    def test_randomgen_caching(self):
+        nb_rng = np.random.default_rng(1)
+        np_rng = np.random.default_rng(1)
+
+        numba_func = numba.njit(lambda x: x.random(10), cache=True)
+        self.assertPreciseEqual(np_rng.random(10), numba_func(nb_rng))
+        # Run the function twice to make sure caching doesn't break anything.
+        self.assertPreciseEqual(np_rng.random(10), numba_func(nb_rng))
+
     def test_random(self):
         # Test with no arguments
         dist_func = lambda x, size, dtype:x.random()

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1,0 +1,79 @@
+import numba
+import numpy as np
+
+from numba import types
+from numba.tests.support import TestCase
+from numba.np.random.generator_methods import get_proper_func
+from numpy.random import MT19937, Generator
+from numpy.testing import assert_equal, assert_array_equal, assert_raises
+
+
+def test_proper_func_provider():
+    def test_32bit_func():
+        return 32
+
+    def test_64bit_func():
+        return 64
+
+    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
+                                 np.float64)[0](), 64)
+    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
+                                 np.float32)[0](), 32)
+    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
+                                 types.float64)[0](), 64)
+    assert_equal(get_proper_func(test_32bit_func, test_64bit_func,
+                                 types.float32)[0](), 32)
+
+    # With any other datatype it should return a TypeError
+    with assert_raises(TypeError):
+        get_proper_func(test_32bit_func, test_64bit_func, np.int32)
+
+
+class TestRandomGenerators(TestCase):
+    def check_numpy_parity(self, distribution_func,
+                           bitgen_instance=None, seed=1,
+                           test_sizes=None, test_dtypes=None):
+
+        distribution_func = numba.njit(distribution_func)
+        if bitgen_instance is None:
+            numba_rng_instance = np.random.default_rng(seed=seed)
+            numpy_rng_instance = np.random.default_rng(seed=seed)
+        else:
+            numba_rng_instance = Generator(bitgen_instance(seed))
+            numpy_rng_instance = Generator(bitgen_instance(seed))
+
+        if test_sizes is None:
+            test_sizes = [None, (), (100,), (10,20,30)]
+        if test_dtypes is None:
+            test_dtypes = [np.float32, np.float64]
+
+        # Check parity for different size cases
+        for size in test_sizes:
+            for dtype in test_dtypes:
+                numba_res = distribution_func(numba_rng_instance,
+                                              size, dtype)
+                numpy_res = distribution_func.py_func(numpy_rng_instance,
+                                                      size, dtype)
+
+                assert_array_equal(numba_res, numpy_res)
+
+        # Check if the end state of both BitGenerators is same
+        # after drawing the distributions
+        numba_gen_state = numba_rng_instance.__getstate__()['state']
+        numpy_gen_state = numpy_rng_instance.__getstate__()['state']
+
+        for _state_key in numpy_gen_state:
+            assert_equal(numba_gen_state[_state_key],
+                         numpy_gen_state[_state_key])
+
+    def test_random(self):
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.random()
+        # Provide single values so this test would run exactly once
+        self.check_numpy_parity(dist_func, test_sizes=[100],
+                                test_dtypes=[np.float64])
+        self.check_numpy_parity(dist_func, bitgen_instance=MT19937)
+
+        dist_func = lambda x, size, dtype:x.random(size=size, dtype=dtype)
+        self.check_numpy_parity(dist_func)
+        self.check_numpy_parity(dist_func, bitgen_instance=MT19937)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -2,7 +2,7 @@ import numba
 import numpy as np
 
 from numba import types
-from numba.tests.support import TestCase
+from numba.tests.support import TestCase, MemoryLeakMixin
 from numba.np.random.generator_methods import _get_proper_func
 from numba.np.random.generator_core import next_uint32, next_uint64, next_double
 from numpy.random import MT19937, Generator
@@ -35,7 +35,7 @@ class TestHelperFuncs(TestCase):
         )
 
 
-class TestRandomGenerators(TestCase):
+class TestRandomGenerators(MemoryLeakMixin, TestCase):
     def check_numpy_parity(self, distribution_func,
                            bitgen_type=None, seed=1,
                            test_sizes=None, test_dtypes=None):

--- a/numba/tests/test_typeof.py
+++ b/numba/tests/test_typeof.py
@@ -309,6 +309,15 @@ class TestTypeof(ValueTypingTestBase, TestCase):
         self.assertEqual(len({ty0, ty1, ty2}), 3)
         self.assertEqual(ty3, ty2)
 
+    def test_np_random(self):
+        rng = np.random.default_rng()
+        ty_rng = typeof(rng)
+        ty_bitgen = typeof(rng.bit_generator)
+
+        self.assertEqual(ty_rng, types.npy_rng)
+        self.assertEqual(ty_bitgen, types.npy_bitgen)
+
+
 class DistinctChecker(object):
 
     def __init__(self):


### PR DESCRIPTION
This PR adds the core `BitGenerator` implementation from #7900 and adds support for `np.random.Generator().random()`

cc @esc @stuartarchibald 