### PR TITLE
Add numpy argpartition function support

### DIFF
--- a/docs/source/reference/numpysupported.rst
+++ b/docs/source/reference/numpysupported.rst
@@ -306,6 +306,7 @@ The following methods of NumPy arrays are supported:
 
 * :meth:`~numpy.ndarray.argmax` (``axis`` keyword argument supported).
 * :meth:`~numpy.ndarray.argmin` (``axis`` keyword argument supported).
+* :func:`numpy.argpartition` (only the 2 first arguments)
 * :meth:`~numpy.ndarray.argsort` (``kind`` key word argument supported for
   values ``'quicksort'`` and ``'mergesort'``)
 * :meth:`~numpy.ndarray.astype` (only the 1-argument form)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1474,8 +1474,9 @@ def nan_aware_less_than(a, b):
 
 
 def _partition_factory(pivotimpl):
-    def _partition(A, low, high):
+    def _partition(A, low, high, I=np.arange(0)):
         mid = (low + high) >> 1
+        argpartition = True if len(I) else False
         # NOTE: the pattern of swaps below for the pivot choice and the
         # partitioning gives good results (i.e. regular O(n log n))
         # on sorted, reverse-sorted, and uniform arrays.  Subtle changes
@@ -1484,13 +1485,21 @@ def _partition_factory(pivotimpl):
         # Use median of three {low, middle, high} as the pivot
         if pivotimpl(A[mid], A[low]):
             A[low], A[mid] = A[mid], A[low]
+            if argpartition:
+                I[low], I[mid] = I[mid], I[low]
         if pivotimpl(A[high], A[mid]):
             A[high], A[mid] = A[mid], A[high]
+            if argpartition:
+                I[high], I[mid] = I[mid], I[high]
         if pivotimpl(A[mid], A[low]):
             A[low], A[mid] = A[mid], A[low]
+            if argpartition:
+                I[low], I[mid] = I[mid], I[low]
         pivot = A[mid]
 
         A[high], A[mid] = A[mid], A[high]
+        if argpartition:
+            I[high], I[mid] = I[mid], I[high]
         i = low
         j = high - 1
         while True:
@@ -1501,11 +1510,15 @@ def _partition_factory(pivotimpl):
             if i >= j:
                 break
             A[i], A[j] = A[j], A[i]
+            if argpartition:
+                I[i], I[j] = I[j], I[i]
             i += 1
             j -= 1
         # Put the pivot back in its final place (all items before `i`
         # are smaller than the pivot, all items at/after `i` are larger)
         A[i], A[high] = A[high], A[i]
+        if argpartition:
+            I[i], I[high] = I[high], I[i]
         return i
     return _partition
 
@@ -1515,18 +1528,18 @@ _partition_w_nan = register_jitable(_partition_factory(nan_aware_less_than))
 
 
 def _select_factory(partitionimpl):
-    def _select(arry, k, low, high):
+    def _select(arry, k, low, high, idx=np.arange(0)):
         """
         Select the k'th smallest element in array[low:high + 1].
         """
-        i = partitionimpl(arry, low, high)
+        i = partitionimpl(arry, low, high, idx)
         while i != k:
             if i < k:
                 low = i + 1
-                i = partitionimpl(arry, low, high)
+                i = partitionimpl(arry, low, high, idx)
             else:
                 high = i - 1
-                i = partitionimpl(arry, low, high)
+                i = partitionimpl(arry, low, high, idx)
         return arry[k]
     return _select
 
@@ -1809,6 +1822,28 @@ def np_partition_impl_inner(a, kth_array):
 
 
 @register_jitable
