### PR TITLE
Updates for Python 3.8 baseline/Python 3.11 migration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -160,7 +160,6 @@ exclude =
     numba/tests/test_indexing.py
     numba/tests/test_pycc.py
     numba/tests/annotation_usecases.py
-    numba/tests/test_extended_arg.py
     numba/tests/test_alignment.py
     numba/tests/test_multi3.py
     numba/tests/test_overlap.py

--- a/numba/_devicearray.cpp
+++ b/numba/_devicearray.cpp
@@ -41,10 +41,10 @@ PyTypeObject DeviceArrayType = {
     sizeof(DeviceArray),                         /* tp_basicsize */
     0,                                           /* tp_itemsize */
     0,                                           /* tp_dealloc */
-    0,                                           /* tp_print */
+    0,                                           /* tp_vectorcall_offset */
     0,                                           /* tp_getattr */
     0,                                           /* tp_setattr */
-    0,                                           /* tp_compare */
+    0,                                           /* tp_as_async */
     0,                                           /* tp_repr */
     0,                                           /* tp_as_number */
     0,                                           /* tp_as_sequence */
@@ -85,10 +85,31 @@ PyTypeObject DeviceArrayType = {
     0,                                           /* tp_del */
     0,                                           /* tp_version_tag */
     0,                                           /* tp_finalize */
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 8
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
     0,                                           /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
     0,                                           /* tp_print */
 #endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 /* CUDA device array C API */

--- a/numba/_dispatcher.cpp
+++ b/numba/_dispatcher.cpp
@@ -1112,10 +1112,10 @@ static PyTypeObject DispatcherType = {
     sizeof(Dispatcher),                          /* tp_basicsize */
     0,                                           /* tp_itemsize */
     (destructor)Dispatcher_dealloc,              /* tp_dealloc */
-    0,                                           /* tp_print */
+    0,                                           /* tp_vectorcall_offset */
     0,                                           /* tp_getattr */
     0,                                           /* tp_setattr */
-    0,                                           /* tp_compare */
+    0,                                           /* tp_as_async */
     0,                                           /* tp_repr */
     0,                                           /* tp_as_number */
     0,                                           /* tp_as_sequence */
@@ -1155,11 +1155,31 @@ static PyTypeObject DispatcherType = {
     0,                                           /* tp_del */
     0,                                           /* tp_version_tag */
     0,                                           /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
     0,                                           /* tp_vectorcall */
-/* Python 3.8 has two slots. */
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
     0,                                           /* tp_print */
 #endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 

--- a/numba/_dynfunc.c
+++ b/numba/_dynfunc.c
@@ -88,58 +88,78 @@ env_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
 static PyTypeObject EnvironmentType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_dynfunc.Environment",   /*tp_name*/
-    sizeof(EnvironmentObject), /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    (destructor) env_dealloc,  /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-    0,                         /* tp_doc */
-    (traverseproc) env_traverse, /* tp_traverse */
-    (inquiry) env_clear,       /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    0,                         /* tp_methods */
-    env_members,               /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    0,                         /* tp_init */
-    0,                         /* tp_alloc */
-    env_new,                   /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
-    0,                         /* tp_version_tag */
-    0,                         /* tp_finalize */
-    0,                         /* tp_vectorcall */
-/* Python 3.8 has two slots. */
+    "_dynfunc.Environment",                  /* tp_name */
+    sizeof(EnvironmentObject),               /* tp_basicsize */
+    0,                                       /* tp_itemsize */
+    (destructor) env_dealloc,                /* tp_dealloc */
+    0,                                       /* tp_vectorcall_offset */
+    0,                                       /* tp_getattr*/
+    0,                                       /* tp_setattr */
+    0,                                       /* tp_as_async */
+    0,                                       /* tp_repr */
+    0,                                       /* tp_as_number */
+    0,                                       /* tp_as_sequence */
+    0,                                       /* tp_as_mapping */
+    0,                                       /* tp_hash */
+    0,                                       /* tp_call */
+    0,                                       /* tp_str */
+    0,                                       /* tp_getattro */
+    0,                                       /* tp_setattro */
+    0,                                       /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+    0,                                       /* tp_doc */
+    (traverseproc) env_traverse,             /* tp_traverse */
+    (inquiry) env_clear,                     /* tp_clear */
+    0,                                       /* tp_richcompare */
+    0,                                       /* tp_weaklistoffset */
+    0,                                       /* tp_iter */
+    0,                                       /* tp_iternext */
+    0,                                       /* tp_methods */
+    env_members,                             /* tp_members */
+    0,                                       /* tp_getset */
+    0,                                       /* tp_base */
+    0,                                       /* tp_dict */
+    0,                                       /* tp_descr_get */
+    0,                                       /* tp_descr_set */
+    0,                                       /* tp_dictoffset */
+    0,                                       /* tp_init */
+    0,                                       /* tp_alloc */
+    env_new,                                 /* tp_new */
+    0,                                       /* tp_free */
+    0,                                       /* tp_is_gc */
+    0,                                       /* tp_bases */
+    0,                                       /* tp_mro */
+    0,                                       /* tp_cache */
+    0,                                       /* tp_subclasses */
+    0,                                       /* tp_weaklist */
+    0,                                       /* tp_del */
+    0,                                       /* tp_version_tag */
+    0,                                       /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                       /* tp_vectorcall */
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
-    0,                         /* tp_print */
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                       /* tp_print */
 #endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 /* A closure object is created for each call to make_function(), and stored
@@ -194,58 +214,78 @@ closure_dealloc(ClosureObject *clo)
 
 static PyTypeObject ClosureType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_dynfunc._Closure",    /*tp_name*/
-    sizeof(ClosureObject),     /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    (destructor) closure_dealloc, /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
-    0,                         /* tp_doc */
-    (traverseproc) closure_traverse, /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    offsetof(ClosureObject, weakreflist), /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    0,                         /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    0,                         /* tp_init */
-    0,                         /* tp_alloc */
-    0,                         /* tp_new */
-    0,                         /* tp_free */
-    0,                         /* tp_is_gc */
-    0,                         /* tp_bases */
-    0,                         /* tp_mro */
-    0,                         /* tp_cache */
-    0,                         /* tp_subclasses */
-    0,                         /* tp_weaklist */
-    0,                         /* tp_del */
-    0,                         /* tp_version_tag */
-    0,                         /* tp_finalize */
-    0,                         /* tp_vectorcall */
-/* Python 3.8 has two slots. */
+    "_dynfunc._Closure",                     /* tp_name */
+    sizeof(ClosureObject),                   /* tp_basicsize */
+    0,                                       /* tp_itemsize */
+    (destructor) closure_dealloc,            /* tp_dealloc */
+    0,                                       /* tp_vectorcall_offset */
+    0,                                       /* tp_getattr */
+    0,                                       /* tp_setattr */
+    0,                                       /* tp_as_async */
+    0,                                       /* tp_repr */
+    0,                                       /* tp_as_number */
+    0,                                       /* tp_as_sequence */
+    0,                                       /* tp_as_mapping */
+    0,                                       /* tp_hash */
+    0,                                       /* tp_call */
+    0,                                       /* tp_str */
+    0,                                       /* tp_getattro */
+    0,                                       /* tp_setattro */
+    0,                                       /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+    0,                                       /* tp_doc */
+    (traverseproc) closure_traverse,         /* tp_traverse */
+    0,                                       /* tp_clear */
+    0,                                       /* tp_richcompare */
+    offsetof(ClosureObject, weakreflist),    /* tp_weaklistoffset */
+    0,                                       /* tp_iter */
+    0,                                       /* tp_iternext */
+    0,                                       /* tp_methods */
+    0,                                       /* tp_members */
+    0,                                       /* tp_getset */
+    0,                                       /* tp_base */
+    0,                                       /* tp_dict */
+    0,                                       /* tp_descr_get */
+    0,                                       /* tp_descr_set */
+    0,                                       /* tp_dictoffset */
+    0,                                       /* tp_init */
+    0,                                       /* tp_alloc */
+    0,                                       /* tp_new */
+    0,                                       /* tp_free */
+    0,                                       /* tp_is_gc */
+    0,                                       /* tp_bases */
+    0,                                       /* tp_mro */
+    0,                                       /* tp_cache */
+    0,                                       /* tp_subclasses */
+    0,                                       /* tp_weaklist */
+    0,                                       /* tp_del */
+    0,                                       /* tp_version_tag */
+    0,                                       /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                       /* tp_vectorcall */
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
-    0,                         /* tp_print */
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                       /* tp_print */
 #endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 
@@ -404,10 +444,10 @@ static PyTypeObject GeneratorType = {
     offsetof(GeneratorObject, state),         /* tp_basicsize*/
     1,                                        /* tp_itemsize*/
     (destructor) generator_dealloc,           /* tp_dealloc*/
-    0,                                        /* tp_print*/
+    0,                                        /* tp_vectorcall_offset*/
     0,                                        /* tp_getattr*/
     0,                                        /* tp_setattr*/
-    0,                                        /* tp_compare*/
+    0,                                        /* tp_as_async*/
     0,                                        /* tp_repr*/
     0,                                        /* tp_as_number*/
     0,                                        /* tp_as_sequence*/
@@ -419,7 +459,7 @@ static PyTypeObject GeneratorType = {
     0,                                        /* tp_setattro*/
     0,                                        /* tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC
-                       | Py_TPFLAGS_BASETYPE,  /* tp_flags*/
+                       | Py_TPFLAGS_BASETYPE, /* tp_flags*/
     0,                                        /* tp_doc */
     (traverseproc) generator_traverse,        /* tp_traverse */
     (inquiry) generator_clear,                /* tp_clear */
@@ -448,11 +488,31 @@ static PyTypeObject GeneratorType = {
     0,                                        /* tp_del */
     0,                                        /* tp_version_tag */
     0,                                        /* tp_finalize */
-    0,                         /* tp_vectorcall */
-/* Python 3.8 has two slots. */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                        /* tp_vectorcall */
 #if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
-    0,                         /* tp_print */
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                        /* tp_print */
 #endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 /* Dynamically create a new generator object */

--- a/numba/core/runtime/_nrt_python.c
+++ b/numba/core/runtime/_nrt_python.c
@@ -171,25 +171,25 @@ static PyGetSetDef MemInfo_getsets[] = {
 
 static PyTypeObject MemInfoType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_nrt_python._MemInfo",                   /* tp_name*/
-    sizeof(MemInfoObject),                    /* tp_basicsize*/
-    0,                                        /* tp_itemsize*/
-    (destructor)MemInfo_dealloc,              /* tp_dealloc*/
-    0,                                        /* tp_print*/
-    0,                                        /* tp_getattr*/
-    0,                                        /* tp_setattr*/
-    0,                                        /* tp_compare*/
-    0,                                        /* tp_repr*/
-    0,                                        /* tp_as_number*/
-    0,                                        /* tp_as_sequence*/
-    0,                                        /* tp_as_mapping*/
+    "_nrt_python._MemInfo",                   /* tp_name */
+    sizeof(MemInfoObject),                    /* tp_basicsize */
+    0,                                        /* tp_itemsize */
+    (destructor)MemInfo_dealloc,              /* tp_dealloc */
+    0,                                        /* tp_vectorcall_offset */
+    0,                                        /* tp_getattr */
+    0,                                        /* tp_setattr */
+    0,                                        /* tp_as_async */
+    0,                                        /* tp_repr */
+    0,                                        /* tp_as_number */
+    0,                                        /* tp_as_sequence */
+    0,                                        /* tp_as_mapping */
     0,                                        /* tp_hash */
-    0,                                        /* tp_call*/
-    0,                                        /* tp_str*/
-    0,                                        /* tp_getattro*/
-    0,                                        /* tp_setattro*/
-    &MemInfo_bufferProcs,                      /* tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags*/
+    0,                                        /* tp_call */
+    0,                                        /* tp_str */
+    0,                                        /* tp_getattro */
+    0,                                        /* tp_setattro */
+    &MemInfo_bufferProcs,                     /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
     0,                                        /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */
@@ -208,8 +208,42 @@ static PyTypeObject MemInfoType = {
     (initproc)MemInfo_init,                   /* tp_init */
     0,                                        /* tp_alloc */
     0,                                        /* tp_new */
-};
+    0,                                        /* tp_free */
+    0,                                        /* tp_is_gc */
+    0,                                        /* tp_bases */
+    0,                                        /* tp_mro */
+    0,                                        /* tp_cache */
+    0,                                        /* tp_subclasses */
+    0,                                        /* tp_weaklist */
+    0,                                        /* tp_del */
+    0,                                        /* tp_version_tag */
+    0,                                        /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                        /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                        /* tp_print */
+#endif
 
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
+};
 
 /*
 Return a MemInfo* as a MemInfoObject*

--- a/numba/experimental/jitclass/_box.c
+++ b/numba/experimental/jitclass/_box.c
@@ -52,43 +52,78 @@ static const char Box_doc[] = "A box for numba created jit-class instance";
 
 static PyTypeObject BoxType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_box.Box",                /*tp_name*/
-    sizeof(BoxObject),         /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    (destructor)box_dealloc,   /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-    Box_doc,                   /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    0,                         /* tp_methods */
-    0,                         /* tp_members */
-    0,                         /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)Box_init,        /* tp_init */
-    0,                         /* tp_alloc */
-    PyType_GenericNew,         /* tp_new */
+    "_box.Box",                               /* tp_name */
+    sizeof(BoxObject),                        /* tp_basicsize */
+    0,                                        /* tp_itemsize */
+    (destructor)box_dealloc,                  /* tp_dealloc */
+    0,                                        /* tp_vectorcall_offset */
+    0,                                        /* tp_getattr */
+    0,                                        /* tp_setattr */
+    0,                                        /* tp_as_async */
+    0,                                        /* tp_repr */
+    0,                                        /* tp_as_number */
+    0,                                        /* tp_as_sequence */
+    0,                                        /* tp_as_mapping */
+    0,                                        /* tp_hash */
+    0,                                        /* tp_call */
+    0,                                        /* tp_str */
+    0,                                        /* tp_getattro */
+    0,                                        /* tp_setattro */
+    0,                                        /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
+    Box_doc,                                  /* tp_doc */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    0,                                        /* tp_iter */
+    0,                                        /* tp_iternext */
+    0,                                        /* tp_methods */
+    0,                                        /* tp_members */
+    0,                                        /* tp_getset */
+    0,                                        /* tp_base */
+    0,                                        /* tp_dict */
+    0,                                        /* tp_descr_get */
+    0,                                        /* tp_descr_set */
+    0,                                        /* tp_dictoffset */
+    (initproc)Box_init,                       /* tp_init */
+    0,                                        /* tp_alloc */
+    PyType_GenericNew,                        /* tp_new */
+    0,                                        /* tp_free */
+    0,                                        /* tp_is_gc */
+    0,                                        /* tp_bases */
+    0,                                        /* tp_mro */
+    0,                                        /* tp_cache */
+    0,                                        /* tp_subclasses */
+    0,                                        /* tp_weaklist */
+    0,                                        /* tp_del */
+    0,                                        /* tp_version_tag */
+    0,                                        /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                        /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                        /* tp_print */
+#endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 

--- a/numba/mviewbuf.c
+++ b/numba/mviewbuf.c
@@ -286,28 +286,26 @@ static PyBufferProcs MemAlloc_as_buffer = {
 
 static PyTypeObject MemAllocType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "mviewbuf.MemAlloc",                            /* tp_name */
-    sizeof(MemAllocObject),                   /* tp_basicsize */
+    "mviewbuf.MemAlloc",                        /* tp_name */
+    sizeof(MemAllocObject),                     /* tp_basicsize */
     0,                                          /* tp_itemsize */
-    /* methods */
-    0,                  /* tp_dealloc */
-    0,                            /* tp_vectorcall_offset */
+    0,                                          /* tp_dealloc */
+    0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    0,                         /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    &MemAlloc_as_buffer,        /*tp_as_buffer*/
-    (Py_TPFLAGS_DEFAULT| Py_TPFLAGS_BASETYPE),                    /* tp_flags */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    0,                                          /* tp_getattro */
+    0,                                          /* tp_setattro */
+    &MemAlloc_as_buffer,                        /* tp_as_buffer */
+    (Py_TPFLAGS_DEFAULT| Py_TPFLAGS_BASETYPE),  /* tp_flags */
     0,                                          /* tp_doc */
-
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -334,6 +332,32 @@ static PyTypeObject MemAllocType = {
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
     0,                                          /* tp_version_tag */
+    0,                                          /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                          /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                          /* tp_print */
+#endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 

--- a/numba/np/ufunc/_internal.c
+++ b/numba/np/ufunc/_internal.c
@@ -45,16 +45,11 @@ PyTypeObject PyUFuncCleaner_Type = {
     "numba._UFuncCleaner",                      /* tp_name*/
     sizeof(PyUFuncCleaner),                     /* tp_basicsize*/
     0,                                          /* tp_itemsize */
-    /* methods */
     (destructor) cleaner_dealloc,               /* tp_dealloc */
-    0,                                          /* tp_print */
+    0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-#if defined(NPY_PY3K)
-    0,                                          /* tp_reserved */
-#else
-    0,                                          /* tp_compare */
-#endif
+    0,                                          /* tp_as_async */
     0,                                          /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -93,6 +88,32 @@ PyTypeObject PyUFuncCleaner_Type = {
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
     0,                                          /* tp_version_tag */
+    0,                                          /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                          /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                          /* tp_print */
+#endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 /* ______________________________________________________________________
@@ -695,12 +716,11 @@ PyTypeObject PyDUFunc_Type = {
     "numba._DUFunc",                            /* tp_name*/
     sizeof(PyDUFuncObject),                     /* tp_basicsize*/
     0,                                          /* tp_itemsize */
-    /* methods */
     (destructor) dufunc_dealloc,                /* tp_dealloc */
-    0,                                          /* tp_print */
+    0,                                          /* tp_vectorcall_offset */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
-    0,                                          /* tp_compare/tp_reserved */
+    0,                                          /* tp_as_async */
     (reprfunc) dufunc_repr,                     /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
@@ -739,6 +759,32 @@ PyTypeObject PyDUFunc_Type = {
     0,                                          /* tp_weaklist */
     0,                                          /* tp_del */
     0,                                          /* tp_version_tag */
+    0,                                          /* tp_finalize */
+/* The docs suggest Python 3.8 has no tp_vectorcall
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Doc/c-api/typeobj.rst?plain=1#L146
+ * but the header has it:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L257
+ */
+    0,                                          /* tp_vectorcall */
+#if (PY_MAJOR_VERSION == 3) && (PY_MINOR_VERSION == 8)
+/* This is Python 3.8 only.
+ * See: https://github.com/python/cpython/blob/3.8/Include/cpython/object.h
+ * there's a tp_print preserved for backwards compatibility. xref:
+ * https://github.com/python/cpython/blob/d917cfe4051d45b2b755c726c096ecfcc4869ceb/Include/cpython/object.h#L260
+ */
+    0,                                          /* tp_print */
+#endif
+
+/* WARNING: Do not remove this, only modify it! It is a version guard to
+ * act as a reminder to update this struct on Python version update! */
+#if (PY_MAJOR_VERSION == 3)
+#if ! ((PY_MINOR_VERSION == 8) || (PY_MINOR_VERSION == 9) || (PY_MINOR_VERSION == 10))
+#error "Python minor version is not supported."
+#endif
+#else
+#error "Python major version is not supported."
+#endif
+/* END WARNING*/
 };
 
 /* ______________________________________________________________________

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -671,25 +671,6 @@ def compile_function(name, code, globs):
     eval(co, globs, ns)
     return ns[name]
 
-def tweak_code(func, codestring=None, consts=None):
-    """
-    Tweak the code object of the given function by replacing its
-    *codestring* (a bytes object) and *consts* tuple, optionally.
-    """
-    co = func.__code__
-    tp = type(co)
-    if codestring is None:
-        codestring = co.co_code
-    if consts is None:
-        consts = co.co_consts
-    new_code = tp(co.co_argcount, co.co_posonlyargcount,
-                  co.co_kwonlyargcount, co.co_nlocals,
-                  co.co_stacksize, co.co_flags, codestring,
-                  consts, co.co_names, co.co_varnames,
-                  co.co_filename, co.co_name, co.co_firstlineno,
-                  co.co_lnotab)
-    func.__code__ = new_code
-
 
 _trashcan_dir = 'numba-tests'
 

--- a/numba/tests/test_analysis.py
+++ b/numba/tests/test_analysis.py
@@ -660,27 +660,8 @@ class TestBranchPrunePredicates(TestBranchPruneBase, SerialMixin):
             co_consts[k] = v
         new_consts = tuple([v for _, v in sorted(co_consts.items())])
 
-        # create new code parts
-        co_args = [pyfunc_code.co_argcount,
-                   pyfunc_code.co_posonlyargcount,
-                   pyfunc_code.co_kwonlyargcount,
-                   pyfunc_code.co_nlocals,
-                   pyfunc_code.co_stacksize,
-                   pyfunc_code.co_flags,
-                   pyfunc_code.co_code,
-                   new_consts,
-                   pyfunc_code.co_names,
-                   pyfunc_code.co_varnames,
-                   pyfunc_code.co_filename,
-                   pyfunc_code.co_name,
-                   pyfunc_code.co_firstlineno,
-                   pyfunc_code.co_lnotab,
-                   pyfunc_code.co_freevars,
-                   pyfunc_code.co_cellvars
-                   ]
-
         # create code object with mutation
-        new_code = pytypes.CodeType(*co_args)
+        new_code = pyfunc_code.replace(co_consts=new_consts)
 
         # get function
         return pytypes.FunctionType(new_code, globals())

--- a/numba/tests/test_extended_arg.py
+++ b/numba/tests/test_extended_arg.py
@@ -2,10 +2,9 @@ import unittest
 
 import dis
 import struct
-import sys
 
 from numba import jit
-from numba.tests.support import TestCase, tweak_code
+from numba.tests.support import TestCase
 
 
 class TestExtendedArg(TestCase):
@@ -27,7 +26,7 @@ class TestExtendedArg(TestCase):
         bytecode_format = "<BB"
         consts = consts + (None,) * bytecode_len + (42,)
         b[:0] = struct.pack(bytecode_format, dis.EXTENDED_ARG, 1)
-        tweak_code(f, codestring=bytes(b), consts=consts)
+        f.__code__ = f.__code__.replace(co_code=bytes(b), co_consts=consts)
         return f
 
     def test_extended_arg_load_const(self):
@@ -35,7 +34,6 @@ class TestExtendedArg(TestCase):
         self.assertPreciseEqual(pyfunc(), 42)
         cfunc = jit(nopython=True)(pyfunc)
         self.assertPreciseEqual(cfunc(), 42)
-
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_ir.py
+++ b/numba/tests/test_ir.py
@@ -432,7 +432,7 @@ class TestIRCompounds(CheckEquality):
             blk = z_ir.blocks[label]
             ref = blk.body[:-1]
             idx = None
-            for i in range(len(ref)):
+            for i in range(len(ref) - 1):
                 # look for two adjacent Del
                 if (isinstance(ref[i], ir.Del) and
                         isinstance(ref[i + 1], ir.Del)):

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -3360,27 +3360,9 @@ class TestPrangeBase(TestParforsBase):
                 new_code[idx] = prange_idx
             new_code = bytes(new_code)
 
-        # create new code parts
-        co_args = [pyfunc_code.co_argcount,
-                   pyfunc_code.co_posonlyargcount,
-                   pyfunc_code.co_kwonlyargcount,
-                   pyfunc_code.co_nlocals,
-                   pyfunc_code.co_stacksize,
-                   pyfunc_code.co_flags,
-                   new_code,
-                   pyfunc_code.co_consts,
-                   prange_names,
-                   pyfunc_code.co_varnames,
-                   pyfunc_code.co_filename,
-                   pyfunc_code.co_name,
-                   pyfunc_code.co_firstlineno,
-                   pyfunc_code.co_lnotab,
-                   pyfunc_code.co_freevars,
-                   pyfunc_code.co_cellvars
-                   ]
-
         # create code object with prange mutation
-        prange_code = pytypes.CodeType(*co_args)
+        prange_code = pyfunc_code.replace(co_code=new_code,
+                                          co_names=prange_names)
 
         # get function
         pfunc = pytypes.FunctionType(prange_code, globals())


### PR DESCRIPTION
This series of patches contains two things
1. Clean-up following removal of Python 3.7/migration of the baseline Python version to 3.8
2. Clean-up with view of minimising the diff against Python 3.11 work, as located on the `py3.11` branch.

Patches do the following:
* Fix `PyTypeObject` structs/initializers with respect to the now supported Python 3.8, 3.9 and 3.10.
* Remove the custom code object manipulation code in favour of `CodeType.replace()` calls (already in the `py3.11` branch).
* Fixes a bug in the loop bound of a test in `test_ir.py` (already in the `py3.11` branch)
* Marks `test_extended_arg.py` as `flake8` compliant (already in the `py3.11` branch).
