### PR TITLE
[WIP] Extend cache invalidation to include changes in other files

### DIFF
--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -592,14 +592,12 @@ class Cache(_Cache):
     # The following class variables must be overridden by subclass.
     _impl_class = None
 
-    def __init__(self, py_func,
-                 index_info_callback: pt.Callable[[], pt.Tuple[str, str]]):
+    def __init__(self, py_func, index_key: pt.Callable[[], pt.Tuple[str, str]]):
         # self._dispatcher_index_key is function that returns
         # a tuple of hashed code and hashed content of closure variables
         # it's a callable instead of a tuple to delay the calculation of the
         # index key until all globals have been linked to the function
-        # If None is provided, the index_key will be based only
-        self._dispatcher_index_info = index_info_callback
+        self._dispatcher_index_key = index_key
         self._name = repr(py_func)
         self._py_func = py_func
         self._impl = self._impl_class(py_func)
@@ -688,8 +686,7 @@ class Cache(_Cache):
         """
         # self._dispatcher_index_key is a function that returns a tuple of
         # hashed code and hashed content of closure variables
-        index_key = self._dispatcher_index_info(sig).index_key
-        return (sig, codegen.magic_tuple(), index_key)
+        return (sig, codegen.magic_tuple(), self._dispatcher_index_key())
 
 
 class FunctionCache(Cache):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -596,9 +596,11 @@ class Cache(_Cache):
     # The following class variables must be overridden by subclass.
     _impl_class = None
 
-    def __init__(self, py_func, index_key: pt.Tuple[str, str]):
-        # self._dispatcher_index_key is a tuple of hashed code and
-        # hashed content of closure variables
+    def __init__(self, py_func, index_key: pt.Callable[[], pt.Tuple[str, str]]):
+        # self._dispatcher_index_key is function that returns
+        # a tuple of hashed code and hashed content of closure variables
+        # it's a callable instead of a tuple to delay the calculation of the
+        # index key until all globals have been linked to the function
         self._dispatcher_index_key = index_key
         self._name = repr(py_func)
         self._py_func = py_func
@@ -686,9 +688,9 @@ class Cache(_Cache):
         the bytecode for the function and, if the function has a __closure__,
         a hash of the cell_contents.
         """
-        # self._dispatcher_index_key is a tuple of hashed code and
-        # hashed content of closure variables
-        return (sig, codegen.magic_tuple(), self._dispatcher_index_key)
+        # self._dispatcher_index_key is a function that returns a tuple of
+        # hashed code and hashed content of closure variables
+        return (sig, codegen.magic_tuple(), self._dispatcher_index_key())
 
 
 class FunctionCache(Cache):

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -2,7 +2,6 @@
 Caching mechanism for compiled functions.
 """
 
-
 from abc import ABCMeta, abstractmethod, abstractproperty
 import contextlib
 import errno
@@ -21,9 +20,6 @@ from numba.misc.appdirs import AppDirs
 
 import numba
 from numba.core.errors import NumbaWarning
-from numba.core.base import BaseContext
-from numba.core.codegen import CodeLibrary
-from numba.core.compiler import CompileResult
 from numba.core import config, compiler
 from numba.core.serialize import dumps
 
@@ -725,4 +721,3 @@ def make_library_cache(prefix):
         _impl_class = CustomCodeLibraryCacheImpl
 
     return LibraryCache
-

--- a/numba/core/caching.py
+++ b/numba/core/caching.py
@@ -592,12 +592,14 @@ class Cache(_Cache):
     # The following class variables must be overridden by subclass.
     _impl_class = None
 
-    def __init__(self, py_func, index_key: pt.Callable[[], pt.Tuple[str, str]]):
+    def __init__(self, py_func,
+                 index_info_callback: pt.Callable[[], pt.Tuple[str, str]]):
         # self._dispatcher_index_key is function that returns
         # a tuple of hashed code and hashed content of closure variables
         # it's a callable instead of a tuple to delay the calculation of the
         # index key until all globals have been linked to the function
-        self._dispatcher_index_key = index_key
+        # If None is provided, the index_key will be based only
+        self._dispatcher_index_info = index_info_callback
         self._name = repr(py_func)
         self._py_func = py_func
         self._impl = self._impl_class(py_func)
@@ -686,7 +688,8 @@ class Cache(_Cache):
         """
         # self._dispatcher_index_key is a function that returns a tuple of
         # hashed code and hashed content of closure variables
-        return (sig, codegen.magic_tuple(), self._dispatcher_index_key())
+        index_key = self._dispatcher_index_info(sig).index_key
+        return (sig, codegen.magic_tuple(), index_key)
 
 
 class FunctionCache(Cache):

