### PR TITLE
[CI only] Use nightly build of cubinlinker

### DIFF
--- a/buildscripts/gpuci/build.sh
+++ b/buildscripts/gpuci/build.sh
@@ -63,7 +63,7 @@ gpuci_logger "Create testing env"
 gpuci_mamba_retry create -n numba_ci -y \
                   "python=${PYTHON_VER}" \
                   "cudatoolkit=${CUDA_TOOLKIT_VER}" \
-                  "rapidsai::cubinlinker" \
+                  "rapidsai-nightly::cubinlinker" \
                   "conda-forge::ptxcompiler" \
                   "numba/label/dev::llvmlite" \
                   "${NUMPY_CHANNEL_PKG}=${NUMPY_VER}" \


### PR DESCRIPTION
This is to test cubinlinker 0.3.0 on CI ahead of promoting it to the main RAPIDS channel. It is not intended to be merged into Numba.