### PR TITLE
[Unicode] support startswith with args, start and end.

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -839,7 +839,7 @@ def unicode_startswith(s, prefix, start=None, end=None):
 
     if not is_nonelike(end) and not isinstance(end, types.Integer):
         raise TypingError(
-            "When specified, the arg 'end' must be an Integer or nonelike")
+            "When specified, the arg 'end' must be an Integer or None")
 
     if isinstance(prefix, (types.Tuple, types.UniTuple)):
         if isinstance(prefix, types.Tuple) or \

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -835,7 +835,7 @@ def _adjust_indices(length, start, end):
 def unicode_startswith(s, prefix, start=None, end=None):
     if not is_nonelike(start) and not isinstance(start, types.Integer):
         raise TypingError(
-            "When specified, the arg 'start' must be an Integer or nonelike")
+            "When specified, the arg 'start' must be an Integer or None")
 
     if not is_nonelike(end) and not isinstance(end, types.Integer):
         raise TypingError(

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -841,11 +841,8 @@ def unicode_startswith(s, prefix, start=None, end=None):
         raise TypingError(
             "When specified, the arg 'end' must be an Integer or None")
 
-    if isinstance(prefix, (types.Tuple, types.UniTuple)):
-        if isinstance(prefix, types.Tuple) or \
-                not isinstance(prefix.dtype, types.UnicodeType):
-            raise TypingError(
-                "The arg 'prefix' should a UniTuple of UnicodeType")
+    if isinstance(prefix, types.UniTuple) and \
+            isinstance(prefix.dtype, types.UnicodeType):
 
         def startswith_tuple_impl(s, prefix, start=None, end=None):
             for item in prefix:
@@ -881,6 +878,10 @@ def unicode_startswith(s, prefix, start=None, end=None):
             return _cmp_region(s_slice, 0, prefix, 0, prefix_length) == 0
 
         return startswith_unicode_impl
+
+    else:
+        raise TypingError(
+            "The arg 'prefix' should be a string or a tuple of strings")
 
 
 @overload_method(types.UnicodeType, 'endswith')

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -835,7 +835,7 @@ def unicode_startswith(s, substr, start=None, end=None):
     if not (start is None or isinstance(start, (types.Omitted,
                                                 types.Integer,
                                                 types.NoneType))):
-        raise TypingError('The arg must be a Integer or None')
+        raise TypingError('When specified, the arg "start" must be an Integer')
 
     if not (end is None or isinstance(end, (types.Omitted,
                                             types.Integer,

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -840,7 +840,7 @@ def unicode_startswith(s, substr, start=None, end=None):
     if not (end is None or isinstance(end, (types.Omitted,
                                             types.Integer,
                                             types.NoneType))):
-        raise TypingError('The arg must be a Integer or None')
+        raise TypingError('When specified, the arg "end" must be an Integer')
 
     if isinstance(substr, (types.Tuple, types.UniTuple)):
         def startswith_tuple_impl(s, substr, start=None, end=None):

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -861,7 +861,7 @@ def unicode_startswith(s, prefix, start=None, end=None):
 
         return startswith_char_seq_impl
 
-    if isinstance(prefix, types.UnicodeType):
+    elif isinstance(prefix, types.UnicodeType):
         def startswith_unicode_impl(s, prefix, start=None, end=None):
             length, prefix_length = len(s), len(prefix)
             if start is None:

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -855,7 +855,7 @@ def unicode_startswith(s, prefix, start=None, end=None):
 
         return startswith_tuple_impl
 
-    if isinstance(prefix, types.UnicodeCharSeq):
+    elif isinstance(prefix, types.UnicodeCharSeq):
         def startswith_char_seq_impl(s, prefix, start=None, end=None):
             return s.startswith(str(prefix), start, end)
 

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -831,7 +831,7 @@ def _adjust_indices(length, start, end):
 
 
 @overload_method(types.UnicodeType, 'startswith')
-def unicode_startswith(s, substr, start=None, end=None):
+def unicode_startswith(s, prefix, start=None, end=None):
     if not (start is None or isinstance(start, (types.Omitted,
                                                 types.Integer,
                                                 types.NoneType))):
@@ -842,25 +842,25 @@ def unicode_startswith(s, substr, start=None, end=None):
                                             types.NoneType))):
         raise TypingError('When specified, the arg "end" must be an Integer')
 
-    if isinstance(substr, (types.Tuple, types.UniTuple)):
-        def startswith_tuple_impl(s, substr, start=None, end=None):
-            for item in substr:
+    if isinstance(prefix, (types.Tuple, types.UniTuple)):
+        def startswith_tuple_impl(s, prefix, start=None, end=None):
+            for item in prefix:
                 if s.startswith(item, start, end):
                     return True
             return False
 
         return startswith_tuple_impl
 
-    if isinstance(substr, types.UnicodeCharSeq):
-        def startswith_char_seq_impl(s, substr, start=None, end=None):
-            return s.startswith(str(substr), start, end)
+    if isinstance(prefix, types.UnicodeCharSeq):
+        def startswith_char_seq_impl(s, prefix, start=None, end=None):
+            return s.startswith(str(prefix), start, end)
 
         return startswith_char_seq_impl
 
-    if isinstance(substr, types.UnicodeType):
-        def startswith_unicode_impl(s, substr, start=None, end=None):
+    if isinstance(prefix, types.UnicodeType):
+        def startswith_unicode_impl(s, prefix, start=None, end=None):
             length = len(s)
-            sub_length = len(substr)
+            sub_length = len(prefix)
             if start is None:
                 start = 0
             if end is None:
@@ -875,7 +875,7 @@ def unicode_startswith(s, substr, start=None, end=None):
 
             s = s[start:end]
 
-            return _cmp_region(s, 0, substr, 0, sub_length) == 0
+            return _cmp_region(s, 0, prefix, 0, sub_length) == 0
 
         return startswith_unicode_impl
 

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -610,12 +610,19 @@ class TestUnicode(BaseTest):
                                          cfunc(s, prefix, start, end))
 
     def test_startswith_exception_invalid_args(self):
