### PR TITLE
Fix #8903. `NumbaDeprecationWarning`s raised from `@{gu,}vectorize`.

### DIFF
--- a/numba/np/ufunc/dufunc.py
+++ b/numba/np/ufunc/dufunc.py
@@ -81,9 +81,10 @@ class DUFunc(serialize.ReduceMixin, _internal._DUFunc):
     def __init__(self, py_func, identity=None, cache=False, targetoptions={}):
         if is_jitted(py_func):
             py_func = py_func.py_func
-        dispatcher = jit(_target='npyufunc',
-                         cache=cache,
-                         **targetoptions)(py_func)
+        with ufuncbuilder._suppress_deprecation_warning_nopython_not_supplied():
+            dispatcher = jit(_target='npyufunc',
+                             cache=cache,
+                             **targetoptions)(py_func)
         self._initialize(dispatcher, identity)
         functools.update_wrapper(self, py_func)
 

--- a/numba/np/ufunc/ufuncbuilder.py
+++ b/numba/np/ufunc/ufuncbuilder.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import inspect
+import warnings
 from contextlib import contextmanager
 
 from numba.core import config, targetconfig
 from numba.core.decorators import jit
 from numba.core.descriptors import TargetDescriptor
 from numba.core.extending import is_jitted
+from numba.core.errors import NumbaDeprecationWarning
 from numba.core.options import TargetOptions, include_default_options
 from numba.core.registry import cpu_target
 from numba.core.target_extension import dispatcher_registry, target_registry
@@ -230,6 +232,20 @@ def parse_identity(identity):
     return identity
 
 
