### PR TITLE
migrate cmath.exp to use overload

### DIFF
--- a/numba/core/typing/cmathdecl.py
+++ b/numba/core/typing/cmathdecl.py
@@ -18,7 +18,6 @@ infer_global = registry.register_global
 @infer_global(cmath.atanh)
 @infer_global(cmath.cos)
 @infer_global(cmath.cosh)
-@infer_global(cmath.exp)
 @infer_global(cmath.log10)
 @infer_global(cmath.sin)
 @infer_global(cmath.sinh)

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -5,6 +5,7 @@ Python builtins
 """
 
 
+import cmath
 import math
 
 import llvmlite.ir
@@ -591,7 +592,11 @@ def np_real_exp_impl(context, builder, sig, args):
 
 def np_complex_exp_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
-    return cmathimpl.exp_impl(context, builder, sig, args)
+
+    def impl(z):
+        return cmath.exp(z)
+
+    return context.compile_internal(builder, impl, sig, args)
 
 ########################################################################
 # NumPy exp2


### PR DESCRIPTION
This is a follow up PR of https://github.com/numba/numba/pull/8575 which contains the migration of `cmath.exp` to use `@overload`