### PR TITLE
Fix typeguard import hook location.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -5,7 +5,13 @@ import os
 if bool(os.environ.get('NUMBA_USE_TYPEGUARD')):
     # The typeguard import hook must be installed prior to importing numba.
     # Therefore, this cannot be part of the numba package.
-    from typeguard.importhook import install_import_hook
+    try:
+        # version 3+ exports this at the top level
+        from typeguard import install_import_hook
+    except ImportError:
+        # try location for version 2.x
+        from typeguard.importhook import install_import_hook
+
     install_import_hook(packages=['numba'])
 
 # ensure full tracebacks are available and no help messages appear in test mode


### PR DESCRIPTION
Package ``typeguard`` moved the function ``install_import_hook`` to the top level module for version 3+. This adapts the test runner to accept both the old and the new location.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
