### PR TITLE
make some typedlist C-APIs public

### DIFF
--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -552,11 +552,6 @@ Typed List
   functionality or suffer from unexpectedly bad performance, please report
   this, ideally by opening an issue on the Numba issue tracker.
 
-.. warning::
-  Most interfaces listed in ``numba/cext/listobject.h`` are exported,
-  but they're not supported/stable, and these interfaces or underlying
-  implementations could be changed or removed in future without notice.
-
 As of version 0.45.0 a new implementation of the list data type is available,
 the so-called *typed-list*. This is compiled library backed, type-homogeneous
 list data type that is an improvement over the *reflected-list* mentioned

--- a/docs/source/reference/pysupported.rst
+++ b/docs/source/reference/pysupported.rst
@@ -552,6 +552,11 @@ Typed List
   functionality or suffer from unexpectedly bad performance, please report
   this, ideally by opening an issue on the Numba issue tracker.
 
+.. warning::
+  Most interfaces listed in ``numba/cext/listobject.h`` are exported,
+  but they're not supported/stable, and these interfaces or underlying
+  implementations could be changed or removed in future without notice.
+
 As of version 0.45.0 a new implementation of the list data type is available,
 the so-called *typed-list*. This is compiled library backed, type-homogeneous
 list data type that is an improvement over the *reflected-list* mentioned

--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -13,8 +13,10 @@
 #if (__has_attribute(visibility) || \
      (defined(__GNUC__) && __GNUC__ >= 4))
 #define VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
+#define VISIBILITY_GLOBAL __attribute__ ((visibility("default")))
 #else
 #define VISIBILITY_HIDDEN
+#define VISIBILITY_GLOBAL
 #endif
 
 /*

--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -10,13 +10,16 @@
  * but are not exposed outside of a shared library or executable.
  * Note this is default behaviour for global symbols under Windows.
  */
-#if (__has_attribute(visibility) || \
-     (defined(__GNUC__) && __GNUC__ >= 4))
-#define VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
-#define VISIBILITY_GLOBAL __attribute__ ((visibility("default")))
+#if (__has_attribute(visibility) || (defined(__GNUC__) && __GNUC__ >= 4))
+    #define VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
+#ifdef _MSC_VER
+    #define VISIBILITY_GLOBAL __declspec(dllexport)
 #else
-#define VISIBILITY_HIDDEN
-#define VISIBILITY_GLOBAL
+    #define VISIBILITY_GLOBAL __attribute__ ((visibility("default")))
+#endif
+#else
+    #define VISIBILITY_HIDDEN
+    #define VISIBILITY_GLOBAL
 #endif
 
 /*

--- a/numba/_numba_common.h
+++ b/numba/_numba_common.h
@@ -10,13 +10,12 @@
  * but are not exposed outside of a shared library or executable.
  * Note this is default behaviour for global symbols under Windows.
  */
-#if (__has_attribute(visibility) || (defined(__GNUC__) && __GNUC__ >= 4))
-    #define VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
+    #define VISIBILITY_HIDDEN
     #define VISIBILITY_GLOBAL __declspec(dllexport)
-#else
+#elif (__has_attribute(visibility) || (defined(__GNUC__) && __GNUC__ >= 4))
+    #define VISIBILITY_HIDDEN __attribute__ ((visibility("hidden")))
     #define VISIBILITY_GLOBAL __attribute__ ((visibility("default")))
-#endif
 #else
     #define VISIBILITY_HIDDEN
     #define VISIBILITY_GLOBAL

--- a/numba/cext/cext.h
+++ b/numba/cext/cext.h
@@ -9,8 +9,7 @@
 #define NUMBA_EXPORT_FUNC(_rettype) VISIBILITY_HIDDEN _rettype
 #define NUMBA_EXPORT_DATA(_vartype) VISIBILITY_HIDDEN _vartype
 
-/* Define symbols in this C module, and export them outside the
-   shared library in various platforms, including Windows. */
+/* Use to declare a symbol as exported (global). */
 #define NUMBA_GLOBAL_FUNC(_rettype) VISIBILITY_GLOBAL _rettype
 
 NUMBA_EXPORT_FUNC(Py_ssize_t)

--- a/numba/cext/cext.h
+++ b/numba/cext/cext.h
@@ -9,6 +9,10 @@
 #define NUMBA_EXPORT_FUNC(_rettype) VISIBILITY_HIDDEN _rettype
 #define NUMBA_EXPORT_DATA(_vartype) VISIBILITY_HIDDEN _vartype
 
+/* Define symbols in this C module, and export them outside the
+   shared library in various platforms, including Windows. */
+#define NUMBA_GLOBAL_FUNC(_rettype) VISIBILITY_GLOBAL _rettype
+
 NUMBA_EXPORT_FUNC(Py_ssize_t)
 aligned_size(Py_ssize_t sz);
 

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -5,9 +5,10 @@
  * https://github.com/python/cpython/blob/51ddab8dae056867f3595ab3400bffc93f67c8d4/Include/listobject.h
  *
  * WARNING:
- * Most interfaces listed here are exported, but they're not supported/stable,
- * and these interfaces or underlying implementations could be changed or
- * removed in future without notice.
+ * Most interfaces listed here are exported (global), but they are not
+ * supported, stable, or part of Numba's public API. These interfaces and their
+ * underlying implementations may be changed or removed in future without
+ * notice.
  * */
 
 #ifndef NUMBA_LIST_H

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -4,7 +4,10 @@
  *
  * https://github.com/python/cpython/blob/51ddab8dae056867f3595ab3400bffc93f67c8d4/Include/listobject.h
  *
- *
+ * WARNING:
+ * Most interfaces listed here are exported, but they're not supported/stable,
+ * and these interfaces or underlying implementations could be changed or
+ * removed in future without notice.
  * */
 
 #ifndef NUMBA_LIST_H
