### PR TITLE
Vary NumPy version on gpuCI

### DIFF
--- a/buildscripts/gpuci/axis.yaml
+++ b/buildscripts/gpuci/axis.yaml
@@ -6,9 +6,13 @@ CUDA_VER:
 
 CUDA_TOOLKIT_VER:
 - "11.0"
+  NUMPY_VER: "1.19"
 - "11.1"
+  NUMPY_VER: "1.21"
 - "11.2"
+  NUMPY_VER: "1.22"
 - "11.5"
+  NUMPY_VER: "1.23"
 
 LINUX_VER:
 - ubuntu18.04

--- a/buildscripts/gpuci/axis.yaml
+++ b/buildscripts/gpuci/axis.yaml
@@ -5,14 +5,10 @@ CUDA_VER:
 - "11.2"
 
 CUDA_TOOLKIT_VER:
-- "11.0":
-  NUMPY_VER: "1.19"
-- "11.1":
-  NUMPY_VER: "1.21"
-- "11.2":
-  NUMPY_VER: "1.22"
-- "11.5":
-  NUMPY_VER: "1.23"
+- "11.0"
+- "11.1"
+- "11.2"
+- "11.5"
 
 LINUX_VER:
 - ubuntu18.04

--- a/buildscripts/gpuci/axis.yaml
+++ b/buildscripts/gpuci/axis.yaml
@@ -5,13 +5,13 @@ CUDA_VER:
 - "11.2"
 
 CUDA_TOOLKIT_VER:
-- "11.0"
+- "11.0":
   NUMPY_VER: "1.19"
-- "11.1"
+- "11.1":
   NUMPY_VER: "1.21"
-- "11.2"
+- "11.2":
   NUMPY_VER: "1.22"
-- "11.5"
+- "11.5":
   NUMPY_VER: "1.23"
 
 LINUX_VER:

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -24,6 +24,13 @@ else
   export NUMBA_CUDA_USE_NVIDIA_BINDING=0;
 fi;
 
+# Test with different NumPy versions with each toolkit (it's not worth testing
+# the cartesian product of versions here, we just need to test with different
+# CUDA and NumPy versions).
+declare -A CTK_NUMPY_VMAP=( ["11.0"]="1.19" ["11.1"]="1.21" ["11.2"]="1.22" ["11.5"]="1.23")
+NUMPY_VER="${CTK_NUMPY_VMAP[$CUDA_TOOLKIT_VER]}"
+
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -25,7 +25,7 @@ else
 fi;
 
 # Test with different NumPy versions with each toolkit (it's not worth testing
-# the cartesian product of versions here, we just need to test with different
+# the Cartesian product of versions here, we just need to test with different
 # CUDA and NumPy versions).
 declare -A CTK_NUMPY_VMAP=( ["11.0"]="1.19" ["11.1"]="1.21" ["11.2"]="1.22" ["11.5"]="1.23")
 NUMPY_VER="${CTK_NUMPY_VMAP[$CUDA_TOOLKIT_VER]}"

--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -40,7 +40,7 @@ gpuci_mamba_retry create -n numba_ci -y \
                   "python=${PYTHON_VER}" \
                   "cudatoolkit=${CUDA_TOOLKIT_VER}" \
                   "numba/label/dev::llvmlite" \
-                  "numpy=1.21" \
+                  "numpy=${NUMPY_VER}" \
                   "scipy" \
                   "cffi" \
                   "psutil" \


### PR DESCRIPTION
Test with different NumPy versions on gpuCI. It doesn't matter which NumPy version goes with which CUDA toolkit, and there's no point having the cartesian product tested.

This tests the oldest supported NumPy (1.19 for0.57+), and then the most recent versions (1.21, 1.22, and 1.23).

As one would expect, NumPy 1.23 is failing because that's broken on mainline.