### PR TITLE
Close stale issues after 7 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,4 @@ jobs:
           stale-issue-label: 'stale'
           any-of-labels: 'question,needtriage,more info needed'
           days-before-issue-stale: 30
-          days-before-issue-close: -1
+          days-before-issue-close: 7


### PR DESCRIPTION
If no maintainer removes the stale label after 7 days, then the issue can be closed - this should reduce some minor admin burden for FPOCs / maintainers (as suggested by @stuartarchibald in OOB discussion).