### PR TITLE
Import jitclass from numba.experimental in jitclass documentation

### DIFF
--- a/docs/source/user/jitclass.rst
+++ b/docs/source/user/jitclass.rst
@@ -99,7 +99,8 @@ First, using explicit Numba types and explicit construction.
 
 .. code-block:: python
 
-    from numba import jitclass, types, typed
+    from numba import types, typed
+    from numba.experimental import jitclass
 
     # key and value types
     kv_ty = (types.int64, types.unicode_type)
@@ -131,7 +132,8 @@ example:
 
 .. code-block:: python
 
-    from numba import jitclass, typed, typeof
+    from numba import typed, typeof
+    from numba.experimental import jitclass
 
     d = typed.Dict()
     d[1] = "apple"
@@ -158,7 +160,8 @@ instance of the type specified.
 
 .. code-block:: python
 
-    from numba import jitclass, types
+    from numba import types
+    from numba.experimental import jitclass
 
     dict_ty = types.DictType(types.int64, types.unicode_type)
 


### PR DESCRIPTION
`jitclass` is still part of experimental support, so it should be imported from `numba.experimental`. Updating the documentation for `jitclass` to reflect it.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
