### PR TITLE
Clean up / remove support for old NumPy versions

### DIFF
--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -316,13 +316,6 @@ _unsupported = set([ 'frexp',
                      'modf',
                  ])
 
-# A list of ufuncs that are in fact aliases of other ufuncs. They need to insert the
-# resolve method, but not register the ufunc itself
-_aliases = set(["bitwise_not", "mod", "abs"])
-
-# In python3 np.divide is mapped to np.true_divide
-if np.divide == np.true_divide:
-    _aliases.add("divide")
 
 def _numpy_ufunc(name):
     func = getattr(np, name)
@@ -331,7 +324,11 @@ def _numpy_ufunc(name):
 
     typing_class.__name__ = "resolve_{0}".format(name)
 
-    if not name in _aliases:
+    # A list of ufuncs that are in fact aliases of other ufuncs. They need to
+    # insert the resolve method, but not register the ufunc itself
+    aliases = ("abs", "bitwise_not", "divide", "abs")
+
+    if name not in aliases:
         infer_global(func, types.Function(typing_class))
 
 all_ufuncs = sum([_math_operations, _trigonometric_functions,
@@ -360,7 +357,7 @@ supported_array_operators = set(
 
 del _math_operations, _trigonometric_functions, _bit_twiddling_functions
 del _comparison_functions, _floating_functions, _unsupported
-del _aliases, _numpy_ufunc
+del _numpy_ufunc
 
 
 # -----------------------------------------------------------------------------

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -2011,24 +2011,22 @@ def np_ediff1d(ary, to_end=None, to_begin=None):
             # Numpy tries to do this: return ary[1:] - ary[:-1] which
             # results in a TypeError exception being raised
 
-    # since np 1.16 there are casting checks for to_end and to_begin to make
-    # sure they are compatible with the ary
-    if numpy_version >= (1, 16):
-        ary_dt = _dtype_of_compound(ary)
-        to_begin_dt = None
-        if not(is_nonelike(to_begin)):
-            to_begin_dt = _dtype_of_compound(to_begin)
-        to_end_dt = None
-        if not(is_nonelike(to_end)):
-            to_end_dt = _dtype_of_compound(to_end)
+    # Check that to_end and to_begin are compatible with ary
+    ary_dt = _dtype_of_compound(ary)
+    to_begin_dt = None
+    if not(is_nonelike(to_begin)):
+        to_begin_dt = _dtype_of_compound(to_begin)
+    to_end_dt = None
+    if not(is_nonelike(to_end)):
+        to_end_dt = _dtype_of_compound(to_end)
 
-        if to_begin_dt is not None and not np.can_cast(to_begin_dt, ary_dt):
-            msg = "dtype of to_begin must be compatible with input ary"
-            raise NumbaTypeError(msg)
+    if to_begin_dt is not None and not np.can_cast(to_begin_dt, ary_dt):
+        msg = "dtype of to_begin must be compatible with input ary"
+        raise NumbaTypeError(msg)
 
-        if to_end_dt is not None and not np.can_cast(to_end_dt, ary_dt):
-            msg = "dtype of to_end must be compatible with input ary"
-            raise NumbaTypeError(msg)
+    if to_end_dt is not None and not np.can_cast(to_end_dt, ary_dt):
+        msg = "dtype of to_end must be compatible with input ary"
+        raise NumbaTypeError(msg)
 
     def np_ediff1d_impl(ary, to_end=None, to_begin=None):
         # transform each input into an equivalent 1d array

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -2374,7 +2374,7 @@ def np_interp_impl_complex_inner(x, xp, fp, dtype):
                     imag = (dy[j + 1].imag - dy[j].imag) * inv_dx
                     slope = real + 1j * imag
 
-                # Numpy 1.17 handles NaN correctly - this is a copy of
+                # NumPy 1.17 handles NaN correctly - this is a copy of
                 # innermost part of arr_interp_complex post 1.17:
                 # https://github.com/numpy/numpy/blob/maintenance/1.17.x/numpy/core/src/multiarray/compiled_base.c    # noqa: E501
                 # Permanent reference:

--- a/numba/np/npdatetime.py
+++ b/numba/np/npdatetime.py
@@ -296,79 +296,74 @@ def timedelta_over_timedelta(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig.return_type, res)
 
 
-if numpy_support.numpy_version >= (1, 16):
-    # np 1.16 added support for:
-    # * np.floor_divide on mm->q
-    # * np.remainder on mm->m
+@lower_builtin(operator.floordiv, *TIMEDELTA_BINOP_SIG)
+def timedelta_floor_div_timedelta(context, builder, sig, args):
+    [va, vb] = args
+    [ta, tb] = sig.args
+    ll_ret_type = context.get_value_type(sig.return_type)
+    not_nan = are_not_nat(builder, [va, vb])
+    ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
+    zero = Constant(ll_ret_type, 0)
+    one = Constant(ll_ret_type, 1)
+    builder.store(zero, ret)
+    with cgutils.if_likely(builder, not_nan):
+        va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
+        # is the denominator zero or NaT?
+        denom_ok = builder.not_(builder.icmp_signed('==', vb, zero))
+        with cgutils.if_likely(builder, denom_ok):
+            # is either arg negative?
+            vaneg = builder.icmp_signed('<', va, zero)
+            neg = builder.or_(vaneg, builder.icmp_signed('<', vb, zero))
+            with builder.if_else(neg) as (then, otherwise):
+                with then:  # one or more value negative
+                    with builder.if_else(vaneg) as (negthen, negotherwise):
+                        with negthen:
+                            top = builder.sub(va, one)
+                            div = builder.sdiv(top, vb)
+                            builder.store(div, ret)
+                        with negotherwise:
+                            top = builder.add(va, one)
+                            div = builder.sdiv(top, vb)
+                            builder.store(div, ret)
+                with otherwise:
+                    div = builder.sdiv(va, vb)
+                    builder.store(div, ret)
+    res = builder.load(ret)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
 
-    @lower_builtin(operator.floordiv, *TIMEDELTA_BINOP_SIG)
-    def timedelta_floor_div_timedelta(context, builder, sig, args):
-        [va, vb] = args
-        [ta, tb] = sig.args
-        ll_ret_type = context.get_value_type(sig.return_type)
-        not_nan = are_not_nat(builder, [va, vb])
-        ret = cgutils.alloca_once(builder, ll_ret_type, name='ret')
-        zero = Constant(ll_ret_type, 0)
-        one = Constant(ll_ret_type, 1)
-        builder.store(zero, ret)
-        with cgutils.if_likely(builder, not_nan):
-            va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
-            # is the denominator zero or NaT?
-            denom_ok = builder.not_(builder.icmp_signed('==', vb, zero))
-            with cgutils.if_likely(builder, denom_ok):
-                # is either arg negative?
-                vaneg = builder.icmp_signed('<', va, zero)
-                neg = builder.or_(vaneg, builder.icmp_signed('<', vb, zero))
-                with builder.if_else(neg) as (then, otherwise):
-                    with then:  # one or more value negative
-                        with builder.if_else(vaneg) as (negthen, negotherwise):
-                            with negthen:
-                                top = builder.sub(va, one)
-                                div = builder.sdiv(top, vb)
-                                builder.store(div, ret)
-                            with negotherwise:
-                                top = builder.add(va, one)
-                                div = builder.sdiv(top, vb)
-                                builder.store(div, ret)
-                    with otherwise:
-                        div = builder.sdiv(va, vb)
-                        builder.store(div, ret)
-        res = builder.load(ret)
-        return impl_ret_untracked(context, builder, sig.return_type, res)
+def timedelta_mod_timedelta(context, builder, sig, args):
+    # inspired by https://github.com/numpy/numpy/blob/fe8072a12d65e43bd2e0b0f9ad67ab0108cc54b3/numpy/core/src/umath/loops.c.src#L1424
+    # alg is basically as `a % b`:
+    # if a or b is NaT return NaT
+    # elseif b is 0 return NaT
+    # else pretend a and b are int and do pythonic int modulus
 
-    def timedelta_mod_timedelta(context, builder, sig, args):
-        # inspired by https://github.com/numpy/numpy/blob/fe8072a12d65e43bd2e0b0f9ad67ab0108cc54b3/numpy/core/src/umath/loops.c.src#L1424
-        # alg is basically as `a % b`:
-        # if a or b is NaT return NaT
-        # elseif b is 0 return NaT
-        # else pretend a and b are int and do pythonic int modulus
+    [va, vb] = args
+    [ta, tb] = sig.args
+    not_nan = are_not_nat(builder, [va, vb])
+    ll_ret_type = context.get_value_type(sig.return_type)
+    ret = alloc_timedelta_result(builder)
+    builder.store(NAT, ret)
+    zero = Constant(ll_ret_type, 0)
+    with cgutils.if_likely(builder, not_nan):
+        va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
+        # is the denominator zero or NaT?
+        denom_ok = builder.not_(builder.icmp_signed('==', vb, zero))
+        with cgutils.if_likely(builder, denom_ok):
+            # is either arg negative?
+            vapos = builder.icmp_signed('>', va, zero)
+            vbpos = builder.icmp_signed('>', vb, zero)
+            rem = builder.srem(va, vb)
+            cond = builder.or_(builder.and_(vapos, vbpos),
+                               builder.icmp_signed('==', rem, zero))
+            with builder.if_else(cond) as (then, otherwise):
+                with then:
+                    builder.store(rem, ret)
+                with otherwise:
+                    builder.store(builder.add(rem, vb), ret)
 
-        [va, vb] = args
-        [ta, tb] = sig.args
-        not_nan = are_not_nat(builder, [va, vb])
-        ll_ret_type = context.get_value_type(sig.return_type)
-        ret = alloc_timedelta_result(builder)
-        builder.store(NAT, ret)
-        zero = Constant(ll_ret_type, 0)
-        with cgutils.if_likely(builder, not_nan):
-            va, vb = normalize_timedeltas(context, builder, va, vb, ta, tb)
-            # is the denominator zero or NaT?
-            denom_ok = builder.not_(builder.icmp_signed('==', vb, zero))
-            with cgutils.if_likely(builder, denom_ok):
-                # is either arg negative?
-                vapos = builder.icmp_signed('>', va, zero)
-                vbpos = builder.icmp_signed('>', vb, zero)
-                rem = builder.srem(va, vb)
-                cond = builder.or_(builder.and_(vapos, vbpos),
-                                   builder.icmp_signed('==', rem, zero))
-                with builder.if_else(cond) as (then, otherwise):
-                    with then:
-                        builder.store(rem, ret)
-                    with otherwise:
-                        builder.store(builder.add(rem, vb), ret)
-
-        res = builder.load(ret)
-        return impl_ret_untracked(context, builder, sig.return_type, res)
+    res = builder.load(ret)
+    return impl_ret_untracked(context, builder, sig.return_type, res)
 
 # Comparison operators on timedelta64
 


### PR DESCRIPTION
Removes some support / legacy code for old NumPy versions (and one instance where NumPy differs between Python 2 and 3). 

The comments in `np.interp` support warn not to refactor it, but I think the reason for not refactoring is to avoid diverging from the NumPy source - however, because the Numba implementation supported multiple NumPy versions, and it now does not, after the refactor it is actually closer to the C source of the NumPy versions we do support, so I think this is an acceptable refactoring.