### PR TITLE
Fix `np.fmod` to match numpy behavior

### DIFF
--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -269,7 +269,7 @@ def np_int_fmod_impl(context, builder, sig, args):
     result.add_incoming(mod, bb_if)
 
     # set the sign to match the numerator
-    num_gt_zero = builder.icmp(lc.ICMP_SGT, num, ZERO)
+    num_gt_zero = builder.icmp_signed(">", num, ZERO)
 
     return builder.select(num_gt_zero, result, builder.neg(result))
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -252,14 +252,14 @@ def np_int_fmod_impl(context, builder, sig, args):
     ty = sig.args[0]  # any arg type will do, homogeneous
 
     ZERO = context.get_constant(ty, 0)
-    den_not_zero = builder.icmp(lc.ICMP_NE, ZERO, den)
+    den_not_zero = builder.icmp_signed("!=", ZERO, den)
     bb_no_if = builder.basic_block
     with cgutils.if_unlikely(builder, den_not_zero):
         bb_if = builder.basic_block
 
         # use the abs of the numerator and denominator
-        num_neg = builder.icmp(lc.ICMP_SLT, num, ZERO)
-        den_neg = builder.icmp(lc.ICMP_SLT, den, ZERO)
+        num_neg = builder.icmp_signed("<", num, ZERO)
+        den_neg = builder.icmp_signed("<", den, ZERO)
         num_abs = builder.select(num_neg, builder.neg(num), num)
         den_abs = builder.select(den_neg, builder.neg(den), den)
         mod = builder.urem(num_abs, den_abs)

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -269,15 +269,15 @@ def _fill_ufunc_db(ufunc_db):
 
     ufunc_db[np.fmod] = {
         'bb->b': npyfuncs.np_int_fmod_impl,
-        'BB->B': npyfuncs.np_int_fmod_impl,
+        'BB->B': npyfuncs.np_int_urem_impl,
         'hh->h': npyfuncs.np_int_fmod_impl,
-        'HH->H': npyfuncs.np_int_fmod_impl,
+        'HH->H': npyfuncs.np_int_urem_impl,
         'ii->i': npyfuncs.np_int_fmod_impl,
-        'II->I': npyfuncs.np_int_fmod_impl,
+        'II->I': npyfuncs.np_int_urem_impl,
         'll->l': npyfuncs.np_int_fmod_impl,
-        'LL->L': npyfuncs.np_int_fmod_impl,
+        'LL->L': npyfuncs.np_int_urem_impl,
         'qq->q': npyfuncs.np_int_fmod_impl,
-        'QQ->Q': npyfuncs.np_int_fmod_impl,
+        'QQ->Q': npyfuncs.np_int_urem_impl,
         'ff->f': npyfuncs.np_real_fmod_impl,
         'dd->d': npyfuncs.np_real_fmod_impl,
     }

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -334,7 +334,7 @@ class TestUFuncs(BaseUFuncTest, TestCase):
     def test_fmod_ufunc(self, flags=no_pyobj_flags):
         self.basic_ufunc_test(np.fmod, flags=flags,
             additional_inputs = [
-                ((np.int64(-4), np.int64(10)), types.uint64)
+                ((np.int64(-4), np.int64(10)), types.int64)
             ])
 
     def test_abs_ufunc(self, flags=no_pyobj_flags, ufunc=np.abs):

--- a/numba/tests/test_ufuncs.py
+++ b/numba/tests/test_ufuncs.py
@@ -332,7 +332,10 @@ class TestUFuncs(BaseUFuncTest, TestCase):
             ])
 
     def test_fmod_ufunc(self, flags=no_pyobj_flags):
-        self.basic_ufunc_test(np.fmod, flags=flags)
+        self.basic_ufunc_test(np.fmod, flags=flags,
+            additional_inputs = [
+                ((np.int64(-4), np.int64(10)), types.uint64)
+            ])
 
     def test_abs_ufunc(self, flags=no_pyobj_flags, ufunc=np.abs):
         self.basic_ufunc_test(ufunc, flags=flags,


### PR DESCRIPTION
Fix for `np.fmod` so that `np.fmod` with negative numbers matches numpy's behavior
