### PR TITLE
Attempted fix to #8789 by changing `compile_ptx` to accept a signature instead of argument tuple

### DIFF
--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -1,5 +1,5 @@
 from numba.core.typing.templates import ConcreteTemplate
-from numba.core import types, typing, funcdesc, config, compiler
+from numba.core import types, typing, funcdesc, config, compiler, sigutils
 from numba.core.compiler import (sanitize_compile_result_entries, CompilerBase,
                                  DefaultPassBuilder, Flags, Option,
                                  CompileResult)
@@ -235,12 +235,13 @@ def compile_cuda(pyfunc, return_type, args, debug=False, lineinfo=False,
 
 
 @global_compiler_lock
-def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
+def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
                 fastmath=False, cc=None, opt=True):
     """Compile a Python function to PTX for a given set of argument types.
 
     :param pyfunc: The Python function to compile.
-    :param args: A tuple of argument types to compile for.
+    :param sig: The signature representing the function's input and output
+                     types.
     :param debug: Whether to include debug info in the generated PTX.
     :type debug: bool
     :param lineinfo: Whether to include a line mapping from the generated PTX
@@ -255,8 +256,8 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
     :param fastmath: Whether to enable fast math flags (ftz=1, prec_sqrt=0,
                      prec_div=, and fma=1)
     :type fastmath: bool
-    :param cc: Compute capability to compile for, as a tuple ``(MAJOR, MINOR)``.
-               Defaults to ``(5, 3)``.
+    :param cc: Compute capability to compile for, as a tuple
+               ``(MAJOR, MINOR)``. Defaults to ``(5, 3)``.
     :type cc: tuple
     :param opt: Enable optimizations. Defaults to ``True``.
     :type opt: bool
@@ -276,9 +277,11 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
         'opt': 3 if opt else 0
     }
 
+    args, return_type = sigutils.normalize_signature(sig)
+
     cc = cc or config.CUDA_DEFAULT_PTX_CC
-    cres = compile_cuda(pyfunc, None, args, debug=debug, lineinfo=lineinfo,
-                        fastmath=fastmath,
+    cres = compile_cuda(pyfunc, return_type, args, debug=debug,
+                        lineinfo=lineinfo, fastmath=fastmath,
                         nvvm_options=nvvm_options, cc=cc)
     resty = cres.signature.return_type
 
@@ -300,13 +303,13 @@ def compile_ptx(pyfunc, args, debug=False, lineinfo=False, device=False,
     return ptx, resty
 
 
-def compile_ptx_for_current_device(pyfunc, args, debug=False, lineinfo=False,
+def compile_ptx_for_current_device(pyfunc, sig, debug=False, lineinfo=False,
                                    device=False, fastmath=False, opt=True):
     """Compile a Python function to PTX for a given set of argument types for
     the current device's compute capabilility. This calls :func:`compile_ptx`
     with an appropriate ``cc`` value for the current device."""
     cc = get_current_device().compute_capability
-    return compile_ptx(pyfunc, args, debug=debug, lineinfo=lineinfo,
+    return compile_ptx(pyfunc, sig, debug=debug, lineinfo=lineinfo,
                        device=device, fastmath=fastmath, cc=cc, opt=True)
 
 

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -241,7 +241,7 @@ def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
 
     :param pyfunc: The Python function to compile.
     :param sig: The signature representing the function's input and output
-                     types.
+                types.
     :param debug: Whether to include debug info in the generated PTX.
     :type debug: bool
     :param lineinfo: Whether to include a line mapping from the generated PTX

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -196,7 +196,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for ty, size in zip(fromtys, sizes):
-            ptx, _ = compile_ptx(to_float16, (ty), device=True)
+            ptx, _ = compile_ptx(to_float16, (ty,), device=True)
             self.assertIn(f"cvt.rn.f16.u{size}", ptx)
 
     @skip_unless_cc_53

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -134,7 +134,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for pyfunc, size in zip(pyfuncs, sizes):
-            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2,), device=True)
             self.assertIn(f"cvt.rni.s{size}.f16", ptx)
 
     @skip_unless_cc_53
@@ -156,7 +156,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for pyfunc, size in zip(pyfuncs, sizes):
-            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2,), device=True)
             self.assertIn(f"cvt.rni.u{size}.f16", ptx)
 
     @skip_unless_cc_53
@@ -187,7 +187,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for ty, size in zip(fromtys, sizes):
-            ptx, _ = compile_ptx(to_float16, (ty), device=True)
+            ptx, _ = compile_ptx(to_float16, (ty,), device=True)
             self.assertIn(f"cvt.rn.f16.s{size}", ptx)
 
     @skip_on_cudasim('Compilation unsupported in the simulator')
@@ -222,7 +222,7 @@ class TestCasting(CUDATestCase):
         postfixes = ("f32", "f64")
 
         for pyfunc, postfix in zip(pyfuncs, postfixes):
-            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2,), device=True)
             self.assertIn(f"cvt.{postfix}.f16", ptx)
 
     @skip_unless_cc_53

--- a/numba/cuda/tests/cudapy/test_casting.py
+++ b/numba/cuda/tests/cudapy/test_casting.py
@@ -134,7 +134,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for pyfunc, size in zip(pyfuncs, sizes):
-            ptx, _ = compile_ptx(pyfunc, [f2], device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
             self.assertIn(f"cvt.rni.s{size}.f16", ptx)
 
     @skip_unless_cc_53
@@ -156,7 +156,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for pyfunc, size in zip(pyfuncs, sizes):
-            ptx, _ = compile_ptx(pyfunc, [f2], device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
             self.assertIn(f"cvt.rni.u{size}.f16", ptx)
 
     @skip_unless_cc_53
@@ -187,7 +187,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for ty, size in zip(fromtys, sizes):
-            ptx, _ = compile_ptx(to_float16, [ty], device=True)
+            ptx, _ = compile_ptx(to_float16, (ty), device=True)
             self.assertIn(f"cvt.rn.f16.s{size}", ptx)
 
     @skip_on_cudasim('Compilation unsupported in the simulator')
@@ -196,7 +196,7 @@ class TestCasting(CUDATestCase):
         sizes = (8, 16, 32, 64)
 
         for ty, size in zip(fromtys, sizes):
-            ptx, _ = compile_ptx(to_float16, [ty], device=True)
+            ptx, _ = compile_ptx(to_float16, (ty), device=True)
             self.assertIn(f"cvt.rn.f16.u{size}", ptx)
 
     @skip_unless_cc_53
@@ -222,7 +222,7 @@ class TestCasting(CUDATestCase):
         postfixes = ("f32", "f64")
 
         for pyfunc, postfix in zip(pyfuncs, postfixes):
-            ptx, _ = compile_ptx(pyfunc, [f2], device=True)
+            ptx, _ = compile_ptx(pyfunc, (f2), device=True)
             self.assertIn(f"cvt.{postfix}.f16", ptx)
 
     @skip_unless_cc_53

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -1,5 +1,5 @@
 from math import sqrt
-from numba import cuda, float32, uint32, void
+from numba import cuda, float32, int32, uint32, void
 from numba.cuda import compile_ptx, compile_ptx_for_current_device
 from numba.cuda.cudadrv.nvvm import NVVM
 
@@ -42,6 +42,11 @@ class TestCompileToPTX(unittest.TestCase):
         self.assertNotIn('.visible .entry', ptx)
         # Inferred return type as expected?
         self.assertEqual(resty, float32)
+        
+        # Check that function's output matches signature
+        sig_int = int32(int32, int32)
+        ptx, resty = compile_ptx(add, sig_int, device=True)
+        self.assertEqual(resty, int32)
 
     def test_fastmath(self):
         def f(x, y, z, d):

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -1,5 +1,5 @@
 from math import sqrt
-from numba import cuda, float32, int32, uint32, void
+from numba import cuda, float32, int16, int32, uint32, void
 from numba.cuda import compile_ptx, compile_ptx_for_current_device
 from numba.cuda.cudadrv.nvvm import NVVM
 
@@ -30,8 +30,8 @@ class TestCompileToPTX(unittest.TestCase):
         def add(x, y):
             return x + y
 
-        args = (float32, float32)
-        ptx, resty = compile_ptx(add, args, device=True)
+        sig = (float32, float32)
+        ptx, resty = compile_ptx(add, sig, device=True)
 
         # Device functions take a func_retval parameter for storing the
         # returned value in by reference
@@ -44,9 +44,17 @@ class TestCompileToPTX(unittest.TestCase):
         self.assertEqual(resty, float32)
 
         # Check that function's output matches signature
-        sig_int = int32(int32, int32)
-        ptx, resty = compile_ptx(add, sig_int, device=True)
+        sig_int32 = int32(int32, int32)
+        ptx, resty = compile_ptx(add, sig_int32, device=True)
         self.assertEqual(resty, int32)
+
+        sig_int16 = int16(int16, int16)
+        ptx, resty = compile_ptx(add, sig_int16, device=True)
+        self.assertEqual(resty, int16)
+
+        sig_string = "uint32(uint32, uint32)"
+        ptx, resty = compile_ptx(add, sig_string, device=True)
+        self.assertEqual(resty, uint32)
 
     def test_fastmath(self):
         def f(x, y, z, d):
@@ -135,8 +143,8 @@ class TestCompileToPTXForCurrentDevice(CUDATestCase):
         def add(x, y):
             return x + y
 
-        args = (float32, float32)
-        ptx, resty = compile_ptx_for_current_device(add, args, device=True)
+        sig = (float32, float32)
+        ptx, resty = compile_ptx_for_current_device(add, sig, device=True)
 
         # Check we target the current device's compute capability, or the
         # closest compute capability supported by the current toolkit.

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -98,7 +98,7 @@ class TestCompileToPTX(unittest.TestCase):
         def f():
             pass
 
-        ptx, resty = compile_ptx(f, [], device=True, debug=True)
+        ptx, resty = compile_ptx(f, (), device=True, debug=True)
         self.check_debug_info(ptx)
 
     def test_kernel_with_debug(self):
@@ -106,7 +106,7 @@ class TestCompileToPTX(unittest.TestCase):
         def f():
             pass
 
-        ptx, resty = compile_ptx(f, [], debug=True)
+        ptx, resty = compile_ptx(f, (), debug=True)
         self.check_debug_info(ptx)
 
     def check_line_info(self, ptx):
@@ -119,14 +119,14 @@ class TestCompileToPTX(unittest.TestCase):
         def f():
             pass
 
-        ptx, resty = compile_ptx(f, [], device=True, lineinfo=True)
+        ptx, resty = compile_ptx(f, (), device=True, lineinfo=True)
         self.check_line_info(ptx)
 
     def test_kernel_with_line_info(self):
         def f():
             pass
 
-        ptx, resty = compile_ptx(f, [], lineinfo=True)
+        ptx, resty = compile_ptx(f, (), lineinfo=True)
         self.check_line_info(ptx)
 
     def test_non_void_return_type(self):

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -30,8 +30,8 @@ class TestCompileToPTX(unittest.TestCase):
         def add(x, y):
             return x + y
 
-        sig = (float32, float32)
-        ptx, resty = compile_ptx(add, sig, device=True)
+        args = (float32, float32)
+        ptx, resty = compile_ptx(add, args, device=True)
 
         # Device functions take a func_retval parameter for storing the
         # returned value in by reference
@@ -51,7 +51,7 @@ class TestCompileToPTX(unittest.TestCase):
         sig_int16 = int16(int16, int16)
         ptx, resty = compile_ptx(add, sig_int16, device=True)
         self.assertEqual(resty, int16)
-
+        # Using string as signature
         sig_string = "uint32(uint32, uint32)"
         ptx, resty = compile_ptx(add, sig_string, device=True)
         self.assertEqual(resty, uint32)
@@ -143,8 +143,8 @@ class TestCompileToPTXForCurrentDevice(CUDATestCase):
         def add(x, y):
             return x + y
 
-        sig = (float32, float32)
-        ptx, resty = compile_ptx_for_current_device(add, sig, device=True)
+        args = (float32, float32)
+        ptx, resty = compile_ptx_for_current_device(add, args, device=True)
 
         # Check we target the current device's compute capability, or the
         # closest compute capability supported by the current toolkit.

--- a/numba/cuda/tests/cudapy/test_compiler.py
+++ b/numba/cuda/tests/cudapy/test_compiler.py
@@ -42,7 +42,7 @@ class TestCompileToPTX(unittest.TestCase):
         self.assertNotIn('.visible .entry', ptx)
         # Inferred return type as expected?
         self.assertEqual(resty, float32)
-        
+
         # Check that function's output matches signature
         sig_int = int32(int32, int32)
         ptx, resty = compile_ptx(add, sig_int, device=True)

--- a/numba/cuda/tests/cudapy/test_libdevice.py
+++ b/numba/cuda/tests/cudapy/test_libdevice.py
@@ -152,7 +152,8 @@ def make_test_call(libname):
             pyargs = pyreturns + pyargs
         else:
             pyargs.insert(0, sig.return_type[::1])
-
+        
+        pyargs = tuple(pyargs)
         ptx, resty = compile_ptx(pyfunc, pyargs)
 
         # If the function body was discarded by optimization (therefore making

--- a/numba/cuda/tests/cudapy/test_libdevice.py
+++ b/numba/cuda/tests/cudapy/test_libdevice.py
@@ -152,7 +152,7 @@ def make_test_call(libname):
             pyargs = pyreturns + pyargs
         else:
             pyargs.insert(0, sig.return_type[::1])
-        
+
         pyargs = tuple(pyargs)
         ptx, resty = compile_ptx(pyfunc, pyargs)
 


### PR DESCRIPTION
Think this should work. This fix would be backwards compatible with how it worked previously (when one only specified the argument types of the inputs only) but also allows specifying output type.

Fixes #8789 

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
