### PR TITLE
Add support for NamedTuple casting and constructor default arguments

### DIFF
--- a/numba/core/typing/collections.py
+++ b/numba/core/typing/collections.py
@@ -1,10 +1,10 @@
 from .. import types, utils, errors
 import operator
-from .templates import (AttributeTemplate, ConcreteTemplate, AbstractTemplate,
-                        infer_global, infer, infer_getattr,
-                        signature, bound_function, make_callable_template)
+from .templates import (AttributeTemplate, AbstractTemplate, Signature,
+                        infer_global, infer_getattr,
+                        signature, fold_arguments)
 from .builtins import normalize_1d_index
-
+from .typeof import typeof
 
 @infer_global(operator.contains)
 class InContainer(AbstractTemplate):
@@ -94,6 +94,35 @@ class NamedTupleAttribute(AttributeTemplate):
         return tup[index]
 
 
+class NamedTupleCallTemplate(AbstractTemplate):
+    """Base call template for NamedTuple class constructors.
+    
+    Subclasses should define class variables `instance_class` and `key`.
+    """
+
+    def generic(self, args, kws):
+        pysig = utils.pysignature(self.instance_class)
+
+        def stararg_handler(index, param, value):
+            raise NotImplementedError(
+                "stararg not implemented for NamedTuple constructors"
+            )
+
+        # Handle default arguments by looking up their type.
+        folded = fold_arguments(
+            pysig=pysig,
+            args=args,
+            kws=kws,
+            normal_handler=lambda index, param, value: value,
+            default_handler=lambda index, param, default: typeof(default),
+            stararg_handler=stararg_handler,
+        )
+
+        return_type = types.BaseTuple.from_types(folded, self.instance_class)
+        sig = Signature(return_type, args=folded, recvr=None, pysig=pysig)
+        return sig
+
+
 @infer_getattr
 class NamedTupleClassAttribute(AttributeTemplate):
     key = types.NamedTupleClass
@@ -102,20 +131,11 @@ class NamedTupleClassAttribute(AttributeTemplate):
         """
         Resolve the named tuple constructor, aka the class's __call__ method.
         """
+        class SpecificNamedTupleCallTemplate(NamedTupleCallTemplate):
+            key = classty.instance_class
+            instance_class = classty.instance_class
+
         instance_class = classty.instance_class
         pysig = utils.pysignature(instance_class)
 
-        def typer(*args, **kws):
-            # Fold keyword args
-            try:
-                bound = pysig.bind(*args, **kws)
-            except TypeError as e:
-                msg = "In '%s': %s" % (instance_class, e)
-                e.args = (msg,)
-                raise
-            assert not bound.kwargs
-            return types.BaseTuple.from_types(bound.args, instance_class)
-
-        # Override the typer's pysig to match the namedtuple constructor's
-        typer.pysig = pysig
-        return types.Function(make_callable_template(self.key, typer))
+        return types.Function(SpecificNamedTupleCallTemplate)

--- a/numba/cpython/tupleobj.py
+++ b/numba/cpython/tupleobj.py
@@ -378,10 +378,23 @@ def static_getitem_tuple(context, builder, sig, args):
 def tuple_to_tuple(context, builder, fromty, toty, val):
     if (isinstance(fromty, types.BaseNamedTuple)
         or isinstance(toty, types.BaseNamedTuple)):
-        # Disallowed by typing layer
+        # Namedtuple casts handled below
         raise NotImplementedError
 
     if len(fromty) != len(toty):
+        # Disallowed by typing layer
+        raise NotImplementedError
+
+    olditems = cgutils.unpack_tuple(builder, val, len(fromty))
+    items = [context.cast(builder, v, f, t)
+             for v, f, t in zip(olditems, fromty, toty)]
+    return context.make_tuple(builder, toty, items)
+
+
+@lower_cast(types.BaseNamedTuple, types.BaseNamedTuple)
+def namedtuple_to_namedtuple(context, builder, fromty, toty, val):
+    if (fromty.instance_class != toty.instance_class
+        or fromty.count != toty.count):
         # Disallowed by typing layer
         raise NotImplementedError
 

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import typing
 
 import numpy as np
 
@@ -17,6 +18,11 @@ Point = collections.namedtuple('Point', ('x', 'y', 'z'))
 Point2 = collections.namedtuple('Point2', ('x', 'y', 'z'))
 
 Empty = collections.namedtuple('Empty', ())
+
+class PointWithDefaults(typing.NamedTuple):
+    x: int
+    y: int = 2
+    z: int = 3
 
 def tuple_return_usecase(a, b):
     return a, b
@@ -489,6 +495,15 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
 
         check(make_point)
         check(make_point_kws)
