### PR TITLE
Remove public facing and CI references to 32 bit linux support.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   # Change the following along with adding new TEST_START_INDEX.
-  TEST_COUNT: 20
+  TEST_COUNT: 19
 
 jobs:
 # Mac and Linux use the same template with different matrixes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,19 +29,12 @@ jobs:
     name: Linux
     vmImage: ubuntu-20.04
     matrix:
-      py37_np118_32bit:
-        # 32 bit linux only has np 1.15
-        PYTHON: '3.7'
-        NUMPY: '1.18'
-        CONDA_ENV: azure_ci
-        BITS32: yes
-        TEST_START_INDEX: 2
       py37_np118_vanilla:
         PYTHON: '3.7'
         NUMPY: '1.18'
         CONDA_ENV: azure_ci
         VANILLA_INSTALL: yes
-        TEST_START_INDEX: 3
+        TEST_START_INDEX: 2
       py38_np118_cov:
         PYTHON: '3.8'
         NUMPY: '1.18'
@@ -49,79 +42,79 @@ jobs:
         RUN_COVERAGE: yes
         RUN_FLAKE8: yes
         RUN_MYPY: yes
-        TEST_START_INDEX: 4
+        TEST_START_INDEX: 3
       py38_np119_tbb:
         PYTHON: '3.8'
         NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: 'tbb'
-        TEST_START_INDEX: 5
+        TEST_START_INDEX: 4
       py38_np119_omp:
         PYTHON: '3.8'
         NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: omp
-        TEST_START_INDEX: 6
+        TEST_START_INDEX: 5
       py38_np119_workqueue:
         PYTHON: '3.8'
         NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
         TEST_THREADING: workqueue
-        TEST_START_INDEX: 7
+        TEST_START_INDEX: 6
       py38_np120_doc:
         PYTHON: '3.8'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
         BUILD_DOC: yes
-        TEST_START_INDEX: 8
+        TEST_START_INDEX: 7
       py38_np120_pickle5:
         PYTHON: '3.8'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
         TEST_PICKLE5: yes
-        TEST_START_INDEX: 9
+        TEST_START_INDEX: 8
       py38_np120_svml:
         PYTHON: '3.8'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
         TEST_SVML: yes
-        TEST_START_INDEX: 10
+        TEST_START_INDEX: 9
       py38_np122:
         PYTHON: '3.8'
         NUMPY: '1.22'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 11
+        TEST_START_INDEX: 10
       py39_np119:
         PYTHON: '3.9'
         NUMPY: '1.19.2=*_0'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 12
+        TEST_START_INDEX: 11
       py39_np120_typeguard:
         PYTHON: '3.9'
         NUMPY: '1.20'
         CONDA_ENV: azure_ci
         RUN_TYPEGUARD: yes
-        TEST_START_INDEX: 13
+        TEST_START_INDEX: 12
       py39_np121:
         PYTHON: '3.9'
         NUMPY: '1.21'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 14
+        TEST_START_INDEX: 13
       py39_np123:
         PYTHON: '3.9'
         NUMPY: '1.23'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 15
+        TEST_START_INDEX: 14
       py310_np121:
         PYTHON: '3.10'
         NUMPY: '1.21'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 16
+        TEST_START_INDEX: 15
       py310_np123:
         PYTHON: '3.10'
         NUMPY: '1.23'
         CONDA_ENV: azure_ci
-        TEST_START_INDEX: 17
+        TEST_START_INDEX: 16
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -13,7 +13,6 @@ jobs:
 
   steps:
     - script: |
-        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -14,7 +14,6 @@ jobs:
   steps:
     - script: |
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
-        if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" != "linux-32" && "$BITS32" != "yes" ]]; then sudo apt-get install -y gdb; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -12,12 +12,12 @@ jobs:
         PYTHON: '3.10'
         NUMPY: '1.23'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 18
+        TEST_START_INDEX: 17
       py37_np118:
         PYTHON: '3.7'
         NUMPY: '1.18'
         CONDA_ENV: 'testenv'
-        TEST_START_INDEX: 19
+        TEST_START_INDEX: 18
 
   steps:
     - task: CondaEnvironment@1

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -19,14 +19,14 @@ build:
     - lib/libiomp5.dylib # [osx]
   ignore_run_exports:
     # tbb-devel triggers hard dependency on tbb, this is not the case.
