### PR TITLE
Make the initialisation of the NRT more lazy for the njit decorator.

### DIFF
--- a/numba/core/cpu.py
+++ b/numba/core/cpu.py
@@ -48,7 +48,6 @@ class CPUContext(BaseContext):
 
     @global_compiler_lock
     def init(self):
-        self._nrt_initialized = False
         self.is32bit = (utils.MACHINE_BITS == 32)
         self._internal_codegen = codegen.JITCPUCodegen("numba.exec")
 
@@ -63,11 +62,9 @@ class CPUContext(BaseContext):
         # Only initialize the NRT once something is about to be compiled. The
         # "initialized" state doesn't need to be threadsafe, there's a lock
         # around the internal compilation and the rtsys.initialize call can be
-        # made multiple times, worse case this just gets called a bit more often
+        # made multiple times, worse case init just gets called a bit more often
         # than optimal.
-        if not self._nrt_initialized:
-            rtsys.initialize(self)
-            self._nrt_initialized = True
+        rtsys.initialize(self)
 
         # Add implementations that work via import
         from numba.cpython import (builtins, charseq, enumimpl, # noqa F401


### PR DESCRIPTION
This patch makes it so that the NRT is only compiled when compilation starts as the result of the user electing to trigger compilation. A new test is added to ensure that decorating a function with `njit` doesn't trigger NRT compilation.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
