### PR TITLE
Split parfor pass into 3 parts. (old)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,12 +1,19 @@
 [flake8]
 ignore =
-    E20,   # Extra space in brackets
-    E231,E241,  # Multiple spaces around ","
-    E26,   # Comments
-    E731,  # Assigning lambda expression
-    E741,  # Ambiguous variable names
-    W503,  # line break before binary operator
-    W504,  # line break after binary operator
+    # Extra space in brackets
+    E20,
+    # Multiple spaces around ","
+    E231,E241,
+    # Comments
+    E26,
+    # Assigning lambda expression
+    E731,
+    # Ambiguous variable names
+    E741,
+    # line break before binary operator
+    W503,
+    # line break after binary operator
+    W504,
 max-line-length = 80
 
 exclude =

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,14 +13,25 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
+          # issues
           stale-issue-message: >
             This issue is marked as stale as it has had no activity in the past
             30 days. Please close this issue if no further response or action is
             needed. Otherwise, please respond with any updates and confirm that
             this issue still needs to be addressed.
           stale-issue-label: 'stale'
-          any-of-labels: 'question,needtriage,more info needed'
+          any-of-issue-labels: 'question,needtriage,more info needed'
           days-before-issue-stale: 30
           days-before-issue-close: 7
+          # pull requests
+          stale-pr-message: >
+            This pull request is marked as stale as it has had no activity in
+            the past 3 months. Please respond to this comment if you're still
+            interested in working on this. Many thanks!
+          days-before-pr-stale: 90  # 3 months
+          days-before-pr-close: 7
+          any-of-pr-labels: '2 - In progress,4 - Waiting on author'
+          stale-pr-label: 'stale'
+          close-pr-label: 'abandoned'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -31,7 +31,7 @@ jobs:
         set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y flake8
-        flake8 numba
+        flake8 -j auto numba
       displayName: 'Flake8'
       condition: eq(variables['RUN_FLAKE8'], 'yes')
 

--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -166,9 +166,11 @@ Array access
 ------------
 
 Arrays support normal iteration.  Full basic indexing and slicing is
