### PR TITLE
Cherry-pick #8895 into release0.57 (CUDA: Enable caching functions that use CG)

### DIFF
--- a/numba/cuda/dispatcher.py
+++ b/numba/cuda/dispatcher.py
@@ -16,7 +16,6 @@ from numba.cuda.args import wrap_arg
 from numba.cuda.compiler import compile_cuda, CUDACompiler
 from numba.cuda.cudadrv import driver
 from numba.cuda.cudadrv.devices import get_context
-from numba.cuda.cudadrv.libs import get_cudalib
 from numba.cuda.descriptor import cuda_target
 from numba.cuda.errors import (missing_launch_config_msg,
                                normalize_kernel_dimensions)
@@ -104,7 +103,7 @@ class _Kernel(serialize.ReduceMixin):
         self.cooperative = 'cudaCGGetIntrinsicHandle' in lib.get_asm_str()
         # We need to link against cudadevrt if grid sync is being used.
         if self.cooperative:
-            link.append(get_cudalib('cudadevrt', static=True))
+            lib.needs_cudadevrt = True
 
         res = [fn for fn in cuda_fp16_math_funcs
                if (f'__numba_wrapper_{fn}' in lib.get_asm_str())]

--- a/numba/cuda/tests/cudapy/cache_usecases.py
+++ b/numba/cuda/tests/cudapy/cache_usecases.py
@@ -198,6 +198,17 @@ def simple_usecase_kernel(r, x):
 simple_usecase_caller = CUDAUseCase(simple_usecase_kernel)
 
 
+# Usecase with cooperative groups
+
+@cuda.jit(cache=True)
+def cg_usecase_kernel(r, x):
+    grid = cuda.cg.this_grid()
+    grid.sync()
+
+
+cg_usecase = CUDAUseCase(cg_usecase_kernel)
+
+
 class _TestModule(CUDATestCase):
     """
     Tests for functionality of this module's functions.

--- a/numba/cuda/tests/cudapy/test_caching.py
+++ b/numba/cuda/tests/cudapy/test_caching.py
@@ -6,8 +6,9 @@ import warnings
 
 from numba import cuda
 from numba.core.errors import NumbaWarning
-from numba.cuda.codegen import CUDACodeLibrary
-from numba.cuda.testing import CUDATestCase, skip_on_cudasim, test_data_dir
+from numba.cuda.testing import (CUDATestCase, skip_on_cudasim,
+                                skip_unless_cc_60, skip_if_cudadevrt_missing,
+                                skip_if_mvc_enabled, test_data_dir)
 from numba.tests.support import SerialMixin
 from numba.tests.test_caching import (DispatcherCacheUsecasesTest,
                                       skip_bad_access)
@@ -152,6 +153,22 @@ class CUDACachingTest(SerialMixin, DispatcherCacheUsecasesTest):
         self.assertPreciseEqual(f(2), 4)
         f = mod.renamed_function2
         self.assertPreciseEqual(f(2), 8)
+
+    @skip_unless_cc_60
+    @skip_if_cudadevrt_missing
+    @skip_if_mvc_enabled('CG not supported with MVC')
+    def test_cache_cg(self):
+        # Functions using cooperative groups should be cacheable. See Issue
+        # #8888: https://github.com/numba/numba/issues/8888
+        self.check_pycache(0)
+        mod = self.import_module()
+        self.check_pycache(0)
+
+        mod.cg_usecase(0)
+        self.check_pycache(2)  # 1 index, 1 data
+
+        # Check the code runs ok from another process
+        self.run_in_separate_process()
 
     def _test_pycache_fallback(self):
         """
@@ -482,6 +499,10 @@ class TestCUDACodeLibrary(CUDATestCase):
     # explicitly check
 
     def test_cannot_serialize_unfinalized(self):
+        # The CUDA codegen failes to import under the simulator, so we cannot
+        # import it at the top level
+        from numba.cuda.codegen import CUDACodeLibrary
+
         # Usually a CodeLibrary requires a real CodeGen, but since we don't
         # interact with it, anything will do
         codegen = object()


### PR DESCRIPTION
This is based on PR #8895 which was merged into `main`.

I've tested this with RAPIDS and it appears not to introduce any regressions, so I have more confidence in introducing this to 0.57.1 (as discussed in last week's Numba dev / triage meetings).

Original commit / PR message follows:

> Caching functions that use Cooperative Groups was blocked because the dispatcher adds a file to link, the `cudadevrt` cudalib, to the code library, and pickling code libraries with linking files is not supported.
>
> To enable caching of functions that use cooperative groups, we push the linking of `cudadevrt` into the code library. We push it in here rather than special-casing the check for linked libraries because a recompile of a cached function (e.g. for a different compute capability) might require `cudadevrt` from a different location to the one found during the initial compile; locating the library at the cubin linking time ensures the correct version will be used.