### PR TITLE
Python 3.11 - fix majority of remaining test failures.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -161,7 +161,6 @@ exclude =
     numba/tests/test_indexing.py
     numba/tests/test_pycc.py
     numba/tests/annotation_usecases.py
-    numba/tests/test_extended_arg.py
     numba/tests/test_alignment.py
     numba/tests/test_multi3.py
     numba/tests/test_overlap.py

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -246,7 +246,7 @@ class _ByteCode(object):
                 table[adj_offset].lineno = lineno
         # Assign unfilled lineno
         # Start with first bytecode's lineno
-        known = table[_FIXED_OFFSET].lineno
+        known = code.co_firstlineno
         for inst in table.values():
             if inst.lineno >= 0:
                 known = inst.lineno

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -94,7 +94,9 @@ class ByteCodeInst(object):
             if self.opcode in (dis.opmap[k]
                                for k in ("JUMP_BACKWARD",
                                          "POP_JUMP_BACKWARD_IF_TRUE",
-                                         "POP_JUMP_BACKWARD_IF_FALSE")):
+                                         "POP_JUMP_BACKWARD_IF_FALSE",
+                                         "POP_JUMP_BACKWARD_IF_NONE",
+                                         "POP_JUMP_BACKWARD_IF_NOT_NONE",)):
                 return self.offset - (self.arg - 1) * 2
         elif PYVERSION > (3, 11):
             raise NotImplementedError(PYVERSION)

--- a/numba/core/bytecode.py
+++ b/numba/core/bytecode.py
@@ -155,7 +155,15 @@ def _unpack_opargs(code):
                 arg |= code[i + j] << (8 * j)
             i += ARG_LEN
             if op == EXTENDED_ARG:
+                # This is a deviation from what dis does...
+                # In python 3.11 it seems like EXTENDED_ARGs appear more often
+                # and are also used as jump targets. So as to not have to do
+                # "book keeping" for where EXTENDED_ARGs have been "skipped"
+                # they are replaced with NOPs so as to provide a legal jump
+                # target and also ensure that the bytecode offsets are correct.
+                yield (offset, OPCODE_NOP, arg, i)
                 extended_arg = arg << 8 * ARG_LEN
+                offset = i
                 continue
         else:
             arg = None

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -1071,6 +1071,11 @@ class TraceRunner(object):
             varkwarg = None
         vararg = state.pop()
         func = state.pop()
+
+        if PYVERSION == (3, 11):
+            if "$null" in state.peek(1):
+                state.pop() # pop NULL, it's not used
+
         res = state.make_temp()
         state.append(inst, func=func, vararg=vararg, varkwarg=varkwarg, res=res)
         state.push(res)

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -1073,7 +1073,7 @@ class TraceRunner(object):
         func = state.pop()
 
         if PYVERSION == (3, 11):
-            if "$null" in state.peek(1):
+            if _is_null_temp_reg(state.peek(1)):
                 state.pop() # pop NULL, it's not used
 
         res = state.make_temp()

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -7,7 +7,7 @@ import logging
 from collections import namedtuple, defaultdict, deque
 from functools import total_ordering
 
-from numba.core.utils import UniqueDict, PYVERSION
+from numba.core.utils import UniqueDict, PYVERSION, ALL_BINOPS_TO_OPERATORS
 from numba.core.controlflow import NEW_BLOCKERS, CFGraph
 from numba.core.ir import Loc
 from numba.core.errors import UnsupportedError
@@ -1296,7 +1296,8 @@ class TraceRunner(object):
         op = dis._nb_ops[inst.arg][1]
         rhs = state.pop()
         lhs = state.pop()
-        res = state.make_temp(prefix=f"binop_{op}")
+        op_name = ALL_BINOPS_TO_OPERATORS[op].__name__
+        res = state.make_temp(prefix=f"binop_{op_name}")
         state.append(inst, op=op, lhs=lhs, rhs=rhs, res=res)
         state.push(res)
 

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -751,6 +751,12 @@ class TraceRunner(object):
     def op_POP_JUMP_FORWARD_IF_NOT_NONE(self, state, inst):
         self._op_POP_JUMP_IF(state, inst)
 
+    def op_POP_JUMP_BACKWARD_IF_NONE(self, state, inst):
+        self._op_POP_JUMP_IF(state, inst)
+
+    def op_POP_JUMP_BACKWARD_IF_NOT_NONE(self, state, inst):
+        self._op_POP_JUMP_IF(state, inst)
+
     def op_POP_JUMP_FORWARD_IF_FALSE(self, state, inst):
         self._op_POP_JUMP_IF(state, inst)
 

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -2858,14 +2858,16 @@ class Interpreter(object):
         self._op_JUMP_IF(inst, pred=pred, iftrue=True)
 
     def _jump_if_none(self, inst, pred, iftrue):
