### PR TITLE
support for latest CUDA driver codes #8363

### DIFF
--- a/numba/cuda/cudadrv/enums.py
+++ b/numba/cuda/cudadrv/enums.py
@@ -1,8 +1,10 @@
 """
 Enum values for CUDA driver. Information about the values
 can be found on the official NVIDIA documentation website.
-ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES
+ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html
+anchor: #group__CUDA__TYPES
 """
+
 
 # Error codes
 
@@ -168,19 +170,19 @@ CU_MEMHOSTREGISTER_PORTABLE = 0x01
 # Flag for cuMemHostRegister()
 CU_MEMHOSTREGISTER_DEVICEMAP = 0x02
 
-# If set, the passed memory pointer is treated as pointing to some 
+# If set, the passed memory pointer is treated as pointing to some
 # memory-mapped I/O space, e.g. belonging to a third-party PCIe device.
-# On Windows the flag is a no-op. On Linux that memory is marked 
+# On Windows the flag is a no-op. On Linux that memory is marked
 # as non cache-coherent for the GPU and is expected
 # to be physically contiguous. It may return CUDA_ERROR_NOT_PERMITTED
 # if run as an unprivileged user, CUDA_ERROR_NOT_SUPPORTED on older
-# Linux kernel versions. On all other platforms, it is not supported 
-# and CUDA_ERROR_NOT_SUPPORTED is returned. 
+# Linux kernel versions. On all other platforms, it is not supported
+# and CUDA_ERROR_NOT_SUPPORTED is returned.
 # Flag for cuMemHostRegister()
 CU_MEMHOSTREGISTER_IOMEMORY = 0x04
 
 # If set, the passed memory pointer is treated as pointing to memory
-# that is considered read-only by the device. On platforms without 
+# that is considered read-only by the device. On platforms without
 # CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
 # this flag is required in order to register memory mapped
 # to the CPU as read-only. Support for the use of this flag can be
@@ -268,7 +270,8 @@ CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17
 CU_POINTER_ATTRIBUTE_MAPPING_SIZE = 18
 # The start address of the mapping that the pointer belongs to
 CU_POINTER_ATTRIBUTE_MAPPING_BASE_ADDR = 19
-# A process-wide unique id corresponding to the physical allocation the pointer belongs to
+# A process-wide unique id corresponding to the
+# physical allocation the pointer belongs to
 CU_POINTER_ATTRIBUTE_MEMORY_BLOCK_ID = 20
 
 
@@ -461,7 +464,8 @@ CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8
 # in percent of the total shared memory. Refer to
 # CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR.
 # This is only a hint, and the driver can choose a different ratio
-# if required to execute the function. See cuFuncSetAttribute, cuKernelSetAttribute
+# if required to execute the function.
+# See cuFuncSetAttribute, cuKernelSetAttribute
 CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9
 
 # If this attribute is set, the kernel must launch with a valid cluster
@@ -494,7 +498,7 @@ CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH = 13
 
 # Whether the function can be launched with non-portable cluster size.
 # 1 is allowed, 0 is disallowed. A non-portable cluster size may only
-# function on the specific SKUs the program is tested on. 
+# function on the specific SKUs the program is tested on.
 # The launch might fail if the program is run on a different hardware platform.
 # For more details refer to link :
 # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES
@@ -506,8 +510,8 @@ CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED = 14
 CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = 15
 
 
-
 # Device attributes
+
 CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
 CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2
 CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3

--- a/numba/cuda/cudadrv/enums.py
+++ b/numba/cuda/cudadrv/enums.py
@@ -1,7 +1,10 @@
 """
-Enum values for CUDA driver
+Enum values for CUDA driver. Information about the values
+can be found on the official NVIDIA documentation website.
+ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES
 """
 
+# Error codes
 
 CUDA_SUCCESS = 0
 CUDA_ERROR_INVALID_VALUE = 1
@@ -12,8 +15,11 @@ CUDA_ERROR_PROFILER_DISABLED = 5
 CUDA_ERROR_PROFILER_NOT_INITIALIZED = 6
 CUDA_ERROR_PROFILER_ALREADY_STARTED = 7
 CUDA_ERROR_PROFILER_ALREADY_STOPPED = 8
