### PR TITLE
Make C++ extensions compile with correct compiler

### DIFF
--- a/docs/source/developer/repomap.rst
+++ b/docs/source/developer/repomap.rst
@@ -201,7 +201,7 @@ with CPython APIs.
 - :ghfile:`numba/_pymodule.h` - C macros for Python 2/3 portable naming of C
   API functions
 - :ghfile:`numba/mviewbuf.c` - Handles Python memoryviews
-- :ghfile:`numba/_typeof.{h,c}` - C implementation of type fingerprinting,
+- :ghfile:`numba/_typeof.{h,cpp}` - C++ implementation of type fingerprinting,
   used by dispatcher
 - :ghfile:`numba/_numba_common.h` - Portable C macro for marking symbols
   that can be shared between object files, but not outside the
@@ -267,7 +267,7 @@ Misc Support
 Core Python Data Types
 ''''''''''''''''''''''
 
-- :ghfile:`numba/_hashtable.{h,c}` - Adaptation of the Python 3.7 hash table
+- :ghfile:`numba/_hashtable.{h,cpp}` - Adaptation of the Python 3.7 hash table
   implementation
 - :ghfile:`numba/cext/dictobject.{h,c}` - C level implementation of typed
   dictionary

--- a/numba/_hashtable.h
+++ b/numba/_hashtable.h
@@ -71,15 +71,15 @@ typedef struct {
 } _Numba_hashtable_t;
 
 /* hash and compare functions for integers and pointers */
-PyAPI_FUNC(Py_uhash_t) _Numba_hashtable_hash_ptr(const void *key);
-PyAPI_FUNC(Py_uhash_t) _Numba_hashtable_hash_int(const void *key);
-PyAPI_FUNC(int) _Numba_hashtable_compare_direct(const void *key, const _Numba_hashtable_entry_t *entry);
+extern "C" PyAPI_FUNC(Py_uhash_t) _Numba_hashtable_hash_ptr(const void *key);
+extern "C" PyAPI_FUNC(Py_uhash_t) _Numba_hashtable_hash_int(const void *key);
+extern "C" PyAPI_FUNC(int) _Numba_hashtable_compare_direct(const void *key, const _Numba_hashtable_entry_t *entry);
 
-PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_new(
+extern "C" PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_new(
     size_t data_size,
     _Numba_hashtable_hash_func hash_func,
     _Numba_hashtable_compare_func compare_func);
-PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_new_full(
+extern "C" PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_new_full(
     size_t data_size,
     size_t init_size,
     _Numba_hashtable_hash_func hash_func,
@@ -88,36 +88,36 @@ PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_new_full(
     _Numba_hashtable_free_data_func free_data_func,
     _Numba_hashtable_get_data_size_func get_data_size_func,
     _Numba_hashtable_allocator_t *allocator);
-PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_copy(_Numba_hashtable_t *src);
-PyAPI_FUNC(void) _Numba_hashtable_clear(_Numba_hashtable_t *ht);
-PyAPI_FUNC(void) _Numba_hashtable_destroy(_Numba_hashtable_t *ht);
+extern "C" PyAPI_FUNC(_Numba_hashtable_t *) _Numba_hashtable_copy(_Numba_hashtable_t *src);
+extern "C" PyAPI_FUNC(void) _Numba_hashtable_clear(_Numba_hashtable_t *ht);
+extern "C" PyAPI_FUNC(void) _Numba_hashtable_destroy(_Numba_hashtable_t *ht);
 
 typedef int (*_Numba_hashtable_foreach_func) (_Numba_hashtable_entry_t *entry, void *arg);
 
-PyAPI_FUNC(int) _Numba_hashtable_foreach(
+extern "C" PyAPI_FUNC(int) _Numba_hashtable_foreach(
     _Numba_hashtable_t *ht,
     _Numba_hashtable_foreach_func func, void *arg);
-PyAPI_FUNC(size_t) _Numba_hashtable_size(_Numba_hashtable_t *ht);
+extern "C" PyAPI_FUNC(size_t) _Numba_hashtable_size(_Numba_hashtable_t *ht);
 
-PyAPI_FUNC(_Numba_hashtable_entry_t*) _Numba_hashtable_get_entry(
+extern "C" PyAPI_FUNC(_Numba_hashtable_entry_t*) _Numba_hashtable_get_entry(
     _Numba_hashtable_t *ht,
     const void *key);
-PyAPI_FUNC(int) _Numba_hashtable_set(
+extern "C" PyAPI_FUNC(int) _Numba_hashtable_set(
     _Numba_hashtable_t *ht,
     const void *key,
     void *data,
     size_t data_size);
-PyAPI_FUNC(int) _Numba_hashtable_get(
+extern "C" PyAPI_FUNC(int) _Numba_hashtable_get(
     _Numba_hashtable_t *ht,
     const void *key,
     void *data,
     size_t data_size);
-PyAPI_FUNC(int) _Numba_hashtable_pop(
+extern "C" PyAPI_FUNC(int) _Numba_hashtable_pop(
     _Numba_hashtable_t *ht,
     const void *key,
     void *data,
     size_t data_size);
-PyAPI_FUNC(void) _Numba_hashtable_delete(
+extern "C" PyAPI_FUNC(void) _Numba_hashtable_delete(
     _Numba_hashtable_t *ht,
     const void *key);
 

--- a/numba/_typeof.cpp
+++ b/numba/_typeof.cpp
@@ -101,9 +101,9 @@ string_writer_ensure(string_writer_t *w, size_t bytes)
     if (newsize < bytes)
         newsize = bytes;
     if (w->buf == w->static_buf)
-        w->buf = malloc(newsize);
+        w->buf = (char *) malloc(newsize);
     else
-        w->buf = realloc(w->buf, newsize);
+        w->buf = (char *) realloc(w->buf, newsize);
     if (w->buf) {
         w->allocated = newsize;
         return 0;
@@ -842,6 +842,10 @@ int typecode_devicendarray(PyObject *dispatcher, PyObject *ary)
     int dtype;
     int ndim;
     int layout = 0;
+    PyObject *ndim_obj = nullptr;
+    PyObject* num_obj = nullptr;
+    PyObject* dtype_obj = nullptr;
+    int dtype_num = 0;
 
     PyObject* flags = PyObject_GetAttrString(ary, "flags");
     if (flags == NULL)
@@ -858,7 +862,7 @@ int typecode_devicendarray(PyObject *dispatcher, PyObject *ary)
 
     Py_DECREF(flags);
 
-    PyObject *ndim_obj = PyObject_GetAttrString(ary, "ndim");
+    ndim_obj = PyObject_GetAttrString(ary, "ndim");
     if (ndim_obj == NULL) {
         /* If there's no ndim, try to proceed by clearing the error and using the
          * fallback. */
@@ -879,14 +883,14 @@ int typecode_devicendarray(PyObject *dispatcher, PyObject *ary)
     if (ndim <= 0 || ndim > N_NDIM)
         goto FALLBACK;
 
-    PyObject* dtype_obj = PyObject_GetAttrString(ary, "dtype");
+    dtype_obj = PyObject_GetAttrString(ary, "dtype");
     if (dtype_obj == NULL) {
         /* No dtype: try the fallback. */
         PyErr_Clear();
         goto FALLBACK;
     }
 
-    PyObject* num_obj = PyObject_GetAttrString(dtype_obj, "num");
+    num_obj = PyObject_GetAttrString(dtype_obj, "num");
     Py_DECREF(dtype_obj);
 
     if (num_obj == NULL) {
@@ -895,7 +899,7 @@ int typecode_devicendarray(PyObject *dispatcher, PyObject *ary)
         goto FALLBACK;
     }
 
-    int dtype_num = PyLong_AsLong(num_obj);
+    dtype_num = PyLong_AsLong(num_obj);
     Py_DECREF(num_obj);
 
     if (PyErr_Occurred()) {
@@ -934,7 +938,7 @@ FALLBACK:
     return typecode_using_fingerprint(dispatcher, (PyObject *) ary);
 }
 
-int
+extern "C" int
 typeof_typecode(PyObject *dispatcher, PyObject *val)
 {
     PyTypeObject *tyobj = Py_TYPE(val);
@@ -1051,7 +1055,7 @@ int init_numpy(void) {
  * typeof_init(omittedarg_type, typecode_dict)
  * (called from dispatcher.py to fill in missing information)
  */
-PyObject *
+extern "C" PyObject *
 typeof_init(PyObject *self, PyObject *args)
 {
     PyObject *tmpobj;

--- a/numba/_typeof.cpp
+++ b/numba/_typeof.cpp
@@ -843,8 +843,8 @@ int typecode_devicendarray(PyObject *dispatcher, PyObject *ary)
     int ndim;
     int layout = 0;
     PyObject *ndim_obj = nullptr;
-    PyObject* num_obj = nullptr;
-    PyObject* dtype_obj = nullptr;
+    PyObject *num_obj = nullptr;
+    PyObject *dtype_obj = nullptr;
     int dtype_num = 0;
 
     PyObject* flags = PyObject_GetAttrString(ary, "flags");

--- a/setup.py
+++ b/setup.py
@@ -161,12 +161,13 @@ def get_ext_modules():
 
     ext_dispatcher = Extension(name="numba._dispatcher",
                                sources=['numba/_dispatcher.cpp',
-                                        'numba/_typeof.c',
-                                        'numba/_hashtable.c',
+                                        'numba/_typeof.cpp',
+                                        'numba/_hashtable.cpp',
                                         'numba/core/typeconv/typeconv.cpp'],
                                depends=["numba/_pymodule.h",
                                         "numba/_typeof.h",
                                         "numba/_hashtable.h"],
+                               extra_compile_args=['-std=c++11'],
                                **np_compile_args)
 
     ext_helperlib = Extension(name="numba._helperlib",
@@ -191,6 +192,7 @@ def get_ext_modules():
                              sources=["numba/core/typeconv/typeconv.cpp",
                                       "numba/core/typeconv/_typeconv.cpp"],
                              depends=["numba/_pymodule.h"],
+                             extra_compile_args=['-std=c++11'],
                              )
 
     ext_np_ufunc = Extension(name="numba.np.ufunc._internal",


### PR DESCRIPTION
Some extension files are C++ but have `.c` extensions. GCC will compile these
as C++, but clang will not.