### PR TITLE
Preserve module name of jitted class

### DIFF
--- a/numba/experimental/jitclass/decorators.py
+++ b/numba/experimental/jitclass/decorators.py
@@ -74,7 +74,13 @@ def jitclass(cls_or_spec=None, spec=None):
         else:
             from numba.experimental.jitclass.base import (register_class_type,
                                                           ClassBuilder)
-            return register_class_type(cls, spec, types.ClassType, ClassBuilder)
+            cls_jitted = register_class_type(cls, spec, types.ClassType,
+                                             ClassBuilder)
+
+            # Preserve the module name of the original class
+            cls_jitted.__module__ = cls.__module__
+
+            return cls_jitted
 
     if cls_or_spec is None:
         return wrap

--- a/numba/tests/test_jitclasses.py
+++ b/numba/tests/test_jitclasses.py
@@ -1166,6 +1166,16 @@ class TestJitClass(TestCase, MemoryLeakMixin):
             Foo()
         self.assertIn("Method '__enter__' is not supported.", str(e.exception))
 
+    def test_modulename(self):
+        @jitclass
+        class TestModname(object):
+            def __init__(self):
+                self.x = 12
+
+        thisModule = __name__
+        classModule = TestModname.__module__
+        self.assertEqual(thisModule, classModule)
+
 
 class TestJitClassOverloads(MemoryLeakMixin, TestCase):
 


### PR DESCRIPTION
A normal Python class has a `__module__` attribute which tells what module it comes from. However, when a class is decorated with `@jitclass`, this changes to be `numba.experimental.jitclass.base`, and so the class looks like it has been imported from some other module.

Documentation tools such as the Python `help()` function, or Sphinx, will omit classes which are not from the module being processed, and so documentation for `@jitclass` classes is skipped. 

The proposed change carries the module name over from the Python class to the `@jitclass` version, and thus allows such documentation tools to include them. This will also be consistent with functions decorated with `@jit`, as they keep their module name unchanged. 

I ran the full test suite with this change, using pre-built binaries (0.56.3)  from conda, and it does not seem to affect anything. I was unable to set up a full test environment using conda (apparently because of glibc version conflicts??), so could not test with the current HEAD, but am hopeful that nothing else will be affected. 

It was not clear if this change would be worth an explicit test, but happy to try and think of something if reviewers think it important to do so. 

