### PR TITLE
CUDA: Add CUDA 11.8 / Hopper support and required fixes

### DIFF
--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -380,7 +380,8 @@ def ccs_supported_by_ctk(ctk_version):
     except KeyError:
         # For unsupported CUDA toolkit versions, all we can do is assume all
         # non-deprecated versions we are aware of are supported.
-        return tuple([cc for cc in COMPUTE_CAPABILITIES if cc >= (5, 3)])
+        return tuple([cc for cc in COMPUTE_CAPABILITIES
+                      if cc >= config.CUDA_DEFAULT_PTX_CC])
 
 
 def get_supported_ccs():
@@ -394,11 +395,13 @@ def get_supported_ccs():
         return _supported_cc
 
     # Ensure the minimum CTK version requirement is met
-    if cudart_version < (11, 0):
+    min_cudart = min(CTK_SUPPORTED)
+    if cudart_version < min_cudart:
         _supported_cc = ()
         ctk_ver = f"{cudart_version[0]}.{cudart_version[1]}"
         unsupported_ver = (f"CUDA Toolkit {ctk_ver} is unsupported by Numba - "
-                           "11.0 is the minimum required version.")
+                           f"{min_cudart[0]}.{min_cudart[1]} is the minimum "
+                           "required version.")
         warnings.warn(unsupported_ver)
         return _supported_cc
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -343,51 +343,69 @@ class CompilationUnit(object):
         return ''
 
 
+COMPUTE_CAPABILITIES = (
+    (3, 5), (3, 7),
+    (5, 0), (5, 2), (5, 3),
+    (6, 0), (6, 1), (6, 2),
+    (7, 0), (7, 2), (7, 5),
+    (8, 0), (8, 6), (8, 7), (8, 9),
+    (9, 0)
+)
+
+# Maps CTK version -> (min supported cc, max supported cc)
+CTK_SUPPORTED = {
+    (11, 0): ((3, 5), (8, 0)),
+    (11, 1): ((3, 5), (8, 6)),
+    (11, 2): ((3, 5), (8, 6)),
+    (11, 3): ((3, 5), (8, 6)),
+    (11, 4): ((3, 5), (8, 7)),
+    (11, 5): ((3, 5), (8, 7)),
+    (11, 6): ((3, 5), (8, 7)),
+    (11, 7): ((3, 5), (8, 7)),
+    (11, 8): ((3, 5), (9, 0)),
+}
+
+
+def ccs_supported_by_ctk(ctk_version):
+    try:
+        # For supported versions, we look up the range of supported CCs
+        min_cc, max_cc = CTK_SUPPORTED[ctk_version]
+        return tuple([cc for cc in COMPUTE_CAPABILITIES
+                      if min_cc <= cc <= max_cc])
+    except KeyError:
+        # For unsupported CUDA toolkit versions, all we can do is assume all
+        # non-deprecated versions we are aware of are supported.
+        return tuple([cc for cc in COMPUTE_CAPABILITIES if cc >= (5, 3)])
+
+
 _supported_cc = None
 
 
 def get_supported_ccs():
+    # Attempt to return cached list
     global _supported_cc
-
-    if _supported_cc:
+    if _supported_cc is not None:
         return _supported_cc
 
     try:
         from numba.cuda.cudadrv.runtime import runtime
         cudart_version = runtime.get_version()
     except: # noqa: E722
-        # The CUDA Runtime may not be present
-        cudart_version = (0, 0)
-
-    ctk_ver = f"{cudart_version[0]}.{cudart_version[1]}"
-    unsupported_ver = f"CUDA Toolkit {ctk_ver} is unsupported by Numba - " \
-                      + "11.0 is the minimum required version."
-
-    # List of supported compute capability in sorted order
-    if cudart_version == (0, 0):
+        # We can't support anything if there's an error getting the runtime
+        # version (e.g. if it's not present or there's another issue)
         _supported_cc = ()
-    elif cudart_version == (11, 0):
-        _supported_cc = ((3, 5), (3, 7),
-                         (5, 0), (5, 2), (5, 3),
-                         (6, 0), (6, 1), (6, 2),
-                         (7, 0), (7, 2), (7, 5),
-                         (8, 0))
-    elif cudart_version > (11, 0):
-        _supported_cc = ((3, 5), (3, 7),
-                         (5, 0), (5, 2), (5, 3),
-                         (6, 0), (6, 1), (6, 2),
-                         (7, 0), (7, 2), (7, 5),
-                         (8, 0), (8, 6))
-    elif cudart_version > (11, 4):
-        _supported_cc = ((3, 5), (3, 7),
-                         (5, 0), (5, 2), (5, 3),
-                         (6, 0), (6, 1), (6, 2),
-                         (7, 0), (7, 2), (7, 5),
-                         (8, 0), (8, 6), (8, 7))
-    else:
+        return _supported_cc
+
+    # Ensure the minimum CTK version requirement is met
+    if cudart_version < (11, 0):
         _supported_cc = ()
