### PR TITLE
CUDA compare and swap with index

### DIFF
--- a/docs/source/cuda-reference/kernel.rst
+++ b/docs/source/cuda-reference/kernel.rst
@@ -175,7 +175,7 @@ Synchronization and Atomic Operations
     indices for indexing into multiple dimensional arrays. The number of element
     in ``idx`` must match the number of dimension of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.sub(array, idx, value)
@@ -185,7 +185,7 @@ Synchronization and Atomic Operations
     indices for indexing into multi-dimensional arrays. The number of elements
     in ``idx`` must match the number of dimensions of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.and_(array, idx, value)
@@ -195,7 +195,7 @@ Synchronization and Atomic Operations
     integer indices for indexing into multi-dimensional arrays. The number
     of elements in ``idx`` must match the number of dimensions of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.or_(array, idx, value)
@@ -205,7 +205,7 @@ Synchronization and Atomic Operations
     integer indices for indexing into multi-dimensional arrays. The number
     of elements in ``idx`` must match the number of dimensions of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.xor(array, idx, value)
@@ -215,7 +215,7 @@ Synchronization and Atomic Operations
     integer indices for indexing into multi-dimensional arrays. The number
     of elements in ``idx`` must match the number of dimensions of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.exch(array, idx, value)
@@ -225,7 +225,7 @@ Synchronization and Atomic Operations
     integer indices for indexing into multi-dimensional arrays. The number
     of elements in ``idx`` must match the number of dimensions of ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.inc(array, idx, value)
@@ -236,7 +236,7 @@ Synchronization and Atomic Operations
     The number of elements in ``idx`` must match the number of dimensions of
     ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.dec(array, idx, value)
@@ -248,7 +248,7 @@ Synchronization and Atomic Operations
     The number of elements in ``idx`` must match the number of dimensions of
     ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
 
 .. function:: numba.cuda.atomic.max(array, idx, value)
@@ -259,8 +259,19 @@ Synchronization and Atomic Operations
     The number of element in ``idx`` must match the number of dimension of
     ``array``.
 
-    Returns the value of ``array[idx]`` before the storing the new value.
+    Returns the value of ``array[idx]`` before storing the new value.
     Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.cas(array, idx, old, value)
+
+    Perform ``if array[idx] == old: array[idx] = value``. Supports int32,
+    int64, uint32, uint64 indexes only. The ``idx`` argument can be an integer
+    or a tuple of integer indices for indexing into multi-dimensional arrays.
+    The number of elements in ``idx`` must match the number of dimensions of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic compare and swap.
 
 
 .. function:: numba.cuda.syncthreads

--- a/numba/cuda/cudadecl.py
+++ b/numba/cuda/cudadecl.py
@@ -515,6 +515,24 @@ class Cuda_atomic_compare_and_swap(AbstractTemplate):
 
 
 @register
+class Cuda_atomic_cas(AbstractTemplate):
+    key = cuda.atomic.cas
+
+    def generic(self, args, kws):
+        assert not kws
+        ary, idx, old, val = args
+        dty = ary.dtype
+
+        if dty not in integer_numba_types:
+            return
+
+        if ary.ndim == 1:
+            return signature(dty, ary, types.intp, dty, dty)
+        elif ary.ndim > 1:
+            return signature(dty, ary, idx, dty, dty)
+
+
+@register
 class Cuda_nanosleep(ConcreteTemplate):
     key = cuda.nanosleep
 
@@ -601,6 +619,9 @@ class CudaAtomicTemplate(AttributeTemplate):
 
     def resolve_compare_and_swap(self, mod):
         return types.Function(Cuda_atomic_compare_and_swap)
+
+    def resolve_cas(self, mod):
+        return types.Function(Cuda_atomic_cas)
 
 
 @register_attr

--- a/numba/cuda/cudaimpl.py
+++ b/numba/cuda/cudaimpl.py
@@ -708,7 +708,7 @@ lower(math.degrees, types.f4)(gen_deg_rad(_rad2deg))
 lower(math.degrees, types.f8)(gen_deg_rad(_rad2deg))
 
 