-supported.  A subset of advanced indexing is also supported: only one
-advanced index is allowed, and it has to be a one-dimensional array
-(it can be combined with an arbitrary number of basic indices as well).
+supported along with passing ``None`` / ``np.newaxis`` as indices for
+additional resulting dimensions. A subset of advanced indexing is also
+supported: only one advanced index is allowed, and it has to be a
+one-dimensional array (it can be combined with an arbitrary number
+of basic indices as well).
 
 .. seealso::
    `NumPy indexing <http://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_

--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -7,6 +7,55 @@ import re
 import sys
 import warnings
 
+
+# ---------------------- WARNING WARNING WARNING ----------------------------
+# THIS MUST RUN FIRST, DO NOT MOVE... SEE DOCSTRING IN _ensure_critical_deps
+def _ensure_critical_deps():
+    """
+    Make sure the Python, NumPy and SciPy present are supported versions.
+    This has to be done _before_ importing anything from Numba such that
+    incompatible versions can be reported to the user. If this occurs _after_
+    importing things from Numba and there's an issue in e.g. a Numba c-ext, a
+    SystemError might have occurred which prevents reporting the likely cause of
+    the problem (incompatible versions of critical dependencies).
+    """
+    #NOTE THIS CODE SHOULD NOT IMPORT ANYTHING FROM NUMBA!
+
+    def extract_version(mod):
+        return tuple(map(int, mod.__version__.split('.')[:2]))
+
+    PYVERSION = sys.version_info[:2]
+
+    if PYVERSION < (3, 8):
+        msg = ("Numba needs Python 3.8 or greater. Got Python "
+               f"{PYVERSION[0]}.{PYVERSION[1]}.")
+        raise ImportError(msg)
+
+    import numpy as np
+    numpy_version = extract_version(np)
+
+    if numpy_version < (1, 18):
+        msg = (f"Numba needs NumPy 1.18 or greater. Got NumPy "
+               f"{numpy_version[0]}.{numpy_version[1]}.")
+        raise ImportError(msg)
+
+    try:
+        import scipy
+    except ImportError:
+        pass
+    else:
+        sp_version = extract_version(scipy)
+        if sp_version < (1, 0):
+            msg = ("Numba requires SciPy version 1.0 or greater. Got SciPy "
+                   f"{scipy.__version__}.")
+            raise ImportError(msg)
+
+
+_ensure_critical_deps()
+# END DO NOT MOVE
+# ---------------------- WARNING WARNING WARNING ----------------------------
+
+
 from ._version import get_versions
 from numba.misc.init_utils import generate_version_info
 
@@ -130,34 +179,6 @@ def _ensure_llvm():
 
     check_jit_execution()
 
-def _ensure_critical_deps():
-    """
-    Make sure Python, NumPy and SciPy have supported versions.
-    """
-    from numba.np.numpy_support import numpy_version
-    from numba.core.utils import PYVERSION
-
-    if PYVERSION < (3, 8):
-        msg = ("Numba needs Python 3.8 or greater. Got Python "
-               f"{PYVERSION[0]}.{PYVERSION[1]}.")
-        raise ImportError(msg)
-
-    if numpy_version < (1, 18):
-        msg = (f"Numba needs NumPy 1.18 or greater. Got NumPy "
-               f"{numpy_version[0]}.{numpy_version[1]}.")
-        raise ImportError(msg)
-
-    try:
-        import scipy
-    except ImportError:
-        pass
-    else:
-        sp_version = tuple(map(int, scipy.__version__.split('.')[:2]))
-        if sp_version < (1, 0):
-            msg = ("Numba requires SciPy version 1.0 or greater. Got SciPy "
-                   f"{scipy.__version__}.")
-            raise ImportError(msg)
-
 
 def _try_enable_svml():
     """
@@ -207,7 +228,6 @@ def _try_enable_svml():
     return False
 
 _ensure_llvm()
-_ensure_critical_deps()
 
 # we know llvmlite is working as the above tests passed, import it now as SVML
 # needs to mutate runtime options (sets the `-vector-library`).

--- a/numba/_pymodule.h
+++ b/numba/_pymodule.h
@@ -3,9 +3,9 @@
 
 #define PY_SSIZE_T_CLEAN
 
-#include <Python.h>
-#include <structmember.h>
-#include <frameobject.h>
+#include "Python.h"
+#include "structmember.h"
+#include "frameobject.h"
 
 #define MOD_ERROR_VAL NULL
 #define MOD_SUCCESS_VAL(val) val

--- a/numba/cext/dictobject.h
+++ b/numba/cext/dictobject.h
@@ -1,6 +1,4 @@
 /* Adapted from CPython3.7 Objects/dict-common.h */
-#include "Python.h"
-#include "../_pymodule.h"
 #include "cext.h"
 
 #ifndef NUMBA_DICT_COMMON_H

--- a/numba/cext/listobject.h
+++ b/numba/cext/listobject.h
@@ -14,7 +14,6 @@
 #ifndef NUMBA_LIST_H
 #define NUMBA_LIST_H
 
-#include "Python.h"
 #include "cext.h"
 
 typedef void (*list_refcount_op_t)(const void*);

--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -447,7 +447,7 @@ def dead_branch_prune(func_ir, called_args):
             if len(const_conds) == 2:
                 # prune the branch, switch the branch for an unconditional jump
                 prune_stat, taken = prune(branch, condition, blk, *const_conds)
-                if(prune_stat):
+                if (prune_stat):
                     # add the condition to the list of nullified conditions
                     nullified_conditions.append(nullified(condition, taken,
                                                           True))
@@ -464,7 +464,7 @@ def dead_branch_prune(func_ir, called_args):
 
             if not isinstance(resolved_const, Unknown):
                 prune_stat, taken = prune_by_predicate(branch, condition, blk)
-                if(prune_stat):
+                if (prune_stat):
                     # add the condition to the list of nullified conditions
                     nullified_conditions.append(nullified(condition, taken,
                                                           False))

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -1168,7 +1168,8 @@ def snprintf(builder, buffer, bufsz, format, *args):
 
 
 def snprintf_stackbuffer(builder, bufsz, format, *args):
-    """Similar to `snprintf()` but the buffer is stack allocated to size *bufsz*.
+    """Similar to `snprintf()` but the buffer is stack allocated to size
+    *bufsz*.
 
     Returns the buffer pointer as i8*.
     """

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -619,6 +619,18 @@ class DefaultPassBuilder(object):
         return pm
 
     @staticmethod
+    def define_parfor_gufunc_pipeline(state, name="parfor_gufunc_typed"):
+        """Returns the typed part of the nopython pipeline"""
+        pm = PassManager(name)
+        assert state.func_ir
+        pm.add_pass(IRProcessing, "processing IR")
+        pm.add_pass(NopythonTypeInference, "nopython frontend")
+        pm.add_pass(ParforPreLoweringPass, "parfor prelowering")
+
+        pm.finalize()
+        return pm
+
+    @staticmethod
     def define_untyped_pipeline(state, name='untyped'):
         """Returns an untyped part of the nopython pipeline"""
         pm = PassManager(name)

--- a/numba/core/compiler.py
+++ b/numba/core/compiler.py
@@ -31,6 +31,7 @@ from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
                                      InlineOverloads, PreLowerStripPhis,
                                      NativeLowering, NativeParforLowering,
                                      NoPythonSupportedFeatureValidation,
+                                     ParforFusionPass, ParforPreLoweringPass
                                      )
 
 from numba.core.object_mode_passes import (ObjectModeFrontEnd,
@@ -611,6 +612,8 @@ class DefaultPassBuilder(object):
             pm.add_pass(NopythonRewrites, "nopython rewrites")
         if state.flags.auto_parallel.enabled:
             pm.add_pass(ParforPass, "convert to parfors")
+            pm.add_pass(ParforFusionPass, "fuse parfors")
+            pm.add_pass(ParforPreLoweringPass, "parfor prelowering")
 
         pm.finalize()
         return pm

--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -474,8 +474,8 @@ def _prepare_chrome_trace_data(listener: RecordingListener):
 
 
 def _setup_chrome_trace_exit_handler():
-    """Setup a RecordingListener and an exit handler to write the captured events
-    to file.
+    """Setup a RecordingListener and an exit handler to write the captured
+    events to file.
     """
     listener = RecordingListener()
     register("numba:run_pass", listener)

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -414,7 +414,7 @@ class InlineWorker(object):
         callee_scopes = _get_all_scopes(callee_blocks)
         self.debug_print("callee_scopes = ", callee_scopes)
         #    one function should only have one local scope
-        assert(len(callee_scopes) == 1)
+        assert (len(callee_scopes) == 1)
         callee_scope = callee_scopes[0]
         var_dict = {}
         for var in tuple(callee_scope.localvars._con.values()):
@@ -538,8 +538,8 @@ class InlineWorker(object):
         return state.func_ir
 
     def update_type_and_call_maps(self, callee_ir, arg_typs):
-        """ Updates the type and call maps based on calling callee_ir with arguments
-        from arg_typs"""
+        """ Updates the type and call maps based on calling callee_ir with
+        arguments from arg_typs"""
         from numba.core.ssa import reconstruct_ssa
         from numba.core.typed_passes import PreLowerStripPhis
 
@@ -575,7 +575,8 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
                         targetctx=None, arg_typs=None, typemap=None,
                         calltypes=None, work_list=None, callee_validator=None,
                         replace_freevars=True):
-    """Inline the body of `callee` at its callsite (`i`-th instruction of `block`)
+    """Inline the body of `callee` at its callsite (`i`-th instruction of
+    `block`)
 
     `func_ir` is the func_ir object of the caller function and `glbls` is its
     global variable environment (func_ir.func_id.func.__globals__).
@@ -631,7 +632,7 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     callee_scopes = _get_all_scopes(callee_blocks)
     debug_print("callee_scopes = ", callee_scopes)
     #    one function should only have one local scope
-    assert(len(callee_scopes) == 1)
+    assert (len(callee_scopes) == 1)
     callee_scope = callee_scopes[0]
     var_dict = {}
     for var in callee_scope.localvars._con.values():
@@ -661,10 +662,10 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
             cellget.argtypes = (ctypes.py_object,)
             items = tuple(cellget(x) for x in closure)
         else:
-            assert(isinstance(closure, ir.Expr)
-                   and closure.op == 'build_tuple')
+            assert (isinstance(closure, ir.Expr)
+                    and closure.op == 'build_tuple')
             items = closure.items
-        assert(len(callee_code.co_freevars) == len(items))
+        assert (len(callee_code.co_freevars) == len(items))
         _replace_freevars(callee_blocks, items)
         debug_print("After closure rename")
         _debug_dump(callee_ir)
@@ -786,8 +787,8 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
             elif (isinstance(callee_defaults, ir.Var)
                     or isinstance(callee_defaults, str)):
                 default_tuple = func_ir.get_definition(callee_defaults)
-                assert(isinstance(default_tuple, ir.Expr))
-                assert(default_tuple.op == "build_tuple")
+                assert (isinstance(default_tuple, ir.Expr))
+                assert (default_tuple.op == "build_tuple")
                 const_vals = [func_ir.get_definition(x) for
                               x in default_tuple.items]
                 args = args + const_vals
@@ -829,7 +830,7 @@ def _replace_args_with(blocks, args):
         for stmt in assigns:
             if isinstance(stmt.value, ir.Arg):
                 idx = stmt.value.index
-                assert(idx < len(args))
+                assert (idx < len(args))
                 stmt.value = args[idx]
 
 
@@ -842,7 +843,7 @@ def _replace_freevars(blocks, args):
         for stmt in assigns:
             if isinstance(stmt.value, ir.FreeVar):
                 idx = stmt.value.index
-                assert(idx < len(args))
+                assert (idx < len(args))
                 if isinstance(args[idx], ir.Var):
                     stmt.value = args[idx]
                 else:
@@ -858,7 +859,7 @@ def _replace_returns(blocks, target, return_label):
         for i in range(len(block.body)):
             stmt = block.body[i]
             if isinstance(stmt, ir.Return):
-                assert(i + 1 == len(block.body))
+                assert (i + 1 == len(block.body))
                 block.body[i] = ir.Assign(stmt.value, target, stmt.loc)
                 block.body.append(ir.Jump(return_label, stmt.loc))
                 # remove cast of the returned value
@@ -931,8 +932,8 @@ def _find_arraycall(func_ir, block):
 
 
 def _find_iter_range(func_ir, range_iter_var, swapped):
-    """Find the iterator's actual range if it is either range(n), or range(m, n),
-    otherwise return raise GuardException.
+    """Find the iterator's actual range if it is either range(n), or
+    range(m, n), otherwise return raise GuardException.
     """
     debug_print = _make_debug_print("find_iter_range")
     range_iter_def = get_definition(func_ir, range_iter_var)
@@ -1194,7 +1195,7 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             # when range doesn't start from 0, index_var becomes loop index
             # (iter_first_var) minus an offset (range_def[0])
             terminator = loop_header.terminator
-            assert(isinstance(terminator, ir.Branch))
+            assert (isinstance(terminator, ir.Branch))
             # find the block in the loop body that header jumps to
             block_id = terminator.truebr
             blk = func_ir.blocks[block_id]
@@ -1256,8 +1257,8 @@ def _find_unsafe_empty_inferred(func_ir, expr):
 
 
 def _fix_nested_array(func_ir):
-    """Look for assignment like: a[..] = b, where both a and b are numpy arrays, and
-    try to eliminate array b by expanding a with an extra dimension.
+    """Look for assignment like: a[..] = b, where both a and b are numpy arrays,
+    and try to eliminate array b by expanding a with an extra dimension.
     """
     blocks = func_ir.blocks
     cfg = compute_cfg_from_blocks(blocks)

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -192,8 +192,8 @@ NumbaPickler.dispatch_table[_CustomPickled] = _custom_reduce__custompickled
 
 
 class ReduceMixin(abc.ABC):
-    """A mixin class for objects that should be reduced by the NumbaPickler instead
-    of the standard pickler.
+    """A mixin class for objects that should be reduced by the NumbaPickler
+    instead of the standard pickler.
     """
     # Subclass MUST override the below methods
 

--- a/numba/core/typed_passes.py
+++ b/numba/core/typed_passes.py
@@ -10,7 +10,8 @@ from numba.core import (errors, types, typing, ir, funcdesc, rewrites,
 from numba.parfors.parfor import PreParforPass as _parfor_PreParforPass
 from numba.parfors.parfor import ParforPass as _parfor_ParforPass
 from numba.parfors.parfor import ParforFusionPass as _parfor_ParforFusionPass
-from numba.parfors.parfor import ParforPreLoweringPass as _parfor_ParforPreLoweringPass
+from numba.parfors.parfor import ParforPreLoweringPass as \
+    _parfor_ParforPreLoweringPass
 from numba.parfors.parfor import Parfor
 from numba.parfors.parfor_lowering import ParforLower
 

--- a/numba/core/types/abstract.py
+++ b/numba/core/types/abstract.py
@@ -115,6 +115,9 @@ class Type(metaclass=_TypeMetaclass):
     def __repr__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
     def __hash__(self):
         return hash(self.key)
 

--- a/numba/core/types/containers.py
+++ b/numba/core/types/containers.py
@@ -256,6 +256,9 @@ class UniTuple(BaseAnonymousTuple, _HomogeneousTuple, Sequence):
     def __unliteral__(self):
         return type(self)(dtype=unliteral(self.dtype), count=self.count)
 
+    def __repr__(self):
+        return f"UniTuple({repr(self.dtype)}, {self.count})"
+
 
 class UniTupleIter(BaseContainerIterator):
     """
@@ -340,6 +343,9 @@ class Tuple(BaseAnonymousTuple, _HeterogeneousTuple):
 
             if all(t is not None for t in unified):
                 return Tuple(unified)
+
+    def __repr__(self):
+        return f"Tuple({tuple(ty for ty in self.types)})"
 
 
 class _StarArgTupleMixin:
@@ -467,6 +473,9 @@ class List(MutableSequence, InitialValue):
         return List(self.dtype, reflected=self.reflected,
                     initial_value=None)
 
+    def __repr__(self):
+        return f"List({self.dtype}, {self.reflected})"
+
 
 class LiteralList(Literal, ConstSized, Hashable):
     """A heterogeneous immutable list (basically a tuple with list semantics).
@@ -577,6 +586,9 @@ class Set(Container):
             if dtype is not None:
                 return Set(dtype, reflected)
 
+    def __repr__(self):
+        return f"Set({self.dtype}, {self.reflected})"
+
 
 class SetIter(BaseContainerIterator):
     """
@@ -654,6 +666,9 @@ class ListType(IterableType):
         if isinstance(other, ListType):
             if not other.is_precise():
                 return self
+
+    def __repr__(self):
+        return f"ListType({self.item_type})"
 
 
 class ListTypeIterableType(SimpleIterableType):
@@ -759,6 +774,9 @@ class DictType(IterableType, InitialValue):
 
     def __unliteral__(self):
         return DictType(self.key_type, self.value_type)
+
+    def __repr__(self):
+        return f"DictType({self.key_type}, {self.value_type})"
 
 
 class LiteralStrKeyDict(Literal, ConstSized, Hashable):

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -138,6 +138,8 @@ class Record(Type):
         name = 'Record({};{};{})'.format(desc, self.size, self.aligned)
         super(Record, self).__init__(name)
 
+        self.bitwidth = self.dtype.itemsize * 8
+
     @classmethod
     def _normalize_fields(cls, fields):
         """
@@ -446,6 +448,9 @@ class Array(Buffer):
         if (not aligned or
             (isinstance(dtype, Record) and not dtype.aligned)):
             self.aligned = False
+        if isinstance(dtype, NestedArray):
+            ndim += dtype.ndim
+            dtype = dtype.dtype
         if name is None:
             type_name = "array"
             if not self.mutable:
@@ -577,6 +582,10 @@ class NestedArray(Array):
     """
 
     def __init__(self, dtype, shape):
+        if isinstance(dtype, NestedArray):
+            tmp = Array(dtype.dtype, dtype.ndim, 'C')
+            shape += dtype.shape
+            dtype = tmp.dtype
         assert dtype.bitwidth % 8 == 0, \
             "Dtype bitwidth must be a multiple of bytes"
         self._shape = shape

--- a/numba/core/types/npytypes.py
+++ b/numba/core/types/npytypes.py
@@ -58,6 +58,9 @@ class UnicodeCharSeq(Type):
             # on.
             return Conversion.safe
 
+    def __repr__(self):
+        return f"UnicodeCharSeq({self.count})"
+
 
 _RecordField = collections.namedtuple(
     '_RecordField',
@@ -233,6 +236,18 @@ class Record(Type):
                           category=NumbaExperimentalFeatureWarning)
             return Conversion.safe
 
+    def __repr__(self):
+        fields = [f"('{f_name}', " +
+                  f"{{'type': {repr(f_info.type)}, " +
+                  f"'offset': {f_info.offset}, " +
+                  f"'alignment': {f_info.alignment}, " +
+                  f"'title': {f_info.title}, " +
+                  f"}}" +
+                  ")"
+                  for f_name, f_info in self.fields.items()
+                  ]
+        fields = "[" + ", ".join(fields) + "]"
+        return f"Record({fields}, {self.size}, {self.aligned})"
 
 class DType(DTypeSpec, Opaque):
     """
@@ -500,6 +515,11 @@ class Array(Buffer):
         """
         return np.ndarray
 
+    def __repr__(self):
+        return (
+            f"Array({repr(self.dtype)}, {self.ndim}, '{self.layout}', "
+            f"{not self.mutable}, aligned={self.aligned})"
+                )
 
 class ArrayCTypes(Type):
     """
@@ -591,6 +611,9 @@ class NestedArray(Array):
     @property
     def key(self):
         return self.dtype, self.shape
+
+    def __repr__(self):
+        return f"NestedArray({repr(self.dtype)}, {self.shape})"
 
 
 class NumPyRandomBitGeneratorType(Type):

--- a/numba/core/typing/npydecl.py
+++ b/numba/core/typing/npydecl.py
@@ -481,7 +481,7 @@ def _parse_nested_sequence(context, typ):
     heterogeneous, as long as it converts to the given dtype.
     """
     if isinstance(typ, (types.Buffer,)):
-        raise TypingError("%r not allowed in a homogeneous sequence" % typ)
+        raise TypingError("%s not allowed in a homogeneous sequence" % typ)
     elif isinstance(typ, (types.Sequence,)):
         n, dtype = _parse_nested_sequence(context, typ.dtype)
         return n + 1, dtype
@@ -494,12 +494,12 @@ def _parse_nested_sequence(context, typ):
         for i in range(1, typ.count):
             _n, dtype = _parse_nested_sequence(context, typ[i])
             if _n != n:
-                raise TypingError("type %r does not have a regular shape"
+                raise TypingError("type %s does not have a regular shape"
                                   % (typ,))
             dtypes.append(dtype)
         dtype = context.unify_types(*dtypes)
         if dtype is None:
-            raise TypingError("cannot convert %r to a homogeneous type" % typ)
+            raise TypingError("cannot convert %s to a homogeneous type" % typ)
         return n + 1, dtype
     else:
         # Scalar type => check it's valid as a Numpy array dtype

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -1285,7 +1285,7 @@ class MixedContainerUnroller(FunctionPass):
         # 3. No multiple mix-tuple use
 
         # keep running the transform loop until it reports no more changes
-        while(True):
+        while (True):
             stat = self.apply_transform(state)
             mutated |= stat
             if not stat:

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -848,7 +848,7 @@ def unicode_count(src, sub, start=None, end=None):
             if sub_len == 0:
                 return src_len + 1
 
-            while(start + sub_len <= src_len):
+            while (start + sub_len <= src_len):
                 if src[start : start + sub_len] == sub:
                     count += 1
                     start += sub_len
@@ -2020,7 +2020,7 @@ def _is_upper(is_lower, is_upper, is_title):
             code_point = _get_code_point(a, idx)
             if is_lower(code_point) or is_title(code_point):
                 return False
-            elif(not cased and is_upper(code_point)):
+            elif (not cased and is_upper(code_point)):
                 cased = True
         return cased
     return impl

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -270,6 +270,10 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
                         fastmath=fastmath,
                         nvvm_options=nvvm_options)
     resty = cres.signature.return_type
+
+    if resty and not device and resty != types.void:
+        raise TypeError("CUDA kernel must have void return type.")
+
     if device:
         lib = cres.library
     else:

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -107,7 +107,7 @@ class _Kernel(serialize.ReduceMixin):
             link.append(get_cudalib('cudadevrt', static=True))
 
         res = [fn for fn in cuda_fp16_math_funcs
-               if(f'__numba_wrapper_{fn}' in lib.get_asm_str())]
+               if (f'__numba_wrapper_{fn}' in lib.get_asm_str())]
 
         if res:
             # Path to the source containing the foreign function

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -116,6 +116,13 @@ class TestCompileToPTX(unittest.TestCase):
         ptx, resty = compile_ptx(f, [], lineinfo=True)
         self.check_line_info(ptx)
 
+    def test_non_void_return_type(self):
+        def f(x, y):
+            return x[0] + y[0]
+
+        with self.assertRaisesRegex(TypeError, 'must have void return type'):
+            compile_ptx(f, (uint32[::1], uint32[::1]))
+
 
 @skip_on_cudasim('Compilation unsupported in the simulator')
 class TestCompileToPTXForCurrentDevice(CUDATestCase):

--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -312,9 +312,12 @@ class TestDispatcher(CUDATestCase):
         self.assertRegexpMatches(
             str(cm.exception),
             r"Ambiguous overloading for <function add_kernel [^>]*> "
-            r"\(array\(float64, 1d, C\), float64, float64\):\n"
-            r"\(array\(float64, 1d, C\), float32, float64\) -> none\n"
-            r"\(array\(float64, 1d, C\), float64, float32\) -> none"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float64,"
+            r" float64\):\n"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float32,"
+            r" float64\) -> none\n"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float64,"
+            r" float32\) -> none"
         )
         # The integer signature is not part of the best matches
         self.assertNotIn("int64", str(cm.exception))

--- a/numba/cuda/tests/cudapy/test_nondet.py
+++ b/numba/cuda/tests/cudapy/test_nondet.py
@@ -11,8 +11,8 @@ def generate_input(n):
 
 class TestCudaNonDet(CUDATestCase):
     def test_for_pre(self):
-        """Test issue with loop not running due to bad sign-extension at the for loop
-        precondition.
+        """Test issue with loop not running due to bad sign-extension at the for
+        loop precondition.
         """
 
         @cuda.jit(void(float32[:, :], float32[:, :], float32[:]))

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1132,7 +1132,7 @@ def _isclose_item(x, y, rtol, atol, equal_nan):
 
 @overload(np.isclose)
 def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-    if not(type_can_asarray(a) and type_can_asarray(b)):
+    if not (type_can_asarray(a) and type_can_asarray(b)):
         raise TypingError("Inputs for `np.isclose` must be array-like.")
 
     if isinstance(a, types.Array) and isinstance(b, types.Number):
@@ -2077,10 +2077,10 @@ def np_ediff1d(ary, to_end=None, to_begin=None):
     # Check that to_end and to_begin are compatible with ary
     ary_dt = _dtype_of_compound(ary)
     to_begin_dt = None
-    if not(is_nonelike(to_begin)):
+    if not (is_nonelike(to_begin)):
         to_begin_dt = _dtype_of_compound(to_begin)
     to_end_dt = None
-    if not(is_nonelike(to_end)):
+    if not (is_nonelike(to_end)):
         to_end_dt = _dtype_of_compound(to_end)
 
     if to_begin_dt is not None and not np.can_cast(to_begin_dt, ary_dt):

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -379,6 +379,7 @@ def basic_indexing(context, builder, aryty, ary, index_types, indices,
     the corresponding view.
     """
     zero = context.get_constant(types.intp, 0)
+    one = context.get_constant(types.intp, 1)
 
     shapes = cgutils.unpack_tuple(builder, ary.shape, aryty.ndim)
     strides = cgutils.unpack_tuple(builder, ary.strides, aryty.ndim)
@@ -387,11 +388,12 @@ def basic_indexing(context, builder, aryty, ary, index_types, indices,
     output_shapes = []
     output_strides = []
 
+    num_newaxes = len([idx for idx in index_types if is_nonelike(idx)])
     ax = 0
     for indexval, idxty in zip(indices, index_types):
         if idxty is types.ellipsis:
             # Fill up missing dimensions at the middle
-            n_missing = aryty.ndim - len(indices) + 1
+            n_missing = aryty.ndim - len(indices) + 1 + num_newaxes
             for i in range(n_missing):
                 output_indices.append(zero)
                 output_shapes.append(shapes[ax])
@@ -414,6 +416,10 @@ def basic_indexing(context, builder, aryty, ary, index_types, indices,
             if boundscheck:
                 cgutils.do_boundscheck(context, builder, ind, shapes[ax], ax)
             output_indices.append(ind)
+        elif is_nonelike(idxty):
+            output_shapes.append(one)
+            output_strides.append(zero)
+            ax -= 1
         else:
             raise NotImplementedError("unexpected index type: %s" % (idxty,))
         ax += 1
@@ -954,18 +960,22 @@ class FancyIndexer(object):
         self.shapes = cgutils.unpack_tuple(builder, ary.shape, aryty.ndim)
         self.strides = cgutils.unpack_tuple(builder, ary.strides, aryty.ndim)
         self.ll_intp = self.context.get_value_type(types.intp)
+        self.newaxes = []
 
         indexers = []
+        num_newaxes = len([idx for idx in index_types if is_nonelike(idx)])
 
-        ax = 0
+        ax = 0 # keeps track of position of original axes
+        new_ax = 0 # keeps track of position for inserting new axes
         for indexval, idxty in zip(indices, index_types):
             if idxty is types.ellipsis:
                 # Fill up missing dimensions at the middle
-                n_missing = aryty.ndim - len(indices) + 1
+                n_missing = aryty.ndim - len(indices) + 1 + num_newaxes
                 for i in range(n_missing):
                     indexer = EntireIndexer(context, builder, aryty, ary, ax)
                     indexers.append(indexer)
                     ax += 1
+                    new_ax += 1
                 continue
 
             # Regular index value
@@ -991,9 +1001,13 @@ class FancyIndexer(object):
                 else:
                     assert 0
                 indexers.append(indexer)
+            elif is_nonelike(idxty):
+                self.newaxes.append(new_ax)
+                ax -= 1
             else:
                 raise AssertionError("unexpected index type: %s" % (idxty,))
             ax += 1
+            new_ax += 1
 
         # Fill up missing dimensions at the end
         assert ax <= aryty.ndim, (ax, aryty.ndim)
@@ -1008,8 +1022,21 @@ class FancyIndexer(object):
     def prepare(self):
         for i in self.indexers:
             i.prepare()
-        # Compute the resulting shape
-        self.indexers_shape = sum([i.get_shape() for i in self.indexers], ())
+
+        one = self.context.get_constant(types.intp, 1)
+
+        # Compute the resulting shape given by the indices
+        res_shape = [i.get_shape() for i in self.indexers]
+
+        # At every position where newaxis/None is present insert
+        # one as a constant shape in the resulting list of shapes.
+        for i in self.newaxes:
+            res_shape.insert(i, (one,))
+
+        # Store the shape as a tuple, we can't do a simple
+        # tuple(res_shape) here since res_shape is a list
+        # of tuples which may be differently sized.
+        self.indexers_shape = sum(res_shape, ())
 
     def get_shape(self):
         """
@@ -1236,7 +1263,6 @@ def maybe_copy_source(context, builder, use_copy,
             builder.store(builder.load(src_ptr), dest_ptr)
 
     def src_getitem(source_indices):
-        assert len(source_indices) == srcty.ndim
         src_ptr = cgutils.alloca_once(builder, ptrty)
         with builder.if_else(use_copy, likely=False) as (if_copy, otherwise):
             with if_copy:
@@ -1700,11 +1726,25 @@ def fancy_setslice(context, builder, sig, args, index_types, indices):
         def src_cleanup():
             pass
 
+    zero = context.get_constant(types.uintp, 0)
     # Loop on destination and copy from source to destination
     dest_indices, counts = indexer.begin_loops()
 
     # Source is iterated in natural order
-    source_indices = tuple(c for c in counts if c is not None)
+
+    # Counts represent a counter for the number of times a specified axis
+    # is being accessed, during setitem they are used as source
+    # indices
+    counts = list(counts)
+
+    # We need to artifically introduce the index zero wherever a
+    # newaxis is present within the indexer. These always remain
+    # zero.
+    for i in indexer.newaxes:
+        counts.insert(i, zero)
+
+    source_indices = [c for c in counts if c is not None]
+
     val = src_getitem(source_indices)
 
     # Cast to the destination dtype (cross-dtype slice assignment is allowed)

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -368,7 +368,7 @@ def ufunc_find_matching_loop(ufunc, arg_types):
     # Separate logical input from explicit output arguments
     input_types = arg_types[:ufunc.nin]
     output_types = arg_types[ufunc.nin:]
-    assert(len(input_types) == ufunc.nin)
+    assert (len(input_types) == ufunc.nin)
 
     try:
         np_input_types = [as_dtype(x) for x in input_types]

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -78,7 +78,7 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
     # zero.
     rng_excl = uint8(rng) + uint8(1)
 
-    assert(rng != 0xFF)
+    assert (rng != 0xFF)
 
     # Generate a scaled random number.
     n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
@@ -114,7 +114,7 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
     # zero.
     rng_excl = uint16(rng) + uint16(1)
 
-    assert(rng != 0xFFFF)
+    assert (rng != 0xFFFF)
 
     # Generate a scaled random number.
     n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
@@ -143,7 +143,7 @@ def buffered_bounded_lemire_uint32(bitgen, rng):
     """
     rng_excl = uint32(rng) + uint32(1)
 
-    assert(rng != 0xFFFFFFFF)
+    assert (rng != 0xFFFFFFFF)
 
     # Generate a scaled random number.
     m = uint64(next_uint32(bitgen)) * uint64(rng_excl)
@@ -170,7 +170,7 @@ def bounded_lemire_uint64(bitgen, rng):
     """
     rng_excl = uint64(rng) + uint64(1)
 
-    assert(rng != 0xFFFFFFFFFFFFFFFF)
+    assert (rng != 0xFFFFFFFFFFFFFFFF)
 
     x = next_uint64(bitgen)
 

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -4065,7 +4065,7 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata, func_ir, typemap):
     report = None
 
     # fusion of parfors with different lowerers is not possible
-    if len(parfor1.lowerer) != len(parfor2.lowerer):
+    if parfor1.lowerer != parfor2.lowerer:
         dprint("try_fuse: parfors different lowerers")
         msg = "- fusion failed: lowerer mismatch"
         report = FusionReport(parfor1.id, parfor2.id, msg)

--- a/numba/parfors/parfor.py
+++ b/numba/parfors/parfor.py
@@ -584,6 +584,11 @@ class Parfor(ir.Expr, ir.Stmt):
         self.races = races
         self.redvars = []
         self.reddict = {}
+        # If the lowerer is None then the standard lowerer will be used.
+        # This can be set to a function to have that function act as the lowerer
+        # for this parfor.  This lowerer field will also prevent parfors from
+        # being fused unless they have use the same lowerer.
+        self.lowerer = None
         if config.DEBUG_ARRAY_OPT_STATS:
             fmt = 'Parallel for-loop #{} is produced from pattern \'{}\' at {}'
             print(fmt.format(
@@ -2888,6 +2893,29 @@ class ParforPass(ParforPassStates):
 
         dprint_func_ir(self.func_ir, "after parfor pass")
 
+    def _find_mask(self, arr_def):
+        """check if an array is of B[...M...], where M is a
+        boolean array, and other indices (if available) are ints.
+        If found, return B, M, M's type, and a tuple representing mask indices.
+        Otherwise, raise GuardException.
+        """
+        return _find_mask(self.typemap, self.func_ir, arr_def)
+
+    def _mk_parfor_loops(self, size_vars, scope, loc):
+        """
+        Create loop index variables and build LoopNest objects for a parfor.
+        """
+        return _mk_parfor_loops(self.typemap, size_vars, scope, loc)
+
+
+class ParforFusionPass(ParforPassStates):
+
+    """ParforFusionPass class is responsible for fusing parfors
+    """
+
+    def run(self):
+        """run parfor fusion pass"""
+
         # simplify CFG of parfor body loops since nested parfors with extra
         # jumps can be created with prange conversion
         n_parfors = simplify_parfor_body_CFG(self.func_ir.blocks)
@@ -2937,6 +2965,61 @@ class ParforPass(ParforPassStates):
             dprint_func_ir(self.func_ir, "after fusion")
             # remove dead code after fusion to remove extra arrays and variables
             simplify(self.func_ir, self.typemap, self.calltypes, self.metadata["parfors"])
+
+    def fuse_parfors(self, array_analysis, blocks, func_ir, typemap):
+        for label, block in blocks.items():
+            equiv_set = array_analysis.get_equiv_set(label)
+            fusion_happened = True
+            while fusion_happened:
+                fusion_happened = False
+                new_body = []
+                i = 0
+                while i < len(block.body) - 1:
+                    stmt = block.body[i]
+                    next_stmt = block.body[i + 1]
+                    if isinstance(stmt, Parfor) and isinstance(next_stmt, Parfor):
+                        # we have to update equiv_set since they have changed due to
+                        # variables being renamed before fusion.
+                        equiv_set = array_analysis.get_equiv_set(label)
+                        stmt.equiv_set = equiv_set
+                        next_stmt.equiv_set = equiv_set
+                        fused_node, fuse_report = try_fuse(equiv_set, stmt, next_stmt,
+                            self.metadata["parfors"], func_ir, typemap)
+                        # accumulate fusion reports
+                        self.diagnostics.fusion_reports.append(fuse_report)
+                        if fused_node is not None:
+                            fusion_happened = True
+                            self.diagnostics.fusion_info[stmt.id].extend([next_stmt.id])
+                            new_body.append(fused_node)
+                            self.fuse_recursive_parfor(fused_node, equiv_set, func_ir, typemap)
+                            i += 2
+                            continue
+                    new_body.append(stmt)
+                    if isinstance(stmt, Parfor):
+                        self.fuse_recursive_parfor(stmt, equiv_set, func_ir, typemap)
+                    i += 1
+                new_body.append(block.body[-1])
+                block.body = new_body
+        return
+
+    def fuse_recursive_parfor(self, parfor, equiv_set, func_ir, typemap):
+        blocks = wrap_parfor_blocks(parfor)
+        maximize_fusion(self.func_ir, blocks, self.typemap)
+        dprint_func_ir(self.func_ir, "after recursive maximize fusion down", blocks)
+        arr_analysis = array_analysis.ArrayAnalysis(self.typingctx, self.func_ir,
+                                                self.typemap, self.calltypes)
+        arr_analysis.run(blocks, equiv_set)
+        self.fuse_parfors(arr_analysis, blocks, func_ir, typemap)
+        unwrap_parfor_blocks(parfor)
+
+
+class ParforPreLoweringPass(ParforPassStates):
+
+    """ParforPreLoweringPass class is responsible for preparing parfors for lowering.
+    """
+
+    def run(self):
+        """run parfor prelowering pass"""
 
         # push function call variables inside parfors so gufunc function
         # wouldn't need function variables as argument
@@ -3011,68 +3094,6 @@ class ParforPass(ParforPassStates):
                            after_fusion, name, n_parfors, parfor_ids))
                 else:
                     print('Function {} has no Parfor.'.format(name))
-
-        return
-
-    def _find_mask(self, arr_def):
-        """check if an array is of B[...M...], where M is a
-        boolean array, and other indices (if available) are ints.
-        If found, return B, M, M's type, and a tuple representing mask indices.
-        Otherwise, raise GuardException.
-        """
-        return _find_mask(self.typemap, self.func_ir, arr_def)
-
-    def _mk_parfor_loops(self, size_vars, scope, loc):
-        """
-        Create loop index variables and build LoopNest objects for a parfor.
-        """
-        return _mk_parfor_loops(self.typemap, size_vars, scope, loc)
-
-    def fuse_parfors(self, array_analysis, blocks, func_ir, typemap):
-        for label, block in blocks.items():
-            equiv_set = array_analysis.get_equiv_set(label)
-            fusion_happened = True
-            while fusion_happened:
-                fusion_happened = False
-                new_body = []
-                i = 0
-                while i < len(block.body) - 1:
-                    stmt = block.body[i]
-                    next_stmt = block.body[i + 1]
-                    if isinstance(stmt, Parfor) and isinstance(next_stmt, Parfor):
-                        # we have to update equiv_set since they have changed due to
-                        # variables being renamed before fusion.
-                        equiv_set = array_analysis.get_equiv_set(label)
-                        stmt.equiv_set = equiv_set
-                        next_stmt.equiv_set = equiv_set
-                        fused_node, fuse_report = try_fuse(equiv_set, stmt, next_stmt,
-                            self.metadata["parfors"], func_ir, typemap)
-                        # accumulate fusion reports
-                        self.diagnostics.fusion_reports.append(fuse_report)
-                        if fused_node is not None:
-                            fusion_happened = True
-                            self.diagnostics.fusion_info[stmt.id].extend([next_stmt.id])
-                            new_body.append(fused_node)
-                            self.fuse_recursive_parfor(fused_node, equiv_set, func_ir, typemap)
-                            i += 2
-                            continue
-                    new_body.append(stmt)
-                    if isinstance(stmt, Parfor):
-                        self.fuse_recursive_parfor(stmt, equiv_set, func_ir, typemap)
-                    i += 1
-                new_body.append(block.body[-1])
-                block.body = new_body
-        return
-
-    def fuse_recursive_parfor(self, parfor, equiv_set, func_ir, typemap):
-        blocks = wrap_parfor_blocks(parfor)
-        maximize_fusion(self.func_ir, blocks, self.typemap)
-        dprint_func_ir(self.func_ir, "after recursive maximize fusion down", blocks)
-        arr_analysis = array_analysis.ArrayAnalysis(self.typingctx, self.func_ir,
-                                                self.typemap, self.calltypes)
-        arr_analysis.run(blocks, equiv_set)
-        self.fuse_parfors(arr_analysis, blocks, func_ir, typemap)
-        unwrap_parfor_blocks(parfor)
 
 
 def _remove_size_arg(call_name, expr):
@@ -4042,6 +4063,13 @@ def try_fuse(equiv_set, parfor1, parfor2, metadata, func_ir, typemap):
 
     # default report is None
     report = None
+
+    # fusion of parfors with different lowerers is not possible
+    if len(parfor1.lowerer) != len(parfor2.lowerer):
+        dprint("try_fuse: parfors different lowerers")
+        msg = "- fusion failed: lowerer mismatch"
+        report = FusionReport(parfor1.id, parfor2.id, msg)
+        return None, report
 
     # fusion of parfors with different dimensions not supported yet
     if len(parfor1.loop_nests) != len(parfor2.loop_nests):

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -54,6 +54,13 @@ class ParforLower(lowering.Lower):
 
 
 def _lower_parfor_parallel(lowerer, parfor):
+    if parfor.lowerer is None:
+        return _lower_parfor_parallel_std(lowerer, parfor)
+    else:
+        return parfor.lowerer(lowerer, parfor)
+
+
+def _lower_parfor_parallel_std(lowerer, parfor):
     """Lowerer that handles LLVM code generation for parfor.
     This function lowers a parfor IR node to LLVM.
     The general approach is as follows:

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -1527,6 +1527,13 @@ def _create_gufunc_for_parfor_body(
         flags.noalias = True
 
     fixup_var_define_in_scope(gufunc_ir.blocks)
+
+    class ParforGufuncCompiler(compiler.CompilerBase):
+        def define_pipelines(self):
+            pms = [compiler.DefaultPassBuilder.define_parfor_gufunc_pipeline(self.state),
+                   compiler.DefaultPassBuilder.define_nopython_lowering_pipeline(self.state)]
+            return pms
+
     kernel_func = compiler.compile_ir(
         typingctx,
         targetctx,
@@ -1534,7 +1541,8 @@ def _create_gufunc_for_parfor_body(
         gufunc_param_types,
         types.none,
         flags,
-        locals)
+        locals,
+        pipeline_class=ParforGufuncCompiler)
 
     flags.noalias = old_alias
 

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -52,12 +52,18 @@ from numba.core.extending import (
 from numba.core.datamodel.models import OpaqueModel
 from numba.pycc.platform import external_compiler_works
 
-
 try:
     import scipy
 except ImportError:
     scipy = None
 
+# Make sure that coverage is set up.
+try:
+    import coverage
+except ImportError:
+    pass
+else:
+    coverage.process_startup()
 
 enable_pyobj_flags = Flags()
 enable_pyobj_flags.enable_pyobject = True
@@ -583,6 +589,10 @@ class TestCase(unittest.TestCase):
         cmd = [sys.executable, '-m', 'numba.runtests', fully_qualified_test]
         env_copy = os.environ.copy()
         env_copy['SUBPROC_TEST'] = '1'
+        try:
+            env_copy['COVERAGE_PROCESS_START'] = os.environ['COVERAGE_RCFILE']
+        except KeyError:
+            pass   # ignored
         envvars = pytypes.MappingProxyType({} if envvars is None else envvars)
         env_copy.update(envvars)
         status = subprocess.run(cmd, stdout=subprocess.PIPE,

--- a/numba/tests/test_fancy_indexing.py
+++ b/numba/tests/test_fancy_indexing.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 
 import unittest
-from numba import jit, typeof
+from numba import jit, typeof, njit
 from numba.core import types
 from numba.core.errors import TypingError
 from numba.tests.support import MemoryLeakMixin, TestCase, tag
@@ -255,6 +255,50 @@ class TestFancyIndexing(MemoryLeakMixin, TestCase):
 
         #exceptions leak refs
         self.disable_leak_check()
+
+    def test_newaxis(self):
+        @njit
+        def np_new_axis_getitem(a, idx):
+            return a[idx]
+
+        @njit
+        def np_new_axis_setitem(a, idx, item):
+            a[idx] = item
+            return a
+
+        a = np.arange(4 * 5 * 6 * 7).reshape((4, 5, 6, 7))
+        idx_cases = [
+            (slice(None), np.newaxis),
+            (np.newaxis, slice(None)),
+            (slice(1), np.newaxis, np.array([1, 2, 1])),
+            (np.newaxis, np.array([1, 2, 1]), slice(None)),
+            (slice(1), Ellipsis, np.newaxis, np.array([1, 2, 1])),
+            (np.array([1, 2, 1]), np.newaxis, Ellipsis),
+            (np.newaxis, slice(1), np.newaxis, np.array([1, 2, 1])),
+            (np.array([1, 2, 1]), Ellipsis, None, np.newaxis),
+            (np.newaxis, slice(1), Ellipsis, np.newaxis, np.array([1, 2, 1])),
+            (np.array([1, 2, 1]), np.newaxis, np.newaxis, Ellipsis),
+            (np.newaxis, np.array([1, 2, 1]), np.newaxis, Ellipsis),
+            (slice(3), np.array([1, 2, 1]), np.newaxis, None),
+            (np.newaxis, np.array([1, 2, 1]), Ellipsis, None),
+        ]
+        pyfunc_getitem = np_new_axis_getitem.py_func
+        cfunc_getitem = np_new_axis_getitem
+
+        pyfunc_setitem = np_new_axis_setitem.py_func
+        cfunc_setitem = np_new_axis_setitem
+
+        for idx in idx_cases:
+            expected = pyfunc_getitem(a, idx)
+            got = cfunc_getitem(a, idx)
+            np.testing.assert_equal(expected, got)
+
+            a_empty = np.zeros_like(a)
+            item = a[idx]
+
+            expected = pyfunc_setitem(a_empty.copy(), idx, item)
+            got = cfunc_setitem(a_empty.copy(), idx, item)
+            np.testing.assert_equal(expected, got)
 
 
 if __name__ == '__main__':

--- a/numba/tests/test_inlining.py
+++ b/numba/tests/test_inlining.py
@@ -19,7 +19,8 @@ from numba.core.typed_passes import (NopythonTypeInference, AnnotateTypes,
                            NopythonRewrites, PreParforPass, ParforPass,
                            DumpParforDiagnostics, NativeLowering,
                            NativeParforLowering, IRLegalization,
-                           NoPythonBackend, NativeLowering)
+                           NoPythonBackend, NativeLowering,
+                           ParforFusionPass, ParforPreLoweringPass)
 
 from numba.core.compiler_machinery import FunctionPass, PassManager, register_pass
 import unittest
@@ -89,6 +90,8 @@ def gen_pipeline(state, test_pass):
             pm.add_pass(NopythonRewrites, "nopython rewrites")
         if state.flags.auto_parallel.enabled:
             pm.add_pass(ParforPass, "convert to parfors")
+            pm.add_pass(ParforFusionPass, "fuse parfors")
+            pm.add_pass(ParforPreLoweringPass, "parfor prelowering")
 
         pm.add_pass(test_pass, "inline test")
 

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -517,6 +517,16 @@ def get_optimized_numba_ir(test_func, args, **kws):
             tp.state.return_type, tp.state.typingctx, tp.state.targetctx,
             options, flags, tp.state.metadata, diagnostics=diagnostics)
         parfor_pass.run()
+        parfor_pass = numba.parfors.parfor.ParforFusionPass(
+            tp.state.func_ir, tp.state.typemap, tp.state.calltypes,
+            tp.state.return_type, tp.state.typingctx, tp.state.targetctx,
+            options, flags, tp.state.metadata, diagnostics=diagnostics)
+        parfor_pass.run()
+        parfor_pass = numba.parfors.parfor.ParforPreLoweringPass(
+            tp.state.func_ir, tp.state.typemap, tp.state.calltypes,
+            tp.state.return_type, tp.state.typingctx, tp.state.targetctx,
+            options, flags, tp.state.metadata, diagnostics=diagnostics)
+        parfor_pass.run()
         test_ir._definitions = build_definitions(test_ir.blocks)
 
     return test_ir, tp

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1732,6 +1732,73 @@ class TestNestedArrays(TestCase):
 
         np.testing.assert_array_equal(expected, got)
 
+    def test_issue_1469_1(self):
+        # Dimensions of nested arrays as a dtype are concatenated with the
+        # dimensions of the array.
+        nptype = np.dtype((np.float64, (4,)))
+        nbtype = types.Array(numpy_support.from_dtype(nptype), 2, 'C')
+        expected = types.Array(types.float64, 3, 'C')
+        self.assertEqual(nbtype, expected)
+
+    def test_issue_1469_2(self):
+        # Nesting nested arrays results in concatentated dimensions -
+        # In this example a 3D array of a 2D nested array of 2D nested arrays
+        # results in a 7D type.
+        nptype = np.dtype((np.dtype((np.float64, (5, 2))), (3, 6)))
+        nbtype = types.Array(numpy_support.from_dtype(nptype), 3, 'C')
+        expected = types.Array(types.float64, 7, 'C')
+        self.assertEqual(nbtype, expected)
+
+    def test_issue_1469_3(self):
+        # Nested arrays in record dtypes are accepted, but alignment is not
+        # guaranteed.
+        nptype = np.dtype([('a', np.float64,(4,))])
+        nbtype = types.Array(numpy_support.from_dtype(nptype), 2, 'C')
+
+        # Manual construction of expected array of record type
+        natype = types.NestedArray(types.float64, (4,))
+        fields = [('a', {'type': natype, 'offset': 0})]
+        rectype = types.Record(fields=fields, size=32, aligned=False)
+        expected = types.Array(rectype, 2, 'C', aligned=False)
+
+        self.assertEqual(nbtype, expected)
+
+    def test_issue_3158_1(self):
+        # A nested array dtype.
+        item = np.dtype([('some_field', np.int32)])
+        items = np.dtype([('items', item, 3)])
+
+        @njit
+        def fn(x):
+            return x[0]
+
+        arr = np.asarray([([(0,), (1,), (2,)],),
+                          ([(3,), (4,), (5,)],)],
+                         dtype=items)
+
+        expected = fn.py_func(arr)
+        actual = fn(arr)
+
+        self.assertEqual(expected, actual)
+
+    def test_issue_3158_2(self):
+        # A slightly more complex nested array dtype example.
+        dtype1 = np.dtype([('a', 'i8'), ('b', 'i4')])
+        dtype2 = np.dtype((dtype1, (2, 2)))
+        dtype3 = np.dtype([('x', '?'), ('y', dtype2)])
+
+        @njit
+        def fn(arr):
+            return arr[0]
+
+        arr = np.asarray([(False, [[(0, 1), (2, 3)], [(4, 5), (6, 7)]]),
+                          (True, [[(8, 9), (10, 11)], [(12, 13), (14, 15)]])],
+                         dtype=dtype3)
+        expected = fn.py_func(arr)
+        actual = fn(arr)
+
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/numba/tests/test_repr.py
+++ b/numba/tests/test_repr.py
@@ -1,0 +1,63 @@
+import unittest
+import numpy as np
+
+from numba.tests.support import TestCase
+from numba import typeof
+from numba.core import types
+from numba.typed import List, Dict
+
+NB_TYPES = [
+    types.Array,
+    types.NestedArray,
+    types.bool_,
+    types.unicode_type,
+    types.Record,
+    types.UnicodeCharSeq,
+    types.UniTuple,
+    types.List,
+    types.Tuple,
+    types.DictType,
+    types.ListType,
+    types.Set,
+] + list(types.number_domain)
+
+
+class TestRepr(TestCase):
+    def setUp(self) -> None:
+        tys_ns = {ty.__name__: ty for ty in NB_TYPES if hasattr(ty, "__name__")}
+        tys_ns.update({ty.name: ty for ty in NB_TYPES if hasattr(ty, "name")})
+        self.tys_ns = tys_ns
+
+    def check_repr(self, val):
+        ty = typeof(val)
+        ty2 = eval(repr(ty), self.tys_ns)
+        self.assertEqual(ty, ty2)
+
+    def test_types(self):
+        # define some values for the test cases
+        rec_dtype = [("a", "f8"), ("b", "U8"), ("c", "i8", (2, 3))]
+        nb_dict = Dict()
+        nb_dict['a'] = 1
+        # tests cases: list of different types + list comp of number types
+        val_types_cases = [
+            True,
+            "a",
+            (1, 2),
+            (1, "a"),
+            [1, "a"],
+            ([1, "a"], [2, "b"]),
+            ((1, 2), (3, "b")),
+            ((1, 2), (3, [1, 2])),
+            np.ones(3),
+            np.array([(1, "a", np.ones((2, 3)))], dtype=rec_dtype),
+            nb_dict,
+            List([1, 2]),
+            {1, 2},
+        ] + [number(1.1) for number in types.number_domain]
+
+        for val in val_types_cases:
+            self.check_repr(val)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -247,7 +247,7 @@ class TestReportedSSAIssues(SSABaseTest):
             for i in range(1):
                 arr = arr.reshape(3 * 2)
                 arr = arr.reshape(3, 2)
-            return(arr)
+            return (arr)
 
         np.testing.assert_allclose(foo(np.zeros((3, 2))),
                                    foo.py_func(np.zeros((3, 2))))

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -603,7 +603,7 @@ class TestStencil(TestStencilBase):
         for compiler in [self.compile_njit, self.compile_parallel]:
             try:
                 compiler(wrapped,())
-            except(NumbaValueError, LoweringError) as e:
+            except (NumbaValueError, LoweringError) as e:
                 self.assertIn(msg, str(e))
             else:
                 raise AssertionError("Expected error was not raised")
@@ -3056,7 +3056,7 @@ class TestManyStencils(TestStencilBase):
         """ Issue #3454, const(int) == const(int) evaluating incorrectly. """
         def kernel(a):
             b = 0
-            if(2 == 0):
+            if (2 == 0):
                 b = 2
             return a[0, 0] + b
         # ----------------------------------------------------------------------

--- a/numba/typed/listobject.py
+++ b/numba/typed/listobject.py
@@ -1134,7 +1134,7 @@ def impl_insert(l, index, item):
                 l.append(l[0])
                 # reverse iterate over the list and shift all elements
                 i = len(l) - 1
-                while(i > index):
+                while (i > index):
                     l[i] = l[i - 1]
                     i -= 1
                 # finally, insert the item


### PR DESCRIPTION
Split parfor pass into 1) parfor conversion, 2) fusion, and 3) post-fusion miscellaneous passes.  Adding a lowerer tag to the parfor node, which defaults to the existing lowerer.  Applications that change the pipeline can insert passes between 1) and 2) that change the lowerer.  Parfors with different lowerers will then not fuse.  The lowerer tag is then used during the lowering phase to lowerer this parfor.  This allows different parfors in the same function to be lowered differently, e.g., for CPU or GPU.