### PR TITLE
Revert PR#8751 for buildfarm stability

### DIFF
--- a/numba/testing/main.py
+++ b/numba/testing/main.py
@@ -770,24 +770,28 @@ class ParallelTestRunner(runner.TextTestRunner):
 
         # Split the tests and recycle the worker process to tame memory usage.
         chunk_size = 100
+        splitted_tests = [self._ptests[i:i + chunk_size]
+                          for i in range(0, len(self._ptests), chunk_size)]
 
-        pool = multiprocessing.Pool(self.nprocs, maxtasksperchild=chunk_size)
-        try:
-            self._run_parallel_tests(result, pool, child_runner, self._ptests)
-        except:
-            # On exception, kill still active workers immediately
-            pool.terminate()
-            # Make sure exception is reported and not ignored
-            raise
-        else:
-            # Close the pool cleanly unless asked to early out
-            if result.shouldStop:
+        for tests in splitted_tests:
+            pool = multiprocessing.Pool(self.nprocs)
+            try:
+                self._run_parallel_tests(result, pool, child_runner, tests)
+            except:
+                # On exception, kill still active workers immediately
                 pool.terminate()
+                # Make sure exception is reported and not ignored
+                raise
             else:
-                pool.close()
-        finally:
-            # Always join the pool (this is necessary for coverage.py)
-            pool.join()
+                # Close the pool cleanly unless asked to early out
+                if result.shouldStop:
+                    pool.terminate()
+                    break
+                else:
+                    pool.close()
+            finally:
+                # Always join the pool (this is necessary for coverage.py)
+                pool.join()
         if not result.shouldStop:
             stests = SerialSuite(self._stests)
             stests.run(result)


### PR DESCRIPTION
Revert "Merge pull request #8751 from apmasell/mulitprocess_recycling" as an attempt to establish the baseline.


#8751 exposed many latent bug in the testsuite and fixing all of them may take a while. That's why I suggest revert the PR for now and continue to fix the problems in #8776.