### PR TITLE
Add fastmath support to cc.export

### DIFF
--- a/numba/pycc/compiler.py
+++ b/numba/pycc/compiler.py
@@ -68,10 +68,11 @@ class ExportEntry(object):
     A simple record for exporting symbols.
     """
 
-    def __init__(self, symbol, signature, function):
+    def __init__(self, symbol, signature, function, fastmath=False):
         self.symbol = symbol
         self.signature = signature
         self.function = function
+        self.fastmath = fastmath
 
     def __repr__(self):
         return "ExportEntry(%r, %r)" % (self.symbol, self.signature)
@@ -150,6 +151,8 @@ class _ModuleCompiler(object):
             library.add_ir_module(nrt_module)
 
         for entry in self.export_entries:
+            if entry.fastmath:
+                flags_aux.set('fastmath', value=cpu.FastMathOptions(True))
             cres = compile_extra(self.typing_context, self.context,
                                 entry.function,
                                 entry.signature.args,

--- a/numba/tests/compile_with_pycc.py
+++ b/numba/tests/compile_with_pycc.py
@@ -31,6 +31,11 @@ def get_none():
 def div(x, y):
     return x / y
 
+# Test fastmath
+@cc.export('tanh', 'f8(f8)', fastmath=True)
+def tanh(x):    
+  return 2/(1+np.exp(-2*x)) - 1
+
 _two = 2
 
 # This one can't be compiled by the legacy API as it doesn't execute

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -220,6 +220,8 @@ class TestCC(BasePYCCTest):
             self.assertPreciseEqual(res, 987.0 * 321.0)
             res = lib.square(5)
             self.assertPreciseEqual(res, 25)
+            res = lib.tanh(0.7)
+            self.assertPreciseEqual(res, np.tanh(0.7))
             self.assertIs(lib.get_none(), None)
             with self.assertRaises(ZeroDivisionError):
                 lib.div(1, 0)


### PR DESCRIPTION
This PR implements the feature resolves numba/numba/issues/7179. 