### PR TITLE
CUDA: Fix #7806, Division by zero stops the kernel

### DIFF
--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -26,9 +26,14 @@ For details please consult the
 Floating Point Error Model
 --------------------------
 
-By default, CUDA Python kernels execute with the NumPy error model. In this model, division by zero raises no exception and instead produces a result of ``inf`` / ``-inf`` or ``nan``. This differs from the normal Python error model, in which divisions by zero raise a ``ZeroDivisionError``.
+By default, CUDA Python kernels execute with the NumPy error model. In this
+model, division by zero raises no exception and instead produces a result of
+``inf``, ``-inf`` or ``nan``. This differs from the normal Python error model,
+in which division by zero raises a ``ZeroDivisionError``.
 
-When debug is enabled (by passing ``debug=True`` to the :func:`@cuda.jit <numba.cuda.jit>` decorator), the Python error model is used. This allows division-by-zero errors during kernel execution to be identified.
+When debug is enabled (by passing ``debug=True`` to the
+:func:`@cuda.jit <numba.cuda.jit>` decorator), the Python error model is used.
+This allows division-by-zero errors during kernel execution to be identified.
 
 Constructs
 ----------

--- a/docs/source/cuda/cudapysupported.rst
+++ b/docs/source/cuda/cudapysupported.rst
@@ -23,6 +23,13 @@ For details please consult the
 `CUDA Programming Guide
 <http://docs.nvidia.com/cuda/cuda-c-programming-guide/#programming-model>`_.
 
+Floating Point Error Model
+--------------------------
+
+By default, CUDA Python kernels execute with the NumPy error model. In this model, division by zero raises no exception and instead produces a result of ``inf`` / ``-inf`` or ``nan``. This differs from the normal Python error model, in which divisions by zero raise a ``ZeroDivisionError``.
+
+When debug is enabled (by passing ``debug=True`` to the :func:`@cuda.jit <numba.cuda.jit>` decorator), the Python error model is used. This allows division-by-zero errors during kernel execution to be identified.
+
 Constructs
 ----------
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -196,6 +196,9 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
         # later want to overload some other behavior on the debug flag.
         # In particular, -opt=3 is not supported with -g.
         flags.debuginfo = True
+        flags.error_model = 'python'
+    else:
+        flags.error_model = 'numpy'
     if inline:
         flags.forceinline = True
     if fastmath:

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -91,9 +91,10 @@ def jit(func_or_sig=None, device=False, debug=False, argtypes=None,
         def jitwrapper(fn):
             return FakeCUDAKernel(fn,
                                   device=device,
-                                  fastmath=fastmath)
+                                  fastmath=fastmath,
+                                  debug=debug)
         return jitwrapper
-    return FakeCUDAKernel(func_or_sig, device=device)
+    return FakeCUDAKernel(func_or_sig, device=device, debug=debug)
 
 
 @contextmanager

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -77,7 +77,7 @@ event = Event
 
 def jit(func_or_sig=None, device=False, debug=False, argtypes=None,
         inline=False, restype=None, fastmath=False, link=None,
-        boundscheck=None,
+        boundscheck=None, opt=True
         ):
     # Here for API compatibility
     if boundscheck:

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -45,6 +45,7 @@ class TestException(CUDATestCase):
         divergence.
         """
         with_opt_mode = not with_debug_mode
+
         @cuda.jit(debug=with_debug_mode, opt=with_opt_mode)
         def problematic(x, y):
             tid = cuda.threadIdx.x
@@ -136,7 +137,7 @@ class TestException(CUDATestCase):
         else:
             exc = ZeroDivisionError
 
-        with self.assertRaises(exc) as raises:
+        with self.assertRaises(exc):
             f[1, 1](r, x, y)
 
         self.assertEqual(r[0], 0, 'Expected result to be left unset')

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -98,7 +98,7 @@ class TestException(CUDATestCase):
 
     def test_no_zero_division_error(self):
         # When debug is False:
-        # - Zero by division raises no exception
+        # - Division by zero raises no exception
         # - Execution proceeds after a divide by zero
         @cuda.jit
         def f(r, x, y):

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -16,7 +16,7 @@ class TestException(CUDATestCase):
                 ary.shape[-x]
 
         unsafe_foo = cuda.jit(foo)
-        safe_foo = cuda.jit(debug=True)(foo)
+        safe_foo = cuda.jit(debug=True, opt=False)(foo)
 
         if not config.ENABLE_CUDASIM:
             # Simulator throws exceptions regardless of debug
@@ -28,7 +28,7 @@ class TestException(CUDATestCase):
         self.assertIn("tuple index out of range", str(cm.exception))
 
     def test_user_raise(self):
-        @cuda.jit(debug=True)
+        @cuda.jit(debug=True, opt=False)
         def foo(do_raise):
             if do_raise:
                 raise ValueError
@@ -44,7 +44,8 @@ class TestException(CUDATestCase):
         of unifying branch target and resulting in unexpected warp
         divergence.
         """
-        @cuda.jit(debug=with_debug_mode)
+        with_opt_mode = not with_debug_mode
+        @cuda.jit(debug=with_debug_mode, opt=with_opt_mode)
         def problematic(x, y):
             tid = cuda.threadIdx.x
             ntid = cuda.blockDim.x

--- a/numba/cuda/tests/cudapy/test_exception.py
+++ b/numba/cuda/tests/cudapy/test_exception.py
@@ -125,7 +125,17 @@ class TestException(CUDATestCase):
         x = np.zeros(1)
         y = np.ones(1)
 
-        with self.assertRaises(ZeroDivisionError) as raises:
+        # Simulator and device behaviour differs slightly in the exception
+        # raised - in debug mode, the CUDA target uses the Python error model,
+        # which gives a ZeroDivision error. The simulator uses NumPy with the
+        # error mode for division by zero set to raise, which results in a
+        # FloatingPointError instead.
+        if config.ENABLE_CUDASIM:
+            exc = FloatingPointError
+        else:
+            exc = ZeroDivisionError
+
+        with self.assertRaises(exc) as raises:
             f[1, 1](r, x, y)
 
         self.assertEqual(r[0], 0, 'Expected result to be left unset')


### PR DESCRIPTION
The expected behaviour is that execution proceeds after division by zero, as the CUDA target doesn't normally have a way to signal the exception. When debug is enabled, it can signal the exception so an exception should be raised and execution should stop. This is implemented by setting CUDA kernels to use the NumPy error model in general, and only switching back to the Python error model when debug is on.

This PR also adds support for raising on divide by zero when debug is on in the simulator - this helps align the behaviour of the simulator with that of the real device. The error behaviour in NumPy is configured on a per-thread basis, so it's essential to use `np.seterr()` when the target thread starts running. Since threads are ephemeral for the life of the kernel launch, no attempt is made to save and restore the initial state of the error behaviour.

Finally, there were some illegal uses of debug with optimization in the `test_exception.py` file I was working on, so I fixed that while I was working in this area.

Fixes #7806.