### PR TITLE
Fix bare reraise support

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -891,18 +891,19 @@ void traceback_add_loc(PyObject *loc) {
 static
 int reraise_exc_is_none(void) {
     /* Reraise */
-    PyThreadState *tstate = PyThreadState_GET();
     PyObject *tb, *type, *value;
-#if (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 7)
+
+#if (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 11)
+    /* intentionally empty */
+#elif (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 7)
+    PyThreadState *tstate = PyThreadState_GET();
     _PyErr_StackItem *tstate_exc = tstate->exc_info;
 #else
     PyThreadState *tstate_exc = tstate;
 #endif
 
 #if (PY_MAJOR_VERSION >= 3) && (PY_MINOR_VERSION >= 11)
-    type = tstate->curexc_type;
-    value = tstate->curexc_value;
-    tb = tstate->curexc_traceback;
+    PyErr_GetExcInfo(&type, &value, &tb);
 #else
     type = tstate_exc->exc_type;
     value = tstate_exc->exc_value;

--- a/numba/core/byteflow.py
+++ b/numba/core/byteflow.py
@@ -802,10 +802,13 @@ class TraceRunner(object):
         def op_RAISE_VARARGS(self, state, inst):
             if inst.arg == 0:
                 exc = None
-                raise UnsupportedError(
-                    "The re-raising of an exception is not yet supported.",
-                    loc=self.get_debug_loc(inst.lineno),
-                )
+                # No re-raising within a try-except block.
+                # But we allow bare reraise.
+                if state.has_active_try():
+                    raise UnsupportedError(
+                        "The re-raising of an exception is not yet supported.",
+                        loc=self.get_debug_loc(inst.lineno),
+                    )
             elif inst.arg == 1:
                 exc = state.pop()
             else:


### PR DESCRIPTION
- restore lost logic that we only ban reraise within a try-except block, but bare reraise (causes the interpreter to reraise existing exception value) is supported.
- fix C logic in handling reraise. C API changed and old code needs access to now opaque struct (`_PyErr_StackItem`). Use [PyErr_GetExcInfo](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_GetExcInfo) instead.