+CUDA_ERROR_STUB_LIBRARY = 34
+CUDA_ERROR_DEVICE_UNAVAILABLE = 46
 CUDA_ERROR_NO_DEVICE = 100
 CUDA_ERROR_INVALID_DEVICE = 101
+CUDA_ERROR_DEVICE_NOT_LICENSED = 102
 CUDA_ERROR_INVALID_IMAGE = 200
 CUDA_ERROR_INVALID_CONTEXT = 201
 CUDA_ERROR_CONTEXT_ALREADY_CURRENT = 202
@@ -29,12 +35,22 @@ CUDA_ERROR_NOT_MAPPED_AS_POINTER = 213
 CUDA_ERROR_ECC_UNCORRECTABLE = 214
 CUDA_ERROR_UNSUPPORTED_LIMIT = 215
 CUDA_ERROR_CONTEXT_ALREADY_IN_USE = 216
+CUDA_ERROR_PEER_ACCESS_UNSUPPORTED = 217
+CUDA_ERROR_INVALID_PTX = 218
+CUDA_ERROR_INVALID_GRAPHICS_CONTEXT = 219
+CUDA_ERROR_NVLINK_UNCORRECTABLE = 220
+CUDA_ERROR_JIT_COMPILER_NOT_FOUND = 221
+CUDA_ERROR_UNSUPPORTED_PTX_VERSION = 222
+CUDA_ERROR_JIT_COMPILATION_DISABLED = 223
+CUDA_ERROR_UNSUPPORTED_EXEC_AFFINITY = 224
+CUDA_ERROR_UNSUPPORTED_DEVSIDE_SYNC = 225
 CUDA_ERROR_INVALID_SOURCE = 300
 CUDA_ERROR_FILE_NOT_FOUND = 301
 CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302
 CUDA_ERROR_SHARED_OBJECT_INIT_FAILED = 303
 CUDA_ERROR_OPERATING_SYSTEM = 304
 CUDA_ERROR_INVALID_HANDLE = 400
+CUDA_ERROR_ILLEGAL_STATE = 401
 CUDA_ERROR_NOT_FOUND = 500
 CUDA_ERROR_NOT_READY = 600
 CUDA_ERROR_LAUNCH_FAILED = 700
@@ -58,8 +74,34 @@ CUDA_ERROR_LAUNCH_FAILED = 719
 CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE = 720
 CUDA_ERROR_NOT_PERMITTED = 800
 CUDA_ERROR_NOT_SUPPORTED = 801
+CUDA_ERROR_SYSTEM_NOT_READY = 802
+CUDA_ERROR_SYSTEM_DRIVER_MISMATCH = 803
+CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE = 804
+CUDA_ERROR_MPS_CONNECTION_FAILED = 805
+CUDA_ERROR_MPS_RPC_FAILURE = 806
+CUDA_ERROR_MPS_SERVER_NOT_READY = 807
+CUDA_ERROR_MPS_MAX_CLIENTS_REACHED = 808
+CUDA_ERROR_MPS_MAX_CONNECTIONS_REACHED = 809
+CUDA_ERROR_MPS_CLIENT_TERMINATED = 810
+CUDA_ERROR_CDP_NOT_SUPPORTED = 811
+CUDA_ERROR_CDP_VERSION_MISMATCH = 812
+CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED = 900
+CUDA_ERROR_STREAM_CAPTURE_INVALIDATED = 901
+CUDA_ERROR_STREAM_CAPTURE_MERGE = 902
+CUDA_ERROR_STREAM_CAPTURE_UNMATCHED = 903
+CUDA_ERROR_STREAM_CAPTURE_UNJOINED = 904
+CUDA_ERROR_STREAM_CAPTURE_ISOLATION = 905
+CUDA_ERROR_STREAM_CAPTURE_IMPLICIT = 906
+CUDA_ERROR_CAPTURED_EVENT = 907
+CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD = 908
+CUDA_ERROR_TIMEOUT = 909
+CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE = 910
+CUDA_ERROR_EXTERNAL_DEVICE = 911
+CUDA_ERROR_INVALID_CLUSTER_SIZE = 912
 CUDA_ERROR_UNKNOWN = 999
 
+
+# Function cache configurations
 
 # no preference for shared memory or L1 (default)
 CU_FUNC_CACHE_PREFER_NONE = 0x00