-        msg_invalid_start = 'When specified, the arg "start" must be an Integer'
+        msg_invalid_prefix = "The arg 'prefix' should a UniTuple of UnicodeType"
+        with self.assertRaisesRegex(TypingError, msg_invalid_prefix):
+            cfunc = njit(startswith_usecase)
+            cfunc("hello", (1, "he"))
+
+        msg_invalid_start = \
+            "When specified, the arg 'start' must be an Integer or nonelike"
         with self.assertRaisesRegex(TypingError, msg_invalid_start):
             cfunc = njit(startswith_with_start_only_usecase)
             cfunc("hello", "he", "invalid start")
 
-        msg_invalid_end = 'When specified, the arg "end" must be an Integer'
+        msg_invalid_end = \
+            "When specified, the arg 'end' must be an Integer or nonelike"
         with self.assertRaisesRegex(TypingError, msg_invalid_end):
             cfunc = njit(startswith_with_start_end_usecase)
             cfunc("hello", "he", 0, "invalid end")

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -571,8 +571,8 @@ class TestUnicode(BaseTest):
         extra_subs = ['hellohellohello', ' ']
         for s in cpython_str + UNICODE_EXAMPLES:
             default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
-            for sub_str in cpython_subs + default_subs + extra_subs:
-                self.assertEqual(pyfunc(s, sub_str), cfunc(s, sub_str))
+            for prefix in cpython_subs + default_subs + extra_subs:
+                self.assertEqual(pyfunc(s, prefix), cfunc(s, prefix))
 
     def test_startswith_with_start(self):
         pyfunc = startswith_with_start_only_usecase
@@ -586,12 +586,10 @@ class TestUnicode(BaseTest):
         extra_subs = ['hellohellohello', ' ']
         for s in cpython_str + UNICODE_EXAMPLES:
             default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
-            for sub_str in cpython_subs + default_subs + extra_subs:
+            for prefix in cpython_subs + default_subs + extra_subs:
                 for start in list(range(-20, 20)) + [None]:
-                    self.assertEqual(pyfunc(s, sub_str, start),
-                                     cfunc(s, sub_str, start))
-        with self.assertRaises(TypingError):
-            cfunc('hello', 'he', 0.1)
+                    self.assertEqual(pyfunc(s, prefix, start),
+                                     cfunc(s, prefix, start))
 
     def test_startswith_with_start_end(self):
         pyfunc = startswith_with_start_end_usecase
@@ -605,13 +603,22 @@ class TestUnicode(BaseTest):
         extra_subs = ['hellohellohello', ' ']
         for s in cpython_str + UNICODE_EXAMPLES:
             default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
-            for sub_str in cpython_subs + default_subs + extra_subs:
+            for prefix in cpython_subs + default_subs + extra_subs:
                 for start in list(range(-20, 20)) + [None]:
                     for end in list(range(-20, 20)) + [None]:
-                        self.assertEqual(pyfunc(s, sub_str, start, end),
-                                         cfunc(s, sub_str, start, end))
-        with self.assertRaises(TypingError):
-            cfunc('hello', 'he', 0, 0.1)
+                        self.assertEqual(pyfunc(s, prefix, start, end),
+                                         cfunc(s, prefix, start, end))
+
+    def test_startswith_exception_invalid_args(self):
+        msg_invalid_start = 'When specified, the arg "start" must be an Integer'
+        with self.assertRaisesRegex(TypingError, msg_invalid_start):
+            cfunc = njit(startswith_with_start_only_usecase)
+            cfunc("hello", "he", "invalid start")
+
+        msg_invalid_end = 'When specified, the arg "end" must be an Integer'
+        with self.assertRaisesRegex(TypingError, msg_invalid_end):
+            cfunc = njit(startswith_with_start_end_usecase)
+            cfunc("hello", "he", 0, "invalid end")
 
     def test_startswith_tuple(self):
         pyfunc = startswith_usecase
