### PR TITLE
Support nesting of nested array types

### DIFF
--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -212,6 +212,10 @@ class Record(Type):
 
         return as_struct_dtype(self)
 
+    @property
+    def bitwidth(self):
+        return self.dtype.itemsize * 8
+
     def can_convert_to(self, typingctx, other):
         """
         Convert this Record to the *other*.
@@ -430,6 +434,10 @@ class Array(Buffer):
         if (not aligned or
             (isinstance(dtype, Record) and not dtype.aligned)):
             self.aligned = False
+        if isinstance(dtype, NestedArray):
+            tmp = Array(dtype.dtype, dtype.ndim, 'C')
+            ndim += tmp.ndim
+            dtype = tmp.dtype
         if name is None:
             type_name = "array"
             if not self.mutable:
@@ -556,6 +564,10 @@ class NestedArray(Array):
     """
 
     def __init__(self, dtype, shape):
+        if isinstance(dtype, NestedArray):
+            tmp = Array(dtype.dtype, dtype.ndim, 'C')
+            shape += dtype.shape
+            dtype = tmp.dtype
         assert dtype.bitwidth % 8 == 0, \
             "Dtype bitwidth must be a multiple of bytes"
         self._shape = shape

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -134,6 +134,8 @@ class Record(Type):
         name = 'Record({};{};{})'.format(desc, self.size, self.aligned)
         super(Record, self).__init__(name)
 
+        self.bitwidth = self.dtype.itemsize * 8
+
     @classmethod
     def _normalize_fields(cls, fields):
         """
@@ -211,10 +213,6 @@ class Record(Type):
         from numba.np.numpy_support import as_struct_dtype
 
         return as_struct_dtype(self)
-
-    @property
-    def bitwidth(self):
-        return self.dtype.itemsize * 8
 
     def can_convert_to(self, typingctx, other):
         """
@@ -435,9 +433,8 @@ class Array(Buffer):
             (isinstance(dtype, Record) and not dtype.aligned)):
             self.aligned = False
         if isinstance(dtype, NestedArray):
-            tmp = Array(dtype.dtype, dtype.ndim, 'C')
-            ndim += tmp.ndim
-            dtype = tmp.dtype
+            ndim += dtype.ndim
+            dtype = dtype.dtype
         if name is None:
             type_name = "array"
             if not self.mutable:

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1773,7 +1773,7 @@ class TestNestedArrays(TestCase):
             return x[0]
 
         arr = np.asarray([([(0,), (1,), (2,)],),
-                          ([(4,), (5,), (6,)],)],
+                          ([(3,), (4,), (5,)],)],
                          dtype=items)
 
         expected = fn.py_func(arr)

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1766,13 +1766,16 @@ class TestNestedArrays(TestCase):
     def test_issue_3158_1(self):
         # A nested array dtype.
         item = np.dtype([('some_field', np.int32)])
-        items = np.dtype([('items', item, 10)])
+        items = np.dtype([('items', item, 3)])
 
         @njit
         def fn(x):
             return x[0]
 
-        arr = np.zeros((2,), items)
+        arr = np.asarray([([(0,), (1,), (2,)],),
+                          ([(4,), (5,), (6,)],)],
+                         dtype=items)
+
         expected = fn.py_func(arr)
         actual = fn(arr)
 
@@ -1788,7 +1791,9 @@ class TestNestedArrays(TestCase):
         def fn(arr):
             return arr[0]
 
-        arr = np.zeros(2, dtype3)
+        arr = np.asarray([(False, [[(0, 1), (2, 3)], [(4, 5), (6, 7)]]),
+                          (True, [[(8, 9), (10, 11)], [(12, 13), (14, 15)]])],
+                         dtype=dtype3)
         expected = fn.py_func(arr)
         actual = fn(arr)
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1735,8 +1735,8 @@ class TestNestedArrays(TestCase):
     def test_issue_1469_1(self):
         # Dimensions of nested arrays as a dtype are concatenated with the
         # dimensions of the array.
-        nptype = np.dtype((np.float64,(4,)))
-        nbtype = types.Array(numpy_support.from_dtype(nptype),2,'C')
+        nptype = np.dtype((np.float64, (4,)))
+        nbtype = types.Array(numpy_support.from_dtype(nptype), 2, 'C')
         expected = types.Array(types.float64, 3, 'C')
         self.assertEqual(nbtype, expected)
 
@@ -1753,7 +1753,7 @@ class TestNestedArrays(TestCase):
         # Nested arrays in record dtypes are accepted, but alignment is not
         # guaranteed.
         nptype = np.dtype([('a', np.float64,(4,))])
-        nbtype = types.Array(numpy_support.from_dtype(nptype),2,'C')
+        nbtype = types.Array(numpy_support.from_dtype(nptype), 2, 'C')
 
         # Manual construction of expected array of record type
         natype = types.NestedArray(types.float64, (4,))


### PR DESCRIPTION
Adds support for nesting of nested array types. Test cases are based on those provided in Issues #1469 and #3158.

Fixes #1469.
Fixes #3158.