-        brs = {
-            True: inst.get_jump_target(),
-            False: inst.next,
-        }
-        truebr = brs[iftrue]
-        falsebr = brs[not iftrue]
+        # branch pruning assumes true falls through and false is jump
+        truebr = inst.next
+        falsebr = inst.get_jump_target()
 
-        op = BINOPS_TO_OPERATORS["is"]
+        # this seems strange
+        if not iftrue:
+            op = BINOPS_TO_OPERATORS["is"]
+        else:
+            op = BINOPS_TO_OPERATORS["is not"]
+
         rhs = self.store(value=ir.Const(None, loc=self.loc),
                          name=f"$constNone{inst.offset}")
         lhs = self.get(pred)

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -1329,8 +1329,12 @@ class Interpreter(object):
     """A bytecode interpreter that builds up the IR.
     """
 
+    _DEBUG_PRINT = False
+
     def __init__(self, func_id):
         self.func_id = func_id
+        if self._DEBUG_PRINT:
+            print(func_id.func)
         self.arg_count = func_id.arg_count
         self.arg_names = func_id.arg_names
         self.loc = self.first_loc = ir.Loc.from_function_id(func_id)
@@ -1754,6 +1758,8 @@ class Interpreter(object):
         return self.bytecode.co_freevars
 
     def _dispatch(self, inst, kws):
+        if self._DEBUG_PRINT:
+            print(inst)
         assert self.current_block is not None
         if PYVERSION == (3, 11):
             if self.syntax_blocks:
@@ -2226,13 +2232,11 @@ class Interpreter(object):
             self.store(gl, res)
     elif PYVERSION < (3, 11):
         def op_LOAD_DEREF(self, inst, res):
-            n_cellvars = len(self.code_cellvars)
-            if inst.arg < n_cellvars:
-                name = self.code_cellvars[inst.arg]
+            name = self.func_id.func.__code__._varname_from_oparg(inst.arg)
+            if name in self.code_cellvars:
                 gl = self.get(name)
-            else:
-                idx = inst.arg - n_cellvars
-                name = self.code_freevars[idx]
+            elif name in self.code_freevars:
+                idx = self.code_freevars.index(name)
                 value = self.get_closure_value(idx)
                 gl = ir.FreeVar(idx, name, value, loc=self.loc)
             self.store(gl, res)
@@ -2244,14 +2248,9 @@ class Interpreter(object):
             pass  # ignored bytecode
 
         def op_STORE_DEREF(self, inst, value):
-            idx = inst.arg - len(self.code_locals)
-            n_cellvars = len(self.code_cellvars)
-            if idx < n_cellvars:
-                dstname = self.code_cellvars[idx]
-            else:
-                dstname = self.code_freevars[idx - n_cellvars]
+            name = self.func_id.func.__code__._varname_from_oparg(inst.arg)
             value = self.get(value)
-            self.store(value=value, name=dstname)
+            self.store(value=value, name=name)
     elif PYVERSION < (3, 11):
         def op_STORE_DEREF(self, inst, value):
             n_cellvars = len(self.code_cellvars)
@@ -3013,20 +3012,19 @@ class Interpreter(object):
     if PYVERSION == (3, 11):
 
         def op_LOAD_CLOSURE(self, inst, res):
-            n_cellvars = len(self.code_cellvars)
-            arg = inst.arg - len(self.code_locals)
-            if arg < n_cellvars:
-                name = self.code_cellvars[arg]
+            name = self.func_id.func.__code__._varname_from_oparg(inst.arg)
+            if name in self.code_cellvars:
                 try:
                     gl = self.get(name)
                 except NotDefinedError:
                     msg = "Unsupported use of op_LOAD_CLOSURE encountered"
                     raise NotImplementedError(msg)
-            else:
-                idx = arg - n_cellvars
-                name = self.code_freevars[idx]
+            elif name in self.code_freevars:
+                idx = self.code_freevars.index(name)
                 value = self.get_closure_value(idx)
                 gl = ir.FreeVar(idx, name, value, loc=self.loc)
+            else:
+                assert 0, "unreachable"
             self.store(gl, res)
 
     elif PYVERSION < (3, 11):

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -2897,6 +2897,12 @@ class Interpreter(object):
     def op_POP_JUMP_FORWARD_IF_NOT_NONE(self, inst, pred):
         self._jump_if_none(inst, pred, False)
 
