### PR TITLE
Rewrite most of the set API to use overloads

### DIFF
--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -59,14 +59,6 @@ class SetAttribute(AttributeTemplate):
             sig = sig.replace(recvr=set.copy(dtype=unified))
             return sig
 
-    def _resolve_xxx_update(self, set, args, kws):
-        assert not kws
-        iterable, = args
-        # Set arguments only supported for now
-        # (note we can mix non-reflected and reflected arguments)
-        if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
-            return signature(types.none, iterable)
-
     def _resolve_operator(self, set, args, kws):
         assert not kws
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -131,10 +131,6 @@ class SetAttribute(AttributeTemplate):
     def resolve_issubset(self, set, args, kws):
         return self._resolve_comparator(set, args, kws)
 
-    @bound_function("set.issuperset")
-    def resolve_issuperset(self, set, args, kws):
-        return self._resolve_comparator(set, args, kws)
-
 
 class SetOperator(AbstractTemplate):
 
@@ -169,7 +165,7 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
         key = op_key
 
 
-for op_key in (operator.eq, operator.ne, operator.lt, operator.le, operator.ge, operator.gt):
+for op_key in (operator.eq, operator.ne, operator.lt, operator.le, operator.gt):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -117,10 +117,6 @@ class SetAttribute(AttributeTemplate):
         if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
             return signature(set, iterable)
 
-    @bound_function("set.union")
-    def resolve_union(self, set, args, kws):
-        return self._resolve_operator(set, args, kws)
-
     def _resolve_comparator(self, set, args, kws):
         assert not kws
         arg, = args
@@ -161,7 +157,7 @@ class SetComparison(AbstractTemplate):
             return signature(types.boolean, *args)
 
 
-for op_key in (operator.add, operator.or_, operator.invert):
+for op_key in (operator.add, operator.invert):
     @infer_global(op_key)
     class ConcreteSetOperator(SetOperator):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -165,7 +165,7 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
         key = op_key
 
 
-for op_key in (operator.le, operator.gt):
+for op_key in (operator.le,):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -45,12 +45,6 @@ class SetAttribute(AttributeTemplate):
             sig = sig.replace(recvr=set.copy(dtype=unified))
             return sig
 
-    @bound_function("set.clear")
-    def resolve_clear(self, set, args, kws):
-        assert not kws
-        if not args:
-            return signature(types.none)
-
     @bound_function("set.copy")
     def resolve_copy(self, set, args, kws):
         assert not kws

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -63,12 +63,6 @@ class SetAttribute(AttributeTemplate):
         assert not kws
         return signature(types.none, set.dtype)
 
-    @bound_function("set.pop")
-    def resolve_pop(self, set, args, kws):
-        assert not kws
-        if not args:
-            return signature(set.dtype)
-
     @bound_function("set.update")
     def resolve_update(self, set, args, kws):
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -165,7 +165,7 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
         key = op_key
 
 
-for op_key in (operator.ne, operator.lt, operator.le, operator.gt):
+for op_key in (operator.lt, operator.le, operator.gt):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -117,10 +117,6 @@ class SetAttribute(AttributeTemplate):
         if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
             return signature(set, iterable)
 
-    @bound_function("set.difference")
-    def resolve_difference(self, set, args, kws):
-        return self._resolve_operator(set, args, kws)
-
     @bound_function("set.intersection")
     def resolve_intersection(self, set, args, kws):
         return self._resolve_operator(set, args, kws)
@@ -173,7 +169,7 @@ class SetComparison(AbstractTemplate):
             return signature(types.boolean, *args)
 
 
-for op_key in (operator.add, operator.sub, operator.and_, operator.or_, operator.xor, operator.invert):
+for op_key in (operator.add, operator.and_, operator.or_, operator.xor, operator.invert):
     @infer_global(op_key)
     class ConcreteSetOperator(SetOperator):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -69,12 +69,6 @@ class SetAttribute(AttributeTemplate):
         if not args:
             return signature(set.dtype)
 
-    @bound_function("set.remove")
-    def resolve_remove(self, set, args, kws):
-        item, = args
-        assert not kws
-        return signature(types.none, set.dtype)
-
     @bound_function("set.update")
     def resolve_update(self, set, args, kws):
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -117,10 +117,6 @@ class SetAttribute(AttributeTemplate):
         if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
             return signature(set, iterable)
 