--- a/numba/core/caching_utils.py
+++ b/numba/core/caching_utils.py
@@ -1,0 +1,106 @@
+import ast
+import hashlib
+import inspect
+import textwrap
+import typing as pt
+import warnings
+from types import FunctionType
+
+from numba.core import types
+from numba.core.serialize import dumps
+
+DispatcherOrFunctionType = pt.TypeVar(
+    'DispatcherOrFunctionType', type[FunctionType], type[types.Dispatcher]
+)
+
+
+def get_index_key(py_func, caller_class: DispatcherOrFunctionType):
+    """
+    Compute index key for the given signature and codegen.
+    It includes a description of the OS, target architecture and hashes of
+    the bytecode for the function and, if the function has a __closure__,
+    a hash of the cell_contents.
+    """
+    # retrieve codebytes and cvarbytes of this function
+    codebytes = py_func.__code__.co_code
+    if py_func.__closure__ is not None:
+        cvars = tuple([x.cell_contents for x in py_func.__closure__])
+        # Note: cloudpickle serializes a function differently depending
+        #       on how the process is launched; e.g. multiprocessing.Process
+        cvarbytes = dumps(cvars)
+    else:
+        cvarbytes = b''
+    # retrieve codebytes and cvarbytes of each dispatcher used in py_func
+    for dep in get_function_dependencies(py_func, (caller_class,)):
+        print(dep)
+        index_key = dep.cache_index_key
+        codebytes += index_key[0].encode()
+        cvarbytes += index_key[1].encode()
+
+    hasher = lambda x: hashlib.sha256(x).hexdigest()
+
+    return hasher(codebytes), hasher(cvarbytes)
+
+
+def get_function_dependencies(
+        py_func, fc_classes: pt.Tuple[DispatcherOrFunctionType]
+) -> pt.List[DispatcherOrFunctionType]:
+    """ given a py func, will return all dispatchers on which this depends
+
+
+    this function supports the cache mechanism, so it ignores dependencies
+    that are not callable objects. The classes used to identify what to include
+    in the hash and what to ignore, are given by parameter ``fc_classes``
+
+    The following cases are planned, but not all of them implemented
+    - the called function is a global: implemented. The dependency is returned.
+    - the called function is a builtin: implemented. The dependency is ignored.
+    - the called function is a local: not implemented
+
+    :param py_func: python function object to analyze
+    :param fc_classes: classes to be considered callable objects that should
+     be included in the hashes
+    :return:
+    :return:
+    """
+    deps = []
+    unknown = []
+    # Retrieve all function calls
+    source = textwrap.dedent(inspect.getsource(py_func))
+    ast_parsed = ast.parse(source)
+    ast_walker = ast.walk(ast_parsed)
+    # we create a list of all function calls, which is filtered in several
+    # steps so only dispatchers remain
+    disp_calls = (op.func.id for op in ast_walker if isinstance(op, ast.Call))
+    disp_calls = set(disp_calls)
+    # filter out builtins
+    if not hasattr(py_func, "__builtins__"):
+        builtin_names = __builtins__
+        disp_calls = (name for name in disp_calls if name not in builtin_names)
+    else:
+        builtin_names = py_func.__builtins__
+        disp_calls = (name for name in disp_calls if name not in builtin_names)
+    # filter out input parameters
+    sig_params = list(inspect.signature(py_func).parameters.keys())
+    disp_calls = (name for name in disp_calls if name not in sig_params)
+    # filter out globals if not a Dispatcher
+    # retrieve object from globals if a Dispatcher
+    fc_globals = py_func.__globals__
+    for var_name in disp_calls:
+        if var_name in fc_globals:
+            var_obj = fc_globals[var_name]
+            if isinstance(var_obj, fc_classes):
+                deps.append(var_obj)
+            # else ignore, not a Dispatcher
+        else:
+            unknown.append(var_name)
+
+    if unknown:
+        warnings.warn(f"Functions {unknown} will be cached but changes made to "
+                      f"them might not be detected, resulting in possible use"
+                      f"of stale cached versions")
+    if not unknown:
+        return deps
+    # case: function is a getitem or attribute of a global
+    # not yet implemented
+    return deps

--- a/numba/core/caching_utils.py
+++ b/numba/core/caching_utils.py
@@ -4,17 +4,20 @@ import inspect
 import textwrap
 import typing as pt
 import warnings
-from types import FunctionType
+from typing import TYPE_CHECKING
 
-from numba.core import types
 from numba.core.serialize import dumps
 
+
+if TYPE_CHECKING:
+    from numba.core import dispatcher, ccallback
+
 DispatcherOrFunctionType = pt.TypeVar(
-    'DispatcherOrFunctionType', type[FunctionType], type[types.Dispatcher]
+    'DispatcherOrFunctionType', type["ccallback.CFunc"], type["dispatcher.Dispatcher"]
 )
 
 
-def get_index_key(py_func, caller_class: DispatcherOrFunctionType):
+def get_index_key(py_func, caller_class: "DispatcherOrFunctionType"):
     """
     Compute index key for the given signature and codegen.
     It includes a description of the OS, target architecture and hashes of
@@ -32,7 +35,6 @@ def get_index_key(py_func, caller_class: DispatcherOrFunctionType):
         cvarbytes = b''
     # retrieve codebytes and cvarbytes of each dispatcher used in py_func
     for dep in get_function_dependencies(py_func, (caller_class,)):
-        print(dep)
         index_key = dep.cache_index_key
         codebytes += index_key[0].encode()
         cvarbytes += index_key[1].encode()

--- a/numba/core/caching_utils.py
+++ b/numba/core/caching_utils.py
@@ -2,16 +2,16 @@ import ast
 import hashlib
 import inspect
 import textwrap
-import typing as pt
 import warnings
-from typing import TYPE_CHECKING
+import typing as pt
+import sys, os
+
 
 from numba.core.serialize import dumps
+from numba.core import types
 
-
-if TYPE_CHECKING:
+if pt.TYPE_CHECKING:
     from numba.core import dispatcher, ccallback
-
 
 DispatcherOrFunctionType = pt.TypeVar(
     'DispatcherOrFunctionType',
@@ -20,12 +20,38 @@ DispatcherOrFunctionType = pt.TypeVar(
 )
 
 
-def get_index_key(py_func, caller_class: "DispatcherOrFunctionType"):
+class PyFileStats(pt.NamedTuple):
+    mtime: float
+    size: int
+
+
+class IndexKey(pt.NamedTuple):
+    codebytes_hash: str
+    cvarbytes_hash: str
+    dep_files: pt.Dict[str, PyFileStats]
+
+
+class IndexInfo(pt.NamedTuple):
+    index_key: IndexKey
+    dep_files: pt.Dict[str, PyFileStats]
+
+
+def get_index_info(py_func, overload: "CompileResult") -> IndexInfo:
     """
     Compute index key for the given signature and codegen.
