### PR TITLE
CUDA: Refactor handling of target options

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -9,6 +9,34 @@ be configured and launched:
 
 .. autofunction:: numba.cuda.jit
 
+Kernel launch parameter handling extensions
+-------------------------------------------
+
+Numba supports passing a limited set of types of objects (scalars, arrays, and
+tuples) to CUDA kernels. The set of supported types can be augmented by passing
+*kernel launch parameter handling extensions* to the :py:func:`@cuda.jit
+<numba.cuda.jit>` decorator in the ``extensions`` keyword argument. Each
+extension defines a method, ``prepare_args()``, which processes an argument
+passed to the kernel.
+
+When a kernel is called, each argument is passed through the ``prepare_args()``
+method of each registered extension. The ``prepare_args()`` method must return a
+tuple ``(ty, val)``, which will be passed in turn to the next registered
+extension. After all the extensions have been called, the resulting
+``(ty, val)`` pair will be passed into Numba's default argument marshalling
+logic.
+
+Each extension should define its ``prepare_args()`` method as:
+
+.. function:: prepare_args(self, ty, val, stream=None, retr=None)
+   :noindex:
+
+   :param ty: The numba type of the argument
+   :param val: The argument value itself
+   :param stream: The CUDA stream used for the current call to the kernel
+   :param retr: an optional list of zero-arg functions that you may want to
+                append post-call cleanup work to.
+   :return: The ``(ty, val)`` pair representing the transformed argument.
 
 Dispatcher objects
 ------------------
@@ -58,7 +86,7 @@ creating a specialized instance:
 
 .. autoclass:: numba.cuda.dispatcher.CUDADispatcher
    :members: inspect_asm, inspect_llvm, inspect_sass, inspect_types,
-             get_regs_per_thread, specialize, specialized, extensions, forall,
+             get_regs_per_thread, specialize, specialized, forall,
              get_shared_mem_per_block, get_const_mem_size,
              get_local_mem_per_thread
 

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -11,7 +11,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
+def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
         opt=True, cache=False, **kws):
     """
     JIT compile a Python function for CUDA GPUs.
@@ -54,6 +54,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
     :type cache: bool
     """
 
+    link = link or []
     if link and config.ENABLE_CUDASIM:
         raise NotImplementedError('Cannot link PTX in the simulator')
 

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -105,10 +105,10 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
             targetoptions['link'] = link
             targetoptions['opt'] = opt
             targetoptions['fastmath'] = fastmath
-            targetoptions['device'] = device
             targetoptions['extensions'] = extensions
 
-            disp = CUDADispatcher(func, targetoptions=targetoptions)
+            disp = CUDADispatcher(func, targetoptions=targetoptions,
+                                  device=device)
 
             if cache:
                 disp.enable_caching()
@@ -155,9 +155,9 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
                 targetoptions['opt'] = opt
                 targetoptions['link'] = link
                 targetoptions['fastmath'] = fastmath
-                targetoptions['device'] = device
                 targetoptions['extensions'] = extensions
-                disp = CUDADispatcher(func_or_sig, targetoptions=targetoptions)
+                disp = CUDADispatcher(func_or_sig, targetoptions=targetoptions,
+                                      device=device)
 
                 if cache:
                     disp.enable_caching()

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -11,8 +11,8 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
                                  "positional argument.")
 
 
-def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
-        opt=True, cache=False, extensions=None, **kws):
+def jit(func_or_sig=None, device=False, link=None, debug=None, opt=True,
+        cache=False, extensions=None, **kws):
     """
     JIT compile a Python function for CUDA GPUs.
 

--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -12,7 +12,7 @@ _msg_deprecated_signature_arg = ("Deprecated keyword argument `{0}`. "
 
 
 def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
-        opt=True, cache=False, **kws):
+        opt=True, cache=False, extensions=None, **kws):
     """
     JIT compile a Python function for CUDA GPUs.
 
@@ -52,6 +52,9 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
     :type lineinfo: bool
     :param cache: If True, enables the file-based cache for this function.
     :type cache: bool
