### PR TITLE
Migrate `cmath.*` to use overload

### DIFF
--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -16,7 +16,6 @@ infer_global = registry.register_global
 @infer_global(cmath.asinh)
 @infer_global(cmath.atan)
 @infer_global(cmath.atanh)
-@infer_global(cmath.cos)
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)
 @infer_global(cmath.log10)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -16,7 +16,6 @@ infer_global = registry.register_global
 @infer_global(cmath.exp)
 @infer_global(cmath.log10)
 @infer_global(cmath.sinh)
-@infer_global(cmath.tan)
 @infer_global(cmath.tanh)
 class CMath_unary(ConcreteTemplate):
     cases = [signature(tp, tp) for tp in sorted(types.complex_domain)]

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -11,7 +11,6 @@ infer_global = registry.register_global
 
 
 @infer_global(cmath.acosh)
-@infer_global(cmath.asin)
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)
 @infer_global(cmath.log10)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -26,16 +26,6 @@ class CMath_unary(ConcreteTemplate):
     cases = [signature(tp, tp) for tp in sorted(types.complex_domain)]
 
 
-class CMath_predicate(ConcreteTemplate):
-    cases = [signature(types.boolean, tp) for tp in
-             sorted(types.complex_domain)]
-
-
-@infer_global(cmath.isfinite)
-class CMath_isfinite(CMath_predicate):
-    pass
-
-
 @infer_global(cmath.phase)
 class Cmath_phase(ConcreteTemplate):
     cases = [signature(tp, types.complex128) for tp in [types.float64]]

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -40,14 +40,6 @@ class CMath_isfinite(CMath_predicate):
     pass
 
 
-@infer_global(cmath.log)
-class Cmath_log(ConcreteTemplate):
-    # unary cmath.log()
-    cases = [signature(tp, tp) for tp in sorted(types.complex_domain)]
-    # binary cmath.log()
-    cases += [signature(tp, tp, tp) for tp in sorted(types.complex_domain)]
-
-
 @infer_global(cmath.phase)
 class Cmath_phase(ConcreteTemplate):
     cases = [signature(tp, types.complex128) for tp in [types.float64]]

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -13,7 +13,6 @@ infer_global = registry.register_global
 @infer_global(cmath.acosh)
 @infer_global(cmath.asin)
 @infer_global(cmath.asinh)
-@infer_global(cmath.atan)
 @infer_global(cmath.atanh)
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -12,7 +12,6 @@ infer_global = registry.register_global
 
 @infer_global(cmath.acosh)
 @infer_global(cmath.asin)
-@infer_global(cmath.asinh)
 @infer_global(cmath.atanh)
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -27,7 +27,6 @@ class CMath_unary(ConcreteTemplate):
 
 
 @infer_global(cmath.isinf)
-@infer_global(cmath.isnan)
 class CMath_predicate(ConcreteTemplate):
     cases = [signature(types.boolean, tp) for tp in
              sorted(types.complex_domain)]

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -21,7 +21,6 @@ infer_global = registry.register_global
 @infer_global(cmath.log10)
 @infer_global(cmath.sin)
 @infer_global(cmath.sinh)
-@infer_global(cmath.sqrt)
 @infer_global(cmath.tan)
 @infer_global(cmath.tanh)
 class CMath_unary(ConcreteTemplate):

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -10,7 +10,6 @@ infer_global = registry.register_global
 # TODO: support non-complex arguments (floats and ints)
 
 
-@infer_global(cmath.acos)
 @infer_global(cmath.acosh)
 @infer_global(cmath.asin)
 @infer_global(cmath.asinh)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -19,7 +19,6 @@ infer_global = registry.register_global
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)
 @infer_global(cmath.log10)
-@infer_global(cmath.sin)
 @infer_global(cmath.sinh)
 @infer_global(cmath.tan)
 @infer_global(cmath.tanh)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -12,7 +12,6 @@ infer_global = registry.register_global
 
 @infer_global(cmath.acosh)
 @infer_global(cmath.asin)
-@infer_global(cmath.atanh)
 @infer_global(cmath.cosh)
 @infer_global(cmath.exp)
 @infer_global(cmath.log10)

--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -26,7 +26,6 @@ class CMath_unary(ConcreteTemplate):
     cases = [signature(tp, tp) for tp in sorted(types.complex_domain)]
 
 
