### PR TITLE
Remove setuptools as a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,11 +371,13 @@ def get_ext_modules():
 
 packages = find_packages(include=["numba", "numba.*"])
 
-build_requires = ['numpy >={}'.format(min_numpy_build_version)]
+build_requires = [
+    'numpy >={}'.format(min_numpy_build_version),
+    'setuptools <60',
+]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'setuptools <60',
     'importlib_metadata; python_version < "3.9"',
 ]
 


### PR DESCRIPTION
This PR removes setuptools as a runtime dependency, to make downstream packaging
with tools that don't allow dependency cycles (e.g., nix) easier.

I couldn't find any actual runtime uses of `setuptools`, only build time, so
I'm happy to close this out if somehow `setuptools` is required at runtime.
