### PR TITLE
Don't document AArch64 installation separately

### DIFF
--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -21,8 +21,8 @@ Our supported platforms are:
 
 :ref:`numba-parallel` is only available on 64-bit platforms.
 
-Installing using conda on x86/x86_64/POWER Platforms
-----------------------------------------------------
+Installing using conda
+----------------------
 
 The easiest way to install Numba and get updates is by using ``conda``,
 a cross-platform package manager and software distribution maintained
@@ -69,28 +69,6 @@ To use CUDA with Numba installed by `pip`, you need to install the `CUDA SDK
 :ref:`cudatoolkit-lookup` for details. Numba can also detect CUDA libraries
 installed system-wide on Linux.
 
-
-Installing on Linux ARMv8 (AArch64) Platforms
----------------------------------------------
-
-We build and test conda packages on the `NVIDIA Jetson TX2
-<https://www.nvidia.com/en-us/autonomous-machines/embedded-systems-dev-kits-modules/>`_,
-but they are likely to work for other AArch64 platforms.  (Note that while the
-CPUs in the Raspberry Pi 3, 4, and Zero 2 W are 64-bit, Raspberry Pi OS may be
-running in 32-bit mode depending on the OS image in use).
-
-Conda-forge support for AArch64 is still quite experimental and packages are limited,
-but it does work enough for Numba to build and pass tests.  To set up the environment:
-
-* Install `miniforge <https://github.com/conda-forge/miniforge>`_.
-  This will create a minimal conda environment.
-
-* Then you can install Numba from the ``numba`` channel::
-
-    $ conda install -c numba numba
-
-On CUDA-enabled systems, like the Jetson, the CUDA toolkit should be
-automatically detected in the environment.
 
 .. _numba-source-install-instructions:
 


### PR DESCRIPTION
Anaconda publishes AArch64 Numba packages, so conda can be used for all architectures in the same way.