### PR TITLE
Refactor `numba.np.arraymath` methods from lower_builtins to overloads

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -391,6 +391,8 @@ Reductions
 The following reduction functions are supported:
 
 * :func:`numpy.diff` (only the 2 first arguments)
+* :func:`numpy.amin` (only the first argument, also aliased as np.min)
+* :func:`numpy.amax` (only the first argument, also aliased as np.max)
 * :func:`numpy.median` (only the first argument)
 * :func:`numpy.nancumprod` (only the first argument)
 * :func:`numpy.nancumsum` (only the first argument)

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -816,8 +816,10 @@ def install_array_method(name, generic, prefer_literal=True):
 
     setattr(ArrayAttribute, "resolve_" + name, array_attribute_attachment)
 
+
 # Functions that return a machine-width type, to avoid overflows
 install_array_method("sum", sum_expand, prefer_literal=True)
+
 
 @infer_global(operator.eq)
 class CmpOpEqArray(AbstractTemplate):

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -816,27 +816,8 @@ def install_array_method(name, generic, prefer_literal=True):
 
     setattr(ArrayAttribute, "resolve_" + name, array_attribute_attachment)
 
-# Functions that return the same type as the array
-for fname in ["min", "max"]:
-    install_array_method(fname, generic_homog)
-
 # Functions that return a machine-width type, to avoid overflows
-install_array_method("prod", generic_expand)
 install_array_method("sum", sum_expand, prefer_literal=True)
-
-# Functions that return a machine-width type, to avoid overflows
-for fname in ["cumsum", "cumprod"]:
-    install_array_method(fname, generic_expand_cumulative)
-
-# Functions that require integer arrays get promoted to float64 return
-for fName in ["mean"]:
-    install_array_method(fName, generic_hetero_real)
-
-# var and std by definition return in real space and int arrays
-# get promoted to float64 return
-for fName in ["var", "std"]:
-    install_array_method(fName, generic_hetero_always_real)
-
 
 @infer_global(operator.eq)
 class CmpOpEqArray(AbstractTemplate):

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -413,6 +413,7 @@ def _numpy_redirect(fname):
                dict(key=numpy_function, method_name=fname))
     infer_global(numpy_function, types.Function(cls))
 
+
 for func in ['sum', 'argsort', 'nonzero', 'ravel']:
     _numpy_redirect(func)
 

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -413,8 +413,7 @@ def _numpy_redirect(fname):
                dict(key=numpy_function, method_name=fname))
     infer_global(numpy_function, types.Function(cls))
 
-for func in ['min', 'max', 'sum', 'prod', 'mean', 'var', 'std',
-             'cumsum', 'cumprod', 'argsort', 'nonzero', 'ravel']:
+for func in ['sum', 'argsort', 'nonzero', 'ravel']:
     _numpy_redirect(func)
 
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -358,9 +358,9 @@ def array_prod(arr):
         dtype = as_dtype(arr.dtype)
 
         if dtype.type == np.timedelta64:
-            acc_init = np.int64(0).view(dtype)
+            acc_init = np.int64(1).view(dtype)
         else:
-            acc_init = dtype.type(0)
+            acc_init = dtype.type(1)
 
         def array_prod_impl(arr):
             c = acc_init
@@ -412,9 +412,9 @@ def array_cumprod(arr):
             dtype = as_dtype(arr.dtype)
 
         if dtype.type == np.timedelta64:
-            acc_init = np.int64(0).view(dtype)
+            acc_init = np.int64(1).view(dtype)
         else:
-            acc_init = dtype.type(0)
+            acc_init = dtype.type(1)
 
         def array_cumprod_impl(arr):
             out = np.empty(arr.size, dtype)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -351,16 +351,21 @@ def array_sum_axis(context, builder, sig, args):
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
 
+def get_accumulator(dtype, value):
+    if dtype.type == np.timedelta64:
+        acc_init = np.int64(value).view(dtype)
+    else:
+        acc_init = dtype.type(value)
+    return acc_init
+
+
 @overload(np.prod)
 @overload_method(types.Array, "prod")
 def array_prod(arr):
     if isinstance(arr, types.Array):
         dtype = as_dtype(arr.dtype)
 