+    def op_POP_JUMP_BACKWARD_IF_NONE(self, inst, pred):
+        self._jump_if_none(inst, pred, True)
+
+    def op_POP_JUMP_BACKWARD_IF_NOT_NONE(self, inst, pred):
+        self._jump_if_none(inst, pred, False)
+
     def op_POP_JUMP_FORWARD_IF_FALSE(self, inst, pred):
         self._op_JUMP_IF(inst, pred=pred, iftrue=False)
 

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -1396,7 +1396,7 @@ class Interpreter(object):
         if PYVERSION in [(3, 9), (3, 10), (3, 11)]:
             peepholes.append(peep_hole_list_to_tuple)
         peepholes.append(peep_hole_delete_with_exit)
-        if PYVERSION == (3, 10):
+        if PYVERSION in [(3, 10), (3, 11)]:
             # peep_hole_call_function_ex_to_call_function_kw
             # depends on peep_hole_list_to_tuple converting
             # any large number of arguments from a list to a

--- a/numba/core/interpreter.py
+++ b/numba/core/interpreter.py
@@ -2867,10 +2867,10 @@ class Interpreter(object):
 
         op = BINOPS_TO_OPERATORS["is"]
 
-        constnone = self.store(value=ir.Const(None, loc=self.loc),
-                         name="${inst.offset}constnone")
-        pred = self.get(pred)
-        isnone = ir.Expr.binop(op, lhs=pred, rhs=constnone, loc=self.loc)
+        lhs = self.store(value=ir.Const(None, loc=self.loc),
+                         name=f"${inst.offset}constnone")
+        rhs = self.get(pred)
+        isnone = ir.Expr.binop(op, lhs=lhs, rhs=rhs, loc=self.loc)
 
         pname = "$%spred" % (inst.offset)
         predicate = self.store(value=isnone, name=pname)

--- a/numba/core/utils.py
+++ b/numba/core/utils.py
@@ -99,6 +99,11 @@ INPLACE_BINOPS_TO_OPERATORS = {
     '@=': operator.imatmul,
 }
 
+
+ALL_BINOPS_TO_OPERATORS = {**BINOPS_TO_OPERATORS,
+                           **INPLACE_BINOPS_TO_OPERATORS}
+
+
 UNARY_BUITINS_TO_OPERATORS = {
     '+': operator.pos,
     '-': operator.neg,

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -39,9 +39,7 @@ _PyHASH_MULTIPLIER = 0xf4243  # 1000003UL
 _PyHASH_IMAG = _PyHASH_MULTIPLIER
 _PyLong_SHIFT = sys.int_info.bits_per_digit
 _Py_HASH_CUTOFF = sys.hash_info.cutoff
-_Py_hashfunc_name = ("siphash24"
-                     if utils.PYVERSION >= (3, 11)
-                     else sys.hash_info.algorithm)
+_Py_hashfunc_name = sys.hash_info.algorithm
 
 
 # hash(obj) is implemented by calling obj.__hash__()
@@ -509,7 +507,7 @@ _hashsecret = _build_hashsecret()
 # ------------------------------------------------------------------------------
 
 
-if _Py_hashfunc_name in ('siphash24', 'fnv'):
+if _Py_hashfunc_name in ('siphash13', 'siphash24', 'fnv'):
 
     # Check for use of the FNV hashing alg, warn users that it's not implemented
     # and functionality relying of properties derived from hashing will be fine
@@ -527,6 +525,12 @@ if _Py_hashfunc_name in ('siphash24', 'fnv'):
 
     # This is a translation of CPython's siphash24 function:
     # https://github.com/python/cpython/blob/d1dd6be613381b996b9071443ef081de8e5f3aff/Python/pyhash.c#L287-L413    # noqa: E501
+    # and also, since Py 3.11, a translation of CPython's siphash13 function:
+    # https://github.com/python/cpython/blob/9dda9020abcf0d51d59b283a89c58c8e1fb0f574/Python/pyhash.c#L376-L424
+    # the only differences are in the use of SINGLE_ROUND in siphash13 vs.
+    # DOUBLE_ROUND in siphash24, and that siphash13 has an extra "ROUND" applied
+    # just before the final XORing of components to create the return value.
+
 
     # /* *********************************************************************
     # <MIT License>
@@ -588,9 +592,7 @@ if _Py_hashfunc_name in ('siphash24', 'fnv'):
                               'v1': types.uint64,
                               'v2': types.uint64,
                               'v3': types.uint64, })
-    def _DOUBLE_ROUND(v0, v1, v2, v3):
-        v0, v1, v2, v3 = _HALF_ROUND(v0, v1, v2, v3, 13, 16)
-        v2, v1, v0, v3 = _HALF_ROUND(v2, v1, v0, v3, 17, 21)
+    def _SINGLE_ROUND(v0, v1, v2, v3):
         v0, v1, v2, v3 = _HALF_ROUND(v0, v1, v2, v3, 13, 16)
         v2, v1, v0, v3 = _HALF_ROUND(v2, v1, v0, v3, 17, 21)
         return v0, v1, v2, v3
