### PR TITLE
Remove dtype from kwarg list during function replacement in pre-parfor pass.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -1478,6 +1478,10 @@ class PreParforPass(object):
 
                             require(repl_func is not None)
                             typs = tuple(self.typemap[x.name] for x in expr.args)
+                            # The dtype keyword argument is handled by typing and can
+                            # be removed here during the implementation replacement so
+                            # that subsequent typing and argument handling won't fail.
+                            expr.kws = list(filter(lambda x: x[0] != "dtype", expr.kws))
                             try:
                                 new_func =  repl_func(lhs_typ, *typs)
                             except:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -908,12 +908,28 @@ class TestParforNumPy(TestParforsBase):
             return np.arange(n)
         # start and stop
         def test_impl2(s, n):
-            return np.arange(n)
+            return np.arange(s, n)
         # start, step, stop
         def test_impl3(s, n, t):
             return np.arange(s, n, t)
 
         for arg in [11, 128, 30.0, complex(4,5), complex(5,4)]:
+            self.check(test_impl1, arg)
+            self.check(test_impl2, 2, arg)
+            self.check(test_impl3, 2, arg, 2)
+
+    def test_arange_dtype(self):
+        # test with stop only
+        def test_impl1(n):
+            return np.arange(n, dtype=np.float32)
+        # start and stop
+        def test_impl2(s, n):
+            return np.arange(s, n, dtype=np.float32)
+        # start, step, stop
+        def test_impl3(s, n, t):
+            return np.arange(s, n, t, dtype=np.float32)
+
+        for arg in [11, 128, 30.0]:
             self.check(test_impl1, arg)
             self.check(test_impl2, 2, arg)
             self.check(test_impl3, 2, arg, 2)


### PR DESCRIPTION
Resolves #8225

Generally, dtype kwargs to NumPy functions only have an effect on the typing aspect of Numba and not any runtime ramifications.  So, in the parfor code, we can filter out dtype kwargs and rely on typing to handle them.  I wrote this in a generic way but the only function it may now affect is arange.  Many other functions that the pre-parfor pass replaces don't take a dtype parameter and others like linspace don't support dtype for typing either.