### PR TITLE
Split up parfor pass

### DIFF
--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -26,7 +26,10 @@ from numba.core.untyped_passes import (ExtractByteCode, TranslateByteCode,
 
 from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
                                      NopythonRewrites, PreParforPass,
-                                     ParforPass, DumpParforDiagnostics,
+                                     ParforPassConversion,
+                                     ParforPassFusion,
+                                     ParforPassFinalize,
+                                     DumpParforDiagnostics,
                                      IRLegalization, NoPythonBackend,
                                      InlineOverloads, PreLowerStripPhis,
                                      NativeLowering, NativeParforLowering,
@@ -610,7 +613,9 @@ class DefaultPassBuilder(object):
         if not state.flags.no_rewrites:
             pm.add_pass(NopythonRewrites, "nopython rewrites")
         if state.flags.auto_parallel.enabled:
-            pm.add_pass(ParforPass, "convert to parfors")
+            pm.add_pass(ParforPassConversion, "convert to parfors")
+            pm.add_pass(ParforPassFusion, "convert to parfors")
+            pm.add_pass(ParforPassFinalize, "convert to parfors")
 
         pm.finalize()
         return pm

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -393,6 +393,26 @@ class ParforPassFinalize(FunctionPass):
         return True
 
 
+@register_pass(mutates_CFG=True, analysis_only=False)
+class DefaultParforPass(FunctionPass):
+
+    _name = "parfor_pass_default"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        from .compiler_machinery import PassManager
+
+        pm = PassManager("parfor pass manager")
+        pm.add_pass(ParforPassConversion)
+        pm.add_pass(ParforPassFusion)
+        pm.add_pass(ParforPassFinalize)
+        pm.finalize()
+        pm.run(state)
+        return True
+
+
 @register_pass(mutates_CFG=False, analysis_only=True)
 class DumpParforDiagnostics(AnalysisPass):
 

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -282,9 +282,9 @@ def _reload_parfors():
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)
-class ParforPass(FunctionPass):
+class ParforPassConversion(FunctionPass):
 
-    _name = "parfor_pass"
+    _name = "parfor_pass_conversion"
 
     def __init__(self):
         FunctionPass.__init__(self)
@@ -305,7 +305,64 @@ class ParforPass(FunctionPass):
                                          state.flags,
                                          state.metadata,
                                          state.parfor_diagnostics)
-        parfor_pass.run()
+        parfor_pass.run_conversions()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforPassFusion(FunctionPass):
+
+    _name = "parfor_pass_fusion"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Convert data-parallel computations into Parfor nodes
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+
+        parfor_pass = _parfor_ParforPass(state.func_ir,
+                                         state.typemap,
+                                         state.calltypes,
+                                         state.return_type,
+                                         state.typingctx,
+                                         state.targetctx,
+                                         state.flags.auto_parallel,
+                                         state.flags,
+                                         state.metadata,
+                                         state.parfor_diagnostics)
+        parfor_pass.run_fusion()
+        return True
+
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class ParforPassFinalize(FunctionPass):
+
+    _name = "parfor_pass_finalize"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        """
+        Convert data-parallel computations into Parfor nodes
+        """
+        # Ensure we have an IR and type information.
+        assert state.func_ir
+        parfor_pass = _parfor_ParforPass(state.func_ir,
+                                         state.typemap,
+                                         state.calltypes,
+                                         state.return_type,
+                                         state.typingctx,
+                                         state.targetctx,
+                                         state.flags.auto_parallel,
+                                         state.flags,
+                                         state.metadata,
+                                         state.parfor_diagnostics)
+        parfor_pass.run_finalize()
 
         # check the parfor pass worked and warn if it didn't
         has_parfor = False

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -2847,7 +2847,6 @@ def _find_mask(typemap, func_ir, arr_def):
 
 
 class ParforPass(ParforPassStates):
-
     """ParforPass class is responsible for converting NumPy
     calls in Numba intermediate representation to Parfors, which
     will lower into either sequential or parallel loops during lowering
@@ -2864,6 +2863,11 @@ class ParforPass(ParforPassStates):
     def run(self):
         """run parfor conversion pass: replace Numpy calls
         with Parfors when possible and optimize the IR."""
+        self.run_conversions()
+        self.run_fusion()
+        self.run_finalize()
+
+    def run_conversions(self):
         self._pre_run()
         # run stencil translation to parfor
         if self.options.stencil:
@@ -2883,6 +2887,7 @@ class ParforPass(ParforPassStates):
         if self.options.inplace_binop:
             ConvertInplaceBinop(self).run(self.func_ir.blocks)
 
+    def run_fusion(self):
         # setup diagnostics now parfors are found
         self.diagnostics.setup(self.func_ir, self.options.fusion)
 
@@ -2938,6 +2943,7 @@ class ParforPass(ParforPassStates):
             # remove dead code after fusion to remove extra arrays and variables
             simplify(self.func_ir, self.typemap, self.calltypes, self.metadata["parfors"])
 
+    def run_finalize(self):
         # push function call variables inside parfors so gufunc function
         # wouldn't need function variables as argument
         push_call_vars(self.func_ir.blocks, {}, {}, self.typemap)

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -16,7 +16,7 @@ from numba.core.untyped_passes import (ExtractByteCode, TranslateByteCode, Fixup
                              WithLifting, PreserveIR, InlineClosureLikes)
 
 from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
-                           NopythonRewrites, PreParforPass, ParforPass,
+                           NopythonRewrites, PreParforPass, DefaultParforPass,
                            DumpParforDiagnostics, NativeLowering,
                            NativeParforLowering, IRLegalization,
                            NoPythonBackend, NativeLowering)
@@ -88,7 +88,7 @@ def gen_pipeline(state, test_pass):
         if not state.flags.no_rewrites:
             pm.add_pass(NopythonRewrites, "nopython rewrites")
         if state.flags.auto_parallel.enabled:
-            pm.add_pass(ParforPass, "convert to parfors")
+            pm.add_pass(DefaultParforPass, "convert to parfors")
 
         pm.add_pass(test_pass, "inline test")
 

--- a/numba/tests/test_remove_dead.py
+++ b/numba/tests/test_remove_dead.py
@@ -21,7 +21,7 @@ from numba.core.untyped_passes import (ExtractByteCode, TranslateByteCode, Fixup
                              WithLifting, PreserveIR, InlineClosureLikes)
 
 from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
-                           NopythonRewrites, PreParforPass, ParforPass,
+                           NopythonRewrites, PreParforPass,
                            DumpParforDiagnostics, NativeLowering,
                            IRLegalization, NoPythonBackend, NativeLowering)
 import numpy as np


### PR DESCRIPTION
Split up the passes to allow custom compiler pipelines to change parfor behavior while reusing some existing behavior. 