### PR TITLE
remove myself from automatic reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # ------------------------------------------------------------------------------
 # These people are the default "owners" for everything in the repo unless a
 # later match is made, they will automatically be requested to review PRs.
-* @sklam @stuartarchibald @esc
+* @sklam @stuartarchibald
 
 # Owners of specific parts of the code, will be requested to review if a PR
 # touches code in the matched pattern


### PR DESCRIPTION
With the new Burndown model and the weekly assignment of reviewers, I don't want to be automatically assigned as a reviewer for every incoming PR. I'd rather be assigned manually to only those PRs that I will actually review. 