### PR TITLE
Install llvmlite 0.38 for Numba 0.55.*

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -25,8 +25,8 @@ conda list
 conda create -n %CONDA_ENV% -q -y python=%PYTHON% numpy=%NUMPY% cffi pip scipy jinja2 ipython gitpython pyyaml
 
 call activate %CONDA_ENV%
-@rem Install latest llvmlite build
-%CONDA_INSTALL% -c numba/label/dev llvmlite
+@rem Install correct llvmlite build
+%CONDA_INSTALL% -c numba/label/dev llvmlite=0.38
 @rem Install dependencies for building the documentation
 if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx sphinx_rtd_theme pygments)
 @rem Install dependencies for code coverage (codecov.io)

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -95,8 +95,8 @@ elif [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]] ; then
     $PIP_INSTALL numpy==$NUMPY
 fi
 
-# Install latest llvmlite build
-$CONDA_INSTALL -c numba/label/dev llvmlite
+# Install llvmlite build
+$CONDA_INSTALL -c numba/label/dev llvmlite=0.38
 
 
 # Install dependencies for building the documentation


### PR DESCRIPTION
The public CI configuration assumes that the latest llvmlite should be installed. This is 0.39.0dev0 at the time of writing. However, Numba 0.55.* requires llvmlite 0.38.* -- so we install that instead.

```
    Traceback (most recent call last):
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 579, in _build_master
        ws.require(__requires__)
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 897, in require
        needed = self.resolve(parse_requirements(requirements))
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 788, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.ContextualVersionConflict: (llvmlite 0.39.0.dev0+80.g409cd6d (/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages), Requirement.parse('llvmlite<0.39,>=0.38.0rc1'), {'numba'})

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/home/vsts/miniconda3/envs/azure_ci/bin/numba", line 4, in <module>
        __import__('pkg_resources').require('numba==0.55.1+2.g4bb1964e1')
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3246, in <module>
        @_call_aside
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3221, in _call_aside
        f(*args, **kwargs)
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3259, in _initialize_master_working_set
        working_set = WorkingSet._build_master()
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 581, in _build_master
        return cls._build_from_requirements(__requires__)
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 594, in _build_from_requirements
        dists = ws.resolve(reqs, Environment())
      File "/home/vsts/miniconda3/envs/azure_ci/lib/python3.7/site-packages/pkg_resources/__init__.py", line 783, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'llvmlite<0.39,>=0.38.0rc1' distribution was not found and is required by numba
```