### PR TITLE
Move minimum supported TBB version to 2021.6

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     # NOTE: 2021.1..2021.5 are API compatible for Numba's purposes.
     # NOTE: ppc64le exclusion is temporary until packages are more generally
     #       available.
-    - tbb-devel >=2021,<2021.6       # [not (aarch64 or ppc64le)]
+    - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
   run:
     - python >=3.8
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
@@ -50,8 +50,8 @@ requirements:
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.40.0dev0,<0.40
   run_constrained:
-    # If TBB is present it must be at least version 2021
-    - tbb >=2021    # [not (aarch64 or ppc64le)]
+    # If TBB is present it must be at least version 2021.6
+    - tbb >=2021.6    # [not (aarch64 or ppc64le)]
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     # 0.3.17 buggy on M1 silicon
@@ -75,7 +75,7 @@ test:
     - scipy
     - ipython                  # [not aarch64]
     - setuptools
-    - tbb  >=2021              # [not (aarch64 or ppc64le)]
+    - tbb >=2021.6             # [not (aarch64 or ppc64le)]
     - llvm-openmp              # [osx]
     # This is for driving gdb tests
     - pexpect                  # [linux64]

--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -18,7 +18,7 @@ build:
     - lib/libiomp5.dylib # [osx]
   ignore_run_exports:
     # tbb-devel triggers hard dependency on tbb, this is not the case.
-    - tbb     # [not aarch64]
+    - tbb     # [not (aarch64 or win32)]
 
 requirements:
   # build and run dependencies are duplicated to avoid setuptools issues
@@ -36,11 +36,7 @@ requirements:
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.40.0dev0,<0.40
     # TBB devel version is to match TBB libs.
-    # 2020.3 is the last version with the "old" ABI
-    # NOTE: 2021.1..2021.5 are API compatible for Numba's purposes.
-    # NOTE: ppc64le exclusion is temporary until packages are more generally
-    #       available.
-    - tbb-devel >=2021.6       # [not (aarch64 or ppc64le)]
+    - tbb-devel >=2021.6       # [not (aarch64 or win32)]
   run:
     - python >=3.8
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
@@ -51,7 +47,7 @@ requirements:
     - llvmlite >=0.40.0dev0,<0.40
   run_constrained:
     # If TBB is present it must be at least version 2021.6
-    - tbb >=2021.6    # [not (aarch64 or ppc64le)]
+    - tbb >=2021.6    # [not (aarch64 or win32)]
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     # 0.3.17 buggy on M1 silicon
@@ -75,7 +71,7 @@ test:
     - scipy
     - ipython                  # [not aarch64]
     - setuptools
-    - tbb >=2021.6             # [not (aarch64 or ppc64le)]
+    - tbb >=2021.6             # [not (aarch64 or win32)]
     - llvm-openmp              # [osx]
     # This is for driving gdb tests
     - pexpect                  # [linux64]

--- a/buildscripts/condarecipe.local/run_test.bat
+++ b/buildscripts/condarecipe.local/run_test.bat
@@ -3,6 +3,11 @@ set NUMBA_DISABLE_ERROR_MESSAGE_HIGHLIGHTING=1
 set NUMBA_CAPTURED_ERRORS=new_style
 set PYTHONFAULTHANDLER=1
 
+@rem no parallel target support for 32 bit windows and no TBB packages
+if "%ARCH%"=="32" (
+    set NUMBA_DISABLE_TBB=1
+)
+
 @rem Check Numba executable is there
 numba -h
 

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -37,7 +37,7 @@ if "%BUILD_DOC%" == "yes" (%CONDA_INSTALL% sphinx sphinx_rtd_theme pygments)
 @rem Install dependencies for code coverage (codecov.io)
 if "%RUN_COVERAGE%" == "yes" (%PIP_INSTALL% codecov)
 @rem Install TBB
-%CONDA_INSTALL% -c numba tbb=2021 "tbb-devel>=2021,<2021.6"
+%CONDA_INSTALL% -c numba tbb>=2021.6 tbb-devel>=2021.6
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo "DEBUG ENV:"

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -85,7 +85,7 @@ if [ "$RUN_COVERAGE" == "yes" ]; then $PIP_INSTALL codecov; fi
 # Install SVML
 if [ "$TEST_SVML" == "yes" ]; then $CONDA_INSTALL -c numba icc_rt; fi
 # Install Intel TBB parallel backend
-if [ "$TEST_THREADING" == "tbb" ]; then $CONDA_INSTALL -c numba tbb=2021 "tbb-devel>=2021,<2021.6"; fi
+if [ "$TEST_THREADING" == "tbb" ]; then $CONDA_INSTALL -c numba tbb>=2021.6 tbb-devel>=2021.6; fi
 # Install typeguard
 if [ "$RUN_TYPEGUARD" == "yes" ]; then $CONDA_INSTALL conda-forge::typeguard; fi
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -196,7 +196,7 @@ vary with target operating system and hardware. The following lists them all
   * ``llvm-openmp`` (OSX) - provides headers for compiling OpenMP support into
     Numba's threading backend
   * ``tbb-devel`` - provides TBB headers/libraries for compiling TBB support
