### PR TITLE
change return type of np.broadcast_shapes to a tuple

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1425,7 +1425,7 @@ def ol_numpy_broadcast_shapes(*args):
 
     # discover the number of dimensions
     m = 0
-    for arg in literal_unroll(args):
+    for arg in args:
         if isinstance(arg, types.Integer):
             m = max(m, 1)
         elif isinstance(arg, types.BaseTuple):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1423,24 +1423,32 @@ def ol_numpy_broadcast_shapes(*args):
                    f'Got {arg}')
             raise errors.TypingError(msg)
 
-    def impl(*args):
-        # discover the number of dimensions
-        m = 0
-        for val in literal_unroll(args):
-            if isinstance(val, int):
-                m = max(m, 1)
-            else:
-                m = max(m, len(val))
+    # discover the number of dimensions
+    m = 0
+    for arg in literal_unroll(args):
+        if isinstance(arg, types.Integer):
+            m = max(m, 1)
+        elif isinstance(arg, types.BaseTuple):
+            m = max(m, len(arg))
 
-        # propagate args
-        r = [1] * m
-        for arg in literal_unroll(args):
-            if isinstance(arg, tuple) and len(arg) > 0:
-                numpy_broadcast_shapes_list(r, m, arg)
-            elif isinstance(arg, int):
-                numpy_broadcast_shapes_list(r, m, (arg,))
-        return r
-    return impl
+    if m == 0:
+        return lambda *args: ()
+    else:
+        tup_init = (1,) * m
+
+        def impl(*args):
+            # propagate args
+            r = [1] * m
+            tup = tup_init
+            for arg in literal_unroll(args):
+                if isinstance(arg, tuple) and len(arg) > 0:
+                    numpy_broadcast_shapes_list(r, m, arg)
+                elif isinstance(arg, int):
+                    numpy_broadcast_shapes_list(r, m, (arg,))
+            for idx, elem in enumerate(r):
+                tup = tuple_setitem(tup, idx, elem)
+            return tup
+        return impl
 
 
 if numpy_version >= (1, 20):

--- a/numba/tests/test_array_manipulation.py
+++ b/numba/tests/test_array_manipulation.py
@@ -878,8 +878,9 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         # Tests taken from
         # https://github.com/numpy/numpy/blob/623bc1fae1d47df24e7f1e29321d0c0ba2771ce0/numpy/lib/tests/test_stride_tricks.py#L296-L334
         data = [
-            # [[], ()],
+            # [[], ()],  # cannot compute fingerprint of empty list
             [()],
+            [(), ()],
             [(7,)],
             [(1, 2),],
             [(1, 1)],
@@ -909,6 +910,7 @@ class TestArrayManipulation(MemoryLeakMixin, TestCase):
         for input_shape in data:
             expected = pyfunc(*input_shape)
             got = cfunc(*input_shape)
+            self.assertIsInstance(got, tuple)
             self.assertPreciseEqual(expected, got)
 
     @unittest.skipIf(numpy_version < (1, 20), "requires NumPy 1.20 or newer")


### PR DESCRIPTION
This is a follow-up PR of https://github.com/numba/numba/pull/8003. It changes the return type of `np.broadcast_shapes` to a tuple, which matches the [NumPy spec](https://numpy.org/doc/stable/reference/generated/numpy.broadcast_shapes.html#numpy.broadcast_shapes).

I also notice in PR https://github.com/numba/numba/pull/7067 that by returning a list, `np.broadcast_shapes` is pretty much unusable. 