### PR TITLE
CUDA: Update deprecation notes for 0.56.

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -227,47 +227,6 @@ compiled in :term:`object mode`.
 .. _deprecation-strict-strides:
 
 
-Deprecation of the ``inspect_ptx()`` method
-===========================================
-
-The undocumented ``inspect_ptx()`` method of functions decorated with
-``@cuda.jit(device=True)`` is sometimes used to compile a Python function to
-PTX for use outside of Numba. An interface for this specific purpose is
-provided in the :func:`compile_ptx() <numba.cuda.compile_ptx>` function.
-``inspect_ptx()`` has one or two longstanding issues and presents a maintenance
-burden for upcoming changes in the CUDA target, so it is deprecated and will be
-removed in favor of the use of :func:`compile_ptx() <numba.cuda.compile_ptx>`.
-
-Recommendations
----------------
-
-Replace any code that compiles device functions to PTX using the following
-pattern:
-
-.. code-block:: python
-
-    @cuda.jit(signature, device=True)
-    def func(args):
-        ...
-
-    ptx_code = func.inspect_ptx(nvvm_options=nvvm_options).decode()
-
-with:
-
-.. code-block:: python
-
-    def func(args):
-        ...
-
-    ptx_code, return_type = compile_ptx(func, signature, device=True, nvvm_options=nvvm_options)
-
-Schedule
---------
-
-- In Numba 0.54: ``inspect_ptx()`` was deprecated.
-- In Numba 0.55: ``inspect_ptx()`` was removed.
-
-
 Deprecation of eager compilation of CUDA device functions
 =========================================================
 

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -3,13 +3,12 @@ import os
 import sys
 import ctypes
 import functools
-import warnings
 
 from numba.core import config, serialize, sigutils, types, typing, utils
 from numba.core.caching import Cache, CacheImpl
 from numba.core.compiler_lock import global_compiler_lock
 from numba.core.dispatcher import Dispatcher
-from numba.core.errors import NumbaPerformanceWarning, NumbaDeprecationWarning
+from numba.core.errors import NumbaPerformanceWarning
 from numba.core.typing.typeof import Purpose, typeof
 
 from numba.cuda.api import get_current_device
@@ -177,20 +176,6 @@ class _Kernel(serialize.ReduceMixin):
         Force binding to current CUDA context
         """
         self._codelibrary.get_cufunc()
-
-    @property
-    def ptx(self):
-        '''
-        PTX code for this kernel.
-        '''
-        warnings.warn(
-            "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve the compiled machine code of the CUDA function for a "
-            "given CUDA compute compatibility `cc`, use the `inspect_asm(cc)` "
-            "method."
-            , NumbaDeprecationWarning
-        )
-        return self._codelibrary.get_asm_str()
 
     @property
     def device(self):
@@ -895,16 +880,6 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
         for _, defn in self.overloads.items():
             defn.inspect_types(file=file)
-
-    @property
-    def ptx(self):
-        warnings.warn(
-            "Attribute `ptx` is deprecated and will be removed in the future. "
-            "To retrieve the compiled machine code of the CUDA function for a "
-            "given signature `sig`, use the method `inspect_asm(sig)`."
-            , NumbaDeprecationWarning
-        )
-        return {sig: overload.ptx for sig, overload in self.overloads.items()}
 
     def bind(self):
         for defn in self.overloads.values():

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -1,12 +1,8 @@
 import numpy as np
 import threading
-import warnings
-from contextlib import contextmanager
 
 from numba import cuda, float32, float64, int32, int64, void
-from numba.core.errors import NumbaDeprecationWarning
 from numba.cuda.testing import skip_on_cudasim, unittest, CUDATestCase
-from numba.tests.support import ignore_internal_warnings
 import math
 
 
@@ -290,51 +286,6 @@ class TestDispatcher(CUDATestCase):
 
         self.assertEqual("Add two integers, kernel version", add_kernel.__doc__)
         self.assertEqual("Add two integers, device version", add_device.__doc__)
-
-
-@contextmanager
-def deprecation_warning_catcher():
-    with warnings.catch_warnings(record=True) as w:
-        ignore_internal_warnings()
-        warnings.simplefilter("always", category=NumbaDeprecationWarning)
-        yield w
-
-
-@skip_on_cudasim('Dispatcher objects not used in the simulator')
-class TestDispatcherDeprecation(CUDATestCase):
-    def check_warning(self, warnings, expected_str, category):
-        self.assertEqual(len(warnings), 1)
-        for w in warnings:
-            self.assertEqual(w.category, category)
-            self.assertIn(expected_str, str(w.message))
-
-    def test_ptx_deprecation(self):
-        def f(x):
-            x[0] = 42
-
-        msg = "Attribute `ptx` is deprecated and will be removed in the "
-        "future. "
-
-        # Kernel code path
-        with self.subTest(
-            name="DispatcherOnCudaKernel"
-        ), deprecation_warning_catcher() as w:
-            dispatcher = cuda.jit(f)
-            dispatcher.ptx
-            self.check_warning(w, msg, NumbaDeprecationWarning)
-        with self.subTest(
-            name="KernelObjectOnCudaKernel"
-        ), deprecation_warning_catcher() as w:
-            kernel = dispatcher.compile((float32[::1],))
-            kernel.ptx
-            self.check_warning(w, msg, NumbaDeprecationWarning)
-        # Device function code path
-        with self.subTest(
-            name="DispatcherOnDeviceFunction"
-        ), deprecation_warning_catcher() as w:
-            device_f_dispatcher = cuda.jit(f, device=True)
-            device_f_dispatcher.ptx
-            self.check_warning(w, msg, NumbaDeprecationWarning)
 
 
 if __name__ == '__main__':

--- a/numba/cuda/tests/cudapy/test_localmem.py
+++ b/numba/cuda/tests/cudapy/test_localmem.py
@@ -56,8 +56,6 @@ class TestCudaLocalMem(CUDATestCase):
     def test_local_array_complex(self):
         sig = 'void(complex128[:], complex128[:])'
         jculocalcomplex = cuda.jit(sig)(culocalcomplex)
-        # The local memory would be turned into register
-        # self.assertTrue('.local' in jculocalcomplex.ptx)
         A = (np.arange(100, dtype='complex128') - 1) / 2j
         B = np.zeros_like(A)
         jculocalcomplex[1, 1](A, B)


### PR DESCRIPTION
This removes the `.ptx` property which was supposed to be removed in 0.55 (the deprecation / removal notice for it was even already removed). It also removes the notice for `inspect_ptx()`, which was gone in 0.55.