-def _normalize_indices(context, builder, indty, inds):
+def _normalize_indices(context, builder, indty, inds, aryty, valty):
     """
     Convert integer indices into tuple of intp
     """
@@ -719,6 +719,15 @@ def _normalize_indices(context, builder, indty, inds):
         indices = cgutils.unpack_tuple(builder, inds, count=len(indty))
     indices = [context.cast(builder, i, t, types.intp)
                for t, i in zip(indty, indices)]
+
+    dtype = aryty.dtype
+    if dtype != valty:
+        raise TypeError("expect %s but got %s" % (dtype, valty))
+
+    if aryty.ndim != len(indty):
+        raise TypeError("indexing %d-D array with %d-D index" %
+                        (aryty.ndim, len(indty)))
+
     return indty, indices
 
 
@@ -729,14 +738,8 @@ def _atomic_dispatcher(dispatch_fn):
         ary, inds, val = args
         dtype = aryty.dtype
 
-        indty, indices = _normalize_indices(context, builder, indty, inds)
-
-        if dtype != valty:
-            raise TypeError("expect %s but got %s" % (dtype, valty))
-
-        if aryty.ndim != len(indty):
-            raise TypeError("indexing %d-D array with %d-D index" %
-                            (aryty.ndim, len(indty)))
+        indty, indices = _normalize_indices(context, builder, indty, inds,
+                                            aryty, valty)
 
         lary = context.make_array(aryty)(context, builder, ary)
         ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices,
@@ -933,6 +936,28 @@ def ptx_atomic_cas_tuple(context, builder, sig, args):
     else:
         raise TypeError('Unimplemented atomic compare_and_swap '
                         'with %s array' % dtype)
+
+
+@lower(stubs.atomic.cas, types.Array, types.intp, types.Any, types.Any)
+@lower(stubs.atomic.cas, types.Array, types.Tuple, types.Any, types.Any)
+@lower(stubs.atomic.cas, types.Array, types.UniTuple, types.Any, types.Any)
+def ptx_atomic_cas(context, builder, sig, args):
+    aryty, indty, oldty, valty = sig.args
+    ary, inds, old, val = args
+
+    indty, indices = _normalize_indices(context, builder, indty, inds, aryty,
+                                        valty)
+
+    lary = context.make_array(aryty)(context, builder, ary)
+    ptr = cgutils.get_item_pointer(context, builder, aryty, lary, indices,
+                                   wraparound=True)
+
+    if aryty.dtype in (cuda.cudadecl.integer_numba_types):
+        lmod = builder.module
+        bitwidth = aryty.dtype.bitwidth
+        return nvvmutils.atomic_cmpxchg(builder, lmod, bitwidth, ptr, old, val)
+    else:
+        raise TypeError('Unimplemented atomic cas with %s array' % aryty.dtype)
 
 
 # -----------------------------------------------------------------------------

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -128,8 +128,8 @@ orlock = threading.Lock()
 xorlock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
+compare_and_swaplock = threading.Lock()
 caslock = threading.Lock()
-casindexlock = threading.Lock()
 inclock = threading.Lock()
 declock = threading.Lock()
 exchlock = threading.Lock()
@@ -215,7 +215,7 @@ class FakeCUDAAtomic(object):
         return old
 
     def compare_and_swap(self, array, old, val):
-        with caslock:
+        with compare_and_swaplock:
             index = (0,) * array.ndim
             loaded = array[index]
             if loaded == old:
@@ -223,7 +223,7 @@ class FakeCUDAAtomic(object):
             return loaded
 
     def cas(self, array, index, old, val):
-        with casindexlock:
+        with caslock:
             loaded = array[index]
             if loaded == old:
                 array[index] = val

--- a/numba/cuda/simulator/kernelapi.py
+++ b/numba/cuda/simulator/kernelapi.py
@@ -129,6 +129,7 @@ xorlock = threading.Lock()
 maxlock = threading.Lock()
 minlock = threading.Lock()
 caslock = threading.Lock()
