### PR TITLE
Fix year in change log

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,4 +1,4 @@
-Version 0.57.0 (1 May, 2022)
+Version 0.57.0 (1 May, 2023)
 ----------------------------
 
 This release continues to add new features, bug fixes and stability improvements


### PR DESCRIPTION
I just stumbled across this typo.

Same issue on the 0.57 release branch (https://github.com/numba/numba/blob/release0.57/CHANGE_LOG).