### PR TITLE
Backport #8109 Pin TBB support with respect to incompatible 2021.6 API.

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -37,9 +37,10 @@ requirements:
     - llvmlite 0.38.*
     # TBB devel version is to match TBB libs.
     # 2020.3 is the last version with the "old" ABI
+    # NOTE: 2021.1..2021.5 are API compatible for Numba's purposes.
     # NOTE: ppc64le exclusion is temporary until packages are more generally
     #       available.
-    - tbb-devel 2021.*       # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
+    - tbb-devel >=2021,<2021.6       # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
   run:
     - python >=3.7
     - numpy >=1.18,<1.23

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -214,7 +214,8 @@ vary with target operating system and hardware. The following lists them all
   * ``llvm-openmp`` (OSX) - provides headers for compiling OpenMP support into
     Numba's threading backend
   * ``tbb-devel`` - provides TBB headers/libraries for compiling TBB support
-    into Numba's threading backend (version >= 2021 required).
+    into Numba's threading backend (2021 <= version < 2021.6 required).
+  * ``importlib_metadata`` (for Python versions < 3.9)
 
 * Optional runtime are:
 

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -27,8 +27,8 @@ Implement parallel vectorize workqueue on top of Intel TBB.
  * from here:
  * https://github.com/intel/tbb/blob/2019_U5/include/tbb/tbb_stddef.h#L29
  */
-#if TBB_INTERFACE_VERSION < 12010
-#error "TBB version is too old, 2021 update 1, i.e. TBB_INTERFACE_VERSION >= 12010 required"
+#if (TBB_INTERFACE_VERSION >= 12060) || (TBB_INTERFACE_VERSION < 12010)
+#error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
 #endif
 
 #define _DEBUG 0


### PR DESCRIPTION
As title. Numba is not yet compatible with TBB 2021.6 API, but the
ABI seems ok.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
