### PR TITLE
Ensure gc.collect() is called before checking refcount in tests.

### DIFF
--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -266,6 +266,16 @@ class TestCase(unittest.TestCase):
                 self.fail("Refcount changed from %d to %d for object: %r"
                           % (old, new, obj))
 
+    def assertRefCountEqual(self, *objects):
+        gc.collect()
+        rc = [sys.getrefcount(x) for x in objects]
+        for i, x in enumerate(objects[1:], start=1):
+            rc_0 = rc[0]
+            rc_i = rc[i]
+            if rc_0 != rc_i:
+                self.fail(f"Refcount for objects does not match. "
+                          f"#0({rc_0}) != #{i}({rc_i}) does not match.")
+
     @contextlib.contextmanager
     def assertNoNRTLeak(self):
         """

--- a/numba/tests/support.py
+++ b/numba/tests/support.py
@@ -269,8 +269,8 @@ class TestCase(unittest.TestCase):
     def assertRefCountEqual(self, *objects):
         gc.collect()
         rc = [sys.getrefcount(x) for x in objects]
-        for i, x in enumerate(objects[1:], start=1):
-            rc_0 = rc[0]
+        rc_0 = rc[0]
+        for i in range(len(objects))[1:]:
             rc_i = rc[i]
             if rc_0 != rc_i:
                 self.fail(f"Refcount for objects does not match. "

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -1,4 +1,3 @@
-import sys
 import numpy as np
 
 import unittest
@@ -393,8 +392,7 @@ class TestNrtArrayGen(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(py_ary, c_ary)
         self.assertEqual(py_res, c_res)
         # Check reference count
-        self.assertEqual(sys.getrefcount(py_ary),
-                         sys.getrefcount(c_ary))
+        self.assertRefCountEqual(py_ary, c_ary)
 
     def test_nrt_gen1(self):
         pygen = nrt_gen1
@@ -413,10 +411,8 @@ class TestNrtArrayGen(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(py_ary2, c_ary2)
         self.assertEqual(py_res, c_res)
         # Check reference count
-        self.assertEqual(sys.getrefcount(py_ary1),
-                         sys.getrefcount(c_ary1))
-        self.assertEqual(sys.getrefcount(py_ary2),
-                         sys.getrefcount(c_ary2))
+        self.assertRefCountEqual(py_ary1, c_ary1)
+        self.assertRefCountEqual(py_ary2, c_ary2)
 
     def test_combine_gen0_gen1(self):
         """
