### PR TITLE
Backport #8097: Exclude libopenblas 0.3.20 on osx-arm64

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -54,7 +54,9 @@ requirements:
     # 0.3.17 buggy on M1 silicon
     # https://github.com/xianyi/OpenBLAS/blob/v0.3.20/Changelog.txt#L118
     # https://github.com/numba/numba/issues/7822#issuecomment-1063229855
-    - libopenblas >=0.3.18     # [arm64]
+    # Exclude 0.3.20 too
+    # https://github.com/numba/numba/issues/8096
+    - libopenblas >=0.3.18, !=0.3.20     # [arm64]
     # CUDA 9.2 or later is required for CUDA support
     - cudatoolkit >=9.2
     # scipy 1.0 or later


### PR DESCRIPTION
As title

