### PR TITLE
Work around issue #8898. Defer `exp2` (and `log2`) calls to Numba internal symbols.

### DIFF
--- a/numba/_helperlib.c
+++ b/numba/_helperlib.c
@@ -122,6 +122,30 @@ numba_ldexpf(float x, int exp)
     return x;
 }
 
+NUMBA_EXPORT_FUNC(double)
+numba_exp2(double x)
+{
+    return exp2(x);
+}
+
+NUMBA_EXPORT_FUNC(float)
+numba_exp2f(float x)
+{
+    return exp2f(x);
+}
+
+NUMBA_EXPORT_FUNC(double)
+numba_log2(double x)
+{
+    return log2(x);
+}
+
+NUMBA_EXPORT_FUNC(float)
+numba_log2f(float x)
+{
+    return log2f(x);
+}
+
 /* provide complex power */
 NUMBA_EXPORT_FUNC(void)
 numba_cpow(Py_complex *a, Py_complex *b, Py_complex *out) {

--- a/numba/_helpermod.c
+++ b/numba/_helpermod.c
@@ -55,6 +55,10 @@ build_c_helpers_dict(void)
     declmethod(frexpf);
     declmethod(ldexp);
     declmethod(ldexpf);
+    declmethod(exp2);
+    declmethod(exp2f);
+    declmethod(log2);
+    declmethod(log2f);
     declmethod(cpow);
     declmethod(cpowf);
     declmethod(erf);

--- a/numba/np/npyfuncs.py
+++ b/numba/np/npyfuncs.py
@@ -648,11 +648,13 @@ def np_complex_exp_impl(context, builder, sig, args):
 def np_real_exp2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    ll_ty = args[0].type
-    fnty = llvmlite.ir.FunctionType(ll_ty, [ll_ty,])
-    fn = cgutils.insert_pure_function(builder.module, fnty,
-                                      name='llvm.exp2')
-    return builder.call(fn, [args[0]])
+    dispatch_table = {
+        types.float32: 'numba_exp2f',
+        types.float64: 'numba_exp2',
+    }
+
+    return _dispatch_func_by_name_type(context, builder, sig, args,
+                                       dispatch_table, 'exp2')
 
 
 def np_complex_exp2_impl(context, builder, sig, args):
@@ -685,11 +687,13 @@ def np_complex_log_impl(context, builder, sig, args):
 def np_real_log2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)
 
-    ll_ty = args[0].type
-    fnty = llvmlite.ir.FunctionType(ll_ty, [ll_ty,])
-    fn = cgutils.insert_pure_function(builder.module, fnty,
-                                      name='llvm.log2')
-    return builder.call(fn, [args[0]])
+    dispatch_table = {
+        types.float32: 'numba_log2f',
+        types.float64: 'numba_log2',
+    }
+
+    return _dispatch_func_by_name_type(context, builder, sig, args,
+                                       dispatch_table, 'log2')
 
 def np_complex_log2_impl(context, builder, sig, args):
     _check_arity_and_homogeneity(sig, args, 1)

--- a/numba/tests/npyufunc/test_ufunc.py
+++ b/numba/tests/npyufunc/test_ufunc.py
@@ -141,5 +141,33 @@ class TestUFuncs(TestCase):
         self.assertIn(msg, str(raises.exception))
 
 
+class TestUFuncsMisc(TestCase):
+    # Test for miscellaneous ufunc issues
+
+    def test_exp2(self):
+        # See issue #8898
+        @njit
+        def foo(x):
+            return np.exp2(x)
+
+        for ty in (np.int8, np.uint16):
+            x = ty(2)
+            expected = foo.py_func(x)
+            got = foo(x)
+            self.assertPreciseEqual(expected, got)
+
+    def test_log2(self):
+        # See issue #8898
+        @njit
+        def foo(x):
+            return np.log2(x)
+
+        for ty in (np.int8, np.uint16):
+            x = ty(2)
+            expected = foo.py_func(x)
+            got = foo(x)
+            self.assertPreciseEqual(expected, got)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As title.

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
