### PR TITLE
Make the workqueue threading backend once again fork safe.

### DIFF
--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -690,6 +690,42 @@ class TestMiscBackendIssues(ThreadLayerTestHelper):
             self.assertIn("Terminating: Nested parallel kernel launch detected",
                           e_msg)
 
+    def test_workqueue_handles_fork_from_non_main_thread(self):
+        # For context see #7872, but essentially the multiprocessing pool
+        # implementation has a number of Python threads for handling the worker
+        # processes, one of which calls fork(2), this results in a fork from a
+        # non-main thread.
+
+        runme = """if 1:
+            from numba import njit, prange, threading_layer
+            import numpy as np
+            import multiprocessing
+
+            if __name__ == "__main__":
+
+                @njit(parallel=True)
+                def func(x):
+                    return 10. * x
+
+                arr = np.arange(2.)
+
+                # run in single process to start Numba's thread pool
+                np.testing.assert_allclose(func(arr), func.py_func(arr))
+
+                # now run in a multiprocessing pool to get a fork from a
+                # non-main thread
+                with multiprocessing.Pool(10) as p:
+                    result = p.map(func, [arr])
+                np.testing.assert_allclose(result,
+                                           func.py_func(np.expand_dims(arr, 0)))
+        """
+        cmdline = [sys.executable, '-c', runme]
+        env = os.environ.copy()
+        env['NUMBA_THREADING_LAYER'] = "workqueue"
+        env['NUMBA_NUM_THREADS'] = "4"
+
+        self.run_cmd(cmdline, env=env)
+
 
 # 32bit or windows py27 (not that this runs on windows)
 @skip_parfors_unsupported


### PR DESCRIPTION
As title, this fixes the workqueue threading backend such that it
is fork safe from _any_ thread, not just the main thread.

Fixes #7872

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
