### PR TITLE
Fix segfault for invalid axes in np.split

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from numba import pndindex, literal_unroll
 from numba.core import types, utils, typing, errors, cgutils, extending
+from numba.core.decorators import generated_jit
 from numba.np.numpy_support import (as_dtype, carray, farray, is_contiguous,
                                     is_fortran, check_is_integer,
                                     type_is_scalar)
@@ -26,7 +27,7 @@ from numba.core.imputils import (lower_builtin, lower_getattr,
                                  impl_ret_new_ref, impl_ret_untracked,
                                  RefType)
 from numba.core.typing import signature
-from numba.core.types import Literal
+from numba.core.types import StringLiteral
 from numba.core.extending import (register_jitable, overload, overload_method,
                                   intrinsic)
 from numba.misc import quicksort, mergesort
@@ -271,14 +272,10 @@ def update_array_info(aryty, array):
                                           get_itemsize(context, aryty))
 
 
+@generated_jit(nopython=True)
 def normalize_axis(func_name, ndim, axis):
     """Constrain axis values to valid positive values."""
-    raise NotImplementedError()
-
-
-@overload(normalize_axis)
-def _normalize_axis_overloads(func_name, ndim, axis):
-    if not isinstance(func_name, Literal):
+    if not isinstance(func_name, StringLiteral):
         raise errors.TypingError("func_name must be a str literal.")
 
     msg = f"{func_name.literal_value}: Axis out of bounds"

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -26,6 +26,7 @@ from numba.core.imputils import (lower_builtin, lower_getattr,
                                  impl_ret_new_ref, impl_ret_untracked,
                                  RefType)
 from numba.core.typing import signature
+from numba.core.types import Literal
 from numba.core.extending import (register_jitable, overload, overload_method,
                                   intrinsic)
 from numba.misc import quicksort, mergesort
@@ -268,6 +269,29 @@ def update_array_info(aryty, array):
 
     array.itemsize = context.get_constant(types.intp,
                                           get_itemsize(context, aryty))
+
+
+def normalize_axis(func_name, ndim, axis):
+    """Constrain axis values to valid positive values."""
+    raise NotImplementedError()
+
+
+@overload(normalize_axis)
+def _normalize_axis_overloads(func_name, ndim, axis):
+    if not isinstance(func_name, Literal):
+        raise errors.TypingError("func_name must be a str literal.")
+
+    msg = f"{func_name.literal_value}: Axis out of bounds"
+
+    def impl(func_name, ndim, axis):
+        if axis < 0:
+            axis += ndim
+        if axis < 0 or axis >= ndim:
+            raise ValueError(msg)
+
+        return axis
+
+    return impl
 
 
 @lower_builtin('getiter', types.Buffer)
@@ -5939,8 +5963,10 @@ def np_array_split(ary, indices_or_sections, axis=0):
     ):
         def impl(ary, indices_or_sections, axis=0):
             slice_tup = build_full_slice_tuple(ary.ndim)
-            out = list()
+            axis = normalize_axis("np.split", ary.ndim, axis)
+            out = []
             prev = 0
+            cur = 0
             for cur in indices_or_sections:
                 idx = tuple_setitem(slice_tup, axis, slice(prev, cur))
                 out.append(ary[idx])
@@ -5956,8 +5982,10 @@ def np_array_split(ary, indices_or_sections, axis=0):
     ):
         def impl(ary, indices_or_sections, axis=0):
             slice_tup = build_full_slice_tuple(ary.ndim)
-            out = list()
+            axis = normalize_axis("np.split", ary.ndim, axis)
+            out = []
             prev = 0
+            cur = 0
             for cur in literal_unroll(indices_or_sections):
                 idx = tuple_setitem(slice_tup, axis, slice(prev, cur))
                 out.append(ary[idx])
@@ -6222,12 +6250,8 @@ def numpy_swapaxes(arr, axis1, axis2):
     axes_list = tuple(range(ndim))
 
     def impl(arr, axis1, axis2):
