### PR TITLE
Reorder typeof checks to avoid infinite loops on StructrefProxy  __hash__

### DIFF
--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -53,7 +53,7 @@ def typeof_impl(val, c):
         return tp
 
     tp = getattr(val, "_numba_type_", None)
-    if(tp is not None):
+    if tp is not None:
         return tp
 
     # cffi is handled here as it does not expose a public base class

--- a/numba/core/typing/typeof.py
+++ b/numba/core/typing/typeof.py
@@ -52,6 +52,10 @@ def typeof_impl(val, c):
     if tp is not None:
         return tp
 
+    tp = getattr(val, "_numba_type_", None)
+    if(tp is not None):
+        return tp
+
     # cffi is handled here as it does not expose a public base class
     # for exported functions or CompiledFFI instances.
     from numba.core.typing import cffi_utils
@@ -61,7 +65,7 @@ def typeof_impl(val, c):
         if cffi_utils.is_ffi_instance(val):
             return types.ffi
 
-    return getattr(val, "_numba_type_", None)
+    return None
 
 
 def _typeof_buffer(val, c):

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -230,8 +230,8 @@ class TestStructRefBasic(MemoryLeakMixin, TestCase):
             td['b'] = MyStruct(2.3, 1)
 
     def test_MyStructType_hash_no_typeof_recursion(self):
-        '''Tests that __hash__ is not called prematurely in typeof 
-           causing infinite recursion (see #8241).'''
+        # Tests that __hash__ is not called prematurely in typeof
+        # causing infinite recursion (see #8241).
         st = MyStruct(1, 2)
         typeof(st)
 

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -235,7 +235,7 @@ class TestStructRefBasic(MemoryLeakMixin, TestCase):
         st = MyStruct(1, 2)
         typeof(st)
 
-        assert hash(st) == 3
+        self.assertEqual(hash(st), 3)
 
 
 @overload_method(MyStructType, "testme")

--- a/numba/tests/test_struct_ref.py
+++ b/numba/tests/test_struct_ref.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 
-from numba import typed, njit, errors
+from numba import typed, njit, errors, typeof
 from numba.core import types
 from numba.experimental import structref
 from numba.extending import overload_method, overload_attribute
@@ -57,6 +57,9 @@ class MyStruct(structref.StructRefProxy):
     @property
     def prop(self):
         return self.values, self.counter
+
+    def __hash__(self):
+        return compute_fields(self)
 
 
 @structref.register
@@ -225,6 +228,14 @@ class TestStructRefBasic(MemoryLeakMixin, TestCase):
             # because first field is not a float;
             # the second field is now an integer.
             td['b'] = MyStruct(2.3, 1)
+
+    def test_MyStructType_hash_no_typeof_recursion(self):
+        '''Tests that __hash__ is not called prematurely in typeof 
+           causing infinite recursion (see #8241).'''
+        st = MyStruct(1, 2)
+        typeof(st)
+
+        assert hash(st) == 3
 
 
 @overload_method(MyStructType, "testme")


### PR DESCRIPTION
I was having an issue where I couldn't implement `__hash__` for a StructRefProxy by calling into a dispatcher that takes the structref as an argument because the dispatcher calls typeof on the proxy instance which in turn calls cffi_utils.is_cffi_func() which calls `__hash__` on the instance creating an infinite loop. 

I'm not sure how often typeof is called (I suspect a lot), but my guess is that putting the `_numba_type_` check first might provide a small compile-time performance benefit. I would imagine objects with `_numba_type_` are more common than cffi functions and thus should be checked first. 

I don't have a ton of time, but I'm happy to add a test if ya'll think it would be worth it. 

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
