### PR TITLE
Removes context.compile_internal where easy on `numba/cpython/listobj.py`

### DIFF
--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -170,7 +170,3 @@ class ListCompare(AbstractTemplate):
 @infer_global(operator.eq)
 class ListEq(ListCompare): pass
     #key = operator.eq
-
-@infer_global(operator.ge)
-class ListGe(ListCompare): pass
-    #key = operator.ge

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -171,10 +171,6 @@ class ListCompare(AbstractTemplate):
 class ListEq(ListCompare): pass
     #key = operator.eq
 
-@infer_global(operator.le)
-class ListLe(ListCompare): pass
-    #key = operator.le
-
 @infer_global(operator.gt)
 class ListGt(ListCompare): pass
     #key = operator.gt

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -109,13 +109,6 @@ class ListAttribute(AttributeTemplate):
         if len(args) == 1:
             return signature(types.none, list.dtype)
 
-    @bound_function("list.reverse")
-    def resolve_reverse(self, list, args, kws):
-        assert not args
-        assert not kws
-        return signature(types.none)
-
-
 @infer_global(operator.add)
 class AddList(AbstractTemplate):
 

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -171,10 +171,6 @@ class ListCompare(AbstractTemplate):
 class ListEq(ListCompare): pass
     #key = operator.eq
 
-@infer_global(operator.lt)
-class ListLt(ListCompare): pass
-    #key = operator.lt
-
 @infer_global(operator.le)
 class ListLe(ListCompare): pass
     #key = operator.le

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -49,12 +49,6 @@ class ListAttribute(AttributeTemplate):
         assert not kws
         return signature(types.none)
 
-    @bound_function("list.copy")
-    def resolve_copy(self, list, args, kws):
-        assert not args
-        assert not kws
-        return signature(list)
-
     @bound_function("list.count")
     def resolve_count(self, list, args, kws):
         item, = args

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -49,12 +49,6 @@ class ListAttribute(AttributeTemplate):
         assert not kws
         return signature(types.none)
 
-    @bound_function("list.count")
-    def resolve_count(self, list, args, kws):
-        item, = args
-        assert not kws
-        return signature(types.intp, list.dtype)
-
     @bound_function("list.extend")
     def resolve_extend(self, list, args, kws):
         iterable, = args

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -84,12 +84,6 @@ class ListAttribute(AttributeTemplate):
             if isinstance(idx, types.Integer):
                 return signature(list.dtype, types.intp)
 
-    @bound_function("list.remove")
-    def resolve_remove(self, list, args, kws):
-        assert not kws
-        if len(args) == 1:
-            return signature(types.none, list.dtype)
-
 @infer_global(operator.add)
 class AddList(AbstractTemplate):
 

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -171,10 +171,6 @@ class ListCompare(AbstractTemplate):
 class ListEq(ListCompare): pass
     #key = operator.eq
 
-@infer_global(operator.gt)
-class ListGt(ListCompare): pass
-    #key = operator.gt
-
 @infer_global(operator.ge)
 class ListGe(ListCompare): pass
     #key = operator.ge

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -63,19 +63,6 @@ class ListAttribute(AttributeTemplate):
             sig = sig.replace(recvr = list.copy(dtype=unified))
             return sig
 
-    @bound_function("list.index")
-    def resolve_index(self, list, args, kws):
-        assert not kws
-        if len(args) == 1:
-            return signature(types.intp, list.dtype)
-        elif len(args) == 2:
-            if isinstance(args[1], types.Integer):
-                return signature(types.intp, list.dtype, types.intp)
-        elif len(args) == 3:
-            if (isinstance(args[1], types.Integer)
-                and isinstance(args[2], types.Integer)):
-                return signature(types.intp, list.dtype, types.intp, types.intp)
-
     @bound_function("list.insert")
     def resolve_insert(self, list, args, kws):
         idx, item = args

--- a/numba/core/typing/listdecl.py
+++ b/numba/core/typing/listdecl.py
@@ -171,10 +171,6 @@ class ListCompare(AbstractTemplate):
 class ListEq(ListCompare): pass
     #key = operator.eq
 
-@infer_global(operator.ne)
-class ListNe(ListCompare): pass
-    #key = operator.ne
-
 @infer_global(operator.lt)
 class ListLt(ListCompare): pass
     #key = operator.lt

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -888,8 +888,9 @@ def list_copy(lst):
 
     return list_copy_impl
 
-@lower_builtin("list.count", types.List, types.Any)
-def list_count(context, builder, sig, args):
+
+@overload_method(types.List, "count")
+def list_count(lst, value):
 
     def list_count_impl(lst, value):
         res = 0
@@ -898,7 +899,8 @@ def list_count(context, builder, sig, args):
                 res += 1
         return res
 
