### PR TITLE
Searchsorted unichr

### DIFF
--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -750,7 +750,8 @@ def ol_isinstance(var, typs):
                         types.DictType, types.LiteralStrKeyDict, types.List,
                         types.ListType, types.Tuple, types.UniTuple, types.Set,
                         types.Function, types.ClassType, types.UnicodeType,
-                        types.ClassInstanceType, types.NoneType, types.Array)
+                        types.ClassInstanceType, types.NoneType, types.Array,
+                        types.UnicodeCharSeq)
     if not isinstance(var_ty, supported_var_ty):
         msg = f'isinstance() does not support variables of type "{var_ty}".'
         raise NumbaTypeError(msg)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3857,13 +3857,15 @@ def _searchsorted(func):
 
         .. [1] https://github.com/numpy/numpy/blob/809e8d26b03f549fd0b812a17b8a166bcd966889/numpy/core/src/npysort/binsearch.cpp#L173
         """  # noqa: E501
-        if np.isnan(v):
-            # Find the first nan (i.e. the last from the end of a,
-            # since there shouldn't be many of them in practice)
-            for i in range(n, 0, -1):
-                if not np.isnan(a[i - 1]):
-                    return i
-            return 0
+        # handle NaN where appropriate
+        if isinstance(v, (float, complex)):
+            if np.isnan(v):
+                # Find the first nan (i.e. the last from the end of a,
+                # since there shouldn't be many of them in practice)
+                for i in range(n, 0, -1):
+                    if not np.isnan(a[i - 1]):
+                        return i
+                return 0
 
         if v_last < v:
             hi = n

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -1088,6 +1088,42 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             # Sequence values
             check(a, list(values))
 
+        # Third with unichr (no NaNs)
+        unicode_a = 97
+        alphabet_size = 26
+        string_length = 8
+
+        np.random.seed(42)
+        bins_unicode = np.random.choice(
+            np.arange(
+                unicode_a,
+                unicode_a + alphabet_size,
+                dtype=np.uint32,
+            ),
+            size=(5, string_length),
+        )
+        bins_unsorted = bins_unicode.view(f"<U{string_length}").reshape(-1)
+        bins = np.sort(bins_unsorted)
+        values_unicode = np.random.choice(
+            np.arange(
+                unicode_a,
+                unicode_a + alphabet_size,
+                dtype=np.uint32,
+            ),
+            size=(20, string_length),
+        )
+        values = values_unicode.view(f"<U{string_length}").reshape(-1)
+
+        for a in (bins, list(bins)):
+            # Scalar values
+            for v in values:
+                check(a, v)
+            # Array values
+            for v in (values, values.reshape((4, 5))):
+                check(a, v)
+            # Sequence values
+            check(a, list(values))
+
         # nonsense value for 'side' raises TypingError
         def bad_side(a, v):
             return np.searchsorted(a, v, side='nonsense')


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes #8190. Fixes `searchsorted` so that it works for types where `np.isnan` is not implemented, motivated by the `unichr` type.

Summary of changes:
1. Add additional `if` statement to `searchsorted_inner` so that inserted item `v` is only checked using `np.isnan` when it is of the `float` or `complex` types.
2. Update `isinstance` implementation to support `UnicodeCharSeq`.
3. Test `searchsorted` using `unichr` type.
