### PR TITLE
Support for NumPy BitGenerators PR#5: Generator Shuffling Methods.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -628,10 +628,12 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().negative_binomial()` (*)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`
+* :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)
 * :func:`numpy.random.Generator().poisson()` (*)
 * :func:`numpy.random.Generator().power()`
 * :func:`numpy.random.Generator().random()`
 * :func:`numpy.random.Generator().rayleigh()`
+* :func:`numpy.random.Generator().shuffle()` (Only accepts NumPy ndarrays.)
 * :func:`numpy.random.Generator().standard_cauchy()`
 * :func:`numpy.random.Generator().standard_exponential()`
 * :func:`numpy.random.Generator().standard_gamma()` (*)

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -176,7 +176,8 @@ def NumPyRandomGeneratorType_shuffle(inst, arr, axis=0):
     axis_impl = tuple([slice(None, None)] * arr.ndim)
 
     def impl(inst, arr, axis=0):
-
+        if axis > arr.ndim - 1:
+            raise IndexError("tuple index out of range")
         for i in range(arr.shape[axis] - 1, 0, -1):
             j = types.intp(random_methods.random_interval(inst.bit_generator,
                                                           i))

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -173,7 +173,8 @@ def NumPyRandomGeneratorType_shuffle(inst, arr):
 
     def impl(inst, arr):
         for i in range(arr.shape[0] - 1, 0, -1):
-            j = random_methods.random_interval(inst.bit_generator, i)
+            j = types.intp(random_methods.random_interval(inst.bit_generator,
+                                                          i))
             if i == j:
                 continue
             if arr.ndim != 1:

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -200,7 +200,7 @@ def NumPyRandomGeneratorType_shuffle(inst, x, axis=0):
 # Overload the Generator().permutation()
 @overload_method(types.NumPyRandomGeneratorType, 'permutation')
 def NumPyRandomGeneratorType_permutation(inst, x, axis=0):