-    - tbb     # [not (armv6l or armv7l or aarch64 or linux32)]
+    - tbb     # [not aarch64]
 
 requirements:
   # build and run dependencies are duplicated to avoid setuptools issues
   # when we also set install_requires in setup.py
   build:
-    - {{ compiler('c') }}      # [not (armv6l or armv7l or aarch64)]
-    - {{ compiler('cxx') }}    # [not (armv6l or armv7l or aarch64)]
+    - {{ compiler('c') }}      # [not aarch64]
+    - {{ compiler('cxx') }}    # [not aarch64]
     # OpenMP headers from llvm needed for OSX.
     - llvm-openmp              # [osx]
   host:
@@ -41,7 +41,7 @@ requirements:
     # NOTE: 2021.1..2021.5 are API compatible for Numba's purposes.
     # NOTE: ppc64le exclusion is temporary until packages are more generally
     #       available.
-    - tbb-devel >=2021,<2021.6       # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
+    - tbb-devel >=2021,<2021.6       # [not (aarch64 or ppc64le)]
   run:
     - python >=3.7
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
@@ -52,7 +52,7 @@ requirements:
     - llvmlite >=0.40.0dev0,<0.40
   run_constrained:
     # If TBB is present it must be at least version 2021
-    - tbb >=2021    # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
+    - tbb >=2021    # [not (aarch64 or ppc64le)]
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     # 0.3.17 buggy on M1 silicon
@@ -73,19 +73,18 @@ test:
     - jinja2
     # Required to test optional Numba features
     - cffi
-    # temporarily disable scipy testing on ARM, need to build out more packages
-    - scipy                    # [not (armv6l or armv7l)]
-    - ipython                  # [not (armv6l or armv7l or aarch64)]
+    - scipy
+    - ipython                  # [not aarch64]
     - setuptools <60
-    - tbb  >=2021              # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]
+    - tbb  >=2021              # [not (aarch64 or ppc64le)]
     - llvm-openmp              # [osx]
     # This is for driving gdb tests
     - pexpect                  # [linux64]
     # For testing ipython
     - ipykernel
     # Need these for AOT. Do not init msvc as it may not be present
-    - {{ compiler('c') }}      # [not (win or armv6l or armv7l or aarch64)]
-    - {{ compiler('cxx') }}    # [not (win or armv6l or armv7l or aarch64)]
+    - {{ compiler('c') }}      # [not (win or aarch64)]
+    - {{ compiler('cxx') }}    # [not (win or aarch64)]
 
 about:
   home: https://numba.pydata.org/

