### PR TITLE
Added runtime check for np.nditer's input array layouts

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -3829,6 +3829,10 @@ def make_array_nditer(context, builder, sig, args):
     nditerty = sig.return_type
     arrtys = nditerty.arrays
 
+    if any(_arrty.layout not in 'CF' for _arrty in arrtys):
+        raise TypeError('Only C or F contiguous arrays are '
+                        'accepted by Numba implementation of np.nditer')
+
     if isinstance(sig.args[0], types.BaseTuple):
         arrays = cgutils.unpack_tuple(builder, args[0])
     else:


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
Fixes: https://github.com/numba/numba/issues/7774

A simple run-time check to see if array layouts are defined (either `C` or `F` continuous) in `np.nditer`. It's implementation is made under assumption that layout of arguments are either `C` or `F` continuous but there aren't any checks that enforced this.  