@@ -456,8 +452,7 @@ class TestNrtArrayGen(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(py_ary, c_ary)
         self.assertEqual(py_res, c_res)
         # Check reference count
-        self.assertEqual(sys.getrefcount(py_ary),
-                         sys.getrefcount(c_ary))
+        self.assertRefCountEqual(py_ary, c_ary)
 
     def test_nrt_gen0_no_iter(self):
         """
@@ -479,8 +474,7 @@ class TestNrtArrayGen(MemoryLeakMixin, TestCase):
         np.testing.assert_equal(py_ary, c_ary)
 
         # Check reference count
-        self.assertEqual(sys.getrefcount(py_ary),
-                         sys.getrefcount(c_ary))
+        self.assertRefCountEqual(py_ary, c_ary)
 
 
 # TODO: fix nested generator and MemoryLeakMixin
@@ -512,8 +506,7 @@ class TestNrtNestedGen(TestCase):
 
         np.testing.assert_equal(py_res, c_res)
 
-        self.assertEqual(sys.getrefcount(py_res),
-                         sys.getrefcount(c_res))
+        self.assertRefCountEqual(py_res, c_res)
 
         # The below test will fail due to generator finalizer not invoked.
         # This kept a reference of the c_old.
@@ -543,8 +536,7 @@ class TestNrtNestedGen(TestCase):
         self.assertIs(py_old, py_arr)
         self.assertIs(c_old, c_arr)
 
-        self.assertEqual(sys.getrefcount(py_old),
-                         sys.getrefcount(c_old))
+        self.assertRefCountEqual(py_old, c_old)
 
     def test_nrt_nested_nopython_gen(self):
         """

--- a/numba/tests/test_lists.py
+++ b/numba/tests/test_lists.py
@@ -882,7 +882,7 @@ class TestListReflection(MemoryLeakMixin, TestCase):
         got = cfunc(clist, clist)
         self.assertPreciseEqual(expected, got)
         self.assertPreciseEqual(pylist, clist)
-        self.assertPreciseEqual(sys.getrefcount(pylist), sys.getrefcount(clist))
+        self.assertRefCountEqual(pylist, clist)
 
     def test_reflect_clean(self):
         """

--- a/numba/tests/test_np_randomgen.py
+++ b/numba/tests/test_np_randomgen.py
@@ -2,6 +2,7 @@ import numba
 import numpy as np
 import sys
 import itertools
+import gc
 
 from numba import types
 from numba.tests.support import TestCase, MemoryLeakMixin
@@ -231,9 +232,11 @@ class TestRandomGenerators(MemoryLeakMixin, TestCase):
         do_box = numba.njit(lambda x:x)
 
         y = do_box(rng_instance)
+        gc.collect()
         ref_1 = sys.getrefcount(rng_instance)
         del y
         no_box(rng_instance)
+        gc.collect()
         ref_2 = sys.getrefcount(rng_instance)
 
         self.assertEqual(ref_1, ref_2 + 1)

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import ctypes
 from numba import jit, literal_unroll, njit, typeof
@@ -448,7 +446,7 @@ nested_array1_dtype = np.dtype([("array1", np.int16, (3,))], align=True)
 nested_array2_dtype = np.dtype([("array2", np.int16, (3, 2))], align=True)
 
 
-class TestRecordDtypeMakeCStruct(unittest.TestCase):
+class TestRecordDtypeMakeCStruct(TestCase):
     def test_two_scalars(self):
 
         class Ref(ctypes.Structure):
@@ -556,7 +554,7 @@ class TestRecordDtypeMakeCStruct(unittest.TestCase):
         np.testing.assert_array_equal(extracted_array, data)
 
 
-class TestRecordDtype(unittest.TestCase):
+class TestRecordDtype(TestCase):
 
     def _createSampleArrays(self):
         '''
@@ -775,44 +773,42 @@ class TestRecordDtype(unittest.TestCase):
         attrs = 'abc'
         valtypes = types.float64, types.int16, types.complex64
         values = 1.23, 12345, 123 + 456j
-        old_refcnt = sys.getrefcount(nbval)
-
-        for attr, valtyp, val in zip(attrs, valtypes, values):
-            expected = getattr(npval, attr)
-            nbrecord = numpy_support.from_dtype(recordtype)
-
-            # Test with a record as either the first argument or the second
-            # argument (issue #870)
-            if revargs:
-                prefix = 'get_record_rev_'
-                argtypes = (valtyp, nbrecord)
-                args = (val, nbval)
-            else:
-                prefix = 'get_record_'
-                argtypes = (nbrecord, valtyp)
-                args = (nbval, val)
-
-            pyfunc = globals()[prefix + attr]
-            cfunc = self.get_cfunc(pyfunc, argtypes)
-
-            got = cfunc(*args)
-            try:
-                self.assertEqual(expected, got)
-            except AssertionError:
-                # On ARM, a LLVM misoptimization can produce buggy code,
-                # see https://llvm.org/bugs/show_bug.cgi?id=24669
-                import llvmlite.binding as ll
-                if attr != 'c':
-                    raise
-                if ll.get_default_triple() != 'armv7l-unknown-linux-gnueabihf':
-                    raise
-                self.assertEqual(val, got)
-            else:
-                self.assertEqual(nbval[attr], val)
-            del got, expected, args
-
         # Check for potential leaks (issue #441)
-        self.assertEqual(sys.getrefcount(nbval), old_refcnt)
+        with self.assertRefCount(nbval):
+            for attr, valtyp, val in zip(attrs, valtypes, values):
+                expected = getattr(npval, attr)
+                nbrecord = numpy_support.from_dtype(recordtype)
+
+                # Test with a record as either the first argument or the second
+                # argument (issue #870)
+                if revargs:
+                    prefix = 'get_record_rev_'
+                    argtypes = (valtyp, nbrecord)
+                    args = (val, nbval)
+                else:
+                    prefix = 'get_record_'
+                    argtypes = (nbrecord, valtyp)
+                    args = (nbval, val)
+
+                pyfunc = globals()[prefix + attr]
+                cfunc = self.get_cfunc(pyfunc, argtypes)
+
+                got = cfunc(*args)
+                try:
+                    self.assertEqual(expected, got)
+                except AssertionError:
+                    # On ARM, a LLVM misoptimization can produce buggy code,
+                    # see https://llvm.org/bugs/show_bug.cgi?id=24669
+                    import llvmlite.binding as ll
+                    if attr != 'c':
+                        raise
+                    triple = 'armv7l-unknown-linux-gnueabihf'
+                    if ll.get_default_triple() != triple:
+                        raise
+                    self.assertEqual(val, got)
+                else:
+                    self.assertEqual(nbval[attr], val)
+                del got, expected, args
 
     def test_record_args(self):
         self._test_record_args(False)
@@ -867,15 +863,14 @@ class TestRecordDtype(unittest.TestCase):
         indices = [0, 1, 2]
         for index, attr in zip(indices, attrs):
             nbary = self.nbsample1d.copy()
-            old_refcnt = sys.getrefcount(nbary)
-            res = cfunc(nbary, index)
-            self.assertEqual(nbary[index], res)
-            # Prove that this is a by-value copy
-            setattr(res, attr, 0)
-            self.assertNotEqual(nbary[index], res)
-            del res
             # Check for potential leaks
-            self.assertEqual(sys.getrefcount(nbary), old_refcnt)
+            with self.assertRefCount(nbary):
+                res = cfunc(nbary, index)
+                self.assertEqual(nbary[index], res)
+                # Prove that this is a by-value copy
+                setattr(res, attr, 0)
+                self.assertNotEqual(nbary[index], res)
+                del res
 
     def test_record_arg_transform(self):
         # Testing that transforming the name of a record type argument to a
@@ -1015,7 +1010,7 @@ class TestRecordDtypeWithStructArraysAndDispatcher(TestRecordDtypeWithStructArra
 
 
 @skip_ppc64le_issue6465
-class TestRecordDtypeWithCharSeq(unittest.TestCase):
+class TestRecordDtypeWithCharSeq(TestCase):
 
     def _createSampleaArray(self):
         self.refsample1d = np.recarray(3, dtype=recordwithcharseq)
@@ -1129,7 +1124,7 @@ class TestRecordDtypeWithCharSeq(unittest.TestCase):
             self.assertEqual(expected, got)
 
 
-class TestRecordArrayGetItem(unittest.TestCase):
+class TestRecordArrayGetItem(TestCase):
 
     # Test getitem when index is Literal[str]
 
@@ -1213,7 +1208,7 @@ class TestRecordArrayGetItem(unittest.TestCase):
         np.testing.assert_allclose(expected, got)
 
 
-class TestRecordArraySetItem(unittest.TestCase):
+class TestRecordArraySetItem(TestCase):
     """
     Test setitem when index is Literal[str]
     """

--- a/numba/tests/test_sets.py
+++ b/numba/tests/test_sets.py
@@ -825,7 +825,7 @@ class TestSetReflection(BaseTest):
         got = cfunc(cset, cset)
         self.assertPreciseEqual(expected, got)
         self.assertPreciseEqual(pyset, cset)
-        self.assertPreciseEqual(sys.getrefcount(pyset), sys.getrefcount(cset))
+        self.assertRefCountEqual(pyset, cset)
 
     def test_reflect_clean(self):
         """


### PR DESCRIPTION
Splitted from https://github.com/numba/numba/pull/8776#issuecomment-1442164785 as requested by reviewer.