### PR TITLE
Deprecate numba.generated_jit

### DIFF
--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -224,7 +224,146 @@ supply the keyword argument ``forceobj=True`` to ensure the function is always
 compiled in :term:`object mode`.
 
 
-.. _deprecation-strict-strides:
+.. _deprecation-of-generated-jit:
+
+Deprecation of ``generated_jit``
+================================
+The top level API function ``numba.generated_jit`` provides functionality that
+allows users to write JIT compilable functions that have different
+implementations based on the types of the arguments to the function. This is a
+hugely useful concept and is also key to Numba's internal implementation.
+
+Reason for deprecation
+----------------------
+
+There are a number of reasons for this deprecation.
+
+First, ``generated_jit`` breaks the concept of "JIT transparency" in that if the
+JIT compiler is disabled, the source code does not execute the same way as it
+would were the JIT compiler present.
+
+Second, internally Numba uses the ``numba.extending.overload`` family of
+decorators to access an equivalent functionality to ``generated_jit``. The
+``overload`` family of decorators are more powerful than ``generated_jit`` as
+they support far more options and both the CPU and CUDA targets. Essentially a
+replacement for ``generated_jit`` already exists and has been recommended and
+preferred for a long while.
+
+Third, the public extension API decorators are far better maintained than
+``generated_jit``. This is an important consideration due to Numba's limited
+resources, fewer duplicated pieces of functionality to maintain will reduce
+pressure on these resources.
+
+For more information on the ``overload`` family of decorators see the
+:ref:`high level extension API documentation <high-level-extending>`.
+
+Example(s) of the impact
+------------------------
+
+Any source code using ``generated_jit`` would fail to work once the
+functionality has been removed.
+
+Schedule
+--------
+
+This feature will be removed with respect to this schedule:
+
+* Deprecation warnings will be issued in version 0.57.0.
+* Removal will take place in version 0.59.0.
+
+Recommendations
+---------------
+
+Projects that need/rely on the deprecated behaviour should pin their dependency
+on Numba to a version prior to removal of this behaviour, or consider following
+replacement instructions below that outline how to adjust to the change.
+
+Replacement
+-----------
+
+The ``overload`` decorator offers a replacement for the functionality available
+through ``generated_jit``. An example follows of translating from one to the
+other. First define a type specialised function dispatch with the
+``generated_jit`` decorator::
+
+  from numba import njit, generated_jit, types
+
+  @generated_jit
+  def select(x):
+      if isinstance(x, types.Float):
+          def impl(x):
+              return x + 1
+          return impl
+      elif isinstance(x, types.UnicodeType):
+          def impl(x):
+              return x + " the number one"
+          return impl
+      else:
+          raise TypeError("Unsupported Type")
+
+  @njit
+  def foo(x):
+      return select(x)
+
+  print(foo(1.))
+  print(foo("a string"))
+
+Conceptually, ``generated_jit`` is like ``overload``, but with ``generated_jit``
+the overloaded function is the decorated function. Taking the example above and
+adjusting it to use the ``overload`` API::
+
+  from numba import njit, types
+  from numba.extending import overload
+
+  # A pure python implementation that will run if the JIT compiler is disabled.
+  def select(x):
+      if isinstance(x, float):
+          return x + 1
+      elif isinstance(x, str):
+          return x + " the number one"
+      else:
+          raise TypeError("Unsupported Type")
+
+  # An overload for the `select` function cf. generated_jit
+  @overload(select)
+  def ol_select(x):
+      if isinstance(x, types.Float):
+          def impl(x):
+              return x + 1
+          return impl
+      elif isinstance(x, types.UnicodeType):
+          def impl(x):
+              return x + " the number one"
+          return impl
+      else:
+          raise TypeError("Unsupported Type")
+
+  @njit
+  def foo(x):
+      return select(x)
+
+  print(foo(1.))
+  print(foo("a string"))
+
+Further, users that are using ``generated_jit`` to dispatch on some of the more
+primitive types may find that Numba's support for ``isinstance`` is sufficient,
+for example::
+
+  @njit # NOTE: standard @njit decorator.
+  def select(x):
+      if isinstance(x, float):
+          return x + 1
+      elif isinstance(x, str):
+          return x + " the number one"
+      else:
+          raise TypeError("Unsupported Type")
+
+  @njit
+  def foo(x):
+      return select(x)
+
+  print(foo(1.))
+  print(foo("a string"))
 
 
 Deprecation of eager compilation of CUDA device functions

--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -231,6 +231,13 @@ def generated_jit(function=None, cache=False,
     function is called at compile-time with the *types* of the arguments
     and should return an implementation function for those types.
     """
+    url_s = "https://numba.readthedocs.io/en/stable/reference/deprecation.html"
+    url_anchor = "#deprecation-of-generated-jit"
+    url = f"{url_s}{url_anchor}"
+    msg = ("numba.generated_jit is deprecated. Please see the documentation "
+           f"at: {url} for more information and advice on a suitable "
+           "replacement.")
+    warnings.warn(msg, NumbaDeprecationWarning)
     dispatcher_args = {}
     if pipeline_class is not None:
         dispatcher_args['pipeline_class'] = pipeline_class


### PR DESCRIPTION
This deprecates numba.generated_jit as outlined in #8466

Closes #8466

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
