### PR TITLE
Fix failing typeguard test.

### DIFF
--- a/numba/tests/test_typeguard.py
+++ b/numba/tests/test_typeguard.py
@@ -17,11 +17,13 @@ def guard_ret(val) -> int:
 @skip_unless_typeguard
 class TestTypeGuard(TestCase):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
+        super().setUp()
         import typeguard
+        # This is a test class invariant but the Numba multiprocesses test
+        # runner doesn't respect `setUpClass` so just use `setUp`.
         # typeguard 3+ uses typeguard.TypeCheckError, 2.x uses TypeError
-        cls._exception_type = getattr(typeguard, 'TypeCheckError', TypeError)
+        self._exception_type = getattr(typeguard, 'TypeCheckError', TypeError)
 
     def test_check_args(self):
         with self.assertRaises(self._exception_type):

--- a/numba/tests/test_typeguard.py
+++ b/numba/tests/test_typeguard.py
@@ -16,12 +16,19 @@ def guard_ret(val) -> int:
 
 @skip_unless_typeguard
 class TestTypeGuard(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        import typeguard
+        # typeguard 3+ uses typeguard.TypeCheckError, 2.x uses TypeError
+        cls._exception_type = getattr(typeguard, 'TypeCheckError', TypeError)
+
     def test_check_args(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(self._exception_type):
             guard_args(float(1.2))
 
     def test_check_ret(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(self._exception_type):
             guard_ret(float(1.2))
 
     def test_check_does_not_work_with_inner_func(self):


### PR DESCRIPTION
`typeguard` 3+ uses its own exception classes to report type violations opposed to `TypeError`, the patch accommodates this.

Closes #8835

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
