### PR TITLE
Fix refcount issue with reflected list pop/del.

### DIFF
--- a/numba/cpython/listobj.py
+++ b/numba/cpython/listobj.py
@@ -1010,7 +1010,7 @@ def list_pop(context, builder, sig, args):
     inst.guard_index(idx, "pop index out of range")
 
     res = inst.getitem(idx)
-
+    inst.incref_value(res)
     one = ir.Constant(n.type, 1)
     n = builder.sub(n, ir.Constant(n.type, 1))
     inst.move(idx, builder.add(idx, one), builder.sub(n, idx))

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -463,6 +463,19 @@ class TestLists(MemoryLeakMixin, TestCase):
             cfunc(1, 5)
         self.assertEqual(str(cm.exception), "pop index out of range")
 
+    def test_pop_refcounted(self):
+        # See issue #8753.
+
+        @njit
+        def foo():
+            lst = [[1,]]
+            x = [10,]
+            lst.pop(0)
+            lst.append(x)
+            return lst[0]
+
+        self.assertPreciseEqual(foo(), foo.py_func())
+
     def test_insert(self):
         pyfunc = list_insert
         cfunc = jit(nopython=True)(pyfunc)


### PR DESCRIPTION
This adds a missing incref for the `pop()`'d item of a reflected list of reference counted objects. It impacts `__delitem__` too as that is simply implemented as a call to `pop(<index to delete>)`.

Fixes #8753

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
