### PR TITLE
Add __name__ attribute to CUDAGUFuncVectorize plus test case

### DIFF
--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -305,7 +305,7 @@ class TestCUDAGufunc(CUDATestCase):
         self.check_tuple_arg(a, b)
 
     def test_name_attribute(self):
-        @nb.guvectorize('void(f8[:], f8[:])', '()->()', target = 'cuda')
+        @guvectorize('void(f8[:], f8[:])', '()->()', target = 'cuda')
         def bar(x, y):
             y[0] = x[0] ** 2
 

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -304,6 +304,13 @@ class TestCUDAGufunc(CUDATestCase):
              np.asarray((4.5, 5.5, 6.5)))
         self.check_tuple_arg(a, b)
 
+    def test_name_attribute(self):
+        @nb.guvectorize('void(f8[:], f8[:])', '()->()', target = 'cuda')
+        def bar(x, y):
+            y[0] = x[0] ** 2
+
+        self.assertEqual(bar.__name__, 'bar')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/cuda/tests/cudapy/test_gufunc.py
+++ b/numba/cuda/tests/cudapy/test_gufunc.py
@@ -305,7 +305,7 @@ class TestCUDAGufunc(CUDATestCase):
         self.check_tuple_arg(a, b)
 
     def test_name_attribute(self):
-        @guvectorize('void(f8[:], f8[:])', '()->()', target = 'cuda')
+        @guvectorize('void(f8[:],f8[:])', '()->()', target='cuda')
         def bar(x, y):
             y[0] = x[0] ** 2
 

--- a/numba/cuda/vectorizers.py
+++ b/numba/cuda/vectorizers.py
@@ -241,7 +241,9 @@ def __gufunc_{name}({args}):
 class CUDAGUFuncVectorize(deviceufunc.DeviceGUFuncVectorize):
     def build_ufunc(self):
         engine = deviceufunc.GUFuncEngine(self.inputsig, self.outputsig)
-        return CUDAGenerializedUFunc(kernelmap=self.kernelmap, engine=engine, pyfunc=self.pyfunc)
+        return CUDAGenerializedUFunc(kernelmap=self.kernelmap,
+                                     engine=engine,
+                                     pyfunc=self.pyfunc)
 
     def _compile_kernel(self, fnobj, sig):
         return cuda.jit(sig)(fnobj)

--- a/numba/cuda/vectorizers.py
+++ b/numba/cuda/vectorizers.py
@@ -125,6 +125,10 @@ class _CUDAGUFuncCallSteps(GUFuncCallSteps):
 
 
 class CUDAGenerializedUFunc(GenerializedUFunc):
+    def __init__(self, *args, pyfunc, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__name__ = pyfunc.__name__
+
     @property
     def _call_steps(self):
         return _CUDAGUFuncCallSteps
@@ -237,7 +241,7 @@ def __gufunc_{name}({args}):
 class CUDAGUFuncVectorize(deviceufunc.DeviceGUFuncVectorize):
     def build_ufunc(self):
         engine = deviceufunc.GUFuncEngine(self.inputsig, self.outputsig)
-        return CUDAGenerializedUFunc(kernelmap=self.kernelmap, engine=engine)
+        return CUDAGenerializedUFunc(kernelmap=self.kernelmap, engine=engine, pyfunc=self.pyfunc)
 
     def _compile_kernel(self, fnobj, sig):
         return cuda.jit(sig)(fnobj)


### PR DESCRIPTION
This solves what is basically a variation of #8272: `CUDAGUFuncVectorize` does not have a `__name__` attribute.