### PR TITLE
Make external compiler discovery lazy in the test suite.

### DIFF
--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -44,9 +44,13 @@ def _gentmpfile(suffix):
         else:
             os.rmdir(tmpdir)
 
-def _check_external_compiler():
-    # see if the external compiler bound in numpy.distutil is present
-    # and working
+
+@functools.lru_cache
+def external_compiler_works():
+    """
+    Returns True if the "external compiler" bound in numpy.distutil is present
+    and working, False otherwise.
+    """
     compiler = new_compiler()
     customize_compiler(compiler)
     for suffix in ['.c', '.cxx']:
@@ -63,10 +67,6 @@ def _check_external_compiler():
             return False
     return True
 
-# boolean on whether the externally provided compiler is present and
-# functioning correctly
-_external_compiler_ok = _check_external_compiler()
-
 
 class _DummyExtension(object):
     libraries = []
@@ -75,7 +75,7 @@ class _DummyExtension(object):
 class Toolchain(object):
 
     def __init__(self):
-        if not _external_compiler_ok:
+        if not external_compiler_works():
             self._raise_external_compiler_error()
 
         # Need to import it here since setuptools may monkeypatch it

--- a/numba/pycc/platform.py
+++ b/numba/pycc/platform.py
@@ -45,7 +45,7 @@ def _gentmpfile(suffix):
             os.rmdir(tmpdir)
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=1)
 def external_compiler_works():
     """
     Returns True if the "external compiler" bound in numpy.distutil is present

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -39,8 +39,8 @@ from numba.core.untyped_passes import PreserveIR
 import unittest
 from numba.core.runtime import rtsys
 from numba.np import numpy_support
-from numba.pycc.platform import _external_compiler_ok
 from numba.core.runtime import _nrt_python as _nrt
+from numba.pycc.platform import external_compiler_works
 
 
 try:
@@ -155,12 +155,6 @@ needs_blas = unittest.skipUnless(has_blas, "BLAS needs SciPy 1.0+")
 # with this environment variable set.
 _exec_cond = os.environ.get('SUBPROC_TEST', None) == '1'
 needs_subprocess = unittest.skipUnless(_exec_cond, "needs subprocess harness")
-
-
-# decorate for test needs external compilers
-needs_external_compilers = unittest.skipIf(not _external_compiler_ok,
-                                           ('Compatible external compilers are '
-                                            'missing'))
 
 
 def ignore_internal_warnings():
@@ -616,6 +610,16 @@ class TestCase(unittest.TestCase):
             return wrapper(maybefunc)
         else:
             return wrapper
+
+    def skip_if_no_external_compiler(self):
+        """
+        Call this to ensure the test is skipped if no suitable external compiler
+        is found. This is a method on the TestCase opposed to a stand-alone
+        decorator so as to make it "lazy" via runtime evaluation opposed to
+        running at test-discovery time.
+        """
+        if not external_compiler_works():
+            self.skipTest("No suitable external compiler was found.")
 
 
 class SerialMixin(object):

--- a/numba/tests/test_parallel_backend.py
+++ b/numba/tests/test_parallel_backend.py
@@ -18,8 +18,7 @@ import numpy as np
 
 from numba import jit, vectorize, guvectorize, set_num_threads
 from numba.tests.support import (temp_directory, override_config, TestCase, tag,
-                                 skip_parfors_unsupported, linux_only,
-                                 needs_external_compilers)
+                                 skip_parfors_unsupported, linux_only)
 
 import queue as t_queue
 from numba.testing.main import _TIMEOUT as _RUNNER_TIMEOUT
@@ -1064,9 +1063,11 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
             print("OUT:", out)
             print("ERR:", err)
 
-    @needs_external_compilers
     @linux_only # fork required.
     def test_lifetime_of_task_scheduler_handle(self):
+
+        self.skip_if_no_external_compiler() # external compiler needed
+
         # See PR #7280 for context.
         BROKEN_COMPILERS = 'SKIP: COMPILATION FAILED'
         runme = """if 1:
@@ -1074,11 +1075,11 @@ class TestTBBSpecificIssues(ThreadLayerTestHelper):
             import sys
             import multiprocessing as mp
             from tempfile import TemporaryDirectory, NamedTemporaryFile
-            from numba.pycc.platform import Toolchain, _external_compiler_ok
+            from numba.pycc.platform import Toolchain, external_compiler_works
             from numba import njit, prange, threading_layer
             import faulthandler
             faulthandler.enable()
-            if not _external_compiler_ok:
+            if not external_compiler_works():
                 raise AssertionError('External compilers are not found.')
             with TemporaryDirectory() as tmpdir:
                 with NamedTemporaryFile(dir=tmpdir) as tmpfile:

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -261,7 +261,6 @@ class TestCC(BasePYCCTest):
 
 class TestDistutilsSupport(TestCase):
 
-
     def setUp(self):
         super().setUp()
         self.skip_if_no_external_compiler() # external compiler needed

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -15,10 +15,10 @@ import llvmlite.binding as ll
 from numba.core import utils
 from numba.pycc.decorators import clear_export_registry
 from numba.pycc.platform import find_shared_ending, find_pyext_ending
-from numba.pycc.platform import _external_compiler_ok
+from numba.pycc.platform import external_compiler_works
 
 from numba.tests.support import (TestCase, tag, import_dynamic, temp_directory,
-                                 has_blas, needs_external_compilers)
+                                 has_blas)
 import unittest
 
 
@@ -48,12 +48,12 @@ class TestCompilerChecks(TestCase):
     @_windows_only
     def test_windows_compiler_validity(self):
         # When inside conda-build VSINSTALLDIR should be set and windows should
-        # have a valid compiler available, `_external_compiler_ok` should  agree
-        # with this. If this is not the case then error out to alert devs.
+        # have a valid compiler available, `external_compiler_works()` should
+        # agree with this. If this is not the case then error out to alert devs.
         is_running_conda_build = os.environ.get('CONDA_BUILD', None) is not None
         if is_running_conda_build:
             if os.environ.get('VSINSTALLDIR', None) is not None:
-                self.assertTrue(_external_compiler_ok)
+                self.assertTrue(external_compiler_works())
 
 
 class BasePYCCTest(TestCase):
@@ -84,11 +84,11 @@ class BasePYCCTest(TestCase):
             sys.modules.pop(name, None)
 
 
-@needs_external_compilers
 class TestCC(BasePYCCTest):
 
     def setUp(self):
         super(TestCC, self).setUp()
+        self.skip_if_no_external_compiler() # external compiler needed
         from numba.tests import compile_with_pycc
         self._test_module = compile_with_pycc
         imp.reload(self._test_module)
@@ -259,10 +259,13 @@ class TestCC(BasePYCCTest):
             self.assertPreciseEqual(got, expect)
 
 
-@needs_external_compilers
 class TestDistutilsSupport(TestCase):
 
+
     def setUp(self):
+        super().setUp()
+        self.skip_if_no_external_compiler() # external compiler needed
+
         unset_macosx_deployment_target()
 
         # Copy the test project into a temp directory to avoid


### PR DESCRIPTION
This aims to make it so that external compilers are only probed when absolutely necessary and that the result of the probe is cached. This should speed up initialisation of the testing framework and consequently speed up tests running in subprocesses.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
