### PR TITLE
Backport #7786 for 0.55.2: Remove dependency on intel-openmp for OSX

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -27,9 +27,8 @@ requirements:
   build:
     - {{ compiler('c') }}      # [not (armv6l or armv7l or aarch64)]
     - {{ compiler('cxx') }}    # [not (armv6l or armv7l or aarch64)]
-    # both of these are needed on osx, llvm for the headers, Intel for the lib
+    # OpenMP headers from llvm needed for OSX.
     - llvm-openmp              # [osx]
-    - intel-openmp             # [osx]
   host:
     - python
     - numpy
@@ -69,7 +68,7 @@ test:
     - ipython                  # [not (armv6l or armv7l or aarch64)]
     - setuptools
     - tbb  2021.*              # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
-    - intel-openmp             # [osx]
+    - llvm-openmp              # [osx]
     # This is for driving gdb tests
     - pexpect                  # [linux64]
     # For testing ipython

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -81,8 +81,9 @@ if [[ $(uname) == Linux ]]; then
     fi
 elif  [[ $(uname) == Darwin ]]; then
     $CONDA_INSTALL clang_osx-64 clangxx_osx-64
-    # Install llvm-openmp and intel-openmp on OSX too
-    $CONDA_INSTALL llvm-openmp intel-openmp
+    # Install llvm-openmp on OSX for headers during build and runtime during
+    # testing
+    $CONDA_INSTALL llvm-openmp
 fi
 
 # `pip install` all the dependencies on Python 3.10

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -99,8 +99,7 @@ Then create an environment with the right dependencies::
 .. note::
    This installs an environment based on Python 3.8, but you can of course
    choose another version supported by Numba.  To test additional features,
-   you may also need to install ``tbb`` and/or ``llvm-openmp`` and
-   ``intel-openmp``.
+   you may also need to install ``tbb`` and/or ``llvm-openmp``.
 
 To activate the environment for the current shell session::
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -168,9 +168,9 @@ otherwise build by default along with information on configuration options.
   * For Linux and Windows it is necessary to provide OpenMP C headers and
     runtime  libraries compatible with the compiler tool chain mentioned above,
     and for these to be accessible to the compiler via standard flags.
-  * For OSX the conda packages ``llvm-openmp`` and ``intel-openmp`` provide
-    suitable C headers and libraries. If the compilation requirements are not
-    met the OpenMP threading backend will not be compiled
+  * For OSX the conda package ``llvm-openmp`` provides suitable C headers and
+    libraries. If the compilation requirements are not met the OpenMP threading
+    backend will not be compiled.
 
 .. envvar:: NUMBA_DISABLE_TBB (default: not set)
 
@@ -212,8 +212,6 @@ vary with target operating system and hardware. The following lists them all
 
   * ``llvm-openmp`` (OSX) - provides headers for compiling OpenMP support into
     Numba's threading backend
-  * ``intel-openmp`` (OSX) - provides OpenMP library support for Numba's
-    threading backend.
   * ``tbb-devel`` - provides TBB headers/libraries for compiling TBB support
     into Numba's threading backend (version >= 2021 required).
 
@@ -226,8 +224,10 @@ vary with target operating system and hardware. The following lists them all
   * ``jinja2`` - for "pretty" type annotation output (HTML) via the ``numba``
     CLI
   * ``cffi`` - permits use of CFFI bindings in Numba compiled functions
-  * ``intel-openmp`` - (OSX) provides OpenMP library support for Numba's OpenMP
-    threading backend
+  * ``llvm-openmp`` - (OSX) provides OpenMP library support for Numba's OpenMP
+    threading backend.
+  * ``intel-openmp`` - (OSX) provides an alternative OpenMP library for use with
+    Numba's OpenMP threading backend.
   * ``ipython`` - if in use, caching will use IPython's cache
     directories/caching still works
   * ``pyyaml`` - permits the use of a ``.numba_config.yaml``

--- a/docs/source/user/threading-layer.rst
+++ b/docs/source/user/threading-layer.rst
@@ -157,8 +157,9 @@ and requirements are as follows:
 |                      | Windows   | MS OpenMP libraries (very likely this will|
 |                      |           | already exist)                            |
 |                      |           |                                           |
-|                      | OSX       | The ``intel-openmp`` package (``$ conda   |
-|                      |           | install intel-openmp``)                   |
+|                      | OSX       | Either the ``intel-openmp`` package or the|
+|                      |           | ``llvm-openmp`` package                   |
+|                      |           | (``conda install`` the package as named). |
 +----------------------+-----------+-------------------------------------------+
 | ``workqueue``        | All       | None                                      |
 +----------------------+-----------+-------------------------------------------+


### PR DESCRIPTION
As title.