+
     It includes a description of the OS, target architecture and hashes of
     the bytecode for the function and, if the function has a __closure__,
     a hash of the cell_contents.
+
+    It will include the hashed bytecode and hashed call_contents of any
+    function that is called, if this function is an instance of caller_classes
+
+    :param py_func: a python function object to be analyzed
+    :param caller_classes: a tuple of Numba Dispatcher classes (or equivalent).
+      Any function call to an object belonging to these classes will be
+      included in the index_key, to figerprint dependencies.
+    :return:
     """
     # retrieve codebytes and cvarbytes of this function
     codebytes = py_func.__code__.co_code
@@ -37,18 +63,14 @@ def get_index_key(py_func, caller_class: "DispatcherOrFunctionType"):
     else:
         cvarbytes = b''
     # retrieve codebytes and cvarbytes of each dispatcher used in py_func
-    for dep in get_function_dependencies(py_func, (caller_class,)):
-        index_key = dep.cache_index_key
-        codebytes += index_key[0].encode()
-        cvarbytes += index_key[1].encode()
-
+    deps = get_function_dependencies(overload)
     hasher = lambda x: hashlib.sha256(x).hexdigest()
+    index_key = IndexKey(hasher(codebytes), hasher(cvarbytes))
+    return IndexInfo(index_key, deps)
 
-    return hasher(codebytes), hasher(cvarbytes)
 
-
-def get_function_dependencies(
-        py_func, fc_classes: pt.Tuple[DispatcherOrFunctionType]
+def get_function_dependencies2(
+        py_func, fc_classes: pt.Tuple[DispatcherOrFunctionType, ...]
 ) -> pt.List[DispatcherOrFunctionType]:
     """ given a py func, will return all dispatchers on which this depends
 