-@infer_global(cmath.isinf)
 class CMath_predicate(ConcreteTemplate):
     cases = [signature(types.boolean, tp) for tp in
              sorted(types.complex_domain)]

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -543,8 +543,11 @@ def atan_impl(z):
     return atan_impl
 
 
-@lower(cmath.atanh, types.Complex)
-def atanh_impl(context, builder, sig, args):
+@overload(cmath.atanh, target='generic')
+def atanh_impl(z):
+    if not isinstance(z, types.Complex):
+        return
+
     LN_4 = math.log(4)
     THRES_LARGE = math.sqrt(mathimpl.FLT_MAX / 4)
     THRES_SMALL = math.sqrt(mathimpl.FLT_MIN)
@@ -594,5 +597,4 @@ def atanh_impl(context, builder, sig, args):
         else:
             return complex(real, imag)
 
-    res = context.compile_internal(builder, atanh_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return atanh_impl

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -309,15 +309,18 @@ def cosh_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 
-@lower(cmath.sin, types.Complex)
-def sin_impl(context, builder, sig, args):
+@overload(cmath.sin, target="generic")
+def ol_cmath_sin(z):
+    if not isinstance(z, types.Complex):
+        return
+
     def sin_impl(z):
         """cmath.sin(z) = -j * cmath.sinh(z j)"""
         r = cmath.sinh(complex(-z.imag, z.real))
         return complex(r.imag, -r.real)
 
-    res = context.compile_internal(builder, sin_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return sin_impl
+
 
 @lower(cmath.sinh, types.Complex)
 def sinh_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -394,15 +394,18 @@ def sinh_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 
-@lower(cmath.tan, types.Complex)
-def tan_impl(context, builder, sig, args):
+@overload(cmath.tan, target='generic')
+def tan_impl(z):
+    if not isinstance(z, types.Complex):
+        return
+
     def tan_impl(z):
         """cmath.tan(z) = -j * cmath.tanh(z j)"""
         r = cmath.tanh(complex(-z.imag, z.real))
         return complex(r.imag, -r.real)
 
-    res = context.compile_internal(builder, tan_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return tan_impl
+
 
 @lower(cmath.tanh, types.Complex)
 def tanh_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -521,8 +521,12 @@ def asin_impl(context, builder, sig, args):
     res = context.compile_internal(builder, asin_impl, sig, args)
     return impl_ret_untracked(context, builder, sig, res)
 
-@lower(cmath.atan, types.Complex)
-def atan_impl(context, builder, sig, args):
+
+@overload(cmath.atan, target='generic')
+def atan_impl(z):
+    if not isinstance(z, types.Complex):
+        return
+
     def atan_impl(z):
         """cmath.atan(z) = -j * cmath.atanh(z j)"""
         r = cmath.atanh(complex(-z.imag, z.real))
@@ -532,8 +536,8 @@ def atan_impl(context, builder, sig, args):
         else:
             return complex(r.imag, -r.real)
 
-    res = context.compile_internal(builder, atan_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return atan_impl
+
 
 @lower(cmath.atanh, types.Complex)
 def atanh_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -7,7 +7,7 @@ import cmath
 import math
 
 from numba.core.imputils import Registry, impl_ret_untracked
-from numba.core import types, cgutils
+from numba.core import types, cgutils, errors
 from numba.core.typing import signature
 from numba.cpython import builtins, mathimpl
 from numba.core.extending import overload, intrinsic

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -432,8 +432,11 @@ def tanh_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 
-@lower(cmath.acos, types.Complex)
-def acos_impl(context, builder, sig, args):
+@overload(cmath.acos, target='generic')
+def ol_cmath_acos(z):
+    if not isinstance(z, types.Complex):
+        return
+
     LN_4 = math.log(4)
     THRES = mathimpl.FLT_MAX / 4
 
@@ -455,8 +458,8 @@ def acos_impl(context, builder, sig, args):
             imag = math.asinh(s2.real * s1.imag - s2.imag * s1.real)
             return complex(real, imag)
 
-    res = context.compile_internal(builder, acos_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return acos_impl
+
 
 @lower(cmath.acosh, types.Complex)
 def acosh_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -487,8 +487,12 @@ def acosh_impl(context, builder, sig, args):
     res = context.compile_internal(builder, acosh_impl, sig, args)
     return impl_ret_untracked(context, builder, sig, res)
 
-@lower(cmath.asinh, types.Complex)
-def asinh_impl(context, builder, sig, args):
+
+@overload(cmath.asinh, target='generic')
+def asinh_impl(z):
+    if not isinstance(z, types.Complex):
+        return
+
     LN_4 = math.log(4)
     THRES = mathimpl.FLT_MAX / 4
 
@@ -508,8 +512,8 @@ def asinh_impl(context, builder, sig, args):
             imag = math.atan2(z.imag, s1.real * s2.real - s1.imag * s2.imag)
             return complex(real, imag)
 
-    res = context.compile_internal(builder, asinh_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return asinh_impl
+
 
 @lower(cmath.asin, types.Complex)
 def asin_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -10,6 +10,7 @@ from numba.core.imputils import Registry, impl_ret_untracked
 from numba.core import types, cgutils
 from numba.core.typing import signature
 from numba.cpython import builtins, mathimpl
+from numba.core.extending import overload, intrinsic
 
 registry = Registry('cmathimpl')
 lower = registry.lower
@@ -261,14 +262,17 @@ def sqrt_impl(context, builder, sig, args):
     return impl_ret_untracked(context, builder, sig, res)
 
 
-@lower(cmath.cos, types.Complex)
-def cos_impl(context, builder, sig, args):
+@overload(cmath.cos, target="generic")
+def ol_cmath_cos(z):
+    if not isinstance(z, types.Complex):
+        return
+
     def cos_impl(z):
         """cmath.cos(z) = cmath.cosh(z j)"""
         return cmath.cosh(complex(-z.imag, z.real))
 
-    res = context.compile_internal(builder, cos_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return cos_impl
+
 
 @lower(cmath.cosh, types.Complex)
 def cosh_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -206,13 +206,15 @@ def polar_impl(x, y, x_is_finite, y_is_finite):
     return math.hypot(x, y), math.atan2(y, x)
 
 
-@lower(cmath.sqrt, types.Complex)
-def sqrt_impl(context, builder, sig, args):
-    # We risk spurious overflow for components >= FLT_MAX / (1 + sqrt(2)).
+@overload(cmath.sqrt, target="generic")
+def ol_cmath_sqrt(z):
+    if not isinstance(z, types.Complex):
+        return
 
+    # We risk spurious overflow for components >= FLT_MAX / (1 + sqrt(2)).
     SQRT2 = 1.414213562373095048801688724209698079E0
     ONE_PLUS_SQRT2 = (1. + SQRT2)
-    theargflt = sig.args[0].underlying_float
+    theargflt = z.underlying_float
     # Get a type specific maximum value so scaling for overflow is based on that
     MAX = mathimpl.DBL_MAX if theargflt.bitwidth == 64 else mathimpl.FLT_MAX
     # THRES will be double precision, should not impact typing as it's just
@@ -263,8 +265,7 @@ def sqrt_impl(context, builder, sig, args):
         else:
             return complex(real, imag)
 
-    res = context.compile_internal(builder, sqrt_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return sqrt_impl
 
 
 @overload(cmath.cos, target="generic")

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -28,13 +28,29 @@ def is_finite(builder, z):
                         mathimpl.is_finite(builder, z.imag))
 
 
-@lower(cmath.isnan, types.Complex)
-def isnan_float_impl(context, builder, sig, args):
-    [typ] = sig.args
-    [value] = args
-    z = context.make_complex(builder, typ, value=value)
-    res = is_nan(builder, z)
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+@intrinsic
+def _isnan(typingctx, z):
+    sig = types.boolean(z)
+
+    def codegen(context, builder, sig, args):
+        [typ] = sig.args
+        [value] = args
+        z = context.make_complex(builder, typ, value=value)
+        res = is_nan(builder, z)
+        return impl_ret_untracked(context, builder, sig.return_type, res)
+
+    return sig, codegen
+
+
+@overload(cmath.isnan, target='generic')
+def ol_cmath_isnan(z):
+    if not isinstance(z, types.Complex):
+        return
+
+    def impl(z):
+        return _isnan(z)
+    return impl
+
 
 @lower(cmath.isinf, types.Complex)
 def isinf_float_impl(context, builder, sig, args):

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -518,15 +518,17 @@ def asinh_impl(z):
     return asinh_impl
 
 
-@lower(cmath.asin, types.Complex)
-def asin_impl(context, builder, sig, args):
+@overload(cmath.asin, target='generic')
+def asin_impl(z):
+    if not isinstance(z, types.Complex):
+        return
+
     def asin_impl(z):
         """cmath.asin(z) = -j * cmath.asinh(z j)"""
         r = cmath.asinh(complex(-z.imag, z.real))
         return complex(r.imag, -r.real)
 
-    res = context.compile_internal(builder, asin_impl, sig, args)
-    return impl_ret_untracked(context, builder, sig, res)
+    return asin_impl
 
 
 @overload(cmath.atan, target='generic')

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -52,13 +52,28 @@ def ol_cmath_isnan(z):
     return impl
 
 
-@lower(cmath.isinf, types.Complex)
-def isinf_float_impl(context, builder, sig, args):
-    [typ] = sig.args
-    [value] = args
-    z = context.make_complex(builder, typ, value=value)
-    res = is_inf(builder, z)
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+@intrinsic
+def _isinf(typingctx, z):
+    sig = types.boolean(z)
+
+    def codegen(context, builder, sig, args):
+        [typ] = sig.args
+        [value] = args
+        z = context.make_complex(builder, typ, value=value)
+        res = is_inf(builder, z)
+        return impl_ret_untracked(context, builder, sig.return_type, res)
+
+    return sig, codegen
+
+
+@overload(cmath.isinf, target='generic')
+def ol_cmath_isnan(z):
+    if not isinstance(z, types.Complex):
+        return
+
+    def impl(z):
+        return _isinf(z)
+    return impl
 
 
 @lower(cmath.isfinite, types.Complex)

--- a/numba/cpython/cmathimpl.py
+++ b/numba/cpython/cmathimpl.py
@@ -76,13 +76,28 @@ def ol_cmath_isnan(z):
     return impl
 
 
-@lower(cmath.isfinite, types.Complex)
-def isfinite_float_impl(context, builder, sig, args):
-    [typ] = sig.args
-    [value] = args
-    z = context.make_complex(builder, typ, value=value)
-    res = is_finite(builder, z)
-    return impl_ret_untracked(context, builder, sig.return_type, res)
+@intrinsic
+def _isfinite(typingctx, z):
+    sig = types.boolean(z)
+
+    def codegen(context, builder, sig, args):
+        [typ] = sig.args
+        [value] = args
+        z = context.make_complex(builder, typ, value=value)
+        res = is_finite(builder, z)
+        return impl_ret_untracked(context, builder, sig.return_type, res)
+
+    return sig, codegen
+
+
+@overload(cmath.isfinite, target='generic')
+def ol_cmath_isnan(z):
+    if not isinstance(z, types.Complex):
+        return
+
+    def impl(z):
+        return _isfinite(z)
+    return impl
 
 
 @lower(cmath.rect, types.Float, types.Float)

--- a/numba/cuda/extending.py
+++ b/numba/cuda/extending.py
@@ -2,6 +2,13 @@
 Added for symmetry with the core API
 """
 
+from functools import partial
 from numba.core.extending import intrinsic as _intrinsic
+from numba.core.extending import overload as _overload
+from numba.core.extending import overload_method as _overload_method
+from numba.core.extending import overload_attribute as _overload_attribute
 
 intrinsic = _intrinsic(target='cuda')
+overload = partial(_overload, target='cuda')
+overload_method = partial(_overload_method, target='cuda')
+overload_attribute = partial(_overload_attribute, target='cuda')

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -904,6 +904,15 @@ def np_real_tan_impl(context, builder, sig, args):
     return mathimpl.tan_impl(context, builder, sig, args)
 
 
+def np_complex_tan_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1)
+
+    def impl(z):
+        return cmath.tan(z)
+
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy asin
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -14,7 +14,7 @@ from numba.core.imputils import impl_ret_untracked
 from numba.core import typing, types, errors, lowering, cgutils
 from numba.core.extending import register_jitable
 from numba.np import npdatetime
-from numba.cpython import mathimpl, numbers
+from numba.cpython import cmathimpl, mathimpl, numbers
 
 # some NumPy constants. Note that we could generate some of them using
 # the math library, but having the values copied from npy_math seems to

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -5,7 +5,7 @@ Python builtins
 """
 
 
-import math
+import cmath
 
 import llvmlite.ir
 import numpy as np

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -630,7 +630,11 @@ def np_real_log_impl(context, builder, sig, args):
 
 def np_complex_log_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-    return cmathimpl.log_impl(context, builder, sig, args)
+
+    def impl(z):
+        return cmath.log(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 ########################################################################
 # NumPy log2

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -920,6 +920,12 @@ def np_real_acos_impl(context, builder, sig, args):
     return mathimpl.acos_impl(context, builder, sig, args)
 
 
+def np_complex_acos_impl(context, builder, sig, args):
+    def impl(z):
+        return cmath.acos(z)
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy atan
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -1576,10 +1576,11 @@ def np_real_isinf_impl(context, builder, sig, args):
 
 def np_complex_isinf_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
-    x, = args
-    ty, = sig.args
-    complex_val = context.make_complex(builder, ty, value=x)
-    return cmathimpl.is_inf(builder, complex_val)
+
+    def impl(z):
+        return cmath.isinf(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 def np_real_signbit_impl(context, builder, sig, args):

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -1530,10 +1530,10 @@ def np_real_isnan_impl(context, builder, sig, args):
 def np_complex_isnan_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
 
-    x, = args
-    ty, = sig.args
-    complex_val = context.make_complex(builder, ty, value=x)
-    return cmathimpl.is_nan(builder, complex_val)
+    def impl(z):
+        return cmath.isnan(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 def np_int_isfinite_impl(context, builder, sig, args):

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -921,6 +921,15 @@ def np_real_asin_impl(context, builder, sig, args):
     return mathimpl.asin_impl(context, builder, sig, args)
 
 
+def np_complex_asin_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1)
+
+    def impl(z):
+        return cmath.asin(z)
+
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy acos
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -1076,6 +1076,13 @@ def np_real_asinh_impl(context, builder, sig, args):
     return mathimpl.asinh_impl(context, builder, sig, args)
 
 
+def np_complex_asinh_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1)
+    def impl(z):
+        return cmath.asinh(z)
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy acosh
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -872,7 +872,11 @@ def np_real_sin_impl(context, builder, sig, args):
 
 def np_complex_sin_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-    return cmathimpl.sin_impl(context, builder, sig, args)
+
+    def impl(z):
+        return cmath.sin(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 ########################################################################

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -877,7 +877,11 @@ def np_real_cos_impl(context, builder, sig, args):
 
 def np_complex_cos_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-    return cmathimpl.cos_impl(context, builder, sig, args)
+
+    def impl(z):
+        return cmath.cos(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 ########################################################################

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -14,7 +14,7 @@ from numba.core.imputils import impl_ret_untracked
 from numba.core import typing, types, errors, lowering, cgutils
 from numba.core.extending import register_jitable
 from numba.np import npdatetime
-from numba.cpython import cmathimpl, mathimpl, numbers
+from numba.cpython import mathimpl, numbers
 
 # some NumPy constants. Note that we could generate some of them using
 # the math library, but having the values copied from npy_math seems to
@@ -1558,10 +1558,11 @@ def np_real_isfinite_impl(context, builder, sig, args):
 
 def np_complex_isfinite_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1, return_type=types.boolean)
-    x, = args
-    ty, = sig.args
-    complex_val = context.make_complex(builder, ty, value=x)
-    return cmathimpl.is_finite(builder, complex_val)
+
+    def impl(z):
+        return cmath.isfinite(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 def np_int_isinf_impl(context, builder, sig, args):

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -1126,6 +1126,13 @@ def np_real_atanh_impl(context, builder, sig, args):
     return mathimpl.atanh_impl(context, builder, sig, args)
 
 
+def np_complex_atanh_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1)
+    def impl(z):
+        return cmath.atanh(z)
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy floor
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -934,6 +934,13 @@ def np_real_atan_impl(context, builder, sig, args):
     return mathimpl.atan_impl(context, builder, sig, args)
 
 
+def np_complex_atan_impl(context, builder, sig, args):
+    _check_arity_and_homogeneity(sig, args, 1)
+    def impl(z):
+        return cmath.atan(z)
+    return context.compile_internal(builder, impl, sig, args)
+
+
 ########################################################################
 # NumPy atan2
 

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -751,7 +751,11 @@ def np_real_sqrt_impl(context, builder, sig, args):
 
 def np_complex_sqrt_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-    return cmathimpl.sqrt_impl(context, builder, sig, args)
+
+    def impl(z):
+        return cmath.sqrt(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 
 ########################################################################

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -48,7 +48,7 @@ def _fill_ufunc_db(ufunc_db):
     # imports if done at global scope when importing the numba
     # module.
     from numba.np import npyfuncs
-    from numba.cpython import cmathimpl, mathimpl, numbers
+    from numba.cpython import mathimpl, numbers
     from numba.np.numpy_support import numpy_version
 
     ufunc_db[np.isnat] = {

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -503,13 +503,11 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': npyfuncs.np_complex_acos_impl,
     }
 
-    arctan_impl = cmathimpl.atan_impl
-
     ufunc_db[np.arctan] = {
         'f->f': npyfuncs.np_real_atan_impl,
         'd->d': npyfuncs.np_real_atan_impl,
-        'F->F': arctan_impl,
-        'D->D': arctan_impl,
+        'F->F': npyfuncs.np_complex_atan_impl,
+        'D->D': npyfuncs.np_complex_atan_impl,
     }
 
     ufunc_db[np.arctan2] = {

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -485,13 +485,11 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': npyfuncs.np_complex_tan_impl,
     }
 
-    arcsin_impl = cmathimpl.asin_impl
-
     ufunc_db[np.arcsin] = {
         'f->f': npyfuncs.np_real_asin_impl,
         'd->d': npyfuncs.np_real_asin_impl,
-        'F->F': arcsin_impl,
-        'D->D': arcsin_impl,
+        'F->F': npyfuncs.np_complex_asin_impl,
+        'D->D': npyfuncs.np_complex_asin_impl,
     }
 
     ufunc_db[np.arccos] = {

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -478,13 +478,11 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': npyfuncs.np_complex_cos_impl,
     }
 
-    tan_impl = cmathimpl.tan_impl
-
     ufunc_db[np.tan] = {
         'f->f': npyfuncs.np_real_tan_impl,
         'd->d': npyfuncs.np_real_tan_impl,
-        'F->F': tan_impl,
-        'D->D': tan_impl,
+        'F->F': npyfuncs.np_complex_tan_impl,
+        'D->D': npyfuncs.np_complex_tan_impl,
     }
 
     arcsin_impl = cmathimpl.asin_impl

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -541,13 +541,11 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': npyfuncs.np_complex_tanh_impl,
     }
 
-    arcsinh_impl = cmathimpl.asinh_impl
-
     ufunc_db[np.arcsinh] = {
         'f->f': npyfuncs.np_real_asinh_impl,
         'd->d': npyfuncs.np_real_asinh_impl,
-        'F->F': arcsinh_impl,
-        'D->D': arcsinh_impl,
+        'F->F': npyfuncs.np_complex_asinh_impl,
+        'D->D': npyfuncs.np_complex_asinh_impl,
     }
 
     ufunc_db[np.arccosh] = {

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -555,13 +555,11 @@ def _fill_ufunc_db(ufunc_db):
         'D->D': npyfuncs.np_complex_acosh_impl,
     }
 
-    arctanh_impl = cmathimpl.atanh_impl
-
     ufunc_db[np.arctanh] = {
         'f->f': npyfuncs.np_real_atanh_impl,
         'd->d': npyfuncs.np_real_atanh_impl,
-        'F->F': arctanh_impl,
-        'D->D': arctanh_impl,
+        'F->F': npyfuncs.np_complex_atanh_impl,
+        'D->D': npyfuncs.np_complex_atanh_impl,
     }
 
     ufunc_db[np.deg2rad] = {

--- a/numba/np/ufunc_db.py
+++ b/numba/np/ufunc_db.py
@@ -499,8 +499,8 @@ def _fill_ufunc_db(ufunc_db):
     ufunc_db[np.arccos] = {
         'f->f': npyfuncs.np_real_acos_impl,
         'd->d': npyfuncs.np_real_acos_impl,
-        'F->F': cmathimpl.acos_impl,
-        'D->D': cmathimpl.acos_impl,
+        'F->F': npyfuncs.np_complex_acos_impl,
+        'D->D': npyfuncs.np_complex_acos_impl,
     }
 
     arctan_impl = cmathimpl.atan_impl

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -48,7 +48,7 @@ from numba.tests.support import (TestCase, captured_stdout, MemoryLeakMixin,
                       needs_lapack, disabled_test, skip_unless_scipy,
                       needs_subprocess)
 from numba.core.extending import register_jitable
-import cmath
+import math
 import unittest
 
 # NOTE: Each parfors test class is run in separate subprocess, this is to reduce
@@ -1416,7 +1416,7 @@ class TestParfors(TestParforsBase):
         def test_impl():
             acc = 0
             for i in prange(1):
-                acc = cmath.sqrt(acc)
+                acc = math.sqrt(acc)
             return acc
 
         # checks that invalid use of reduction variable is detected


### PR DESCRIPTION
This is a follow-up of #8494 and migrate the rest of cmath functions to use overloads.