-    return context.compile_internal(builder, list_count_impl, sig, args)
+    return list_count_impl
+
 
 def _list_extend_list(context, builder, sig, args):
     src = ListInstance(context, builder, sig.args[1], args[1])

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -5,7 +5,6 @@ Support for native homogeneous lists.
 
 import math
 import operator
-import numpy as np
 
 from llvmlite import ir
 from numba.core import types, typing, errors, cgutils
@@ -941,28 +940,28 @@ def list_extend(context, builder, sig, args):
     return context.compile_internal(builder, list_extend, sig, args)
 
 
-intp_max = np.iinfo(as_dtype(types.intp)).max
+intp_max = types.intp.maxval
 
 
 @overload_method(types.List, "index")
-def list_index(lst, value, start=0, end=intp_max):
+def list_index(lst, value, start=0, stop=intp_max):
 
     if not isinstance(start, (int, types.Integer, types.Omitted)):
         raise TypeError(f'arg "start" must be an Integer. Got {start}')
-    if not isinstance(end, (int, types.Integer, types.Omitted)):
+    if not isinstance(stop, (int, types.Integer, types.Omitted)):
         raise TypeError(f'arg "end" must be an Integer. Got {end}')
 
-    def list_index_impl(lst, value, start=0, end=intp_max):
+    def list_index_impl(lst, value, start=0, stop=intp_max):
         n = len(lst)
         if start < 0:
             start += n
             if start < 0:
                 start = 0
-        if end < 0:
-            end += n
-        if end > n:
-            end = n
-        for i in range(start, end):
+        if stop < 0:
+            stop += n
+        if stop > n:
+            stop = n
+        for i in range(start, stop):
             if lst[i] == value:
                 return i
         # XXX references are leaked when raising

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -1028,8 +1028,8 @@ def list_pop(context, builder, sig, args):
     inst.resize(n)
     return impl_ret_new_ref(context, builder, sig.return_type, res)
 
-@lower_builtin("list.remove", types.List, types.Any)
-def list_remove(context, builder, sig, args):
+@overload_method(types.List, "remove")
+def list_remove(lst, value):
 
     def list_remove_impl(lst, value):
         for i in range(len(lst)):
@@ -1039,7 +1039,7 @@ def list_remove(context, builder, sig, args):
         # XXX references are leaked when raising
         raise ValueError("list.remove(x): x not in list")
 
-    return context.compile_internal(builder, list_remove_impl, sig, args)
+    return list_remove_impl
 
 @overload_method(types.List, "reverse")
 def list_reverse(lst):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -838,13 +838,15 @@ def impl_list_lt(a, b):
 
     return list_lt_impl
 
-@lower_builtin(operator.ge, types.List, types.List)
-def list_ge(context, builder, sig, args):
+@overload(operator.ge)
+def impl_list_ge(a, b):
+    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+        return
 
     def list_ge_impl(a, b):
         return b <= a
 
-    return context.compile_internal(builder, list_ge_impl, sig, args)
+    return list_ge_impl
 
 @overload(operator.gt)
 def impl_list_gt(a, b):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -946,9 +946,9 @@ intp_max = types.intp.maxval
 def list_index(lst, value, start=0, stop=intp_max):
 
     if not isinstance(start, (int, types.Integer, types.Omitted)):
-        raise TypeError(f'arg "start" must be an Integer. Got {start}')
+        raise errors.TypingError(f'arg "start" must be an Integer. Got {start}')
     if not isinstance(stop, (int, types.Integer, types.Omitted)):
-        raise TypeError(f'arg "stop" must be an Integer. Got {stop}')
+        raise errors.TypingError(f'arg "stop" must be an Integer. Got {stop}')
 
     def list_index_impl(lst, value, start=0, stop=intp_max):
         n = len(lst)

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -794,13 +794,15 @@ def list_eq(context, builder, sig, args):
 
     return builder.load(res)
 
-@lower_builtin(operator.ne, types.List, types.List)
-def list_ne(context, builder, sig, args):
+@overload(operator.ne)
+def impl_list_ne(a, b):
+    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+        return
 
     def list_ne_impl(a, b):
         return not (a == b)
 
-    return context.compile_internal(builder, list_ne_impl, sig, args)
+    return list_ne_impl
 
 @lower_builtin(operator.le, types.List, types.List)
 def list_le(context, builder, sig, args):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -870,12 +870,13 @@ def list_clear(context, builder, sig, args):
 
     return context.get_dummy_value()
 
-@lower_builtin("list.copy", types.List)
-def list_copy(context, builder, sig, args):
+
+@overload_method(types.List, "copy")
+def list_copy(lst):
     def list_copy_impl(lst):
         return list(lst)
 
-    return context.compile_internal(builder, list_copy_impl, sig, args)
+    return list_copy_impl
 
 @lower_builtin("list.count", types.List, types.Any)
 def list_count(context, builder, sig, args):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -819,8 +819,10 @@ def list_le(context, builder, sig, args):
 
     return context.compile_internal(builder, list_le_impl, sig, args)
 