@@ -112,3 +134,44 @@ def get_function_dependencies(
     # case: function is a getitem or attribute of a global
     # not yet implemented
     return deps
+
+# which numba types are considered dependencies to be identified in cache
+dep_types = (types.Dispatcher, )
+dep_object_py_func = []
+
+
+def get_function_dependencies(overload: "CompileResult") -> pt.Dict[str, PyFileStats]:
+    deps = {}
+    # for ty in overload.type_annotation.typemap.values():
+    #     if not isinstance(ty, dep_types):
+    #         continue
+    #     if isinstance(ty, types.Dispatcher):
+    #         py_func = ty.dispatcher.py_func
+    #         py_file = py_func.__code__.co_filename
+    #         deps[py_file] = get_source_stamp(py_file)
+    #
+    #         deps.update(ty.dispatcher.cache_index_key())
+    typemap = overload.type_annotation.typemap
+    calltypes = overload.type_annotation.calltypes
+    for call_op in calltypes:
+        name = call_op.list_vars()[0].name
+        fc_ty = typemap[name]
+        sig = calltypes[call_op]
+        if not isinstance(fc_ty, dep_types):
+            continue
+        if isinstance(fc_ty, types.Dispatcher):
+            py_func = fc_ty.dispatcher.py_func
+            py_file = py_func.__code__.co_filename
+            deps[py_file] = get_source_stamp(py_file)
+            deps.update(fc_ty.dispatcher.cache_index_key(sig.args))
+    return deps
+
+
+def get_source_stamp(py_file) -> PyFileStats:
+    if getattr(sys, 'frozen', False):
+        st = os.stat(sys.executable)
+    else:
+        st = os.stat(py_file)
+    # We use both timestamp and size as some filesystems only have second
+    # granularity.
+    return PyFileStats(st.st_mtime, st.st_size)

--- a/numba/core/caching_utils.py
+++ b/numba/core/caching_utils.py
@@ -12,8 +12,11 @@ from numba.core.serialize import dumps
 if TYPE_CHECKING:
     from numba.core import dispatcher, ccallback
 
+
 DispatcherOrFunctionType = pt.TypeVar(
-    'DispatcherOrFunctionType', type["ccallback.CFunc"], type["dispatcher.Dispatcher"]
+    'DispatcherOrFunctionType',
+    pt.Type["ccallback.CFunc"],
+    pt.Type["dispatcher.Dispatcher"]
 )
 
 

--- a/numba/core/caching_utils.py
+++ b/numba/core/caching_utils.py
@@ -73,7 +73,10 @@ def get_function_dependencies(
     ast_walker = ast.walk(ast_parsed)
     # we create a list of all function calls, which is filtered in several
     # steps so only dispatchers remain
-    disp_calls = (op.func.id for op in ast_walker if isinstance(op, ast.Call))
+    disp_calls = (op.func.id
+                  for op in ast_walker
+                  if isinstance(op, ast.Call) and hasattr(op.func, 'id')
+                  )
     disp_calls = set(disp_calls)
     # filter out builtins
     if not hasattr(py_func, "__builtins__"):

--- a/numba/core/ccallback.py
+++ b/numba/core/ccallback.py
@@ -9,7 +9,7 @@ import typing as pt
 from numba.core.utils import cached_property
 from numba.core import utils, compiler, registry
 from numba.core.caching import NullCache, FunctionCache
-from numba.core.caching_utils import get_index_key
+from numba.core.caching_utils import get_index_info
 from numba.core.dispatcher import _FunctionCompiler
 from numba.core.typing import signature
 from numba.core.typing.ctypes_utils import to_ctypes
@@ -70,7 +70,7 @@ class CFunc(object):
         """Hash the code of its function, the closure variables and add them
         to the respective hashes of all its function dependencies
         """
-        return get_index_key(self._pyfunc, CFunc)
+        return get_index_info(self._pyfunc, (CFunc,))
 
     @global_compiler_lock
     def compile(self):

--- a/numba/core/ccallback.py
+++ b/numba/core/ccallback.py
@@ -9,7 +9,7 @@ import typing as pt
 from numba.core.utils import cached_property
 from numba.core import utils, compiler, registry
 from numba.core.caching import NullCache, FunctionCache
-from numba.core.caching_utils import get_index_info
+from numba.core.caching_utils import get_index_key
 from numba.core.dispatcher import _FunctionCompiler
 from numba.core.typing import signature
 from numba.core.typing.ctypes_utils import to_ctypes
@@ -70,7 +70,7 @@ class CFunc(object):
         """Hash the code of its function, the closure variables and add them
         to the respective hashes of all its function dependencies
         """
-        return get_index_info(self._pyfunc, (CFunc,))
+        return get_index_key(self._pyfunc, CFunc)
 
     @global_compiler_lock
     def compile(self):

--- a/numba/core/ccallback.py
+++ b/numba/core/ccallback.py
@@ -14,7 +14,7 @@ from numba.core.dispatcher import _FunctionCompiler
 from numba.core.typing import signature
 from numba.core.typing.ctypes_utils import to_ctypes
 from numba.core.compiler_lock import global_compiler_lock
-from numba.core.types.function_type import FunctionType
+
 
 class _CFuncCompiler(_FunctionCompiler):
 
@@ -70,7 +70,7 @@ class CFunc(object):
         """Hash the code of its function, the closure variables and add them
         to the respective hashes of all its function dependencies
         """
-        return get_index_key(self._pyfunc, FunctionType)
+        return get_index_key(self._pyfunc, CFunc)
 
     @global_compiler_lock
     def compile(self):

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -1432,7 +1432,6 @@ def get_function_dependencies(py_func) -> pt.List[Dispatcher]:
     disp_calls = set(disp_calls)
     # filter out builtins
     if not hasattr(py_func, "__builtins__"):
-        print("function without builtins", type(py_func), dir(py_func))
         builtin_names = __builtins__
         disp_calls = (name for name in disp_calls if name not in builtin_names)
     else:

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -2,7 +2,6 @@
 import ast
 import collections
 import functools
-import hashlib
 import inspect
 import sys
 import types as pytypes
@@ -878,7 +877,7 @@ class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
         """Hash the code of its function, the closure variables and add them
         to the respective hashes of all its function dependencies
         """
-        return get_index_key(self.py_func, types.Dispatcher)
+        return get_index_key(self.py_func, Dispatcher)
 
     def __get__(self, obj, objtype=None):
         '''Allow a JIT function to be bound as a method to an object'''

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -1433,6 +1433,8 @@ def get_function_dependencies(py_func) -> pt.List[Dispatcher]:
     # filter out builtins
     if not hasattr(py_func, "__builtins__"):
         print("function without builtins", type(py_func), dir(py_func))
+        builtin_names = __builtins__
+        disp_calls = (name for name in disp_calls if name not in builtin_names)
     else:
         builtin_names = py_func.__builtins__
         disp_calls = (name for name in disp_calls if name not in builtin_names)

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -1431,8 +1431,11 @@ def get_function_dependencies(py_func) -> pt.List[Dispatcher]:
     disp_calls = (op.func.id for op in ast_walker if isinstance(op, ast.Call))
     disp_calls = set(disp_calls)
     # filter out builtins
-    builtin_names = py_func.__builtins__
-    disp_calls = (name for name in disp_calls if name not in builtin_names)
+    if not hasattr(py_func, "__builtins__"):
+        print("function without builtins", type(py_func), dir(py_func))
+    else:
+        builtin_names = py_func.__builtins__
+        disp_calls = (name for name in disp_calls if name not in builtin_names)
     # filter out input parameters
     sig_params = list(inspect.signature(py_func).parameters.keys())
     disp_calls = (name for name in disp_calls if name not in sig_params)

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -23,7 +23,8 @@ from numba.core.typing.templates import fold_arguments
 from numba.core.typing.typeof import Purpose, typeof
 from numba.core.bytecode import get_code_object
 from numba.core.caching import NullCache, FunctionCache
-from numba.core.caching_utils import get_index_key, get_function_dependencies
+from numba.core.caching_utils import get_index_info, get_function_dependencies, \
+    IndexKey, IndexInfo
 from numba.core import entrypoints
 from numba.core.retarget import BaseRetarget
 from numba.core.utils import cached_property
@@ -867,17 +868,18 @@ class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
 
     def enable_caching(self):
         # provide a function for delayed calculation of the index key
-        def get_cache_index_key():
-            return self.cache_index_key
+        def get_cache_index_info(sig_args):
+            return self.cache_index_info(sig_args)
 
-        self._cache = FunctionCache(self.py_func, get_cache_index_key)
+        self._cache = FunctionCache(self.py_func, get_cache_index_info)
 
-    @cached_property
-    def cache_index_key(self,) -> pt.Tuple[str, str]:
+    @functools.lru_cache()
+    def cache_index_info(self, sig_args) -> IndexInfo:
         """Hash the code of its function, the closure variables and add them
         to the respective hashes of all its function dependencies
         """
-        return get_index_key(self.py_func, Dispatcher)
+        print(self.overloads)
+        return get_index_info(self.py_func, self.overloads[sig_args])
 
     def __get__(self, obj, objtype=None):
         '''Allow a JIT function to be bound as a method to an object'''
@@ -1337,52 +1339,3 @@ class ObjModeLiftedWith(LiftedWith):
 _dispatcher.typeof_init(
     OmittedArg,
     dict((str(t), t._code) for t in types.number_domain))
-
-
-def get_function_dependencies2(py_func):
-    """ given a py func, will return all dispatchers on which this depends
-
-    this function supports the cache mechanism, so it ignores dependencies
-    that are not cached
-    The following cases are planned, but not all of them implemented
-    - the called function is a global: implemented. The dependency is returned.
-    - the called function is a builtin: implemented. The dependency is ignored.
-    - the called function is a local: not implemented
-
-    :return:
-    """
-    deps = []
-    # case: dependency is a global
-    pending = []
-    names = py_func.__code__.co_names
-    fc_globals = py_func.__globals__
-    for var_name in names:
-        if var_name in fc_globals:
-            var_obj = fc_globals[var_name]
-            if isinstance(var_obj, Dispatcher):
-                deps.append(var_obj)
-            # else ignore, not a Dispatcher
-        else:
-            pending.append(var_name)
-
-    if not pending:
-        return deps
-    # Those pending names are now filtered if they are builtins
-    builtin_names = py_func.__builtins__
-    pending = [name for name in pending if name not in builtin_names]
-    if not pending:
-        return deps
-    # Those pending names (not globals) are now filtered to only keep
-    # function calls
-    ast_walker = ast.walk(ast.parse(inspect.getsource(py_func)))
-    fc_calls = [op.func.id for op in ast_walker if isinstance(op, ast.Call)]
-    pending = [name for name in pending if name in fc_calls]
-    if pending:
-        warnings.warn(f"Functions {pending} will be cached but changes made to "
-                      f"them might not be detected, resulting in possible use"
-                      f"of stale cached versions")
-    if not pending:
-        return deps
-    # case: function is a getitem or attribute of a global
-    # not yet implemented
-    return deps

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -2,14 +2,10 @@
 
 import inspect
 from contextlib import contextmanager
-import typing as pt
 
-from numba.core.utils import cached_property
 from numba.core import config, targetconfig
-from numba.core.caching_utils import get_index_info
 from numba.core.decorators import jit
 from numba.core.descriptors import TargetDescriptor
-from numba.core.dispatcher import Dispatcher
 from numba.core.extending import is_jitted
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.registry import cpu_target
@@ -103,18 +99,7 @@ class UFuncDispatcher(serialize.ReduceMixin):
         return cls(py_func=pyfunc, locals=locals, targetoptions=targetoptions)
 
     def enable_caching(self):
-        # provide a function for delayed calculation of the index key
-        def get_cache_index_key():
-            return self.cache_index_key
-
-        self.cache = FunctionCache(self.py_func, get_cache_index_key)
-
-    @cached_property
-    def cache_index_key(self,) -> pt.Tuple[str, str]:
-        """Hash the code of its function, the closure variables and add them
-        to the respective hashes of all its function dependencies
-        """
-        return get_index_info(self.py_func, (UFuncDispatcher, Dispatcher))
+        self.cache = FunctionCache(self.py_func)
 
     def compile(self, sig, locals={}, **targetoptions):
         locs = self.locals.copy()

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -2,10 +2,14 @@
 
 import inspect
 from contextlib import contextmanager
+import typing as pt
 
+from numba.core.utils import cached_property
 from numba.core import config, targetconfig
+from numba.core.caching_utils import get_index_info
 from numba.core.decorators import jit
 from numba.core.descriptors import TargetDescriptor
+from numba.core.dispatcher import Dispatcher
 from numba.core.extending import is_jitted
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.registry import cpu_target
@@ -99,7 +103,18 @@ class UFuncDispatcher(serialize.ReduceMixin):
         return cls(py_func=pyfunc, locals=locals, targetoptions=targetoptions)
 
     def enable_caching(self):
-        self.cache = FunctionCache(self.py_func)
+        # provide a function for delayed calculation of the index key
+        def get_cache_index_key():
+            return self.cache_index_key
+
+        self.cache = FunctionCache(self.py_func, get_cache_index_key)
+
+    @cached_property
+    def cache_index_key(self,) -> pt.Tuple[str, str]:
+        """Hash the code of its function, the closure variables and add them
+        to the respective hashes of all its function dependencies
+        """
+        return get_index_info(self.py_func, (UFuncDispatcher, Dispatcher))
 
     def compile(self, sig, locals={}, **targetoptions):
         locs = self.locals.copy()

--- a/numba/tests/cache_usecases.py
+++ b/numba/tests/cache_usecases.py
@@ -23,6 +23,9 @@ def simple_usecase(x):
 def simple_usecase_caller(x):
     return simple_usecase(x)
 
+def simple_usecase_caller2(x):
+    fc = simple_usecase
+    return fc(x)
 
 @jit(cache=True, nopython=True)
 def add_usecase(x, y):
@@ -97,6 +100,11 @@ def ambiguous_function(x):
     return x + 6
 
 renamed_function2 = ambiguous_function
+
+
+@jit(nopython=True)
+def call_ambiguous(x):
+    return renamed_function1(x)
 
 
 def make_closure(x):
@@ -182,3 +190,16 @@ def self_test():
 @jit(parallel=True, cache=True, nopython=True)
 def parfor_usecase(ary):
     return ary * ary + ary
+
+
+fc_tuple = (simple_usecase, )
+
+@jit(nopython=True)
+def call_tuple_member(x):
+    fc = fc_tuple[0]
+    return fc(x)
+
+class FcContainer:
+    fc = simple_usecase
+
+fc_container = FcContainer

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1290,7 +1290,7 @@ class TestFunctionDependencies(TestCase):
 
     def setUp(self) -> None:
         # self.use_cases_mod = import_dynamic("cache_usecases")
-
+        self.use_cases_mod = sys.modules["cache_usecases"]
     def test_simple1(self):
         # no dependencies, no variables
         fc = self.use_cases_mod.simple_usecase

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1127,6 +1127,11 @@ def function1(x):
 def function2(x):
     return x + 1
     """
+    def tearDown(self):
+        sys.modules.pop(self.modname, None)
+        sys.path.remove(self.tempdir)
+        shutil.rmtree(self.tempdir)
+
     def test_invalidation(self):
         # test cache is invalidated after source file modification
 
@@ -1225,6 +1230,13 @@ def function1(x):
 def function2(x):
     return x + 1
     """
+
+    def tearDown(self):
+        sys.modules.pop(self.modname, None)
+        sys.path.remove(self.tempdir)
+        shutil.rmtree(self.tempdir)
+
+
     def test_invalidation(self):
         # test cache is invalidated after source file modification
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -13,7 +13,7 @@ import traceback
 import unittest
 import warnings
 from numba import njit
-from numba.core import codegen
+from numba.core import codegen, types, dispatcher
 from numba.core.caching import _UserWideCacheLocator
 from numba.core.caching_utils import get_function_dependencies
 from numba.core.errors import NumbaWarning
@@ -1362,7 +1362,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.simple_usecase
         expected = []
-        self.assertEqual(expected, get_function_dependencies(fc.py_func))
+        self.assertEqual(expected, get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,)))
 
     def test_simple2(self):
         # 1 dependency on a simple function, no other variables.
