### PR TITLE
Introduce internal _isinstance_no_warn

### DIFF
--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -754,7 +754,6 @@ def ol_isinstance(var, typs):
     # Warn about the experimental nature of this feature.
     msg = "Use of isinstance() detected. This is an experimental feature."
     warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
-    assert 0 # find which tests use isinstance
 
     return ol_isinstance_no_warn(var, typs)
 
@@ -788,10 +787,6 @@ def ol_isinstance_no_warn(var, typs):
     if not isinstance(var_ty, supported_var_ty):
         msg = f'isinstance() does not support variables of type "{var_ty}".'
         raise NumbaTypeError(msg)
-
-    # # Warn about the experimental nature of this feature.
-    # msg = "Use of isinstance() detected. This is an experimental feature."
-    # warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
 
     t_typs = typs
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -754,6 +754,7 @@ def ol_isinstance(var, typs):
     # Warn about the experimental nature of this feature.
     msg = "Use of isinstance() detected. This is an experimental feature."
     warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
+    assert 0 # find which tests use isinstance
 
     return ol_isinstance_no_warn(var, typs)
 

--- a/numba/cpython/builtins.py
+++ b/numba/cpython/builtins.py
@@ -745,8 +745,21 @@ def ol_filter(func, iterable):
     return impl
 
 
+def _isinstance_no_warn(var, typs):
+    pass
+
+
 @overload(isinstance)
 def ol_isinstance(var, typs):
+    # Warn about the experimental nature of this feature.
+    msg = "Use of isinstance() detected. This is an experimental feature."
+    warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
+
+    return ol_isinstance_no_warn(var, typs)
+
+
+@overload(_isinstance_no_warn)
+def ol_isinstance_no_warn(var, typs):
 
     def true_impl(var, typs):
         return True
@@ -775,9 +788,9 @@ def ol_isinstance(var, typs):
         msg = f'isinstance() does not support variables of type "{var_ty}".'
         raise NumbaTypeError(msg)
 
-    # Warn about the experimental nature of this feature.
-    msg = "Use of isinstance() detected. This is an experimental feature."
-    warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
+    # # Warn about the experimental nature of this feature.
+    # msg = "Use of isinstance() detected. This is an experimental feature."
+    # warnings.warn(msg, category=NumbaExperimentalFeatureWarning)
 
     t_typs = typs
 

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3371,6 +3371,8 @@ def ov_np_where_x_y(condition, x, y):
     x_arr = isinstance(x, types.Array)
     y_arr = isinstance(y, types.Array)
 
+    from numba.cpython.builtins import _isinstance_no_warn
+
     if cond_arr:
         x_dt = determine_dtype(x)
         y_dt = determine_dtype(y)
@@ -3378,8 +3380,8 @@ def ov_np_where_x_y(condition, x, y):
 
         # corner case - 0 dim values
         def check_0_dim(arg):
-            return isinstance(arg, types.Number) or (
-                isinstance(arg, types.Array) and arg.ndim == 0)
+            return _isinstance_no_warn(arg, types.Number) or (
+                _isinstance_no_warn(arg, types.Array) and arg.ndim == 0)
         special_0_case = all([check_0_dim(a) for a in (condition, x, y)])
         if special_0_case:
             return _where_zero_size_array_impl(dtype)

--- a/numba/np/arraymath.py
+++ b/numba/np/arraymath.py
@@ -3371,8 +3371,6 @@ def ov_np_where_x_y(condition, x, y):
     x_arr = isinstance(x, types.Array)
     y_arr = isinstance(y, types.Array)
 
-    from numba.cpython.builtins import _isinstance_no_warn
-
     if cond_arr:
         x_dt = determine_dtype(x)
         y_dt = determine_dtype(y)
@@ -3380,8 +3378,8 @@ def ov_np_where_x_y(condition, x, y):
 
         # corner case - 0 dim values
         def check_0_dim(arg):
-            return _isinstance_no_warn(arg, types.Number) or (
-                _isinstance_no_warn(arg, types.Array) and arg.ndim == 0)
+            return isinstance(arg, types.Number) or (
+                isinstance(arg, types.Array) and arg.ndim == 0)
         special_0_case = all([check_0_dim(a) for a in (condition, x, y)])
         if special_0_case:
             return _where_zero_size_array_impl(dtype)

--- a/numba/np/arrayobj.py
+++ b/numba/np/arrayobj.py
@@ -1543,14 +1543,16 @@ def ol_numpy_broadcast_shapes(*args):
     else:
         tup_init = (1,) * m
 
+        from numba.cpython.builtins import _isinstance_no_warn
+
         def impl(*args):
             # propagate args
             r = [1] * m
             tup = tup_init
             for arg in literal_unroll(args):
-                if isinstance(arg, tuple) and len(arg) > 0:
+                if _isinstance_no_warn(arg, tuple) and len(arg) > 0:
                     numpy_broadcast_shapes_list(r, m, arg)
-                elif isinstance(arg, int):
+                elif _isinstance_no_warn(arg, int):
                     numpy_broadcast_shapes_list(r, m, (arg,))
             for idx, elem in enumerate(r):
                 tup = tuple_setitem(tup, idx, elem)

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -8,7 +8,8 @@ import numpy as np
 from numba import jit, typeof
 from numba.core import types
 from numba.core.compiler import compile_isolated
-from numba.core.errors import TypingError, LoweringError, NumbaValueError
+from numba.core.errors import (TypingError, LoweringError, NumbaValueError,
+                               NumbaExperimentalFeatureWarning)
 from numba.np.numpy_support import as_dtype, numpy_version
 from numba.tests.support import (TestCase, CompilationCache, MemoryLeak,
                                  MemoryLeakMixin, tag, needs_blas)
@@ -783,6 +784,22 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
     def test_np_where_1(self):
         self.check_nonzero(np_where_1)
+
+    def test_np_where_no_isinstance_warn(self):
+        # TODO: remove this test before Numba 0.58 release
+        msg = 'Use of isinstance() detected. This is an experimental feature.'
+        category = NumbaExperimentalFeatureWarning
+        a = np.arange(10)
+        cfunc = jit(nopython=True)(np_where_3)
+
+        with warnings.catch_warnings(record=True) as catch:
+            cfunc(a < 5, a, 10 * a)
+
+            found = False
+            for w in catch:
+                if msg in str(w.message) and w.category == category:
+                    found = True
+            self.assertFalse(found)
 
     def test_np_where_3(self):
         pyfunc = np_where_3

--- a/numba/tests/test_array_methods.py
+++ b/numba/tests/test_array_methods.py
@@ -787,6 +787,7 @@ class TestArrayMethods(MemoryLeakMixin, TestCase):
 
     def test_np_where_no_isinstance_warn(self):
         # TODO: remove this test before Numba 0.58 release
+        # When _isinstance_no_warn has been removed.
         msg = 'Use of isinstance() detected. This is an experimental feature.'
         category = NumbaExperimentalFeatureWarning
         a = np.arange(10)


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities here, please click the arrow besides
   "Create Pull Request" and choose "Create Draft Pull Request".
   When it's ready for review, you can click the button "ready to review" near
   the end of the pull request
   (besides "This pull request is still a work in progress".)
   The maintainers will then be automatically notified to review it.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on main/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against main they should
   be resolved by merging main into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

Fix https://github.com/numba/numba/issues/8936. Replaces internal uses of `isinstance` by `_isinstance_no_warn` and should be reverted once Numba 0.58 lands with patch from #8911 
