### PR TITLE
Throw error for unsupported dunder methods

### DIFF
--- a/numba/experimental/jitclass/boxing.py
+++ b/numba/experimental/jitclass/boxing.py
@@ -151,7 +151,7 @@ def _specialize_box(typ):
             and name.endswith("__")
             and name not in supported_dunders
         ):
-            raise TypeError("Method {0} is not supported".format(name))
+            raise TypeError(f"Method '{name}' is not supported.")
         dct[name] = _generate_method(name, func)
 
     # Inject static methods as class members

--- a/numba/experimental/jitclass/boxing.py
+++ b/numba/experimental/jitclass/boxing.py
@@ -144,12 +144,14 @@ def _specialize_box(typ):
         "__ixor__",
     }
     for name, func in typ.methods.items():
+        if name == "__init__":
+            continue
         if (
             name.startswith("__")
             and name.endswith("__")
             and name not in supported_dunders
         ):
-            continue
+            raise TypeError("Method {0} is not supported".format(name))
         dct[name] = _generate_method(name, func)
 
     # Inject static methods as class members

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -1164,7 +1164,7 @@ class TestJitClass(TestCase, MemoryLeakMixin):
                 def __enter__(self):
                     return None
             Foo()
-        self.assertIn("__enter__", str(e.exception))
+        self.assertIn("Method '__enter__' is not supported.", str(e.exception))
 
 
 class TestJitClassOverloads(MemoryLeakMixin, TestCase):

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -1154,6 +1154,18 @@ class TestJitClass(TestCase, MemoryLeakMixin):
         self.assertEqual(pyfunc(Bar(123)), cfunc(Bar(123)))
         self.assertEqual(pyfunc(0), cfunc(0))
 
+    def test_jitclass_unsupported_dunder(self):
+        with self.assertRaises(TypeError) as e:
+            @jitclass
+            class Foo(object):
+                def __init__(self):
+                    return
+
+                def __enter__(self):
+                    return None
+            Foo()
+        self.assertIn("__enter__", str(e.exception))
+
 
 class TestJitClassOverloads(MemoryLeakMixin, TestCase):
 


### PR DESCRIPTION
Make jitclass throw an error rather than ignore unhandled `__X__` methods.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