@@ -598,80 +600,109 @@ if _Py_hashfunc_name in ('siphash24', 'fnv'):
     @register_jitable(locals={'v0': types.uint64,
                               'v1': types.uint64,
                               'v2': types.uint64,
-                              'v3': types.uint64,
-                              'b': types.uint64,
-                              'mi': types.uint64,
-                              'tmp': types.Array(types.uint64, 1, 'C'),
-                              't': types.uint64,
-                              'mask': types.uint64,
-                              'jmp': types.uint64,
-                              'ohexefef': types.uint64})
-    def _siphash24(k0, k1, src, src_sz):
-        b = types.uint64(src_sz) << 56
-        v0 = k0 ^ types.uint64(0x736f6d6570736575)
-        v1 = k1 ^ types.uint64(0x646f72616e646f6d)
-        v2 = k0 ^ types.uint64(0x6c7967656e657261)
-        v3 = k1 ^ types.uint64(0x7465646279746573)
+                              'v3': types.uint64, })
+    def _DOUBLE_ROUND(v0, v1, v2, v3):
+        v0, v1, v2, v3 = _SINGLE_ROUND(v0, v1, v2, v3)
+        v0, v1, v2, v3 = _SINGLE_ROUND(v0, v1, v2, v3)
+        return v0, v1, v2, v3
 
-        idx = 0
-        while (src_sz >= 8):
-            mi = grab_uint64_t(src, idx)
-            idx += 1
-            src_sz -= 8
-            v3 ^= mi
-            v0, v1, v2, v3 = _DOUBLE_ROUND(v0, v1, v2, v3)
-            v0 ^= mi
+    def _gen_siphash(alg):
+        if alg == 'siphash13':
+            _ROUNDER = _SINGLE_ROUND
+            _EXTRA_ROUND = True
+        elif alg == 'siphash24':
+            _ROUNDER = _DOUBLE_ROUND
+            _EXTRA_ROUND = False
+        else:
+            assert 0, 'unreachable'
 
-        # this is the switch fallthrough:
-        # https://github.com/python/cpython/blob/d1dd6be613381b996b9071443ef081de8e5f3aff/Python/pyhash.c#L390-L400    # noqa: E501
-        t = types.uint64(0x0)
-        boffset = idx * 8
-        ohexefef = types.uint64(0xff)
-        if src_sz >= 7:
-            jmp = (6 * 8)
-            mask = ~types.uint64(ohexefef << jmp)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 6))
-                              << jmp)
-        if src_sz >= 6:
-            jmp = (5 * 8)
-            mask = ~types.uint64(ohexefef << jmp)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 5))
-                              << jmp)
-        if src_sz >= 5:
-            jmp = (4 * 8)
-            mask = ~types.uint64(ohexefef << jmp)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 4))
-                              << jmp)
-        if src_sz >= 4:
-            t &= types.uint64(0xffffffff00000000)
-            for i in range(4):
-                jmp = i * 8
+        @register_jitable(locals={'v0': types.uint64,
+                                  'v1': types.uint64,
+                                  'v2': types.uint64,
+                                  'v3': types.uint64,
+                                  'b': types.uint64,
+                                  'mi': types.uint64,
+                                  't': types.uint64,
+                                  'mask': types.uint64,
+                                  'jmp': types.uint64,
+                                  'ohexefef': types.uint64})
+        def _siphash(k0, k1, src, src_sz):
+            b = types.uint64(src_sz) << 56
+            v0 = k0 ^ types.uint64(0x736f6d6570736575)
+            v1 = k1 ^ types.uint64(0x646f72616e646f6d)
+            v2 = k0 ^ types.uint64(0x6c7967656e657261)
+            v3 = k1 ^ types.uint64(0x7465646279746573)
+
+            idx = 0
+            while (src_sz >= 8):
+                mi = grab_uint64_t(src, idx)
+                idx += 1
+                src_sz -= 8
+                v3 ^= mi
+                v0, v1, v2, v3 = _ROUNDER(v0, v1, v2, v3)
+                v0 ^= mi
+
+            # this is the switch fallthrough:
+            # https://github.com/python/cpython/blob/d1dd6be613381b996b9071443ef081de8e5f3aff/Python/pyhash.c#L390-L400    # noqa: E501
+            t = types.uint64(0x0)
+            boffset = idx * 8
+            ohexefef = types.uint64(0xff)
+            if src_sz >= 7:
+                jmp = (6 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
-                t = (t & mask) | (types.uint64(grab_byte(src, boffset + i))
-                                  << jmp)
-        if src_sz >= 3:
-            jmp = (2 * 8)
-            mask = ~types.uint64(ohexefef << jmp)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 2))
-                              << jmp)
-        if src_sz >= 2:
-            jmp = (1 * 8)
-            mask = ~types.uint64(ohexefef << jmp)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 1))
-                              << jmp)
-        if src_sz >= 1:
-            mask = ~(ohexefef)
-            t = (t & mask) | (types.uint64(grab_byte(src, boffset + 0)))
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 6))
+                                << jmp)
+            if src_sz >= 6:
+                jmp = (5 * 8)
+                mask = ~types.uint64(ohexefef << jmp)
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 5))
+                                << jmp)
+            if src_sz >= 5:
+                jmp = (4 * 8)
+                mask = ~types.uint64(ohexefef << jmp)
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 4))
+                                << jmp)
+            if src_sz >= 4:
+                t &= types.uint64(0xffffffff00000000)
+                for i in range(4):
+                    jmp = i * 8
+                    mask = ~types.uint64(ohexefef << jmp)
+                    t = (t & mask) | (types.uint64(grab_byte(src, boffset + i))
+                                    << jmp)
+            if src_sz >= 3:
+                jmp = (2 * 8)
+                mask = ~types.uint64(ohexefef << jmp)
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 2))
+                                << jmp)
+            if src_sz >= 2:
+                jmp = (1 * 8)
+                mask = ~types.uint64(ohexefef << jmp)
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 1))
+                                << jmp)
+            if src_sz >= 1:
+                mask = ~(ohexefef)
+                t = (t & mask) | (types.uint64(grab_byte(src, boffset + 0)))
 
