### PR TITLE
Add decorator to run a test in a subprocess.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -594,7 +594,7 @@ class TestCase(unittest.TestCase):
             raise ValueError("Too many args.")
         def wrapper(func):
             def inner(self, *args, **kwargs):
-                if os.environ.get("SUBPROC_TEST", None) is None:
+                if "SUBPROC_TEST" not in os.environ:
                     # Not in a subprocess, so stage the call to run the
                     # test in a subprocess which will set the env var.
                     class_name = self.__class__.__name__

--- a/numba/tests/test_builtins.py
+++ b/numba/tests/test_builtins.py
@@ -12,8 +12,7 @@ import warnings
 from numba.core.compiler import compile_isolated, Flags
 from numba import jit, typeof, njit, typed
 from numba.core import errors, types, utils, config
-from numba.tests.support import (TestCase, tag, ignore_internal_warnings,
-                                 needs_subprocess)
+from numba.tests.support import TestCase, tag, ignore_internal_warnings
 
 py38orlater = utils.PYVERSION >= (3, 8)
 
@@ -1376,10 +1375,11 @@ class TestIsinstanceBuiltin(TestCase):
             got = foo(x)
             self.assertEqual(got, expected)
 
-    @needs_subprocess
-    def test_experimental_warning_impl(self):
+    @TestCase.run_test_in_subprocess
+    def test_experimental_warning(self):
         # Check that if the isinstance feature is in use then an experimental
-        # warning is raised.
+        # warning is raised. Needs subproc as something else in the test suite
+        # might triggered the warning already.
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always', errors.NumbaWarning)
@@ -1398,12 +1398,6 @@ class TestIsinstanceBuiltin(TestCase):
             msg = ("Use of isinstance() detected. This is an experimental "
                    "feature.")
             self.assertIn(msg, str(w[0].message))
-
-    def test_experimental_warning(self):
-        test_name = 'test_experimental_warning_impl'
-        self.subprocess_test_runner(test_module=self.__module__,
-                                    test_class=type(self).__name__,
-                                    test_name=test_name,)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_debuginfo.py
+++ b/numba/tests/test_debuginfo.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 import unittest
 import warnings
 
