### PR TITLE
Fix flake8 checks since upgrade to flake8=6.x

### DIFF
--- a/numba/core/analysis.py
+++ b/numba/core/analysis.py
@@ -447,7 +447,7 @@ def dead_branch_prune(func_ir, called_args):
             if len(const_conds) == 2:
                 # prune the branch, switch the branch for an unconditional jump
                 prune_stat, taken = prune(branch, condition, blk, *const_conds)
-                if(prune_stat):
+                if (prune_stat):
                     # add the condition to the list of nullified conditions
                     nullified_conditions.append(nullified(condition, taken,
                                                           True))
@@ -464,7 +464,7 @@ def dead_branch_prune(func_ir, called_args):
 
             if not isinstance(resolved_const, Unknown):
                 prune_stat, taken = prune_by_predicate(branch, condition, blk)
-                if(prune_stat):
+                if (prune_stat):
                     # add the condition to the list of nullified conditions
                     nullified_conditions.append(nullified(condition, taken,
                                                           False))

--- a/numba/core/cgutils.py
+++ b/numba/core/cgutils.py
@@ -1168,7 +1168,8 @@ def snprintf(builder, buffer, bufsz, format, *args):
 
 
 def snprintf_stackbuffer(builder, bufsz, format, *args):
-    """Similar to `snprintf()` but the buffer is stack allocated to size *bufsz*.
+    """Similar to `snprintf()` but the buffer is stack allocated to size
+    *bufsz*.
 
     Returns the buffer pointer as i8*.
     """

--- a/numba/core/event.py
+++ b/numba/core/event.py
@@ -474,8 +474,8 @@ def _prepare_chrome_trace_data(listener: RecordingListener):
 
 
 def _setup_chrome_trace_exit_handler():
-    """Setup a RecordingListener and an exit handler to write the captured events
-    to file.
+    """Setup a RecordingListener and an exit handler to write the captured
+    events to file.
     """
     listener = RecordingListener()
     register("numba:run_pass", listener)

--- a/numba/core/inline_closurecall.py
+++ b/numba/core/inline_closurecall.py
@@ -414,7 +414,7 @@ class InlineWorker(object):
         callee_scopes = _get_all_scopes(callee_blocks)
         self.debug_print("callee_scopes = ", callee_scopes)
         #    one function should only have one local scope
-        assert(len(callee_scopes) == 1)
+        assert (len(callee_scopes) == 1)
         callee_scope = callee_scopes[0]
         var_dict = {}
         for var in tuple(callee_scope.localvars._con.values()):
@@ -538,8 +538,8 @@ class InlineWorker(object):
         return state.func_ir
 
     def update_type_and_call_maps(self, callee_ir, arg_typs):
-        """ Updates the type and call maps based on calling callee_ir with arguments
-        from arg_typs"""
+        """ Updates the type and call maps based on calling callee_ir with
+        arguments from arg_typs"""
         from numba.core.ssa import reconstruct_ssa
         from numba.core.typed_passes import PreLowerStripPhis
 
@@ -575,7 +575,8 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
                         targetctx=None, arg_typs=None, typemap=None,
                         calltypes=None, work_list=None, callee_validator=None,
                         replace_freevars=True):
-    """Inline the body of `callee` at its callsite (`i`-th instruction of `block`)
+    """Inline the body of `callee` at its callsite (`i`-th instruction of
+    `block`)
 
     `func_ir` is the func_ir object of the caller function and `glbls` is its
     global variable environment (func_ir.func_id.func.__globals__).
@@ -631,7 +632,7 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
     callee_scopes = _get_all_scopes(callee_blocks)
     debug_print("callee_scopes = ", callee_scopes)
     #    one function should only have one local scope
-    assert(len(callee_scopes) == 1)
+    assert (len(callee_scopes) == 1)
     callee_scope = callee_scopes[0]
     var_dict = {}
     for var in callee_scope.localvars._con.values():