+def np_argpartition_impl_inner(a, kth_array):
+
+    # allocate and fill empty array rather than copy a and mutate in place
+    # as the latter approach fails to preserve strides
+    out = np.empty_like(a, dtype=np.int64)
+
+    idx = np.ndindex(a.shape[:-1])  # Numpy default partition axis is -1
+    for s in idx:
+        arry = a[s].copy()
+        idx_arry = np.arange(len(arry))
+        low = 0
+        high = len(arry) - 1
+
+        for kth in kth_array:
+            _select_w_nan(arry, kth, low, high, idx_arry)
+            low = kth  # narrow span of subsequent partition
+
+        out[s] = idx_arry
+    return out
+
+
+@register_jitable
 def valid_kths(a, kth):
     """
     Returns a sorted, unique array of kth values which serve
@@ -1866,6 +1901,31 @@ def np_partition(a, kth):
             return np_partition_impl_inner(a_tmp, kth_array)
 
     return np_partition_impl
+
+
+@overload(np.argpartition)
+def np_argpartition(a, kth):
+
+    if not isinstance(a, (types.Array, types.Sequence, types.Tuple)):
+        raise TypeError('The first argument must be an array-like')
+
+    if isinstance(a, types.Array) and a.ndim == 0:
+        raise TypeError('The first argument must be at least 1-D (found 0-D)')
+
+    kthdt = getattr(kth, 'dtype', kth)
+    if not isinstance(kthdt, (types.Boolean, types.Integer)):
+        # bool gets cast to int subsequently
+        raise TypeError('Partition index must be integer')
+
+    def np_argpartition_impl(a, kth):
+        a_tmp = _asarray(a)
+        if a_tmp.size == 0:
+            return a_tmp.copy().astype('int64')
+        else:
+            kth_array = valid_kths(a_tmp, kth)
+            return np_argpartition_impl_inner(a_tmp, kth_array)
+
+    return np_argpartition_impl
 
 
 #----------------------------------------------------------------------------

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1524,7 +1524,10 @@ def _partition_factory(pivotimpl, argpartition=False):
 
 _partition = register_jitable(_partition_factory(less_than))
 _partition_w_nan = register_jitable(_partition_factory(nan_aware_less_than))
-_argpartition_w_nan = register_jitable(_partition_factory(nan_aware_less_than, argpartition=True))
+_argpartition_w_nan = register_jitable(_partition_factory(
+    nan_aware_less_than,
+    argpartition=True)
+)
 
 
 def _select_factory(partitionimpl):

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1476,7 +1476,7 @@ def nan_aware_less_than(a, b):
 def _partition_factory(pivotimpl):
     def _partition(A, low, high, I=None):
         mid = (low + high) >> 1
-        argpartition = True if I is None else False
+        argpartition = False if I is None else True
         # NOTE: the pattern of swaps below for the pivot choice and the
         # partitioning gives good results (i.e. regular O(n log n))
         # on sorted, reverse-sorted, and uniform arrays.  Subtle changes

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1474,9 +1474,9 @@ def nan_aware_less_than(a, b):
 
 
 def _partition_factory(pivotimpl):
-    def _partition(A, low, high, I=np.arange(0)):
+    def _partition(A, low, high, I=None):
         mid = (low + high) >> 1
-        argpartition = True if len(I) else False
+        argpartition = True if I is None else False
         # NOTE: the pattern of swaps below for the pivot choice and the
         # partitioning gives good results (i.e. regular O(n log n))
         # on sorted, reverse-sorted, and uniform arrays.  Subtle changes
@@ -1528,7 +1528,7 @@ _partition_w_nan = register_jitable(_partition_factory(nan_aware_less_than))
 
 
 def _select_factory(partitionimpl):
-    def _select(arry, k, low, high, idx=np.arange(0)):
+    def _select(arry, k, low, high, idx=None):
         """
         Select the k'th smallest element in array[low:high + 1].
         """

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -1473,10 +1473,9 @@ def nan_aware_less_than(a, b):
             return a < b
 
 
-def _partition_factory(pivotimpl):
+def _partition_factory(pivotimpl, argpartition=False):
     def _partition(A, low, high, I=None):
         mid = (low + high) >> 1
-        argpartition = False if I is None else True
         # NOTE: the pattern of swaps below for the pivot choice and the
         # partitioning gives good results (i.e. regular O(n log n))
         # on sorted, reverse-sorted, and uniform arrays.  Subtle changes
@@ -1525,6 +1524,7 @@ def _partition_factory(pivotimpl):
 
 _partition = register_jitable(_partition_factory(less_than))
 _partition_w_nan = register_jitable(_partition_factory(nan_aware_less_than))
+_argpartition_w_nan = register_jitable(_partition_factory(nan_aware_less_than, argpartition=True))
 
 
 def _select_factory(partitionimpl):
@@ -1546,6 +1546,7 @@ def _select_factory(partitionimpl):
 
 _select = register_jitable(_select_factory(_partition))
 _select_w_nan = register_jitable(_select_factory(_partition_w_nan))
+_arg_select_w_nan = register_jitable(_select_factory(_argpartition_w_nan))
 
 
 @register_jitable
@@ -1836,7 +1837,7 @@ def np_argpartition_impl_inner(a, kth_array):
         high = len(arry) - 1
 
         for kth in kth_array:
-            _select_w_nan(arry, kth, low, high, idx_arry)
+            _arg_select_w_nan(arry, kth, low, high, idx_arry)
             low = kth  # narrow span of subsequent partition
 
         out[s] = idx_arry

--- a/numba/tests/test_np_functions.py
+++ b/numba/tests/test_np_functions.py
@@ -283,6 +283,10 @@ def partition(a, kth):
     return np.partition(a, kth)
 
 
+def argpartition(a, kth):
+    return np.argpartition(a, kth)
+
+
 def cov(m, y=None, rowvar=True, bias=False, ddof=None):
     return np.cov(m, y, rowvar, bias, ddof)
 
@@ -1817,6 +1821,21 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         # likewise the unordered collection of elements from the kth onwards
         self.assertPreciseEqual(np.unique(expected[kth:]), np.unique(got[kth:]))
 
+    def argpartition_sanity_check(self, pyfunc, cfunc, a, kth):
+        # as NumPy uses a different algorithm, we do not expect to
+        # match outputs exactly...
+        expected = pyfunc(a, kth)
+        got = cfunc(a, kth)
+
+        # but we do expect the unordered collection of elements up to the
+        # kth to tie out
+        self.assertPreciseEqual(np.unique(a[expected[:kth]]),
+                                np.unique(a[got[:kth]]))
+
+        # likewise the unordered collection of elements from the kth onwards
+        self.assertPreciseEqual(np.unique(a[expected[kth:]]),
+                                np.unique(a[got[kth:]]))
+
     def test_partition_fuzz(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
@@ -1841,10 +1860,55 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 for k in kth:
                     self.partition_sanity_check(pyfunc, cfunc, d, k)
 
+    def test_argpartition_fuzz(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for j in range(10, 30):
+            for i in range(1, j - 2):
+                d = np.arange(j)
+                self.rnd.shuffle(d)
+                d = d % self.rnd.randint(2, 30)
+                idx = self.rnd.randint(d.size)
+                kth = [0, idx, i, i + 1, -idx, -i]  # include negative kth's
+                tgt = np.argsort(d)[kth]
+                self.assertPreciseEqual(d[cfunc(d, kth)[kth]],
+                                        d[tgt])  # a -> array
+                self.assertPreciseEqual(d[cfunc(d.tolist(), kth)[kth]],
+                                        d[tgt])  # a -> list
+                self.assertPreciseEqual(d[cfunc(tuple(d.tolist()), kth)[kth]],
+                                        d[tgt])  # a -> tuple
+
+                for k in kth:
+                    self.argpartition_sanity_check(pyfunc, cfunc, d, k)
+
     def test_partition_exception_out_of_range(self):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
         pyfunc = partition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        # Test out of range values in kth raise an error
+        a = np.arange(10)
+
+        def _check(a, kth):
+            with self.assertRaises(ValueError) as e:
+                cfunc(a, kth)
+            assert str(e.exception) == "kth out of bounds"
+
+        _check(a, 10)
+        _check(a, -11)
+        _check(a, (3, 30))
+
+    def test_argpartition_exception_out_of_range(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
+        pyfunc = argpartition
         cfunc = jit(nopython=True)(pyfunc)
 
         # Exceptions leak references
@@ -1882,8 +1946,44 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         _check(a, (3.3, 4.4))
         _check(a, np.array((1, 2, np.nan)))
 
+    def test_argpartition_exception_non_integer_kth(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        def _check(a, kth):
+            with self.assertTypingError() as raises:
+                cfunc(a, kth)
+            self.assertIn("Partition index must be integer",
+                          str(raises.exception))
+
+        a = np.arange(10)
+        _check(a, 9.0)
+        _check(a, (3.3, 4.4))
+        _check(a, np.array((1, 2, np.nan)))
+
     def test_partition_exception_a_not_array_like(self):
         pyfunc = partition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        def _check(a, kth):
+            with self.assertTypingError() as raises:
+                cfunc(a, kth)
+            self.assertIn('The first argument must be an array-like',
+                          str(raises.exception))
+
+        _check(4, 0)
+        _check('Sausages', 0)
+
+    def test_argpartition_exception_a_not_array_like(self):
+        pyfunc = argpartition
         cfunc = jit(nopython=True)(pyfunc)
 
         # Exceptions leak references
@@ -1913,8 +2013,37 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
 
         _check(np.array(1), 0)
 
+    def test_argpartition_exception_a_zero_dim(self):
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        def _check(a, kth):
+            with self.assertTypingError() as raises:
+                cfunc(a, kth)
+            self.assertIn('The first argument must be at least 1-D (found 0-D)',
+                          str(raises.exception))
+
+        _check(np.array(1), 0)
+
     def test_partition_exception_kth_multi_dimensional(self):
         pyfunc = partition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        # Exceptions leak references
+        self.disable_leak_check()
+
+        def _check(a, kth):
+            with self.assertRaises(ValueError) as raises:
+                cfunc(a, kth)
+            self.assertIn('kth must be scalar or 1-D', str(raises.exception))
+
+        _check(np.arange(10), kth=np.arange(6).reshape(3, 2))
+
+    def test_argpartition_exception_kth_multi_dimensional(self):
+        pyfunc = argpartition
         cfunc = jit(nopython=True)(pyfunc)
 
         # Exceptions leak references
@@ -1931,6 +2060,25 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         # inspired by the test of the same name in:
         # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
         pyfunc = partition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(a, kth=0):
+            expected = pyfunc(a, kth)
+            got = cfunc(a, kth)
+            self.assertPreciseEqual(expected, got)
+
+        # check axis handling for multidimensional empty arrays
+        a = np.array([])
+        a.shape = (3, 2, 1, 0)
+
+        # include this with some other empty data structures
+        for arr in a, (), np.array([]):
+            check(arr)
+
+    def test_argpartition_empty_array(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
+        pyfunc = argpartition
         cfunc = jit(nopython=True)(pyfunc)
 
         def check(a, kth=0):
@@ -2047,6 +2195,108 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                 # sanity check
                 self.partition_sanity_check(pyfunc, cfunc, d, i)
 
+    def test_argpartition_basic(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py    # noqa: E501
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        d = np.array([], dtype=np.int64)
+        got = cfunc(d, 0)
+        self.assertPreciseEqual(d, got)
+
+        d = np.ones(1, dtype=np.int64)
+        expected = np.zeros(1, dtype=np.int64)
+        got = cfunc(d, 0)
+        self.assertPreciseEqual(expected, got)
+
+        # kth not modified
+        kth = np.array([30, 15, 5])
+        okth = kth.copy()
+        cfunc(np.arange(40), kth)
+        self.assertPreciseEqual(kth, okth)
+
+        for r in ([2, 1], [1, 2], [1, 1]):
+            d = np.array(r)
+            tgt = np.argsort(d)
+            for k in 0, 1:
+                self.assertPreciseEqual(d[cfunc(d, k)[k]], d[tgt[k]])
+                self.argpartition_sanity_check(pyfunc, cfunc, d, k)
+
+        for r in ([3, 2, 1], [1, 2, 3], [2, 1, 3], [2, 3, 1],
+                  [1, 1, 1], [1, 2, 2], [2, 2, 1], [1, 2, 1]):
+            d = np.array(r)
+            tgt = np.argsort(d)
+            for k in 0, 1, 2:
+                self.assertPreciseEqual(d[cfunc(d, k)[k]], d[tgt[k]])
+                self.argpartition_sanity_check(pyfunc, cfunc, d, k)
+
+        d = np.ones(50)
+        self.assertPreciseEqual(d[cfunc(d, 0)], d)
+
+        # sorted
+        d = np.arange(49)
+        for k in 5, 15:
+            self.assertEqual(cfunc(d, k)[k], k)
+            self.partition_sanity_check(pyfunc, cfunc, d, k)
+
+        # rsorted, with input flavours: array, list and tuple
+        d = np.arange(47)[::-1]
+        for a in d, d.tolist(), tuple(d.tolist()):
+            self.assertEqual(cfunc(a, 6)[6], 40)
+            self.assertEqual(cfunc(a, 16)[16], 30)
+            self.assertPreciseEqual(cfunc(a, -6), cfunc(a, 41))
+            self.assertPreciseEqual(cfunc(a, -16), cfunc(a, 31))
+            self.argpartition_sanity_check(pyfunc, cfunc, d, -16)
+
+        # median of 3 killer, O(n^2) on pure median 3 pivot quickselect
+        # exercises the median of median of 5 code used to keep O(n)
+        d = np.arange(1000000)
+        x = np.roll(d, d.size // 2)
+        mid = x.size // 2 + 1
+        self.assertEqual(x[cfunc(x, mid)[mid]], mid)
+        d = np.arange(1000001)
+        x = np.roll(d, d.size // 2 + 1)
+        mid = x.size // 2 + 1
+        self.assertEqual(x[cfunc(x, mid)[mid]], mid)
+
+        # max
+        d = np.ones(10)
+        d[1] = 4
+        self.assertEqual(d[cfunc(d, (2, -1))[-1]], 4)
+        self.assertEqual(d[cfunc(d, (2, -1))[2]], 1)
+        d[1] = np.nan
+        assert np.isnan(d[cfunc(d, (2, -1))[-1]])
+
+        # equal elements
+        d = np.arange(47) % 7
+        tgt = np.sort(np.arange(47) % 7)
+        self.rnd.shuffle(d)
+        for i in range(d.size):
+            self.assertEqual(d[cfunc(d, i)[i]], tgt[i])
+            self.argpartition_sanity_check(pyfunc, cfunc, d, i)
+
+        d = np.array([0, 1, 2, 3, 4, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+                      7, 7, 7, 7, 7, 9])
+        kth = [0, 3, 19, 20]
+        self.assertEqual(tuple(d[cfunc(d, kth)[kth]]), (0, 3, 7, 7))
+
+        td = [(dt, s) for dt in [np.int32, np.float32] for s in (9, 16)]
+        for dt, s in td:
+            d = np.arange(s, dtype=dt)
+            self.rnd.shuffle(d)
+            d1 = np.tile(np.arange(s, dtype=dt), (4, 1))
+            map(self.rnd.shuffle, d1)
+            for i in range(d.size):
+                p = d[cfunc(d, i)]
+                self.assertEqual(p[i], i)
+                # all before are smaller
+                np.testing.assert_array_less(p[:i], p[i])
+                # all after are larger
+                np.testing.assert_array_less(p[i], p[i + 1:])
+                # sanity check
+                self.argpartition_sanity_check(pyfunc, cfunc, d, i)
+
     def assert_partitioned(self, pyfunc, cfunc, d, kth):
         prev = 0
         for k in np.sort(kth):
@@ -2057,6 +2307,17 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
                                  "%d" % (k, d[k:], d[k])))
             prev = k + 1
             self.partition_sanity_check(pyfunc, cfunc, d, k)
+
+    def assert_argpartitioned(self, pyfunc, cfunc, d, kth):
+        prev = 0
+        for k in np.sort(kth):
+            np.testing.assert_array_less(d[prev:k], d[k],
+                                         err_msg='kth %d' % k)
+            self.assertTrue((d[k:] >= d[k]).all(),
+                            msg=("kth %d, %r not greater equal "
+                                 "%d" % (k, d[k:], d[k])))
+            prev = k + 1
+            self.argpartition_sanity_check(pyfunc, cfunc, d, k)
 
     def test_partition_iterative(self):
         # inspired by the test of the same name in:
@@ -2092,6 +2353,42 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         assert_partitioned(cfunc(d, [5] * 4), [5])
         assert_partitioned(cfunc(d, [5] * 4 + [6, 13]), [5] * 4 + [6, 13])
 
+    def test_argpartition_iterative(self):
+        # inspired by the test of the same name in:
+        # https://github.com/numpy/numpy/blob/043a840/numpy/core/tests/test_multiarray.py
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        assert_argpartitioned = partial(self.assert_argpartitioned,
+                                        pyfunc,
+                                        cfunc)
+
+        d = np.array([3, 4, 2, 1])
+        p = d[cfunc(d, (0, 3))]
+        assert_argpartitioned(p, (0, 3))
+        assert_argpartitioned(d[np.argpartition(d, (0, 3))], (0, 3))
+
+        self.assertPreciseEqual(p, d[cfunc(d, (-3, -1))])
+
+        d = np.arange(17)
+        self.rnd.shuffle(d)
+        self.assertPreciseEqual(np.arange(17), d[cfunc(d, list(range(d.size)))])
+
+        # test unsorted kth
+        d = np.arange(17)
+        self.rnd.shuffle(d)
+        keys = np.array([1, 3, 8, -2])
+        self.rnd.shuffle(d)
+        p = d[cfunc(d, keys)]
+        assert_argpartitioned(p, keys)
+        self.rnd.shuffle(keys)
+        self.assertPreciseEqual(d[cfunc(d, keys)], p)
+
+        # equal kth
+        d = np.arange(20)[::-1]
+        assert_argpartitioned(d[cfunc(d, [5] * 4)], [5])
+        assert_argpartitioned(d[cfunc(d, [5] * 4 + [6, 13])], [5] * 4 + [6, 13])
+
     def test_partition_multi_dim(self):
         pyfunc = partition
         cfunc = jit(nopython=True)(pyfunc)
@@ -2126,6 +2423,44 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
             for k in range(-3, 3):
                 check(arr, k)
 
+    def test_argpartition_multi_dim(self):
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        def check(a, kth):
+            expected = pyfunc(a, kth)
+            got = cfunc(a, kth)
+            a = np.asarray(a)
+            idx = np.ndindex(a.shape[:-1])
+            for s in idx:
+                self.assertPreciseEqual(a[s][expected[s][kth]],
+                                        a[s][got[s][kth]])
+
+            for s in np.ndindex(expected.shape[:-1]):
+                self.assertPreciseEqual(np.unique(a[s][expected[s][:kth]]),
+                                        np.unique(a[s][got[s][:kth]]))
+                self.assertPreciseEqual(np.unique(a[s][expected[s][kth:]]),
+                                        np.unique(a[s][got[s][kth:]]))
+
+        def a_variations(a):
+            yield a
+            yield a.T
+            yield np.asfortranarray(a)
+            yield np.full_like(a, fill_value=np.nan)
+            yield np.full_like(a, fill_value=np.inf)
+            # multi-dimensional tuple input
+            yield (((1.0, 3.142, -np.inf, 3),),)
+
+        a = np.linspace(1, 10, 48)
+        a[4:7] = np.nan
+        a[8] = -np.inf
+        a[9] = np.inf
+        a = a.reshape((4, 3, 4))
+
+        for arr in a_variations(a):
+            for k in range(-3, 3):
+                check(arr, k)
+
     def test_partition_boolean_inputs(self):
         pyfunc = partition
         cfunc = jit(nopython=True)(pyfunc)
@@ -2133,6 +2468,14 @@ class TestNPFunctions(MemoryLeakMixin, TestCase):
         for d in np.linspace(1, 10, 17), np.array((True, False, True)):
             for kth in True, False, -1, 0, 1:
                 self.partition_sanity_check(pyfunc, cfunc, d, kth)
+
+    def test_argpartition_boolean_inputs(self):
+        pyfunc = argpartition
+        cfunc = jit(nopython=True)(pyfunc)
+
+        for d in np.linspace(1, 10, 17), np.array((True, False, True)):
+            for kth in True, False, -1, 0, 1:
+                self.argpartition_sanity_check(pyfunc, cfunc, d, kth)
 
     @needs_blas
     def test_cov_invalid_ddof(self):


### PR DESCRIPTION
Add numpy argpartition function support. 

I used some of the implementation of `partition`. Something to note it that I modified the already existing `_partition_factory` to add an optional argument if the user would need `np.argpartition` instead of `np.partition`, as you will see in the code it doesn't look the most pretty, but it was either that or write a `_argpartition_factory` function which has exactly the same logic it just swaps index elements at the same time it swaps the array with the values being sorted.

Let me know if you prefer to leave it as is or go the duplication route. I think this is the best compromise to not repeat code and have a single source of truth of partition logic.

Solves #2445
#4074 would need to be updated.


cheers

