### PR TITLE
Fix #8477: Allow copies with different strides for 0-length data

### DIFF
--- a/numba/cuda/cudadrv/devicearray.py
+++ b/numba/cuda/cudadrv/devicearray.py
@@ -895,6 +895,8 @@ def check_array_compatibility(ary1, ary2):
     if ary1sq.shape != ary2sq.shape:
         raise ValueError('incompatible shape: %s vs. %s' %
                          (ary1.shape, ary2.shape))
-    if ary1sq.strides != ary2sq.strides:
+    # We check strides only if the size is nonzero, because strides are
+    # irrelevant (and can differ) for zero-length copies.
+    if ary1.size and ary1sq.strides != ary2sq.strides:
         raise ValueError('incompatible strides: %s vs. %s' %
                          (ary1.strides, ary2.strides))

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -420,6 +420,28 @@ class TestCudaNDArray(CUDATestCase):
         got = np.asarray(dary)
         self.assertEqual(got.dtype, dary.dtype)
 
+    def test_issue_8477(self):
+        # Ensure that we can copy a zero-length device array to a zero-length
+        # host array when the strides of the device and host arrays differ -
+        # this should be possible because the strides are irrelevant when the
+        # length is zero. For more info see
+        # https://github.com/numba/numba/issues/8477.
+
+        # Create a device array with shape (0,) and strides (8,)
+        src = devicearray.DeviceNDArray(shape=(0,), strides=(8,), dtype=np.int8)
+
+        # Create a host array with shape (0,) and strides (0,)
+        dest = np.ndarray(shape=(0,), strides=(0,), dtype=np.int8)
+
+        # Sanity check for this test - ensure our destination has the strides
+        # we expect, because strides can be ignored in some cases by the
+        # ndarray constructor - checking here ensures that we haven't failed to
+        # account for unexpected behaviour across different versions of NumPy
+        self.assertEqual(dest.strides, (0,))
+
+        # Ensure that the copy succeeds
+        src.copy_to_host(dest)
+
 
 class TestRecarray(CUDATestCase):
     def test_recarray(self):

--- a/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
+++ b/numba/cuda/tests/cudadrv/test_cuda_ndarray.py
@@ -420,6 +420,7 @@ class TestCudaNDArray(CUDATestCase):
         got = np.asarray(dary)
         self.assertEqual(got.dtype, dary.dtype)
 
+    @skip_on_cudasim('DeviceNDArray class not present in simulator')
     def test_issue_8477(self):
         # Ensure that we can copy a zero-length device array to a zero-length
         # host array when the strides of the device and host arrays differ -


### PR DESCRIPTION
Since NumPy 1.23, it is possible for zero-length ndarrays to have different strides (e.g. `(0,)`, and `(8,)`). If we attempt to copy from a zero-length device array to a zero-length host array where the strides differ, our compatibility check fails because it compares strides.

This commit fixes the issue by only considering strides when checking compatibility of nonzero-length arrays. I believe this to be valid because the following works normally with NumPy 1.23:

```python
import numpy as np

ary1 = np.arange(0)
ary2 = np.ndarray((0,), buffer=ary1.data)
ary3 = np.empty_like(ary2)

ary3[:] = ary2
ary3[...] = ary2
np.copyto(ary2, ary3)
```

i.e. copying zero-length arrays with different strides generally works as expected.

The included test is written in such a way that it should test this change in behaviour regardless of the installed NumPy version - we explicitly construct zero-length device and host arrays with differing strides. The additional sanity check ensures that the host array has the strides we expect, just in case there is some version of NumPy in which setting the strides explicitly didn't result in the expected strides - I have observed that requesting nonzero strides for a zero length array can result still in zero strides (a separate but related behaviour), so this sanity check is provided to account for any other unexpected behaviour of this nature. I have tested locally with NumPy 1.22 and 1.23 (pre- and post-changes to strides).

See also https://github.com/dask/distributed/pull/7089 where a workaround for an observation of this issue was needed. This would not be needed with the fix in this commit.

Fixes #8477.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