@@ -1378,8 +1378,8 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.add_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
-        print(get_function_dependencies(fc.py_func))
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        print(get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,)))
         self.assertEqual(expected, res)
 
     def test_simple4(self):
@@ -1387,7 +1387,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.use_c_sin
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     @unittest.expectedFailure
@@ -1406,7 +1406,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.add_objmode_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     def test_generated_jit(self):
@@ -1414,7 +1414,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.generated_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     def test_ambiguous(self):
@@ -1422,7 +1422,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.call_ambiguous
         expected = ['ambiguous_function']
-        deps = get_function_dependencies(fc.py_func)
+        deps = get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))
         res = [fc.py_func.__name__ for fc in deps]
         self.assertEqual(expected, res)
         self.assertEqual(3, deps[0](1))
@@ -1432,7 +1432,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.closure4
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     def test_first_class_function(self):
@@ -1440,7 +1440,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.first_class_function_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func)]
+        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     @unittest.expectedFailure
@@ -1451,9 +1451,9 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.call_tuple_member
         expected = ['simple_usecase']
-        with warnings.catch_warnings(UserWarning):
+        with warnings.catch_warnings():
             res = [fc.py_func.__name__
-                   for fc in get_function_dependencies(fc.py_func)]
+                   for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
         self.assertEqual(expected, res)
 
     def test_getitem_warning(self):
