### PR TITLE
Fix index URL for ptxcompiler/cubinlinker packages.

### DIFF
--- a/docs/source/cuda/minor_version_compatibility.rst
+++ b/docs/source/cuda/minor_version_compatibility.rst
@@ -37,7 +37,7 @@ To install with pip, use the NVIDIA package index:
 
 .. code:: bash
 
-   pip install ptxcompiler-cu11 cubinlinker-cu11 --extra-index-url=https://pypi.ngc.nvidia.com
+   pip install ptxcompiler-cu11 cubinlinker-cu11 --extra-index-url=https://pypi.nvidia.com
 
 MVC support is enabled by setting the environment variable:
 


### PR DESCRIPTION
This PR fixes an outdated index URL for the `ptxcompiler-cu11` and `cubinlinker-cu11` packages. The URL should be `pypi.nvidia.com` rather than `pypi.ngc.nvidia.com`.