### PR TITLE
Support kwargs for np.arange in parallel=True

### DIFF
--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -777,7 +777,7 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
             else:
                 raise NotImplementedError(
                     "Unsupported defaults to make_function: {}".format(
-                        defaults))
+                        callee_defaults))
         return args
 
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1505,7 +1505,11 @@ class PreParforPass(object):
                             pysig = calltype.pysig
                             arg_typs = [self.typemap[x.name] for x in expr.args]
                             kws_typs = [(x, self.typemap[y.name]) for x, y in expr.kws]
-                            folded_arg_typs = self.fold_argument_types(pysig, arg_typs, kws_typs)
+                            if pysig is None:
+                                # If there is no overload we don't support kwargs yet.
+                                folded_arg_typs = tuple(arg_typs)
+                            else:
+                                folded_arg_typs = self.fold_argument_types(pysig, arg_typs, kws_typs)
                             try:
                                 new_func =  repl_func(lhs_typ, *folded_arg_typs)
                             except:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -908,7 +908,7 @@ class TestParforNumPy(TestParforsBase):
             return np.arange(n)
         # start and stop
         def test_impl2(s, n):
-            return np.arange(n)
+            return np.arange(s, n)
         # start, step, stop
         def test_impl3(s, n, t):
             return np.arange(s, n, t)
@@ -917,6 +917,23 @@ class TestParforNumPy(TestParforsBase):
             self.check(test_impl1, arg)
             self.check(test_impl2, 2, arg)
             self.check(test_impl3, 2, arg, 2)
+
+    def test_arange_kwargs(self):
+        # Test arange where values include kwargs
+
+        def test_impl1(n, dtype):
+            return np.arange(n, dtype=dtype)
+        # start and stop
+        def test_impl2(s, n, dtype):
+            return np.arange(s, n, dtype=dtype)
+        # start, step, stop
+        def test_impl3(s, n, t, dtype):
+            return np.arange(s, n, t, dtype=dtype)
+
+        for arg in [11, 128, 30.0, complex(4,5), complex(5,4)]:
+            self.check(test_impl1, arg, np.float64)
+            self.check(test_impl2, 2, arg, np.float64)
+            self.check(test_impl3, 2, arg, 2, np.float64)
 
     def test_linspace(self):
         # without num

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -240,6 +240,8 @@ class TestParforsBase(TestCase):
                     new_args.append(copy.deepcopy(x))
                 elif isinstance(x, list):
                     new_args.append(x[:])
+                elif isinstance(x, type):
+                    new_args.append(x)
                 else:
                     raise ValueError('Unsupported argument type encountered')
             return tuple(new_args)
@@ -926,14 +928,18 @@ class TestParforNumPy(TestParforsBase):
         # start and stop
         def test_impl2(s, n, dtype):
             return np.arange(s, n, dtype=dtype)
+        # start and step
+        def test_impl3(n, t, dtype):
+            return np.arange(n, step=t, dtype=dtype)
         # start, step, stop
-        def test_impl3(s, n, t, dtype):
+        def test_impl4(s, n, t, dtype):
             return np.arange(s, n, t, dtype=dtype)
 
-        for arg in [11, 128, 30.0, complex(4,5), complex(5,4)]:
+        for arg in [11, 128, 30.0]:
             self.check(test_impl1, arg, np.float64)
             self.check(test_impl2, 2, arg, np.float64)
-            self.check(test_impl3, 2, arg, 2, np.float64)
+            self.check(test_impl3, arg, 2, np.float64)
+            self.check(test_impl4, 2, arg, 2, np.float64)
 
     def test_linspace(self):
         # without num


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Closes #8225 

Adds support for using kwargs in `np.arange` with `parallel=True`. This should provide other parallel implementations with the opportunity to accept kwargs once the low-level APIs are replaced with the high-level APIs containing a `pysig`.
