### PR TITLE
Add support for keyword and default arguments during closure inlining.

### DIFF
--- a/numba/tests/test_closure.py
+++ b/numba/tests/test_closure.py
@@ -387,10 +387,25 @@ class TestInlinedClosure(TestCase):
             x = 1, 2
             bar(*x)
 
+        def outer23(x):
+            """Keyword and default arguments passed in different orders"""
+            def inner(y, z=100):
+                # y may be passed positionally or as a keyword
+                # z may be passed positionally, as keyword, or omitted
+                return (x, y, z)
+
+            return (
+                inner(1),
+                inner(2, 200),
+                inner(3, z=300),
+                inner(z=400, y=4),
+                inner(y=5),
+            )
+
         # functions to test that are expected to pass
         f = [outer1, outer2, outer5, outer6, outer7, outer8,
              outer9, outer10, outer12, outer13, outer14,
-             outer15, outer19, outer20, outer21]
+             outer15, outer19, outer20, outer21, outer23]
         for ref in f:
             cfunc = njit(ref)
             var = 10


### PR DESCRIPTION
Currently, numba has only partial support for keyword and default arguments in closures. Specifically, when the closure object is a `make_function` op in the IR, the keyword arguments are silently ignored, and default arguments are appended to the argument list even when values for those arguments were actually provided. This can produce incorrect and surprising behavior when writing code that uses closures with keyword or default arguments.

This change reworks the `_get_callee_args` function to build a full Python signature for closures, and then use `fold_arguments` to handle them in the same way that arguments are handled for other Python functions.

To avoid reimplementing the existing `inspect` logic for determining the signature of a Python callable, this change constructs a new `_FakeFunction` object that has all the fields of a normal Python callable and then fetches the signature of that object. (It's not possible to directly construct the Python callable that the closure corresponds to, because we do not have concrete values for any closed-over variables yet.)

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