+@contextmanager
+def _suppress_deprecation_warning_nopython_not_supplied():
+    """This suppresses the NumbaDeprecationWarning that occurs through the use
+    of `jit` without the `nopython` kwarg. This use of `jit` occurs in a few
+    places in the `{g,}ufunc` mechanism in Numba, predominantly to wrap the
+    "kernel" function."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore',
+                                category=NumbaDeprecationWarning,
+                                message=(".*The 'nopython' keyword argument "
+                                         "was not supplied*"),)
+        yield
+
+
 # Class definitions
 
 class _BaseUFuncBuilder(object):
@@ -260,9 +276,10 @@ class UFuncBuilder(_BaseUFuncBuilder):
             py_func = py_func.py_func
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(_target='npyufunc',
-                           cache=cache,
-                           **targetoptions)(py_func)
+        with _suppress_deprecation_warning_nopython_not_supplied():
+            self.nb_func = jit(_target='npyufunc',
+                               cache=cache,
+                               **targetoptions)(py_func)
         self._sigs = []
         self._cres = {}
 
@@ -325,7 +342,8 @@ class GUFuncBuilder(_BaseUFuncBuilder):
                  targetoptions={}, writable_args=()):
         self.py_func = py_func
         self.identity = parse_identity(identity)
-        self.nb_func = jit(_target='npyufunc', cache=cache)(py_func)
+        with _suppress_deprecation_warning_nopython_not_supplied():
+            self.nb_func = jit(_target='npyufunc', cache=cache)(py_func)
         self.signature = signature
         self.sin, self.sout = parse_signature(signature)
         self.targetoptions = targetoptions

--- a/numba/tests/npyufunc/test_ufunc.py
+++ b/numba/tests/npyufunc/test_ufunc.py
@@ -104,7 +104,7 @@ class TestUFuncs(TestCase):
         tests = []
         expect = "ufunc 'sin' called with an explicit output that is read-only"
         tests.append((jit(nopython=True), TypingError, expect))
-        tests.append((jit(nopython=False), ValueError,
+        tests.append((jit(forceobj=True), ValueError,
                       "output array is read-only"))
 
         for dec, exc, msg in tests:

--- a/numba/tests/npyufunc/test_vectorize_decor.py
+++ b/numba/tests/npyufunc/test_vectorize_decor.py
@@ -93,7 +93,7 @@ class TestParallelVectorizeDecor(unittest.TestCase, BaseVectorizeDecor):
 
 class TestCPUVectorizeJitted(unittest.TestCase, BaseVectorizeDecor):
     target = 'cpu'
-    wrapper = jit
+    wrapper = jit(nopython=True)
 
 
 class BaseVectorizeNopythonArg(unittest.TestCase, CheckWarningsMixin):

--- a/numba/tests/test_deprecations.py
+++ b/numba/tests/test_deprecations.py
@@ -1,9 +1,19 @@
 import warnings
-from numba import jit, generated_jit
+import unittest
+from contextlib import contextmanager
+
+from numba import jit, generated_jit, vectorize, guvectorize
 from numba.core.errors import (NumbaDeprecationWarning,
                                NumbaPendingDeprecationWarning, NumbaWarning)
 from numba.tests.support import TestCase
-import unittest
+
+
+@contextmanager
+def _catch_numba_deprecation_warnings():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("ignore", category=NumbaWarning)
+        warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        yield w
 
 
 class TestDeprecation(TestCase):
@@ -18,9 +28,7 @@ class TestDeprecation(TestCase):
     def test_jitfallback(self):
         # tests that @jit falling back to object mode raises a
         # NumbaDeprecationWarning
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("ignore", category=NumbaWarning)
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        with _catch_numba_deprecation_warnings() as w:
             # ignore the warning about the nopython kwarg not being supplied
             warnings.filterwarnings("ignore",
                                     message=(r".*The 'nopython' keyword "
@@ -40,9 +48,7 @@ class TestDeprecation(TestCase):
     def test_default_missing_nopython_kwarg(self):
         # test that not supplying `nopython` kwarg to @jit raises a warning
         # about the default changing.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("ignore", category=NumbaWarning)
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        with _catch_numba_deprecation_warnings() as w:
 
             @jit
             def foo():
@@ -58,9 +64,7 @@ class TestDeprecation(TestCase):
         # tests that explicitly setting `nopython=False` in @jit raises a
         # warning about the default changing and it being an error in the
         # future.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("ignore", category=NumbaWarning)
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        with _catch_numba_deprecation_warnings() as w:
 
             @jit(nopython=False)
             def foo():
@@ -76,9 +80,7 @@ class TestDeprecation(TestCase):
         # Checks that if forceobj is set and the nopython kwarg is also not
         # present then no warning is raised. The user intentially wants objmode.
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("ignore", category=NumbaWarning)
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        with _catch_numba_deprecation_warnings() as w:
 
             @jit(forceobj=True)
             def foo():
@@ -87,6 +89,224 @@ class TestDeprecation(TestCase):
             foo()
 
         # no warnings should be raised.
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_missing_nopython_kwarg_not_reported(self):
+        # Checks that use of @vectorize without a nopython kwarg doesn't raise
+        # a warning about lack of said kwarg.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # This compiles via nopython mode directly
+            @vectorize('float64(float64)')
+            def foo(a):
+                return a + 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_nopython_false_is_reported(self):
+        # Checks that use of @vectorize with nopython=False raises a warning
+        # about supplying it.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # This compiles via nopython mode directly
+            @vectorize('float64(float64)', nopython=False)
+            def foo(a):
+                return a + 1
+
+        msg = "The keyword argument 'nopython=False' was supplied"
+        self.check_warning(w, msg, NumbaDeprecationWarning)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_objmode_missing_nopython_kwarg_not_reported(self):
+        # Checks that use of @vectorize without a nopython kwarg doesn't raise
+        # a warning about lack of the nopython kwarg, but does raise a warning
+        # about falling back to obj mode to compile.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # This compiles via objmode fallback
+            @vectorize('float64(float64)')
+            def foo(a):
+                object()
+                return a + 1
+
+        msg = ("Fall-back from the nopython compilation path to the object "
+               "mode compilation path")
+        self.check_warning(w, msg, NumbaDeprecationWarning)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_objmode_nopython_false_is_reported(self):
+        # Checks that use of @vectorize with a nopython kwarg set to False
+        # doesn't raise a warning about lack of the nopython kwarg, but does
+        # raise a warning about it being False and then a warning about falling
+        # back to obj mode to compile.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # This compiles via objmode fallback with a warning about
+            # nopython=False supplied.
+            @vectorize('float64(float64)', nopython=False)
+            def foo(a):
+                object()
+                return a + 1
+
+        # 2 warnings: 1. use of nopython=False, then, 2. objmode fallback
+        self.assertEqual(len(w), 2)
+
+        msg = "The keyword argument 'nopython=False' was supplied"
+        self.check_warning([w[0]], msg, NumbaDeprecationWarning)
+
+        msg = ("Fall-back from the nopython compilation path to the object "
+               "mode compilation path")
+        self.check_warning([w[1]], msg, NumbaDeprecationWarning)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_objmode_direct_compilation_no_warnings(self):
+        # Checks that use of @vectorize with forceobj=True raises no warnings.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # Compiles via objmode directly with no warnings raised
+            @vectorize('float64(float64)', forceobj=True)
+            def foo(a):
+                object()
+                return a + 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_objmode_compilation_nopython_false_no_warnings(self):
+        # Checks that use of @vectorize with forceobj set and nopython set as
+        # False raises no warnings.
+
+        with _catch_numba_deprecation_warnings() as w:
+            # Compiles via objmode directly with no warnings raised
+            @vectorize('float64(float64)', forceobj=True, nopython=False)
+            def foo(a):
+                object()
+                return a + 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_parallel_true_no_warnings(self):
+        # Checks that use of @vectorize with the parallel target doesn't
+        # raise warnings about nopython kwarg, the parallel target doesn't
+        # support objmode so nopython=True is implicit.
+        with _catch_numba_deprecation_warnings() as w:
+            @vectorize('float64(float64)', target='parallel')
+            def foo(x):
+                return x + 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_parallel_true_nopython_true_no_warnings(self):
+        # Checks that use of @vectorize with the parallel target and
+        # nopython=True doesn't raise warnings about nopython kwarg.
+        with _catch_numba_deprecation_warnings() as w:
+            @vectorize('float64(float64)', target='parallel', nopython=True)
+            def foo(x):
+                return x + 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_parallel_true_nopython_false_warns(self):
+        # Checks that use of @vectorize with the parallel target and
+        # nopython=False raises a warning about the nopython kwarg being False.
+        with _catch_numba_deprecation_warnings() as w:
+            @vectorize('float64(float64)', target='parallel', nopython=False)
+            def foo(x):
+                return x + 1
+
+        msg = "The keyword argument 'nopython=False' was supplied"
+        self.check_warning(w, msg, NumbaDeprecationWarning)
+
+    @TestCase.run_test_in_subprocess
+    def test_vectorize_calling_jit_with_nopython_false_warns_from_jit(self):
+        # Checks the scope of the suppression of deprecation warnings that are
+        # present in e.g. vectorize. The function `bar` should raise a
+        # deprecation warning, the `@vectorize`d `foo` function should not,
+        # even though both don't have a nopython kwarg.
+
+        # First check that the @vectorize call doesn't raise anything
+        with _catch_numba_deprecation_warnings() as w:
+            @vectorize('float64(float64)', forceobj=True)
+            def foo(x):
+                return bar(x + 1)
+
+            def bar(*args):
+                pass
+
+        self.assertFalse(w)
+
+        # Now check the same compilation but this time compiling through to a
+        # @jit call.
+        with _catch_numba_deprecation_warnings() as w:
+            @vectorize('float64(float64)', forceobj=True)
+            def foo(x):
+                return bar(x + 1)
+
+            @jit
+            def bar(x):
+                return x
+
+        msg = "The 'nopython' keyword argument was not supplied"
+        self.check_warning(w, msg, NumbaDeprecationWarning)
+
+    @TestCase.run_test_in_subprocess
+    def test_guvectorize_implicit_nopython_no_warnings(self):
+        # Checks that use of @guvectorize with implicit nopython compilation
+        # does not warn on compilation.
+        with _catch_numba_deprecation_warnings() as w:
+
+            @guvectorize('void(float64[::1], float64[::1])', '(n)->(n)')
+            def bar(a, b):
+                a += 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_guvectorize_forceobj_no_warnings(self):
+        # Checks that use of @guvectorize with direct objmode compilation does
+        # not warn.
+        with _catch_numba_deprecation_warnings() as w:
+
+            @guvectorize('void(float64[::1], float64[::1])', '(n)->(n)',
+                         forceobj=True)
+            def bar(a, b):
+                object()
+                a += 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_guvectorize_parallel_implicit_nopython_no_warnings(self):
+        # Checks that use of @guvectorize with parallel target and implicit
+        # nopython mode compilation does not warn.
+        with _catch_numba_deprecation_warnings() as w:
+
+            @guvectorize('void(float64[::1], float64[::1])', '(n)->(n)',
+                         target='parallel')
+            def bar(a, b):
+                a += 1
+
+        self.assertFalse(w)
+
+    @TestCase.run_test_in_subprocess
+    def test_guvectorize_parallel_forceobj_no_warnings(self):
+        # Checks that use of @guvectorize with parallel target and direct
+        # objmode compilation does not warn.
+        with _catch_numba_deprecation_warnings() as w:
+
+            # This compiles somewhat surprisingly for the parallel target using
+            # object mode?!
+            @guvectorize('void(float64[::1], float64[::1])', '(n)->(n)',
+                         target='parallel', forceobj=True)
+            def bar(a, b):
+                object()
+                a += 1
+
         self.assertFalse(w)
 
     @TestCase.run_test_in_subprocess
@@ -119,9 +339,7 @@ class TestDeprecation(TestCase):
     @TestCase.run_test_in_subprocess
     def test_generated_jit(self):
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("ignore", category=NumbaWarning)
-            warnings.simplefilter("always", category=NumbaDeprecationWarning)
+        with _catch_numba_deprecation_warnings() as w:
 
             @generated_jit
             def bar():

--- a/numba/tests/test_deprecations.py
+++ b/numba/tests/test_deprecations.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from numba import jit, generated_jit, vectorize, guvectorize
 from numba.core.errors import (NumbaDeprecationWarning,
                                NumbaPendingDeprecationWarning, NumbaWarning)
-from numba.tests.support import TestCase
+from numba.tests.support import TestCase, needs_setuptools
 
 
 @contextmanager
@@ -244,11 +244,11 @@ class TestDeprecation(TestCase):
         # @jit call.
         with _catch_numba_deprecation_warnings() as w:
             @vectorize('float64(float64)', forceobj=True)
-            def foo(x):
+            def foo(x): # noqa : F811
                 return bar(x + 1)
 
             @jit
-            def bar(x):
+            def bar(x): # noqa : F811
                 return x
 
         msg = "The 'nopython' keyword argument was not supplied"
@@ -354,6 +354,7 @@ class TestDeprecation(TestCase):
             self.check_warning(w, "numba.generated_jit is deprecated",
                                NumbaDeprecationWarning)
 
+    @needs_setuptools
     @TestCase.run_test_in_subprocess
     def test_pycc_module(self):
         # checks import of module warns
@@ -366,6 +367,7 @@ class TestDeprecation(TestCase):
             expected_str = ("The 'pycc' module is pending deprecation.")
             self.check_warning(w, expected_str, NumbaPendingDeprecationWarning)
 
+    @needs_setuptools
     @TestCase.run_test_in_subprocess
     def test_pycc_CC(self):
         # check the most commonly used functionality (CC) warns


### PR DESCRIPTION
This adds localised suppressions for `NumbaDeprecationWarning`s that would have been raised from the code path for `@{gu,}vectorize` due to Numba's internal use of `@jit()` with the `nopython` kwarg not present.

This is considered acceptable due to the following: Deprecation warnings from Numba's internal use of its own API should not be visible to users. Unfortunately there's no trivial programmatic way to work around the internal use of `@jit`-with-no-kwargs in this case as numerous code paths go through the same operations and user code may well be relying on "object mode" fall-back. What this patch does it makes it so that users will not see `NumbaDeprecationWarning`s for this internal use. However, if a user defines a `@{gu,}vectorize` function that ends up using the fall-back to the object mode pipeline during compilation, Numba will continue to raise numerous loud warnings about this happening which should provide a hint as to the problem and how to fix it.

Numerous tests have been added to check combinations of kwargs/use of default kwargs being passed through to `@{gu,}vectorize`. These tests make sure that there are no additional `NumbaDeprecationWarning`s raised to do with Numba's internal use of `@jit()` in `@{gu,}vectorize` where the `nopython` kwarg is not supplied.

Closes #8903

<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