@@ -69,6 +111,9 @@ CU_FUNC_CACHE_PREFER_SHARED = 0x01
 CU_FUNC_CACHE_PREFER_L1 = 0x02
 # prefer equal sized L1 cache and shared memory
 CU_FUNC_CACHE_PREFER_EQUAL = 0x03
+
+
+# Context creation flags
 
 # Automatic scheduling
 CU_CTX_SCHED_AUTO = 0x00
@@ -80,14 +125,23 @@ CU_CTX_SCHED_YIELD = 0x02
 CU_CTX_SCHED_BLOCKING_SYNC = 0x04
 
 CU_CTX_SCHED_MASK = 0x07
-
 # Support mapped pinned allocations
+#   This flag was deprecated as of CUDA 11.0 and it no longer has effect.
+#   All contexts as of CUDA 3.2 behave as though the flag is enabled.
 CU_CTX_MAP_HOST = 0x08
 # Keep local memory allocation after launch
 CU_CTX_LMEM_RESIZE_TO_MAX = 0x10
+# Trigger coredumps from exceptions in this context
+CU_CTX_COREDUMP_ENABLE = 0x20
+# Enable user pipe to trigger coredumps in this context
+CU_CTX_USER_COREDUMP_ENABLE = 0x40
+# Force synchronous blocking on cudaMemcpy/cudaMemset
+CU_CTX_SYNC_MEMOPS = 0x80
 
-CU_CTX_FLAGS_MASK = 0x1f
+CU_CTX_FLAGS_MASK = 0xff
 
+
+# DEFINES
 
 # If set, host memory is portable between CUDA contexts.
 # Flag for cuMemHostAlloc()
@@ -104,6 +158,7 @@ CU_MEMHOSTALLOC_DEVICEMAP = 0x02
 # Flag for cuMemHostAlloc()
 CU_MEMHOSTALLOC_WRITECOMBINED = 0x04
 
+
 # If set, host memory is portable between CUDA contexts.
 # Flag for cuMemHostRegister()
 CU_MEMHOSTREGISTER_PORTABLE = 0x01
@@ -113,6 +168,31 @@ CU_MEMHOSTREGISTER_PORTABLE = 0x01
 # Flag for cuMemHostRegister()
 CU_MEMHOSTREGISTER_DEVICEMAP = 0x02
 
+# If set, the passed memory pointer is treated as pointing to some 
+# memory-mapped I/O space, e.g. belonging to a third-party PCIe device.
+# On Windows the flag is a no-op. On Linux that memory is marked 
+# as non cache-coherent for the GPU and is expected
+# to be physically contiguous. It may return CUDA_ERROR_NOT_PERMITTED
+# if run as an unprivileged user, CUDA_ERROR_NOT_SUPPORTED on older
+# Linux kernel versions. On all other platforms, it is not supported 
+# and CUDA_ERROR_NOT_SUPPORTED is returned. 
+# Flag for cuMemHostRegister()
+CU_MEMHOSTREGISTER_IOMEMORY = 0x04
+
+# If set, the passed memory pointer is treated as pointing to memory
+# that is considered read-only by the device. On platforms without 
+# CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
+# this flag is required in order to register memory mapped
+# to the CPU as read-only. Support for the use of this flag can be
+# queried from the device attribute
+# CU_DEVICE_ATTRIBUTE_READ_ONLY_HOST_REGISTER_SUPPORTED.
+# Using this flag with a current context associated with a device
+# that does not have this attribute set will cause cuMemHostRegister
+# to error with CUDA_ERROR_NOT_SUPPORTED.
+CU_MEMHOSTREGISTER_READ_ONLY = 0x08
+
+
+# CUDA Mem Attach Flags
 
 # If set, managed memory is accessible from all streams on all devices.
 CU_MEM_ATTACH_GLOBAL = 0x01
@@ -130,6 +210,8 @@ CU_MEM_ATTACH_HOST = 0x02
 CU_MEM_ATTACH_SINGLE = 0x04
 
 
+# Event creation flags
+
 # Default event flag
 CU_EVENT_DEFAULT = 0x0
 # Event uses blocking synchronization
@@ -138,6 +220,9 @@ CU_EVENT_BLOCKING_SYNC = 0x1
 CU_EVENT_DISABLE_TIMING = 0x2
 # Event is suitable for interprocess use. CU_EVENT_DISABLE_TIMING must be set
 CU_EVENT_INTERPROCESS = 0x4
