### PR TITLE
Fix typos of "Generalized" in GUFunc-related code

### DIFF
--- a/numba/cuda/vectorizers.py
+++ b/numba/cuda/vectorizers.py
@@ -1,7 +1,7 @@
 from numba import cuda
 from numpy import array as np_array
 from numba.np.ufunc import deviceufunc
-from numba.np.ufunc.deviceufunc import (UFuncMechanism, GenerializedUFunc,
+from numba.np.ufunc.deviceufunc import (UFuncMechanism, GeneralizedUFunc,
                                         GUFuncCallSteps)
 
 
@@ -124,7 +124,7 @@ class _CUDAGUFuncCallSteps(GUFuncCallSteps):
         kernel.forall(nelem, stream=self._stream)(*args)
 
 
-class CUDAGenerializedUFunc(GenerializedUFunc):
+class CUDAGeneralizedUFunc(GeneralizedUFunc):
     def __init__(self, kernelmap, engine, pyfunc):
         self.__name__ = pyfunc.__name__
         super().__init__(kernelmap, engine)
@@ -241,9 +241,9 @@ def __gufunc_{name}({args}):
 class CUDAGUFuncVectorize(deviceufunc.DeviceGUFuncVectorize):
     def build_ufunc(self):
         engine = deviceufunc.GUFuncEngine(self.inputsig, self.outputsig)
-        return CUDAGenerializedUFunc(kernelmap=self.kernelmap,
-                                     engine=engine,
-                                     pyfunc=self.pyfunc)
+        return CUDAGeneralizedUFunc(kernelmap=self.kernelmap,
+                                    engine=engine,
+                                    pyfunc=self.pyfunc)
 
     def _compile_kernel(self, fnobj, sig):
         return cuda.jit(sig)(fnobj)

--- a/numba/np/ufunc/decorators.py
+++ b/numba/np/ufunc/decorators.py
@@ -133,7 +133,7 @@ def vectorize(ftylist_or_function=(), **kws):
 def guvectorize(*args, **kwargs):
     """guvectorize(ftylist, signature, target='cpu', identity=None, **kws)
 
-    A decorator to create numpy generialized-ufunc object from Numba compiled
+    A decorator to create numpy generalized-ufunc object from Numba compiled
     code.
 
     Args
@@ -144,7 +144,7 @@ def guvectorize(*args, **kwargs):
         function type.
 
     signature: str
-        A NumPy generialized-ufunc signature.
+        A NumPy generalized-ufunc signature.
         e.g. "(m, n), (n, p)->(m, p)"
 
     identity: int, str, or None
@@ -161,7 +161,7 @@ def guvectorize(*args, **kwargs):
     Returns
     --------
 
-    A NumPy generialized universal-function
+    A NumPy generalized universal-function
 
     Example
     -------

--- a/numba/np/ufunc/decorators.py
+++ b/numba/np/ufunc/decorators.py
@@ -133,7 +133,7 @@ def vectorize(ftylist_or_function=(), **kws):
 def guvectorize(*args, **kwargs):
     """guvectorize(ftylist, signature, target='cpu', identity=None, **kws)
 
-    A decorator to create numpy generalized-ufunc object from Numba compiled
+    A decorator to create NumPy generalized-ufunc object from Numba compiled
     code.
 
     Args

--- a/numba/np/ufunc/deviceufunc.py
+++ b/numba/np/ufunc/deviceufunc.py
@@ -635,7 +635,7 @@ class GUFuncSchedule(object):
         return pprint.pformat(dict(values))
 
 
-class GenerializedUFunc(object):
+class GeneralizedUFunc(object):
     def __init__(self, kernelmap, engine):
         self.kernelmap = kernelmap
         self.engine = engine


### PR DESCRIPTION
This typo has annoyed me for long enough. As in https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html, it should be *Generalized*, not *Generialized*.