### PR TITLE
Remove _DispatcherBase._types_active_call

### DIFF
--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -253,8 +253,6 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         self.func_code = get_code_object(py_func)
         # but newer python uses a different name
         self.__code__ = self.func_code
-        # a place to keep an active reference to the types of the active call
-        self._types_active_call = []
         # Default argument values match the py_func
         self.__defaults__ = py_func.__defaults__
 
@@ -485,8 +483,6 @@ class _DispatcherBase(_dispatcher.Dispatcher):
                     e.patch_message('\n'.join((str(e).rstrip(), help_msg)))
             # ignore the FULL_TRACEBACKS config, this needs reporting!
             raise e
-        finally:
-            self._types_active_call = []
         return return_val
 
     def inspect_llvm(self, signature=None):
@@ -736,7 +732,6 @@ class _DispatcherBase(_dispatcher.Dispatcher):
         else:
             if tp is None:
                 tp = types.pyobject
-        self._types_active_call.append(tp)
         return tp
 
     def _callback_add_timer(self, duration, cres, lock_name):


### PR DESCRIPTION
Keeping a list of the argument types for the current call appears to be pointless - even if it weren't pointless, I'm not convinced it wouldn't be a source of race conditions when an njitted function is called by multiple threads.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
