### PR TITLE
Cherry-pick and squash PR #8978 (Import MVC packages when using MVCLinker) for Release 0.57.1

### DIFF
--- a/numba/cuda/cudadrv/driver.py
+++ b/numba/cuda/cudadrv/driver.py
@@ -37,15 +37,6 @@ from .drvapi import API_PROTOTYPES
 from .drvapi import cu_occupancy_b2d_size, cu_stream_callback_pyobj, cu_uuid
 from numba.cuda.cudadrv import enums, drvapi, _extras
 
-if config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY:
-    try:
-        from ptxcompiler import compile_ptx
-        from cubinlinker import CubinLinker, CubinLinkerError
-    except ImportError as ie:
-        msg = ("Minor version compatibility requires ptxcompiler and "
-               "cubinlinker packages to be available")
-        raise ImportError(msg) from ie
-
 USE_NV_BINDING = config.CUDA_USE_NVIDIA_BINDING
 
 if USE_NV_BINDING:
@@ -2670,12 +2661,23 @@ class Linker(metaclass=ABCMeta):
         """
 
 
+_MVC_ERROR_MESSAGE = (
+    "Minor version compatibility requires ptxcompiler and cubinlinker packages "
+    "to be available"
+)
+
+
 class MVCLinker(Linker):
     """
     Linker supporting Minor Version Compatibility, backed by the cubinlinker
     package.
     """
     def __init__(self, max_registers=None, lineinfo=False, cc=None):
+        try:
+            from cubinlinker import CubinLinker
+        except ImportError as err:
+            raise ImportError(_MVC_ERROR_MESSAGE) from err
+
         if cc is None:
             raise RuntimeError("MVCLinker requires Compute Capability to be "
                                "specified, but cc is None")
@@ -2700,6 +2702,11 @@ class MVCLinker(Linker):
         return self._linker.error_log
 
     def add_ptx(self, ptx, name='<cudapy-ptx>'):
+        try:
+            from ptxcompiler import compile_ptx
+            from cubinlinker import CubinLinkerError
+        except ImportError as err:
+            raise ImportError(_MVC_ERROR_MESSAGE) from err
         compile_result = compile_ptx(ptx.decode(), self.ptx_compile_options)
         try:
             self._linker.add_cubin(compile_result.compiled_program, name)
@@ -2707,6 +2714,11 @@ class MVCLinker(Linker):
             raise LinkerError from e
 
     def add_file(self, path, kind):
+        try:
+            from cubinlinker import CubinLinkerError
+        except ImportError as err:
+            raise ImportError(_MVC_ERROR_MESSAGE) from err
+
         try:
             with open(path, 'rb') as f:
                 data = f.read()
@@ -2743,6 +2755,11 @@ class MVCLinker(Linker):
         self.add_ptx(program.ptx.rstrip(b'\x00'), ptx_name)
 
     def complete(self):
+        try:
+            from cubinlinker import CubinLinkerError
+        except ImportError as err:
+            raise ImportError(_MVC_ERROR_MESSAGE) from err
+
         try:
             return self._linker.complete()
         except CubinLinkerError as e:

--- a/numba/cuda/tests/cudadrv/test_mvc.py
+++ b/numba/cuda/tests/cudadrv/test_mvc.py
@@ -1,0 +1,52 @@
+import multiprocessing as mp
+import traceback
+from numba.cuda.testing import unittest, CUDATestCase
+from numba.cuda.testing import skip_on_cudasim, skip_under_cuda_memcheck
+from numba.tests.support import linux_only
+
+
+def child_test():
+    from numba import config, cuda
+
+    # Change the MVC config after importing numba.cuda
+    config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = 1
+
+    @cuda.jit
+    def f():
+        pass
+
+    f[1, 1]()
+
+
+def child_test_wrapper(result_queue):
+    try:
+        output = child_test()
+        success = True
+    # Catch anything raised so it can be propagated
+    except: # noqa: E722
+        output = traceback.format_exc()
+        success = False
+
+    result_queue.put((success, output))
+
+
+@linux_only
+@skip_under_cuda_memcheck('May hang CUDA memcheck')
+@skip_on_cudasim('Simulator does not require or implement MVC')
+class TestMinorVersionCompatibility(CUDATestCase):
+    def test_mvc(self):
+        # Run test with Minor Version Compatibility enabled in a child process
+        ctx = mp.get_context('spawn')
+        result_queue = ctx.Queue()
+        proc = ctx.Process(target=child_test_wrapper, args=(result_queue,))
+        proc.start()
+        proc.join()
+        success, output = result_queue.get()
+
+        # Ensure the child process ran to completion before checking its output
+        if not success:
+            self.fail(output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -392,8 +392,8 @@ def get_sysinfo():
                 sys_info[_cu_mvc_available] = False
 
             sys_info[_cu_mvc_needed] = cu_rt_ver > cu_drv_ver
-            mvc_used = hasattr(cudadrv.driver, 'CubinLinker')
-            sys_info[_cu_mvc_in_use] = mvc_used
+            sys_info[_cu_mvc_in_use] = bool(
+                config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY)
         except Exception as e:
             _warning_log.append(
                 "Warning (cuda): Probing CUDA failed "


### PR DESCRIPTION
This cherry-pick and squash incorporates the fix for Issue #8977 (NameError from CubinLinker with `CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY`) from PR #8978 (Import MVC packages when using MVCLinker). As discussed during triage / FPOC discussions, this is for 0.57.1 because it forces cuDF to monkey-patch Numba to avoid `NameError`s in a supported use case: importing `numba.cuda` then enabling Minor Version Compatibility (MVC) prior to use of the CUDA functionality.

Tested locally with and without MVC enabled, by running the CUDA tests (`python runtests.py numba.cuda.tests`) and verifying the output of the sysinfo tool by inspection.

cc @bdice.