### PR TITLE
Fix buildscripts, setup.py, docs for setuptools becoming optional.

### DIFF
--- a/buildscripts/condarecipe.local/meta.yaml
+++ b/buildscripts/condarecipe.local/meta.yaml
@@ -45,7 +45,6 @@ requirements:
     - python >=3.8
     # NumPy 1.22.0, 1.22.1, 1.22.2 are all broken for ufuncs, see #7756
     - numpy >=1.21, !=1.22.0, !=1.22.1, !=1.22.2
-    - setuptools
     - importlib_metadata       # [py<39]
     # On channel https://anaconda.org/numba/
     - llvmlite >=0.40.0dev0,<0.40
@@ -74,6 +73,7 @@ test:
     - cffi
     - scipy
     - ipython                  # [not aarch64]
+    # for pycc
     - setuptools
     - tbb  >=2021              # [not (aarch64 or ppc64le)]
     - llvm-openmp              # [osx]

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -8,8 +8,11 @@ set -v -e
 # If the build is a "Vanilla" variant, then remove the setuptools package. It
 # was installed at build time for setup.py to use, but is an _optional_ runtime
 # dependency of Numba and therefore shouldn't be present in "Vanilla" testing.
+# This package is "force" removed so that its removal doesn't uninstall
+# things that might depend on it (the dependencies are present but are not of
+# interest to Numba as those code paths are not used by Numba).
 if [ "${VANILLA_INSTALL}" == "yes" ]; then
-    conda remove -y setuptools
+    conda remove --force -y setuptools
 fi
 
 # Ensure the README is correctly formatted
@@ -19,10 +22,17 @@ pushd docs
 if [ "$BUILD_DOC" == "yes" ]; then make SPHINXOPTS=-W clean html; fi
 popd
 # Run system and gdb info tools
-pushd bin
-numba -s
-numba -g
-popd
+if [ "${VANILLA_INSTALL}" == "yes" ]; then
+    # Vanilla install has no access to pkg_resources as setuptools is removed,
+    # so run these via their modules.
+    python -m numba -s
+    python -m numba -g
+else
+    pushd bin
+    numba -s
+    numba -g
+    popd
+fi
 
 # switch off color messages
 export NUMBA_DISABLE_ERROR_MESSAGE_HIGHLIGHTING=1

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -5,6 +5,13 @@ source activate $CONDA_ENV
 # Make sure any error below is reported as such
 set -v -e
 
+# If the build is a "Vanilla" variant, then remove the setuptools package. It
+# was installed at build time for setup.py to use, but is an _optional_ runtime
+# dependency of Numba and therefore shouldn't be present in "Vanilla" testing.
+if [ "${VANILLA_INSTALL}" == "yes" ]; then
+    conda remove -y setuptools
+fi
+
 # Ensure the README is correctly formatted
 if [ "$BUILD_DOC" == "yes" ]; then rstcheck README.rst; fi
 # Ensure that the documentation builds without warnings

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -184,7 +184,6 @@ vary with target operating system and hardware. The following lists them all
 
 * Required run time:
 
-  * ``setuptools``
   * ``numpy``
   * ``llvmlite``
 
@@ -222,6 +221,8 @@ vary with target operating system and hardware. The following lists them all
   * ``pygments`` - for "pretty" type annotation
   * ``gdb`` as an executable on the ``$PATH`` - if you would like to use the gdb
     support
+  * ``setuptools`` - permits the use of ``pycc`` for Ahead-of-Time (AOT)
+    compilation
   * Compiler toolchain mentioned above, if you would like to use ``pycc`` for
     Ahead-of-Time (AOT) compilation
   * ``r2pipe`` - required for assembly CFG inspection.

--- a/docs/source/user/pycc.rst
+++ b/docs/source/user/pycc.rst
@@ -8,6 +8,10 @@ Compiling code ahead of time
 While Numba's main use case is :term:`Just-in-Time compilation`, it also
 provides a facility for :term:`Ahead-of-Time compilation` (AOT).
 
+.. note:: To use this feature the ``setuptools`` package is required at
+          compilation time, but it is not a runtime dependency of the
+          extension module produced.
+
 .. note:: This module is pending deprecation. Please see
           :ref:`deprecation-numba-pycc` for more information.
 
@@ -20,7 +24,7 @@ Benefits
 
 #. AOT compilation produces a compiled extension module which does not depend
    on Numba: you can distribute the module on machines which do not have
-   Numba installed (but Numpy is required).
+   Numba installed (but NumPy is required).
 
 #. There is no compilation overhead at runtime (but see the
    ``@jit`` :ref:`cache <jit-cache>` option), nor any overhead of importing

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -19,11 +19,6 @@ from numba.tests.support import (TestCase, tag, import_dynamic, temp_directory,
 import unittest
 
 
-try:
-    import setuptools
-except ImportError:
-    setuptools = None
-
 _skip_reason = 'windows only'
 _windows_only = unittest.skipIf(not sys.platform.startswith('win'),
                                 _skip_reason)
@@ -353,11 +348,11 @@ class TestDistutilsSupport(TestCase):
     def test_setup_py_distutils_nested(self):
         self.check_setup_nested_py("setup_distutils_nested.py")
 
-    @unittest.skipIf(setuptools is None, "test needs setuptools")
+    @needs_setuptools
     def test_setup_py_setuptools(self):
         self.check_setup_py("setup_setuptools.py")
 
-    @unittest.skipIf(setuptools is None, "test needs setuptools")
+    @needs_setuptools
     def test_setup_py_setuptools_nested(self):
         self.check_setup_nested_py("setup_setuptools_nested.py")
 

--- a/numba/tests/test_pycc.py
+++ b/numba/tests/test_pycc.py
@@ -34,6 +34,8 @@ def unset_macosx_deployment_target():
     if 'MACOSX_DEPLOYMENT_TARGET' in os.environ:
         del os.environ['MACOSX_DEPLOYMENT_TARGET']
 
+
+@needs_setuptools
 class TestCompilerChecks(TestCase):
 
     # NOTE: THIS TEST MUST ALWAYS RUN ON WINDOWS, DO NOT SKIP
@@ -263,6 +265,7 @@ class TestCC(BasePYCCTest):
             self.assertPreciseEqual(got, expect)
 
 
+@needs_setuptools
 class TestDistutilsSupport(TestCase):
 
     def setUp(self):
@@ -348,11 +351,9 @@ class TestDistutilsSupport(TestCase):
     def test_setup_py_distutils_nested(self):
         self.check_setup_nested_py("setup_distutils_nested.py")
 
-    @needs_setuptools
     def test_setup_py_setuptools(self):
         self.check_setup_py("setup_setuptools.py")
 
-    @needs_setuptools
     def test_setup_py_setuptools_nested(self):
         self.check_setup_nested_py("setup_setuptools_nested.py")
 

--- a/setup.py
+++ b/setup.py
@@ -367,7 +367,6 @@ build_requires = ['numpy >={}'.format(min_numpy_build_version)]
 install_requires = [
     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
     'numpy >={}'.format(min_numpy_run_version),
-    'setuptools',
     'importlib_metadata; python_version < "3.9"',
 ]
 


### PR DESCRIPTION
This builds on #8476.

As the setuptools package is moved to an optional runtime
dependency, various packaging, docs and testing infrastructure has
to be changed to reflect this. This patch contains the necessary
changes.