-    @bound_function("set.intersection")
-    def resolve_intersection(self, set, args, kws):
-        return self._resolve_operator(set, args, kws)
-
     @bound_function("set.symmetric_difference")
     def resolve_symmetric_difference(self, set, args, kws):
         return self._resolve_operator(set, args, kws)
@@ -169,7 +165,7 @@ class SetComparison(AbstractTemplate):
             return signature(types.boolean, *args)
 
 
-for op_key in (operator.add, operator.and_, operator.or_, operator.xor, operator.invert):
+for op_key in (operator.add, operator.or_, operator.xor, operator.invert):
     @infer_global(op_key)
     class ConcreteSetOperator(SetOperator):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -139,7 +139,7 @@ for op_key in (operator.add, operator.invert):
         key = op_key
 
 
-for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operator.ixor):
+for op_key in (operator.iadd,):
     @infer_global(op_key)
     class ConcreteInplaceSetOperator(SetOperator):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -45,12 +45,6 @@ class SetAttribute(AttributeTemplate):
             sig = sig.replace(recvr=set.copy(dtype=unified))
             return sig
 
-    @bound_function("set.copy")
-    def resolve_copy(self, set, args, kws):
-        assert not kws
-        if not args:
-            return signature(set)
-
     @bound_function("set.update")
     def resolve_update(self, set, args, kws):
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -101,10 +101,6 @@ class SetAttribute(AttributeTemplate):
     def resolve_difference_update(self, set, args, kws):
         return self._resolve_xxx_update(set, args, kws)
 
-    @bound_function("set.intersection_update")
-    def resolve_intersection_update(self, set, args, kws):
-        return self._resolve_xxx_update(set, args, kws)
-
     def _resolve_operator(self, set, args, kws):
         assert not kws
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -165,7 +165,7 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
         key = op_key
 
 
-for op_key in (operator.eq, operator.ne, operator.lt, operator.le, operator.gt):
+for op_key in (operator.ne, operator.lt, operator.le, operator.gt):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -57,12 +57,6 @@ class SetAttribute(AttributeTemplate):
         if not args:
             return signature(set)
 
-    @bound_function("set.discard")
-    def resolve_discard(self, set, args, kws):
-        item, = args
-        assert not kws
-        return signature(types.none, set.dtype)
-
     @bound_function("set.update")
     def resolve_update(self, set, args, kws):
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -117,10 +117,6 @@ class SetAttribute(AttributeTemplate):
         if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
             return signature(set, iterable)
 
-    @bound_function("set.symmetric_difference")
-    def resolve_symmetric_difference(self, set, args, kws):
-        return self._resolve_operator(set, args, kws)
-
     @bound_function("set.union")
     def resolve_union(self, set, args, kws):
         return self._resolve_operator(set, args, kws)
@@ -165,7 +161,7 @@ class SetComparison(AbstractTemplate):
             return signature(types.boolean, *args)
 
 
-for op_key in (operator.add, operator.or_, operator.xor, operator.invert):
+for op_key in (operator.add, operator.or_, operator.invert):
     @infer_global(op_key)
     class ConcreteSetOperator(SetOperator):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -127,10 +127,6 @@ class SetAttribute(AttributeTemplate):
     def resolve_isdisjoint(self, set, args, kws):
         return self._resolve_comparator(set, args, kws)
 
-    @bound_function("set.issubset")
-    def resolve_issubset(self, set, args, kws):
-        return self._resolve_comparator(set, args, kws)
-
 
 class SetOperator(AbstractTemplate):
 
@@ -163,10 +159,3 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
     @infer_global(op_key)
     class ConcreteInplaceSetOperator(SetOperator):
         key = op_key
-
-
-for op_key in (operator.le,):
-    @infer_global(op_key)
-    class ConcreteSetComparison(SetComparison):
-        key = op_key
-

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -97,10 +97,6 @@ class SetAttribute(AttributeTemplate):
         if isinstance(iterable, types.Set) and iterable.dtype == set.dtype:
             return signature(types.none, iterable)
 
