### PR TITLE
CUDA: Get rid of `_nvvm_options_type`

### DIFF
--- a/numba/core/targetconfig.py
+++ b/numba/core/targetconfig.py
@@ -15,7 +15,7 @@ class Option:
     """
     __slots__ = "_type", "_default", "_doc"
 
-    def __init__(self, type, *, default, doc):
+    def __init__(self, type, *, default=None, doc=None):
         """
         Parameters
         ----------
@@ -29,6 +29,7 @@ class Option:
         """
         self._type = type
         self._default = default
+        doc = doc or ""
         self._doc = doc
 
     @property

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -16,7 +16,6 @@ from numba.cuda.api import get_current_device
 class CUDAFlags(Flags):
     nvvm_options = Option(
         type=dict,
-        default=None,
         doc="NVVM options",
     )
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -13,18 +13,9 @@ from warnings import warn
 from numba.cuda.api import get_current_device
 
 
-def _nvvm_options_type(x):
-    if x is None:
-        return None
-
-    else:
-        assert isinstance(x, dict)
-        return x
-
-
 class CUDAFlags(Flags):
     nvvm_options = Option(
-        type=_nvvm_options_type,
+        type=dict,
         default=None,
         doc="NVVM options",
     )
@@ -184,6 +175,8 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
     from .descriptor import cuda_target
     typingctx = cuda_target.typing_context
     targetctx = cuda_target.target_context
+
+    nvvm_options = nvvm_options or {}
 
     flags = CUDAFlags()
     # Do not compile (generate native code), just lower (to LLVM)


### PR DESCRIPTION
This isn't really necessary - it only existed because there were sometimes no options as `None` instead of an empty dict. This commit ensures it is always a dict and uses the standard dict type for it.