### PR TITLE
CUDA: Reduce memory pressure from local memory tests

### DIFF
--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -377,11 +377,11 @@ class TestDispatcher(CUDATestCase):
         self.assertIsInstance(shared_mem_per_block, int)
         self.assertEqual(shared_mem_per_block, 400)
 
-    def test_get_local_mem_per_block_unspecialized(self):
+    def test_get_local_mem_per_thread_unspecialized(self):
         # NOTE: A large amount of local memory must be allocated
         # otherwise the compiler will optimize out the call to
         # cuda.local.array and use local registers instead
-        N = 10000
+        N = 1000
 
         @cuda.jit
         def simple_lmem(ary):
@@ -412,16 +412,16 @@ class TestDispatcher(CUDATestCase):
         # Check that getting the local memory per thread for all signatures
         # provides the same values as getting the shared mem per block for
         # individual signatures.
-        sh_mem_f32_all = simple_lmem.get_local_mem_per_thread()
-        sh_mem_f64_all = simple_lmem.get_local_mem_per_thread()
-        self.assertEqual(sh_mem_f32_all[sig_f32.args], local_mem_f32)
-        self.assertEqual(sh_mem_f64_all[sig_f64.args], local_mem_f64)
+        local_mem_f32_all = simple_lmem.get_local_mem_per_thread()
+        local_mem_f64_all = simple_lmem.get_local_mem_per_thread()
+        self.assertEqual(local_mem_f32_all[sig_f32.args], local_mem_f32)
+        self.assertEqual(local_mem_f64_all[sig_f64.args], local_mem_f64)
 
     def test_get_local_mem_per_thread_specialized(self):
         # NOTE: A large amount of local memory must be allocated
         # otherwise the compiler will optimize out the call to
         # cuda.local.array and use local registers instead
-        N = 10000
+        N = 1000
 
         @cuda.jit(void(float32[::1]))
         def simple_lmem(ary):

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -412,10 +412,9 @@ class TestDispatcher(CUDATestCase):
         # Check that getting the local memory per thread for all signatures
         # provides the same values as getting the shared mem per block for
         # individual signatures.
-        local_mem_f32_all = simple_lmem.get_local_mem_per_thread()
-        local_mem_f64_all = simple_lmem.get_local_mem_per_thread()
-        self.assertEqual(local_mem_f32_all[sig_f32.args], local_mem_f32)
-        self.assertEqual(local_mem_f64_all[sig_f64.args], local_mem_f64)
+        local_mem_all = simple_lmem.get_local_mem_per_thread()
+        self.assertEqual(local_mem_all[sig_f32.args], local_mem_f32)
+        self.assertEqual(local_mem_all[sig_f64.args], local_mem_f64)
 
     def test_get_local_mem_per_thread_specialized(self):
         # NOTE: A large amount of local memory must be allocated


### PR DESCRIPTION
Local memory usage requires a reservation of (bytes per thread) * (number of SMs) * (Max resident threads per SM), which for kernels with local memory requirements of 80KB per thread (as is the case for these tests) forces allocations into the low GBs - this is a problem on the buildfarm as multiple tests run concurrently and can result in out-of-memory conditions.

This commit reduces the local memory allocations by a factor of 10 - I worry that reducing by another order of magnitude might cause local memory not to be allocated in some cases.

Some copy/paste errors that slipped through in these tests are also resolved (including the name of one of the tests!).

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
