### PR TITLE
Make target for `@overload` have 'generic' as default.

### DIFF
--- a/numba/core/extending.py
+++ b/numba/core/extending.py
@@ -53,8 +53,10 @@ def type_callable(func):
 
 
 # By default, an *overload* does not have a cpython wrapper because it is not
-# callable from python.
-_overload_default_jit_options = {'no_cpython_wrapper': True}
+# callable from python. It also has `nopython=True`, this has been default since
+# its inception!
+_overload_default_jit_options = {'no_cpython_wrapper': True,
+                                 'nopython':True}
 
 
 def overload(func, jit_options={}, strict=True, inline='never',

--- a/numba/core/typing/templates.py
+++ b/numba/core/typing/templates.py
@@ -716,37 +716,30 @@ class _OverloadFunctionTemplate(AbstractTemplate):
     def _get_jit_decorator(self):
         """Gets a jit decorator suitable for the current target"""
 
-        jitter_str = self.metadata.get('target', None)
-        if jitter_str is None:
-            from numba import jit
-            # There is no target requested, use default, this preserves
-            # original behaviour
-            jitter = lambda *args, **kwargs: jit(*args, nopython=True, **kwargs)
-        else:
-            from numba.core.target_extension import (target_registry,
-                                                     get_local_target,
-                                                     jit_registry)
+        from numba.core.target_extension import (target_registry,
+                                                 get_local_target,
+                                                 jit_registry)
 
-            # target has been requested, see what it is...
-            jitter = jit_registry.get(jitter_str, None)
+        jitter_str = self.metadata.get('target', 'generic')
+        jitter = jit_registry.get(jitter_str, None)
 
-            if jitter is None:
-                # No JIT known for target string, see if something is
-                # registered for the string and report if not.
-                target_class = target_registry.get(jitter_str, None)
-                if target_class is None:
-                    msg = ("Unknown target '{}', has it been ",
-                           "registered?")
-                    raise ValueError(msg.format(jitter_str))
+        if jitter is None:
+            # No JIT known for target string, see if something is
+            # registered for the string and report if not.
+            target_class = target_registry.get(jitter_str, None)
+            if target_class is None:
+                msg = ("Unknown target '{}', has it been ",
+                       "registered?")
+                raise ValueError(msg.format(jitter_str))
 
-                target_hw = get_local_target(self.context)
+            target_hw = get_local_target(self.context)
 
-                # check that the requested target is in the hierarchy for the
-                # current frame's target.
-                if not issubclass(target_hw, target_class):
-                    msg = "No overloads exist for the requested target: {}."
+            # check that the requested target is in the hierarchy for the
+            # current frame's target.
+            if not issubclass(target_hw, target_class):
+                msg = "No overloads exist for the requested target: {}."
 
-                jitter = jit_registry[target_hw]
+            jitter = jit_registry[target_hw]
 
         if jitter is None:
             raise ValueError("Cannot find a suitable jit decorator")


### PR DESCRIPTION
This makes the default `target` for `@overload` the `'generic'` target, as, in effect, very few `@overload` implementations are genuinely target specific. Further, the use of the standard `numba.jit` wrapper (with no `target` set) for `@overload` implementations leads to strange cases where some function cannot be resolved on e.g. the CUDA target, but because there's no target set in the `jit` wrapper the error message cannot tell you why, it just materialises as a lowering error (i.e. this should fix #8530).

The first commit in this PR (a3ecb1f) is from @gmarkall's Numba fork on branch `overload-target-generic`, the corresponding commit is: 38b537993dbcf7c73c95c815e1bc955d6f917010, authorship is preserved, many thanks @gmarkall!