### PR TITLE
Add `.tobytes()` method for Numpy arrays

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -337,6 +337,7 @@ The following methods of NumPy arrays are supported:
     inputs), while NumPy would use a 32-bit accumulator in those cases.
 
 
+* :meth:`~numpy.ndarray.tobytes` (without arguments)
 * :meth:`~numpy.ndarray.transpose`
 * :meth:`~numpy.ndarray.view` (only the 1-argument form)
 * :meth:`~numpy.ndarray.__contains__`

--- a/numba/cpython/randomimpl.py
+++ b/numba/cpython/randomimpl.py
@@ -12,11 +12,9 @@ from llvmlite import ir
 
 from numba.core.cgutils import is_nonelike
 from numba.core.extending import intrinsic, overload, register_jitable
-from numba.core.imputils import (Registry, impl_ret_untracked,
-                                    impl_ret_new_ref)
+from numba.core.imputils import Registry
 from numba.core.typing import signature
 from numba.core import types, cgutils
-from numba.np import arrayobj
 from numba.core.errors import NumbaTypeError
 
 

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -31,7 +31,7 @@ from numba.core.extending import (register_jitable, overload, overload_method,
                                   intrinsic)
 from numba.misc import quicksort, mergesort
 from numba.cpython import slicing
-from numba.cpython.charseq import _make_constant_bytes
+from numba.cpython.charseq import _make_constant_bytes, bytes_type
 from numba.cpython.unsafe.tuple import tuple_setitem, build_full_slice_tuple
 from numba.core.extending import overload_classmethod
 from numba.core.typing.npydecl import (parse_dtype as ty_parse_dtype,
@@ -4843,6 +4843,26 @@ def array_astype(context, builder, sig, args):
         store_item(context, builder, rettype, item, dest_ptr)
 
     return impl_ret_new_ref(context, builder, sig.return_type, ret._getvalue())
+
+
+@intrinsic
+def array_tobytes(typingctx, b):
+    assert isinstance(b, types.Array)
+    sig = bytes_type(b)
+
+    def codegen(context, builder, sig, args):
+        [arr] = args
+        return array_to_bytes(context, builder, b, bytes_type, arr)
+    return sig, codegen
+
+
+@overload(bytes)
+@overload_method(types.Array, "tobytes")
+def impl_array_tobytes(arr):
+    if isinstance(arr, types.Array):
+        def impl(arr):
+            return array_tobytes(arr)
+        return impl
 
 
 @intrinsic

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -4846,7 +4846,7 @@ def array_astype(context, builder, sig, args):
 
 
 @intrinsic
-def array_tobytes(typingctx, b):
+def _array_tobytes_intrinsic(typingctx, b):
     assert isinstance(b, types.Array)
     sig = bytes_type(b)
 
@@ -4856,12 +4856,11 @@ def array_tobytes(typingctx, b):
     return sig, codegen
 
 
-@overload(bytes)
 @overload_method(types.Array, "tobytes")
 def impl_array_tobytes(arr):
     if isinstance(arr, types.Array):
         def impl(arr):
-            return array_tobytes(arr)
+            return _array_tobytes_intrinsic(arr)
         return impl
 
 

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -169,6 +169,12 @@ def np_frombuffer_allocated_dtype(shape):
 def identity_usecase(a, b):
     return (a is b), (a is not b)
 
+def bytes_cast(a):
+    return bytes(a)
+
+def array_tobytes(a):
+    return a.tobytes()
+
 def array_nonzero(a):
     return a.nonzero()
 
@@ -599,6 +605,18 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         self.assertIn('array.astype if dtype is a string it must be constant',
                       str(raises.exception))
 
+    def test_array_tobytes(self):
+        self.check_layout_dependent_func(
+            array_tobytes,
+            memoryaddr=lambda x: np.frombuffer(x, dtype=np.uint8).ctypes.data,
+        )
+
+    def test_bytecast_array(self):
+        self.check_layout_dependent_func(
+            bytes_cast,
+            memoryaddr=lambda x: np.frombuffer(x, dtype=np.uint8).ctypes.data,
+        )
+
     def check_np_frombuffer(self, pyfunc):
         def run(buf):
             cres = self.ccache.compile(pyfunc, (typeof(buf),))
@@ -666,15 +684,19 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
         with self.assertRaisesRegex(TypingError, msg) as raises:
             func(None)
 
-    def check_layout_dependent_func(self, pyfunc, fac=np.arange):
-        def is_same(a, b):
-            return a.ctypes.data == b.ctypes.data
+    def check_layout_dependent_func(
+        self, pyfunc, fac=np.arange, memoryaddr=lambda x: x.ctypes.data
+    ):
         def check_arr(arr):
             cres = compile_isolated(pyfunc, (typeof(arr),))
             expected = pyfunc(arr)
             got = cres.entry_point(arr)
             self.assertPreciseEqual(expected, got)
-            self.assertEqual(is_same(expected, arr), is_same(got, arr))
+            self.assertEqual(
+                arr.ctypes.data == memoryaddr(expected),
+                arr.ctypes.data == memoryaddr(got),
+            )
+
         arr = fac(24)
         check_arr(arr)
         check_arr(arr.reshape((3, 8)))

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -169,9 +169,6 @@ def np_frombuffer_allocated_dtype(shape):
 def identity_usecase(a, b):
     return (a is b), (a is not b)
 
-def bytes_cast(a):
-    return bytes(a)
-
 def array_tobytes(a):
     return a.tobytes()
 
@@ -608,12 +605,6 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
     def test_array_tobytes(self):
         self.check_layout_dependent_func(
             array_tobytes,
-            memoryaddr=lambda x: np.frombuffer(x, dtype=np.uint8).ctypes.data,
-        )
-
-    def test_bytecast_array(self):
-        self.check_layout_dependent_func(
-            bytes_cast,
             memoryaddr=lambda x: np.frombuffer(x, dtype=np.uint8).ctypes.data,
         )
 


### PR DESCRIPTION
This adds support for the `tobytes` method for NumPy arrays. This makes it easier to hash numpy arrays, so we can use short arrays as dictionary keys (which is useful for certain structured arrays).

I tried my best to figure out how everything fits together, but feel free to tell me if I did something incorrectly! In particular, I'm still confused about two things:
- the `array_tobytes` intrinsic seems unnecessary, but I couldn't figure out how to just call the casting code from the `@lower_cast` `array_to_bytes` in my overload. Is there some way to do that, or some other way I should structure the code?
- I'm a little concerned about the speed. In particular, for c-contiguous arrays, somehow I end up being 2-3 times slower than the Numpy's implementation, even for large arrays (e.g. `np.random.rand(50000, 2, 3)`). I can't see how to optimize it any further (presumably memcpy should be as fast as possible?), so not sure how where this slowdown occurs.

Closes #5149