### PR TITLE
fix compilation error on mac

### DIFF
--- a/numba/core/typeconv/typeconv.cpp
+++ b/numba/core/typeconv/typeconv.cpp
@@ -27,7 +27,11 @@ void TCCMap::insert(const TypePair &key, TypeCompatibleCode val) {
             return;
         }
     }
-    bin.push_back({key, val});
+    TCCRecord data;
+    data.key = key;
+    data.val = val;
+    bin.push_back(data);
+//    bin.push_back({key, val});
     nb_records++;
 }
 

--- a/numba/core/typeconv/typeconv.cpp
+++ b/numba/core/typeconv/typeconv.cpp
@@ -31,7 +31,6 @@ void TCCMap::insert(const TypePair &key, TypeCompatibleCode val) {
     data.key = key;
     data.val = val;
     bin.push_back(data);
-//    bin.push_back({key, val});
     nb_records++;
 }
 


### PR DESCRIPTION
Fixes https://github.com/numba/numba/issues/8222.

I tried on my MacOS, with clang 13.1.6 installed.

Just revert several changed line in https://github.com/numba/numba/pull/7364.

But I still to set envvar `NUMBA_DISABLE_OPENMP=1` to avoid another compilation error `clang: error: unsupported option '-fopenmp'`. I feel the new error is unrelated with this PR.