### PR TITLE
[Unicode] Add more string view usages for unicode operations

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -1662,10 +1662,13 @@ def unicode_getitem(s, idx):
                 idx = normalize_str_idx(idx, len(s))
                 cp = _get_code_point(s, idx)
                 kind = _codepoint_to_kind(cp)
-                is_ascii = _codepoint_is_ascii(cp)
-                ret = _empty_string(kind, 1, is_ascii)
-                _set_code_point(ret, 0, cp)
-                return ret
+                if kind == s._kind:
+                    return _get_str_slice_view(s, idx, 1)
+                else:
+                    is_ascii = _codepoint_is_ascii(cp)
+                    ret = _empty_string(kind, 1, is_ascii)
+                    _set_code_point(ret, 0, cp)
+                    return ret
             return getitem_char
         elif isinstance(idx, types.SliceType):
             def getitem_slice(s, idx):


### PR DESCRIPTION
Hi, I added string view usages for `operator.getitem`.

For the testcase below:
```
    def test_getitem_perf(self):
        @njit
        def text_distance_getitem(s1, s2):
            s1_size = len(s1)
            s2_size = len(s2)
            minimum = min(s1_size, s2_size)
            for i in range(minimum):
                tmp = (s1[i] == s2[i])

        @njit
        def text_distance_getslice(s1, s2):
            s1_size = len(s1)
            s2_size = len(s2)
            minimum = min(s1_size, s2_size)
            for i in range(minimum - 2):
                tmp = (s1[i:i + 2] == s2[i:i + 2])

        import time
        for c_func in [text_distance_getitem, text_distance_getslice]:
            py_func = c_func.py_func

            s = "abcdefasdlfkjsdflahglakhasdklh13.23.5k534,.12n35m25n" * 10
            t = "abcdefasdlfkjsdflahglakhasdklh13.23.5k53shkf123lkjfh" * 10

            p_ret = py_func(s, t)
            j_ret = c_func(s, t)
            self.assertEqual(p_ret, j_ret)

            n = 100
            total = 0
            for _ in range(n):
                start = time.time()
                py_func(s, t)
                total += time.time() - start
            print(f"py: {total}")

            total = 0
            for _ in range(n):
                start = time.time()
                c_func(s, t)
                total += time.time() - start
            print(f"nb: {total}")
```
before this PR, its output:
```
py: 0.0035886764526367188
nb: 0.01157069206237793  getitem without string_view
py: 0.011766195297241211
nb: 0.003027677536010742
```
After this PR:
```
py: 0.00434565544128418
nb: 0.0032203197479248047 getitem with string_view
py: 0.011176824569702148
nb: 0.0029859542846679688
```
I will try to find similar places that can use string_view.

Besides, I want to implement a `two-way matching algorithm` for unicode `find` API in the future, which has already used in cpython and absl. Currently, numba unicode `find` is slower 10~100x than those efficient implementations. 