### PR TITLE
Move strace() check into tests that actually need it.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -1129,7 +1129,7 @@ def strace(work, syscalls, timeout=10):
     return strace_data
 
 
-def _strace_supported():
+def strace_supported():
     """Checks if strace is supported and working"""
 
     # Only support this on linux where the `strace` binary is likely to be the
@@ -1146,12 +1146,6 @@ def _strace_supported():
     except Exception:
         return False
     return syscall in ''.join(trace)
-
-
-_HAVE_STRACE = _strace_supported()
-
-
-needs_strace = unittest.skipUnless(_HAVE_STRACE, "needs working strace")
 
 
 class IRPreservingTestPipeline(CompilerBase):

--- a/numba/tests/test_withlifting.py
+++ b/numba/tests/test_withlifting.py
@@ -19,8 +19,8 @@ from numba.core.compiler import compile_ir, DEFAULT_FLAGS
 from numba import njit, typeof, objmode, types
 from numba.core.extending import overload
 from numba.tests.support import (MemoryLeak, TestCase, captured_stdout,
-                                 skip_unless_scipy, needs_strace, linux_only,
-                                 strace)
+                                 skip_unless_scipy, linux_only,
+                                 strace_supported, strace)
 from numba.core.utils import PYVERSION
 from numba.experimental import jitclass
 import unittest
@@ -1226,7 +1226,6 @@ class TestMisc(TestCase):
     _numba_parallel_test_ = False
 
     @linux_only
-    @needs_strace
     @TestCase.run_test_in_subprocess
     def test_no_fork_in_compilation(self):
         # Checks that there is no fork/clone/execve during compilation, see
@@ -1234,6 +1233,10 @@ class TestMisc(TestCase):
         # call that triggered #7881 occurs on the first call to uuid1 as it's
         # part if the initialisation process for that function (gets hardware
         # address of machine).
+
+        if not strace_supported():
+            # Needs strace support.
+            self.skipTest("strace support missing")
 
         def force_compile():
             @njit('void()') # force compilation


### PR DESCRIPTION
Having the strace() check on the import path for
`numba.tests.support` leads to the check occurring at every run of
a test in a subprocess. This moves the check for `strace()`
support to the point of use.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