@@ -1463,7 +1463,7 @@ class TestFunctionDependencies(BaseCacheTest):
         fc = mod.call_tuple_member
         expected = ['simple_usecase']
         with self.assertWarns(UserWarning) as uw:
-            get_function_dependencies(fc.py_func)
+            get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))
 
         self.assertIn("Functions ['fc'] will be cached", str(uw.warning))
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1285,11 +1285,11 @@ def function2(x):
         self.check_pycache(5)  # 1 index, 4 data for foo
         self.check_hits(fc, 0, 2)
 
-
+import cache_usecases
 class TestFunctionDependencies(TestCase):
 
     def setUp(self) -> None:
-        self.use_cases_mod = import_dynamic("cache_usecases")
+        # self.use_cases_mod = import_dynamic("cache_usecases")
 
     def test_simple1(self):
         # no dependencies, no variables

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 from typing import Iterable, List
 
@@ -1290,7 +1291,9 @@ class TestFunctionDependencies(TestCase):
 
     def setUp(self) -> None:
         # __import__("cache_usecases")
-        import cache_usecases
+        # import cache_usecases
+        importlib.invalidate_caches()
+        importlib.import_module("cache_usecases")
         # self.use_cases_mod = import_dynamic("cache_usecases")
         self.use_cases_mod = sys.modules["cache_usecases"]
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1357,12 +1357,19 @@ class TestFunctionDependencies(BaseCacheTest):
     usecases_file = os.path.join(here, "cache_usecases.py")
     modname = "caching_file_dep_fodder"
 
