### PR TITLE
CUDA: Fix some missed changes from dropping 9.2

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -61,8 +61,8 @@ requirements:
     # Exclude 0.3.20 too
     # https://github.com/numba/numba/issues/8096
     - libopenblas >=0.3.18, !=0.3.20     # [arm64]
-    # CUDA 9.2 or later is required for CUDA support
-    - cudatoolkit >=9.2
+    # CUDA 10.2 or later is required for CUDA support
+    - cudatoolkit >=10.2
     # scipy 1.0 or later
     - scipy >=1.0
     # CUDA Python 11.6 or later

--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -201,10 +201,6 @@ def _getpid():
 
 ERROR_MAP = _build_reverse_error_map()
 
-MISSING_FUNCTION_ERRMSG = """driver missing function: %s.
-Requires CUDA 9.2 or above.
-"""
-
 
 class Driver(object):
     """
@@ -371,7 +367,7 @@ class Driver(object):
         # Not found.
         # Delay missing function error to use
         def absent_function(*args, **kws):
-            raise CudaDriverError(MISSING_FUNCTION_ERRMSG % fname)
+            raise CudaDriverError(f'Driver missing function: {fname}')
 
         setattr(self, fname, absent_function)
         return absent_function

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -132,19 +132,7 @@ class NVVM(object):
 
                 # Find & populate functions
                 for name, proto in inst._PROTOTYPES.items():
-                    try:
-                        func = getattr(inst.driver, name)
-                    except AttributeError:
-                        # CUDA 9.2 has no nvvmLazyAddModuleToProgram, but
-                        # nvvmAddModuleToProgram fulfils the same function,
-                        # just less efficiently, so we work around this here.
-                        # This workaround to be removed once support for CUDA
-                        # 9.2 is dropped.
-                        if name == 'nvvmLazyAddModuleToProgram':
-                            func = getattr(inst.driver,
-                                           'nvvmAddModuleToProgram')
-                        else:
-                            raise
+                    func = getattr(inst.driver, name)
                     func.restype = proto[0]
                     func.argtypes = proto[1:]
                     setattr(inst, name, func)


### PR DESCRIPTION
When toolkit 9.2-10.1 support was dropped in #7878, a couple of bits got missed.

- Most importantly, the Conda recipe still required only 9.2 - it should be 10.2.
- The missing function error message stated that it required CUDA 9.2. Since all APIs we use are available in all supported toolkit versions, the error message need no longer state a CUDA requirement.
- All supported toolkit versions implement `nvvmLazyAddModuleToProgram`, so we no longer need a workaround for it.