### PR TITLE
CUDA: Verify NVVM IR prior to compilation

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -113,6 +113,10 @@ class NVVM(object):
         #                           int* minorDbg )
         'nvvmIRVersion': (nvvm_result, POINTER(c_int), POINTER(c_int),
                           POINTER(c_int), POINTER(c_int)),
+        # nvvmResult nvvmVerifyProgram (nvvmProgram prog, int numOptions,
+        #                               const char** options)
+        'nvvmVerifyProgram': (nvvm_result, nvvm_program, c_int,
+                              POINTER(c_char_p))
     }
 
     # Singleton reference
@@ -278,9 +282,13 @@ class CompilationUnit(object):
             optstr = ', '.join(map(repr, options.keys()))
             raise NvvmError("unsupported option {0}".format(optstr))
 
-        # compile
         c_opts = (c_char_p * len(opts))(*[c_char_p(x.encode('utf8'))
                                           for x in opts])
+        # verify
+        err = self.driver.nvvmVerifyProgram(self._handle, len(opts), c_opts)
+        self._try_error(err, 'Failed to verify\n')
+
+        # compile
         err = self.driver.nvvmCompileProgram(self._handle, len(opts), c_opts)
         self._try_error(err, 'Failed to compile\n')
 

--- a/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -9,6 +9,7 @@ from numba.cuda.testing import skip_on_cudasim
 class TestCudaInlineAsm(ContextResettingTestCase):
     def test_inline_rsqrt(self):
         mod = ir.Module(__name__)
+        mod.triple = 'nvptx64-nvidia-cuda'
         fnty = ir.FunctionType(ir.VoidType(), [ir.PointerType(ir.FloatType())])
         fn = ir.Function(mod, fnty, 'cu_rsqrt')
         bldr = ir.IRBuilder(fn.append_basic_block('entry'))

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -43,6 +43,13 @@ class TestNvvmDriver(unittest.TestCase):
         else:
             self.assertTrue('.address_size 32' in ptx)
 
+    def test_nvvm_ir_verify_fail(self):
+        m = ir.Module("test_bad_ir")
+        m.triple = "unknown-unknown-unknown"
+        fix_data_layout(m)
+        with self.assertRaisesRegex(NvvmError, 'Invalid target triple'):
+            llvm_to_ptx(str(m))
+
     def _test_nvvm_support(self, arch):
         compute_xx = 'compute_{0}{1}'.format(*arch)
         nvvmir = self.get_nvvmir()

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -28,6 +28,7 @@ class TestNvvmDriver(unittest.TestCase):
 
     def test_nvvm_from_llvm(self):
         m = ir.Module("test_nvvm_from_llvm")
+        m.triple = 'nvptx64-nvidia-cuda'
         fty = ir.FunctionType(ir.VoidType(), [ir.IntType(32)])
         kernel = ir.Function(m, fty, name='mycudakernel')
         bldr = ir.IRBuilder(kernel.append_basic_block('entry'))
@@ -96,7 +97,7 @@ class TestLibDevice(unittest.TestCase):
 
 
 nvvmir_generic = '''\
-target triple="nvptx64-"
+target triple="nvptx64-nvidia-cuda"
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"
 
 define i32 @ave(i32 %a, i32 %b) {

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -61,6 +61,7 @@ class TestNvvmWithoutCuda(unittest.TestCase):
         c = ir.Constant(ir.ArrayType(ir.IntType(8), 256),
                         bytearray(range(256)))
         m = ir.Module()
+        m.triple = 'nvptx64-nvidia-cuda'
         gv = ir.GlobalVariable(m, c.type, "myconstant")
         gv.global_constant = True
         gv.initializer = c


### PR DESCRIPTION
It is a good idea to verify the NVVM IR before compilation. The NVVM IR verifier provides the same function as the LLVM IR verifier with some additional CUDA-specific checks.

I had originally planned to make the verification optional, but given that the CPU target always runs the verifier I have decided to always run verification - I expect this might help catch future issues more easily.

There were some small fix-ups to the tests that needed making in order for them to pass verification, but this was only because they left the target triple unspecified or invalid.