### PR TITLE
Add support for `.nbytes` accessor for numpy arrays

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -235,6 +235,7 @@ The following attributes of NumPy arrays are supported:
 * :attr:`~numpy.ndarray.flags`
 * :attr:`~numpy.ndarray.flat`
 * :attr:`~numpy.ndarray.itemsize`
+* :attr:`~numpy.ndarray.nbytes`
 * :attr:`~numpy.ndarray.ndim`
 * :attr:`~numpy.ndarray.shape`
 * :attr:`~numpy.ndarray.size`

--- a/numba/core/typing/arraydecl.py
+++ b/numba/core/typing/arraydecl.py
@@ -248,6 +248,9 @@ class ArrayAttribute(AttributeTemplate):
     def resolve_dtype(self, ary):
         return types.DType(ary.dtype)
 
+    def resolve_nbytes(self, ary):
+        return types.intp
+
     def resolve_itemsize(self, ary):
         return types.intp
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2644,6 +2644,7 @@ def array_itemsize(context, builder, typ, value):
     return impl_ret_untracked(context, builder, typ, res)
 
 
+@lower_getattr(types.Array, "nbytes")
 @lower_getattr(types.MemoryView, "nbytes")
 def array_nbytes(context, builder, typ, value):
     """

--- a/numba/tests/test_array_attr.py
+++ b/numba/tests/test_array_attr.py
@@ -23,6 +23,10 @@ def array_itemsize(a):
     return a.itemsize
 
 
+def array_nbytes(a):
+    return a.nbytes
+
+
 def array_shape(a, i):
     return a.shape[i]
 
@@ -52,6 +56,8 @@ def array_flags_f_contiguous(a):
 def nested_array_itemsize(a):
     return a.f.itemsize
 
+def nested_array_nbytes(a):
+    return a.f.nbytes
 
 def nested_array_shape(a):
     return a.f.shape
@@ -144,6 +150,9 @@ class TestArrayAttr(MemoryLeakMixin, TestCase):
     def test_itemsize(self):
         self.check_unary_with_arrays(array_itemsize)
 
+    def test_nbytes(self):
+        self.check_unary_with_arrays(array_nbytes)
+
     def test_dtype(self):
         pyfunc = array_dtype
         self.check_unary(pyfunc, self.a)
@@ -194,6 +203,12 @@ class TestNestedArrayAttr(MemoryLeakMixin, unittest.TestCase):
 
     def test_ndim(self):
         pyfunc = nested_array_ndim
+        cfunc = self.get_cfunc(pyfunc)
+
+        self.assertEqual(pyfunc(self.a), cfunc(self.a))
+
+    def test_nbytes(self):
+        pyfunc = nested_array_nbytes
         cfunc = self.get_cfunc(pyfunc)
 
         self.assertEqual(pyfunc(self.a), cfunc(self.a))


### PR DESCRIPTION
The `arr.nbytes` accessor is the same as `arr.size * arr.itemsize`, so it's fairly easy to add in. I haven't figured out how to actually build Numba locally yet, so I only tested this by manually editing an installed conda build.