### PR TITLE
Fix fusion bug.

### DIFF
--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -4279,6 +4279,8 @@ def has_cross_iter_dep(
         if array_accessed in non_indexed_arrays:
             return True
 
+        indexed_arrays.add(array_accessed)
+
         npsize = len(new_position)
         # See if we have not seen a npsize dimensioned array accessed before.
         if npsize not in index_positions:

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -2252,10 +2252,9 @@ class TestParfors(TestParforsBase):
         self.check(test_impl, arr, 10, False)
 
     def test_issue8515(self):
-        """ issue8515: an array is filled in the first prange and
-            then accessed with c[i - 1] in the next prange which
-            should prevent fusion with the previous prange.
-        """
+        # issue8515: an array is filled in the first prange and
+        # then accessed with c[i - 1] in the next prange which
+        # should prevent fusion with the previous prange.
         def test_impl(n):
             r = np.zeros(n, dtype=np.intp)
             c = np.zeros(n, dtype=np.intp)

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4311,7 +4311,7 @@ class TestPrangeSpecific(TestPrangeBase):
                 r[i] = c[i] - c[i - 1]
             return r[1:]
 
-        self.prange_tester(test_impl, 15, patch_instance=[0,2])
+        self.prange_tester(test_impl, 15, patch_instance=[0, 2])
 
 
 @skip_parfors_unsupported

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -4294,7 +4294,7 @@ class TestPrangeSpecific(TestPrangeBase):
         self.assertIn("TEST PASSED", out.decode())
 
     def test_issue8515(self):
-        """ issue8515: an array is filled in my one prange and
+        """ issue8515: an array is filled in the first prange and
             then accessed with c[i - 1] in the next prange which
             should prevent fusion with the previous prange.
         """


### PR DESCRIPTION
Resolves #8515 

Somehow, one of the sets in the fusion code that tracks which arrays have been accessed with a parfor index variable was never being added to like the documentation says it should.  That problem has been remedied.