### PR TITLE
Remove setuptools as runtime dependency

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -75,6 +75,7 @@ test:
     # temporarily disable scipy testing on ARM, need to build out more packages
     - scipy                    # [not (armv6l or armv7l)]
     - ipython                  # [not (armv6l or armv7l or aarch64)]
+    - setuptools <60
     - tbb  >=2021              # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
     - llvm-openmp              # [osx]
     # This is for driving gdb tests

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -46,7 +46,6 @@ requirements:
     - python >=3.7
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
     - numpy >=1.18, !=1.22.0, !=1.22.1, !=1.22.2
-    - setuptools <60
     - importlib_metadata       # [py<39]
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.40.0dev0,<0.40
@@ -76,7 +75,6 @@ test:
     # temporarily disable scipy testing on ARM, need to build out more packages
     - scipy                    # [not (armv6l or armv7l)]
     - ipython                  # [not (armv6l or armv7l or aarch64)]
-    - setuptools <60
     - tbb  >=2021              # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
     - llvm-openmp              # [osx]
     # This is for driving gdb tests

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - llvmlite=0.40
   - numpy
   - numpydoc
-  - setuptools<60
   # https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-fileA
   - docutils==0.16
   # The following is needed to fix RTD.

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -201,7 +201,6 @@ vary with target operating system and hardware. The following lists them all
 
 * Required run time:
 
-  * ``setuptools<60``
   * ``numpy``
   * ``llvmlite``
 

--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,6 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'setuptools <60',
     'importlib_metadata; python_version < "3.9"',
 ]
 


### PR DESCRIPTION
It was added in #4794, as you imported `pkg_resources` at the time.

Since #5209 you no longer import it and therefore no longer have a runtime dependency on setuptools.