### PR TITLE
Make LLVM initialization lazy in the CPU target.

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -51,6 +51,13 @@ class CPUContext(BaseContext):
                         codegen.JITCPUCodegen("numba.exec")
         return self._internal_codegen_ref
 
+    @_internal_codegen.setter
+    def _internal_codegen(self, value):
+        # subtarget creation often replaces the codegen, see the code in
+        # BaseContext.subtarget() which is essentially creating a shallow copy
+        # of this class with given attrs overwritten.
+        self._internal_codegen_ref = value
+
     # Overrides
     def create_module(self, name):
         return self._internal_codegen._create_empty_module(name)

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -83,7 +83,7 @@ class TestNrtMemInfo(unittest.TestCase):
         # Reset the Dummy class
         Dummy.alive = 0
         # initialize the NRT (in case the tests are run in isolation)
-        cpu_target.target_context
+        rtsys.initialize(cpu_target.target_context)
 
     def test_meminfo_refct_1(self):
         d = Dummy()

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -717,6 +717,10 @@ class TestNrtStatistics(TestCase):
         def foo():
             return np.arange(10)[0]
 
+        # Need to init the NRT via compilation due to lazy init on jit
+        # decoration.
+        foo()
+
         assert _nrt_python.memsys_stats_enabled()
         orig_stats = rtsys.get_allocation_stats()
         foo()


### PR DESCRIPTION
This patch pushes the LLVM initialization and all compilation off the import path and the `jit` decorator path for the CPU target.

The result of this patch is that both LLVM and the NRT are not initialized until Numba is definitely going to be required to compile something.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
