### PR TITLE
Fix failing test_dispatcher test case

### DIFF
--- a/numba/cuda/tests/cudapy/test_dispatcher.py
+++ b/numba/cuda/tests/cudapy/test_dispatcher.py
@@ -312,9 +312,12 @@ class TestDispatcher(CUDATestCase):
         self.assertRegexpMatches(
             str(cm.exception),
             r"Ambiguous overloading for <function add_kernel [^>]*> "
-            r"\(array\(float64, 1d, C\), float64, float64\):\n"
-            r"\(array\(float64, 1d, C\), float32, float64\) -> none\n"
-            r"\(array\(float64, 1d, C\), float64, float32\) -> none"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float64,"
+            r" float64\):\n"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float32,"
+            r" float64\) -> none\n"
+            r"\(Array\(float64, 1, 'C', False, aligned=True\), float64,"
+            r" float32\) -> none"
         )
         # The integer signature is not part of the best matches
         self.assertNotIn("int64", str(cm.exception))


### PR DESCRIPTION
This pull request fixes a failing test case in test_dispatch due to a change in the way cuda types are represented. The corresponding issue is here: https://github.com/numba/numba/issues/8745