### PR TITLE
Fix 0.57 release changelog

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -402,7 +402,7 @@ Pull-Requests:
 * PR `#8909 <https://github.com/numba/numba/pull/8909>`_: Fix #8903. ``NumbaDeprecationWarning``s raised from ``@{gu,}vectorize``. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8929 <https://github.com/numba/numba/pull/8929>`_: Update CHANGE_LOG for 0.57.0 final. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8930 <https://github.com/numba/numba/pull/8930>`_: Fix year in change log (`jtilly <https://github.com/jtilly>`_)
-* PR `#8932 <https://github.com/numba/numba/pull/8932>`_: Fix 0.57 release changelog (`jtilly <https://github.com/jtilly>`_ `sklam <https://github.com/sklam>`_)
+* PR `#8932 <https://github.com/numba/numba/pull/8932>`_: Fix 0.57 release changelog (`sklam <https://github.com/sklam>`_)
 
 Authors:
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,4 +1,4 @@
-Version 0.57.0 (1 May, 2022)
+Version 0.57.0 (1 May, 2023)
 ----------------------------
 
 This release continues to add new features, bug fixes and stability improvements

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -402,6 +402,7 @@ Pull-Requests:
 * PR `#8909 <https://github.com/numba/numba/pull/8909>`_: Fix #8903. ``NumbaDeprecationWarning``s raised from ``@{gu,}vectorize``. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8929 <https://github.com/numba/numba/pull/8929>`_: Update CHANGE_LOG for 0.57.0 final. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8930 <https://github.com/numba/numba/pull/8930>`_: Fix year in change log (`jtilly <https://github.com/jtilly>`_)
+* PR `#8932 <https://github.com/numba/numba/pull/8932>`_: Fix 0.57 release changelog (`jtilly <https://github.com/jtilly>`_ `sklam <https://github.com/sklam>`_)
 
 Authors:
 
@@ -430,6 +431,7 @@ Authors:
 * `ianthomas23 <https://github.com/ianthomas23>`_
 * `jamesobutler <https://github.com/jamesobutler>`_
 * `jorgepiloto <https://github.com/jorgepiloto>`_
+* `jtilly <https://github.com/jtilly>`_
 * `k1m190r <https://github.com/k1m190r>`_
 * `kc611 <https://github.com/kc611>`_
 * `kozlov-alexey <https://github.com/kozlov-alexey>`_

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -401,6 +401,7 @@ Pull-Requests:
 * PR `#8907 <https://github.com/numba/numba/pull/8907>`_: Work around issue #8898. Defer ``exp2`` (and ``log2``) calls to Numba internal symbols. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8909 <https://github.com/numba/numba/pull/8909>`_: Fix #8903. ``NumbaDeprecationWarning``s raised from ``@{gu,}vectorize``. (`stuartarchibald <https://github.com/stuartarchibald>`_)
 * PR `#8929 <https://github.com/numba/numba/pull/8929>`_: Update CHANGE_LOG for 0.57.0 final. (`stuartarchibald <https://github.com/stuartarchibald>`_)
+* PR `#8930 <https://github.com/numba/numba/pull/8930>`_: Fix year in change log (`jtilly <https://github.com/jtilly>`_)
 
 Authors:
 


### PR DESCRIPTION
Combine https://github.com/numba/numba/pull/8930 and PR entry list update into one PR to reduce work.