### PR TITLE
Import MVC packages when using MVCLinker.

### DIFF
--- a/numba/cuda/tests/cudadrv/test_mvc.py
+++ b/numba/cuda/tests/cudadrv/test_mvc.py
@@ -1,0 +1,47 @@
+import multiprocessing as mp
+import traceback
+from numba.cuda.testing import unittest, CUDATestCase
+
+
+def child_test():
+    from numba import config, cuda
+
+    # Change the MVC config after importing numba.cuda
+    config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = 1
+
+    @cuda.jit
+    def f():
+        pass
+
+    f[1, 1, 0]()
+
+
+def child_test_wrapper(result_queue):
+    try:
+        output = child_test()
+        success = True
+    # Catch anything raised so it can be propagated
+    except: # noqa: E722
+        output = traceback.format_exc()
+        success = False
+
+    result_queue.put((success, output))
+
+
+class TestMinorVersionCompatibility(CUDATestCase):
+    def test_mvc(self):
+        # Run a test with MinorVersionCompatibility enabled in a child process
+        ctx = mp.get_context('spawn')
+        result_queue = ctx.Queue()
+        proc = ctx.Process(target=child_test_wrapper, args=(result_queue,))
+        proc.start()
+        proc.join()
+        success, output = result_queue.get()
+
+        # Ensure the child process ran to completion before checking its output
+        if not success:
+            self.fail(output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/cuda/tests/cudadrv/test_mvc.py
+++ b/numba/cuda/tests/cudadrv/test_mvc.py
@@ -1,6 +1,8 @@
 import multiprocessing as mp
 import traceback
 from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim
+from numba.tests.support import linux_only
 
 
 def child_test():
@@ -28,6 +30,8 @@ def child_test_wrapper(result_queue):
     result_queue.put((success, output))
 
 
+@linux_only
+@skip_on_cudasim('MVC tests not needed on simulator')
 class TestMinorVersionCompatibility(CUDATestCase):
     def test_mvc(self):
         # Run test with Minor Version Compatibility enabled in a child process

--- a/numba/cuda/tests/cudadrv/test_mvc.py
+++ b/numba/cuda/tests/cudadrv/test_mvc.py
@@ -1,7 +1,7 @@
 import multiprocessing as mp
 import traceback
 from numba.cuda.testing import unittest, CUDATestCase
-from numba.cuda.testing import skip_on_cudasim
+from numba.cuda.testing import skip_on_cudasim, skip_under_cuda_memcheck
 from numba.tests.support import linux_only
 
 
@@ -31,7 +31,8 @@ def child_test_wrapper(result_queue):
 
 
 @linux_only
-@skip_on_cudasim('MVC tests not needed on simulator')
+@skip_under_cuda_memcheck('May hang CUDA memcheck')
+@skip_on_cudasim('Simulator does not require or implement MVC')
 class TestMinorVersionCompatibility(CUDATestCase):
     def test_mvc(self):
         # Run test with Minor Version Compatibility enabled in a child process

--- a/numba/cuda/tests/cudadrv/test_mvc.py
+++ b/numba/cuda/tests/cudadrv/test_mvc.py
@@ -30,7 +30,7 @@ def child_test_wrapper(result_queue):
 
 class TestMinorVersionCompatibility(CUDATestCase):
     def test_mvc(self):
-        # Run a test with MinorVersionCompatibility enabled in a child process
+        # Run test with Minor Version Compatibility enabled in a child process
         ctx = mp.get_context('spawn')
         result_queue = ctx.Queue()
         proc = ctx.Process(target=child_test_wrapper, args=(result_queue,))

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -392,8 +392,7 @@ def get_sysinfo():
                 sys_info[_cu_mvc_available] = False
 
             sys_info[_cu_mvc_needed] = cu_rt_ver > cu_drv_ver
-            mvc_used = hasattr(cudadrv.driver, 'CubinLinker')
-            sys_info[_cu_mvc_in_use] = mvc_used
+            sys_info[_cu_mvc_in_use] = config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY
         except Exception as e:
             _warning_log.append(
                 "Warning (cuda): Probing CUDA failed "


### PR DESCRIPTION
Closes #8977.

The previous behavior conditionally imported `ptxcompiler` and `cubinlinker` when importing `numba.cuda`. This PR changes that behavior to perform the imports of `ptxcompiler` and `cubinlinker` as late as possible, when instantiating `MVCLinker`.

This change fixes the `NameError` while preserving a helpful error message if `ptxcompiler` or `cubinlinker` are not available. Now that error occurs when instantiating the linker rather than at `numba.cuda` import time.