### PR TITLE
Fix len of two concatenated Bytes objects bug

### DIFF
--- a/numba/cpython/charseq.py
+++ b/numba/cpython/charseq.py
@@ -204,9 +204,12 @@ def _make_constant_bytes(context, builder, nbytes):
     bstr.itemsize = ir.Constant(bstr.itemsize.type, 1)
     bstr.data = context.nrt.meminfo_data(builder, bstr.meminfo)
     bstr.parent = cgutils.get_null_value(bstr.parent.type)
-    # bstr.shape and bstr.strides are not used
-    bstr.shape = cgutils.get_null_value(bstr.shape.type)
-    bstr.strides = cgutils.get_null_value(bstr.strides.type)
+    bstr.shape = cgutils.pack_array(builder, [bstr.nitems],
+                                    context.get_value_type(types.intp))
+    bstr.strides = cgutils.pack_array(builder,
+                                      [ir.Constant(bstr.strides.type.element,
+                                       1)],
+                                      context.get_value_type(types.intp))
     return bstr
 
 

--- a/numba/tests/test_bytes.py
+++ b/numba/tests/test_bytes.py
@@ -1,0 +1,41 @@
+from numba.tests.support import (TestCase, no_pyobj_flags, MemoryLeakMixin)
+from numba import njit
+import unittest
+
+
+def addbytes_len_usecase(a, b):
+    output = len(b''.join([a, b]))
+    return output
+
+
+BYTES_EXAMPLES = [
+    b"abcdef",
+    b"12345",
+    b"AAAA",
+    b"zzzzz",
+    b'z',
+    b'1',
+    bytes(5),
+    bytes(10)
+]
+
+
+class BaseTest(MemoryLeakMixin, TestCase):
+    def setUp(self):
+        super(BaseTest, self).setUp()
+
+
+class TestBytesData(BaseTest):
+    def test_addbytes_len(self, flags=no_pyobj_flags):
+        pyfunc = addbytes_len_usecase
+        cfunc = njit(pyfunc)
+        num_objs = len(BYTES_EXAMPLES)
+
+        for i in range(num_objs):
+            obj1 = BYTES_EXAMPLES[i]
+            obj2 = BYTES_EXAMPLES[num_objs - i - 1]
+            self.assertEqual(pyfunc(obj1, obj2), cfunc(obj1, obj2))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Since `Bytes` inherits from `ArrayCompatible`, which utilizes the `shape` field to compute length (see `array_analysis::_analyze_op_call_builtins_len`), we must set the `shape` properly, in particular, using `nitems`.

The `strides` field also should be set to 1 for a Bytes object.

Closes #8305 


@njriasan 
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
