### PR TITLE
Support "static" __getitem__ on Numba types in `@njit` code.

### DIFF
--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -102,9 +102,8 @@ the beginning or the end of the index specification::
    >>> numba.float32[::1, :, :]
    array(float32, 3d, F)
 
-This style of type declaration is supported within Numba :term:`JIT` compiled
-functions e.g. declaring the type of a :ref:`typed.List <feature-typed-list>`.
-::
+This style of type declaration is supported within Numba compiled-functions,
+e.g. declaring the type of a :ref:`typed.List <feature-typed-list>`.::
 
     from numba import njit, types, typed
 
@@ -112,6 +111,8 @@ functions e.g. declaring the type of a :ref:`typed.List <feature-typed-list>`.
     def example():
         return typed.List.empty_list(types.float64[:, ::1])
 
+Note that this feature is only supported for simple numerical types. Application
+to compound types, e.g. record types, is not supported.
 
 Functions
 ---------

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -102,6 +102,17 @@ the beginning or the end of the index specification::
    >>> numba.float32[::1, :, :]
    array(float32, 3d, F)
 
+This style of type declaration is supported within Numba :term:`JIT` compiled
+functions e.g. declaring the type of a :ref:`typed.List <feature-typed-list>`.
+::
+
+    from numba import njit, types, typed
+
+    @njit
+    def example():
+        return typed.List.empty_list(types.float64[:, ::1])
+
+
 Functions
 ---------
 

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -656,18 +656,16 @@ class StaticGetItemLiteralStrKeyDict(AbstractTemplate):
 
 @infer
 class StaticGetItemClass(AbstractTemplate):
-    """This handles the "static_getitem" that occurs when a Numba type has a
-    __getitem__ made on it in input source e.g:
+    """This handles the "static_getitem" when a Numba type is subscripted e.g:
     var = typed.List.empty_list(float64[::1, :])
-    it only allows this on simple numerical types i.e. compound types, like
+    It only allows this on simple numerical types. Compound types, like
     records, are not supported.
     """
     key = "static_getitem"
 
     def generic(self, args, kws):
         clazz, idx = args
-        accept = (types.NumberClass, types.Boolean)
-        if not isinstance(clazz, accept):
+        if not isinstance(clazz, types.NumberClass):
             return
         ret = clazz.dtype[idx]
         sig = signature(ret, *args)

--- a/numba/core/typing/builtins.py
+++ b/numba/core/typing/builtins.py
@@ -654,6 +654,26 @@ class StaticGetItemLiteralStrKeyDict(AbstractTemplate):
             sig = signature(ret, *args)
             return sig
 
+@infer
+class StaticGetItemClass(AbstractTemplate):
+    """This handles the "static_getitem" that occurs when a Numba type has a
+    __getitem__ made on it in input source e.g:
+    var = typed.List.empty_list(float64[::1, :])
+    it only allows this on simple numerical types i.e. compound types, like
+    records, are not supported.
+    """
+    key = "static_getitem"
+
+    def generic(self, args, kws):
+        clazz, idx = args
+        accept = (types.NumberClass, types.Boolean)
+        if not isinstance(clazz, accept):
+            return
+        ret = clazz.dtype[idx]
+        sig = signature(ret, *args)
+        return sig
+
+
 # Generic implementation for "not in"
 
 @infer

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -2926,12 +2926,12 @@ lower_getattr(types.DType, 'kind')(dtype_type)
 # static_getitem on Numba numerical types to create "array" types
 
 
-@lower_builtin('static_getitem', types.Boolean, types.Any)
 @lower_builtin('static_getitem', types.NumberClass, types.Any)
 def static_getitem_number_clazz(context, builder, sig, args):
-    """This handles the "static_getitem" that occurs when a Numba type a
-    __getitem__ made on it in input source e.g:
+    """This handles the "static_getitem" when a Numba type is subscripted e.g:
     var = typed.List.empty_list(float64[::1, :])
+    It only allows this on simple numerical types. Compound types, like
+    records, are not supported.
     """
     retty = sig.return_type
     if isinstance(retty, types.Array):

