### PR TITLE
Cherry-pick #8976 (fix index URL for ptxcompiler/cubinlinker packages) for Release 0.57.1

### DIFF
--- a/docs/source/cuda/minor_version_compatibility.rst
+++ b/docs/source/cuda/minor_version_compatibility.rst
@@ -37,7 +37,7 @@ To install with pip, use the NVIDIA package index:
 
 .. code:: bash
 
-   pip install ptxcompiler-cu11 cubinlinker-cu11 --extra-index-url=https://pypi.ngc.nvidia.com
+   pip install ptxcompiler-cu11 cubinlinker-cu11 --extra-index-url=https://pypi.nvidia.com
 
 MVC support is enabled by setting the environment variable:
 


### PR DESCRIPTION
This cherry-pick incorporates a doc update that fixes the PyPI index URL for MVC packages - the motivation for including this on the release branch is so that the correct URLs show up in the docs for the "stable" release as well as the "latest", following the release of 0.57.1. (Discussed previously with @stuartarchibald in FPOC discussion)

cc @bdice 