+    :param extensions: An optional list of kernel launch parameter handling
+                       extensions
+    :type extensions: list
     """
 
     link = link or []
@@ -73,7 +76,6 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
 
     debug = config.CUDA_DEBUGINFO_DEFAULT if debug is None else debug
     fastmath = kws.get('fastmath', False)
-    extensions = kws.get('extensions', [])
 
     if debug and opt:
         msg = ("debug=True with opt=True (the default) "
@@ -105,10 +107,9 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
             targetoptions['link'] = link
             targetoptions['opt'] = opt
             targetoptions['fastmath'] = fastmath
-            targetoptions['extensions'] = extensions
 
             disp = CUDADispatcher(func, targetoptions=targetoptions,
-                                  device=device)
+                                  device=device, extensions=extensions)
 
             if cache:
                 disp.enable_caching()
@@ -155,9 +156,8 @@ def jit(func_or_sig=None, device=False, inline=False, link=None, debug=None,
                 targetoptions['opt'] = opt
                 targetoptions['link'] = link
                 targetoptions['fastmath'] = fastmath
-                targetoptions['extensions'] = extensions
                 disp = CUDADispatcher(func_or_sig, targetoptions=targetoptions,
-                                      device=device)
+                                      device=device, extensions=extensions)
 
                 if cache:
                     disp.enable_caching()

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -68,7 +68,7 @@ class _Kernel(serialize.ReduceMixin):
         debug = targetoptions.get('debug')
         lineinfo = targetoptions.get('lineinfo')
         fastmath = targetoptions.get('fastmath')
-        opt = targetoptions.get('opt')
+        opt = targetoptions.get('opt', True)
         inline = targetoptions.get('inline')
         max_registers = targetoptions.get('max_registers')
 
@@ -813,11 +813,12 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
                 debug = self.targetoptions.get('debug')
                 inline = self.targetoptions.get('inline')
+                opt = self.targetoptions.get('opt', True)
                 fastmath = self.targetoptions.get('fastmath')
 
                 nvvm_options = {
                     'debug': debug,
-                    'opt': 3 if self.targetoptions.get('opt') else 0,
+                    'opt': 3 if opt else 0,
                     'fastmath': fastmath
                 }
 

--- a/numba/cuda/tests/cudapy/test_array_args.py
+++ b/numba/cuda/tests/cudapy/test_array_args.py
@@ -8,7 +8,7 @@ from numba.cuda.testing import unittest, CUDATestCase
 class TestCudaArrayArg(CUDATestCase):
     def test_array_ary(self):
 
-        @cuda.jit('double(double[:],int64)', device=True, inline=True)
+        @cuda.jit('double(double[:],int64)', device=True)
         def device_function(a, c):
             return a[c]
 

--- a/numba/cuda/tests/cudapy/test_blackscholes.py
+++ b/numba/cuda/tests/cudapy/test_blackscholes.py
@@ -64,7 +64,7 @@ class TestBlackScholes(CUDATestCase):
             black_scholes(callResultNumpy, putResultNumpy, stockPrice,
                           optionStrike, optionYears, RISKFREE, VOLATILITY)
 
-        @cuda.jit(double(double), device=True, inline=True)
+        @cuda.jit(double(double), device=True)
         def cnd_cuda(d):
             K = 1.0 / (1.0 + 0.2316419 * math.fabs(d))
             ret_val = (RSQRT2PI * math.exp(-0.5 * d * d) *

--- a/numba/cuda/tests/cudapy/test_laplace.py
+++ b/numba/cuda/tests/cudapy/test_laplace.py
@@ -15,7 +15,7 @@ SM_SIZE = tpb, tpb
 class TestCudaLaplace(CUDATestCase):
     def test_laplace_small(self):
 
-        @cuda.jit(float64(float64, float64), device=True, inline=True)
+        @cuda.jit(float64(float64, float64), device=True)
         def get_max(a, b):
             if a > b:
                 return a

--- a/numba/cuda/vectorizers.py
+++ b/numba/cuda/vectorizers.py
@@ -207,7 +207,7 @@ def __vectorized_{name}({args}, __out__):
 
 class CUDAVectorize(deviceufunc.DeviceVectorize):
     def _compile_core(self, sig):
-        cudevfn = cuda.jit(sig, device=True, inline=True)(self.pyfunc)
+        cudevfn = cuda.jit(sig, device=True)(self.pyfunc)
         return cudevfn, cudevfn.overloads[sig.args].signature.return_type
 
     def _get_globals(self, corefn):


### PR DESCRIPTION
The broad aim of this PR is to handle target options in CUDA more closely to how they are handled by the CPU target, with the longer-term aim of fixing the inheritance of options (for example, so that a device function could inherit `lineinfo=True` if its caller had `lineinfo=True`), and also to minimise the differences between the way decorators work in the CPU and CUDA targets. This PR doesn't reach the point where the decorator implementations are quite ready to unify, but it does move in the right direction.

I checked the generated code from this branch compared with `main`, and no difference is made to code generation.

This work was originally done with a view towards integrating it into #8594 so that the inheritance of lineinfo could be rectified there, but it has turned out to be too large a chunk of work to dump on top of an already-reviewed PR.

Individual commit messages provide more details, and the patches should be reviewable individually (this may be an easier way of reading them than as a whole).