### PR TITLE
Revise CUDA deprecation notices

### DIFF
--- a/docs/source/cuda/overview.rst
+++ b/docs/source/cuda/overview.rst
@@ -38,18 +38,19 @@ Supported GPUs
 --------------
 
 Numba supports CUDA-enabled GPUs with Compute Capability 3.5 or greater.
-Support for devices with Compute Capability less than 5.3 is deprecated, and
+Support for devices with Compute Capability less than 5.0 is deprecated, and
 will be removed in a future Numba release.
 
-Devices with Compute Capability 5.3 or greater include (but are not limited to):
+Devices with Compute Capability 5.0 or greater include (but are not limited to):
 
-- Embedded platforms: NVIDIA Jetson Nano, TX1, TX2, Xavier NX, AGX Xavier, AGX
-  Orin.
-- Desktop / Server GPUs: All GPUs with Pascal microarchitecture or later. E.g.
-  GTX 10 / 16 series, RTX 20 / 30 series, Quadro P / V / RTX series, RTX A
-  series, H100.
-- Laptop GPUs: All GPUs with Pascal microarchitecture or later. E.g. MX series,
-  Quadro P / T series (mobile), RTX 20 / 30 series (mobile), RTX A series (mobile).
+- Embedded platforms: NVIDIA Jetson Nano, Jetson Orin Nano, TX1, TX2, Xavier
+  NX, AGX Xavier, AGX Orin.
+- Desktop / Server GPUs: All GPUs with Maxwell microarchitecture or later. E.g.
+  GTX 9 / 10 / 16 series, RTX 20 / 30 / 40 series, Quadro / Tesla M / P / V /
+  RTX series, RTX A series, RTX Ada / SFF, A / L series, H100.
+- Laptop GPUs: All GPUs with Maxwell microarchitecture or later. E.g. MX series,
+  Quadro M / P / T series (mobile), RTX 20 / 30 series (mobile), RTX A series
+  (mobile).
 
 Software
 --------

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -468,12 +468,16 @@ upgrade path. At the point of the new technology being deemed suitable,
 replacement instructions will be issued.
 
 
-Deprecation and removal of CUDA Toolkits < 11.0 and devices with CC < 5.3
+Deprecation and removal of CUDA Toolkits < 11.2 and devices with CC < 5.0
 =========================================================================
 
 - Support for CUDA toolkits less than 11.0 has been removed.
-- Support for devices with Compute Capability < 5.3 is deprecated and will be
+- Support for CUDA toolkits less than 11.2 will be removed in future.
+- Support for devices with Compute Capability < 5.0 is deprecated and will be
   removed in the future.
+- Previous deprecation notices stated that support for Compute Capability < 5.3
+  was deprecated - this has now been modified such that 5.0 - 5.2 is
+  undeprecated, and only support for devices with CC < 5.0 is deprecated.
 
 
 Recommendations
@@ -488,5 +492,6 @@ Schedule
 
 - In Numba 0.55.1: support for CC < 5.3 and CUDA toolkits < 10.2 was deprecated.
 - In Numba 0.56: support for CC < 3.5 and CUDA toolkits < 10.2 was removed.
-- In Numba 0.57: Support for CUDA toolkit 10.2 was removed. Support for CC < 5.3
-  will be removed.
+- In Numba 0.57: Support for CUDA toolkit 10.2 was removed.
+- In Numba 0.58: Support for CC < 5.0 and CUDA toolkits 11.0 and 11.1 will be
+  removed.

--- a/docs/source/reference/deprecation.rst
+++ b/docs/source/reference/deprecation.rst
@@ -468,68 +468,6 @@ upgrade path. At the point of the new technology being deemed suitable,
 replacement instructions will be issued.
 
 