-    into Numba's threading backend (2021 <= version < 2021.6 required).
+    into Numba's threading backend (version >= 2021.6 required).
   * ``importlib_metadata`` (for Python versions < 3.9)
 
 * Optional runtime are:
@@ -260,7 +260,7 @@ information.
 +----------++--------------+---------------------------+----------------------------+------------------------------+-------------------+-----------------------------+
 | Numba     | Release date | Python                    | NumPy                      | llvmlite                     | LLVM              | TBB                         |
 +===========+==============+===========================+============================+==============================+===================+=============================+
-| 0.57.0    | TBC          | 3.8.x <= version < 3.12   | 1.21 <= version < 1.25     | 0.40.x                       | 11.x              | 2021.x                      |
+| 0.57.0    | TBC          | 3.8.x <= version < 3.12   | 1.21 <= version < 1.25     | 0.40.x                       | 11.x              | 2021.6 <= version           |
 +-----------+--------------+---------------------------+----------------------------+------------------------------+-------------------+-----------------------------+
 | 0.56.4    | 2022-11-03   | 3.7.x <= version < 3.11   | 1.18 <= version < 1.24     | 0.39.x                       | 11.x              | 2021.x                      |
 +-----------+--------------+---------------------------+----------------------------+------------------------------+-------------------+-----------------------------+

--- a/numba/np/ufunc/parallel.py
+++ b/numba/np/ufunc/parallel.py
@@ -360,10 +360,10 @@ def _check_tbb_version_compatible():
         version_func.argtypes = []
         version_func.restype = c_int
         tbb_iface_ver = version_func()
-        if tbb_iface_ver < 12010: # magic number from TBB
+        if tbb_iface_ver < 12060: # magic number from TBB
             msg = ("The TBB threading layer requires TBB "
-                   "version 2021 update 1 or later i.e., "
-                   "TBB_INTERFACE_VERSION >= 12010. Found "
+                   "version 2021 update 6 or later i.e., "
+                   "TBB_INTERFACE_VERSION >= 12060. Found "
                    "TBB_INTERFACE_VERSION = %s. The TBB "
                    "threading layer is disabled.") % tbb_iface_ver
             problem = errors.NumbaWarning(msg)

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -32,7 +32,7 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
 #endif
 
-tbb::task_scheduler_handle tbb_tsh_attach()
+static tbb::task_scheduler_handle tbb_tsh_attach()
 {
 #if TBB_INTERFACE_VERSION >= 12060
     return tbb::attach();
@@ -41,7 +41,7 @@ tbb::task_scheduler_handle tbb_tsh_attach()
 #endif
 }
 