+casindexlock = threading.Lock()
 inclock = threading.Lock()
 declock = threading.Lock()
 exchlock = threading.Lock()
@@ -216,6 +217,13 @@ class FakeCUDAAtomic(object):
     def compare_and_swap(self, array, old, val):
         with caslock:
             index = (0,) * array.ndim
+            loaded = array[index]
+            if loaded == old:
+                array[index] = val
+            return loaded
+
+    def cas(self, array, index, old, val):
+        with casindexlock:
             loaded = array[index]
             if loaded == old:
                 array[index] = val

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -509,8 +509,8 @@ class atomic(Stub):
     class cas(Stub):
         """cas(ary, idx, old, val)
 
-        Conditionally assign ``val`` to the element ary[idx] of an array
-        ``ary`` if the current value of ary[idx] matches ``old``.
+        Conditionally assign ``val`` to the element ``idx`` of an array
+        ``ary`` if the current value of ``ary[idx]`` matches ``old``.
 
         Supported on int32, int64, uint32, uint64 operands only.
 

--- a/numba/cuda/stubs.py
+++ b/numba/cuda/stubs.py
@@ -503,7 +503,18 @@ class atomic(Stub):
 
         Supported on int32, int64, uint32, uint64 operands only.
 
-        Returns the current value as if it is loaded atomically.
+        Returns the old value as if it is loaded atomically.
+        """
+
+    class cas(Stub):
+        """cas(ary, idx, old, val)
+
+        Conditionally assign ``val`` to the element ary[idx] of an array
+        ``ary`` if the current value of ary[idx] matches ``old``.
+
+        Supported on int32, int64, uint32, uint64 operands only.
+
+        Returns the old value as if it is loaded atomically.
         """
 
 

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -452,22 +452,19 @@ def gen_atomic_extreme_funcs(func):
 def atomic_compare_and_swap(res, old, ary, fill_val):
     gid = cuda.grid(1)
     if gid < res.size:
-        out = cuda.atomic.compare_and_swap(res[gid:], fill_val, ary[gid])
-        old[gid] = out
+        old[gid] = cuda.atomic.compare_and_swap(res[gid:], fill_val, ary[gid])
 
 
 def atomic_cas_1dim(res, old, ary, fill_val):
     gid = cuda.grid(1)
     if gid < res.size:
-        out = cuda.atomic.cas(res, gid, fill_val, ary[gid])
-        old[gid] = out
+        old[gid] = cuda.atomic.cas(res, gid, fill_val, ary[gid])
 
 
 def atomic_cas_2dim(res, old, ary, fill_val):
     gid = cuda.grid(2)
     if gid[0] < res.shape[0] and gid[1] < res.shape[1]:
-        out = cuda.atomic.cas(res, gid, fill_val, ary[gid])
-        old[gid] = out
+        old[gid] = cuda.atomic.cas(res, gid, fill_val, ary[gid])
 
 
 class TestCudaAtomics(CUDATestCase):

--- a/numba/cuda/tests/cudapy/test_atomics.py
+++ b/numba/cuda/tests/cudapy/test_atomics.py
@@ -456,6 +456,20 @@ def atomic_compare_and_swap(res, old, ary, fill_val):
         old[gid] = out
 
 
+def atomic_cas_1dim(res, old, ary, fill_val):
+    gid = cuda.grid(1)
+    if gid < res.size:
+        out = cuda.atomic.cas(res, gid, fill_val, ary[gid])
+        old[gid] = out
+
+
+def atomic_cas_2dim(res, old, ary, fill_val):
+    gid = cuda.grid(2)
+    if gid[0] < res.shape[0] and gid[1] < res.shape[1]:
+        out = cuda.atomic.cas(res, gid, fill_val, ary[gid])
+        old[gid] = out
+
+
 class TestCudaAtomics(CUDATestCase):
     def setUp(self):
         super().setUp()