@@ -73,7 +76,7 @@ typedef struct {
     Py_ssize_t       pos;
 } NB_ListIter;
 
-NUMBA_EXPORT_FUNC(void)
+void
 numba_list_set_method_table(NB_List *lp, list_type_based_methods_table *methods);
 
 int
@@ -82,22 +85,22 @@ numba_list_new(NB_List **out, Py_ssize_t item_size, Py_ssize_t allocated);
 void
 numba_list_free(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(char *)
+char *
 numba_list_base_ptr(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(Py_ssize_t)
+Py_ssize_t
 numba_list_size_address(NB_List *lp);
 
 Py_ssize_t
 numba_list_length(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(Py_ssize_t)
+Py_ssize_t
 numba_list_allocated(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_is_mutable(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(void)
+void
 numba_list_set_is_mutable(NB_List *lp, int is_mutable);
 
 int
@@ -109,24 +112,23 @@ numba_list_getitem(NB_List *lp, Py_ssize_t index, char *out);
 int
 numba_list_append(NB_List *lp, const char *item);
 
-// FIXME: should this be public?
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_resize(NB_List *lp, Py_ssize_t newsize);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_delitem(NB_List *lp, Py_ssize_t index);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_delete_slice(NB_List *lp,
                         Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step);
 
-NUMBA_EXPORT_FUNC(size_t)
+size_t
 numba_list_iter_sizeof(void);
 
-NUMBA_EXPORT_FUNC(void)
+void
 numba_list_iter(NB_ListIter *it, NB_List *l);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_iter_next(NB_ListIter *it, const char **item_ptr);
 
 NUMBA_EXPORT_FUNC(int)

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -76,10 +76,10 @@ typedef struct {
 NUMBA_EXPORT_FUNC(void)
 numba_list_set_method_table(NB_List *lp, list_type_based_methods_table *methods);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_new(NB_List **out, Py_ssize_t item_size, Py_ssize_t allocated);
 
-NUMBA_EXPORT_FUNC(void)
+void
 numba_list_free(NB_List *lp);
 
 NUMBA_EXPORT_FUNC(char *)
@@ -88,7 +88,7 @@ numba_list_base_ptr(NB_List *lp);
 NUMBA_EXPORT_FUNC(Py_ssize_t)
 numba_list_size_address(NB_List *lp);
 
-NUMBA_EXPORT_FUNC(Py_ssize_t)
+Py_ssize_t
 numba_list_length(NB_List *lp);
 
 NUMBA_EXPORT_FUNC(Py_ssize_t)
@@ -100,13 +100,13 @@ numba_list_is_mutable(NB_List *lp);
 NUMBA_EXPORT_FUNC(void)
 numba_list_set_is_mutable(NB_List *lp, int is_mutable);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_setitem(NB_List *lp, Py_ssize_t index, const char *item);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_getitem(NB_List *lp, Py_ssize_t index, char *out);
 
-NUMBA_EXPORT_FUNC(int)
+int
 numba_list_append(NB_List *lp, const char *item);
 
 // FIXME: should this be public?

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -77,59 +77,59 @@ typedef struct {
     Py_ssize_t       pos;
 } NB_ListIter;
 
-void
+NUMBA_GLOBAL_FUNC(void)
 numba_list_set_method_table(NB_List *lp, list_type_based_methods_table *methods);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_new(NB_List **out, Py_ssize_t item_size, Py_ssize_t allocated);
 
-void
+NUMBA_GLOBAL_FUNC(void)
 numba_list_free(NB_List *lp);
 
-char *
+NUMBA_GLOBAL_FUNC(char *)
 numba_list_base_ptr(NB_List *lp);
 
-Py_ssize_t
+NUMBA_GLOBAL_FUNC(Py_ssize_t)
 numba_list_size_address(NB_List *lp);
 
-Py_ssize_t
+NUMBA_GLOBAL_FUNC(Py_ssize_t)
 numba_list_length(NB_List *lp);
 
-Py_ssize_t
+NUMBA_GLOBAL_FUNC(Py_ssize_t)
 numba_list_allocated(NB_List *lp);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_is_mutable(NB_List *lp);
 
-void
+NUMBA_GLOBAL_FUNC(void)
 numba_list_set_is_mutable(NB_List *lp, int is_mutable);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_setitem(NB_List *lp, Py_ssize_t index, const char *item);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_getitem(NB_List *lp, Py_ssize_t index, char *out);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_append(NB_List *lp, const char *item);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_resize(NB_List *lp, Py_ssize_t newsize);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_delitem(NB_List *lp, Py_ssize_t index);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_delete_slice(NB_List *lp,
                         Py_ssize_t start, Py_ssize_t stop, Py_ssize_t step);
 
-size_t
+NUMBA_GLOBAL_FUNC(size_t)
 numba_list_iter_sizeof(void);
 
-void
+NUMBA_GLOBAL_FUNC(void)
 numba_list_iter(NB_ListIter *it, NB_List *l);
 
-int
+NUMBA_GLOBAL_FUNC(int)
 numba_list_iter_next(NB_ListIter *it, const char **item_ptr);
 
 NUMBA_EXPORT_FUNC(int)


### PR DESCRIPTION
Hi. I make some typedlist C-APIs public, since I want to use typedlist C-APIs in my C++ code, which will be called from jitted numba code, via `intrinsic`, `lower_builtin`, and etc.

At least, (I feel) I need `new`, `free`, `get_length`, `setitem`, and `getitem` APIs. I hope this PR won't bother other parts in numba or the design principle of Numba. If not, please shout.

I mark this PR as a draft, when I finish my extension and test it, then I will mark this as an official PR.