-void tbb_tsh_release(tbb::task_scheduler_handle& tsh)
+static void tbb_tsh_release(tbb::task_scheduler_handle& tsh)
 {
 #if TBB_INTERFACE_VERSION >= 12060
     tsh.release();

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -21,34 +21,10 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 
 #include "gufunc_scheduler.h"
 
-/* TBB 2019 U5 is the minimum required version as this is needed:
- * https://github.com/intel/tbb/blob/18070344d755ece04d169e6cc40775cae9288cee/CHANGES#L133-L134
- * and therefore
- * https://github.com/intel/tbb/blob/18070344d755ece04d169e6cc40775cae9288cee/CHANGES#L128-L129
- * from here:
- * https://github.com/intel/tbb/blob/2019_U5/include/tbb/tbb_stddef.h#L29
- */
-#if (TBB_INTERFACE_VERSION >= 12060) || (TBB_INTERFACE_VERSION < 12010)
-#error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
+/* TBB 2021.6 is the minimum version */
+#if (TBB_INTERFACE_VERSION < 12060)
+#error "TBB version is incompatible, 2021.6 or greater required, i.e. TBB_INTERFACE_VERSION >= 12060"
 #endif
-
-static tbb::task_scheduler_handle tbb_tsh_attach()
-{
-#if TBB_INTERFACE_VERSION >= 12060
-    return tbb::attach();
-#else
-    return tbb::task_scheduler_handle::get();
-#endif
-}
-
-static void tbb_tsh_release(tbb::task_scheduler_handle& tsh)
-{
-#if TBB_INTERFACE_VERSION >= 12060
-    tsh.release();
-#else
-    tbb::task_scheduler_handle::release(tsh);
-#endif
-}
 
 #define _DEBUG 0
 #define _TRACE_SPLIT 0
@@ -254,7 +230,7 @@ static void prepare_fork(void)
         {
             if (!tbb::finalize(tsh, std::nothrow))
             {
-                tbb_tsh_release(tsh);
+                tsh.release();
                 puts("Unable to join threads to shut down before fork(). "
                      "This can break multithreading in child processes.\n");
             }
@@ -279,7 +255,7 @@ static void reset_after_fork(void)
 
     if(need_reinit_after_fork)
     {
-        tsh = tbb_tsh_attach();
+        tsh = tbb::attach();
         set_main_thread();
         tsh_was_initialized = true;
         need_reinit_after_fork = false;
@@ -317,7 +293,7 @@ static void launch_threads(int count)
     if(count < 1)
         count = tbb::task_arena::automatic;
 
-    tsh = tbb_tsh_attach();
+    tsh = tbb::attach();
     tsh_was_initialized = true;
 
     tg = new tbb::task_group;

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -32,15 +32,23 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
 #endif
 
-#if TBB_INTERFACE_VERSION < 12010
-#error "TBB version is too old, 2021 update 1, i.e. TBB_INTERFACE_VERSION >= 12010 required"
-#elif TBB_INTERFACE_VERSION >= 12060
-#define TSH_ATTACH tbb::attach
-#define TSH_RELEASE(TSH) TSH.release()
+tbb::task_scheduler_handle tbb_tsh_attach()
+{
+#if TBB_INTERFACE_VERSION >= 12060
+    return tbb::attach();
 #else
-#define TSH_ATTACH tbb::task_scheduler_handle::get
-#define TSH_RELEASE(TSH) tbb::task_scheduler_handle::release(TSH)
+    return tbb::task_scheduler_handle::get();
+#endif
+}
 
+void tbb_tsh_release(tbb::task_scheduler_handle& tsh)
+{
+#if TBB_INTERFACE_VERSION >= 12060
+    tsh.release();
+#else
+    tbb::task_scheduler_handle::release(tsh);
+#endif
+}
 
 #define _DEBUG 0
 #define _TRACE_SPLIT 0
@@ -246,7 +254,7 @@ static void prepare_fork(void)
         {
             if (!tbb::finalize(tsh, std::nothrow))
             {
-                TSH_RELEASE(tsh);
+                tbb_tsh_release(tsh);
                 puts("Unable to join threads to shut down before fork(). "
                      "This can break multithreading in child processes.\n");
             }
@@ -271,7 +279,7 @@ static void reset_after_fork(void)
 
     if(need_reinit_after_fork)
     {
-        tsh = TSH_ATTACH();
+        tsh = tbb_tsh_attach();
         set_main_thread();
         tsh_was_initialized = true;
         need_reinit_after_fork = false;
@@ -309,7 +317,7 @@ static void launch_threads(int count)
     if(count < 1)
         count = tbb::task_arena::automatic;
 
-    tsh = TSH_ATTACH();
+    tsh = tbb_tsh_attach();
     tsh_was_initialized = true;
 
     tg = new tbb::task_group;

--- a/numba/np/ufunc/tbbpool.cpp
+++ b/numba/np/ufunc/tbbpool.cpp
@@ -12,6 +12,7 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #undef _XOPEN_SOURCE
 #endif
 
+#include <tbb/version.h>
 #include <tbb/tbb.h>
 #include <string.h>
 #include <stdio.h>
@@ -30,6 +31,16 @@ Implement parallel vectorize workqueue on top of Intel TBB.
 #if (TBB_INTERFACE_VERSION >= 12060) || (TBB_INTERFACE_VERSION < 12010)
 #error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
 #endif
+
+#if TBB_INTERFACE_VERSION < 12010
+#error "TBB version is too old, 2021 update 1, i.e. TBB_INTERFACE_VERSION >= 12010 required"
+#elif TBB_INTERFACE_VERSION >= 12060
+#define TSH_ATTACH tbb::attach
+#define TSH_RELEASE(TSH) TSH.release()
+#else
+#define TSH_ATTACH tbb::task_scheduler_handle::get
+#define TSH_RELEASE(TSH) tbb::task_scheduler_handle::release(TSH)
+
 
 #define _DEBUG 0
 #define _TRACE_SPLIT 0
@@ -235,7 +246,7 @@ static void prepare_fork(void)
         {
             if (!tbb::finalize(tsh, std::nothrow))
             {
-                tbb::task_scheduler_handle::release(tsh);
+                TSH_RELEASE(tsh);
                 puts("Unable to join threads to shut down before fork(). "
                      "This can break multithreading in child processes.\n");
             }
@@ -260,7 +271,7 @@ static void reset_after_fork(void)
 
     if(need_reinit_after_fork)
     {
-        tsh = tbb::task_scheduler_handle::get();
+        tsh = TSH_ATTACH();
         set_main_thread();
         tsh_was_initialized = true;
         need_reinit_after_fork = false;
@@ -298,7 +309,7 @@ static void launch_threads(int count)
     if(count < 1)
         count = tbb::task_arena::automatic;
 
-    tsh = tbb::task_scheduler_handle::get();
+    tsh = TSH_ATTACH();
     tsh_was_initialized = true;
 
     tg = new tbb::task_group;


### PR DESCRIPTION
This is a continuation of PR #7608 (the starting point is that PR rebased on `main`). It moves the minimum supported TBB version to 2021.6 and updates source, docs, packaging configuration and CI to reflect this.

With thanks to @kozlov-alexey and @Hardcode84 for the original patches and review in #7608.