@@ -1251,12 +1265,14 @@ class TestCudaAtomics(CUDATestCase):
         gold = np.min(vals)
         np.testing.assert_equal(res, gold)
 
-    def check_compare_and_swap(self, n, fill, unfill, dtype):
+    def check_cas(self, n, fill, unfill, dtype, cas_func, ndim=1):
         res = [fill] * (n // 2) + [unfill] * (n // 2)
         np.random.shuffle(res)
         res = np.asarray(res, dtype=dtype)
+        if ndim == 2:
+            res.shape = (10, -1)
         out = np.zeros_like(res)
-        ary = np.random.randint(1, 10, size=res.size).astype(res.dtype)
+        ary = np.random.randint(1, 10, size=res.shape).astype(res.dtype)
 
         fill_mask = res == fill
         unfill_mask = res == unfill
@@ -1265,33 +1281,76 @@ class TestCudaAtomics(CUDATestCase):
         expect_res[fill_mask] = ary[fill_mask]
         expect_res[unfill_mask] = unfill
 
-        expect_out = np.zeros_like(out)
-        expect_out[fill_mask] = res[fill_mask]
-        expect_out[unfill_mask] = unfill
+        expect_out = res.copy()
 
-        cuda_func = cuda.jit(atomic_compare_and_swap)
-        cuda_func[10, 10](res, out, ary, fill)
+        cuda_func = cuda.jit(cas_func)
+        if ndim == 1:
+            cuda_func[10, 10](res, out, ary, fill)
+        else:
+            cuda_func[(10, 10), (10, 10)](res, out, ary, fill)
 
         np.testing.assert_array_equal(expect_res, res)
         np.testing.assert_array_equal(expect_out, out)
 
     def test_atomic_compare_and_swap(self):
-        self.check_compare_and_swap(n=100, fill=-99, unfill=-1, dtype=np.int32)
+        self.check_cas(n=100, fill=-99, unfill=-1, dtype=np.int32,
+                       cas_func=atomic_compare_and_swap)
 
     def test_atomic_compare_and_swap2(self):
-        self.check_compare_and_swap(n=100, fill=-45, unfill=-1, dtype=np.int64)
+        self.check_cas(n=100, fill=-45, unfill=-1, dtype=np.int64,
+                       cas_func=atomic_compare_and_swap)
 
     def test_atomic_compare_and_swap3(self):
         rfill = np.random.randint(50, 500, dtype=np.uint32)
         runfill = np.random.randint(1, 25, dtype=np.uint32)
-        self.check_compare_and_swap(n=100, fill=rfill, unfill=runfill,
-                                    dtype=np.uint32)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint32,
+                       cas_func=atomic_compare_and_swap)
 
     def test_atomic_compare_and_swap4(self):
         rfill = np.random.randint(50, 500, dtype=np.uint64)
         runfill = np.random.randint(1, 25, dtype=np.uint64)
-        self.check_compare_and_swap(n=100, fill=rfill, unfill=runfill,
-                                    dtype=np.uint64)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint64,
+                       cas_func=atomic_compare_and_swap)
+
+    def test_atomic_cas_1dim(self):
+        self.check_cas(n=100, fill=-99, unfill=-1, dtype=np.int32,
+                       cas_func=atomic_cas_1dim)
+
+    def test_atomic_cas_2dim(self):
+        self.check_cas(n=100, fill=-99, unfill=-1, dtype=np.int32,
+                       cas_func=atomic_cas_2dim, ndim=2)
+
+    def test_atomic_cas2_1dim(self):
+        self.check_cas(n=100, fill=-45, unfill=-1, dtype=np.int64,
+                       cas_func=atomic_cas_1dim)
+
+    def test_atomic_cas2_2dim(self):
+        self.check_cas(n=100, fill=-45, unfill=-1, dtype=np.int64,
+                       cas_func=atomic_cas_2dim, ndim=2)
+
+    def test_atomic_cas3_1dim(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint32)
+        runfill = np.random.randint(1, 25, dtype=np.uint32)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint32,
+                       cas_func=atomic_cas_1dim)
+
+    def test_atomic_cas3_2dim(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint32)
+        runfill = np.random.randint(1, 25, dtype=np.uint32)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint32,
+                       cas_func=atomic_cas_2dim, ndim=2)
+
+    def test_atomic_cas4_1dim(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint64)
+        runfill = np.random.randint(1, 25, dtype=np.uint64)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint64,
+                       cas_func=atomic_cas_1dim)
+
+    def test_atomic_cas4_2dim(self):
+        rfill = np.random.randint(50, 500, dtype=np.uint64)
+        runfill = np.random.randint(1, 25, dtype=np.uint64)
+        self.check_cas(n=100, fill=rfill, unfill=runfill, dtype=np.uint64,
+                       cas_func=atomic_cas_2dim, ndim=2)
 
     # Tests that the atomic add, min, and max operations return the old value -
     # in the simulator, they did not (see Issue #5458). The max and min have