-        b |= t
-        v3 ^= b
-        v0, v1, v2, v3 = _DOUBLE_ROUND(v0, v1, v2, v3)
-        v0 ^= b
-        v2 ^= ohexefef
-        v0, v1, v2, v3 = _DOUBLE_ROUND(v0, v1, v2, v3)
-        v0, v1, v2, v3 = _DOUBLE_ROUND(v0, v1, v2, v3)
-        t = (v0 ^ v1) ^ (v2 ^ v3)
-        return t
+            b |= t
+            v3 ^= b
+            v0, v1, v2, v3 = _ROUNDER(v0, v1, v2, v3)
+            v0 ^= b
+            v2 ^= ohexefef
+            v0, v1, v2, v3 = _ROUNDER(v0, v1, v2, v3)
+            v0, v1, v2, v3 = _ROUNDER(v0, v1, v2, v3)
+            if _EXTRA_ROUND:
+                v0, v1, v2, v3 = _ROUNDER(v0, v1, v2, v3)
+            t = (v0 ^ v1) ^ (v2 ^ v3)
+            return t
+
+        return _siphash
+
+
+    _siphash13 = _gen_siphash('siphash13')
+    _siphash24 = _gen_siphash('siphash24')
+
+    _siphasher = _siphash13 if  _Py_hashfunc_name == 'siphash13' else _siphash24
+
 else:
     msg = "Unsupported hashing algorithm in use %s" % _Py_hashfunc_name
     raise ValueError(msg)
@@ -732,7 +763,7 @@ def _Py_HashBytes(val, _len):
         _hash ^= _len
         _hash ^= _load_hashsecret('djbx33a_suffix')
     else:
-        tmp = _siphash24(types.uint64(_load_hashsecret('siphash_k0')),
+        tmp = _siphasher(types.uint64(_load_hashsecret('siphash_k0')),
                          types.uint64(_load_hashsecret('siphash_k1')),
                          val, _len)
         _hash = process_return(tmp)

--- a/numba/cpython/hashing.py
+++ b/numba/cpython/hashing.py
@@ -531,7 +531,6 @@ if _Py_hashfunc_name in ('siphash13', 'siphash24', 'fnv'):
     # DOUBLE_ROUND in siphash24, and that siphash13 has an extra "ROUND" applied
     # just before the final XORing of components to create the return value.
 
-
     # /* *********************************************************************
     # <MIT License>
     # Copyright (c) 2013  Marek Majkowski <marek@popcount.org>
@@ -651,34 +650,34 @@ if _Py_hashfunc_name in ('siphash13', 'siphash24', 'fnv'):
                 jmp = (6 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 6))
-                                << jmp)
+                                  << jmp)
             if src_sz >= 6:
                 jmp = (5 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 5))
-                                << jmp)
+                                  << jmp)
             if src_sz >= 5:
                 jmp = (4 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 4))