--- a/buildscripts/incremental/install_miniconda.sh
+++ b/buildscripts/incremental/install_miniconda.sh
@@ -5,11 +5,7 @@ set -v -e
 # Install Miniconda
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
-    if [[ "$BITS32" == "yes" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh -O miniconda.sh
-    else
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-    fi
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 elif [[ "$unamestr" == 'Darwin' ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
 else

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -71,12 +71,12 @@ if [ "${VANILLA_INSTALL}" != "yes" ]; then
     fi
 fi
 
-# Install the compiler toolchain
+# Install the compiler toolchain and gdb (if available)
 if [[ $(uname) == Linux ]]; then
     if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]] ; then
         $CONDA_INSTALL gcc_linux-32 gxx_linux-32
     else
-        $CONDA_INSTALL gcc_linux-64 gxx_linux-64
+        $CONDA_INSTALL gcc_linux-64 gxx_linux-64 gdb gdb-pretty-printer
     fi
 elif  [[ $(uname) == Darwin ]]; then
     $CONDA_INSTALL clang_osx-64 clangxx_osx-64

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -9,11 +9,6 @@ conda config --set remote_connect_timeout_secs 30.15
 conda config --set remote_max_retries 10
 conda config --set remote_read_timeout_secs 120.2
 conda config --set show_channel_urls true
-if [[ $(uname) == Linux ]]; then
-    if [[ "$CONDA_SUBDIR" != "linux-32" && "$BITS32" != "yes" ]] ; then
-        conda config --set restore_free_channel true
-    fi
-fi
 conda info
 conda config --show
 
@@ -38,13 +33,7 @@ conda list
 # Create a base env first and then add to it...
 # NOTE: gitpython is needed for CI testing to do the test slicing
 # NOTE: pyyaml is used to ensure that the Azure CI config is valid
-# NOTE: 32 bit linux... do not install NumPy, there's no conda package for >1.15
-# so it has to come from pip later
-if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then
-    conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON pip gitpython pyyaml
-else
-    conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON numpy=$NUMPY pip gitpython pyyaml "setuptools<60"
-fi
+conda create -n $CONDA_ENV -q -y ${EXTRA_CHANNELS} python=$PYTHON numpy=$NUMPY pip gitpython pyyaml "setuptools<60"
 
 # Activate first
 set +v
@@ -60,34 +49,21 @@ if [ "${VANILLA_INSTALL}" != "yes" ]; then
     # pexpect is used to run the gdb tests.
     # ipykernel is used for testing ipython behaviours.
     $CONDA_INSTALL ${EXTRA_CHANNELS} cffi jinja2 ipython ipykernel pygments pexpect
-    # Only install scipy on 64bit, else it'll pull in NumPy, 32bit linux needs
-    # to get scipy from pip
-    if [[ "$CONDA_SUBDIR" != "linux-32" && "$BITS32" != "yes" ]] ; then
-        if [[ "$NUMPY" == "1.23" ]] ; then
-            $CONDA_INSTALL ${EXTRA_CHANNELS} conda-forge::scipy
-        else
-            $CONDA_INSTALL ${EXTRA_CHANNELS} scipy
-        fi
+    if [[ "$NUMPY" == "1.23" ]] ; then
+        $CONDA_INSTALL ${EXTRA_CHANNELS} conda-forge::scipy
+    else
+        $CONDA_INSTALL ${EXTRA_CHANNELS} scipy
     fi
 fi
 
 # Install the compiler toolchain and gdb (if available)
 if [[ $(uname) == Linux ]]; then
-    if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]] ; then
-        $CONDA_INSTALL gcc_linux-32 gxx_linux-32
-    else
-        $CONDA_INSTALL gcc_linux-64 gxx_linux-64 gdb gdb-pretty-printer
-    fi
+    $CONDA_INSTALL gcc_linux-64 gxx_linux-64 gdb gdb-pretty-printer
 elif  [[ $(uname) == Darwin ]]; then
     $CONDA_INSTALL clang_osx-64 clangxx_osx-64
     # Install llvm-openmp on OSX for headers during build and runtime during
     # testing
     $CONDA_INSTALL llvm-openmp
-fi
-
-# If on 32bit linux, now pip install NumPy (no conda package), SciPy is broken?!
-if [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]] ; then
-    $PIP_INSTALL numpy==$NUMPY
 fi
 
 # Install latest correct build

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -83,15 +83,11 @@ fi
 # Find catchsegv
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
-    if [[ "${BITS32}" == "yes" ]]; then
-        SEGVCATCH=""
-    else
-        SEGVCATCH=catchsegv
-    fi
+    SEGVCATCH=catchsegv
 elif [[ "$unamestr" == 'Darwin' ]]; then
-  SEGVCATCH=""
+    SEGVCATCH=""
 else
-  echo Error
+    echo Error
 fi
 
 # limit CPUs in use on PPC64LE, fork() issues

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -11,9 +11,10 @@ if [ "$BUILD_DOC" == "yes" ]; then rstcheck README.rst; fi
 pushd docs
 if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi
 popd
-# Run system info tool
+# Run system and gdb info tools
 pushd bin
 numba -s
+numba -g
 popd
 
 # switch off color messages

--- a/docs/source/user/5minguide.rst
+++ b/docs/source/user/5minguide.rst
@@ -12,10 +12,9 @@ part of your code can subsequently run at native machine code speed!
 
 Out of the box Numba works with the following:
 
-* OS: Windows (32 and 64 bit), OSX, Linux (32 and 64 bit). Unofficial support on
+* OS: Windows (32 and 64 bit), OSX, Linux (64 bit). Unofficial support on
   \*BSD.
-* Architecture: x86, x86_64, ppc64le, armv7l, armv8l (aarch64). Unofficial
-  support on M1/Arm64.
+* Architecture: x86, x86_64, ppc64le, armv8l (aarch64), M1/Arm64.
 * GPUs: Nvidia CUDA.
 * CPython
 * NumPy 1.18 - latest

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -9,7 +9,7 @@ Numba is compatible with Python 3.7--3.10, and NumPy versions 1.18 or later.
 
 Our supported platforms are:
 