-    check_types(x, [types.Array, int, types.Integer], 'x')
+    check_types(x, [types.Array, types.Integer], 'x')
     check_types(axis, [int, types.Integer], 'axis')
 
     if isinstance(x, types.Integer):

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -175,7 +175,6 @@ def NumPyRandomGeneratorType_integers(inst, low, high, size=None,
 def NumPyRandomGeneratorType_shuffle(inst, x, axis=0):
     check_types(x, [types.Array], 'x')
     check_types(axis, [int, types.Integer], 'axis')
-
     axis_impl = tuple([slice(None, None)] * x.ndim)
 
     def impl(inst, x, axis=0):
@@ -201,7 +200,7 @@ def NumPyRandomGeneratorType_shuffle(inst, x, axis=0):
 # Overload the Generator().permutation()
 @overload_method(types.NumPyRandomGeneratorType, 'permutation')
 def NumPyRandomGeneratorType_permutation(inst, x, axis=0):
-    check_types(x, [types.Array, int, types.Integers], 'x')
+    check_types(x, [types.Array, int, types.Integer], 'x')
     check_types(axis, [int, types.Integer], 'axis')
 
     if isinstance(x, types.Integer):

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -346,11 +346,12 @@ def _randint_arg_check(low, high, endpoint, lower_bound, upper_bound):
 
 
 @register_jitable
-def random_interval(bitgen, max):
-    if (max == 0):
+def random_interval(bitgen, max_val):
+    if (max_val == 0):
         return 0
 
-    mask = max
+    max_val = uint64(max_val)
+    mask = uint64(max_val)
 
     mask |= mask >> 1
     mask |= mask >> 2
@@ -359,13 +360,13 @@ def random_interval(bitgen, max):
     mask |= mask >> 16
     mask |= mask >> 32
 
-    if (max <= 0xffffffff):
-        value = next_uint32(bitgen) & mask
-        while value > max:
-            value = next_uint32(bitgen) & mask
+    if (max_val <= 0xffffffff):
+        value = uint64(next_uint32(bitgen)) & mask
+        while value > max_val:
+            value = uint64(next_uint32(bitgen)) & mask
     else:
         value = next_uint64(bitgen) & mask
-        while value > max:
+        while value > max_val:
             value = next_uint64(bitgen) & mask
 
-    return value
+    return uint64(value)

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -351,14 +351,7 @@ def random_interval(bitgen, max_val):
         return 0
 
     max_val = uint64(max_val)
-    mask = uint64(max_val)
-
-    mask |= mask >> 1
-    mask |= mask >> 2
-    mask |= mask >> 4
-    mask |= mask >> 8
-    mask |= mask >> 16
-    mask |= mask >> 32
+    mask = uint64(gen_mask(max_val))
 
     if (max_val <= 0xffffffff):
         value = uint64(next_uint32(bitgen)) & mask

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -946,6 +946,50 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self._check_invalid_types(dist_func, ['n', 'p', 'size'],
                                   [1, 0.75, (1,)], ['x', 'x', ('x',)])
 
+    def test_shuffle(self):
+        test_sizes = [(100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        def dist_func(x, size, dtype):
+            arr = x.random(size=size)
+            x.shuffle(arr)
+            return arr
+
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        def dist_func(x, arr):
+            x.shuffle(arr)
+            return arr
+
+        self._check_invalid_types(dist_func, ['arr'],
+                                  [np.array([3,4,5])], ['x'])
+
+    def test_permutation(self):
+        test_sizes = [(100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        def dist_func(x, size, dtype):
+            arr = x.random(size=size)
+            return x.permutation(arr)
+
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
+
+        def dist_func(x, arr):
+            return x.permutation(arr)
+
+        self._check_invalid_types(dist_func, ['arr'],
+                                  [np.array([3,4,5])], ['x'])
+
 
 class TestGeneratorCaching(TestCase, SerialMixin):
     def test_randomgen_caching(self):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -960,7 +960,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
                                             None, _size, None,
-                                            adjusted_ulp_prec)
+                                            0)
 
         def dist_func(x, arr, axis):
             x.shuffle(arr, axis=axis)
@@ -982,7 +982,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
                                             None, _size, None,
-                                            adjusted_ulp_prec)
+                                            0)
 
         def dist_func(x, arr, axis):
             return x.permutation(arr, axis=axis)

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -2,6 +2,7 @@ import numba
 import numpy as np
 import sys
 import platform
+import itertools
 
 from numba import types
 from numba.core.config import IS_32BITS
@@ -946,49 +947,73 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         self._check_invalid_types(dist_func, ['n', 'p', 'size'],
                                   [1, 0.75, (1,)], ['x', 'x', ('x',)])
 
+    # NumPy tests at:
+    # https://github.com/numpy/numpy/blob/95e3e7f445407e4f355b23d6a9991d8774f0eb0c/numpy/random/tests/test_generator_mt19937.py#L936
+    # Written in following format for semblance with existing Generator tests.
     def test_shuffle(self):
         test_sizes = [(10, 20, 30)]
         bitgen_types = [None, MT19937]
+        axes = [0, 1, 2]
 
-        def dist_func(x, size, dtype):
-            arr = x.random(size=size)
-            x.shuffle(arr, axis=1)
-            return arr
-
-        for _size in test_sizes:
-            for _bitgen in bitgen_types:
-                with self.subTest(_size=_size, _bitgen=_bitgen):
-                    self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            0)
+        for _size, _bitgen, _axis in itertools.product(test_sizes,
+                                                       bitgen_types,
+                                                       axes):
+            with self.subTest(_size=_size, _bitgen=_bitgen, _axis=_axis):
+                def dist_func(x, size, dtype):
+                    arr = x.random(size=size)
+                    x.shuffle(arr, axis=_axis)
+                    return arr
+                self.check_numpy_parity(dist_func, _bitgen,
+                                        None, _size, None,
+                                        0)
 
         def dist_func(x, arr, axis):
             x.shuffle(arr, axis=axis)
             return arr
 