-        if dtype.type == np.timedelta64:
-            acc_init = np.int64(1).view(dtype)
-        else:
-            acc_init = dtype.type(1)
+        acc_init = get_accumulator(dtype, 1)
 
         def array_prod_impl(arr):
             c = acc_init
@@ -383,10 +388,7 @@ def array_cumsum(arr):
         else:
             dtype = as_dtype(arr.dtype)
 
-        if dtype.type == np.timedelta64:
-            acc_init = np.int64(0).view(dtype)
-        else:
-            acc_init = dtype.type(0)
+        acc_init = get_accumulator(dtype, 0)
 
         def array_cumsum_impl(arr):
             out = np.empty(arr.size, dtype)
@@ -411,10 +413,7 @@ def array_cumprod(arr):
         else:
             dtype = as_dtype(arr.dtype)
 
-        if dtype.type == np.timedelta64:
-            acc_init = np.int64(1).view(dtype)
-        else:
-            acc_init = dtype.type(1)
+        acc_init = get_accumulator(dtype, 1)
 
         def array_cumprod_impl(arr):
             out = np.empty(arr.size, dtype)
@@ -437,10 +436,7 @@ def array_mean(arr):
         else:
             dtype = as_dtype(arr.dtype)
 
-        if dtype.type == np.timedelta64:
-            acc_init = np.int64(0).view(dtype)
-        else:
-            acc_init = dtype.type(0)
+        acc_init = get_accumulator(dtype, 0)
 
         def array_mean_impl(arr):
             # Can't use the naive `arr.sum() / arr.size`, as it would return

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -445,7 +445,7 @@ def zero_dim_msg(fn_name):
 
 @overload(np.min)
 @overload_method(types.Array, "min")
-def npy_min(x, axis=None):
+def npy_min(x):
     if isinstance(x.dtype, (types.NPDatetime, types.NPTimedelta)):
         pre_return_func = njit(lambda x: np.isnat(x))
         comparator = njit(lambda x, min_val: x < min_val)
@@ -490,7 +490,7 @@ def npy_min(x, axis=None):
 
 @overload(np.max)
 @overload_method(types.Array, "max")
-def npy_max(x, axis=None):
+def npy_max(x):
     if isinstance(x.dtype, (types.NPDatetime, types.NPTimedelta)):
         pre_return_func = njit(lambda x: np.isnat(x))
         comparator = njit(lambda x, max_val: x > max_val)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -439,7 +439,7 @@ def array_std(x):
 
 def zero_dim_msg(fn_name):
     msg = ("zero-size array to reduction operation "
-           "{0} which has no identity".format(fn_name))
+           f"{fn_name} which has no identity")
     return msg
 
 
@@ -468,9 +468,11 @@ def npy_min(x):
         pre_return_func = njit(lambda x: False)
         comparator = njit(lambda x, min_val: x < min_val)
 
+    fail_str = zero_dim_msg("minimum")
+
     def impl_min(x):
         if x.size == 0:
-            raise ValueError(zero_dim_msg("minimum"))
+            raise ValueError(fail_str)
 
         it = np.nditer(x)
         min_value = next(it).take(0)
@@ -513,9 +515,11 @@ def npy_max(x):
         pre_return_func = njit(lambda x: False)
         comparator = njit(lambda x, max_val: x > max_val)
 
+    fail_str = zero_dim_msg("maximum")
+
     def impl_max(x):
         if x.size == 0:
-            raise ValueError(zero_dim_msg("maximum"))
+            raise ValueError(fail_str)
 
         it = np.nditer(x)
         max_value = next(it).take(0)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -368,8 +368,10 @@ def array_prod(arr):
 @overload_method(types.Array, "cumsum")
 def array_cumsum(arr):
     if isinstance(arr, types.Array):
-        is_integer = arr.dtype in types.signed_domain | frozenset([types.bool_])
-        if is_integer:
+        is_integer = arr.dtype in types.signed_domain
+        is_bool = arr.dtype == types.bool_
+        if (is_integer and arr.dtype.bitwidth < types.intp.bitwidth)\
+                or is_bool:
             dtype = np.intp
         else:
             dtype = arr.dtype