-from numba.tests.support import (TestCase, override_config, needs_subprocess,
+from numba.tests.support import (TestCase, override_config,
                                  ignore_internal_warnings)
 from numba import jit, njit
 from numba.core import types
@@ -139,14 +139,6 @@ class TestDebugInfoEmission(TestCase):
             if meta_re.match(line):
                 metadata.append(line)
         return metadata
-
-    def _subprocess_test_runner(self, test_name):
-        themod = self.__module__
-        thecls = type(self).__name__
-        self.subprocess_test_runner(test_module=themod,
-                                    test_class=thecls,
-                                    test_name=test_name,
-                                    envvars=self._NUMBA_OPT_0_ENV)
 
     def _get_metadata_map(self, metadata):
         """Gets the map of DI label to md, e.g.
@@ -302,13 +294,21 @@ class TestDebugInfoEmission(TestCase):
         else:
             self.fail('Assertion on DILocalVariable not made')
 
-    @needs_subprocess
-    def test_DILocation_entry_blk_impl(self):
-        """ This tests that the unconditional jump emitted at the tail of
-        the entry block has no debug metadata associated with it. In practice,
-        if debug metadata is associated with it, it manifests as the
-        prologue_end being associated with the end_sequence or similar (due to
-        the way code gen works for the entry block)."""
+    @TestCase.run_test_in_subprocess(envvars=_NUMBA_OPT_0_ENV)
+    def test_DILocation_entry_blk(self):
+        # Needs a subprocess as jitting literally anything at any point in the
+        # lifetime of the process ends up with a codegen at opt 3. This is not
+        # amenable to this test!
+        # This test relies on the CFG not being simplified as it checks the jump
+        # from the entry block to the first basic block. Force OPT as 0, if set
+        # via the env var the targetmachine and various pass managers all end up
+        # at OPT 0 and the IR is minimally transformed prior to lowering to ELF.
+        #
+        # This tests that the unconditional jump emitted at the tail of
+        # the entry block has no debug metadata associated with it. In practice,
+        # if debug metadata is associated with it, it manifests as the
+        # prologue_end being associated with the end_sequence or similar (due to
+        # the way code gen works for the entry block).
 
         @njit(debug=True)
         def foo(a):
@@ -351,19 +351,8 @@ class TestDebugInfoEmission(TestCase):
         # check the uncondition jump instr itself has no metadata
         self.assertTrue(str(ujmp).endswith(target))
 
-    def test_DILocation_entry_blk(self):
-        # Test runner for test_DILocation_entry_blk_impl, needs a subprocess
-        # as jitting literally anything at any point in the lifetime of the
-        # process ends up with a codegen at opt 3. This is not amenable to this
-        # test!
-        # This test relies on the CFG not being simplified as it checks the jump
-        # from the entry block to the first basic block. Force OPT as 0, if set
-        # via the env var the targetmachine and various pass managers all end up
-        # at OPT 0 and the IR is minimally transformed prior to lowering to ELF.
-        self._subprocess_test_runner('test_DILocation_entry_blk_impl')
-
-    @needs_subprocess
-    def test_DILocation_decref_impl(self):
+    @TestCase.run_test_in_subprocess(envvars=_NUMBA_OPT_0_ENV)
+    def test_DILocation_decref(self):
         """ This tests that decref's generated from `ir.Del`s as variables go
         out of scope do not have debuginfo associated with them (the location of
         `ir.Del` is an implementation detail).
@@ -394,11 +383,6 @@ class TestDebugInfoEmission(TestCase):
                 self.assertRegex(line, r'.*meminfo\.[0-9]+\)$')
                 count += 1
         self.assertGreater(count, 0) # make sure there were some decrefs!
-
-    def test_DILocation_decref(self):
-        # Test runner for test_DILocation_decref_impl, needs a subprocess
-        # with opt=0 to preserve decrefs.
-        self._subprocess_test_runner('test_DILocation_decref_impl')
 
     def test_DILocation_undefined(self):
         """ Tests that DILocation information for undefined vars is associated

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -18,7 +18,7 @@ from numba.core.config import IS_WIN32, IS_32BITS
 from numba.core.utils import pysignature
 from numba.np.extensions import cross2d
 from numba.tests.support import (TestCase, CompilationCache, MemoryLeakMixin,
-                                 needs_blas, needs_subprocess)
+                                 needs_blas)
 import unittest
 
 
@@ -4818,8 +4818,8 @@ def foo():
             cfunc(np.float64(7))
 
     @unittest.skipUnless(numpy_version >= (1, 22), "Needs NumPy >= 1.22")
-    @needs_subprocess
-    def test_np_MachAr_deprecation_np122_impl(self):
+    @TestCase.run_test_in_subprocess
+    def test_np_MachAr_deprecation_np122(self):
         # Tests that Numba is replaying the NumPy 1.22 deprecation warning
         # raised on the getattr of 'MachAr' on the NumPy module.
         # Needs to be run in a subprocess as the warning is generated from the
@@ -4835,13 +4835,6 @@ def foo():
 
         self.assertEqual(len(w), 1)
         self.assertIn('`np.MachAr` is deprecated', str(w[0]))
-
-    @unittest.skipUnless(numpy_version >= (1, 22), "Needs NumPy >= 1.22")
-    def test_np_MachAr_deprecation_np122(self):
-        test_name = 'test_np_MachAr_deprecation_np122_impl'
-        self.subprocess_test_runner(test_module=self.__module__,
-                                    test_class=type(self).__name__,
-                                    test_name=test_name,)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -20,7 +20,7 @@ from numba import njit, typeof, objmode, types
 from numba.core.extending import overload
 from numba.tests.support import (MemoryLeak, TestCase, captured_stdout,
                                  skip_unless_scipy, needs_strace, linux_only,
-                                 strace, needs_subprocess)
+                                 strace)
 from numba.core.utils import PYVERSION
 from numba.experimental import jitclass
 import unittest
@@ -1227,8 +1227,8 @@ class TestMisc(TestCase):
 
     @linux_only
     @needs_strace
-    @needs_subprocess
-    def test_no_fork_in_compilation_impl(self):
+    @TestCase.run_test_in_subprocess
+    def test_no_fork_in_compilation(self):
         # Checks that there is no fork/clone/execve during compilation, see
         # issue #7881. This needs running in a subprocess as the offending fork
         # call that triggered #7881 occurs on the first call to uuid1 as it's
@@ -1247,16 +1247,6 @@ class TestMisc(TestCase):
         # check that compilation does not trigger fork, clone or execve
         strace_data = strace(force_compile, syscalls)
         self.assertFalse(strace_data)
-
-    @linux_only
-    @needs_strace
-    def test_no_fork_in_compilation(self):
-        # Runs the test_no_fork_in_compilation_impl test in a subprocess
-        themod = f'numba.tests.test_withlifting'
-        testname = 'test_no_fork_in_compilation_impl'
-        self.subprocess_test_runner(test_module=themod,
-                                    test_class='TestMisc',
-                                    test_name=testname,)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a decorator method to Numba's `TestCase` class which
can be used to specify that a test case should be run in a
subprocess. This patch further cleans up the test suite to use
this decorator where it's reasonable to do so.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
