### PR TITLE
Fix np.allclose not handling default args

### DIFF
--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -840,22 +840,22 @@ def _allclose_scalars(a_v, b_v, rtol=1e-05, atol=1e-08, equal_nan=False):
 def np_allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
 
     if not type_can_asarray(a):
-        raise TypeError('The first argument "a" must be array-like')
+        raise TypingError('The first argument "a" must be array-like')
 
     if not type_can_asarray(b):
-        raise TypeError('The second argument "b" must be array-like')
+        raise TypingError('The second argument "b" must be array-like')
 
-    if not isinstance(rtol, types.Float):
-        raise TypeError('The third argument "rtol" must be a '
-                        'floating point')
+    if not isinstance(rtol, (float, types.Float)):
+        raise TypingError('The third argument "rtol" must be a '
+                          'floating point')
 
-    if not isinstance(atol, types.Float):
+    if not isinstance(atol, (float, types.Float)):
         raise TypingError('The fourth argument "atol" must be a '
                           'floating point')
 
-    if not isinstance(equal_nan, types.Boolean):
-        raise TypeError('The fifth argument "equal_nan" must be a '
-                        'boolean')
+    if not isinstance(equal_nan, (bool, types.Boolean)):
+        raise TypingError('The fifth argument "equal_nan" must be a '
+                          'boolean')
 
     is_a_scalar = isinstance(a, types.Number)
     is_b_scalar = isinstance(b, types.Number)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fix issue #8860:
* Replace `TypeError` by `TypingError`
* Add a few tests to ensure exceptions are raised
* Add `float` class to `isinstance` comparison

Also, wondering if Numba should have the same checks on `np.isclose` implementation?
