### PR TITLE
Add string comparison operators from the numpy.char module.

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -411,6 +411,19 @@ The following reduction functions are supported:
 * :func:`numpy.quantile` (only the 2 first arguments, complex dtypes
   unsupported)
 
+String Operations
+-----------------
+
+Comparison operators are supported on 1-D contiguous arrays of strings or bytes:
+
+* :func:`numpy.char.compare_chararrays`
+* :func:`numpy.char.equal`
+* :func:`numpy.char.greater_equal`
+* :func:`numpy.char.greater`
+* :func:`numpy.char.less_equal`
+* :func:`numpy.char.less`
+* :func:`numpy.char.not_equal`
+
 Other functions
 ---------------
 

--- a/numba/np/char.py
+++ b/numba/np/char.py
@@ -147,8 +147,8 @@ def greater_equal(chr_array, len_chr, size_chr,
                 greater_equal_than[i] = ((inv and -cmp_ord) or cmp_ord) >= 0
                 break
         else:
-            greater_equal_than[i] = size_margin >= 0 \
-                                    or not cmp_array[stride_cmp + size_stride]
+            greater_equal_than[i] = (size_margin >= 0
+                                     or not cmp_array[stride_cmp + size_stride])
         stride += size_chr
         stride_cmp += size_cmp
     return greater_equal_than
@@ -173,7 +173,7 @@ def greater(chr_array, len_chr, size_chr,
                 break
         else:
             greater_than[i] = size_margin > 0 \
-                              and chr_array[stride + size_stride]
+                and chr_array[stride + size_stride]
         stride += size_chr
         stride_cmp += size_cmp
     return greater_than
@@ -190,8 +190,8 @@ def equal(chr_array, len_chr, size_chr, cmp_array, len_cmp, size_cmp):
         if size_chr > size_cmp:
             for i in range(len_chr):
                 equal_to[i] = chr_array[ix + size_cmp] == 0 \
-                              and not _compare_any(cmp_array,
-                                                   chr_array[ix:ix + size_cmp])
+                    and not _compare_any(cmp_array,
+                                         chr_array[ix:ix + size_cmp])
                 ix += size_chr
         else:
             for i in range(len_chr):
@@ -204,15 +204,15 @@ def equal(chr_array, len_chr, size_chr, cmp_array, len_cmp, size_cmp):
         if size_chr < size_cmp:
             for i in range(len_chr):
                 equal_to[i] = cmp_array[iy + size_chr] == 0 \
-                              and not _compare_any(chr_array[ix:ix + size_chr],
-                                                   cmp_array[iy:iy + size_chr])
+                    and not _compare_any(chr_array[ix:ix + size_chr],
+                                         cmp_array[iy:iy + size_chr])
                 ix += size_chr
                 iy += size_cmp
         elif size_chr > size_cmp:
             for i in range(len_chr):
                 equal_to[i] = chr_array[ix + size_cmp] == 0 \
-                              and not _compare_any(chr_array[ix:ix + size_cmp],
-                                                   cmp_array[iy:iy + size_cmp])
+                    and not _compare_any(chr_array[ix:ix + size_cmp],
+                                         cmp_array[iy:iy + size_cmp])
                 ix += size_chr
                 iy += size_cmp
         else:

--- a/numba/np/char.py
+++ b/numba/np/char.py
@@ -1,0 +1,400 @@
+"""Implementation of numpy.char routines."""
+
+from numba.extending import overload, register_jitable
+from numba import types
+import numpy as np
+
+
+# -----------------------------------------------------------------------------
+# Support Functions
+
+
+@register_jitable
+def _register_bytes(b, rstrip=True):
+    """Expose the numerical representation of ASCII bytes."""
+    if isinstance(b, bytes):
+        len_chr = 1
+        size_chr = len(b)
+    else:
+        len_chr = b.size
+        size_chr = b.itemsize
+    if rstrip and size_chr > 1:
+        return (
+            _rstrip_inner(np.frombuffer(b, 'uint8').copy(), size_chr),
+            len_chr,
+            size_chr
+        )
+    return np.frombuffer(b, 'uint8'), len_chr, size_chr
+
+
+@register_jitable
+def _register_strings(s, rstrip=True):
+    """Expose the numerical representation of UTF-32 strings."""
+    if isinstance(s, str):
+        len_chr = 1
+        size_chr = len(s)
+        chr_array = np.empty(size_chr, 'int32')
+        for i in range(size_chr):
+            chr_array[i] = ord(s[i])
+    else:
+        len_chr = s.size
+        size_chr = s.itemsize // 4
+        chr_array = np.ravel(s).view(np.dtype('int32'))
+    if rstrip and size_chr > 1:
+        return _rstrip_inner(chr_array, size_chr), len_chr, size_chr
+    return chr_array, len_chr, size_chr
+
+
+@register_jitable
+def _rstrip_inner(chr_array, size_chr):
+    r"""
+    Removes trailing \t\n\r\f\v\s characters.
+    As is the case when used on character comparison operators, this variation
+    ignores the first character.
+    """
+    if size_chr == 1:
+        return chr_array
+
+    def bisect_null(a, j, k):
+        """Bisect null right-padded strings with the form '\x00'."""
+        while j < k:
+            m = (k + j) // 2
+            c = a[m]
+            if c != 0:
+                j = m + 1
+            elif c == 0:
+                k = m
+            else:
+                return m
+        return j
+
+    whitespace = {0, 9, 10, 11, 12, 13, 32}
+    size_stride = size_chr - 1
+
+    for i in range(size_stride, chr_array.size, size_chr):
+        if chr_array[i] not in whitespace:
+            continue
+
+        o = i - size_stride
+        p = bisect_null(chr_array, o, i - 1)
+        while p > o and chr_array[p] in whitespace:
+            p -= 1
+        chr_array[p + 1: i + 1] = 0
+
+    return chr_array
+
+
+# -----------------------------------------------------------------------------
+# Comparison Operators
+
+
+@register_jitable
+def _cast_comparison(size_chr, len_chr, len_cmp, size_cmp):
+    if len_cmp > 1 and len_cmp != len_chr:
+        raise ValueError('shape mismatch: objects cannot be broadcast to a '
+                         'single shape.  Mismatch is between arg 0 and arg 1.')
+    size_margin = size_chr - size_cmp
+    if len_cmp == 1:
+        size_stride = min(size_chr, size_cmp + (size_margin < 0))
+        size_cmp = 0
+    else:
+        size_stride = min(size_chr, size_cmp)
+    return size_cmp, size_stride, size_margin
+
+
+@register_jitable
+def _compare_any(x1: np.ndarray, x2: np.ndarray) -> bool:
+    for i in range(x1.size):
+        if x1[i] != x2[i]:
+            return True
+    return False
+
+
+@register_jitable(locals={'cmp_ord': types.int32})
+def greater_equal(chr_array, len_chr, size_chr,
+                  cmp_array, len_cmp, size_cmp, inv=False):
+    """Native Implementation of np.char.greater_equal"""
+    if 1 == size_chr == size_cmp:
+        return cmp_array >= chr_array if inv else chr_array >= cmp_array
+
+    size_cmp, size_stride, size_margin = _cast_comparison(size_chr, len_chr,
+                                                          len_cmp, size_cmp)
+    greater_equal_than = np.zeros(len_chr, 'bool')
+    stride = stride_cmp = 0
+    for i in range(len_chr):
+        for j in range(size_stride):
+            cmp_ord = chr_array[stride + j] - cmp_array[stride_cmp + j]
+            if cmp_ord != 0:
+                greater_equal_than[i] = ((inv and -cmp_ord) or cmp_ord) >= 0
+                break
+        else:
+            greater_equal_than[i] = size_margin >= 0 \
+                                    or not cmp_array[stride_cmp + size_stride]
+        stride += size_chr
+        stride_cmp += size_cmp
+    return greater_equal_than
+
+
+@register_jitable(locals={'cmp_ord': types.int32})
+def greater(chr_array, len_chr, size_chr,
+            cmp_array, len_cmp, size_cmp, inv=False):
+    """Native Implementation of np.char.greater"""
+    if 1 == size_chr == size_cmp:
+        return cmp_array > chr_array if inv else chr_array > cmp_array
+
+    size_cmp, size_stride, size_margin = _cast_comparison(size_chr, len_chr,
+                                                          len_cmp, size_cmp)
+    greater_than = np.zeros(len_chr, 'bool')
+    stride = stride_cmp = 0
+    for i in range(len_chr):
+        for j in range(size_stride):
+            cmp_ord = chr_array[stride + j] - cmp_array[stride_cmp + j]
+            if cmp_ord != 0:
+                greater_than[i] = ((inv and -cmp_ord) or cmp_ord) >= 0
+                break
+        else:
+            greater_than[i] = size_margin > 0 \
+                              and chr_array[stride + size_stride]
+        stride += size_chr
+        stride_cmp += size_cmp
+    return greater_than
+
+
+@register_jitable
+def equal(chr_array, len_chr, size_chr, cmp_array, len_cmp, size_cmp):
+    """Native Implementation of np.char.equal"""
+    ix = 0
+    if len_cmp == 1:
+        if size_chr < size_cmp:
+            return np.zeros(len_chr, 'bool')
+        equal_to = np.empty(len_chr, 'bool')
+        if size_chr > size_cmp:
+            for i in range(len_chr):
+                equal_to[i] = chr_array[ix + size_cmp] == 0 \
+                              and not _compare_any(cmp_array,
+                                                   chr_array[ix:ix + size_cmp])
+                ix += size_chr
+        else:
+            for i in range(len_chr):
+                equal_to[i] = not _compare_any(cmp_array,
+                                               chr_array[ix:ix + size_cmp])
+                ix += size_chr
+    elif len_chr == len_cmp:
+        iy = 0
+        equal_to = np.empty(len_chr, 'bool')
+        if size_chr < size_cmp:
+            for i in range(len_chr):
+                equal_to[i] = cmp_array[iy + size_chr] == 0 \
+                              and not _compare_any(chr_array[ix:ix + size_chr],
+                                                   cmp_array[iy:iy + size_chr])
+                ix += size_chr
+                iy += size_cmp
+        elif size_chr > size_cmp:
+            for i in range(len_chr):
+                equal_to[i] = chr_array[ix + size_cmp] == 0 \
+                              and not _compare_any(chr_array[ix:ix + size_cmp],
+                                                   cmp_array[iy:iy + size_cmp])
+                ix += size_chr
+                iy += size_cmp
+        else:
+            if size_chr == 1:
+                return chr_array == cmp_array
+            for i in range(len_chr):
+                equal_to[i] = not _compare_any(chr_array[ix:ix + size_chr],
+                                               cmp_array[ix:ix + size_chr])
+                ix += size_chr
+    else:
+        msg = 'shape mismatch: objects cannot be broadcast to a single shape.' \
+              '  Mismatch is between arg 0 and arg 1.'
+        raise ValueError(msg)
+    return equal_to
+
+
+@register_jitable
+def compare_chararrays(chr_array, len_chr, size_chr,
+                       cmp_array, len_cmp, size_cmp, inv, cmp):
+    """Native Implementation of np.char.compare_chararrays"""
+    # {“<”, “<=”, “==”, “>=”, “>”, “!=”}
+    # { (60,) (60, 61), (61, 61), (62, 61), (62,), (33, 61) }
+    # The argument cmp can be passed as bytes or string, hence ordinal mapping.
+    if len(cmp) == 1:
+        cmp_ord = ord(cmp)
+        if cmp_ord == 60:
+            return ~greater_equal(chr_array, len_chr, size_chr,
+                                  cmp_array, len_cmp, size_cmp, inv)
+        elif cmp_ord == 62:
+            return greater(chr_array, len_chr, size_chr,
+                           cmp_array, len_cmp, size_cmp, inv)
+    elif len(cmp) == 2 and ord(cmp[1]) == 61:
+        cmp_ord = ord(cmp[0])
+        if cmp_ord == 60:
+            return ~greater(chr_array, len_chr, size_chr,
+                            cmp_array, len_cmp, size_cmp, inv)
+        elif cmp_ord == 61:
+            return equal(chr_array, len_chr, size_chr,
+                         cmp_array, len_cmp, size_cmp)
+        elif cmp_ord == 62:
+            return greater_equal(chr_array, len_chr, size_chr,
+                                 cmp_array, len_cmp, size_cmp, inv)
+        elif cmp_ord == 33:
+            return ~equal(chr_array, len_chr, size_chr,
+                          cmp_array, len_cmp, size_cmp)
+    raise ValueError("comparison must be '==', '!=', '<', '>', '<=', '>='")
+
+
+@register_jitable
+def _ensure_type(x):
+    ndim = 0
+    if isinstance(x, types.Array):
+        ndim = x.ndim
+        if ndim > 1 or x.layout != 'C':
+            msg = 'shape mismatch: objects cannot be broadcast to a single ' \
+                  'shape.  Mismatch is between arg 0 and arg 1.'
+            raise ValueError(msg)
+        x = x.dtype
+        if not isinstance(x, (types.CharSeq,
+                              types.UnicodeCharSeq)) or not x.count:
+            raise TypeError('comparison of non-string arrays')
+    elif not isinstance(x, (types.Bytes, types.UnicodeType)):
+        raise TypeError('comparison of non-string arrays')
+    return x, ndim
+
+
+@register_jitable
+def _get_register_type(x1, x2):
+
+    (x1_type, x1_dim), (x2_type, x2_dim) = _ensure_type(x1), _ensure_type(x2)
+    byte_types = (types.Bytes, types.CharSeq)
+    str_types = (types.UnicodeType, types.UnicodeCharSeq)
+
+    register_type = cmp_type = None
+    if isinstance(x1_type, byte_types) and isinstance(x2_type, byte_types):
+        register_type = _register_bytes
+        cmp_type = bytes
+    elif isinstance(x1_type, str_types) and isinstance(x2_type, str_types):
+        register_type = _register_strings
+        cmp_type = str
+
+    if not register_type:
+        raise NotImplementedError('NotImplemented')
+    return register_type, cmp_type, x1_dim, x2_dim
+
+
+@overload(np.char.equal)
+def ov_char_equal(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return equal(*register_type(x2), *register_type(x1))
+            return equal(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(equal(*register_type(x1), *register_type(x2))[0])
+    return impl
+
+
+@overload(np.char.not_equal)
+def ov_char_not_equal(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return ~equal(*register_type(x2), *register_type(x1))
+            return ~equal(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(~equal(*register_type(x1), *register_type(x2))[0])
+    return impl
+
+
+@overload(np.char.greater_equal)
+def ov_char_greater_equal(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return greater_equal(*register_type(x2),
+                                     *register_type(x1), True)
+            return greater_equal(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(greater_equal(*register_type(x1),
+                                          *register_type(x2))[0])
+    return impl
+
+
+@overload(np.char.greater)
+def ov_char_greater(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return greater(*register_type(x2), *register_type(x1), True)
+            return greater(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(greater(*register_type(x1), *register_type(x2))[0])
+    return impl
+
+
+@overload(np.char.less)
+def ov_char_less(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return ~greater_equal(*register_type(x2),
+                                      *register_type(x1), True)
+            return ~greater_equal(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(~greater_equal(*register_type(x1),
+                                           *register_type(x2))[0])
+    return impl
+
+
+@overload(np.char.less_equal)
+def ov_char_less_equal(x1, x2):
+    register_type, cmp_type, x1_dim, x2_dim = _get_register_type(x1, x2)
+
+    if x1_dim or x2_dim:
+        def impl(x1, x2):
+            if isinstance(x1, cmp_type) and not isinstance(x2, cmp_type):
+                return ~greater(*register_type(x2), *register_type(x1), True)
+            return ~greater(*register_type(x1), *register_type(x2))
+    else:
+        def impl(x1, x2):
+            return np.array(~greater(*register_type(x1), *register_type(x2))[0])
+    return impl
+
+
+@register_jitable
+@overload(np.char.compare_chararrays)
+def ov_char_compare_chararrays(a1, a2, cmp, rstrip):
+    if not isinstance(cmp, (types.Bytes, types.UnicodeType)):
+        raise TypeError(f'a bytes-like object is required, not {cmp.name}')
+
+    register_type, cmp_type, a1_dim, a2_dim = _get_register_type(a1, a2)
+
+    if a1_dim or a2_dim:
+        def impl(a1, a2, cmp, rstrip):
+            if isinstance(a1, cmp_type) and not isinstance(a2, cmp_type):
+                return compare_chararrays(*register_type(a2, rstrip),
+                                          *register_type(a1, rstrip), True, cmp)
+            return compare_chararrays(*register_type(a1, rstrip),
+                                      *register_type(a2, rstrip), False, cmp)
+    else:
+        def impl(a1, a2, cmp, rstrip):
+            return np.array(compare_chararrays(*register_type(a1, rstrip),
+                                               *register_type(a2, rstrip),
+                                               False, cmp)[0])
+    return impl
+
+
+# -----------------------------------------------------------------------------

--- a/numba/np/char.py
+++ b/numba/np/char.py
@@ -106,6 +106,9 @@ def _rstrip_inner(chr_array, size_chr):
 
 @register_jitable
 def _cast_comparison(size_chr, len_chr, len_cmp, size_cmp):
+    """
+    Determines the character offsets used to align the comparison to the target.
+    """
     if len_cmp > 1 and len_cmp != len_chr:
         raise ValueError('shape mismatch: objects cannot be broadcast to a '
                          'single shape.  Mismatch is between arg 0 and arg 1.')
@@ -301,7 +304,6 @@ def _get_register_type(x1, x2):
 
 @overload(np.char.equal)
 def ov_char_equal(x1, x2):
-    """Native Overload of np.char.equal"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -317,7 +319,6 @@ def ov_char_equal(x1, x2):
 
 @overload(np.char.not_equal)
 def ov_char_not_equal(x1, x2):
-    """Native Overload of np.char.not_equal"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -333,7 +334,6 @@ def ov_char_not_equal(x1, x2):
 
 @overload(np.char.greater_equal)
 def ov_char_greater_equal(x1, x2):
-    """Native Overload of np.char.greater_equal"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -343,13 +343,13 @@ def ov_char_greater_equal(x1, x2):
             return greater_equal(*register_x1(x1), *register_x2(x2))
     else:
         def impl(x1, x2):
-            return np.array(greater_equal(*register_x1(x1), *register_x2(x2))[0])
+            return np.array(greater_equal(*register_x1(x1),
+                                          *register_x2(x2))[0])
     return impl
 
 
 @overload(np.char.greater)
 def ov_char_greater(x1, x2):
-    """Native Overload of np.char.greater"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -365,7 +365,6 @@ def ov_char_greater(x1, x2):
 
 @overload(np.char.less)
 def ov_char_less(x1, x2):
-    """Native Overload of np.char.less"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -382,7 +381,6 @@ def ov_char_less(x1, x2):
 
 @overload(np.char.less_equal)
 def ov_char_less_equal(x1, x2):
-    """Native Overload of np.char.less_equal"""
     register_x1, register_x2, x1_dim, x2_dim = _get_register_type(x1, x2)
 
     if x1_dim > 0 or x2_dim > 0:
@@ -398,7 +396,6 @@ def ov_char_less_equal(x1, x2):
 
 @overload(np.char.compare_chararrays)
 def ov_char_compare_chararrays(a1, a2, cmp, rstrip):
-    """Native Overload of np.char.compare_chararrays"""
     if not isinstance(cmp, (types.Bytes, types.UnicodeType)):
         raise TypeError(f'a bytes-like object is required, not {cmp.name}')
 

--- a/numba/tests/test_np_char.py
+++ b/numba/tests/test_np_char.py
@@ -3,11 +3,10 @@
 from itertools import product
 from numba import jit
 from numba.core.errors import TypingError
-from numba.np import char
+from numba.np.char import np
 from numba.tests.support import TestCase
 from sys import maxunicode
 
-import numpy as np
 import unittest
 
 

--- a/numba/tests/test_np_char.py
+++ b/numba/tests/test_np_char.py
@@ -73,24 +73,24 @@ class TestComparisonOperators(TestCase):
 
     @classmethod
     def set_arguments(cls):
-        length = 500
+        length = 300
         np.random.seed(42)
-        # 500 UTF-32 strings of length 1 to 200 in range(1, sys.maxunicode)
+        # 300 UTF-32 strings of length 1 to 200 in range(1, sys.maxunicode)
         # Python 3.7 can not decode unicode in range(55296, 57344)
         q = np.array([''.join([chr(np.random.randint(1, 55295)) if i % 2
                                else chr(np.random.randint(57345, maxunicode))
                                for i in range(np.random.randint(1, 200))])
                       for _ in range(length)])
-        # 500 ASCII strings of length 0 to 50
+        # 300 ASCII strings of length 0 to 50
         r = np.array([''.join([chr(np.random.randint(1, 127))
                                for _ in range(np.random.randint(0, 50))])
                       for _ in range(length)])
-        s: tuple = (np.array(['abc', 'def'] * length),
-                    np.array(['cba', 'fed'] * length))
-        t: tuple = (np.array(['ab', 'bc'] * length),
-                    np.array(['bc', 'ab'] * length))
-        u: tuple = (np.array(['ba', 'cb'] * length),
-                    np.array(['cb', 'ba'] * length))
+        s: tuple = (np.array(['abc', 'def'] * 2),
+                    np.array(['cba', 'fed'] * 2))
+        t: tuple = (np.array(['ab', 'bc'] * 2),
+                    np.array(['bc', 'ab'] * 2))
+        u: tuple = (np.array(['ba', 'cb'] * 2),
+                    np.array(['cb', 'ba'] * 2))
         v = np.random.choice(['abcd', 'abc', 'abcde'], length)
 
         # Whitespace to end of strings & single ASCII characters in range(0, 33)
@@ -133,37 +133,44 @@ class TestComparisonOperators(TestCase):
         setattr(cls, 'byte_args', byte_args)
         setattr(cls, 'string_args', string_args)
 
-    def test_comparison_operators(self):
+    def test_comparisons(self):
 
         def check_output(pyfunc_, cfunc_, x1, x2):
             expected = pyfunc_(x1, x2)
             got = cfunc_(x1, x2)
             self.assertPreciseEqual(expected, got)
 
-        def check_exceptions(cfunc_, x1, x2):
-            em = ".*shape mismatch: objects cannot be broadcast to.*"
-            with self.assertRaisesRegex(ValueError, em):
-                cfunc_(x1, np.empty_like(x1[:1]))
-                cfunc_(x1[:10], x2[:5])
+        def check_shape_exception(cfunc_, x1):
+            error_msg = ".*shape mismatch: objects cannot be broadcast to.*"
+            with self.assertRaisesRegex(ValueError, error_msg):
+                cfunc_(x1, x1[:2])
 
-            em = ".*comparison of non-string arrays.*"
-            with self.assertRaisesRegex((TypingError, TypeError), em):
-                cfunc_(x1[:5], None)
-                cfunc_('abc', 123)
+        def check_comparison_exception(cfunc_, x1):
+            error_msg = ".*comparison of non-string arrays.*"
+            accepted_errors = (TypingError, TypeError)
+            with self.assertRaisesRegex(accepted_errors, error_msg):
+                cfunc_(x1, None)
+            with self.assertRaisesRegex(accepted_errors, error_msg):
+                cfunc_(x1, 123)
 
-            em = ".*NotImplemented.*"
-            with self.assertRaisesRegex((TypingError, NotImplementedError), em):
-                cfunc_(x1.astype('U'), x1.astype('S'))
+        def check_notimplemented_exception(cfunc_, x1):
+            error_msg = ".*NotImplemented.*"
+            accepted_errors = (TypingError, NotImplementedError)
+            with self.assertRaisesRegex(accepted_errors, error_msg):
+                cfunc_(x1.astype('S'), x1.astype('U'))
+            with self.assertRaisesRegex(accepted_errors, error_msg):
                 cfunc_('abc', b'abc')
 
         pyfuncs = (np_char_equal, np_char_not_equal,
                    np_char_greater_equal, np_char_greater,
                    np_char_less_equal, np_char_less)
 
-        args = self.string_args[0]
+        arg = np.array(['abc', 'def', 'hij'], 'S')
         for pyfunc in pyfuncs:
             cfunc = jit(nopython=True)(pyfunc)
-            check_exceptions(cfunc, *args)
+            check_shape_exception(cfunc, arg)
+            check_comparison_exception(cfunc, arg)
+            check_notimplemented_exception(cfunc, arg)
 
         for pyfunc in pyfuncs:
             cfunc = jit(nopython=True)(pyfunc)
@@ -175,31 +182,38 @@ class TestComparisonOperators(TestCase):
                 check_output(pyfunc, cfunc, *args)
                 check_output(pyfunc, cfunc, *args[::-1])
 
-        byte_args = list(_pack_arguments(self.byte_args,
-                                         [('==', '!=', '>=', '>', '<', '<='),
-                                          (True, False)]))
+    def test_compare_chararrays(self):
 
-        string_args = list(_pack_arguments(self.string_args,
-                                           [('==', '!=', '>=', '>', '<', '<='),
-                                            (True, False)]))
-
-        def check_compare_chararrays(a1, a2, cmp, rstrip):
-            pyfunc_ = np_char_compare_chararrays
-            cfunc_ = jit(nopython=True)(pyfunc_)
-
-            expected = pyfunc_(a1, a2, cmp, rstrip)
-            got = cfunc_(a1, a2, cmp, rstrip)
+        def check_output(a1, a2, cmp, rstrip):
+            expected = pyfunc(a1, a2, cmp, rstrip)
+            got = cfunc(a1, a2, cmp, rstrip)
             self.assertPreciseEqual(expected, got)
 
-            em = ".*a bytes-like object is required.*"
-            with self.assertRaisesRegex((TypingError, TypeError), em):
-                cfunc_(a1, a2, 123, rstrip)
+        def check_cmp_exception():
+            cmp = 123
+            error_msg = ".*a bytes-like object is required.*"
+            accepted_errors = (TypingError, TypeError)
+            with self.assertRaisesRegex(accepted_errors, error_msg):
+                cfunc('abc', 'abc', cmp, True)
+
+        pyfunc = np_char_compare_chararrays
+        cfunc = jit(nopython=True)(pyfunc)
+
+        byte_args = _pack_arguments(self.byte_args[:1],
+                                    [('==', '!=', '>=', '>', '<', '<='),
+                                     (True, False)])
+
+        string_args = _pack_arguments(self.string_args[:1],
+                                      [('==', '!=', '>=', '>', '<', '<='),
+                                       (True, False)])
+
+        check_cmp_exception()
 
         for args in byte_args:
-            check_compare_chararrays(*args)
+            check_output(*args)
 
         for args in string_args:
-            check_compare_chararrays(*args)
+            check_output(*args)
 
 
 TestComparisonOperators.set_arguments()

--- a/numba/tests/test_np_char.py
+++ b/numba/tests/test_np_char.py
@@ -19,7 +19,7 @@ def _pack_arguments(main_args: (list, tuple), args: (list, tuple)):
     arg_product = tuple(product(*args))
     for a in main_args:
         for args in arg_product:
-            yield *a, *args
+            yield (*a, *args)
 
 
 def _arguments_as_bytes(args: (list, tuple)):
@@ -75,10 +75,12 @@ class TestComparisonOperators(TestCase):
     @classmethod
     def set_arguments(cls):
         length = 500
-        # 500 UTF-32 strings of length 1 to 200 in range(1, sys.maxunicode)
         np.random.seed(42)
-        q = np.array([''.join([chr(np.random.randint(maxunicode))
-                               for _ in range(np.random.randint(1, 200))])
+        # 500 UTF-32 strings of length 1 to 200 in range(1, sys.maxunicode)
+        # Python 3.7 can not decode unicode in range(55296, 57344)
+        q = np.array([''.join([chr(np.random.randint(1, 55295)) if i % 2
+                               else chr(np.random.randint(57345, maxunicode))
+                               for i in range(np.random.randint(1, 200))])
                       for _ in range(length)])
         # 500 ASCII strings of length 0 to 50
         r = np.array([''.join([chr(np.random.randint(1, 127))

--- a/numba/tests/test_np_char.py
+++ b/numba/tests/test_np_char.py
@@ -1,0 +1,200 @@
+"""Test string operations of the numpy.char module."""
+
+from itertools import product
+from numba import jit
+from numba.core.errors import TypingError
+from numba.np import char
+from numba.tests.support import TestCase
+from sys import maxunicode
+
+import numpy as np
+import unittest
+
+
+# -----------------------------------------------------------------------------
+# Support Functions
+
+def _pack_arguments(main_args: (list, tuple), args: (list, tuple)):
+    """Generate combinations of arguments for a list of main arguments"""
+    arg_product = tuple(product(*args))
+    for a in main_args:
+        for args in arg_product:
+            yield *a, *args
+
+
+def _arguments_as_bytes(args: (list, tuple)):
+    """Yield byte counterparts of string arguments, given a list of arguments"""
+    for pair in args:
+        as_bytes = []
+        for arg in pair:
+            if isinstance(arg, np.ndarray):
+                as_bytes.append(arg.astype('S'))
+            elif isinstance(arg, str):
+                as_bytes.append(bytes(arg, 'UTF-8'))
+            else:
+                as_bytes.append(arg)
+        yield as_bytes
+
+
+# -----------------------------------------------------------------------------
+# Comparison Operators
+
+def np_char_equal(x1, x2):
+    return np.char.equal(x1, x2)
+
+
+def np_char_not_equal(x1, x2):
+    return np.char.not_equal(x1, x2)
+
+
+def np_char_greater(x1, x2):
+    return np.char.greater(x1, x2)
+
+
+def np_char_greater_equal(x1, x2):
+    return np.char.greater_equal(x1, x2)
+
+
+def np_char_less(x1, x2):
+    return np.char.less(x1, x2)
+
+
+def np_char_less_equal(x1, x2):
+    return np.char.less_equal(x1, x2)
+
+
+def np_char_compare_chararrays(a1, a2, cmp, rstrip):
+    return np.char.compare_chararrays(a1, a2, cmp, rstrip)
+
+
+class TestComparisonOperators(TestCase):
+    """Test comparison operators of the numpy.char module."""
+
+    byte_args, string_args = [], []
+
+    @classmethod
+    def set_arguments(cls):
+        length = 500
+        # 500 UTF-32 strings of length 1 to 200 in range(1, sys.maxunicode)
+        np.random.seed(42)
+        q = np.array([''.join([chr(np.random.randint(maxunicode))
+                               for _ in range(np.random.randint(1, 200))])
+                      for _ in range(length)])
+        # 500 ASCII strings of length 0 to 50
+        r = np.array([''.join([chr(np.random.randint(1, 127))
+                               for _ in range(np.random.randint(0, 50))])
+                      for _ in range(length)])
+        s: tuple = (np.array(['abc', 'def'] * length),
+                    np.array(['cba', 'fed'] * length))
+        t: tuple = (np.array(['ab', 'bc'] * length),
+                    np.array(['bc', 'ab'] * length))
+        u: tuple = (np.array(['ba', 'cb'] * length),
+                    np.array(['cb', 'ba'] * length))
+        v = np.random.choice(['abcd', 'abc', 'abcde'], length)
+
+        # Whitespace to end of strings & single ASCII characters in range(0, 33)
+        w = [chr(i) for i in range(33)]
+        x = np.concatenate([w, np.char.add(r, np.random.choice(w, length))])
+
+        # Single ASCII characters
+        c = np.random.choice([chr(__i) for __i in range(128)], length)
+
+        arrays = [
+            s, t, u,
+            (c, np.random.choice(c, c.size)),
+            (v, np.random.choice(v, v.size)),
+            (x, x),
+            (x, np.random.choice(x, x.size)),
+            (x, 'abcdefg'), (x, 'abcdefg' * 50),
+            ('abc', 'abc'), ('abc', 'abd'), ('abc', 'abb'),
+            ('abc', 'abc' * 100), ('ab', 'ba'),
+        ]
+
+        # Character buffers of different length
+        arrays += [
+            (x, x.astype('U200')),
+            (s[0].astype('U20'), s[1].astype('U40')),
+            (x.astype('U60'), x.astype('U61')),
+            (np.array('hello' * 100, dtype='U200'),
+             np.array('hello' * 100, dtype='U100'))
+        ]
+
+        # UTF-32
+        arrays += [
+            (q, np.random.choice(q)),
+            (q, np.random.choice(q, len(q))),
+            (q, np.char.add(q, np.random.choice(w, len(q))))
+        ]
+
+        byte_args = list(_arguments_as_bytes(arrays[:-3]))
+        string_args = arrays
+
+        setattr(cls, 'byte_args', byte_args)
+        setattr(cls, 'string_args', string_args)
+
+    def test_comparison_operators(self):
+
+        def check_output(pyfunc_, cfunc_, x1, x2):
+            expected = pyfunc_(x1, x2)
+            got = cfunc_(x1, x2)
+            self.assertPreciseEqual(expected, got)
+
+        def check_exceptions(cfunc_, x1, x2):
+            with self.assertRaisesRegex(ValueError, 'shape mismatch'):
+                cfunc_(x1, np.empty_like(x1[:1]))
+                cfunc_(x1[:10], x2[:5])
+
+            with self.assertRaisesRegex(TypingError, 'non-string arrays'):
+                cfunc_(x1[:5], None)
+                cfunc_('abc', 123)
+
+            with self.assertRaisesRegex(TypingError, 'NotImplemented'):
+                cfunc_(x1.astype('U'), x1.astype('S'))
+                cfunc_('abc', b'abc')
+
+        pyfuncs = (np_char_equal, np_char_not_equal,
+                   np_char_greater_equal, np_char_greater,
+                   np_char_less_equal, np_char_less)
+
+        args = self.string_args[0]
+        for pyfunc in pyfuncs:
+            cfunc = jit(nopython=True)(pyfunc)
+            check_exceptions(cfunc, *args)
+
+        for pyfunc in pyfuncs:
+            cfunc = jit(nopython=True)(pyfunc)
+            for args in self.byte_args:
+                check_output(pyfunc, cfunc, *args)
+                check_output(pyfunc, cfunc, *args[::-1])
+
+            for args in self.string_args:
+                check_output(pyfunc, cfunc, *args)
+                check_output(pyfunc, cfunc, *args[::-1])
+
+        byte_args = list(_pack_arguments(self.byte_args,
+                                         [('==', '!=', '>=', '>', '<', '<='),
+                                          (True, False)]))
+
+        string_args = list(_pack_arguments(self.string_args,
+                                           [('==', '!=', '>=', '>', '<', '<='),
+                                            (True, False)]))
+
+        def check_compare_chararrays(a1, a2, cmp, rstrip):
+            pyfunc_ = np_char_compare_chararrays
+            cfunc_ = jit(nopython=True)(pyfunc_)
+            expected = pyfunc_(a1, a2, cmp, rstrip)
+            got = cfunc_(a1, a2, cmp, rstrip)
+            self.assertPreciseEqual(expected, got)
+
+        for args in byte_args:
+            check_compare_chararrays(*args)
+
+        for args in string_args:
+            check_compare_chararrays(*args)
+
+
+TestComparisonOperators.set_arguments()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch adds support for the following string array operations:

- 'char.equal'
- 'char.not_equal'
- 'char.greater_equal'
- 'char.less_equal'
- 'char.greater'
- 'char.less'
- 'char.compare_chararrays'

Included is support for UTF-32 strings and ASCII bytes on contiguous arrays of 1-dimension and scalars, a light framework for future supported string array functions, tests, and updated documentation.