### PR TITLE
support register_jitable-ed function as njit function argument

### DIFF
--- a/numba/core/boxing.py
+++ b/numba/core/boxing.py
@@ -1063,6 +1063,11 @@ def box_pyobject(typ, val, c):
     return val
 
 
+@unbox(types.Function)
+def unbox_function(typ, obj, c):
+    return NativeValue(obj)
+
+
 def unbox_unsupported(typ, obj, c):
     c.pyapi.err_set_string("PyExc_TypeError",
                            "can't unbox {!r} type".format(typ))

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -732,7 +732,8 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         try:
             tp = typeof(val, Purpose.argument)
         except ValueError:
-            self.targetctx.refresh()
+            with global_compiler_lock:
+                self.targetctx.refresh()
             tp = self.typingctx._get_global_type(val)
             if tp is None:
                 tp = types.pyobject

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -732,7 +732,10 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         try:
             tp = typeof(val, Purpose.argument)
         except ValueError:
-            tp = types.pyobject
+            self.targetctx.refresh()
+            tp = self.typingctx._get_global_type(val)
+            if tp is None:
+                tp = types.pyobject
         else:
             if tp is None:
                 tp = types.pyobject

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -1,7 +1,6 @@
 """
 Define typing templates
 """
-import threading
 from abc import ABC, abstractmethod
 import functools
 import sys
@@ -1303,12 +1302,10 @@ class BaseRegistryLoader(object):
         self._registrations = dict(
             (name, utils.stream_list(getattr(registry, name)))
             for name in self.registry_items)
-        self.lock = threading.lock()
 
     def new_registrations(self, name):
-        with self.lock:
-            for item in next(self._registrations[name]):
-                yield item
+        for item in next(self._registrations[name]):
+            yield item
 
 
 class RegistryLoader(BaseRegistryLoader):

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -1,6 +1,7 @@
 """
 Define typing templates
 """
+
 from abc import ABC, abstractmethod
 import functools
 import sys

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -1,7 +1,7 @@
 """
 Define typing templates
 """
-
+import threading
 from abc import ABC, abstractmethod
 import functools
 import sys
@@ -1303,10 +1303,12 @@ class BaseRegistryLoader(object):
         self._registrations = dict(
             (name, utils.stream_list(getattr(registry, name)))
             for name in self.registry_items)
+        self.lock = threading.lock()
 
     def new_registrations(self, name):
-        for item in next(self._registrations[name]):
-            yield item
+        with self.lock:
+            for item in next(self._registrations[name]):
+                yield item
 
 
 class RegistryLoader(BaseRegistryLoader):

--- a/numba/tests/test_extending.py
+++ b/numba/tests/test_extending.py
@@ -1551,6 +1551,19 @@ class TestRegisterJitable(unittest.TestCase):
         )
         self.assertIn(msg, str(raises.exception))
 
+    def test_as_njit_argument(self):
+        @register_jitable
+        def g():
+            return 1
+
+        @njit
+        def f(x):
+            return g(), x()
+
+        pv = f.py_func(g)
+        jv = f(g)
+        self.assertEqual(pv, jv)
+
 
 class TestImportCythonFunction(unittest.TestCase):
     @unittest.skipIf(sc is None, "Only run if SciPy >= 0.19 is installed")


### PR DESCRIPTION
fix #7043 . 

- [x] typeof/typer OK: getting `global_type` via `typingctx` will avoid the first `TypingError`
- [x] unbox OK: add `unbox` for `types.Function`
- [x] CI pass
- [ ] because of holding lock on `typeof_pyval`, it results in much time comsumption in some CUDA test cases