### PR TITLE
Disable SLP vectorisation due to miscompilations.

### DIFF
--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -312,8 +312,10 @@ Compilation options
 .. envvar:: NUMBA_SLP_VECTORIZE
 
    If set to non-zero, enable LLVM superword-level parallelism vectorization.
+   Note that use of this feature has occasionally resulted in LLVM producing
+   miscompilations, hence it is off by default.
 
-   *Default value:* 1
+   *Default value:* 0
 
 .. envvar:: NUMBA_ENABLE_AVX
 

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -305,8 +305,9 @@ class _EnvReloader(object):
         LOOP_VECTORIZE = _readenv("NUMBA_LOOP_VECTORIZE", int,
                                   not (IS_WIN32 and IS_32BITS))
 
-        # Switch on  superword-level parallelism vectorization, default is on.
-        SLP_VECTORIZE = _readenv("NUMBA_SLP_VECTORIZE", int, 1)
+        # Enable superword-level parallelism vectorization, default is off
+        # since #8705 (miscompilation).
+        SLP_VECTORIZE = _readenv("NUMBA_SLP_VECTORIZE", int, 0)
 
         # Force dump of generated assembly
         DUMP_ASSEMBLY = _readenv("NUMBA_DUMP_ASSEMBLY", int, DEBUG)

--- a/numba/tests/test_vectorization.py
+++ b/numba/tests/test_vectorization.py
@@ -1,8 +1,8 @@
 import platform
 import numpy as np
 from numba import types
-from unittest import TestCase, skipIf
-from numba.tests.support import override_env_config
+import unittest
+from numba.tests.support import override_env_config, TestCase
 from numba.core.compiler import compile_isolated, Flags
 from numba.core.cpu_options import FastMathOptions
 
@@ -13,7 +13,7 @@ if _DEBUG:
     llvm.set_option("", "--debug-only=loop-vectorize")
 
 
-@skipIf(platform.machine() != 'x86_64', 'x86_64 only test')
+@unittest.skipIf(platform.machine() != 'x86_64', 'x86_64 only test')
 class TestVectorization(TestCase):
     """
     Tests to assert that code which should vectorize does indeed vectorize
@@ -40,6 +40,9 @@ class TestVectorization(TestCase):
         self.assertIn("vector.body", llvm_ir)
         self.assertIn("llvm.loop.isvectorized", llvm_ir)
 
+    # SLP is off by default due to miscompilations, see #8705. Put this into a
+    # subprocess to isolate any potential issues.
+    @TestCase.run_test_in_subprocess(envvars={'NUMBA_SLP_VECTORIZE': '1'})
     def test_slp(self):
         # Sample translated from:
         # https://www.llvm.org/docs/Vectorizers.html#the-slp-vectorizer
@@ -71,3 +74,7 @@ class TestVectorization(TestCase):
                               fastmath=True)
         self.assertIn("vector.body", llvm_ir)
         self.assertIn("llvm.loop.isvectorized", llvm_ir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This switches off SLP vectorisation by default due to reported and confirmed miscompilations. It fixes up the SLP vectorisation checking unit test by running it in a subprocess with SLP enabled so as to isolate any potential issues. Docs and config defaults are updated.

xref #8705 #8681

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