### PR DESCRIPTION
Closes #6702.

Currently `numba.cuda.atomic.compare_and_swap` only operates on the first array element. This PR adds support for operating on any array element by index. Much of this PR is derived from a previous attempt (#7844) with the permission of the original author @bryevdv. The new function is called `numba.cuda.atomic.cas` and it takes one more argument (the array index) than `compare_and_swap`.

My use case is in datashader to create bespoke CUDA atomic operations that are more complicated than simple add or max. Datashader essentially writes to a 2D array, each element of which represents an output pixel, and multiple CUDA threads may write to the same pixel at the same time. The indexed `cas` function allows the use of a 2D integer array as an array of mutexes, one per pixel, to limit access to a single thread at a time per pixel.

For anyone interested, here is my "datashader lite" implementation in which each pixel is visited multiple times with different integer values. Each pixel stores the two maximum values, in decreasing order, of all visits to that pixel. Without the `cas`-based locking mechanism the checking and shuffling operation of the max values per pixel isn't atomic.

```python
# Datashader-like max2.
# Locking a single pixel at a time using CUDA CAS mutex.
import cupy
from numba import cuda
import numpy as np

@cuda.jit(device=True)
def lock(mutex, index):  # 2D index here
    while cuda.atomic.cas(mutex, index, 0, 1) != 0:
        pass
    cuda.threadfence()  # This may not be necessary?

@cuda.jit(device=True)
def unlock(mutex, index):  # 2D index here
    cuda.threadfence()
    cuda.atomic.exch(mutex, index, 0)

@cuda.jit
def datashader_lite(x, y, val, max2, mutex):
    offset = cuda.grid(1)
    if offset < x.size:
        i, j, v = x[offset], y[offset], val[offset]
        lock(mutex, (j, i))

        # max aggregator would normally have configurable length, but here hard-coded as 2
        if max2[j, i, 0] == -1:
            max2[j, i, 0] = v
        elif v > max2[j, i, 0]:
            max2[j, i, 1] = max2[j, i, 0]
            max2[j, i, 0] = v
        elif v > max2[j, i, 1]:
            max2[j, i, 1] = v

        unlock(mutex, (j, i))

x   = cupy.array([0, 0, 1, 1, 2, 2,  0,  0,  1, 1, 2, 2])
y   = cupy.array([0, 0, 0, 0, 0, 0,  1,  1,  1, 1, 1, 1])
val = cupy.array([1, 2, 3, 4, 5, 6, 12, 11, 10, 9, 8, 7])

ny, nx = 2, 3  # Pixels in target array
max2 = cupy.full((ny, nx, 2), -1)  # -1 is the unset value
mutex = cupy.zeros((ny, nx), dtype=np.uint32)  # Supports integer dtypes
tpb = 10
bpg = int(np.ceil(len(x)/tpb))
datashader_lite[bpg, tpb](x, y, val, max2, mutex)
print('max2', max2)
```
Output using this PR is:
```
max2 [[[ 2  1]
  [ 4  3]
  [ 6  5]]

 [[12 11]
  [10  9]
  [ 8  7]]]
```

This is my first `numba` PR 😃 