### PR TITLE
Rename "nb:run_pass" to "numba:run_pass" and document it.

### DIFF
--- a/numba/core/compiler_machinery.py
+++ b/numba/core/compiler_machinery.py
@@ -304,7 +304,7 @@ class PassManager(object):
             args=str(internal_state.args),
             return_type=str(internal_state.return_type),
         )
-        with ev.trigger_event("nb:run_pass", data=ev_details):
+        with ev.trigger_event("numba:run_pass", data=ev_details):
             with SimpleTimer() as init_time:
                 mutated |= check(pss.run_initialization, internal_state)
             with SimpleTimer() as pass_time:

--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -19,6 +19,15 @@ The following events are built in:
 - ``"numba:llvm_lock"`` is broadcast when the internal LLVM-lock is acquired.
   This is used internally to measure time spent with the lock acquired.
 
+- ``"numba:run_pass"`` is broadcast when a compiler pass is running.
+
+    - ``"name"``: pass name.
+    - ``"qualname"``: qualified name of the function being compiled.
+    - ``"module"``: module name of the function being compiled.
+    - ``"flags"``: compile flags.
+    - ``"args"``: argument types.
+    - ``"return_type"`` return type.
+
 Applications can register callbacks that are listening for specific events using
 ``register(kind: str, listener: Listener)``, where ``listener`` is an instance
 of ``Listener`` that defines custom actions on occurrence of the specific event.
@@ -50,6 +59,7 @@ _builtin_kinds = frozenset([
     "numba:compiler_lock",
     "numba:compile",
     "numba:llvm_lock",
+    "numba:run_pass",
 ])
 
 
@@ -466,7 +476,7 @@ def _setup_chrome_trace_exit_handler():
     to file.
     """
     listener = RecordingListener()
-    register("nb:run_pass", listener)
+    register("numba:run_pass", listener)
     filename = config.CHROME_TRACE
 
     @atexit.register


### PR DESCRIPTION
`run_pass` event should have been a builtin event.