+        ctk_ver = f"{cudart_version[0]}.{cudart_version[1]}"
+        unsupported_ver = (f"CUDA Toolkit {ctk_ver} is unsupported by Numba - "
+                           "11.0 is the minimum required version.")
         warnings.warn(unsupported_ver)
+        return _supported_cc
 
+    _supported_cc = ccs_supported_by_ctk(cudart_version)
     return _supported_cc
 
 

--- a/numba/cuda/cudadrv/nvvm.py
+++ b/numba/cuda/cudadrv/nvvm.py
@@ -357,7 +357,7 @@ COMPUTE_CAPABILITIES = (
     (9, 0)
 )
 
-# Maps CTK version -> (min supported cc, max supported cc)
+# Maps CTK version -> (min supported cc, max supported cc) inclusive
 CTK_SUPPORTED = {
     (11, 0): ((3, 5), (8, 0)),
     (11, 1): ((3, 5), (8, 6)),

--- a/numba/cuda/tests/cudadrv/test_inline_ptx.py
+++ b/numba/cuda/tests/cudadrv/test_inline_ptx.py
@@ -10,6 +10,7 @@ class TestCudaInlineAsm(ContextResettingTestCase):
     def test_inline_rsqrt(self):
         mod = ir.Module(__name__)
         mod.triple = 'nvptx64-nvidia-cuda'
+        nvvm.add_ir_version(mod)
         fnty = ir.FunctionType(ir.VoidType(), [ir.PointerType(ir.FloatType())])
         fn = ir.Function(mod, fnty, 'cu_rsqrt')
         bldr = ir.IRBuilder(fn.append_basic_block('entry'))

--- a/numba/cuda/tests/cudadrv/test_nvvm_driver.py
+++ b/numba/cuda/tests/cudadrv/test_nvvm_driver.py
@@ -1,8 +1,7 @@
 import warnings
 
 from llvmlite import ir
-from numba.cuda.cudadrv.nvvm import (llvm_to_ptx, set_cuda_kernel,
-                                     get_arch_option, get_supported_ccs)
+from numba.cuda.cudadrv import nvvm
 from ctypes import c_size_t, c_uint64, sizeof
 from numba.cuda.testing import unittest
 from numba.cuda.cudadrv.nvvm import LibDevice, NvvmError, NVVM
@@ -15,7 +14,8 @@ is64bit = sizeof(c_size_t) == sizeof(c_uint64)
 class TestNvvmDriver(unittest.TestCase):
     def get_nvvmir(self):
         if NVVM().is_nvvm70:
-            metadata = metadata_nvvm70
+            versions = NVVM().get_ir_version()
+            metadata = metadata_nvvm70 % versions
         else:
             metadata = metadata_nvvm34
 
@@ -25,21 +25,22 @@ class TestNvvmDriver(unittest.TestCase):
 
     def test_nvvm_compile_simple(self):
         nvvmir = self.get_nvvmir()
-        ptx = llvm_to_ptx(nvvmir).decode('utf8')
+        ptx = nvvm.llvm_to_ptx(nvvmir).decode('utf8')
         self.assertTrue('simple' in ptx)
         self.assertTrue('ave' in ptx)
 
     def test_nvvm_from_llvm(self):
         m = ir.Module("test_nvvm_from_llvm")
         m.triple = 'nvptx64-nvidia-cuda'
+        nvvm.add_ir_version(m)
         fty = ir.FunctionType(ir.VoidType(), [ir.IntType(32)])
         kernel = ir.Function(m, fty, name='mycudakernel')
         bldr = ir.IRBuilder(kernel.append_basic_block('entry'))
         bldr.ret_void()
-        set_cuda_kernel(kernel)
+        nvvm.set_cuda_kernel(kernel)
 
         m.data_layout = NVVM().data_layout
-        ptx = llvm_to_ptx(str(m)).decode('utf8')
+        ptx = nvvm.llvm_to_ptx(str(m)).decode('utf8')
         self.assertTrue('mycudakernel' in ptx)
         if is64bit:
             self.assertTrue('.address_size 64' in ptx)
@@ -50,14 +51,15 @@ class TestNvvmDriver(unittest.TestCase):
         m = ir.Module("test_bad_ir")
         m.triple = "unknown-unknown-unknown"
         m.data_layout = NVVM().data_layout
+        nvvm.add_ir_version(m)
         with self.assertRaisesRegex(NvvmError, 'Invalid target triple'):
-            llvm_to_ptx(str(m))
+            nvvm.llvm_to_ptx(str(m))
 
     def _test_nvvm_support(self, arch):
         compute_xx = 'compute_{0}{1}'.format(*arch)
         nvvmir = self.get_nvvmir()
-        ptx = llvm_to_ptx(nvvmir, arch=compute_xx, ftz=1, prec_sqrt=0,
-                          prec_div=0).decode('utf8')
+        ptx = nvvm.llvm_to_ptx(nvvmir, arch=compute_xx, ftz=1, prec_sqrt=0,
+                               prec_div=0).decode('utf8')
         self.assertIn(".target sm_{0}{1}".format(*arch), ptx)
         self.assertIn('simple', ptx)
         self.assertIn('ave', ptx)
@@ -65,25 +67,26 @@ class TestNvvmDriver(unittest.TestCase):
     def test_nvvm_support(self):
         """Test supported CC by NVVM
         """
-        for arch in get_supported_ccs():
+        for arch in nvvm.get_supported_ccs():
             self._test_nvvm_support(arch=arch)
 
     def test_nvvm_warning(self):
         m = ir.Module("test_nvvm_warning")
         m.triple = 'nvptx64-nvidia-cuda'
         m.data_layout = NVVM().data_layout
+        nvvm.add_ir_version(m)
 
         fty = ir.FunctionType(ir.VoidType(), [])
         kernel = ir.Function(m, fty, name='inlinekernel')
         builder = ir.IRBuilder(kernel.append_basic_block('entry'))
         builder.ret_void()
-        set_cuda_kernel(kernel)
+        nvvm.set_cuda_kernel(kernel)
 
         # Add the noinline attribute to trigger NVVM to generate a warning
         kernel.attributes.add('noinline')
 
         with warnings.catch_warnings(record=True) as w:
-            llvm_to_ptx(str(m))
+            nvvm.llvm_to_ptx(str(m))
 
         self.assertEqual(len(w), 1)
         self.assertIn('overriding noinline attribute', str(w[0]))
@@ -107,14 +110,14 @@ class TestNvvmDriver(unittest.TestCase):
 class TestArchOption(unittest.TestCase):
     def test_get_arch_option(self):
         # Test returning the nearest lowest arch.
-        self.assertEqual(get_arch_option(5, 3), 'compute_53')
-        self.assertEqual(get_arch_option(7, 5), 'compute_75')
-        self.assertEqual(get_arch_option(7, 7), 'compute_75')
+        self.assertEqual(nvvm.get_arch_option(5, 3), 'compute_53')
+        self.assertEqual(nvvm.get_arch_option(7, 5), 'compute_75')
+        self.assertEqual(nvvm.get_arch_option(7, 7), 'compute_75')
         # Test known arch.
-        supported_cc = get_supported_ccs()
+        supported_cc = nvvm.get_supported_ccs()
         for arch in supported_cc:
-            self.assertEqual(get_arch_option(*arch), 'compute_%d%d' % arch)
-        self.assertEqual(get_arch_option(1000, 0),
+            self.assertEqual(nvvm.get_arch_option(*arch), 'compute_%d%d' % arch)
+        self.assertEqual(nvvm.get_arch_option(1000, 0),
                          'compute_%d%d' % supported_cc[-1])
 
 
@@ -163,7 +166,7 @@ declare i32 @llvm.nvvm.read.ptx.sreg.tid.x() nounwind readnone
 
 metadata_nvvm70 = '''
 !nvvmir.version = !{!1}
-!1 = !{i32 1, i32 6, i32 3, i32 0}
+!1 = !{i32 %s, i32 %s, i32 %s, i32 %s}
 
 !nvvm.annotations = !{!2}
 !2 = !{void (i32*)* @simple, !"kernel", i32 1}

--- a/numba/cuda/tests/nocuda/test_nvvm.py
+++ b/numba/cuda/tests/nocuda/test_nvvm.py
@@ -62,6 +62,7 @@ class TestNvvmWithoutCuda(unittest.TestCase):
                         bytearray(range(256)))
         m = ir.Module()
         m.triple = 'nvptx64-nvidia-cuda'
+        nvvm.add_ir_version(m)
         gv = ir.GlobalVariable(m, c.type, "myconstant")
         gv.global_constant = True
         gv.initializer = c


### PR DESCRIPTION
See individual commit messages for full descriptions. The required fixes consist of:

- Correcting the logic for determining supported compute capabilities, which was completely broken on `main`.
- Using the correct NVVM IR version in all tests.