### PR TITLE
added lifted loops to glossary term

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -33,6 +33,7 @@ Glossary
       Shorthand for "a function :term:`JIT-compiled <JIT>` with Numba using
       the :ref:`@jit <jit>` decorator."
 
+   lifted loops
    loop-lifting
    loop-jitting
       A feature of compilation in :term:`object mode` where a loop can be


### PR DESCRIPTION
This commit adds the term "lift loops" to the Numba glossary, with the same definitions as "loop-lifting" and "loop-jifting".

Resolves #8828