@@ -626,9 +633,9 @@ class TestUnicode(BaseTest):
         for s in cpython_str + UNICODE_EXAMPLES:
             default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
             for sub_str in cpython_subs + default_subs + extra_subs:
-                tuple_subs = (sub_str, 'lo')
-                self.assertEqual(pyfunc(s, tuple_subs),
-                                 cfunc(s, tuple_subs))
+                prefix = (sub_str, 'lo')
+                self.assertEqual(pyfunc(s, prefix),
+                                 cfunc(s, prefix))
 
     def test_startswith_tuple_args(self):
         pyfunc = startswith_with_start_end_usecase
@@ -645,9 +652,9 @@ class TestUnicode(BaseTest):
             for sub_str in cpython_subs + default_subs + extra_subs:
                 for start in list(range(-20, 20)) + [None]:
                     for end in list(range(-20, 20)) + [None]:
-                        tuple_subs = (sub_str, 'lo')
-                        self.assertEqual(pyfunc(s, tuple_subs, start, end),
-                                         cfunc(s, tuple_subs, start, end))
+                        prefix = (sub_str, 'lo')
+                        self.assertEqual(pyfunc(s, prefix, start, end),
+                                         cfunc(s, prefix, start, end))
 
     def test_endswith_default(self):
         pyfunc = endswith_usecase

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -610,19 +610,20 @@ class TestUnicode(BaseTest):
                                          cfunc(s, prefix, start, end))
 
     def test_startswith_exception_invalid_args(self):
-        msg_invalid_prefix = "The arg 'prefix' should a UniTuple of UnicodeType"
+        msg_invalid_prefix = \
+            "The arg 'prefix' should be a string or a tuple of strings"
         with self.assertRaisesRegex(TypingError, msg_invalid_prefix):
             cfunc = njit(startswith_usecase)
             cfunc("hello", (1, "he"))
 
         msg_invalid_start = \
-            "When specified, the arg 'start' must be an Integer or nonelike"
+            "When specified, the arg 'start' must be an Integer or None"
         with self.assertRaisesRegex(TypingError, msg_invalid_start):
             cfunc = njit(startswith_with_start_only_usecase)
             cfunc("hello", "he", "invalid start")
 
         msg_invalid_end = \
-            "When specified, the arg 'end' must be an Integer or nonelike"
+            "When specified, the arg 'end' must be an Integer or None"
         with self.assertRaisesRegex(TypingError, msg_invalid_end):
             cfunc = njit(startswith_with_start_end_usecase)
             cfunc("hello", "he", 0, "invalid end")

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -590,6 +590,8 @@ class TestUnicode(BaseTest):
                 for start in list(range(-20, 20)) + [None]:
                     self.assertEqual(pyfunc(s, sub_str, start),
                                      cfunc(s, sub_str, start))
+        with self.assertRaises(TypingError):
+            cfunc('hello', 'he', 0.1)
 
     def test_startswith_with_start_end(self):
         pyfunc = startswith_with_start_end_usecase
@@ -608,6 +610,8 @@ class TestUnicode(BaseTest):
                     for end in list(range(-20, 20)) + [None]:
                         self.assertEqual(pyfunc(s, sub_str, start, end),
                                          cfunc(s, sub_str, start, end))
+        with self.assertRaises(TypingError):
+            cfunc('hello', 'he', 0, 0.1)
 
     def test_startswith_tuple(self):
         pyfunc = startswith_usecase

--- a/numba/tests/test_unicode.py
+++ b/numba/tests/test_unicode.py
@@ -177,6 +177,14 @@ def expandtabs_with_tabsize_kwarg_usecase(s, tabsize):
     return s.expandtabs(tabsize=tabsize)
 
 
+def startswith_with_start_only_usecase(x, y, start):
+    return x.startswith(y, start)
+
+
+def startswith_with_start_end_usecase(x, y, start, end):
+    return x.startswith(y, start, end)
+
+
 def endswith_with_start_only_usecase(x, y, start):
     return x.endswith(y, start)
 
@@ -551,23 +559,91 @@ class TestUnicode(BaseTest):
         msg = '"tabsize" must be {}, not float'.format(accepted_types)
         self.assertIn(msg, str(raises.exception))
 
-    def test_startswith(self, flags=no_pyobj_flags):
+    def test_startswith_default(self):
         pyfunc = startswith_usecase
         cfunc = njit(pyfunc)