-        self._check_invalid_types(dist_func, ['arr', 'axis'],
+        self._check_invalid_types(dist_func, ['x', 'axis'],
                                   [np.array([3,4,5]), 0], ['x', 'x'])
 
+        rng = np.random.default_rng(1)
+        with self.assertRaises(IndexError) as raises:
+            numba.njit(dist_func)(rng, np.array([3,4,5]), 2)
+        self.assertIn(
+            'Axis is out of bounds for the given array',
+            str(raises.exception)
+        )
+
+    # NumPy tests at:
+    # https://github.com/numpy/numpy/blob/95e3e7f445407e4f355b23d6a9991d8774f0eb0c/numpy/random/tests/test_generator_mt19937.py#L1030
+    # Written in following format for semblance with existing Generator tests.
     def test_permutation(self):
         test_sizes = [(10, 20, 30)]
         bitgen_types = [None, MT19937]
+        axes = [0, 1, 2]
 
-        def dist_func(x, size, dtype):
-            arr = x.random(size=size)
-            return x.permutation(arr, axis=1)
-
-        for _size in test_sizes:
-            for _bitgen in bitgen_types:
-                with self.subTest(_size=_size, _bitgen=_bitgen):
-                    self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            0)
+        for _size, _bitgen, _axis in itertools.product(test_sizes,
+                                                       bitgen_types,
+                                                       axes):
+            with self.subTest(_size=_size, _bitgen=_bitgen, _axis=_axis):
+                def dist_func(x, size, dtype):
+                    arr = x.random(size=size)
+                    return x.permutation(arr, axis=1)
+                self.check_numpy_parity(dist_func, _bitgen,
+                                        None, _size, None,
+                                        0)
 
         def dist_func(x, arr, axis):
             return x.permutation(arr, axis=axis)
 
-        self._check_invalid_types(dist_func, ['arr', 'axis'],
+        self._check_invalid_types(dist_func, ['x', 'axis'],
                                   [np.array([3,4,5]), 0], ['x', 'x'])
+
+        rng = np.random.default_rng(1)
+        with self.assertRaises(IndexError) as raises:
+            numba.njit(dist_func)(rng, np.array([3,4,5]), 2)
+        self.assertIn(
+            'Axis is out of bounds for the given array',
+            str(raises.exception)
+        )
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -947,12 +947,12 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                   [1, 0.75, (1,)], ['x', 'x', ('x',)])
 
     def test_shuffle(self):
-        test_sizes = [(100,), (10, 20, 30)]
+        test_sizes = [(10, 20, 30)]
         bitgen_types = [None, MT19937]
 
         def dist_func(x, size, dtype):
             arr = x.random(size=size)
-            x.shuffle(arr)
+            x.shuffle(arr, axis=1)
             return arr
 
         for _size in test_sizes:
@@ -962,20 +962,20 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                             None, _size, None,
                                             adjusted_ulp_prec)
 
-        def dist_func(x, arr):
-            x.shuffle(arr)
+        def dist_func(x, arr, axis):
+            x.shuffle(arr, axis=axis)
             return arr
 
-        self._check_invalid_types(dist_func, ['arr'],
-                                  [np.array([3,4,5])], ['x'])
+        self._check_invalid_types(dist_func, ['arr', 'axis'],
+                                  [np.array([3,4,5]), 0], ['x', 'x'])
 
     def test_permutation(self):
-        test_sizes = [(100,), (10, 20, 30)]
+        test_sizes = [(10, 20, 30)]
         bitgen_types = [None, MT19937]
 
         def dist_func(x, size, dtype):
             arr = x.random(size=size)
-            return x.permutation(arr)
+            return x.permutation(arr, axis=1)
 
         for _size in test_sizes:
             for _bitgen in bitgen_types:
@@ -984,11 +984,11 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                             None, _size, None,
                                             adjusted_ulp_prec)
 
-        def dist_func(x, arr):
-            return x.permutation(arr)
+        def dist_func(x, arr, axis):
+            return x.permutation(arr, axis=axis)
 
