### PR TITLE
Enforce that no warnings are raised on listing of tests.

### DIFF
--- a/numba/tests/serialize_usecases.py
+++ b/numba/tests/serialize_usecases.py
@@ -112,3 +112,10 @@ def _get_dyn_func(**jit_args):
 
 dyn_func = _get_dyn_func(nopython=True)
 dyn_func_objmode = _get_dyn_func(forceobj=True)
+
+
+__all__ = ['add_nopython', 'add_nopython_fail', 'add_with_sig',
+           'add_without_sig', 'closure', 'closure_calling_other_closure',
+           'closure_calling_other_function', 'closure_with_globals',
+           'dyn_func', 'dyn_func_objmode', 'generated_add',
+           'get_global_objmode', 'get_renamed_module', 'other_function',]

--- a/numba/tests/test_nested_calls.py
+++ b/numba/tests/test_nested_calls.py
@@ -45,19 +45,21 @@ def argcast_inner(a, b):
 def argcast(a, b):
     return argcast_inner(int32(a), b)
 
-@generated_jit(nopython=True)
-def generated_inner(x, y=5, z=6):
-    if isinstance(x, types.Complex):
-        def impl(x, y, z):
-            return x + y, z
-    else:
-        def impl(x, y, z):
-            return x - y, z
-    return impl
+def gen_call_generated_case():
+    @generated_jit(nopython=True)
+    def generated_inner(x, y=5, z=6):
+        if isinstance(x, types.Complex):
+            def impl(x, y, z):
+                return x + y, z
+        else:
+            def impl(x, y, z):
+                return x - y, z
+        return impl
 
-def call_generated(a, b):
-    return generated_inner(a, z=b)
+    def call_generated(a, b):
+        return generated_inner(a, z=b)
 
+    return call_generated
 
 class TestNestedCall(TestCase):
 
@@ -137,7 +139,8 @@ class TestNestedCall(TestCase):
         """
         Test a nested function call to a generated jit function.
         """
-        cfunc = jit(nopython=True)(call_generated)
+        func = gen_call_generated_case()
+        cfunc = jit(nopython=True)(func)
         self.assertPreciseEqual(cfunc(1, 2), (-4, 2))
         self.assertPreciseEqual(cfunc(1j, 2), (1j + 5, 2))
 

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -169,6 +169,16 @@ class TestCase(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             self.get_testsuite_listing(['-g=ancest'], subp_kwargs=subp_kwargs)
 
+    def test_no_warnings_on_listing(self):
+        # Checks that the equivalent of ./runtests -l does not produce warnings
+        code = 'from numba.testing._runtests import _main; _main(["-l"])'
+        # See: https://github.com/numba/numba/issues/6831
+        # ignore bug in setuptools/packaging causing a deprecation warning
+        flags = ["-Werror", "-Wignore::DeprecationWarning:packaging.version:",
+                 "-Wignore::DeprecationWarning:numpy.distutils.misc_util:"]
+        cmd = [sys.executable, *flags, '-c', code]
+        subprocess.check_output(cmd)
+
     @unittest.skipUnless(has_pyyaml, "Requires pyyaml")
     def test_azure_config(self):
         from yaml import Loader

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -12,10 +12,17 @@ from numba.core.errors import TypingError
 from numba.tests.support import TestCase
 from numba.core.target_extension import resolve_dispatcher_from_str
 from numba.cloudpickle import dumps, loads
-from .serialize_usecases import *
 
 
 class TestDispatcherPickling(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        # delay import of these so as to not trigger e.g. deprecation warnings
+        # present on Numba decorator APIs on import.
+        import numba.tests.serialize_usecases as ucs
+        g = globals()
+        g.update({x: getattr(ucs, x) for x in ucs.__all__})
 
     def run_with_protocols(self, meth, *args, **kwargs):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):


### PR DESCRIPTION
As title. This is minor clean up to ensure that there are no warnings raised when the tests are listed e.g. via `./runtests.py -l`.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