-        for a in UNICODE_EXAMPLES:
-            for b in ['', 'x', a[:-2], a[3:], a, a + a]:
-                self.assertEqual(pyfunc(a, b),
-                                 cfunc(a, b),
-                                 '%s, %s' % (a, b))
 
-    def test_endswith(self, flags=no_pyobj_flags):
-        pyfunc = endswith_usecase
+        cpython_str = ['hello', 'helloworld', '']
+        cpython_subs = [
+            'he', 'hello', 'helloworld', 'ello',
+            '', 'lowo', 'lo', 'he', 'lo', 'o',
+        ]
+        extra_subs = ['hellohellohello', ' ']
+        for s in cpython_str + UNICODE_EXAMPLES:
+            default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
+            for sub_str in cpython_subs + default_subs + extra_subs:
+                self.assertEqual(pyfunc(s, sub_str), cfunc(s, sub_str))
+
+    def test_startswith_with_start(self):
+        pyfunc = startswith_with_start_only_usecase
         cfunc = njit(pyfunc)
-        for a in UNICODE_EXAMPLES:
-            for b in ['', 'x', a[:-2], a[3:], a, a + a]:
-                self.assertEqual(pyfunc(a, b),
-                                 cfunc(a, b),
-                                 '%s, %s' % (a, b))
+
+        cpython_str = ['hello', 'helloworld', '']
+        cpython_subs = [
+            'he', 'hello', 'helloworld', 'ello',
+            '', 'lowo', 'lo', 'he', 'lo', 'o',
+        ]
+        extra_subs = ['hellohellohello', ' ']
+        for s in cpython_str + UNICODE_EXAMPLES:
+            default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
+            for sub_str in cpython_subs + default_subs + extra_subs:
+                for start in list(range(-20, 20)) + [None]:
+                    self.assertEqual(pyfunc(s, sub_str, start),
+                                     cfunc(s, sub_str, start))
+
+    def test_startswith_with_start_end(self):
+        pyfunc = startswith_with_start_end_usecase
+        cfunc = njit(pyfunc)
+
+        cpython_str = ['hello', 'helloworld', '']
+        cpython_subs = [
+            'he', 'hello', 'helloworld', 'ello',
+            '', 'lowo', 'lo', 'he', 'lo', 'o',
+        ]
+        extra_subs = ['hellohellohello', ' ']
+        for s in cpython_str + UNICODE_EXAMPLES:
+            default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
+            for sub_str in cpython_subs + default_subs + extra_subs:
+                for start in list(range(-20, 20)) + [None]:
+                    for end in list(range(-20, 20)) + [None]:
+                        self.assertEqual(pyfunc(s, sub_str, start, end),
+                                         cfunc(s, sub_str, start, end))
+
+    def test_startswith_tuple(self):
+        pyfunc = startswith_usecase
+        cfunc = njit(pyfunc)
+
+        cpython_str = ['hello', 'helloworld', '']
+        cpython_subs = [
+            'he', 'hello', 'helloworld', 'ello',
+            '', 'lowo', 'lo', 'he', 'lo', 'o',
+        ]
+        extra_subs = ['hellohellohello', ' ']
+        for s in cpython_str + UNICODE_EXAMPLES:
+            default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
+            for sub_str in cpython_subs + default_subs + extra_subs:
+                tuple_subs = (sub_str, 'lo')
+                self.assertEqual(pyfunc(s, tuple_subs),
+                                 cfunc(s, tuple_subs))
+
+    def test_startswith_tuple_args(self):
+        pyfunc = startswith_with_start_end_usecase
+        cfunc = njit(pyfunc)
+
+        cpython_str = ['hello', 'helloworld', '']
+        cpython_subs = [
+            'he', 'hello', 'helloworld', 'ello',
+            '', 'lowo', 'lo', 'he', 'lo', 'o',
+        ]
+        extra_subs = ['hellohellohello', ' ']
+        for s in cpython_str + UNICODE_EXAMPLES:
+            default_subs = ['', 'x', s[:-2], s[3:], s, s + s]
+            for sub_str in cpython_subs + default_subs + extra_subs:
+                for start in list(range(-20, 20)) + [None]:
+                    for end in list(range(-20, 20)) + [None]:
+                        tuple_subs = (sub_str, 'lo')
+                        self.assertEqual(pyfunc(s, tuple_subs, start, end),
+                                         cfunc(s, tuple_subs, start, end))
 
     def test_endswith_default(self):
         pyfunc = endswith_usecase


### PR DESCRIPTION
As it is, support `start` and `end` optional arguments for `startswith`.

Most added code comes from the implementation of `endswith`, with marginal changes.

PS, I also have aother PR about supporting `int(str)` based on this one, and I will open that one after merging this.

BTW, I have a question about `_nrt=False`, I didn't find any document about this, what is it for in the Numba Runtime level? Disable any memory allocation/refct/release?