### PR TITLE
change the include style in _pymodule.h and remove unused or duplicate headers in two header files

### DIFF
--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -3,9 +3,9 @@
 
 #define PY_SSIZE_T_CLEAN
 
-#include <Python.h>
-#include <structmember.h>
-#include <frameobject.h>
+#include "Python.h"
+#include "structmember.h"
+#include "frameobject.h"
 
 #define MOD_ERROR_VAL NULL
 #define MOD_SUCCESS_VAL(val) val

--- a/numba/cext/dictobject.h
+++ b/numba/cext/dictobject.h
@@ -1,6 +1,4 @@
 /* Adapted from CPython3.7 Objects/dict-common.h */
-#include "Python.h"
-#include "../_pymodule.h"
 #include "cext.h"
 
 #ifndef NUMBA_DICT_COMMON_H

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -10,7 +10,6 @@
 #ifndef NUMBA_LIST_H
 #define NUMBA_LIST_H
 
-#include "Python.h"
 #include "cext.h"
 
 typedef void (*list_refcount_op_t)(const void*);


### PR DESCRIPTION
Hi, guys.

In this PR, I changed the include style from <..> to ".." in `_pymodule.h`. Since I want to use some Numba headers in my numba extension, and meanwhile I use bazel to build a `cc` file in my extension (because I also depends on a 3rd C++ library). But because of these "ill-formed" include usages, bazel will output some errors to me, like this:
```
external/numba/cext/../_pymodule.h:6:10: error: 'Python.h' file not found with <angled> include; use "quotes" instead
```

Meanwhile, I also deleted `Python.h` in `listobject.h` and `dictobject.h`, because `cext.h` will include this for them. I also deleted `../_pymodule.h` in `dictobject.h`, since they seem not use any marcos or other things in it. 

After these changes, the building process seems still good. 

PS, I hope these changes in `_pymodule.h` can be merged into a recent Numba release version at least, thanks.

=============
updates [Sept. 29]: After changing the include style in the `_pymodule.h`, bazel can successfully compile the `cc` file for me.

Sure, I have done some tricky things in `WORKSPACE`:
```
# Convert the python include dir to a local repo
new_local_repository(
    name = "python",
    # FIXME: DON'T use hardcode python include path
    path = "/Users/ld/opt/anaconda3/envs/numba-pandas/include/python3.10",
    build_file_content = """
package(default_visibility = ["//visibility:public"])
cc_library(
    name = "headers",
    hdrs = glob(["**/*.h"])
)
"""
)

# Convert the site-packages/numba dir to a local repo
new_local_repository(
    name = "numba",
    path = "/Users/ld/opt/anaconda3/envs/numba-pandas/lib/python3.10/site-packages/numba",
    build_file_content = """
package(default_visibility = ["//visibility:public"])
cc_library(
    name = "headers",
    hdrs = glob(["**/*.h"])
)
"""
)
```
Then, add these two headers into the cc_binary arguments.