### PR TITLE
fix failure of test_cache_invalidate due to read-only install

### DIFF
--- a/numba/tests/test_caching.py
+++ b/numba/tests/test_caching.py
@@ -3,6 +3,7 @@ import llvmlite.binding as ll
 import multiprocessing
 import numpy as np
 import os
+import stat
 import shutil
 import subprocess
 import sys
@@ -206,6 +207,7 @@ class BaseCacheTest(TestCase):
         self.modfile = os.path.join(self.tempdir, self.modname + ".py")
         self.cache_dir = os.path.join(self.tempdir, "__pycache__")
         shutil.copy(self.usecases_file, self.modfile)
+        os.chmod(self.modfile, stat.S_IREAD | stat.S_IWRITE)
         self.maxDiff = None
 
     def tearDown(self):


### PR DESCRIPTION
In certain circumstances, such as installation through the Nix package manager, Numba's source code is marked read-only. When the cache test file is copied using `shutil.copy`, the destination ends up read-only as that function copies file permissions too. This causes `test_cache_invalidate` to fail because it cannot write to the file to attempt to invalidate it. Fix the issue by ensuring the file is read-write after the copy.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