+
+
+# Pointer information
 
 # The CUcontext on which a pointer was allocated or registered
 CU_POINTER_ATTRIBUTE_CONTEXT = 1
@@ -149,6 +234,45 @@ CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3
 CU_POINTER_ATTRIBUTE_HOST_POINTER = 4
 # A pair of tokens for use with the nv-p2p.h Linux kernel interface
 CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5
+# Synchronize every synchronous memory operation initiated on this region
+CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6
+# A process-wide unique ID for an allocated memory region
+CU_POINTER_ATTRIBUTE_BUFFER_ID = 7
+# Indicates if the pointer points to managed memory
+CU_POINTER_ATTRIBUTE_IS_MANAGED = 8
+# A device ordinal of a device on which a pointer was allocated or registered
+CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9
+# 1 if this pointer maps to an allocation
+# that is suitable for cudaIpcGetMemHandle, 0 otherwise
+CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10
+# Starting address for this requested pointer
+CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11
+# Size of the address range for this requested pointer
+CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12
+# 1 if this pointer is in a valid address range
+# that is mapped to a backing allocation, 0 otherwise
+CU_POINTER_ATTRIBUTE_MAPPED = 13
+# Bitmask of allowed CUmemAllocationHandleType for this allocation
+CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14
+# 1 if the memory this pointer is referencing
+# can be used with the GPUDirect RDMA API
+CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15
+# Returns the access flags the device associated
+# with the current context has on the corresponding
+# memory referenced by the pointer given
+CU_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16
+# Returns the mempool handle for the allocation
+# if it was allocated from a mempool. Otherwise returns NULL
+CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17
+# Size of the actual underlying mapping that the pointer belongs to
+CU_POINTER_ATTRIBUTE_MAPPING_SIZE = 18
+# The start address of the mapping that the pointer belongs to
+CU_POINTER_ATTRIBUTE_MAPPING_BASE_ADDR = 19
+# A process-wide unique id corresponding to the physical allocation the pointer belongs to
+CU_POINTER_ATTRIBUTE_MEMORY_BLOCK_ID = 20
+
+
+# Memory types
 
 # Host memory
 CU_MEMORYTYPE_HOST = 0x01
@@ -159,6 +283,8 @@ CU_MEMORYTYPE_ARRAY = 0x03
 # Unified device or host memory
 CU_MEMORYTYPE_UNIFIED = 0x04
 
+
+# Device code formats
 
 # Compiled device-class-specific device code
 # Applicable options: none
@@ -180,13 +306,15 @@ CU_JIT_INPUT_OBJECT = 3
 # Applicable options: PTX compiler options, ::CU_JIT_FALLBACK_STRATEGY
 CU_JIT_INPUT_LIBRARY = 4
 
+CU_JIT_NUM_INPUT_TYPES = 6
+
+
+# Online compiler and linker options
 
 # Max number of registers that a thread may use.
 # Option type: unsigned int
 # Applies to: compiler only
-
 CU_JIT_MAX_REGISTERS = 0
-
 
 # IN: Specifies minimum number of threads per block to target compilation
 # for
@@ -199,119 +327,187 @@ CU_JIT_MAX_REGISTERS = 0
 # Cannot be combined with ::CU_JIT_TARGET.
 # Option type: unsigned int
 # Applies to: compiler only
-
 CU_JIT_THREADS_PER_BLOCK = 1
-
 
 # Overwrites the option value with the total wall clock time, in
 # milliseconds, spent in the compiler and linker
 # Option type: float
 # Applies to: compiler and linker
-
 CU_JIT_WALL_TIME = 2
-
 
 # Pointer to a buffer in which to print any log messages
 # that are informational in nature (the buffer size is specified via
 # option ::CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES)
 # Option type: char *
 # Applies to: compiler and linker
-
 CU_JIT_INFO_LOG_BUFFER = 3
-
 
 # IN: Log buffer size in bytes.  Log messages will be capped at this size
 # (including null terminator)
 # OUT: Amount of log buffer filled with messages
 # Option type: unsigned int
 # Applies to: compiler and linker
-
 CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES = 4
-
 
 # Pointer to a buffer in which to print any log messages that
 # reflect errors (the buffer size is specified via option
 # ::CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES)
 # Option type: char *
 # Applies to: compiler and linker
