### PR TITLE
Remove use of `compile_isolated` from generator tests.

### DIFF
--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -1,20 +1,13 @@
 import numpy as np
 
 import unittest
-from numba.core.compiler import compile_isolated, Flags
 from numba import jit, njit
 from numba.core import types
 from numba.tests.support import TestCase, MemoryLeakMixin
 from numba.core.datamodel.testing import test_factory
 
-
-enable_pyobj_flags = Flags()
-enable_pyobj_flags.enable_pyobject = True
-
-forceobj_flags = Flags()
-forceobj_flags.force_pyobject = True
-
-no_pyobj_flags = Flags()
+forceobj_flags = {'nopython': False, 'forceobj': True}
+nopython_flags = {'nopython': True}
 
 
 def make_consumer(gen_func):
@@ -151,100 +144,97 @@ class TestGenerators(MemoryLeakMixin, TestCase):
         with self.assertRaises(StopIteration):
             next(cgen)
 
-    def check_gen1(self, flags=no_pyobj_flags):
+    def check_gen1(self, **kwargs):
         pyfunc = gen1
-        cr = compile_isolated(pyfunc, (types.int32,), flags=flags)
+        cr = jit((types.int32,), **kwargs)(pyfunc)
         pygen = pyfunc(8)
-        cgen = cr.entry_point(8)
+        cgen = cr(8)
         self.check_generator(pygen, cgen)
 
     def test_gen1(self):
-        self.check_gen1()
+        self.check_gen1(**nopython_flags)
 
     def test_gen1_objmode(self):
-        self.check_gen1(flags=forceobj_flags)
+        self.check_gen1(**forceobj_flags)
 
-    def check_gen2(self, flags=no_pyobj_flags):
+    def check_gen2(self, **kwargs):
         pyfunc = gen2
-        cr = compile_isolated(pyfunc, (types.int32,), flags=flags)
+        cr = jit((types.int32,), **kwargs)(pyfunc)
         pygen = pyfunc(8)
-        cgen = cr.entry_point(8)
+        cgen = cr(8)
         self.check_generator(pygen, cgen)
 
     def test_gen2(self):
-        self.check_gen2()
+        self.check_gen2(**nopython_flags)
 
     def test_gen2_objmode(self):
-        self.check_gen2(flags=forceobj_flags)
+        self.check_gen2(**forceobj_flags)
 
-    def check_gen3(self, flags=no_pyobj_flags):
+    def check_gen3(self, **kwargs):
         pyfunc = gen3
-        cr = compile_isolated(pyfunc, (types.int32,), flags=flags)
+        cr = jit((types.int32,), **kwargs)(pyfunc)
         pygen = pyfunc(8)
-        cgen = cr.entry_point(8)
+        cgen = cr(8)
         self.check_generator(pygen, cgen)
 
     def test_gen3(self):
-        self.check_gen3()
+        self.check_gen3(**nopython_flags)
 
     def test_gen3_objmode(self):
-        self.check_gen3(flags=forceobj_flags)
+        self.check_gen3(**forceobj_flags)
 
-    def check_gen4(self, flags=no_pyobj_flags):
+    def check_gen4(self, **kwargs):
         pyfunc = gen4
-        cr = compile_isolated(pyfunc, (types.int32,) * 3, flags=flags)
+        cr = jit((types.int32,) * 3, **kwargs)(pyfunc)
         pygen = pyfunc(5, 6, 7)
-        cgen = cr.entry_point(5, 6, 7)
+        cgen = cr(5, 6, 7)
         self.check_generator(pygen, cgen)
 
     def test_gen4(self):
-        self.check_gen4()
+        self.check_gen4(**nopython_flags)
 
     def test_gen4_objmode(self):
-        self.check_gen4(flags=forceobj_flags)
+        self.check_gen4(**forceobj_flags)
 
     def test_gen5(self):
-        with self.assertTypingError() as cm:
-            compile_isolated(gen5, ())
+        with self.assertTypingError() as raises:
+            jit((), **nopython_flags)(gen5)
         self.assertIn("Cannot type generator: it does not yield any value",
-                      str(cm.exception))
+                      str(raises.exception))
 
     def test_gen5_objmode(self):
