### PR TITLE
Support for Numpy BitGenerators PR#6: Added Gumbel and Vonmises distributions 

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -632,6 +632,7 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().f()`
 * :func:`numpy.random.Generator().gamma()`
 * :func:`numpy.random.Generator().geometric()`
+* :func:`numpy.random.Generator().gumbel()`
 * :func:`numpy.random.Generator().integers()` (Both `low` and `high` are required
   arguments. Array values for low and high are currently not supported.)
 * :func:`numpy.random.Generator().laplace()`
@@ -662,6 +663,7 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().standard_t()`
 * :func:`numpy.random.Generator().triangular()`
 * :func:`numpy.random.Generator().uniform()`
+* :func:`numpy.random.Generator().von_mises()`
 * :func:`numpy.random.Generator().wald()`
 * :func:`numpy.random.Generator().weibull()`
 * :func:`numpy.random.Generator().zipf()`

--- a/numba/np/random/distributions.py
+++ b/numba/np/random/distributions.py
@@ -15,7 +15,8 @@ from numba.np.random._constants import (wi_double, ki_double,
                                         ziggurat_exp_r, fe_double,
                                         we_float, ke_float,
                                         ziggurat_exp_r_f, fe_float,
-                                        INT64_MAX, ziggurat_nor_inv_r)
+                                        INT64_MAX, ziggurat_nor_inv_r,
+                                        M_PI)
 from numba.np.random.generator_core import (next_double, next_float,
                                             next_uint32, next_uint64)
 from numba import float32, int64
@@ -574,3 +575,56 @@ def random_logseries(bitgen, p):
             return 1
         else:
             return 2
+
+
+@register_jitable
+def random_gumbel(bitgen, loc, scale):
+    U = 1.0 - next_double(bitgen)
+    while U >= 1.0:
+        U = 1.0 - next_double(bitgen)
+    return loc - scale * np.log(-np.log(U))
+
+
+@register_jitable
+def random_vonmises(bitgen, mu, kappa):
+    if (kappa < 1e-8):
+        return M_PI * (2 * next_double(bitgen) - 1)
+    else:
+        if (kappa < 1e-5):
+            s = (1. / kappa + kappa)
+        else:
+            if (kappa <= 1e6):
+                r = 1 + np.sqrt(1 + 4 * kappa * kappa)
+                rho = (r - np.sqrt(2 * r)) / (2 * kappa)
+                s = (1 + rho * rho) / (2 * rho)
+            else:
+                result = mu + np.sqrt(1. / kappa) * \
+                    random_standard_normal(bitgen)
+                if (result < -M_PI):
+                    result += 2 * M_PI
+                if (result > M_PI):
+                    result -= 2 * M_PI
+                return result
+
+        while 1:
+            U = next_double(bitgen)
+            Z = np.cos(M_PI * U)
+            W = (1 + s * Z) / (s + Z)
+            Y = kappa * (s - W)
+            V = next_double(bitgen)
+            if ((Y * (2 - Y) - V >= 0) or (np.log(Y / V) + 1 - Y >= 0)):
+                break
+
+        U = next_double(bitgen)
+
+        result = np.arccos(W)
+        if (U < 0.5):
+            result = -result
+        result += mu
+        neg = (result < 0)
+        mod = np.fabs(result)
+        mod = (np.fmod(mod + M_PI, 2 * M_PI) - M_PI)
+        if (neg):
+            mod *= -1
+
+        return mod

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -973,8 +973,9 @@ def NumPyRandomGeneratorType_vonmises(inst, mu, kappa, size=None):
         def impl(inst, mu, kappa, size=None):
             check_arg_bounds(kappa)
             out = np.empty(size, dtype=np.float64)
-            for i in np.ndindex(size):
-                out[i] = random_vonmises(inst.bit_generator, mu, kappa)
+            out_f = out.flat
+            for i in range(out.size):
+                out_f[i] = random_vonmises(inst.bit_generator, mu, kappa)
             return out
         return impl
 
@@ -1002,7 +1003,8 @@ def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
         def impl(inst, loc=0.0, scale=1.0, size=None):
             check_arg_bounds(scale)
             out = np.empty(size, dtype=np.float64)
-            for i in np.ndindex(size):
-                out[i] = random_gumbel(inst.bit_generator, loc, scale)
+            out_f = out.flat
+            for i in range(out.size):
+                out_f[i] = random_gumbel(inst.bit_generator, loc, scale)
             return out
         return impl

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1172,8 +1172,9 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             self.assertIn('p < 0, p >= 1 or p is NaN', str(raises.exception))
 
     def test_gumbel(self):