-                                << jmp)
+                                  << jmp)
             if src_sz >= 4:
                 t &= types.uint64(0xffffffff00000000)
                 for i in range(4):
                     jmp = i * 8
                     mask = ~types.uint64(ohexefef << jmp)
                     t = (t & mask) | (types.uint64(grab_byte(src, boffset + i))
-                                    << jmp)
+                                      << jmp)
             if src_sz >= 3:
                 jmp = (2 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 2))
-                                << jmp)
+                                  << jmp)
             if src_sz >= 2:
                 jmp = (1 * 8)
                 mask = ~types.uint64(ohexefef << jmp)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 1))
-                                << jmp)
+                                  << jmp)
             if src_sz >= 1:
                 mask = ~(ohexefef)
                 t = (t & mask) | (types.uint64(grab_byte(src, boffset + 0)))
@@ -697,11 +696,10 @@ if _Py_hashfunc_name in ('siphash13', 'siphash24', 'fnv'):
 
         return _siphash
 
-
     _siphash13 = _gen_siphash('siphash13')
     _siphash24 = _gen_siphash('siphash24')
 
-    _siphasher = _siphash13 if  _Py_hashfunc_name == 'siphash13' else _siphash24
+    _siphasher = _siphash13 if _Py_hashfunc_name == 'siphash13' else _siphash24
 
 else:
     msg = "Unsupported hashing algorithm in use %s" % _Py_hashfunc_name

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -674,40 +674,6 @@ def compile_function(name, code, globs):
     eval(co, globs, ns)
     return ns[name]
 
-def tweak_code(func, codestring=None, consts=None):
-    """
-    Tweak the code object of the given function by replacing its
-    *codestring* (a bytes object) and *consts* tuple, optionally.
-    """
-    co = func.__code__
-    tp = type(co)
-    if codestring is None:
-        codestring = co.co_code
-    if consts is None:
-        consts = co.co_consts
-    if utils.PYVERSION >= (3, 11):
-        new_code = tp(co.co_argcount, co.co_posonlyargcount,
-                      co.co_kwonlyargcount, co.co_nlocals,
-                      co.co_stacksize, co.co_flags, codestring,
-                      consts, co.co_names, co.co_varnames,
-                      co.co_filename, co.co_name, co.co_qualname,
-                      co.co_firstlineno, co.co_lnotab, co.co_exceptiontable,
-                      co.co_freevars, co.co_cellvars)
-    elif utils.PYVERSION >= (3, 8):
-        new_code = tp(co.co_argcount, co.co_posonlyargcount,
-                      co.co_kwonlyargcount, co.co_nlocals,
-                      co.co_stacksize, co.co_flags, codestring,
-                      consts, co.co_names, co.co_varnames,
-                      co.co_filename, co.co_name, co.co_firstlineno,
-                      co.co_lnotab)
-    else:
-        new_code = tp(co.co_argcount, co.co_kwonlyargcount, co.co_nlocals,
-                      co.co_stacksize, co.co_flags, codestring,
-                      consts, co.co_names, co.co_varnames,
-                      co.co_filename, co.co_name, co.co_firstlineno,
-                      co.co_lnotab)
-    func.__code__ = new_code
-
 
 _trashcan_dir = 'numba-tests'
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -685,7 +685,15 @@ def tweak_code(func, codestring=None, consts=None):
         codestring = co.co_code
     if consts is None:
         consts = co.co_consts
