### PR TITLE
[unicode-PERF]: use optmized BM algorithm to replace the brute-force finder

### DIFF
--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -71,9 +71,7 @@ _py38_or_later = utils.PYVERSION >= (3, 8)
 _MAX_UNICODE = 0x10ffff
 
 # https://github.com/python/cpython/blob/1960eb005e04b7ad8a91018088cfdb0646bc1ca0/Objects/stringlib/fastsearch.h#L31    # noqa: E501
-# I fix the _bloom_width, not chosen from (32, 64, 128) based on machines.
-#   Not sure if impacting the bloom-filter effectiveness.
-_BLOOM_WIDTH = 64
+_BLOOM_WIDTH = types.intp.bitwidth
 
 # DATA MODEL
 
@@ -612,7 +610,6 @@ def _bloom_check(mask, ch):
 
 
 # https://github.com/python/cpython/blob/1960eb005e04b7ad8a91018088cfdb0646bc1ca0/Objects/stringlib/fastsearch.h#L550    # noqa: E501
-# XXX: Why we don't have the FAST_COUNT flag as cpython?
 @register_jitable
 def _default_find(data, substr, start, end):
     """Left finder."""
@@ -623,8 +620,8 @@ def _default_find(data, substr, start, end):
     gap = mlast = m - 1
     last = _get_code_point(substr, mlast)
 
-    # How to coerce mask to be an uint64 as cpython does?
-    mask = _bloom_add(0, last)
+    zero = types.intp(0)
+    mask = _bloom_add(zero, last)
     for i in range(mlast):
         ch = _get_code_point(substr, i)
         mask = _bloom_add(mask, ch)

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -70,6 +70,11 @@ _py38_or_later = utils.PYVERSION >= (3, 8)
 # https://github.com/python/cpython/blob/1d4b6ba19466aba0eb91c4ba01ba509acf18c723/Objects/unicodeobject.c#L84-L85    # noqa: E501
 _MAX_UNICODE = 0x10ffff
 
+# https://github.com/python/cpython/blob/1960eb005e04b7ad8a91018088cfdb0646bc1ca0/Objects/stringlib/fastsearch.h#L31    # noqa: E501
+# I fix the _bloom_width, not chosen from (32, 64, 128) based on machines.
+#   Not sure if impacting the bloom-filter effectiveness.
+_BLOOM_WIDTH = 64
+
 # DATA MODEL
 
 
@@ -593,6 +598,117 @@ def unicode_sub_check_type(ty, name):
         raise TypingError(msg)
 
 