+    @staticmethod
+    def get_dep_disp(fc):
+        """ Retrieve all dispatchers on which the python function depends on
+        """
+        return get_function_dependencies(fc, (dispatcher.Dispatcher,))
+
     def test_simple1(self):
         # no dependencies, no variables
         mod = self.import_module()
         fc = mod.simple_usecase
         expected = []
-        self.assertEqual(expected, get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,)))
+        deps = self.get_dep_disp(fc.py_func)
+        self.assertEqual(expected, deps)
 
     def test_simple2(self):
         # 1 dependency on a simple function, no other variables.
@@ -1370,7 +1377,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.simple_usecase_caller
         expected = ['simple_usecase']
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc)]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc)]
         self.assertEqual(expected, res)
 
     def test_simple3(self):
@@ -1378,8 +1385,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.add_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
-        print(get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,)))
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     def test_simple4(self):
@@ -1387,7 +1393,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.use_c_sin
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     @unittest.expectedFailure
@@ -1397,8 +1403,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.simple_usecase_caller2
         expected = ['simple_usecase']
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc)]
-        print(res)
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc)]
         self.assertEqual(expected, res)
 
     def test_builtin_call(self):
@@ -1406,7 +1411,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.add_objmode_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     def test_generated_jit(self):
@@ -1414,7 +1419,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.generated_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     def test_ambiguous(self):
@@ -1422,7 +1427,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.call_ambiguous
         expected = ['ambiguous_function']
-        deps = get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))
+        deps = self.get_dep_disp(fc.py_func)
         res = [fc.py_func.__name__ for fc in deps]
         self.assertEqual(expected, res)
         self.assertEqual(3, deps[0](1))
@@ -1432,7 +1437,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.closure4
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     def test_first_class_function(self):
@@ -1440,7 +1445,7 @@ class TestFunctionDependencies(BaseCacheTest):
         mod = self.import_module()
         fc = mod.first_class_function_usecase
         expected = []
-        res = [fc.py_func.__name__ for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+        res = [fc.py_func.__name__ for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     @unittest.expectedFailure
@@ -1453,7 +1458,7 @@ class TestFunctionDependencies(BaseCacheTest):
         expected = ['simple_usecase']
         with warnings.catch_warnings():
             res = [fc.py_func.__name__
-                   for fc in get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))]
+                   for fc in self.get_dep_disp(fc.py_func)]
         self.assertEqual(expected, res)
 
     def test_getitem_warning(self):
@@ -1463,7 +1468,7 @@ class TestFunctionDependencies(BaseCacheTest):
         fc = mod.call_tuple_member
         expected = ['simple_usecase']
         with self.assertWarns(UserWarning) as uw:
-            get_function_dependencies(fc.py_func, (dispatcher.Dispatcher,))
+            self.get_dep_disp(fc.py_func)
 
         self.assertIn("Functions ['fc'] will be cached", str(uw.warning))
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1138,11 +1138,11 @@ def function2(x):
         sys.path.insert(0, self.tempdir)
         file1 = self.import_module()
         fc = file1.foo
-        import inspect
-        print(fc.cache_index_key, fc(2))
-        print(inspect.getsource(fc.py_func.__globals__['function2']))
-        print("functio2 cache",
-              (fc.py_func.__globals__['function2'].cache_index_key))
+        # import inspect
+        # print(fc.cache_index_key, fc(2))
+        # print(inspect.getsource(fc.py_func.__globals__['function2']))
+        # print("functio2 cache",
+        #       (fc.py_func.__globals__['function2'].cache_index_key))
         self.assertPreciseEqual(fc(2), 2)
         self.check_pycache(4)  # 2 index, 2 data for each function
         self.assertPreciseEqual(fc(2.5), 2.5)
@@ -1168,14 +1168,14 @@ def function2(x):
             print(self.source_text_file2_alt, file=fout)
 
 
-        print("### importing module #")
+        # print("### importing module #")
         file1, file2 = self.import_modules(
             ["file1", "file2"], [self.file1, self.file2]
         )
         fc = file1.foo
 
-        print(inspect.getsource(fc.py_func.__globals__['function2']))
-        print("function2 cache", (fc.py_func.__globals__['function2'].cache_index_key))
+        # print(inspect.getsource(fc.py_func.__globals__['function2']))
+        # print("function2 cache", (fc.py_func.__globals__['function2'].cache_index_key))
         # print(fc.cache_index_key, fc(2))
         self.assertPreciseEqual(fc(2), 3)
         # 2 index, 3 data for foo function (2 from previous function2 versions
@@ -1235,18 +1235,18 @@ def function2(x):
         sys.path.insert(0, self.tempdir)
         file1 = self.import_module()
         fc = file1.foo
-        import inspect
-        print(fc.cache_index_key, fc(2))
-        print(inspect.getsource(fc.py_func.__globals__['function2']))
-        print("functio2 cache",
-              (fc.py_func.__globals__['function2'].cache_index_key))
+        # import inspect
+        # print(fc.cache_index_key, fc(2))
+        # print(inspect.getsource(fc.py_func.__globals__['function2']))
+        # print("functio2 cache",
+        #       (fc.py_func.__globals__['function2'].cache_index_key))
         self.assertPreciseEqual(fc(2), 2)
         self.check_pycache(2)  # 1 index, 1 data only for foo
         self.assertPreciseEqual(fc(2.5), 2.5)
         self.check_pycache(3)  # 1 index, 2 data for foo
         self.check_hits(fc, 0, 2)
 