-        self._check_invalid_types(dist_func, ['arr'],
-                                  [np.array([3,4,5])], ['x'])
+        self._check_invalid_types(dist_func, ['arr', 'axis'],
+                                  [np.array([3,4,5]), 0], ['x', 'x'])
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -978,7 +978,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         nb_func = numba.njit(dist_func)
         rng = lambda: np.random.default_rng(1)
 
-        np.testing.assert_equal(dist_func(rng(), a), nb_func(rng(), b))
+        self.assertPreciseEqual(dist_func(rng(), a), nb_func(rng(), b))
 
     def test_shuffle_check(self):
         self.disable_leak_check()
@@ -1017,6 +1017,14 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                         None, _size, None,
                                         0)
 
+        # Test that permutation is actually done on a copy of the array
+        dist_func = numba.njit(lambda rng, arr: rng.permutation(arr))
+        rng = np.random.default_rng()
+        arr = rng.random(size=(10, 20))
+        arr_cpy = arr.copy()
+        dist_func(rng, arr)
+        self.assertPreciseEqual(arr, arr_cpy)
+
     def test_permutation_exception(self):
         self.disable_leak_check()
 
@@ -1044,7 +1052,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         nb_func = numba.njit(dist_func)
         rng = lambda: np.random.default_rng(1)
 
-        np.testing.assert_equal(dist_func(rng(), a), nb_func(rng(), b))
+        self.assertPreciseEqual(dist_func(rng(), a), nb_func(rng(), b))
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -967,6 +967,22 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                         None, _size, None,
                                         0)
 
+    def test_shuffle_empty(self):
+        a = np.array([])
+        b = np.array([])
+
+        def dist_func(x, arr):
+            x.shuffle(arr)
+            return arr
+
+        nb_func = numba.njit(dist_func)
+        rng = lambda: np.random.default_rng(1)
+
+        np.testing.assert_equal(dist_func(rng(), a), nb_func(rng(), b))
+
+    def test_shuffle_check(self):
+        self.disable_leak_check()
+
         def dist_func(x, arr, axis):
             x.shuffle(arr, axis=axis)
             return arr
@@ -1001,6 +1017,9 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                                         None, _size, None,
                                         0)
 
+    def test_permutation_exception(self):
+        self.disable_leak_check()
+
         def dist_func(x, arr, axis):
             return x.permutation(arr, axis=axis)
 
@@ -1014,6 +1033,18 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             'Axis is out of bounds for the given array',
             str(raises.exception)
         )
+
+    def test_permutation_empty(self):
+        a = np.array([])
+        b = np.array([])
+
+        def dist_func(x, arr):
+            return x.permutation(arr)
+
+        nb_func = numba.njit(dist_func)
+        rng = lambda: np.random.default_rng(1)
+
+        np.testing.assert_equal(dist_func(rng(), a), nb_func(rng(), b))
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1004,7 +1004,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
     def test_permutation(self):
         test_sizes = [(10, 20, 30)]
         bitgen_types = [None, MT19937]
-        axes = [0, 1, 2]
+        axes = [0, 1, 2, -1, -2]
 
         for _size, _bitgen, _axis in itertools.product(test_sizes,
                                                        bitgen_types,
@@ -1037,6 +1037,12 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         rng = np.random.default_rng(1)
         with self.assertRaises(IndexError) as raises:
             numba.njit(dist_func)(rng, np.array([3,4,5]), 2)
+        self.assertIn(
+            'Axis is out of bounds for the given array',
+            str(raises.exception)
+        )
+        with self.assertRaises(IndexError) as raises:
+            numba.njit(dist_func)(rng, np.array([3,4,5]), -2)
         self.assertIn(
             'Axis is out of bounds for the given array',
             str(raises.exception)


### PR DESCRIPTION
This PR builds on top of #8041

Currently has the following `Generator` methods:
- `Generator().shuffle()`
- `Generator().permutation()`