### PR TITLE
CUDA: Fix returned dtype of vectorized functions (Issue #8400)

### DIFF
--- a/numba/cuda/decorators.py
+++ b/numba/cuda/decorators.py
@@ -121,7 +121,7 @@ def jit(func_or_sig=None, device=False, inline=False, link=[], debug=None,
                 if device:
                     from numba.core import typeinfer
                     with typeinfer.register_dispatcher(disp):
-                        disp.compile_device(argtypes)
+                        disp.compile_device(argtypes, restype)
                 else:
                     disp.compile(argtypes)
 

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -846,7 +846,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
 
         return call_template, pysig, args, kws
 
-    def compile_device(self, args):
+    def compile_device(self, args, return_type=None):
         """Compile the device function for the given argument types.
 
         Each signature is compiled once by caching the compiled function inside
@@ -868,7 +868,7 @@ class CUDADispatcher(Dispatcher, serialize.ReduceMixin):
                 }
 
                 cc = get_current_device().compute_capability
-                cres = compile_cuda(self.py_func, None, args,
+                cres = compile_cuda(self.py_func, return_type, args,
                                     debug=debug,
                                     inline=inline,
                                     fastmath=fastmath,

--- a/numba/cuda/tests/cudapy/test_vectorize.py
+++ b/numba/cuda/tests/cudapy/test_vectorize.py
@@ -1,26 +1,44 @@
 import numpy as np
 
 from collections import namedtuple
+from itertools import product
 from numba import vectorize
 from numba import cuda, int32, float32, float64
 from numba.cuda.testing import skip_on_cudasim
 from numba.cuda.testing import CUDATestCase
 import unittest
 
-sig = [int32(int32, int32),
-       float32(float32, float32),
-       float64(float64, float64)]
+signatures = [int32(int32, int32),
+              float32(float32, float32),
+              float64(float64, float64)]
 
-test_dtypes = np.float32, np.int32
+# The order here is chosen such that each subsequent dtype might have been
+# casted to a previously-used dtype. This is unlikely to be an issue for CUDA,
+# but there might be future circumstances in which it becomes relevant, perhaps
+# if it supported Dynamic UFuncs, and we want to ensure that an implementation
+# for a the given dtype is used rather than casting the input upwards.
+dtypes = (np.float64, np.float32, np.int32)
+
+# NumPy ndarray orders
+orders = ('C', 'F')
+
+# Input sizes corresponding to operations:
+# - Less than one warp,
+# - Less than one block,
+# - Greater than one block (i.e. many blocks)
+input_sizes = (8, 100, 2 ** 10 + 1)
 
 
 @skip_on_cudasim('ufunc API unsupported in the simulator')
 class TestCUDAVectorize(CUDATestCase):
+    # Presumably chosen as an odd number unlikely to coincide with the total
+    # thread count, and large enough to ensure a significant number of blocks
+    # are used.
     N = 1000001
 
     def test_scalar(self):
 
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
@@ -31,157 +49,118 @@ class TestCUDAVectorize(CUDATestCase):
 
     def test_1d(self):
 
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
-        cuda_ufunc = vector_add
-
-        # build python ufunc
-        np_ufunc = np.add
-
-        # test it out
-        def test(ty):
+        for ty in dtypes:
             data = np.array(np.random.random(self.N), dtype=ty)
-
-            result = cuda_ufunc(data, data)
-            gold = np_ufunc(data, data)
-            self.assertTrue(np.allclose(gold, result), (gold, result))
-
-        test(np.double)
-        test(np.float32)
-        test(np.int32)
+            expected = np.add(data, data)
+            actual = vector_add(data, data)
+            np.testing.assert_allclose(expected, actual)
 
     def test_1d_async(self):
 
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
-        cuda_ufunc = vector_add
+        stream = cuda.stream()
 
-        # build python ufunc
-        np_ufunc = np.add
-
-        # test it out
-        def test(ty):
+        for ty in dtypes:
             data = np.array(np.random.random(self.N), dtype=ty)
-
-            stream = cuda.stream()
             device_data = cuda.to_device(data, stream)
-            dresult = cuda_ufunc(device_data, device_data, stream=stream)
-            result = dresult.copy_to_host()
-            stream.synchronize()
 
-            gold = np_ufunc(data, data)
+            dresult = vector_add(device_data, device_data, stream=stream)
+            actual = dresult.copy_to_host()
 
-            self.assertTrue(np.allclose(gold, result), (gold, result))
+            expected = np.add(data, data)
 
-        test(np.double)
-        test(np.float32)
-        test(np.int32)
+            np.testing.assert_allclose(expected, actual)
 
     def test_nd(self):
 
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
-        cuda_ufunc = vector_add
+        for nd, dtype, order in product(range(1, 8), dtypes, orders):
+            shape = (4,) * nd
+            data = np.random.random(shape).astype(dtype)
+            data2 = np.array(data.T, order=order)
 
-        def test(dtype, order, nd, size=4):
-            data = np.random.random((size,) * nd).astype(dtype)
-            data[data != data] = 2.4
-            data[data == float('inf')] = 3.8
-            data[data == float('-inf')] = -3.8
-            data2 = np.array(data.T, order=order)  # .copy(order=order)
-
-            result = data + data2
-            our_result = cuda_ufunc(data, data2)
-            self.assertTrue(np.allclose(result, our_result),
-                            (dtype, order, result, our_result))
-
-        for nd in range(1, 8):
-            for dtype in test_dtypes:
-                for order in ('C', 'F'):
-                    test(dtype, order, nd)
-
-    def test_ufunc_attrib(self):
-        self.reduce_test(8)
-        self.reduce_test(100)
-        self.reduce_test(2 ** 10 + 1)
-        self.reduce_test2(8)
-        self.reduce_test2(100)
-        self.reduce_test2(2 ** 10 + 1)
+            expected = data + data2
+            actual = vector_add(data, data2)
+            np.testing.assert_allclose(expected, actual)
 
     def test_output_arg(self):
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
         A = np.arange(10, dtype=np.float32)
         B = np.arange(10, dtype=np.float32)
-        C = np.empty_like(A)
-        vector_add(A, B, out=C)
-        self.assertTrue(np.allclose(A + B, C))
 
-    def reduce_test(self, n):
-        @vectorize(sig, target='cuda')
+        expected = A + B
+        actual = np.empty_like(A)
+        vector_add(A, B, out=actual)
+
+        np.testing.assert_allclose(expected, actual)
+
+    def test_reduce(self):
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
-        cuda_ufunc = vector_add
-        x = np.arange(n, dtype=np.int32)
-        gold = np.add.reduce(x)
-        result = cuda_ufunc.reduce(x)
-        self.assertEqual(result, gold)
+        for n in input_sizes:
+            x = np.arange(n, dtype=np.int32)
+            expected = np.add.reduce(x)
+            actual = vector_add.reduce(x)
+            self.assertEqual(expected, actual)
 
-    def reduce_test2(self, n):
+    def test_reduce_async(self):
 
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 
-        cuda_ufunc = vector_add
-
-        x = np.arange(n, dtype=np.int32)
-        gold = np.add.reduce(x)
         stream = cuda.stream()
-        dx = cuda.to_device(x, stream)
-        result = cuda_ufunc.reduce(dx, stream=stream)
-        self.assertEqual(result, gold)
 
-    def test_auto_transfer(self):
-        @vectorize(sig, target='cuda')
+        for n in input_sizes:
+            x = np.arange(n, dtype=np.int32)
+            expected = np.add.reduce(x)
+            dx = cuda.to_device(x, stream)
+            actual = vector_add.reduce(dx, stream=stream)
+            self.assertEqual(expected, actual)
+
+    def test_manual_transfer(self):
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
-
-        cuda_ufunc = vector_add
 
         n = 10
         x = np.arange(n, dtype=np.int32)
         dx = cuda.to_device(x)
-        y = cuda_ufunc(x, dx).copy_to_host()
-        np.testing.assert_equal(y, x + x)
+        expected = x + x
+        actual = vector_add(x, dx).copy_to_host()
+        np.testing.assert_equal(expected, actual)
 
-    def test_ufunc_output_ravel(self):
-        @vectorize(sig, target='cuda')
+    def test_ufunc_output_2d(self):
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
-
-        cuda_ufunc = vector_add
 
         n = 10
         x = np.arange(n, dtype=np.int32).reshape(2, 5)
         dx = cuda.to_device(x)
-        cuda_ufunc(dx, dx, out=dx)
+        vector_add(dx, dx, out=dx)
 
-        got = dx.copy_to_host()
-        expect = x + x
-        np.testing.assert_equal(got, expect)
+        expected = x + x
+        actual = dx.copy_to_host()
+        np.testing.assert_equal(expected, actual)
 
     def check_tuple_arg(self, a, b):
-        @vectorize(sig, target='cuda')
+        @vectorize(signatures, target='cuda')
         def vector_add(a, b):
             return a + b
 


### PR DESCRIPTION
The return dtype was never passed through to the compilation, so the inferred dtype was always used instead, which could result in some widening. This commit passes the required return dtype through.

Vectorize tests are updated to check the return dtype.

The first commit on this branch is a cleanup and modernization of the tests for the CUDA `@vectorize` decorator - it dates from NumbaPro, and some changes were made to make it clearer, simpler, and easier to augment with tests for the return dtype.

See individual commits for details of changes - the patch is probably easiest reviewed as each commit individually.

Fixes #8400.