-        print("### importing module #")
+        # print("### importing module #")
         del fc
         del file1
         file1, file2 = self.import_modules(
@@ -1265,14 +1265,14 @@ def function2(x):
             print(self.source_text_file2_alt, file=fout)
 
 
-        print("### importing module #")
+        # print("### importing module #")
         file1, file2 = self.import_modules(
             ["file1", "file2"], [self.file1, self.file2]
         )
         fc = file1.foo
 
-        print(inspect.getsource(fc.py_func.__globals__['function2']))
-        print("function2 cache", (fc.py_func.__globals__['function2'].cache_index_key))
+        # print(inspect.getsource(fc.py_func.__globals__['function2']))
+        # print("function2 cache", (fc.py_func.__globals__['function2'].cache_index_key))
         # print(fc.cache_index_key, fc(2))
         self.assertPreciseEqual(fc(2), 3)
         # 1 index, 3 data for foo function (2 from previous function2 versions

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1392,7 +1392,5 @@ class TestFunctionDependencies(TestCase):
     def test_global(self):
         pass
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -15,8 +15,8 @@ import warnings
 from numba import njit
 from numba.core import codegen
 from numba.core.caching import _UserWideCacheLocator
+from numba.core.caching_utils import get_function_dependencies
 from numba.core.errors import NumbaWarning
-from numba.core.dispatcher import get_function_dependencies
 from numba.parfors import parfor
 from numba.tests.support import (
     TestCase,
@@ -1093,8 +1093,7 @@ class TestCFuncCache(BaseCacheTest):
         self.run_in_separate_process()
 
 
-class TestCachingModifiedFiles2(DispatcherCacheUsecasesTest
-):
+class TestCachingModifiedFiles2(DispatcherCacheUsecasesTest):
     source_text_file1 = """
 from numba import njit
 from file2 import function2
@@ -1127,7 +1126,8 @@ def function2(x):
     return x + 1
     """
     def setUp(self):
-        self.tempdir = temp_directory('test_cache_file_loc')
+        self.tempdir = temp_directory('test_cache_file_modfiles2')
+        self.cache_dir = os.path.join(self.tempdir, "__pycache__")
 
         self.file1 = os.path.join(self.tempdir, 'file1.py')
         with open(self.file1, 'w') as fout:
@@ -1139,6 +1139,7 @@ def function2(x):
 
     def tearDown(self):
         sys.modules.pop(self.modname, None)
+        sys.modules.pop("file2", None)
         sys.path.remove(self.tempdir)
         shutil.rmtree(self.tempdir)
 
@@ -1223,8 +1224,7 @@ def function2(x):
         self.check_hits(fc, 0, 2)
 
 
-class TestCachingModifiedFiles3(DispatcherCacheUsecasesTest
-):
+class TestCachingModifiedFiles3(DispatcherCacheUsecasesTest):
     source_text_file1 = """
 from numba import njit
 from file2 import function2
@@ -1257,7 +1257,8 @@ def function2(x):
     return x + 1
     """
     def setUp(self):
-        self.tempdir = temp_directory('test_cache_file_loc')
+        self.tempdir = temp_directory('test_cache_file_modfiles3')
+        self.cache_dir = os.path.join(self.tempdir, "__pycache__")
 
         self.file1 = os.path.join(self.tempdir, 'file1.py')
         with open(self.file1, 'w') as fout:
@@ -1269,6 +1270,7 @@ def function2(x):
 
     def tearDown(self):
         sys.modules.pop(self.modname, None)
+        sys.modules.pop("file2", None)
         sys.path.remove(self.tempdir)
         shutil.rmtree(self.tempdir)
 

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1289,9 +1289,11 @@ def function2(x):
 class TestFunctionDependencies(TestCase):
 
     def setUp(self) -> None:
-        __import__("cache_usecases")
+        # __import__("cache_usecases")
+        import cache_usecases
         # self.use_cases_mod = import_dynamic("cache_usecases")
         self.use_cases_mod = sys.modules["cache_usecases"]
+
     def test_simple1(self):
         # no dependencies, no variables
         fc = self.use_cases_mod.simple_usecase

--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -1285,10 +1285,11 @@ def function2(x):
         self.check_pycache(5)  # 1 index, 4 data for foo
         self.check_hits(fc, 0, 2)
 
-import cache_usecases
+# import cache_usecases
 class TestFunctionDependencies(TestCase):
 
     def setUp(self) -> None:
+        __import__("cache_usecases")
         # self.use_cases_mod = import_dynamic("cache_usecases")
         self.use_cases_mod = sys.modules["cache_usecases"]
     def test_simple1(self):


### PR DESCRIPTION
This PR extends the cache invalidation mechanism to detect changes in functions imported from other files and used in the main function. It does that by including the code and closure variables of any dispatcher called in the main function in the index key used in the cache.

This PR is still a draft.

Implementation notes:
 - The process is recursive. Each function hashes its own code and closures, and that of its direct dependencies.
 - The merging of the code and closure is not done at the content level and then hashed. Since the process is recursive, the content of one functions is concatenated with the **hashed** content of its dependencies and then hashed. Intuitively this is ok, but it should be confirmed by someone with better understanding of hash functions.
 - since the index_key is now a property of the dispatcher object, it's necessary to pass it to the cache object.

Open questions:
- what to do with ever growing cache size?
- should invalidation of cache index be based on code signature, not on file timestamp?

TODO:
- clean tests