-* Linux x86 (32-bit and 64-bit)
+* Linux x86_64
 * Linux ppcle64 (POWER8, POWER9)
 * Windows 7 and later (32-bit and 64-bit)
 * OS X 10.9 and later (64-bit and unofficial support on M1/Arm64)
@@ -17,7 +17,6 @@ Our supported platforms are:
 * NVIDIA GPUs of compute capability 5.3 and later
 
   * Compute capabilities 3.5 - 5.2 are supported, but deprecated.
-* ARMv7 (32-bit little-endian, such as Raspberry Pi 2 and 3)
 * ARMv8 (64-bit little-endian, such as the NVIDIA Jetson)
 
 :ref:`numba-parallel` is only available on 64-bit platforms.
@@ -71,32 +70,14 @@ To use CUDA with Numba installed by `pip`, you need to install the `CUDA SDK
 installed system-wide on Linux.
 
 
-.. _numba-install-armv7:
-
-Installing on Linux ARMv7 Platforms
------------------------------------
-
-`Berryconda <https://github.com/jjhelmus/berryconda>`_ is a
-conda-based Python distribution for the Raspberry Pi.  We are now uploading
-packages to the ``numba`` channel on Anaconda Cloud for 32-bit little-endian,
-ARMv7-based boards, which currently includes the Raspberry Pi 2 and 3,
-but not the Pi 1 or Zero.  These can be installed using conda from the
-``numba`` channel::
-
-    $ conda install -c numba numba
-
-Berryconda and Numba may work on other Linux-based ARMv7 systems, but this has
-not been tested.
-
-
 Installing on Linux ARMv8 (AArch64) Platforms
 ---------------------------------------------
 
 We build and test conda packages on the `NVIDIA Jetson TX2
 <https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_,
 but they are likely to work for other AArch64 platforms.  (Note that while the
-Raspberry Pi CPU is 64-bit, Raspbian runs it in 32-bit mode, so look at
-:ref:`numba-install-armv7` instead.)
+Raspberry Pi CPU is 64-bit, depending on configuration Raspbian may be running
+it in 32-bit mode).
 
 Conda-forge support for AArch64 is still quite experimental and packages are limited,
 but it does work enough for Numba to build and pass tests.  To set up the environment:
@@ -136,7 +117,6 @@ Source archives of the latest release can also be found on
 * A C compiler compatible with your Python installation.  If you are using
   Anaconda, you can use the following conda packages:
 
-  * Linux ``x86``: ``gcc_linux-32`` and ``gxx_linux-32``
   * Linux ``x86_64``: ``gcc_linux-64`` and ``gxx_linux-64``
   * Linux ``POWER``: ``gcc_linux-ppc64le`` and ``gxx_linux-ppc64le``
   * Linux ``ARM``: no conda packages, use the system compiler

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -76,8 +76,8 @@ Installing on Linux ARMv8 (AArch64) Platforms
 We build and test conda packages on the `NVIDIA Jetson TX2
 <https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_,
 but they are likely to work for other AArch64 platforms.  (Note that while the
-Raspberry Pi CPU is 64-bit, depending on configuration Raspbian may be running
-it in 32-bit mode).
+CPUs in the Raspberry Pi 3, 4, and Zero 2 W are 64-bit, Raspberry Pi OS may be
+running in 32-bit mode depending on the OS image in use).
 
 Conda-forge support for AArch64 is still quite experimental and packages are limited,
 but it does work enough for Numba to build and pass tests.  To set up the environment:


### PR DESCRIPTION
As noted in the release notes for 0.56, it is the last release to support `linux-32` (i.e. linux running on 32 bit x86 hardware). This patch series:
* Removes 32 bit linux support from the build scripts/conda recipes.
* Removes 32 bit linux builds from Azure CI.
* Fixes up the documentation to not refer to `linux-32` as supported.
* Removes references to other 32 bit linux systems which are no longer tested/supported, i.e. `armv6l` and `armv7l`.

This patch series does not address changes needed to the code base itself that are necessary to remove `linux-32` support.

This PR depends on merging #8422, that patch is included as the first in the series for this PR as it touches the same code.