### PR TITLE
pin NumPy to build 0 of 1.19.2 on public CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,19 +52,19 @@ jobs:
         TEST_START_INDEX: 4
       py38_np119_tbb:
         PYTHON: '3.8'
-        NUMPY: '1.19'
+        NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: 'tbb'
         TEST_START_INDEX: 5
       py38_np119_omp:
         PYTHON: '3.8'
-        NUMPY: '1.19'
+        NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: omp
         TEST_START_INDEX: 6
       py38_np119_workqueue:
         PYTHON: '3.8'
-        NUMPY: '1.19'
+        NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: workqueue
         TEST_START_INDEX: 7
@@ -93,7 +93,7 @@ jobs:
         TEST_START_INDEX: 11
       py39_np119:
         PYTHON: '3.9'
-        NUMPY: '1.19'
+        NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_START_INDEX: 12
       py39_np120_typeguard:


### PR DESCRIPTION
Fixes #8152 