### PR TITLE
CI: Use `set -e` in "Before Install" step and fix install

### DIFF
--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -22,11 +22,13 @@ jobs:
       displayName: 'Before Install'
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/build.sh
       displayName: 'Build'
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y flake8
         flake8 numba
@@ -34,6 +36,7 @@ jobs:
       condition: eq(variables['RUN_FLAKE8'], 'yes')
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y mypy
         mypy
@@ -41,6 +44,7 @@ jobs:
       condition: eq(variables['RUN_MYPY'], 'yes')
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -13,6 +13,7 @@ jobs:
 
   steps:
     - script: |
+        set -e
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
         export PATH=$HOME/miniconda3/bin:$PATH

--- a/buildscripts/incremental/install_miniconda.sh
+++ b/buildscripts/incremental/install_miniconda.sh
@@ -12,4 +12,4 @@ else
   echo Error
 fi
 chmod +x miniconda.sh
-./miniconda.sh -b
+bash ./miniconda.sh -b


### PR DESCRIPTION
`miniconda.sh` needs to be run with `bash` because it uses `[[`, which is not available in all `sh` implementations.

We also add `set -e` to the "Before Install" step so that problems installing Miniconda cause the build to fail.