### PR TITLE
Support NVRTC using the ctypes binding

### DIFF
--- a/numba/cuda/cudadrv/nvrtc_ctype_binding.py
+++ b/numba/cuda/cudadrv/nvrtc_ctype_binding.py
@@ -149,24 +149,6 @@ class NVRTCInterface(object):
         ]
         self._lib.nvrtcGetProgramLog.restype = c_int
 
-        self._lib.nvrtcAddNameExpression.argtypes = [
-            c_void_p,           # prog
-            c_char_p            # nameExpression
-        ]
-        self._lib.nvrtcAddNameExpression.restype = c_int
-
-        self._lib.nvrtcGetLoweredName.argtypes = [
-            c_void_p,           # prog
-            c_char_p,           # nameExpression
-            POINTER(c_char_p)   # loweredName
-        ]
-        self._lib.nvrtcGetLoweredName.restype = c_int
-
-        self._lib.nvrtcGetErrorString.argtypes = [
-            c_int               # result
-        ]
-        self._lib.nvrtcGetErrorString.restype = c_char_p
-
         self._lib.nvrtcVersion.argtypes = [
             POINTER(c_int),     # major
             POINTER(c_int)      # minor
@@ -246,36 +228,6 @@ class NVRTCInterface(object):
         code = self._lib.nvrtcGetProgramLogSize(prog, byref(size))
         return (nvrtcResult(code), size.value)
 
-    def nvrtcAddNameExpression(self, prog, name_expression):
-        """
-        Notes the given name expression denoting a __global__ function or
-        function template instantiation.
-        """
-        code = self._lib.nvrtcAddNameExpression(prog,
-                                                c_char_p(encode_str(name_expression)))
-        self._throw_on_error(code)
-        return
-
-    def nvrtcGetLoweredName(self, prog, name_expression):
-        """
-        Notes the given name expression denoting a __global__ function or
-        function template instantiation.
-        """
-        lowered_name = c_char_p()
-        code = self._lib.nvrtcGetLoweredName(prog,
-                                             c_char_p(encode_str(name_expression)),
-                                             byref(lowered_name))
-        self._throw_on_error(code)
-        return lowered_name.value.decode('utf-8')
-
-    def nvrtcGetErrorString(self, code):
-        """
-        Returns a text identifier for the given NVRTC status code.
-        """
-        code_int = c_int(code)
-        res = self._lib.nvrtcGetErrorString(code_int)
-        return res.decode('utf-8')
-
     def nvrtcVersion(self):
         """
         Returns the loaded NVRTC library version as a (major, minor) tuple.
@@ -283,11 +235,10 @@ class NVRTCInterface(object):
         major = c_int()
         minor = c_int()
         code = self._lib.nvrtcVersion(byref(major), byref(minor))
-        self._throw_on_error(code)
-        return (major.value, minor.value)
+        return (nvrtcResult(code), major.value, minor.value)
 
     def __str__(self):
-        (major, minor) = self.nvrtcVersion()
+        code, major, minor = self.nvrtcVersion()
         return 'NVRTC Interface (Version: %d.%d)' % (major, minor)
 
     def __repr__(self):

--- a/numba/cuda/cudadrv/nvrtc_ctype_binding.py
+++ b/numba/cuda/cudadrv/nvrtc_ctype_binding.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2014-2018, NVIDIA Corporation.  All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from ctypes import (
+    POINTER,
+    c_int,
+    c_void_p,
+    byref,
+    c_char_p,
+    c_size_t,
+    cdll,
+)
+from ctypes.util import find_library
+from enum import IntEnum
+
+
+class nvrtcResult(IntEnum):
+    NVRTC_SUCCESS = 0
+    NVRTC_ERROR_OUT_OF_MEMORY = 1
+    NVRTC_ERROR_PROGRAM_CREATION_FAILURE = 2
+    NVRTC_ERROR_INVALID_INPUT = 3
+    NVRTC_ERROR_INVALID_PROGRAM = 4
+    NVRTC_ERROR_INVALID_OPTION = 5
+    NVRTC_ERROR_COMPILATION = 6
+    NVRTC_ERROR_BUILTIN_OPERATION_FAILURE = 7
+
+
+# NVRTC status codes
+NVRTC_SUCCESS = 0
+NVRTC_ERROR_OUT_OF_MEMORY = 1
+NVRTC_ERROR_PROGRAM_CREATION_FAILURE = 2
+NVRTC_ERROR_INVALID_INPUT = 3
+NVRTC_ERROR_INVALID_PROGRAM = 4
+NVRTC_ERROR_INVALID_OPTION = 5
+NVRTC_ERROR_COMPILATION = 6
+NVRTC_ERROR_BUILTIN_OPERATION_FAILURE = 7
+
+
+def encode_str(s):
+    return s
+
+
+def encode_str_list(str_list):
+    return list(map(encode_str, str_list))
+
+
+class NVRTCException(Exception):
+    """
+    Exception wrapper for NVRTC error codes.
+    """
+    def __init__(self, msg):
+        Exception.__init__(self)
+        self._msg = msg
+
+    def __str__(self):
+        return 'NVRTC Error: %s' % self._msg
+
+    def __repr__(self):
+        return str(self)
+
+
+class NVRTCInterface(object):
+    """
+    Low-level interface to NVRTC.  This class is primarily designed for
+    interfacing the high-level API with the NVRTC binary, but clients
+    are free to use NVRTC directly through this class.
+    """
+    def __init__(self, lib_path=''):
+        self._lib = None
+        self._load_nvrtc_lib(lib_path)
+
+    def _load_nvrtc_lib(self, lib_path):
+        """
+        Loads the NVRTC shared library, with an optional search path in
+        lib_path.
+        """
+        def_lib_name = "nvrtc"
+
+        if len(lib_path) == 0:
+            name = def_lib_name
+        else:
+            name = lib_path
+
+        found_library = find_library(name)
+        self._lib = cdll.LoadLibrary(found_library)
+
+        self._lib.nvrtcCreateProgram.argtypes = [
+            POINTER(c_void_p),  # prog
+            c_char_p,           # src
+            c_char_p,           # name
+            c_int,              # numHeaders
+            POINTER(c_char_p),  # headers
+            POINTER(c_char_p)   # include_names
+        ]
+        self._lib.nvrtcCreateProgram.restype = c_int
+
+        self._lib.nvrtcDestroyProgram.argtypes = [
+            POINTER(c_void_p)   # prog
+        ]
+        self._lib.nvrtcDestroyProgram.restype = c_int
+
+        self._lib.nvrtcCompileProgram.argtypes = [
+            c_void_p,           # prog
+            c_int,              # numOptions
+            POINTER(c_char_p)   # options
+        ]
+        self._lib.nvrtcCompileProgram.restype = c_int
+
+        self._lib.nvrtcGetPTXSize.argtypes = [
+            c_void_p,           # prog
+            POINTER(c_size_t)   # ptxSizeRet
+        ]
+        self._lib.nvrtcGetPTXSize.restype = c_int
+
+        self._lib.nvrtcGetPTX.argtypes = [
+            c_void_p,           # prog
+            c_char_p            # ptx
+        ]
+        self._lib.nvrtcGetPTX.restype = c_int
+
+        self._lib.nvrtcGetProgramLogSize.argtypes = [
+            c_void_p,           # prog
+            POINTER(c_size_t)   # logSizeRet
+        ]
+        self._lib.nvrtcGetProgramLogSize.restype = c_int
+
+        self._lib.nvrtcGetProgramLog.argtypes = [
+            c_void_p,           # prog
+            c_char_p            # log
+        ]
+        self._lib.nvrtcGetProgramLog.restype = c_int
+
+        self._lib.nvrtcAddNameExpression.argtypes = [
+            c_void_p,           # prog
+            c_char_p            # nameExpression
+        ]
+        self._lib.nvrtcAddNameExpression.restype = c_int
+
+        self._lib.nvrtcGetLoweredName.argtypes = [
+            c_void_p,           # prog
+            c_char_p,           # nameExpression
+            POINTER(c_char_p)   # loweredName
+        ]
+        self._lib.nvrtcGetLoweredName.restype = c_int
+
+        self._lib.nvrtcGetErrorString.argtypes = [
+            c_int               # result
+        ]
+        self._lib.nvrtcGetErrorString.restype = c_char_p
+
+        self._lib.nvrtcVersion.argtypes = [
+            POINTER(c_int),     # major
+            POINTER(c_int)      # minor
+        ]
+        self._lib.nvrtcVersion.restype = c_int
+
+    def _throw_on_error(self, code):
+        """
+        Raises an NVRTCException is the given code is not NVRTC_SUCCESS.
+        """
+        if code == NVRTC_SUCCESS:
+            return
+        else:
+            raise NVRTCException(self.nvrtcGetErrorString(code))
+
+    def nvrtcCreateProgram(self, src, name, num_headers, headers,
+                           include_names):
+        """
+        Creates and returns a new NVRTC program object.
+        """
+        res = c_void_p()
+        headers_array = (c_char_p * num_headers)()
+        headers_array[:] = encode_str_list(headers)
+        include_names_array = (c_char_p * len(include_names))()
+        include_names_array[:] = encode_str_list(include_names)
+        code = self._lib.nvrtcCreateProgram(byref(res),
+                                            c_char_p(encode_str(src)),
+                                            c_char_p(encode_str(name)),
+                                            len(headers),
+                                            headers_array, include_names_array)
+
+        return (nvrtcResult(code), res)
+
+    def nvrtcDestroyProgram(self, prog):
+        """
+        Destroys the given NVRTC program object.
+        """
+        code = self._lib.nvrtcDestroyProgram(byref(prog))
+        return (nvrtcResult(code),)
+
+    def nvrtcCompileProgram(self, prog, options_len, options):
+        """
+        Compiles the NVRTC program object into PTX, using the provided options
+        array.  See the NVRTC API documentation for accepted options.
+        """
+
+        options_array = (c_char_p * options_len)()
+        options_array[:] = encode_str_list(options)
+        code = self._lib.nvrtcCompileProgram(prog, options_len, options_array)
+        return (nvrtcResult(code),)
+
+    def nvrtcGetPTX(self, prog, ptx_buf):
+        """
+        Returns the compiled PTX for the NVRTC program object.
+        """
+        code = self._lib.nvrtcGetPTX(prog, ptx_buf)
+        return (nvrtcResult(code),)
+
+    def nvrtcGetPTXSize(self, prog):
+        size = c_size_t()
+        code = self._lib.nvrtcGetPTXSize(prog, byref(size))
+
+        return (nvrtcResult(code), size.value)
+
+    def nvrtcGetProgramLog(self, prog, log_buf):
+        """
+        Returns the log for the NVRTC program object.
+
+        Only useful after calls to nvrtcCompileProgram or nvrtcVerifyProgram.
+        """
+        code = self._lib.nvrtcGetProgramLog(prog, log_buf)
+
+        return (nvrtcResult(code),)
+
+    def nvrtcGetProgramLogSize(self, prog):
+        size = c_size_t()
+        code = self._lib.nvrtcGetProgramLogSize(prog, byref(size))
+        return (nvrtcResult(code), size.value)
+
+    def nvrtcAddNameExpression(self, prog, name_expression):
+        """
+        Notes the given name expression denoting a __global__ function or
+        function template instantiation.
+        """
+        code = self._lib.nvrtcAddNameExpression(prog,
+                                                c_char_p(encode_str(name_expression)))
+        self._throw_on_error(code)
+        return
+
+    def nvrtcGetLoweredName(self, prog, name_expression):
+        """
+        Notes the given name expression denoting a __global__ function or
+        function template instantiation.
+        """
+        lowered_name = c_char_p()
+        code = self._lib.nvrtcGetLoweredName(prog,
+                                             c_char_p(encode_str(name_expression)),
+                                             byref(lowered_name))
+        self._throw_on_error(code)
+        return lowered_name.value.decode('utf-8')
+
+    def nvrtcGetErrorString(self, code):
+        """
+        Returns a text identifier for the given NVRTC status code.
+        """
+        code_int = c_int(code)
+        res = self._lib.nvrtcGetErrorString(code_int)
+        return res.decode('utf-8')
+
+    def nvrtcVersion(self):
+        """
+        Returns the loaded NVRTC library version as a (major, minor) tuple.
+        """
+        major = c_int()
+        minor = c_int()
+        code = self._lib.nvrtcVersion(byref(major), byref(minor))
+        self._throw_on_error(code)
+        return (major.value, minor.value)
+
+    def __str__(self):
+        (major, minor) = self.nvrtcVersion()
+        return 'NVRTC Interface (Version: %d.%d)' % (major, minor)
+
+    def __repr__(self):
+        return str(self)

--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -110,15 +110,6 @@ class _Kernel(serialize.ReduceMixin):
                if (f'__numba_wrapper_{fn}' in lib.get_asm_str())]
 
         if res:
-            if not config.CUDA_USE_NVIDIA_BINDING:
-                s = "https://numba.readthedocs.io/en/stable/cuda/bindings.html"
-                msg = ("Use of float16 requires the use of the NVIDIA CUDA "
-                       "bindings and setting the "
-                       "NUMBA_CUDA_USE_NVIDIA_BINDING environment variable to "
-                       "1. Relevant documentation is available here:\n"
-                       f"{s}")
-                raise NotImplementedError(msg)
-
             # Path to the source containing the foreign function
 
             basedir = os.path.dirname(os.path.abspath(__file__))

--- a/numba/cuda/tests/cudadrv/test_linker.py
+++ b/numba/cuda/tests/cudadrv/test_linker.py
@@ -1,13 +1,12 @@
 import numpy as np
 import warnings
-from numba.cuda.testing import skip_if_mvc_enabled, skip_unless_cc_53, unittest
-from numba.cuda.testing import (skip_on_cudasim, skip_unless_cuda_python,
-                                skip_if_cuda_includes_missing)
+from numba.cuda.testing import unittest
+from numba.cuda.testing import (skip_on_cudasim, skip_if_cuda_includes_missing)
 from numba.cuda.testing import CUDATestCase, test_data_dir
 from numba.cuda.cudadrv.driver import (CudaAPIError, Linker,
                                        LinkerError, NvrtcError)
 from numba.cuda import require_context
-from numba.tests.support import TestCase, ignore_internal_warnings
+from numba.tests.support import ignore_internal_warnings
 from numba import cuda, void, float64, int64, int32, typeof, float32
 
 
@@ -143,7 +142,6 @@ class TestLinker(CUDATestCase):
     def test_linking_eager_compile(self):
         self._test_linking(eager=True)
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_linking_cu(self):
         bar = cuda.declare_device('bar', 'int32(int32)')
 
@@ -165,7 +163,6 @@ class TestLinker(CUDATestCase):
         expected = x * 2
         np.testing.assert_array_equal(r, expected)
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_linking_cu_log_warning(self):
         bar = cuda.declare_device('bar', 'int32(int32)')
 
@@ -184,7 +181,6 @@ class TestLinker(CUDATestCase):
         # Check the message pertaining to the unused variable is provided
         self.assertIn('declared but never referenced', str(w[0].message))
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_linking_cu_error(self):
         bar = cuda.declare_device('bar', 'int32(int32)')
 
@@ -203,38 +199,6 @@ class TestLinker(CUDATestCase):
         # Check the filename is reported correctly
         self.assertIn('in the compilation of "error.cu"', msg)
 
-    # We need to run the test in a subprocess because the Linker class
-    # that instantiates either the CudaPythonLinker or CtypesLinker
-    # sets USE_NV_BINDING = config.CUDA_USE_NVIDIA_BINDING at
-    # module import time, so overriding the config variable does
-    # not help.
-
-    @skip_if_mvc_enabled('NVRTC not available when ctypes binding is used.')
-    @TestCase.run_test_in_subprocess(envvars=_NUMBA_NVIDIA_BINDING_0_ENV)
-    def test_linking_cu_ctypes_unsupported(self):
-        link = str(test_data_dir / 'jitlink.cu')
-        msg = ('Linking CUDA source files is not supported with the ctypes '
-               'binding')
-
-        with self.assertRaisesRegex(NotImplementedError, msg):
-            @cuda.jit('void()', link=[link])
-            def f():
-                pass
-
-    # Float16 math functions require linking in a .cu file, verify that
-    # we generate the appropriate exception and message if the NVIDIA
-    # bindings are not enabled or installed.
-
-    @skip_unless_cc_53
-    @TestCase.run_test_in_subprocess(envvars=_NUMBA_NVIDIA_BINDING_0_ENV)
-    def test_linking_float16_unsupported(self):
-        msg = ("Use of float16 requires the use of the NVIDIA CUDA "
-               "bindings and setting the ")
-        with self.assertRaisesRegex(NotImplementedError, msg):
-            @cuda.jit('void(float16[::1])')
-            def hexp10_vectors(x):
-                cuda.fp16.hexp10(x[0])
-
     def test_linking_unknown_filetype_error(self):
         expected_err = "Don't know how to link file with extension .cuh"
         with self.assertRaisesRegex(RuntimeError, expected_err):
@@ -250,7 +214,6 @@ class TestLinker(CUDATestCase):
                 pass
 
     @skip_if_cuda_includes_missing
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_linking_cu_cuda_include(self):
         link = str(test_data_dir / 'cuda_include.cu')
 

--- a/numba/cuda/tests/cudapy/test_intrinsics.py
+++ b/numba/cuda/tests/cudapy/test_intrinsics.py
@@ -7,7 +7,7 @@ from numba.cuda import compile_ptx
 from numba.core.errors import TypingError
 from numba.core.types import f2
 from numba.cuda.testing import (unittest, CUDATestCase, skip_on_cudasim,
-                                skip_unless_cc_53, skip_unless_cuda_python)
+                                skip_unless_cc_53)
 
 
 def simple_threadidx(ary):
@@ -652,7 +652,6 @@ class TestCudaIntrinsic(CUDATestCase):
         self.assertIn('mul.f16', ptx)
 
     @skip_unless_cc_53
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_hdiv_scalar(self):
         compiled = cuda.jit("void(f2[:], f2, f2)")(simple_hdiv_scalar)
         ary = np.zeros(1, dtype=np.float16)
@@ -663,7 +662,6 @@ class TestCudaIntrinsic(CUDATestCase):
         np.testing.assert_allclose(ary[0], ref)
 
     @skip_unless_cc_53
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_hdiv(self):
         compiled = cuda.jit("void(f2[:], f2[:], f2[:])")(simple_hdiv_kernel)
         arry1 = np.random.randint(-65504, 65505, size=500).astype(np.float16)
@@ -721,7 +719,6 @@ class TestCudaIntrinsic(CUDATestCase):
         self.assertIn('abs.f16', ptx)
 
     @skip_unless_cc_53
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_fp16_intrinsics_common(self):
         kernels = (simple_hsin, simple_hcos,
                    simple_hlog, simple_hlog2, simple_hlog10,
@@ -757,7 +754,6 @@ class TestCudaIntrinsic(CUDATestCase):
                 np.testing.assert_allclose(r, expected)
 
     @skip_unless_cc_53
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_hexp10(self):
         @cuda.jit()
         def hexp10_vectors(r, x):

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -393,6 +393,10 @@ class TestCudaMath(CUDATestCase):
         self.unary_template_float16(math_sqrt, np.sqrt)
         self.unary_template_float16(math_ceil, np.ceil)
         self.unary_template_float16(math_floor, np.floor)
+
+    @skip_on_cudasim("numpy does not support trunc for float16")
+    @skip_unless_cc_53
+    def test_math_fp16_trunc(self):
         self.unary_template_float16(math_trunc, np.trunc)
 
     #---------------------------------------------------------------------------

--- a/numba/cuda/tests/cudapy/test_math.py
+++ b/numba/cuda/tests/cudapy/test_math.py
@@ -1,6 +1,5 @@
 import numpy as np
 from numba.cuda.testing import (skip_unless_cc_53,
-                                skip_unless_cuda_python,
                                 unittest,
                                 CUDATestCase,
                                 skip_on_cudasim)
@@ -383,7 +382,6 @@ class TestCudaMath(CUDATestCase):
         self.unary_template_uint64(math_cos, np.cos)
 
     @skip_unless_cc_53
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     def test_math_fp16(self):
         self.unary_template_float16(math_sin, np.sin)
         self.unary_template_float16(math_cos, np.cos)

--- a/numba/cuda/tests/cudapy/test_operator.py
+++ b/numba/cuda/tests/cudapy/test_operator.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba.cuda.testing import (unittest, CUDATestCase, skip_unless_cc_53,
-                                skip_on_cudasim, skip_unless_cuda_python)
+                                skip_on_cudasim)
 from numba import cuda
 from numba.core.types import f2, b1
 from numba.cuda import compile_ptx
@@ -144,7 +144,6 @@ class TestOperatorModule(CUDATestCase):
     def test_floordiv(self):
         self.operator_template(operator.floordiv)
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     @skip_unless_cc_53
     def test_fp16_binary(self):
         functions = (simple_fp16add, simple_fp16sub, simple_fp16mul,
@@ -173,7 +172,6 @@ class TestOperatorModule(CUDATestCase):
                 ptx, _ = compile_ptx(fn, args, cc=(5, 3))
                 self.assertIn(instr, ptx)
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     @skip_unless_cc_53
     def test_mixed_fp16_binary_arithmetic(self):
         functions = (simple_fp16add, simple_fp16sub, simple_fp16mul,
@@ -205,7 +203,6 @@ class TestOperatorModule(CUDATestCase):
                 ptx, _ = compile_ptx(fn, args, cc=(5, 3))
                 self.assertIn(instr, ptx)
 
-    @skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
     @skip_unless_cc_53
     def test_fp16_inplace_binary(self):
         functions = (simple_fp16_iadd, simple_fp16_isub, simple_fp16_imul,

--- a/numba/cuda/tests/doc_examples/test_ffi.py
+++ b/numba/cuda/tests/doc_examples/test_ffi.py
@@ -2,11 +2,9 @@
 # "magictoken" is used for markers as beginning and ending of example text.
 
 import unittest
-from numba.cuda.testing import (CUDATestCase, skip_on_cudasim,
-                                skip_unless_cuda_python)
+from numba.cuda.testing import (CUDATestCase, skip_on_cudasim)
 
 
-@skip_unless_cuda_python('NVIDIA Binding needed for NVRTC')
 @skip_on_cudasim("cudasim doesn't support cuda import at non-top-level")
 class TestFFI(CUDATestCase):
     def test_ex_linking_cu(self):


### PR DESCRIPTION
This pull request allows NVRTC to be used with the ctypes binding. This eliminates a class of errors when using cuda most notably support for float16, which currently requires the NVIDIA bindings to work fully. This pull request address this open issue:

https://github.com/numba/numba/issues/8821