### PR TITLE
Fix math.pow with int64 argument for CUDA

### DIFF
--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -99,6 +99,8 @@ class Math_pow(ConcreteTemplate):
     cases = [
         signature(types.float32, types.float32, types.float32),
         signature(types.float64, types.float64, types.float64),
+        signature(types.float64, types.float64, types.int64),
+        signature(types.float64, types.float64, types.uint64),
         signature(types.float32, types.float32, types.int32),
         signature(types.float64, types.float64, types.int32),
     ]

--- a/numba/cuda/cudamath.py
+++ b/numba/cuda/cudamath.py
@@ -102,7 +102,6 @@ class Math_pow(ConcreteTemplate):
         signature(types.float64, types.float64, types.int64),
         signature(types.float64, types.float64, types.uint64),
         signature(types.float32, types.float32, types.int32),
-        signature(types.float64, types.float64, types.int32),
     ]
 
 

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -334,7 +334,6 @@ def impl_pow_int(ty, libfunc):
 
 def impl_pow_int64(ty, int_ty):
     def lower_pow_impl_int64(context, builder, sig, args):
-        print("In lower_pow_impl_int64")
         return int_power_impl(context, builder, sig, args)
 
     lower(math.pow, ty, int_ty)(lower_pow_impl_int64)

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -3,10 +3,10 @@ import operator
 from llvmlite import ir
 from numba.core import types, typing, cgutils, targetconfig
 from numba.core.imputils import Registry
-from numba.cpython.numbers import int_power_impl
 from numba.types import float32, float64, int64, uint64
 from numba.cuda import libdevice
 from numba import cuda
+import numpy as np
 
 registry = Registry()
 lower = registry.lower
@@ -331,12 +331,55 @@ def impl_pow_int(ty, libfunc):
 
     lower(math.pow, ty, types.int32)(lower_pow_impl_int)
 
+# Copied from cpython/numbers.py
+# Copied to eliminate test case failure in
+# test_import.py
+#
+# Also copied and modified to remove exception
+# raising which is not supported in CUDA.
+
+
+def int_power_impl(context, builder, sig, args):
+    """
+    a ^ b, where a is an integer or real, and b an integer
+    """
+    is_integer = isinstance(sig.args[0], types.Integer)
+    tp = sig.return_type
+
+    def int_power(a, b):
+        # Ensure computations are done with a large enough width
+        r = tp(1)
+        a = tp(a)
+        if b < 0:
+            invert = True
+            exp = -b
+            if exp < 0:
+                return np.nan
+            if is_integer:
+                if a == 0:
+                    return -1 << (tp.bitwidth - 1)
+                if a != 1 and a != -1:
+                    return 0
+        else:
+            invert = False
+            exp = b
+        if exp > 0x10000:
+            # Optimization cutoff: fallback on the generic algorithm
+            return math.pow(a, float(b))
+        while exp != 0:
+            if exp & 1:
+                r *= a
+            exp >>= 1
+            a *= a
+
+        return 1.0 / r if invert else r
+
+    res = context.compile_internal(builder, int_power, sig, args)
+    return res
+
 
 def impl_pow_int64(ty, int_ty):
-    def lower_pow_impl_int64(context, builder, sig, args):
-        return int_power_impl(context, builder, sig, args)
-
-    lower(math.pow, ty, int_ty)(lower_pow_impl_int64)
+    lower(math.pow, ty, int_ty)(int_power_impl)
 
 
 impl_pow_int(types.float32, libdevice.powif)

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -6,7 +6,7 @@ from numba.core.imputils import Registry
 from numba.types import float32, float64, int64, uint64
 from numba.cuda import libdevice
 from numba import cuda
-import numpy as np
+
 
 registry = Registry()
 lower = registry.lower
@@ -331,10 +331,12 @@ def impl_pow_int(ty, libfunc):
 
     lower(math.pow, ty, types.int32)(lower_pow_impl_int)
 
