### PR TITLE
Support for Numpy BitGenerators PR#4: Generator().integers() Support.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -620,8 +620,8 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().f()` (*)
 * :func:`numpy.random.Generator().gamma()` (*)
 * :func:`numpy.random.Generator().geometric()` (*)
-* :func:`numpy.random.Generator().integers()`: Both `low` and `high` are required
- arguments. Array values for low and high are currently not supported.
+* :func:`numpy.random.Generator().integers()` (Both `low` and `high` are required
+  arguments. Array values for low and high are currently not supported.)
 * :func:`numpy.random.Generator().laplace()` (*)
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -620,6 +620,8 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().f()` (*)
 * :func:`numpy.random.Generator().gamma()` (*)
 * :func:`numpy.random.Generator().geometric()` (*)
+* :func:`numpy.random.Generator().integers()`: Both `low` and `high` are required
+ arguments. Array values for low and high are currently not supported.
 * :func:`numpy.random.Generator().laplace()` (*)
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -21,10 +21,7 @@ from numba.np.random.distributions import \
      random_lognormal, random_rayleigh, random_standard_t, random_wald,
      random_geometric, random_zipf, random_triangular,
      random_poisson, random_negative_binomial)
-from numba.np.random.random_methods import \
-    (random_bounded_uint64_fill, random_bounded_uint32_fill,
-     random_bounded_uint16_fill, random_bounded_uint8_fill,
-     random_bounded_bool_fill, _randint_arg_check)
+from numba.np.random import random_methods
 
 
 def _get_proper_func(func_32, func_64, dtype, dist_name="the given"):
@@ -93,6 +90,7 @@ def NumPyRandomGeneratorType_integers(inst, low, high=None, size=None,
     check_types(high, [types.Float, types.Integer, types.Boolean,
                        bool, int, float, type(None)], 'high')
     check_types(endpoint, [types.Boolean, bool], 'endpoint')
+
     if isinstance(size, types.Omitted):
         size = size.value
 
@@ -107,54 +105,30 @@ def NumPyRandomGeneratorType_integers(inst, low, high=None, size=None,
         nb_dt = dtype
         _dtype = as_dtype(nb_dt)
 
-    if _dtype == np.int32:
-        int_func = random_bounded_uint32_fill
-        lower_bound = -0x80000000
-        upper_bound = 0x7FFFFFFF
-    elif _dtype == np.int64:
-        int_func = random_bounded_uint64_fill
-        lower_bound = -0x8000000000000000
-        upper_bound = 0x7FFFFFFFFFFFFFFF
-    elif _dtype == np.int16:
-        int_func = random_bounded_uint16_fill
-        lower_bound = -0x8000
-        upper_bound = 0xFFFF
-    elif _dtype == np.int8:
-        int_func = random_bounded_uint8_fill
-        lower_bound = -0x80
-        upper_bound = 0xFF
-    elif _dtype == np.uint32:
-        int_func = random_bounded_uint32_fill
-        lower_bound = -0x80000000
-        upper_bound = 0x7FFFFFFF
-    elif _dtype == np.uint64:
-        int_func = random_bounded_uint64_fill
-        lower_bound = -0x8000000000000000
-        upper_bound = 0x7FFFFFFFFFFFFFFF
-    elif _dtype == np.uint16:
-        int_func = random_bounded_uint16_fill
-        lower_bound = -0x8000
-        upper_bound = 0xFFFF
-    elif _dtype == np.uint8:
-        int_func = random_bounded_uint8_fill
-        lower_bound = -0x80
-        upper_bound = 0xFF
-    elif _dtype == np.bool_:
-        int_func = random_bounded_bool_fill
+    if _dtype == np.bool_:
+        int_func = random_methods.random_bounded_bool_fill
         lower_bound = -1
         upper_bound = 2
     else:
-        raise TypingError("Argument dtype is not one of the" +
-                          " expected type(s): " +
-                          "np.int32, np.int64, np.int16, np.int8, "
-                          "np.uint32, np.uint64, np.uint16, np.uint8, "
-                          "np.bool_")
+        try:
+            i_info = np.iinfo(_dtype)
+            int_func = getattr(random_methods,
+                               f'random_bounded_{i_info.dtype}_fill')
+            lower_bound = i_info.min
+            upper_bound = i_info.max
+        except ValueError:
+            raise TypingError("Argument dtype is not one of the" +
+                              " expected type(s): " +
+                              "np.int32, np.int64, np.int16, np.int8, "
+                              "np.uint32, np.uint64, np.uint16, np.uint8, "
+                              "np.bool_")
 
     if is_nonelike(size):
         def impl(inst, low, high=None, size=None,
                  dtype=np.int64, endpoint=False):
-            low, rng = _randint_arg_check(low, high, endpoint,
-                                          lower_bound, upper_bound)
+            low, rng = random_methods._randint_arg_check(low, high, endpoint,
+                                                         lower_bound,
+                                                         upper_bound)
             mask = None
             return int_func(inst.bit_generator, low, rng, mask, 1, dtype)[0]
         return impl
@@ -163,8 +137,9 @@ def NumPyRandomGeneratorType_integers(inst, low, high=None, size=None,
 
         def impl(inst, low, high=None, size=None,
                  dtype=np.int64, endpoint=False):
-            low, rng = _randint_arg_check(low, high, endpoint,
-                                          lower_bound, upper_bound)
+            low, rng = random_methods._randint_arg_check(low, high, endpoint,
+                                                         lower_bound,
+                                                         upper_bound)
             mask = None
             return int_func(inst.bit_generator, low, rng, mask, size, dtype)
         return impl

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -135,10 +135,15 @@ def NumPyRandomGeneratorType_integers(inst, low, high, size=None,
                                               lower_bound, upper_bound)
             if not endpoint:
                 high -= dtype(1)
-            low = dtype(low)
-            high = dtype(high)
-            rng = high - low
-            return int_func(inst.bit_generator, low, rng, 1, dtype)[0]
+                low = dtype(low)
+                high = dtype(high)
+                rng = high - low
+                return int_func(inst.bit_generator, low, rng, 1, dtype)[0]
+            else:
+                low = dtype(low)
+                high = dtype(high)
+                rng = high - low
+                return int_func(inst.bit_generator, low, rng, 1, dtype)[0]
         return impl
     else:
         check_size(size)
@@ -149,11 +154,15 @@ def NumPyRandomGeneratorType_integers(inst, low, high, size=None,
                                               lower_bound, upper_bound)
             if not endpoint:
                 high -= dtype(1)
-            low = dtype(low)
-            high = dtype(high)
-            rng = high - low
-
-            return int_func(inst.bit_generator, low, rng, size, dtype)
+                low = dtype(low)
+                high = dtype(high)
+                rng = high - low
+                return int_func(inst.bit_generator, low, rng, size, dtype)
+            else:
+                low = dtype(low)
+                high = dtype(high)
+                rng = high - low
+                return int_func(inst.bit_generator, low, rng, size, dtype)
         return impl
 
 

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -131,30 +131,29 @@ def NumPyRandomGeneratorType_integers(inst, low, high, size=None,
     if is_nonelike(size):
         def impl(inst, low, high, size=None,
                  dtype=np.int64, endpoint=False):
+            random_methods._randint_arg_check(low, high, endpoint,
+                                              lower_bound, upper_bound)
             if not endpoint:
                 high -= dtype(1)
             low = dtype(low)
             high = dtype(high)
             rng = high - low
-            random_methods._randint_arg_check(low, high,
-                                              lower_bound, upper_bound)
-            mask = None
-            return int_func(inst.bit_generator, low, rng, mask, 1, dtype)[0]
+            return int_func(inst.bit_generator, low, rng, 1, dtype)[0]
         return impl
     else:
         check_size(size)
 
         def impl(inst, low, high, size=None,
                  dtype=np.int64, endpoint=False):
+            random_methods._randint_arg_check(low, high, endpoint,
+                                              lower_bound, upper_bound)
             if not endpoint:
                 high -= dtype(1)
             low = dtype(low)
             high = dtype(high)
             rng = high - low
-            random_methods._randint_arg_check(low, high,
-                                              lower_bound, upper_bound)
-            mask = None
-            return int_func(inst.bit_generator, low, rng, mask, size, dtype)
+
+            return int_func(inst.bit_generator, low, rng, size, dtype)
         return impl
 
 

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -97,25 +97,22 @@ def bounded_masked_uint64(bitgen, rng, mask):
 
 @register_jitable
 def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
-    # /*
-    # * Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
-    # *
-    # * Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
-    # * zero.
-    # */
+    # Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
+    # Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
+    # zero.
     rng_excl = (rng + 1) & 0xFF
 
     assert(rng != 0xFF)
 
-    # /* Generate a scaled random number. */
+    # Generate a scaled random number.
     n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
     m = n * rng_excl
 
-    # /* Rejection sampling to remove any bias */
+    # Rejection sampling to remove any bias
     leftover = m & 0xFF
 
     if (leftover < rng_excl):
-        # /* `rng_excl` is a simple upper bound for `threshold`. */
+        # `rng_excl` is a simple upper bound for `threshold`.
         threshold = ((UINT8_MAX - rng) % rng_excl) & 0xFF
 
         while (leftover < threshold):
@@ -128,25 +125,22 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
 
 @register_jitable
 def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
-    # /*
-    # * Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
-    # *
-    # * Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
-    # * zero.
-    # */
+    # Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
+    # Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
+    # zero.
     rng_excl = (rng + 1) & 0xFFFF
 
     assert(rng != 0xFFFF)
 
-    # /* Generate a scaled random number. */
+    # Generate a scaled random number.
     n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
     m = n * rng_excl
 
-    # /* Rejection sampling to remove any bias */
+    # Rejection sampling to remove any bias
     leftover = m & 0xFFFF
 
     if (leftover < rng_excl):
-        # /* `rng_excl` is a simple upper bound for `threshold`. */
+        # `rng_excl` is a simple upper bound for `threshold`.
         threshold = ((UINT16_MAX - rng) % rng_excl) & 0xFFFF
 
         while (leftover < threshold):
@@ -200,8 +194,8 @@ def bounded_lemire_uint64(bitgen, rng):
     return (m >> 64)
 
 
-#  Fills an array with cnt random npy_uint64 between off and off + rng
-#  inclusive. The numbers wrap if rng is sufficiently large.
+# Fills an array with cnt random npy_uint64 between off and off + rng
+# inclusive. The numbers wrap if rng is sufficiently large.
 @register_jitable
 def random_bounded_uint64_fill(bitgen, low, rng, mask, size, dtype):
     out = np.empty(size, dtype=dtype)
@@ -243,7 +237,7 @@ def random_bounded_uint32_fill(bitgen, low, rng, mask, size, dtype):
         for i in np.ndindex(size):
             out[i] = low
     elif rng == 0xFFFFFFFF:
-        # /* Lemire32 doesn't support rng = 0xFFFFFFFF. */
+        # Lemire32 doesn't support rng = 0xFFFFFFFF.
         for i in np.ndindex(size):
             out[i] = low + next_uint32(bitgen)
     else:
@@ -266,14 +260,14 @@ def random_bounded_uint16_fill(bitgen, low, rng, mask, size, dtype):
         for i in np.ndindex(size):
             out[i] = low
     elif rng == 0xFFFF:
-        # /* Lemire16 doesn't support rng = 0xFFFF. */
+        # Lemire16 doesn't support rng = 0xFFFF.
         for i in np.ndindex(size):
             val, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
             out[i] = low + val
 
     else:
         if mask is not None:
-            # /* Smallest bit mask >= max */
+            # Smallest bit mask >= max
             for i in np.ndindex(size):
                 val, bcnt, buf = \
                     buffered_bounded_masked_uint16(bitgen, rng,
@@ -298,13 +292,13 @@ def random_bounded_uint8_fill(bitgen, low, rng, mask, size, dtype):
         for i in np.ndindex(size):
             out[i] = low
     elif rng == 0xFF:
-        # /* Lemire8 doesn't support rng = 0xFF. */
+        # Lemire8 doesn't support rng = 0xFF.
         for i in np.ndindex(size):
             val, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
             out[i] = low + val
     else:
         if mask is not None:
-            # /* Smallest bit mask >= max */
+            # Smallest bit mask >= max
             for i in np.ndindex(size):
                 val, bcnt, buf = \
                     buffered_bounded_masked_uint8(bitgen, rng,

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -319,6 +319,12 @@ def random_bounded_uint8_fill(bitgen, low, rng, mask, size, dtype):
     return out
 
 
+random_bounded_int8_fill = random_bounded_uint8_fill
+random_bounded_int16_fill = random_bounded_uint16_fill
+random_bounded_int32_fill = random_bounded_uint32_fill
+random_bounded_int64_fill = random_bounded_uint64_fill
+
+
 @register_jitable
 def random_bounded_bool_fill(bitgen, low, rng, mask, size, dtype):
     buf = 0

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -315,7 +315,7 @@ def _randint_arg_check(low, high, endpoint, lower_bound, upper_bound):
     # This is being done to avoid high being accidentally
     # casted to int64/32 while subtracting 1 before
     # checking bounds, avoids overflow.
-    if high > 0 and endpoint:
+    if high > 0 and not endpoint:
         high = uint64(high) - uint64(1)
 
     if high > upper_bound:

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -1,0 +1,349 @@
+import numpy as np
+
+from numba.core.extending import register_jitable
+
+from numba.np.random._constants import (UINT32_MAX, UINT64_MAX,
+                                        UINT16_MAX, UINT8_MAX)
+from numba.np.random.generator_core import next_uint32, next_uint64
+
+# All following implementations are direct translations from:
+# https://github.com/numpy/numpy/blob/7cfef93c77599bd387ecc6a15d186c5a46024dac/numpy/random/src/distributions/distributions.c
+
+
+@register_jitable
+def gen_mask(mask):
+    mask = mask | (mask >> 1)
+    mask = mask | (mask >> 2)
+    mask = mask | (mask >> 4)
+    mask = mask | (mask >> 8)
+    mask = mask | (mask >> 16)
+    mask = mask | (mask >> 32)
+    return mask
+
+
+@register_jitable
+def buffered_bounded_bool(bitgen, off, rng, mask, bcnt, buf):
+    if (rng == 0):
+        return off, bcnt, buf
+    if not bcnt:
+        buf = next_uint32(bitgen)
+        bcnt = 31
+    else:
+        buf >>= 1
+        bcnt -= 1
+
+    return ((buf & 1) != 0), bcnt, buf
+
+
+@register_jitable
+def buffered_uint8(bitgen, bcnt, buf):
+    if not bcnt:
+        buf = next_uint32(bitgen)
+        bcnt = 3
+    else:
+        buf >>= 8
+        bcnt -= 1
+
+    return buf & 0xff, bcnt, buf
+
+
+@register_jitable
+def buffered_uint16(bitgen, bcnt, buf):
+    if not bcnt:
+        buf = next_uint32(bitgen)
+        bcnt = 1
+    else:
+        buf >>= 16
+        bcnt -= 1
+
+    return buf & 0xffff, bcnt, buf
+
+
+@register_jitable
+def buffered_bounded_masked_uint32(bitgen, rng, mask):
+    val = (next_uint32(bitgen) & mask)
+    while (val > rng):
+        val = (next_uint32(bitgen) & mask)
+    return val
+
+
+@register_jitable
+def buffered_bounded_masked_uint16(bitgen, rng, mask, bcnt, buf):
+    val, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
+
+    while (val & mask) > rng:
+        val, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
+
+    return val, bcnt, buf
+
+
+@register_jitable
+def buffered_bounded_masked_uint8(bitgen, rng, mask, bcnt, buf):
+    val, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
+
+    while (val & mask) > rng:
+        val, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
+
+    return val, bcnt, buf
+
+
+@register_jitable
+def bounded_masked_uint64(bitgen, rng, mask):
+    val = (next_uint64(bitgen) & mask)
+    while (val > rng):
+        val = (next_uint64(bitgen) & mask)
+    return val
+
+
+@register_jitable
+def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
+    # /*
+    # * Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
+    # *
+    # * Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
+    # * zero.
+    # */
+    rng_excl = (rng + 1) & 0xFF
+
+    assert(rng != 0xFF)
+
+    # /* Generate a scaled random number. */
+    n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
+    m = n * rng_excl
+
+    # /* Rejection sampling to remove any bias */
+    leftover = m & 0xFF
+
+    if (leftover < rng_excl):
+        # /* `rng_excl` is a simple upper bound for `threshold`. */
+        threshold = ((UINT8_MAX - rng) % rng_excl) & 0xFF
+
+        while (leftover < threshold):
+            n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
+            m = n * rng_excl
+            leftover = m & 0xFF
+
+    return (m >> 8) & 0xFF, bcnt, buf
+
+
+@register_jitable
+def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
+    # /*
+    # * Uses Lemire's algorithm - https://arxiv.org/abs/1805.10941
+    # *
+    # * Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
+    # * zero.
+    # */
+    rng_excl = (rng + 1) & 0xFFFF
+
+    assert(rng != 0xFFFF)
+
+    # /* Generate a scaled random number. */
+    n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
+    m = n * rng_excl
+
+    # /* Rejection sampling to remove any bias */
+    leftover = m & 0xFFFF
+
+    if (leftover < rng_excl):
+        # /* `rng_excl` is a simple upper bound for `threshold`. */
+        threshold = ((UINT16_MAX - rng) % rng_excl) & 0xFFFF
+
+        while (leftover < threshold):
+            n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
+            m = n * rng_excl
+            leftover = m & 0xFFFF
+
+    return (m >> 16) & 0xFFFF, bcnt, buf
+
+
+@register_jitable
+def buffered_bounded_lemire_uint32(bitgen, rng):
+    rng_excl = rng + 1
+
+    assert(rng != 0xFFFFFFFF)
+
+    # Generate a scaled random number.
+    m = next_uint32(bitgen) * rng_excl
+
+    # Rejection sampling to remove any bias
+    leftover = m & 0xFFFFFFFF
+
+    if (leftover < rng_excl):
+        # `rng_excl` is a simple upper bound for `threshold`.
+        threshold = (UINT32_MAX - rng) % rng_excl
+
+        while (leftover < threshold):
+            m = next_uint32(bitgen) * rng_excl
+            leftover = m & 0xFFFFFFFF
+
+    return (m >> 32)
+
+
+@register_jitable
+def bounded_lemire_uint64(bitgen, rng):
+    rng_excl = rng + 1
+
+    assert(rng != 0xFFFFFFFFFFFFFFFF)
+
+    m = next_uint64(bitgen) * rng_excl
+
+    leftover = m & 0xFFFFFFFFFFFFFFFF
+
+    if (leftover < rng_excl):
+        threshold = (UINT64_MAX - rng) % rng_excl
+
+        while (leftover < threshold):
+            m = next_uint64(bitgen) * rng_excl
+            leftover = m & 0xFFFFFFFFFFFFFFFF
+
+    return (m >> 64)
+
+
+#  Fills an array with cnt random npy_uint64 between off and off + rng
+#  inclusive. The numbers wrap if rng is sufficiently large.
+@register_jitable
+def random_bounded_uint64_fill(bitgen, low, rng, mask, size, dtype):
+    out = np.empty(size, dtype=dtype)
+    if rng == 0:
+        for i in np.ndindex(size):
+            out[i] = low
+    elif rng <= 0xFFFFFFFF:
+        if (rng == 0xFFFFFFFF):
+            for i in np.ndindex(size):
+                out[i] = low + next_uint32(bitgen)
+        else:
+            if mask is not None:
+                for i in np.ndindex(size):
+                    out[i] = low + \
+                        buffered_bounded_masked_uint32(bitgen,
+                                                       rng, mask)
+            else:
+                for i in np.ndindex(size):
+                    out[i] = low + buffered_bounded_lemire_uint32(bitgen, rng)
+
+    elif (rng == 0xFFFFFFFFFFFFFFFF):
+        for i in np.ndindex(size):
+            out[i] = low + next_uint64(bitgen)
+    else:
+        if mask is not None:
+            for i in np.ndindex(size):
+                out[i] = low + bounded_masked_uint64(bitgen, rng, mask)
+        else:
+            for i in np.ndindex(size):
+                out[i] = low + bounded_lemire_uint64(bitgen, rng)
+
+    return out
+
+
+@register_jitable
+def random_bounded_uint32_fill(bitgen, low, rng, mask, size, dtype):
+    out = np.empty(size, dtype=dtype)
+    if rng == 0:
+        for i in np.ndindex(size):
+            out[i] = low
+    elif rng == 0xFFFFFFFF:
+        # /* Lemire32 doesn't support rng = 0xFFFFFFFF. */
+        for i in np.ndindex(size):
+            out[i] = low + next_uint32(bitgen)
+    else:
+        if mask is not None:
+            for i in np.ndindex(size):
+                out[i] = low + buffered_bounded_masked_uint32(bitgen, rng, mask)
+        else:
+            for i in np.ndindex(size):
+                out[i] = low + buffered_bounded_lemire_uint32(bitgen, rng)
+    return out
+
+
+@register_jitable
+def random_bounded_uint16_fill(bitgen, low, rng, mask, size, dtype):
+    buf = 0
+    bcnt = 0
+
+    out = np.empty(size, dtype=dtype)
+    if rng == 0:
+        for i in np.ndindex(size):
+            out[i] = low
+    elif rng == 0xFFFF:
+        # /* Lemire16 doesn't support rng = 0xFFFF. */
+        for i in np.ndindex(size):
+            val, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
+            out[i] = low + val
+
+    else:
+        if mask is not None:
+            # /* Smallest bit mask >= max */
+            for i in np.ndindex(size):
+                val, bcnt, buf = \
+                    buffered_bounded_masked_uint16(bitgen, rng,
+                                                   mask, bcnt, buf)
+                out[i] = low + val
+        else:
+            for i in np.ndindex(size):
+                val, bcnt, buf = \
+                    buffered_bounded_lemire_uint16(bitgen, rng,
+                                                   bcnt, buf)
+                out[i] = low + val
+    return out
+
+
+@register_jitable
+def random_bounded_uint8_fill(bitgen, low, rng, mask, size, dtype):
+    buf = 0
+    bcnt = 0
+
+    out = np.empty(size, dtype=dtype)
+    if rng == 0:
+        for i in np.ndindex(size):
+            out[i] = low
+    elif rng == 0xFF:
+        # /* Lemire8 doesn't support rng = 0xFF. */
+        for i in np.ndindex(size):
+            val, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
+            out[i] = low + val
+    else:
+        if mask is not None:
+            # /* Smallest bit mask >= max */
+            for i in np.ndindex(size):
+                val, bcnt, buf = \
+                    buffered_bounded_masked_uint8(bitgen, rng,
+                                                  mask, bcnt, buf)
+                out[i] = low + val
+        else:
+            for i in np.ndindex(size):
+                val, bcnt, buf = \
+                    buffered_bounded_lemire_uint8(bitgen, rng,
+                                                  bcnt, buf)
+                out[i] = low + val
+    return out
+
+
+@register_jitable
+def random_bounded_bool_fill(bitgen, low, rng, mask, size, dtype):
+    buf = 0
+    bcnt = 0
+    out = np.empty(size, dtype=dtype)
+    for i in np.ndindex(size):
+        val, bcnt, buf = buffered_bounded_bool(bitgen, low, rng,
+                                               mask, bcnt, buf)
+        out[i] = low + val
+    return out
+
+
+@register_jitable
+def _randint_arg_check(low, high, endpoint, lower_bound, upper_bound):
+    if high is None:
+        high = low
+        low = 0
+    if not endpoint:
+        high -= 1
+
+    if low < lower_bound:
+        raise ValueError("low is out of bounds")
+    if high > upper_bound:
+        raise ValueError("high is out of bounds")
+    if low > high:  # -1 already subtracted, closed interval
+        raise ValueError("low is greater than high in given interval")
+    rng = (high - low)
+    return low, rng

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -64,7 +64,7 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
     """
     # Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
     # zero.
-    rng_excl = rng + uint8(1)
+    rng_excl = uint8(rng) + uint8(1)
 
     assert(rng != 0xFF)
 
@@ -100,7 +100,7 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
     """
     # Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
     # zero.
-    rng_excl = rng + uint16(1)
+    rng_excl = uint16(rng) + uint16(1)
 
     assert(rng != 0xFFFF)
 
@@ -129,7 +129,7 @@ def buffered_bounded_lemire_uint32(bitgen, rng):
     Generates a random unsigned 32 bit integer bounded
     within a given interval using Lemire's rejection.
     """
-    rng_excl = rng + uint32(1)
+    rng_excl = uint32(rng) + uint32(1)
 
     assert(rng != 0xFFFFFFFF)
 
@@ -156,7 +156,7 @@ def bounded_lemire_uint64(bitgen, rng):
     Generates a random unsigned 64 bit integer bounded
     within a given interval using Lemire's rejection.
     """
-    rng_excl = rng + uint64(1)
+    rng_excl = uint64(rng) + uint64(1)
 
     assert(rng != 0xFFFFFFFFFFFFFFFF)
 
@@ -315,13 +315,19 @@ def _randint_arg_check(low, high, endpoint, lower_bound, upper_bound):
     # This is being done to avoid high being accidentally
     # casted to int64/32 while subtracting 1 before
     # checking bounds, avoids overflow.
-    if high > 0 and not endpoint:
-        high = uint64(high) - uint64(1)
+    if high > 0:
+        high = uint64(high)
+        if not endpoint:
+            high -= uint64(1)
         upper_bound = uint64(upper_bound)
         if low > 0:
             low = uint64(low)
-
-    if high >= upper_bound:
-        raise ValueError("high is out of bounds")
-    if low > high:  # -1 already subtracted, closed interval
-        raise ValueError("low is greater than high in given interval")
+        if high > upper_bound:
+            raise ValueError("high is out of bounds")
+        if low > high:  # -1 already subtracted, closed interval
+            raise ValueError("low is greater than high in given interval")
+    else:
+        if high > upper_bound:
+            raise ValueError("high is out of bounds")
+        if low > high:  # -1 already subtracted, closed interval
+            raise ValueError("low is greater than high in given interval")

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from numba import uint64, uint32, uint16
+from numba import uint64, uint32, uint16, uint8
 from numba.core.extending import register_jitable
 
 from numba.np.random._constants import (UINT32_MAX, UINT64_MAX,
@@ -34,7 +34,7 @@ def buffered_uint8(bitgen, bcnt, buf):
         buf >>= 8
         bcnt -= 1
 
-    return buf & 0xff, bcnt, buf
+    return uint8(buf), bcnt, buf
 
 
 @register_jitable
@@ -46,7 +46,7 @@ def buffered_uint16(bitgen, bcnt, buf):
         buf >>= 16
         bcnt -= 1
 
-    return buf & 0xffff, bcnt, buf
+    return uint16(buf), bcnt, buf
 
 
 @register_jitable
@@ -93,9 +93,9 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
     Generates a random unsigned 8 bit integer bounded
     within a given interval using Lemire's rejection.
 
-    The buffer acts as a storage for a 32 bit integer
-    drawn from the associated BitGenerator so that we
-    can generate multiple integers of smaller bitsize
+    The buffer acts as storage for a 32 bit integer
+    drawn from the associated BitGenerator so that
+    multiple integers of smaller bitsize can be generated
     from a single draw of the BitGenerator.
     """
     # Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
@@ -129,9 +129,9 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
     Generates a random unsigned 16 bit integer bounded
     within a given interval using Lemire's rejection.
 
-    The buffer acts as a storage for a 32 bit integer
-    drawn from the associated BitGenerator so that we
-    can generate multiple integers of smaller bitsize
+    The buffer acts as storage for a 32 bit integer
+    drawn from the associated BitGenerator so that
+    multiple integers of smaller bitsize can be generated
     from a single draw of the BitGenerator.
     """
     # Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
@@ -221,12 +221,10 @@ def bounded_lemire_uint64(bitgen, rng):
     return m1
 
 
-# Fills an array with cnt random npy_uint64 between off and off + rng
-# inclusive. The numbers wrap if rng is sufficiently large.
 @register_jitable
 def random_bounded_uint64_fill(bitgen, low, rng, mask, size, dtype):
     """
-    Fills an array of given size with 64 bit integers
+    Returns a new array of given size with 64 bit integers
     bounded by given interval.
     """
     out = np.empty(size, dtype=dtype)
@@ -264,7 +262,7 @@ def random_bounded_uint64_fill(bitgen, low, rng, mask, size, dtype):
 @register_jitable
 def random_bounded_uint32_fill(bitgen, low, rng, mask, size, dtype):
     """
-    Fills an array of given size with 32 bit integers
+    Returns a new array of given size with 32 bit integers
     bounded by given interval.
     """
     out = np.empty(size, dtype=dtype)
@@ -288,7 +286,7 @@ def random_bounded_uint32_fill(bitgen, low, rng, mask, size, dtype):
 @register_jitable
 def random_bounded_uint16_fill(bitgen, low, rng, mask, size, dtype):
     """
-    Fills an array of given size with 16 bit integers
+    Returns a new array of given size with 16 bit integers
     bounded by given interval.
     """
     buf = 0
@@ -324,7 +322,7 @@ def random_bounded_uint16_fill(bitgen, low, rng, mask, size, dtype):
 @register_jitable
 def random_bounded_uint8_fill(bitgen, low, rng, mask, size, dtype):
     """
-    Fills an array of given size with 8 bit integers
+    Returns a new array of given size with 8 bit integers
     bounded by given interval.
     """
     buf = 0
@@ -359,7 +357,7 @@ def random_bounded_uint8_fill(bitgen, low, rng, mask, size, dtype):
 @register_jitable
 def random_bounded_bool_fill(bitgen, low, rng, mask, size, dtype):
     """
-    Fills an array of given size with boolean values.
+    Returns a new array of given size with boolean values.
     """
     buf = 0
     bcnt = 0

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -165,12 +165,12 @@ def buffered_bounded_lemire_uint32(bitgen, rng):
     Generates a random unsigned 32 bit integer bounded
     within a given interval using Lemire's rejection.
     """
-    rng_excl = rng + 1
+    rng_excl = rng + uint32(1)
 
     assert(rng != 0xFFFFFFFF)
 
     # Generate a scaled random number.
-    m = uint64(next_uint32(bitgen) * rng_excl)
+    m = uint64(next_uint32(bitgen)) * uint64(rng_excl)
 
     # Rejection sampling to remove any bias
     leftover = m & 0xFFFFFFFF
@@ -180,7 +180,7 @@ def buffered_bounded_lemire_uint32(bitgen, rng):
         threshold = (UINT32_MAX - rng) % rng_excl
 
         while (leftover < threshold):
-            m = uint64(next_uint32(bitgen) * rng_excl)
+            m = uint64(next_uint32(bitgen)) * uint64(rng_excl)
             leftover = m & 0xFFFFFFFF
 
     return (m >> 32)

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -64,7 +64,7 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
     """
     # Note: `rng` should not be 0xFF. When this happens `rng_excl` becomes
     # zero.
-    rng_excl = (rng + 1) & 0xFF
+    rng_excl = rng + uint8(1)
 
     assert(rng != 0xFF)
 
@@ -77,7 +77,7 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
 
     if (leftover < rng_excl):
         # `rng_excl` is a simple upper bound for `threshold`.
-        threshold = ((UINT8_MAX - rng) % rng_excl) & 0xFF
+        threshold = ((uint8(UINT8_MAX) - rng) % rng_excl)
 
         while (leftover < threshold):
             n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
@@ -100,7 +100,7 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
     """
     # Note: `rng` should not be 0xFFFF. When this happens `rng_excl` becomes
     # zero.
-    rng_excl = (rng + 1) & 0xFFFF
+    rng_excl = rng + uint16(1)
 
     assert(rng != 0xFFFF)
 
@@ -113,7 +113,7 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
 
     if (leftover < rng_excl):
         # `rng_excl` is a simple upper bound for `threshold`.
-        threshold = ((UINT16_MAX - rng) % rng_excl) & 0xFFFF
+        threshold = ((uint16(UINT16_MAX) - rng) % rng_excl)
 
         while (leftover < threshold):
             n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
@@ -317,8 +317,11 @@ def _randint_arg_check(low, high, endpoint, lower_bound, upper_bound):
     # checking bounds, avoids overflow.
     if high > 0 and not endpoint:
         high = uint64(high) - uint64(1)
+        upper_bound = uint64(upper_bound)
+        if low > 0:
+            low = uint64(low)
 
-    if high > upper_bound:
+    if high >= upper_bound:
         raise ValueError("high is out of bounds")
     if low > high:  # -1 already subtracted, closed interval
         raise ValueError("low is greater than high in given interval")

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -67,6 +67,7 @@ class TestHelperFuncs(TestCase):
         py_func = lambda x, low, high, dtype: \
             x.integers(low=low, high=high, dtype=dtype, endpoint=True)
         numba_func = numba.njit()(py_func)
+        numba_func_low = numba.njit()(py_func)
 
         py_func = lambda x, low, high, dtype: \
             x.integers(low=low, high=high, dtype=dtype, endpoint=False)
@@ -85,7 +86,7 @@ class TestHelperFuncs(TestCase):
             with self.subTest(low=low, high=high, dtype=dtype):
                 with self.assertRaises(ValueError) as raises:
                     # min - 1
-                    numba_func(rng, low - 1, high, dtype)
+                    numba_func_low(rng, low - 1, high, dtype)
                 self.assertIn(
                     'low is out of bounds',
                     str(raises.exception)
@@ -111,7 +112,7 @@ class TestHelperFuncs(TestCase):
                             np.iinfo(np.uint64).max, np.uint64)
         with self.assertRaises(ValueError) as raises:
             # min - 1
-            numba_func(rng, low - 1, high, dtype)
+            numba_func_low(rng, low - 1, high, dtype)
         self.assertIn(
             'low is out of bounds',
             str(raises.exception)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -184,18 +184,16 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
 
         # Checking dtype = bool seperately
         test_sizes = [None, (), (100,), (10, 20, 30)]
-        test_dtypes = [np.bool_]
         bitgen_types = [None, MT19937]
 
         dist_func = lambda x, size, dtype:\
-            x.integers(False, True, size=size, dtype=dtype)
+            x.integers(False, True, size=size, dtype=np.bool_)
         for _size in test_sizes:
-            for _dtype in test_dtypes:
-                for _bitgen in bitgen_types:
-                    with self.subTest(_size=_size, _dtype=_dtype,
-                                      _bitgen=_bitgen):
-                        self.check_numpy_parity(dist_func, _bitgen,
-                                                None, _size, _dtype)
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size,
+                                  _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, np.bool_)
 
         dist_func = lambda x, low, high, size, dtype, endpoint:\
             x.integers(low=low, high=high, size=size,
@@ -204,6 +202,102 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                   ['low', 'high', 'size', 'dtype', 'endpoint'],
                                   [1, 5, (1,), np.int64, True],
                                   ['x', 'x', ('x',), np.float64, 'x'])
+
+    # Testing .integers() dtype wise
+    def test_integers_uint64(self):
+        size = (2, 3)
+        # rng stands for range
+        # rng == 0
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 6, size=size, dtype=np.uint64)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint64)
+
+        # rng <= 0xFFFFFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 100, size=size, dtype=np.uint64)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint64)
+
+        # rng > 0xFFFFFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFFFFFFFF, size=size,
+                       dtype=np.uint64, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint64)
+
+        # rng == 0xFFFFFFFFFFFFFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFFFFFFFFFFFFFF, size=size,
+                       dtype=np.uint64, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint64)
+
+    def test_integers_uint32(self):
+        size = (2, 3)
+        # rng stands for range
+        # rng == 0
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 6, size=size, dtype=np.uint32)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint32)
+
+        # rng < 0xFFFFFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 100, size=size, dtype=np.uint32)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint32)
+
+        # rng == 0xFFFFFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFFFFFF, size=size,
+                       dtype=np.uint32, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint32)
+
+    def test_integers_uint16(self):
+        size = (2, 3)
+        # rng stands for range
+        # rng == 0
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 6, size=size, dtype=np.uint16)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint16)
+
+        # rng < 0xFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 100, size=size, dtype=np.uint16)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint16)
+
+        # rng == 0xFFFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFF, size=size,
+                       dtype=np.uint16, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint16)
+
+    def test_integers_uint8(self):
+        size = (2, 3)
+        # rng stands for range
+        # rng == 0
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 6, size=size, dtype=np.uint8)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint8)
+
+        # rng < 0xFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(5, 10, size=size, dtype=np.uint8)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint8)
+
+        # rng == 0xFF
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFF, size=size,
+                       dtype=np.uint8, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint8)
 
     def test_random(self):
         test_sizes = [None, (), (100,), (10, 20, 30)]

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -165,7 +165,8 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
 
     def test_integers(self):
         test_sizes = [None, (), (100,), (10, 20, 30)]
-        test_dtypes = [np.int64, np.int32, np.int16, np.int8]
+        test_dtypes = [np.int64, np.int32, np.int16, np.int8,
+                       np.uint64, np.uint32, np.uint16, np.uint8]
         bitgen_types = [None, MT19937]
 
         dist_func = lambda x, size, dtype:\

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -201,6 +201,13 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                     self.check_numpy_parity(dist_func, _bitgen,
                                             None, _size, np.bool_)
 
+        # Test dtype casting for high and low
+        dist_func = lambda x, size, dtype: \
+            x.integers(np.uint8(0), np.int64(100))
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
         dist_func = lambda x, low, high, size, dtype, endpoint:\
             x.integers(low=low, high=high, size=size,
                        dtype=dtype, endpoint=endpoint)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -92,13 +92,16 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                       test_size, test_dtype)
         numpy_res = distribution_func.py_func(numpy_rng_instance,
                                               test_size, test_dtype)
-        # assert_array_max_ulp doesn't compare scalar booleans/ boolean arrays
-        if isinstance(numba_res, bool) or (isinstance(numba_res, np.ndarray)
-                                           and numba_res.dtype == bool):
-            assert np.all(numba_res == numpy_res)
-        else:
+
+        if (isinstance(numba_res, np.ndarray) and
+            np.issubdtype(numba_res.dtype, np.floating)) \
+                or isinstance(numba_res, float):
+            # Float scalars and arrays
             np.testing.assert_array_max_ulp(numpy_res, numba_res,
                                             maxulp=ulp_prec, dtype=test_dtype)
+        else:
+            # Bool/int scalars and arrays
+            np.testing.assert_equal(numba_res, numpy_res)
 
         # Check if the end state of both BitGenerators is same
         # after drawing the distributions

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -66,11 +66,11 @@ class TestHelperFuncs(TestCase):
         rng = np.random.default_rng(1)
         py_func = lambda x, low, high, dtype: \
             x.integers(low=low, high=high, dtype=dtype, endpoint=True)
-        numba_func = numba.njit(cache=True)(py_func)
+        numba_func = numba.njit()(py_func)
 
         py_func = lambda x, low, high, dtype: \
             x.integers(low=low, high=high, dtype=dtype, endpoint=False)
-        numba_func_endpoint_false = numba.njit(cache=True)(py_func)
+        numba_func_endpoint_false = numba.njit()(py_func)
 
         cases = [
             # low, high, dtype

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -172,6 +172,12 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                        np.uint64, np.uint32, np.uint16, np.uint8]
         bitgen_types = [None, MT19937]
 
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.integers(0, 100)
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
         dist_func = lambda x, size, dtype:\
             x.integers(5, 10, size=size, dtype=dtype)
         for _size in test_sizes:

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -226,6 +226,13 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self.check_numpy_parity(dist_func, None,
                                 None, size, np.uint64)
 
+        # rng == 0xFFFFFFFFFFFFFFFF - 1
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFFFFFFFFFFFFFF - 1, size=size,
+                       dtype=np.uint64, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint64)
+
         # rng == 0xFFFFFFFFFFFFFFFF
         dist_func = lambda x, size, dtype:\
             x.integers(0, 0xFFFFFFFFFFFFFFFF, size=size,
@@ -245,6 +252,13 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         # rng < 0xFFFFFFFF
         dist_func = lambda x, size, dtype:\
             x.integers(5, 100, size=size, dtype=np.uint32)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint32)
+
+        # rng == 0xFFFFFFFF - 1
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFFFFFF - 1, size=size,
+                       dtype=np.uint32, endpoint=True)
         self.check_numpy_parity(dist_func, None,
                                 None, size, np.uint32)
 
@@ -270,6 +284,13 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self.check_numpy_parity(dist_func, None,
                                 None, size, np.uint16)
 
+        # rng == 0xFFFF - 1
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFFFF - 1, size=size,
+                       dtype=np.uint16, endpoint=True)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint16)
+
         # rng == 0xFFFF
         dist_func = lambda x, size, dtype:\
             x.integers(0, 0xFFFF, size=size,
@@ -289,6 +310,13 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         # rng < 0xFF
         dist_func = lambda x, size, dtype:\
             x.integers(5, 10, size=size, dtype=np.uint8)
+        self.check_numpy_parity(dist_func, None,
+                                None, size, np.uint8)
+
+        # rng == 0xFF - 1
+        dist_func = lambda x, size, dtype:\
+            x.integers(0, 0xFF - 1, size=size,
+                       dtype=np.uint8, endpoint=True)
         self.check_numpy_parity(dist_func, None,
                                 None, size, np.uint8)
 


### PR DESCRIPTION
This PR builds on top of #8040

Adds the following distributions as `Generator` methods:
- `Generator().integers()`