### PR TITLE
CUDA: Remove context query in launch config

### DIFF
--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -206,8 +206,7 @@ class TestCUDAGufunc(CUDATestCase):
                 numba_dist_cuda(a, b, dist)
                 self.assertEqual(w[0].category, NumbaPerformanceWarning)
                 self.assertIn('Grid size', str(w[0].message))
-                self.assertIn('2 * SM count',
-                              str(w[0].message))
+                self.assertIn('low occupancy', str(w[0].message))
 
     def test_efficient_launch_configuration(self):
         @guvectorize(['void(float32[:], float32[:], float32[:])'],

--- a/numba/cuda/tests/cudapy/test_warning.py
+++ b/numba/cuda/tests/cudapy/test_warning.py
@@ -19,7 +19,7 @@ class TestWarnings(CUDATestCase):
 
         self.assertEqual(w[0].category, NumbaPerformanceWarning)
         self.assertIn('Grid size', str(w[0].message))
-        self.assertIn('2 * SM count', str(w[0].message))
+        self.assertIn('low occupancy', str(w[0].message))
 
     def test_efficient_launch_configuration(self):
         @cuda.jit


### PR DESCRIPTION
This swaps the context query in the launch configuration for a statically-chosen threshold of 128 blocks, removing a source of overhead in kernel configuration.

This also fixes a failure in `TestWarnings.test_efficient_launch_configuration`, which fails with:

```
======================================================================
FAIL: test_efficient_launch_configuration (numba.cuda.tests.cudapy.test_warning.TestWarnings)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/swqa/NUMBA/envs/NumbaGPUTest/lib/python3.9/site-packages/numba/cuda/tests/cudapy/test_warning.py", line 33, in test_efficient_launch_configuration
    self.assertEqual(len(w), 0)
AssertionError: 1 != 0
```

when run on a device with 132 SMs - this is because the test launched 256 blocks, but the check for emitting the warning requires 2 * (SM count), which is 268 (the test was written assuming such a large GPU did not exist).

Fixes #7926.