+
 def register_int_power_impls():
     # int_power_impl is used because libdevice.powi has slightly different
-    # semantics to math.pow. See Issue #8218 
+    # semantics to math.pow. See Issue #8218
     from numba.cpython.numbers import int_power_impl
+
     def impl_pow_int64(ty, int_ty):
         lower(math.pow, ty, int_ty)(int_power_impl)
 
@@ -343,6 +345,7 @@ def register_int_power_impls():
 
 
 impl_pow_int(types.float32, libdevice.powif)
+
 
 def impl_modf(ty, libfunc):
     retty = types.UniTuple(ty, 2)

--- a/numba/cuda/mathimpl.py
+++ b/numba/cuda/mathimpl.py
@@ -344,10 +344,6 @@ def register_int_power_impls():
 
 impl_pow_int(types.float32, libdevice.powif)
 
-impl_pow_int64(types.float64, int64)
-impl_pow_int64(types.float64, uint64)
-
-
 def impl_modf(ty, libfunc):
     retty = types.UniTuple(ty, 2)
 

--- a/numba/cuda/target.py
+++ b/numba/cuda/target.py
@@ -10,6 +10,7 @@ from numba.core.base import BaseContext
 from numba.core.callconv import MinimalCallConv
 from numba.core.typing import cmathdecl
 from numba.core import datamodel
+from numba.cuda.mathimpl import register_int_power_impls
 
 from .cudadrv import nvvm
 from numba.cuda import codegen, nvvmutils, ufuncs
@@ -119,6 +120,7 @@ class CUDATargetContext(BaseContext):
         self.install_registry(cmathimpl.registry)
         self.install_registry(mathimpl.registry)
         self.install_registry(vector_types.impl_registry)
+        register_int_power_impls()
 
     def codegen(self):
         return self._internal_codegen

--- a/numba/cuda/tests/cudapy/test_powi.py
+++ b/numba/cuda/tests/cudapy/test_powi.py
@@ -71,31 +71,23 @@ class TestCudaPowi(CUDATestCase):
         kernel[1, A.shape](A, power, Aout)
         self.assertTrue(np.allclose(Aout, A ** power))
 
-    def test_powi_int64(self):
-        dec = cuda.jit(void(float64[:, :], int64, float64[:, :]))
+    def _run_test(self, dtype):
+        dec = cuda.jit(void(float64[:, :], dtype, float64[:, :]))
         kernel = dec(cu_mat_power_v2)
 
         A = np.arange(10, dtype=np.float64).reshape(2, 5)
         Aout = np.empty_like(A)
 
         for power in range(1, 11):
-            power = np.int64(power)
+            power = dtype(power)
             kernel[1, A.shape](A, power, Aout)
-            result = np.allclose(Aout, A ** power)
-            self.assertTrue(result, f"Failed on int64 power {power}")
+            np.testing.assert_allclose(Aout, A ** power)
+
+    def test_powi_int64(self):
+        self._run_test(int64)
 
     def test_powi_uint64(self):
-        dec = cuda.jit(void(float64[:, :], uint64, float64[:, :]))
-        kernel = dec(cu_mat_power_v2)
-
-        A = np.arange(10, dtype=np.float64).reshape(2, 5)
-        Aout = np.empty_like(A)
-
-        for power in range(1, 11):
-            power = np.uint64(power)
-            kernel[1, A.shape](A, power, Aout)
-            result = np.allclose(Aout, A ** power)
-            self.assertTrue(result, f"Failed on uint64 power {power}")
+        self._run_test(uint64)
 
     def test_powi_binop(self):
         dec = cuda.jit(void(float64[:, :], int8, float64[:, :]))


### PR DESCRIPTION
This pull request addresses an issue on the CUDA target where a [u]int64 argument to math.pow can produce incorrect results. The issue is detailed in this [bug report](https://github.com/numba/numba/issues/8218).