### PR TITLE
Make ol_compatible_view accessible on all targets

### DIFF
--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2495,7 +2495,7 @@ def _compatible_view(a, dtype):
     pass
 
 
-@overload(_compatible_view)
+@overload(_compatible_view, target='generic')
 def ol_compatible_view(a, dtype):
     """Determines if the array and dtype are compatible for forming a view."""
     # NOTE: NumPy 1.23+ uses this check.


### PR DESCRIPTION
This is to fix Issue #8529, where test_reinterpret_array_type fails on CUDA with NumPy 1.23 because this overload is needed. Making it accessible to the CUDA target should resolve the issue.

Fixes #8529.