### PR TITLE
Revert "Merge pull request #8299 from Biswa96/mingw-fix"

### DIFF
--- a/numba/np/ufunc/omppool.cpp
+++ b/numba/np/ufunc/omppool.cpp
@@ -15,7 +15,7 @@ Threading layer on top of OpenMP.
 #include "workqueue.h"
 #include "gufunc_scheduler.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <malloc.h>
 #else
 #include <sys/types.h>
@@ -32,9 +32,7 @@ Threading layer on top of OpenMP.
 #elif defined(__clang__)
 #define _OMP_VENDOR "Intel"
 #elif defined(__GNUC__) // NOTE: clang also defines this, but it's checked above
-#ifndef _WIN32
 #define _NOT_FORKSAFE 1 // GNU OpenMP Not forksafe
-#endif
 #define _OMP_VENDOR "GNU"
 #endif
 

--- a/numba/np/ufunc/omppool.cpp
+++ b/numba/np/ufunc/omppool.cpp
@@ -18,6 +18,7 @@ Threading layer on top of OpenMP.
 #ifdef _MSC_VER
 #include <malloc.h>
 #else
+#include <pthread.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <signal.h>

--- a/numba/np/ufunc/workqueue.c
+++ b/numba/np/ufunc/workqueue.c
@@ -16,7 +16,7 @@ race conditions.
 #undef _XOPEN_SOURCE
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 /* Windows */
 #include <windows.h>
 #include <process.h>

--- a/setup.py
+++ b/setup.py
@@ -240,15 +240,9 @@ def get_ext_modules():
     # Set various flags for use in TBB and openmp. On OSX, also find OpenMP!
     have_openmp = True
     if sys.platform.startswith('win'):
-        if 'MSC' in sys.version:
-            cpp11flags = []
-            ompcompileflags = ['-openmp']
-            omplinkflags = []
-        else:
-            # For non-MSVC toolchain e.g. gcc and clang with mingw
-            cpp11flags = ['-std=c++11']
-            ompcompileflags = ['-fopenmp']
-            omplinkflags = ['-fopenmp']
+        cpp11flags = []
+        ompcompileflags = ['-openmp']
+        omplinkflags = []
     elif sys.platform.startswith('darwin'):
         cpp11flags = ['-std=c++11']
         # This is a bit unusual but necessary...

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,9 @@ versioneer.parentdir_prefix = 'numba-'
 cmdclass = versioneer.get_cmdclass()
 cmdclass['build_doc'] = build_doc
 
-extra_link_args = []
 install_name_tool_fixer = []
 if sys.platform == 'darwin':
     install_name_tool_fixer += ['-headerpad_max_install_names']
-if platform.machine() == 'ppc64le':
-    extra_link_args += ['-pthread']
 
 build_ext = cmdclass.get('build_ext', build_ext)
 
@@ -175,9 +172,7 @@ def get_ext_modules():
                                        "numba/cext/dictobject.c",
                                        "numba/cext/listobject.c",
                                        ],
-                              # numba/_random.c needs pthreads
-                              extra_link_args=install_name_tool_fixer +
-                              extra_link_args,
+                              extra_link_args=install_name_tool_fixer,
                               depends=["numba/_pymodule.h",
                                        "numba/_helperlib.c",
                                        "numba/_lapack.c",
@@ -283,7 +278,6 @@ def get_ext_modules():
                 depends=['numba/np/ufunc/workqueue.h'],
                 include_dirs=[os.path.join(tbb_root, 'include')],
                 extra_compile_args=cpp11flags,
-                extra_link_args=extra_link_args,
                 libraries=['tbb'],  # TODO: if --debug or -g, use 'tbb_debug'
                 library_dirs=[
                     # for Linux
@@ -325,8 +319,7 @@ def get_ext_modules():
         name='numba.np.ufunc.workqueue',
         sources=['numba/np/ufunc/workqueue.c',
                  'numba/np/ufunc/gufunc_scheduler.cpp'],
-        depends=['numba/np/ufunc/workqueue.h'],
-        extra_link_args=extra_link_args)
+        depends=['numba/np/ufunc/workqueue.h'])
     ext_np_ufunc_backends.append(ext_np_ufunc_workqueue_backend)
 
     ext_mviewbuf = Extension(name='numba.mviewbuf',


### PR DESCRIPTION
This reverts commit e0701d9a22d38c890f5737f4bf63cc3c41f8609e, reversing
changes made to 3a5627831ca85255cd1d3c74d07b602731fa51cb.

This is an experimental commit to diagnose recent RTD failures of the form

```
building 'numba._dynfunc' extension
/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/dist.py:530: UserWarning: Normalizing '0.57.0dev0+218.g2e9b58cfc.dirty' to '0.57.0.dev0+218.g2e9b58cfc.dirty'
  warnings.warn(tmpl.format(**locals()))
/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/install.py:37: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  setuptools.SetuptoolsDeprecationWarning,
/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/easy_install.py:147: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
  EasyInstallDeprecationWarning,
Traceback (most recent call last):
  File "./setup.py", line 429, in <module>
    setup(**metadata)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/__init__.py", line 87, in setup
    return distutils.core.setup(**attrs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 973, in run_commands
    self.run_command(cmd)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/dist.py", line 1217, in run_command
    super().run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 992, in run_command
    cmd_obj.run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/install.py", line 74, in run
    self.do_egg_install()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/install.py", line 123, in do_egg_install
    self.run_command('bdist_egg')
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/cmd.py", line 319, in run_command
    self.distribution.run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/dist.py", line 1217, in run_command
    super().run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 992, in run_command
    cmd_obj.run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 165, in run
    cmd = self.call_command('install_lib', warn_dir=0)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/bdist_egg.py", line 151, in call_command
    self.run_command(cmdname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/cmd.py", line 319, in run_command
    self.distribution.run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/dist.py", line 1217, in run_command
    super().run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 992, in run_command
    cmd_obj.run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/command/install_lib.py", line 11, in run
    self.build()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/command/install_lib.py", line 112, in build
    self.run_command('build_ext')
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/cmd.py", line 319, in run_command
    self.distribution.run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/dist.py", line 1217, in run_command
    super().run_command(command)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/dist.py", line 992, in run_command
    cmd_obj.run()
  File "./setup.py", line 110, in run
    super().run()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/command/build_ext.py", line 346, in run
    self.build_extensions()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/command/build_ext.py", line 466, in build_extensions
    self._build_extensions_serial()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/command/build_ext.py", line 492, in _build_extensions_serial
    self.build_extension(ext)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/setuptools/_distutils/command/build_ext.py", line 554, in build_extension
    depends=ext.depends,
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/ccompiler.py", line 89, in <lambda>
    m = lambda self, *args, **kw: func(self, *args, **kw)
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/ccompiler.py", line 273, in CCompiler_compile
    jobs = get_num_build_jobs()
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/misc_util.py", line 90, in get_num_build_jobs
    from numpy.distutils.core import get_distribution
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/core.py", line 24, in <module>
    from numpy.distutils.command import config, config_compiler, \
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/command/config.py", line 19, in <module>
    from numpy.distutils.mingw32ccompiler import generate_manifest
  File "/home/docs/checkouts/readthedocs.org/user_builds/numba/conda/latest/lib/python3.7/site-packages/numpy/distutils/mingw32ccompiler.py", line 29, in <module>
    from distutils.msvccompiler import get_build_version as get_build_msvc_version
ModuleNotFoundError: No module named 'distutils.msvccompiler'
```

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