+# FAST SEARCH algorithm implementation from cpython
+
+@register_jitable
+def _bloom_add(mask, ch):
+    mask |= (1 << (ch & (_BLOOM_WIDTH - 1)))
+    return mask
+
+
+@register_jitable
+def _bloom_check(mask, ch):
+    return mask & (1 << (ch & (_BLOOM_WIDTH - 1)))
+
+
+# https://github.com/python/cpython/blob/1960eb005e04b7ad8a91018088cfdb0646bc1ca0/Objects/stringlib/fastsearch.h#L550    # noqa: E501
+# XXX: Why we don't have the FAST_COUNT flag as cpython?
+@register_jitable
+def _default_find(data, substr, start, end):
+    """Left finder."""
+    m = len(substr)
+    if m == 0:
+        return start
+
+    gap = mlast = m - 1
+    last = _get_code_point(substr, mlast)
+
+    # How to coerce mask to be an uint64 as cpython does?
+    mask = _bloom_add(0, last)
+    for i in range(mlast):
+        ch = _get_code_point(substr, i)
+        mask = _bloom_add(mask, ch)
+        if ch == last:
+            gap = mlast - i - 1
+
+    i = start
+    while i <= end - m:
+        ch = _get_code_point(data, mlast + i)
+        if ch == last:
+            j = 0
+            while j < mlast:
+                haystack_ch = _get_code_point(data, i + j)
+                needle_ch = _get_code_point(substr, j)
+                if haystack_ch != needle_ch:
+                    break
+                j += 1
+            if j == mlast:
+                # got a match
+                return i
+
+            ch = _get_code_point(data, mlast + i + 1)
+            if _bloom_check(mask, ch) == 0:
+                i += m
+            else:
+                i += gap
+        else:
+            ch = _get_code_point(data, mlast + i + 1)
+            if _bloom_check(mask, ch) == 0:
+                i += m
+        i += 1
+
+    return -1
+
+
+@register_jitable
+def _default_rfind(data, substr, start, end):
+    """Right finder."""
+    m = len(substr)
+    if m == 0:
+        return end
+
+    skip = mlast = m - 1
+    mfirst = _get_code_point(substr, 0)
+    mask = _bloom_add(0, mfirst)
+    i = mlast
+    while i > 0:
+        ch = _get_code_point(substr, i)
+        mask = _bloom_add(mask, ch)
+        if ch == mfirst:
+            skip = i - 1
+        i -= 1
+
+    i = end - m
+    while i >= start:
+        ch = _get_code_point(data, i)
+        if ch == mfirst:
+            j = mlast
+            while j > 0:
+                haystack_ch = _get_code_point(data, i + j)
+                needle_ch = _get_code_point(substr, j)
+                if haystack_ch != needle_ch:
+                    break
+                j -= 1
+
+            if j == 0:
+                # got a match
+                return i
+
+            ch = _get_code_point(data, i - 1)
+            if i > start and _bloom_check(mask, ch) == 0:
+                i -= m
+            else:
+                i -= skip
+
+        else:
+            ch = _get_code_point(data, i - 1)
+            if i > start and _bloom_check(mask, ch) == 0:
+                i -= m
+        i -= 1
+
+    return -1
+
+
 def generate_finder(find_func):
     """Generate finder either left or right."""
     def impl(data, substr, start=None, end=None):
@@ -612,30 +728,8 @@ def generate_finder(find_func):
     return impl
 
 
-@register_jitable
-def _finder(data, substr, start, end):
-    """Left finder."""
-    if len(substr) == 0:
-        return start
-    for i in range(start, min(len(data), end) - len(substr) + 1):
-        if _cmp_region(data, i, substr, 0, len(substr)) == 0:
-            return i
-    return -1
-
-
-@register_jitable
-def _rfinder(data, substr, start, end):
-    """Right finder."""
-    if len(substr) == 0:
-        return end
-    for i in range(min(len(data), end) - len(substr), start - 1, -1):
-        if _cmp_region(data, i, substr, 0, len(substr)) == 0:
-            return i
-    return -1
-
-
-_find = register_jitable(generate_finder(_finder))
-_rfind = register_jitable(generate_finder(_rfinder))
+_find = register_jitable(generate_finder(_default_find))
+_rfind = register_jitable(generate_finder(_default_rfind))
 
 
 @overload_method(types.UnicodeType, 'find')


### PR DESCRIPTION
Hi, after some digging, I found cpython has at least 3 ways to tackle string-matching operations, based on some metrics on `needle` and `haystack` lengths:
1. `find_char`: use `memchr` as possible as we can, which using hand-tuned assembly code with vectorized instructions; 	
2. `default_find`: use `Boyer-Moore` algorithm with `Horspool` (`O(1)` space) and `Sunday` (`bloom filter`) optimizations (merged in 2006);
3. `_two_way_find`: a more advanced but longer preprocessing algorithm (merged in 2021).

Indeed, I haven't known how to implement a vectorized find for char search (any idea? I would like to contribute, but don't know exactly the details), so right now I just implemented the second algorithm for numba default string find underlying impl.

I haven't perf the speedup ratio, but choose to trust cpython's decision. If needed, I could make up some perf tests to show how much reduced comparsions w/ this PR.

PS, during the development, I found numba doesn't support python `reversed` keyword, is this owing to some numba limitations? Or we just didn't have time to implement it?