@@ -661,10 +662,10 @@ def inline_closure_call(func_ir, glbls, block, i, callee, typingctx=None,
             cellget.argtypes = (ctypes.py_object,)
             items = tuple(cellget(x) for x in closure)
         else:
-            assert(isinstance(closure, ir.Expr)
-                   and closure.op == 'build_tuple')
+            assert (isinstance(closure, ir.Expr)
+                    and closure.op == 'build_tuple')
             items = closure.items
-        assert(len(callee_code.co_freevars) == len(items))
+        assert (len(callee_code.co_freevars) == len(items))
         _replace_freevars(callee_blocks, items)
         debug_print("After closure rename")
         _debug_dump(callee_ir)
@@ -786,8 +787,8 @@ def _get_callee_args(call_expr, callee, loc, func_ir):
             elif (isinstance(callee_defaults, ir.Var)
                     or isinstance(callee_defaults, str)):
                 default_tuple = func_ir.get_definition(callee_defaults)
-                assert(isinstance(default_tuple, ir.Expr))
-                assert(default_tuple.op == "build_tuple")
+                assert (isinstance(default_tuple, ir.Expr))
+                assert (default_tuple.op == "build_tuple")
                 const_vals = [func_ir.get_definition(x) for
                               x in default_tuple.items]
                 args = args + const_vals
@@ -829,7 +830,7 @@ def _replace_args_with(blocks, args):
         for stmt in assigns:
             if isinstance(stmt.value, ir.Arg):
                 idx = stmt.value.index
-                assert(idx < len(args))
+                assert (idx < len(args))
                 stmt.value = args[idx]
 
 
@@ -842,7 +843,7 @@ def _replace_freevars(blocks, args):
         for stmt in assigns:
             if isinstance(stmt.value, ir.FreeVar):
                 idx = stmt.value.index
-                assert(idx < len(args))
+                assert (idx < len(args))
                 if isinstance(args[idx], ir.Var):
                     stmt.value = args[idx]
                 else:
@@ -858,7 +859,7 @@ def _replace_returns(blocks, target, return_label):
         for i in range(len(block.body)):
             stmt = block.body[i]
             if isinstance(stmt, ir.Return):
-                assert(i + 1 == len(block.body))
+                assert (i + 1 == len(block.body))
                 block.body[i] = ir.Assign(stmt.value, target, stmt.loc)
                 block.body.append(ir.Jump(return_label, stmt.loc))
                 # remove cast of the returned value
@@ -931,8 +932,8 @@ def _find_arraycall(func_ir, block):
 
 
 def _find_iter_range(func_ir, range_iter_var, swapped):
-    """Find the iterator's actual range if it is either range(n), or range(m, n),
-    otherwise return raise GuardException.
+    """Find the iterator's actual range if it is either range(n), or
+    range(m, n), otherwise return raise GuardException.
     """
     debug_print = _make_debug_print("find_iter_range")
     range_iter_def = get_definition(func_ir, range_iter_var)
@@ -1194,7 +1195,7 @@ def _inline_arraycall(func_ir, cfg, visited, loop, swapped, enable_prange=False,
             # when range doesn't start from 0, index_var becomes loop index
             # (iter_first_var) minus an offset (range_def[0])
             terminator = loop_header.terminator
-            assert(isinstance(terminator, ir.Branch))
+            assert (isinstance(terminator, ir.Branch))
             # find the block in the loop body that header jumps to
             block_id = terminator.truebr
             blk = func_ir.blocks[block_id]
@@ -1256,8 +1257,8 @@ def _find_unsafe_empty_inferred(func_ir, expr):
 
 
 def _fix_nested_array(func_ir):
-    """Look for assignment like: a[..] = b, where both a and b are numpy arrays, and
-    try to eliminate array b by expanding a with an extra dimension.
+    """Look for assignment like: a[..] = b, where both a and b are numpy arrays,
+    and try to eliminate array b by expanding a with an extra dimension.
     """
     blocks = func_ir.blocks
     cfg = compute_cfg_from_blocks(blocks)

--- a/numba/core/serialize.py
+++ b/numba/core/serialize.py
@@ -192,8 +192,8 @@ NumbaPickler.dispatch_table[_CustomPickled] = _custom_reduce__custompickled
 
 
 class ReduceMixin(abc.ABC):
-    """A mixin class for objects that should be reduced by the NumbaPickler instead
-    of the standard pickler.
+    """A mixin class for objects that should be reduced by the NumbaPickler
+    instead of the standard pickler.
     """
     # Subclass MUST override the below methods
 

--- a/numba/core/untyped_passes.py
+++ b/numba/core/untyped_passes.py
@@ -1285,7 +1285,7 @@ class MixedContainerUnroller(FunctionPass):
         # 3. No multiple mix-tuple use
 
         # keep running the transform loop until it reports no more changes
-        while(True):
+        while (True):
             stat = self.apply_transform(state)
             mutated |= stat
             if not stat:

--- a/numba/cpython/unicode.py
+++ b/numba/cpython/unicode.py
@@ -848,7 +848,7 @@ def unicode_count(src, sub, start=None, end=None):
             if sub_len == 0:
                 return src_len + 1
 
-            while(start + sub_len <= src_len):
+            while (start + sub_len <= src_len):
                 if src[start : start + sub_len] == sub:
                     count += 1
                     start += sub_len
@@ -2020,7 +2020,7 @@ def _is_upper(is_lower, is_upper, is_title):
             code_point = _get_code_point(a, idx)
             if is_lower(code_point) or is_title(code_point):
                 return False
-            elif(not cased and is_upper(code_point)):
+            elif (not cased and is_upper(code_point)):
                 cased = True
         return cased
     return impl

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -107,7 +107,7 @@ class _Kernel(serialize.ReduceMixin):
             link.append(get_cudalib('cudadevrt', static=True))
 
         res = [fn for fn in cuda_fp16_math_funcs
-               if(f'__numba_wrapper_{fn}' in lib.get_asm_str())]
+               if (f'__numba_wrapper_{fn}' in lib.get_asm_str())]
 
         if res:
             # Path to the source containing the foreign function

--- a/numba/cuda/tests/cudapy/test_nondet.py
+++ b/numba/cuda/tests/cudapy/test_nondet.py
@@ -11,8 +11,8 @@ def generate_input(n):
 
 class TestCudaNonDet(CUDATestCase):
     def test_for_pre(self):
-        """Test issue with loop not running due to bad sign-extension at the for loop
-        precondition.
+        """Test issue with loop not running due to bad sign-extension at the for
+        loop precondition.
         """
 
         @cuda.jit(void(float32[:, :], float32[:, :], float32[:]))

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1132,7 +1132,7 @@ def _isclose_item(x, y, rtol, atol, equal_nan):
 
 @overload(np.isclose)
 def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-    if not(type_can_asarray(a) and type_can_asarray(b)):
+    if not (type_can_asarray(a) and type_can_asarray(b)):
         raise TypingError("Inputs for `np.isclose` must be array-like.")
 
     if isinstance(a, types.Array) and isinstance(b, types.Number):
@@ -2077,10 +2077,10 @@ def np_ediff1d(ary, to_end=None, to_begin=None):
     # Check that to_end and to_begin are compatible with ary
     ary_dt = _dtype_of_compound(ary)
     to_begin_dt = None
-    if not(is_nonelike(to_begin)):
+    if not (is_nonelike(to_begin)):
         to_begin_dt = _dtype_of_compound(to_begin)
     to_end_dt = None
-    if not(is_nonelike(to_end)):
+    if not (is_nonelike(to_end)):
         to_end_dt = _dtype_of_compound(to_end)
 
     if to_begin_dt is not None and not np.can_cast(to_begin_dt, ary_dt):

--- a/numba/np/numpy_support.py
+++ b/numba/np/numpy_support.py
@@ -368,7 +368,7 @@ def ufunc_find_matching_loop(ufunc, arg_types):
     # Separate logical input from explicit output arguments
     input_types = arg_types[:ufunc.nin]
     output_types = arg_types[ufunc.nin:]
-    assert(len(input_types) == ufunc.nin)
+    assert (len(input_types) == ufunc.nin)
 
     try:
         np_input_types = [as_dtype(x) for x in input_types]

--- a/numba/np/random/random_methods.py
+++ b/numba/np/random/random_methods.py
@@ -78,7 +78,7 @@ def buffered_bounded_lemire_uint8(bitgen, rng, bcnt, buf):
     # zero.
     rng_excl = uint8(rng) + uint8(1)
 
-    assert(rng != 0xFF)
+    assert (rng != 0xFF)
 
     # Generate a scaled random number.
     n, bcnt, buf = buffered_uint8(bitgen, bcnt, buf)
@@ -114,7 +114,7 @@ def buffered_bounded_lemire_uint16(bitgen, rng, bcnt, buf):
     # zero.
     rng_excl = uint16(rng) + uint16(1)
 
-    assert(rng != 0xFFFF)
+    assert (rng != 0xFFFF)
 
     # Generate a scaled random number.
     n, bcnt, buf = buffered_uint16(bitgen, bcnt, buf)
@@ -143,7 +143,7 @@ def buffered_bounded_lemire_uint32(bitgen, rng):
     """
     rng_excl = uint32(rng) + uint32(1)
 
-    assert(rng != 0xFFFFFFFF)
+    assert (rng != 0xFFFFFFFF)
 
     # Generate a scaled random number.
     m = uint64(next_uint32(bitgen)) * uint64(rng_excl)
@@ -170,7 +170,7 @@ def bounded_lemire_uint64(bitgen, rng):
     """
     rng_excl = uint64(rng) + uint64(1)
 
-    assert(rng != 0xFFFFFFFFFFFFFFFF)
+    assert (rng != 0xFFFFFFFFFFFFFFFF)
 
     x = next_uint64(bitgen)
 

--- a/numba/tests/test_ssa.py
+++ b/numba/tests/test_ssa.py
@@ -247,7 +247,7 @@ class TestReportedSSAIssues(SSABaseTest):
             for i in range(1):
                 arr = arr.reshape(3 * 2)
                 arr = arr.reshape(3, 2)
-            return(arr)
+            return (arr)
 
         np.testing.assert_allclose(foo(np.zeros((3, 2))),
                                    foo.py_func(np.zeros((3, 2))))

--- a/numba/tests/test_stencils.py
+++ b/numba/tests/test_stencils.py
@@ -603,7 +603,7 @@ class TestStencil(TestStencilBase):
         for compiler in [self.compile_njit, self.compile_parallel]:
             try:
                 compiler(wrapped,())
-            except(NumbaValueError, LoweringError) as e:
+            except (NumbaValueError, LoweringError) as e:
                 self.assertIn(msg, str(e))
             else:
                 raise AssertionError("Expected error was not raised")
@@ -3056,7 +3056,7 @@ class TestManyStencils(TestStencilBase):
         """ Issue #3454, const(int) == const(int) evaluating incorrectly. """
         def kernel(a):
             b = 0
-            if(2 == 0):
+            if (2 == 0):
                 b = 2
             return a[0, 0] + b
         # ----------------------------------------------------------------------

--- a/numba/typed/listobject.py
+++ b/numba/typed/listobject.py
@@ -1134,7 +1134,7 @@ def impl_insert(l, index, item):
                 l.append(l[0])
                 # reverse iterate over the list and shift all elements
                 i = len(l) - 1
-                while(i > index):
+                while (i > index):
                     l[i] = l[i - 1]
                     i -= 1
                 # finally, insert the item


### PR DESCRIPTION
It seems like public CI updating to use flake8=6.x has resulted in a few additional formatting violations being picked up. This patch simply addresses these and nothing more.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