-    if utils.PYVERSION >= (3, 8):
+    if utils.PYVERSION >= (3, 11):
+        new_code = tp(co.co_argcount, co.co_posonlyargcount,
+                      co.co_kwonlyargcount, co.co_nlocals,
+                      co.co_stacksize, co.co_flags, codestring,
+                      consts, co.co_names, co.co_varnames,
+                      co.co_filename, co.co_name, co.co_qualname,
+                      co.co_firstlineno, co.co_lnotab, co.co_exceptiontable,
+                      co.co_freevars, co.co_cellvars)
+    elif utils.PYVERSION >= (3, 8):
         new_code = tp(co.co_argcount, co.co_posonlyargcount,
                       co.co_kwonlyargcount, co.co_nlocals,
                       co.co_stacksize, co.co_flags, codestring,

--- a/numba/tests/test_debug.py
+++ b/numba/tests/test_debug.py
@@ -10,7 +10,7 @@ from numba.tests.support import (TestCase, override_config, override_env_config,
                       captured_stdout, forbid_codegen, skip_parfors_unsupported,
                       needs_blas)
 from numba import jit
-from numba.core import types, compiler
+from numba.core import types, compiler, utils
 from numba.core.compiler import compile_isolated, Flags
 from numba.core.cpu import ParallelOptions
 from numba.core.errors import NumbaPerformanceWarning
@@ -71,7 +71,10 @@ class DebugTestBase(TestCase):
                 self.assert_fails(check_meth, out)
 
     def _check_dump_bytecode(self, out):
-        self.assertIn('BINARY_ADD', out)
+        if utils.PYVERSION >= (3, 11):
+            self.assertIn('BINARY_OP', out)
+        else:
+            self.assertIn('BINARY_ADD', out)
 
     def _check_dump_cfg(self, out):
         self.assertIn('CFG dominators', out)

--- a/numba/tests/test_exceptions.py
+++ b/numba/tests/test_exceptions.py
@@ -158,7 +158,10 @@ class TestRaising(TestCase):
 
             # check exception and the injected frame are the same
             for expf, gotf in zip(expected_frames, got_frames):
-                self.assertEqual(expf, gotf)
+                # Note use of assertIn not assertEqual, Py 3.11 has markers (^)
+                # that point to the variable causing the problem, Numba doesn't
+                # do this so only the start of the string will match.
+                self.assertIn(gotf, expf)
 
     def check_raise_class(self, flags):
         pyfunc = raise_class(MyError)

--- a/numba/tests/test_extended_arg.py
+++ b/numba/tests/test_extended_arg.py
@@ -2,17 +2,17 @@ import unittest
 
 import dis
 import struct
-import sys
 
 from numba import jit
 from numba.core import utils
-from numba.tests.support import TestCase, tweak_code
+from numba.tests.support import TestCase
 
 
 class TestExtendedArg(TestCase):
     """
     Test support for the EXTENDED_ARG opcode.
     """
+    bytecode_len = 0xff
 
     def get_extended_arg_load_const(self):
         """
@@ -24,9 +24,8 @@ class TestExtendedArg(TestCase):
 
         b = bytearray(f.__code__.co_code)
         consts = f.__code__.co_consts
-        bytecode_len = 0xff
         bytecode_format = "<BB"
-        consts = consts + (None,) * bytecode_len + (42,)
+        consts = consts + (None,) * self.bytecode_len + (42,)
         if utils.PYVERSION >= (3, 11):
             # Python 3.11 has a RESUME op code at the start of a function, need
             # to inject the EXTENDED_ARG after this to influence the LOAD_CONST
@@ -36,15 +35,16 @@ class TestExtendedArg(TestCase):
 
         packed_extend_arg = struct.pack(bytecode_format, dis.EXTENDED_ARG, 1)
         b[:] = b[:offset] + packed_extend_arg + b[offset:]
-        tweak_code(f, codestring=bytes(b), consts=consts)
+        f.__code__ = f.__code__.replace(co_code=bytes(b), co_consts=consts)
         return f
 
     def test_extended_arg_load_const(self):
         pyfunc = self.get_extended_arg_load_const()
+        # make sure that the pyfunc contains the expected modification
+        self.assertGreater(len(pyfunc.__code__.co_consts), self.bytecode_len)
         self.assertPreciseEqual(pyfunc(), 42)
         cfunc = jit(nopython=True)(pyfunc)
         self.assertPreciseEqual(cfunc(), 42)
-
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_hashing.py
+++ b/numba/tests/test_hashing.py
@@ -5,6 +5,7 @@ Test hashing of various supported types.
 
 import unittest
 
+import os
 import sys
 import subprocess
 from collections import defaultdict
@@ -12,11 +13,11 @@ from textwrap import dedent
 
 import numpy as np
 
-from numba import jit
+from numba import jit, config
 from numba.core import types, utils
 import unittest
 from numba.tests.support import (TestCase, tag, CompilationCache,
-                                 skip_unless_py10_or_later)
+                                 skip_unless_py10_or_later, run_in_subprocess)
 
 from numba.cpython.unicode import compile_time_get_string_data
 from numba.cpython import hashing
@@ -69,6 +70,89 @@ class TestHashingSetup(TestCase):
                 raise RuntimeError("Expected warning not found")
         """
         subprocess.check_call([sys.executable, '-c', dedent(work)])
+
+
+class TestHashAlgs(TestCase):
+    # This tests Numba hashing replication against cPython "gold", i.e. the
+    # actual hash values for given inputs, algs and PYTHONHASHSEEDs
+    # Test adapted from:
+    # https://github.com/python/cpython/blob/9dda9020abcf0d51d59b283a89c58c8e1fb0f574/Lib/test/test_hash.py#L197-L264
+    # and
+    # https://github.com/python/cpython/blob/9dda9020abcf0d51d59b283a89c58c8e1fb0f574/Lib/test/test_hash.py#L174-L189
+
+    # 32bit little, 64bit little, 32bit big, 64bit big
+    known_hashes = {
+        'djba33x': [ # only used for small strings
+            # seed 0, 'abc'
+            [193485960, 193485960,  193485960, 193485960],
+            # seed 42, 'abc'
+            [-678966196, 573763426263223372, -820489388, -4282905804826039665],
+            ],
+        'siphash13': [
+            # NOTE: PyUCS2 layout depends on endianness
+            # seed 0, 'abc'
+            [69611762, -4594863902769663758, 69611762, -4594863902769663758],
+            # seed 42, 'abc'
+            [-975800855, 3869580338025362921, -975800855, 3869580338025362921],
+            # seed 42, 'abcdefghijk'
+            [-595844228, 7764564197781545852, -595844228, 7764564197781545852],
+            # seed 0, 'äú∑ℇ'
+            [-1093288643, -2810468059467891395, -1041341092, 4925090034378237276],
+            # seed 42, 'äú∑ℇ'
+            [-585999602, -2845126246016066802, -817336969, -2219421378907968137],
+        ],
+        'siphash24': [
+            # NOTE: PyUCS2 layout depends on endianness
+            # seed 0, 'abc'
+            [1198583518, 4596069200710135518, 1198583518, 4596069200710135518],
+            # seed 42, 'abc'
+            [273876886, -4501618152524544106, 273876886, -4501618152524544106],
+            # seed 42, 'abcdefghijk'
+            [-1745215313, 4436719588892876975, -1745215313, 4436719588892876975],
+            # seed 0, 'äú∑ℇ'
+            [493570806, 5749986484189612790, -1006381564, -5915111450199468540],
+            # seed 42, 'äú∑ℇ'
+            [-1677110816, -2947981342227738144, -1860207793, -4296699217652516017],
+        ],
+    }
+
+    def get_expected_hash(self, position, length):
+        if length < sys.hash_info.cutoff:
+            algorithm = "djba33x"
+        else:
+            algorithm = sys.hash_info.algorithm
+        IS_64BIT = not config.IS_32BITS
+        if sys.byteorder == 'little':
+            platform = 1 if IS_64BIT else 0
+        else:
+            assert(sys.byteorder == 'big')
+            platform = 3 if IS_64BIT else 2
+        return self.known_hashes[algorithm][position][platform]
+
+    def get_hash_command(self, repr_):
+        return 'print(hash(eval(%a)))' % repr_
+
+    def get_hash(self, repr_, seed=None):
+        env = os.environ.copy()
+        if seed is not None:
+            env['PYTHONHASHSEED'] = str(seed)
+        else:
+            env.pop('PYTHONHASHSEED', None)
+        out, _ = run_in_subprocess(code=self.get_hash_command(repr_),
+                                   env=env)
+        stdout = out.decode().strip()
+        return int(stdout)
+
+    def test_against_cpython_gold(self):
+
+        args = (('abc', 0, 0), ('abc', 42, 1), ('abcdefghijk', 42, 2),
+                ('äú∑ℇ', 0, 3), ('äú∑ℇ', 42, 4),)
+
+        for input_str, seed, position in args:
+            with self.subTest(input_str=input_str, seed=seed):
+                got = self.get_hash(repr(input_str), seed=seed)
+                expected = self.get_expected_hash(position, len(input_str))
+                self.assertEqual(got, expected)
 
 
 class BaseTest(TestCase):

--- a/numba/tests/test_ir.py
+++ b/numba/tests/test_ir.py
@@ -432,7 +432,7 @@ class TestIRCompounds(CheckEquality):
             blk = z_ir.blocks[label]
             ref = blk.body[:-1]
             idx = None
-            for i in range(len(ref)):
+            for i in range(len(ref) - 1):
                 # look for two adjacent Del
                 if (isinstance(ref[i], ir.Del) and
                         isinstance(ref[i + 1], ir.Del)):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3355,6 +3355,9 @@ class TestPrangeBase(TestParforsBase):
             prange_names.append('prange')
             prange_names = tuple(prange_names)
             prange_idx = len(prange_names) - 1
+            if utils.PYVERSION == (3, 11):
+                # this is the inverse of _fix_LOAD_GLOBAL_arg
+                prange_idx = 1 + (prange_idx << 1)
             new_code = bytearray(pyfunc_code.co_code)
             assert len(patch_instance) <= len(range_locations)
             # patch up the new byte code


### PR DESCRIPTION
This branch is based on the `py3.11` branch from 61e6a51.
* #8614 is included as patches c96fa09 and 34e2ed7 (the first in the series of patches in this PR).
* #8621 is included from 7c067fe through to 1af5b2c inclusive (with conflicts resolved).
* Additional patches are added based on feedback in the above PRs and also to match conventions adopted in the above PRs.