### PR TITLE
Make `always_run` test decorator a tag and improve shard tests.

### DIFF
--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -51,12 +51,12 @@ jobs:
     - script: |
         call activate %CONDA_ENV%
         set NUMBA_CAPTURED_ERRORS=new_style
-        echo "Running slice of discovered tests: %TEST_START_INDEX%,None,%TEST_COUNT%"
         python -m numba.runtests -b -v -g -m 2 -- numba.tests
       displayName: 'Test modified test files'
 
     - script: |
         call activate %CONDA_ENV%
         set NUMBA_CAPTURED_ERRORS=new_style
+        echo "Running shard of discovered tests: %TEST_START_INDEX%:%TEST_COUNT%"
         python runtests.py -m 2 -b -j "%TEST_START_INDEX%:%TEST_COUNT%"  --exclude-tags='long_running'  -- numba.tests
-      displayName: 'Test slice of test files'
+      displayName: 'Test shard of test files'

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -53,7 +53,7 @@ jobs:
         call activate %CONDA_ENV%
         set NUMBA_CAPTURED_ERRORS=new_style
         set NUMBA_ENABLE_CUDASIM=1
-        echo "Running slice of discovered tests: %TEST_START_INDEX%,None,%TEST_COUNT%"
+        echo "Running shard of discovered tests: %TEST_START_INDEX%,None,%TEST_COUNT%"
         python -m numba.runtests -b -v -g -m 2 -- numba.tests
       displayName: 'Test modified test files'
 

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -112,7 +112,7 @@ NUMBA_ENABLE_CUDASIM=1 $SEGVCATCH python -m numba.runtests -b -v -g -m $TEST_NPR
 echo "INFO: All discovered tests:"
 python -m numba.runtests -l
 
-# Now run the Numba test suite with slicing
+# Now run the Numba test suite with sharding
 # Note that coverage is run from the checkout dir to match the "source"
 # directive in .coveragerc
 echo "INFO: Running shard of discovered tests: ($TEST_START_INDEX:$TEST_COUNT)"

--- a/numba/testing/__init__.py
+++ b/numba/testing/__init__.py
@@ -59,9 +59,3 @@ def run_tests(argv=None, defaultTest=None, topleveldir=None,
                             verbosity=verbosity,
                             nomultiproc=nomultiproc)
     return prog.result
-
-
-def always_test(cls, value=True):
-    """Makes a test class always run when sharded"""
-    setattr(cls, "always_test", value)
-    return cls

--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -112,7 +112,8 @@ def parse_slice(useslice):
         raise ValueError("Sharding out of range")
     else:
         def decide(test):
-            if getattr(test, "always_test", False):
+            func = getattr(test, test._testMethodName)
+            if "always_test" in getattr(func, 'tags', {}):
                 return True
             return abs(zlib.crc32(test.id().encode('utf-8'))) % count == index
         return decide

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -62,7 +62,10 @@ nrt_flags = Flags()
 nrt_flags.nrt = True
 
 
-tag = testing.make_tag_decorator(['important', 'long_running'])
+tag = testing.make_tag_decorator(['important', 'long_running', 'always_test'])
+
+# Use to mark a test as a test that must always run when sharded
+always_test = tag('always_test')
 
 _32bit = sys.maxsize <= 2 ** 32
 is_parfors_unsupported = _32bit

--- a/numba/tests/test_api.py
+++ b/numba/tests/test_api.py
@@ -3,12 +3,10 @@ import warnings
 import numba
 from numba import jit, njit
 
-from numba.tests.support import TestCase
-from numba.testing import always_test
+from numba.tests.support import TestCase, always_test
 import unittest
 
 