-        if axis1 >= ndim or abs(axis1) > ndim:
-            raise ValueError('The second argument "axis1" is out of bounds '
-                             'for array of given dimension')
-        if axis2 >= ndim or abs(axis2) > ndim:
-            raise ValueError('The third argument "axis2" is out of bounds '
-                             'for array of given dimension')
+        axis1 = normalize_axis("np.swapaxes", ndim, axis1)
+        axis2 = normalize_axis("np.swapaxes", ndim, axis2)
 
         # to ensure tuple_setitem support of negative values
         if axis1 < 0:
@@ -6253,8 +6277,7 @@ def _take_along_axis_impl(
 
     # Wrap axis, it's used in tuple_setitem so must be (axis >= 0) to ensure
     # the GEP is in bounds.
-    if axis < 0:
-        axis = arr.ndim + axis
+    axis = normalize_axis("np.take_along_axis", arr.ndim, axis)
 
     # Broadcast the two arrays to matching shapes:
     arr_shape = list(arr.shape)

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2774,7 +2774,8 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         with self.assertRaises(ValueError) as raises:
             njit(split)(np.ones(5), [3], axis=-3)
-        self.assertIn("np.split", str(raises.exception))
+        self.assertIn("np.split: Argument axis out of bounds",
+                      str(raises.exception))
 
     def test_roll_basic(self):
         pyfunc = roll
@@ -4659,12 +4660,14 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(ValueError) as raises:
             cfunc(np.arange(4), 1, 0)
 
-        self.assertIn('np.swapaxes', str(raises.exception))
+        self.assertIn('np.swapaxes: Argument axis1 out of bounds',
+                      str(raises.exception))
 
         with self.assertRaises(ValueError) as raises:
             cfunc(np.arange(8).reshape(2, 4), 0, -3)
 
-        self.assertIn('np.swapaxes', str(raises.exception))
+        self.assertIn('np.swapaxes: Argument axis2 out of bounds',
+                      str(raises.exception))
 
     def test_take_along_axis(self):
         a = np.arange(24).reshape((3, 1, 4, 2))

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -2708,6 +2708,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             yield a, [1, 3]
             yield a, [1, 3], 1
             yield a, [1, 3], 2
+            yield a, [1], -1
+            yield a, [1], -2
+            yield a, [1], -3
+            yield a, np.array([], dtype=np.int64), 0
 
             a = np.arange(100).reshape(2, -1)
             yield a, 1
@@ -2767,6 +2771,10 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             "array split does not result in an equal division",
             str(raises.exception)
         )
+
+        with self.assertRaises(ValueError) as raises:
+            njit(split)(np.ones(5), [3], axis=-3)
+        self.assertIn("np.split", str(raises.exception))
 
     def test_roll_basic(self):
         pyfunc = roll
@@ -4651,14 +4659,12 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         with self.assertRaises(ValueError) as raises:
             cfunc(np.arange(4), 1, 0)
 
-        self.assertIn('The second argument "axis1" is out of bounds for array'
-                      ' of given dimension', str(raises.exception))
+        self.assertIn('np.swapaxes', str(raises.exception))
 
         with self.assertRaises(ValueError) as raises:
             cfunc(np.arange(8).reshape(2, 4), 0, -3)
 
-        self.assertIn('The third argument "axis2" is out of bounds for array'
-                      ' of given dimension', str(raises.exception))
+        self.assertIn('np.swapaxes', str(raises.exception))
 
     def test_take_along_axis(self):
         a = np.arange(24).reshape((3, 1, 4, 2))


### PR DESCRIPTION
This adds a new function `normalize_axis` to `arrayobj.py`, and uses this function to verify axis arguments in `np.split`. There already is a similar function that could be wrapped in an intrinsic, but because the error message needs to be constant that seems more complicated than necessary to me.

I also use the new `normalize_axis` function to simplify `np.swapaxes` and `np.take_along_axis` a bit.

Fixes #8257