### PR TITLE
Use NumPy logic for lessthan in sort to move NaNs to the back.

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -5665,7 +5665,11 @@ _sorts = {}
 
 
 def lt_floats(a, b):
-    return math.isnan(b) or a < b
+    # Adapted from NumPy commit 717c7acf which introduced the behavior of
+    # putting NaNs at the end.
+    # The code is later moved to numpy/core/src/npysort/npysort_common.h
+    # This info is gathered as of NumPy commit d8c09c50
+    return a < b or (np.isnan(b) and not np.isnan(a))
 
 
 def get_sort_func(kind, is_float, is_argsort=False):

--- a/numba/tests/test_sort.py
+++ b/numba/tests/test_sort.py
@@ -831,6 +831,11 @@ class TestNumpySort(TestCase):
             orig = np.random.random(size=size) * 100
             orig[np.random.random(size=size) < 0.1] = float('nan')
             yield orig
+        # 90% of values are NaNs.
+        for size in (50, 500):
+            orig = np.random.random(size=size) * 100
+            orig[np.random.random(size=size) < 0.9] = float('nan')
+            yield orig
 
     def has_duplicates(self, arr):
         """


### PR DESCRIPTION
Fix #8382.

With this patch Numba is faster than NumPy using the reproducer from the issue:

```python
from numba import njit
import numpy as np

@njit
def test(a):
    return np.sort(a)

arr = np.full(100_000, np.nan)
# compile it
test(arr[:10])

%time test(arr)
# CPU times: user 1.27 ms, sys: 153 µs, total: 1.42 ms
# Wall time: 1.42 ms

%time test.py_func(arr)
# CPU times: user 2.65 ms, sys: 39 µs, total: 2.69 ms
# Wall time: 2.72 ms
```