@@ -389,8 +391,10 @@ def array_cumsum(arr):
 @overload_method(types.Array, "cumprod")
 def array_cumprod(arr):
     if isinstance(arr, types.Array):
-        is_integer = arr.dtype in types.signed_domain | frozenset([types.bool_])
-        if is_integer:
+        is_integer = arr.dtype in types.signed_domain
+        is_bool = arr.dtype == types.bool_
+        if (is_integer and arr.dtype.bitwidth < types.intp.bitwidth)\
+                or is_bool:
             dtype = np.intp
         else:
             dtype = arr.dtype

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -369,12 +369,12 @@ def array_prod(arr):
 def array_cumsum(arr):
     if isinstance(arr, types.Array):
         is_integer = arr.dtype in types.signed_domain | frozenset([types.bool_])
+        if is_integer:
+            dtype = np.intp
+        else:
+            dtype = arr.dtype
 
         def array_cumsum_impl(arr):
-            if is_integer:
-                dtype = np.intp
-            else:
-                dtype = arr.dtype
             out = np.empty(arr.size, dtype)
             c = np.zeros(1, dtype)[0]
             for idx, v in enumerate(arr.flat):
@@ -390,12 +390,12 @@ def array_cumsum(arr):
 def array_cumprod(arr):
     if isinstance(arr, types.Array):
         is_integer = arr.dtype in types.signed_domain | frozenset([types.bool_])
+        if is_integer:
+            dtype = np.intp
+        else:
+            dtype = arr.dtype
 
         def array_cumprod_impl(arr):
-            if is_integer:
-                dtype = np.intp
-            else:
-                dtype = arr.dtype
             out = np.empty(arr.size, dtype)
             c = np.ones(1, dtype)[0]
             for idx, v in enumerate(arr.flat):
@@ -411,14 +411,14 @@ def array_cumprod(arr):
 def array_mean(arr):
     if isinstance(arr, types.Array):
         is_number = arr.dtype in types.integer_domain | frozenset([types.bool_])
+        if is_number:
+            dtype = types.float64
+        else:
+            dtype = arr.dtype
 
         def array_mean_impl(arr):
             # Can't use the naive `arr.sum() / arr.size`, as it would return
             # a wrong result on integer sum overflow.
-            if is_number:
-                dtype = types.float64
-            else:
-                dtype = arr.dtype
             c = np.zeros(1, dtype)[0]
             for v in np.nditer(arr):
                 c += v.item()

--- a/numba/tests/test_errorhandling.py
+++ b/numba/tests/test_errorhandling.py
@@ -453,14 +453,14 @@ class TestDeveloperSpecificErrorMessages(SerialMixin, unittest.TestCase):
     def test_bound_function_error_string(self):
         # See PR #5952
         def foo(x):
-            x.max(-1) # axis not supported
+            x.max(-1)
 
         with override_config('DEVELOPER_MODE', 1):
             with self.assertRaises(errors.TypingError) as raises:
                 njit("void(int64[:,:])")(foo)
 
         excstr = str(raises.exception)
-        self.assertIn("args not supported", excstr)
+        self.assertIn("too many positional arguments", excstr)
 
 
 class TestCapturedErrorHandling(SerialMixin, unittest.TestCase):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR refactors methods in `numba.np.arraymath` to use the new `@overload` API. It refactors the following functions:
- [x] `np.prod`
- [x] `np.cumsum`
- [x] `np.cumprod`
- [x] `np.mean`
- [x] `np.var`
- [x] `np.std`
- [x] `np.min`
- [x] `np.max`

The two remaining functions in `arraymath` that use `@lower_builtin` are:
- `np.nonzero` (which would be trivial once #8258 goes in) 
- `np.sum` (which is big enough to need it's own separate PR, due to it's support for `axis` argument). 

Ultimately the goal with these PRs would be to get `axis` support for all the methods i.e. extending `axis` framework used in `np.sum` to all the other methods in `arraymath`. 