### PR TITLE
CUDA: Replace use of deprecated NVVM IR features, questionable constructs

### DIFF
--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -349,7 +349,7 @@ class JITCUDACodegen(Codegen):
     _library_class = CUDACodeLibrary
 
     def __init__(self, module_name):
-        self._data_layout = nvvm.data_layout
+        self._data_layout = nvvm.NVVM().data_layout
         self._target_data = ll.create_target_data(self._data_layout)
 
     def _create_empty_module(self, name):

--- a/numba/cuda/codegen.py
+++ b/numba/cuda/codegen.py
@@ -1,4 +1,3 @@
-from llvmlite import binding as ll
 from llvmlite import ir
 from warnings import warn
 
@@ -349,14 +348,12 @@ class JITCUDACodegen(Codegen):
     _library_class = CUDACodeLibrary
 
     def __init__(self, module_name):
-        self._data_layout = nvvm.NVVM().data_layout
-        self._target_data = ll.create_target_data(self._data_layout)
+        pass
 
     def _create_empty_module(self, name):
         ir_module = ir.Module(name)
         ir_module.triple = CUDA_TRIPLE
-        if self._data_layout:
-            ir_module.data_layout = self._data_layout
+        ir_module.data_layout = nvvm.NVVM().data_layout
         nvvm.add_ir_version(ir_module)
         return ir_module
 

--- a/numba/cuda/cudadrv/error.py
+++ b/numba/cuda/cudadrv/error.py
@@ -17,3 +17,7 @@ class NvvmError(Exception):
 
 class NvvmSupportError(ImportError):
     pass
+
+
+class NvvmWarning(Warning):
+    pass

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -895,6 +895,10 @@ def set_cuda_kernel(lfunc):
     nmd = cgutils.get_or_insert_named_metadata(mod, 'nvvm.annotations')
     nmd.add(md)
 
+    # Marking a kernel 'noinline' causes NVVM to generate a warning, so remove
+    # it if it is present.
+    lfunc.attributes.discard('noinline')
+
 
 def add_ir_version(mod):
     """Add NVVM IR version to module"""

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -12,7 +12,7 @@ import threading
 
 from llvmlite import ir
 
-from .error import NvvmError, NvvmSupportError
+from .error import NvvmError, NvvmSupportError, NvvmWarning
 from .libs import get_libdevice, open_libdevice, open_cudalib
 from numba.core import cgutils, config
 
@@ -312,6 +312,8 @@ class CompilationUnit(object):
 
         # get log
         self.log = self.get_log()
+        if self.log:
+            warnings.warn(self.log, category=NvvmWarning)
 
         return ptxbuf[:]
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -904,13 +904,7 @@ def set_cuda_kernel(lfunc):
 
 def add_ir_version(mod):
     """Add NVVM IR version to module"""
-    i32 = ir.IntType(32)
-    if NVVM().is_nvvm70:
-        # NVVM IR 1.6, DWARF 3.0
-        ir_versions = [i32(1), i32(6), i32(3), i32(0)]
-    else:
-        # NVVM IR 1.1, DWARF 2.0
-        ir_versions = [i32(1), i32(2), i32(2), i32(0)]
-
+    # We specify the IR version to match the current NVVM's IR version
+    ir_versions = [ir.IntType(32)(v) for v in NVVM().get_ir_version()]
     md_ver = mod.add_metadata(ir_versions)
     mod.add_named_metadata('nvvmir.version', md_ver)

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -47,6 +47,15 @@ NVVM_ERROR_COMPILATION
 for i, k in enumerate(RESULT_CODE_NAMES):
     setattr(sys.modules[__name__], k, i)
 
