### PR TITLE
FIX: Add missing `**targetoptions` to `jit` in `GUFuncBuilder`

### DIFF
--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -325,7 +325,9 @@ class GUFuncBuilder(_BaseUFuncBuilder):
                  targetoptions={}, writable_args=()):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(_target='npyufunc', cache=cache)(py_func)
+        self.nb_func = jit(_target='npyufunc',
+                           cache=cache,
+                           **targetoptions)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
         self.targetoptions = targetoptions


### PR DESCRIPTION
Fix #8903

* Add missing `**targetoptions` to `self.nb_func = jit(...)` in `GUFuncBuilder.__init__`, as in the corresponding part in `UFuncBuilder.__init__`: https://github.com/numba/numba/blob/320a9f533201c642ef6fd01baf7b3376bd4daa9b/numba/np/ufunc/ufuncbuilder.py#L263-L265