### PR TITLE
Mark gufuncs as having mutable outputs

### DIFF
--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -182,7 +182,7 @@ dufunc_init(PyDUFuncObject *self, PyObject *args, PyObject *kws)
     PyObject *dispatcher=NULL, *keepalive=NULL, *py_func_obj=NULL, *tmp;
     PyUFuncObject *ufunc=NULL;
     int identity=PyUFunc_None;
-    int nin=-1, nout=1;
+    int nin=-1, nout=1, idx;
     const char *name=NULL, *doc=NULL;
 
     static char * kwlist[] = {"dispatcher", "identity", "_keepalive", "nin",
@@ -229,6 +229,10 @@ dufunc_init(PyDUFuncObject *self, PyObject *args, PyObject *kws)
                                                      name, doc, 0);
     if (!ufunc) {
         return -1;
+    }
+
+    for (idx = 0; idx < nout; idx++) {
+        ufunc->op_flags[idx + nin] |= NPY_ITER_READWRITE | NPY_ITER_UPDATEIFCOPY | NPY_ITER_ALLOCATE;
     }
 
     /* Construct a keepalive list if none was given. */

--- a/numba/np/ufunc/_ufunc.c
+++ b/numba/np/ufunc/_ufunc.c
@@ -36,7 +36,7 @@ ufunc_fromfunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
     char *signature = NULL;
     int identity;
 
-    int i, j;
+    int i, j, idx;
     int custom_dtype = 0;
     PyUFuncGenericFunction *funcs;
     int *types;
@@ -201,6 +201,10 @@ ufunc_fromfunc(PyObject *NPY_UNUSED(dummy), PyObject *args)
         PyArray_free(data);
         funcs = NULL;
         data = NULL;
+    }
+
+    for (idx = 0; idx < nout; idx++) {
+        ufunc->op_flags[idx + nin] |= NPY_ITER_READWRITE | NPY_ITER_UPDATEIFCOPY | NPY_ITER_ALLOCATE;
     }
 
     /* Create the sentinel object to clean up dynamically-allocated fields


### PR DESCRIPTION
Indicate that functions generated with `guvectorize` should be allowed to
mutate their inputs so that NumPy will copy any mutations and prevent
uninitialized values from being exposed.

Closes #6864