+
+    def test_construct_with_defaults(self):
+        pyfunc = lambda x, z: PointWithDefaults(x, z=z)
+        cfunc = jit(nopython=True)(pyfunc)
+        for args in (5, 6), (5.5, 6j):
+            expected = pyfunc(*args)
+            got = cfunc(*args)
+            self.assertIs(type(got), type(expected))
+            self.assertPreciseEqual(got, expected)
 
     def test_type(self):
         # Test the type() built-in on named tuples

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -618,6 +618,36 @@ class TestConversions(TestCase):
         msg = "No conversion from UniTuple(int32 x 2) to UniTuple(float32 x 1)"
         self.assertIn(msg, str(raises.exception))
 
+    def test_namedtuple_conversions(self):
+        check = self.check_conversion
+        fromty = types.NamedUniTuple(types.int32, 3, Point)
+        check(fromty, types.NamedUniTuple(types.float32, 3, Point), Point(4, 5, 6))
+        check(fromty,
+            types.NamedTuple((types.float32, types.int16, types.int32), Point),
+            Point(4, 5, 6))
+        aty = types.NamedUniTuple(types.int32, 0, Empty)
+        bty = types.NamedTuple((), Empty)
+        check(aty, bty, Empty())
+        check(bty, aty, Empty())
+
+        with self.assertRaises(errors.TypingError) as raises:
+            check(fromty, types.UniTuple(types.float32, 3), Point(4, 5, 6))
+        msg = "No conversion from Point(int32 x 3) to UniTuple(float32 x 3)"
+        self.assertIn(msg, str(raises.exception))
+
+        with self.assertRaises(errors.TypingError) as raises:
+            check(fromty, types.NamedUniTuple(types.int32, 3, Point2),
+                Point(4, 5, 6))
+        msg = "No conversion from Point(int32 x 3) to Point2(int32 x 3)"
+        self.assertIn(msg, str(raises.exception))
+
+        with self.assertRaises(errors.TypingError) as raises:
+            check(types.UniTuple(types.int32, 3),
+                types.NamedUniTuple(types.int32, 3, Point),
+                Point(4, 5, 6))
+        msg = "No conversion from UniTuple(int32 x 3) to Point(int32 x 3)"
+        self.assertIn(msg, str(raises.exception))
+
 
 class TestMethods(TestCase):
 

--- a/numba/tests/test_tuples.py
+++ b/numba/tests/test_tuples.py
@@ -505,6 +505,14 @@ class TestNamedTuple(TestCase, MemoryLeakMixin):
             self.assertIs(type(got), type(expected))
             self.assertPreciseEqual(got, expected)
 
+    def test_construct_with_defaults_and_access_field(self):
+        pyfunc = lambda x: PointWithDefaults(x).y
+        cfunc = jit(nopython=True)(pyfunc)
+        expected = pyfunc(1)
+        got = cfunc(1)
+        self.assertIs(type(got), type(expected))
+        self.assertPreciseEqual(got, expected)
+
     def test_type(self):
         # Test the type() built-in on named tuples
         pyfunc = type_usecase


### PR DESCRIPTION
This PR adds support for some additional features for named tuples.

### Casting

Enables casts between NamedTuple types with the same instance class and compatible element types, similar to how regular tuples can be cast if they have compatible element types. Casting is supported for both NamedTuple and NamedUniTuple. Casts remain unsupported between tuples of different instance classes (i.e. with different Python types).

This makes it possible to use namedtuples in place of regular tuples in more situations. For instance, we can pass a namedtuple containing ints to a function that expects floats, or a namedtuple containing None to a function expecting that element to be optional. Before this change, both of those resulted in an error unless each element was cast manually.

### Constructor default arguments

NamedTuple classes can have default arguments in Python 3.7 and later. This is especially convenient when defining a NamedTuple class by subclassing `typing.NamedTuple`.

However, Numba does not currently process the default arguments in the correct way. This appears to be due to the use of `make_callable_template` to build the callable template for the constructor, which inspects the signature of the `typer` function itself and then ["hacks omitted parameters out"](https://github.com/numba/numba/blob/4535cb650da992a4c06bd252f94ee50095795f46/numba/core/typing/templates.py#L448-L454). In this case the lowering function for namedtuples expects to receive values for these parameters, and in some cases this can lead to trying to access memory out of the allocated bounds, e.g. if we define
```
class Foo(typing.NamedTuple):
    foo: int
    bar: int = 0
```
then construct `foo = Foo(1)` and try to access `foo.bar` inside `nopython` jit code.

This change modifies the call template for the namedtuple class object to infer default arguments from the python signature, by using `fold_arguments` and `generic` to build an explicit template instead of deferring to `make_callable_template`.