-
 CU_JIT_ERROR_LOG_BUFFER = 5
-
 
 # IN: Log buffer size in bytes.  Log messages will be capped at this size
 # (including null terminator)
 # OUT: Amount of log buffer filled with messages
 # Option type: unsigned int
 # Applies to: compiler and linker
-
 CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES = 6
-
 
 # Level of optimizations to apply to generated code (0 - 4), with 4
 # being the default and highest level of optimizations.
 # Option type: unsigned int
 # Applies to: compiler only
-
 CU_JIT_OPTIMIZATION_LEVEL = 7
-
 
 # No option value required. Determines the target based on the current
 # attached context (default)
 # Option type: No option value needed
 # Applies to: compiler and linker
-
 CU_JIT_TARGET_FROM_CUCONTEXT = 8
-
 
 # Target is chosen based on supplied ::CUjit_target.  Cannot be
 # combined with ::CU_JIT_THREADS_PER_BLOCK.
 # Option type: unsigned int for enumerated type ::CUjit_target
 # Applies to: compiler and linker
-
 CU_JIT_TARGET = 9
-
 
 # Specifies choice of fallback strategy if matching cubin is not found.
 # Choice is based on supplied ::CUjit_fallback.
 # Option type: unsigned int for enumerated type ::CUjit_fallback
 # Applies to: compiler only
-
 CU_JIT_FALLBACK_STRATEGY = 10
-
 
 # Specifies whether to create debug information in output (-g)
 # (0: false, default)
 # Option type: int
 # Applies to: compiler and linker
-
 CU_JIT_GENERATE_DEBUG_INFO = 11
-
 
 # Generate verbose log messages (0: false, default)
 # Option type: int
 # Applies to: compiler and linker
-
 CU_JIT_LOG_VERBOSE = 12
-
 
 # Generate line number information (-lineinfo) (0: false, default)
 # Option type: int
 # Applies to: compiler only
-
 CU_JIT_GENERATE_LINE_INFO = 13
-
 
 # Specifies whether to enable caching explicitly (-dlcm)
 # Choice is based on supplied ::CUjit_cacheMode_enum.
 # Option type: unsigned int for enumerated type ::CUjit_cacheMode_enum
 # Applies to: compiler only
-
 CU_JIT_CACHE_MODE = 14
 
 
+# CUfunction_attribute
+
+# The maximum number of threads per block, beyond which a launch of the
+# function would fail. This number depends on both the function and the
+# device on which the function is currently loaded.
+CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0
+
+# The size in bytes of statically-allocated shared memory required by
+# this function. This does not include dynamically-allocated shared
+# memory requested by the user at runtime.
+CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1
+
+# The size in bytes of user-allocated constant memory required by this
+# function.
+CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2
+
+# The size in bytes of local memory used by each thread of this function.
+CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3
+
+# The number of registers used by each thread of this function.
+CU_FUNC_ATTRIBUTE_NUM_REGS = 4
+
+# The PTX virtual architecture version for which the function was
+# compiled. This value is the major PTX version * 10 + the minor PTX
+# version, so a PTX version 1.3 function would return the value 13.
+# Note that this may return the undefined value of 0 for cubins
+# compiled prior to CUDA 3.0.
+CU_FUNC_ATTRIBUTE_PTX_VERSION = 5
+
+# The binary architecture version for which the function was compiled.
+# This value is the major binary version * 10 + the minor binary version,
+# so a binary version 1.3 function would return the value 13. Note that
+# this will return a value of 10 for legacy cubins that do not have a
+# properly-encoded binary architecture version.
+CU_FUNC_ATTRIBUTE_BINARY_VERSION = 6
+
+# The attribute to indicate whether the function has been compiled
+# with user specified option "-Xptxas --dlcm=ca" set
+CU_FUNC_ATTRIBUTE_CACHE_MODE_CA = 7
+
+# The maximum size in bytes of dynamically-allocated shared memory
+# that can be used by this function. If the user-specified
+# dynamic shared memory size is larger than this value,
+# the launch will fail. See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES = 8
+
+# On devices where the L1 cache and shared memory use the same
+# hardware resources, this sets the shared memory carveout preference,
+# in percent of the total shared memory. Refer to
+# CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR.
+# This is only a hint, and the driver can choose a different ratio
+# if required to execute the function. See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT = 9
+
+# If this attribute is set, the kernel must launch with a valid cluster
+# size specified. See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_CLUSTER_SIZE_MUST_BE_SET = 10
+
+# The required cluster width in blocks. The values must either all be 0
+# or all be positive. The validity of the cluster dimensions
+# is otherwise checked at launch time. If the value is set during
+# compile time, it cannot be set at runtime.
+# Setting it at runtime will return CUDA_ERROR_NOT_PERMITTED.
+# See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH = 11
+
+# The required cluster height in blocks. The values must either all be 0
+# or all be positive. The validity of the cluster dimensions
+# is otherwise checked at launch time.If the value is set during
+# compile time, it cannot be set at runtime.
+# Setting it at runtime should return CUDA_ERROR_NOT_PERMITTED.
+# See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT = 12
+
+# The required cluster depth in blocks. The values must either all be 0
+# or all be positive. The validity of the cluster dimensions
+# is otherwise checked at launch time.If the value is set during
+# compile time, it cannot be set at runtime.
+# Setting it at runtime should return CUDA_ERROR_NOT_PERMITTED.
+# See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH = 13
+
+# Whether the function can be launched with non-portable cluster size.
+# 1 is allowed, 0 is disallowed. A non-portable cluster size may only
+# function on the specific SKUs the program is tested on. 
+# The launch might fail if the program is run on a different hardware platform.
+# For more details refer to link :
+# https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES
+CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED = 14
+
+# The block scheduling policy of a function.
+# The value type is CUclusterSchedulingPolicy / cudaClusterSchedulingPolicy.
+# See cuFuncSetAttribute, cuKernelSetAttribute
+CU_FUNC_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE = 15
+
+
+
 # Device attributes