+# Data layouts. NVVM IR 1.8 (CUDA 11.6) introduced 128-bit integer support.
+
+_datalayout_original = ('e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-'
+                        'i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-'
+                        'v64:64:64-v128:128:128-n16:32:64')
+_datalayout_i128 = ('e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-'
+                    'i128:128:128-f32:32:32-f64:64:64-v16:16:16-v32:32:32-'
+                    'v64:64:64-v128:128:128-n16:32:64')
+
 
 def is_available():
     """
@@ -152,6 +161,13 @@ class NVVM(object):
         # nvvmAddModuleToProgram in
         # https://docs.nvidia.com/cuda/libnvvm-api/group__compilation.html
         return (self._majorIR, self._minorIR) >= (1, 6)
+
+    @property
+    def data_layout(self):
+        if (self._majorIR, self._minorIR) < (1, 8):
+            return _datalayout_original
+        else:
+            return _datalayout_i128
 
     def get_version(self):
         major = c_int()
@@ -315,12 +331,6 @@ class CompilationUnit(object):
             return logbuf.value.decode('utf8')  # populate log attribute
 
         return ''
-
-
-data_layout = (
-    'e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-'
-    'f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64'
-)
 
 
 _supported_cc = None
@@ -591,7 +601,7 @@ def _replace_datalayout(llvmir):
     for i, ln in enumerate(lines):
         if ln.startswith("target datalayout"):
             tmp = 'target datalayout = "{0}"'
-            lines[i] = tmp.format(data_layout)
+            lines[i] = tmp.format(NVVM().data_layout)
             break
     return '\n'.join(lines)
 
@@ -898,7 +908,3 @@ def add_ir_version(mod):
 
     md_ver = mod.add_metadata(ir_versions)
     mod.add_named_metadata('nvvmir.version', md_ver)
-
-
-def fix_data_layout(module):
-    module.data_layout = data_layout

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -913,6 +913,7 @@ def set_cuda_kernel(lfunc):
 def add_ir_version(mod):
     """Add NVVM IR version to module"""
     # We specify the IR version to match the current NVVM's IR version
-    ir_versions = [ir.IntType(32)(v) for v in NVVM().get_ir_version()]
+    i32 = ir.IntType(32)
+    ir_versions = [i32(v) for v in NVVM().get_ir_version()]
     md_ver = mod.add_metadata(ir_versions)
     mod.add_named_metadata('nvvmir.version', md_ver)

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -1067,7 +1067,7 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
         addrspaceptr = gvmem.bitcast(ir.PointerType(ir.IntType(8), addrspace))
         dataptr = builder.call(conv, [addrspaceptr])
 
-    targetdata = ll.create_target_data(nvvm.data_layout)
+    targetdata = ll.create_target_data(nvvm.NVVM().data_layout)
     lldtype = context.get_data_type(dtype)
     itemsize = lldtype.get_abi_size(targetdata)
 

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -1063,9 +1063,8 @@ def _generic_array(context, builder, shape, dtype, symbol_name, addrspace,
             gvmem.initializer = ir.Constant(laryty, ir.Undefined)
 
         # Convert to generic address-space
-        conv = nvvmutils.insert_addrspace_conv(lmod, ir.IntType(8), addrspace)
-        addrspaceptr = gvmem.bitcast(ir.PointerType(ir.IntType(8), addrspace))
-        dataptr = builder.call(conv, [addrspaceptr])
+        dataptr = builder.addrspacecast(gvmem, ir.PointerType(ir.IntType(8)),
+                                        'generic')
 
     targetdata = ll.create_target_data(nvvm.NVVM().data_layout)
     lldtype = context.get_data_type(dtype)

--- a/numba/cuda/simulator/cudadrv/nvvm.py
+++ b/numba/cuda/simulator/cudadrv/nvvm.py
@@ -16,7 +16,6 @@ class NVVM(object):
 CompilationUnit = None
 llvm_to_ptx = None
 set_cuda_kernel = None
-fix_data_layout = None
 get_arch_option = None
 LibDevice = None
 NvvmError = None

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -86,7 +86,7 @@ class CUDATargetContext(BaseContext):
 
     def init(self):
         self._internal_codegen = codegen.JITCUDACodegen("numba.cuda.jit")
-        self._target_data = ll.create_target_data(nvvm.NVVM().data_layout)
+        self._target_data = None
 
     def load_additional_registries(self):
         # side effect of import needed for numba.cpython.*, the builtins
@@ -113,6 +113,8 @@ class CUDATargetContext(BaseContext):
 
     @property
     def target_data(self):
+        if self._target_data is None:
+            self._target_data = ll.create_target_data(nvvm.NVVM().data_layout)
         return self._target_data
 
     @cached_property

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -86,7 +86,7 @@ class CUDATargetContext(BaseContext):
 
     def init(self):
         self._internal_codegen = codegen.JITCUDACodegen("numba.cuda.jit")
-        self._target_data = ll.create_target_data(nvvm.data_layout)
+        self._target_data = ll.create_target_data(nvvm.NVVM().data_layout)
 
     def load_additional_registries(self):
         # side effect of import needed for numba.cpython.*, the builtins

--- a/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -24,7 +24,7 @@ class TestCudaInlineAsm(ContextResettingTestCase):
         bldr.ret_void()
 
         # generate ptx
-        nvvm.fix_data_layout(mod)
+        mod.data_layout = nvvm.NVVM().data_layout
         nvvm.set_cuda_kernel(fn)
         nvvmir = str(mod)
         ptx = nvvm.llvm_to_ptx(nvvmir)

--- a/numba/cuda/tests/cudapy/test_const_string.py
+++ b/numba/cuda/tests/cudapy/test_const_string.py
@@ -12,7 +12,7 @@ class TestConstStringCodegen(unittest.TestCase):
     def test_const_string(self):
         # These imports are incompatible with CUDASIM
         from numba.cuda.descriptor import cuda_target
-        from numba.cuda.cudadrv.nvvm import llvm_to_ptx, ADDRSPACE_CONSTANT
+        from numba.cuda.cudadrv.nvvm import llvm_to_ptx
 
         targetctx = cuda_target.target_context
         mod = targetctx.create_module("")
@@ -32,8 +32,8 @@ class TestConstStringCodegen(unittest.TestCase):
         # Using insert_const_string
         fn = ir.Function(mod, fnty, "test_insert_const_string")
         builder = ir.IRBuilder(fn.append_basic_block())
-        res = targetctx.insert_addrspace_conv(builder, gv0,
-                                              addrspace=ADDRSPACE_CONSTANT)
+        res = builder.addrspacecast(gv0, ir.PointerType(ir.IntType(8)),
+                                    'generic')
         builder.ret(res)
 
         matches = re.findall(r"@\"__conststring__.*internal.*constant.*\["

--- a/numba/cuda/tests/cudapy/test_constmem.py
+++ b/numba/cuda/tests/cudapy/test_constmem.py
@@ -136,19 +136,10 @@ class TestCudaConstantMemory(CUDATestCase):
         self.assertTrue(np.all(A == CONST3D))
 
         if not ENABLE_CUDASIM:
-            # CUDA <= 11.1 uses two f32 loads to load the complex. CUDA >= 11.2
-            # uses a vector of 2x f32. The root cause of these codegen
-            # differences is not known, but must be accounted for in this test.
-            if cuda.runtime.get_version() > (11, 1):
-                complex_load = 'ld.const.v2.f32'
-                description = 'Load the complex as a vector of 2x f32'
-            else:
-                complex_load = 'ld.const.f32'
-                description = 'load each half of the complex as f32'
-
-            self.assertIn(
-                complex_load, jcuconst3d.inspect_asm(sig), description
-            )
+            asm = jcuconst3d.inspect_asm(sig)
+            complex_load = 'ld.const.v2.f32'
+            description = 'Load the complex as a vector of 2x f32'
+            self.assertIn(complex_load, asm, description)
 
     def test_const_record_empty(self):
         jcuconstRecEmpty = cuda.jit('void(int64[:])')(cuconstRecEmpty)

--- a/numba/cuda/tests/cudapy/test_debuginfo.py
+++ b/numba/cuda/tests/cudapy/test_debuginfo.py
@@ -87,7 +87,7 @@ class TestCudaDebugInfo(CUDATestCase):
             self.assertEqual(len(defines), 1)
 
             wrapper_define = defines[0]
-            self.assertIn('noinline !dbg', wrapper_define)
+            self.assertIn('!dbg', wrapper_define)
         else:
             # NVVM 3.4 subprogram debuginfo refers to the definition.
             # '786478' is a constant referring to a subprogram.

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -64,7 +64,7 @@ class TestNvvmWithoutCuda(unittest.TestCase):
         gv = ir.GlobalVariable(m, c.type, "myconstant")
         gv.global_constant = True
         gv.initializer = c
-        nvvm.fix_data_layout(m)
+        m.data_layout = nvvm.NVVM().data_layout
 
         # Parse with LLVM then dump the parsed module into NVVM
         parsed = llvm.parse_assembly(str(m))


### PR DESCRIPTION
This change the following:

- Data layouts. Since CUDA 11.6 the preferred datalayout includes 128 bit integers. Since these are not supported on prior toolkits, we need to keep to old datalayout for CUDA 11.5 and earlier. Reference: [Data layouts NVVM IR spec for CUDA 11.6](https://docs.nvidia.com/cuda/archive/11.6.0/nvvm-ir-spec/index.html#data-layout).
- Address space conversions. The standard `addrspacecast` instruction is supported, and the intrinsics are deprecated. References:
  - [`addrspacecast` instruction](https://releases.llvm.org/7.0.1/docs/LangRef.html#addrspacecast-to-instruction)
  - [Supported conversion operations in CUDA 10.2](https://docs.nvidia.com/cuda/archive/10.2/nvvm-ir-spec/index.html#conversion-operations) - includes `addrspacecast` (referenced as this is the oldest supported version)
  - [Address space conversion intrinsics in CUDA 10.2](https://docs.nvidia.com/cuda/archive/10.2/nvvm-ir-spec/index.html#nvvm-intrin-addrsp) - they were even deprecated in 10.2!
- We ensure that kernels don't have the `noinline` attribute, as this causes NVVM to generate a warning
- We now declare that the IR version we supply is the same as the IR version of the current NVVM (rather than trying to guess based on whether we are using NVVM70 or not).
- Since this now causes NVVM to produce no known warnings, I also added raising of NVVM warnings if they are present (and added a test)

Commit messages contain some additional commentary on some small refactorings that were done as part of this work.