### PR TITLE
[structref] Add  a method  for `_Utils` class in structref

### DIFF
--- a/numba/experimental/structref.py
+++ b/numba/experimental/structref.py
@@ -59,7 +59,7 @@ class _Utils:
         inst_struct = context.make_helper(builder, struct_type)
         inst_struct.meminfo = meminfo
 
-        return inst_struct._getvalue()
+        return inst_struct
 
     def new_struct_ref_with_mi(self, mi):
         """Encapsulate the MemInfo from a `StructRefPayload` in a `StructRef`
@@ -322,7 +322,8 @@ def new(typingctx, struct_type):
 
     def codegen(context, builder, signature, args):
         utils = _Utils(context, builder, inst_type)
-        return utils.new_struct_ref_without_mi()
+        inst_struct = utils.new_struct_ref_without_mi()
+        return inst_struct._getvalue()
 
     sig = inst_type(struct_type)
     return sig, codegen


### PR DESCRIPTION
Hi, guys.

I refactor some implementation in `structref`, extending one `new_struct_ref` method of `_Utils` to two methods, i.e., `new_struct_ref_without_mi` and `new_struct_ref_with_mi`, the latter is corresponding to original one.

Here are my arguments to explain where this PR is coming from:

1. Although numba doc shows `structref` can be used companying with a `StructrefProxy` python class, but sometimes we are no need to or cannot define this kind of Proxy class, since we only want to implement the `unbox`/`box` logic between `structref` type and a 3rd-party class (e.g., someone wants to support Pandas defined `Index` class, or any complicated class (always holding heterogeneous fields) in other libraries).
2. And after splitting `new_struct_ref` into two methods, we can support simple usage in boxing code when the situation above is triggered. Indeed, we help 3rd-party developers using numba more easy and neat.

More concretely to speaking, if I want to support the basic `Index` class of Pandas in numba. First, I have to define the type and relating typeof, and don't define any Proxy class (just proof-of-concept):
<details>

```python
@structref.register
class IndexType(types.StructRef):
    ...
    
@typeof_impl.register(pd.Index)
def _typeof_index(val, c):
    # if Index's dtype is object, presumably as str
    if val.dtype == object:
        data_type = types.ListType(types.unicode_type)
    else:
        data_type = typeof_impl(val._data, c)

    name_type = typeof_impl(val.name, c)
    fields = [
        ("data", data_type),
        ("name", name_type),
    ]
    return indexes.IndexType(fields)
``` 
</details>

Without this PR, we should write bunch of codes for `unbox`:
<details>

```python
# https://github.com/numba/numba/blob/main/numba/experimental/structref.py#L285    # noqa: E501
def codegen_new(context, builder, inst_type):
    model = context.data_model_manager[inst_type.get_data_type()]
    alloc_type = model.get_value_type()
    alloc_size = context.get_abi_sizeof(alloc_type)

    meminfo = context.nrt.meminfo_alloc_dtor_unchecked(
        builder,
        context.get_constant(types.uintp, alloc_size),
        imp_dtor(context, builder.module, inst_type),
    )
    data_pointer = context.nrt.meminfo_data(builder, meminfo)
    data_pointer = builder.bitcast(data_pointer, alloc_type.as_pointer())

    # Nullify all data
    builder.store(cgutils.get_null_value(alloc_type), data_pointer)

    inst_struct = context.make_helper(builder, inst_type)
    inst_struct.meminfo = meminfo

    return inst_struct._getvalue()


@unbox(IndexType)
def unbox_index(typ, obj, c):
    context, builder, pyapi = c.context, c.builder, c.pyapi

    np_array = pyapi.object_getattr_string(obj, "_data")
    py_name = pyapi.object_getattr_string(obj, "name")
    nb_array_or_list = c.unbox(typ.field_dict['data'], np_array).value
    nb_name = c.unbox(typ.field_dict['name'], py_name).value

    pyapi.decref(np_array)
    pyapi.decref(py_name)

    utils = _Utils(context, builder, typ)
    index = codegen_new(context, builder, typ)
    payload_struct = utils.get_data_struct(index)
    setattr(payload_struct, "data", nb_array_or_list)
    setattr(payload_struct, "name", nb_name)

    return NativeValue(index)
```
</details>

With this PR, we can simplify our `unbox` code like this:
<details>

```python
@unbox(IndexType)
def unbox_index(typ, obj, c):
    context, builder, pyapi = c.context, c.builder, c.pyapi

    np_array = pyapi.object_getattr_string(obj, "_data")
    py_name = pyapi.object_getattr_string(obj, "name")
    nb_array_or_list = c.unbox(typ.field_dict['data'], np_array).value
    nb_name = c.unbox(typ.field_dict['name'], py_name).value

    pyapi.decref(np_array)
    pyapi.decref(py_name)

    utils = _Utils(context, builder, typ)
    index_struct = utils.new_struct_ref_without_mi()
    index = index_struct._getvalue()
    payload_struct = utils.get_data_struct(index)
    setattr(payload_struct, "data", nb_array_or_list)
    setattr(payload_struct, "name", nb_name)

    return NativeValue(index)
```
</details>

According to the commit history, I think @sklam can give this a look, thanks. If the idea of this PR is acceptable, then I can migrate this example into `pdlike_usecase` or in the doc for `structref`.

And I wonder if numba can support a special kind of numpy ndarray with the `object` dtype? Is this supporting very difficult to implement?