### PR TITLE
Remove old warning about imports after SVML init

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -211,12 +211,3 @@ import llvmlite
 Is set to True if Intel SVML is in use.
 """
 config.USING_SVML = _try_enable_svml()
-
-
-# ---------------------- WARNING WARNING WARNING ----------------------------
-# The following imports occur below here (SVML init) because somewhere in their
-# import sequence they have a `@njit` wrapped function. This triggers too early
-# a bind to the underlying LLVM libraries which then irretrievably sets the LLVM
-# SVML state to "no SVML". See https://github.com/numba/numba/issues/4689 for
-# context.
-# ---------------------- WARNING WARNING WARNING ----------------------------


### PR DESCRIPTION
This warning applied to imports that followed SVML initialization, but now there are none.

Related question - do we have a test that ensures that nothing is `@njit`-ed during Numba import?