### PR TITLE
CUDA: Revert numba_nvvm intrinsic name workaround

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -651,12 +651,6 @@ def llvm_replace(llvmir):
     for decl, fn in replacements:
         llvmir = llvmir.replace(decl, fn)
 
-    # llvm.numba_nvvm.atomic is used to prevent LLVM 9 onwards auto-upgrading
-    # these intrinsics into atomicrmw instructions, which are not recognized by
-    # NVVM. We can now replace them with the real intrinsic names, ready to
-    # pass to NVVM.
-    llvmir = llvmir.replace('llvm.numba_nvvm.atomic', 'llvm.nvvm.atomic')
-
     if NVVM().is_nvvm70:
         llvmir = llvm100_to_70_ir(llvmir)
     else:

--- a/numba/cuda/nvvmutils.py
+++ b/numba/cuda/nvvmutils.py
@@ -22,14 +22,9 @@ def atomic_cmpxchg(builder, lmod, isize, ptr, cmp, val):
         return builder.call(declare_atomic_cas_int(lmod, isize),
                             (ptr, cmp, val))
 
-# For atomic intrinsics, "numba_nvvm" prevents LLVM 9 onwards auto-upgrading
-# them into atomicrmw instructions that are not recognized by NVVM. It is
-# replaced with "nvvm" in llvm_to_ptx later, after the module has been parsed
-# and dumped by LLVM.
-
 
 def declare_atomic_add_float32(lmod):
-    fname = 'llvm.numba_nvvm.atomic.load.add.f32.p0f32'
+    fname = 'llvm.nvvm.atomic.load.add.f32.p0f32'
     fnty = ir.FunctionType(ir.FloatType(),
                            (ir.PointerType(ir.FloatType(), 0), ir.FloatType()))
     return cgutils.get_or_insert_function(lmod, fnty, fname)
@@ -37,7 +32,7 @@ def declare_atomic_add_float32(lmod):
 
 def declare_atomic_add_float64(lmod):
     if current_context().device.compute_capability >= (6, 0):
-        fname = 'llvm.numba_nvvm.atomic.load.add.f64.p0f64'
+        fname = 'llvm.nvvm.atomic.load.add.f64.p0f64'
     else:
         fname = '___numba_atomic_double_add'
     fnty = ir.FunctionType(ir.DoubleType(),


### PR DESCRIPTION
This is a small tidy-up of an old workaround (added in #6080) that prevented auto-upgrade of the IR when it passed through the llvmlite LLVM version - since this is no longer done, the workaround is no longer needed.