-
-
 CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
 CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2
 CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3
@@ -405,40 +601,3 @@ CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM = 91
 CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH = 95
 CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH = 96
 CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = 97
-
-
-# CUfunction_attribute
-
-# The maximum number of threads per block, beyond which a launch of the
-# function would fail. This number depends on both the function and the
-# device on which the function is currently loaded.
-CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 0
-
-# The size in bytes of statically-allocated shared memory required by
-# this function. This does not include dynamically-allocated shared
-# memory requested by the user at runtime.
-CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES = 1
-
-# The size in bytes of user-allocated constant memory required by this
-# function.
-CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES = 2
-
-# The size in bytes of local memory used by each thread of this function.
-CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES = 3
-
-# The number of registers used by each thread of this function.
-CU_FUNC_ATTRIBUTE_NUM_REGS = 4
-
-# The PTX virtual architecture version for which the function was
-# compiled. This value is the major PTX version * 10 + the minor PTX
-# version, so a PTX version 1.3 function would return the value 13.
-# Note that this may return the undefined value of 0 for cubins
-# compiled prior to CUDA 3.0.
-CU_FUNC_ATTRIBUTE_PTX_VERSION = 5
-
-# The binary architecture version for which the function was compiled.
-# This value is the major binary version * 10 + the minor binary version,
-# so a binary version 1.3 function would return the value 13. Note that
-# this will return a value of 10 for legacy cubins that do not have a
-# properly-encoded binary architecture version.
-CU_FUNC_ATTRIBUTE_BINARY_VERSION = 6

--- a/numba/tests/test_enums.py
+++ b/numba/tests/test_enums.py
@@ -8,8 +8,9 @@ import unittest
 from numba import jit, vectorize, int8, int16, int32
 
 from numba.tests.support import TestCase
-from .enum_usecases import Color, Shape, Shake, Planet, RequestError, \
-                           IntEnumWithNegatives
+from numba.tests.enum_usecases import (Color, Shape, Shake,
+                                       Planet, RequestError,
+                                       IntEnumWithNegatives)
 
 
 def compare_usecase(a, b):


### PR DESCRIPTION
fix #8363
I have added support for the latest CUDA driver codes. 

During the addition, I was guided by the values from the official documentation at the link: **https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES**
I also tried to make the file with the codes a little more readable.

p.s. UNKNOWN_CUDA_ERROR was returning to me, although I understood what error was in my code. But it didn't exist in the file numba/cuda/cudadrv/enums.py. This signaled me to update this file