### PR TITLE
Chrome trace timestamp should be in microseconds not seconds.

### DIFF
--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -461,11 +461,13 @@ def _prepare_chrome_trace_data(listener: RecordingListener):
     for ts, rec in listener.buffer:
         data = rec.data
         cat = str(rec.kind)
+        ts_scaled = ts * 10 ** 6   # scale to microseconds
         ph = 'B' if rec.is_start else 'E'
         name = data['name']
         args = data
         ev = dict(
-            cat=cat, pid=pid, tid=tid, ts=ts, ph=ph, name=name, args=args,
+            cat=cat, pid=pid, tid=tid, ts=ts_scaled, ph=ph, name=name,
+            args=args,
         )
         evs.append(ev)
     return evs

--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -461,7 +461,7 @@ def _prepare_chrome_trace_data(listener: RecordingListener):
     for ts, rec in listener.buffer:
         data = rec.data
         cat = str(rec.kind)
-        ts_scaled = ts * 1_000_000   # scale to seconds
+        ts_scaled = ts * 1_000_000   # scale to microseconds
         ph = 'B' if rec.is_start else 'E'
         name = data['name']
         args = data

--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -461,7 +461,7 @@ def _prepare_chrome_trace_data(listener: RecordingListener):
     for ts, rec in listener.buffer:
         data = rec.data
         cat = str(rec.kind)
-        ts_scaled = ts * 10 ** 6   # scale to microseconds
+        ts_scaled = ts * 1_000_000   # scale to seconds
         ph = 'B' if rec.is_start else 'E'
         name = data['name']
         args = data


### PR DESCRIPTION
Fix #8599. 