### PR TITLE
Check for void return type in `cuda.compile_ptx`

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -270,6 +270,10 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
                         fastmath=fastmath,
                         nvvm_options=nvvm_options)
     resty = cres.signature.return_type
+
+    if resty and not device and resty != types.void:
+        raise TypeError("CUDA kernel must have void return type.")
+
     if device:
         lib = cres.library
     else:

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -116,6 +116,13 @@ class TestCompileToPTX(unittest.TestCase):
         ptx, resty = compile_ptx(f, [], lineinfo=True)
         self.check_line_info(ptx)
 
+    def test_non_void_return_type(self):
+        def f(x, y):
+            return x[0] + y[0]
+
+        with self.assertRaisesRegex(TypeError, 'must have void return type'):
+            compile_ptx(f, (uint32[::1], uint32[::1]))
+
 
 @skip_on_cudasim('Compilation unsupported in the simulator')
 class TestCompileToPTXForCurrentDevice(CUDATestCase):


### PR DESCRIPTION
This PR adds a check for void return types to `cuda.compile_ptx`.

Closes #8717