### PR TITLE
Make Python 3.10 kwarg peephole less restrictive

### DIFF
--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -702,11 +702,7 @@ def peep_hole_call_function_ex_to_call_function_kw(func_ir):
                         found = True
                     else:
                         vararg_loc -= 1
-                if not found:
-                    # If we couldn't find where the args are created
-                    # then we can't handle this format.
-                    raise UnsupportedError(errmsg)
-                else:
+                if found:
                     # If this value is still a list to tuple raise the
                     # exception.
                     expr = blk.body[vararg_loc].value

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -867,7 +867,7 @@ def peep_hole_list_to_tuple(func_ir):
                 # Finally write the result back into the original build list as
                 # everything refers to it.
                 append_and_fix(ir.Assign(acc, t2l_agn.target,
-                                          the_build_list.loc))
+                                         the_build_list.loc))
                 if _DEBUG:
                     print("\nNEW HOLE:")
                     for x in new_hole:


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Closes #8043

Fixes a bug in peep_hole_call_function_ex_to_call_function_kw where we raised the error if we couldn't find the varargs in the basic block and no kwargs are passed. This is an inaccurate check and we should only raise an exception if we find the args have the wrong definition.

This also fixes a bug in `peep_hole_list_to_tuple` where the definition of the final assignment wasn't properly set.