-        # For this test the dtype argument is never used, so we pass [None] as the dtype
-        # to make sure it runs only once with default system type.
+        # For this test the dtype argument is never used, so we pass
+        # [None] as the dtype to make sure it runs only once with
+        # default system type.
 
         test_sizes = [None, (), (100,), (10, 20, 30)]
         bitgen_types = [None, MT19937]
@@ -1184,7 +1185,8 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             self.check_numpy_parity(dist_func, test_size=None,
                                     test_dtype=None)
 
-        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0, scale=1.5, size=size)
+        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,
+                                                   scale=1.5, size=size)
         for _size in test_sizes:
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
@@ -1215,6 +1217,23 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             x.vonmises(mu=mu, kappa=kappa, size=size)
         self._check_invalid_types(dist_func, ['mu', 'kappa', 'size'],
                                   [5, 1, (1,)], ['x', 'x', ('x',)])
+
+    def test_vonmises_cases(self):
+        cases = [
+            # mu, kappa
+            (1, 0), # (kappa < 1e-8)
+            (10, 1e-7), # (kappa < 1e-5)
+            (3, 1e3), # (kappa <= 1e6)
+            (4, 1e10) # (kappa > 1e6)
+        ]
+        size = (2, 3)
+
+        for mu, kappa in cases:
+            with self.subTest(mu=mu, kappa=kappa):
+                dist_func = lambda x, size, dtype:\
+                    x.vonmises(mu, kappa, size=size)
+                self.check_numpy_parity(dist_func, None,
+                                        None, size, None, 0)
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1172,7 +1172,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             self.assertIn('p < 0, p >= 1 or p is NaN', str(raises.exception))
 
     def test_gumbel(self):
-        # For this test dtype argument is never used, so we pass [None] as dtype
+        # For this test the dtype argument is never used, so we pass [None] as the dtype
         # to make sure it runs only once with default system type.
 
         test_sizes = [None, (), (100,), (10, 20, 30)]
@@ -1184,7 +1184,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             self.check_numpy_parity(dist_func, test_size=None,
                                     test_dtype=None)
 
-        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,scale=1.5, size=size)
+        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0, scale=1.5, size=size)
         for _size in test_sizes:
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1211,7 +1211,8 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, adjusted_ulp_prec)
+                                            None, _size, None,
+                                            adjusted_ulp_prec)
 
         dist_func = lambda x, mu, kappa, size:\
             x.vonmises(mu=mu, kappa=kappa, size=size)
@@ -1233,7 +1234,8 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                 dist_func = lambda x, size, dtype:\
                     x.vonmises(mu, kappa, size=size)
                 self.check_numpy_parity(dist_func, None,
-                                        None, size, None, adjusted_ulp_prec)
+                                        None, size, None,
+                                        adjusted_ulp_prec)
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1171,6 +1171,51 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                 nb_dist_func(*curr_args)
             self.assertIn('p < 0, p >= 1 or p is NaN', str(raises.exception))
 
+    def test_gumbel(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.gumbel()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
+        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, loc, scale, size:\
+            x.gumbel(loc=loc, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_vonmises(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.vonmises(mu=5.0, kappa=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, mu, kappa, size:\
+            x.vonmises(mu=mu, kappa=kappa, size=size)
+        self._check_invalid_types(dist_func, ['mu', 'kappa', 'size'],
+                                  [5, 1, (1,)], ['x', 'x', ('x',)])
+
 
 class TestGeneratorCaching(TestCase, SerialMixin):
     def test_randomgen_caching(self):

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1211,7 +1211,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None)
+                                            None, _size, adjusted_ulp_prec)
 
         dist_func = lambda x, mu, kappa, size:\
             x.vonmises(mu=mu, kappa=kappa, size=size)
@@ -1233,7 +1233,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                 dist_func = lambda x, size, dtype:\
                     x.vonmises(mu, kappa, size=size)
                 self.check_numpy_parity(dist_func, None,
-                                        None, size, None, 0)
+                                        None, size, None, adjusted_ulp_prec)
 
 
 class TestGeneratorCaching(TestCase, SerialMixin):


### PR DESCRIPTION
Builds on top of #8040 

This PR removes the precision adjustments made for certain architectures where Numpy defaults to floating point contraction assembly instructions (`fmadd` and `fmsub`) in it's linux-32 bit, aarch64 and ppc64le builds. 

It also adds the following distributions:
- numpy.random.Generator().gumbel()
- numpy.random.Generator().von_mises()

(The purpose of adding above distributions are that they use `fmsub`, which is not used by any other distribution within Numba)