-        cr = compile_isolated(gen5, (), flags=forceobj_flags)
-        cgen = cr.entry_point()
-        self.assertEqual(list(cgen), [])
+        cr = jit((), **forceobj_flags)(gen5)()
+        self.assertEqual(list(cr), [])
         with self.assertRaises(StopIteration):
-            next(cgen)
+            next(cr)
 
-    def check_gen6(self, flags=no_pyobj_flags):
-        pyfunc = gen6
-        cr = compile_isolated(pyfunc, (types.int32,) * 2, flags=flags)
-        cgen = cr.entry_point(5, 6)
+    def check_gen6(self, **kwargs):
+        cr = jit((types.int32,) * 2, **kwargs)(gen6)
+        cgen = cr(5, 6)
         l = []
         for i in range(3):
             l.append(next(cgen))
         self.assertEqual(l, [14] * 3)
 
     def test_gen6(self):
-        self.check_gen6()
+        self.check_gen6(**nopython_flags)
 
     def test_gen6_objmode(self):
-        self.check_gen6(flags=forceobj_flags)
+        self.check_gen6(**forceobj_flags)
 
-    def check_gen7(self, flags=no_pyobj_flags):
+    def check_gen7(self, **kwargs):
         pyfunc = gen7
-        cr = compile_isolated(pyfunc, (types.Array(types.float64, 1, 'C'),),
-                              flags=flags)
+        cr = jit((types.Array(types.float64, 1, 'C'),), **kwargs)(pyfunc)
         arr = np.linspace(1, 10, 7)
         pygen = pyfunc(arr.copy())
-        cgen = cr.entry_point(arr)
+        cgen = cr(arr)
         self.check_generator(pygen, cgen)
 
     def test_gen7(self):
-        self.check_gen7()
+        self.check_gen7(**nopython_flags)
 
     def test_gen7_objmode(self):
-        self.check_gen7(flags=forceobj_flags)
+        self.check_gen7(**forceobj_flags)
 
     def check_gen8(self, **jit_args):
         pyfunc = gen8
@@ -265,18 +255,18 @@ class TestGenerators(MemoryLeakMixin, TestCase):
     def test_gen8_objmode(self):
         self.check_gen8(forceobj=True)
 
-    def check_gen9(self, flags=no_pyobj_flags):
+    def check_gen9(self, **kwargs):
         pyfunc = gen_bool
-        cr = compile_isolated(pyfunc, (), flags=flags)
+        cr = jit((), **kwargs)(pyfunc)
         pygen = pyfunc()
-        cgen = cr.entry_point()
+        cgen = cr()
         self.check_generator(pygen, cgen)
 
     def test_gen9(self):
-        self.check_gen9(flags=no_pyobj_flags)
+        self.check_gen9(**nopython_flags)
 
     def test_gen9_objmode(self):
-        self.check_gen9(flags=forceobj_flags)
+        self.check_gen9(**forceobj_flags)
 
     def check_consume_generator(self, gen_func):
         cgen = jit(nopython=True)(gen_func)
@@ -297,60 +287,57 @@ class TestGenerators(MemoryLeakMixin, TestCase):
 
     # Check generator storage of some types
 
-    def check_ndindex(self, flags=no_pyobj_flags):
+    def check_ndindex(self, **kwargs):
         pyfunc = gen_ndindex
-        cr = compile_isolated(pyfunc, (types.UniTuple(types.intp, 2),),
-                              flags=flags)
+        cr = jit((types.UniTuple(types.intp, 2),), **kwargs)(pyfunc)
         shape = (2, 3)
         pygen = pyfunc(shape)
-        cgen = cr.entry_point(shape)
+        cgen = cr(shape)
         self.check_generator(pygen, cgen)
 
     def test_ndindex(self):
-        self.check_ndindex()
+        self.check_ndindex(**nopython_flags)
 
     def test_ndindex_objmode(self):
