### PR TITLE
implement new Python 3.11 opcode: RESUME

### DIFF
--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -287,6 +287,9 @@ class TraceRunner(object):
     def op_NOP(self, state, inst):
         state.append(inst)
 
+    def op_RESUME(self, state, inst):
+        state.append(inst)
+
     def op_FORMAT_VALUE(self, state, inst):
         """
         FORMAT_VALUE(flags): flags argument specifies format spec which is

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -1709,6 +1709,9 @@ class Interpreter(object):
     def op_NOP(self, inst):
         pass
 
+    def op_RESUME(self, inst):
+        pass
+
     def op_PRINT_ITEM(self, inst, item, printvar, res):
         item = self.get(item)
         printgv = ir.Global("print", print, loc=self.loc)


### PR DESCRIPTION
With Python 3.11 a new Bytecode has been introduced: `RESUME`.

The documentation states that:

```
RESUME has been added. It is a no-op. Performs internal tracing, debugging and optimization checks.
```

And so, this is implemented as a `NOP` (no-operation) in Numba.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
