### PR TITLE
Support for Numpy BitGenerators PR#3: Advanced Distributions Support.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -620,7 +620,6 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().f()` (*)
 * :func:`numpy.random.Generator().gamma()` (*)
 * :func:`numpy.random.Generator().geometric()` (*)
-* :func:`numpy.random.Generator().gumbel()`
 * :func:`numpy.random.Generator().laplace()` (*)
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
@@ -638,7 +637,6 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().standard_t()` (*)
 * :func:`numpy.random.Generator().triangular()`
 * :func:`numpy.random.Generator().uniform()` (*)
-* :func:`numpy.random.Generator().von_mises()`
 * :func:`numpy.random.Generator().wald()` (*)
 * :func:`numpy.random.Generator().weibull()`
 * :func:`numpy.random.Generator().zipf()`

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -614,14 +614,34 @@ execution logic.
 
 The following :py:class:`Generator` methods are supported:
 
+* :func:`numpy.random.Generator().beta()` (*)
+* :func:`numpy.random.Generator().chisquare()` (*)
 * :func:`numpy.random.Generator().exponential()`
+* :func:`numpy.random.Generator().f()` (*)
 * :func:`numpy.random.Generator().gamma()` (*)
+* :func:`numpy.random.Generator().geometric()` (*)
+* :func:`numpy.random.Generator().gumbel()`
+* :func:`numpy.random.Generator().laplace()` (*)
+* :func:`numpy.random.Generator().logistic()` (*)
+* :func:`numpy.random.Generator().lognormal()` (*)
+* :func:`numpy.random.Generator().negative_binomial()` (*)
 * :func:`numpy.random.Generator().normal()` (*)
+* :func:`numpy.random.Generator().pareto()`
+* :func:`numpy.random.Generator().poisson()` (*)
+* :func:`numpy.random.Generator().power()`
 * :func:`numpy.random.Generator().random()`
-* :func:`numpy.random.Generator().standard_normal()`
+* :func:`numpy.random.Generator().rayleigh()`
+* :func:`numpy.random.Generator().standard_cauchy()`
 * :func:`numpy.random.Generator().standard_exponential()`
 * :func:`numpy.random.Generator().standard_gamma()` (*)
+* :func:`numpy.random.Generator().standard_normal()`
+* :func:`numpy.random.Generator().standard_t()` (*)
+* :func:`numpy.random.Generator().triangular()`
 * :func:`numpy.random.Generator().uniform()` (*)
+* :func:`numpy.random.Generator().von_mises()`
+* :func:`numpy.random.Generator().wald()` (*)
+* :func:`numpy.random.Generator().weibull()`
+* :func:`numpy.random.Generator().zipf()`
 
 .. note::
   Users can expect Numba to replicate NumPy's results to within

--- a/numba/np/random/distributions.py
+++ b/numba/np/random/distributions.py
@@ -4,6 +4,7 @@ of random distributions.
 """
 
 import numpy as np
+
 from numba.core.extending import register_jitable
 from numba.np.random._constants import (wi_double, ki_double,
                                         ziggurat_nor_r, fi_double,
@@ -14,6 +15,7 @@ from numba.np.random._constants import (wi_double, ki_double,
                                         ziggurat_exp_r, fe_double,
                                         we_float, ke_float,
                                         ziggurat_exp_r_f, fe_float,
+                                        M_PI, INT64_MAX,
                                         ziggurat_nor_inv_r)
 from numba.np.random.generator_core import (next_double, next_float,
                                             next_uint32, next_uint64)
@@ -31,6 +33,10 @@ if numpy_version >= (1, 21):
     @register_jitable
     def np_log1pf(x):
         return np.log1p(float32(x))
+
+    @register_jitable
+    def random_rayleigh(bitgen, mode):
+        return mode * np.sqrt(2.0 * random_standard_exponential(bitgen))
 else:
     @register_jitable
     def np_log1p(x):
@@ -40,6 +46,19 @@ else:
     def np_log1pf(x):
         f32_one = np.float32(1.0)
         return np.log(f32_one + float32(x))
+
+    @register_jitable
+    def random_rayleigh(bitgen, mode):
+        return mode * np.sqrt(-2.0 * np.log(1.0 - next_double(bitgen)))
+
+if numpy_version >= (1, 22):
+    @register_jitable
+    def np_expm1(x):
+        return np.expm1(x)
+else:
+    @register_jitable
+    def np_expm1(x):
+        return np.exp(x) - 1.0
 
 
 @register_jitable
@@ -257,3 +276,310 @@ def random_gamma(bitgen, shape, scale):
 @register_jitable
 def random_gamma_f(bitgen, shape, scale):
     return float32(scale * random_standard_gamma_f(bitgen, shape))
+
+
+@register_jitable
+def random_beta(bitgen, a, b):
+    if a <= 1.0 and b <= 1.0:
+        while 1:
+            U = next_double(bitgen)
+            V = next_double(bitgen)
+            X = pow(U, 1.0 / a)
+            Y = pow(V, 1.0 / b)
+            XpY = X + Y
+            if XpY <= 1.0 and XpY > 0.0:
+                if (X + Y > 0):
+                    return X / XpY
+                else:
+                    logX = np.log(U) / a
+                    logY = np.log(V) / b
+                    logM = min(logX, logY)
+                    logX -= logM
+                    logY -= logM
+
+                    return np.exp(logX - np.log(np.exp(logX) + np.exp(logY)))
+    else:
+        Ga = random_standard_gamma(bitgen, a)
+        Gb = random_standard_gamma(bitgen, b)
+        return Ga / (Ga + Gb)
+
+
+@register_jitable
+def random_chisquare(bitgen, df):
+    return 2.0 * random_standard_gamma(bitgen, df / 2.0)
+
+
+@register_jitable
+def random_f(bitgen, dfnum, dfden):
+    return ((random_chisquare(bitgen, dfnum) * dfden) /
+            (random_chisquare(bitgen, dfden) * dfnum))
+
+
+@register_jitable
+def random_standard_cauchy(bitgen):
+    return random_standard_normal(bitgen) / random_standard_normal(bitgen)
+
+
+@register_jitable
+def random_pareto(bitgen, a):
+    return np_expm1(random_standard_exponential(bitgen) / a)
+
+
+@register_jitable
+def random_weibull(bitgen, a):
+    if (a == 0.0):
+        return 0.0
+    return pow(random_standard_exponential(bitgen), 1. / a)
+
+
+@register_jitable
+def random_power(bitgen, a):
+    return pow(-np_expm1(-random_standard_exponential(bitgen)), 1. / a)
+
+
+@register_jitable
+def random_laplace(bitgen, loc, scale):
+    U = next_double(bitgen)
+    while U <= 0:
+        U = next_double(bitgen)
+    if (U >= 0.5):
+        U = loc - scale * np.log(2.0 - U - U)
+    elif (U > 0.0):
+        U = loc + scale * np.log(U + U)
+    return U
+
+
+@register_jitable
+def random_gumbel(bitgen, loc, scale):
+    U = 1.0 - next_double(bitgen)
+    while U >= 1.0:
+        U = 1.0 - next_double(bitgen)
+    return loc - scale * np.log(-np.log(U))
+
+
+@register_jitable
+def random_logistic(bitgen, loc, scale):
+    U = next_double(bitgen)
+    while U <= 0.0:
+        U = next_double(bitgen)
+    return loc + scale * np.log(U / (1.0 - U))
+
+
+@register_jitable
+def random_lognormal(bitgen, mean, sigma):
+    return np.exp(random_normal(bitgen, mean, sigma))
+
+
+@register_jitable
+def random_standard_t(bitgen, df):
+    num = random_standard_normal(bitgen)
+    denom = random_standard_gamma(bitgen, df / 2)
+    return np.sqrt(df / 2) * num / np.sqrt(denom)
+
+
+@register_jitable
+def random_wald(bitgen, mean, scale):
+    mu_2l = mean / (2 * scale)
+    Y = random_standard_normal(bitgen)
+    Y = mean * Y * Y
+    X = mean + mu_2l * (Y - np.sqrt(4 * scale * Y + Y * Y))
+    U = next_double(bitgen)
+    if (U <= mean / (mean + X)):
+        return X
+    else:
+        return mean * mean / X
+
+
+@register_jitable
+def random_vonmises(bitgen, mu, kappa):
+    if (kappa < 1e-8):
+        return M_PI * (2 * next_double(bitgen) - 1)
+    else:
+        if (kappa < 1e-5):
+            s = (1. / kappa + kappa)
+        else:
+            if (kappa <= 1e6):
+                r = 1 + np.sqrt(1 + 4 * kappa * kappa)
+                rho = (r - np.sqrt(2 * r)) / (2 * kappa)
+                s = (1 + rho * rho) / (2 * rho)
+            else:
+                result = mu + np.sqrt(1. / kappa) * \
+                    random_standard_normal(bitgen)
+                if (result < -M_PI):
+                    result += 2 * M_PI
+                if (result > M_PI):
+                    result -= 2 * M_PI
+                return result
+
+        while 1:
+            U = next_double(bitgen)
+            Z = np.cos(M_PI * U)
+            W = (1 + s * Z) / (s + Z)
+            Y = kappa * (s - W)
+            V = next_double(bitgen)
+            if ((Y * (2 - Y) - V >= 0) or (np.log(Y / V) + 1 - Y >= 0)):
+                break
+
+        U = next_double(bitgen)
+
+        result = np.arccos(W)
+        if (U < 0.5):
+            result = -result
+        result += mu
+        neg = (result < 0)
+        mod = np.fabs(result)
+        mod = (np.fmod(mod + M_PI, 2 * M_PI) - M_PI)
+        if (neg):
+            mod *= -1
+
+        return mod
+
+
+@register_jitable
+def random_geometric_search(bitgen, p):
+    X = 1
+    sum = prod = p
+    q = 1.0 - p
+    U = next_double(bitgen)
+    while (U > sum):
+        prod *= q
+        sum += prod
+        X = X + 1
+    return X
+
+
+@register_jitable
+def random_geometric_inversion(bitgen, p):
+    return np.ceil(-random_standard_exponential(bitgen) / np.log1p(-p))
+
+
+@register_jitable
+def random_geometric(bitgen, p):
+    if (p >= 0.333333333333333333333333):
+        return random_geometric_search(bitgen, p)
+    else:
+        return random_geometric_inversion(bitgen, p)
+
+
+@register_jitable
+def random_zipf(bitgen, a):
+    am1 = a - 1.0
+    b = pow(2.0, am1)
+    while 1:
+        U = 1.0 - next_double(bitgen)
+        V = next_double(bitgen)
+        X = np.floor(pow(U, -1.0 / am1))
+        if (X > INT64_MAX or X < 1.0):
+            continue
+
+        T = pow(1.0 + 1.0 / X, am1)
+        if (V * X * (T - 1.0) / (b - 1.0) <= T / b):
+            return X
+
+
+@register_jitable
+def random_triangular(bitgen, left, mode,
+                      right):
+    base = right - left
+    leftbase = mode - left
+    ratio = leftbase / base
+    leftprod = leftbase * base
+    rightprod = (right - mode) * base
+
+    U = next_double(bitgen)
+    if (U <= ratio):
+        return left + np.sqrt(U * leftprod)
+    else:
+        return right - np.sqrt((1.0 - U) * rightprod)
+
+
+@register_jitable
+def random_loggam(x):
+    a = [8.333333333333333e-02, -2.777777777777778e-03,
+         7.936507936507937e-04, -5.952380952380952e-04,
+         8.417508417508418e-04, -1.917526917526918e-03,
+         6.410256410256410e-03, -2.955065359477124e-02,
+         1.796443723688307e-01, -1.39243221690590e+00]
+
+    if ((x == 1.0) or (x == 2.0)):
+        return 0.0
+    elif (x < 7.0):
+        n = int(7 - x)
+    else:
+        n = 0
+
+    x0 = x + n
+    x2 = (1.0 / x0) * (1.0 / x0)
+    # /* log(2 * M_PI) */
+    lg2pi = 1.8378770664093453e+00
+    gl0 = a[9]
+
+    for k in range(0, 9):
+        gl0 *= x2
+        gl0 += a[8 - k]
+
+    gl = gl0 / x0 + 0.5 * lg2pi + (x0 - 0.5) * np.log(x0) - x0
+    if (x < 7.0):
+        for k in range(1, n + 1):
+            gl = gl - np.log(x0 - 1.0)
+            x0 = x0 - 1.0
+
+    return gl
+
+
+@register_jitable
+def random_poisson_mult(bitgen, lam):
+    enlam = np.exp(-lam)
+    X = 0
+    prod = 1.0
+    while (1):
+        U = next_double(bitgen)
+        prod *= U
+        if (prod > enlam):
+            X += 1
+        else:
+            return X
+
+
+@register_jitable
+def random_poisson_ptrs(bitgen, lam):
+
+    slam = np.sqrt(lam)
+    loglam = np.log(lam)
+    b = 0.931 + 2.53 * slam
+    a = -0.059 + 0.02483 * b
+    invalpha = 1.1239 + 1.1328 / (b - 3.4)
+    vr = 0.9277 - 3.6224 / (b - 2)
+
+    while (1):
+        U = next_double(bitgen) - 0.5
+        V = next_double(bitgen)
+        us = 0.5 - np.fabs(U)
+        k = int((2 * a / us + b) * U + lam + 0.43)
+        if ((us >= 0.07) and (V <= vr)):
+            return k
+
+        if ((k < 0) or ((us < 0.013) and (V > us))):
+            continue
+
+        # /* log(V) == log(0.0) ok here */
+        # /* if U==0.0 so that us==0.0, log is ok since always returns */
+        if ((np.log(V) + np.log(invalpha) - np.log(a / (us * us) + b)) <=
+           (-lam + k * loglam - random_loggam(k + 1))):
+            return k
+
+
+@register_jitable
+def random_poisson(bitgen, lam):
+    if (lam >= 10):
+        return random_poisson_ptrs(bitgen, lam)
+    elif (lam == 0):
+        return 0
+    else:
+        return random_poisson_mult(bitgen, lam)
+
+
+@register_jitable
+def random_negative_binomial(bitgen, n, p):
+    Y = random_gamma(bitgen, n, (1 - p) / p)
+    return random_poisson(bitgen, Y)

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -17,9 +17,9 @@ from numba.np.random.distributions import \
      random_standard_exponential_f, random_standard_gamma_f, random_normal,
      random_exponential, random_gamma, random_beta, random_power,
      random_f,random_chisquare,random_standard_cauchy,random_pareto,
-     random_weibull, random_laplace, random_gumbel, random_logistic,
+     random_weibull, random_laplace, random_logistic,
      random_lognormal, random_rayleigh, random_standard_t, random_wald,
-     random_vonmises, random_geometric, random_zipf, random_triangular,
+     random_geometric, random_zipf, random_triangular,
      random_poisson, random_negative_binomial)
 
 
@@ -465,28 +465,6 @@ def NumPyRandomGeneratorType_laplace(inst, loc=0.0, scale=1.0, size=None):
         return impl
 
 
-@overload_method(types.NumPyRandomGeneratorType, 'gumbel')
-def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
-    check_types(loc, [types.Float, types.Integer, int, float], 'loc')
-    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
-    if isinstance(size, types.Omitted):
-        size = size.value
-
-    if is_nonelike(size):
-        def impl(inst, loc=0.0, scale=1.0, size=None):
-            return random_gumbel(inst.bit_generator, loc, scale)
-        return impl
-    else:
-        check_size(size)
-
-        def impl(inst, loc=0.0, scale=1.0, size=None):
-            out = np.empty(size)
-            for i in np.ndindex(size):
-                out[i] = random_gumbel(inst.bit_generator, loc, scale)
-            return out
-        return impl
-
-
 @overload_method(types.NumPyRandomGeneratorType, 'logistic')
 def NumPyRandomGeneratorType_logistic(inst, loc=0.0, scale=1.0, size=None):
     check_types(loc, [types.Float, types.Integer, int, float], 'loc')
@@ -591,28 +569,6 @@ def NumPyRandomGeneratorType_wald(inst, mean, scale, size=None):
             out = np.empty(size)
             for i in np.ndindex(size):
                 out[i] = random_wald(inst.bit_generator, mean, scale)
-            return out
-        return impl
-
-
-@overload_method(types.NumPyRandomGeneratorType, 'vonmises')
-def NumPyRandomGeneratorType_vonmises(inst, mu, kappa, size=None):
-    check_types(mu, [types.Float, types.Integer, int, float], 'mu')
-    check_types(kappa, [types.Float, types.Integer, int, float], 'kappa')
-    if isinstance(size, types.Omitted):
-        size = size.value
-
-    if is_nonelike(size):
-        def impl(inst, mu, kappa, size=None):
-            return random_vonmises(inst.bit_generator, mu, kappa)
-        return impl
-    else:
-        check_size(size)
-
-        def impl(inst, mu, kappa, size=None):
-            out = np.empty(size)
-            for i in np.ndindex(size):
-                out[i] = random_vonmises(inst.bit_generator, mu, kappa)
             return out
         return impl
 

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -15,7 +15,12 @@ from numba.np.random.distributions import \
      random_standard_exponential, random_standard_normal_f,
      random_standard_gamma, random_standard_normal, random_uniform,
      random_standard_exponential_f, random_standard_gamma_f, random_normal,
-     random_exponential, random_gamma)
+     random_exponential, random_gamma, random_beta, random_power,
+     random_f,random_chisquare,random_standard_cauchy,random_pareto,
+     random_weibull, random_laplace, random_gumbel, random_logistic,
+     random_lognormal, random_rayleigh, random_standard_t, random_wald,
+     random_vonmises, random_geometric, random_zipf, random_triangular,
+     random_poisson, random_negative_binomial)
 
 
 def _get_proper_func(func_32, func_64, dtype, dist_name="the given"):
@@ -282,5 +287,440 @@ def NumPyRandomGeneratorType_gamma(inst, shape, scale=1.0, size=None):
             out = np.empty(size, dtype=np.float64)
             for i in np.ndindex(size):
                 out[i] = random_gamma(inst.bit_generator, shape, scale)
+            return out
+        return impl
+
+
+# Overload the Generator().beta() method
+@overload_method(types.NumPyRandomGeneratorType, 'beta')
+def NumPyRandomGeneratorType_beta(inst, a, b, size=None):
+    check_types(a, [types.Float, types.Integer, int, float], 'a')
+    check_types(b, [types.Float, types.Integer, int, float], 'b')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, a, b, size=None):
+            return random_beta(inst.bit_generator, a, b)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, a, b, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_beta(inst.bit_generator, a, b)
+            return out
+        return impl
+
+
+# Overload the Generator().f() method
+@overload_method(types.NumPyRandomGeneratorType, 'f')
+def NumPyRandomGeneratorType_f(inst, dfnum, dfden, size=None):
+    check_types(dfnum, [types.Float, types.Integer, int, float], 'dfnum')
+    check_types(dfden, [types.Float, types.Integer, int, float], 'dfden')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, dfnum, dfden, size=None):
+            return random_f(inst.bit_generator, dfnum, dfden)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, dfnum, dfden, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_f(inst.bit_generator, dfnum, dfden)
+            return out
+        return impl
+
+
+# Overload the Generator().chisquare() method
+@overload_method(types.NumPyRandomGeneratorType, 'chisquare')
+def NumPyRandomGeneratorType_chisquare(inst, df, size=None):
+    check_types(df, [types.Float, types.Integer, int, float], 'df')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, df, size=None):
+            return random_chisquare(inst.bit_generator, df)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, df, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_chisquare(inst.bit_generator, df)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'standard_cauchy')
+def NumPyRandomGeneratorType_standard_cauchy(inst, size=None):
+
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, size=None):
+            return random_standard_cauchy(inst.bit_generator)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_standard_cauchy(inst.bit_generator)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'pareto')
+def NumPyRandomGeneratorType_pareto(inst, a, size=None):
+    check_types(a, [types.Float, types.Integer, int, float], 'a')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, a, size=None):
+            return random_pareto(inst.bit_generator, a)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, a, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_pareto(inst.bit_generator, a)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'weibull')
+def NumPyRandomGeneratorType_weibull(inst, a, size=None):
+    check_types(a, [types.Float, types.Integer, int, float], 'a')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, a, size=None):
+            return random_weibull(inst.bit_generator, a)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, a, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_weibull(inst.bit_generator, a)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'power')
+def NumPyRandomGeneratorType_power(inst, a, size=None):
+    check_types(a, [types.Float, types.Integer, int, float], 'a')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, a, size=None):
+            return random_power(inst.bit_generator, a)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, a, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_power(inst.bit_generator, a)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'laplace')
+def NumPyRandomGeneratorType_laplace(inst, loc=0.0, scale=1.0, size=None):
+    check_types(loc, [types.Float, types.Integer, int, float], 'loc')
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            return random_laplace(inst.bit_generator, loc, scale)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_laplace(inst.bit_generator, loc, scale)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'gumbel')
+def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
+    check_types(loc, [types.Float, types.Integer, int, float], 'loc')
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            return random_gumbel(inst.bit_generator, loc, scale)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_gumbel(inst.bit_generator, loc, scale)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'logistic')
+def NumPyRandomGeneratorType_logistic(inst, loc=0.0, scale=1.0, size=None):
+    check_types(loc, [types.Float, types.Integer, int, float], 'loc')
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            return random_logistic(inst.bit_generator, loc, scale)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_logistic(inst.bit_generator, loc, scale)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'lognormal')
+def NumPyRandomGeneratorType_lognormal(inst, mean=0.0, sigma=1.0, size=None):
+    check_types(mean, [types.Float, types.Integer, int, float], 'mean')
+    check_types(sigma, [types.Float, types.Integer, int, float], 'sigma')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, mean=0.0, sigma=1.0, size=None):
+            return random_lognormal(inst.bit_generator, mean, sigma)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, mean=0.0, sigma=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_lognormal(inst.bit_generator, mean, sigma)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'rayleigh')
+def NumPyRandomGeneratorType_rayleigh(inst, scale=1.0, size=None):
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, scale=1.0, size=None):
+            return random_rayleigh(inst.bit_generator, scale)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, scale=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_rayleigh(inst.bit_generator, scale)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'standard_t')
+def NumPyRandomGeneratorType_standard_t(inst, df, size=None):
+    check_types(df, [types.Float, types.Integer, int, float], 'df')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, df, size=None):
+            return random_standard_t(inst.bit_generator, df)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, df, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_standard_t(inst.bit_generator, df)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'wald')
+def NumPyRandomGeneratorType_wald(inst, mean, scale, size=None):
+    check_types(mean, [types.Float, types.Integer, int, float], 'mean')
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, mean, scale, size=None):
+            return random_wald(inst.bit_generator, mean, scale)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, mean, scale, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_wald(inst.bit_generator, mean, scale)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'vonmises')
+def NumPyRandomGeneratorType_vonmises(inst, mu, kappa, size=None):
+    check_types(mu, [types.Float, types.Integer, int, float], 'mu')
+    check_types(kappa, [types.Float, types.Integer, int, float], 'kappa')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, mu, kappa, size=None):
+            return random_vonmises(inst.bit_generator, mu, kappa)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, mu, kappa, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_vonmises(inst.bit_generator, mu, kappa)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'geometric')
+def NumPyRandomGeneratorType_geometric(inst, p, size=None):
+    check_types(p, [types.Float, types.Integer, int, float], 'p')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, p, size=None):
+            return np.int64(random_geometric(inst.bit_generator, p))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, p, size=None):
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_geometric(inst.bit_generator, p)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'zipf')
+def NumPyRandomGeneratorType_zipf(inst, a, size=None):
+    check_types(a, [types.Float, types.Integer, int, float], 'a')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, a, size=None):
+            return np.int64(random_zipf(inst.bit_generator, a))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, a, size=None):
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_zipf(inst.bit_generator, a)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'triangular')
+def NumPyRandomGeneratorType_triangular(inst, left, mode, right, size=None):
+    check_types(left, [types.Float, types.Integer, int, float], 'left')
+    check_types(mode, [types.Float, types.Integer, int, float], 'mode')
+    check_types(right, [types.Float, types.Integer, int, float], 'right')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, left, mode, right, size=None):
+            return random_triangular(inst.bit_generator, left, mode, right)
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, left, mode, right, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_triangular(inst.bit_generator,
+                                           left, mode, right)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'poisson')
+def NumPyRandomGeneratorType_poisson(inst, lam , size=None):
+    check_types(lam, [types.Float, types.Integer, int, float], 'lam')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, lam , size=None):
+            return np.int64(random_poisson(inst.bit_generator, lam))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, lam , size=None):
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_poisson(inst.bit_generator, lam)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'negative_binomial')
+def NumPyRandomGeneratorType_negative_binomial(inst, n, p, size=None):
+    check_types(n, [types.Float, types.Integer, int, float], 'n')
+    check_types(p, [types.Float, types.Integer, int, float], 'p')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst,  n, p , size=None):
+            return np.int64(random_negative_binomial(inst.bit_generator, n, p))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, n, p , size=None):
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_negative_binomial(inst.bit_generator, n, p)
             return out
         return impl

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -533,33 +533,6 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
                                   [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
 
-    def test_gumbel(self):
-        # For this test dtype argument is never used, so we pass [None] as dtype
-        # to make sure it runs only once with default system type.
-
-        test_sizes = [None, (), (100,), (10, 20, 30)]
-        bitgen_types = [None, MT19937]
-
-        # Test with no arguments
-        dist_func = lambda x, size, dtype:x.gumbel()
-        with self.subTest():
-            self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
-
-        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,scale=1.5, size=size)
-        for _size in test_sizes:
-            for _bitgen in bitgen_types:
-                with self.subTest(_size=_size, _bitgen=_bitgen):
-                    self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
-
-        dist_func = lambda x, loc, scale, size:\
-            x.gumbel(loc=loc, scale=scale, size=size)
-        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
-                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
-
     def test_logistic(self):
         # For this test dtype argument is never used, so we pass [None] as dtype
         # to make sure it runs only once with default system type.
@@ -678,27 +651,6 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             x.wald(mean=mean, scale=scale, size=size)
         self._check_invalid_types(dist_func, ['mean', 'scale', 'size'],
                                   [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
-
-    def test_vonmises(self):
-        # For this test dtype argument is never used, so we pass [None] as dtype
-        # to make sure it runs only once with default system type.
-
-        test_sizes = [None, (), (100,), (10, 20, 30)]
-        bitgen_types = [None, MT19937]
-
-        dist_func = lambda x, size, dtype:\
-            x.vonmises(mu=5.0, kappa=1.5, size=size)
-        for _size in test_sizes:
-            for _bitgen in bitgen_types:
-                with self.subTest(_size=_size, _bitgen=_bitgen):
-                    self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
-
-        dist_func = lambda x, mu, kappa, size:\
-            x.vonmises(mu=mu, kappa=kappa, size=size)
-        self._check_invalid_types(dist_func, ['mu', 'kappa', 'size'],
-                                  [5, 1, (1,)], ['x', 'x', ('x',)])
 
     def test_geometric(self):
         # For this test dtype argument is never used, so we pass [None] as dtype

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -368,6 +368,435 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self._check_invalid_types(dist_func, ['shape', 'scale', 'size'],
                                   [5.0, 1.5, (1,)], ['x', 'x', ('x',)])
 
+    def test_beta(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.beta(a=1.5, b=2.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, a, b, size:x.beta(a=a, b=b, size=size)
+        self._check_invalid_types(dist_func, ['a', 'b', 'size'],
+                                  [5.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_f(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.f(dfnum=2, dfden=3, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, dfnum, dfden, size:\
+            x.f(dfnum=dfnum, dfden=dfden, size=size)
+        self._check_invalid_types(dist_func, ['dfnum', 'dfden', 'size'],
+                                  [5, 1, (1,)], ['x', 'x', ('x',)])
+
+    def test_chisquare(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.chisquare(df=2, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, df, size:\
+            x.chisquare(df=df, size=size)
+        self._check_invalid_types(dist_func, ['df', 'size'],
+                                  [2, (1,)], ['x', ('x',)])
+
+    def test_standard_cauchy(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.standard_cauchy()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
+        dist_func = lambda x, size, dtype:x.standard_cauchy(size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, size:x.standard_cauchy(size=size)
+        self._check_invalid_types(dist_func, ['size'],
+                                  [(1,)], [('x',)])
+
+    def test_pareto(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.pareto(a=1.0, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, a, size:x.pareto(a=a, size=size)
+        self._check_invalid_types(dist_func, ['a', 'size'],
+                                  [1, (1,)], ['x', ('x',)])
+
+    def test_weibull(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.weibull(a=1.0, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, a, size:x.weibull(a=a, size=size)
+        self._check_invalid_types(dist_func, ['a', 'size'],
+                                  [1, (1,)], ['x', ('x',)])
+
+    def test_power(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.power(a=0.75, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, a, size:x.power(a=a, size=size)
+        self._check_invalid_types(dist_func, ['a', 'size'],
+                                  [0.75, (1,)], ['x', ('x',)])
+
+    def test_laplace(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.laplace()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None,
+                                    ulp_prec=adjusted_ulp_prec)
+
+        dist_func = lambda x, size, dtype:\
+            x.laplace(loc=1.0, scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, loc, scale, size:\
+            x.laplace(loc=loc, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_gumbel(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.gumbel()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None,
+                                    ulp_prec=adjusted_ulp_prec)
+
+        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, loc, scale, size:\
+            x.gumbel(loc=loc, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_logistic(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.logistic()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None,
+                                    ulp_prec=adjusted_ulp_prec)
+
+        dist_func = lambda x, size, dtype:\
+            x.logistic(loc=1.0,scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, loc, scale, size:\
+            x.logistic(loc=loc, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_lognormal(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.lognormal()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None,
+                                    ulp_prec=adjusted_ulp_prec)
+
+        dist_func = lambda x, size, dtype:\
+            x.lognormal(mean=5.0, sigma=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, mean, sigma, size:\
+            x.lognormal(mean=mean, sigma=sigma, size=size)
+        self._check_invalid_types(dist_func, ['mean', 'sigma', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_rayleigh(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.rayleigh()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
+        dist_func = lambda x, size, dtype:x.rayleigh(scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, scale, size:x.rayleigh(scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['scale', 'size'],
+                                  [1.5, (1,)], ['x', ('x',)])
+
+    def test_standard_t(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.standard_t(df=2, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, df, size:x.standard_t(df=df, size=size)
+        self._check_invalid_types(dist_func, ['df', 'size'],
+                                  [2, (1,)], ['x', ('x',)])
+
+    def test_wald(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.wald(mean=5.0, scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, mean, scale, size:\
+            x.wald(mean=mean, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['mean', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_vonmises(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.vonmises(mu=5.0, kappa=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, mu, kappa, size:\
+            x.vonmises(mu=mu, kappa=kappa, size=size)
+        self._check_invalid_types(dist_func, ['mu', 'kappa', 'size'],
+                                  [5, 1, (1,)], ['x', 'x', ('x',)])
+
+    def test_geometric(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.geometric(p=0.75, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, p, size:x.geometric(p=p, size=size)
+        self._check_invalid_types(dist_func, ['p', 'size'],
+                                  [0.75, (1,)], ['x', ('x',)])
+
+    def test_zipf(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.zipf(a=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, a, size:x.zipf(a=a, size=size)
+        self._check_invalid_types(dist_func, ['a', 'size'],
+                                  [1, (1,)], ['x', ('x',)])
+
+    def test_triangular(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.triangular(left=0, mode=3, right=5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, left, mode, right, size:\
+            x.triangular(left=left, mode=mode, right=right, size=size)
+        self._check_invalid_types(dist_func, ['left', 'mode', 'right', 'size'],
+                                  [0, 3, 5, (1,)], ['x', 'x', 'x', ('x',)])
+
+    def test_poisson(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:x.poisson(lam=15, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, lam, size:x.poisson(lam=lam, size=size)
+        self._check_invalid_types(dist_func, ['lam', 'size'],
+                                  [15, (1,)], ['x', ('x',)])
+
+    def test_negative_binomial(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.negative_binomial(n=1, p=0.1, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        dist_func = lambda x, n, p, size:\
+            x.negative_binomial(n=n, p=p, size=size)
+        self._check_invalid_types(dist_func, ['n', 'p', 'size'],
+                                  [1, 0.75, (1,)], ['x', 'x', ('x',)])
+
 
 class TestGeneratorCaching(TestCase, SerialMixin):
     def test_randomgen_caching(self):


### PR DESCRIPTION
This PR builds on top of #8038

Adds the following distributions as `Generator` methods:
- `Generator().beta()`
- `Generator().f()`
- `Generator().chisquare()`
- `Generator().standard_cauchy()`
- `Generator().pareto()`
- `Generator().weibull()`
- `Generator().power()`
- `Generator().laplace()`
- `Generator().logistic()`
- `Generator().lognormal()`
- `Generator().rayleigh()`
- `Generator().standard_t()`
- `Generator().wald()`
- `Generator().geometric()`
- `Generator().zipf()`
- `Generator().triangular()`
- `Generator().poisson()`
- `Generator().negative_binomial()`
