### PR TITLE
PR #8232 continued

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -611,16 +611,18 @@ execution logic.
   values from useful distributions. Numba will ``unbox`` the :py:class:`Generator` objects
   and will maintain a reference to the underlying :py:class:`BitGenerator` objects using NumPy's
   ``ctypes`` interface bindings. Hence :py:class:`Generator` objects can cross the JIT boundary
-  and their functions be used within Numba-Jit code. Note that since only references
-  to :py:class:`BitGenerator` objects are maintained, any change to the state of a particular
-  :py:class:`Generator` object outside Numba code would affect the state of :py:class:`Generator`
-  inside the Numba code.
+  and their functions be used within Numba-Jit code.
 
 .. literalinclude:: ../../../numba/tests/doc_examples/test_numpy_generators.py
    :language: python
    :start-after: magictoken.npgen_usage.begin
    :end-before: magictoken.npgen_usage.end
    :dedent: 8
+
+.. warning::
+   Note that since only references to :py:class:`BitGenerator` objects are maintained,
+   any change to the state of a particular :py:class:`Generator` object outside Numba
+   code would affect the state of :py:class:`Generator` inside the Numba code.
 
 The following :py:class:`Generator` methods are supported:
 
@@ -630,6 +632,7 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().f()` (*)
 * :func:`numpy.random.Generator().gamma()` (*)
 * :func:`numpy.random.Generator().geometric()` (*)
+* :func:`numpy.random.Generator().gumbel()`
 * :func:`numpy.random.Generator().integers()` (Both `low` and `high` are required
   arguments. Array values for low and high are currently not supported.)
 * :func:`numpy.random.Generator().laplace()` (*)
@@ -660,21 +663,11 @@ The following :py:class:`Generator` methods are supported:
 * :func:`numpy.random.Generator().standard_t()` (*)
 * :func:`numpy.random.Generator().triangular()`
 * :func:`numpy.random.Generator().uniform()` (*)
+* :func:`numpy.random.Generator().von_mises()`
 * :func:`numpy.random.Generator().wald()` (*)
 * :func:`numpy.random.Generator().weibull()`
 * :func:`numpy.random.Generator().zipf()`
 
-.. note::
-  Users can expect Numba to replicate NumPy's results to within
-  the last few (at max 5) ULPs for Linux-x86_64, Windows-x86_64 and macOS.
-
-  For distributions marked above with `(*)`: Due to instruction selection
-  differences across compilers, there may be discrepancies in the order of
-  1000s of ULPs on 32-bit architectures as well as linux-aarch64 and
-  linux-ppc64le platforms. The differences are unlikely to impact the "quality"
-  of the random number generation as they occur through changes in
-  rounding that happen when fused-multiply-add is used instead of multiplication
-  followed by addition.
 
 RandomState and legacy Random number generation
 '''''''''''''''''''''''''''''''''''''''''''''''

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -17,6 +17,8 @@ from numba.cuda import cudadrv
 from numba.cuda.cudadrv.driver import driver as cudriver
 from numba.cuda.cudadrv.runtime import runtime as curuntime
 from numba.core import config
+from numba.np.random.distributions import _get_fastmath_args
+
 
 _psutil_import = False
 try:
@@ -67,6 +69,7 @@ _numpy_supported_simd_features = 'NumPy Supported SIMD features'
 _numpy_supported_simd_dispatch = 'NumPy Supported SIMD dispatch'
 _numpy_supported_simd_baseline = 'NumPy Supported SIMD baseline'
 _numpy_AVX512_SKX_detected = 'NumPy AVX512_SKX detected'
+_numpy_rng_uses_fma = 'NumPy RNG uses FMA'
 # SVML info
 _svml_state, _svml_loaded = 'SVML State', 'SVML Lib Loaded'
 _llvm_svml_patched = 'LLVM SVML Patched'
@@ -400,6 +403,7 @@ def get_sysinfo():
         sys_info[_numpy_supported_simd_baseline] = __cpu_baseline__
         sys_info[_numpy_AVX512_SKX_detected] = \
             __cpu_features__.get("AVX512_SKX", False)
+    sys_info[_numpy_rng_uses_fma] = _get_fastmath_args() != {}
 
     # SVML information
     # Replicate some SVML detection logic from numba.__init__ here.
@@ -602,6 +606,8 @@ def display_sysinfo(info=None, sep_pos=45):
                     or ('None found.',))),
         ("NumPy AVX512_SKX support detected",
          info.get(_numpy_AVX512_SKX_detected, '?')),
+        ("NumPy RNG uses FMA",
+         info.get(_numpy_rng_uses_fma, '?')),
         ("",),
         ("__SVML Information__",),
         ("SVML State, config.USING_SVML", info.get(_svml_state, '?')),

--- a/numba/np/random/distributions.py
+++ b/numba/np/random/distributions.py
@@ -4,9 +4,7 @@ of random distributions.
 """
 
 import numpy as np
-import platform
 
-from numba.core.config import IS_32BITS
 from numba.np.random._constants import (wi_double, ki_double,
                                         ziggurat_nor_r, fi_double,
                                         wi_float, ki_float,
@@ -24,12 +22,6 @@ from numba import float32, int64, njit
 from numba.np.numpy_support import numpy_version
 # All of the following implementations are direct translations from:
 # https://github.com/numpy/numpy/blob/7cfef93c77599bd387ecc6a15d186c5a46024dac/numpy/random/src/distributions/distributions.c
-
-
-if IS_32BITS or platform.machine() in ['ppc64le', 'aarch64']:
-    fastmath_args = {'contract':True}
-else:
-    fastmath_args = {}
 
 
 if numpy_version >= (1, 21):
@@ -66,6 +58,9 @@ else:
     @njit
     def np_expm1(x):
         return np.exp(x) - 1.0
+
+
+fastmath_args = {'contract': True}
 
 
 @njit

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -965,14 +965,14 @@ def NumPyRandomGeneratorType_vonmises(inst, mu, kappa, size=None):
     if is_nonelike(size):
         def impl(inst, mu, kappa, size=None):
             check_arg_bounds(kappa)
-            return np.int64(random_vonmises(inst.bit_generator, mu, kappa))
+            return np.float64(random_vonmises(inst.bit_generator, mu, kappa))
         return impl
     else:
         check_size(size)
 
         def impl(inst, mu, kappa, size=None):
             check_arg_bounds(kappa)
-            out = np.empty(size, dtype=np.int64)
+            out = np.empty(size, dtype=np.float64)
             for i in np.ndindex(size):
                 out[i] = random_vonmises(inst.bit_generator, mu, kappa)
             return out
@@ -994,14 +994,14 @@ def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
     if is_nonelike(size):
         def impl(inst, loc=0.0, scale=1.0, size=None):
             check_arg_bounds(scale)
-            return np.int64(random_gumbel(inst.bit_generator, loc, scale))
+            return np.float64(random_gumbel(inst.bit_generator, loc, scale))
         return impl
     else:
         check_size(size)
 
         def impl(inst, loc=0.0, scale=1.0, size=None):
             check_arg_bounds(scale)
-            out = np.empty(size, dtype=np.int64)
+            out = np.empty(size, dtype=np.float64)
             for i in np.ndindex(size):
                 out[i] = random_gumbel(inst.bit_generator, loc, scale)
             return out

--- a/numba/np/random/generator_methods.py
+++ b/numba/np/random/generator_methods.py
@@ -21,7 +21,8 @@ from numba.np.random.distributions import \
      random_lognormal, random_rayleigh, random_standard_t, random_wald,
      random_geometric, random_zipf, random_triangular,
      random_poisson, random_negative_binomial, random_logseries,
-     random_noncentral_chisquare, random_noncentral_f)
+     random_noncentral_chisquare, random_noncentral_f,
+     random_vonmises, random_gumbel)
 from numba.np.random import random_methods
 
 
@@ -944,5 +945,64 @@ def NumPyRandomGeneratorType_logseries(inst, p, size=None):
             out_f = out.flat
             for i in range(out.size):
                 out_f[i] = random_logseries(inst.bit_generator, p)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'vonmises')
+def NumPyRandomGeneratorType_vonmises(inst, mu, kappa, size=None):
+    check_types(mu, [types.Float, types.Integer, int, float], 'mu')
+    check_types(kappa, [types.Float, types.Integer, int, float], 'kappa')
+
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    @register_jitable
+    def check_arg_bounds(kappa):
+        if kappa < 0:
+            raise ValueError("kappa should be >= 0")
+
+    if is_nonelike(size):
+        def impl(inst, mu, kappa, size=None):
+            check_arg_bounds(kappa)
+            return np.int64(random_vonmises(inst.bit_generator, mu, kappa))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, mu, kappa, size=None):
+            check_arg_bounds(kappa)
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_vonmises(inst.bit_generator, mu, kappa)
+            return out
+        return impl
+
+
+@overload_method(types.NumPyRandomGeneratorType, 'gumbel')
+def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
+    check_types(loc, [types.Float, types.Integer, int, float], 'loc')
+    check_types(scale, [types.Float, types.Integer, int, float], 'scale')
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    @register_jitable
+    def check_arg_bounds(scale):
+        if scale < 0:
+            raise ValueError("scale must be non-negative")
+
+    if is_nonelike(size):
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            check_arg_bounds(scale)
+            return np.int64(random_gumbel(inst.bit_generator, loc, scale))
+        return impl
+    else:
+        check_size(size)
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            check_arg_bounds(scale)
+            out = np.empty(size, dtype=np.int64)
+            for i in np.ndindex(size):
+                out[i] = random_gumbel(inst.bit_generator, loc, scale)
             return out
         return impl

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -1,25 +1,15 @@
 import numba
 import numpy as np
 import sys
-import platform
 import itertools
 
 from numba import types
-from numba.core.config import IS_32BITS
 from numba.tests.support import TestCase, MemoryLeakMixin
 from numba.np.random.generator_methods import _get_proper_func
 from numba.np.random.generator_core import next_uint32, next_uint64, next_double
 from numpy.random import MT19937, Generator
 from numba.core.errors import TypingError
 from numba.tests.support import run_in_new_process_caching, SerialMixin
-
-
-# The following logic is to mitigate:
-# https://github.com/numba/numba/pull/8038#issuecomment-1165571368
-if IS_32BITS or platform.machine() in ['ppc64le', 'aarch64']:
-    adjusted_ulp_prec = 2048
-else:
-    adjusted_ulp_prec = 5
 
 
 class TestHelperFuncs(TestCase):
@@ -463,8 +453,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
                     with self.subTest(_size=_size, _dtype=_dtype,
                                       _bitgen=_bitgen):
                         self.check_numpy_parity(dist_func, _bitgen,
-                                                None, _size, _dtype,
-                                                adjusted_ulp_prec)
+                                                None, _size, _dtype)
         dist_func = lambda x, shape, size, dtype:\
             x.standard_gamma(shape=shape, size=size, dtype=dtype)
         self._check_invalid_types(dist_func, ['shape', 'size', 'dtype'],
@@ -481,16 +470,14 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         dist_func = lambda x, size, dtype:x.normal()
         with self.subTest():
             self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
+                                    test_dtype=None)
 
         dist_func = lambda x, size, dtype:x.normal(loc=1.5, scale=3, size=size)
         for _size in test_sizes:
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
         dist_func = lambda x, loc, scale, size:\
             x.normal(loc=loc, scale=scale, size=size)
         self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
@@ -507,16 +494,14 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         dist_func = lambda x, size, dtype:x.uniform()
         with self.subTest():
             self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
+                                    test_dtype=None)
 
         dist_func = lambda x, size, dtype:x.uniform(low=1.5, high=3, size=size)
         for _size in test_sizes:
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
         dist_func = lambda x, low, high, size:\
             x.uniform(low=low, high=high, size=size)
         self._check_invalid_types(dist_func, ['low', 'high', 'size'],
@@ -559,8 +544,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
         dist_func = lambda x, shape, scale, size:\
             x.gamma(shape=shape, scale=scale, size=size)
         self._check_invalid_types(dist_func, ['shape', 'scale', 'size'],
@@ -578,8 +562,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, a, b, size:x.beta(a=a, b=b, size=size)
         self._check_invalid_types(dist_func, ['a', 'b', 'size'],
@@ -597,8 +580,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, dfnum, dfden, size:\
             x.f(dfnum=dfnum, dfden=dfden, size=size)
@@ -617,8 +599,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, df, size:\
             x.chisquare(df=df, size=size)
@@ -714,8 +695,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         dist_func = lambda x, size, dtype:x.laplace()
         with self.subTest():
             self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
+                                    test_dtype=None)
 
         dist_func = lambda x, size, dtype:\
             x.laplace(loc=1.0, scale=1.5, size=size)
@@ -723,11 +703,35 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, loc, scale, size:\
             x.laplace(loc=loc, scale=scale, size=size)
+        self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
+                                  [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_gumbel(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        # Test with no arguments
+        dist_func = lambda x, size, dtype:x.gumbel()
+        with self.subTest():
+            self.check_numpy_parity(dist_func, test_size=None,
+                                    test_dtype=None)
+
+        dist_func = lambda x, size, dtype:x.gumbel(loc=1.0,scale=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, loc, scale, size:\
+            x.gumbel(loc=loc, scale=scale, size=size)
         self._check_invalid_types(dist_func, ['loc', 'scale', 'size'],
                                   [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
 
@@ -742,8 +746,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         dist_func = lambda x, size, dtype:x.logistic()
         with self.subTest():
             self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
+                                    test_dtype=None)
 
         dist_func = lambda x, size, dtype:\
             x.logistic(loc=1.0,scale=1.5, size=size)
@@ -751,8 +754,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, loc, scale, size:\
             x.logistic(loc=loc, scale=scale, size=size)
@@ -770,8 +772,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         dist_func = lambda x, size, dtype:x.lognormal()
         with self.subTest():
             self.check_numpy_parity(dist_func, test_size=None,
-                                    test_dtype=None,
-                                    ulp_prec=adjusted_ulp_prec)
+                                    test_dtype=None)
 
         dist_func = lambda x, size, dtype:\
             x.lognormal(mean=5.0, sigma=1.5, size=size)
@@ -779,8 +780,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, mean, sigma, size:\
             x.lognormal(mean=mean, sigma=sigma, size=size)
@@ -823,8 +823,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, df, size:x.standard_t(df=df, size=size)
         self._check_invalid_types(dist_func, ['df', 'size'],
@@ -842,13 +841,32 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, mean, scale, size:\
             x.wald(mean=mean, scale=scale, size=size)
         self._check_invalid_types(dist_func, ['mean', 'scale', 'size'],
                                   [1.0, 1.5, (1,)], ['x', 'x', ('x',)])
+
+    def test_vonmises(self):
+        # For this test dtype argument is never used, so we pass [None] as dtype
+        # to make sure it runs only once with default system type.
+
+        test_sizes = [None, (), (100,), (10, 20, 30)]
+        bitgen_types = [None, MT19937]
+
+        dist_func = lambda x, size, dtype:\
+            x.vonmises(mu=5.0, kappa=1.5, size=size)
+        for _size in test_sizes:
+            for _bitgen in bitgen_types:
+                with self.subTest(_size=_size, _bitgen=_bitgen):
+                    self.check_numpy_parity(dist_func, _bitgen,
+                                            None, _size, None)
+
+        dist_func = lambda x, mu, kappa, size:\
+            x.vonmises(mu=mu, kappa=kappa, size=size)
+        self._check_invalid_types(dist_func, ['mu', 'kappa', 'size'],
+                                  [5, 1, (1,)], ['x', 'x', ('x',)])
 
     def test_geometric(self):
         # For this test dtype argument is never used, so we pass [None] as dtype
@@ -862,8 +880,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, p, size:x.geometric(p=p, size=size)
         self._check_invalid_types(dist_func, ['p', 'size'],
@@ -919,8 +936,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, lam, size:x.poisson(lam=lam, size=size)
         self._check_invalid_types(dist_func, ['lam', 'size'],
@@ -939,8 +955,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
             for _bitgen in bitgen_types:
                 with self.subTest(_size=_size, _bitgen=_bitgen):
                     self.check_numpy_parity(dist_func, _bitgen,
-                                            None, _size, None,
-                                            adjusted_ulp_prec)
+                                            None, _size, None)
 
         dist_func = lambda x, n, p, size:\
             x.negative_binomial(n=n, p=p, size=size)
@@ -1109,8 +1124,7 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         for _size, _bitgen in itertools.product(test_sizes, bitgen_types):
             with self.subTest(_size=_size, _bitgen=_bitgen):
                 self.check_numpy_parity(dist_func, _bitgen,
-                                        None, _size, None,
-                                        adjusted_ulp_prec)
+                                        None, _size, None)
 
         dist_func = lambda x, dfnum, dfden, nonc, size:\
             x.noncentral_f(dfnum=dfnum, dfden=dfden, nonc=nonc, size=size)


### PR DESCRIPTION
A continuation of #8232 (it's rebased on current `main` c910705) with view of debugging/fixing the issues cause by `fma` instructions present on certain NumPy versions compiled for M1 arch.