-@lower_builtin(operator.lt, types.List, types.List)
-def list_lt(context, builder, sig, args):
+@overload(operator.lt)
+def impl_list_lt(a, b):
+    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+        return
 
     def list_lt_impl(a, b):
         m = len(a)
@@ -832,7 +834,7 @@ def list_lt(context, builder, sig, args):
                 return False
         return m < n
 
-    return context.compile_internal(builder, list_lt_impl, sig, args)
+    return list_lt_impl
 
 @lower_builtin(operator.ge, types.List, types.List)
 def list_ge(context, builder, sig, args):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -5,6 +5,7 @@ Support for native homogeneous lists.
 
 import math
 import operator
+import numpy as np
 
 from llvmlite import ir
 from numba.core import types, typing, errors, cgutils
@@ -17,7 +18,7 @@ from numba.core.utils import cached_property
 from numba.misc import quicksort
 from numba.cpython import slicing
 from numba import literal_unroll
-from numba.np.numpy_support import is_nonelike
+from numba.np.numpy_support import as_dtype
 
 
 def get_list_payload(context, builder, list_type, value):
@@ -940,47 +941,33 @@ def list_extend(context, builder, sig, args):
     return context.compile_internal(builder, list_extend, sig, args)
 
 
-@overload_method(types.List, "index")
-def list_index(lst, value, start=None, end=None):
+intp_max = np.iinfo(as_dtype(types.intp)).max
 
-    if is_nonelike(start) and is_nonelike(end):
-        def list_index_impl(lst, value, start=None, end=None):
-            for i in range(len(lst)):
-                if lst[i] == value:
-                    return i
-            # XXX references are leaked when raising
-            raise ValueError("value not in list")
-        return list_index_impl
-    elif is_nonelike(end) and isinstance(start, types.Integer):
-        def list_index_impl(lst, value, start=None, end=None):
-            n = len(lst)
+
+@overload_method(types.List, "index")
+def list_index(lst, value, start=0, end=intp_max):
+
+    if not isinstance(start, (int, types.Integer, types.Omitted)):
+        raise TypeError(f'arg "start" must be an Integer. Got {start}')
+    if not isinstance(end, (int, types.Integer, types.Omitted)):
+        raise TypeError(f'arg "end" must be an Integer. Got {end}')
+
+    def list_index_impl(lst, value, start=0, end=intp_max):
+        n = len(lst)
+        if start < 0:
+            start += n
             if start < 0:
-                start += n
-                if start < 0:
-                    start = 0
-            for i in range(start, len(lst)):
-                if lst[i] == value:
-                    return i
-            # XXX references are leaked when raising
-            raise ValueError("value not in list")
-        return list_index_impl
-    elif all([isinstance(typ, types.Integer) for typ in (start, end)]):
-        def list_index_impl(lst, value, start=None, end=None):
-            n = len(lst)
-            if start < 0:
-                start += n
-                if start < 0:
-                    start = 0
-            if end < 0:
-                end += n
-            if end > n:
-                end = n
-            for i in range(start, end):
-                if lst[i] == value:
-                    return i
-            # XXX references are leaked when raising
-            raise ValueError("value not in list")
-        return list_index_impl
+                start = 0
+        if end < 0:
+            end += n
+        if end > n:
+            end = n
+        for i in range(start, end):
+            if lst[i] == value:
+                return i
+        # XXX references are leaked when raising
+        raise ValueError("value not in list")
+    return list_index_impl
 
 
 @lower_builtin("list.insert", types.List, types.Integer,

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -17,7 +17,6 @@ from numba.core.utils import cached_property
 from numba.misc import quicksort
 from numba.cpython import slicing
 from numba import literal_unroll
-from numba.np.numpy_support import as_dtype
 
 
 def get_list_payload(context, builder, list_type, value):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -948,7 +948,7 @@ def list_index(lst, value, start=0, stop=intp_max):
     if not isinstance(start, (int, types.Integer, types.Omitted)):
         raise TypeError(f'arg "start" must be an Integer. Got {start}')
     if not isinstance(stop, (int, types.Integer, types.Omitted)):
-        raise TypeError(f'arg "end" must be an Integer. Got {end}')
+        raise TypeError(f'arg "stop" must be an Integer. Got {stop}')
 
     def list_index_impl(lst, value, start=0, stop=intp_max):
         n = len(lst)

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -804,8 +804,10 @@ def impl_list_ne(a, b):
 
     return list_ne_impl
 
-@lower_builtin(operator.le, types.List, types.List)
-def list_le(context, builder, sig, args):
+@overload(operator.le)
+def impl_list_le(a, b):
+    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+        return
 
     def list_le_impl(a, b):
         m = len(a)
@@ -817,7 +819,7 @@ def list_le(context, builder, sig, args):
                 return False
         return m <= n
 
-    return context.compile_internal(builder, list_le_impl, sig, args)
+    return list_le_impl
 
 @overload(operator.lt)
 def impl_list_lt(a, b):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -1046,16 +1046,15 @@ def list_remove(context, builder, sig, args):
 
     return context.compile_internal(builder, list_remove_impl, sig, args)
 
-@lower_builtin("list.reverse", types.List)
-def list_reverse(context, builder, sig, args):
+@overload_method(types.List, "reverse")
+def list_reverse(lst):
 
     def list_reverse_impl(lst):
         for a in range(0, len(lst) // 2):
             b = -a - 1
             lst[a], lst[b] = lst[b], lst[a]
 
-    return context.compile_internal(builder, list_reverse_impl, sig, args)
-
+    return list_reverse_impl
 
 # -----------------------------------------------------------------------------
 # Sorting

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -795,9 +795,13 @@ def list_eq(context, builder, sig, args):
 
     return builder.load(res)
 
+
+def all_list(*args):
+    return all([isinstance(typ, types.List) for typ in args])
+
 @overload(operator.ne)
 def impl_list_ne(a, b):
-    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+    if not all_list(a, b):
         return
 
     def list_ne_impl(a, b):
@@ -807,7 +811,7 @@ def impl_list_ne(a, b):
 
 @overload(operator.le)
 def impl_list_le(a, b):
-    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+    if not all_list(a, b):
         return
 
     def list_le_impl(a, b):
@@ -824,7 +828,7 @@ def impl_list_le(a, b):
 
 @overload(operator.lt)
 def impl_list_lt(a, b):
-    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+    if not all_list(a, b):
         return
 
     def list_lt_impl(a, b):
@@ -841,7 +845,7 @@ def impl_list_lt(a, b):
 
 @overload(operator.ge)
 def impl_list_ge(a, b):
-    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+    if not all_list(a, b):
         return
 
     def list_ge_impl(a, b):
@@ -851,7 +855,7 @@ def impl_list_ge(a, b):
 
 @overload(operator.gt)
 def impl_list_gt(a, b):
-    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+    if not all_list(a, b):
         return
 
     def list_gt_impl(a, b):

--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -846,13 +846,15 @@ def list_ge(context, builder, sig, args):
 
     return context.compile_internal(builder, list_ge_impl, sig, args)
 
-@lower_builtin(operator.gt, types.List, types.List)
-def list_gt(context, builder, sig, args):
+@overload(operator.gt)
+def impl_list_gt(a, b):
+    if not all([isinstance(typ, types.List) for typ in [a, b]]):
+        return
 
     def list_gt_impl(a, b):
         return b < a
 
-    return context.compile_internal(builder, list_gt_impl, sig, args)
+    return list_gt_impl
 
 #-------------------------------------------------------------------------------
 # Methods

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -597,14 +597,16 @@ class TestLists(MemoryLeakMixin, TestCase):
             for start, stop in itertools.product(indices, indices):
                 self.check_index_result(pyfunc, cfunc, (16, v, start, stop))
 
-    def test_index_exceptions(self):
-        self.disable_leak_check()
+    def test_index_exception1(self):
         pyfunc = list_index3
         cfunc = jit(nopython=True)(pyfunc)
         msg = 'arg "start" must be an Integer.'
         with self.assertRaisesRegex(errors.TypingError, msg):
             cfunc(10, 0, 'invalid', 5)
 
+    def test_index_exception2(self):
+        pyfunc = list_index3
+        cfunc = jit(nopython=True)(pyfunc)
         msg = 'arg "stop" must be an Integer.'
         with self.assertRaisesRegex(errors.TypingError, msg):
             cfunc(10, 0, 0, 'invalid')

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -597,6 +597,18 @@ class TestLists(MemoryLeakMixin, TestCase):
             for start, stop in itertools.product(indices, indices):
                 self.check_index_result(pyfunc, cfunc, (16, v, start, stop))
 
+    def test_index_exceptions(self):
+        self.disable_leak_check()
+        pyfunc = list_index3
+        cfunc = jit(nopython=True)(pyfunc)
+        msg = 'arg "start" must be an Integer.'
+        with self.assertRaisesRegex(errors.TypingError, msg):
+            cfunc(10, 0, 'invalid', 5)
+
+        msg = 'arg "stop" must be an Integer.'
+        with self.assertRaisesRegex(errors.TypingError, msg):
+            cfunc(10, 0, 0, 'invalid')
+
     def test_remove(self):
         pyfunc = list_remove
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
- list.copy
- list.reverse
- list.count
- list.index
- list.remove
- operator.ne
- operator.lt
- operator.le
- operator.gt
- operator.ge