### PR TITLE
Update bot to close PRs waiting on authors for more than 3 months

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,14 +13,24 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
+          # issues
           stale-issue-message: >
             This issue is marked as stale as it has had no activity in the past
             30 days. Please close this issue if no further response or action is
             needed. Otherwise, please respond with any updates and confirm that
             this issue still needs to be addressed.
           stale-issue-label: 'stale'
-          any-of-labels: 'question,needtriage,more info needed'
+          any-of-issue-labels: 'question,needtriage,more info needed'
           days-before-issue-stale: 30
           days-before-issue-close: 7
+          # pull requests
+          stale-pr-message: >
+            This pull request is marked as stale as it has had no activity in
+            the past 6 months. Please respond to this comment if you're still
+            interested in working on this.
+          days-before-pr-stale: 90  # 3 months
+          days-before-pr-close: 90
+          any-of-pr-labels: '2 - In progress,4 - Waiting on author'
+          stale-pr-label: 'abandoned'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,9 +28,10 @@ jobs:
           # pull requests
           stale-pr-message: >
             This pull request is marked as stale as it has had no activity in
-            the past 6 months. Please respond to this comment if you're still
+            the past 3 months. Please respond to this comment if you're still
             interested in working on this.
           days-before-pr-stale: 90  # 3 months
-          days-before-pr-close: 90
+          days-before-pr-close: 7
           any-of-pr-labels: '2 - In progress,4 - Waiting on author'
-          stale-pr-label: 'abandoned'
+          stale-pr-label: 'stale'
+          close-pr-label: 'abandoned'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
           stale-pr-message: >
             This pull request is marked as stale as it has had no activity in
             the past 3 months. Please respond to this comment if you're still
-            interested in working on this.
+            interested in working on this. Many thanks!
           days-before-pr-stale: 90  # 3 months
           days-before-pr-close: 7
           any-of-pr-labels: '2 - In progress,4 - Waiting on author'


### PR DESCRIPTION
Following some recent discussion on Numba public meeting. It was decided that we will close PRs waiting for author response for more than 3 months. Since we already had a bot for staling PRs, I just updated it to accommodate the new changes.