### PR TITLE
Fix doctest for `@vectorize`

### DIFF
--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -1,3 +1,5 @@
+import functools
+
 from numba import jit, typeof
 from numba.core import cgutils, types, serialize, sigutils
 from numba.core.extending import is_jitted
@@ -83,6 +85,7 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc):
                          cache=cache,
                          **targetoptions)(py_func)
         self._initialize(dispatcher, identity)
+        functools.update_wrapper(self, py_func)
 
     def _initialize(self, dispatcher, identity):
         identity = ufuncbuilder.parse_identity(identity)

--- a/numba/tests/doctest_usecase.py
+++ b/numba/tests/doctest_usecase.py
@@ -1,0 +1,31 @@
+"""
+Test that all docstrings are the same:
+
+>>> len({f.__doc__ for f in (a, b, c, d)})
+1
+"""
+from numba import guvectorize, int64, njit, vectorize
+
+
+def a():
+    """>>> x = 1"""
+    return 1
+
+
+@njit
+def b():
+    """>>> x = 1"""
+    return 1
+
+
+@guvectorize([(int64[:], int64, int64[:])], "(n),()->(n)")
+def c(x, y, res):
+    """>>> x = 1"""
+    for i in range(x.shape[0]):
+        res[i] = x[i] + y
+
+
+@vectorize([int64(int64, int64)])
+def d(x, y):
+    """>>> x = 1"""
+    return x + y

--- a/numba/tests/test_doctest.py
+++ b/numba/tests/test_doctest.py
@@ -1,0 +1,28 @@
+import doctest
+import unittest
+from numba.tests.support import TestCase
+
+
+class TestDocTest(TestCase):
+    def test_basic_decorators(self):
+        from . import doctest_usecase
+
+        # Make sure the finder see all the doctest
+        finder = doctest.DocTestFinder()
+        tests = finder.find(doctest_usecase)
+        testnames = {x.name for x in tests}
+        expected = {
+            'numba.tests.doctest_usecase',
+            'numba.tests.doctest_usecase.a',
+            'numba.tests.doctest_usecase.b',
+            'numba.tests.doctest_usecase.c',
+            'numba.tests.doctest_usecase.d',
+        }
+        self.assertEqual(testnames, expected)
+
+        # Execute the doctest in the module
+        doctest.testmod(doctest_usecase)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #8694

- Apply same patch as in https://github.com/numba/numba/blob/009ae4e84ede1b6a750682ed5c357601c496495a/numba/np/ufunc/gufunc.py#L31 for gufunc
- Add a `test_doctest.py` to exercise doctest functionality for decorators, including `njit`, `vectorize`, `guvectorize`