-Deprecation of eager compilation of CUDA device functions
-=========================================================
-
-In future versions of Numba, the ``device`` kwarg to the ``@cuda.jit`` decorator
-will be obviated, and whether a device function or global kernel is compiled will
-be inferred from the context. With respect to kernel / device functions and lazy
-/ eager compilation, four cases were handled:
-
-1. ``device=True``, eager compilation with a signature provided
-2. ``device=False``, eager compilation with a signature provided
-3. ``device=True``, lazy compilation with no signature
-4. ``device=False``, lazy compilation with no signature
-
-The latter two cases can be differentiated without the ``device`` kwarg, because
-it can be inferred from the calling context - if the call is from the host, then
-a global kernel should be compiled, and if the call is from a kernel or another
-device function, then a device function should be compiled.
-
-The first two cases cannot be differentiated in the absence of the ``device``
-kwarg - without it, it will not be clear from a signature alone whether a device
-function or global kernel should be compiled. In order to resolve this, device
-functions will no longer be eagerly compiled. When a signature is provided to a
-device function, it will only be used to enforce the types of arguments that
-the function accepts.
-
-.. note::
-
-   In previous releases this notice stated that support for providing
-   signatures to device functions would be removed completely - however, this
-   precludes the common use case of enforcing the types that can be passed to a
-   device function (and the automatic insertion of casts that it implies) so
-   this notice has been updated to retain support for passing signatures.
-
-
-Schedule
---------
-
-- In Numba 0.54: Eager compilation of device functions will be deprecated.
-- In Numba 0.55: Eager compilation of device functions will be unsupported and
-  the provision of signatures for device functions will only enforce casting.
-
-
-Deprecation and removal of ``numba.core.base.BaseContext.add_user_function()``
-==============================================================================
-
-``add_user_function()``  offered the same functionality as
-``insert_user_function()``, only with a check that the function has already
-been inserted at least once.  It is now removed as it was no longer used
-internally and it was expected that it was not used externally.
-
-Recommendations
----------------
-
-Replace any uses of ``add_user_function()`` with ``insert_user_function()``.
-
-Schedule
---------
-
-- In Numba 0.55: ``add_user_function()`` was deprecated.
-- In Numba 0.56: ``add_user_function()`` was removed.
-
-
 Deprecation and removal of CUDA Toolkits < 11.0 and devices with CC < 5.3
 =========================================================================
 

--- a/docs/source/user/installing.rst
+++ b/docs/source/user/installing.rst
@@ -14,9 +14,9 @@ Our supported platforms are:
 * Windows 7 and later (32-bit and 64-bit)
 * OS X 10.9 and later (64-bit and unofficial support on M1/Arm64)
 * \*BSD (unofficial support only)
-* NVIDIA GPUs of compute capability 5.3 and later
+* NVIDIA GPUs of compute capability 5.0 and later
 
-  * Compute capabilities 3.5 - 5.2 are supported, but deprecated.
+  * Compute capabilities 3.5 and 3.7 are supported, but deprecated.
 * ARMv8 (64-bit little-endian, such as the NVIDIA Jetson)
 
 :ref:`numba-parallel` is only available on 64-bit platforms.

--- a/numba/core/config.py
+++ b/numba/core/config.py
@@ -376,7 +376,7 @@ class _EnvReloader(object):
 
         # The default compute capability to target when compiling to PTX.
         CUDA_DEFAULT_PTX_CC = _readenv("NUMBA_CUDA_DEFAULT_PTX_CC", _parse_cc,
-                                       (5, 3))
+                                       (5, 0))
 
         # Disable CUDA support
         DISABLE_CUDA = _readenv("NUMBA_DISABLE_CUDA",

--- a/numba/cuda/api.py
+++ b/numba/cuda/api.py
@@ -485,7 +485,7 @@ def detect():
         attrs += [('FP32/FP64 Performance Ratio', fp32_to_fp64_ratio)]
         if cc < (3, 5):
             support = '[NOT SUPPORTED: CC < 3.5]'
-        elif cc < (5, 3):
+        elif cc < (5, 0):
             support = '[SUPPORTED (DEPRECATED)]'
             supported_count += 1
         else:

--- a/numba/cuda/compiler.py
+++ b/numba/cuda/compiler.py
@@ -265,7 +265,7 @@ def compile_ptx(pyfunc, sig, debug=False, lineinfo=False, device=False,
                      prec_div=, and fma=1)
     :type fastmath: bool
     :param cc: Compute capability to compile for, as a tuple
-               ``(MAJOR, MINOR)``. Defaults to ``(5, 3)``.
+               ``(MAJOR, MINOR)``. Defaults to ``(5, 0)``.
     :type cc: tuple
     :param opt: Enable optimizations. Defaults to ``True``.
     :type opt: bool

--- a/numba/cuda/simulator/api.py
+++ b/numba/cuda/simulator/api.py
@@ -49,7 +49,7 @@ def declare_device(*args, **kwargs):
 def detect():
     print('Found 1 CUDA devices')
     print('id %d    %20s %40s' % (0, 'SIMULATOR', '[SUPPORTED]'))
-    print('%40s: 5.3' % 'compute capability')
+    print('%40s: 5.0' % 'compute capability')
 
 
 def list_devices():


### PR DESCRIPTION
Based on #8864 to avoid a merge conflict shortly.

- Revise deprecation of CC to < 5.0.
- Note removal of CTK < 11.2 support (this is not new per se, just in keeping with the usual schedule of dropping support for old toolkits).