-    @bound_function("set.difference_update")
-    def resolve_difference_update(self, set, args, kws):
-        return self._resolve_xxx_update(set, args, kws)
-
     def _resolve_operator(self, set, args, kws):
         assert not kws
         iterable, = args

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -165,7 +165,7 @@ for op_key in (operator.iadd, operator.isub, operator.iand, operator.ior, operat
         key = op_key
 
 
-for op_key in (operator.lt, operator.le, operator.gt):
+for op_key in (operator.le, operator.gt):
     @infer_global(op_key)
     class ConcreteSetComparison(SetComparison):
         key = op_key

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -123,10 +123,6 @@ class SetAttribute(AttributeTemplate):
         if arg == set:
             return signature(types.boolean, arg)
 
-    @bound_function("set.isdisjoint")
-    def resolve_isdisjoint(self, set, args, kws):
-        return self._resolve_comparator(set, args, kws)
-
 
 class SetOperator(AbstractTemplate):
 

--- a/numba/core/typing/setdecl.py
+++ b/numba/core/typing/setdecl.py
@@ -105,10 +105,6 @@ class SetAttribute(AttributeTemplate):
     def resolve_intersection_update(self, set, args, kws):
         return self._resolve_xxx_update(set, args, kws)
 
-    @bound_function("set.symmetric_difference_update")
-    def resolve_symmetric_difference_update(self, set, args, kws):
-        return self._resolve_xxx_update(set, args, kws)
-
     def _resolve_operator(self, set, args, kws):
         assert not kws
         iterable, = args

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1298,13 +1298,25 @@ def set_add(context, builder, sig, args):
 
     return context.get_dummy_value()
 
-@lower_builtin("set.discard", types.Set, types.Any)
+
 def set_discard(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     item = args[1]
     inst.discard(item)
 
     return context.get_dummy_value()
+
+
+@intrinsic
+def _set_discard(typingctx, s, item):
+    sig = types.none(s, item)
+    return sig, set_discard
+
+
+@overload_method(types.Set, "discard")
+def ol_set_discard(s, item):
+    return lambda s, item: _set_discard(s, item)
+
 
 def set_pop(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1484,12 +1484,25 @@ def set_union(a, b):
 
 # Predicates
 
-@lower_builtin("set.isdisjoint", types.Set, types.Set)
-def set_isdisjoint(context, builder, sig, args):
-    inst = SetInstance(context, builder, sig.args[0], args[0])
-    other = SetInstance(context, builder, sig.args[1], args[1])
+@intrinsic
+def _set_isdisjoint(typingctx, a, b):
+    sig = types.boolean(a, b)
 
-    return inst.isdisjoint(other)
+    def codegen(context, builder, sig, args):
+        inst = SetInstance(context, builder, sig.args[0], args[0])
+        other = SetInstance(context, builder, sig.args[1], args[1])
+
+        return inst.isdisjoint(other)
+
+    return sig, codegen
+
+
+@overload_method(types.Set, "isdisjoint")
+def set_isdisjoint(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
+    return lambda a, b: _set_isdisjoint(a, b)
 
 
 @intrinsic

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1509,9 +1509,8 @@ def gen_operator_impl(op, impl):
 
     @overload(op)
     def _ol_set_operator(a, b):
-        if all([isinstance(typ, types.Set) for typ in (a, b)]) and \
-                (a.dtype == b.dtype):
-            return lambda a, b: _set_operator_intr(a, b)
+        check_all_set(a, b)
+        return lambda a, b: _set_operator_intr(a, b)
 
 
 for op_, op_impl in [

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1316,7 +1316,7 @@ def set_pop(context, builder, sig, args):
 
     return inst.pop()
 
-@lower_builtin("set.remove", types.Set, types.Any)
+
 def set_remove(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     item = args[1]
@@ -1326,6 +1326,18 @@ def set_remove(context, builder, sig, args):
                                           ("set.remove(): key not in set",))
 
     return context.get_dummy_value()
+
+
+@intrinsic
+def _set_remove(typingctx, s, item):
+    sig = types.none(s, item)
+    return sig, set_remove
+
+
+@overload_method(types.Set, "remove")
+def ol_set_remove(s, item):
+    # XXX: should item have the same type as s.dtype?
+    return lambda s, item: _set_remove(s, item)
 
 
 # Mutating set operations

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -110,8 +110,6 @@ def check_all_set(*args):
     if not all([args[0].dtype == s.dtype for s in args]):
         raise TypingError(f"All Sets must be of the same type, got {args}")
 
-    return True
-
 
 SetLoop = collections.namedtuple('SetLoop', ('index', 'entry', 'do_break'))
 

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1510,12 +1510,25 @@ def set_issuperset(a, b):
 
     return superset_impl
 
-@lower_builtin(operator.eq, types.Set, types.Set)
-def set_isdisjoint(context, builder, sig, args):
-    inst = SetInstance(context, builder, sig.args[0], args[0])
-    other = SetInstance(context, builder, sig.args[1], args[1])
+@intrinsic
+def _set_eq(typingctx, a, b):
+    sig = types.boolean(a, b)
 
-    return inst.equals(other)
+    def codegen(context, builder, sig, args):
+        inst = SetInstance(context, builder, sig.args[0], args[0])
+        other = SetInstance(context, builder, sig.args[1], args[1])
+
+        return inst.equals(other)
+
+    return sig, codegen
+
+@overload(operator.eq)
+def set_eq(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
+    return lambda a, b: _set_eq(a, b)
+
 
 @lower_builtin(operator.ne, types.Set, types.Set)
 def set_ne(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1499,13 +1499,16 @@ def set_issubset(context, builder, sig, args):
 
     return inst.issubset(other)
 
-@lower_builtin(operator.ge, types.Set, types.Set)
-@lower_builtin("set.issuperset", types.Set, types.Set)
-def set_issuperset(context, builder, sig, args):
+@overload(operator.ge)
+@overload_method(types.Set, "issuperset")
+def set_issuperset(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
     def superset_impl(a, b):
         return b.issubset(a)
 
-    return context.compile_internal(builder, superset_impl, sig, args)
+    return superset_impl
 
 @lower_builtin(operator.eq, types.Set, types.Set)
 def set_isdisjoint(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1558,13 +1558,15 @@ def set_lt(a, b):
 
     return lambda a, b: _set_lt(a, b)
 
+@overload(operator.gt)
+def set_gt(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
 
-@lower_builtin(operator.gt, types.Set, types.Set)
-def set_gt(context, builder, sig, args):
     def gt_impl(a, b):
         return b < a
 
-    return context.compile_internal(builder, gt_impl, sig, args)
+    return gt_impl
 
 @lower_builtin(operator.is_, types.Set, types.Set)
 def set_is(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1364,11 +1364,21 @@ def ol_set_remove(s, item):
 
 # Mutating set operations
 
-@lower_builtin("set.clear", types.Set)
 def set_clear(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     inst.clear()
     return context.get_dummy_value()
+
+
+@intrinsic
+def _set_clear(typingctx, s):
+    sig = types.none(s)
+    return sig, set_clear
+
+
+@overload_method(types.Set, "clear")
+def ol_set_clear(s):
+    return lambda s: _set_clear(s)
 
 @lower_builtin("set.copy", types.Set)
 def set_copy(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1306,7 +1306,6 @@ def set_discard(context, builder, sig, args):
 
     return context.get_dummy_value()
 
-@lower_builtin("set.pop", types.Set)
 def set_pop(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     used = inst.payload.used
@@ -1315,6 +1314,17 @@ def set_pop(context, builder, sig, args):
                                           ("set.pop(): empty set",))
 
     return inst.pop()
+
+
+@intrinsic
+def _set_pop(typingctx, s):
+    sig = s.dtype(s)
+    return sig, set_pop
+
+
+@overload_method(types.Set, "pop")
+def ol_set_pop(s):
+    return lambda s: _set_pop(s)
 
 
 def set_remove(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1351,14 +1351,29 @@ def set_difference_update(context, builder, sig, args):
 
     return context.get_dummy_value()
 
-@lower_builtin("set.intersection_update", types.Set, types.Set)
-def set_intersection_update(context, builder, sig, args):
-    inst = SetInstance(context, builder, sig.args[0], args[0])
-    other = SetInstance(context, builder, sig.args[1], args[1])
 
-    inst.intersect(other)
+@intrinsic
+def _set_intersection_update(typingctx, a, b):
+    sig = types.none(a, b)
 
-    return context.get_dummy_value()
+    def codegen(context, builder, sig, args):
+        inst = SetInstance(context, builder, sig.args[0], args[0])
+        other = SetInstance(context, builder, sig.args[1], args[1])
+
+        inst.intersect(other)
+
+        return context.get_dummy_value()
+
+    return sig, codegen
+
+
+@overload_method(types.Set, "intersection_update")
+def set_intersection_update(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
+    return lambda a, b: _set_intersection_update(a, b)
+
 
 @intrinsic
 def _set_symmetric_difference_update(typingctx, a, b):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1463,10 +1463,12 @@ def set_symmetric_difference(a, b):
 
     return symmetric_difference_impl
 
+@overload(operator.or_)
+@overload_method(types.Set, "union")
+def set_union(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
 
-@lower_builtin(operator.or_, types.Set, types.Set)
-@lower_builtin("set.union", types.Set, types.Set)
-def set_union(context, builder, sig, args):
     def union_impl(a, b):
         if len(a) > len(b):
             s = a.copy()
@@ -1477,7 +1479,7 @@ def set_union(context, builder, sig, args):
             s.update(a)
             return s
 
-    return context.compile_internal(builder, union_impl, sig, args)
+    return union_impl
 
 
 # Predicates

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1427,10 +1427,12 @@ def impl_set_difference(a, b):
 
     return difference_impl
 
+@overload(operator.and_)
+@overload_method(types.Set, "intersection")
+def set_intersection(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
 
-@lower_builtin(operator.and_, types.Set, types.Set)
-@lower_builtin("set.intersection", types.Set, types.Set)
-def set_intersection(context, builder, sig, args):
     def intersection_impl(a, b):
         if len(a) < len(b):
             s = a.copy()
@@ -1441,7 +1443,8 @@ def set_intersection(context, builder, sig, args):
             s.intersection_update(a)
             return s
 
-    return context.compile_internal(builder, intersection_impl, sig, args)
+    return intersection_impl
+
 
 @lower_builtin(operator.xor, types.Set, types.Set)
 @lower_builtin("set.symmetric_difference", types.Set, types.Set)

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1380,11 +1380,22 @@ def _set_clear(typingctx, s):
 def ol_set_clear(s):
     return lambda s: _set_clear(s)
 
-@lower_builtin("set.copy", types.Set)
+
 def set_copy(context, builder, sig, args):
     inst = SetInstance(context, builder, sig.args[0], args[0])
     other = inst.copy()
     return impl_ret_new_ref(context, builder, sig.return_type, other.value)
+
+
+@intrinsic
+def _set_copy(typingctx, s):
+    sig = s(s)
+    return sig, set_copy
+
+
+@overload_method(types.Set, "copy")
+def ol_set_copy(s):
+    return lambda s: _set_copy(s)
 
 
 def set_difference_update(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1539,12 +1539,25 @@ def set_ne(a, b):
 
     return ne_impl
 
-@lower_builtin(operator.lt, types.Set, types.Set)
-def set_lt(context, builder, sig, args):
-    inst = SetInstance(context, builder, sig.args[0], args[0])
-    other = SetInstance(context, builder, sig.args[1], args[1])
+@intrinsic
+def _set_lt(typingctx, a, b):
+    sig = types.boolean(a, b)
 
-    return inst.issubset(other, strict=True)
+    def codegen(context, builder, sig, args):
+        inst = SetInstance(context, builder, sig.args[0], args[0])
+        other = SetInstance(context, builder, sig.args[1], args[1])
+
+        return inst.issubset(other, strict=True)
+
+    return sig, codegen
+
+@overload(operator.lt)
+def set_lt(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
+    return lambda a, b: _set_lt(a, b)
+
 
 @lower_builtin(operator.gt, types.Set, types.Set)
 def set_gt(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1360,14 +1360,28 @@ def set_intersection_update(context, builder, sig, args):
 
     return context.get_dummy_value()
 
-@lower_builtin("set.symmetric_difference_update", types.Set, types.Set)
-def set_symmetric_difference_update(context, builder, sig, args):
-    inst = SetInstance(context, builder, sig.args[0], args[0])
-    other = SetInstance(context, builder, sig.args[1], args[1])
+@intrinsic
+def _set_symmetric_difference_update(typingctx, a, b):
+    sig = types.none(a, b)
 
-    inst.symmetric_difference(other)
+    def codegen(context, builder, sig, args):
+        inst = SetInstance(context, builder, sig.args[0], args[0])
+        other = SetInstance(context, builder, sig.args[1], args[1])
 
-    return context.get_dummy_value()
+        inst.symmetric_difference(other)
+
+        return context.get_dummy_value()
+
+    return sig, codegen
+
+
+@overload_method(types.Set, "symmetric_difference_update")
+def set_symmetric_difference_update(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
+
+    return lambda a, b: _set_symmetric_difference_update(a, b)
+
 
 @lower_builtin("set.update", types.Set, types.IterableType)
 def set_update(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1529,13 +1529,15 @@ def set_eq(a, b):
 
     return lambda a, b: _set_eq(a, b)
 
+@overload(operator.ne)
+def set_ne(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
 
-@lower_builtin(operator.ne, types.Set, types.Set)
-def set_ne(context, builder, sig, args):
     def ne_impl(a, b):
         return not a == b
 
-    return context.compile_internal(builder, ne_impl, sig, args)
+    return ne_impl
 
 @lower_builtin(operator.lt, types.Set, types.Set)
 def set_lt(context, builder, sig, args):

--- a/numba/cpython/setobj.py
+++ b/numba/cpython/setobj.py
@@ -1445,10 +1445,12 @@ def set_intersection(a, b):
 
     return intersection_impl
 
+@overload(operator.xor)
+@overload_method(types.Set, "symmetric_difference")
+def set_symmetric_difference(a, b):
+    if not all([isinstance(typ, types.Set) for typ in (a, b)]):
+        return
 
-@lower_builtin(operator.xor, types.Set, types.Set)
-@lower_builtin("set.symmetric_difference", types.Set, types.Set)
-def set_symmetric_difference(context, builder, sig, args):
     def symmetric_difference_impl(a, b):
         if len(a) > len(b):
             s = a.copy()
@@ -1459,8 +1461,8 @@ def set_symmetric_difference(context, builder, sig, args):
             s.symmetric_difference_update(a)
             return s
 
-    return context.compile_internal(builder, symmetric_difference_impl,
-                                    sig, args)
+    return symmetric_difference_impl
+
 
 @lower_builtin(operator.or_, types.Set, types.Set)
 @lower_builtin("set.union", types.Set, types.Set)

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -171,36 +171,25 @@ def union_usecase(a, b):
     s = sa.union(set(b))
     return list(s)
 
+def difference_usecase__2(a, b):
+    s = a.difference(b)
+    return list(s)
+
+def intersection_usecase__2(a, b):
+    s = a.intersection(b)
+    return list(s)
+
+def symmetric_difference_usecase__2(a, b):
+    s = a.symmetric_difference(b)
+    return list(s)
+
+def union_usecase__2(a, b):
+    s = a.union(b)
+    return list(s)
+
 def set_return_usecase(a):
     s = set(a)
     return s
-
-
-def make_operator_usecase(op):
-    code = """if 1:
-    def operator_usecase(a, b):
-        s = set(a) %(op)s set(b)
-        return list(s)
-    """ % dict(op=op)
-    return compile_function('operator_usecase', code, globals())
-
-def make_inplace_operator_usecase(op):
-    code = """if 1:
-    def inplace_operator_usecase(a, b):
-        sa = set(a)
-        sb = set(b)
-        sc = sa
-        sc %(op)s sb
-        return list(sc), list(sa)
-    """ % dict(op=op)
-    return compile_function('inplace_operator_usecase', code, globals())
-
-def make_comparison_usecase(op):
-    code = """if 1:
-    def comparison_usecase(a, b):
-        return set(a) %(op)s set(b)
-    """ % dict(op=op)
-    return compile_function('comparison_usecase', code, globals())
 
 
 def noop(x):
@@ -539,6 +528,32 @@ class TestSets(BaseTest):
             b = self.sparse_array(nb)
             check(a, b)
 
+    def make_operator_usecase(self, op):
+        code = """if 1:
+        def operator_usecase(a, b):
+            s = set(a) %(op)s set(b)
+            return list(s)
+        """ % dict(op=op)
+        return compile_function('operator_usecase', code, globals())
+
+    def make_inplace_operator_usecase(self, op):
+        code = """if 1:
+        def inplace_operator_usecase(a, b):
+            sa = set(a)
+            sb = set(b)
+            sc = sa
+            sc %(op)s sb
+            return list(sc), list(sa)
+        """ % dict(op=op)
+        return compile_function('inplace_operator_usecase', code, globals())
+
+    def make_comparison_usecase(self, op):
+        code = """if 1:
+        def comparison_usecase(a, b):
+            return set(a) %(op)s set(b)
+        """ % dict(op=op)
+        return compile_function('comparison_usecase', code, globals())
+
     def test_difference(self):
         self._test_set_operator(difference_usecase)
 
@@ -552,46 +567,46 @@ class TestSets(BaseTest):
         self._test_set_operator(union_usecase)
 
     def test_and(self):
-        self._test_set_operator(make_operator_usecase('&'))
+        self._test_set_operator(self.make_operator_usecase('&'))
 
     def test_or(self):
-        self._test_set_operator(make_operator_usecase('|'))
+        self._test_set_operator(self.make_operator_usecase('|'))
 
     def test_sub(self):
-        self._test_set_operator(make_operator_usecase('-'))
+        self._test_set_operator(self.make_operator_usecase('-'))
 
     def test_xor(self):
-        self._test_set_operator(make_operator_usecase('^'))
+        self._test_set_operator(self.make_operator_usecase('^'))
 
     def test_eq(self):
-        self._test_set_operator(make_comparison_usecase('=='))
+        self._test_set_operator(self.make_comparison_usecase('=='))
 
     def test_ne(self):
-        self._test_set_operator(make_comparison_usecase('!='))
+        self._test_set_operator(self.make_comparison_usecase('!='))
 
     def test_le(self):
-        self._test_set_operator(make_comparison_usecase('<='))
+        self._test_set_operator(self.make_comparison_usecase('<='))
 
     def test_lt(self):
-        self._test_set_operator(make_comparison_usecase('<'))
+        self._test_set_operator(self.make_comparison_usecase('<'))
 
     def test_ge(self):
-        self._test_set_operator(make_comparison_usecase('>='))
+        self._test_set_operator(self.make_comparison_usecase('>='))
 
     def test_gt(self):
-        self._test_set_operator(make_comparison_usecase('>'))
+        self._test_set_operator(self.make_comparison_usecase('>'))
 
     def test_iand(self):
-        self._test_set_operator(make_inplace_operator_usecase('&='))
+        self._test_set_operator(self.make_inplace_operator_usecase('&='))
 
     def test_ior(self):
-        self._test_set_operator(make_inplace_operator_usecase('|='))
+        self._test_set_operator(self.make_inplace_operator_usecase('|='))
 
     def test_isub(self):
-        self._test_set_operator(make_inplace_operator_usecase('-='))
+        self._test_set_operator(self.make_inplace_operator_usecase('-='))
 
     def test_ixor(self):
-        self._test_set_operator(make_inplace_operator_usecase('^='))
+        self._test_set_operator(self.make_inplace_operator_usecase('^='))
 
 
 class TestFloatSets(TestSets):
@@ -624,18 +639,72 @@ class TestUnicodeSets(TestSets):
     def _range(self, stop):
         return ['A{}'.format(i) for i in range(int(stop))]
 
+
 class TestSetsInvalidDtype(TestSets):
 
     def _test_set_operator(self, pyfunc):
         # it is invalid to apply some set operations on
         # sets with different dtype
         check = self.unordered_checker(pyfunc)
+        # cfunc = jit(nopython=True)(pyfunc)
+
         a = set([1, 2, 4, 11])
         b = set(['a', 'b', 'c'])
-
-        msg = 'No implementation of function'
+        msg = 'All Sets must be of the same type'
         with self.assertRaisesRegex(TypingError, msg):
             check(a, b)
+
+
+class TestSetsInvalid(TestSets):
+
+    def _test_set_operator(self, pyfunc):
+        # it is invalid to apply some set operations on
+        # sets with different dtype
+        cfunc = jit(nopython=True)(pyfunc)
+
+        a = set([1, 2, 4, 11])
+        b = (1, 2, 3)
+        msg = 'All arguments must be Sets'
+        with self.assertRaisesRegex(TypingError, msg):
+            cfunc(a, b)
+
+    def test_difference(self):
+        self._test_set_operator(difference_usecase__2)
+
+    def test_intersection(self):
+        self._test_set_operator(intersection_usecase__2)
+
+    def test_symmetric_difference(self):
+        self._test_set_operator(symmetric_difference_usecase__2)
+
+    def test_union(self):
+        self._test_set_operator(union_usecase__2)
+
+    def make_operator_usecase(self, op):
+        code = """if 1:
+        def operator_usecase(a, b):
+            s = a %(op)s b
+            return list(s)
+        """ % dict(op=op)
+        return compile_function('operator_usecase', code, globals())
+
+    def make_inplace_operator_usecase(self, op):
+        code = """if 1:
+        def inplace_operator_usecase(a, b):
+            sa = a
+            sb = b
+            sc = sa
+            sc %(op)s sb
+            return list(sc), list(sa)
+        """ % dict(op=op)
+        return compile_function('inplace_operator_usecase', code, globals())
+
+    def make_comparison_usecase(self, op):
+        code = """if 1:
+        def comparison_usecase(a, b):
+            return set(a) %(op)s b
+        """ % dict(op=op)
+        return compile_function('comparison_usecase', code, globals())
 
 
 class TestUnboxing(BaseTest):

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -171,22 +171,6 @@ def union_usecase(a, b):
     s = sa.union(set(b))
     return list(s)
 
-def difference_usecase__2(a, b):
-    s = a.difference(b)
-    return list(s)
-
-def intersection_usecase__2(a, b):
-    s = a.intersection(b)
-    return list(s)
-
-def symmetric_difference_usecase__2(a, b):
-    s = a.symmetric_difference(b)
-    return list(s)
-
-def union_usecase__2(a, b):
-    s = a.union(b)
-    return list(s)
-
 def set_return_usecase(a):
     s = set(a)
     return s
@@ -645,17 +629,32 @@ class TestSetsInvalidDtype(TestSets):
     def _test_set_operator(self, pyfunc):
         # it is invalid to apply some set operations on
         # sets with different dtype
-        check = self.unordered_checker(pyfunc)
-        # cfunc = jit(nopython=True)(pyfunc)
+        cfunc = jit(nopython=True)(pyfunc)
 
         a = set([1, 2, 4, 11])
         b = set(['a', 'b', 'c'])
         msg = 'All Sets must be of the same type'
         with self.assertRaisesRegex(TypingError, msg):
-            check(a, b)
+            cfunc(a, b)
 
 
 class TestSetsInvalid(TestSets):
+
+    def symmetric_difference_usecase(a, b):
+        s = a.symmetric_difference(b)
+        return list(s)
+
+    def difference_usecase(a, b):
+        s = a.difference(b)
+        return list(s)
+
+    def intersection_usecase(a, b):
+        s = a.intersection(b)
+        return list(s)
+
+    def union_usecase(a, b):
+        s = a.union(b)
+        return list(s)
 
     def _test_set_operator(self, pyfunc):
         # it is invalid to apply some set operations on
@@ -669,16 +668,16 @@ class TestSetsInvalid(TestSets):
             cfunc(a, b)
 
     def test_difference(self):
-        self._test_set_operator(difference_usecase__2)
+        self._test_set_operator(TestSetsInvalid.difference_usecase)
 
     def test_intersection(self):
-        self._test_set_operator(intersection_usecase__2)
+        self._test_set_operator(TestSetsInvalid.intersection_usecase)
 
     def test_symmetric_difference(self):
-        self._test_set_operator(symmetric_difference_usecase__2)
+        self._test_set_operator(TestSetsInvalid.symmetric_difference_usecase)
 
     def test_union(self):
-        self._test_set_operator(union_usecase__2)
+        self._test_set_operator(TestSetsInvalid.union_usecase)
 
     def make_operator_usecase(self, op):
         code = """if 1:

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -6,6 +6,7 @@ import itertools
 import math
 import random
 import sys
+from numba.core.errors import TypingError
 
 import numpy as np
 
@@ -622,6 +623,19 @@ class TestUnicodeSets(TestSets):
     """
     def _range(self, stop):
         return ['A{}'.format(i) for i in range(int(stop))]
+
+class TestSetsInvalidDtype(TestSets):
+
+    def _test_set_operator(self, pyfunc):
+        # it is invalid to apply some set operations on
+        # sets with different dtype
+        check = self.unordered_checker(pyfunc)
+        a = set([1, 2, 4, 11])
+        b = set(['a', 'b', 'c'])
+
+        msg = 'No implementation of function'
+        with self.assertRaisesRegex(TypingError, msg):
+            check(a, b)
 
 
 class TestUnboxing(BaseTest):


### PR DESCRIPTION
Methods changed:
- set.copy
- set.clear
- set.discard
- set.pop
- set.remove
- set.difference_update
- set.intersection_update
- set.symmetric_difference_update
- set.isdisjoint
- set.issubset
- set.issuperset
- set.union
- set.symetryc_difference
- set.intersection
- set.difference
- operator.sub
- operator.and_
- operator.xor
- operator.or_
- operator.iand
- operator.ior
- operator.isub
- operator.ixor
- operator.le
- operator.gt
- operator.lt
- operator.ge
- operator.ne
- operator.eq
