### PR TITLE
CUDA: Don't add device kwarg for jit registry

### DIFF
--- a/numba/cuda/initialize.py
+++ b/numba/cuda/initialize.py
@@ -2,16 +2,12 @@ def initialize_all():
     # Import models to register them with the data model manager
     import numba.cuda.models  # noqa: F401
 
-    from numba import cuda
+    from numba.cuda.decorators import jit
     from numba.cuda.dispatcher import CUDADispatcher
     from numba.core.target_extension import (target_registry,
                                              dispatcher_registry,
                                              jit_registry)
 
-    def cuda_jit_device(*args, **kwargs):
-        kwargs['device'] = True
-        return cuda.jit(*args, **kwargs)
-
     cuda_target = target_registry["cuda"]
-    jit_registry[cuda_target] = cuda_jit_device
+    jit_registry[cuda_target] = jit
     dispatcher_registry[cuda_target] = CUDADispatcher


### PR DESCRIPTION
The device kwarg has no effect - the need for a device function is inferred by logic in the dispatcher. Therefore, we no longer need to get in front of the `cuda.jit` decorator to insert it for the JIT registry.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
