### PR TITLE
Allow ufunc builder to use previously JITed function

### DIFF
--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -1,9 +1,9 @@
 from numba import jit, typeof
 from numba.core import cgutils, types, serialize, sigutils
+from numba.core.extending import is_jitted
 from numba.core.typing import npydecl
 from numba.core.typing.templates import AbstractTemplate, signature
 from numba.np.ufunc import _internal
-from numba.core.dispatcher import Dispatcher
 from numba.parfors import array_analysis
 from numba.np.ufunc import ufuncbuilder
 from numba.np import numpy_support
@@ -77,7 +77,7 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc):
     __base_kwargs = set(('identity', '_keepalive', 'nin', 'nout'))
 
     def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
-        if isinstance(py_func, Dispatcher):
+        if is_jitted(py_func):
             py_func = py_func.py_func
         dispatcher = jit(_target='npyufunc',
                          cache=cache,

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from numba.core import config, targetconfig
 from numba.core.decorators import jit
 from numba.core.descriptors import TargetDescriptor
+from numba.core.extending import is_jitted
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.registry import cpu_target
 from numba.core.target_extension import dispatcher_registry, target_registry
@@ -254,6 +255,8 @@ class _BaseUFuncBuilder(object):
 class UFuncBuilder(_BaseUFuncBuilder):
 
     def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
+        if is_jitted(py_func):
+            py_func = py_func.py_func
         self.py_func = py_func
         self.identity = parse_identity(identity)
         self.nb_func = jit(_target='npyufunc',

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -8,7 +8,7 @@ from io import StringIO
 
 import numpy as np
 
-from numba import njit, jit, generated_jit, typeof
+from numba import njit, jit, generated_jit, typeof, vectorize
 from numba.core import types, errors
 from numba import _dispatcher
 from numba.core.compiler import compile_isolated
@@ -1203,6 +1203,24 @@ class TestMultiprocessingDefaultParameters(SerialMixin, unittest.TestCase):
         """ Tests a function as a default parameter"""
 
         self.run_fc_multiproc(add_func)
+
+
+class TestVectorizeDifferentTargets(unittest.TestCase):
+    """Test that vectorize can be reapplied if the target is different
+    """
+
+    def test_cpu_vs_parallel(self):
+        @jit
+        def add(x, y):
+            return x + y
+
+        custom_vectorize = vectorize([], identity=None, target='cpu')
+
+        custom_vectorize(add)
+
+        custom_vectorize_2 = vectorize([], identity=None, target='parallel')
+
+        custom_vectorize_2(add)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This permits the ufunc builder to look inside a dispatcher and JIT the original
Python function so that `vectorize` can be applied to a JITed function when in
non-CPU mode (CPU alread works).

Closes #7409