--- a/numba/tests/test_getitem_on_types.py
+++ b/numba/tests/test_getitem_on_types.py
@@ -1,0 +1,107 @@
+import unittest
+from itertools import product
+from numba import types, njit, typed, errors
+from numba.tests.support import TestCase
+
+
+class TestGetitemOnTypes(TestCase):
+    # Tests getitem on the type types.
+
+    def test_static_getitem_on_type(self):
+
+        def gen(numba_type, index):
+            def foo():
+                ty = numba_type[index] # a static_getitem
+                return typed.List.empty_list(ty)
+            return foo
+
+        # test a few types
+        tys = (types.bool_, types.float64, types.uint8, types.complex128,)
+
+        # and a few indexes of increasing complexity
+        contig = slice(None, None, 1) # unit stride
+        noncontig = slice(None, None, None)
+        indexes = (contig, # 1d contig -> C order
+                   noncontig, # 1d non-contig -> A order
+                   (noncontig, contig), # 2d C order
+                   (contig, noncontig), # 2d F order
+                   (noncontig, noncontig), # 2d A order
+                   (noncontig, noncontig, contig), # 3d C order
+                   (contig, noncontig, noncontig), # 3d F order
+                   (noncontig, noncontig, noncontig), # 3d A order
+                   )
+
+        for ty, idx in product(tys, indexes):
+            compilable = njit(gen(ty, idx))
+            # check the type of the typed list returned matches the type
+            # as constructed in the interpreter
+            expected = ty[idx]
+            # check execution
+            self.assertEqual(compilable()._dtype, expected)
+            got = compilable.nopython_signatures[0].return_type.dtype
+            # check sig
+            self.assertEqual(got, expected)
+
+    def test_shorthand_syntax(self):
+        # tests a couple of shorthand syntax examples
+        # (test_static_getitem_on_type is a more extensive test of the
+        # functionality but it uses slices directly).
+
+        @njit
+        def foo1():
+            ty = types.float32[::1, :] # 2d F order
+            return typed.List.empty_list(ty)
+
+        self.assertEqual(foo1()._dtype, types.float32[::1, :])
+
+        @njit
+        def foo2():
+            ty = types.complex64[:, :, :] # 3d A order
+            return typed.List.empty_list(ty)
+
+        self.assertEqual(foo2()._dtype, types.complex64[:, :, :])
+
+    def test_static_getitem_on_invalid_type(self):
+        # check that an unsupported type cannot be instantiated in njit code
+
+        # check this executes in the interpreter:
+        types.void[:]
+
+        # check the same fails in compilation as it's not supported
+        # it'll fall back to a generic getitem
+        with self.assertRaises(errors.TypingError) as raises:
+            @njit
+            def foo():
+                types.void[:]
+
+            foo()
+
+        msg = ("No implementation",
+               "getitem(typeref[none], slice<a:b>)")
+
+        excstr = str(raises.exception)
+        for m in msg:
+            self.assertIn(m, excstr)
+
+    def test_standard_getitem_on_type(self):
+        # not supported at present, should be doable if the slice is a literal
+        # though.
+
+        # check using a non-static arg to the getitem raises
+        with self.assertRaises(errors.TypingError) as raises:
+            @njit
+            def foo(not_static):
+                types.float64[not_static]
+
+            foo(slice(None, None, 1))
+
+        msg = ("No implementation",
+               "getitem(class(float64), slice<a:b>)")
+
+        excstr = str(raises.exception)
+        for m in msg:
+            self.assertIn(m, excstr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds support for the `__getitem__` operation on Numba types within `@njit` compiled regions. i.e. it makes this sort of thing possible:

```python
from numba import njit, types, typed

@njit
def foo():
    return typed.List.empty_list(types.float64[:, ::1])

foo()
```

The logic in the Type metaclass is relatively relaxed over what's acceptable in a `__getitem__`, this patch is necessarily more restrictive and the compilable `__getitem__` is implemented only for types that are practical for this sort of use i.e. those in the numerical type system.

Tests are added and docs are updated to note that this is now supported.

Closes #8808
Closes #7683
Closes #5748

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
