### PR TITLE
Support `Optional(...)` in Typed List

### DIFF
--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -618,9 +618,6 @@ class ListType(IterableType):
     def __init__(self, itemty):
         assert not isinstance(itemty, TypeRef)
         itemty = unliteral(itemty)
-        if isinstance(itemty, Optional):
-            fmt = "List.item_type cannot be of type {}"
-            raise TypingError(fmt.format(itemty))
         # FIXME: _sentry_forbidden_types(itemty)
         self.item_type = itemty
         self.dtype = itemty

--- a/numba/tests/test_typedlist.py
+++ b/numba/tests/test_typedlist.py
@@ -19,9 +19,9 @@ from numba.experimental import jitclass
 
 
 # global typed-list for testing purposes
-global_typed_list = List.empty_list(int32)
-for i in (1, 2, 3):
-    global_typed_list.append(int32(i))
+# global_typed_list = List.empty_list(int32)
+# for i in (1, 2, 3):
+#     global_typed_list.append(int32(i))
 
 
 def to_tl(l):
@@ -1658,3 +1658,61 @@ class TestListFromIter(MemoryLeakMixin, TestCase):
             "List() takes no keyword arguments",
             str(raises.exception),
         )
+
+
+def _print(lst):
+    print(f'python: list dtype={lst._numba_type_}, size={len(lst)}')
+
+
+class TestOptionalType(MemoryLeakMixin, TestCase):
+    import os
+    # os.environ['NUMBA_DEBUG_TYPEINFER'] = '1'
+
+    def test_misc(self):
+        @njit
+        def foo(a):
+            if a > 0:
+                b = None
+            else:
+                b = a
+            return b
+
+        print(f"{foo(1)}, {foo(0)}")
+
+    def test_optional_constructor(self):
+        py_list = [None, 1]
+        nb_list = List(py_list)
+        print(nb_list)
+
+    def test_optional_in_python(self):
+        lst = List()
+        lst.append(None)
+        lst.append(None)
+        _print(lst)
+        lst.append(1)
+        # list.append(None)
+        lst.append(2)
+        _print(lst)
+
+    def test_optional_in_python_again(self):
+        lst = List()
+        lst.append(None)
+        lst.append(None)
+
+    def test_optional_in_jit(self):
+        @njit
+        def foo():
+            lst = List()
+            lst.append(None)
+            lst.append(1)
+
+        foo()
+
+    def test_optional_in_jit_again(self):
+        @njit
+        def foo():
+            lst = List()
+            lst.append(1)
+            lst.append(None)
+
+        foo()

--- a/numba/typed/typedlist.py
+++ b/numba/typed/typedlist.py
@@ -490,7 +490,6 @@ def box_lsttype(typ, val, c):
         builder.store(res, result_var)
     return builder.load(result_var)
 
-
 @unbox(types.ListType)
 def unbox_listtype(typ, val, c):
     context = c.context


### PR DESCRIPTION
Hi, I'm implementing this feature. Don't need to review right now.

I have already achieved some kinds of initial success for supporting this feature (see the testcase `test_optional_in_python(self)`, it has already worked, although still flawed). 

But I do have a question about `_gen_getitem`. Why do we need to wrap a not-none item type into an optional type?

https://github.com/numba/numba/blob/c91070592448ebc2243442677f5358988f5feb62/numba/typed/listobject.py#L689-L700

It does confuse me. From the git history, perhaps @stuartarchibald can give me some tips? Indeed, I want to remove this wrapper logic, since I'm trying to support optional item_type natively.