### PR TITLE
Document that AOT compilation of recursive functions is unsupported

### DIFF
--- a/docs/source/user/pycc.rst
+++ b/docs/source/user/pycc.rst
@@ -33,6 +33,8 @@ Limitations
 
 #. AOT compilation only allows for regular functions, not :term:`ufuncs <ufunc>`.
 
+#. Compilation of recursive functions is unsupported.
+
 #. You have to specify function signatures explicitly.
 
 #. Each exported function can have only one signature (but you can export


### PR DESCRIPTION
See Issue #6513 - also this popped up on Discourse recently: https://numba.discourse.group/t/how-to-compile-ahead-of-time-a-recursive-function/1630