### PR TITLE
Added noncentral-chisquared, noncentral-f and logseries distributions

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -627,13 +627,16 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().laplace()` (*)
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
-* :func:`numpy.random.Generator().logseries()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for ``p`` are currently not supported.)
+* :func:`numpy.random.Generator().logseries()` (Accepts float values as well as
+  datatypes that cast to floats. Array values for ``p`` are currently not
+  supported.)
 * :func:`numpy.random.Generator().negative_binomial()` (*)
-* :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for ``dfnum`` and ``nonc`` are currently not supported.)
-* :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for ``dfnum``, ``dfden`` and ``nonc`` are currently not supported.)
+* :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values
+  as well as datatypes that cast to floats. Array values for ``dfnum`` and
+  ``nonc`` are currently not supported.)
+* :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well
+  as datatypes that cast to floats. Array values for ``dfnum``, ``dfden`` and
+  ``nonc`` are currently not supported.)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`
 * :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -627,7 +627,13 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().laplace()` (*)
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
+* :func:`numpy.random.Generator().logseries()` (Accepts float values as well as datatypes
+ that cast to floats. Array values for p are currently not supported.)
 * :func:`numpy.random.Generator().negative_binomial()` (*)
+* :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values as well as datatypes
+ that cast to floats. Array values for dfnum and nonc are currently not supported.)
+* :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well as datatypes
+ that cast to floats. Array values for dfnum, dfden and nonc are currently not supported.)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`
 * :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -628,12 +628,12 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
 * :func:`numpy.random.Generator().logseries()` (Accepts float values as well as datatypes
- that cast to floats. Array values for p are currently not supported.)
+  that cast to floats. Array values for p are currently not supported.)
 * :func:`numpy.random.Generator().negative_binomial()` (*)
 * :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values as well as datatypes
- that cast to floats. Array values for dfnum and nonc are currently not supported.)
+  that cast to floats. Array values for dfnum and nonc are currently not supported.)
 * :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well as datatypes
- that cast to floats. Array values for dfnum, dfden and nonc are currently not supported.)
+  that cast to floats. Array values for dfnum, dfden and nonc are currently not supported.)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`
 * :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -628,12 +628,12 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
 * :func:`numpy.random.Generator().logseries()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for p are currently not supported.)
+  that cast to floats. Array values for ``p`` are currently not supported.)
 * :func:`numpy.random.Generator().negative_binomial()` (*)
 * :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for dfnum and nonc are currently not supported.)
+  that cast to floats. Array values for ``dfnum`` and ``nonc`` are currently not supported.)
 * :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well as datatypes
-  that cast to floats. Array values for dfnum, dfden and nonc are currently not supported.)
+  that cast to floats. Array values for ``dfnum``, ``dfden`` and ``nonc`` are currently not supported.)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`
 * :func:`numpy.random.Generator().permutation()` (Only accepts NumPy ndarrays and integers.)

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -628,14 +628,14 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().logistic()` (*)
 * :func:`numpy.random.Generator().lognormal()` (*)
 * :func:`numpy.random.Generator().logseries()` (Accepts float values as well as
-  datatypes that cast to floats. Array values for ``p`` are currently not
+  data types that cast to floats. Array values for ``p`` are currently not
   supported.)
 * :func:`numpy.random.Generator().negative_binomial()` (*)
 * :func:`numpy.random.Generator().noncentral_chisquare()` (Accepts float values
-  as well as datatypes that cast to floats. Array values for ``dfnum`` and
+  as well as data types that cast to floats. Array values for ``dfnum`` and
   ``nonc`` are currently not supported.)
 * :func:`numpy.random.Generator().noncentral_f()` (Accepts float values as well
-  as datatypes that cast to floats. Array values for ``dfnum``, ``dfden`` and
+  as data types that cast to floats. Array values for ``dfnum``, ``dfden`` and
   ``nonc`` are currently not supported.)
 * :func:`numpy.random.Generator().normal()` (*)
 * :func:`numpy.random.Generator().pareto()`

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -20,7 +20,8 @@ from numba.np.random.distributions import \
      random_weibull, random_laplace, random_logistic,
      random_lognormal, random_rayleigh, random_standard_t, random_wald,
      random_geometric, random_zipf, random_triangular,
-     random_poisson, random_negative_binomial)
+     random_poisson, random_negative_binomial, random_logseries,
+     random_noncentral_chisquare, random_noncentral_f)
 from numba.np.random import random_methods
 
 
@@ -817,5 +818,77 @@ def NumPyRandomGeneratorType_negative_binomial(inst, n, p, size=None):
             out = np.empty(size, dtype=np.int64)
             for i in np.ndindex(size):
                 out[i] = random_negative_binomial(inst.bit_generator, n, p)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'noncentral_chisquare')
+def NumPyRandomGeneratorType_noncentral_chisquare(inst, df, nonc, size=None):
+    check_types(df, [types.Float, float], 'df')
+    check_types(nonc, [types.Float, float], 'nonc')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, df, nonc, size=None):
+            return np.float64(random_noncentral_chisquare(inst.bit_generator,
+                                                          df, nonc))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, df, nonc, size=None):
+            out = np.empty(size, dtype=np.float64)
+            for i in np.ndindex(size):
+                out[i] = random_noncentral_chisquare(inst.bit_generator,
+                                                     df, nonc)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'noncentral_f')
+def NumPyRandomGeneratorType_noncentral_f(inst, dfnum, dfden, nonc, size=None):
+    check_types(dfnum, [types.Float, float], 'dfnum')
+    check_types(dfden, [types.Float, float], 'dfden')
+    check_types(nonc, [types.Float, float], 'nonc')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst,  dfnum, dfden, nonc, size=None):
+            return np.float64(random_noncentral_f(inst.bit_generator,
+                                                  dfnum, dfden, nonc))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, dfnum, dfden, nonc, size=None):
+            out = np.empty(size, dtype=np.float64)
+            for i in np.ndindex(size):
+                out[i] = random_noncentral_f(inst.bit_generator,
+                                             dfnum, dfden, nonc)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'logseries')
+def NumPyRandomGeneratorType_logseries(inst, p, size=None):
+    check_types(p, [types.Float, float], 'p')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+        def impl(inst, p, size=None):
+            if p < 0 or p > 1 or np.isnan(p):
+                raise ValueError("p < 0, p > 1 or p is NaN")
+            return np.int64(random_logseries(inst.bit_generator, p))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, p, size=None):
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_logseries(inst.bit_generator, p)
             return out
         return impl

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -846,6 +846,7 @@ def NumPyRandomGeneratorType_noncentral_chisquare(inst, df, nonc, size=None):
         check_size(size)
 
         def impl(inst, df, nonc, size=None):
+            check_arg_bounds(df, nonc)
             out = np.empty(size, dtype=np.float64)
             for i in np.ndindex(size):
                 out[i] = random_noncentral_chisquare(inst.bit_generator,
@@ -881,6 +882,7 @@ def NumPyRandomGeneratorType_noncentral_f(inst, dfnum, dfden, nonc, size=None):
         check_size(size)
 
         def impl(inst, dfnum, dfden, nonc, size=None):
+            check_arg_bounds(dfnum, dfden, nonc)
             out = np.empty(size, dtype=np.float64)
             for i in np.ndindex(size):
                 out[i] = random_noncentral_f(inst.bit_generator,
@@ -895,18 +897,21 @@ def NumPyRandomGeneratorType_logseries(inst, p, size=None):
     if isinstance(size, types.Omitted):
         size = size.value
 
+    @register_jitable
+    def check_arg_bounds(p):
+        if p < 0 or p >= 1 or np.isnan(p):
+            raise ValueError("p < 0, p >= 1 or p is NaN")
+
     if is_nonelike(size):
         def impl(inst, p, size=None):
-            if p < 0 or p >= 1 or np.isnan(p):
-                raise ValueError("p < 0, p >= 1 or p is NaN")
+            check_arg_bounds(p)
             return np.int64(random_logseries(inst.bit_generator, p))
         return impl
     else:
         check_size(size)
 
         def impl(inst, p, size=None):
-            if p < 0 or p > 1 or np.isnan(p):
-                raise ValueError("p < 0, p > 1 or p is NaN")
+            check_arg_bounds(p)
             out = np.empty(size, dtype=np.int64)
             for i in np.ndindex(size):
                 out[i] = random_logseries(inst.bit_generator, p)

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -865,9 +865,9 @@ def NumPyRandomGeneratorType_noncentral_f(inst, dfnum, dfden, nonc, size=None):
     @register_jitable
     def check_arg_bounds(dfnum, dfden, nonc):
         if dfnum <= 0:
-            raise ValueError("df <= 0")
+            raise ValueError("dfnum <= 0")
         if dfden <= 0:
-            raise ValueError("df <= 0")
+            raise ValueError("dfden <= 0")
         if nonc < 0:
             raise ValueError("nonc < 0")
 
@@ -897,8 +897,8 @@ def NumPyRandomGeneratorType_logseries(inst, p, size=None):
 
     if is_nonelike(size):
         def impl(inst, p, size=None):
-            if p < 0 or p > 1 or np.isnan(p):
-                raise ValueError("p < 0, p > 1 or p is NaN")
+            if p < 0 or p >= 1 or np.isnan(p):
+                raise ValueError("p < 0, p >= 1 or p is NaN")
             return np.int64(random_logseries(inst.bit_generator, p))
         return impl
     else:

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1060,6 +1060,64 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
 
         self.assertPreciseEqual(dist_func(rng(), a), nb_func(rng(), b))
 
+    def test_noncentral_chisquare(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.noncentral_chisquare(3.0, 20.0, size=size)
+        for _size, _bitgen in itertools.product(test_sizes, bitgen_types):
+            with self.subTest(_size=_size, _bitgen=_bitgen):
+                self.check_numpy_parity(dist_func, _bitgen,
+                                        None, _size, None)
+
+        dist_func = lambda x, df, nonc, size:\
+            x.noncentral_chisquare(df=df, nonc=nonc, size=size)
+        self._check_invalid_types(dist_func, ['df', 'nonc', 'size'],
+                                  [3.0, 5.0, (1,)], ['x', 'x', ('x',)])
+
+    def test_noncentral_f(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.noncentral_f(3.0, 20.0, 3.0, size=size)
+        for _size, _bitgen in itertools.product(test_sizes, bitgen_types):
+            with self.subTest(_size=_size, _bitgen=_bitgen):
+                self.check_numpy_parity(dist_func, _bitgen,
+                                        None, _size, None)
+
+        dist_func = lambda x, dfnum, dfden, nonc, size:\
+            x.noncentral_f(dfnum=dfnum, dfden=dfden, nonc=nonc, size=size)
+        self._check_invalid_types(dist_func, ['dfnum', 'dfden', 'nonc', 'size'],
+                                  [3.0, 5.0, 3.0, (1,)],
+                                  ['x', 'x', 'x', ('x',)])
+
+    def test_logseries(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.logseries(0.3, size=size)
+        for _size, _bitgen in itertools.product(test_sizes, bitgen_types):
+            with self.subTest(_size=_size, _bitgen=_bitgen):
+                self.check_numpy_parity(dist_func, _bitgen,
+                                        None, _size, None)
+
+        dist_func = lambda x, p, size:\
+            x.logseries(p=p, size=size)
+        self._check_invalid_types(dist_func, ['p', 'size'],
+                                  [0.3, (1,)], ['x', ('x',)])
+
 
 class TestGeneratorCaching(TestCase, SerialMixin):
     def test_randomgen_caching(self):


### PR DESCRIPTION
As titled, this PR adds support for following distributions:

- `numpy.random.Generator.logseries`
- `numpy.random.Generator.noncentral_chisquare`
- `numpy.random.Generator.noncentral_f`