-        self.check_ndindex(flags=forceobj_flags)
+        self.check_ndindex(**forceobj_flags)
 
-    def check_np_flat(self, pyfunc, flags=no_pyobj_flags):
-        cr = compile_isolated(pyfunc, (types.Array(types.int32, 2, "C"),),
-                              flags=flags)
+    def check_np_flat(self, pyfunc, **kwargs):
+        cr = jit((types.Array(types.int32, 2, "C"),), **kwargs)(pyfunc)
         arr = np.arange(6, dtype=np.int32).reshape((2, 3))
-        self.check_generator(pyfunc(arr), cr.entry_point(arr))
-        cr = compile_isolated(pyfunc, (types.Array(types.int32, 2, "A"),),
-                              flags=flags)
+        self.check_generator(pyfunc(arr), cr(arr))
+        crA = jit((types.Array(types.int32, 2, "A"),), **kwargs)(pyfunc)
         arr = arr.T
-        self.check_generator(pyfunc(arr), cr.entry_point(arr))
+        self.check_generator(pyfunc(arr), crA(arr))
 
     def test_np_flat(self):
-        self.check_np_flat(gen_flat)
+        self.check_np_flat(gen_flat, **nopython_flags)
 
     def test_np_flat_objmode(self):
-        self.check_np_flat(gen_flat, flags=forceobj_flags)
+        self.check_np_flat(gen_flat, **forceobj_flags)
 
     def test_ndenumerate(self):
-        self.check_np_flat(gen_ndenumerate)
+        self.check_np_flat(gen_ndenumerate, **nopython_flags)
 
     def test_ndenumerate_objmode(self):
-        self.check_np_flat(gen_ndenumerate, flags=forceobj_flags)
+        self.check_np_flat(gen_ndenumerate, **forceobj_flags)
 
     def test_type_unification_error(self):
         pyfunc = gen_unification_error
-        with self.assertTypingError() as e:
-            compile_isolated(pyfunc, (), flags=no_pyobj_flags)
+        with self.assertTypingError() as raises:
+            jit((), **nopython_flags)(pyfunc)
 
         msg = ("Can't unify yield type from the following types: complex128, "
                "none")
-        self.assertIn(msg, str(e.exception))
+        self.assertIn(msg, str(raises.exception))
 
     def test_optional_expansion_type_unification_error(self):
         pyfunc = gen_optional_and_type_unification_error
-        with self.assertTypingError() as e:
-            compile_isolated(pyfunc, (), flags=no_pyobj_flags)
+        with self.assertTypingError() as raises:
+            jit((), **nopython_flags)(pyfunc)
 
         msg = ("Can't unify yield type from the following types: complex128, "
                "int%s, none")
-        self.assertIn(msg % types.intp.bitwidth, str(e.exception))
+        self.assertIn(msg % types.intp.bitwidth, str(raises.exception))
 
     def test_changing_tuple_type(self):
         # test https://github.com/numba/numba/issues/7295

--- a/numba/tests/test_generators.py
+++ b/numba/tests/test_generators.py
@@ -203,10 +203,10 @@ class TestGenerators(MemoryLeakMixin, TestCase):
                       str(raises.exception))
 
     def test_gen5_objmode(self):
-        cr = jit((), **forceobj_flags)(gen5)()
-        self.assertEqual(list(cr), [])
+        cgen = jit((), **forceobj_flags)(gen5)()
+        self.assertEqual(list(cgen), [])
         with self.assertRaises(StopIteration):
-            next(cr)
+            next(cgen)
 
     def check_gen6(self, **kwargs):
         cr = jit((types.int32,) * 2, **kwargs)(gen6)


### PR DESCRIPTION
As title. Use of `compile_isolated` leads to hard to track down life-time bugs such as that in #8873. Essentially the `CodeLibrary` containing the generator destructors was being free'd before the generators had actually had their destructors invoked such that the code that should have been executed was missing. This patch replaces `compile_isolated` with `jit` which has an easier to reason about lifetime behaviour for `CodeLibrary` instances etc.

Fixes #8873

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
