### PR TITLE
WIP: support numpy array comparison with string

### DIFF
--- a/numba/tests/test_array_exprs.py
+++ b/numba/tests/test_array_exprs.py
@@ -738,5 +738,21 @@ class TestExternalTypes(MemoryLeakMixin, unittest.TestCase):
             np.testing.assert_array_equal(arr_expr_neg(4), np.array([-4]))
 
 
+class TestStringExpressions(MemoryLeakMixin, unittest.TestCase):
+
+    def test_eq(self):
+        @njit
+        def foo(a, s):
+            return a == s
+
+        a = np.array(["A", "B"])
+        s = "A"
+        pv = foo.py_func(a, s)
+        jv = foo(a, s)
+        print(foo.inspect_types())
+        self.assertIsInstance(jv, np.ndarray)
+        np.testing.assert_array_equal(pv, jv)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fix #7859 .

Choose an alternative to implement this feature:

- [x] Aligned with NumPy, use special case to handle string ufunc (I don't want to choose this way, because I guess this makes string case cannot use ufunc-related optimization?)
- [x] Pending on NumPy new version (1.23?), then use an unified way to handle all ufuncs
  -  tested on NumPy==1.23.0rc2, it doesn't unify string case and others. [2022-6-6]

Updates on 2022-6-21:

- [ ] I choose to help NumPy to complete the string ufunc unification PRs. 
- [ ] Then back to Numba string ufuncs.