### PR TITLE
CUDA: Fix missing space in low occupancy warning

### DIFF
--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -498,7 +498,7 @@ class _LaunchConfiguration:
             min_grid_size = 128
             grid_size = griddim[0] * griddim[1] * griddim[2]
             if grid_size < min_grid_size:
-                msg = (f"Grid size {grid_size} will likely result in GPU"
+                msg = (f"Grid size {grid_size} will likely result in GPU "
                        "under-utilization due to low occupancy.")
                 warn(NumbaPerformanceWarning(msg))
 


### PR DESCRIPTION
The message was printing:

> Grid size N will likely result in GPUunder-utilization due to low occupancy.

instead of:

> Grid size N will likely result in GPU under-utilization due to low occupancy.