-@always_test
 class TestNumbaModule(TestCase):
     """
     Test the APIs exposed by the top-level `numba` module.
@@ -18,6 +16,7 @@ class TestNumbaModule(TestCase):
         self.assertTrue(hasattr(numba, name), name)
         self.assertIn(name, numba.__all__)
 
+    @always_test
     def test_numba_module(self):
         # jit
         self.check_member("jit")

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -159,8 +159,8 @@ class TestCase(unittest.TestCase):
 
         # check that each shard contains no repeats
         sharded_sets = [set(x) for x in sharded]
-        [self.assertEqual(len(sharded_sets[i]), len(sharded[i]))
-         for i in range(len(sharded))]
+        for i in range(len(sharded)):
+            self.assertEqual(len(sharded_sets[i]), len(sharded[i]))
 
         # check that the always running tests are in every shard, and then
         # remove them from the shards
@@ -178,7 +178,8 @@ class TestCase(unittest.TestCase):
         # same as the full listing
 
         sum_of_parts = set()
-        [sum_of_parts.update(x) for x in sharded_sets]
+        for x in sharded_sets:
+            sum_of_parts.update(x)
         sum_of_parts.update(always_running)
 
         full_listing = set(self._get_numba_tests_from_listing(

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -4,6 +4,7 @@ import subprocess
 
 from numba import cuda
 import unittest
+import itertools
 
 try:
     import git  # noqa: F401 from gitpython package
@@ -64,6 +65,11 @@ class TestCase(unittest.TestCase):
         self.assertTrue(any('numba.tests.npyufunc.test_' in line
                             for line in lines),)
 
+    def _get_numba_tests_from_listing(self, listing):
+        """returns a filter on strings starting with 'numba.', useful for
+        selecting the 'numba' test names from a test listing."""
+        return filter(lambda x: x.startswith('numba.'), listing)
+
     def test_default(self):
         self.check_all([])
 
@@ -119,34 +125,66 @@ class TestCase(unittest.TestCase):
             excluded = get_count(['--exclude-tags=%s' % tag, 'numba.tests'])
             self.assertEqual(total, included + excluded)
 
-    def test_check_slice(self):
+    def test_check_shard(self):
         tmpAll = self.get_testsuite_listing([])
         tmp1 = self.get_testsuite_listing(['-j', '0:2'])
         tmp2 = self.get_testsuite_listing(['-j', '1:2'])
-        lAll = {x for x in tmpAll if x.startswith('numba.')}
-        l1 = {x for x in tmp1 if x.startswith('numba.')}
-        l2 = {x for x in tmp2 if x.startswith('numba.')}
+
+        lAll = set(self._get_numba_tests_from_listing(tmpAll))
+        l1 = set(self._get_numba_tests_from_listing(tmp1))
+        l2 = set(self._get_numba_tests_from_listing(tmp2))
+
         # The difference between two adjacent shards should be less than 5% of
         # the total
         self.assertLess(abs(len(l2) - len(l1)), len(lAll) / 20)
         self.assertLess(len(l1), len(lAll))
         self.assertLess(len(l2), len(lAll))
-        # Test should always run
-        self.assertIn("numba.tests.test_api.TestNumbaModule.test_numba_module",
-                      l1)
-        self.assertIn("numba.tests.test_api.TestNumbaModule.test_numba_module",
-                      l2)
 
-    def test_check_slicing_equivalent(self):
-        def filter_test(xs):
-            return {x for x in xs if x.startswith('numba.')}
-        full = filter_test(self.get_testsuite_listing([]))
-        sliced = set()
+    def test_check_sharding_equivalent(self):
+        # get some shards
+        sharded = list()
         for i in range(3):
             subset = self.get_testsuite_listing(['-j', '{}:3'.format(i)])
-            sliced.update(filter_test(subset))
-        # The tests must be equivalent
-        self.assertEqual(full, sliced)
+            slist = [*self._get_numba_tests_from_listing(subset)]
+            # there's at least 100 tests in a shard of roughly 1/3!
+            self.assertGreater(len(slist), 100)
+            sharded.append(slist)
+
+        # get the always running tests
+        tmp = self.get_testsuite_listing(['--tag', 'always_test'])
+        always_running = set(self._get_numba_tests_from_listing(tmp))
+
+        # make sure there is at least one test that always runs
+        self.assertGreaterEqual(len(always_running), 1)
+
+        # check that each shard contains no repeats
+        sharded_sets = [set(x) for x in sharded]
+        [self.assertEqual(len(sharded_sets[i]), len(sharded[i]))
+         for i in range(len(sharded))]
+
+        # check that the always running tests are in every shard, and then
+        # remove them from the shards
+        for shard in sharded_sets:
+            for test in always_running:
+                self.assertIn(test, shard)
+                shard.remove(test)
+                self.assertNotIn(test, shard)
+
+        # check that there is no overlap between the shards
+        for a, b in itertools.combinations(sharded_sets, 2):
+            self.assertFalse(a & b)
+
+        # check that the sum of the shards and the always running tests is the
+        # same as the full listing
+
+        sum_of_parts = set()
+        [sum_of_parts.update(x) for x in sharded_sets]
+        sum_of_parts.update(always_running)
+
+        full_listing = set(self._get_numba_tests_from_listing(
+            self.get_testsuite_listing([])))
+
+        self.assertEqual(sum_of_parts, full_listing)
 
     @unittest.skipUnless(has_gitpython, "Requires gitpython")
     def test_gitdiff(self):

--- a/numba/tests/test_runtests.py
+++ b/numba/tests/test_runtests.py
@@ -146,8 +146,6 @@ class TestCase(unittest.TestCase):
         for i in range(3):
             subset = self.get_testsuite_listing(['-j', '{}:3'.format(i)])
             slist = [*self._get_numba_tests_from_listing(subset)]
-            # there's at least 100 tests in a shard of roughly 1/3!
-            self.assertGreater(len(slist), 100)
             sharded.append(slist)
 
         # get the always running tests


### PR DESCRIPTION
This patch:

* Makes an `always_run` test decorator to use on tests that should run in all test shards, it's based on the existing test `tag` mechanism.
* Updates the test runner to recognise the `always_run` tag when sharding so as to ensure that tests tagged with this tag will always be included in a shard.
* Updates the unit tests to ensure fundamental properties with regards to sharding. This includes shard uniqueness, the presence of the `always_run` tests in shards and also that the sum of the test shards and `always_run` tests is the same as the full test listing.
* Fixes up a few references slice->shard.

Fixes #8657

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
